### PR TITLE
feat: coordinator persona, user Bullpen access, onboarding CLI, and README updates

### DIFF
--- a/docs/specs/01-memory-system.md
+++ b/docs/specs/01-memory-system.md
@@ -23,16 +23,25 @@ Short-lived context for active agent tasks. Stored in `working_memory` table, sc
 
 ## Tier 2: The Bullpen (inter-agent discussion)
 
-Shared workspace where agents have structured, threaded conversations:
+Shared workspace where agents — and the user — have structured, threaded conversations:
 - Any agent can open a thread addressed to other agents
 - Flows through the bus as `agent.discuss` events (same security model)
 - Threaded and async — agents subscribe to `agent.discuss` events and respond when addressed. The dispatcher also checks for pending Bullpen threads when routing any `agent.task`, ensuring agents see discussion messages even if they only activate via inbound user messages.
 - All threads are logged, auditable, and visible to the user via dashboard
 - Dispatcher can mediate stuck discussions or escalate to user
 
+### User Participation
+
+The CEO can participate in Bullpen threads:
+- **Observe** — all threads are visible via the dashboard SSE stream or HTTP API
+- **Intervene** — send a message to a thread via any channel (e.g., `@bullpen: focus on Q2 expenses, not Q1`) or the dashboard. The dispatcher translates this into an `agent.discuss` event with `sender: "user"`.
+- **Start threads** — ask a question that multiple agents respond to (e.g., `@bullpen: what does everyone know about this vendor?`)
+
+User messages in the Bullpen carry the same audit trail as any other event. The `sender` field distinguishes user messages from agent messages.
+
 **Tables:**
 - `bullpen_threads` — id, topic, participants (TEXT[]), status, created_at
-- `bullpen_messages` — id, thread_id, agent_id, content (JSONB), created_at
+- `bullpen_messages` — id, thread_id, sender_type (TEXT: "agent" | "user"), sender_id (TEXT), content (JSONB), created_at
 
 ---
 

--- a/docs/specs/02-agent-system.md
+++ b/docs/specs/02-agent-system.md
@@ -1,5 +1,57 @@
 # 02 — Agent System
 
+## Coordinator Agent & Unified Persona
+
+All external communication flows through a single **Coordinator agent** — the user's unified point of contact. The Coordinator is a persona (e.g., "Alex") that the CEO names and configures. Specialist agents (expense-tracker, research-analyst, etc.) work internally but never communicate directly with the outside world.
+
+### How It Works
+
+1. Every inbound message routes to the Coordinator — no exceptions
+2. The Coordinator decides: handle it directly (small talk, acknowledgments) or delegate to specialists
+3. Specialist agents return results to the Coordinator via the Bullpen or `agent.response`
+4. The Coordinator synthesizes results and responds in its own voice
+5. The external recipient never knows multiple agents were involved
+
+### Coordinator Config
+
+```yaml
+# agents/coordinator.yaml
+name: coordinator
+role: coordinator                # special role — dispatch always routes here
+persona:
+  display_name: Alex             # what end-users see in emails, messages
+  tone: professional but warm
+  email_signature: |
+    Alex
+    Office of Joseph Fung
+model:
+  provider: anthropic
+  model: claude-sonnet-4-20250514
+system_prompt: |
+  You are ${persona.display_name}, executive assistant to the CEO.
+  You are the single point of contact for all communications.
+  You have a team of specialists you can delegate to, but you always
+  respond in your own voice. The sender should never know multiple
+  agents were involved.
+
+  For casual messages, respond naturally as yourself.
+  For tasks, delegate to the appropriate specialist and synthesize
+  their work into your response.
+pinned_skills:
+  - skill-registry
+  - scheduler
+  - memory-query
+allow_discovery: true
+```
+
+The `role: coordinator` field tells the dispatch layer to route all inbound messages here. There is exactly one coordinator per deployment.
+
+### Internal Agent Handles
+
+Specialist agents have internal handles (e.g., `@expense-tracker`, `@research-analyst`) used in the Bullpen and audit log. These are never exposed to external users — they're internal identifiers for the Coordinator and other agents to reference.
+
+---
+
 ## Agent Definition (Hybrid: YAML + optional TypeScript)
 
 ### Simple Agents (YAML config)
@@ -182,14 +234,12 @@ Every LLM call records: provider, model, input tokens, output tokens, estimated 
 
 ## Dispatch Layer
 
-Routes inbound messages to the correct agent based on:
-- Channel-specific rules (e.g., "all Telegram messages go to general-assistant")
-- Explicit addressing (e.g., "@expense-tracker process this receipt")
-- Keyword/intent matching (configurable patterns in dispatch rules)
+**All inbound messages route to the Coordinator.** The dispatch layer does not classify or route messages to specialist agents — that's the Coordinator's job. The dispatcher's responsibilities are:
 
