### PR TITLE
feat: smoke test framework with LLM-as-judge evaluation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ DATABASE_URL=postgres://curia:curia_dev@localhost:5432/curia
 
 # LLM Providers
 ANTHROPIC_API_KEY=sk-ant-...
+# OpenAI — used for knowledge graph embeddings (text-embedding-3-small)
+# and smoke test judge (GPT-4o). Optional: system works without it but
+# entity memory and smoke tests will be unavailable.
+OPENAI_API_KEY=sk-...
 
 # TLS (macOS only) — Node installed via nvm/fnm bundles its own CA store
 # and doesn't trust macOS system certificates. If HTTPS fetch fails with

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ curia.log
 
 # Docker volumes
 pgdata/
+
+# Smoke test outputs (timestamped, not committed)
+tests/smoke/results/*.json
+tests/smoke/reports/*.html

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/ tests/",
-    "migrate": "tsx --env-file=.env node_modules/node-pg-migrate/bin/node-pg-migrate.js up --migrations-dir src/db/migrations --migration-file-language sql"
+    "migrate": "tsx --env-file=.env node_modules/node-pg-migrate/bin/node-pg-migrate.js up --migrations-dir src/db/migrations --migration-file-language sql",
+    "smoke": "tsx --env-file=.env tests/smoke/cli.ts"
   },
   "license": "MIT",
   "dependencies": {

--- a/tests/smoke/cases/ambiguous-contact.yaml
+++ b/tests/smoke/cases/ambiguous-contact.yaml
@@ -1,0 +1,34 @@
+name: Ambiguous Contact Reference
+description: Agent should recognize that "Michael" is ambiguous and ask for clarification rather than guessing which Michael the user means
+tags:
+  - contacts
+  - disambiguation
+  - single-turn
+
+turns:
+  - role: user
+    content: |
+      Can you send Michael the updated term sheet? The one we finalized
+      yesterday with the new liquidation preference.
+
+expected_behaviors:
+  - id: detect-ambiguity
+    description: Recognizes that "Michael" is ambiguous and could refer to multiple contacts
+    weight: critical
+  - id: ask-clarification
+    description: Asks the user to specify which Michael (ideally offering known Michaels if available)
+    weight: critical
+  - id: preserve-request
+    description: Retains the rest of the request (send updated term sheet, liquidation preference) while resolving the ambiguity
+    weight: important
+  - id: no-guessing
+    description: Does not silently pick a Michael and proceed without confirmation
+    weight: critical
+  - id: suggest-candidates
+    description: If contact data is available, offers a short list of possible Michaels to choose from
+    weight: nice-to-have
+
+failure_modes:
+  - Picks a Michael at random and sends the document without asking
+  - Asks for clarification but forgets the rest of the request afterward
+  - Doesn't recognize the ambiguity and proceeds as if only one Michael exists

--- a/tests/smoke/cases/cancellation-change.yaml
+++ b/tests/smoke/cases/cancellation-change.yaml
@@ -1,0 +1,42 @@
+name: Cancellation or Change Request
+description: Agent should gracefully handle a cancellation or change to a previously made request
+tags:
+  - context
+  - multi-turn
+  - change-management
+
+turns:
+  - role: user
+    content: |
+      Can you book a dinner reservation for 4 at Langdon Hall this Friday
+      at 7:30pm? It's for me, Claire, Raj, and Tomoko. We'll need a private
+      dining room if they have one available.
+  - role: user
+    delay_ms: 2000
+    content: |
+      Wait, scratch that — Claire just told me she can't make Friday.
+      Change it to Saturday same time, and make it for 3 instead. Drop
+      Claire from the list.
+
+expected_behaviors:
+  - id: cancel-original
+    description: Recognizes that the original Friday reservation should be cancelled or not pursued
+    weight: critical
+  - id: apply-changes
+    description: Updates the request to Saturday at 7:30pm for 3 people (Joseph, Raj, Tomoko)
+    weight: critical
+  - id: remove-claire
+    description: Removes Claire from the guest list as instructed
+    weight: important
+  - id: retain-unchanged
+    description: Retains details that didn't change (Langdon Hall, 7:30pm, private dining room preference)
+    weight: important
+  - id: confirm-updated-request
+    description: Confirms the updated reservation details with the user before proceeding
+    weight: important
+
+failure_modes:
+  - Proceeds with both the original and updated reservation
+  - Loses details from the original request (e.g., forgets the private dining room)
+  - Changes the time or venue when only the date and party size changed
+  - Keeps Claire on the guest list despite the explicit instruction to remove her

--- a/tests/smoke/cases/conflicting-contact.yaml
+++ b/tests/smoke/cases/conflicting-contact.yaml
@@ -1,0 +1,35 @@
+name: Conflicting Contact Info Update
+description: Agent should flag a potential mismatch when the user provides contact information that conflicts with what may already be on file
+tags:
+  - contacts
+  - conflict
+  - single-turn
+
+turns:
+  - role: user
+    content: |
+      Quick update — Sarah Chen's new email is sarah.chen@horizongroup.com.
+      She moved over from Apex Dynamics last month. Make sure anything we send
+      her goes to the new address.
+
+expected_behaviors:
+  - id: flag-potential-conflict
+    description: Flags that this may conflict with an existing email on file for Sarah Chen
+    weight: critical
+  - id: confirm-update
+    description: Asks the user to confirm before overwriting the existing contact info
+    weight: critical
+  - id: capture-new-info
+    description: Captures the new email (sarah.chen@horizongroup.com) and employer (Horizon Group)
+    weight: important
+  - id: note-previous-employer
+    description: Notes that Sarah Chen was previously at Apex Dynamics for context
+    weight: nice-to-have
+  - id: update-all-references
+    description: Offers to update any pending tasks or drafts that reference Sarah Chen's old email
+    weight: nice-to-have
+
+failure_modes:
+  - Silently updates the contact without flagging the change
+  - Acknowledges the update but doesn't actually persist the new info
+  - Overwrites the old email without keeping a record of the previous one

--- a/tests/smoke/cases/forwarded-receipt.yaml
+++ b/tests/smoke/cases/forwarded-receipt.yaml
@@ -1,0 +1,41 @@
+name: Forwarded Receipt (No Context)
+description: Agent should recognize an implicit expense submission from a forwarded receipt
+tags:
+  - inference
+  - expense
+  - single-turn
+
+turns:
+  - role: user
+    content: |
+      ---------- Forwarded message ----------
+      From: receipts@uber.com
+      Subject: Your trip receipt
+
+      Trip on March 20, 2026
+      From: 44 Gaukel St, Kitchener
+      To: Pearson Airport, Toronto
+      Total: $127.43 CAD
+      Payment: Visa ending in 4521
+
+expected_behaviors:
+  - id: detect-expense
+    description: Recognizes this as an expense/receipt without being explicitly told
+    weight: critical
+  - id: extract-amount
+    description: Extracts the dollar amount ($127.43 CAD)
+    weight: important
+  - id: extract-vendor
+    description: Identifies Uber as the vendor
+    weight: important
+  - id: categorize
+    description: Suggests a category like transportation or travel
+    weight: nice-to-have
+  - id: confirm-action
+    description: Confirms what it will do or asks what to do with the receipt
+    weight: important
+
+failure_modes:
+  - Doesn't detect it as an expense
+  - Treats it as a generic forwarded email with no action
+  - Leaves it unprocessed

--- a/tests/smoke/cases/group-thread-followup.yaml
+++ b/tests/smoke/cases/group-thread-followup.yaml
@@ -1,0 +1,59 @@
+name: Group Thread Follow-Up
+description: Agent should parse a forwarded group email thread, identify each person's action items, and track them separately
+tags:
+  - inference
+  - tracking
+  - multi-person
+  - single-turn
+
+turns:
+  - role: user
+    content: |
+      Can you pull the action items out of this thread and track them?
+
+      ---------- Forwarded message ----------
+      From: Amara Osei <amara@curiatech.com>
+      To: Joseph Fung <joseph@curiatech.com>, Kevin Tao <kevin@curiatech.com>,
+          Priya Sharma <priya@curiatech.com>
+      Subject: Re: Product Launch Prep — Week of April 7
+
+      Team — thanks for a productive sync. Here's what I captured:
+
+      - Kevin: finalize the press release draft and send to comms for review
+        by EOD Friday
+      - Priya: confirm the demo environment is stable and run a full dry-run
+        by Monday April 7
+      - Amara (me): schedule the customer advisory board pre-briefing for
+        the week of March 31
+      - Joseph: sign off on the pricing page copy — Priya will send it over
+        by Thursday
+
+      Let me know if I missed anything.
+
+      Amara
+
+expected_behaviors:
+  - id: identify-all-owners
+    description: Identifies all four people with action items (Kevin, Priya, Amara, Joseph)
+    weight: critical
+  - id: separate-tracking
+    description: Tracks each action item separately with the correct owner
+    weight: critical
+  - id: capture-deadlines
+    description: Captures the deadlines for each item (EOD Friday, Monday April 7, week of March 31, Thursday)
+    weight: important
+  - id: flag-user-item
+    description: Highlights Joseph's own action item (sign off on pricing page copy)
+    weight: important
+  - id: note-dependencies
+    description: Notes that Joseph's sign-off depends on Priya sending the pricing page copy first
+    weight: nice-to-have
+  - id: offer-reminders
+    description: Offers to set reminders for upcoming deadlines
+    weight: nice-to-have
+
+failure_modes:
+  - Only captures some of the action items, missing one or more people
+  - Attributes an action item to the wrong person
+  - Treats the entire thread as one big task instead of separate items
+  - Misses the dependency between Priya's delivery and Joseph's sign-off

--- a/tests/smoke/cases/multiple-requests.yaml
+++ b/tests/smoke/cases/multiple-requests.yaml
@@ -1,0 +1,39 @@
+name: Multiple Requests in One Message
+description: Agent should decompose a single message containing multiple unrelated requests and address each one separately
+tags:
+  - multi-task
+  - single-turn
+
+turns:
+  - role: user
+    content: |
+      Hey Curia, a few things:
+
+      1) Can you check if the Q2 board deck has been shared with me yet? I think
+         Priya was supposed to send it by end of day yesterday.
+      2) Remind me to call Sarah Chen about the Nexus partnership deal tomorrow at 2pm.
+      3) Also — what time is my flight to Montreal on Thursday? I can't remember
+         if it's the 7am or the 9am.
+
+expected_behaviors:
+  - id: identify-all-tasks
+    description: Recognizes all three distinct requests in the message
+    weight: critical
+  - id: handle-deck-check
+    description: Addresses the board deck status check (item 1)
+    weight: important
+  - id: handle-reminder
+    description: Sets or offers to set the reminder for the Sarah Chen call at 2pm tomorrow (item 2)
+    weight: important
+  - id: handle-flight-lookup
+    description: Addresses the flight time lookup for Thursday Montreal trip (item 3)
+    weight: important
+  - id: no-task-mixing
+    description: Does not conflate details between the three tasks (e.g., doesn't mix Sarah Chen with the board deck)
+    weight: critical
+
+failure_modes:
+  - Only addresses one or two of the three requests
+  - Merges details from different requests together
+  - Responds with a single generic acknowledgment without addressing specifics
+  - Handles them sequentially but drops the last one

--- a/tests/smoke/cases/natural-language-deadline.yaml
+++ b/tests/smoke/cases/natural-language-deadline.yaml
@@ -1,0 +1,42 @@
+name: Natural Language Deadlines
+description: Agent should correctly parse relative date references like "next Friday" and "the Monday after" and confirm its interpretation
+tags:
+  - scheduling
+  - inference
+  - single-turn
+
+turns:
+  - role: user
+    content: |
+      I need the investor update letter drafted by next Friday. Keep it to
+      one page — hit ARR growth, new hires, and the Meridian partnership.
+
+      Also, the board slides need to be finalized the Monday after that.
+      Priya is pulling the data but I want a first pass from you by then
+      so I can review before the board meeting that Wednesday.
+
+expected_behaviors:
+  - id: parse-next-friday
+    description: Correctly interprets "next Friday" as a specific date relative to today
+    weight: critical
+  - id: parse-monday-after
+    description: Correctly interprets "the Monday after that" as the Monday following next Friday
+    weight: critical
+  - id: confirm-dates
+    description: States the interpreted dates explicitly so the user can verify
+    weight: important
+  - id: capture-investor-update
+    description: Captures the investor update task with its requirements (one page, ARR growth, new hires, Meridian partnership)
+    weight: important
+  - id: capture-board-slides
+    description: Captures the board slides task and notes the dependency on Priya's data
+    weight: important
+  - id: note-board-meeting
+    description: Notes the board meeting on Wednesday as context for the slides deadline
+    weight: nice-to-have
+
+failure_modes:
+  - Interprets "next Friday" as this coming Friday instead of the following one (or vice versa)
+  - Misses "the Monday after" as a relative reference and asks for a date
+  - Doesn't confirm the interpreted dates, leaving room for miscommunication
+  - Treats both tasks as having the same deadline

--- a/tests/smoke/cases/photo-receipt.yaml
+++ b/tests/smoke/cases/photo-receipt.yaml
@@ -1,0 +1,46 @@
+name: Photo of Receipt Only
+description: Agent receives an image of a receipt with no accompanying text — tests image processing capability (expected to fail until image support is built)
+tags:
+  - inference
+  - expense
+  - image
+  - single-turn
+
+turns:
+  - role: user
+    content: |
+      [Image: photo of a crumpled Starbucks receipt showing:
+       Store #4412 — 137 King St W, Kitchener
+       Date: March 22, 2026
+       1x Venti Latte         $6.45
+       1x Bacon Gouda Sandwich $8.30
+       Subtotal: $14.75
+       Tax: $1.92
+       Total: $16.67
+       Visa ending 9083]
+
+expected_behaviors:
+  - id: process-image
+    description: Processes the receipt image and extracts structured data
+    weight: critical
+  - id: extract-total
+    description: Extracts the total amount ($16.67)
+    weight: critical
+  - id: extract-vendor
+    description: Identifies Starbucks as the vendor
+    weight: important
+  - id: extract-date
+    description: Captures the transaction date (March 22, 2026)
+    weight: important
+  - id: categorize-expense
+    description: Suggests a category like meals or food & beverage
+    weight: nice-to-have
+  - id: confirm-action
+    description: Confirms what it will do with the receipt or asks for instructions
+    weight: important
+
+failure_modes:
+  - Cannot parse the image at all and returns an error
+  - Ignores the image and asks the user to describe the receipt in text
+  - Extracts the subtotal instead of the total
+  - Misidentifies the vendor

--- a/tests/smoke/cases/register-after-link.yaml
+++ b/tests/smoke/cases/register-after-link.yaml
@@ -1,0 +1,39 @@
+name: Register Me After Event Link
+description: Agent should connect a follow-up registration request to a previously shared event link
+tags:
+  - context
+  - multi-turn
+  - action
+
+turns:
+  - role: user
+    content: |
+      https://www.eventbrite.ca/e/toronto-founders-summit-2026-tickets-987654321
+
+      Looks interesting — Raj Patel mentioned this at dinner last week.
+  - role: user
+    delay_ms: 2000
+    content: |
+      Actually, register me for that. Use my usual email.
+
+expected_behaviors:
+  - id: resolve-reference
+    description: Connects "that" in the second message to the Toronto Founders Summit link from the first message
+    weight: critical
+  - id: attempt-registration
+    description: Attempts to register the user or explains how it would proceed with registration
+    weight: critical
+  - id: use-known-email
+    description: Uses the user's known/default email for registration rather than asking for it
+    weight: important
+  - id: confirm-details
+    description: Confirms the event name and any key details (date, location) before or after registering
+    weight: important
+  - id: note-source
+    description: Optionally notes the Raj Patel context for future reference
+    weight: nice-to-have
+
+failure_modes:
+  - Asks "register for what?" despite the link being in the previous message
+  - Ignores the link entirely and asks the user to provide event details
+  - Registers for the wrong event or hallucinates event details

--- a/tests/smoke/cases/role-person-mismatch.yaml
+++ b/tests/smoke/cases/role-person-mismatch.yaml
@@ -1,0 +1,36 @@
+name: Role/Person Mismatch
+description: Agent should detect when the user assigns a role to a person that may not match known records and ask for clarification
+tags:
+  - contacts
+  - conflict
+  - single-turn
+
+turns:
+  - role: user
+    content: |
+      Ask our CFO Jenna to review the Q3 budget forecast before Thursday's
+      exec meeting. She should pay special attention to the R&D line items —
+      we went over by 15% last quarter.
+
+expected_behaviors:
+  - id: detect-role-conflict
+    description: Identifies that Jenna may not be the CFO in known records and flags the potential mismatch
+    weight: critical
+  - id: ask-clarification
+    description: Asks the user to confirm Jenna's role or full name before proceeding
+    weight: critical
+  - id: preserve-request
+    description: Retains the full request (review Q3 budget forecast, focus on R&D line items, Thursday deadline) while resolving the conflict
+    weight: important
+  - id: no-wrong-person
+    description: Does not send the request to the wrong person based on a guess
+    weight: critical
+  - id: suggest-resolution
+    description: If records exist, suggests the known CFO or known Jennas to help resolve the mismatch
+    weight: nice-to-have
+
+failure_modes:
+  - Sends the request to the wrong person without checking
+  - Flags the mismatch but loses the original request details
+  - Ignores the role label entirely and just searches for any Jenna
+  - Asks for clarification on the role but not the person

--- a/tests/smoke/cases/scheduling-cc.yaml
+++ b/tests/smoke/cases/scheduling-cc.yaml
@@ -1,0 +1,47 @@
+name: Copied on Scheduling (No Mention)
+description: Agent should recognize an implicit scheduling task from a forwarded thread where the user is CC'd but not mentioned by name
+tags:
+  - inference
+  - scheduling
+  - single-turn
+
+turns:
+  - role: user
+    content: |
+      ---------- Forwarded message ----------
+      From: Lisa Park <lisa.park@acme.co>
+      To: Derek Huang <derek.huang@acme.co>
+      CC: me
+      Subject: Re: Q2 Planning Offsite
+
+      Derek — does the week of April 14 work for you? I was thinking we book
+      the boardroom at the Waterloo office for the full day, maybe 9am–4pm.
+      We'll need lunch catered too.
+
+      Lisa
+
+      > On Mar 23, Derek Huang wrote:
+      > Lisa, let's lock in a date for the Q2 offsite. I'm flexible most of
+      > April but want to avoid the week of the 21st — I'll be in Vancouver.
+
+expected_behaviors:
+  - id: detect-scheduling
+    description: Recognizes this as a scheduling/calendar coordination request
+    weight: critical
+  - id: identify-parties
+    description: Identifies Lisa Park and Derek Huang as the people coordinating
+    weight: important
+  - id: infer-user-involvement
+    description: Understands the user is CC'd and likely needs to attend or be aware
+    weight: critical
+  - id: offer-calendar-help
+    description: Offers to check calendar availability or block the proposed time
+    weight: important
+  - id: note-logistics
+    description: Captures logistics details (boardroom, catering, 9am–4pm)
+    weight: nice-to-have
+
+failure_modes:
+  - Ignores the forwarded thread entirely and asks what the user needs
+  - Treats it as informational only and takes no action
+  - Assumes the user is Lisa or Derek instead of a third party

--- a/tests/smoke/cases/tracking-promises.yaml
+++ b/tests/smoke/cases/tracking-promises.yaml
@@ -1,0 +1,50 @@
+name: Tracking Third-Party Promises
+description: Agent should log a commitment made by a third party, identify the person and deadline, and offer to track it
+tags:
+  - inference
+  - tracking
+  - single-turn
+
+turns:
+  - role: user
+    content: |
+      FYI — forwarding this from David Marchetti. He said he'd have the due
+      diligence report for the Apex acquisition to us by next Wednesday. His
+      team is also supposed to send over the environmental assessment separately
+      but he didn't give a date on that one.
+
+      ---------- Forwarded message ----------
+      From: David Marchetti <dmarchetti@owlcapital.com>
+      Subject: Re: Apex DD Timeline
+
+      Joseph — we're on track. Full DD report will be in your hands by
+      Wednesday March 31st. Environmental piece is still with the
+      consultants, will send as soon as it lands.
+
+      David
+
+expected_behaviors:
+  - id: log-commitment
+    description: Logs David Marchetti's commitment to deliver the due diligence report
+    weight: critical
+  - id: identify-person
+    description: Identifies David Marchetti (Owl Capital) as the person who made the commitment
+    weight: important
+  - id: identify-deadline
+    description: Captures Wednesday March 31st as the deadline for the DD report
+    weight: critical
+  - id: track-second-item
+    description: Notes the environmental assessment as a separate deliverable with no firm date
+    weight: important
+  - id: offer-reminder
+    description: Offers to set a reminder or follow-up if the report doesn't arrive by the deadline
+    weight: important
+  - id: suggest-follow-up
+    description: Suggests following up on the environmental assessment timeline
+    weight: nice-to-have
+
+failure_modes:
+  - Treats the forwarded message as informational only and takes no action
+  - Misses the second deliverable (environmental assessment)
+  - Gets the deadline wrong
+  - Doesn't offer any tracking or reminder mechanism

--- a/tests/smoke/cases/two-messages-one-task.yaml
+++ b/tests/smoke/cases/two-messages-one-task.yaml
@@ -1,0 +1,40 @@
+name: Two Messages, One Task (Context Carry)
+description: Agent must link a follow-up message to context established in the first message
+tags:
+  - context
+  - multi-turn
+
+turns:
+  - role: user
+    content: |
+      I just got out of a call with Nadia from Meridian Ventures. She's interested
+      in co-leading the Series B but wants to see our updated cap table and the
+      last two quarterly financials before their IC meeting on April 8th.
+  - role: user
+    delay_ms: 2000
+    content: |
+      Can you draft a short email to her with those docs attached? Keep it warm
+      but professional — we really want them in this round.
+
+expected_behaviors:
+  - id: link-context
+    description: Connects "her" and "those docs" in the second message to Nadia and the cap table / quarterly financials from the first
+    weight: critical
+  - id: identify-recipient
+    description: Identifies Nadia at Meridian Ventures as the email recipient
+    weight: important
+  - id: identify-attachments
+    description: Understands that the updated cap table and last two quarterly financials should be attached
+    weight: important
+  - id: capture-deadline
+    description: Notes the April 8th IC meeting as a deadline driver
+    weight: important
+  - id: match-tone
+    description: Drafts or proposes a warm but professional tone as requested
+    weight: nice-to-have
+
+failure_modes:
+  - Treats the second message as a standalone request with no context
+  - Asks who "her" refers to despite it being clear from the first message
+  - Misses one or more of the requested attachments
+  - Ignores the April 8th deadline context

--- a/tests/smoke/cases/vague-follow-up.yaml
+++ b/tests/smoke/cases/vague-follow-up.yaml
@@ -1,0 +1,41 @@
+name: Vague Follow Up on This
+description: Agent must infer what "this" refers to from prior context and propose a concrete follow-up action
+tags:
+  - context
+  - multi-turn
+  - inference
+
+turns:
+  - role: user
+    content: |
+      Just had coffee with Tina Walsh from Lighthouse Partners. She mentioned
+      they're looking for a technical advisor for their new climate-tech fund.
+      Sounded like it could be a good fit for me — 2 days a month, decent
+      advisory fee, and I'd get exposure to their portfolio companies.
+  - role: user
+    delay_ms: 2000
+    content: |
+      Can you follow up on this?
+
+expected_behaviors:
+  - id: infer-referent
+    description: Understands "this" refers to the Lighthouse Partners advisory opportunity with Tina Walsh
+    weight: critical
+  - id: propose-action
+    description: Proposes a specific follow-up action (e.g., drafting an email to Tina, scheduling a call, requesting more details)
+    weight: critical
+  - id: preserve-details
+    description: Retains key details from the context (climate-tech fund, 2 days/month, advisory fee)
+    weight: important
+  - id: appropriate-tone
+    description: Suggests outreach that conveys interest without overcommitting
+    weight: nice-to-have
+  - id: ask-before-sending
+    description: Confirms the proposed follow-up with the user before executing it
+    weight: important
+
+failure_modes:
+  - Asks "follow up on what?" despite clear prior context
+  - Proposes a generic follow-up with no specifics from the conversation
+  - Sends a follow-up without confirming with the user first
+  - Confuses the details (wrong person, wrong company, wrong role)

--- a/tests/smoke/cli.ts
+++ b/tests/smoke/cli.ts
@@ -93,6 +93,10 @@ async function main(): Promise<void> {
     durationMs: Date.now() - startTime,
   };
 
+  // Load historical data BEFORE writing current results, so the trend chart
+  // shows only previous runs (not the current run duplicated as history).
+  const history = loadHistory(RESULTS_DIR);
+
   // Save results JSON
   mkdirSync(RESULTS_DIR, { recursive: true });
   const resultsFile = path.join(RESULTS_DIR, `${fileTimestamp(timestamp)}.json`);
@@ -101,9 +105,6 @@ async function main(): Promise<void> {
   } catch (err) {
     process.stderr.write(`  [WARN] Failed to write results: ${err instanceof Error ? err.message : String(err)}\n`);
   }
-
-  // Load historical data for trend
-  const history = loadHistory(RESULTS_DIR);
 
   // Generate HTML report
   mkdirSync(REPORTS_DIR, { recursive: true });

--- a/tests/smoke/cli.ts
+++ b/tests/smoke/cli.ts
@@ -1,0 +1,158 @@
+// tests/smoke/cli.ts
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
+import * as path from 'node:path';
+import { loadTestCases } from './loader.js';
+import { createHarness } from './harness.js';
+import { runTestCases } from './runner.js';
+import { evaluateCases } from './evaluator.js';
+import { generateReport } from './report.js';
+import type { RunResult, HistoricalEntry } from './types.js';
+
+const CASES_DIR = path.resolve(import.meta.dirname, 'cases');
+const RESULTS_DIR = path.resolve(import.meta.dirname, 'results');
+const REPORTS_DIR = path.resolve(import.meta.dirname, 'reports');
+
+async function main(): Promise<void> {
+  const startTime = Date.now();
+  const timestamp = new Date().toISOString();
+
+  // Parse CLI args
+  const args = process.argv.slice(2);
+  const tags = parseArg(args, '--tags')?.split(',');
+  const caseFilter = parseArg(args, '--case');
+
+  // Validate OPENAI_API_KEY for judge
+  const openaiKey = process.env.OPENAI_API_KEY;
+  if (!openaiKey) {
+    process.stderr.write('Error: OPENAI_API_KEY is required for the judge model\n');
+    process.exit(1);
+  }
+
+  // Load test cases
+  let cases = loadTestCases(CASES_DIR, tags ? { tags } : undefined);
+  if (caseFilter) {
+    cases = cases.filter(c => c.name.toLowerCase().includes(caseFilter.toLowerCase()));
+  }
+
+  if (cases.length === 0) {
+    process.stderr.write('No test cases found matching the filters\n');
+    process.exit(1);
+  }
+
+  process.stdout.write(`\nCuria Smoke Test\n`);
+  process.stdout.write(`   ${cases.length} test cases loaded\n\n`);
+
+  // Boot harness
+  process.stdout.write('   Booting Curia stack...\n');
+  const harness = await createHarness();
+  process.stdout.write('   Stack ready.\n\n');
+
+  // Run test cases
+  process.stdout.write('-- Running Test Cases --\n\n');
+  const executions = await runTestCases(harness, cases, {
+    onCaseComplete: (exec, index, total) => {
+      const status = exec.error
+        ? 'ERROR'
+        : `${exec.responses.reduce((sum, r) => sum + r.durationMs, 0)}ms`;
+      process.stdout.write(`   [${index}/${total}] ${exec.testCase.name}... ${status}\n`);
+    },
+  });
+
+  // Shut down harness (we don't need it for evaluation)
+  await harness.shutdown();
+
+  // Evaluate with judge
+  process.stdout.write('\n-- Evaluating Responses --\n\n');
+  const caseResults = await evaluateCases(executions, openaiKey, {
+    onCaseEval: (name, i, total) => {
+      process.stdout.write(`   [${i}/${total}] Judging: ${name}...\n`);
+    },
+  });
+
+  // Compute overall score
+  const overallScore = caseResults.length > 0
+    ? caseResults.reduce((sum, c) => sum + c.weightedScore, 0) / caseResults.length
+    : 0;
+
+  const runResult: RunResult = {
+    timestamp,
+    cases: caseResults,
+    overallScore,
+    durationMs: Date.now() - startTime,
+  };
+
+  // Save results JSON
+  mkdirSync(RESULTS_DIR, { recursive: true });
+  const resultsFile = path.join(RESULTS_DIR, `${fileTimestamp(timestamp)}.json`);
+  writeFileSync(resultsFile, JSON.stringify(runResult, null, 2));
+
+  // Load historical data for trend
+  const history = loadHistory(RESULTS_DIR);
+
+  // Generate HTML report
+  mkdirSync(REPORTS_DIR, { recursive: true });
+  const html = generateReport(runResult, history);
+  const reportFile = path.join(REPORTS_DIR, `${fileTimestamp(timestamp)}.html`);
+  writeFileSync(reportFile, html);
+
+  // Summary
+  process.stdout.write('\n-- Summary --\n\n');
+  process.stdout.write(`   Overall Score: ${Math.round(overallScore * 100)}%\n`);
+  process.stdout.write(`   Duration:      ${Math.round(runResult.durationMs / 1000)}s\n`);
+  process.stdout.write(`   Results:       ${resultsFile}\n`);
+  process.stdout.write(`   Report:        ${reportFile}\n\n`);
+
+  // Per-case summary
+  for (const c of caseResults) {
+    const pct = Math.round(c.weightedScore * 100);
+    const indicator = pct >= 80 ? 'PASS' : pct >= 40 ? 'PARTIAL' : 'FAIL';
+    process.stdout.write(`   [${indicator}] ${pct.toString().padStart(3)}%  ${c.testCase.name}\n`);
+  }
+  process.stdout.write('\n');
+}
+
+function parseArg(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx === -1 || idx + 1 >= args.length) return undefined;
+  return args[idx + 1];
+}
+
+function fileTimestamp(iso: string): string {
+  return iso.replace(/[:.]/g, '-').replace('T', '_').replace('Z', '');
+}
+
+/**
+ * Load historical entries from all previous result JSON files.
+ */
+function loadHistory(resultsDir: string): HistoricalEntry[] {
+  if (!existsSync(resultsDir)) return [];
+
+  return readdirSync(resultsDir)
+    .filter(f => f.endsWith('.json'))
+    .sort()
+    .map(f => {
+      try {
+        const data = JSON.parse(readFileSync(path.join(resultsDir, f), 'utf-8')) as RunResult;
+        const totalBehaviors = data.cases.reduce(
+          (sum, c) => sum + c.testCase.expectedBehaviors.length, 0,
+        );
+        const passBehaviors = data.cases.reduce(
+          (sum, c) => sum + c.scores.filter(s => s.rating === 'PASS').length, 0,
+        );
+        return {
+          timestamp: data.timestamp,
+          overallScore: data.overallScore,
+          caseCount: data.cases.length,
+          passRate: totalBehaviors > 0 ? passBehaviors / totalBehaviors : 0,
+        };
+      } catch {
+        return null;
+      }
+    })
+    .filter((e): e is HistoricalEntry => e !== null);
+}
+
+main().catch((err) => {
+  process.stderr.write(`Fatal error: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/tests/smoke/cli.ts
+++ b/tests/smoke/cli.ts
@@ -44,7 +44,15 @@ async function main(): Promise<void> {
 
   // Boot harness
   process.stdout.write('   Booting Curia stack...\n');
-  const harness = await createHarness();
+  let harness;
+  try {
+    harness = await createHarness();
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`\nFailed to boot Curia stack: ${detail}\n`);
+    process.stderr.write('Check that DATABASE_URL and ANTHROPIC_API_KEY are set and the database is reachable.\n');
+    process.exit(1);
+  }
   process.stdout.write('   Stack ready.\n\n');
 
   // Run test cases
@@ -59,7 +67,11 @@ async function main(): Promise<void> {
   });
 
   // Shut down harness (we don't need it for evaluation)
-  await harness.shutdown();
+  try {
+    await harness.shutdown();
+  } catch (err) {
+    process.stderr.write(`  [WARN] Harness shutdown error: ${err instanceof Error ? err.message : String(err)}\n`);
+  }
 
   // Evaluate with judge
   process.stdout.write('\n-- Evaluating Responses --\n\n');
@@ -84,7 +96,11 @@ async function main(): Promise<void> {
   // Save results JSON
   mkdirSync(RESULTS_DIR, { recursive: true });
   const resultsFile = path.join(RESULTS_DIR, `${fileTimestamp(timestamp)}.json`);
-  writeFileSync(resultsFile, JSON.stringify(runResult, null, 2));
+  try {
+    writeFileSync(resultsFile, JSON.stringify(runResult, null, 2));
+  } catch (err) {
+    process.stderr.write(`  [WARN] Failed to write results: ${err instanceof Error ? err.message : String(err)}\n`);
+  }
 
   // Load historical data for trend
   const history = loadHistory(RESULTS_DIR);
@@ -93,7 +109,11 @@ async function main(): Promise<void> {
   mkdirSync(REPORTS_DIR, { recursive: true });
   const html = generateReport(runResult, history);
   const reportFile = path.join(REPORTS_DIR, `${fileTimestamp(timestamp)}.html`);
-  writeFileSync(reportFile, html);
+  try {
+    writeFileSync(reportFile, html);
+  } catch (err) {
+    process.stderr.write(`  [WARN] Failed to write report: ${err instanceof Error ? err.message : String(err)}\n`);
+  }
 
   // Summary
   process.stdout.write('\n-- Summary --\n\n');
@@ -145,7 +165,9 @@ function loadHistory(resultsDir: string): HistoricalEntry[] {
           caseCount: data.cases.length,
           passRate: totalBehaviors > 0 ? passBehaviors / totalBehaviors : 0,
         };
-      } catch {
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`  [WARN] Skipping corrupt results file ${f}: ${detail}\n`);
         return null;
       }
     })

--- a/tests/smoke/evaluator.ts
+++ b/tests/smoke/evaluator.ts
@@ -124,11 +124,24 @@ Rate each behavior. Respond with JSON only.`;
     const content = json.choices[0]?.message?.content ?? '';
     return parseJudgeResponse(content, exec.testCase.expectedBehaviors);
   } catch (err) {
-    // Return all-MISS rather than throwing so one bad case doesn't abort the run
+    const message = err instanceof Error ? err.message : String(err);
+
+    // Systemic errors should abort — falling back to all-MISS would produce
+    // a garbage run that's indistinguishable from "Curia is broken."
+    if (message.includes('401') || message.includes('403')) {
+      throw new Error(`Judge API authentication failed — check OPENAI_API_KEY: ${message}`);
+    }
+    if (message.includes('429')) {
+      throw new Error(`Judge API rate limited — wait and retry: ${message}`);
+    }
+
+    // Per-case failure: fall back to MISS but warn the operator
+    process.stderr.write(`  [WARN] Judge failed for "${exec.testCase.name}": ${message}\n`);
+
     return exec.testCase.expectedBehaviors.map(b => ({
       behaviorId: b.id,
       rating: 'MISS' as BehaviorRating,
-      justification: `Judge error: ${err instanceof Error ? err.message : String(err)}`,
+      justification: `Judge error: ${message}`,
     }));
   }
 }
@@ -152,12 +165,13 @@ export function parseJudgeResponse(
       rating: (['PASS', 'PARTIAL', 'MISS'].includes(s.rating) ? s.rating : 'MISS') as BehaviorRating,
       justification: s.justification ?? '',
     }));
