### PR TITLE
Fix tool-use conversation context and dev environment issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,14 @@ DATABASE_URL=postgres://curia:curia_dev@localhost:5432/curia
 # LLM Providers
 ANTHROPIC_API_KEY=sk-ant-...
 
+# TLS (macOS only) — Node installed via nvm/fnm bundles its own CA store
+# and doesn't trust macOS system certificates. If HTTPS fetch fails with
+# "unable to get local issuer certificate", export your system certs:
+#
+#   security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain > ~/.config/curia/macos-ca-certs.pem
+#
+# Then uncomment the line below. Not needed on Linux.
+# NODE_EXTRA_CA_CERTS=/Users/yourname/.config/curia/macos-ca-certs.pem
+
 # Logging
 LOG_LEVEL=info

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "tsx watch --env-file=.env --ignore curia.log src/index.ts",
-    "local": "tsx --env-file=.env src/index.ts",
+    "local": "eval $(grep '^[A-Z]' .env | sed 's/^/export /') && tsx --env-file=.env src/index.ts",
     "build": "tsup src/index.ts --format esm --dts",
     "start": "node dist/index.js",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "tsx watch --env-file=.env --ignore curia.log src/index.ts",
-    "run": "tsx --env-file=.env src/index.ts",
+    "local": "tsx --env-file=.env src/index.ts",
     "build": "tsup src/index.ts --format esm --dts",
     "start": "node dist/index.js",
     "test": "vitest run",

