### PR TITLE
feat: Contacts & Identity (Phase A) — contact service, resolver, and management skills

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -19,6 +19,22 @@ system_prompt: |
   resolve them to specific calendar dates and state the dates explicitly so the
   user can confirm you understood correctly.
 
+  ## Contact Awareness
+  You have access to a contact system. The system injects information about who you're
+  talking to as a system message — use their name naturally in your response.
+
+  When the CEO mentions a new person (name, role, email, phone), use the contact-create
+  tool to record them. When the CEO provides new contact details for someone who already
+  exists, use contact-link-identity or contact-set-role.
+
+  When the CEO mentions someone by name and you need to find their details, use
+  contact-lookup. If a name is ambiguous (e.g., "Michael" could be multiple people),
+  use contact-lookup to check, then ask the CEO to clarify.
+
+  When you notice conflicting information about a contact (e.g., a different email or
+  role than what's on file), flag the discrepancy and ask the CEO to confirm before
+  updating.
+
   ## Your Team
   You have specialist agents you can delegate to using the "delegate" tool.
   When a request requires specialized expertise, delegate to the right specialist.
@@ -37,4 +53,9 @@ system_prompt: |
 pinned_skills:
   - web-fetch
   - delegate
+  - contact-create
+  - contact-lookup
+  - contact-link-identity
+  - contact-set-role
+  - contact-list
 allow_discovery: true

--- a/skills/contact-create/handler.ts
+++ b/skills/contact-create/handler.ts
@@ -1,0 +1,89 @@
+// handler.ts — contact-create skill implementation.
+//
+// Creates a new contact and optionally links channel identities (email, phone,
+// signal, telegram). Automatically creates a knowledge graph person node via
+// the ContactService.
+//
+// This is an infrastructure skill — it requires contactService access.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+// Channel names that this skill accepts as optional inputs.
+// Each maps to a channel type used by linkIdentity().
+const CHANNEL_INPUTS = ['email', 'phone', 'signal', 'telegram'] as const;
+
+export class ContactCreateHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { name, role, notes, email, phone, signal, telegram } = ctx.input as {
+      name?: string;
+      role?: string;
+      notes?: string;
+      email?: string;
+      phone?: string;
+      signal?: string;
+      telegram?: string;
+    };
+
+    // Validate required inputs
+    if (!name || typeof name !== 'string') {
+      return { success: false, error: 'Missing required input: name (string)' };
+    }
+
+    // Infrastructure skills need contactService
+    if (!ctx.contactService) {
+      return {
+        success: false,
+        error: 'contact-create skill requires infrastructure access (contactService). Is infrastructure: true set in the manifest?',
+      };
+    }
+
+    ctx.log.info({ name, role }, 'Creating contact');
+
+    try {
+      // Create the contact — this auto-creates a KG person node if entityMemory is available
+      const contact = await ctx.contactService.createContact({
+        displayName: name,
+        role: role ?? undefined,
+        notes: notes ?? undefined,
+        source: 'ceo_stated',
+      });
+
+      // Link any provided channel identities
+      const channelValues: Record<string, string | undefined> = { email, phone, signal, telegram };
+      let identitiesAdded = 0;
+
+      for (const channel of CHANNEL_INPUTS) {
+        const identifier = channelValues[channel];
+        if (identifier && typeof identifier === 'string') {
+          await ctx.contactService.linkIdentity({
+            contactId: contact.id,
+            channel,
+            channelIdentifier: identifier,
+            source: 'ceo_stated',
+          });
+          identitiesAdded++;
+        }
+      }
+
+      ctx.log.info(
+        { contactId: contact.id, identitiesAdded },
+        'Contact created successfully',
+      );
+
+      return {
+        success: true,
+        data: {
+          contact_id: contact.id,
+          display_name: contact.displayName,
+          role: contact.role,
+          kg_node_id: contact.kgNodeId,
+          identities_added: identitiesAdded,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, name }, 'Failed to create contact');
+      return { success: false, error: `Failed to create contact: ${message}` };
+    }
+  }
+}

--- a/skills/contact-create/handler.ts
+++ b/skills/contact-create/handler.ts
@@ -29,6 +29,23 @@ export class ContactCreateHandler implements SkillHandler {
       return { success: false, error: 'Missing required input: name (string)' };
     }
 
+    // Input length limits — prevent oversized payloads reaching the DB or LLM context
+    if (name.length > 500) {
+      return { success: false, error: 'Name must be 500 characters or fewer' };
+    }
+    if (role && role.length > 200) {
+      return { success: false, error: 'Role must be 200 characters or fewer' };
+    }
+    if (notes && notes.length > 5000) {
+      return { success: false, error: 'Notes must be 5000 characters or fewer' };
+    }
+    for (const ch of CHANNEL_INPUTS) {
+      const val = ({ email, phone, signal, telegram } as Record<string, string | undefined>)[ch];
+      if (val && val.length > 500) {
+        return { success: false, error: `${ch} identifier must be 500 characters or fewer` };
+      }
+    }
+
     // Infrastructure skills need contactService
     if (!ctx.contactService) {
       return {

--- a/skills/contact-create/skill.json
+++ b/skills/contact-create/skill.json
@@ -1,0 +1,26 @@
+{
+  "name": "contact-create",
+  "description": "Create a new contact. Provide the person's name and optionally their role, notes, and channel identifiers (email, phone, signal, telegram). Automatically creates a knowledge graph entry.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "name": "string",
+    "role": "string?",
+    "notes": "string?",
+    "email": "string?",
+    "phone": "string?",
+    "signal": "string?",
+    "telegram": "string?"
+  },
+  "outputs": {
+    "contact_id": "string",
+    "display_name": "string",
+    "role": "string?",
+    "kg_node_id": "string?",
+    "identities_added": "number"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/skills/contact-link-identity/handler.ts
+++ b/skills/contact-link-identity/handler.ts
@@ -28,6 +28,20 @@ export class ContactLinkIdentityHandler implements SkillHandler {
       return { success: false, error: 'Missing required input: identifier (string)' };
     }
 
+    // Input length limits — prevent oversized payloads reaching the DB
+    if (identifier.length > 500) {
+      return { success: false, error: 'Identifier must be 500 characters or fewer' };
+    }
+    if (label && label.length > 200) {
+      return { success: false, error: 'Label must be 200 characters or fewer' };
+    }
+
+    // Channel allowlist — only accept known channel types
+    const ALLOWED_CHANNELS = ['email', 'phone', 'signal', 'telegram'];
+    if (!ALLOWED_CHANNELS.includes(channel)) {
+      return { success: false, error: `Invalid channel '${channel}'. Allowed: ${ALLOWED_CHANNELS.join(', ')}` };
+    }
+
     // Infrastructure skills need contactService
     if (!ctx.contactService) {
       return {

--- a/skills/contact-link-identity/handler.ts
+++ b/skills/contact-link-identity/handler.ts
@@ -1,0 +1,68 @@
+// handler.ts — contact-link-identity skill implementation.
+//
+// Adds a channel identity (email, phone, Signal, Telegram) to an existing
+// contact. Uses source 'ceo_stated' since the coordinator acts on behalf
+// of the CEO, which means the identity is auto-verified.
+//
+// This is an infrastructure skill — it requires contactService access.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class ContactLinkIdentityHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { contact_id, channel, identifier, label } = ctx.input as {
+      contact_id?: string;
+      channel?: string;
+      identifier?: string;
+      label?: string;
+    };
+
+    // Validate required inputs
+    if (!contact_id || typeof contact_id !== 'string') {
+      return { success: false, error: 'Missing required input: contact_id (string)' };
+    }
+    if (!channel || typeof channel !== 'string') {
+      return { success: false, error: 'Missing required input: channel (string)' };
+    }
+    if (!identifier || typeof identifier !== 'string') {
+      return { success: false, error: 'Missing required input: identifier (string)' };
+    }
+
+    // Infrastructure skills need contactService
+    if (!ctx.contactService) {
+      return {
+        success: false,
+        error: 'contact-link-identity skill requires infrastructure access (contactService). Is infrastructure: true set in the manifest?',
+      };
+    }
+
+    ctx.log.info({ contact_id, channel, identifier }, 'Linking identity to contact');
+
+    try {
+      const identity = await ctx.contactService.linkIdentity({
+        contactId: contact_id,
+        channel,
+        channelIdentifier: identifier,
+        label: label ?? undefined,
+        source: 'ceo_stated',
+      });
+
+      ctx.log.info(
+        { identityId: identity.id, contactId: contact_id, verified: identity.verified },
+        'Identity linked successfully',
+      );
+
+      return {
+        success: true,
+        data: {
+          identity_id: identity.id,
+          verified: identity.verified,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, contact_id, channel }, 'Failed to link identity');
+      return { success: false, error: `Failed to link identity: ${message}` };
+    }
+  }
+}

--- a/skills/contact-link-identity/skill.json
+++ b/skills/contact-link-identity/skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "contact-link-identity",
+  "description": "Add a channel identity (email, phone, Signal, Telegram) to an existing contact.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "contact_id": "string",
+    "channel": "string",
+    "identifier": "string",
+    "label": "string?"
+  },
+  "outputs": {
+    "identity_id": "string",
+    "verified": "boolean"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -1,0 +1,49 @@
+// handler.ts — contact-list skill implementation.
+//
+// Lists all contacts, optionally filtered by role.
+// Returns an array of contact summaries.
+//
+// This is an infrastructure skill — it requires contactService access.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class ContactListHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { role } = ctx.input as {
+      role?: string;
+    };
+
+    // Infrastructure skills need contactService
+    if (!ctx.contactService) {
+      return {
+        success: false,
+        error: 'contact-list skill requires infrastructure access (contactService). Is infrastructure: true set in the manifest?',
+      };
+    }
+
+    ctx.log.info({ role: role ?? '(all)' }, 'Listing contacts');
+
+    try {
+      const contacts = role && typeof role === 'string'
+        ? await ctx.contactService.findContactByRole(role)
+        : await ctx.contactService.listContacts();
+
+      return {
+        success: true,
+        data: {
+          contacts: contacts.map((c) => ({
+            contact_id: c.id,
+            display_name: c.displayName,
+            role: c.role,
+            kg_node_id: c.kgNodeId,
+          })),
+          count: contacts.length,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, role }, 'Failed to list contacts');
+      return { success: false, error: `Failed to list contacts: ${message}` };
+    }
+  }
+}

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -13,6 +13,11 @@ export class ContactListHandler implements SkillHandler {
       role?: string;
     };
 
