### PR TITLE
chore: add contributor docs, license, and GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Report a bug in Curia
+title: "bug: "
+labels: bug
+---
+
+## Description
+
+What happened?
+
+## Expected Behavior
+
+What should have happened?
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- Curia version:
+- Node.js version:
+- OS:
+- Docker version (if applicable):
+
+## Logs / Error Output
+
+```
+Paste relevant logs here
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest a feature or improvement
+title: "feat: "
+labels: enhancement
+---
+
+## Problem
+
+What problem does this solve?
+
+## Proposed Solution
+
+How should it work?
+
+## Alternatives Considered
+
+What other approaches did you consider?
+
+## Spec Impact
+
+Which spec documents would this affect? (see `docs/specs/`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+What does this PR do and why?
+
+## Changes
+
+-
+-
+
+## Related Issues
+
+Closes #
+
+## Checklist
+
+- [ ] Code follows project conventions (see CLAUDE.md)
+- [ ] Tests added/updated for new functionality
+- [ ] No `any` types introduced
+- [ ] No empty `catch {}` blocks
+- [ ] No `console.log` (use pino)
+- [ ] Spec docs updated if behavior changes
+- [ ] CI passes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Project README with architecture overview and security narrative
+- Architecture specification documents (docs/specs/00 through 08)
+- Contributor documentation (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
+- Project structure with agents/, skills/, config/ directories
+- CI workflow with structure verification

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# Curia — Claude Code Instructions
+
+## Project Overview
+
+Curia is a multi-agent AI platform for executives. Architecture specs are in `docs/specs/`. Read `docs/specs/00-overview.md` first for the full picture.
+
+## Architecture
+
+Four hard-separated layers connected by a message bus. Every component declares its layer at startup; the bus enforces which event types each layer can publish/subscribe to.
+
+- **Channel Layer** — translates platform messages (Telegram, Email, etc.) into normalized bus events
+- **Dispatch Layer** — routes messages to agents, enforces policy, translates responses back
+- **Agent Layer** — LLM-powered agents with isolated memory scopes
+- **Execution Layer** — runs skills (local or MCP), validates permissions, sanitizes outputs
+
+Cross-cutting: Audit Logger, Memory Engine, Scheduler.
+
+## Code Conventions
+
+### TypeScript
+- ESM only (`"type": "module"`, `.js` extensions on all relative imports)
+- Node 22+, use `import.meta.dirname` instead of `__dirname`
+- No `any` — use proper types, generics, or discriminated unions
+- All event types defined as discriminated unions in `src/bus/events.ts`
+- All errors normalized to `AgentError` type (see `docs/specs/05-error-recovery.md`)
+
+### Database
+- PostgreSQL 16+ with pgvector
+- Parameterized queries only — never interpolate variables into SQL strings
+- Migrations in `src/db/migrations/` using node-pg-migrate (plain SQL)
+
+### Error Handling
+- No empty `catch {}` blocks — every catch must log, audit, and propagate
+- Use structured `AgentError` types, not string matching
+- Skills return `{ success: true, data }` or `{ success: false, error }` — never throw
+
+### Logging
+- pino for all logging (structured JSON)
+- No `console.log` anywhere — enforced by lint rule
+- Log levels: error, warn, info, debug
+
+### Testing
+- Vitest for unit and integration tests
+- Integration tests use real Postgres (via Docker), not mocks
+- Tests live next to the code they test, or in `tests/unit/` and `tests/integration/`
+
+## Key Files
+
+- `src/index.ts` — bootstrap orchestrator, wires everything in dependency order
+- `src/bus/events.ts` — event type registry (discriminated union), source of truth
+- `src/bus/permissions.ts` — layer-to-event authorization map (security boundary)
+- `agents/*.yaml` — agent configuration files
+- `skills/*/skill.json` — skill manifests
+- `config/default.yaml` — base configuration
+
+## Adding Things
+
+### New Channel Adapter
+1. Create `src/channels/<name>/` implementing `ChannelAdapter` interface
+2. Register as `layer: "channel"` with the bus
+3. Add config section to `config/default.yaml`
+4. Write tests
+
+### New Skill
+1. Create `skills/<name>/skill.json` (manifest) + `handler.ts`
+2. Declare permissions and secrets in the manifest
+3. Write `handler.test.ts`
+
+### New Agent
+1. Create `agents/<name>.yaml` with required fields (name, description, model, system_prompt)
+2. Optionally add `handler: ./<name>.handler.ts` for custom logic
+
+## Scope Discipline
+
+- Fix what was asked. Don't refactor surrounding code.
+- If you spot issues nearby, mention them — don't touch them.
+- No drive-by type annotations on code you didn't change.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainer at **conduct@josephfung.ca**.
+
+All complaints will be reviewed and investigated promptly and fairly. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to Curia
+
+Thank you for your interest in contributing to Curia. This document explains how to get involved, what we expect from contributions, and how to set up your development environment.
+
+## Getting Started
+
+1. Read the [architecture overview](docs/specs/00-overview.md) to understand the design philosophy
+2. Check [open issues](https://github.com/josephfung/curia/issues) — look for `good first issue` labels
+3. Fork the repo and create a feature branch
+
+## Development Setup
+
+```bash
+git clone https://github.com/YOUR_USERNAME/curia.git
+cd curia
+cp .env.example .env
+# Edit .env with your API keys
+docker compose up
+```
+
+Requires: Node.js 22+, Docker, PostgreSQL 16+ (via Docker Compose).
+
+## Making Changes
+
+### Branch Naming
+
+Use conventional prefixes:
+- `feat/` — new features
+- `fix/` — bug fixes
+- `chore/` — maintenance, docs, tooling
+
+### Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add Telegram channel adapter
+fix: prevent infinite retry loop in scheduler
+chore: update pgvector to 0.8.0
+```
+
+### Code Standards
+
+- **TypeScript ESM** — `"type": "module"`, `.js` extensions on imports
+- **No `any` types** — use proper types or generics
+- **Parameterized SQL** — never interpolate variables into SQL strings
+- **Structured error handling** — no empty `catch {}` blocks (see [error recovery spec](docs/specs/05-error-recovery.md))
+- **Structured logging** — use pino, never `console.log`
+- **Comment liberally** — explain *why*, not just *what*
+
+### Testing
+
+- Write tests for new features and bug fixes
+- Run the full test suite before submitting: `pnpm test`
+- Integration tests should use real Postgres (via Docker), not mocks
+
+### Pull Requests
+
+- Keep PRs focused — one logical change per PR
+- Reference the issue number if applicable
+- Fill out the PR template
+- Ensure CI passes before requesting review
+
+## Architecture
+
+Curia uses a message bus architecture with four hard-separated layers. Before proposing changes, understand which layer your change affects:
+
+- **Channel Layer** — input/output adapters (Signal, Telegram, Email, etc.)
+- **Dispatch Layer** — routing, policy enforcement
+- **Agent Layer** — LLM-powered agent execution
+- **Execution Layer** — skill invocation, MCP clients
+
+Each layer has strict bus permissions. See [architecture overview](docs/specs/00-overview.md) for details.
+
+## Adding a New Channel Adapter
+
+1. Create `src/channels/<name>/` with a class implementing `ChannelAdapter`
+2. Add channel config to `config/default.yaml`
+3. Write unit tests in `tests/unit/channels/<name>/`
+4. Document in [channels spec](docs/specs/04-channels.md)
+
+## Adding a New Skill
+
+1. Create `skills/<name>/` with `skill.json` manifest and `handler.ts`
+2. Write tests in `skills/<name>/handler.test.ts`
+3. Declare permissions and secrets in the manifest
+
+## AI-Assisted Contributions
+
+AI-assisted contributions (Claude Code, Copilot, Codex, etc.) are welcome. We evaluate code quality, not authorship. Requirements:
+
+- **You must understand and be able to explain any code you submit** — if asked during review, you should be able to discuss the design choices
+- **Same standards apply** — AI-generated code must pass lint, tests, type checks, and code review like any other contribution
+- **Disclose substantial AI use** — if a PR is predominantly AI-generated, note this in the PR description. This is for transparency, not gatekeeping.
+- **`CLAUDE.md` is your friend** — contributors using Claude Code will automatically follow project conventions via the repo-level CLAUDE.md
+
+## Reporting Issues
+
+- **Bugs**: Use the bug report issue template
+- **Features**: Use the feature request issue template
+- **Security vulnerabilities**: See [SECURITY.md](SECURITY.md) — do NOT file a public issue
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold these standards.
+
+## Questions?
+
+Open a [Discussion](https://github.com/josephfung/curia/discussions) for questions that aren't bugs or feature requests.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Joseph Fung
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -349,13 +349,20 @@ Infrastructure is managed separately via the [ceo-deploy](https://github.com/jos
 
 ## Contributing
 
-Curia is in early development. If you're interested in contributing, start by reading the [architecture spec](docs/specs/00-overview.md) to understand the design philosophy. Issues and PRs welcome.
+Curia is in early development and welcomes contributions — including AI-assisted ones.
+
+- Read the **[Contributing Guide](CONTRIBUTING.md)** for dev setup, code standards, and how to add channels/skills/agents
+- Read **[CLAUDE.md](CLAUDE.md)** for repo-level conventions (if you're using Claude Code, these load automatically)
+- Check **[open issues](https://github.com/josephfung/curia/issues)** — look for `good first issue` labels
+- Report security vulnerabilities via **[SECURITY.md](SECURITY.md)** — not public issues
+
+We evaluate code quality, not authorship. AI-generated contributions are held to the same review standards as human-written code. See the [AI contributions policy](CONTRIBUTING.md#ai-assisted-contributions) for details.
 
 ---
 
 ## License
 
-MIT
+[MIT](LICENSE)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+Security is the core design principle of Curia. We take vulnerability reports seriously.
+
+## Reporting a Vulnerability
+
+**Do NOT file a public GitHub issue for security vulnerabilities.**
+
+Email **security@josephfung.ca** with:
+
+1. Description of the vulnerability
+2. Steps to reproduce
+3. Potential impact
+4. Suggested fix (if you have one)
+
+You will receive an acknowledgment within 48 hours and a detailed response within 7 days.
+
+## Scope
+
+The following are in scope for security reports:
+
+- Bus layer enforcement bypasses (a channel publishing unauthorized events)
+- Audit log integrity issues (mutations, deletions, gaps)
+- Secret leakage (secrets appearing in logs, LLM context, or API responses)
+- Prompt injection via tool outputs or channel messages
+- Authentication/authorization bypasses on the HTTP API
+- Intent drift detection failures (agent acting outside its mandate undetected)
+- Skill permission escalation (a skill accessing undeclared secrets or capabilities)
+
+## Out of Scope
+
+- Vulnerabilities in upstream dependencies (report to the dependency maintainer)
+- Denial of service via resource exhaustion (covered by error budgets, but not a security vulnerability)
+- Social engineering attacks against the project maintainer
+
+## Disclosure Policy
+
+We follow coordinated disclosure:
+
+1. Reporter notifies us privately
+2. We confirm and develop a fix
+3. We release the fix
+4. We publicly disclose the vulnerability (with credit to the reporter, if desired)
+
+We aim to resolve critical vulnerabilities within 14 days of confirmation.
+
+## Security Architecture
+
+For details on Curia's security model, see [Audit & Security spec](docs/specs/06-audit-and-security.md).


### PR DESCRIPTION
## Summary

- Add MIT license
- Add contributor documentation (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
- Add CHANGELOG.md (Keep a Changelog format)
- Add repo-level CLAUDE.md with Curia-specific conventions
- Add GitHub issue templates (bug report, feature request) and PR template

## Files

| File | Purpose |
|---|---|
| `LICENSE` | MIT license |
| `CONTRIBUTING.md` | Dev setup, code standards, how to add channels/skills/agents, AI contributions policy |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1 |
| `SECURITY.md` | Vulnerability reporting process and scope |
| `CHANGELOG.md` | Project changelog (Keep a Changelog format) |
| `CLAUDE.md` | Repo-level Claude Code conventions |
| `.github/ISSUE_TEMPLATE/bug_report.md` | Bug report template |
| `.github/ISSUE_TEMPLATE/feature_request.md` | Feature request template |
| `.github/PULL_REQUEST_TEMPLATE.md` | PR checklist template |

## Test plan

- [ ] Verify LICENSE renders correctly on GitHub
- [ ] Verify issue templates appear when creating new issues
- [ ] Verify PR template appears when creating new PRs
- [ ] Verify SECURITY.md email addresses are correct
- [ ] CI passes