### PR TITLE
fix: hold messages from provisional and blocked senders

### DIFF
--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -93,6 +93,62 @@ export class Dispatcher {
               channelIdentifier: payload.senderId,
               parentEventId: event.id,
             }));
+
+            // Provisional contacts are treated like unknown senders for policy purposes.
+            // They have a contact record (so the resolver finds them), but the CEO hasn't
+            // confirmed them yet. Apply the same hold/reject policy as unknown senders.
+            if (senderContext.status === 'provisional' || senderContext.status === 'blocked') {
+              const policy = this.channelPolicies?.[payload.channelId];
+
+              if (senderContext.status === 'blocked') {
+                this.logger.info(
+                  { channel: payload.channelId, senderId: payload.senderId, contactId: senderContext.contactId },
+                  'Blocked sender — dropping message',
+                );
+                return;
+              }
+
+              if (policy?.unknownSender === 'hold_and_notify' && this.heldMessages) {
+                try {
+                  const subject = (payload.metadata as Record<string, unknown> | undefined)?.subject as string | null ?? null;
+                  const heldId = await this.heldMessages.hold({
+                    channel: payload.channelId,
+                    senderId: payload.senderId,
+                    conversationId: payload.conversationId,
+                    content: payload.content,
+                    subject,
+                    metadata: payload.metadata ?? {},
+                  });
+
+                  await this.bus.publish('dispatch', createMessageHeld({
+                    heldMessageId: heldId,
+                    channel: payload.channelId,
+                    senderId: payload.senderId,
+                    subject,
+                    parentEventId: event.id,
+                  }));
+
+                  this.logger.info(
+                    { heldMessageId: heldId, channel: payload.channelId, senderId: payload.senderId, contactId: senderContext.contactId },
+                    'Message held from provisional sender',
+                  );
+                } catch (holdErr) {
+                  this.logger.error(
+                    { err: holdErr, channel: payload.channelId, senderId: payload.senderId },
+                    'Failed to hold provisional sender message — dropping (fail-closed)',
+                  );
+                }
+                return;
+              }
+
+              if (policy?.unknownSender === 'reject') {
+                this.logger.info(
+                  { channel: payload.channelId, senderId: payload.senderId },
+                  'Rejected message from provisional sender',
+                );
+                return;
+              }
+            }
           }
         } else {
           // Unknown sender — publish audit event and check channel policy


### PR DESCRIPTION
## **User description**
## Summary

The dispatcher only applied the unknown sender hold/reject policy when the contact resolver returned `resolved: false`. But provisional contacts (auto-created from email participants) resolve as `true` — they have a contact record and a linked identity. This meant emails from unconfirmed senders bypassed the hold policy and went straight to the coordinator.

## Fix

After contact resolution succeeds, check the contact's status:
- **provisional**: apply the same hold/reject policy as unknown senders (per channel config)
- **blocked**: always drop the message silently
- **confirmed**: proceed to coordinator as before

Both paths use the same fail-closed pattern: if the hold operation fails, drop the message rather than routing an unconfirmed sender to the coordinator.

## How it was found

Live email testing: sent an email from an unknown address, expected it to be held, but it was replied to. The contact had been auto-created as provisional by the email adapter's participant extraction, so the resolver found it and the hold policy was never checked.

## Test plan

- [x] 269 tests passing, typecheck clean
- [ ] Live test: email from provisional sender gets held, CLI notification appears


___

## **CodeAnt-AI Description**
**Hold or drop messages from provisional and blocked senders**

### What Changed
- Messages from provisional contacts now follow the same sender policy as unknown senders: they can be held for review or rejected instead of reaching the coordinator.
- Messages from blocked senders are now dropped immediately.
- If holding a provisional sender’s message fails, the message is dropped instead of being forwarded.

### Impact
`✅ Fewer unconfirmed senders reaching inbox workflows`
`✅ Safer handling of blocked contacts`
`✅ Fewer accidental replies to provisional senders`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
