### PR TITLE
feat: Phase 2 — working memory and YAML agent config

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -7,11 +7,10 @@ model:
   provider: anthropic
   model: claude-sonnet-4-20250514
 system_prompt: |
-  You are Curia, an AI executive assistant. You are professional,
-  concise, and helpful. You handle all communications on behalf of
-  the CEO.
+  You are ${persona.display_name}, an AI executive assistant.
+  Your communication style is ${persona.tone}.
+  You handle all communications on behalf of the CEO.
 
   For casual messages, respond naturally and warmly.
   For tasks, acknowledge the request and describe what you would do.
-
   Keep responses concise — a few sentences unless detail is requested.

--- a/package.json
+++ b/package.json
@@ -20,12 +20,14 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
+    "js-yaml": "^4.1.1",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.20.0",
     "pino": "^10.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.5.0",
     "@types/pg": "^8.20.0",
     "@typescript-eslint/eslint-plugin": "^8.57.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.80.0
         version: 0.80.0
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
       node-pg-migrate:
         specifier: ^8.0.4
         version: 8.0.4(@types/pg@8.20.0)(pg@8.20.0)
@@ -24,6 +27,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.1.0)
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -570,6 +576,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -690,6 +699,9 @@ packages:
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -952,6 +964,10 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1888,6 +1904,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/node@25.5.0':
@@ -2052,6 +2070,8 @@ snapshots:
       color-convert: 2.0.1
 
   any-promise@1.3.0: {}
+
+  argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
 