--- a/src/agents/llm/anthropic.ts
+++ b/src/agents/llm/anthropic.ts
@@ -39,12 +39,34 @@ export class AnthropicProvider implements LLMProvider {
     // not as an element in the messages array. We extract it here so agent
     // code can use a uniform Message[] convention without knowing this detail.
     const systemMessage = messages.find((m) => m.role === 'system');
+
+    // Build the Anthropic message array from our provider-neutral Message type.
+    // Messages with string content are simple text; messages with ContentBlock[]
+    // carry tool_use or tool_result blocks for multi-turn tool-use conversations.
     const conversationMessages: MessageParam[] = messages
       .filter((m) => m.role !== 'system')
-      .map((m) => ({ role: m.role as 'user' | 'assistant', content: m.content }));
+      .map((m) => {
+        if (typeof m.content === 'string') {
+          return { role: m.role as 'user' | 'assistant', content: m.content };
+        }
+        // ContentBlock[] — map our provider-neutral blocks to Anthropic SDK shapes
+        return {
+          role: m.role as 'user' | 'assistant',
+          content: m.content.map(block => {
+            if (block.type === 'tool_use') {
+              return { type: 'tool_use' as const, id: block.id, name: block.name, input: block.input };
+            }
+            if (block.type === 'tool_result') {
+              return { type: 'tool_result' as const, tool_use_id: block.tool_use_id, content: block.content, is_error: block.is_error };
+            }
+            // TextContent
+            return { type: 'text' as const, text: block.text };
+          }),
+        } as MessageParam;
+      });
 
-    // If the caller has tool results from a previous tool_use response, we
-    // append them as a user turn so the model can see the execution outcomes.
+    // Legacy toolResults parameter — append as a user turn if provided.
+    // Prefer building tool_result blocks directly in the messages array instead.
     if (toolResults && toolResults.length > 0) {
       const toolResultBlocks: ToolResultBlockParam[] = toolResults.map(tr => ({
         type: 'tool_result' as const,
@@ -63,7 +85,8 @@ export class AnthropicProvider implements LLMProvider {
       const createParams: Anthropic.Messages.MessageCreateParamsNonStreaming = {
         model,
         max_tokens: 4096,
-        system: systemMessage?.content,
+        // System messages are always plain strings (never content blocks)
+        system: typeof systemMessage?.content === 'string' ? systemMessage.content : undefined,
         messages: conversationMessages,
       };
 

--- a/src/agents/llm/provider.ts
+++ b/src/agents/llm/provider.ts
@@ -6,9 +6,37 @@
 //
 // Adding a new provider: implement LLMProvider, wire it in the DI layer.
 
+/**
+ * Content block types for multi-turn tool-use conversations.
+ * The Anthropic API requires assistant turns to contain tool_use blocks
+ * and user turns to contain tool_result blocks — plain strings won't work.
+ * These mirror the Anthropic SDK shapes but are provider-neutral.
+ */
+export interface ToolUseContent {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface ToolResultContent {
+  type: 'tool_result';
+  tool_use_id: string;
+  content: string;
+  is_error?: boolean;
+}
+
+export interface TextContent {
+  type: 'text';
+  text: string;
+}
+
+export type ContentBlock = TextContent | ToolUseContent | ToolResultContent;
+
 export interface Message {
   role: 'system' | 'user' | 'assistant';
-  content: string;
+  /** Plain string for simple messages, or an array of content blocks for tool-use turns */
+  content: string | ContentBlock[];
 }
 
 export interface LLMUsage {

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1,4 +1,4 @@
-import type { LLMProvider, Message, ToolDefinition, ToolResult } from './llm/provider.js';
+import type { LLMProvider, Message, ToolDefinition, ContentBlock, ToolUseContent, ToolResultContent, TextContent } from './llm/provider.js';
 import type { EventBus } from '../bus/bus.js';
 import { createAgentResponse, createSkillInvoke, createSkillResult, type AgentTaskEvent } from '../bus/events.js';
 import type { Logger } from '../logger.js';
@@ -102,8 +102,9 @@ export class AgentRuntime {
 
     // Tool-use loop: call LLM, handle tool calls, feed results back, repeat.
     // The Anthropic API requires the full conversation context including the
-    // assistant's tool_use response and the user's tool_result turn. We build
-    // this up in the messages array across iterations.
+    // assistant's tool_use content blocks and the user's tool_result blocks.
+    // We build these as structured ContentBlock[] in the messages array so
+    // the provider can pass them through to the API correctly.
     let response = await provider.chat({ messages, tools: skillToolDefs });
     let iterations = 0;
 
@@ -114,23 +115,26 @@ export class AgentRuntime {
         'LLM requested tool calls',
       );
 
-      // Append the assistant's tool_use turn to the conversation so the LLM
-      // has full context on the next call. We represent the assistant turn as
-      // a text summary since our Message type doesn't carry tool_use blocks.
-      // The actual tool results are passed via the toolResults parameter.
-      const toolCallSummary = response.toolCalls
-        .map(tc => `[Calling tool: ${tc.name}]`)
-        .join(' ');
-      messages.push({
-        role: 'assistant',
-        content: response.content
-          ? `${response.content} ${toolCallSummary}`
-          : toolCallSummary,
-      });
+      // Build the assistant turn with the actual tool_use content blocks.
+      // The Anthropic API requires these to exist so tool_result blocks can
+      // reference their IDs in the next user turn.
+      const assistantBlocks: ContentBlock[] = [];
+      if (response.content) {
+        assistantBlocks.push({ type: 'text', text: response.content } as TextContent);
+      }
+      for (const tc of response.toolCalls) {
+        assistantBlocks.push({
+          type: 'tool_use',
+          id: tc.id,
+          name: tc.name,
+          input: tc.input,
+        } as ToolUseContent);
+      }
+      messages.push({ role: 'assistant', content: assistantBlocks });
 
       // Execute each tool call through the execution layer.
       // Publish skill.invoke and skill.result bus events for audit coverage.
-      const toolResults: ToolResult[] = [];
+      const toolResultBlocks: ContentBlock[] = [];
       for (const toolCall of response.toolCalls) {
         logger.info({ agentId, skill: toolCall.name, callId: toolCall.id }, 'Invoking skill');
 
@@ -165,23 +169,31 @@ export class AgentRuntime {
 
         if (result.success) {
           const resultContent = typeof result.data === 'string' ? result.data : JSON.stringify(result.data);
-          toolResults.push({ id: toolCall.id, content: resultContent });
+          toolResultBlocks.push({
+            type: 'tool_result',
+            tool_use_id: toolCall.id,
+            content: resultContent,
+          } as ToolResultContent);
         } else {
           // Sanitize error messages before sending to LLM — skill errors
           // can contain injection vectors from external sources
           const sanitizedError = sanitizeOutput(result.error, { isError: true });
-          toolResults.push({ id: toolCall.id, content: sanitizedError, is_error: true });
+          toolResultBlocks.push({
+            type: 'tool_result',
+            tool_use_id: toolCall.id,
+            content: sanitizedError,
+            is_error: true,
+          } as ToolResultContent);
         }
       }
 
-      // Append a user turn summarizing tool results for conversation context
-      const resultsSummary = toolResults
-        .map(tr => tr.is_error ? `[Tool error: ${tr.content}]` : `[Tool result received]`)
-        .join(' ');
-      messages.push({ role: 'user', content: resultsSummary });
+      // Append tool results as a user turn with structured content blocks.
+      // This is the format the Anthropic API expects — each tool_result references
+      // a tool_use_id from the preceding assistant turn.
+      messages.push({ role: 'user', content: toolResultBlocks });
 
-      // Feed tool results back to the LLM and continue the loop
-      response = await provider.chat({ messages, tools: skillToolDefs, toolResults });
+      // Continue the loop — the full conversation history is now in messages
+      response = await provider.chat({ messages, tools: skillToolDefs });
     }
 
     // Handle the final response (text or error)

--- a/tests/integration/skill-invocation.test.ts
+++ b/tests/integration/skill-invocation.test.ts
@@ -3,7 +3,7 @@ import { EventBus } from '../../src/bus/bus.js';
 import { AgentRuntime } from '../../src/agents/runtime.js';
 import { SkillRegistry } from '../../src/skills/registry.js';
 import { ExecutionLayer } from '../../src/skills/execution.js';
-import type { LLMProvider, ToolResult } from '../../src/agents/llm/provider.js';
+import type { LLMProvider, Message, ContentBlock } from '../../src/agents/llm/provider.js';
 import type { SkillManifest, SkillHandler, SkillContext } from '../../src/skills/types.js';
 import { createAgentTask } from '../../src/bus/events.js';
 import pino from 'pino';
@@ -44,7 +44,7 @@ describe('Skill invocation integration', () => {
     let llmCallCount = 0;
     const mockProvider: LLMProvider = {
       id: 'mock',
-      chat: async ({ toolResults }: { toolResults?: ToolResult[] }) => {
+      chat: async ({ messages }: { messages: Message[] }) => {
         llmCallCount++;
         if (llmCallCount === 1) {
           return {
@@ -53,9 +53,14 @@ describe('Skill invocation integration', () => {
             usage: { inputTokens: 50, outputTokens: 20 },
           };
         }
+        // On the second call, check if tool results were passed as content blocks
+        // in the messages array (the runtime builds structured conversation turns)
+        const hasToolResults = messages.some(m =>
+          Array.isArray(m.content) && m.content.some((b: ContentBlock) => b.type === 'tool_result'),
+        );
         return {
           type: 'text' as const,
-          content: `The echo skill responded. Tool results were provided: ${toolResults ? 'yes' : 'no'}`,
+          content: `The echo skill responded. Tool results were provided: ${hasToolResults ? 'yes' : 'no'}`,
           usage: { inputTokens: 100, outputTokens: 30 },
         };
       },
@@ -125,7 +130,7 @@ describe('Skill invocation integration', () => {
     let llmCallCount = 0;
     const mockProvider: LLMProvider = {
       id: 'mock',
-      chat: async ({ toolResults }: { toolResults?: ToolResult[] }) => {
+      chat: async ({ messages }: { messages: Message[] }) => {
         llmCallCount++;
         if (llmCallCount === 1) {
           return {
@@ -134,10 +139,15 @@ describe('Skill invocation integration', () => {
             usage: { inputTokens: 50, outputTokens: 20 },
           };
         }
-        const errorInfo = toolResults?.[0]?.is_error ? 'got error' : 'no error';
+        // Check if any tool_result block in messages has is_error set
+        const hasError = messages.some(m =>
+          Array.isArray(m.content) && m.content.some(
+            (b: ContentBlock) => b.type === 'tool_result' && b.is_error,
+          ),
+        );
         return {
           type: 'text' as const,
-          content: `Handled the failure: ${errorInfo}`,
+          content: `Handled the failure: ${hasError ? 'got error' : 'no error'}`,
           usage: { inputTokens: 100, outputTokens: 30 },
         };
       },


### PR DESCRIPTION
## Summary

- Fix tool-use loop to build proper Anthropic conversation turns with structured content blocks (tool_use + tool_result), fixing API rejection errors
- Add ContentBlock union type to Message interface for multi-turn tool-use
- Rename `run` script to `local` to avoid `pnpm run` collision
- Fix NODE_EXTRA_CA_CERTS loading so TLS works on macOS with nvm/fnm
- Document macOS TLS cert setup in .env.example

## Test plan

- [x] 94 tests passing
- [x] Typecheck and lint clean
- [x] Manual smoke test: `pnpm local` → "What's on https://example.com?" returns summarized page content