### PR TITLE
chore: rename project from "CEO Office" to "Curia"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 <p align="center">
-  <img src="docs/assets/ceo-office-header.png" alt="CEO Office" width="800" />
+  <img src="docs/assets/curia-header.png" alt="Curia" width="800" />
 </p>
 
 <p align="center">
-  <strong>The AI executive staff your C-Suite will use and your Board will trust.</strong>
+  <strong>The AI executive staff your C-Suite will use and your Board will trust.</strong><br/>
+  <em>Curia — the Roman administrative court. Where governance happened.</em>
 </p>
 
 <p align="center">
@@ -30,11 +31,11 @@ Most agent frameworks treat security as a configuration option and audit trails 
 
 That's fine for a demo. It's not fine when the agent is reading your email, tracking your expenses, or acting on your behalf.
 
-**CEO Office was built for the people who can't afford "it probably won't go rogue."**
+**Curia was built for the people who can't afford "it probably won't go rogue."**
 
 ---
 
-## What Is CEO Office?
+## What Is Curia?
 
 A multi-agent AI platform designed for executives and their teams. It runs continuously on your own server, handles real workflows across multiple channels, and maintains a sophisticated memory of your world — all with the security posture and audit trail that enterprise governance demands.
 
@@ -51,7 +52,7 @@ Think of it as a digital executive office: specialized agents sit at their desks
 
 ### What Makes It Different
 
-| | Typical Agent Framework | CEO Office |
+| | Typical Agent Framework | Curia |
 |---|---|---|
 | **Security model** | "Trust the agent" | Hard-enforced layer separation — channel adapters *physically cannot* invoke tools |
 | **Audit trail** | Console.log | Append-only Postgres with causal tracing across every event |
@@ -107,7 +108,7 @@ The message bus enforces these boundaries at registration time. A channel adapte
 
 ## Security
 
-Security isn't a feature of CEO Office. It's the reason it exists.
+Security isn't a feature of Curia. It's the reason it exists.
 
 ### 1. Hard Layer Separation
 
@@ -139,7 +140,7 @@ Every agent task has hard caps: maximum LLM round-trips, maximum dollar spend, m
 
 ## Memory
 
-Most agent frameworks forget everything between sessions. CEO Office remembers — and knows what it doesn't know anymore.
+Most agent frameworks forget everything between sessions. Curia remembers — and knows what it doesn't know anymore.
 
 ### Knowledge Graph
 
@@ -277,12 +278,12 @@ Each agent specifies its provider and model. Configure fallbacks for resilience 
 
 ## Quick Start
 
-> **Note:** CEO Office is in pre-alpha. The spec is complete; implementation is underway. Star the repo to follow progress.
+> **Note:** Curia is in pre-alpha. The spec is complete; implementation is underway. Star the repo to follow progress.
 
 ```bash
 # Clone
-git clone https://github.com/josephfung/ceo-office.git
-cd ceo-office
+git clone https://github.com/josephfung/curia.git
+cd curia
 
 # Configure
 cp .env.example .env
@@ -336,7 +337,7 @@ The framework starts Postgres, runs migrations, connects to configured channels,
 
 ## Deployment
 
-CEO Office runs anywhere Docker runs:
+Curia runs anywhere Docker runs:
 
 - **Local development** — `docker compose up` on your laptop
 - **Single VPS** — One Hetzner/DigitalOcean/Linode instance with Docker + Caddy
@@ -348,7 +349,7 @@ Infrastructure is managed separately via the [ceo-deploy](https://github.com/jos
 
 ## Contributing
 
-CEO Office is in early development. If you're interested in contributing, start by reading the [architecture spec](docs/specs/00-overview.md) to understand the design philosophy. Issues and PRs welcome.
+Curia is in early development. If you're interested in contributing, start by reading the [architecture spec](docs/specs/00-overview.md) to understand the design philosophy. Issues and PRs welcome.
 
 ---
 

--- a/docs/specs/00-overview.md
+++ b/docs/specs/00-overview.md
@@ -1,4 +1,4 @@
-# CEO Office Framework — Architecture Overview
+# Curia Framework — Architecture Overview
 
 **Date:** 2026-03-24
 **Status:** Approved
@@ -21,9 +21,9 @@
 
 ## Context
 
-After auditing four open-source agent frameworks (agentsystems, Daemora, ForgeAI, Edict), all were found to be high-risk for production use — single-maintainer projects with no code review, thin tests, and immature architectures. The decision is to build a minimal custom framework ("CEO Office") purpose-built for a long-running, VPS-hosted executive assistant system.
+After auditing four open-source agent frameworks (agentsystems, Daemora, ForgeAI, Edict), all were found to be high-risk for production use — single-maintainer projects with no code review, thin tests, and immature architectures. The decision is to build a minimal custom framework ("Curia") purpose-built for a long-running, VPS-hosted executive assistant system.
 
-The framework replaces the existing Zora dependency entirely (clean break). It lives in the `ceo-office` repo (currently an empty scaffold) and deploys via the existing `ceo-deploy` infrastructure (Hetzner VPS, Docker Compose, Caddy).
+The framework replaces the existing Zora dependency entirely (clean break). It lives in the `curia` repo (currently an empty scaffold) and deploys via the existing `ceo-deploy` infrastructure (Hetzner VPS, Docker Compose, Caddy).
 
 **Zora migration:** No data migration. Zora's audit logs, policies, and dashboard state are discarded. The existing Zora container in `ceo-deploy` will be replaced with the new framework container. This is a conscious decision — Zora was an evaluation, not a production system with accumulated data worth preserving.
 

--- a/docs/specs/08-operations.md
+++ b/docs/specs/08-operations.md
@@ -56,20 +56,20 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: ceo_office
+      POSTGRES_DB: curia
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
       interval: 5s
 
-  ceo-office:
+  curia:
     build: .
     depends_on:
       postgres:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@postgres:5432/ceo_office
+      DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@postgres:5432/curia
       NODE_ENV: ${NODE_ENV:-development}
     env_file: .env
     healthcheck:
@@ -187,7 +187,7 @@ Migrations run automatically on startup (before the bus starts accepting events)
 ## Project Structure
 
 ```
-ceo-office/
+curia/
 ├── src/
 │   ├── bus/                    # Message bus, event types, layer permissions
 │   │   ├── bus.ts


### PR DESCRIPTION
## Summary

- Rename all references from "CEO Office" / "ceo-office" / "ceo_office" to "Curia" / "curia"
- Add etymology note to README header: *"Curia — the Roman administrative court. Where governance happened."*
- Update Docker service name, database name, clone URL, and header image reference

## Files changed

- `README.md` — all name references + etymology tagline
- `docs/specs/00-overview.md` — framework name in title and context section
- `docs/specs/08-operations.md` — Docker service name, DB name, project structure tree

## After merge

1. Rename the GitHub repo: `gh repo rename curia --repo josephfung/ceo-office` (GitHub auto-redirects old URLs)
2. Update root workspace README

## Test plan

- [ ] Verify `grep -ri "ceo.office" .` returns zero results
- [ ] Verify CI passes