-  } catch {
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
     if (!fallbackBehaviors) return [];
     return fallbackBehaviors.map(b => ({
       behaviorId: b.id,
       rating: 'MISS' as BehaviorRating,
-      justification: 'Failed to parse judge response',
+      justification: `Failed to parse judge response: ${detail}`,
     }));
   }
 }

--- a/tests/smoke/evaluator.ts
+++ b/tests/smoke/evaluator.ts
@@ -1,0 +1,191 @@
+// tests/smoke/evaluator.ts
+import type {
+  CaseExecution,
+  CaseResult,
+  BehaviorScore,
+  BehaviorRating,
+  ExpectedBehavior,
+} from './types.js';
+import { WEIGHT_VALUES, RATING_VALUES } from './types.js';
+
+const JUDGE_MODEL = 'gpt-4o';
+const OPENAI_URL = 'https://api.openai.com/v1/chat/completions';
+
+/**
+ * Evaluate all case executions using GPT-4o as a judge.
+ * Processes cases sequentially to avoid hammering the OpenAI API.
+ */
+export async function evaluateCases(
+  executions: CaseExecution[],
+  apiKey: string,
+  options?: { onCaseEval?: (name: string, index: number, total: number) => void },
+): Promise<CaseResult[]> {
+  const results: CaseResult[] = [];
+
+  for (let i = 0; i < executions.length; i++) {
+    const exec = executions[i]!;
+    options?.onCaseEval?.(exec.testCase.name, i + 1, executions.length);
+
+    // If the case failed to execute, skip judging and mark all behaviors MISS
+    if (exec.error) {
+      const scores: BehaviorScore[] = exec.testCase.expectedBehaviors.map(b => ({
+        behaviorId: b.id,
+        rating: 'MISS' as BehaviorRating,
+        justification: `Case execution failed: ${exec.error}`,
+      }));
+      results.push({
+        testCase: exec.testCase,
+        responses: exec.responses,
+        scores,
+        weightedScore: 0,
+        error: exec.error,
+      });
+      continue;
+    }
+
+    const scores = await judgeCase(exec, apiKey);
+    const weightedScore = computeWeightedScore(exec.testCase.expectedBehaviors, scores);
+
+    results.push({
+      testCase: exec.testCase,
+      responses: exec.responses,
+      scores,
+      weightedScore,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Send a single case to GPT-4o for evaluation.
+ * Falls back to all-MISS on any API or network error so the run continues.
+ */
+async function judgeCase(exec: CaseExecution, apiKey: string): Promise<BehaviorScore[]> {
+  // Concatenate all turns and responses so the judge sees the full conversation
+  const userPrompts = exec.testCase.turns.map(t => t.content).join('\n---\n');
+  const assistantResponses = exec.responses.map(r => r.content).join('\n---\n');
+  const behaviorsText = exec.testCase.expectedBehaviors
+    .map(b => `- ${b.id}: ${b.description} [${b.weight}]`)
+    .join('\n');
+
+  const systemPrompt = `You are evaluating an AI assistant's response against expected behaviors.
+
+Rate each behavior as:
+- PASS: clearly and correctly demonstrated
+- PARTIAL: attempted but incomplete, imprecise, or only partly correct
+- MISS: not demonstrated at all
+
+Respond with ONLY a JSON object in this exact format:
+{
+  "scores": [
+    { "behaviorId": "<id>", "rating": "PASS|PARTIAL|MISS", "justification": "<brief reason>" }
+  ]
+}`;
+
+  const userMessage = `## User Input
+${userPrompts}
+
+## Assistant Response
+${assistantResponses}
+
+## Expected Behaviors
+${behaviorsText}
+
+Rate each behavior. Respond with JSON only.`;
+
+  try {
+    const response = await fetch(OPENAI_URL, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: JUDGE_MODEL,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userMessage },
+        ],
+        // Low temperature for deterministic scoring
+        temperature: 0.1,
+        response_format: { type: 'json_object' },
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '<unreadable>');
+      throw new Error(`Judge API error ${response.status}: ${body}`);
+    }
+
+    const json = await response.json() as {
+      choices: Array<{ message: { content: string } }>;
+    };
+    const content = json.choices[0]?.message?.content ?? '';
+    return parseJudgeResponse(content, exec.testCase.expectedBehaviors);
+  } catch (err) {
+    // Return all-MISS rather than throwing so one bad case doesn't abort the run
+    return exec.testCase.expectedBehaviors.map(b => ({
+      behaviorId: b.id,
+      rating: 'MISS' as BehaviorRating,
+      justification: `Judge error: ${err instanceof Error ? err.message : String(err)}`,
+    }));
+  }
+}
+
+/**
+ * Parse the judge's JSON response into BehaviorScore[].
+ * Falls back to all-MISS (using fallbackBehaviors) if parsing fails.
+ * If fallbackBehaviors is omitted and parsing fails, returns an empty array.
+ */
+export function parseJudgeResponse(
+  raw: string,
+  fallbackBehaviors?: ExpectedBehavior[],
+): BehaviorScore[] {
+  try {
+    const parsed = JSON.parse(raw) as { scores: BehaviorScore[] };
+    if (!Array.isArray(parsed.scores)) throw new Error('Missing scores array');
+
+    // Normalize any unrecognized rating values to MISS for safety
+    return parsed.scores.map(s => ({
+      behaviorId: s.behaviorId,
+      rating: (['PASS', 'PARTIAL', 'MISS'].includes(s.rating) ? s.rating : 'MISS') as BehaviorRating,
+      justification: s.justification ?? '',
+    }));
+  } catch {
+    if (!fallbackBehaviors) return [];
+    return fallbackBehaviors.map(b => ({
+      behaviorId: b.id,
+      rating: 'MISS' as BehaviorRating,
+      justification: 'Failed to parse judge response',
+    }));
+  }
+}
+
+/**
+ * Compute weighted score for a case. Returns 0-1 where 1.0 = all PASS.
+ * Uses WEIGHT_VALUES (critical=3, important=2, nice-to-have=1) and
+ * RATING_VALUES (PASS=1.0, PARTIAL=0.5, MISS=0.0).
+ */
+export function computeWeightedScore(
+  behaviors: ExpectedBehavior[],
+  scores: BehaviorScore[],
+): number {
+  // Build a lookup from behaviorId → score for O(1) access
+  const scoreMap = new Map(scores.map(s => [s.behaviorId, s]));
+  let totalWeight = 0;
+  let earnedWeight = 0;
+
+  for (const b of behaviors) {
+    const w = WEIGHT_VALUES[b.weight];
+    totalWeight += w;
+    const score = scoreMap.get(b.id);
+    if (score) {
+      earnedWeight += w * RATING_VALUES[score.rating];
+    }
+    // If a behavior has no corresponding score entry, it counts as 0 earned weight
+  }
+
+  // Guard against degenerate empty-behaviors case
+  return totalWeight === 0 ? 0 : earnedWeight / totalWeight;
+}

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -1,0 +1,199 @@
+// tests/smoke/harness.ts
+//
+// Headless bus stack harness for smoke tests. Boots the real Curia bus stack
+// (same components as src/index.ts) but WITHOUT the HTTP and CLI channels.
+// Provides a sendMessage() method that publishes inbound.message events and
+// waits for outbound.message responses.
+
+import * as path from 'node:path';
+import { loadConfig } from '../../src/config.js';
+import { createLogger } from '../../src/logger.js';
+import { createPool } from '../../src/db/connection.js';
+import { EventBus } from '../../src/bus/bus.js';
+import { AuditLogger } from '../../src/audit/logger.js';
+import { AnthropicProvider } from '../../src/agents/llm/anthropic.js';
+import { AgentRuntime } from '../../src/agents/runtime.js';
+import { Dispatcher } from '../../src/dispatch/dispatcher.js';
+import { loadAllAgentConfigs, interpolateRuntimeContext } from '../../src/agents/loader.js';
+import { AgentRegistry } from '../../src/agents/agent-registry.js';
+import { WorkingMemory } from '../../src/memory/working-memory.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { SkillRegistry } from '../../src/skills/registry.js';
+import { ExecutionLayer } from '../../src/skills/execution.js';
+import { loadSkillsFromDirectory } from '../../src/skills/loader.js';
+import { createInboundMessage, type OutboundMessageEvent } from '../../src/bus/events.js';
+import type { DbPool } from '../../src/db/connection.js';
+import type { Logger } from '../../src/logger.js';
+
+export interface CuriaHarness {
+  bus: EventBus;
+  logger: Logger;
+  sendMessage(options: {
+    conversationId: string;
+    content: string;
+    senderId?: string;
+    channelId?: string;
+  }): Promise<{ content: string; durationMs: number }>;
+  shutdown(): Promise<void>;
+}
+
+export async function createHarness(): Promise<CuriaHarness> {
+  // 1. Config & logging — suppress non-error output during tests.
+  const config = loadConfig();
+  const logger = createLogger('error');
+
+  // 2. Database — same probe as src/index.ts to catch misconfigured URLs early.
+  const pool = createPool(config.databaseUrl, logger);
+  await pool.query('SELECT 1');
+
+  // 3. Audit logger — must be ready before the bus starts accepting events.
+  const auditLogger = new AuditLogger(pool, logger);
+
+  // 4. Message bus — write-ahead hook ensures every event is durably recorded.
+  const bus = new EventBus(logger, (event) => auditLogger.log(event));
+
+  // 5. LLM provider — smoke tests require a real API key since they exercise
+  //    the full agent stack end-to-end.
+  if (!config.anthropicApiKey) throw new Error('ANTHROPIC_API_KEY required for smoke tests');
+  const llmProvider = new AnthropicProvider(config.anthropicApiKey, logger);
+
+  // Working memory — Postgres-backed, same as production.
+  const memory = WorkingMemory.createWithPostgres(pool, logger);
+
+  // Entity memory — optional, same as src/index.ts. Agents still work without it.
+  let entityMemory: EntityMemory | undefined;
+  if (config.openaiApiKey) {
+    const embeddingService = EmbeddingService.createWithOpenAI(config.openaiApiKey, logger);
+    const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(kgStore, embeddingService);
+    entityMemory = new EntityMemory(kgStore, validator, embeddingService);
+  }
+
+  // Skill registry — loads all skills from the skills/ directory.
+  // Resolve relative to this file's location, up to project root, into skills/.
+  const skillRegistry = new SkillRegistry();
+  const skillsDir = path.resolve(import.meta.dirname, '../../skills');
+  await loadSkillsFromDirectory(skillsDir, skillRegistry, logger);
+
+  // Agent registry — tracks all running agents for delegation and listing.
+  const agentRegistry = new AgentRegistry();
+
+  // Execution layer — with bus and agent registry for infrastructure skills.
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry });
+
+  // Load all agent configs from the agents/ directory.
+  const agentsDir = path.resolve(import.meta.dirname, '../../agents');
+  const agentConfigs = loadAllAgentConfigs(agentsDir);
+
+  // Two-pass agent registration (same as src/index.ts):
+  // Pass 1: Populate registry so specialistSummary() is complete before
+  //         the coordinator's system prompt is interpolated.
+  for (const agentConfig of agentConfigs) {
+    agentRegistry.register(agentConfig.name, {
+      role: agentConfig.role ?? 'specialist',
+      description: agentConfig.description ?? agentConfig.name,
+    });
+  }
+
+  // Pass 2: Create AgentRuntime instances with fully interpolated prompts.
+  for (const agentConfig of agentConfigs) {
+    const agentPinnedSkills = agentConfig.pinned_skills ?? [];
+    const agentToolDefs = skillRegistry.toToolDefinitions(agentPinnedSkills);
+
+    let systemPrompt = agentConfig.system_prompt;
+    if (agentConfig.role === 'coordinator') {
+      systemPrompt = interpolateRuntimeContext(systemPrompt, {
+        availableSpecialists: agentRegistry.specialistSummary(),
+      });
+    }
+
+    const agent = new AgentRuntime({
+      agentId: agentConfig.name,
+      systemPrompt,
+      provider: llmProvider,
+      bus,
+      logger,
+      memory,
+      entityMemory,
+      executionLayer,
+      pinnedSkills: agentPinnedSkills,
+      skillToolDefs: agentToolDefs,
+    });
+    agent.register();
+  }
+
+  // Dispatcher — subscribes to inbound.message + agent.response.
+  // Registered after agents so agent.task already has handlers.
+  const dispatcher = new Dispatcher({ bus, logger });
+  dispatcher.register();
+
+  // -- No HTTP adapter, no CLI adapter, no SIGTERM handler --
+  // This harness is headless: the only way to inject messages is sendMessage().
+
+  /**
+   * Publish an inbound.message and wait for the corresponding outbound.message.
+   *
+   * IMPORTANT: bus.subscribe() returns void — there is no unsubscribe mechanism.
+   * We use a `resolved` boolean flag inside the handler to ignore events after
+   * the first match or timeout. The handler stays registered but becomes a no-op.
+   */
+  async function sendMessage(options: {
+    conversationId: string;
+    content: string;
+    senderId?: string;
+    channelId?: string;
+  }): Promise<{ content: string; durationMs: number }> {
+    const start = Date.now();
+
+    return new Promise((resolve, reject) => {
+      let resolved = false;
+
+      const timeout = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          reject(new Error('Timeout waiting for response (60s)'));
+        }
+      }, 60_000);
+
+      // Subscribe to outbound.message as the channel layer (matching how
+      // real channel adapters receive responses). The handler filters by
+      // conversationId so concurrent sendMessage() calls don't cross-talk.
+      bus.subscribe('outbound.message', 'channel', (event) => {
+        if (resolved) return;
+        const outbound = event as OutboundMessageEvent;
+        if (outbound.payload.conversationId === options.conversationId) {
+          resolved = true;
+          clearTimeout(timeout);
+          resolve({
+            content: outbound.payload.content,
+            durationMs: Date.now() - start,
+          });
+        }
+      });
+
+      // Publish the inbound message as the channel layer.
+      const inbound = createInboundMessage({
+        conversationId: options.conversationId,
+        channelId: options.channelId ?? 'smoke-test',
+        senderId: options.senderId ?? 'smoke-test-user',
+        content: options.content,
+      });
+      bus.publish('channel', inbound).catch((err) => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          reject(err);
+        }
+      });
+    });
+  }
+
+  async function shutdown(): Promise<void> {
+    await pool.end();
+  }
+
+  return { bus, logger, sendMessage, shutdown };
+}

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -25,7 +25,6 @@ import { SkillRegistry } from '../../src/skills/registry.js';
 import { ExecutionLayer } from '../../src/skills/execution.js';
 import { loadSkillsFromDirectory } from '../../src/skills/loader.js';
 import { createInboundMessage, type OutboundMessageEvent } from '../../src/bus/events.js';
