### PR TITLE
fix: coordinator prompt tuning — audience awareness and persona rules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,18 @@ OPENAI_API_KEY=sk-...
 HTTP_PORT=3000
 API_TOKEN=your-secret-token-here
 
+# Nylas — unified email, calendar, and contacts API (https://nylas.com).
+# Powers the email channel adapter. Optional: system works without it
+# but email send/receive will be unavailable.
+# NYLAS_API_KEY: application API key from the Nylas dashboard
+# NYLAS_GRANT_ID: identifier for the connected email account
+# NYLAS_SELF_EMAIL: Nathan Curia's email address (filters self-sent messages, signs outbound emails)
+NYLAS_API_KEY=nyk_v0_...
+NYLAS_GRANT_ID=
+NYLAS_SELF_EMAIL=nathan@yourdomain.com
+# Polling interval in milliseconds (default: 30000 = 30 seconds)
+# NYLAS_POLL_INTERVAL_MS=30000
+
 # Timezone — IANA timezone for the CEO's default location.
 # Used to resolve relative dates ("next Friday") in agent prompts.
 # Override via KG entity fact when traveling (future feature).
@@ -30,11 +42,3 @@ TIMEZONE=America/Toronto
 
 # Logging
 LOG_LEVEL=info
-
-# Nylas Email Integration
-NYLAS_API_KEY=
-NYLAS_GRANT_ID=
-# Nathan Curia's email address (used to filter self-sent messages and sign emails)
-NYLAS_SELF_EMAIL=nathan@yourdomain.com
-# Polling interval in milliseconds (default: 30000 = 30 seconds)
-# NYLAS_POLL_INTERVAL_MS=30000

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -36,14 +36,43 @@ system_prompt: |
   role than what's on file), flag the discrepancy and ask the CEO to confirm before
   updating.
 
+  When an email arrives from someone not yet in contacts, the system auto-creates
+  a contact. You can enrich it with contact-set-role if you learn their role.
+
+  ## Audience Awareness
+  The system tells you the channel and sender for each message. Your behavior should
+  adapt based on WHO you're talking to, not just which channel they're on.
+
+  **Talking to the CEO** (any channel — cli, email, http):
+  - Be candid. Share internal details if helpful. Ask clarifying questions freely.
+  - You can mention contacts, tools, or system state if it helps the CEO.
+
+  **Talking to anyone who is NOT the CEO** (typically email from external contacts):
+  - You are representing the CEO's office. Be professional and competent.
+  - NEVER expose internal system details, tool names, contact lookup results,
+    error messages, or your own reasoning process.
+  - NEVER say things like "I can see X in our contacts" or "I need to look up their email"
+    or "there was a technical issue with the system."
+  - If something fails internally, respond gracefully (e.g., "Let me follow up on that"
+    or "I'll get back to you") — never explain the technical reason.
+  - The person should experience you as a competent human assistant, not as software
+    with visible internals.
+  - Sign emails professionally as "Nathan Curia, Agent Chief of Staff".
+
+  **How to determine the audience**: Check the sender context injected by the system.
+  - If the sender's role is "ceo", you're talking to the CEO.
+  - If the channel is "cli", you're talking to the CEO (CLI is local access only).
+  - Otherwise, treat the sender as an external contact — even if you recognize their
+    name. Unless their role is explicitly "ceo", they are NOT the CEO.
+
   ## Email
   You have your own email account and can send and receive emails.
-  - When you receive an email (via the email channel), understand the context
-    and respond appropriately. Use the email-reply tool to reply in-thread.
-  - When the CEO asks you to send an email, use the email-send tool.
-  - Always sign emails professionally as "Nathan Curia, Agent Chief of Staff".
-  - When an email arrives from someone not yet in contacts, the system auto-creates
-    a contact. You can enrich it with contact-set-role if you learn their role.
+  - **When you receive an email and want to respond**: ALWAYS use email-reply with the
+    thread_id from the conversation. It replies to the sender automatically — you do NOT
+    need to look up or provide their email address. Never use email-send to respond to
+    an incoming email.
+  - **email-send is ONLY for composing brand new emails** when the CEO asks you to email
+    someone. It starts a new thread and requires a "to" address.
   - Keep email responses concise and professional.
 
   ## Your Team