+    // Input length limit — prevent oversized payloads reaching the DB
+    if (role && typeof role === 'string' && role.length > 200) {
+      return { success: false, error: 'Role must be 200 characters or fewer' };
+    }
+
     // Infrastructure skills need contactService
     if (!ctx.contactService) {
       return {

--- a/skills/contact-list/skill.json
+++ b/skills/contact-list/skill.json
@@ -1,0 +1,17 @@
+{
+  "name": "contact-list",
+  "description": "List all contacts, optionally filtered by role.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "role": "string?"
+  },
+  "outputs": {
+    "contacts": "array",
+    "count": "number"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}

--- a/skills/contact-lookup/handler.ts
+++ b/skills/contact-lookup/handler.ts
@@ -31,6 +31,11 @@ export class ContactLookupHandler implements SkillHandler {
       return { success: false, error: `Invalid lookup type: "${by}". Must be one of: name, role, channel` };
     }
 
+    // Input length limits — prevent oversized payloads reaching the DB
+    if (query.length > 500) {
+      return { success: false, error: 'Query must be 500 characters or fewer' };
+    }
+
     // Infrastructure skills need contactService
     if (!ctx.contactService) {
       return {

--- a/skills/contact-lookup/handler.ts
+++ b/skills/contact-lookup/handler.ts
@@ -1,0 +1,123 @@
+// handler.ts — contact-lookup skill implementation.
+//
+// Looks up contacts by name, role, or channel identifier.
+// The `by` field determines the search strategy:
+//   - "name": case-insensitive name match via findContactByName()
+//   - "role": exact role match via findContactByRole()
+//   - "channel": resolves by "channel:identifier" via resolveByChannelIdentity()
+//
+// This is an infrastructure skill — it requires contactService access.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+/** Valid lookup strategies */
+const VALID_BY_VALUES = new Set(['name', 'role', 'channel']);
+
+export class ContactLookupHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { query, by } = ctx.input as {
+      query?: string;
+      by?: string;
+    };
+
+    // Validate required inputs
+    if (!query || typeof query !== 'string') {
+      return { success: false, error: 'Missing required input: query (string)' };
+    }
+    if (!by || typeof by !== 'string') {
+      return { success: false, error: 'Missing required input: by (string)' };
+    }
+    if (!VALID_BY_VALUES.has(by)) {
+      return { success: false, error: `Invalid lookup type: "${by}". Must be one of: name, role, channel` };
+    }
+
+    // Infrastructure skills need contactService
+    if (!ctx.contactService) {
+      return {
+        success: false,
+        error: 'contact-lookup skill requires infrastructure access (contactService). Is infrastructure: true set in the manifest?',
+      };
+    }
+
+    ctx.log.info({ query, by }, 'Looking up contact');
+
+    try {
+      if (by === 'name') {
+        const contacts = await ctx.contactService.findContactByName(query);
+        return {
+          success: true,
+          data: {
+            contacts: contacts.map(contactToSummary),
+            count: contacts.length,
+          },
+        };
+      }
+
+      if (by === 'role') {
+        const contacts = await ctx.contactService.findContactByRole(query);
+        return {
+          success: true,
+          data: {
+            contacts: contacts.map(contactToSummary),
+            count: contacts.length,
+          },
+        };
+      }
+
+      // by === 'channel': parse query as "channel:identifier"
+      const colonIndex = query.indexOf(':');
+      if (colonIndex === -1) {
+        return {
+          success: false,
+          error: 'Channel lookup query must be in format "channel:identifier" (e.g., "email:jenna@acme.com")',
+        };
+      }
+
+      const channel = query.slice(0, colonIndex);
+      const identifier = query.slice(colonIndex + 1);
+
+      if (!channel || !identifier) {
+        return {
+          success: false,
+          error: 'Channel lookup query must have both channel and identifier (e.g., "email:jenna@acme.com")',
+        };
+      }
+
+      const resolved = await ctx.contactService.resolveByChannelIdentity(channel, identifier);
+      if (!resolved) {
+        return {
+          success: true,
+          data: { contacts: [], count: 0 },
+        };
+      }
+
+      return {
+        success: true,
+        data: {
+          contacts: [{
+            contact_id: resolved.contactId,
+            display_name: resolved.displayName,
+            role: resolved.role,
+            kg_node_id: resolved.kgNodeId,
+            verified: resolved.verified,
+          }],
+          count: 1,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, query, by }, 'Contact lookup failed');
+      return { success: false, error: `Contact lookup failed: ${message}` };
+    }
+  }
+}
+
+/** Convert a Contact to a summary object for the skill output */
+function contactToSummary(contact: { id: string; displayName: string; role: string | null; kgNodeId: string | null }) {
+  return {
+    contact_id: contact.id,
+    display_name: contact.displayName,
+    role: contact.role,
+    kg_node_id: contact.kgNodeId,
+  };
+}

--- a/skills/contact-lookup/skill.json
+++ b/skills/contact-lookup/skill.json
@@ -1,0 +1,18 @@
+{
+  "name": "contact-lookup",
+  "description": "Look up a contact by name, role, or channel identifier. Returns matching contacts with their details.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "query": "string",
+    "by": "string"
+  },
+  "outputs": {
+    "contacts": "array",
+    "count": "number"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}

--- a/skills/contact-set-role/handler.ts
+++ b/skills/contact-set-role/handler.ts
@@ -1,0 +1,57 @@
+// handler.ts — contact-set-role skill implementation.
+//
+// Sets or changes a contact's role (e.g., CFO, board member, advisor).
+// Returns the updated contact details.
+//
+// This is an infrastructure skill — it requires contactService access.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class ContactSetRoleHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { contact_id, role } = ctx.input as {
+      contact_id?: string;
+      role?: string;
+    };
+
+    // Validate required inputs
+    if (!contact_id || typeof contact_id !== 'string') {
+      return { success: false, error: 'Missing required input: contact_id (string)' };
+    }
+    if (!role || typeof role !== 'string') {
+      return { success: false, error: 'Missing required input: role (string)' };
+    }
+
+    // Infrastructure skills need contactService
+    if (!ctx.contactService) {
+      return {
+        success: false,
+        error: 'contact-set-role skill requires infrastructure access (contactService). Is infrastructure: true set in the manifest?',
+      };
+    }
+
+    ctx.log.info({ contact_id, role }, 'Setting contact role');
+
+    try {
+      const updated = await ctx.contactService.setRole(contact_id, role);
+
+      ctx.log.info(
+        { contactId: updated.id, role: updated.role },
+        'Contact role updated',
+      );
+
+      return {
+        success: true,
+        data: {
+          contact_id: updated.id,
+          display_name: updated.displayName,
+          role: updated.role,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, contact_id, role }, 'Failed to set contact role');
+      return { success: false, error: `Failed to set contact role: ${message}` };
+    }
+  }
+}

--- a/skills/contact-set-role/handler.ts
+++ b/skills/contact-set-role/handler.ts
@@ -22,6 +22,11 @@ export class ContactSetRoleHandler implements SkillHandler {
       return { success: false, error: 'Missing required input: role (string)' };
     }
 