@@ -2311,6 +2331,10 @@ snapshots:
       '@isaacs/cliui': 9.0.0
 
   joycon@3.1.1: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   json-buffer@3.0.1: {}
 

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -1,0 +1,115 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+
+/**
+ * Shape of an agent YAML config file.
+ * Fields match what's in agents/*.yaml.
+ */
+export interface AgentYamlConfig {
+  name: string;
+  role?: string;
+  description?: string;
+  persona?: {
+    display_name?: string;
+    tone?: string;
+    email_signature?: string;
+  };
+  model: {
+    provider: string;
+    model: string;
+    fallback?: {
+      provider: string;
+      model: string;
+    };
+  };
+  system_prompt: string;
+  pinned_skills?: string[];
+  allow_discovery?: boolean;
+  memory?: {
+    scopes?: string[];
+  };
+  schedule?: Array<{
+    cron: string;
+    task: string;
+  }>;
+  error_budget?: {
+    max_turns?: number;
+    max_cost_usd?: number;
+    max_errors?: number;
+  };
+}
+
+/**
+ * Load a single agent config from a YAML file.
+ * Interpolates ${persona.*} placeholders in system_prompt.
+ */
+export function loadAgentConfig(filePath: string): AgentYamlConfig {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    throw new Error(`Cannot read agent config at ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  let config: AgentYamlConfig;
+  try {
+    config = yaml.load(raw) as AgentYamlConfig;
+  } catch (err) {
+    throw new Error(`Invalid YAML in agent config at ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // Validate required fields
+  if (!config.name) {
+    throw new Error(`Agent config at ${filePath} is missing required field: name`);
+  }
+  if (!config.model?.provider || !config.model?.model) {
+    throw new Error(`Agent config '${config.name}' at ${filePath} is missing model.provider or model.model`);
+  }
+  if (!config.system_prompt) {
+    throw new Error(`Agent config '${config.name}' at ${filePath} is missing system_prompt`);
+  }
+
+  // Interpolate ${persona.*} placeholders in the system prompt.
+  // The persona section is the single source of truth for display name, tone, etc.
+  // Keeping them as references in system_prompt avoids duplication and makes
+  // persona changes a one-field edit rather than a find-and-replace across the prompt.
+  if (config.persona) {
+    config.system_prompt = interpolatePersona(config.system_prompt, config.persona);
+  }
+
+  return config;
+}
+
+/**
+ * Load all agent configs from a directory.
+ * Reads every .yaml and .yml file in the directory.
+ */
+export function loadAllAgentConfigs(dirPath: string): AgentYamlConfig[] {
+  const files = fs.readdirSync(dirPath)
+    .filter(f => f.endsWith('.yaml') || f.endsWith('.yml'));
+
+  return files.map(f => loadAgentConfig(path.join(dirPath, f)));
+}
+
+/**
+ * Replace ${persona.field_name} placeholders with actual values from the persona block.
+ *
+ * Why: The system_prompt is a template — it references persona.display_name
+ * and persona.tone by name so agents can be "re-skinned" by editing only the
+ * persona section, without touching the prose of the prompt.
+ *
+ * Unresolved placeholders (referencing fields not present in persona) are left
+ * as-is rather than substituting empty string — a visible `${persona.unknown}`
+ * in a response makes the misconfiguration obvious during development.
+ */
+function interpolatePersona(
+  template: string,
+  persona: NonNullable<AgentYamlConfig['persona']>,
+): string {
+  return template.replace(/\$\{persona\.(\w+)\}/g, (_match, field: string) => {
+    const value = persona[field as keyof typeof persona];
+    // Leave unresolved placeholders intact so misconfiguration is visible
+    return value ?? `\${persona.${field}}`;
+  });
+}

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -2,6 +2,7 @@ import type { LLMProvider, Message } from './llm/provider.js';
 import type { EventBus } from '../bus/bus.js';
 import { createAgentResponse, type AgentTaskEvent } from '../bus/events.js';
 import type { Logger } from '../logger.js';
+import { WorkingMemory } from '../memory/working-memory.js';
 
 export interface AgentConfig {
   agentId: string;
@@ -9,6 +10,8 @@ export interface AgentConfig {
   provider: LLMProvider;
   bus: EventBus;
   logger: Logger;
+  /** Optional working memory for conversation persistence across turns. */
+  memory?: WorkingMemory;
 }
 
 /**
@@ -45,19 +48,35 @@ export class AgentRuntime {
   }
 
   /**
-   * Process a task: call the LLM with system prompt + user content,
-   * then publish the response back to the bus as agent.response.
+   * Process a task: load conversation history (if memory is configured),
+   * call the LLM with system prompt + history + user content, persist both
+   * the user message and assistant response to memory, then publish the
+   * response back to the bus as agent.response.
    */
   private async handleTask(taskEvent: AgentTaskEvent): Promise<void> {
-    const { agentId, systemPrompt, provider, bus, logger } = this.config;
+    const { agentId, systemPrompt, provider, bus, logger, memory } = this.config;
     const { content, conversationId } = taskEvent.payload;
 
+    // Load conversation history from working memory (if configured).
+    // Without memory, each task is treated as a fresh single-turn exchange.
+    const history = memory
+      ? await memory.getHistory(conversationId, agentId)
+      : [];
+
+    // Assemble LLM context: system prompt + prior turns + new user message
     const messages: Message[] = [
       { role: 'system', content: systemPrompt },
+      ...history,
       { role: 'user', content },
     ];
 
-    logger.info({ agentId, conversationId }, 'Agent processing task');
+    logger.info({ agentId, conversationId, historyLength: history.length }, 'Agent processing task');
+
+    // Persist the incoming user message before calling the LLM so that a
+    // crash during the LLM call still records what the user said
+    if (memory) {
+      await memory.addTurn(conversationId, agentId, { role: 'user', content });
+    }
 
     const response = await provider.chat({ messages });
 
@@ -71,6 +90,11 @@ export class AgentRuntime {
         'Agent task completed',
       );
       responseContent = response.content;
+    }
+
+    // Persist the assistant response so subsequent turns include it as context
+    if (memory) {
+      await memory.addTurn(conversationId, agentId, { role: 'assistant', content: responseContent });
     }
 
     // Publish response back to the bus — the dispatcher subscribes to

--- a/src/db/migrations/002_create_working_memory.sql
+++ b/src/db/migrations/002_create_working_memory.sql
@@ -1,0 +1,18 @@
+-- Up Migration
+
+CREATE TABLE working_memory (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id TEXT NOT NULL,
+  agent_id        TEXT NOT NULL,
+  role            TEXT NOT NULL,
+  content         TEXT NOT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at      TIMESTAMPTZ
+);
+
+-- Primary query pattern: load conversation history for a specific agent + conversation
+-- in chronological order. The composite index covers the WHERE + ORDER BY.
+CREATE INDEX idx_wm_conversation ON working_memory (conversation_id, agent_id, created_at);
+
+-- Cleanup query: find and delete expired entries periodically
+CREATE INDEX idx_wm_expires ON working_memory (expires_at) WHERE expires_at IS NOT NULL;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@
  * and the audit logger must be connected before events start flowing.
  */
 
+import * as path from 'node:path';
 import { loadConfig } from './config.js';
 import { createLogger } from './logger.js';
 import { createPool } from './db/connection.js';
@@ -25,6 +26,8 @@ import { AnthropicProvider } from './agents/llm/anthropic.js';
 import { AgentRuntime } from './agents/runtime.js';
 import { Dispatcher } from './dispatch/dispatcher.js';
 import { CliAdapter } from './channels/cli/cli-adapter.js';
+import { loadAgentConfig } from './agents/loader.js';
+import { WorkingMemory } from './memory/working-memory.js';
 
 async function main(): Promise<void> {
   // 1. Config & logging — no dependencies, must come first.
@@ -67,21 +70,25 @@ async function main(): Promise<void> {
   }
   const llmProvider = new AnthropicProvider(config.anthropicApiKey, logger);
 
+  // Working memory — created after the pool is confirmed healthy so we know
+  // the working_memory table is reachable before the first message arrives.
+  const memory = WorkingMemory.createWithPostgres(pool, logger);
+
   // 6. Coordinator agent — subscribes to agent.task, publishes agent.response.
   // Must register before the dispatcher so there is a handler for agent.task
   // by the time the first inbound.message is converted.
-  // TODO: Load system prompt from agents/coordinator.yaml instead of
-  // hardcoding here; requires a yaml-parsing step at startup.
+  // Load coordinator config from YAML — persona fields are interpolated by the loader.
+  const coordinatorConfig = loadAgentConfig(
+    path.resolve(import.meta.dirname, '../agents/coordinator.yaml'),
+  );
+
   const coordinator = new AgentRuntime({
-    agentId: 'coordinator',
-    systemPrompt: `You are Curia, an AI executive assistant. You are professional,
-concise, and helpful. You handle all communications on behalf of the CEO.
-For casual messages, respond naturally and warmly.
-For tasks, acknowledge the request and describe what you would do.
-Keep responses concise — a few sentences unless detail is requested.`,
+    agentId: coordinatorConfig.name,
+    systemPrompt: coordinatorConfig.system_prompt,
     provider: llmProvider,
     bus,
     logger,
+    memory,
   });
   coordinator.register();
 

--- a/src/memory/working-memory.ts
+++ b/src/memory/working-memory.ts
@@ -1,0 +1,123 @@
+import type { DbPool } from '../db/connection.js';
+import type { Logger } from '../logger.js';
+
+export interface ConversationTurn {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+interface StorageBackend {
+  add(conversationId: string, agentId: string, turn: ConversationTurn): Promise<void>;
+  get(conversationId: string, agentId: string, maxTurns?: number): Promise<ConversationTurn[]>;
+}
+
+/**
+ * Working memory stores conversation turns per conversation + agent pair.
+ * This is Tier 1 memory — short-lived, scoped to a conversation, survives restarts.
+ *
+ * Uses a backend interface so unit tests can use in-memory storage
+ * while production uses Postgres.
+ */
+export class WorkingMemory {
+  private backend: StorageBackend;
+
+  private constructor(backend: StorageBackend) {
+    this.backend = backend;
+  }
+
+  /** Create a Postgres-backed instance for production use */
+  static createWithPostgres(pool: DbPool, logger: Logger): WorkingMemory {
+    return new WorkingMemory(new PostgresBackend(pool, logger));
+  }
+
+  /** Create an in-memory instance for testing */
+  static createInMemory(): WorkingMemory {
+    return new WorkingMemory(new InMemoryBackend());
+  }
+
+  async addTurn(
+    conversationId: string,
+    agentId: string,
+    turn: ConversationTurn,
+  ): Promise<void> {
+    await this.backend.add(conversationId, agentId, turn);
+  }
+
+  async getHistory(
+    conversationId: string,
+    agentId: string,
+    options?: { maxTurns?: number },
+  ): Promise<ConversationTurn[]> {
+    return this.backend.get(conversationId, agentId, options?.maxTurns);
+  }
+}
+
+/**
+ * Postgres-backed storage. Conversation turns are rows in the working_memory table.
+ * History is returned in chronological order (oldest first) so the LLM sees
+ * the conversation in natural reading order.
+ */
+class PostgresBackend implements StorageBackend {
+  constructor(private pool: DbPool, private logger: Logger) {}
+
+  async add(conversationId: string, agentId: string, turn: ConversationTurn): Promise<void> {
+    this.logger.debug({ conversationId, agentId, role: turn.role }, 'working_memory: adding turn');
+    await this.pool.query(
+      `INSERT INTO working_memory (conversation_id, agent_id, role, content)
+       VALUES ($1, $2, $3, $4)`,
+      [conversationId, agentId, turn.role, turn.content],
+    );
+  }
+
+  async get(conversationId: string, agentId: string, maxTurns?: number): Promise<ConversationTurn[]> {
+    const limit = maxTurns ?? 50;
+
+    // Subquery gets the most recent N rows (newest first by created_at),
+    // then outer query reverses to chronological order for LLM context.
+    // This ensures we always get the LAST N turns, not the first N.
+    const result = await this.pool.query<{ role: string; content: string }>(
+      `SELECT role, content FROM (
+         SELECT role, content, created_at
+         FROM working_memory
+         WHERE conversation_id = $1 AND agent_id = $2
+         ORDER BY created_at DESC
+         LIMIT $3
+       ) sub ORDER BY created_at ASC`,
+      [conversationId, agentId, limit],
+    );
+
+    return result.rows.map((row) => ({
+      role: row.role as ConversationTurn['role'],
+      content: row.content,
+    }));
+  }
+}
+
+/**
+ * In-memory storage for testing. No database required.
+ * Maintains insertion order so chronological retrieval works naturally.
+ */
+class InMemoryBackend implements StorageBackend {
+  private store = new Map<string, ConversationTurn[]>();
+
+  private key(conversationId: string, agentId: string): string {
+    return `${conversationId}:${agentId}`;
+  }
+
+  async add(conversationId: string, agentId: string, turn: ConversationTurn): Promise<void> {
+    const k = this.key(conversationId, agentId);
+    const turns = this.store.get(k) ?? [];
+    turns.push(turn);
+    this.store.set(k, turns);
+  }
+
+  async get(conversationId: string, agentId: string, maxTurns?: number): Promise<ConversationTurn[]> {
+    const k = this.key(conversationId, agentId);
+    const turns = this.store.get(k) ?? [];
+    if (maxTurns && turns.length > maxTurns) {
+      // Return the last N turns (most recent), preserving chronological order
+      return turns.slice(-maxTurns);
+    }
+    return [...turns];
+  }
+}

--- a/tests/integration/conversation-memory.test.ts
+++ b/tests/integration/conversation-memory.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventBus } from '../../src/bus/bus.js';
+import { Dispatcher } from '../../src/dispatch/dispatcher.js';
+import { AgentRuntime } from '../../src/agents/runtime.js';
+import { WorkingMemory } from '../../src/memory/working-memory.js';
+import { createInboundMessage, type OutboundMessageEvent } from '../../src/bus/events.js';
+import type { LLMProvider } from '../../src/agents/llm/provider.js';
+import { createLogger } from '../../src/logger.js';
+
+describe('Multi-turn conversation with working memory', () => {
+  it('includes prior conversation turns in LLM context on second message', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const memory = WorkingMemory.createInMemory();
+
+    // Track what messages the LLM receives on each call
+    const llmCalls: Array<{ messages: unknown[] }> = [];
+    let callCount = 0;
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockImplementation((params) => {
+        llmCalls.push(params);
+        callCount++;
+        return Promise.resolve({
+          type: 'text' as const,
+          content: `Response ${callCount}`,
+          usage: { inputTokens: 10, outputTokens: 5 },
+        });
+      }),
+    };
+
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are helpful.',
+      provider: mockProvider,
+      bus,
+      logger,
+      memory,
+    });
+    coordinator.register();
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    const outbound: OutboundMessageEvent[] = [];
+    bus.subscribe('outbound.message', 'channel', (event) => {
+      outbound.push(event as OutboundMessageEvent);
+    });
+
+    // --- First message ---
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Hello',
+    }));
+
+    // First LLM call: system + user message only (no history yet)
+    expect(llmCalls[0]?.messages).toHaveLength(2);
+
+    // --- Second message (same conversation) ---
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Follow-up question',
+    }));
+
+    // Second LLM call: system + first user + first assistant + second user
+    expect(llmCalls[1]?.messages).toHaveLength(4);
+
+    // Verify both responses arrived
+    expect(outbound).toHaveLength(2);
+    expect(outbound[0]?.payload.content).toBe('Response 1');
+    expect(outbound[1]?.payload.content).toBe('Response 2');
+
+    // Verify memory has all 4 turns
+    const history = await memory.getHistory('conv-1', 'coordinator');
+    expect(history).toHaveLength(4);
+    expect(history.map(t => t.role)).toEqual(['user', 'assistant', 'user', 'assistant']);
+  });
+
+  it('keeps separate conversations isolated', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const memory = WorkingMemory.createInMemory();
+
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'Reply',
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+    };
+
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are helpful.',
+      provider: mockProvider,
+      bus,
+      logger,
+      memory,
+    });
+    coordinator.register();
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    bus.subscribe('outbound.message', 'channel', () => {});
+
+    // Message in conversation 1
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Conv 1 message',
+    }));
+
+    // Message in conversation 2
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-2',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Conv 2 message',
+    }));
+
+    // Each conversation should have its own isolated history
+    const h1 = await memory.getHistory('conv-1', 'coordinator');
+    const h2 = await memory.getHistory('conv-2', 'coordinator');
+    expect(h1).toHaveLength(2); // user + assistant
+    expect(h2).toHaveLength(2);
+    expect(h1[0]?.content).toBe('Conv 1 message');
+    expect(h2[0]?.content).toBe('Conv 2 message');
+  });
+});