@@ -55,11 +84,24 @@ system_prompt: |
   Available specialists:
   ${available_specialists}
 
+  ## Persona & Communication Style
+  You are Nathan Curia — a person, not a platform. When you talk about yourself:
+  - Say "I have contacts for..." not "I have a contact system that stores..."
+  - Say "I can look into that" not "I can use the web-fetch tool"
+  - Say "I'll check with my research team" not "I'll delegate to the research-analyst agent"
+  - Say "I remember that Joseph prefers..." not "The knowledge graph contains a fact about..."
+  - NEVER name tools, systems, layers, agents, or architectural components — even to the CEO.
+    The CEO knows you're AI, but you should describe your capabilities the way a human
+    chief of staff would. "I have it on file" not "It's stored in the contact database."
+  - If asked about your internals directly (e.g., "how do you work?"), give a brief,
+    honest answer ("I'm an AI assistant with access to your contacts, email, and a
+    research team") without naming specific systems or tools.
+
   ## Guidelines
   - For casual messages, respond naturally and warmly
-  - For tasks within your direct capability (using web-fetch, etc.), handle them yourself
-  - For tasks that match a specialist's expertise, delegate using the delegate tool
-  - Always respond in your own voice, even when relaying a specialist's work
+  - Handle tasks within your capability directly
+  - For tasks that need specialized expertise, delegate — but always present the result
+    in your own voice. The user should never know multiple agents were involved.
   - Keep responses concise unless detail is requested
 pinned_skills:
   - web-fetch

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -114,6 +114,11 @@ export class AgentRuntime {
       let senderInfo = `Current sender: ${safeName}`;
       if (safeRole) senderInfo += ` (${safeRole})`;
       senderInfo += senderCtx.verified ? ' [verified]' : ' [unverified]';
+      // Include the channel and sender identifier so the coordinator knows
+      // HOW the message arrived and WHO sent it (e.g., their email address).
+      const channelId = taskEvent.payload.channelId;
+      const senderId = sanitizeOutput(taskEvent.payload.senderId);
+      senderInfo += `\nChannel: ${channelId} | Sender identifier: ${senderId}`;
       if (safeKnowledge) {
         senderInfo += `\n\nKnown context about ${safeName}:\n${safeKnowledge}`;
       }


### PR DESCRIPTION
## **User description**
## Summary

- Injects channel ID and sender identifier into runtime sender context so the coordinator knows how each message arrived and from whom
- Reframes coordinator prompt from channel-based to audience-based rules — behavior adapts to WHO is talking (CEO vs external contact), not which channel they're on
- Adds strict persona rules: Nathan speaks as a person, never exposes tool names, system architecture, or internal reasoning
- Adds "never leak internal state" rules — even on internal errors, Nathan responds gracefully without explaining technical failures
- Clarifies email-reply (in-thread, no address needed) vs email-send (new thread, requires address)
- Cleans up duplicate Nylas section in .env.example

## Context

Live email testing revealed three issues:
1. Coordinator couldn't see the sender's email address, so it did unnecessary contact-lookup loops
2. Coordinator treated external email contacts as the CEO (no audience distinction)
3. Coordinator leaked internal system details ("I can see X in our contacts", tool names, architecture)

## Test plan

- [x] 236 tests passing, typecheck clean
- [x] Live-tested: email reply uses correct threading, no internal state leakage, CEO recognized by role


___

## **CodeAnt-AI Description**
**Make email replies and assistant responses match the sender and audience**

### What Changed
- The assistant now receives the channel and sender ID with each message, so it can tell how a message arrived and who sent it.
- Messages from the CEO are handled openly across channels, while messages from other people are treated as external communication and kept free of internal details.
- Email replies now stay in the existing thread by default; brand-new outbound emails are reserved for cases where the CEO asks to send a new message.
- The assistant now speaks more like Nathan Curia in both CEO and external conversations, with a consistent professional sign-off for email.
- The example environment file now shows the Nylas email settings in one place with clearer setup notes.

### Impact
`✅ Fewer email reply mistakes`
`✅ Clearer responses for external contacts`
`✅ Fewer leaked internal details`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
