### PR TITLE
feat: add date and timezone to coordinator system prompt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,5 +23,10 @@ OPENAI_API_KEY=sk-...
 HTTP_PORT=3000
 API_TOKEN=your-secret-token-here
 
+# Timezone — IANA timezone for the CEO's default location.
+# Used to resolve relative dates ("next Friday") in agent prompts.
+# Override via KG entity fact when traveling (future feature).
+TIMEZONE=America/Toronto
+
 # Logging
 LOG_LEVEL=info

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -12,6 +12,13 @@ system_prompt: |
   Your communication style is ${persona.tone}.
   You handle all communications on behalf of the CEO.
 
+  ## Date & Time
+  Today's date: ${current_date}
+  Timezone: ${timezone}
+  When interpreting relative dates ("next Friday", "the Monday after"), always
+  resolve them to specific calendar dates and state the dates explicitly so the
+  user can confirm you understood correctly.
+
   ## Your Team
   You have specialist agents you can delegate to using the "delegate" tool.
   When a request requires specialized expertise, delegate to the right specialist.

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -118,16 +118,31 @@ function interpolatePersona(
  * Interpolate runtime context placeholders in the system prompt.
  * Currently supports:
  * - ${available_specialists} — list of specialist agents from the agent registry
+ * - ${current_date} — today's date in the configured timezone (YYYY-MM-DD, Day)
+ * - ${timezone} — the configured IANA timezone name
  *
  * This runs at bootstrap time (after all agents are registered) and is separate
  * from persona interpolation which runs at config load time.
  */
 export function interpolateRuntimeContext(
   systemPrompt: string,
-  context: { availableSpecialists?: string },
+  context: {
+    availableSpecialists?: string;
+    currentDate?: string;
+    timezone?: string;
+  },
 ): string {
-  return systemPrompt.replace(
-    /\$\{available_specialists\}/g,
-    context.availableSpecialists ?? 'No specialists available yet.',
-  );
+  return systemPrompt
+    .replace(
+      /\$\{available_specialists\}/g,
+      context.availableSpecialists ?? 'No specialists available yet.',
+    )
+    .replace(
+      /\$\{current_date\}/g,
+      context.currentDate ?? new Date().toISOString().split('T')[0] ?? '',
+    )
+    .replace(
+      /\$\{timezone\}/g,
+      context.timezone ?? 'UTC',
+    );
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export interface Config {
   logLevel: string;
   httpPort: number;
   apiToken: string | undefined;
+  timezone: string;
 }
 
 export function loadConfig(): Config {
@@ -25,5 +26,6 @@ export function loadConfig(): Config {
     logLevel: process.env.LOG_LEVEL ?? 'info',
     httpPort,
     apiToken: process.env.API_TOKEN,
+    timezone: process.env.TIMEZONE ?? 'America/Toronto',
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,12 +156,24 @@ async function main(): Promise<void> {
     const agentPinnedSkills = agentConfig.pinned_skills ?? [];
     const agentToolDefs = skillRegistry.toToolDefinitions(agentPinnedSkills);
 
-    // For the coordinator, interpolate runtime context (specialist list).
+    // For the coordinator, interpolate runtime context (specialist list, date, timezone).
     // This runs in pass 2 so all specialists are already in the registry.
+    // Date is formatted as "YYYY-MM-DD, DayName" in the configured timezone
+    // so agents can resolve relative references like "next Friday".
     let systemPrompt = agentConfig.system_prompt;
     if (agentConfig.role === 'coordinator') {
+      const now = new Date();
+      const currentDate = now.toLocaleDateString('en-CA', {
+        timeZone: config.timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        weekday: 'long',
+      });
       systemPrompt = interpolateRuntimeContext(systemPrompt, {
         availableSpecialists: agentRegistry.specialistSummary(),
+        currentDate,
+        timezone: config.timezone,
       });
     }
 

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -104,8 +104,18 @@ export async function createHarness(): Promise<CuriaHarness> {
 
     let systemPrompt = agentConfig.system_prompt;
     if (agentConfig.role === 'coordinator') {
+      const now = new Date();
+      const currentDate = now.toLocaleDateString('en-CA', {
+        timeZone: config.timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        weekday: 'long',
+      });
       systemPrompt = interpolateRuntimeContext(systemPrompt, {
         availableSpecialists: agentRegistry.specialistSummary(),
+        currentDate,
+        timezone: config.timezone,
       });
     }
 


### PR DESCRIPTION
## Summary

- Adds `TIMEZONE` config (defaults to `America/Toronto`, configurable via `.env`)
- Interpolates `${current_date}` and `${timezone}` into the coordinator's system prompt at boot time
- Instructs the coordinator to resolve relative dates ("next Friday") to specific calendar dates
- Updates the smoke test harness to match

This addresses the Natural Language Deadlines smoke test case, which scored 38% because the agent couldn't resolve relative dates without knowing today's date.

## Files changed

- `src/config.ts` — add `timezone` field
- `src/agents/loader.ts` — extend `interpolateRuntimeContext` with `currentDate` and `timezone`
- `src/index.ts` — pass date/timezone to interpolation
- `agents/coordinator.yaml` — add Date & Time section to system prompt
- `tests/smoke/harness.ts` — mirror the same interpolation
- `.env.example` — add `TIMEZONE` with documentation

## Test plan

- [x] 190 tests pass
- [x] Typecheck clean
- [x] Lint clean
- [ ] Re-run `pnpm smoke` to verify Natural Language Deadlines score improves