--- a/tests/unit/agents/loader.test.ts
+++ b/tests/unit/agents/loader.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { loadAgentConfig, loadAllAgentConfigs } from '../../../src/agents/loader.js';
+import * as path from 'node:path';
+
+const agentsDir = path.resolve(import.meta.dirname, '../../../agents');
+
+describe('loadAgentConfig', () => {
+  it('loads and parses coordinator.yaml', () => {
+    const config = loadAgentConfig(path.join(agentsDir, 'coordinator.yaml'));
+    expect(config.name).toBe('coordinator');
+    expect(config.role).toBe('coordinator');
+    expect(config.model.provider).toBe('anthropic');
+    expect(config.system_prompt).toContain('executive assistant');
+  });
+
+  it('interpolates persona fields into system_prompt', () => {
+    const config = loadAgentConfig(path.join(agentsDir, 'coordinator.yaml'));
+    expect(config.system_prompt).toContain('Curia');
+    expect(config.system_prompt).not.toContain('${persona.display_name}');
+    expect(config.system_prompt).toContain('professional but approachable');
+    expect(config.system_prompt).not.toContain('${persona.tone}');
+  });
+
+  it('throws on nonexistent file', () => {
+    expect(() => loadAgentConfig('/nonexistent/path.yaml')).toThrow('Cannot read agent config');
+  });
+
+  it('loads all agent configs from a directory', () => {
+    const configs = loadAllAgentConfigs(agentsDir);
+    expect(configs.length).toBeGreaterThanOrEqual(1);
+    expect(configs.find(c => c.name === 'coordinator')).toBeDefined();
+  });
+});

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -4,6 +4,7 @@ import { EventBus } from '../../../src/bus/bus.js';
 import { createAgentTask, type AgentResponseEvent } from '../../../src/bus/events.js';
 import type { LLMProvider } from '../../../src/agents/llm/provider.js';
 import { createLogger } from '../../../src/logger.js';