-Enforces policy: rate limits, blocked senders, required approvals. Mediates Bullpen discussions — can escalate to user if agents are stuck.
-
-The dispatcher also:
-- Translates `agent.response` → `outbound.message` (completing the response loop)
-- Checks for pending Bullpen threads on every `agent.task` routing
-- Subscribes to `agent.error` and notifies the user on the originating channel
+- Route every `inbound.message` to the Coordinator agent
+- Enforce policy: rate limits, blocked senders, required approvals
+- Translate `agent.response` → `outbound.message` (completing the response loop)
+- Inject `persona.display_name` and `persona.email_signature` into outbound messages
+- Check for pending Bullpen threads on every `agent.task` routing
+- Subscribe to `agent.error` and notify the user on the originating channel
+- Mediate Bullpen discussions — escalate to user if agents are stuck

--- a/docs/specs/03-skills-and-execution.md
+++ b/docs/specs/03-skills-and-execution.md
@@ -158,3 +158,22 @@ The framework ships with these skills (in `skills/` but part of core):
 - `scheduler` — create/list/cancel scheduled jobs
 - `memory-query` — search entity memory and knowledge graph
 - `memory-store` — write facts to entity memory (with validation gates)
+- `web-fetch` — HTTP GET with configurable timeouts and size limits
+- `file-reader` — read files from a configured data directory (not arbitrary filesystem)
+- `file-writer` — write files to a configured output directory
+
+---
+
+## Recommended MCP Servers
+
+These are not bundled but documented as recommended integrations:
+
+| Server | Purpose | Link |
+|---|---|---|
+| **Filesystem** | Scoped file access (read/write/search) | [modelcontextprotocol/servers/filesystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) |
+| **Google Drive** | Read/search Google Docs and Sheets | [modelcontextprotocol/servers/gdrive](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive) |
+| **GitHub** | Repo management, issues, PRs | [modelcontextprotocol/servers/github](https://github.com/modelcontextprotocol/servers/tree/main/src/github) |
+| **Brave Search** | Web search for research agents | [modelcontextprotocol/servers/brave-search](https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search) |
+| **Fetch** | Web fetching with robots.txt compliance | [modelcontextprotocol/servers/fetch](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) |
+
+Custom MCP servers will be needed for Google Calendar and expense platforms (Expensify, QuickBooks). These can be built as local skills initially and promoted to MCP servers when the protocol stabilizes for those APIs.

--- a/docs/specs/08-operations.md
+++ b/docs/specs/08-operations.md
@@ -29,6 +29,54 @@ The merged config is validated against a TypeScript-derived JSON Schema at start
 
 ---
 
+## Onboarding (New Instance Setup)
+
+Setting up a new Curia deployment requires configuring channels, skills, and their secrets (API keys, OAuth tokens, IMAP passwords).
+
+### `curia setup` CLI
+
+A guided CLI command walks through each configured channel and skill, prompting for credentials:
+
+```
+$ curia setup
+Curia Setup
+===========
+
+Coordinator persona:
+  Display name [Curia]: Alex
+  Tone [professional]: professional but warm
+
+Setting up email channel...
+  IMAP host: imap.gmail.com
+  IMAP username: joseph@example.com
+  IMAP password: ********
+  Testing connection... ✓ Connected (14 unread messages)
+  Stored as EMAIL_IMAP_PASSWORD.
+
+Setting up Telegram channel...
+  Bot token: ********
+  Testing connection... ✓ Bot @alex_curia_bot is active
+  Stored as TELEGRAM_BOT_TOKEN.
+
+Setting up Google Calendar skill...
+  This requires OAuth. Opening browser...
+  ✓ Authorized. Token stored as GOOGLE_OAUTH_REFRESH_TOKEN.
+
+Summary:
+  ✓ Email channel ready
+  ✓ Telegram channel ready
+  ✗ Signal channel not configured (skipped)
+  ✓ Google Calendar skill ready
+
+Run 'docker compose up' to start Curia.
+```
+
+**How it works:** The CLI reads all channel adapter configs and skill manifests, identifies which secrets are required, checks which are already set, and prompts for the missing ones. It validates connectivity for each service before storing the secret. Adding a new integration = declaring `secrets` in a skill manifest, and `curia setup` automatically picks it up.
+
+**Future:** A web-based onboarding wizard (via the HTTP API dashboard) with OAuth redirect flows and a visual status page.
+
+---
+
 ## Deployment
 
 ### Local Development


### PR DESCRIPTION
## Summary

Follow-up to PR #10. Adds spec updates from architecture discussion and README refinements.

### Spec updates
- **02-agent-system**: Coordinator agent as unified persona — all external comms flow through one voice. Dispatch routes all inbound to Coordinator.
- **01-memory-system**: User can observe, intervene in, and start Bullpen threads
- **03-skills-and-execution**: Added web-fetch, file-reader, file-writer built-in skills. Documented 5 recommended MCP servers.
- **08-operations**: Added `curia setup` onboarding CLI for guided credential configuration

### README updates
- Contributing section now links to CONTRIBUTING.md, CLAUDE.md, SECURITY.md
- Explicitly mentions AI-friendly contribution policy
- License links to actual LICENSE file

## Test plan

- [x] Verify CI passes
- [x] Verify no stale "CEO Office" references remain