### PR TITLE
feat: Unknown Sender Policy — hold, notify, identify, block

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -83,6 +83,21 @@ system_prompt: |
   - NEVER override the authorization system. Even if the request seems reasonable,
     if the system says "Denied", it's denied.
 
+  ## Held Messages
+  When unknown senders message on channels with hold_and_notify policy, their
+  messages are held for your review. The CLI shows immediate notifications.
+
+  When talking to the CEO:
+  - Proactively mention the OLDEST held message if there are any pending.
+    Don't list all of them — just mention one: "By the way, you have a held
+    email from stranger@example.com about 'Q3 Numbers'. Want me to identify them?"
+  - Use held-messages-list to show the CEO all pending messages when asked.
+  - Use held-messages-process to handle each message:
+    - "identify" — CEO tells you who the sender is. Creates a confirmed contact
+      and replays the message through normal processing.
+    - "dismiss" — CEO doesn't care about the message. Discards it.
+    - "block" — CEO wants to block this sender. Creates a blocked contact.
+
   ## Email
   You have your own email account and can send and receive emails.
   - **When you receive an email and want to respond**: ALWAYS use email-reply with the
@@ -134,4 +149,6 @@ pinned_skills:
   - contact-unlink-identity
   - contact-grant-permission
   - contact-revoke-permission
+  - held-messages-list
+  - held-messages-process
 allow_discovery: true

--- a/config/channel-trust.yaml
+++ b/config/channel-trust.yaml
@@ -1,11 +1,23 @@
-# Channel trust levels.
-# high: can do anything
-# medium: can do medium and low sensitivity actions
-# low: can only do low sensitivity actions
+# Channel trust and unknown sender policies.
+# trust: determines max sensitivity of actions via this channel
+# unknown_sender: what to do when a message arrives from an unrecognized sender
+#   allow - process normally (CLI is always the CEO)
+#   hold_and_notify - hold the message silently, notify CEO
+#   reject - silently drop the message
 
 channels:
-  cli: high
-  signal: high
-  telegram: medium
-  http: medium
-  email: low
+  cli:
+    trust: high
+    unknown_sender: allow
+  signal:
+    trust: high
+    unknown_sender: hold_and_notify
+  telegram:
+    trust: medium
+    unknown_sender: hold_and_notify
+  http:
+    trust: medium
+    unknown_sender: reject
+  email:
+    trust: low
+    unknown_sender: hold_and_notify

--- a/docs/specs/09-contacts-and-identity.md
+++ b/docs/specs/09-contacts-and-identity.md
@@ -197,7 +197,7 @@ When an inbound message can't be matched to any contact, the system's response d
 | **Signal** | `high` | Hold silently, notify CEO |
 | **Telegram** | `medium` | Hold silently, notify CEO |
 | **HTTP API** | `medium` | Reject with 401 (unknown token) |
-| **Email** | `low` | Auto-reply: "Received, forwarding to [CEO name]" |
+| **Email** | `low` | Hold silently, notify CEO |
 
 Policy is configurable per channel in `config/default.yaml`:
 
@@ -218,6 +218,11 @@ Held messages are queued in working memory with a `held_for_identification` flag
 If the CEO identifies the sender, the held message is re-processed with full contact context. If the CEO says "I don't know them," the held message is discarded and the sender remains unresolved.
 
 **Rate limiting:** A maximum of 20 held messages per channel are queued at any time (configurable). When the cap is reached, the oldest held message is discarded. This prevents a flood of unknown-sender messages from consuming unbounded working memory.
+
+> **Open question:** Held message expiration is deferred. Messages are currently held
+> indefinitely until the CEO acts. A future discard/expiration process will need
+> judgment and oversight — not a simple TTL timer. The CEO may want to batch-review
+> old held messages, or have Nathan summarize and triage them.
 
 ---
 