+import { WorkingMemory } from '../../../src/memory/working-memory.js';
 
 function createMockProvider(response: string): LLMProvider {
   return {
@@ -92,5 +93,74 @@ describe('AgentRuntime', () => {
 
     expect(responses).toHaveLength(1);
     expect(responses[0]?.payload.content).toContain('unable to process');
+  });
+
+  it('includes conversation history in LLM context', async () => {
+    const provider = createMockProvider('Response 2');
+    const memory = WorkingMemory.createInMemory();
+
+    // Seed conversation history
+    await memory.addTurn('conv-1', 'coordinator', { role: 'user', content: 'First message' });
+    await memory.addTurn('conv-1', 'coordinator', { role: 'assistant', content: 'First response' });
+
+    const runtime = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are helpful.',
+      provider,
+      bus,
+      logger: createLogger('error'),
+      memory,
+    });
+    runtime.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-1',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Second message',
+      parentEventId: 'parent-1',
+    });
+    await bus.publish('dispatch', task);
+
+    // LLM should receive system + history + new message
+    expect(provider.chat).toHaveBeenCalledWith({
+      messages: [
+        { role: 'system', content: 'You are helpful.' },
+        { role: 'user', content: 'First message' },
+        { role: 'assistant', content: 'First response' },
+        { role: 'user', content: 'Second message' },
+      ],
+    });
+  });
+
+  it('saves both user message and assistant response to memory', async () => {
+    const provider = createMockProvider('Bot reply');
+    const memory = WorkingMemory.createInMemory();
+
+    const runtime = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are helpful.',
+      provider,
+      bus,
+      logger: createLogger('error'),
+      memory,
+    });
+    runtime.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-1',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Hello',
+      parentEventId: 'parent-1',
+    });
+    await bus.publish('dispatch', task);
+
+    const history = await memory.getHistory('conv-1', 'coordinator');
+    expect(history).toHaveLength(2);
+    expect(history[0]).toEqual({ role: 'user', content: 'Hello' });
+    expect(history[1]).toEqual({ role: 'assistant', content: 'Bot reply' });
   });
 });

