### PR TITLE
feat: Email channel via Nylas + Nathan Curia persona

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,11 @@ TIMEZONE=America/Toronto
 
 # Logging
 LOG_LEVEL=info
+
+# Nylas Email Integration
+NYLAS_API_KEY=
+NYLAS_GRANT_ID=
+# Nathan Curia's email address (used to filter self-sent messages and sign emails)
+NYLAS_SELF_EMAIL=nathan@yourdomain.com
+# Polling interval in milliseconds (default: 30000 = 30 seconds)
+# NYLAS_POLL_INTERVAL_MS=30000

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -2,15 +2,16 @@ name: coordinator
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 persona:
-  display_name: Curia
+  display_name: Nathan Curia
   tone: professional but approachable
+  title: Agent Chief of Staff
 model:
   provider: anthropic
   model: claude-sonnet-4-20250514
 system_prompt: |
-  You are ${persona.display_name}, an AI executive assistant.
+  You are ${persona.display_name}, the ${persona.title}.
+  You are an AI executive assistant serving the CEO.
   Your communication style is ${persona.tone}.
-  You handle all communications on behalf of the CEO.
 
   ## Date & Time
   Today's date: ${current_date}
@@ -35,6 +36,16 @@ system_prompt: |
   role than what's on file), flag the discrepancy and ask the CEO to confirm before
   updating.
 
+  ## Email
+  You have your own email account and can send and receive emails.
+  - When you receive an email (via the email channel), understand the context
+    and respond appropriately. Use the email-reply tool to reply in-thread.
+  - When the CEO asks you to send an email, use the email-send tool.
+  - Always sign emails professionally as "Nathan Curia, Agent Chief of Staff".
+  - When an email arrives from someone not yet in contacts, the system auto-creates
+    a contact. You can enrich it with contact-set-role if you learn their role.
+  - Keep email responses concise and professional.
+
   ## Your Team
   You have specialist agents you can delegate to using the "delegate" tool.
   When a request requires specialized expertise, delegate to the right specialist.
@@ -58,4 +69,6 @@ pinned_skills:
   - contact-link-identity
   - contact-set-role
   - contact-list
+  - email-send
+  - email-reply
 allow_discovery: true

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "fastify": "^5.8.4",
     "js-yaml": "^4.1.1",
     "node-pg-migrate": "^8.0.4",
+    "nylas": "^8.0.5",
     "pg": "^8.20.0",
     "pgvector": "^0.2.1",
     "pino": "^10.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       node-pg-migrate:
         specifier: ^8.0.4
         version: 8.0.4(@types/pg@8.20.0)(pg@8.20.0)
+      nylas:
+        specifier: ^8.0.5
+        version: 8.0.5
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -776,9 +779,18 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  camel-case@4.1.2:
+    resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
+
+  capital-case@1.0.4:
+    resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  change-case@4.1.2:
+    resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -808,6 +820,9 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  constant-case@3.0.4:
+    resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -842,6 +857,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dot-case@3.0.4:
+    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -985,6 +1003,14 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data-encoder@4.1.0:
+    resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
+    engines: {node: '>= 18'}
+
+  formdata-node@6.0.3:
+    resolution: {integrity: sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==}
+    engines: {node: '>= 18'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1006,6 +1032,9 @@ packages:
     engines: {node: 20 || >=22}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  header-case@2.0.4:
+    resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -1171,12 +1200,23 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lower-case@2.0.2:
+    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
+
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -1206,6 +1246,9 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  no-case@3.0.4:
+    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
   node-pg-migrate@8.0.4:
     resolution: {integrity: sha512-HTlJ6fOT/2xHhAUtsqSN85PGMAqSbfGJNRwQF8+ZwQ1+sVGNUTl/ZGEshPsOI3yV22tPIyHXrKXr3S0JxeYLrg==}
     engines: {node: '>=20.11.0'}
@@ -1216,6 +1259,10 @@ packages:
     peerDependenciesMeta:
       '@types/pg':
         optional: true
+
+  nylas@8.0.5:
+    resolution: {integrity: sha512-YuYlQ5/0Q6TQ7vcB3vEpHV6B7vqDtWm/A6JZV/+sqRj0J2S6ccsnT6Hxfi5E9JZFSiLXyvLzF97TdwxbNZMImw==}
+    engines: {node: '>=18'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1245,6 +1292,15 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  param-case@3.0.4:
+    resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
+
+  pascal-case@3.1.2:
+    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
+
+  path-case@3.0.4:
+    resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1445,6 +1501,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  sentence-case@3.0.4:
+    resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
@@ -1462,6 +1521,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  snake-case@3.0.4:
+    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -1592,8 +1654,18 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  upper-case-first@2.0.2:
+    resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
+
+  upper-case@2.0.2:
+    resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
 
   vite@8.0.2:
     resolution: {integrity: sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==}
@@ -2262,7 +2334,33 @@ snapshots:
 
   cac@6.7.14: {}
 
+  camel-case@4.1.2:
+    dependencies:
+      pascal-case: 3.1.2
+      tslib: 2.8.1
+
+  capital-case@1.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
+      upper-case-first: 2.0.2
+
   chai@6.2.2: {}
+
+  change-case@4.1.2:
+    dependencies:
+      camel-case: 4.1.2
+      capital-case: 1.0.4
+      constant-case: 3.0.4
+      dot-case: 3.0.4
+      header-case: 2.0.4
+      no-case: 3.0.4
+      param-case: 3.0.4
+      pascal-case: 3.1.2
+      path-case: 3.0.4
+      sentence-case: 3.0.4
+      snake-case: 3.0.4
+      tslib: 2.8.1
 
   chokidar@4.0.3:
     dependencies:
@@ -2288,6 +2386,12 @@ snapshots:
 
   consola@3.4.2: {}
 
+  constant-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
+      upper-case: 2.0.2
+
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
@@ -2309,6 +2413,11 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  dot-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
 
   emoji-regex@8.0.0: {}
 
@@ -2509,6 +2618,10 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data-encoder@4.1.0: {}
+
+  formdata-node@6.0.3: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -2530,6 +2643,11 @@ snapshots:
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
+
+  header-case@2.0.4:
+    dependencies:
+      capital-case: 1.0.4
+      tslib: 2.8.1
 
   help-me@5.0.0: {}
 
@@ -2652,11 +2770,21 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lower-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
   lru-cache@11.2.7: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   minimatch@10.2.4:
     dependencies:
@@ -2685,6 +2813,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  no-case@3.0.4:
+    dependencies:
+      lower-case: 2.0.2
+      tslib: 2.8.1
+
   node-pg-migrate@8.0.4(@types/pg@8.20.0)(pg@8.20.0):
     dependencies:
       glob: 11.1.0
@@ -2692,6 +2825,14 @@ snapshots:
       yargs: 17.7.2
     optionalDependencies:
       '@types/pg': 8.20.0
+
+  nylas@8.0.5:
+    dependencies:
+      change-case: 4.1.2
+      form-data-encoder: 4.1.0
+      formdata-node: 6.0.3
+      mime-types: 2.1.35
+      uuid: 8.3.2
 
   object-assign@4.1.1: {}
 
@@ -2721,6 +2862,21 @@ snapshots:
       p-limit: 3.1.0
 
   package-json-from-dist@1.0.1: {}
+
+  param-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
+
+  pascal-case@3.1.2:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
+
+  path-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
 
   path-exists@4.0.0: {}
 
@@ -2936,6 +3092,12 @@ snapshots:
 
   semver@7.7.4: {}
 
+  sentence-case@3.0.4:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.1
+      upper-case-first: 2.0.2
+
   set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
@@ -2947,6 +3109,11 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  snake-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.8.1
 
   sonic-boom@4.2.1:
     dependencies:
@@ -3021,8 +3188,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsup@8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2):
     dependencies:
@@ -3069,9 +3235,19 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  upper-case-first@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
+  upper-case@2.0.2:
+    dependencies:
+      tslib: 2.8.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  uuid@8.3.2: {}
 
   vite@8.0.2(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0):
     dependencies:

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -56,7 +56,10 @@ export class EmailReplyHandler implements SkillHandler {
         };
       }
 