+    // Input length limit — prevent oversized payloads reaching the DB
+    if (role.length > 200) {
+      return { success: false, error: 'Role must be 200 characters or fewer' };
+    }
+
     // Infrastructure skills need contactService
     if (!ctx.contactService) {
       return {

--- a/skills/contact-set-role/skill.json
+++ b/skills/contact-set-role/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "contact-set-role",
+  "description": "Set or change a contact's role (e.g., CFO, board member, advisor).",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "contact_id": "string",
+    "role": "string"
+  },
+  "outputs": {
+    "contact_id": "string",
+    "display_name": "string",
+    "role": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -96,6 +96,21 @@ export class AgentRuntime {
       { role: 'user', content },
     ];
 
+    // Inject resolved sender context as a system message so the coordinator
+    // knows who it's talking to. Inserted after the system prompt but before
+    // history, so it's visible but doesn't pollute working memory.
+    const senderCtx = taskEvent.payload.senderContext;
+    if (senderCtx?.resolved) {
+      let senderInfo = `Current sender: ${senderCtx.displayName}`;
+      if (senderCtx.role) senderInfo += ` (${senderCtx.role})`;
+      senderInfo += senderCtx.verified ? ' [verified]' : ' [unverified]';
+      if (senderCtx.knowledgeSummary) {
+        senderInfo += `\n\nKnown context about ${senderCtx.displayName}:\n${senderCtx.knowledgeSummary}`;
+      }
+      // Insert after system prompt (index 0) but before history
+      messages.splice(1, 0, { role: 'system', content: senderInfo });
+    }
+
     logger.info({ agentId, conversationId, historyLength: history.length }, 'Agent processing task');
 
     // Persist the incoming user message

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -101,11 +101,21 @@ export class AgentRuntime {
     // history, so it's visible but doesn't pollute working memory.
     const senderCtx = taskEvent.payload.senderContext;
     if (senderCtx?.resolved) {
-      let senderInfo = `Current sender: ${senderCtx.displayName}`;
-      if (senderCtx.role) senderInfo += ` (${senderCtx.role})`;
+      // Sanitize sender fields before prompt inclusion — these originate from
+      // external sources (self-claimed names, imported roles) and could contain
+      // prompt injection attempts.
+      const safeName = sanitizeOutput(senderCtx.displayName);
+      const safeRole = senderCtx.role ? sanitizeOutput(senderCtx.role) : null;
+      // Length-limit knowledgeSummary to prevent context stuffing
+      const safeKnowledge = senderCtx.knowledgeSummary
+        ? sanitizeOutput(senderCtx.knowledgeSummary).slice(0, 2000)
+        : '';
+
+      let senderInfo = `Current sender: ${safeName}`;
+      if (safeRole) senderInfo += ` (${safeRole})`;
       senderInfo += senderCtx.verified ? ' [verified]' : ' [unverified]';
-      if (senderCtx.knowledgeSummary) {
-        senderInfo += `\n\nKnown context about ${senderCtx.displayName}:\n${senderCtx.knowledgeSummary}`;
+      if (safeKnowledge) {
+        senderInfo += `\n\nKnown context about ${safeName}:\n${safeKnowledge}`;
       }
       // Insert after system prompt (index 0) but before history
       messages.splice(1, 0, { role: 'system', content: senderInfo });

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -31,6 +31,8 @@ interface AgentTaskPayload {
   senderId: string;
   content: string;
   metadata?: Record<string, unknown>;
+  /** Resolved sender context from the contact resolver. Undefined if contacts not configured. */
+  senderContext?: import('../contacts/types.js').InboundSenderContext;
 }
 
 interface AgentResponsePayload {

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -61,6 +61,27 @@ interface SkillResultPayload {
   durationMs: number;
 }
 
+// Contact event payloads — emitted by the dispatch layer during contact resolution (Contacts Phase A).
+
+interface ContactResolvedPayload {
+  contactId: string;
+  displayName: string;
+  role: string | null;
+  kgNodeId: string | null;
+  // 'verified' means the contact has been confirmed via an authoritative source (e.g. KG match);
+  // 'unverified' means the identity was inferred but not confirmed.
+  verificationStatus: 'verified' | 'unverified';
+  channel: string;
+  channelIdentifier: string;
+}
+
+interface ContactUnknownPayload {
+  channel: string;
+  senderId: string;
+  /** Channel trust level. Optional in Phase A; Phase B will make it required. */
+  channelTrustLevel?: 'low' | 'medium' | 'high';
+}
+
 // Memory event payloads — used for the knowledge graph audit trail (Phase 6).
 // `source` is a structured provenance string (e.g. "agent:coordinator/task:task-1/channel:cli").
 
@@ -122,6 +143,21 @@ export interface SkillResultEvent extends BaseEvent {
   payload: SkillResultPayload;
 }
 
+// Contact events — emitted by the dispatch layer during the contact resolution step.
+// contact.resolved fires when a sender maps to a known contact; contact.unknown fires when no match is found.
+
+export interface ContactResolvedEvent extends BaseEvent {
+  type: 'contact.resolved';
+  sourceLayer: 'dispatch';
+  payload: ContactResolvedPayload;
+}
+
+export interface ContactUnknownEvent extends BaseEvent {
+  type: 'contact.unknown';
+  sourceLayer: 'dispatch';
+  payload: ContactUnknownPayload;
+}
+
 // Memory events — emitted by the agent layer whenever the knowledge graph is written to or queried.
 // These form the audit trail for memory operations (Phase 6).
 
@@ -144,8 +180,10 @@ export type BusEvent =
   | OutboundMessageEvent
   | SkillInvokeEvent
   | SkillResultEvent
-  | MemoryStoreEvent    // Phase 6: knowledge graph write audit
-  | MemoryQueryEvent;   // Phase 6: knowledge graph read audit
+  | MemoryStoreEvent      // Phase 6: knowledge graph write audit
+  | MemoryQueryEvent      // Phase 6: knowledge graph read audit
+  | ContactResolvedEvent  // Contacts Phase A: sender matched to a known contact
+  | ContactUnknownEvent;  // Contacts Phase A: sender has no contact record
 
 // Convenience alias for use in handler maps / switch statements.
 export type EventType = BusEvent['type'];
@@ -267,6 +305,36 @@ export function createMemoryQuery(
     timestamp: new Date(),
     type: 'memory.query',
     sourceLayer: 'agent',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createContactResolved(
+  // parentEventId is required — every resolution must trace back to the inbound event that triggered it.
+  payload: ContactResolvedPayload & { parentEventId: string },
+): ContactResolvedEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'contact.resolved',
+    sourceLayer: 'dispatch',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createContactUnknown(
+  // parentEventId is required — unknown-contact signals must trace back to the inbound event.
+  payload: ContactUnknownPayload & { parentEventId: string },
+): ContactUnknownEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'contact.unknown',
+    sourceLayer: 'dispatch',
     payload: rest,
     parentEventId,
   };

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -3,12 +3,14 @@ import type { Layer, EventType } from './events.js';
 // Phase 3: agent and execution layers added for skill event types
 // Phase 6: agent layer can publish memory.store and memory.query for the KG audit trail;
 //          system layer gets full access so audit logger and monitoring can observe these events.
+// Contacts Phase A: dispatch layer publishes contact.resolved and contact.unknown after resolution;
+//                   system layer gets full access for audit logging.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message']),
-  dispatch: new Set(['agent.task', 'outbound.message']),
+  dispatch: new Set(['agent.task', 'outbound.message', 'contact.resolved', 'contact.unknown']),
   agent: new Set(['agent.response', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query']),
   execution: new Set(['skill.result']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'outbound.message', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'outbound.message', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown']),
 };
 
 const subscribeAllowlist: Record<Layer, Set<EventType>> = {
@@ -16,7 +18,7 @@ const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   dispatch: new Set(['inbound.message', 'agent.response']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'outbound.message', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'outbound.message', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/contacts/contact-resolver.ts
+++ b/src/contacts/contact-resolver.ts
@@ -1,0 +1,85 @@
+// src/contacts/contact-resolver.ts
+//
+// ContactResolver: resolves inbound message senders to known contacts, enriching
+// with KG facts for the coordinator's prompt context.
+//
+// Runs in the dispatch layer on every inbound message, BEFORE the coordinator sees it.
+// Resolution is deterministic — a simple indexed DB query, no LLM involved.
+
+import type { ContactService } from './contact-service.js';
+import type { EntityMemory } from '../memory/entity-memory.js';
+import type { Logger } from '../logger.js';
+import type { InboundSenderContext } from './types.js';
+
+/**
+ * Resolves inbound message senders to known contacts.
+ * Runs in the dispatch layer on every inbound message, BEFORE the coordinator sees it.
+ * Resolution is deterministic — a simple indexed DB query, no LLM involved.
+ */
+export class ContactResolver {
+  constructor(
+    private contactService: ContactService,
+    private entityMemory: EntityMemory | undefined,
+    private logger: Logger,
+  ) {}
+
+  /**
+   * Resolve a sender to a known contact.
+   * Returns rich SenderContext (with KG facts) for known contacts,
+   * or UnknownSenderContext for unrecognized senders.
+   *
+   * CLI and smoke-test channels always resolve as the primary user (CEO).
+   */
+  async resolve(channel: string, senderId: string): Promise<InboundSenderContext> {
+    // CLI and smoke-test are always the primary user — no resolution needed
+    if (channel === 'cli' || channel === 'smoke-test') {
+      return {
+        resolved: true,
+        contactId: 'primary-user',
+        displayName: 'CEO',
+        role: 'ceo',
+        verified: true,
+        knowledgeSummary: '',
+      };
+    }
+
+    const resolved = await this.contactService.resolveByChannelIdentity(channel, senderId);
+    if (!resolved) {
+      this.logger.info({ channel, senderId }, 'Unknown sender — no contact match');
+      return { resolved: false, channel, senderId };
+    }
+
+    // Enrich with KG facts if available
+    let knowledgeSummary = '';
+    if (resolved.kgNodeId && this.entityMemory) {
+      try {
+        const knowledge = await this.entityMemory.query(resolved.kgNodeId);
+        const factLines = knowledge.facts.map(f => `- ${f.label}`);
+        const relLines = knowledge.relationships.map(r =>
+          `- ${r.edge.type} → ${r.node.label}`
+        );
+        const lines = [...factLines, ...relLines];
+        if (lines.length > 0) {
+          knowledgeSummary = lines.join('\n');
+        }
+      } catch (err) {
+        // KG enrichment is best-effort — don't fail resolution if the KG query errors
+        this.logger.warn({ err, kgNodeId: resolved.kgNodeId }, 'Failed to enrich contact with KG facts');
+      }
+    }
+
+    this.logger.info(
+      { contactId: resolved.contactId, displayName: resolved.displayName, verified: resolved.verified },
+      'Sender resolved to contact',
+    );
+
+    return {
+      resolved: true,
+      contactId: resolved.contactId,
+      displayName: resolved.displayName,
+      role: resolved.role,
+      verified: resolved.verified,
+      knowledgeSummary,
+    };
+  }
+}

--- a/src/contacts/contact-resolver.ts
+++ b/src/contacts/contact-resolver.ts
@@ -31,7 +31,8 @@ export class ContactResolver {
    * CLI and smoke-test channels always resolve as the primary user (CEO).
    */
   async resolve(channel: string, senderId: string): Promise<InboundSenderContext> {
-    // CLI and smoke-test are always the primary user — no resolution needed
+    // CLI and smoke-test are always the primary user — no resolution needed.
+    // kgNodeId is null here because synthetic IDs have no KG node.
     if (channel === 'cli' || channel === 'smoke-test') {
       return {
         resolved: true,
@@ -39,6 +40,7 @@ export class ContactResolver {
         displayName: 'CEO',
         role: 'ceo',
         verified: true,
+        kgNodeId: null,
         knowledgeSummary: '',
       };
     }
@@ -79,6 +81,7 @@ export class ContactResolver {
       displayName: resolved.displayName,
       role: resolved.role,
       verified: resolved.verified,
+      kgNodeId: resolved.kgNodeId,
       knowledgeSummary,
     };
   }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -104,7 +104,17 @@ export class ContactService {
       updatedAt: now,
     };
 
-    await this.backend.createContact(contact);
+    try {
+      await this.backend.createContact(contact);
+    } catch (err) {
+      // If the DB insert fails after we auto-created a KG node, that node is now
+      // orphaned — it exists in the knowledge graph with no corresponding contact row.
+      // TODO: Clean up the orphaned KG node once EntityMemory exposes a delete method.
+      // For now, the orphan will remain. It won't cause functional issues (it's just a
+      // person node with no contact link), but should be cleaned up when entity deletion
+      // is added. Tracked by: https://github.com/curia-ai/curia/issues/TBD
+      throw err;
+    }
     return contact;
   }
 
@@ -153,6 +163,14 @@ export class ContactService {
    * If options.verified is explicitly provided, that takes precedence.
    */
   async linkIdentity(options: LinkIdentityOptions): Promise<ChannelIdentity> {
+    // Validate the contact exists before creating an identity for it.
+    // Postgres would catch this via FK constraint, but the in-memory backend
+    // would silently create a dangling reference without this check.
+    const contact = await this.backend.getContact(options.contactId);
+    if (!contact) {
+      throw new Error(`Contact not found: ${options.contactId}`);
+    }
+
     const now = new Date();
 
     // Determine verification status: explicit override > auto-verify logic

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -181,6 +181,12 @@ export class ContactService {
       verified = AUTO_VERIFIED_SOURCES.has(options.source);
     }
 
+    // Prevent force-verifying self-claimed identities — they must go through
+    // the CEO confirmation flow to become verified.
+    if (options.source === 'self_claimed' && verified) {
+      throw new Error('Cannot force-verify a self_claimed identity — CEO confirmation required');
+    }
+
     const identity: ChannelIdentity = {
       id: randomUUID(),
       contactId: options.contactId,
@@ -501,6 +507,14 @@ class InMemoryContactBackend implements ContactServiceBackend {
   }
 
   async createIdentity(identity: ChannelIdentity): Promise<void> {
+    // Enforce UNIQUE(channel, channel_identifier) to match Postgres behavior.
+    // Without this, the in-memory backend would silently allow duplicates
+    // that Postgres would reject via its unique index.
+    for (const existing of this.identities.values()) {
+      if (existing.channel === identity.channel && existing.channelIdentifier === identity.channelIdentifier) {
+        throw new Error(`Channel identity already exists: ${identity.channel}:${identity.channelIdentifier}`);
+      }
+    }
     this.identities.set(identity.id, identity);
   }
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -1,0 +1,520 @@
+// src/contacts/contact-service.ts
+//
+// ContactService: CRUD operations for contacts and their channel identities,
+// with automatic KG person-node creation and identity auto-verification.
+//
+// Follows the backend-interface pattern from WorkingMemory / KnowledgeGraphStore:
+// - Private constructor, static factory methods
+// - InMemoryContactBackend for tests, PostgresContactBackend for production
+// - Business logic (auto-verify, KG linking) lives in ContactService,
+//   backends are pure storage
+
+import { randomUUID } from 'node:crypto';
+import type { DbPool } from '../db/connection.js';
+import type { Logger } from '../logger.js';
+import type { EntityMemory } from '../memory/entity-memory.js';
+import type {
+  Contact,
+  ChannelIdentity,
+  CreateContactOptions,
+  LinkIdentityOptions,
+  ResolvedSender,
+  IdentitySource,
+} from './types.js';
+
+// -- Backend interface --
+
+interface ContactServiceBackend {
+  createContact(contact: Contact): Promise<void>;
+  getContact(id: string): Promise<Contact | undefined>;
+  findContactByName(name: string): Promise<Contact[]>;
+  findContactByRole(role: string): Promise<Contact[]>;
+  listContacts(): Promise<Contact[]>;
+  updateContact(contact: Contact): Promise<void>;
+  createIdentity(identity: ChannelIdentity): Promise<void>;
+  getIdentitiesForContact(contactId: string): Promise<ChannelIdentity[]>;
+  resolveByChannelIdentity(channel: string, channelIdentifier: string): Promise<ResolvedSender | null>;
+}
+
+// -- Auto-verification sources --
+// Per spec: ceo_stated, email_participant, crm_import, calendar_attendee are auto-verified.
+// Only self_claimed starts unverified.
+const AUTO_VERIFIED_SOURCES: ReadonlySet<IdentitySource> = new Set([
+  'ceo_stated',
+  'email_participant',
+  'crm_import',
+  'calendar_attendee',
+]);
+
+/**
+ * ContactService manages the lifecycle of contacts and their channel identities.
+ *
+ * Key behaviors:
+ * - Auto-creates a KG person node when a contact is created (if entityMemory is available
+ *   and no kgNodeId is provided)
+ * - Auto-verifies identities from trusted sources (ceo_stated, email_participant, etc.)
+ * - Resolves inbound senders by channel + identifier for dispatch routing
+ */
+export class ContactService {
+  private constructor(
+    private backend: ContactServiceBackend,
+    private entityMemory: EntityMemory | undefined,
+  ) {}
+
+  /** Create a Postgres-backed instance for production use */
+  static createWithPostgres(
+    pool: DbPool,
+    entityMemory: EntityMemory | undefined,
+    logger: Logger,
+  ): ContactService {
+    return new ContactService(new PostgresContactBackend(pool, logger), entityMemory);
+  }
+
+  /** Create an in-memory instance for testing */
+  static createInMemory(entityMemory?: EntityMemory): ContactService {
+    return new ContactService(new InMemoryContactBackend(), entityMemory);
+  }
+
+  /**
+   * Create a new contact. If entityMemory is available and no kgNodeId is provided,
+   * auto-creates a KG person node and links it to the contact.
+   */
+  async createContact(options: CreateContactOptions): Promise<Contact> {
+    const now = new Date();
+
+    // Auto-create a KG person node if we have entityMemory and no explicit kgNodeId
+    let kgNodeId: string | null = options.kgNodeId ?? null;
+    if (!kgNodeId && this.entityMemory) {
+      const entity = await this.entityMemory.createEntity({
+        type: 'person',
+        label: options.displayName,
+        properties: options.role ? { role: options.role } : {},
+        source: options.source,
+      });
+      kgNodeId = entity.id;
+    }
+
+    const contact: Contact = {
+      id: randomUUID(),
+      kgNodeId,
+      displayName: options.displayName,
+      role: options.role ?? null,
+      notes: options.notes ?? null,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.backend.createContact(contact);
+    return contact;
+  }
+
+  /** Retrieve a contact by ID. Returns undefined if not found. */
+  async getContact(id: string): Promise<Contact | undefined> {
+    return this.backend.getContact(id);
+  }
+
+  /** Find contacts by display name (case-insensitive exact match). */
+  async findContactByName(name: string): Promise<Contact[]> {
+    return this.backend.findContactByName(name);
+  }
+
+  /** Find contacts by role. */
+  async findContactByRole(role: string): Promise<Contact[]> {
+    return this.backend.findContactByRole(role);
+  }
+
+  /** List all contacts. */
+  async listContacts(): Promise<Contact[]> {
+    return this.backend.listContacts();
+  }
+
+  /** Update a contact's role and updatedAt timestamp. */
+  async setRole(contactId: string, role: string): Promise<Contact> {
+    const contact = await this.backend.getContact(contactId);
+    if (!contact) {
+      throw new Error(`Contact not found: ${contactId}`);
+    }
+
+    const updated: Contact = {
+      ...contact,
+      role,
+      updatedAt: new Date(),
+    };
+
+    await this.backend.updateContact(updated);
+    return updated;
+  }
+
+  /**
+   * Link a channel identity to a contact.
+   *
+   * Auto-verification logic: sources ceo_stated, email_participant, crm_import,
+   * and calendar_attendee are auto-verified. self_claimed starts unverified.
+   * If options.verified is explicitly provided, that takes precedence.
+   */
+  async linkIdentity(options: LinkIdentityOptions): Promise<ChannelIdentity> {
+    const now = new Date();
+
+    // Determine verification status: explicit override > auto-verify logic
+    let verified: boolean;
+    if (options.verified !== undefined) {
+      verified = options.verified;
+    } else {
+      verified = AUTO_VERIFIED_SOURCES.has(options.source);
+    }
+
+    const identity: ChannelIdentity = {
+      id: randomUUID(),
+      contactId: options.contactId,
+      channel: options.channel,
+      channelIdentifier: options.channelIdentifier,
+      label: options.label ?? null,
+      verified,
+      verifiedAt: verified ? now : null,
+      source: options.source,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.backend.createIdentity(identity);
+    return identity;
+  }
+
+  /**
+   * Resolve an inbound sender by channel + identifier.
+   * Joins contacts with contact_channel_identities to find the matching contact.
+   * Returns null if no match.
+   */
+  async resolveByChannelIdentity(
+    channel: string,
+    channelIdentifier: string,
+  ): Promise<ResolvedSender | null> {
+    return this.backend.resolveByChannelIdentity(channel, channelIdentifier);
+  }
+
+  /** Get a contact together with all its linked channel identities. */
+  async getContactWithIdentities(
+    id: string,
+  ): Promise<{ contact: Contact; identities: ChannelIdentity[] } | undefined> {
+    const contact = await this.backend.getContact(id);
+    if (!contact) {
+      return undefined;
+    }
+
+    const identities = await this.backend.getIdentitiesForContact(id);
+    return { contact, identities };
+  }
+}
+
+// -- Postgres backend --
+
+/**
+ * Postgres-backed storage for contacts and channel identities.
+ * Uses parameterized queries throughout — never interpolates user input into SQL.
+ */
+class PostgresContactBackend implements ContactServiceBackend {
+  constructor(
+    private pool: DbPool,
+    private logger: Logger,
+  ) {}
+
+  async createContact(contact: Contact): Promise<void> {
+    this.logger.debug({ contactId: contact.id }, 'contacts: creating contact');
+    await this.pool.query(
+      `INSERT INTO contacts (id, kg_node_id, display_name, role, notes, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [contact.id, contact.kgNodeId, contact.displayName, contact.role, contact.notes, contact.createdAt, contact.updatedAt],
+    );
+  }
+
+  async getContact(id: string): Promise<Contact | undefined> {
+    const result = await this.pool.query<{
+      id: string;
+      kg_node_id: string | null;
+      display_name: string;
+      role: string | null;
+      notes: string | null;
+      created_at: Date;
+      updated_at: Date;
+    }>(
+      `SELECT id, kg_node_id, display_name, role, notes, created_at, updated_at
+       FROM contacts WHERE id = $1`,
+      [id],
+    );
+
+    const row = result.rows[0];
+    if (!row) return undefined;
+
+    return this.rowToContact(row);
+  }
+
+  async findContactByName(name: string): Promise<Contact[]> {
+    // Case-insensitive exact match using lower()
+    const result = await this.pool.query<{
+      id: string;
+      kg_node_id: string | null;
+      display_name: string;
+      role: string | null;
+      notes: string | null;
+      created_at: Date;
+      updated_at: Date;
+    }>(
+      `SELECT id, kg_node_id, display_name, role, notes, created_at, updated_at
+       FROM contacts WHERE lower(display_name) = lower($1)`,
+      [name],
+    );
+
+    return result.rows.map((row) => this.rowToContact(row));
+  }
+
+  async findContactByRole(role: string): Promise<Contact[]> {
+    const result = await this.pool.query<{
+      id: string;
+      kg_node_id: string | null;
+      display_name: string;
+      role: string | null;
+      notes: string | null;
+      created_at: Date;
+      updated_at: Date;
+    }>(
+      `SELECT id, kg_node_id, display_name, role, notes, created_at, updated_at
+       FROM contacts WHERE role = $1`,
+      [role],
+    );
+
+    return result.rows.map((row) => this.rowToContact(row));
+  }
+
+  async listContacts(): Promise<Contact[]> {
+    const result = await this.pool.query<{
+      id: string;
+      kg_node_id: string | null;
+      display_name: string;
+      role: string | null;
+      notes: string | null;
+      created_at: Date;
+      updated_at: Date;
+    }>(
+      `SELECT id, kg_node_id, display_name, role, notes, created_at, updated_at
+       FROM contacts ORDER BY created_at ASC`,
+    );
+
+    return result.rows.map((row) => this.rowToContact(row));
+  }
+
+  async updateContact(contact: Contact): Promise<void> {
+    this.logger.debug({ contactId: contact.id }, 'contacts: updating contact');
+    await this.pool.query(
+      `UPDATE contacts SET kg_node_id = $2, display_name = $3, role = $4, notes = $5, updated_at = $6
+       WHERE id = $1`,
+      [contact.id, contact.kgNodeId, contact.displayName, contact.role, contact.notes, contact.updatedAt],
+    );
+  }
+
+  async createIdentity(identity: ChannelIdentity): Promise<void> {
+    this.logger.debug(
+      { identityId: identity.id, contactId: identity.contactId, channel: identity.channel },
+      'contacts: creating channel identity',
+    );
+    await this.pool.query(
+      `INSERT INTO contact_channel_identities
+         (id, contact_id, channel, channel_identifier, label, verified, verified_at, source, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+      [
+        identity.id,
+        identity.contactId,
+        identity.channel,
+        identity.channelIdentifier,
+        identity.label,
+        identity.verified,
+        identity.verifiedAt,
+        identity.source,
+        identity.createdAt,
+        identity.updatedAt,
+      ],
+    );
+  }
+
+  async getIdentitiesForContact(contactId: string): Promise<ChannelIdentity[]> {
+    const result = await this.pool.query<{
+      id: string;
+      contact_id: string;
+      channel: string;
+      channel_identifier: string;
+      label: string | null;
+      verified: boolean;
+      verified_at: Date | null;
+      source: string;
+      created_at: Date;
+      updated_at: Date;
+    }>(
+      `SELECT id, contact_id, channel, channel_identifier, label, verified, verified_at, source, created_at, updated_at
+       FROM contact_channel_identities WHERE contact_id = $1 ORDER BY created_at ASC`,
+      [contactId],
+    );
+
+    return result.rows.map((row) => this.rowToIdentity(row));
+  }
+
+  async resolveByChannelIdentity(
+    channel: string,
+    channelIdentifier: string,
+  ): Promise<ResolvedSender | null> {
+    const result = await this.pool.query<{
+      id: string;
+      display_name: string;
+      role: string | null;
+      kg_node_id: string | null;
+      verified: boolean;
+    }>(
+      `SELECT c.id, c.display_name, c.role, c.kg_node_id, cci.verified
+       FROM contact_channel_identities cci
+       JOIN contacts c ON c.id = cci.contact_id
+       WHERE cci.channel = $1 AND cci.channel_identifier = $2`,
+      [channel, channelIdentifier],
+    );
+
+    const row = result.rows[0];
+    if (!row) return null;
+
+    return {
+      contactId: row.id,
+      displayName: row.display_name,
+      role: row.role,
+      kgNodeId: row.kg_node_id,
+      verified: row.verified,
+    };
+  }
+
+  // -- Row mapping helpers --
+
+  private rowToContact(row: {
+    id: string;
+    kg_node_id: string | null;
+    display_name: string;
+    role: string | null;
+    notes: string | null;
+    created_at: Date;
+    updated_at: Date;
+  }): Contact {
+    return {
+      id: row.id,
+      kgNodeId: row.kg_node_id,
+      displayName: row.display_name,
+      role: row.role,
+      notes: row.notes,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private rowToIdentity(row: {
+    id: string;
+    contact_id: string;
+    channel: string;
+    channel_identifier: string;
+    label: string | null;
+    verified: boolean;
+    verified_at: Date | null;
+    source: string;
+    created_at: Date;
+    updated_at: Date;
+  }): ChannelIdentity {
+    return {
+      id: row.id,
+      contactId: row.contact_id,
+      channel: row.channel,
+      channelIdentifier: row.channel_identifier,
+      label: row.label,
+      verified: row.verified,
+      verifiedAt: row.verified_at,
+      source: row.source as IdentitySource,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+}
+
+// -- In-memory backend --
+
+/**
+ * In-memory storage for testing. No database required.
+ * Uses Maps for contacts and identities, with array scans for search operations.
+ */
+class InMemoryContactBackend implements ContactServiceBackend {
+  private contacts = new Map<string, Contact>();
+  private identities = new Map<string, ChannelIdentity>();
+
+  async createContact(contact: Contact): Promise<void> {
+    this.contacts.set(contact.id, contact);
+  }
+
+  async getContact(id: string): Promise<Contact | undefined> {
+    return this.contacts.get(id);
+  }
+
+  async findContactByName(name: string): Promise<Contact[]> {
+    const lowerName = name.toLowerCase();
+    const results: Contact[] = [];
+    for (const contact of this.contacts.values()) {
+      if (contact.displayName.toLowerCase() === lowerName) {
+        results.push(contact);
+      }
+    }
+    return results;
+  }
+
+  async findContactByRole(role: string): Promise<Contact[]> {
+    const results: Contact[] = [];
+    for (const contact of this.contacts.values()) {
+      if (contact.role === role) {
+        results.push(contact);
+      }
+    }
+    return results;
+  }
+
+  async listContacts(): Promise<Contact[]> {
+    return [...this.contacts.values()];
+  }
+
+  async updateContact(contact: Contact): Promise<void> {
+    this.contacts.set(contact.id, contact);
+  }
+
+  async createIdentity(identity: ChannelIdentity): Promise<void> {
+    this.identities.set(identity.id, identity);
+  }
+
+  async getIdentitiesForContact(contactId: string): Promise<ChannelIdentity[]> {
+    const results: ChannelIdentity[] = [];
+    for (const identity of this.identities.values()) {
+      if (identity.contactId === contactId) {
+        results.push(identity);
+      }
+    }
+    return results;
+  }
+
+  async resolveByChannelIdentity(
+    channel: string,
+    channelIdentifier: string,
+  ): Promise<ResolvedSender | null> {
+    // Find the matching identity, then look up the contact
+    for (const identity of this.identities.values()) {
+      if (identity.channel === channel && identity.channelIdentifier === channelIdentifier) {
+        const contact = this.contacts.get(identity.contactId);
+        if (contact) {
+          return {
+            contactId: contact.id,
+            displayName: contact.displayName,
+            role: contact.role,
+            kgNodeId: contact.kgNodeId,
+            verified: identity.verified,
+          };
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -76,6 +76,7 @@ export interface SenderContext {
   displayName: string;
   role: string | null;
   verified: boolean;
+  kgNodeId: string | null;
   /** Facts from the KG about this person, formatted for prompt inclusion */
   knowledgeSummary: string;
 }

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -1,0 +1,89 @@
+// src/contacts/types.ts
+
+export interface Contact {
+  id: string;
+  kgNodeId: string | null;
+  displayName: string;
+  role: string | null;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ChannelIdentity {
+  id: string;
+  contactId: string;
+  channel: string;
+  channelIdentifier: string;
+  label: string | null;
+  verified: boolean;
+  verifiedAt: Date | null;
+  source: IdentitySource;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type IdentitySource =
+  | 'ceo_stated'
+  | 'email_participant'
+  | 'crm_import'
+  | 'calendar_attendee'
+  | 'self_claimed';
+
+export interface AuthOverride {
+  id: string;
+  contactId: string;
+  permission: string;
+  granted: boolean;
+  grantedBy: string;
+  createdAt: Date;
+  revokedAt: Date | null;
+}
+
+/** Options for creating a new contact */
+export interface CreateContactOptions {
+  displayName: string;
+  role?: string;
+  notes?: string;
+  /** If provided, links to this existing KG node. Otherwise auto-creates one. */
+  kgNodeId?: string;
+  source: string;
+}
+
+/** Options for adding a channel identity to a contact */
+export interface LinkIdentityOptions {
+  contactId: string;
+  channel: string;
+  channelIdentifier: string;
+  label?: string;
+  source: IdentitySource;
+  verified?: boolean;
+}
+
+/** Result of resolving an inbound sender */
+export interface ResolvedSender {
+  contactId: string;
+  displayName: string;
+  role: string | null;
+  kgNodeId: string | null;
+  verified: boolean;
+}
+
+/** Enriched context about a sender, assembled for the coordinator's prompt */
+export interface SenderContext {
+  resolved: true;
+  contactId: string;
+  displayName: string;
+  role: string | null;
+  verified: boolean;
+  /** Facts from the KG about this person, formatted for prompt inclusion */
+  knowledgeSummary: string;
+}
+
+export interface UnknownSenderContext {
+  resolved: false;
+  channel: string;
+  senderId: string;
+}
+
+export type InboundSenderContext = SenderContext | UnknownSenderContext;

--- a/src/db/migrations/005_create_contacts.sql
+++ b/src/db/migrations/005_create_contacts.sql
@@ -1,0 +1,55 @@
+-- Up Migration
+
+-- Contacts: thin index over KG person nodes for fast dispatch-time lookups.
+-- Rich context about a person lives in the KG — these tables handle
+-- identity resolution, verification, and authorization overrides.
+CREATE TABLE contacts (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  kg_node_id      UUID REFERENCES kg_nodes(id),
+  display_name    TEXT NOT NULL,
+  role            TEXT,
+  notes           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_contacts_kg_node ON contacts (kg_node_id) WHERE kg_node_id IS NOT NULL;
+CREATE INDEX idx_contacts_role ON contacts (role) WHERE role IS NOT NULL;
+CREATE INDEX idx_contacts_display_name ON contacts (lower(display_name));
+
+-- Channel identities: maps (channel, identifier) → contact.
+-- One contact can have multiple identifiers per channel (work + personal email).
+-- UNIQUE constraint prevents two different contacts from claiming the same identifier.
+CREATE TABLE contact_channel_identities (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contact_id          UUID NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  channel             TEXT NOT NULL,
+  channel_identifier  TEXT NOT NULL,
+  label               TEXT,
+  verified            BOOLEAN NOT NULL DEFAULT false,
+  verified_at         TIMESTAMPTZ,
+  source              TEXT NOT NULL,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  UNIQUE(channel, channel_identifier)
+);
+
+CREATE INDEX idx_cci_contact ON contact_channel_identities (contact_id);
+
+-- Authorization overrides: per-contact grants/denials that override role defaults.
+-- Phase B will implement the authorization check flow; for now we just create the table.
+CREATE TABLE contact_auth_overrides (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contact_id      UUID NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  permission      TEXT NOT NULL,
+  granted         BOOLEAN NOT NULL,
+  granted_by      TEXT NOT NULL DEFAULT 'ceo',
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  revoked_at      TIMESTAMPTZ,
+
+  UNIQUE(contact_id, permission)
+);
+
+CREATE INDEX idx_cao_contact_perm ON contact_auth_overrides (contact_id, permission)
+  WHERE revoked_at IS NULL;

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -1,11 +1,14 @@
 import type { EventBus } from '../bus/bus.js';
 import type { InboundMessageEvent, AgentResponseEvent } from '../bus/events.js';
-import { createAgentTask, createOutboundMessage } from '../bus/events.js';
+import { createAgentTask, createOutboundMessage, createContactResolved, createContactUnknown } from '../bus/events.js';
 import type { Logger } from '../logger.js';
+import type { ContactResolver } from '../contacts/contact-resolver.js';
+import type { InboundSenderContext } from '../contacts/types.js';
 
 export interface DispatcherConfig {
   bus: EventBus;
   logger: Logger;
+  contactResolver?: ContactResolver;
 }
 
 /**
@@ -21,6 +24,7 @@ export interface DispatcherConfig {
 export class Dispatcher {
   private bus: EventBus;
   private logger: Logger;
+  private contactResolver?: ContactResolver;
   /**
    * Maps agent.task event ID → channel routing info.
    * When the agent publishes agent.response (with parentEventId pointing to the task),
@@ -34,6 +38,7 @@ export class Dispatcher {
   constructor(config: DispatcherConfig) {
     this.bus = config.bus;
     this.logger = config.logger;
+    this.contactResolver = config.contactResolver;
   }
 
   register(): void {
@@ -57,12 +62,39 @@ export class Dispatcher {
       'Dispatching to coordinator',
     );
 
+    // Resolve sender if contact resolver is available
+    let senderContext: InboundSenderContext | undefined;
+    if (this.contactResolver) {
+      senderContext = await this.contactResolver.resolve(payload.channelId, payload.senderId);
+
+      // Publish contact event for audit trail
+      if (senderContext.resolved) {
+        await this.bus.publish('dispatch', createContactResolved({
+          contactId: senderContext.contactId,
+          displayName: senderContext.displayName,
+          role: senderContext.role,
+          kgNodeId: null, // not available on SenderContext directly
+          verificationStatus: senderContext.verified ? 'verified' : 'unverified',
+          channel: payload.channelId,
+          channelIdentifier: payload.senderId,
+          parentEventId: event.id,
+        }));
+      } else {
+        await this.bus.publish('dispatch', createContactUnknown({
+          channel: senderContext.channel,
+          senderId: senderContext.senderId,
+          parentEventId: event.id,
+        }));
+      }
+    }
+
     const taskEvent = createAgentTask({
       agentId: 'coordinator',
       conversationId: payload.conversationId,
       channelId: payload.channelId,
       senderId: payload.senderId,
       content: payload.content,
+      senderContext,
       parentEventId: event.id,
     });
 

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -62,29 +62,45 @@ export class Dispatcher {
       'Dispatching to coordinator',
     );
 
-    // Resolve sender if contact resolver is available
+    // Resolve sender if contact resolver is available.
+    // Wrapped in try/catch so DB errors degrade gracefully (no sender context)
+    // rather than silently dropping the message — the task still dispatches,
+    // just without enriched sender info.
     let senderContext: InboundSenderContext | undefined;
     if (this.contactResolver) {
-      senderContext = await this.contactResolver.resolve(payload.channelId, payload.senderId);
+      try {
+        senderContext = await this.contactResolver.resolve(payload.channelId, payload.senderId);
 
-      // Publish contact event for audit trail
-      if (senderContext.resolved) {
-        await this.bus.publish('dispatch', createContactResolved({
-          contactId: senderContext.contactId,
-          displayName: senderContext.displayName,
-          role: senderContext.role,
-          kgNodeId: null, // not available on SenderContext directly
-          verificationStatus: senderContext.verified ? 'verified' : 'unverified',
-          channel: payload.channelId,
-          channelIdentifier: payload.senderId,
-          parentEventId: event.id,
-        }));
-      } else {
-        await this.bus.publish('dispatch', createContactUnknown({
-          channel: senderContext.channel,
-          senderId: senderContext.senderId,
-          parentEventId: event.id,
-        }));
+        // Publish contact event for audit trail.
+        // Skip audit for synthetic IDs (primary-user from CLI/smoke-test) to
+        // avoid polluting the audit trail with non-real contacts.
+        if (senderContext.resolved) {
+          if (senderContext.contactId !== 'primary-user') {
+            await this.bus.publish('dispatch', createContactResolved({
+              contactId: senderContext.contactId,
+              displayName: senderContext.displayName,
+              role: senderContext.role,
+              kgNodeId: senderContext.kgNodeId,
+              verificationStatus: senderContext.verified ? 'verified' : 'unverified',
+              channel: payload.channelId,
+              channelIdentifier: payload.senderId,
+              parentEventId: event.id,
+            }));
+          }
+        } else {
+          await this.bus.publish('dispatch', createContactUnknown({
+            channel: senderContext.channel,
+            senderId: senderContext.senderId,
+            parentEventId: event.id,
+          }));
+        }
+      } catch (err) {
+        // Resolution failure must not drop the message — log and continue without
+        // sender context. The coordinator will handle the missing context gracefully.
+        this.logger.error(
+          { err, channelId: payload.channelId, senderId: payload.senderId },
+          'Contact resolution failed — proceeding without sender context',
+        );
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,8 @@ import { EntityMemory } from './memory/entity-memory.js';
 import { SkillRegistry } from './skills/registry.js';
 import { ExecutionLayer } from './skills/execution.js';
 import { loadSkillsFromDirectory } from './skills/loader.js';
+import { ContactService } from './contacts/contact-service.js';
+import { ContactResolver } from './contacts/contact-resolver.js';
 
 async function main(): Promise<void> {
   // 1. Config & logging — no dependencies, must come first.
@@ -96,6 +98,12 @@ async function main(): Promise<void> {
     logger.warn('OPENAI_API_KEY not set — entity memory disabled (knowledge graph unavailable)');
   }
 
+  // Contact system — provides identity resolution and contact management.
+  // Always initialized (contacts work even without entity memory / KG).
+  const contactService = ContactService.createWithPostgres(pool, entityMemory, logger);
+  const contactResolver = new ContactResolver(contactService, entityMemory, logger);
+  logger.info('Contact system initialized');
+
   // Skill registry — loads all skills from the skills/ directory.
   // Skills are the framework's extension mechanism; agents invoke them
   // via the LLM's tool-use API through the execution layer.
@@ -116,7 +124,7 @@ async function main(): Promise<void> {
   const agentRegistry = new AgentRegistry();
 
   // Execution layer — now with bus and agent registry for infrastructure skills.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService });
 
   // Load all agent configs from the agents/ directory.
   // Fail hard on errors — consistent with skill loading and DB connection checks.
@@ -205,7 +213,7 @@ async function main(): Promise<void> {
   // 7. Dispatcher — subscribes to inbound.message + agent.response.
   // Registered after the coordinator so agent.task already has a handler
   // when the dispatcher fans the first inbound message out.
-  const dispatcher = new Dispatcher({ bus, logger });
+  const dispatcher = new Dispatcher({ bus, logger, contactResolver });
   dispatcher.register();
 
   // HTTP API channel — REST + SSE endpoints for external clients.

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -87,11 +87,11 @@ export class ExecutionLayer {
       if (!this.bus || !this.agentRegistry) {
         skillLogger.error(
           { skillName },
-          'Infrastructure skill invoked but ExecutionLayer was not constructed with bus/agentRegistry',
+          'Infrastructure skill invoked but ExecutionLayer was not constructed with bus/agentRegistry/contactService',
         );
         return {
           success: false,
-          error: `Infrastructure skill '${skillName}' cannot run: bus or agent registry not available in ExecutionLayer`,
+          error: `Infrastructure skill '${skillName}' cannot run: bus, agent registry, or contactService not available in ExecutionLayer — ensure all three are passed to the ExecutionLayer constructor`,
         };
       }
       ctx.bus = this.bus;

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -18,18 +18,21 @@ import { sanitizeOutput } from './sanitize.js';
 import type { Logger } from '../logger.js';
 import type { EventBus } from '../bus/bus.js';
 import type { AgentRegistry } from '../agents/agent-registry.js';
+import type { ContactService } from '../contacts/contact-service.js';
 
 export class ExecutionLayer {
   private registry: SkillRegistry;
   private logger: Logger;
   private bus?: EventBus;
   private agentRegistry?: AgentRegistry;
+  private contactService?: ContactService;
 
-  constructor(registry: SkillRegistry, logger: Logger, options?: { bus?: EventBus; agentRegistry?: AgentRegistry }) {
+  constructor(registry: SkillRegistry, logger: Logger, options?: { bus?: EventBus; agentRegistry?: AgentRegistry; contactService?: ContactService }) {
     this.registry = registry;
     this.logger = logger;
     this.bus = options?.bus;
     this.agentRegistry = options?.agentRegistry;
+    this.contactService = options?.contactService;
   }
 
   /**
@@ -93,6 +96,7 @@ export class ExecutionLayer {
       }
       ctx.bus = this.bus;
       ctx.agentRegistry = this.agentRegistry;
+      ctx.contactService = this.contactService;
     }
 
     skillLogger.info({ input: Object.keys(input) }, 'Invoking skill');

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -49,6 +49,8 @@ export interface SkillContext {
   bus?: import('../bus/bus.js').EventBus;
   /** Agent registry — only available to infrastructure skills */
   agentRegistry?: import('../agents/agent-registry.js').AgentRegistry;
+  /** Contact service — only available to infrastructure skills */
+  contactService?: import('../contacts/contact-service.js').ContactService;
 }
 
 /**

--- a/tests/integration/contacts.test.ts
+++ b/tests/integration/contacts.test.ts
@@ -1,0 +1,138 @@
+// tests/integration/contacts.test.ts
+//
+// Integration tests for the Contacts system (ContactService + ContactResolver).
+// Requires a running Postgres with migrations 001-005 applied.
+// Skips gracefully when DATABASE_URL is not set (e.g. in CI without pgvector).
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import { ContactService } from '../../src/contacts/contact-service.js';
+import { ContactResolver } from '../../src/contacts/contact-resolver.js';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { createLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+
+// Skip the entire suite if DATABASE_URL is not set — no database available
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('Contacts Integration', () => {
+  let pool: pg.Pool;
+  let contactService: ContactService;
+  let resolver: ContactResolver;
+  let entityMemory: EntityMemory;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    const logger = createLogger('error');
+    const embeddingService = EmbeddingService.createForTesting();
+    const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(kgStore, embeddingService);
+    entityMemory = new EntityMemory(kgStore, validator, embeddingService);
+    contactService = ContactService.createWithPostgres(pool, entityMemory, logger);
+    resolver = new ContactResolver(contactService, entityMemory, logger);
+
+    // Verify contacts tables exist — will throw if migrations haven't been applied
+    await pool.query('SELECT 1 FROM contacts LIMIT 0');
+  });
+
+  afterAll(async () => {
+    // Clean up test data in dependency order (FK constraints: identities before contacts,
+    // auth overrides before contacts, KG edges before KG nodes)
+    await pool.query('DELETE FROM contact_auth_overrides');
+    await pool.query('DELETE FROM contact_channel_identities');
+    await pool.query('DELETE FROM contacts');
+    // Clean up KG nodes created by auto-linking during contact creation
+    await pool.query('DELETE FROM kg_edges');
+    await pool.query('DELETE FROM kg_nodes');
+    await pool.end();
+  });
+
+  it('creates a contact with auto-linked KG node', async () => {
+    const contact = await contactService.createContact({
+      displayName: 'Integration Test Person',
+      role: 'Advisor',
+      source: 'integration-test',
+    });
+    expect(contact.id).toBeDefined();
+    expect(contact.displayName).toBe('Integration Test Person');
+    expect(contact.role).toBe('Advisor');
+    // entityMemory is wired in, so a KG person node should be auto-created
+    expect(contact.kgNodeId).toBeDefined();
+  });
+
+  it('links a channel identity and resolves it', async () => {
+    const contact = await contactService.createContact({
+      displayName: 'Resolver Test',
+      role: 'CTO',
+      source: 'integration-test',
+    });
+    await contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: 'resolver-test@example.com',
+      source: 'ceo_stated',
+    });
+
+    const resolved = await contactService.resolveByChannelIdentity('email', 'resolver-test@example.com');
+    expect(resolved).toBeDefined();
+    expect(resolved!.displayName).toBe('Resolver Test');
+    expect(resolved!.role).toBe('CTO');
+    // ceo_stated is in AUTO_VERIFIED_SOURCES, so verified should be true
+    expect(resolved!.verified).toBe(true);
+  });
+
+  it('finds contacts by name case-insensitively', async () => {
+    await contactService.createContact({
+      displayName: 'Case Test Person',
+      source: 'integration-test',
+    });
+    // Query with all-lowercase — should still match the mixed-case display name
+    const results = await contactService.findContactByName('case test person');
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some(c => c.displayName === 'Case Test Person')).toBe(true);
+  });
+
+  it('resolves unknown sender as null', async () => {
+    const result = await contactService.resolveByChannelIdentity('telegram', 'nonexistent-id');
+    expect(result).toBeNull();
+  });
+
+  it('full flow: create → link → resolve with KG enrichment', async () => {
+    const contact = await contactService.createContact({
+      displayName: 'Full Flow Test',
+      role: 'CFO',
+      source: 'integration-test',
+    });
+    await contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'signal',
+      channelIdentifier: '+15550001234',
+      source: 'ceo_stated',
+    });
+
+    // Store a KG fact on the auto-created person node so we can verify enrichment
+    if (contact.kgNodeId) {
+      await entityMemory.storeFact({
+        entityNodeId: contact.kgNodeId,
+        label: 'Full Flow Test manages the annual budget',
+        source: 'integration-test',
+      });
+    }
+
+    // ContactResolver.resolve does DB lookup + KG enrichment in one call
+    const result = await resolver.resolve('signal', '+15550001234');
+    expect(result.resolved).toBe(true);
+    if (result.resolved) {
+      expect(result.displayName).toBe('Full Flow Test');
+      expect(result.role).toBe('CFO');
+      expect(result.verified).toBe(true);
+      // knowledgeSummary should include the fact we stored above
+      expect(result.knowledgeSummary).toContain('annual budget');
+    }
+  });
+});

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -24,6 +24,8 @@ import { EntityMemory } from '../../src/memory/entity-memory.js';
 import { SkillRegistry } from '../../src/skills/registry.js';
 import { ExecutionLayer } from '../../src/skills/execution.js';
 import { loadSkillsFromDirectory } from '../../src/skills/loader.js';
+import { ContactService } from '../../src/contacts/contact-service.js';
+import { ContactResolver } from '../../src/contacts/contact-resolver.js';
 import { createInboundMessage, type OutboundMessageEvent } from '../../src/bus/events.js';
 import type { Logger } from '../../src/logger.js';
 
@@ -71,6 +73,11 @@ export async function createHarness(): Promise<CuriaHarness> {
     entityMemory = new EntityMemory(kgStore, validator, embeddingService);
   }
 
+  // Contact system — provides identity resolution and contact management.
+  // Always initialized (contacts work even without entity memory / KG).
+  const contactService = ContactService.createWithPostgres(pool, entityMemory, logger);
+  const contactResolver = new ContactResolver(contactService, entityMemory, logger);
+
   // Skill registry — loads all skills from the skills/ directory.
   // Resolve relative to this file's location, up to project root, into skills/.
   const skillRegistry = new SkillRegistry();
@@ -81,7 +88,7 @@ export async function createHarness(): Promise<CuriaHarness> {
   const agentRegistry = new AgentRegistry();
 
   // Execution layer — with bus and agent registry for infrastructure skills.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService });
 
   // Load all agent configs from the agents/ directory.
   const agentsDir = path.resolve(import.meta.dirname, '../../agents');
@@ -136,7 +143,7 @@ export async function createHarness(): Promise<CuriaHarness> {
 
   // Dispatcher — subscribes to inbound.message + agent.response.
   // Registered after agents so agent.task already has handlers.
-  const dispatcher = new Dispatcher({ bus, logger });
+  const dispatcher = new Dispatcher({ bus, logger, contactResolver });
   dispatcher.register();
 
   // -- No HTTP adapter, no CLI adapter, no SIGTERM handler --

--- a/tests/unit/bus/contact-events.test.ts
+++ b/tests/unit/bus/contact-events.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { createContactResolved, createContactUnknown } from '../../../src/bus/events.js';
+
+describe('Contact bus events', () => {
+  it('creates a contact.resolved event', () => {
+    const event = createContactResolved({
+      contactId: 'contact-123',
+      displayName: 'Jenna Torres',
+      role: 'CFO',
+      kgNodeId: 'node-456',
+      verificationStatus: 'verified',
+      channel: 'telegram',
+      channelIdentifier: '12345',
+      parentEventId: 'inbound-event-id',
+    });
+    expect(event.type).toBe('contact.resolved');
+    expect(event.sourceLayer).toBe('dispatch');
+    expect(event.payload.displayName).toBe('Jenna Torres');
+  });
+
+  it('creates a contact.unknown event', () => {
+    const event = createContactUnknown({
+      channel: 'telegram',
+      senderId: '99999',
+      parentEventId: 'inbound-event-id',
+    });
+    expect(event.type).toBe('contact.unknown');
+    expect(event.sourceLayer).toBe('dispatch');
+  });
+});

--- a/tests/unit/contacts/contact-resolver.test.ts
+++ b/tests/unit/contacts/contact-resolver.test.ts
@@ -1,0 +1,76 @@
+// tests/unit/contacts/contact-resolver.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ContactResolver } from '../../../src/contacts/contact-resolver.js';
+import { ContactService } from '../../../src/contacts/contact-service.js';
+import { KnowledgeGraphStore } from '../../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../../src/memory/embedding.js';
+import { EntityMemory } from '../../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../../src/memory/validation.js';
+import { createLogger } from '../../../src/logger.js';
+
+describe('ContactResolver', () => {
+  let resolver: ContactResolver;
+  let contactService: ContactService;
+  let entityMemory: EntityMemory;
+
+  beforeEach(() => {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    entityMemory = new EntityMemory(store, validator, embeddingService);
+    contactService = ContactService.createInMemory(entityMemory);
+    resolver = new ContactResolver(contactService, entityMemory, createLogger('error'));
+  });
+
+  it('resolves CLI channel as primary user (CEO)', async () => {
+    const result = await resolver.resolve('cli', 'any-id');
+    expect(result.resolved).toBe(true);
+    if (result.resolved) {
+      expect(result.displayName).toBe('CEO');
+      expect(result.role).toBe('ceo');
+    }
+  });
+
+  it('resolves smoke-test channel as primary user', async () => {
+    const result = await resolver.resolve('smoke-test', 'any-id');
+    expect(result.resolved).toBe(true);
+  });
+
+  it('resolves known verified sender with contact details', async () => {
+    const contact = await contactService.createContact({ displayName: 'Jenna Torres', role: 'CFO', source: 'test' });
+    await contactService.linkIdentity({ contactId: contact.id, channel: 'email', channelIdentifier: 'jenna@acme.com', source: 'ceo_stated' });
+
+    const result = await resolver.resolve('email', 'jenna@acme.com');
+    expect(result.resolved).toBe(true);
+    if (result.resolved) {
+      expect(result.displayName).toBe('Jenna Torres');
+      expect(result.role).toBe('CFO');
+      expect(result.verified).toBe(true);
+    }
+  });
+
+  it('returns unknown sender for unrecognized channel identity', async () => {
+    const result = await resolver.resolve('telegram', '99999');
+    expect(result.resolved).toBe(false);
+    if (!result.resolved) {
+      expect(result.channel).toBe('telegram');
+      expect(result.senderId).toBe('99999');
+    }
+  });
+
+  it('enriches resolved sender with KG facts', async () => {
+    const contact = await contactService.createContact({ displayName: 'Jenna Torres', role: 'CFO', source: 'test' });
+    await contactService.linkIdentity({ contactId: contact.id, channel: 'email', channelIdentifier: 'jenna@acme.com', source: 'ceo_stated' });
+
+    // Add a fact about Jenna via entity memory
+    if (contact.kgNodeId) {
+      await entityMemory.storeFact({ entityNodeId: contact.kgNodeId, label: 'Jenna manages the Q3 budget review', source: 'test' });
+    }
+
+    const result = await resolver.resolve('email', 'jenna@acme.com');
+    expect(result.resolved).toBe(true);
+    if (result.resolved) {
+      expect(result.knowledgeSummary).toContain('Q3 budget');
+    }
+  });
+});

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -1,0 +1,157 @@
+// tests/unit/contacts/contact-service.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ContactService } from '../../../src/contacts/contact-service.js';
+import { KnowledgeGraphStore } from '../../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../../src/memory/embedding.js';
+import { EntityMemory } from '../../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../../src/memory/validation.js';
+
+describe('ContactService', () => {
+  let service: ContactService;
+  let entityMemory: EntityMemory;
+
+  beforeEach(() => {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    entityMemory = new EntityMemory(store, validator, embeddingService);
+    service = ContactService.createInMemory(entityMemory);
+  });
+
+  describe('createContact', () => {
+    it('creates a contact and auto-creates a KG person node', async () => {
+      const contact = await service.createContact({
+        displayName: 'Jenna Torres',
+        role: 'CFO',
+        source: 'test',
+      });
+      expect(contact.id).toBeDefined();
+      expect(contact.displayName).toBe('Jenna Torres');
+      expect(contact.role).toBe('CFO');
+      expect(contact.kgNodeId).toBeDefined(); // auto-created
+    });
+
+    it('links to existing KG node when kgNodeId provided', async () => {
+      const entity = await entityMemory.createEntity({
+        type: 'person',
+        label: 'Existing Person',
+        properties: {},
+        source: 'test',
+      });
+      const contact = await service.createContact({
+        displayName: 'Existing Person',
+        kgNodeId: entity.id,
+        source: 'test',
+      });
+      expect(contact.kgNodeId).toBe(entity.id);
+    });
+  });
+
+  describe('getContact', () => {
+    it('retrieves a contact by ID', async () => {
+      const created = await service.createContact({ displayName: 'Alice', source: 'test' });
+      const retrieved = await service.getContact(created.id);
+      expect(retrieved).toBeDefined();
+      expect(retrieved!.displayName).toBe('Alice');
+    });
+
+    it('returns undefined for non-existent ID', async () => {
+      expect(await service.getContact('non-existent')).toBeUndefined();
+    });
+  });
+
+  describe('findContactByName', () => {
+    it('finds contacts case-insensitively', async () => {
+      await service.createContact({ displayName: 'Jenna Torres', source: 'test' });
+      const results = await service.findContactByName('jenna torres');
+      expect(results).toHaveLength(1);
+      expect(results[0]!.displayName).toBe('Jenna Torres');
+    });
+  });
+
+  describe('findContactByRole', () => {
+    it('filters contacts by role', async () => {
+      await service.createContact({ displayName: 'Jenna', role: 'CFO', source: 'test' });
+      await service.createContact({ displayName: 'Kevin', role: 'CTO', source: 'test' });
+      const cfos = await service.findContactByRole('CFO');
+      expect(cfos).toHaveLength(1);
+      expect(cfos[0]!.displayName).toBe('Jenna');
+    });
+  });
+
+  describe('listContacts', () => {
+    it('returns all contacts', async () => {
+      await service.createContact({ displayName: 'A', source: 'test' });
+      await service.createContact({ displayName: 'B', source: 'test' });
+      const all = await service.listContacts();
+      expect(all).toHaveLength(2);
+    });
+  });
+
+  describe('setRole', () => {
+    it('updates the contact role', async () => {
+      const contact = await service.createContact({ displayName: 'Jenna', role: 'VP', source: 'test' });
+      const updated = await service.setRole(contact.id, 'CFO');
+      expect(updated.role).toBe('CFO');
+    });
+  });
+
+  describe('linkIdentity', () => {
+    it('adds a channel identity to a contact', async () => {
+      const contact = await service.createContact({ displayName: 'Jenna', source: 'test' });
+      const identity = await service.linkIdentity({
+        contactId: contact.id,
+        channel: 'email',
+        channelIdentifier: 'jenna@acme.com',
+        source: 'ceo_stated',
+      });
+      expect(identity.channel).toBe('email');
+      expect(identity.verified).toBe(true); // ceo_stated is auto-verified
+    });
+
+    it('self_claimed source is not auto-verified', async () => {
+      const contact = await service.createContact({ displayName: 'Unknown', source: 'test' });
+      const identity = await service.linkIdentity({
+        contactId: contact.id,
+        channel: 'telegram',
+        channelIdentifier: '99999',
+        source: 'self_claimed',
+      });
+      expect(identity.verified).toBe(false);
+    });
+  });
+
+  describe('resolveByChannelIdentity', () => {
+    it('resolves a known sender', async () => {
+      const contact = await service.createContact({ displayName: 'Jenna', role: 'CFO', source: 'test' });
+      await service.linkIdentity({
+        contactId: contact.id,
+        channel: 'email',
+        channelIdentifier: 'jenna@acme.com',
+        source: 'ceo_stated',
+      });
+      const resolved = await service.resolveByChannelIdentity('email', 'jenna@acme.com');
+      expect(resolved).toBeDefined();
+      expect(resolved!.displayName).toBe('Jenna');
+      expect(resolved!.role).toBe('CFO');
+      expect(resolved!.verified).toBe(true);
+    });
+
+    it('returns null for unknown sender', async () => {
+      const resolved = await service.resolveByChannelIdentity('email', 'nobody@example.com');
+      expect(resolved).toBeNull();
+    });
+  });
+
+  describe('getContactWithIdentities', () => {
+    it('returns contact with all channel identities', async () => {
+      const contact = await service.createContact({ displayName: 'Jenna', source: 'test' });
+      await service.linkIdentity({ contactId: contact.id, channel: 'email', channelIdentifier: 'jenna@work.com', source: 'ceo_stated' });
+      await service.linkIdentity({ contactId: contact.id, channel: 'email', channelIdentifier: 'jenna@personal.com', source: 'ceo_stated', label: 'personal' });
+
+      const result = await service.getContactWithIdentities(contact.id);
+      expect(result).toBeDefined();
+      expect(result!.identities).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the contact system foundation — identity resolution, KG-linked contacts, and 5 management skills that let the coordinator create and query contacts conversationally.

- **3 database tables**: `contacts`, `contact_channel_identities`, `contact_auth_overrides` (Phase B will use auth overrides)
- **ContactService**: CRUD for contacts + channel identities, auto-creates KG person nodes, auto-verifies identities from trusted sources (CEO stated, email participant, CRM, calendar)
- **ContactResolver**: dispatch-layer sender lookup — resolves `(channel, sender_id)` to enriched contact context with KG facts before the coordinator sees the message
- **5 contact management skills**: `contact-create`, `contact-lookup`, `contact-link-identity`, `contact-set-role`, `contact-list`
- **Bus events**: `contact.resolved` and `contact.unknown` for audit trail
- **Dispatcher integration**: runs contact resolution on every inbound message, injects sender context as a system message (no working memory pollution)
- **Coordinator prompt**: contact awareness instructions for proactive identity establishment

## What this enables

- Coordinator can create contacts when the CEO mentions people ("Jenna is my CFO, her email is...")
- Coordinator can look up contacts for disambiguation ("which Michael?")
- Coordinator knows who's talking on non-CLI channels (future: email, Signal, Telegram)
- Contact facts are stored in the KG and enriched into the coordinator's context

## Deferred to Phase B

- Authorization model (role defaults, permissions, auth check flow)
- Unknown sender policy (hold, notify, auto-reply per channel)
- Reactive identity establishment (unknown sender → CEO identifies)
- `contact.unlink-identity`, `contact.grant-permission`, `contact.revoke-permission`, `contact.merge` skills
- Channel trust integration

## Test plan

- [x] Unit tests for ContactService (13 tests), ContactResolver (5 tests), bus events (2 tests)
- [x] Integration tests with real Postgres (5 tests, skip gracefully without DATABASE_URL)
- [x] 210 tests pass across 37 files
- [x] Typecheck clean
- [x] Lint clean
- [x] Pre-PR review: code reviewer + silent failure hunter (in progress)