--- a/tests/unit/memory/working-memory.test.ts
+++ b/tests/unit/memory/working-memory.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { WorkingMemory } from '../../../src/memory/working-memory.js';
+
+describe('WorkingMemory', () => {
+  let memory: WorkingMemory;
+
+  beforeEach(() => {
+    memory = WorkingMemory.createInMemory();
+  });
+
+  it('stores and retrieves conversation turns', async () => {
+    await memory.addTurn('conv-1', 'coordinator', { role: 'user', content: 'Hello' });
+    await memory.addTurn('conv-1', 'coordinator', { role: 'assistant', content: 'Hi there!' });
+
+    const history = await memory.getHistory('conv-1', 'coordinator');
+    expect(history).toHaveLength(2);
+    expect(history[0]?.role).toBe('user');
+    expect(history[1]?.role).toBe('assistant');
+  });
+
+  it('returns empty array for unknown conversation', async () => {
+    const history = await memory.getHistory('unknown', 'coordinator');
+    expect(history).toEqual([]);
+  });
+
+  it('keeps conversations separate', async () => {
+    await memory.addTurn('conv-1', 'coordinator', { role: 'user', content: 'First' });
+    await memory.addTurn('conv-2', 'coordinator', { role: 'user', content: 'Second' });
+
+    const h1 = await memory.getHistory('conv-1', 'coordinator');
+    const h2 = await memory.getHistory('conv-2', 'coordinator');
+    expect(h1).toHaveLength(1);
+    expect(h2).toHaveLength(1);
+    expect(h1[0]?.content).toBe('First');
+    expect(h2[0]?.content).toBe('Second');
+  });
+
+  it('limits returned history to maxTurns', async () => {
+    for (let i = 0; i < 25; i++) {
+      await memory.addTurn('conv-1', 'coordinator', { role: 'user', content: `Message ${i}` });
+    }
+
+    const history = await memory.getHistory('conv-1', 'coordinator', { maxTurns: 10 });
+    expect(history).toHaveLength(10);
+    // Should be the LAST 10 (most recent), in chronological order
+    expect(history[0]?.content).toBe('Message 15');
+    expect(history[9]?.content).toBe('Message 24');
+  });
+});


