### PR TITLE
feat: Phase 5 — HTTP API channel (REST + SSE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,9 @@ ANTHROPIC_API_KEY=sk-ant-...
 # Then uncomment the line below. Not needed on Linux.
 # NODE_EXTRA_CA_CERTS=/Users/yourname/.config/curia/macos-ca-certs.pem
 
+# HTTP API
+HTTP_PORT=3000
+API_TOKEN=your-secret-token-here
+
 # Logging
 LOG_LEVEL=info

--- a/docs/plans/2026-03-25-phase5-http-api.md
+++ b/docs/plans/2026-03-25-phase5-http-api.md
@@ -1,0 +1,1115 @@
+# Phase 5: HTTP API Channel — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an HTTP API channel with REST endpoints for sending messages, SSE streaming for real-time events, health checks, agent status, and token-based authentication — enabling web dashboards, mobile apps, and external integrations to interact with Curia.
+
+**Architecture:** A Fastify server runs alongside the CLI adapter, registered as a `channel` layer adapter on the bus. It translates HTTP requests into `inbound.message` events and SSE-streams `outbound.message` events back to connected clients. Authentication uses a configurable bearer token. The server is wired into the bootstrap orchestrator and participates in graceful shutdown.
+
+**Tech Stack:** Fastify (fast, TypeScript-native, schema validation), pino (already used), vitest, `@fastify/cors`
+
+**Reference specs:**
+- `docs/specs/04-channels.md` — HTTP API channel spec, adapter interface, trust levels
+- `docs/specs/08-operations.md` — health endpoint, config, deployment
+- `docs/specs/02-agent-system.md` — agent status for the status endpoint
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|---|---|
+| `src/channels/http/http-adapter.ts` | Fastify server + HTTP channel adapter (routes, SSE, auth) |
+| `src/channels/http/routes/messages.ts` | POST /api/messages, GET /api/messages/stream (SSE) |
+| `src/channels/http/routes/health.ts` | GET /api/health |
+| `src/channels/http/routes/agents.ts` | GET /api/agents/status |
+| `src/channels/http/auth.ts` | Bearer token auth hook |
+| `tests/unit/channels/http/auth.test.ts` | Auth middleware tests |
+| `tests/unit/channels/http/health.test.ts` | Health endpoint tests |
+| `tests/integration/http-api.test.ts` | End-to-end HTTP → bus → agent → SSE response |
+
+### Modified Files
+
+| File | Changes |
+|---|---|
+| `package.json` | Add `fastify`, `@fastify/cors` dependencies |
+| `src/config.ts` | Add `httpPort`, `apiToken` config fields |
+| `src/index.ts` | Start Fastify alongside CLI, wire into shutdown |
+
+---
+
+## Tasks
+
+### Task 1: Add Fastify Dependencies and Config
+
+**Files:**
+- Modify: `package.json`
+- Modify: `src/config.ts`
+- Modify: `tests/unit/config.test.ts`
+
+- [ ] **Step 1: Install Fastify**
+
+Run: `pnpm add fastify @fastify/cors`
+
+- [ ] **Step 2: Update config.ts**
+
+Read `src/config.ts` first. Add `httpPort` and `apiToken` fields:
+
+```typescript
+export interface Config {
+  databaseUrl: string;
+  anthropicApiKey: string | undefined;
+  logLevel: string;
+  httpPort: number;
+  apiToken: string | undefined;
+}
+
+export function loadConfig(): Config {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL environment variable is required');
+  }
+
+  return {
+    databaseUrl,
+    anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+    logLevel: process.env.LOG_LEVEL ?? 'info',
+    httpPort: parseInt(process.env.HTTP_PORT ?? '3000', 10),
+    apiToken: process.env.API_TOKEN,
+  };
+}
+```
+
+- [ ] **Step 3: Update .env.example**
+
+Add to `.env.example`:
+
+```
+# HTTP API
+HTTP_PORT=3000
+API_TOKEN=your-secret-token-here
+```
+
+- [ ] **Step 4: Run existing config tests**
+
+Run: `pnpm test -- tests/unit/config.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml src/config.ts .env.example
+git commit -m "feat: add Fastify dependencies and HTTP config (port, API token)"
+```
+
+---
+
+### Task 2: Bearer Token Auth
+
+**Files:**
+- Create: `src/channels/http/auth.ts`
+- Create: `tests/unit/channels/http/auth.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/channels/http/auth.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { validateBearerToken } from '../../../../src/channels/http/auth.js';
+
+describe('validateBearerToken', () => {
+  it('returns true for a valid token', () => {
+    expect(validateBearerToken('Bearer my-secret-token', 'my-secret-token')).toBe(true);
+  });
+
+  it('returns false for an invalid token', () => {
+    expect(validateBearerToken('Bearer wrong-token', 'my-secret-token')).toBe(false);
+  });
+
+  it('returns false for missing Bearer prefix', () => {
+    expect(validateBearerToken('my-secret-token', 'my-secret-token')).toBe(false);
+  });
+
+  it('returns false for empty authorization header', () => {
+    expect(validateBearerToken('', 'my-secret-token')).toBe(false);
+  });
+
+  it('returns false for undefined authorization header', () => {
+    expect(validateBearerToken(undefined, 'my-secret-token')).toBe(false);
+  });
+
+  it('returns true when no API token is configured (auth disabled)', () => {
+    expect(validateBearerToken(undefined, undefined)).toBe(true);
+  });
+
+  it('returns true for any header when no API token is configured', () => {
+    expect(validateBearerToken('Bearer anything', undefined)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test -- tests/unit/channels/http/auth.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement auth**
+
+Create `src/channels/http/auth.ts`:
+
+```typescript
+// auth.ts — bearer token authentication for the HTTP API.
+//
+// When API_TOKEN is configured, all HTTP requests must include
+// an Authorization header with a matching bearer token. When
+// API_TOKEN is not set, authentication is disabled (useful for
+// local development).
+
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * Validate a bearer token from an Authorization header.
+ * Returns true if:
+ * - No API token is configured (auth disabled)
+ * - The header contains a valid Bearer token matching the configured token
+ *
+ * Uses timing-safe comparison to prevent timing attacks.
+ */
+export function validateBearerToken(
+  authHeader: string | undefined,
+  configuredToken: string | undefined,
+): boolean {
+  // If no token is configured, auth is disabled
+  if (!configuredToken) return true;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return false;
+
+  const provided = authHeader.slice('Bearer '.length);
+
+  // Timing-safe comparison to prevent timing attacks
+  if (provided.length !== configuredToken.length) return false;
+
+  return timingSafeEqual(
+    Buffer.from(provided),
+    Buffer.from(configuredToken),
+  );
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm test -- tests/unit/channels/http/auth.test.ts`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/channels/http/auth.ts tests/unit/channels/http/auth.test.ts
+git commit -m "feat: add bearer token auth for HTTP API (timing-safe comparison)"
+```
+
+---
+
+### Task 3: Health Endpoint
+
+**Files:**
+- Create: `src/channels/http/routes/health.ts`
+- Create: `tests/unit/channels/http/health.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/channels/http/health.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import Fastify from 'fastify';
+import { healthRoutes } from '../../../../src/channels/http/routes/health.js';
+import type { Pool } from 'pg';
+
+describe('GET /api/health', () => {
+  const mockPool = {
+    query: async () => ({ rows: [{ '?column?': 1 }] }),
+  } as unknown as Pool;
+
+  const app = Fastify();
+
+  beforeAll(async () => {
+    app.register(healthRoutes, {
+      pool: mockPool,
+      agentNames: ['coordinator', 'research-analyst'],
+      skillNames: ['web-fetch', 'delegate'],
+    });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns 200 with system status', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/health',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.status).toBe('ok');
+    expect(body.database).toBe('connected');
+    expect(body.agents).toEqual(['coordinator', 'research-analyst']);
+    expect(body.skills).toEqual(['web-fetch', 'delegate']);
+    expect(body).toHaveProperty('uptime');
+  });
+
+  it('returns 503 when database is down', async () => {
+    const failPool = {
+      query: async () => { throw new Error('connection refused'); },
+    } as unknown as Pool;
+
+    const failApp = Fastify();
+    failApp.register(healthRoutes, {
+      pool: failPool,
+      agentNames: ['coordinator'],
+      skillNames: [],
+    });
+    await failApp.ready();
+
+    const response = await failApp.inject({
+      method: 'GET',
+      url: '/api/health',
+    });
+
+    expect(response.statusCode).toBe(503);
+    const body = JSON.parse(response.body);
+    expect(body.status).toBe('degraded');
+    expect(body.database).toBe('disconnected');
+
+    await failApp.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test -- tests/unit/channels/http/health.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement health routes**
+
+Create `src/channels/http/routes/health.ts`:
+
+```typescript
+// health.ts — GET /api/health endpoint.
+//
+// Reports system status: database connectivity, registered agents,
+// loaded skills, and process uptime. Returns 200 for healthy, 503
+// for degraded (e.g., database is down).
+
+import type { FastifyInstance } from 'fastify';
+import type { Pool } from 'pg';
+
+export interface HealthRouteOptions {
+  pool: Pool;
+  agentNames: string[];
+  skillNames: string[];
+}
+
+export async function healthRoutes(
+  app: FastifyInstance,
+  options: HealthRouteOptions,
+): Promise<void> {
+  const { pool, agentNames, skillNames } = options;
+  const startTime = Date.now();
+
+  app.get('/api/health', async (_request, reply) => {
+    let dbStatus = 'connected';
+
+    try {
+      await pool.query('SELECT 1');
+    } catch {
+      dbStatus = 'disconnected';
+    }
+
+    const status = dbStatus === 'connected' ? 'ok' : 'degraded';
+    const statusCode = status === 'ok' ? 200 : 503;
+
+    return reply.status(statusCode).send({
+      status,
+      database: dbStatus,
+      agents: agentNames,
+      skills: skillNames,
+      uptime: Math.floor((Date.now() - startTime) / 1000),
+    });
+  });
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm test -- tests/unit/channels/http/health.test.ts`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/channels/http/routes/health.ts tests/unit/channels/http/health.test.ts
+git commit -m "feat: add GET /api/health endpoint (DB status, agents, skills, uptime)"
+```
+
+---
+
+### Task 4: Agent Status Endpoint
+
+**Files:**
+- Create: `src/channels/http/routes/agents.ts`
+
+- [ ] **Step 1: Implement agent status routes**
+
+Create `src/channels/http/routes/agents.ts`:
+
+```typescript
+// agents.ts — GET /api/agents/status endpoint.
+//
+// Returns a snapshot of all registered agents and their metadata.
+// In Phase 5 this is a static list from the registry; future phases
+// will add real-time agent state (idle/thinking/using_tool/etc.).
+
+import type { FastifyInstance } from 'fastify';
+import type { AgentRegistry } from '../../../agents/agent-registry.js';
+
+export interface AgentRouteOptions {
+  agentRegistry: AgentRegistry;
+}
+
+export async function agentRoutes(
+  app: FastifyInstance,
+  options: AgentRouteOptions,
+): Promise<void> {
+  const { agentRegistry } = options;
+
+  app.get('/api/agents/status', async (_request, reply) => {
+    const agents = agentRegistry.list().map(a => ({
+      name: a.name,
+      role: a.role,
+      description: a.description,
+      // TODO: Add real-time state (idle/thinking/using_tool) in Phase 6
+      state: 'idle',
+    }));
+
+    return reply.send({ agents });
+  });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/channels/http/routes/agents.ts
+git commit -m "feat: add GET /api/agents/status endpoint"
+```
+
+---
+
+### Task 5: Event Router (shared subscriber pattern)
+
+**Files:**
+- Create: `src/channels/http/event-router.ts`
+
+The HTTP adapter needs to dispatch bus events to many HTTP clients without
+creating a new bus subscriber per request. The EventRouter registers ONE
+subscriber per event type at startup and fans out to registered handlers.
+This prevents subscriber leaks — handlers are added/removed via a Map and Set.
+
+- [ ] **Step 1: Implement the event router**
+
+Create `src/channels/http/event-router.ts`:
+
+```typescript
+// event-router.ts — shared subscriber pattern for the HTTP API.
+//
+// The EventBus has no unsubscribe mechanism. If we subscribed per-request,
+// every POST and SSE connection would leak a permanent subscriber. Instead,
+// the EventRouter registers ONE subscriber per event type at startup and
+// dispatches to registered handlers via Maps and Sets.
+//
+// POST /api/messages registers a pending resolver keyed by conversationId.
+// SSE connections register a writer function in a Set.
+// Both are cleaned up when the request completes or the client disconnects.
+
+import type { EventBus } from '../../bus/bus.js';
+import type { BusEvent } from '../../bus/events.js';
+import type { Logger } from '../../logger.js';
+import type { ServerResponse } from 'node:http';
+
+export interface PendingResponse {
+  resolve: (content: string) => void;
+  reject: (error: Error) => void;
+  timeout: NodeJS.Timeout;
+}
+
+export interface SseClient {
+  res: ServerResponse;
+  conversationId?: string; // Optional filter
+}
+
+/**
+ * EventRouter registers shared bus subscribers and dispatches to HTTP clients.
+ * Call setupSubscriptions() once at startup, then use the add/remove methods
+ * per-request.
+ */
+export class EventRouter {
+  private logger: Logger;
+  /** Pending POST /api/messages responses, keyed by conversationId */
+  private pendingResponses = new Map<string, PendingResponse>();
+  /** Active SSE connections */
+  private sseClients = new Set<SseClient>();
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  /**
+   * Register shared subscribers on the bus. Called once at startup.
+   * Uses 'channel' layer for outbound.message (proper permission model)
+   * and 'system' layer for observability events (skill.invoke, skill.result).
+   */
+  setupSubscriptions(bus: EventBus): void {
+    // outbound.message — dispatches to pending POST resolvers and SSE clients
+    bus.subscribe('outbound.message', 'channel', (event: BusEvent) => {
+      if (event.type !== 'outbound.message') return;
+      // Only handle messages for the HTTP channel
+      if (event.payload.channelId !== 'http') return;
+
+      const convId = event.payload.conversationId;
+
+      // Resolve pending POST request if one is waiting for this conversation
+      const pending = this.pendingResponses.get(convId);
+      if (pending) {
+        clearTimeout(pending.timeout);
+        this.pendingResponses.delete(convId);
+        pending.resolve(event.payload.content);
+      }
+
+      // Stream to all SSE clients (filtered by conversationId if set)
+      const sseData = JSON.stringify({
+        type: 'message',
+        conversation_id: convId,
+        content: event.payload.content,
+        timestamp: event.timestamp,
+      });
+      for (const client of this.sseClients) {
+        if (!client.conversationId || client.conversationId === convId) {
+          client.res.write(`data: ${sseData}\n\n`);
+        }
+      }
+    });
+
+    // skill.invoke — observability stream for SSE clients
+    bus.subscribe('skill.invoke', 'system', (event: BusEvent) => {
+      if (event.type !== 'skill.invoke') return;
+      const sseData = JSON.stringify({
+        type: 'skill.invoke',
+        agent: event.payload.agentId,
+        skill: event.payload.skillName,
+        conversation_id: event.payload.conversationId,
+        timestamp: event.timestamp,
+      });
+      for (const client of this.sseClients) {
+        if (!client.conversationId || client.conversationId === event.payload.conversationId) {
+          client.res.write(`data: ${sseData}\n\n`);
+        }
+      }
+    });
+
+    // skill.result — observability stream for SSE clients
+    bus.subscribe('skill.result', 'system', (event: BusEvent) => {
+      if (event.type !== 'skill.result') return;
+      const sseData = JSON.stringify({
+        type: 'skill.result',
+        agent: event.payload.agentId,
+        skill: event.payload.skillName,
+        success: event.payload.result.success,
+        duration_ms: event.payload.durationMs,
+        conversation_id: event.payload.conversationId,
+        timestamp: event.timestamp,
+      });
+      for (const client of this.sseClients) {
+        if (!client.conversationId || client.conversationId === event.payload.conversationId) {
+          client.res.write(`data: ${sseData}\n\n`);
+        }
+      }
+    });
+
+    this.logger.info('HTTP event router subscriptions registered');
+  }
+
+  /** Register a pending POST response. Returns a promise that resolves with the response content. */
+  waitForResponse(conversationId: string, timeoutMs: number): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingResponses.delete(conversationId);
+        reject(new Error('Response timeout — the agent did not respond in time'));
+      }, timeoutMs);
+
+      this.pendingResponses.set(conversationId, { resolve, reject, timeout });
+    });
+  }
+
+  /** Cancel a pending response (e.g., if publish fails). */
+  cancelPending(conversationId: string): void {
+    const pending = this.pendingResponses.get(conversationId);
+    if (pending) {
+      clearTimeout(pending.timeout);
+      this.pendingResponses.delete(conversationId);
+    }
+  }
+
+  /** Register an SSE client. Returns a cleanup function. */
+  addSseClient(client: SseClient): () => void {
+    this.sseClients.add(client);
+    this.logger.debug({ conversationId: client.conversationId }, 'SSE client connected');
+    return () => {
+      this.sseClients.delete(client);
+      this.logger.debug({ conversationId: client.conversationId }, 'SSE client disconnected');
+    };
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/channels/http/event-router.ts
+git commit -m "feat: add EventRouter — shared subscriber pattern for HTTP API (no leak)"
+```
+
+---
+
+### Task 6: Messages Endpoint and SSE Stream
+
+**Files:**
+- Create: `src/channels/http/routes/messages.ts`
+
+Routes use the EventRouter instead of subscribing directly to the bus.
+
+- [ ] **Step 1: Implement message routes**
+
+Create `src/channels/http/routes/messages.ts`:
+
+```typescript
+// messages.ts — message endpoints for the HTTP API channel.
+//
+// POST /api/messages — send a message and get the response.
+// GET /api/messages/stream — SSE endpoint for real-time events.
+//
+// Both use the shared EventRouter to avoid subscriber leaks on the bus.
+// The EventRouter registers ONE subscriber per event type at startup;
+// individual requests register/deregister handlers via Maps and Sets.
+
+import { randomUUID } from 'node:crypto';
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { EventBus } from '../../../bus/bus.js';
+import { createInboundMessage } from '../../../bus/events.js';
+import type { Logger } from '../../../logger.js';
+import type { EventRouter } from '../event-router.js';
+
+export interface MessageRouteOptions {
+  bus: EventBus;
+  logger: Logger;
+  eventRouter: EventRouter;
+}
+
+// How long to wait for an agent response before timing out the POST request
+const RESPONSE_TIMEOUT_MS = 120000;
+
+export async function messageRoutes(
+  app: FastifyInstance,
+  options: MessageRouteOptions,
+): Promise<void> {
+  const { bus, logger, eventRouter } = options;
+
+  /**
+   * POST /api/messages — send a message, wait for response.
+   *
+   * Body: { content: string, conversation_id?: string, sender_id?: string }
+   * Response: { conversation_id, content, agent_id }
+   */
+  app.post('/api/messages', async (request: FastifyRequest, reply: FastifyReply) => {
+    const body = request.body as {
+      content?: string;
+      conversation_id?: string;
+      sender_id?: string;
+    };
+
+    if (!body?.content || typeof body.content !== 'string') {
+      return reply.status(400).send({ error: 'Missing required field: content (string)' });
+    }
+
+    const conversationId = body.conversation_id ?? `http-${randomUUID()}`;
+    const senderId = body.sender_id ?? 'http-user';
+
+    // Register the pending response BEFORE publishing so we don't miss a fast reply
+    const responsePromise = eventRouter.waitForResponse(conversationId, RESPONSE_TIMEOUT_MS);
+
+    const inboundEvent = createInboundMessage({
+      conversationId,
+      channelId: 'http',
+      senderId,
+      content: body.content,
+    });
+
+    try {
+      await bus.publish('channel', inboundEvent);
+      const content = await responsePromise;
+
+      return reply.send({
+        conversation_id: conversationId,
+        content,
+        agent_id: 'coordinator',
+      });
+    } catch (err) {
+      // Clean up the pending response if publish failed
+      eventRouter.cancelPending(conversationId);
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error({ err, conversationId }, 'HTTP message handling failed');
+      return reply.status(504).send({ error: message });
+    }
+  });
+
+  /**
+   * GET /api/messages/stream — SSE endpoint.
+   *
+   * Streams outbound.message, skill.invoke, and skill.result events.
+   * Optionally filter by ?conversation_id=xxx
+   */
+  app.get('/api/messages/stream', async (request: FastifyRequest, reply: FastifyReply) => {
+    const query = request.query as { conversation_id?: string };
+
+    // Set SSE headers
+    reply.raw.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no', // Disable nginx buffering if behind a proxy
+    });
+
+    // Send initial keepalive comment
+    reply.raw.write(':connected\n\n');
+
+    // Register with the event router — returns a cleanup function
+    const cleanup = eventRouter.addSseClient({
+      res: reply.raw,
+      conversationId: query.conversation_id,
+    });
+
+    // Clean up when client disconnects
+    request.raw.on('close', cleanup);
+  });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/channels/http/routes/messages.ts
+git commit -m "feat: add POST /api/messages and GET /api/messages/stream (via EventRouter)"
+```
+
+---
+
+### Task 7: HTTP Adapter (Fastify server)
+
+**Files:**
+- Create: `src/channels/http/http-adapter.ts`
+
+This ties the routes, auth, CORS, and EventRouter together into a single Fastify server.
+
+- [ ] **Step 1: Implement the HTTP adapter**
+
+Create `src/channels/http/http-adapter.ts`:
+
+```typescript
+// http-adapter.ts — Fastify-based HTTP channel adapter.
+//
+// Provides REST + SSE endpoints for external clients (dashboards, mobile apps,
+// integrations). Uses the EventRouter (shared subscriber pattern) to avoid
+// per-request bus subscriber leaks.
+//
+// Endpoints:
+//   POST   /api/messages        — send a message, get response
+//   GET    /api/messages/stream — SSE real-time event stream
+//   GET    /api/health          — system health check
+//   GET    /api/agents/status   — agent registry snapshot
+//
+// The adapter subscribes to the bus at startup via EventRouter:
+//   - 'channel' layer for outbound.message (respects permission model)
+//   - 'system' layer for skill.invoke/skill.result (observability — documented
+//     privilege escalation for the HTTP channel since SSE needs to stream these)
+
+import Fastify, { type FastifyInstance } from 'fastify';
+import cors from '@fastify/cors';
+import type { EventBus } from '../../bus/bus.js';
+import type { Logger } from '../../logger.js';
+import type { Pool } from 'pg';
+import type { AgentRegistry } from '../../agents/agent-registry.js';
+import { validateBearerToken } from './auth.js';
+import { EventRouter } from './event-router.js';
+import { healthRoutes } from './routes/health.js';
+import { agentRoutes } from './routes/agents.js';
+import { messageRoutes } from './routes/messages.js';
+
+export interface HttpAdapterConfig {
+  bus: EventBus;
+  logger: Logger;
+  pool: Pool;
+  agentRegistry: AgentRegistry;
+  port: number;
+  apiToken: string | undefined;
+  agentNames: string[];
+  skillNames: string[];
+}
+
+export class HttpAdapter {
+  private app: FastifyInstance;
+  private config: HttpAdapterConfig;
+  private eventRouter: EventRouter;
+
+  constructor(config: HttpAdapterConfig) {
+    this.config = config;
+    this.eventRouter = new EventRouter(config.logger);
+    this.app = Fastify({
+      logger: false, // We use our own pino logger, not Fastify's built-in
+    });
+  }
+
+  async start(): Promise<void> {
+    const { bus, logger, pool, agentRegistry, port, apiToken, agentNames, skillNames } = this.config;
+
+    // Register shared bus subscriptions BEFORE starting the server.
+    // One subscriber per event type, dispatches to HTTP clients via Maps/Sets.
+    this.eventRouter.setupSubscriptions(bus);
+
+    // CORS — allow all origins in dev, restrict in production later
+    await this.app.register(cors, { origin: true });
+
+    // Auth hook — runs before every request
+    this.app.addHook('onRequest', async (request, reply) => {
+      // Skip auth for health endpoint — it's used by load balancers and monitors
+      if (request.url === '/api/health') return;
+
+      if (!validateBearerToken(request.headers.authorization, apiToken)) {
+        return reply.status(401).send({ error: 'Unauthorized — provide a valid Bearer token' });
+      }
+    });
+
+    // Register routes — message routes receive the eventRouter, not raw bus
+    await this.app.register(healthRoutes, { pool, agentNames, skillNames });
+    await this.app.register(agentRoutes, { agentRegistry });
+    await this.app.register(messageRoutes, { bus, logger, eventRouter: this.eventRouter });
+
+    // Start listening
+    await this.app.listen({ port, host: '0.0.0.0' });
+    logger.info({ port }, 'HTTP API listening');
+  }
+
+  async stop(): Promise<void> {
+    await this.app.close();
+    this.config.logger.info('HTTP API stopped');
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/channels/http/http-adapter.ts
+git commit -m "feat: add HttpAdapter (Fastify server with EventRouter, auth, CORS)"
+```
+
+---
+
+### Task 8: Bootstrap Integration
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Update index.ts**
+
+Read the existing file. Add the HTTP adapter import and wire it in.
+
+Add import at the top:
+
+```typescript
+import { HttpAdapter } from './channels/http/http-adapter.js';
+```
+
+After the dispatcher registration and before the shutdown handler, add:
+
+```typescript
+  // HTTP API channel — REST + SSE endpoints for external clients.
+  // Runs alongside the CLI channel so both can be used simultaneously.
+  const httpAdapter = new HttpAdapter({
+    bus,
+    logger,
+    pool,
+    agentRegistry,
+    port: config.httpPort,
+    apiToken: config.apiToken,
+    agentNames: agentConfigs.map(c => c.name),
+    skillNames: skillRegistry.list().map(s => s.manifest.name),
+  });
+
+  try {
+    await httpAdapter.start();
+  } catch (err) {
+    logger.fatal({ err }, 'Failed to start HTTP API');
+    process.exit(1);
+  }
+```
+
+Update the shutdown handler to also stop the HTTP adapter:
+
+```typescript
+  const shutdown = async () => {
+    logger.info('Shutting down...');
+    try {
+      await httpAdapter.stop();
+    } catch (err) {
+      logger.error({ err }, 'Error stopping HTTP API during shutdown');
+    }
+    try {
+      await pool.end();
+    } catch (err) {
+      logger.error({ err }, 'Error closing database pool during shutdown');
+    }
+    process.exit(0);
+  };
+```
+
+- [ ] **Step 2: Update .env with API_TOKEN**
+
+Add to the actual `.env` file (not `.env.example` — that was done in Task 1):
+
+```
+API_TOKEN=dev-token-change-in-production
+HTTP_PORT=3000
+```
+
+- [ ] **Step 3: Run all tests**
+
+Run: `pnpm test`
+Expected: ALL PASS
+
+- [ ] **Step 4: Run type check**
+
+Run: `pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: wire HTTP API into bootstrap (alongside CLI, with graceful shutdown)"
+```
+
+---
+
+### Task 9: Integration Test
+
+**Files:**
+- Create: `tests/integration/http-api.test.ts`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `tests/integration/http-api.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import Fastify from 'fastify';
+import { EventBus } from '../../src/bus/bus.js';
+import { AgentRuntime } from '../../src/agents/runtime.js';
+import { AgentRegistry } from '../../src/agents/agent-registry.js';
+import { EventRouter } from '../../src/channels/http/event-router.js';
+import { messageRoutes } from '../../src/channels/http/routes/messages.js';
+import { healthRoutes } from '../../src/channels/http/routes/health.js';
+import { agentRoutes } from '../../src/channels/http/routes/agents.js';
+import { Dispatcher } from '../../src/dispatch/dispatcher.js';
+import type { LLMProvider } from '../../src/agents/llm/provider.js';
+import type { Pool } from 'pg';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+describe('HTTP API integration', () => {
+  const app = Fastify();
+  const bus = new EventBus(logger);
+  const agentRegistry = new AgentRegistry();
+  agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main' });
+
+  const mockPool = {
+    query: async () => ({ rows: [{ '?column?': 1 }] }),
+  } as unknown as Pool;
+
+  // Shared event router — same pattern as production HttpAdapter
+  const eventRouter = new EventRouter(logger);
+
+  // Mock LLM that returns a text response
+  const mockProvider: LLMProvider = {
+    id: 'mock',
+    chat: async () => ({
+      type: 'text' as const,
+      content: 'Hello from the HTTP API!',
+      usage: { inputTokens: 10, outputTokens: 5 },
+    }),
+  };
+
+  beforeAll(async () => {
+    // Set up event router subscriptions BEFORE registering routes
+    eventRouter.setupSubscriptions(bus);
+
+    // Set up agent and dispatcher on the bus
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a test agent.',
+      provider: mockProvider,
+      bus,
+      logger,
+    });
+    coordinator.register();
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    // Register routes — message routes get the eventRouter
+    app.register(messageRoutes, { bus, logger, eventRouter });
+    app.register(healthRoutes, { pool: mockPool, agentNames: ['coordinator'], skillNames: ['web-fetch'] });
+    app.register(agentRoutes, { agentRegistry });
+
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /api/messages returns agent response', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/messages',
+      payload: {
+        content: 'Hello!',
+        conversation_id: 'test-conv-1',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.content).toBe('Hello from the HTTP API!');
+    expect(body.conversation_id).toBe('test-conv-1');
+  });
+
+  it('POST /api/messages returns 400 for missing content', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/messages',
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.error).toContain('content');
+  });
+
+  it('GET /api/health returns system status', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/health',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.status).toBe('ok');
+    expect(body.agents).toContain('coordinator');
+    expect(body.skills).toContain('web-fetch');
+  });
+
+  it('GET /api/agents/status returns agent list', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/agents/status',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.agents).toHaveLength(1);
+    expect(body.agents[0].name).toBe('coordinator');
+    expect(body.agents[0].role).toBe('coordinator');
+  });
+});
+```
+
+- [ ] **Step 2: Run integration test**
+
+Run: `pnpm test -- tests/integration/http-api.test.ts`
+Expected: PASS (4 tests)
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `pnpm test`
+Expected: ALL PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/http-api.test.ts
+git commit -m "test: add HTTP API integration tests (messages, health, agents)"
+```
+
+---
+
+### Task 10: Final Verification & PR
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pnpm test`
+Expected: ALL PASS
+
+- [ ] **Step 2: Run type check**
+
+Run: `pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 3: Run lint**
+
+Run: `pnpm lint`
+Expected: No errors
+
+- [ ] **Step 4: Manual smoke test**
+
+Run: `pnpm local` (in the worktree with .env symlinked)
+
+Test the HTTP API:
+
+```bash
+# Health check (no auth needed)
+curl http://localhost:3000/api/health
+
+# Send a message (with auth)
+curl -X POST http://localhost:3000/api/messages \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer dev-token-change-in-production" \
+  -d '{"content": "What is on example.com?"}'
+
+# SSE stream (in a separate terminal)
+curl -N http://localhost:3000/api/messages/stream \
+  -H "Authorization: Bearer dev-token-change-in-production"
+```
+
+- [ ] **Step 5: Push and create PR**
+
+```bash
+git push -u origin feat/phase5-http-api
+```

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
+    "@fastify/cors": "^11.2.0",
+    "fastify": "^5.8.4",
     "js-yaml": "^4.1.1",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.80.0
         version: 0.80.0
+      '@fastify/cors':
+        specifier: ^11.2.0
+        version: 11.2.0
+      fastify:
+        specifier: ^5.8.4
+        version: 5.8.4
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -279,6 +285,27 @@ packages:
   '@eslint/plugin-kit@0.6.1':
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/cors@11.2.0':
+    resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -676,6 +703,9 @@ packages:
   '@vitest/utils@4.1.1':
     resolution: {integrity: sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==}
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -686,8 +716,19 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -710,6 +751,9 @@ packages:
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  avvio@9.2.0:
+    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -765,6 +809,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -783,6 +831,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -862,17 +914,38 @@ packages:
   fast-copy@4.0.2:
     resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
 
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-json-stringify@6.3.0:
+    resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
+
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastify-plugin@5.1.0:
+    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+
+  fastify@5.8.4:
+    resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -886,6 +959,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  find-my-way@9.5.0:
+    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
+    engines: {node: '>=20'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -942,6 +1019,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  ipaddr.js@2.3.0:
+    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
+    engines: {node: '>= 10'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -972,12 +1053,18 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -988,6 +1075,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1272,6 +1362,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
@@ -1297,12 +1390,27 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rolldown@1.0.0-rc.11:
     resolution: {integrity: sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==}
@@ -1312,6 +1420,10 @@ packages:
   rollup@4.60.0:
     resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  safe-regex2@5.1.0:
+    resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==}
     hasBin: true
 
   safe-stable-stringify@2.5.0:
@@ -1325,6 +1437,9 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1407,6 +1522,10 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -1723,6 +1842,34 @@ snapshots:
     dependencies:
       '@eslint/core': 1.1.1
       levn: 0.4.1
+
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+
+  '@fastify/cors@11.2.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      toad-cache: 3.7.0
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.3.0
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.3.0
 
   '@humanfs/core@0.19.1': {}
 
@@ -2050,11 +2197,17 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  abstract-logging@2.0.1: {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv@6.14.0:
     dependencies:
@@ -2062,6 +2215,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -2076,6 +2236,11 @@ snapshots:
   assertion-error@2.0.1: {}
 
   atomic-sleep@1.0.0: {}
+
+  avvio@9.2.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.20.1
 
   balanced-match@4.0.4: {}
 
@@ -2118,6 +2283,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2131,6 +2298,8 @@ snapshots:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
@@ -2247,13 +2416,54 @@ snapshots:
 
   fast-copy@4.0.2: {}
 
+  fast-decode-uri-component@1.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-json-stringify@6.3.0:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
   fast-levenshtein@2.0.6: {}
 
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
+
   fast-safe-stringify@2.1.1: {}
+
+  fast-uri@3.1.0: {}
+
+  fastify-plugin@5.1.0: {}
+
+  fastify@5.8.4:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.3.0
+      find-my-way: 9.5.0
+      light-my-request: 6.6.0
+      pino: 10.3.1
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.4
+      toad-cache: 3.7.0
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -2262,6 +2472,12 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  find-my-way@9.5.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.1.0
 
   find-up@5.0.0:
     dependencies:
@@ -2316,6 +2532,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  ipaddr.js@2.3.0: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -2338,12 +2556,18 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
+
   json-schema-to-ts@3.1.1:
     dependencies:
       '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -2355,6 +2579,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.1.1
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.2
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -2604,6 +2834,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  process-warning@4.0.1: {}
+
   process-warning@5.0.0: {}
 
   pump@3.0.4:
@@ -2621,9 +2853,17 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  ret@0.5.0: {}
+
+  reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rolldown@1.0.0-rc.11:
     dependencies:
@@ -2677,11 +2917,17 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
 
+  safe-regex2@5.1.0:
+    dependencies:
+      ret: 0.5.0
+
   safe-stable-stringify@2.5.0: {}
 
   secure-json-parse@4.1.0: {}
 
   semver@7.7.4: {}
+
+  set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -2753,6 +2999,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
+
+  toad-cache@3.7.0: {}
 
   tree-kill@1.2.2: {}
 

--- a/src/channels/http/auth.ts
+++ b/src/channels/http/auth.ts
@@ -1,0 +1,36 @@
+// auth.ts — bearer token authentication for the HTTP API.
+//
+// When API_TOKEN is configured, all HTTP requests must include
+// an Authorization header with a matching bearer token. When
+// API_TOKEN is not set, authentication is disabled (useful for
+// local development).
+
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * Validate a bearer token from an Authorization header.
+ * Returns true if:
+ * - No API token is configured (auth disabled)
+ * - The header contains a valid Bearer token matching the configured token
+ *
+ * Uses timing-safe comparison to prevent timing attacks.
+ */
+export function validateBearerToken(
+  authHeader: string | undefined,
+  configuredToken: string | undefined,
+): boolean {
+  // If no token is configured, auth is disabled
+  if (!configuredToken) return true;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return false;
+
+  const provided = authHeader.slice('Bearer '.length);
+
+  // Timing-safe comparison to prevent timing attacks
+  if (provided.length !== configuredToken.length) return false;
+
+  return timingSafeEqual(
+    Buffer.from(provided),
+    Buffer.from(configuredToken),
+  );
+}

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -1,0 +1,149 @@
+// event-router.ts — shared subscriber pattern for the HTTP API.
+//
+// The EventBus has no unsubscribe mechanism. If we subscribed per-request,
+// every POST and SSE connection would leak a permanent subscriber. Instead,
+// the EventRouter registers ONE subscriber per event type at startup and
+// dispatches to registered handlers via Maps and Sets.
+//
+// POST /api/messages registers a pending resolver keyed by conversationId.
+// SSE connections register a writer function in a Set.
+// Both are cleaned up when the request completes or the client disconnects.
+
+import type { EventBus } from '../../bus/bus.js';
+import type { BusEvent } from '../../bus/events.js';
+import type { Logger } from '../../logger.js';
+import type { ServerResponse } from 'node:http';
+
+export interface PendingResponse {
+  resolve: (content: string) => void;
+  reject: (error: Error) => void;
+  timeout: NodeJS.Timeout;
+}
+
+export interface SseClient {
+  res: ServerResponse;
+  conversationId?: string; // Optional filter
+}
+
+/**
+ * EventRouter registers shared bus subscribers and dispatches to HTTP clients.
+ * Call setupSubscriptions() once at startup, then use the add/remove methods
+ * per-request.
+ */
+export class EventRouter {
+  private logger: Logger;
+  /** Pending POST /api/messages responses, keyed by conversationId */
+  private pendingResponses = new Map<string, PendingResponse>();
+  /** Active SSE connections */
+  private sseClients = new Set<SseClient>();
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  /**
+   * Register shared subscribers on the bus. Called once at startup.
+   * Uses 'channel' layer for outbound.message (proper permission model)
+   * and 'system' layer for observability events (skill.invoke, skill.result).
+   */
+  setupSubscriptions(bus: EventBus): void {
+    // outbound.message — dispatches to pending POST resolvers and SSE clients
+    bus.subscribe('outbound.message', 'channel', (event: BusEvent) => {
+      if (event.type !== 'outbound.message') return;
+      // Only handle messages for the HTTP channel
+      if (event.payload.channelId !== 'http') return;
+
+      const convId = event.payload.conversationId;
+
+      // Resolve pending POST request if one is waiting for this conversation
+      const pending = this.pendingResponses.get(convId);
+      if (pending) {
+        clearTimeout(pending.timeout);
+        this.pendingResponses.delete(convId);
+        pending.resolve(event.payload.content);
+      }
+
+      // Stream to all SSE clients (filtered by conversationId if set)
+      const sseData = JSON.stringify({
+        type: 'message',
+        conversation_id: convId,
+        content: event.payload.content,
+        timestamp: event.timestamp,
+      });
+      for (const client of this.sseClients) {
+        if (!client.conversationId || client.conversationId === convId) {
+          client.res.write(`data: ${sseData}\n\n`);
+        }
+      }
+    });
+
+    // skill.invoke — observability stream for SSE clients
+    bus.subscribe('skill.invoke', 'system', (event: BusEvent) => {
+      if (event.type !== 'skill.invoke') return;
+      const sseData = JSON.stringify({
+        type: 'skill.invoke',
+        agent: event.payload.agentId,
+        skill: event.payload.skillName,
+        conversation_id: event.payload.conversationId,
+        timestamp: event.timestamp,
+      });
+      for (const client of this.sseClients) {
+        if (!client.conversationId || client.conversationId === event.payload.conversationId) {
+          client.res.write(`data: ${sseData}\n\n`);
+        }
+      }
+    });
+
+    // skill.result — observability stream for SSE clients
+    bus.subscribe('skill.result', 'system', (event: BusEvent) => {
+      if (event.type !== 'skill.result') return;
+      const sseData = JSON.stringify({
+        type: 'skill.result',
+        agent: event.payload.agentId,
+        skill: event.payload.skillName,
+        success: event.payload.result.success,
+        duration_ms: event.payload.durationMs,
+        conversation_id: event.payload.conversationId,
+        timestamp: event.timestamp,
+      });
+      for (const client of this.sseClients) {
+        if (!client.conversationId || client.conversationId === event.payload.conversationId) {
+          client.res.write(`data: ${sseData}\n\n`);
+        }
+      }
+    });
+
+    this.logger.info('HTTP event router subscriptions registered');
+  }
+
+  /** Register a pending POST response. Returns a promise that resolves with the response content. */
+  waitForResponse(conversationId: string, timeoutMs: number): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingResponses.delete(conversationId);
+        reject(new Error('Response timeout — the agent did not respond in time'));
+      }, timeoutMs);
+
+      this.pendingResponses.set(conversationId, { resolve, reject, timeout });
+    });
+  }
+
+  /** Cancel a pending response (e.g., if publish fails). */
+  cancelPending(conversationId: string): void {
+    const pending = this.pendingResponses.get(conversationId);
+    if (pending) {
+      clearTimeout(pending.timeout);
+      this.pendingResponses.delete(conversationId);
+    }
+  }
+
+  /** Register an SSE client. Returns a cleanup function. */
+  addSseClient(client: SseClient): () => void {
+    this.sseClients.add(client);
+    this.logger.debug({ conversationId: client.conversationId }, 'SSE client connected');
+    return () => {
+      this.sseClients.delete(client);
+      this.logger.debug({ conversationId: client.conversationId }, 'SSE client disconnected');
+    };
+  }
+}

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -63,18 +63,16 @@ export class EventRouter {
         pending.resolve(event.payload.content);
       }
 
-      // Stream to all SSE clients (filtered by conversationId if set)
+      // Stream to all SSE clients (filtered by conversationId if set).
+      // Wrap writes in try/catch so a dead client doesn't abort delivery
+      // to the remaining clients in this dispatch cycle.
       const sseData = JSON.stringify({
         type: 'message',
         conversation_id: convId,
         content: event.payload.content,
         timestamp: event.timestamp,
       });
-      for (const client of this.sseClients) {
-        if (!client.conversationId || client.conversationId === convId) {
-          client.res.write(`data: ${sseData}\n\n`);
-        }
-      }
+      this.broadcastToSseClients(sseData, convId);
     });
 
     // skill.invoke — observability stream for SSE clients
@@ -87,11 +85,7 @@ export class EventRouter {
         conversation_id: event.payload.conversationId,
         timestamp: event.timestamp,
       });
-      for (const client of this.sseClients) {
-        if (!client.conversationId || client.conversationId === event.payload.conversationId) {
-          client.res.write(`data: ${sseData}\n\n`);
-        }
-      }
+      this.broadcastToSseClients(sseData, event.payload.conversationId);
     });
 
     // skill.result — observability stream for SSE clients
@@ -106,18 +100,27 @@ export class EventRouter {
         conversation_id: event.payload.conversationId,
         timestamp: event.timestamp,
       });
-      for (const client of this.sseClients) {
-        if (!client.conversationId || client.conversationId === event.payload.conversationId) {
-          client.res.write(`data: ${sseData}\n\n`);
-        }
-      }
+      this.broadcastToSseClients(sseData, event.payload.conversationId);
     });
 
     this.logger.info('HTTP event router subscriptions registered');
   }
 
-  /** Register a pending POST response. Returns a promise that resolves with the response content. */
+  /**
+   * Register a pending POST response. Returns a promise that resolves with the response content.
+   * If a request is already pending for this conversationId, rejects it first to avoid
+   * orphaned promises and leaked timeouts.
+   */
   waitForResponse(conversationId: string, timeoutMs: number): Promise<string> {
+    // Reject any existing pending request for this conversationId to prevent
+    // orphaned promises. This can happen if two POSTs race with the same ID.
+    const existing = this.pendingResponses.get(conversationId);
+    if (existing) {
+      clearTimeout(existing.timeout);
+      this.pendingResponses.delete(conversationId);
+      existing.reject(new Error('Superseded by a newer request for the same conversation_id'));
+    }
+
     return new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.pendingResponses.delete(conversationId);
@@ -134,6 +137,27 @@ export class EventRouter {
     if (pending) {
       clearTimeout(pending.timeout);
       this.pendingResponses.delete(conversationId);
+    }
+  }
+
+  /**
+   * Send an SSE payload to all matching clients. Wraps each write in try/catch
+   * so a dead client (TCP reset between close event and write) doesn't abort
+   * delivery to remaining clients in this dispatch cycle.
+   */
+  private broadcastToSseClients(sseData: string, conversationId?: string): void {
+    for (const client of this.sseClients) {
+      if (!client.conversationId || client.conversationId === conversationId) {
+        try {
+          client.res.write(`data: ${sseData}\n\n`);
+        } catch {
+          // Client connection is dead — remove it. The 'close' event handler
+          // will also fire eventually, but cleaning up here prevents repeated
+          // failed writes for subsequent events in this tick.
+          this.sseClients.delete(client);
+          this.logger.debug({ conversationId: client.conversationId }, 'Removed dead SSE client');
+        }
+      }
     }
   }
 

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -1,0 +1,88 @@
+// http-adapter.ts — Fastify-based HTTP channel adapter.
+//
+// Provides REST + SSE endpoints for external clients (dashboards, mobile apps,
+// integrations). Uses the EventRouter (shared subscriber pattern) to avoid
+// per-request bus subscriber leaks.
+//
+// Endpoints:
+//   POST   /api/messages        — send a message, get response
+//   GET    /api/messages/stream — SSE real-time event stream
+//   GET    /api/health          — system health check
+//   GET    /api/agents/status   — agent registry snapshot
+//
+// The adapter subscribes to the bus at startup via EventRouter:
+//   - 'channel' layer for outbound.message (respects permission model)
+//   - 'system' layer for skill.invoke/skill.result (observability — documented
+//     privilege escalation for the HTTP channel since SSE needs to stream these)
+
+import Fastify, { type FastifyInstance } from 'fastify';
+import cors from '@fastify/cors';
+import type { EventBus } from '../../bus/bus.js';
+import type { Logger } from '../../logger.js';
+import type { Pool } from 'pg';
+import type { AgentRegistry } from '../../agents/agent-registry.js';
+import { validateBearerToken } from './auth.js';
+import { EventRouter } from './event-router.js';
+import { healthRoutes } from './routes/health.js';
+import { agentRoutes } from './routes/agents.js';
+import { messageRoutes } from './routes/messages.js';
+
+export interface HttpAdapterConfig {
+  bus: EventBus;
+  logger: Logger;
+  pool: Pool;
+  agentRegistry: AgentRegistry;
+  port: number;
+  apiToken: string | undefined;
+  agentNames: string[];
+  skillNames: string[];
+}
+
+export class HttpAdapter {
+  private app: FastifyInstance;
+  private config: HttpAdapterConfig;
+  private eventRouter: EventRouter;
+
+  constructor(config: HttpAdapterConfig) {
+    this.config = config;
+    this.eventRouter = new EventRouter(config.logger);
+    this.app = Fastify({
+      logger: false, // We use our own pino logger, not Fastify's built-in
+    });
+  }
+
+  async start(): Promise<void> {
+    const { bus, logger, pool, agentRegistry, port, apiToken, agentNames, skillNames } = this.config;
+
+    // Register shared bus subscriptions BEFORE starting the server.
+    // One subscriber per event type, dispatches to HTTP clients via Maps/Sets.
+    this.eventRouter.setupSubscriptions(bus);
+
+    // CORS — allow all origins in dev, restrict in production later
+    await this.app.register(cors, { origin: true });
+
+    // Auth hook — runs before every request
+    this.app.addHook('onRequest', async (request, reply) => {
+      // Skip auth for health endpoint — it's used by load balancers and monitors
+      if (request.url === '/api/health') return;
+
+      if (!validateBearerToken(request.headers.authorization, apiToken)) {
+        return reply.status(401).send({ error: 'Unauthorized — provide a valid Bearer token' });
+      }
+    });
+
+    // Register routes — message routes receive the eventRouter, not raw bus
+    await this.app.register(healthRoutes, { pool, agentNames, skillNames });
+    await this.app.register(agentRoutes, { agentRegistry });
+    await this.app.register(messageRoutes, { bus, logger, eventRouter: this.eventRouter });
+
+    // Start listening
+    await this.app.listen({ port, host: '0.0.0.0' });
+    logger.info({ port }, 'HTTP API listening');
+  }
+
+  async stop(): Promise<void> {
+    await this.app.close();
+    this.config.logger.info('HTTP API stopped');
+  }
+}

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -48,6 +48,7 @@ export class HttpAdapter {
     this.eventRouter = new EventRouter(config.logger);
     this.app = Fastify({
       logger: false, // We use our own pino logger, not Fastify's built-in
+      bodyLimit: 64 * 1024, // 64 KiB — generous for chat messages, prevents abuse
     });
   }
 
@@ -63,8 +64,9 @@ export class HttpAdapter {
 
     // Auth hook — runs before every request
     this.app.addHook('onRequest', async (request, reply) => {
-      // Skip auth for health endpoint — it's used by load balancers and monitors
-      if (request.url === '/api/health') return;
+      // Skip auth for health endpoint — it's used by load balancers and monitors.
+      // Use routeOptions.url (the registered pattern) so query strings don't break the match.
+      if (request.routeOptions.url === '/api/health') return;
 
       if (!validateBearerToken(request.headers.authorization, apiToken)) {
         return reply.status(401).send({ error: 'Unauthorized — provide a valid Bearer token' });
@@ -72,7 +74,7 @@ export class HttpAdapter {
     });
 
     // Register routes — message routes receive the eventRouter, not raw bus
-    await this.app.register(healthRoutes, { pool, agentNames, skillNames });
+    await this.app.register(healthRoutes, { pool, logger, agentNames, skillNames });
     await this.app.register(agentRoutes, { agentRegistry });
     await this.app.register(messageRoutes, { bus, logger, eventRouter: this.eventRouter });
 

--- a/src/channels/http/routes/agents.ts
+++ b/src/channels/http/routes/agents.ts
@@ -1,0 +1,31 @@
+// agents.ts — GET /api/agents/status endpoint.
+//
+// Returns a snapshot of all registered agents and their metadata.
+// In Phase 5 this is a static list from the registry; future phases
+// will add real-time agent state (idle/thinking/using_tool/etc.).
+
+import type { FastifyInstance } from 'fastify';
+import type { AgentRegistry } from '../../../agents/agent-registry.js';
+
+export interface AgentRouteOptions {
+  agentRegistry: AgentRegistry;
+}
+
+export async function agentRoutes(
+  app: FastifyInstance,
+  options: AgentRouteOptions,
+): Promise<void> {
+  const { agentRegistry } = options;
+
+  app.get('/api/agents/status', async (_request, reply) => {
+    const agents = agentRegistry.list().map(a => ({
+      name: a.name,
+      role: a.role,
+      description: a.description,
+      // TODO: Add real-time state (idle/thinking/using_tool) in Phase 6
+      state: 'idle',
+    }));
+
+    return reply.send({ agents });
+  });
+}

--- a/src/channels/http/routes/health.ts
+++ b/src/channels/http/routes/health.ts
@@ -1,0 +1,43 @@
+// health.ts — GET /api/health endpoint.
+//
+// Reports system status: database connectivity, registered agents,
+// loaded skills, and process uptime. Returns 200 for healthy, 503
+// for degraded (e.g., database is down).
+
+import type { FastifyInstance } from 'fastify';
+import type { Pool } from 'pg';
+
+export interface HealthRouteOptions {
+  pool: Pool;
+  agentNames: string[];
+  skillNames: string[];
+}
+
+export async function healthRoutes(
+  app: FastifyInstance,
+  options: HealthRouteOptions,
+): Promise<void> {
+  const { pool, agentNames, skillNames } = options;
+  const startTime = Date.now();
+
+  app.get('/api/health', async (_request, reply) => {
+    let dbStatus = 'connected';
+
+    try {
+      await pool.query('SELECT 1');
+    } catch {
+      dbStatus = 'disconnected';
+    }
+
+    const status = dbStatus === 'connected' ? 'ok' : 'degraded';
+    const statusCode = status === 'ok' ? 200 : 503;
+
+    return reply.status(statusCode).send({
+      status,
+      database: dbStatus,
+      agents: agentNames,
+      skills: skillNames,
+      uptime: Math.floor((Date.now() - startTime) / 1000),
+    });
+  });
+}

--- a/src/channels/http/routes/health.ts
+++ b/src/channels/http/routes/health.ts
@@ -6,9 +6,11 @@
 
 import type { FastifyInstance } from 'fastify';
 import type { Pool } from 'pg';
+import type { Logger } from '../../../logger.js';
 
 export interface HealthRouteOptions {
   pool: Pool;
+  logger: Logger;
   agentNames: string[];
   skillNames: string[];
 }
@@ -17,7 +19,7 @@ export async function healthRoutes(
   app: FastifyInstance,
   options: HealthRouteOptions,
 ): Promise<void> {
-  const { pool, agentNames, skillNames } = options;
+  const { pool, logger, agentNames, skillNames } = options;
   const startTime = Date.now();
 
   app.get('/api/health', async (_request, reply) => {
@@ -25,7 +27,8 @@ export async function healthRoutes(
 
     try {
       await pool.query('SELECT 1');
-    } catch {
+    } catch (err) {
+      logger.warn({ err }, 'Health check: database probe failed');
       dbStatus = 'disconnected';
     }
 

--- a/src/channels/http/routes/messages.ts
+++ b/src/channels/http/routes/messages.ts
@@ -1,0 +1,109 @@
+// messages.ts — message endpoints for the HTTP API channel.
+//
+// POST /api/messages — send a message and get the response.
+// GET /api/messages/stream — SSE endpoint for real-time events.
+//
+// Both use the shared EventRouter to avoid subscriber leaks on the bus.
+// The EventRouter registers ONE subscriber per event type at startup;
+// individual requests register/deregister handlers via Maps and Sets.
+
+import { randomUUID } from 'node:crypto';
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { EventBus } from '../../../bus/bus.js';
+import { createInboundMessage } from '../../../bus/events.js';
+import type { Logger } from '../../../logger.js';
+import type { EventRouter } from '../event-router.js';
+
+export interface MessageRouteOptions {
+  bus: EventBus;
+  logger: Logger;
+  eventRouter: EventRouter;
+}
+
+// How long to wait for an agent response before timing out the POST request
+const RESPONSE_TIMEOUT_MS = 120000;
+
+export async function messageRoutes(
+  app: FastifyInstance,
+  options: MessageRouteOptions,
+): Promise<void> {
+  const { bus, logger, eventRouter } = options;
+
+  /**
+   * POST /api/messages — send a message, wait for response.
+   *
+   * Body: { content: string, conversation_id?: string, sender_id?: string }
+   * Response: { conversation_id, content, agent_id }
+   */
+  app.post('/api/messages', async (request: FastifyRequest, reply: FastifyReply) => {
+    const body = request.body as {
+      content?: string;
+      conversation_id?: string;
+      sender_id?: string;
+    };
+
+    if (!body?.content || typeof body.content !== 'string') {
+      return reply.status(400).send({ error: 'Missing required field: content (string)' });
+    }
+
+    const conversationId = body.conversation_id ?? `http-${randomUUID()}`;
+    const senderId = body.sender_id ?? 'http-user';
+
+    // Register the pending response BEFORE publishing so we don't miss a fast reply
+    const responsePromise = eventRouter.waitForResponse(conversationId, RESPONSE_TIMEOUT_MS);
+
+    const inboundEvent = createInboundMessage({
+      conversationId,
+      channelId: 'http',
+      senderId,
+      content: body.content,
+    });
+
+    try {
+      await bus.publish('channel', inboundEvent);
+      const content = await responsePromise;
+
+      return reply.send({
+        conversation_id: conversationId,
+        content,
+        agent_id: 'coordinator',
+      });
+    } catch (err) {
+      // Clean up the pending response if publish failed
+      eventRouter.cancelPending(conversationId);
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error({ err, conversationId }, 'HTTP message handling failed');
+      return reply.status(504).send({ error: message });
+    }
+  });
+
+  /**
+   * GET /api/messages/stream — SSE endpoint.
+   *
+   * Streams outbound.message, skill.invoke, and skill.result events.
+   * Optionally filter by ?conversation_id=xxx
+   */
+  app.get('/api/messages/stream', async (request: FastifyRequest, reply: FastifyReply) => {
+    const query = request.query as { conversation_id?: string };
+
+    // Set SSE headers
+    reply.raw.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no', // Disable nginx buffering if behind a proxy
+    });
+
+    // Send initial keepalive comment
+    reply.raw.write(':connected\n\n');
+
+    // Register with the event router — returns a cleanup function
+    const cleanup = eventRouter.addSseClient({
+      res: reply.raw,
+      conversationId: query.conversation_id,
+    });
+
+    // Clean up when client disconnects
+    request.raw.on('close', cleanup);
+  });
+}

--- a/src/channels/http/routes/messages.ts
+++ b/src/channels/http/routes/messages.ts
@@ -42,8 +42,8 @@ export async function messageRoutes(
       sender_id?: string;
     };
 
-    if (!body?.content || typeof body.content !== 'string') {
-      return reply.status(400).send({ error: 'Missing required field: content (string)' });
+    if (!body?.content || typeof body.content !== 'string' || body.content.trim().length === 0) {
+      return reply.status(400).send({ error: 'Missing required field: content (non-empty string)' });
     }
 
     const conversationId = body.conversation_id ?? `http-${randomUUID()}`;
@@ -63,6 +63,9 @@ export async function messageRoutes(
       await bus.publish('channel', inboundEvent);
       const content = await responsePromise;
 
+      // TODO: agent_id is hardcoded — OutboundMessagePayload doesn't carry agentId.
+      // Once we add agentId to the outbound event, extract it here for accuracy
+      // in multi-agent delegation scenarios.
       return reply.send({
         conversation_id: conversationId,
         content,
@@ -73,7 +76,10 @@ export async function messageRoutes(
       eventRouter.cancelPending(conversationId);
       const message = err instanceof Error ? err.message : String(err);
       logger.error({ err, conversationId }, 'HTTP message handling failed');
-      return reply.status(504).send({ error: message });
+
+      // Distinguish timeout errors (504) from internal failures (500)
+      const isTimeout = message.includes('timeout') || message.includes('Timeout');
+      return reply.status(isTimeout ? 504 : 500).send({ error: message });
     }
   });
 
@@ -85,6 +91,10 @@ export async function messageRoutes(
    */
   app.get('/api/messages/stream', async (request: FastifyRequest, reply: FastifyReply) => {
     const query = request.query as { conversation_id?: string };
+
+    // Tell Fastify we're taking over the response — prevents it from
+    // sending a default reply after the async handler returns.
+    reply.hijack();
 
     // Set SSE headers
     reply.raw.writeHead(200, {
@@ -103,7 +113,20 @@ export async function messageRoutes(
       conversationId: query.conversation_id,
     });
 
+    // Periodic heartbeat to prevent proxies (nginx, ALB, Cloudflare) from
+    // closing idle connections — most have a 60-120s idle timeout.
+    const heartbeat = setInterval(() => {
+      try {
+        reply.raw.write(':ping\n\n');
+      } catch {
+        clearInterval(heartbeat);
+      }
+    }, 30000);
+
     // Clean up when client disconnects
-    request.raw.on('close', cleanup);
+    request.raw.on('close', () => {
+      clearInterval(heartbeat);
+      cleanup();
+    });
   });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,8 @@ export interface Config {
   databaseUrl: string;
   anthropicApiKey: string | undefined;
   logLevel: string;
+  httpPort: number;
+  apiToken: string | undefined;
 }
 
 export function loadConfig(): Config {
@@ -14,5 +16,7 @@ export function loadConfig(): Config {
     databaseUrl,
     anthropicApiKey: process.env.ANTHROPIC_API_KEY,
     logLevel: process.env.LOG_LEVEL ?? 'info',
+    httpPort: parseInt(process.env.HTTP_PORT ?? '3000', 10),
+    apiToken: process.env.API_TOKEN,
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,11 +12,16 @@ export function loadConfig(): Config {
     throw new Error('DATABASE_URL environment variable is required');
   }
 
+  const httpPort = parseInt(process.env.HTTP_PORT ?? '3000', 10);
+  if (isNaN(httpPort) || httpPort < 1 || httpPort > 65535) {
+    throw new Error(`HTTP_PORT must be a valid port number (1-65535), got: ${process.env.HTTP_PORT}`);
+  }
+
   return {
     databaseUrl,
     anthropicApiKey: process.env.ANTHROPIC_API_KEY,
     logLevel: process.env.LOG_LEVEL ?? 'info',
-    httpPort: parseInt(process.env.HTTP_PORT ?? '3000', 10),
+    httpPort,
     apiToken: process.env.API_TOKEN,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@
 import * as path from 'node:path';
 import { loadConfig } from './config.js';
 import { createLogger } from './logger.js';
+import { HttpAdapter } from './channels/http/http-adapter.js';
 import { createPool } from './db/connection.js';
 import { EventBus } from './bus/bus.js';
 import { AuditLogger } from './audit/logger.js';
@@ -177,11 +178,34 @@ async function main(): Promise<void> {
   const dispatcher = new Dispatcher({ bus, logger });
   dispatcher.register();
 
-  // 9. Graceful shutdown — stop accepting new input first, let any in-flight
-  // async bus deliveries drain (they are awaited inside bus.publish), then
-  // close the DB pool so Postgres cleans up server-side connections cleanly.
+  // HTTP API channel — REST + SSE endpoints for external clients.
+  // Runs alongside the CLI channel so both can be used simultaneously.
+  const httpAdapter = new HttpAdapter({
+    bus,
+    logger,
+    pool,
+    agentRegistry,
+    port: config.httpPort,
+    apiToken: config.apiToken,
+    agentNames: agentConfigs.map(c => c.name),
+    skillNames: skillRegistry.list().map(s => s.manifest.name),
+  });
+
+  try {
+    await httpAdapter.start();
+  } catch (err) {
+    logger.fatal({ err }, 'Failed to start HTTP API');
+    process.exit(1);
+  }
+
+  // Graceful shutdown — stop accepting new input first, then close connections.
   const shutdown = async () => {
     logger.info('Shutting down...');
+    try {
+      await httpAdapter.stop();
+    } catch (err) {
+      logger.error({ err }, 'Error stopping HTTP API during shutdown');
+    }
     try {
       await pool.end();
     } catch (err) {

--- a/tests/integration/http-api.test.ts
+++ b/tests/integration/http-api.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import Fastify from 'fastify';
+import { EventBus } from '../../src/bus/bus.js';
+import { AgentRuntime } from '../../src/agents/runtime.js';
+import { AgentRegistry } from '../../src/agents/agent-registry.js';
+import { EventRouter } from '../../src/channels/http/event-router.js';
+import { messageRoutes } from '../../src/channels/http/routes/messages.js';
+import { healthRoutes } from '../../src/channels/http/routes/health.js';
+import { agentRoutes } from '../../src/channels/http/routes/agents.js';
+import { Dispatcher } from '../../src/dispatch/dispatcher.js';
+import type { LLMProvider } from '../../src/agents/llm/provider.js';
+import type { Pool } from 'pg';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+describe('HTTP API integration', () => {
+  const app = Fastify();
+  const bus = new EventBus(logger);
+  const agentRegistry = new AgentRegistry();
+  agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main' });
+
+  const mockPool = {
+    query: async () => ({ rows: [{ '?column?': 1 }] }),
+  } as unknown as Pool;
+
+  const eventRouter = new EventRouter(logger);
+
+  const mockProvider: LLMProvider = {
+    id: 'mock',
+    chat: async () => ({
+      type: 'text' as const,
+      content: 'Hello from the HTTP API!',
+      usage: { inputTokens: 10, outputTokens: 5 },
+    }),
+  };
+
+  beforeAll(async () => {
+    eventRouter.setupSubscriptions(bus);
+
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a test agent.',
+      provider: mockProvider,
+      bus,
+      logger,
+    });
+    coordinator.register();
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    app.register(messageRoutes, { bus, logger, eventRouter });
+    app.register(healthRoutes, { pool: mockPool, agentNames: ['coordinator'], skillNames: ['web-fetch'] });
+    app.register(agentRoutes, { agentRegistry });
+
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /api/messages returns agent response', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/messages',
+      payload: {
+        content: 'Hello!',
+        conversation_id: 'test-conv-1',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.content).toBe('Hello from the HTTP API!');
+    expect(body.conversation_id).toBe('test-conv-1');
+  });
+
+  it('POST /api/messages returns 400 for missing content', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/messages',
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.error).toContain('content');
+  });
+
+  it('GET /api/health returns system status', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/health',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.status).toBe('ok');
+    expect(body.agents).toContain('coordinator');
+    expect(body.skills).toContain('web-fetch');
+  });
+
+  it('GET /api/agents/status returns agent list', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/agents/status',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.agents).toHaveLength(1);
+    expect(body.agents[0].name).toBe('coordinator');
+    expect(body.agents[0].role).toBe('coordinator');
+  });
+});

--- a/tests/integration/http-api.test.ts
+++ b/tests/integration/http-api.test.ts
@@ -51,7 +51,7 @@ describe('HTTP API integration', () => {
     dispatcher.register();
 
     app.register(messageRoutes, { bus, logger, eventRouter });
-    app.register(healthRoutes, { pool: mockPool, agentNames: ['coordinator'], skillNames: ['web-fetch'] });
+    app.register(healthRoutes, { pool: mockPool, logger, agentNames: ['coordinator'], skillNames: ['web-fetch'] });
     app.register(agentRoutes, { agentRegistry });
 
     await app.ready();

--- a/tests/unit/channels/http/auth.test.ts
+++ b/tests/unit/channels/http/auth.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { validateBearerToken } from '../../../../src/channels/http/auth.js';
+
+describe('validateBearerToken', () => {
+  it('returns true for a valid token', () => {
+    expect(validateBearerToken('Bearer my-secret-token', 'my-secret-token')).toBe(true);
+  });
+
+  it('returns false for an invalid token', () => {
+    expect(validateBearerToken('Bearer wrong-token', 'my-secret-token')).toBe(false);
+  });
+
+  it('returns false for missing Bearer prefix', () => {
+    expect(validateBearerToken('my-secret-token', 'my-secret-token')).toBe(false);
+  });
+
+  it('returns false for empty authorization header', () => {
+    expect(validateBearerToken('', 'my-secret-token')).toBe(false);
+  });
+
+  it('returns false for undefined authorization header', () => {
+    expect(validateBearerToken(undefined, 'my-secret-token')).toBe(false);
+  });
+
+  it('returns true when no API token is configured (auth disabled)', () => {
+    expect(validateBearerToken(undefined, undefined)).toBe(true);
+  });
+
+  it('returns true for any header when no API token is configured', () => {
+    expect(validateBearerToken('Bearer anything', undefined)).toBe(true);
+  });
+});

--- a/tests/unit/channels/http/health.test.ts
+++ b/tests/unit/channels/http/health.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import Fastify from 'fastify';
+import { healthRoutes } from '../../../../src/channels/http/routes/health.js';
+import type { Pool } from 'pg';
+
+describe('GET /api/health', () => {
+  const mockPool = {
+    query: async () => ({ rows: [{ '?column?': 1 }] }),
+  } as unknown as Pool;
+
+  const app = Fastify();
+
+  beforeAll(async () => {
+    app.register(healthRoutes, {
+      pool: mockPool,
+      agentNames: ['coordinator', 'research-analyst'],
+      skillNames: ['web-fetch', 'delegate'],
+    });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns 200 with system status', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/health',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.status).toBe('ok');
+    expect(body.database).toBe('connected');
+    expect(body.agents).toEqual(['coordinator', 'research-analyst']);
+    expect(body.skills).toEqual(['web-fetch', 'delegate']);
+    expect(body).toHaveProperty('uptime');
+  });
+
+  it('returns 503 when database is down', async () => {
+    const failPool = {
+      query: async () => { throw new Error('connection refused'); },
+    } as unknown as Pool;
+
+    const failApp = Fastify();
+    failApp.register(healthRoutes, {
+      pool: failPool,
+      agentNames: ['coordinator'],
+      skillNames: [],
+    });
+    await failApp.ready();
+
+    const response = await failApp.inject({
+      method: 'GET',
+      url: '/api/health',
+    });
+
+    expect(response.statusCode).toBe(503);
+    const body = JSON.parse(response.body);
+    expect(body.status).toBe('degraded');
+    expect(body.database).toBe('disconnected');
+
+    await failApp.close();
+  });
+});

--- a/tests/unit/channels/http/health.test.ts
+++ b/tests/unit/channels/http/health.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import Fastify from 'fastify';
 import { healthRoutes } from '../../../../src/channels/http/routes/health.js';
 import type { Pool } from 'pg';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
 
 describe('GET /api/health', () => {
   const mockPool = {
@@ -13,6 +16,7 @@ describe('GET /api/health', () => {
   beforeAll(async () => {
     app.register(healthRoutes, {
       pool: mockPool,
+      logger,
       agentNames: ['coordinator', 'research-analyst'],
       skillNames: ['web-fetch', 'delegate'],
     });
@@ -46,6 +50,7 @@ describe('GET /api/health', () => {
     const failApp = Fastify();
     failApp.register(healthRoutes, {
       pool: failPool,
+      logger,
       agentNames: ['coordinator'],
       skillNames: [],
     });


### PR DESCRIPTION
## Summary

- Adds Fastify-based HTTP API with bearer token auth, CORS, and 64 KiB body limit
- **POST /api/messages** — send a message, wait for agent response (request-response via EventRouter)
- **GET /api/messages/stream** — SSE endpoint streaming outbound messages, skill invocations, and results with 30s heartbeat
- **GET /api/health** — database probe, registered agents/skills, uptime (unauthenticated for load balancers)
- **GET /api/agents/status** — agent registry snapshot
- **EventRouter pattern** — single shared bus subscriber per event type, dispatches to HTTP clients via Maps/Sets to prevent per-request subscriber leaks
- Wired into bootstrap with graceful shutdown (HTTP stops before DB pool closes)
- Config extended with `HTTP_PORT` and `API_TOKEN` (validated port range 1-65535)

## Test plan

- [ ] 120 tests passing across 25 test files (unit + integration)
- [ ] Typecheck clean (`tsc --noEmit`)
- [ ] Integration test exercises real EventBus → Dispatcher → AgentRuntime → EventRouter chain
- [ ] Auth unit tests: valid token, missing token, wrong token, no-token mode, timing-safe comparison
- [ ] Health endpoint tests: 200 ok + 503 degraded paths
- [ ] Smoke test: `curl -H "Authorization: Bearer $API_TOKEN" http://localhost:3000/api/health`