--- a/docs/superpowers/plans/2026-03-27-unknown-sender-policy.md
+++ b/docs/superpowers/plans/2026-03-27-unknown-sender-policy.md
@@ -1,0 +1,1217 @@
+# Unknown Sender Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When an unknown sender messages on any channel, hold their message, notify the CEO, and let the CEO identify or dismiss the sender — then replay the held message through the normal pipeline.
+
+**Architecture:** A `held_messages` table stores messages from unknown senders. The dispatcher checks unknown sender policy per channel (from config) and either holds or drops the message instead of routing it to the coordinator. A new `held-messages` skill lets the coordinator list/process held messages. The CLI adapter shows immediate notifications for new held messages. The coordinator proactively mentions the oldest/most important held message when talking to the CEO.
+
+**Tech Stack:** TypeScript/ESM, PostgreSQL (new migration), YAML config extension, vitest
+
+---
+
+## File Structure
+
+### New files
+| File | Responsibility |
+|------|---------------|
+| `src/db/migrations/007_create_held_messages.sql` | Held messages table |
+| `src/contacts/held-messages.ts` | HeldMessageService — CRUD + replay logic |
+| `src/contacts/unknown-sender-policy.ts` | Policy evaluation (per-channel config lookup) |
+| `skills/held-messages-list/skill.json` | Manifest for listing held messages |
+| `skills/held-messages-list/handler.ts` | Handler for listing held messages |
+| `skills/held-messages-process/skill.json` | Manifest for processing a held message (identify/dismiss/block) |
+| `skills/held-messages-process/handler.ts` | Handler for processing a held message |
+| `tests/unit/contacts/held-messages.test.ts` | Unit tests for HeldMessageService |
+| `tests/unit/contacts/unknown-sender-policy.test.ts` | Unit tests for policy evaluation |
+
+### Modified files
+| File | Changes |
+|------|---------|
+| `config/channel-trust.yaml` | Add `unknown_sender` policy per channel |
+| `src/contacts/config-loader.ts` | Parse unknown_sender policy from channel-trust.yaml |
+| `src/contacts/types.ts` | Add HeldMessage type, UnknownSenderPolicy type, extend AuthConfig |
+| `src/dispatch/dispatcher.ts` | Check unknown sender policy, hold or drop instead of routing |
+| `src/channels/cli/cli-adapter.ts` | Subscribe to `contact.unknown` for immediate CLI notification |
+| `src/bus/events.ts` | Add `message.held` event type |
+| `src/bus/permissions.ts` | Allow dispatch to publish `message.held`, system to subscribe |
+| `src/index.ts` | Create HeldMessageService, pass to dispatcher and execution layer |
+| `agents/coordinator.yaml` | Add held message awareness to prompt |
+
+---
+
+### Task 1: Types, Migration, and Config
+
+**Files:**
+- Modify: `src/contacts/types.ts`
+- Create: `src/db/migrations/007_create_held_messages.sql`
+- Modify: `config/channel-trust.yaml`
+- Modify: `src/contacts/config-loader.ts`
+- Modify: `tests/unit/contacts/config-loader.test.ts`
+
+- [ ] **Step 1: Add types to `src/contacts/types.ts`**
+
+Add at the end of the file:
+
+```typescript
+// -- Unknown sender policy --
+
+export type UnknownSenderPolicy = 'allow' | 'hold_and_notify' | 'reject';
+
+export type HeldMessageStatus = 'pending' | 'processed' | 'discarded';
+
+export interface HeldMessage {
+  id: string;
+  channel: string;
+  senderId: string;
+  conversationId: string;
+  content: string;
+  subject: string | null;
+  metadata: Record<string, unknown>;
+  status: HeldMessageStatus;
+  /** Contact ID if the CEO identified the sender */
+  resolvedContactId: string | null;
+  createdAt: Date;
+  processedAt: Date | null;
+}
+
+export interface ChannelPolicyConfig {
+  trust: TrustLevel;
+  unknownSender: UnknownSenderPolicy;
+}
+```
+
+Update `AuthConfig` to include the richer channel config:
+
+```typescript
+export interface AuthConfig {
+  roles: Record<string, RolePermissions>;
+  permissions: Record<string, PermissionDef>;
+  channelTrust: Record<string, TrustLevel>;
+  channelPolicies: Record<string, ChannelPolicyConfig>;
+}
+```
+
+- [ ] **Step 2: Create migration `src/db/migrations/007_create_held_messages.sql`**
+
+```sql
+-- Up Migration
+
+-- Held messages: stores inbound messages from unknown senders pending CEO review.
+-- Messages stay here until the CEO identifies the sender (processed),
+-- dismisses them (discarded), or they are auto-discarded by rate limiting.
+CREATE TABLE held_messages (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  channel             TEXT NOT NULL,
+  sender_id           TEXT NOT NULL,
+  conversation_id     TEXT NOT NULL,
+  content             TEXT NOT NULL,
+  subject             TEXT,
+  metadata            JSONB NOT NULL DEFAULT '{}',
+  status              TEXT NOT NULL DEFAULT 'pending',
+  resolved_contact_id UUID REFERENCES contacts(id),
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  processed_at        TIMESTAMPTZ
+);
+
+-- Index for listing pending messages (the primary query pattern)
+CREATE INDEX idx_held_messages_status ON held_messages (status, created_at)
+  WHERE status = 'pending';
+
+-- Index for rate limiting: count pending messages per channel
+CREATE INDEX idx_held_messages_channel_status ON held_messages (channel, status)
+  WHERE status = 'pending';
+```
+
+- [ ] **Step 3: Update `config/channel-trust.yaml`**
+
+Change from flat trust levels to richer policy config:
+
+```yaml
+# Channel trust and unknown sender policies.
+# trust: determines max sensitivity of actions via this channel
+# unknown_sender: what to do when a message arrives from an unrecognized sender
+#   allow - process normally (CLI is always the CEO)
+#   hold_and_notify - hold the message, notify CEO
+#   reject - silently drop the message
+
+channels:
+  cli:
+    trust: high
+    unknown_sender: allow
+  signal:
+    trust: high
+    unknown_sender: hold_and_notify
+  telegram:
+    trust: medium
+    unknown_sender: hold_and_notify
+  http:
+    trust: medium
+    unknown_sender: reject
+  email:
+    trust: low
+    unknown_sender: hold_and_notify
+```
+
+- [ ] **Step 4: Update config loader to parse new format**
+
+Read `src/contacts/config-loader.ts`. Update the channel trust parsing section to handle both the new object format and extract both `trust` and `unknownSender`:
+
+```typescript
+  // Channel trust levels and unknown sender policies
+  const trustRaw = trustDoc as { channels: Record<string, string | { trust: string; unknown_sender: string }> };
+
+  const channelTrust: Record<string, TrustLevel> = {};
+  const channelPolicies: Record<string, ChannelPolicyConfig> = {};
+
+  for (const [channel, config] of Object.entries(trustRaw.channels)) {
+    if (typeof config === 'string') {
+      // Backwards compat: plain string is just the trust level, default unknown_sender to 'hold_and_notify'
+      const trust = config as TrustLevel;
+      if (!['high', 'medium', 'low'].includes(trust)) {
+        throw new Error(`Invalid trust level '${trust}' for channel '${channel}'`);
+      }
+      channelTrust[channel] = trust;
+      channelPolicies[channel] = { trust, unknownSender: 'hold_and_notify' };
+    } else {
+      const trust = config.trust as TrustLevel;
+      if (!['high', 'medium', 'low'].includes(trust)) {
+        throw new Error(`Invalid trust level '${trust}' for channel '${channel}'`);
+      }
+      const unknownSender = config.unknown_sender as UnknownSenderPolicy;
+      if (!['allow', 'hold_and_notify', 'reject'].includes(unknownSender)) {
+        throw new Error(`Invalid unknown_sender policy '${unknownSender}' for channel '${channel}'`);
+      }
+      channelTrust[channel] = trust;
+      channelPolicies[channel] = { trust, unknownSender };
+    }
+  }
+
+  return { roles, permissions, channelTrust, channelPolicies };
+```
+
+Add imports for `UnknownSenderPolicy` and `ChannelPolicyConfig` from `./types.js`.
+
+- [ ] **Step 5: Update config-loader tests**
+
+Add to `tests/unit/contacts/config-loader.test.ts`:
+
+```typescript
+  it('loads unknown sender policies from YAML', () => {
+    const config = loadAuthConfig(CONFIG_DIR);
+    expect(config.channelPolicies).toBeDefined();
+    expect(config.channelPolicies.cli.unknownSender).toBe('allow');
+    expect(config.channelPolicies.email.unknownSender).toBe('hold_and_notify');
+    expect(config.channelPolicies.http.unknownSender).toBe('reject');
+  });
+
+  it('preserves trust levels alongside policies', () => {
+    const config = loadAuthConfig(CONFIG_DIR);
+    expect(config.channelPolicies.cli.trust).toBe('high');
+    expect(config.channelPolicies.email.trust).toBe('low');
+    expect(config.channelTrust.cli).toBe('high');
+  });
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx vitest run tests/unit/contacts/config-loader.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/contacts/types.ts src/db/migrations/007_create_held_messages.sql config/channel-trust.yaml src/contacts/config-loader.ts tests/unit/contacts/config-loader.test.ts
+git commit -m "feat: add held messages types, migration, and unknown sender config"
+```
+
+---
+
+### Task 2: HeldMessageService
+
+**Files:**
+- Create: `src/contacts/held-messages.ts`
+- Create: `tests/unit/contacts/held-messages.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/contacts/held-messages.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { HeldMessageService } from '../../../src/contacts/held-messages.js';
+
+describe('HeldMessageService', () => {
+  let service: HeldMessageService;
+
+  beforeEach(() => {
+    service = HeldMessageService.createInMemory();
+  });
+
+  it('holds a message and retrieves it', async () => {
+    const id = await service.hold({
+      channel: 'email',
+      senderId: 'stranger@example.com',
+      conversationId: 'email:thread-1',
+      content: 'Can I get the Q3 numbers?',
+      subject: 'Q3 Request',
+      metadata: {},
+    });
+
+    const pending = await service.listPending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe(id);
+    expect(pending[0].senderId).toBe('stranger@example.com');
+    expect(pending[0].status).toBe('pending');
+  });
+
+  it('lists pending messages for a specific channel', async () => {
+    await service.hold({ channel: 'email', senderId: 'a@example.com', conversationId: 'e:1', content: 'test', subject: null, metadata: {} });
+    await service.hold({ channel: 'telegram', senderId: '123', conversationId: 't:1', content: 'test', subject: null, metadata: {} });
+
+    const emailOnly = await service.listPending('email');
+    expect(emailOnly).toHaveLength(1);
+    expect(emailOnly[0].channel).toBe('email');
+  });
+
+  it('marks a message as processed with contact ID', async () => {
+    const id = await service.hold({ channel: 'email', senderId: 'a@example.com', conversationId: 'e:1', content: 'test', subject: null, metadata: {} });
+
+    await service.markProcessed(id, 'contact-uuid-123');
+
+    const pending = await service.listPending();
+    expect(pending).toHaveLength(0);
+
+    const msg = await service.getById(id);
+    expect(msg?.status).toBe('processed');
+    expect(msg?.resolvedContactId).toBe('contact-uuid-123');
+    expect(msg?.processedAt).toBeInstanceOf(Date);
+  });
+
+  it('discards a message', async () => {
+    const id = await service.hold({ channel: 'email', senderId: 'a@example.com', conversationId: 'e:1', content: 'test', subject: null, metadata: {} });
+
+    await service.discard(id);
+
+    const pending = await service.listPending();
+    expect(pending).toHaveLength(0);
+
+    const msg = await service.getById(id);
+    expect(msg?.status).toBe('discarded');
+  });
+
+  it('enforces rate limit per channel', async () => {
+    // Create a service with limit of 3 per channel
+    const limited = HeldMessageService.createInMemory(3);
+
+    await limited.hold({ channel: 'email', senderId: 'a@example.com', conversationId: 'e:1', content: '1', subject: null, metadata: {} });
+    await limited.hold({ channel: 'email', senderId: 'b@example.com', conversationId: 'e:2', content: '2', subject: null, metadata: {} });
+    await limited.hold({ channel: 'email', senderId: 'c@example.com', conversationId: 'e:3', content: '3', subject: null, metadata: {} });
+
+    // This should discard the oldest
+    await limited.hold({ channel: 'email', senderId: 'd@example.com', conversationId: 'e:4', content: '4', subject: null, metadata: {} });
+
+    const pending = await limited.listPending('email');
+    expect(pending).toHaveLength(3);
+    // Oldest (a@) should be gone
+    expect(pending.map(m => m.senderId)).not.toContain('a@example.com');
+    expect(pending.map(m => m.senderId)).toContain('d@example.com');
+  });
+
+  it('rate limit is per channel, not global', async () => {
+    const limited = HeldMessageService.createInMemory(2);
+
+    await limited.hold({ channel: 'email', senderId: 'a@example.com', conversationId: 'e:1', content: '1', subject: null, metadata: {} });
+    await limited.hold({ channel: 'email', senderId: 'b@example.com', conversationId: 'e:2', content: '2', subject: null, metadata: {} });
+    await limited.hold({ channel: 'telegram', senderId: '111', conversationId: 't:1', content: '3', subject: null, metadata: {} });
+
+    const emailPending = await limited.listPending('email');
+    const telegramPending = await limited.listPending('telegram');
+    expect(emailPending).toHaveLength(2);
+    expect(telegramPending).toHaveLength(1);
+  });
+
+  it('returns null for non-existent message', async () => {
+    const msg = await service.getById('non-existent-id');
+    expect(msg).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/contacts/held-messages.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: Implement HeldMessageService**
+
+Create `src/contacts/held-messages.ts`:
+
+```typescript
+// src/contacts/held-messages.ts
+//
+// HeldMessageService: stores and manages messages from unknown senders
+// that are held pending CEO review.
+//
+// Follows the backend-interface pattern (Postgres + InMemory).
+// Rate limiting: max N pending messages per channel (default 20).
+// When the cap is reached, the oldest pending message is auto-discarded.
+
+import { randomUUID } from 'node:crypto';
+import type { DbPool } from '../db/connection.js';
+import type { Logger } from '../logger.js';
+import type { HeldMessage, HeldMessageStatus } from './types.js';
+
+// -- Hold options (what callers pass in) --
+
+export interface HoldMessageOptions {
+  channel: string;
+  senderId: string;
+  conversationId: string;
+  content: string;
+  subject: string | null;
+  metadata: Record<string, unknown>;
+}
+
+// -- Backend interface --
+
+interface HeldMessageBackend {
+  insert(message: HeldMessage): Promise<void>;
+  getById(id: string): Promise<HeldMessage | null>;
+  listPending(channel?: string): Promise<HeldMessage[]>;
+  countPendingByChannel(channel: string): Promise<number>;
+  discardOldest(channel: string): Promise<void>;
+  update(id: string, updates: Partial<Pick<HeldMessage, 'status' | 'resolvedContactId' | 'processedAt'>>): Promise<void>;
+}
+
+// Default max pending messages per channel
+const DEFAULT_MAX_PER_CHANNEL = 20;
+
+/**
+ * HeldMessageService manages messages from unknown senders.
+ *
+ * When a message arrives from an unknown sender on a channel with
+ * hold_and_notify policy, the dispatcher calls hold() to store it.
+ * The CEO then reviews held messages and either identifies the sender
+ * (markProcessed) or dismisses (discard).
+ *
+ * Rate limiting: max N pending messages per channel (configurable).
+ * When the cap is reached, the oldest pending message is auto-discarded.
+ *
+ * TODO: Held message expiration/auto-discard timeout is deferred.
+ * Messages are held indefinitely until the CEO acts. A future discard
+ * process will need judgment and oversight — not a simple timer.
+ */
+export class HeldMessageService {
+  private constructor(
+    private backend: HeldMessageBackend,
+    private maxPerChannel: number,
+  ) {}
+
+  static createWithPostgres(pool: DbPool, logger: Logger, maxPerChannel?: number): HeldMessageService {
+    return new HeldMessageService(
+      new PostgresHeldMessageBackend(pool, logger),
+      maxPerChannel ?? DEFAULT_MAX_PER_CHANNEL,
+    );
+  }
+
+  static createInMemory(maxPerChannel?: number): HeldMessageService {
+    return new HeldMessageService(
+      new InMemoryHeldMessageBackend(),
+      maxPerChannel ?? DEFAULT_MAX_PER_CHANNEL,
+    );
+  }
+
+  /**
+   * Hold a message from an unknown sender.
+   * Enforces per-channel rate limit — if at capacity, discards the oldest.
+   * Returns the held message ID.
+   */
+  async hold(options: HoldMessageOptions): Promise<string> {
+    // Rate limit: check if channel is at capacity
+    const count = await this.backend.countPendingByChannel(options.channel);
+    if (count >= this.maxPerChannel) {
+      await this.backend.discardOldest(options.channel);
+    }
+
+    const message: HeldMessage = {
+      id: randomUUID(),
+      channel: options.channel,
+      senderId: options.senderId,
+      conversationId: options.conversationId,
+      content: options.content,
+      subject: options.subject,
+      metadata: options.metadata,
+      status: 'pending',
+      resolvedContactId: null,
+      createdAt: new Date(),
+      processedAt: null,
+    };
+
+    await this.backend.insert(message);
+    return message.id;
+  }
+
+  /** List pending held messages, optionally filtered by channel. */
+  async listPending(channel?: string): Promise<HeldMessage[]> {
+    return this.backend.listPending(channel);
+  }
+
+  /** Get a specific held message by ID. */
+  async getById(id: string): Promise<HeldMessage | null> {
+    return this.backend.getById(id);
+  }
+
+  /**
+   * Mark a held message as processed (CEO identified the sender).
+   * The contactId is the newly-created or existing contact for the sender.
+   */
+  async markProcessed(id: string, contactId: string): Promise<void> {
+    await this.backend.update(id, {
+      status: 'processed',
+      resolvedContactId: contactId,
+      processedAt: new Date(),
+    });
+  }
+
+  /** Discard a held message (CEO dismissed it). */
+  async discard(id: string): Promise<void> {
+    await this.backend.update(id, {
+      status: 'discarded',
+      processedAt: new Date(),
+    });
+  }
+}
+
+// -- In-memory backend --
+
+class InMemoryHeldMessageBackend implements HeldMessageBackend {
+  private messages = new Map<string, HeldMessage>();
+
+  async insert(message: HeldMessage): Promise<void> {
+    this.messages.set(message.id, message);
+  }
+
+  async getById(id: string): Promise<HeldMessage | null> {
+    return this.messages.get(id) ?? null;
+  }
+
+  async listPending(channel?: string): Promise<HeldMessage[]> {
+    const all = [...this.messages.values()].filter(m => m.status === 'pending');
+    if (channel) {
+      return all.filter(m => m.channel === channel).sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    }
+    return all.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  }
+
+  async countPendingByChannel(channel: string): Promise<number> {
+    return [...this.messages.values()].filter(m => m.channel === channel && m.status === 'pending').length;
+  }
+
+  async discardOldest(channel: string): Promise<void> {
+    const pending = [...this.messages.values()]
+      .filter(m => m.channel === channel && m.status === 'pending')
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    if (pending.length > 0) {
+      this.messages.set(pending[0].id, { ...pending[0], status: 'discarded', processedAt: new Date() });
+    }
+  }
+
+  async update(id: string, updates: Partial<Pick<HeldMessage, 'status' | 'resolvedContactId' | 'processedAt'>>): Promise<void> {
+    const existing = this.messages.get(id);
+    if (!existing) return;
+    this.messages.set(id, { ...existing, ...updates });
+  }
+}
+
+// -- Postgres backend --
+
+class PostgresHeldMessageBackend implements HeldMessageBackend {
+  constructor(private pool: DbPool, private logger: Logger) {}
+
+  async insert(message: HeldMessage): Promise<void> {
+    this.logger.debug({ id: message.id, channel: message.channel, senderId: message.senderId }, 'Inserting held message');
+    await this.pool.query(
+      `INSERT INTO held_messages (id, channel, sender_id, conversation_id, content, subject, metadata, status, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+      [message.id, message.channel, message.senderId, message.conversationId, message.content, message.subject, JSON.stringify(message.metadata), message.status, message.createdAt],
+    );
+  }
+
+  async getById(id: string): Promise<HeldMessage | null> {
+    const result = await this.pool.query<HeldMessageRow>(
+      'SELECT * FROM held_messages WHERE id = $1',
+      [id],
+    );
+    return result.rows[0] ? rowToHeldMessage(result.rows[0]) : null;
+  }
+
+  async listPending(channel?: string): Promise<HeldMessage[]> {
+    if (channel) {
+      const result = await this.pool.query<HeldMessageRow>(
+        `SELECT * FROM held_messages WHERE status = 'pending' AND channel = $1 ORDER BY created_at ASC`,
+        [channel],
+      );
+      return result.rows.map(rowToHeldMessage);
+    }
+    const result = await this.pool.query<HeldMessageRow>(
+      `SELECT * FROM held_messages WHERE status = 'pending' ORDER BY created_at ASC`,
+    );
+    return result.rows.map(rowToHeldMessage);
+  }
+
+  async countPendingByChannel(channel: string): Promise<number> {
+    const result = await this.pool.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM held_messages WHERE channel = $1 AND status = 'pending'`,
+      [channel],
+    );
+    return parseInt(result.rows[0].count, 10);
+  }
+
+  async discardOldest(channel: string): Promise<void> {
+    this.logger.debug({ channel }, 'Discarding oldest held message (rate limit reached)');
+    await this.pool.query(
+      `UPDATE held_messages SET status = 'discarded', processed_at = NOW()
+       WHERE id = (
+         SELECT id FROM held_messages
+         WHERE channel = $1 AND status = 'pending'
+         ORDER BY created_at ASC
+         LIMIT 1
+       )`,
+      [channel],
+    );
+  }
+
+  async update(id: string, updates: Partial<Pick<HeldMessage, 'status' | 'resolvedContactId' | 'processedAt'>>): Promise<void> {
+    const setClauses: string[] = [];
+    const params: unknown[] = [];
+    let paramIndex = 1;
+
+    if (updates.status !== undefined) {
+      setClauses.push(`status = $${paramIndex++}`);
+      params.push(updates.status);
+    }
+    if (updates.resolvedContactId !== undefined) {
+      setClauses.push(`resolved_contact_id = $${paramIndex++}`);
+      params.push(updates.resolvedContactId);
+    }
+    if (updates.processedAt !== undefined) {
+      setClauses.push(`processed_at = $${paramIndex++}`);
+      params.push(updates.processedAt);
+    }
+
+    if (setClauses.length === 0) return;
+
+    params.push(id);
+    await this.pool.query(
+      `UPDATE held_messages SET ${setClauses.join(', ')} WHERE id = $${paramIndex}`,
+      params,
+    );
+  }
+}
+
+// -- Row types --
+
+interface HeldMessageRow {
+  id: string;
+  channel: string;
+  sender_id: string;
+  conversation_id: string;
+  content: string;
+  subject: string | null;
+  metadata: Record<string, unknown>;
+  status: string;
+  resolved_contact_id: string | null;
+  created_at: Date;
+  processed_at: Date | null;
+}
+
+function rowToHeldMessage(row: HeldMessageRow): HeldMessage {
+  return {
+    id: row.id,
+    channel: row.channel,
+    senderId: row.sender_id,
+    conversationId: row.conversation_id,
+    content: row.content,
+    subject: row.subject,
+    metadata: row.metadata,
+    status: row.status as HeldMessageStatus,
+    resolvedContactId: row.resolved_contact_id,
+    createdAt: row.created_at,
+    processedAt: row.processed_at,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/contacts/held-messages.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/contacts/held-messages.ts tests/unit/contacts/held-messages.test.ts
+git commit -m "feat: add HeldMessageService with rate limiting"
+```
+
+---
+
+### Task 3: Bus Events and Dispatcher Integration
+
+**Files:**
+- Modify: `src/bus/events.ts`
+- Modify: `src/bus/permissions.ts`
+- Modify: `src/dispatch/dispatcher.ts`
+- Modify: `src/contacts/types.ts`
+
+- [ ] **Step 1: Add `message.held` event to bus**
+
+Read `src/bus/events.ts`. Add a new event type for held messages:
+
+Payload:
+```typescript
+interface MessageHeldPayload {
+  heldMessageId: string;
+  channel: string;
+  senderId: string;
+  subject: string | null;
+}
+```
+
+Event:
+```typescript
+export interface MessageHeldEvent extends BaseEvent {
+  type: 'message.held';
+  sourceLayer: 'dispatch';
+  payload: MessageHeldPayload;
+}
+```
+
+Add to the `BusEvent` union. Add a factory function `createMessageHeld`.
+
+- [ ] **Step 2: Update permissions**
+
+Read `src/bus/permissions.ts`. Add `'message.held'` to:
+- dispatch publish allowlist
+- system subscribe allowlist
+- channel subscribe allowlist (so CLI adapter can show notifications)
+
+- [ ] **Step 3: Update Dispatcher to check unknown sender policy**
+
+Read `src/dispatch/dispatcher.ts`. The dispatcher needs:
+- Access to the unknown sender policy config (channelPolicies)
+- Access to the HeldMessageService
+
+Update `DispatcherConfig`:
+```typescript
+export interface DispatcherConfig {
+  bus: EventBus;
+  logger: Logger;
+  contactResolver?: ContactResolver;
+  heldMessages?: HeldMessageService;
+  channelPolicies?: Record<string, ChannelPolicyConfig>;
+}
+```
+
+In `handleInbound`, after the contact resolver returns `UnknownSenderContext` (the `else` branch at line 90), check the policy:
+
+```typescript
+        } else {
+          // Unknown sender — check channel policy
+          await this.bus.publish('dispatch', createContactUnknown({
+            channel: senderContext.channel,
+            senderId: senderContext.senderId,
+            parentEventId: event.id,
+          }));
+
+          const policy = this.channelPolicies?.[payload.channelId];
+          if (policy?.unknownSender === 'hold_and_notify' && this.heldMessages) {
+            // Hold the message instead of routing to coordinator
+            const heldId = await this.heldMessages.hold({
+              channel: payload.channelId,
+              senderId: payload.senderId,
+              conversationId: payload.conversationId,
+              content: payload.content,
+              subject: (payload.metadata as Record<string, unknown>)?.subject as string ?? null,
+              metadata: payload.metadata ?? {},
+            });
+
+            // Publish held event so CLI can notify immediately
+            await this.bus.publish('dispatch', createMessageHeld({
+              heldMessageId: heldId,
+              channel: payload.channelId,
+              senderId: payload.senderId,
+              subject: (payload.metadata as Record<string, unknown>)?.subject as string ?? null,
+              parentEventId: event.id,
+            }));
+
+            this.logger.info(
+              { heldMessageId: heldId, channel: payload.channelId, senderId: payload.senderId },
+              'Message held from unknown sender',
+            );
+            return; // Do NOT route to coordinator
+          }
+
+          if (policy?.unknownSender === 'reject') {
+            this.logger.info(
+              { channel: payload.channelId, senderId: payload.senderId },
+              'Rejected message from unknown sender',
+            );
+            return; // Silently drop
+          }
+
+          // 'allow' or no policy configured — fall through to normal routing
+        }
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `npx vitest run`
+Expected: PASS (existing tests may need updates if dispatcher constructor changed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bus/events.ts src/bus/permissions.ts src/dispatch/dispatcher.ts
+git commit -m "feat: dispatcher holds messages from unknown senders per channel policy"
+```
+
+---
+
+### Task 4: CLI Notification
+
+**Files:**
+- Modify: `src/channels/cli/cli-adapter.ts`
+
+- [ ] **Step 1: Subscribe CLI adapter to `message.held` events**
+
+Read `src/channels/cli/cli-adapter.ts`. In the `start()` method, add a subscription for `message.held` events:
+
+```typescript
+    // Notify the CEO immediately when a message is held from an unknown sender.
+    // This uses the channel layer's subscribe permission for message.held.
+    this.bus.subscribe('message.held', 'channel', (event) => {
+      if (event.type === 'message.held') {
+        const held = event as MessageHeldEvent;
+        const { senderId, channel, subject } = held.payload;
+        const subjectLine = subject ? ` — "${subject}"` : '';
+        readline.clearLine(process.stdout, 0);
+        readline.cursorTo(process.stdout, 0);
+        process.stdout.write(`\n[Held] Unknown sender on ${channel}: ${senderId}${subjectLine}\n`);
+        process.stdout.write('  Use "review held messages" to see details.\n\n');
+        this.rl?.prompt();
+      }
+    });
+```
+
+Add the import for `MessageHeldEvent`.
+
+- [ ] **Step 2: Run all tests**
+
+Run: `npx vitest run`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/channels/cli/cli-adapter.ts
+git commit -m "feat: CLI shows immediate notification for held messages"
+```
+
+---
+
+### Task 5: Held Message Skills
+
+**Files:**
+- Create: `skills/held-messages-list/skill.json`
+- Create: `skills/held-messages-list/handler.ts`
+- Create: `skills/held-messages-process/skill.json`
+- Create: `skills/held-messages-process/handler.ts`
+- Modify: `src/skills/types.ts`
+- Modify: `src/skills/execution.ts`
+- Modify: `agents/coordinator.yaml`
+
+- [ ] **Step 1: Add heldMessages to SkillContext**
+
+Read `src/skills/types.ts`. Add `heldMessages?: HeldMessageService` to the `SkillContext` interface (alongside the existing `contactService`, `bus`, etc.).
+
+Read `src/skills/execution.ts`. In the infrastructure skill gate, inject `heldMessages`:
+```typescript
+      if (this.heldMessages) {
+        ctx.heldMessages = this.heldMessages;
+      }
+```
+
+Add `heldMessages` to the ExecutionLayer constructor options and store it.
+
+- [ ] **Step 2: Create held-messages-list skill**
+
+`skills/held-messages-list/skill.json`:
+```json
+{
+  "name": "held-messages-list",
+  "description": "List messages held from unknown senders awaiting your review. Shows sender, channel, subject, and when it arrived.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "channel": "string?"
+  },
+  "outputs": {
+    "messages": "HeldMessage[]",
+    "count": "number"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000
+}
+```
+
+`skills/held-messages-list/handler.ts`:
+```typescript
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class HeldMessagesListHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.heldMessages) {
+      return { success: false, error: 'Held messages service not available. Is infrastructure: true set?' };
+    }
+
+    const { channel } = ctx.input as { channel?: string };
+    const filterChannel = (channel && typeof channel === 'string') ? channel : undefined;
+
+    try {
+      const messages = await ctx.heldMessages.listPending(filterChannel);
+      const summary = messages.map(m => ({
+        id: m.id,
+        channel: m.channel,
+        sender: m.senderId,
+        subject: m.subject,
+        preview: m.content.slice(0, 200),
+        receivedAt: m.createdAt.toISOString(),
+      }));
+
+      ctx.log.info({ count: messages.length, channel: filterChannel ?? 'all' }, 'Listed held messages');
+      return { success: true, data: { messages: summary, count: messages.length } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { success: false, error: `Failed to list held messages: ${message}` };
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Create held-messages-process skill**
+
+`skills/held-messages-process/skill.json`:
+```json
+{
+  "name": "held-messages-process",
+  "description": "Process a held message: identify the sender (create/link contact), dismiss it, or block the sender. After identifying, the message is replayed through normal processing.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "infrastructure": true,
+  "inputs": {
+    "held_message_id": "string",
+    "action": "string",
+    "contact_name": "string?",
+    "contact_role": "string?",
+    "existing_contact_id": "string?"
+  },
+  "outputs": {
+    "result": "string",
+    "contact_id": "string?"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}
+```
+
+`skills/held-messages-process/handler.ts`:
+```typescript
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { createInboundMessage } from '../../src/bus/events.js';
+
+export class HeldMessagesProcessHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { held_message_id, action, contact_name, contact_role, existing_contact_id } = ctx.input as {
+      held_message_id?: string;
+      action?: string;
+      contact_name?: string;
+      contact_role?: string;
+      existing_contact_id?: string;
+    };
+
+    if (!held_message_id || typeof held_message_id !== 'string') {
+      return { success: false, error: 'Missing required input: held_message_id (string)' };
+    }
+    if (!action || !['identify', 'dismiss', 'block'].includes(action)) {
+      return { success: false, error: 'Invalid action — must be "identify", "dismiss", or "block"' };
+    }
+    if (!ctx.heldMessages || !ctx.contactService || !ctx.bus) {
+      return { success: false, error: 'Required services not available. Is infrastructure: true set?' };
+    }
+
+    try {
+      const heldMsg = await ctx.heldMessages.getById(held_message_id);
+      if (!heldMsg) {
+        return { success: false, error: `Held message not found: ${held_message_id}` };
+      }
+      if (heldMsg.status !== 'pending') {
+        return { success: false, error: `Message already ${heldMsg.status}` };
+      }
+
+      if (action === 'dismiss') {
+        await ctx.heldMessages.discard(held_message_id);
+        ctx.log.info({ heldMessageId: held_message_id }, 'Held message dismissed');
+        return { success: true, data: { result: 'dismissed' } };
+      }
+
+      if (action === 'block') {
+        // Create a blocked contact for this sender
+        const contact = await ctx.contactService.createContact({
+          displayName: contact_name || heldMsg.senderId,
+          status: 'blocked',
+          source: 'ceo_stated',
+        });
+        await ctx.contactService.linkIdentity({
+          contactId: contact.id,
+          channel: heldMsg.channel,
+          channelIdentifier: heldMsg.senderId,
+          source: 'ceo_stated',
+        });
+        await ctx.heldMessages.discard(held_message_id);
+        ctx.log.info({ heldMessageId: held_message_id, contactId: contact.id }, 'Sender blocked');
+        return { success: true, data: { result: 'blocked', contact_id: contact.id } };
+      }
+
+      // action === 'identify'
+      let contactId: string;
+
+      if (existing_contact_id) {
+        // Link to existing contact
+        contactId = existing_contact_id;
+        await ctx.contactService.linkIdentity({
+          contactId,
+          channel: heldMsg.channel,
+          channelIdentifier: heldMsg.senderId,
+          source: 'ceo_stated',
+        });
+      } else {
+        // Create new confirmed contact
+        if (!contact_name || typeof contact_name !== 'string') {
+          return { success: false, error: 'contact_name is required when identifying a new sender' };
+        }
+        const contact = await ctx.contactService.createContact({
+          displayName: contact_name,
+          role: contact_role,
+          status: 'confirmed',
+          source: 'ceo_stated',
+        });
+        await ctx.contactService.linkIdentity({
+          contactId: contact.id,
+          channel: heldMsg.channel,
+          channelIdentifier: heldMsg.senderId,
+          source: 'ceo_stated',
+        });
+        contactId = contact.id;
+      }
+
+      // Mark as processed
+      await ctx.heldMessages.markProcessed(held_message_id, contactId);
+
+      // Replay the held message through normal processing.
+      // Re-publish as inbound.message so it goes through the full pipeline
+      // (contact resolution → authorization → coordinator) with the now-known sender.
+      const replayEvent = createInboundMessage({
+        conversationId: heldMsg.conversationId,
+        channelId: heldMsg.channel,
+        senderId: heldMsg.senderId,
+        content: heldMsg.content,
+        metadata: heldMsg.metadata,
+      });
+      await ctx.bus.publish('dispatch', replayEvent);
+
+      ctx.log.info({ heldMessageId: held_message_id, contactId, action: 'identify' }, 'Sender identified, message replayed');
+      return { success: true, data: { result: 'identified_and_replayed', contact_id: contactId } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { success: false, error: `Failed to process held message: ${message}` };
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Add skills to coordinator**
+
+Read `agents/coordinator.yaml`. Add to pinned_skills:
+```yaml
+  - held-messages-list
+  - held-messages-process
+```
+
+Add held message guidance to the prompt (after the Authorization section):
+
+```yaml
+  ## Held Messages
+  When unknown senders message on channels with hold_and_notify policy, their
+  messages are held for your review. The CLI shows immediate notifications.
+
+  When talking to the CEO:
+  - Proactively mention the OLDEST held message if there are any pending.
+    Don't list all of them — just mention one: "By the way, you have a held
+    email from stranger@example.com about 'Q3 Numbers'. Want me to identify them?"
+  - Use held-messages-list to show the CEO all pending messages when asked.
+  - Use held-messages-process to handle each message:
+    - "identify" — CEO tells you who the sender is. Creates a confirmed contact
+      and replays the message through normal processing.
+    - "dismiss" — CEO doesn't care about the message. Discards it.
+    - "block" — CEO wants to block this sender. Creates a blocked contact.
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run: `npx vitest run`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/held-messages-list/ skills/held-messages-process/ src/skills/types.ts src/skills/execution.ts agents/coordinator.yaml
+git commit -m "feat: add held-messages-list and held-messages-process skills"
+```
+
+---
+
+### Task 6: Bootstrap Wiring
+
+**Files:**
+- Modify: `src/index.ts`
+- Modify: `tests/smoke/harness.ts`
+
+- [ ] **Step 1: Wire HeldMessageService into bootstrap**
+
+Read `src/index.ts`. After the contact system initialization, create HeldMessageService:
+
+```typescript
+  // Held messages — stores messages from unknown senders pending CEO review.
+  const { HeldMessageService } = await import('./contacts/held-messages.js');
+  const heldMessages = HeldMessageService.createWithPostgres(pool, logger);
+  logger.info('Held message service initialized');
+```
+
+Actually, use a static import (per the feedback from Phase B1):
+
+```typescript
+import { HeldMessageService } from './contacts/held-messages.js';
+```
+
+Then in the initialization section:
+```typescript
+  const heldMessages = HeldMessageService.createWithPostgres(pool, logger);
+  logger.info('Held message service initialized');
+```
+
+Pass to dispatcher:
+```typescript
+  const dispatcher = new Dispatcher({
+    bus,
+    logger,
+    contactResolver,
+    heldMessages,
+    channelPolicies: authConfig?.channelPolicies,
+  });
+```
+
+Note: `authConfig` needs to be available in the scope where the dispatcher is created. The auth config is loaded a few lines above — store it in a variable.
+
+Pass to execution layer:
+```typescript
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, {
+    bus,
+    agentRegistry,
+    contactService,
+    nylasClient,
+    heldMessages,
+  });
+```
+
+- [ ] **Step 2: Update smoke test harness**
+
+Read `tests/smoke/harness.ts`. Pass `undefined` for new dispatcher/execution layer params.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `npx vitest run`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/index.ts tests/smoke/harness.ts
+git commit -m "feat: wire HeldMessageService into bootstrap"
+```
+
+---
+
+### Task 7: Update Spec and Document Open Questions
+
+**Files:**
+- Modify: `docs/specs/09-contacts-and-identity.md`
+
+- [ ] **Step 1: Update the unknown sender policy section in spec 09**
+
+Read `docs/specs/09-contacts-and-identity.md`. Find the "Unknown Sender Policy" section (around line 192). Update the email channel policy from `auto_reply` to `hold_and_notify`:
+
+Change the table row for email from:
+```
+| **Email** | `low` | Auto-reply: "Received, forwarding to [CEO name]" |
+```
+To:
+```
+| **Email** | `low` | Hold silently, notify CEO |
+```
+
+Also add a note about the open question on held message expiration:
+
+```markdown
+> **Open question:** Held message expiration is deferred. Messages are currently held
+> indefinitely until the CEO acts. A future discard/expiration process will need
+> judgment and oversight — not a simple TTL timer. The CEO may want to batch-review
+> old held messages, or have Nathan summarize and triage them.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/specs/09-contacts-and-identity.md
+git commit -m "docs: update spec 09 — email uses hold_and_notify, document expiration open question"
+```
+
+---
+
+### Task 8: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npx vitest run`
+Expected: ALL PASS
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: Clean
+
+- [ ] **Step 3: Lint**
+
+Run: `npx eslint src/ tests/`
+Expected: Clean
+
+- [ ] **Step 4: Commit plan**
+
+```bash
+git add docs/superpowers/plans/
+git commit -m "docs: add unknown sender policy implementation plan"
+```

--- a/skills/held-messages-list/handler.ts
+++ b/skills/held-messages-list/handler.ts
@@ -1,0 +1,38 @@
+// handler.ts — held-messages-list skill implementation.
+//
+// Lists pending held messages from unknown senders so the CEO can review them.
+// Optionally filters by channel. Returns a summary with sender, subject, preview,
+// and timestamp for each message.
+//
+// This is an infrastructure skill — it requires heldMessages service access.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class HeldMessagesListHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.heldMessages) {
+      return { success: false, error: 'Held messages service not available. Is infrastructure: true set?' };
+    }
+
+    const { channel } = ctx.input as { channel?: string };
+    const filterChannel = (channel && typeof channel === 'string') ? channel : undefined;
+
+    try {
+      const messages = await ctx.heldMessages.listPending(filterChannel);
+      const summary = messages.map(m => ({
+        id: m.id,
+        channel: m.channel,
+        sender: m.senderId,
+        subject: m.subject,
+        preview: m.content.slice(0, 200),
+        receivedAt: m.createdAt.toISOString(),
+      }));
+
+      ctx.log.info({ count: messages.length, channel: filterChannel ?? 'all' }, 'Listed held messages');
+      return { success: true, data: { messages: summary, count: messages.length } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { success: false, error: `Failed to list held messages: ${message}` };
+    }
+  }
+}

--- a/skills/held-messages-list/skill.json
+++ b/skills/held-messages-list/skill.json
@@ -1,0 +1,17 @@
+{
+  "name": "held-messages-list",
+  "description": "List messages held from unknown senders awaiting your review. Shows sender, channel, subject, and when it arrived.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "channel": "string?"
+  },
+  "outputs": {
+    "messages": "object[]",
+    "count": "number"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000
+}

--- a/skills/held-messages-process/handler.ts
+++ b/skills/held-messages-process/handler.ts
@@ -32,6 +32,17 @@ export class HeldMessagesProcessHandler implements SkillHandler {
       return { success: false, error: 'Required services not available. Is infrastructure: true set?' };
     }
 
+    // Validate input lengths to prevent abuse / storage overflow
+    if (contact_name && contact_name.length > 200) {
+      return { success: false, error: 'contact_name must be 200 characters or fewer' };
+    }
+    if (contact_role && contact_role.length > 100) {
+      return { success: false, error: 'contact_role must be 100 characters or fewer' };
+    }
+    if (existing_contact_id && !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(existing_contact_id)) {
+      return { success: false, error: 'existing_contact_id must be a valid UUID' };
+    }
+
     try {
       const heldMsg = await ctx.heldMessages.getById(held_message_id);
       if (!heldMsg) {
@@ -97,14 +108,12 @@ export class HeldMessagesProcessHandler implements SkillHandler {
         contactId = contact.id;
       }
 
-      // Mark as processed
-      await ctx.heldMessages.markProcessed(held_message_id, contactId);
-
       // Replay the held message through normal processing.
       // Re-publish as inbound.message so it goes through the full pipeline
       // (contact resolution -> authorization -> coordinator) with the now-known sender.
-      // Published as 'dispatch' layer because infrastructure skills are trusted
-      // to impersonate layers (same pattern as the delegate skill).
+      // Published as 'channel' layer because inbound.message can only be published
+      // by the channel layer (per bus permissions). A replayed message is re-entering
+      // the system as if from a channel.
       const replayEvent = createInboundMessage({
         conversationId: heldMsg.conversationId,
         channelId: heldMsg.channel,
@@ -112,7 +121,11 @@ export class HeldMessagesProcessHandler implements SkillHandler {
         content: heldMsg.content,
         metadata: heldMsg.metadata,
       });
-      await ctx.bus.publish('dispatch', replayEvent);
+      await ctx.bus.publish('channel', replayEvent);
+
+      // Only mark as processed after successful replay — if replay fails, the
+      // message stays pending so it can be retried rather than lost forever.
+      await ctx.heldMessages.markProcessed(held_message_id, contactId);
 
       ctx.log.info(
         { heldMessageId: held_message_id, contactId, action: 'identify' },

--- a/skills/held-messages-process/handler.ts
+++ b/skills/held-messages-process/handler.ts
@@ -1,0 +1,127 @@
+// handler.ts — held-messages-process skill implementation.
+//
+// Processes a held message from an unknown sender based on CEO direction:
+// - "identify" — create or link a contact for the sender, then replay the
+//   message through normal inbound processing so it gets routed properly.
+// - "dismiss" — discard the held message (CEO doesn't care about it).
+// - "block" — create a blocked contact for the sender and discard the message.
+//
+// This is an infrastructure skill — it requires heldMessages, contactService,
+// and bus access.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { createInboundMessage } from '../../src/bus/events.js';
+
+export class HeldMessagesProcessHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { held_message_id, action, contact_name, contact_role, existing_contact_id } = ctx.input as {
+      held_message_id?: string;
+      action?: string;
+      contact_name?: string;
+      contact_role?: string;
+      existing_contact_id?: string;
+    };
+
+    if (!held_message_id || typeof held_message_id !== 'string') {
+      return { success: false, error: 'Missing required input: held_message_id (string)' };
+    }
+    if (!action || !['identify', 'dismiss', 'block'].includes(action)) {
+      return { success: false, error: 'Invalid action — must be "identify", "dismiss", or "block"' };
+    }
+    if (!ctx.heldMessages || !ctx.contactService || !ctx.bus) {
+      return { success: false, error: 'Required services not available. Is infrastructure: true set?' };
+    }
+
+    try {
+      const heldMsg = await ctx.heldMessages.getById(held_message_id);
+      if (!heldMsg) {
+        return { success: false, error: `Held message not found: ${held_message_id}` };
+      }
+      if (heldMsg.status !== 'pending') {
+        return { success: false, error: `Message already ${heldMsg.status}` };
+      }
+
+      if (action === 'dismiss') {
+        await ctx.heldMessages.discard(held_message_id);
+        ctx.log.info({ heldMessageId: held_message_id }, 'Held message dismissed');
+        return { success: true, data: { result: 'dismissed' } };
+      }
+
+      if (action === 'block') {
+        // Create a blocked contact for this sender
+        const contact = await ctx.contactService.createContact({
+          displayName: contact_name || heldMsg.senderId,
+          status: 'blocked',
+          source: 'ceo_stated',
+        });
+        await ctx.contactService.linkIdentity({
+          contactId: contact.id,
+          channel: heldMsg.channel,
+          channelIdentifier: heldMsg.senderId,
+          source: 'ceo_stated',
+        });
+        await ctx.heldMessages.discard(held_message_id);
+        ctx.log.info({ heldMessageId: held_message_id, contactId: contact.id }, 'Sender blocked');
+        return { success: true, data: { result: 'blocked', contact_id: contact.id } };
+      }
+
+      // action === 'identify'
+      let contactId: string;
+
+      if (existing_contact_id) {
+        // Link to existing contact
+        contactId = existing_contact_id;
+        await ctx.contactService.linkIdentity({
+          contactId,
+          channel: heldMsg.channel,
+          channelIdentifier: heldMsg.senderId,
+          source: 'ceo_stated',
+        });
+      } else {
+        // Create new confirmed contact
+        if (!contact_name || typeof contact_name !== 'string') {
+          return { success: false, error: 'contact_name is required when identifying a new sender' };
+        }
+        const contact = await ctx.contactService.createContact({
+          displayName: contact_name,
+          role: contact_role,
+          status: 'confirmed',
+          source: 'ceo_stated',
+        });
+        await ctx.contactService.linkIdentity({
+          contactId: contact.id,
+          channel: heldMsg.channel,
+          channelIdentifier: heldMsg.senderId,
+          source: 'ceo_stated',
+        });
+        contactId = contact.id;
+      }
+
+      // Mark as processed
+      await ctx.heldMessages.markProcessed(held_message_id, contactId);
+
+      // Replay the held message through normal processing.
+      // Re-publish as inbound.message so it goes through the full pipeline
+      // (contact resolution -> authorization -> coordinator) with the now-known sender.
+      // Published as 'dispatch' layer because infrastructure skills are trusted
+      // to impersonate layers (same pattern as the delegate skill).
+      const replayEvent = createInboundMessage({
+        conversationId: heldMsg.conversationId,
+        channelId: heldMsg.channel,
+        senderId: heldMsg.senderId,
+        content: heldMsg.content,
+        metadata: heldMsg.metadata,
+      });
+      await ctx.bus.publish('dispatch', replayEvent);
+
+      ctx.log.info(
+        { heldMessageId: held_message_id, contactId, action: 'identify' },
+        'Sender identified, message replayed',
+      );
+      return { success: true, data: { result: 'identified_and_replayed', contact_id: contactId } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { success: false, error: `Failed to process held message: ${message}` };
+    }
+  }
+}

--- a/skills/held-messages-process/skill.json
+++ b/skills/held-messages-process/skill.json
@@ -1,0 +1,21 @@
+{
+  "name": "held-messages-process",
+  "description": "Process a held message: identify the sender (create/link contact and replay message), dismiss it, or block the sender.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "infrastructure": true,
+  "inputs": {
+    "held_message_id": "string",
+    "action": "string",
+    "contact_name": "string?",
+    "contact_role": "string?",
+    "existing_contact_id": "string?"
+  },
+  "outputs": {
+    "result": "string",
+    "contact_id": "string?"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -84,6 +84,13 @@ interface ContactUnknownPayload {
   channelTrustLevel?: 'low' | 'medium' | 'high';
 }
 
+interface MessageHeldPayload {
+  heldMessageId: string;
+  channel: string;
+  senderId: string;
+  subject: string | null;
+}
+
 // Memory event payloads — used for the knowledge graph audit trail (Phase 6).
 // `source` is a structured provenance string (e.g. "agent:coordinator/task:task-1/channel:cli").
 
@@ -160,6 +167,12 @@ export interface ContactUnknownEvent extends BaseEvent {
   payload: ContactUnknownPayload;
 }
 
+export interface MessageHeldEvent extends BaseEvent {
+  type: 'message.held';
+  sourceLayer: 'dispatch';
+  payload: MessageHeldPayload;
+}
+
 // Memory events — emitted by the agent layer whenever the knowledge graph is written to or queried.
 // These form the audit trail for memory operations (Phase 6).
 
@@ -185,7 +198,8 @@ export type BusEvent =
   | MemoryStoreEvent      // Phase 6: knowledge graph write audit
   | MemoryQueryEvent      // Phase 6: knowledge graph read audit
   | ContactResolvedEvent  // Contacts Phase A: sender matched to a known contact
-  | ContactUnknownEvent;  // Contacts Phase A: sender has no contact record
+  | ContactUnknownEvent   // Contacts Phase A: sender has no contact record
+  | MessageHeldEvent;     // Unknown sender policy: message held for CEO review
 
 // Convenience alias for use in handler maps / switch statements.
 export type EventType = BusEvent['type'];
@@ -336,6 +350,21 @@ export function createContactUnknown(
     id: randomUUID(),
     timestamp: new Date(),
     type: 'contact.unknown',
+    sourceLayer: 'dispatch',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createMessageHeld(
+  // parentEventId is required — held-message events must trace back to the inbound event.
+  payload: MessageHeldPayload & { parentEventId: string },
+): MessageHeldEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'message.held',
     sourceLayer: 'dispatch',
     payload: rest,
     parentEventId,

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -7,18 +7,18 @@ import type { Layer, EventType } from './events.js';
 //                   system layer gets full access for audit logging.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message']),
-  dispatch: new Set(['agent.task', 'outbound.message', 'contact.resolved', 'contact.unknown']),
+  dispatch: new Set(['agent.task', 'outbound.message', 'contact.resolved', 'contact.unknown', 'message.held']),
   agent: new Set(['agent.response', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query']),
   execution: new Set(['skill.result']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'outbound.message', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'outbound.message', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held']),
 };
 
 const subscribeAllowlist: Record<Layer, Set<EventType>> = {
-  channel: new Set(['outbound.message']),
+  channel: new Set(['outbound.message', 'message.held']),
   dispatch: new Set(['inbound.message', 'agent.response']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'outbound.message', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'outbound.message', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/channels/cli/cli-adapter.ts
+++ b/src/channels/cli/cli-adapter.ts
@@ -1,7 +1,7 @@
 import * as readline from 'node:readline';
 import type { EventBus } from '../../bus/bus.js';
 import { createInboundMessage } from '../../bus/events.js';
-import type { OutboundMessageEvent } from '../../bus/events.js';
+import type { OutboundMessageEvent, MessageHeldEvent } from '../../bus/events.js';
 import type { Logger } from '../../logger.js';
 
 /**
@@ -35,6 +35,20 @@ export class CliAdapter {
         readline.clearLine(process.stdout, 0);
         readline.cursorTo(process.stdout, 0);
         process.stdout.write(`\n${outbound.payload.content}\n\n`);
+        this.rl?.prompt();
+      }
+    });
+
+    // Notify the CEO immediately when a message is held from an unknown sender.
+    this.bus.subscribe('message.held', 'channel', (event) => {
+      if (event.type === 'message.held') {
+        const held = event as MessageHeldEvent;
+        const { senderId, channel, subject } = held.payload;
+        const subjectLine = subject ? ` — "${subject}"` : '';
+        readline.clearLine(process.stdout, 0);
+        readline.cursorTo(process.stdout, 0);
+        process.stdout.write(`\n[Held] Unknown sender on ${channel}: ${senderId}${subjectLine}\n`);
+        process.stdout.write('  Say "review held messages" to see details.\n\n');
         this.rl?.prompt();
       }
     });

--- a/src/contacts/config-loader.ts
+++ b/src/contacts/config-loader.ts
@@ -7,7 +7,7 @@
 import { readFileSync } from 'node:fs';
 import * as path from 'node:path';
 import yaml from 'js-yaml';
-import type { AuthConfig, RolePermissions, PermissionDef, TrustLevel } from './types.js';
+import type { AuthConfig, RolePermissions, PermissionDef, TrustLevel, UnknownSenderPolicy, ChannelPolicyConfig } from './types.js';
 
 interface RawRoleEntry {
   description: string;
@@ -72,15 +72,34 @@ export function loadAuthConfig(configDir: string): AuthConfig {
   if (!trustRaw || typeof trustRaw !== 'object' || !('channels' in trustRaw)) {
     throw new Error("Missing or invalid 'channels' section in channel-trust.yaml");
   }
-  const trustTyped = trustRaw as { channels: Record<string, string> };
+  // Accept either flat strings (legacy) or objects with trust + unknown_sender fields
+  const trustTyped = trustRaw as { channels: Record<string, string | { trust: string; unknown_sender: string }> };
 
   const channelTrust: Record<string, TrustLevel> = {};
-  for (const [channel, level] of Object.entries(trustTyped.channels)) {
-    if (!['high', 'medium', 'low'].includes(level)) {
-      throw new Error(`Invalid trust level '${level}' for channel '${channel}'`);
+  const channelPolicies: Record<string, ChannelPolicyConfig> = {};
+
+  for (const [channel, config] of Object.entries(trustTyped.channels)) {
+    if (typeof config === 'string') {
+      // Backwards compat: plain string is just trust level
+      const trust = config as TrustLevel;
+      if (!['high', 'medium', 'low'].includes(trust)) {
+        throw new Error(`Invalid trust level '${trust}' for channel '${channel}'`);
+      }
+      channelTrust[channel] = trust;
+      channelPolicies[channel] = { trust, unknownSender: 'hold_and_notify' };
+    } else {
+      const trust = (config as { trust: string }).trust as TrustLevel;
+      if (!['high', 'medium', 'low'].includes(trust)) {
+        throw new Error(`Invalid trust level '${trust}' for channel '${channel}'`);
+      }
+      const unknownSender = (config as { unknown_sender: string }).unknown_sender as UnknownSenderPolicy;
+      if (!['allow', 'hold_and_notify', 'reject'].includes(unknownSender)) {
+        throw new Error(`Invalid unknown_sender policy '${unknownSender}' for channel '${channel}'`);
+      }
+      channelTrust[channel] = trust;
+      channelPolicies[channel] = { trust, unknownSender };
     }
-    channelTrust[channel] = level as TrustLevel;
   }
 
-  return { roles, permissions, channelTrust };
+  return { roles, permissions, channelTrust, channelPolicies };
 }

--- a/src/contacts/config-loader.ts
+++ b/src/contacts/config-loader.ts
@@ -86,7 +86,9 @@ export function loadAuthConfig(configDir: string): AuthConfig {
         throw new Error(`Invalid trust level '${trust}' for channel '${channel}'`);
       }
       channelTrust[channel] = trust;
-      channelPolicies[channel] = { trust, unknownSender: 'hold_and_notify' };
+      // Default to 'allow' for legacy configs — silently holding messages would be
+      // a surprising behavior change for deployments using the old flat-string format.
+      channelPolicies[channel] = { trust, unknownSender: 'allow' };
     } else {
       const trust = (config as { trust: string }).trust as TrustLevel;
       if (!['high', 'medium', 'low'].includes(trust)) {

--- a/src/contacts/held-messages.ts
+++ b/src/contacts/held-messages.ts
@@ -1,0 +1,368 @@
+// src/contacts/held-messages.ts
+//
+// HeldMessageService: stores and manages messages from unknown senders.
+//
+// Follows the backend-interface pattern from ContactService / WorkingMemory:
+// - Private constructor, static factory methods
+// - InMemoryHeldMessageBackend for tests, PostgresHeldMessageBackend for production
+// - Business logic (rate limiting, status transitions) lives in HeldMessageService,
+//   backends are pure storage
+
+import { randomUUID } from 'node:crypto';
+import type { DbPool } from '../db/connection.js';
+import type { Logger } from '../logger.js';
+import type { HeldMessage, HeldMessageStatus } from './types.js';
+
+// -- Default cap --
+// 20 held messages per channel. Once the cap is hit, the oldest pending
+// message for that channel is discarded to make room for the new one.
+const DEFAULT_MAX_PER_CHANNEL = 20;
+
+// -- Options --
+
+export interface HoldOptions {
+  channel: string;
+  senderId: string;
+  conversationId: string;
+  content: string;
+  subject: string | null;
+  metadata: Record<string, unknown>;
+}
+
+// -- Backend interface --
+
+interface HeldMessageBackend {
+  /** Insert a new held message row. */
+  insert(message: HeldMessage): Promise<void>;
+  /** Count pending messages for a given channel. */
+  countPending(channel: string): Promise<number>;
+  /** Discard (mark discarded) the oldest pending message for a channel. */
+  discardOldest(channel: string): Promise<void>;
+  /** List all pending messages, optionally filtered by channel, sorted chronologically. */
+  listPending(channel?: string): Promise<HeldMessage[]>;
+  /** Retrieve a message by its ID, or null if not found. */
+  getById(id: string): Promise<HeldMessage | null>;
+  /** Transition a message to 'processed' and record the resolved contact. */
+  markProcessed(id: string, resolvedContactId: string, processedAt: Date): Promise<void>;
+  /** Transition a message to 'discarded'. */
+  discard(id: string): Promise<void>;
+}
+
+/**
+ * HeldMessageService stores messages from unknown senders while the CEO decides
+ * what to do with them.
+ *
+ * Rate limiting: each channel has a cap (default 20). When the cap is reached,
+ * the oldest pending message for that channel is automatically discarded to make
+ * room. This prevents unbounded growth from spam without losing recent messages.
+ *
+ * TODO: Held message expiration/auto-discard timeout is deferred.
+ * Messages are held indefinitely until the CEO acts. A future discard
+ * process will need judgment and oversight — not a simple timer.
+ */
+export class HeldMessageService {
+  private constructor(
+    private backend: HeldMessageBackend,
+    private maxPerChannel: number,
+  ) {}
+
+  /** Create a Postgres-backed instance for production use. */
+  static createWithPostgres(pool: DbPool, logger: Logger, maxPerChannel = DEFAULT_MAX_PER_CHANNEL): HeldMessageService {
+    return new HeldMessageService(new PostgresHeldMessageBackend(pool, logger), maxPerChannel);
+  }
+
+  /** Create an in-memory instance for testing. */
+  static createInMemory(maxPerChannel = DEFAULT_MAX_PER_CHANNEL): HeldMessageService {
+    return new HeldMessageService(new InMemoryHeldMessageBackend(), maxPerChannel);
+  }
+
+  /**
+   * Hold an inbound message from an unknown sender.
+   *
+   * If the channel is already at the rate limit cap, the oldest pending
+   * message for that channel is discarded before inserting the new one,
+   * so the cap is never exceeded.
+   *
+   * Returns the new message's ID.
+   */
+  async hold(options: HoldOptions): Promise<string> {
+    const now = new Date();
+    const id = randomUUID();
+
+    // Enforce rate limit: if at cap, discard oldest pending for this channel
+    // before inserting. This keeps the per-channel queue bounded.
+    const count = await this.backend.countPending(options.channel);
+    if (count >= this.maxPerChannel) {
+      await this.backend.discardOldest(options.channel);
+    }
+
+    const message: HeldMessage = {
+      id,
+      channel: options.channel,
+      senderId: options.senderId,
+      conversationId: options.conversationId,
+      content: options.content,
+      subject: options.subject,
+      metadata: options.metadata,
+      status: 'pending',
+      resolvedContactId: null,
+      createdAt: now,
+      processedAt: null,
+    };
+
+    await this.backend.insert(message);
+    return id;
+  }
+
+  /**
+   * List pending held messages, optionally filtered by channel.
+   * Results are sorted chronologically (oldest first).
+   */
+  async listPending(channel?: string): Promise<HeldMessage[]> {
+    return this.backend.listPending(channel);
+  }
+
+  /** Retrieve a held message by ID. Returns null if not found. */
+  async getById(id: string): Promise<HeldMessage | null> {
+    return this.backend.getById(id);
+  }
+
+  /**
+   * Mark a held message as processed after the CEO has identified the sender.
+   * Records the resolved contact ID and timestamps the action.
+   */
+  async markProcessed(id: string, resolvedContactId: string): Promise<void> {
+    await this.backend.markProcessed(id, resolvedContactId, new Date());
+  }
+
+  /**
+   * Discard a held message (e.g. CEO determined it is spam or irrelevant).
+   */
+  async discard(id: string): Promise<void> {
+    await this.backend.discard(id);
+  }
+}
+
+// -- Postgres backend --
+
+/**
+ * Postgres-backed storage for held messages.
+ * Uses parameterized queries throughout — never interpolates user input into SQL.
+ */
+class PostgresHeldMessageBackend implements HeldMessageBackend {
+  constructor(
+    private pool: DbPool,
+    private logger: Logger,
+  ) {}
+
+  async insert(message: HeldMessage): Promise<void> {
+    this.logger.debug({ messageId: message.id, channel: message.channel, senderId: message.senderId }, 'held_messages: inserting');
+    await this.pool.query(
+      `INSERT INTO held_messages
+         (id, channel, sender_id, conversation_id, content, subject, metadata, status, resolved_contact_id, created_at, processed_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+      [
+        message.id,
+        message.channel,
+        message.senderId,
+        message.conversationId,
+        message.content,
+        message.subject,
+        JSON.stringify(message.metadata),
+        message.status,
+        message.resolvedContactId,
+        message.createdAt,
+        message.processedAt,
+      ],
+    );
+  }
+
+  async countPending(channel: string): Promise<number> {
+    const result = await this.pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM held_messages WHERE channel = $1 AND status = 'pending'`,
+      [channel],
+    );
+    return parseInt(result.rows[0]?.count ?? '0', 10);
+  }
+
+  /**
+   * Discard the oldest pending message for a channel in a single atomic UPDATE.
+   * Uses a subquery to find the oldest row's ID, then updates it in one statement
+   * — avoids a race between SELECT and UPDATE in concurrent scenarios.
+   */
+  async discardOldest(channel: string): Promise<void> {
+    this.logger.debug({ channel }, 'held_messages: discarding oldest pending to enforce rate limit');
+    await this.pool.query(
+      `UPDATE held_messages SET status = 'discarded'
+       WHERE id = (
+         SELECT id FROM held_messages
+         WHERE channel = $1 AND status = 'pending'
+         ORDER BY created_at ASC
+         LIMIT 1
+       )`,
+      [channel],
+    );
+  }
+
+  async listPending(channel?: string): Promise<HeldMessage[]> {
+    if (channel !== undefined) {
+      const result = await this.pool.query<HeldMessageRow>(
+        `SELECT id, channel, sender_id, conversation_id, content, subject, metadata, status,
+                resolved_contact_id, created_at, processed_at
+         FROM held_messages
+         WHERE status = 'pending' AND channel = $1
+         ORDER BY created_at ASC`,
+        [channel],
+      );
+      return result.rows.map((row) => this.rowToMessage(row));
+    }
+
+    const result = await this.pool.query<HeldMessageRow>(
+      `SELECT id, channel, sender_id, conversation_id, content, subject, metadata, status,
+              resolved_contact_id, created_at, processed_at
+       FROM held_messages
+       WHERE status = 'pending'
+       ORDER BY created_at ASC`,
+    );
+    return result.rows.map((row) => this.rowToMessage(row));
+  }
+
+  async getById(id: string): Promise<HeldMessage | null> {
+    const result = await this.pool.query<HeldMessageRow>(
+      `SELECT id, channel, sender_id, conversation_id, content, subject, metadata, status,
+              resolved_contact_id, created_at, processed_at
+       FROM held_messages WHERE id = $1`,
+      [id],
+    );
+
+    const row = result.rows[0];
+    if (!row) return null;
+    return this.rowToMessage(row);
+  }
+
+  async markProcessed(id: string, resolvedContactId: string, processedAt: Date): Promise<void> {
+    this.logger.debug({ messageId: id, resolvedContactId }, 'held_messages: marking processed');
+    await this.pool.query(
+      `UPDATE held_messages
+       SET status = 'processed', resolved_contact_id = $2, processed_at = $3
+       WHERE id = $1`,
+      [id, resolvedContactId, processedAt],
+    );
+  }
+
+  async discard(id: string): Promise<void> {
+    this.logger.debug({ messageId: id }, 'held_messages: discarding');
+    await this.pool.query(
+      `UPDATE held_messages SET status = 'discarded' WHERE id = $1`,
+      [id],
+    );
+  }
+
+  // -- Row mapping --
+
+  private rowToMessage(row: HeldMessageRow): HeldMessage {
+    return {
+      id: row.id,
+      channel: row.channel,
+      senderId: row.sender_id,
+      conversationId: row.conversation_id,
+      content: row.content,
+      subject: row.subject,
+      // metadata is stored as JSON text in Postgres; pg driver may return it
+      // as a string or already-parsed object depending on column type.
+      metadata: typeof row.metadata === 'string'
+        ? (JSON.parse(row.metadata) as Record<string, unknown>)
+        : (row.metadata as Record<string, unknown>),
+      status: row.status,
+      resolvedContactId: row.resolved_contact_id,
+      createdAt: row.created_at,
+      processedAt: row.processed_at,
+    };
+  }
+}
+
+// Shape of a raw Postgres row from held_messages
+interface HeldMessageRow {
+  id: string;
+  channel: string;
+  sender_id: string;
+  conversation_id: string;
+  content: string;
+  subject: string | null;
+  metadata: unknown;
+  status: HeldMessageStatus;
+  resolved_contact_id: string | null;
+  created_at: Date;
+  processed_at: Date | null;
+}
+
+// -- In-memory backend --
+
+/**
+ * In-memory storage for testing. No database required.
+ * Uses a Map keyed by message ID; list/filter operations do array scans.
+ */
+class InMemoryHeldMessageBackend implements HeldMessageBackend {
+  private messages = new Map<string, HeldMessage>();
+
+  async insert(message: HeldMessage): Promise<void> {
+    this.messages.set(message.id, { ...message });
+  }
+
+  async countPending(channel: string): Promise<number> {
+    let count = 0;
+    for (const msg of this.messages.values()) {
+      if (msg.channel === channel && msg.status === 'pending') {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  async discardOldest(channel: string): Promise<void> {
+    // Find the oldest pending message for the channel by scanning and tracking
+    // the minimum createdAt. Insertion order of the Map doesn't guarantee
+    // chronological order if messages arrive out of order.
+    let oldest: HeldMessage | undefined;
+    for (const msg of this.messages.values()) {
+      if (msg.channel === channel && msg.status === 'pending') {
+        if (!oldest || msg.createdAt < oldest.createdAt) {
+          oldest = msg;
+        }
+      }
+    }
+    if (oldest) {
+      this.messages.set(oldest.id, { ...oldest, status: 'discarded' });
+    }
+  }
+
+  async listPending(channel?: string): Promise<HeldMessage[]> {
+    const results: HeldMessage[] = [];
+    for (const msg of this.messages.values()) {
+      if (msg.status !== 'pending') continue;
+      if (channel !== undefined && msg.channel !== channel) continue;
+      results.push(msg);
+    }
+    // Sort chronologically — oldest first
+    results.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    return results;
+  }
+
+  async getById(id: string): Promise<HeldMessage | null> {
+    return this.messages.get(id) ?? null;
+  }
+
+  async markProcessed(id: string, resolvedContactId: string, processedAt: Date): Promise<void> {
+    const msg = this.messages.get(id);
+    if (msg) {
+      this.messages.set(id, { ...msg, status: 'processed', resolvedContactId, processedAt });
+    }
+  }
+
+  async discard(id: string): Promise<void> {
+    const msg = this.messages.get(id);
+    if (msg) {
+      this.messages.set(id, { ...msg, status: 'discarded' });
+    }
+  }
+}

--- a/src/contacts/held-messages.ts
+++ b/src/contacts/held-messages.ts
@@ -42,10 +42,12 @@ interface HeldMessageBackend {
   listPending(channel?: string): Promise<HeldMessage[]>;
   /** Retrieve a message by its ID, or null if not found. */
   getById(id: string): Promise<HeldMessage | null>;
-  /** Transition a message to 'processed' and record the resolved contact. */
-  markProcessed(id: string, resolvedContactId: string, processedAt: Date): Promise<void>;
-  /** Transition a message to 'discarded'. */
-  discard(id: string): Promise<void>;
+  /** Transition a pending message to 'processed' and record the resolved contact.
+   *  Returns true if the update succeeded (message was pending), false otherwise. */
+  markProcessed(id: string, resolvedContactId: string, processedAt: Date): Promise<boolean>;
+  /** Transition a pending message to 'discarded'.
+   *  Returns true if the update succeeded (message was pending), false otherwise. */
+  discard(id: string): Promise<boolean>;
 }
 
 /**
@@ -130,16 +132,22 @@ export class HeldMessageService {
   /**
    * Mark a held message as processed after the CEO has identified the sender.
    * Records the resolved contact ID and timestamps the action.
+   *
+   * Only transitions messages with status 'pending' — returns false if the
+   * message was already processed/discarded (defense-in-depth against races).
    */
-  async markProcessed(id: string, resolvedContactId: string): Promise<void> {
-    await this.backend.markProcessed(id, resolvedContactId, new Date());
+  async markProcessed(id: string, resolvedContactId: string): Promise<boolean> {
+    return this.backend.markProcessed(id, resolvedContactId, new Date());
   }
 
   /**
    * Discard a held message (e.g. CEO determined it is spam or irrelevant).
+   *
+   * Only transitions messages with status 'pending' — returns false if the
+   * message was already processed/discarded.
    */
-  async discard(id: string): Promise<void> {
-    await this.backend.discard(id);
+  async discard(id: string): Promise<boolean> {
+    return this.backend.discard(id);
   }
 }
 
@@ -240,22 +248,27 @@ class PostgresHeldMessageBackend implements HeldMessageBackend {
     return this.rowToMessage(row);
   }
 
-  async markProcessed(id: string, resolvedContactId: string, processedAt: Date): Promise<void> {
+  async markProcessed(id: string, resolvedContactId: string, processedAt: Date): Promise<boolean> {
     this.logger.debug({ messageId: id, resolvedContactId }, 'held_messages: marking processed');
-    await this.pool.query(
+    // Atomic status guard: only transition pending → processed.
+    // Prevents double-processing if two requests race on the same message.
+    const result = await this.pool.query(
       `UPDATE held_messages
        SET status = 'processed', resolved_contact_id = $2, processed_at = $3
-       WHERE id = $1`,
+       WHERE id = $1 AND status = 'pending'`,
       [id, resolvedContactId, processedAt],
     );
+    return (result.rowCount ?? 0) > 0;
   }
 
-  async discard(id: string): Promise<void> {
+  async discard(id: string): Promise<boolean> {
     this.logger.debug({ messageId: id }, 'held_messages: discarding');
-    await this.pool.query(
-      `UPDATE held_messages SET status = 'discarded' WHERE id = $1`,
+    // Atomic status guard: only transition pending → discarded.
+    const result = await this.pool.query(
+      `UPDATE held_messages SET status = 'discarded' WHERE id = $1 AND status = 'pending'`,
       [id],
     );
+    return (result.rowCount ?? 0) > 0;
   }
 
   // -- Row mapping --
@@ -352,17 +365,23 @@ class InMemoryHeldMessageBackend implements HeldMessageBackend {
     return this.messages.get(id) ?? null;
   }
 
-  async markProcessed(id: string, resolvedContactId: string, processedAt: Date): Promise<void> {
+  async markProcessed(id: string, resolvedContactId: string, processedAt: Date): Promise<boolean> {
     const msg = this.messages.get(id);
-    if (msg) {
+    // Status guard: only transition pending → processed (matches Postgres backend behavior)
+    if (msg && msg.status === 'pending') {
       this.messages.set(id, { ...msg, status: 'processed', resolvedContactId, processedAt });
+      return true;
     }
+    return false;
   }
 
-  async discard(id: string): Promise<void> {
+  async discard(id: string): Promise<boolean> {
     const msg = this.messages.get(id);
-    if (msg) {
+    // Status guard: only transition pending → discarded (matches Postgres backend behavior)
+    if (msg && msg.status === 'pending') {
       this.messages.set(id, { ...msg, status: 'discarded' });
+      return true;
     }
+    return false;
   }
 }

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -131,4 +131,31 @@ export interface AuthConfig {
   roles: Record<string, RolePermissions>;
   permissions: Record<string, PermissionDef>;
   channelTrust: Record<string, TrustLevel>;
+  channelPolicies: Record<string, ChannelPolicyConfig>;
+}
+
+// -- Unknown sender policy --
+
+export type UnknownSenderPolicy = 'allow' | 'hold_and_notify' | 'reject';
+
+export type HeldMessageStatus = 'pending' | 'processed' | 'discarded';
+
+export interface HeldMessage {
+  id: string;
+  channel: string;
+  senderId: string;
+  conversationId: string;
+  content: string;
+  subject: string | null;
+  metadata: Record<string, unknown>;
+  status: HeldMessageStatus;
+  /** Contact ID if the CEO identified the sender */
+  resolvedContactId: string | null;
+  createdAt: Date;
+  processedAt: Date | null;
+}
+
+export interface ChannelPolicyConfig {
+  trust: TrustLevel;
+  unknownSender: UnknownSenderPolicy;
 }

--- a/src/db/migrations/007_create_held_messages.sql
+++ b/src/db/migrations/007_create_held_messages.sql
@@ -1,0 +1,24 @@
+-- Up Migration
+
+-- Held messages: stores inbound messages from unknown senders pending CEO review.
+-- Messages stay here until the CEO identifies the sender (processed),
+-- dismisses them (discarded), or they are auto-discarded by rate limiting.
+CREATE TABLE held_messages (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  channel             TEXT NOT NULL,
+  sender_id           TEXT NOT NULL,
+  conversation_id     TEXT NOT NULL,
+  content             TEXT NOT NULL,
+  subject             TEXT,
+  metadata            JSONB NOT NULL DEFAULT '{}',
+  status              TEXT NOT NULL DEFAULT 'pending',
+  resolved_contact_id UUID REFERENCES contacts(id),
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  processed_at        TIMESTAMPTZ
+);
+
+CREATE INDEX idx_held_messages_status ON held_messages (status, created_at)
+  WHERE status = 'pending';
+
+CREATE INDEX idx_held_messages_channel_status ON held_messages (channel, status)
+  WHERE status = 'pending';

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -105,31 +105,41 @@ export class Dispatcher {
           const policy = this.channelPolicies?.[payload.channelId];
 
           if (policy?.unknownSender === 'hold_and_notify' && this.heldMessages) {
-            // Hold the message instead of routing to coordinator
-            const subject = (payload.metadata as Record<string, unknown> | undefined)?.subject as string | null ?? null;
-            const heldId = await this.heldMessages.hold({
-              channel: payload.channelId,
-              senderId: payload.senderId,
-              conversationId: payload.conversationId,
-              content: payload.content,
-              subject,
-              metadata: payload.metadata ?? {},
-            });
+            try {
+              // Hold the message instead of routing to coordinator
+              const subject = (payload.metadata as Record<string, unknown> | undefined)?.subject as string | null ?? null;
+              const heldId = await this.heldMessages.hold({
+                channel: payload.channelId,
+                senderId: payload.senderId,
+                conversationId: payload.conversationId,
+                content: payload.content,
+                subject,
+                metadata: payload.metadata ?? {},
+              });
 
-            // Publish held event so CLI can notify and audit can log
-            await this.bus.publish('dispatch', createMessageHeld({
-              heldMessageId: heldId,
-              channel: payload.channelId,
-              senderId: payload.senderId,
-              subject,
-              parentEventId: event.id,
-            }));
+              // Publish held event so CLI can notify and audit can log
+              await this.bus.publish('dispatch', createMessageHeld({
+                heldMessageId: heldId,
+                channel: payload.channelId,
+                senderId: payload.senderId,
+                subject,
+                parentEventId: event.id,
+              }));
 
-            this.logger.info(
-              { heldMessageId: heldId, channel: payload.channelId, senderId: payload.senderId },
-              'Message held from unknown sender',
-            );
-            return; // Do NOT route to coordinator
+              this.logger.info(
+                { heldMessageId: heldId, channel: payload.channelId, senderId: payload.senderId },
+                'Message held from unknown sender',
+              );
+            } catch (holdErr) {
+              // Fail closed: if we can't hold the message, drop it rather than
+              // routing an unknown sender's message to the coordinator.
+              // This is a security boundary — prefer message loss over policy bypass.
+              this.logger.error(
+                { err: holdErr, channel: payload.channelId, senderId: payload.senderId },
+                'Failed to hold unknown sender message — dropping (fail-closed)',
+              );
+            }
+            return; // Always return — whether hold succeeded or failed
           }
 
           if (policy?.unknownSender === 'reject') {

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -1,14 +1,17 @@
 import type { EventBus } from '../bus/bus.js';
 import type { InboundMessageEvent, AgentResponseEvent } from '../bus/events.js';
-import { createAgentTask, createOutboundMessage, createContactResolved, createContactUnknown } from '../bus/events.js';
+import { createAgentTask, createOutboundMessage, createContactResolved, createContactUnknown, createMessageHeld } from '../bus/events.js';
 import type { Logger } from '../logger.js';
 import type { ContactResolver } from '../contacts/contact-resolver.js';
-import type { InboundSenderContext } from '../contacts/types.js';
+import type { HeldMessageService } from '../contacts/held-messages.js';
+import type { InboundSenderContext, ChannelPolicyConfig } from '../contacts/types.js';
 
 export interface DispatcherConfig {
   bus: EventBus;
   logger: Logger;
   contactResolver?: ContactResolver;
+  heldMessages?: HeldMessageService;
+  channelPolicies?: Record<string, ChannelPolicyConfig>;
 }
 
 /**
@@ -25,6 +28,8 @@ export class Dispatcher {
   private bus: EventBus;
   private logger: Logger;
   private contactResolver?: ContactResolver;
+  private heldMessages?: HeldMessageService;
+  private channelPolicies?: Record<string, ChannelPolicyConfig>;
   /**
    * Maps agent.task event ID → channel routing info.
    * When the agent publishes agent.response (with parentEventId pointing to the task),
@@ -39,6 +44,8 @@ export class Dispatcher {
     this.bus = config.bus;
     this.logger = config.logger;
     this.contactResolver = config.contactResolver;
+    this.heldMessages = config.heldMessages;
+    this.channelPolicies = config.channelPolicies;
   }
 
   register(): void {
@@ -88,11 +95,52 @@ export class Dispatcher {
             }));
           }
         } else {
+          // Unknown sender — publish audit event and check channel policy
           await this.bus.publish('dispatch', createContactUnknown({
             channel: senderContext.channel,
             senderId: senderContext.senderId,
             parentEventId: event.id,
           }));
+
+          const policy = this.channelPolicies?.[payload.channelId];
+
+          if (policy?.unknownSender === 'hold_and_notify' && this.heldMessages) {
+            // Hold the message instead of routing to coordinator
+            const subject = (payload.metadata as Record<string, unknown> | undefined)?.subject as string | null ?? null;
+            const heldId = await this.heldMessages.hold({
+              channel: payload.channelId,
+              senderId: payload.senderId,
+              conversationId: payload.conversationId,
+              content: payload.content,
+              subject,
+              metadata: payload.metadata ?? {},
+            });
+
+            // Publish held event so CLI can notify and audit can log
+            await this.bus.publish('dispatch', createMessageHeld({
+              heldMessageId: heldId,
+              channel: payload.channelId,
+              senderId: payload.senderId,
+              subject,
+              parentEventId: event.id,
+            }));
+
+            this.logger.info(
+              { heldMessageId: heldId, channel: payload.channelId, senderId: payload.senderId },
+              'Message held from unknown sender',
+            );
+            return; // Do NOT route to coordinator
+          }
+
+          if (policy?.unknownSender === 'reject') {
+            this.logger.info(
+              { channel: payload.channelId, senderId: payload.senderId },
+              'Rejected message from unknown sender',
+            );
+            return; // Silently drop
+          }
+
+          // 'allow' policy or no policy configured — fall through to normal routing
         }
       } catch (err) {
         // Resolution failure must not drop the message — log and continue without

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import { NylasClient } from './channels/email/nylas-client.js';
 import { EmailAdapter } from './channels/email/email-adapter.js';
 import { loadAuthConfig } from './contacts/config-loader.js';
 import { AuthorizationService } from './contacts/authorization.js';
+import { HeldMessageService } from './contacts/held-messages.js';
 
 async function main(): Promise<void> {
   // 1. Config & logging — no dependencies, must come first.
@@ -111,9 +112,10 @@ async function main(): Promise<void> {
   // Fatal on failure: authorization is a security boundary. Silent degradation
   // would mean unreviewed senders get the wrong permissions. Fail loudly instead.
   let authService: AuthorizationService | undefined;
+  let authConfig: ReturnType<typeof loadAuthConfig> | undefined;
   try {
     const configDir = path.resolve(import.meta.dirname, '../config');
-    const authConfig = loadAuthConfig(configDir);
+    authConfig = loadAuthConfig(configDir);
     authService = new AuthorizationService(authConfig);
     logger.info('Authorization config loaded');
   } catch (err) {
@@ -123,6 +125,10 @@ async function main(): Promise<void> {
 
   const contactResolver = new ContactResolver(contactService, entityMemory, authService, logger);
   logger.info('Contact system initialized');
+
+  // Held messages — stores messages from unknown senders pending CEO review.
+  const heldMessages = HeldMessageService.createWithPostgres(pool, logger);
+  logger.info('Held message service initialized');
 
   // Email channel — optional, requires NYLAS_API_KEY, NYLAS_GRANT_ID, and NYLAS_SELF_EMAIL.
   let nylasClient: NylasClient | undefined;
@@ -169,7 +175,7 @@ async function main(): Promise<void> {
 
   // Execution layer — now with bus and agent registry for infrastructure skills.
   // nylasClient is passed through so email skills (email-send, email-reply) can use it.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, nylasClient });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, nylasClient, heldMessages });
 
   // Load all agent configs from the agents/ directory.
   // Fail hard on errors — consistent with skill loading and DB connection checks.
@@ -258,7 +264,13 @@ async function main(): Promise<void> {
   // 7. Dispatcher — subscribes to inbound.message + agent.response.
   // Registered after the coordinator so agent.task already has a handler
   // when the dispatcher fans the first inbound message out.
-  const dispatcher = new Dispatcher({ bus, logger, contactResolver });
+  const dispatcher = new Dispatcher({
+    bus,
+    logger,
+    contactResolver,
+    heldMessages,
+    channelPolicies: authConfig?.channelPolicies,
+  });
   dispatcher.register();
 
   // HTTP API channel — REST + SSE endpoints for external clients.

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -20,6 +20,7 @@ import type { EventBus } from '../bus/bus.js';
 import type { AgentRegistry } from '../agents/agent-registry.js';
 import type { ContactService } from '../contacts/contact-service.js';
 import type { NylasClient } from '../channels/email/nylas-client.js';
+import type { HeldMessageService } from '../contacts/held-messages.js';
 
 export class ExecutionLayer {
   private registry: SkillRegistry;
@@ -28,14 +29,16 @@ export class ExecutionLayer {
   private agentRegistry?: AgentRegistry;
   private contactService?: ContactService;
   private nylasClient?: NylasClient;
+  private heldMessages?: HeldMessageService;
 
-  constructor(registry: SkillRegistry, logger: Logger, options?: { bus?: EventBus; agentRegistry?: AgentRegistry; contactService?: ContactService; nylasClient?: NylasClient }) {
+  constructor(registry: SkillRegistry, logger: Logger, options?: { bus?: EventBus; agentRegistry?: AgentRegistry; contactService?: ContactService; nylasClient?: NylasClient; heldMessages?: HeldMessageService }) {
     this.registry = registry;
     this.logger = logger;
     this.bus = options?.bus;
     this.agentRegistry = options?.agentRegistry;
     this.contactService = options?.contactService;
     this.nylasClient = options?.nylasClient;
+    this.heldMessages = options?.heldMessages;
   }
 
   /**
@@ -104,6 +107,10 @@ export class ExecutionLayer {
       // when available but don't gate on it (other infra skills don't need it)
       if (this.nylasClient) {
         ctx.nylasClient = this.nylasClient;
+      }
+      // heldMessages is optional — only held-message skills need it
+      if (this.heldMessages) {
+        ctx.heldMessages = this.heldMessages;
       }
     }
 

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -53,6 +53,8 @@ export interface SkillContext {
   contactService?: import('../contacts/contact-service.js').ContactService;
   /** Nylas email client — only available to infrastructure skills */
   nylasClient?: import('../channels/email/nylas-client.js').NylasClient;
+  /** Held message service for infrastructure skills that manage held messages */
+  heldMessages?: import('../contacts/held-messages.js').HeldMessageService;
 }
 
 /**

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -99,7 +99,7 @@ export async function createHarness(): Promise<CuriaHarness> {
 
   // Execution layer — with bus and agent registry for infrastructure skills.
   // nylasClient passed through so email skills work in tests that exercise them.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, nylasClient });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, nylasClient, heldMessages: undefined });
 
   // Load all agent configs from the agents/ directory.
   const agentsDir = path.resolve(import.meta.dirname, '../../agents');
@@ -154,7 +154,7 @@ export async function createHarness(): Promise<CuriaHarness> {
 
   // Dispatcher — subscribes to inbound.message + agent.response.
   // Registered after agents so agent.task already has handlers.
-  const dispatcher = new Dispatcher({ bus, logger, contactResolver });
+  const dispatcher = new Dispatcher({ bus, logger, contactResolver, heldMessages: undefined, channelPolicies: undefined });
   dispatcher.register();
 
   // -- No HTTP adapter, no CLI adapter, no SIGTERM handler --

--- a/tests/unit/contacts/config-loader.test.ts
+++ b/tests/unit/contacts/config-loader.test.ts
@@ -32,4 +32,19 @@ describe('loadAuthConfig', () => {
     expect(config.roles.unknown).toBeDefined();
     expect(config.roles.unknown.defaultPermissions).toEqual([]);
   });
+
+  it('loads unknown sender policies from YAML', () => {
+    const config = loadAuthConfig(CONFIG_DIR);
+    expect(config.channelPolicies).toBeDefined();
+    expect(config.channelPolicies.cli.unknownSender).toBe('allow');
+    expect(config.channelPolicies.email.unknownSender).toBe('hold_and_notify');
+    expect(config.channelPolicies.http.unknownSender).toBe('reject');
+  });
+
+  it('preserves trust levels alongside policies', () => {
+    const config = loadAuthConfig(CONFIG_DIR);
+    expect(config.channelPolicies.cli.trust).toBe('high');
+    expect(config.channelPolicies.email.trust).toBe('low');
+    expect(config.channelTrust.cli).toBe('high');
+  });
 });

--- a/tests/unit/contacts/held-messages.test.ts
+++ b/tests/unit/contacts/held-messages.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { HeldMessageService } from '../../../src/contacts/held-messages.js';
+
+describe('HeldMessageService', () => {
+  let service: HeldMessageService;
+
+  beforeEach(() => {
+    service = HeldMessageService.createInMemory();
+  });
+
+  it('holds a message and retrieves it', async () => {
+    const id = await service.hold({
+      channel: 'email',
+      senderId: 'stranger@example.com',
+      conversationId: 'email:thread-1',
+      content: 'Can I get the Q3 numbers?',
+      subject: 'Q3 Request',
+      metadata: {},
+    });
+
+    const pending = await service.listPending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe(id);
+    expect(pending[0].senderId).toBe('stranger@example.com');
+    expect(pending[0].status).toBe('pending');
+  });
+
+  it('lists pending messages for a specific channel', async () => {
+    await service.hold({ channel: 'email', senderId: 'a@example.com', conversationId: 'e:1', content: 'test', subject: null, metadata: {} });
+    await service.hold({ channel: 'telegram', senderId: '123', conversationId: 't:1', content: 'test', subject: null, metadata: {} });
+
+    const emailOnly = await service.listPending('email');
+    expect(emailOnly).toHaveLength(1);
+    expect(emailOnly[0].channel).toBe('email');
+  });
+
+  it('marks a message as processed with contact ID', async () => {
+    const id = await service.hold({ channel: 'email', senderId: 'a@example.com', conversationId: 'e:1', content: 'test', subject: null, metadata: {} });
+
+    await service.markProcessed(id, 'contact-uuid-123');
+
+    const pending = await service.listPending();
+    expect(pending).toHaveLength(0);
+
+    const msg = await service.getById(id);
+    expect(msg?.status).toBe('processed');
+    expect(msg?.resolvedContactId).toBe('contact-uuid-123');
+    expect(msg?.processedAt).toBeInstanceOf(Date);
+  });
+
+  it('discards a message', async () => {
+    const id = await service.hold({ channel: 'email', senderId: 'a@example.com', conversationId: 'e:1', content: 'test', subject: null, metadata: {} });
+
+    await service.discard(id);
+
+    const pending = await service.listPending();
+    expect(pending).toHaveLength(0);
+
+    const msg = await service.getById(id);
+    expect(msg?.status).toBe('discarded');
+  });
+
+  it('enforces rate limit per channel', async () => {
+    const limited = HeldMessageService.createInMemory(3);
+
+    await limited.hold({ channel: 'email', senderId: 'a@example.com', conversationId: 'e:1', content: '1', subject: null, metadata: {} });
+    await limited.hold({ channel: 'email', senderId: 'b@example.com', conversationId: 'e:2', content: '2', subject: null, metadata: {} });
+    await limited.hold({ channel: 'email', senderId: 'c@example.com', conversationId: 'e:3', content: '3', subject: null, metadata: {} });
+    await limited.hold({ channel: 'email', senderId: 'd@example.com', conversationId: 'e:4', content: '4', subject: null, metadata: {} });
+
+    const pending = await limited.listPending('email');
+    expect(pending).toHaveLength(3);
+    expect(pending.map(m => m.senderId)).not.toContain('a@example.com');
+    expect(pending.map(m => m.senderId)).toContain('d@example.com');
+  });
+
+  it('rate limit is per channel, not global', async () => {
+    const limited = HeldMessageService.createInMemory(2);
+
+    await limited.hold({ channel: 'email', senderId: 'a@example.com', conversationId: 'e:1', content: '1', subject: null, metadata: {} });
+    await limited.hold({ channel: 'email', senderId: 'b@example.com', conversationId: 'e:2', content: '2', subject: null, metadata: {} });
+    await limited.hold({ channel: 'telegram', senderId: '111', conversationId: 't:1', content: '3', subject: null, metadata: {} });
+
+    const emailPending = await limited.listPending('email');
+    const telegramPending = await limited.listPending('telegram');
+    expect(emailPending).toHaveLength(2);
+    expect(telegramPending).toHaveLength(1);
+  });
+
+  it('returns null for non-existent message', async () => {
+    const msg = await service.getById('non-existent-id');
+    expect(msg).toBeNull();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

When an unknown sender messages on a channel, their message is now handled per channel policy instead of being routed directly to the coordinator:

- **hold_and_notify** (email, Signal, Telegram): message stored in `held_messages` table, CEO notified immediately via CLI notification, coordinator proactively mentions oldest held message
- **reject** (HTTP API): message silently dropped
- **allow** (CLI): processed normally (CLI is always the CEO)

The CEO can then:
- **Identify** the sender → creates a confirmed contact, links the channel identity, replays the held message through normal processing
- **Dismiss** → discards the held message
- **Block** → creates a blocked contact, discards the message

### New components
- `held_messages` table (migration 007) with rate limiting indexes
- `HeldMessageService` — CRUD + rate limiting (max 20 pending per channel, oldest auto-discarded)
- `message.held` bus event for CLI notifications and audit
- Dispatcher policy engine — checks per-channel unknown sender policy before routing
- CLI immediate notification: `[Held] Unknown sender on email: stranger@example.com — "Subject"`
- Two new skills: `held-messages-list`, `held-messages-process`
- Extended `channel-trust.yaml` with `unknown_sender` policy per channel

### Open question (documented in spec)
Held message expiration is deferred. Messages held indefinitely until CEO acts. Future work needs judgment and oversight for auto-discard.

## Test plan

- [x] 269 tests passing across 42 files, typecheck clean, lint clean
- [x] HeldMessageService: 7 unit tests (hold, retrieve, process, discard, rate limiting, per-channel isolation)
- [x] Config loader: new tests for unknown sender policy parsing
- [ ] Live test: send email from unknown address, verify hold + CLI notification + identify flow


___

## **CodeAnt-AI Description**
**Hold unknown-sender messages for review and let the CEO act on them**

### What Changed
- Messages from unknown senders are now handled by channel policy: some are held for review, some are dropped, and CLI keeps working normally.
- Held messages can be listed, identified, dismissed, or blocked; identifying a sender turns them into a contact and sends the message back through normal processing.
- The CLI now alerts the CEO immediately when a message is held and prompts them to review it.
- Channel settings now include both trust level and unknown-sender behavior, with support for the new held-message flow.
- Added storage, boot-up wiring, and tests for held-message handling and policy loading.

### Impact
`✅ Fewer unknown-sender messages reaching the coordinator`
`✅ Faster CEO review of held messages`
`✅ Clearer handling of spam or unrecognized senders`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