-import type { DbPool } from '../../src/db/connection.js';
 import type { Logger } from '../../src/logger.js';
 
 export interface CuriaHarness {

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -132,46 +132,47 @@ export async function createHarness(): Promise<CuriaHarness> {
   // -- No HTTP adapter, no CLI adapter, no SIGTERM handler --
   // This harness is headless: the only way to inject messages is sendMessage().
 
-  /**
-   * Publish an inbound.message and wait for the corresponding outbound.message.
-   *
-   * IMPORTANT: bus.subscribe() returns void — there is no unsubscribe mechanism.
-   * We use a `resolved` boolean flag inside the handler to ignore events after
-   * the first match or timeout. The handler stays registered but becomes a no-op.
-   */
+  // Single persistent listener for outbound messages. Uses a Map to dispatch
+  // responses to the correct sendMessage() caller by conversationId.
+  // This avoids accumulating dead handlers (bus.subscribe returns void —
+  // there is no unsubscribe mechanism).
+  const pendingResponses = new Map<string, {
+    resolve: (value: { content: string; durationMs: number }) => void;
+    reject: (reason: Error) => void;
+    start: number;
+    timeout: ReturnType<typeof setTimeout>;
+  }>();
+
+  bus.subscribe('outbound.message', 'channel', (event) => {
+    const outbound = event as OutboundMessageEvent;
+    const pending = pendingResponses.get(outbound.payload.conversationId);
+    if (pending) {
+      pendingResponses.delete(outbound.payload.conversationId);
+      clearTimeout(pending.timeout);
+      pending.resolve({
+        content: outbound.payload.content,
+        durationMs: Date.now() - pending.start,
+      });
+    }
+  });
+
   async function sendMessage(options: {
     conversationId: string;
     content: string;
     senderId?: string;
     channelId?: string;
   }): Promise<{ content: string; durationMs: number }> {
-    const start = Date.now();
-
     return new Promise((resolve, reject) => {
-      let resolved = false;
+      const start = Date.now();
 
       const timeout = setTimeout(() => {
-        if (!resolved) {
-          resolved = true;
+        if (pendingResponses.has(options.conversationId)) {
+          pendingResponses.delete(options.conversationId);
           reject(new Error('Timeout waiting for response (60s)'));
         }
       }, 60_000);
 
-      // Subscribe to outbound.message as the channel layer (matching how
-      // real channel adapters receive responses). The handler filters by
-      // conversationId so concurrent sendMessage() calls don't cross-talk.
-      bus.subscribe('outbound.message', 'channel', (event) => {
-        if (resolved) return;
-        const outbound = event as OutboundMessageEvent;
-        if (outbound.payload.conversationId === options.conversationId) {
-          resolved = true;
-          clearTimeout(timeout);
-          resolve({
-            content: outbound.payload.content,
-            durationMs: Date.now() - start,
-          });
-        }
-      });
+      pendingResponses.set(options.conversationId, { resolve, reject, start, timeout });
 
       // Publish the inbound message
       try {
@@ -182,15 +183,15 @@ export async function createHarness(): Promise<CuriaHarness> {
           content: options.content,
         });
         bus.publish('channel', inbound).catch((err) => {
-          if (!resolved) {
-            resolved = true;
+          if (pendingResponses.has(options.conversationId)) {
+            pendingResponses.delete(options.conversationId);
             clearTimeout(timeout);
             reject(err);
           }
         });
       } catch (err) {
-        if (!resolved) {
-          resolved = true;
+        if (pendingResponses.has(options.conversationId)) {
+          pendingResponses.delete(options.conversationId);
           clearTimeout(timeout);
           reject(err instanceof Error ? err : new Error(String(err)));
         }

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -173,20 +173,28 @@ export async function createHarness(): Promise<CuriaHarness> {
         }
       });
 
-      // Publish the inbound message as the channel layer.
-      const inbound = createInboundMessage({
-        conversationId: options.conversationId,
-        channelId: options.channelId ?? 'smoke-test',
-        senderId: options.senderId ?? 'smoke-test-user',
-        content: options.content,
-      });
-      bus.publish('channel', inbound).catch((err) => {
+      // Publish the inbound message
+      try {
+        const inbound = createInboundMessage({
+          conversationId: options.conversationId,
+          channelId: options.channelId ?? 'smoke-test',
+          senderId: options.senderId ?? 'smoke-test-user',
+          content: options.content,
+        });
+        bus.publish('channel', inbound).catch((err) => {
+          if (!resolved) {
+            resolved = true;
+            clearTimeout(timeout);
+            reject(err);
+          }
+        });
+      } catch (err) {
         if (!resolved) {
           resolved = true;
           clearTimeout(timeout);
-          reject(err);
+          reject(err instanceof Error ? err : new Error(String(err)));
         }
-      });
+      }
     });
   }
 

--- a/tests/smoke/loader.ts
+++ b/tests/smoke/loader.ts
@@ -1,0 +1,88 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+import type { TestCase, Turn, ExpectedBehavior, BehaviorWeight } from './types.js';
+
+const VALID_WEIGHTS: BehaviorWeight[] = ['critical', 'important', 'nice-to-have'];
+
+// Shape of the raw YAML before we normalize field names (snake_case → camelCase).
+interface RawTestCase {
+  name?: string;
+  description?: string;
+  tags?: string[];
+  turns?: Array<{ role?: string; content?: string; delay_ms?: number }>;
+  expected_behaviors?: Array<{ id?: string; description?: string; weight?: string }>;
+  failure_modes?: string[];
+}
+
+/**
+ * Load a single YAML test case from a file path.
+ * Validates required fields and normalizes the structure into a TestCase.
+ * Throws if the file is missing, malformed, or fails validation.
+ */
+export function loadTestCase(filePath: string): TestCase {
+  // readFileSync will throw ENOENT if the file doesn't exist — that's the
+  // intended behavior for the "validates required fields" test.
+  const raw = yaml.load(readFileSync(filePath, 'utf-8')) as RawTestCase;
+
+  if (!raw || typeof raw !== 'object') {
+    throw new Error(`Invalid test case file: ${filePath}`);
+  }
+  if (!raw.name) throw new Error(`Missing 'name' in ${filePath}`);
+  if (!raw.turns || raw.turns.length === 0) throw new Error(`Missing 'turns' in ${filePath}`);
+  if (!raw.expected_behaviors || raw.expected_behaviors.length === 0) {
+    throw new Error(`Missing 'expected_behaviors' in ${filePath}`);
+  }
+
+  const turns: Turn[] = raw.turns.map((t, i) => {
+    if (!t.content) throw new Error(`Turn ${i} missing 'content' in ${filePath}`);
+    return {
+      role: 'user' as const,
+      content: t.content,
+      delayMs: t.delay_ms,
+    };
+  });
+
+  const expectedBehaviors: ExpectedBehavior[] = raw.expected_behaviors.map((b, i) => {
+    if (!b.id) throw new Error(`Behavior ${i} missing 'id' in ${filePath}`);
+    if (!b.description) throw new Error(`Behavior ${i} missing 'description' in ${filePath}`);
+    // Default weight to 'important' if not specified.
+    const weight = (b.weight ?? 'important') as BehaviorWeight;
+    if (!VALID_WEIGHTS.includes(weight)) {
+      throw new Error(`Invalid weight '${b.weight}' for behavior '${b.id}' in ${filePath}`);
+    }
+    return { id: b.id, description: b.description, weight };
+  });
+
+  return {
+    name: raw.name,
+    description: raw.description ?? '',
+    tags: raw.tags ?? [],
+    turns,
+    expectedBehaviors,
+    failureModes: raw.failure_modes ?? [],
+  };
+}
+
+/**
+ * Load all YAML test cases from a directory.
+ * Files are sorted alphabetically for a stable, predictable load order.
+ * Optionally filter to only cases that have at least one of the given tags.
+ */
+export function loadTestCases(
+  dirPath: string,
+  options?: { tags?: string[] },
+): TestCase[] {
+  const files = readdirSync(dirPath)
+    .filter(f => f.endsWith('.yaml') || f.endsWith('.yml'))
+    .sort();
+
+  let cases = files.map(f => loadTestCase(path.join(dirPath, f)));
+
+  if (options?.tags && options.tags.length > 0) {
+    const filterTags = new Set(options.tags);
+    cases = cases.filter(tc => tc.tags.some(t => filterTags.has(t)));
+  }
+
+  return cases;
+}

--- a/tests/smoke/report.ts
+++ b/tests/smoke/report.ts
@@ -1,0 +1,583 @@
+// tests/smoke/report.ts
+// Generates a self-contained HTML report from smoke test results.
+// No external CSS/JS/fonts — everything is inline.
+
+import type { RunResult, HistoricalEntry, CaseResult, BehaviorRating } from './types.js';
+
+/**
+ * Escape HTML special characters to prevent XSS from user-generated content
+ * (prompts, responses, justifications, etc.).
+ */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/** Format a score (0-1) as a percentage string like "65%" */
+function pct(score: number): string {
+  return `${Math.round(score * 100)}%`;
+}
+
+/** Pick a color based on score thresholds: green >= 0.8, amber 0.4-0.79, red < 0.4 */
+function scoreColor(score: number): string {
+  if (score >= 0.8) return '#22c55e';
+  if (score >= 0.4) return '#f59e0b';
+  return '#ef4444';
+}
+
+/** Map rating to its badge background color */
+function ratingColor(rating: BehaviorRating): string {
+  switch (rating) {
+    case 'PASS': return '#22c55e';
+    case 'PARTIAL': return '#f59e0b';
+    case 'MISS': return '#ef4444';
+  }
+}
+
+/** Format an ISO timestamp into a human-friendly string like "March 25, 2026 at 10:00 PM" */
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZoneName: 'short',
+  });
+}
+
+/** Format a short date for chart labels like "Mar 20" */
+function formatShortDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString('en-US', { month: 'short', day: 'numeric' });
+}
+
+/** Format duration in ms to a human-readable string like "45s" or "2m 15s" */
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+/**
+ * Count PASS / PARTIAL / MISS across all behavior scores in a run.
+ */
+function countRatings(run: RunResult): { pass: number; partial: number; miss: number; total: number } {
+  let pass = 0;
+  let partial = 0;
+  let miss = 0;
+  for (const c of run.cases) {
+    for (const s of c.scores) {
+      switch (s.rating) {
+        case 'PASS': pass++; break;
+        case 'PARTIAL': partial++; break;
+        case 'MISS': miss++; break;
+      }
+    }
+  }
+  return { pass, partial, miss, total: pass + partial + miss };
+}
+
+/**
+ * Build an inline SVG bar chart showing overall score over time.
+ * Each bar is labeled with the date and percentage.
+ */
+function buildTrendChart(history: HistoricalEntry[]): string {
+  if (history.length === 0) return '';
+
+  const barWidth = 48;
+  const barGap = 16;
+  const chartHeight = 180;
+  const labelHeight = 40; // space for date + pct labels below bars
+  const topPadding = 24; // space for pct label above bars
+  const maxBarHeight = chartHeight - labelHeight - topPadding;
+
+  const totalWidth = history.length * (barWidth + barGap) - barGap + 40; // 40 for left padding
+  const svgHeight = chartHeight + 8;
+  const leftPad = 20;
+
+  const bars = history.map((entry, i) => {
+    const x = leftPad + i * (barWidth + barGap);
+    const barH = Math.max(4, entry.overallScore * maxBarHeight); // minimum 4px so zero scores are visible
+    const y = topPadding + (maxBarHeight - barH);
+    const color = scoreColor(entry.overallScore);
+    const label = formatShortDate(entry.timestamp);
+    const scorePct = pct(entry.overallScore);
+
+    return [
+      // Percentage label above bar
+      `<text x="${x + barWidth / 2}" y="${y - 6}" text-anchor="middle" font-size="11" fill="#374151" font-weight="600">${scorePct}</text>`,
+      // The bar itself
+      `<rect x="${x}" y="${y}" width="${barWidth}" height="${barH}" rx="4" fill="${color}" opacity="0.85"/>`,
+      // Date label below bar
+      `<text x="${x + barWidth / 2}" y="${chartHeight - 8}" text-anchor="middle" font-size="10" fill="#6b7280">${escapeHtml(label)}</text>`,
+    ].join('\n      ');
+  });
+
+  return `
+    <div class="section">
+      <h2>Score Trend</h2>
+      <div style="overflow-x: auto;">
+        <svg width="${totalWidth}" height="${svgHeight}" viewBox="0 0 ${totalWidth} ${svgHeight}" xmlns="http://www.w3.org/2000/svg">
+          <!-- Baseline -->
+          <line x1="${leftPad}" y1="${topPadding + maxBarHeight}" x2="${totalWidth - 10}" y2="${topPadding + maxBarHeight}" stroke="#e5e7eb" stroke-width="1"/>
+          ${bars.join('\n          ')}
+        </svg>
+      </div>
+    </div>`;
+}
+
+/**
+ * Render a single case result as a collapsible details card.
+ */
+function renderCaseCard(caseResult: CaseResult): string {
+  const { testCase, responses, scores, weightedScore, error } = caseResult;
+  const color = scoreColor(weightedScore);
+
+  // Tags as pills
+  const tagPills = testCase.tags
+    .map(t => `<span class="tag">${escapeHtml(t)}</span>`)
+    .join(' ');
+
+  // Prompt section — show all user turns
+  const promptBlocks = testCase.turns
+    .map(t => `<pre class="prompt-block">${escapeHtml(t.content)}</pre>`)
+    .join('\n');
+
+  // Response section
+  const responseBlocks = responses
+    .map(r => `
+      <div class="response-block">
+        <div class="response-meta">Agent: ${escapeHtml(r.agentId)} &middot; ${formatDuration(r.durationMs)}</div>
+        <div class="response-content">${escapeHtml(r.content)}</div>
+      </div>`)
+    .join('\n');
+
+  // Behaviors table
+  // Look up the behavior description from expectedBehaviors by matching behaviorId
+  const behaviorMap = new Map(testCase.expectedBehaviors.map(b => [b.id, b]));
+  const behaviorRows = scores
+    .map(s => {
+      const behavior = behaviorMap.get(s.behaviorId);
+      const desc = behavior ? escapeHtml(behavior.description) : escapeHtml(s.behaviorId);
+      const weight = behavior ? behavior.weight : 'unknown';
+      return `
+        <tr>
+          <td>${desc}</td>
+          <td><span class="weight-label">${escapeHtml(weight)}</span></td>
+          <td><span class="badge" style="background:${ratingColor(s.rating)}">${s.rating}</span></td>
+          <td>${escapeHtml(s.justification)}</td>
+        </tr>`;
+    })
+    .join('\n');
+
+  // Failure modes
+  const failureModes = testCase.failureModes.length > 0
+    ? `<div class="failure-modes">
+        <h4>Known Failure Modes</h4>
+        <ul>${testCase.failureModes.map(f => `<li>${escapeHtml(f)}</li>`).join('')}</ul>
+      </div>`
+    : '';
+
+  // Error banner (if execution errored)
+  const errorBanner = error
+    ? `<div class="error-banner">${escapeHtml(error)}</div>`
+    : '';
+
+  return `
+    <details class="case-card">
+      <summary class="case-header">
+        <span class="case-name">${escapeHtml(testCase.name)}</span>
+        ${tagPills}
+        <span class="case-score" style="background:${color}">${pct(weightedScore)}</span>
+      </summary>
+      <div class="case-body">
+        ${errorBanner}
+        <h4>Prompt</h4>
+        ${promptBlocks}
+
+        <h4>Response</h4>
+        ${responseBlocks}
+
+        <h4>Behaviors</h4>
+        <table class="behaviors-table">
+          <thead>
+            <tr>
+              <th>Behavior</th>
+              <th>Weight</th>
+              <th>Rating</th>
+              <th>Justification</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${behaviorRows}
+          </tbody>
+        </table>
+
+        ${failureModes}
+      </div>
+    </details>`;
+}
+
+/**
+ * Generate a complete, self-contained HTML report from smoke test run results.
+ * Optionally includes a historical trend chart if history is provided.
+ */
+export function generateReport(run: RunResult, history?: HistoricalEntry[]): string {
+  const ratings = countRatings(run);
+  const overallColor = scoreColor(run.overallScore);
+  const formattedTime = formatTimestamp(run.timestamp);
+  const duration = formatDuration(run.durationMs);
+
+  const trendSection = history && history.length > 0
+    ? buildTrendChart(history)
+    : '';
+
+  const caseCards = run.cases.map(c => renderCaseCard(c)).join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Curia Smoke Test Report</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f9fafb;
+      color: #111827;
+      line-height: 1.6;
+      padding: 0;
+    }
+
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 32px 24px;
+    }
+
+    /* -- Header -- */
+    .header {
+      text-align: center;
+      padding: 40px 24px;
+      background: #ffffff;
+      border-bottom: 1px solid #e5e7eb;
+      margin-bottom: 24px;
+      border-radius: 12px;
+    }
+
+    .header h1 {
+      font-size: 24px;
+      font-weight: 700;
+      color: #111827;
+      margin-bottom: 8px;
+    }
+
+    .header .meta {
+      font-size: 14px;
+      color: #6b7280;
+      margin-bottom: 20px;
+    }
+
+    .overall-score {
+      font-size: 72px;
+      font-weight: 800;
+      line-height: 1;
+      margin: 16px 0 8px;
+    }
+
+    .overall-label {
+      font-size: 14px;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      font-weight: 600;
+    }
+
+    /* -- Summary stats bar -- */
+    .stats-bar {
+      display: flex;
+      justify-content: center;
+      gap: 12px;
+      flex-wrap: wrap;
+      padding: 16px 24px;
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+      margin-bottom: 24px;
+    }
+
+    .stat {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 14px;
+      color: #374151;
+    }
+
+    .stat-value {
+      font-weight: 700;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 12px;
+      border-radius: 9999px;
+      font-size: 13px;
+      font-weight: 600;
+      color: #fff;
+    }
+
+    .pill-pass { background: #22c55e; }
+    .pill-partial { background: #f59e0b; }
+    .pill-miss { background: #ef4444; }
+    .pill-neutral { background: #6b7280; }
+
+    /* -- Sections -- */
+    .section {
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+      padding: 24px;
+      margin-bottom: 24px;
+    }
+
+    .section h2 {
+      font-size: 18px;
+      font-weight: 700;
+      color: #111827;
+      margin-bottom: 16px;
+    }
+
+    /* -- Case cards -- */
+    .case-card {
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+      margin-bottom: 12px;
+      overflow: hidden;
+    }
+
+    .case-card[open] {
+      border-color: #d1d5db;
+    }
+
+    .case-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 16px 20px;
+      cursor: pointer;
+      list-style: none;
+      user-select: none;
+    }
+
+    /* Hide default marker */
+    .case-header::-webkit-details-marker { display: none; }
+    .case-header::marker { content: ''; }
+
+    .case-header::before {
+      content: '\\25B6';
+      font-size: 10px;
+      color: #9ca3af;
+      transition: transform 0.15s ease;
+    }
+
+    .case-card[open] > .case-header::before {
+      transform: rotate(90deg);
+    }
+
+    .case-name {
+      font-weight: 600;
+      font-size: 15px;
+      color: #111827;
+      flex: 1;
+    }
+
+    .tag {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 11px;
+      font-weight: 600;
+      background: #e0e7ff;
+      color: #3730a3;
+      text-transform: lowercase;
+    }
+
+    .case-score {
+      display: inline-block;
+      padding: 4px 12px;
+      border-radius: 6px;
+      font-size: 13px;
+      font-weight: 700;
+      color: #ffffff;
+      min-width: 48px;
+      text-align: center;
+    }
+
+    .case-body {
+      padding: 0 20px 20px;
+      border-top: 1px solid #f3f4f6;
+    }
+
+    .case-body h4 {
+      font-size: 13px;
+      font-weight: 700;
+      color: #6b7280;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin: 20px 0 8px;
+    }
+
+    .prompt-block {
+      background: #f3f4f6;
+      border-radius: 6px;
+      padding: 12px 16px;
+      font-size: 13px;
+      font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+      white-space: pre-wrap;
+      word-break: break-word;
+      color: #1f2937;
+      margin-bottom: 8px;
+    }
+
+    .response-block {
+      border-left: 3px solid #6366f1;
+      padding: 12px 16px;
+      margin-bottom: 8px;
+      background: #fafbff;
+      border-radius: 0 6px 6px 0;
+    }
+
+    .response-meta {
+      font-size: 11px;
+      color: #9ca3af;
+      margin-bottom: 6px;
+    }
+
+    .response-content {
+      font-size: 14px;
+      color: #1f2937;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    /* -- Behaviors table -- */
+    .behaviors-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+      margin-top: 4px;
+    }
+
+    .behaviors-table th {
+      text-align: left;
+      padding: 8px 10px;
+      border-bottom: 2px solid #e5e7eb;
+      color: #6b7280;
+      font-weight: 600;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+
+    .behaviors-table td {
+      padding: 8px 10px;
+      border-bottom: 1px solid #f3f4f6;
+      vertical-align: top;
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 2px 10px;
+      border-radius: 4px;
+      font-size: 11px;
+      font-weight: 700;
+      color: #ffffff;
+      letter-spacing: 0.02em;
+    }
+
+    .weight-label {
+      font-size: 12px;
+      color: #6b7280;
+    }
+
+    .failure-modes {
+      margin-top: 16px;
+    }
+
+    .failure-modes h4 {
+      margin-bottom: 6px;
+    }
+
+    .failure-modes ul {
+      padding-left: 20px;
+      font-size: 13px;
+      color: #6b7280;
+    }
+
+    .failure-modes li {
+      margin-bottom: 4px;
+    }
+
+    .error-banner {
+      background: #fef2f2;
+      border: 1px solid #fecaca;
+      border-radius: 6px;
+      color: #991b1b;
+      padding: 10px 14px;
+      font-size: 13px;
+      margin-top: 12px;
+    }
+
+    /* -- Footer -- */
+    .footer {
+      text-align: center;
+      padding: 24px;
+      font-size: 12px;
+      color: #9ca3af;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1>Curia Smoke Test Report</h1>
+      <div class="meta">${escapeHtml(formattedTime)} &middot; Duration: ${duration}</div>
+      <div class="overall-label">Overall Score</div>
+      <div class="overall-score" style="color:${overallColor}">${pct(run.overallScore)}</div>
+    </div>
+
+    <div class="stats-bar">
+      <span class="stat"><span class="stat-value">${run.cases.length}</span> cases</span>
+      <span class="stat"><span class="stat-value">${ratings.total}</span> behaviors</span>
+      <span class="pill pill-pass">PASS ${ratings.pass}</span>
+      <span class="pill pill-partial">PARTIAL ${ratings.partial}</span>
+      <span class="pill pill-miss">MISS ${ratings.miss}</span>
+    </div>
+
+    ${trendSection}
+
+    <div class="section">
+      <h2>Test Cases</h2>
+      ${caseCards}
+    </div>
+
+    <div class="footer">Generated by Curia Smoke Test Framework</div>
+  </div>
+</body>
+</html>`;
+}

--- a/tests/smoke/runner.ts
+++ b/tests/smoke/runner.ts
@@ -1,0 +1,66 @@
+// tests/smoke/runner.ts
+import { randomUUID } from 'node:crypto';
+import type { CuriaHarness } from './harness.js';
+import type { TestCase, CaseExecution, CapturedResponse } from './types.js';
+
+/**
+ * Execute all test cases against a live Curia harness.
+ * Each case gets a unique conversationId to avoid cross-contamination.
+ * Multi-turn cases send turns sequentially with configured delays.
+ */
+export async function runTestCases(
+  harness: CuriaHarness,
+  cases: TestCase[],
+  options?: { onCaseComplete?: (exec: CaseExecution, index: number, total: number) => void },
+): Promise<CaseExecution[]> {
+  const results: CaseExecution[] = [];
+
+  for (let i = 0; i < cases.length; i++) {
+    const tc = cases[i]!;
+    let execution: CaseExecution;
+
+    try {
+      execution = await runSingleCase(harness, tc);
+    } catch (err) {
+      // Case-level failure (e.g., all turns timed out)
+      execution = {
+        testCase: tc,
+        responses: [],
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    results.push(execution);
+    options?.onCaseComplete?.(execution, i + 1, cases.length);
+  }
+
+  return results;
+}
+
+async function runSingleCase(
+  harness: CuriaHarness,
+  tc: TestCase,
+): Promise<CaseExecution> {
+  const conversationId = `smoke-${randomUUID()}`;
+  const responses: CapturedResponse[] = [];
+
+  for (const turn of tc.turns) {
+    // Delay between turns for multi-turn cases
+    if (turn.delayMs) {
+      await new Promise(resolve => setTimeout(resolve, turn.delayMs));
+    }
+
+    const response = await harness.sendMessage({
+      conversationId,
+      content: turn.content,
+    });
+
+    responses.push({
+      content: response.content,
+      agentId: 'coordinator', // TODO: capture actual agent from bus events
+      durationMs: response.durationMs,
+    });
+  }
+
+  return { testCase: tc, responses };
+}

--- a/tests/smoke/types.ts
+++ b/tests/smoke/types.ts
@@ -1,0 +1,93 @@
+// tests/smoke/types.ts
+
+// -- Test case definition (loaded from YAML) --
+
+export type BehaviorWeight = 'critical' | 'important' | 'nice-to-have';
+
+export interface ExpectedBehavior {
+  id: string;
+  description: string;
+  weight: BehaviorWeight;
+}
+
+export interface Turn {
+  role: 'user';
+  content: string;
+  /** Delay before sending this turn (ms). Simulates pauses in multi-turn. */
+  delayMs?: number;
+}
+
+export interface TestCase {
+  name: string;
+  description: string;
+  tags: string[];
+  turns: Turn[];
+  expectedBehaviors: ExpectedBehavior[];
+  failureModes: string[];
+}
+
+// -- Execution results --
+
+export interface CapturedResponse {
+  content: string;
+  agentId: string;
+  durationMs: number;
+}
+
+export interface CaseExecution {
+  testCase: TestCase;
+  responses: CapturedResponse[];
+  error?: string;
+}
+
+// -- Evaluation results --
+
+export type BehaviorRating = 'PASS' | 'PARTIAL' | 'MISS';
+
+export interface BehaviorScore {
+  behaviorId: string;
+  rating: BehaviorRating;
+  justification: string;
+}
+
+export interface CaseResult {
+  testCase: TestCase;
+  responses: CapturedResponse[];
+  scores: BehaviorScore[];
+  /** Weighted score 0-1 for this case */
+  weightedScore: number;
+  error?: string;
+}
+
+// -- Run-level results --
+
+export interface RunResult {
+  timestamp: string; // ISO 8601
+  cases: CaseResult[];
+  /** Overall weighted score 0-1 across all cases */
+  overallScore: number;
+  durationMs: number;
+}
+
+// -- Historical tracking --
+
+export interface HistoricalEntry {
+  timestamp: string;
+  overallScore: number;
+  caseCount: number;
+  passRate: number; // fraction of behaviors rated PASS
+}
+
+// -- Scoring constants --
+
+export const WEIGHT_VALUES: Record<BehaviorWeight, number> = {
+  critical: 3,
+  important: 2,
+  'nice-to-have': 1,
+};
+
+export const RATING_VALUES: Record<BehaviorRating, number> = {
+  PASS: 1.0,
+  PARTIAL: 0.5,
+  MISS: 0.0,
+};

--- a/tests/unit/smoke/evaluator.test.ts
+++ b/tests/unit/smoke/evaluator.test.ts
@@ -1,0 +1,71 @@
+// tests/unit/smoke/evaluator.test.ts
+import { describe, it, expect } from 'vitest';
+import { parseJudgeResponse, computeWeightedScore } from '../../smoke/evaluator.js';
+import type { ExpectedBehavior, BehaviorScore } from '../../smoke/types.js';
+
+describe('Evaluator', () => {
+  describe('parseJudgeResponse', () => {
+    it('parses a well-formed judge JSON response', () => {
+      const raw = JSON.stringify({
+        scores: [
+          { behaviorId: 'detect-expense', rating: 'PASS', justification: 'Clearly identified as receipt' },
+          { behaviorId: 'extract-amount', rating: 'PARTIAL', justification: 'Got the amount but wrong currency' },
+          { behaviorId: 'categorize', rating: 'MISS', justification: 'No categorization attempted' },
+        ],
+      });
+
+      const scores = parseJudgeResponse(raw);
+      expect(scores).toHaveLength(3);
+      expect(scores[0]!.rating).toBe('PASS');
+      expect(scores[1]!.rating).toBe('PARTIAL');
+      expect(scores[2]!.rating).toBe('MISS');
+    });
+
+    it('returns MISS for all behaviors if response is unparseable', () => {
+      const behaviors: ExpectedBehavior[] = [
+        { id: 'a', description: 'test', weight: 'critical' },
+        { id: 'b', description: 'test2', weight: 'important' },
+      ];
+      const scores = parseJudgeResponse('not valid json', behaviors);
+      expect(scores).toHaveLength(2);
+      expect(scores.every(s => s.rating === 'MISS')).toBe(true);
+    });
+  });
+
+  describe('computeWeightedScore', () => {
+    it('returns 1.0 for all PASS', () => {
+      const behaviors: ExpectedBehavior[] = [
+        { id: 'a', description: '', weight: 'critical' },
+        { id: 'b', description: '', weight: 'important' },
+      ];
+      const scores: BehaviorScore[] = [
+        { behaviorId: 'a', rating: 'PASS', justification: '' },
+        { behaviorId: 'b', rating: 'PASS', justification: '' },
+      ];
+      expect(computeWeightedScore(behaviors, scores)).toBeCloseTo(1.0);
+    });
+
+    it('returns 0.0 for all MISS', () => {
+      const behaviors: ExpectedBehavior[] = [
+        { id: 'a', description: '', weight: 'critical' },
+      ];
+      const scores: BehaviorScore[] = [
+        { behaviorId: 'a', rating: 'MISS', justification: '' },
+      ];
+      expect(computeWeightedScore(behaviors, scores)).toBeCloseTo(0.0);
+    });
+
+    it('weights critical higher than nice-to-have', () => {
+      const behaviors: ExpectedBehavior[] = [
+        { id: 'a', description: '', weight: 'critical' },
+        { id: 'b', description: '', weight: 'nice-to-have' },
+      ];
+      // critical PASS (3*1.0=3), nice-to-have MISS (1*0.0=0), total=3/4=0.75
+      const scores: BehaviorScore[] = [
+        { behaviorId: 'a', rating: 'PASS', justification: '' },
+        { behaviorId: 'b', rating: 'MISS', justification: '' },
+      ];
+      expect(computeWeightedScore(behaviors, scores)).toBeCloseTo(0.75);
+    });
+  });
+});

--- a/tests/unit/smoke/loader.test.ts
+++ b/tests/unit/smoke/loader.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { loadTestCases, loadTestCase } from '../../smoke/loader.js';
+
+describe('Smoke test loader', () => {
+  it('loads a single YAML test case', () => {
+    const tc = loadTestCase('tests/smoke/cases/forwarded-receipt.yaml');
+    expect(tc.name).toBe('Forwarded Receipt (No Context)');
+    expect(tc.turns).toHaveLength(1);
+    expect(tc.turns[0]!.role).toBe('user');
+    expect(tc.expectedBehaviors.length).toBeGreaterThan(0);
+    expect(tc.tags).toContain('inference');
+  });
+
+  it('loads all test cases from directory', () => {
+    const cases = loadTestCases('tests/smoke/cases');
+    expect(cases.length).toBeGreaterThan(0);
+    for (const tc of cases) {
+      expect(tc.name).toBeDefined();
+      expect(tc.turns.length).toBeGreaterThan(0);
+      expect(tc.expectedBehaviors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('validates required fields', () => {
+    expect(() => loadTestCase('tests/smoke/cases/nonexistent.yaml')).toThrow();
+  });
+
+  it('filters by tag', () => {
+    const all = loadTestCases('tests/smoke/cases');
+    const filtered = loadTestCases('tests/smoke/cases', { tags: ['inference'] });
+    expect(filtered.length).toBeLessThanOrEqual(all.length);
+    for (const tc of filtered) {
+      expect(tc.tags).toContain('inference');
+    }
+  });
+});

--- a/tests/unit/smoke/report.test.ts
+++ b/tests/unit/smoke/report.test.ts
@@ -1,0 +1,53 @@
+// tests/unit/smoke/report.test.ts
+import { describe, it, expect } from 'vitest';
+import { generateReport } from '../../smoke/report.js';
+import type { RunResult, HistoricalEntry } from '../../smoke/types.js';
+
+describe('Report generator', () => {
+  const mockRun: RunResult = {
+    timestamp: '2026-03-25T22:00:00.000Z',
+    durationMs: 45000,
+    overallScore: 0.65,
+    cases: [
+      {
+        testCase: {
+          name: 'Test Case 1',
+          description: 'A test',
+          tags: ['inference'],
+          turns: [{ role: 'user', content: 'Hello' }],
+          expectedBehaviors: [
+            { id: 'greet', description: 'Greets back', weight: 'critical' },
+          ],
+          failureModes: ['Ignores greeting'],
+        },
+        responses: [{ content: 'Hi there!', agentId: 'coordinator', durationMs: 1200 }],
+        scores: [{ behaviorId: 'greet', rating: 'PASS', justification: 'Greeted warmly' }],
+        weightedScore: 1.0,
+      },
+    ],
+  };
+
+  it('generates valid HTML with required sections', () => {
+    const html = generateReport(mockRun);
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('Curia Smoke Test Report');
+    expect(html).toContain('Test Case 1');
+    expect(html).toContain('65%');
+    expect(html).toContain('PASS');
+  });
+
+  it('includes historical trend data when provided', () => {
+    const history: HistoricalEntry[] = [
+      { timestamp: '2026-03-20T00:00:00Z', overallScore: 0.4, caseCount: 10, passRate: 0.3 },
+      { timestamp: '2026-03-25T00:00:00Z', overallScore: 0.65, caseCount: 14, passRate: 0.5 },
+    ];
+    const html = generateReport(mockRun, history);
+    expect(html).toContain('Trend');
+    expect(html).toContain('40%');
+  });
+
+  it('color-codes PASS/PARTIAL/MISS', () => {
+    const html = generateReport(mockRun);
+    expect(html).toMatch(/pass|green|#22c55e/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Manual-run smoke test framework for benchmarking Curia's dialogue capabilities
- 14 YAML test cases covering: inference, multi-turn context, contact disambiguation, scheduling, tracking, and change management
- Headless bus stack harness (full pipeline without HTTP/CLI channels)
- GPT-4o as independent judge (different vendor from Anthropic agents to avoid self-bias)
- Weighted scoring: critical (3x), important (2x), nice-to-have (1x) with PASS/PARTIAL/MISS ratings
- Self-contained HTML report with per-case detail cards and historical trend charts
- Historical tracking via timestamped JSON results

## Usage

```bash
# Run all 14 cases
pnpm smoke

# Filter by tag
pnpm smoke -- --tags inference,multi-turn

# Filter by name
pnpm smoke -- --case "receipt"
```

Requires `ANTHROPIC_API_KEY` (agents), `OPENAI_API_KEY` (judge + embeddings), and `DATABASE_URL`.

## Design decisions

- **Not a CI test** — this is a benchmark, not a pass/fail gate. Run manually pre-release.
- **Aspirational cases included** — image processing, scheduling, and contacts cases will score zero until those features are built. That's the point of a benchmark.
- **Different judge vendor** — GPT-4o evaluates Anthropic agent responses to avoid self-bias.
- **Systemic errors abort** — auth failures and rate limits from the judge API throw instead of silently degrading to all-MISS scores.

## Test plan

- [x] Unit tests for loader, evaluator (score parsing + weighted computation), and report generator
- [x] 190 tests pass across 34 files
- [x] Typecheck clean
- [x] Lint clean
- [x] Pre-PR review: code reviewer + silent failure hunter — findings addressed