### PR DESCRIPTION
## Summary

Makes conversations stateful and agent configs data-driven:

- **Working memory** — conversation turns persist in Postgres, loaded on each agent invocation. Multi-turn conversations now work.
- **YAML config loader** — agent definitions loaded from `agents/*.yaml` with `${persona.*}` placeholder interpolation. No more hardcoded system prompts.
- **Bootstrap wired** — coordinator config from YAML, memory from Postgres, all integrated.

## What Changed

| Component | Files | Tests |
|---|---|---|
| js-yaml dependency | package.json | - |
| Agent config loader | src/agents/loader.ts | 4 tests |
| Working memory migration | src/db/migrations/002_*.sql | - |
| Working memory store | src/memory/working-memory.ts | 4 tests |
| Runtime memory integration | src/agents/runtime.ts | 2 new tests |
| Bootstrap wiring | src/index.ts | - |
| **Integration test** | tests/integration/conversation-memory.test.ts | **2 tests** |
| **Total** | | **42 tests (12 new)** |

## Key Design Decisions

- **Backend interface pattern** — WorkingMemory uses a StorageBackend interface so unit tests use in-memory storage while production uses Postgres. No mocking libraries needed.
- **Memory is optional** — AgentConfig.memory is optional. Agents without it work statelessly (backward compatible).
- **User turn saved before LLM call** — even if the LLM fails, the user's message is recorded.
- **History window** — defaults to last 50 turns, configurable via `maxTurns`.

## Test plan

- [x] 42 unit + integration tests pass
- [x] TypeScript strict mode — no errors
- [x] ESLint — no violations
- [ ] CI passes
- [ ] Manual test: multi-turn conversation via `pnpm run run`