-      const replySubject = `Re: ${original.subject}`;
+      // Strip any existing "Re:" prefix (case-insensitive) before prepending our own,
+      // so we never produce "Re: Re: Re: ..." subject lines.
+      const baseSubject = original.subject.replace(/^Re:\s*/i, '');
+      const replySubject = `Re: ${baseSubject}`;
 
       const sent = await ctx.nylasClient.sendMessage({
         to: [{ email: originalFrom }],

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -15,6 +15,10 @@ const MAX_BODY_LENGTH = 50000;
 
 export class EmailReplyHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
+    // SECURITY TODO: Outbound email has no approval gate. The LLM can send emails
+    // to any address without human confirmation. This must be addressed before
+    // production deployment — options include: recipient allowlist, CEO confirmation
+    // via CLI/HTTP, or per-contact send permissions (Phase B authorization model).
     const { reply_to_message_id: replyToMessageId, body } = ctx.input as {
       reply_to_message_id?: string;
       body?: string;

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -1,0 +1,87 @@
+// handler.ts — email-reply skill implementation.
+//
+// Replies to an existing email thread via the Nylas API. This is an
+// infrastructure skill — it requires nylasClient access in its context.
+// The skill fetches the original message to extract the sender's address
+// and subject, then sends a properly threaded reply.
+//
+// sensitivity: "elevated" — this skill has real-world side effects (sends
+// actual email). No approval flow exists yet; the flag is informational.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+// Input length limit — prevent oversized payloads reaching the email API
+const MAX_BODY_LENGTH = 50000;
+
+export class EmailReplyHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { reply_to_message_id: replyToMessageId, body } = ctx.input as {
+      reply_to_message_id?: string;
+      body?: string;
+    };
+
+    // Validate required inputs
+    if (!replyToMessageId || typeof replyToMessageId !== 'string') {
+      return { success: false, error: 'Missing required input: reply_to_message_id (string)' };
+    }
+    if (!body || typeof body !== 'string') {
+      return { success: false, error: 'Missing required input: body (string)' };
+    }
+
+    // Length limit
+    if (body.length > MAX_BODY_LENGTH) {
+      return { success: false, error: `body must be ${MAX_BODY_LENGTH} characters or fewer` };
+    }
+
+    // Infrastructure skills need nylasClient
+    if (!ctx.nylasClient) {
+      return {
+        success: false,
+        error: 'email-reply skill requires nylasClient access. Is infrastructure: true set in the manifest and nylasClient passed to ExecutionLayer?',
+      };
+    }
+
+    ctx.log.info({ replyToMessageId }, 'Replying to email');
+
+    try {
+      // Fetch the original message to get the sender and subject for threading
+      const original = await ctx.nylasClient.getMessage(replyToMessageId);
+
+      // Extract the original sender's email — this is who we're replying to
+      const originalFrom = original.from[0]?.email;
+      if (!originalFrom) {
+        return {
+          success: false,
+          error: `Original message ${replyToMessageId} has no sender address — cannot reply`,
+        };
+      }
+
+      const replySubject = `Re: ${original.subject}`;
+
+      const sent = await ctx.nylasClient.sendMessage({
+        to: [{ email: originalFrom }],
+        subject: replySubject,
+        body,
+        replyToMessageId,
+      });
+
+      ctx.log.info(
+        { messageId: sent.id, to: originalFrom, subject: replySubject },
+        'Email reply sent successfully',
+      );
+
+      return {
+        success: true,
+        data: {
+          message_id: sent.id,
+          to: originalFrom,
+          subject: replySubject,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, replyToMessageId }, 'Failed to reply to email');
+      return { success: false, error: `Failed to reply to email: ${message}` };
+    }
+  }
+}

--- a/skills/email-reply/skill.json
+++ b/skills/email-reply/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "email-reply",
+  "description": "Reply to an existing email thread. Provide the Nylas message ID to reply to and the reply body. The reply will be threaded correctly and sent to the original sender.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "infrastructure": true,
+  "inputs": {
+    "reply_to_message_id": "string",
+    "body": "string"
+  },
+  "outputs": {
+    "message_id": "string",
+    "to": "string",
+    "subject": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/skills/email-send/handler.ts
+++ b/skills/email-send/handler.ts
@@ -15,21 +15,38 @@ const MAX_TO_LENGTH = 1000;
 const MAX_SUBJECT_LENGTH = 500;
 const MAX_BODY_LENGTH = 50000;
 
+// Minimal RFC-5321-style check: requires at least one non-whitespace/@ char on
+// each side of @ and a dot in the domain. Rejects plain strings, IP-only domains
+// that lack a dot, and values with embedded spaces.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 /**
  * Parse a comma-separated list of email addresses into the array format
  * that Nylas expects: `[{ email: string }]`. Trims whitespace from each
- * address. Skips empty segments (e.g., trailing comma).
+ * address. Skips empty segments (e.g., trailing comma). Throws if any
+ * segment fails the basic email format check — the caller returns a SkillResult
+ * error on failure so the LLM receives a structured message instead of a
+ * raw exception.
  */
 function parseRecipients(raw: string): Array<{ email: string }> {
   return raw
     .split(',')
     .map((s) => s.trim())
     .filter((s) => s.length > 0)
-    .map((email) => ({ email }));
+    .map((email) => {
+      if (!EMAIL_REGEX.test(email)) {
+        throw new Error(`Invalid email address: ${email}`);
+      }
+      return { email };
+    });
 }
 
 export class EmailSendHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
+    // SECURITY TODO: Outbound email has no approval gate. The LLM can send emails
+    // to any address without human confirmation. This must be addressed before
+    // production deployment — options include: recipient allowlist, CEO confirmation
+    // via CLI/HTTP, or per-contact send permissions (Phase B authorization model).
     const { to, cc, subject, body } = ctx.input as {
       to?: string;
       cc?: string;
@@ -59,8 +76,14 @@ export class EmailSendHandler implements SkillHandler {
       return { success: false, error: `body must be ${MAX_BODY_LENGTH} characters or fewer` };
     }
 
-    // Parse recipients
-    const toRecipients = parseRecipients(to);
+    // Parse recipients — parseRecipients now throws on invalid email format
+    let toRecipients: Array<{ email: string }>;
+    try {
+      toRecipients = parseRecipients(to);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { success: false, error: message };
+    }
     if (toRecipients.length === 0) {
       return { success: false, error: 'to field contains no valid email addresses' };
     }
@@ -70,8 +93,14 @@ export class EmailSendHandler implements SkillHandler {
       return { success: false, error: `cc must be ${MAX_TO_LENGTH} characters or fewer` };
     }
 
-    // Parse optional cc
-    const ccRecipients = cc && typeof cc === 'string' ? parseRecipients(cc) : undefined;
+    // Parse optional cc — also validate email format
+    let ccRecipients: Array<{ email: string }> | undefined;
+    try {
+      ccRecipients = cc && typeof cc === 'string' ? parseRecipients(cc) : undefined;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { success: false, error: message };
+    }
 
     // Infrastructure skills need nylasClient
     if (!ctx.nylasClient) {

--- a/skills/email-send/handler.ts
+++ b/skills/email-send/handler.ts
@@ -1,0 +1,111 @@
+// handler.ts — email-send skill implementation.
+//
+// Sends a new email via the Nylas API. This is an infrastructure skill —
+// it requires nylasClient access in its context. Recipient addresses are
+// provided as a comma-separated string and parsed into the array format
+// Nylas expects.
+//
+// sensitivity: "elevated" — this skill has real-world side effects (sends
+// actual email). No approval flow exists yet; the flag is informational.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+// Input length limits — prevent oversized payloads reaching the email API
+const MAX_TO_LENGTH = 1000;
+const MAX_SUBJECT_LENGTH = 500;
+const MAX_BODY_LENGTH = 50000;
+
+/**
+ * Parse a comma-separated list of email addresses into the array format
+ * that Nylas expects: `[{ email: string }]`. Trims whitespace from each
+ * address. Skips empty segments (e.g., trailing comma).
+ */
+function parseRecipients(raw: string): Array<{ email: string }> {
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((email) => ({ email }));
+}
+
+export class EmailSendHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { to, cc, subject, body } = ctx.input as {
+      to?: string;
+      cc?: string;
+      subject?: string;
+      body?: string;
+    };
+
+    // Validate required inputs
+    if (!to || typeof to !== 'string') {
+      return { success: false, error: 'Missing required input: to (string)' };
+    }
+    if (!subject || typeof subject !== 'string') {
+      return { success: false, error: 'Missing required input: subject (string)' };
+    }
+    if (!body || typeof body !== 'string') {
+      return { success: false, error: 'Missing required input: body (string)' };
+    }
+
+    // Length limits
+    if (to.length > MAX_TO_LENGTH) {
+      return { success: false, error: `to must be ${MAX_TO_LENGTH} characters or fewer` };
+    }
+    if (subject.length > MAX_SUBJECT_LENGTH) {
+      return { success: false, error: `subject must be ${MAX_SUBJECT_LENGTH} characters or fewer` };
+    }
+    if (body.length > MAX_BODY_LENGTH) {
+      return { success: false, error: `body must be ${MAX_BODY_LENGTH} characters or fewer` };
+    }
+
+    // Parse recipients
+    const toRecipients = parseRecipients(to);
+    if (toRecipients.length === 0) {
+      return { success: false, error: 'to field contains no valid email addresses' };
+    }
+
+    // Parse optional cc
+    const ccRecipients = cc && typeof cc === 'string' ? parseRecipients(cc) : undefined;
+
+    // Infrastructure skills need nylasClient
+    if (!ctx.nylasClient) {
+      return {
+        success: false,
+        error: 'email-send skill requires nylasClient access. Is infrastructure: true set in the manifest and nylasClient passed to ExecutionLayer?',
+      };
+    }
+
+    ctx.log.info(
+      { to: toRecipients.map((r) => r.email), subject },
+      'Sending email',
+    );
+
+    try {
+      const sent = await ctx.nylasClient.sendMessage({
+        to: toRecipients,
+        cc: ccRecipients,
+        subject,
+        body,
+      });
+
+      ctx.log.info(
+        { messageId: sent.id, to: toRecipients.map((r) => r.email) },
+        'Email sent successfully',
+      );
+
+      return {
+        success: true,
+        data: {
+          message_id: sent.id,
+          to: toRecipients.map((r) => r.email).join(', '),
+          subject,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, to, subject }, 'Failed to send email');
+      return { success: false, error: `Failed to send email: ${message}` };
+    }
+  }
+}

--- a/skills/email-send/handler.ts
+++ b/skills/email-send/handler.ts
@@ -65,6 +65,11 @@ export class EmailSendHandler implements SkillHandler {
       return { success: false, error: 'to field contains no valid email addresses' };
     }
 
+    // cc length check uses the same limit as to — prevents oversized CC lists
+    if (cc && cc.length > MAX_TO_LENGTH) {
+      return { success: false, error: `cc must be ${MAX_TO_LENGTH} characters or fewer` };
+    }
+
     // Parse optional cc
     const ccRecipients = cc && typeof cc === 'string' ? parseRecipients(cc) : undefined;
 

--- a/skills/email-send/skill.json
+++ b/skills/email-send/skill.json
@@ -1,0 +1,21 @@
+{
+  "name": "email-send",
+  "description": "Send a new email. Provide comma-separated recipient email addresses, subject, and body. Emails are sent from Nathan Curia's email address.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "infrastructure": true,
+  "inputs": {
+    "to": "string",
+    "cc": "string?",
+    "subject": "string",
+    "body": "string"
+  },
+  "outputs": {
+    "message_id": "string",
+    "to": "string",
+    "subject": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -13,6 +13,7 @@ export interface AgentYamlConfig {
   persona?: {
     display_name?: string;
     tone?: string;
+    title?: string;
     email_signature?: string;
   };
   model: {

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -109,9 +109,11 @@ export class EmailAdapter {
           'Email received and published to bus',
         );
 
-        // Advance the high-water mark so subsequent polls skip this message
-        if (msg.date > this.lastSeenTimestamp) {
-          this.lastSeenTimestamp = msg.date;
+        // Advance the high-water mark so subsequent polls skip this message.
+        // +1 ensures the next poll's receivedAfter excludes the exact timestamp
+        // we just processed (Nylas timestamps are Unix seconds integers).
+        if (msg.date >= this.lastSeenTimestamp) {
+          this.lastSeenTimestamp = msg.date + 1;
         }
       }
     } catch (err) {
@@ -137,21 +139,28 @@ export class EmailAdapter {
     const threadId = conversationId.slice('email:'.length);
 
     // Find the original message in this thread so we can reply to it.
-    // We fetch recent messages and look for a match by threadId.
+    // Pass threadId directly to Nylas so the API filters server-side —
+    // much cheaper than fetching 50 messages and scanning locally.
     try {
-      const messages = await nylasClient.listMessages({ limit: 50 });
-      const threadMessage = messages.find(m => m.threadId === threadId);
+      const messages = await nylasClient.listMessages({ limit: 1, threadId });
+      const threadMessage = messages[0];
       if (!threadMessage) {
         logger.warn({ threadId }, 'Cannot find message to reply to in thread');
         return;
       }
 
       const fromEmail = threadMessage.from[0]?.email;
-      if (!fromEmail) return;
+      if (!fromEmail) {
+        logger.warn({ threadId, messageId: threadMessage.id }, 'Cannot reply — original message has no from address');
+        return;
+      }
 
+      // Strip any existing "Re:" prefix before prepending our own to avoid
+      // "Re: Re: Re: ..." chains when replying to already-replied threads.
+      const baseSubject = threadMessage.subject.replace(/^Re:\s*/i, '');
       await nylasClient.sendMessage({
         to: [{ email: fromEmail }],
-        subject: `Re: ${threadMessage.subject}`,
+        subject: `Re: ${baseSubject}`,
         body: outbound.payload.content,
         replyToMessageId: threadMessage.id,
       });

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -75,49 +75,67 @@ export class EmailAdapter {
     if (this.processing) return;
     this.processing = true;
 
+    // Separate try/catch for the Nylas API call so a transient network error
+    // doesn't silently drop already-fetched messages.
+    let messages;
     try {
-      const messages = await this.config.nylasClient.listMessages({
+      messages = await this.config.nylasClient.listMessages({
         receivedAfter: this.lastSeenTimestamp,
         unread: true,
         limit: 25,
       });
+    } catch (err) {
+      this.config.logger.error({ err }, 'Email polling failed — will retry');
+      this.processing = false;
+      return;
+    }
 
+    try {
       for (const msg of messages) {
-        // Skip emails sent by Nathan Curia (self) — we only want inbound messages
-        // from external senders, not our own outgoing replies.
-        const fromEmail = msg.from[0]?.email;
-        if (fromEmail === this.config.selfEmail) continue;
-
-        const converted = convertNylasMessage(msg);
-
-        // Auto-create contacts from participants before publishing the inbound event,
-        // so the contact resolver in the dispatch layer can find them immediately.
-        await this.extractParticipants(converted.metadata.participants);
-
-        // Publish inbound message to the bus
-        const event = createInboundMessage({
-          conversationId: converted.conversationId,
-          channelId: converted.channelId,
-          senderId: converted.senderId,
-          content: converted.content,
-          metadata: converted.metadata as unknown as Record<string, unknown>,
-        });
-        await this.config.bus.publish('channel', event);
-
-        this.config.logger.info(
-          { from: fromEmail, subject: msg.subject, threadId: msg.threadId },
-          'Email received and published to bus',
-        );
-
-        // Advance the high-water mark so subsequent polls skip this message.
-        // +1 ensures the next poll's receivedAfter excludes the exact timestamp
-        // we just processed (Nylas timestamps are Unix seconds integers).
+        // Advance the high-water mark BEFORE processing so a permanently broken
+        // message (e.g. malformed payload) is never retried on the next poll cycle.
+        // +1 ensures the next poll's receivedAfter excludes this exact timestamp
+        // (Nylas timestamps are Unix seconds integers).
         if (msg.date >= this.lastSeenTimestamp) {
           this.lastSeenTimestamp = msg.date + 1;
         }
+
+        // Skip emails sent by Nathan Curia (self) — we only want inbound messages
+        // from external senders, not our own outgoing replies.
+        // Case-insensitive to guard against inconsistent casing from mail servers.
+        const fromEmail = msg.from[0]?.email;
+        if (fromEmail?.toLowerCase() === this.config.selfEmail.toLowerCase()) continue;
+
+        try {
+          const converted = convertNylasMessage(msg);
+
+          // Auto-create contacts from participants before publishing the inbound event,
+          // so the contact resolver in the dispatch layer can find them immediately.
+          await this.extractParticipants(converted.metadata.participants);
+
+          // Publish inbound message to the bus
+          const event = createInboundMessage({
+            conversationId: converted.conversationId,
+            channelId: converted.channelId,
+            senderId: converted.senderId,
+            content: converted.content,
+            metadata: converted.metadata as unknown as Record<string, unknown>,
+          });
+          await this.config.bus.publish('channel', event);
+
+          this.config.logger.info(
+            { from: fromEmail, subject: msg.subject, threadId: msg.threadId },
+            'Email received and published to bus',
+          );
+        } catch (err) {
+          // Log and skip — the high-water mark was already advanced above,
+          // so this message will not be retried on the next poll cycle.
+          this.config.logger.error(
+            { err, messageId: msg.id, threadId: msg.threadId, from: fromEmail },
+            'Failed to process inbound email — skipping message',
+          );
+        }
       }
-    } catch (err) {
-      this.config.logger.error({ err }, 'Email polling failed — will retry');
     } finally {
       this.processing = false;
     }
@@ -183,8 +201,9 @@ export class EmailAdapter {
     const { contactService, logger, selfEmail } = this.config;
 
     for (const p of participants) {
-      // Don't create a contact for ourselves
-      if (p.email === selfEmail) continue;
+      // Don't create a contact for ourselves — case-insensitive to guard against
+      // inconsistent casing from mail servers (e.g. "User@Example.com" vs "user@example.com").
+      if (p.email.toLowerCase() === selfEmail.toLowerCase()) continue;
 
       try {
         // Check if this email is already linked to a contact

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -1,0 +1,205 @@
+// src/channels/email/email-adapter.ts
+//
+// Email channel adapter — polls Nylas for new inbound emails, publishes them
+// to the bus as inbound.message events, auto-creates contacts from participants,
+// and sends outbound replies when the coordinator responds to an email thread.
+
+import type { EventBus } from '../../bus/bus.js';
+import type { Logger } from '../../logger.js';
+import type { NylasClient } from './nylas-client.js';
+import type { ContactService } from '../../contacts/contact-service.js';
+import { convertNylasMessage } from './message-converter.js';
+import { createInboundMessage, type OutboundMessageEvent } from '../../bus/events.js';
+
+export interface EmailAdapterConfig {
+  bus: EventBus;
+  logger: Logger;
+  nylasClient: NylasClient;
+  contactService: ContactService;
+  pollingIntervalMs: number;
+  /** Nathan Curia's own email address — used to filter out self-sent messages */
+  selfEmail: string;
+}
+
+export class EmailAdapter {
+  private config: EmailAdapterConfig;
+  private pollTimer?: ReturnType<typeof setInterval>;
+  private lastSeenTimestamp: number = 0;
+  private processing = false;
+
+  constructor(config: EmailAdapterConfig) {
+    this.config = config;
+  }
+
+  async start(): Promise<void> {
+    const { bus, logger, pollingIntervalMs } = this.config;
+
+    // Subscribe to outbound messages for the email channel.
+    // When the coordinator responds to an email-triggered conversation, the dispatcher
+    // creates an outbound.message with channelId 'email'. The adapter sends this as
+    // a reply to the original email thread via Nylas.
+    bus.subscribe('outbound.message', 'channel', async (event) => {
+      const outbound = event as OutboundMessageEvent;
+      if (outbound.payload.channelId !== 'email') return;
+
+      try {
+        await this.sendOutboundReply(outbound);
+      } catch (err) {
+        logger.error({ err, conversationId: outbound.payload.conversationId },
+          'Failed to send email response');
+      }
+    });
+
+    // Initialize last-seen timestamp to now so we only process new emails
+    this.lastSeenTimestamp = Math.floor(Date.now() / 1000);
+
+    // Start polling
+    this.pollTimer = setInterval(() => void this.poll(), pollingIntervalMs);
+    logger.info({ pollingIntervalMs }, 'Email adapter started — polling Nylas');
+
+    // Do an initial poll immediately
+    void this.poll();
+  }
+
+  async stop(): Promise<void> {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = undefined;
+    }
+    this.config.logger.info('Email adapter stopped');
+  }
+
+  private async poll(): Promise<void> {
+    // Guard against overlapping polls — if a previous poll is still running
+    // (e.g. slow Nylas response or many messages to process), skip this cycle.
+    if (this.processing) return;
+    this.processing = true;
+
+    try {
+      const messages = await this.config.nylasClient.listMessages({
+        receivedAfter: this.lastSeenTimestamp,
+        unread: true,
+        limit: 25,
+      });
+
+      for (const msg of messages) {
+        // Skip emails sent by Nathan Curia (self) — we only want inbound messages
+        // from external senders, not our own outgoing replies.
+        const fromEmail = msg.from[0]?.email;
+        if (fromEmail === this.config.selfEmail) continue;
+
+        const converted = convertNylasMessage(msg);
+
+        // Auto-create contacts from participants before publishing the inbound event,
+        // so the contact resolver in the dispatch layer can find them immediately.
+        await this.extractParticipants(converted.metadata.participants);
+
+        // Publish inbound message to the bus
+        const event = createInboundMessage({
+          conversationId: converted.conversationId,
+          channelId: converted.channelId,
+          senderId: converted.senderId,
+          content: converted.content,
+          metadata: converted.metadata as unknown as Record<string, unknown>,
+        });
+        await this.config.bus.publish('channel', event);
+
+        this.config.logger.info(
+          { from: fromEmail, subject: msg.subject, threadId: msg.threadId },
+          'Email received and published to bus',
+        );
+
+        // Advance the high-water mark so subsequent polls skip this message
+        if (msg.date > this.lastSeenTimestamp) {
+          this.lastSeenTimestamp = msg.date;
+        }
+      }
+    } catch (err) {
+      this.config.logger.error({ err }, 'Email polling failed — will retry');
+    } finally {
+      this.processing = false;
+    }
+  }
+
+  /**
+   * Send the coordinator's response as an email reply in the original thread.
+   * The conversationId encodes the thread (email:{threadId}), so we look up the
+   * most recent inbound message in that thread and reply to it.
+   */
+  private async sendOutboundReply(outbound: OutboundMessageEvent): Promise<void> {
+    const { nylasClient, logger } = this.config;
+    const conversationId = outbound.payload.conversationId;
+
+    if (!conversationId.startsWith('email:')) {
+      logger.warn({ conversationId }, 'Cannot send email reply — conversation ID not in email format');
+      return;
+    }
+    const threadId = conversationId.slice('email:'.length);
+
+    // Find the original message in this thread so we can reply to it.
+    // We fetch recent messages and look for a match by threadId.
+    try {
+      const messages = await nylasClient.listMessages({ limit: 50 });
+      const threadMessage = messages.find(m => m.threadId === threadId);
+      if (!threadMessage) {
+        logger.warn({ threadId }, 'Cannot find message to reply to in thread');
+        return;
+      }
+
+      const fromEmail = threadMessage.from[0]?.email;
+      if (!fromEmail) return;
+
+      await nylasClient.sendMessage({
+        to: [{ email: fromEmail }],
+        subject: `Re: ${threadMessage.subject}`,
+        body: outbound.payload.content,
+        replyToMessageId: threadMessage.id,
+      });
+
+      logger.info({ to: fromEmail, threadId }, 'Email reply sent');
+    } catch (err) {
+      logger.error({ err, threadId }, 'Failed to send email reply');
+    }
+  }
+
+  /**
+   * Auto-create contacts from email participants (From/To/CC).
+   * Uses source 'email_participant' which is auto-verified per spec.
+   * Skips participants that already have a contact record, and skips
+   * our own email address (selfEmail) to avoid self-contact creation.
+   */
+  private async extractParticipants(
+    participants: Array<{ email: string; name?: string; role: string }>,
+  ): Promise<void> {
+    const { contactService, logger, selfEmail } = this.config;
+
+    for (const p of participants) {
+      // Don't create a contact for ourselves
+      if (p.email === selfEmail) continue;
+
+      try {
+        // Check if this email is already linked to a contact
+        const existing = await contactService.resolveByChannelIdentity('email', p.email);
+        if (existing) continue;
+
+        // Create a new contact and link the email identity to it
+        const contact = await contactService.createContact({
+          displayName: p.name || p.email,
+          source: 'email_participant',
+        });
+        await contactService.linkIdentity({
+          contactId: contact.id,
+          channel: 'email',
+          channelIdentifier: p.email,
+          source: 'email_participant',
+        });
+
+        logger.info({ email: p.email, name: p.name }, 'Auto-created contact from email participant');
+      } catch (err) {
+        // Warn rather than error — participant auto-creation is best-effort.
+        // The inbound message will still be published even if contact creation fails.
+        logger.warn({ err, email: p.email }, 'Failed to auto-create contact from email participant');
+      }
+    }
+  }
+}

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -10,6 +10,7 @@ import type { NylasClient } from './nylas-client.js';
 import type { ContactService } from '../../contacts/contact-service.js';
 import { convertNylasMessage } from './message-converter.js';
 import { createInboundMessage, type OutboundMessageEvent } from '../../bus/events.js';
+import { sanitizeOutput } from '../../skills/sanitize.js';
 
 export interface EmailAdapterConfig {
   bus: EventBus;
@@ -113,12 +114,22 @@ export class EmailAdapter {
           // so the contact resolver in the dispatch layer can find them immediately.
           await this.extractParticipants(converted.metadata.participants);
 
+          // Sanitize email content to mitigate prompt injection from external senders.
+          // This strips known injection patterns (system/instruction/prompt tags) before
+          // the content reaches the LLM's context window.
+          const sanitizedContent = sanitizeOutput(converted.content, {
+            // Use a large limit here — body truncation already happened in the converter.
+            // We pass maxLength large enough to never double-truncate; the converter's
+            // 50KB cap + subject prefix keeps us well under this ceiling.
+            maxLength: 60_000,
+          });
+
           // Publish inbound message to the bus
           const event = createInboundMessage({
             conversationId: converted.conversationId,
             channelId: converted.channelId,
             senderId: converted.senderId,
-            content: converted.content,
+            content: sanitizedContent,
             metadata: converted.metadata as unknown as Record<string, unknown>,
           });
           await this.config.bus.publish('channel', event);

--- a/src/channels/email/html-to-text.ts
+++ b/src/channels/email/html-to-text.ts
@@ -1,0 +1,42 @@
+/**
+ * Convert HTML email body to plain text for LLM consumption.
+ * Lightweight regex-based approach — handles common email HTML patterns
+ * without pulling in a heavy dependency like turndown or html-to-text.
+ */
+export function htmlToText(html: string | undefined | null): string {
+  if (!html) return '';
+
+  let text = html;
+
+  // Remove <style> and <script> blocks entirely (content + tags)
+  text = text.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');
+  text = text.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '');
+
+  // Convert <br> variants to newlines
+  text = text.replace(/<br\s*\/?>/gi, '\n');
+
+  // Convert block-level closing tags to newlines
+  text = text.replace(/<\/(p|div|h[1-6]|li|tr|blockquote)>/gi, '\n');
+
+  // Convert <hr> to a separator
+  text = text.replace(/<hr\s*\/?>/gi, '\n---\n');
+
+  // Strip all remaining HTML tags
+  text = text.replace(/<[^>]+>/g, '');
+
+  // Decode common HTML entities
+  text = text.replace(/&amp;/g, '&');
+  text = text.replace(/&lt;/g, '<');
+  text = text.replace(/&gt;/g, '>');
+  text = text.replace(/&quot;/g, '"');
+  text = text.replace(/&#39;/g, "'");
+  text = text.replace(/&nbsp;/g, ' ');
+
+  // Collapse runs of whitespace (preserving paragraph breaks)
+  text = text.replace(/[ \t]+/g, ' ');
+  text = text.replace(/\n[ \t]+/g, '\n');
+  text = text.replace(/[ \t]+\n/g, '\n');
+  text = text.replace(/\n{3,}/g, '\n\n');
+
+  return text.trim();
+}

--- a/src/channels/email/message-converter.ts
+++ b/src/channels/email/message-converter.ts
@@ -50,7 +50,14 @@ export function convertNylasMessage(msg: NylasMessage): ConvertedEmail {
 
   // htmlToText returns '' for an empty/falsy body, so also check snippet
   const bodyText = msg.body ? htmlToText(msg.body) : '';
-  const content = bodyText || msg.snippet || '(empty email)';
+
+  // Cap email body at 50KB of text to prevent context stuffing and excessive token usage.
+  // Emails larger than this are truncated with a note.
+  const MAX_BODY_LENGTH = 50_000;
+  let content = bodyText || msg.snippet || '(empty email)';
+  if (content.length > MAX_BODY_LENGTH) {
+    content = content.slice(0, MAX_BODY_LENGTH) + '\n\n[Email truncated — original was ' + content.length + ' characters]';
+  }
 
   // Prepend subject so the LLM always has full context even in isolated chunks
   const formattedContent = `Subject: ${msg.subject}\n\n${content}`;

--- a/src/channels/email/message-converter.ts
+++ b/src/channels/email/message-converter.ts
@@ -1,0 +1,80 @@
+import { htmlToText } from './html-to-text.js';
+import type { NylasMessage } from './nylas-client.js';
+
+// ---------------------------------------------------------------------------
+// Output types — represent the normalized shape fed into the message bus
+// createInboundMessage() event. EmailParticipant is also used by the contact
+// system to upsert participant records from inbound emails.
+// ---------------------------------------------------------------------------
+
+export interface EmailParticipant {
+  email: string;
+  name?: string;
+  role: 'from' | 'to' | 'cc';
+}
+
+export interface ConvertedEmail {
+  conversationId: string;
+  channelId: 'email';
+  /** The sender's email address, used as the bus senderId */
+  senderId: string;
+  /** Plain-text body with subject prepended for LLM context */
+  content: string;
+  metadata: {
+    subject: string;
+    nylasMessageId: string;
+    nylasThreadId: string;
+    participants: EmailParticipant[];
+    receivedAt: Date;
+  };
+}
+
+/**
+ * Convert a Nylas message to a Curia inbound message shape.
+ *
+ * Decisions made here:
+ * - conversationId uses the thread ID so all emails in a thread share the
+ *   same working memory scope in the agent layer.
+ * - Content is plain-text extracted from HTML (better for LLMs than raw HTML).
+ * - Subject is prepended so agents always see it regardless of how the body
+ *   was formatted.
+ * - All participants (from/to/cc) are surfaced so the contact system can
+ *   upsert or update relationship records in one pass.
+ */
+export function convertNylasMessage(msg: NylasMessage): ConvertedEmail {
+  // Use ?? 'unknown' so an empty from array doesn't throw
+  const fromEmail = msg.from[0]?.email ?? 'unknown';
+
+  // Thread ID groups related emails into a single conversation in the bus
+  const conversationId = `email:${msg.threadId}`;
+
+  // htmlToText returns '' for an empty/falsy body, so also check snippet
+  const bodyText = msg.body ? htmlToText(msg.body) : '';
+  const content = bodyText || msg.snippet || '(empty email)';
+
+  // Prepend subject so the LLM always has full context even in isolated chunks
+  const formattedContent = `Subject: ${msg.subject}\n\n${content}`;
+
+  // Collect participants in declaration order: from → to → cc
+  // BCC is intentionally omitted — we don't expose hidden recipients downstream
+  const participants: EmailParticipant[] = [
+    ...msg.from.map((p) => ({ email: p.email, name: p.name, role: 'from' as const })),
+    ...msg.to.map((p) => ({ email: p.email, name: p.name, role: 'to' as const })),
+    ...msg.cc.map((p) => ({ email: p.email, name: p.name, role: 'cc' as const })),
+  ];
+
+  return {
+    conversationId,
+    channelId: 'email',
+    senderId: fromEmail,
+    content: formattedContent,
+    metadata: {
+      subject: msg.subject,
+      nylasMessageId: msg.id,
+      nylasThreadId: msg.threadId,
+      participants,
+      // Nylas stores timestamps as Unix seconds; Date expects milliseconds
+      receivedAt: new Date(msg.date * 1000),
+    },
+  };
+}

--- a/src/channels/email/nylas-client.ts
+++ b/src/channels/email/nylas-client.ts
@@ -129,12 +129,16 @@ export class NylasClient {
 
     // The SDK's list() returns an AsyncListResponse which is both a Promise
     // and an async iterable. Awaiting it gives us the first page of results.
-    const response = await this.nylas.messages.list({
-      identifier: this.grantId,
-      queryParams,
-    });
-
-    return response.data.map((msg) => this.normalizeMessage(msg));
+    try {
+      const response = await this.nylas.messages.list({
+        identifier: this.grantId,
+        queryParams,
+      });
+      return response.data.map((msg) => this.normalizeMessage(msg));
+    } catch (err) {
+      this.log.error({ err, grantId: this.grantId, queryParams }, 'Nylas listMessages failed');
+      throw err;
+    }
   }
 
   /**
@@ -143,12 +147,16 @@ export class NylasClient {
   async getMessage(messageId: string): Promise<NylasMessage> {
     this.log.debug({ messageId }, 'fetching message');
 
-    const response = await this.nylas.messages.find({
-      identifier: this.grantId,
-      messageId,
-    });
-
-    return this.normalizeMessage(response.data);
+    try {
+      const response = await this.nylas.messages.find({
+        identifier: this.grantId,
+        messageId,
+      });
+      return this.normalizeMessage(response.data);
+    } catch (err) {
+      this.log.error({ err, grantId: this.grantId, messageId }, 'Nylas getMessage failed');
+      throw err;
+    }
   }
 
   /**
@@ -161,18 +169,25 @@ export class NylasClient {
       'sending message',
     );
 
-    const response = await this.nylas.messages.send({
-      identifier: this.grantId,
-      requestBody: {
-        to: options.to,
-        cc: options.cc,
-        subject: options.subject,
-        body: options.body,
-        replyToMessageId: options.replyToMessageId,
-      },
-    });
-
-    return this.normalizeMessage(response.data);
+    try {
+      const response = await this.nylas.messages.send({
+        identifier: this.grantId,
+        requestBody: {
+          to: options.to,
+          cc: options.cc,
+          subject: options.subject,
+          body: options.body,
+          replyToMessageId: options.replyToMessageId,
+        },
+      });
+      return this.normalizeMessage(response.data);
+    } catch (err) {
+      this.log.error(
+        { err, grantId: this.grantId, to: options.to, subject: options.subject, isReply: !!options.replyToMessageId },
+        'Nylas sendMessage failed',
+      );
+      throw err;
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -189,7 +204,7 @@ export class NylasClient {
       threadId: msg.threadId ?? '',
       subject: msg.subject ?? '',
       from: (msg.from ?? []).map((p) => ({ name: p.name, email: p.email })),
-      to: msg.to.map((p) => ({ name: p.name, email: p.email })),
+      to: (msg.to ?? []).map((p) => ({ name: p.name, email: p.email })),
       cc: (msg.cc ?? []).map((p) => ({ name: p.name, email: p.email })),
       bcc: (msg.bcc ?? []).map((p) => ({ name: p.name, email: p.email })),
       body: msg.body ?? '',

--- a/src/channels/email/nylas-client.ts
+++ b/src/channels/email/nylas-client.ts
@@ -1,0 +1,197 @@
+// The Nylas SDK v8's type declarations resolve as CJS under TypeScript's
+// nodenext module resolution (their types directory lacks a package.json with
+// "type": "module"). This means `export default Nylas` in the .d.ts is seen
+// as a CJS namespace rather than a constructable class — even though the
+// runtime default import works correctly. We work around this by:
+//   1. Importing the default (runtime value is the Nylas class)
+//   2. Importing the model/response types that DO resolve correctly
+//   3. Defining a minimal NylasLike interface for the instance shape
+//   4. Casting the constructor once in our constructor
+//
+// TODO: Remove this workaround if Nylas ships proper ESM type declarations
+// (i.e., adds "type": "module" or .d.mts files in a future release).
+import NylasDefault from 'nylas';
+import type {
+  Message as NylasSdkMessage,
+  ListMessagesQueryParams,
+  NylasResponse,
+  NylasListResponse,
+  SendMessageRequest,
+} from 'nylas';
+import type { Logger } from '../../logger.js';
+
+/**
+ * Minimal typed interface for the Nylas SDK instance. We only declare the
+ * subset of the API surface that this wrapper actually uses, so the
+ * workaround stays small and easy to verify against the real SDK.
+ */
+interface NylasLike {
+  messages: {
+    list(params: {
+      identifier: string;
+      queryParams?: ListMessagesQueryParams;
+    }): Promise<NylasListResponse<NylasSdkMessage>>;
+
+    find(params: {
+      identifier: string;
+      messageId: string;
+    }): Promise<NylasResponse<NylasSdkMessage>>;
+
+    send(params: {
+      identifier: string;
+      requestBody: SendMessageRequest;
+    }): Promise<NylasResponse<NylasSdkMessage>>;
+  };
+}
+
+/**
+ * The Nylas default export is a class constructor at runtime.
+ * Cast it through unknown so TypeScript treats it as constructable.
+ */
+const NylasSDK = NylasDefault as unknown as new (config: { apiKey: string }) => NylasLike;
+
+// ---------------------------------------------------------------------------
+// Our own simplified message shape — normalized from the Nylas SDK's Message
+// type. Many SDK fields are optional; we default them to safe values so
+// downstream consumers don't have to null-check everything.
+// ---------------------------------------------------------------------------
+
+export interface NylasMessage {
+  id: string;
+  threadId: string;
+  subject: string;
+  from: Array<{ name?: string; email: string }>;
+  to: Array<{ name?: string; email: string }>;
+  cc: Array<{ name?: string; email: string }>;
+  bcc: Array<{ name?: string; email: string }>;
+  body: string;
+  snippet: string;
+  date: number;
+  unread: boolean;
+  folders: string[];
+}
+
+export interface SendEmailOptions {
+  to: Array<{ name?: string; email: string }>;
+  cc?: Array<{ name?: string; email: string }>;
+  subject: string;
+  body: string;
+  replyToMessageId?: string;
+}
+
+export interface ListMessagesOptions {
+  /** Unix timestamp — only return messages received after this time */
+  receivedAfter?: number;
+  /** When true, only return unread messages */
+  unread?: boolean;
+  /** Max number of messages to return (default 50, max 200 per Nylas) */
+  limit?: number;
+}
+
+// ---------------------------------------------------------------------------
+// NylasClient — thin wrapper that hides SDK details and provides typed,
+// normalized responses for the operations the email channel needs.
+// ---------------------------------------------------------------------------
+
+export class NylasClient {
+  private readonly nylas: NylasLike;
+  private readonly grantId: string;
+  private readonly log: Logger;
+
+  constructor(apiKey: string, grantId: string, logger: Logger) {
+    this.nylas = new NylasSDK({ apiKey });
+    this.grantId = grantId;
+    this.log = logger.child({ component: 'nylas-client' });
+  }
+
+  /**
+   * List recent messages, optionally filtered by time / read-state / count.
+   */
+  async listMessages(options?: ListMessagesOptions): Promise<NylasMessage[]> {
+    const queryParams: ListMessagesQueryParams = {};
+
+    if (options?.receivedAfter !== undefined) {
+      queryParams.receivedAfter = options.receivedAfter;
+    }
+    if (options?.unread !== undefined) {
+      queryParams.unread = options.unread;
+    }
+    if (options?.limit !== undefined) {
+      queryParams.limit = options.limit;
+    }
+
+    this.log.debug({ queryParams }, 'listing messages');
+
+    // The SDK's list() returns an AsyncListResponse which is both a Promise
+    // and an async iterable. Awaiting it gives us the first page of results.
+    const response = await this.nylas.messages.list({
+      identifier: this.grantId,
+      queryParams,
+    });
+
+    return response.data.map((msg) => this.normalizeMessage(msg));
+  }
+
+  /**
+   * Fetch a single message by its Nylas message ID.
+   */
+  async getMessage(messageId: string): Promise<NylasMessage> {
+    this.log.debug({ messageId }, 'fetching message');
+
+    const response = await this.nylas.messages.find({
+      identifier: this.grantId,
+      messageId,
+    });
+
+    return this.normalizeMessage(response.data);
+  }
+
+  /**
+   * Send an email — either a brand-new message or a reply to an existing one.
+   * When `replyToMessageId` is set, Nylas threads the reply automatically.
+   */
+  async sendMessage(options: SendEmailOptions): Promise<NylasMessage> {
+    this.log.debug(
+      { to: options.to, subject: options.subject, isReply: !!options.replyToMessageId },
+      'sending message',
+    );
+
+    const response = await this.nylas.messages.send({
+      identifier: this.grantId,
+      requestBody: {
+        to: options.to,
+        cc: options.cc,
+        subject: options.subject,
+        body: options.body,
+        replyToMessageId: options.replyToMessageId,
+      },
+    });
+
+    return this.normalizeMessage(response.data);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Convert the SDK's Message type (with many optional fields) into our
+   * NylasMessage shape where every field has a guaranteed value.
+   */
+  private normalizeMessage(msg: NylasSdkMessage): NylasMessage {
+    return {
+      id: msg.id,
+      threadId: msg.threadId ?? '',
+      subject: msg.subject ?? '',
+      from: (msg.from ?? []).map((p) => ({ name: p.name, email: p.email })),
+      to: msg.to.map((p) => ({ name: p.name, email: p.email })),
+      cc: (msg.cc ?? []).map((p) => ({ name: p.name, email: p.email })),
+      bcc: (msg.bcc ?? []).map((p) => ({ name: p.name, email: p.email })),
+      body: msg.body ?? '',
+      snippet: msg.snippet ?? '',
+      date: msg.date,
+      unread: msg.unread ?? false,
+      folders: msg.folders,
+    };
+  }
+}

--- a/src/channels/email/nylas-client.ts
+++ b/src/channels/email/nylas-client.ts
@@ -86,6 +86,8 @@ export interface ListMessagesOptions {
   unread?: boolean;
   /** Max number of messages to return (default 50, max 200 per Nylas) */
   limit?: number;
+  /** Filter messages to a specific thread ID — used when looking up a reply target */
+  threadId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -118,6 +120,9 @@ export class NylasClient {
     }
     if (options?.limit !== undefined) {
       queryParams.limit = options.limit;
+    }
+    if (options?.threadId !== undefined) {
+      queryParams.threadId = options.threadId;
     }
 
     this.log.debug({ queryParams }, 'listing messages');

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,11 @@ export function loadConfig(): Config {
     throw new Error(`HTTP_PORT must be a valid port number (1-65535), got: ${process.env.HTTP_PORT}`);
   }
 
+  const nylasPollingIntervalMs = parseInt(process.env.NYLAS_POLL_INTERVAL_MS ?? '30000', 10);
+  if (isNaN(nylasPollingIntervalMs) || nylasPollingIntervalMs < 1000) {
+    throw new Error(`NYLAS_POLL_INTERVAL_MS must be a number >= 1000, got: ${process.env.NYLAS_POLL_INTERVAL_MS}`);
+  }
+
   return {
     databaseUrl,
     anthropicApiKey: process.env.ANTHROPIC_API_KEY,
@@ -33,7 +38,7 @@ export function loadConfig(): Config {
     timezone: process.env.TIMEZONE ?? 'America/Toronto',
     nylasApiKey: process.env.NYLAS_API_KEY,
     nylasGrantId: process.env.NYLAS_GRANT_ID,
-    nylasPollingIntervalMs: parseInt(process.env.NYLAS_POLL_INTERVAL_MS ?? '30000', 10),
+    nylasPollingIntervalMs,
     nylasSelfEmail: process.env.NYLAS_SELF_EMAIL ?? '',
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,10 @@ export interface Config {
   httpPort: number;
   apiToken: string | undefined;
   timezone: string;
+  nylasApiKey: string | undefined;
+  nylasGrantId: string | undefined;
+  nylasPollingIntervalMs: number;
+  nylasSelfEmail: string;
 }
 
 export function loadConfig(): Config {
@@ -27,5 +31,9 @@ export function loadConfig(): Config {
     httpPort,
     apiToken: process.env.API_TOKEN,
     timezone: process.env.TIMEZONE ?? 'America/Toronto',
+    nylasApiKey: process.env.NYLAS_API_KEY,
+    nylasGrantId: process.env.NYLAS_GRANT_ID,
+    nylasPollingIntervalMs: parseInt(process.env.NYLAS_POLL_INTERVAL_MS ?? '30000', 10),
+    nylasSelfEmail: process.env.NYLAS_SELF_EMAIL ?? '',
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,8 @@ import { ExecutionLayer } from './skills/execution.js';
 import { loadSkillsFromDirectory } from './skills/loader.js';
 import { ContactService } from './contacts/contact-service.js';
 import { ContactResolver } from './contacts/contact-resolver.js';
+import { NylasClient } from './channels/email/nylas-client.js';
+import { EmailAdapter } from './channels/email/email-adapter.js';
 
 async function main(): Promise<void> {
   // 1. Config & logging — no dependencies, must come first.
@@ -104,6 +106,30 @@ async function main(): Promise<void> {
   const contactResolver = new ContactResolver(contactService, entityMemory, logger);
   logger.info('Contact system initialized');
 
+  // Email channel — optional, requires NYLAS_API_KEY, NYLAS_GRANT_ID, and NYLAS_SELF_EMAIL.
+  let nylasClient: NylasClient | undefined;
+  let emailAdapter: EmailAdapter | undefined;
+  if (config.nylasApiKey && config.nylasGrantId) {
+    nylasClient = new NylasClient(config.nylasApiKey, config.nylasGrantId, logger);
+
+    if (!config.nylasSelfEmail) {
+      logger.warn('NYLAS_SELF_EMAIL not set — email adapter disabled (required to filter self-sent messages)');
+    } else {
+      emailAdapter = new EmailAdapter({
+        bus,
+        logger,
+        nylasClient,
+        contactService,
+        pollingIntervalMs: config.nylasPollingIntervalMs,
+        selfEmail: config.nylasSelfEmail,
+      });
+      await emailAdapter.start();
+      logger.info('Email channel adapter started');
+    }
+  } else {
+    logger.warn('NYLAS_API_KEY/NYLAS_GRANT_ID not set — email channel disabled');
+  }
+
   // Skill registry — loads all skills from the skills/ directory.
   // Skills are the framework's extension mechanism; agents invoke them
   // via the LLM's tool-use API through the execution layer.
@@ -124,7 +150,8 @@ async function main(): Promise<void> {
   const agentRegistry = new AgentRegistry();
 
   // Execution layer — now with bus and agent registry for infrastructure skills.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService });
+  // nylasClient is passed through so email skills (email-send, email-reply) can use it.
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, nylasClient });
 
   // Load all agent configs from the agents/ directory.
   // Fail hard on errors — consistent with skill loading and DB connection checks.
@@ -239,6 +266,13 @@ async function main(): Promise<void> {
   // Graceful shutdown — stop accepting new input first, then close connections.
   const shutdown = async () => {
     logger.info('Shutting down...');
+    if (emailAdapter) {
+      try {
+        await emailAdapter.stop();
+      } catch (err) {
+        logger.error({ err }, 'Error stopping email adapter during shutdown');
+      }
+    }
     try {
       await httpAdapter.stop();
     } catch (err) {

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -19,6 +19,7 @@ import type { Logger } from '../logger.js';
 import type { EventBus } from '../bus/bus.js';
 import type { AgentRegistry } from '../agents/agent-registry.js';
 import type { ContactService } from '../contacts/contact-service.js';
+import type { NylasClient } from '../channels/email/nylas-client.js';
 
 export class ExecutionLayer {
   private registry: SkillRegistry;
@@ -26,13 +27,15 @@ export class ExecutionLayer {
   private bus?: EventBus;
   private agentRegistry?: AgentRegistry;
   private contactService?: ContactService;
+  private nylasClient?: NylasClient;
 
-  constructor(registry: SkillRegistry, logger: Logger, options?: { bus?: EventBus; agentRegistry?: AgentRegistry; contactService?: ContactService }) {
+  constructor(registry: SkillRegistry, logger: Logger, options?: { bus?: EventBus; agentRegistry?: AgentRegistry; contactService?: ContactService; nylasClient?: NylasClient }) {
     this.registry = registry;
     this.logger = logger;
     this.bus = options?.bus;
     this.agentRegistry = options?.agentRegistry;
     this.contactService = options?.contactService;
+    this.nylasClient = options?.nylasClient;
   }
 
   /**
@@ -97,6 +100,11 @@ export class ExecutionLayer {
       ctx.bus = this.bus;
       ctx.agentRegistry = this.agentRegistry;
       ctx.contactService = this.contactService;
+      // nylasClient is optional — only email skills need it, so we inject it
+      // when available but don't gate on it (other infra skills don't need it)
+      if (this.nylasClient) {
+        ctx.nylasClient = this.nylasClient;
+      }
     }
 
     skillLogger.info({ input: Object.keys(input) }, 'Invoking skill');

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -51,6 +51,8 @@ export interface SkillContext {
   agentRegistry?: import('../agents/agent-registry.js').AgentRegistry;
   /** Contact service — only available to infrastructure skills */
   contactService?: import('../contacts/contact-service.js').ContactService;
+  /** Nylas email client — only available to infrastructure skills */
+  nylasClient?: import('../channels/email/nylas-client.js').NylasClient;
 }
 
 /**

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -26,6 +26,7 @@ import { ExecutionLayer } from '../../src/skills/execution.js';
 import { loadSkillsFromDirectory } from '../../src/skills/loader.js';
 import { ContactService } from '../../src/contacts/contact-service.js';
 import { ContactResolver } from '../../src/contacts/contact-resolver.js';
+import { NylasClient } from '../../src/channels/email/nylas-client.js';
 import { createInboundMessage, type OutboundMessageEvent } from '../../src/bus/events.js';
 import type { Logger } from '../../src/logger.js';
 
@@ -87,8 +88,18 @@ export async function createHarness(): Promise<CuriaHarness> {
   // Agent registry — tracks all running agents for delegation and listing.
   const agentRegistry = new AgentRegistry();
 
+  // Nylas client — optional, same as src/index.ts. EmailAdapter is intentionally
+  // skipped here: smoke tests should not start polling for real emails during runs.
+  // The nylasClient is still passed to ExecutionLayer so email skills can be invoked
+  // if a smoke test explicitly calls email-send or email-reply.
+  let nylasClient: NylasClient | undefined;
+  if (config.nylasApiKey && config.nylasGrantId) {
+    nylasClient = new NylasClient(config.nylasApiKey, config.nylasGrantId, logger);
+  }
+
   // Execution layer — with bus and agent registry for infrastructure skills.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService });
+  // nylasClient passed through so email skills work in tests that exercise them.
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, nylasClient });
 
   // Load all agent configs from the agents/ directory.
   const agentsDir = path.resolve(import.meta.dirname, '../../agents');

--- a/tests/unit/channels/email/html-to-text.test.ts
+++ b/tests/unit/channels/email/html-to-text.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { htmlToText } from '../../../../src/channels/email/html-to-text.js';
+
+describe('htmlToText', () => {
+  it('returns plain text unchanged', () => {
+    expect(htmlToText('Hello world')).toBe('Hello world');
+  });
+
+  it('strips HTML tags', () => {
+    expect(htmlToText('<p>Hello</p><p>World</p>')).toContain('Hello');
+    expect(htmlToText('<p>Hello</p><p>World</p>')).toContain('World');
+    expect(htmlToText('<p>Hello</p><p>World</p>')).not.toContain('<p>');
+  });
+
+  it('converts <br> to newlines', () => {
+    expect(htmlToText('Line 1<br>Line 2')).toContain('Line 1\nLine 2');
+  });
+
+  it('converts block elements to newlines', () => {
+    const result = htmlToText('<div>Block 1</div><div>Block 2</div>');
+    expect(result).toContain('Block 1');
+    expect(result).toContain('Block 2');
+  });
+
+  it('strips <style> and <script> blocks entirely', () => {
+    const html = '<style>.foo { color: red; }</style><p>Content</p><script>alert(1)</script>';
+    const result = htmlToText(html);
+    expect(result).toContain('Content');
+    expect(result).not.toContain('color');
+    expect(result).not.toContain('alert');
+  });
+
+  it('decodes common HTML entities', () => {
+    expect(htmlToText('&amp; &lt; &gt; &quot; &#39;')).toBe('& < > " \'');
+  });
+
+  it('collapses excessive whitespace', () => {
+    const result = htmlToText('  Hello   \n\n\n   World  ');
+    expect(result).toBe('Hello\n\nWorld');
+  });
+
+  it('handles empty/undefined input', () => {
+    expect(htmlToText('')).toBe('');
+    expect(htmlToText(undefined as unknown as string)).toBe('');
+  });
+});

--- a/tests/unit/channels/email/message-converter.test.ts
+++ b/tests/unit/channels/email/message-converter.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { convertNylasMessage } from '../../../../src/channels/email/message-converter.js';
+import type { NylasMessage } from '../../../../src/channels/email/nylas-client.js';
+
+// ---------------------------------------------------------------------------
+// Test fixture factory — produces a fully-populated NylasMessage; individual
+// tests override only the fields they care about.
+// ---------------------------------------------------------------------------
+
+function mockMessage(overrides?: Partial<NylasMessage>): NylasMessage {
+  return {
+    id: 'msg-1',
+    threadId: 'thread-1',
+    subject: 'Test Subject',
+    from: [{ email: 'sender@example.com', name: 'Sender' }],
+    to: [{ email: 'nathan@curia.com', name: 'Nathan Curia' }],
+    cc: [],
+    bcc: [],
+    body: '<p>Hello world</p>',
+    snippet: 'Hello world',
+    date: 1711900800, // 2024-03-31T12:00:00Z
+    unread: true,
+    folders: ['inbox'],
+    ...overrides,
+  };
+}
+
+describe('convertNylasMessage', () => {
+  it('sets conversationId from thread ID with "email:" prefix', () => {
+    const result = convertNylasMessage(mockMessage({ threadId: 'thread-abc' }));
+    expect(result.conversationId).toBe('email:thread-abc');
+  });
+
+  it('sets channelId to "email"', () => {
+    const result = convertNylasMessage(mockMessage());
+    expect(result.channelId).toBe('email');
+  });
+
+  it('sets senderId to the first from address', () => {
+    const result = convertNylasMessage(mockMessage({
+      from: [{ email: 'alice@example.com', name: 'Alice' }],
+    }));
+    expect(result.senderId).toBe('alice@example.com');
+  });
+
+  it('falls back to "unknown" when from array is empty', () => {
+    const result = convertNylasMessage(mockMessage({ from: [] }));
+    expect(result.senderId).toBe('unknown');
+  });
+
+  it('converts HTML body to plain text via htmlToText', () => {
+    const result = convertNylasMessage(mockMessage({ body: '<p>Hello world</p>' }));
+    // htmlToText should strip the <p> tags
+    expect(result.content).toContain('Hello world');
+    expect(result.content).not.toContain('<p>');
+  });
+
+  it('falls back to snippet when body is empty string', () => {
+    const result = convertNylasMessage(mockMessage({
+      body: '',
+      snippet: 'Preview text here',
+    }));
+    expect(result.content).toContain('Preview text here');
+  });
+
+  it('falls back to "(empty email)" when both body and snippet are empty', () => {
+    const result = convertNylasMessage(mockMessage({ body: '', snippet: '' }));
+    expect(result.content).toContain('(empty email)');
+  });
+
+  it('prepends "Subject: <subject>" to the content', () => {
+    const result = convertNylasMessage(mockMessage({ subject: 'My Subject' }));
+    expect(result.content).toMatch(/^Subject: My Subject\n\n/);
+  });
+
+  it('stores the correct subject in metadata', () => {
+    const result = convertNylasMessage(mockMessage({ subject: 'Quarterly Review' }));
+    expect(result.metadata.subject).toBe('Quarterly Review');
+  });
+
+  it('stores nylasMessageId in metadata', () => {
+    const result = convertNylasMessage(mockMessage({ id: 'msg-xyz-123' }));
+    expect(result.metadata.nylasMessageId).toBe('msg-xyz-123');
+  });
+
+  it('stores nylasThreadId in metadata', () => {
+    const result = convertNylasMessage(mockMessage({ threadId: 'thread-xyz' }));
+    expect(result.metadata.nylasThreadId).toBe('thread-xyz');
+  });
+
+  it('converts unix timestamp to a Date in receivedAt', () => {
+    // 1711900800 = 2024-03-31T12:00:00.000Z
+    const result = convertNylasMessage(mockMessage({ date: 1711900800 }));
+    expect(result.metadata.receivedAt).toBeInstanceOf(Date);
+    expect(result.metadata.receivedAt.getTime()).toBe(1711900800 * 1000);
+  });
+
+  it('extracts all from participants with role "from"', () => {
+    const result = convertNylasMessage(mockMessage({
+      from: [{ email: 'sender@example.com', name: 'Sender' }],
+    }));
+    const fromParticipants = result.metadata.participants.filter(p => p.role === 'from');
+    expect(fromParticipants).toHaveLength(1);
+    expect(fromParticipants[0]).toMatchObject({
+      email: 'sender@example.com',
+      name: 'Sender',
+      role: 'from',
+    });
+  });
+
+  it('extracts all to participants with role "to"', () => {
+    const result = convertNylasMessage(mockMessage({
+      to: [
+        { email: 'alice@curia.com', name: 'Alice' },
+        { email: 'bob@curia.com', name: 'Bob' },
+      ],
+    }));
+    const toParticipants = result.metadata.participants.filter(p => p.role === 'to');
+    expect(toParticipants).toHaveLength(2);
+    expect(toParticipants[0]).toMatchObject({ email: 'alice@curia.com', role: 'to' });
+    expect(toParticipants[1]).toMatchObject({ email: 'bob@curia.com', role: 'to' });
+  });
+
+  it('extracts cc participants with role "cc"', () => {
+    const result = convertNylasMessage(mockMessage({
+      cc: [{ email: 'cc@example.com', name: 'CC Person' }],
+    }));
+    const ccParticipants = result.metadata.participants.filter(p => p.role === 'cc');
+    expect(ccParticipants).toHaveLength(1);
+    expect(ccParticipants[0]).toMatchObject({
+      email: 'cc@example.com',
+      name: 'CC Person',
+      role: 'cc',
+    });
+  });
+
+  it('handles messages with no CC (empty cc array)', () => {
+    const result = convertNylasMessage(mockMessage({ cc: [] }));
+    const ccParticipants = result.metadata.participants.filter(p => p.role === 'cc');
+    expect(ccParticipants).toHaveLength(0);
+  });
+
+  it('includes all participant types together in the right order', () => {
+    const result = convertNylasMessage(mockMessage({
+      from: [{ email: 'sender@example.com', name: 'Sender' }],
+      to: [{ email: 'to@example.com', name: 'To' }],
+      cc: [{ email: 'cc@example.com', name: 'CC' }],
+    }));
+    // from comes first, then to, then cc
+    expect(result.metadata.participants[0].role).toBe('from');
+    expect(result.metadata.participants[1].role).toBe('to');
+    expect(result.metadata.participants[2].role).toBe('cc');
+    expect(result.metadata.participants).toHaveLength(3);
+  });
+
+  it('handles participants without a name (name is optional)', () => {
+    const result = convertNylasMessage(mockMessage({
+      from: [{ email: 'noreply@example.com' }],
+    }));
+    const fromParticipant = result.metadata.participants.find(p => p.role === 'from');
+    expect(fromParticipant?.email).toBe('noreply@example.com');
+    // name may be undefined — that's acceptable
+    expect(fromParticipant?.name).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a full email channel powered by Nylas, enabling Nathan Curia (Agent Chief of Staff) to send and receive emails through their own email account.

- **Email channel adapter** — polls Nylas for new unread messages on a configurable interval (default 30s), publishes them as `inbound.message` bus events
- **Outbound replies** — subscribes to `outbound.message` and sends threaded email replies via Nylas
- **NylasClient wrapper** — typed wrapper around the Nylas SDK (list, get, send messages)
- **HTML-to-text converter** — strips HTML email bodies to plain text for LLM consumption
- **Message converter** — converts Nylas messages to bus events with participant extraction (From/To/CC)
- **Participant auto-creation** — email participants auto-created as contacts (source: `email_participant`, verified)
- **Two email skills** — `email-send` (compose new) and `email-reply` (threaded reply) with input validation, length limits, and email format validation
- **Coordinator persona** — updated from "Curia" to "Nathan Curia, Agent Chief of Staff" with email awareness instructions
- **Security hardening** — inbound email content sanitized for prompt injection, outbound recipients validated, body size capped at 50KB

## Configuration

Requires three new env vars (all optional — system works without them):
```
NYLAS_API_KEY=nyk_v0_...
NYLAS_GRANT_ID=...
NYLAS_SELF_EMAIL=nathan@yourdomain.com
```

## Security notes (deferred to future work)

- #35 — Outbound email approval gate (no human-in-the-loop before send)
- #36 — Rate-limit contact auto-creation from email spam
- #37 — Harden self-email loop filter (aliases, plus-addressing)
- #38 — Prevent LLM context leakage in outbound emails
- #39 — Sanitize display names at contact creation time

## Test plan

- [x] Unit tests for HTML-to-text converter (8 tests)
- [x] Unit tests for message converter (18 tests)
- [x] 236 tests pass across 39 files
- [x] Typecheck clean
- [x] Lint clean
- [x] Pre-PR review: code reviewer + silent failure hunter — findings addressed
- [x] Security review — HIGH findings fixed, MEDIUM deferred with issues
- [ ] Manual test: send email to Nathan's address, verify polling + response