### PR TITLE
fix: partial name search and identity enrichment in contact-lookup

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -98,6 +98,19 @@ system_prompt: |
     - "dismiss" — CEO doesn't care about the message. Discards it.
     - "block" — CEO wants to block this sender. Creates a blocked contact.
 
+  IMPORTANT: Dismissing a held message only discards the MESSAGE — it does NOT delete
+  the contact record. The sender's contact and email address remain in your contacts
+  as provisional. If the CEO later asks about that person, ALWAYS look up the contact
+  first (contact-lookup by name) before asking for information you might already have.
+
+  ## Contact Lookup Best Practices
+  - contact-lookup supports partial name matching. "Joe" will find "Joseph Brennan".
+  - Always search your contacts before asking the CEO for someone's details.
+  - The lookup returns channel identities (email, phone, etc.) alongside the contact,
+    so you can see their email address without a separate lookup.
+  - If a contact's status is "provisional", tell the CEO and ask if they want to
+    confirm them. Provisional contacts can't take actions until confirmed.
+
   ## Email
   You have your own email account and can send and receive emails.
   - **When you receive an email and want to respond**: ALWAYS use email-reply with the

--- a/skills/contact-lookup/handler.ts
+++ b/skills/contact-lookup/handler.ts
@@ -49,10 +49,13 @@ export class ContactLookupHandler implements SkillHandler {
     try {
       if (by === 'name') {
         const contacts = await ctx.contactService.findContactByName(query);
+        // Enrich each contact with their channel identities so the coordinator
+        // can see email addresses, phone numbers, etc. without a second lookup.
+        const enriched = await Promise.all(contacts.map(c => enrichContact(ctx, c)));
         return {
           success: true,
           data: {
-            contacts: contacts.map(contactToSummary),
+            contacts: enriched,
             count: contacts.length,
           },
         };
@@ -60,10 +63,11 @@ export class ContactLookupHandler implements SkillHandler {
 
       if (by === 'role') {
         const contacts = await ctx.contactService.findContactByRole(query);
+        const enriched = await Promise.all(contacts.map(c => enrichContact(ctx, c)));
         return {
           success: true,
           data: {
-            contacts: contacts.map(contactToSummary),
+            contacts: enriched,
             count: contacts.length,
           },
         };
@@ -117,12 +121,39 @@ export class ContactLookupHandler implements SkillHandler {
   }
 }
 
+/** Enrich a contact with its channel identities */
+async function enrichContact(
+  ctx: SkillContext,
+  contact: { id: string; displayName: string; role: string | null; status: string; kgNodeId: string | null },
+) {
+  const summary = contactToSummary(contact);
+  try {
+    const data = await ctx.contactService!.getContactWithIdentities(contact.id);
+    if (data) {
+      return {
+        ...summary,
+        identities: data.identities.map(i => ({
+          id: i.id,
+          channel: i.channel,
+          identifier: i.channelIdentifier,
+          label: i.label,
+          verified: i.verified,
+        })),
+      };
+    }
+  } catch {
+    // Best effort — return without identities if lookup fails
+  }
+  return { ...summary, identities: [] };
+}
+
 /** Convert a Contact to a summary object for the skill output */
-function contactToSummary(contact: { id: string; displayName: string; role: string | null; kgNodeId: string | null }) {
+function contactToSummary(contact: { id: string; displayName: string; role: string | null; status: string; kgNodeId: string | null }) {
   return {
     contact_id: contact.id,
     display_name: contact.displayName,
     role: contact.role,
+    status: contact.status,
     kg_node_id: contact.kgNodeId,
   };
 }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -337,7 +337,10 @@ class PostgresContactBackend implements ContactServiceBackend {
   }
 
   async findContactByName(name: string): Promise<Contact[]> {
-    // Case-insensitive exact match using lower()
+    // Substring match (case-insensitive) so partial names like "Joe" match "Joseph Brennan".
+    // Uses ILIKE with wildcards — the idx_contacts_display_name btree index won't help here,
+    // but the contacts table is small (hundreds, not millions) so a seq scan is fine.
+    // For exact match, the caller can filter the results further.
     const result = await this.pool.query<{
       id: string;
       kg_node_id: string | null;
@@ -349,8 +352,8 @@ class PostgresContactBackend implements ContactServiceBackend {
       updated_at: Date;
     }>(
       `SELECT id, kg_node_id, display_name, role, status, notes, created_at, updated_at
-       FROM contacts WHERE lower(display_name) = lower($1)`,
-      [name],
+       FROM contacts WHERE display_name ILIKE $1`,
+      [`%${name}%`],
     );
 
     return result.rows.map((row) => this.rowToContact(row));
@@ -601,10 +604,11 @@ class InMemoryContactBackend implements ContactServiceBackend {
   }
 
   async findContactByName(name: string): Promise<Contact[]> {
+    // Substring match (case-insensitive) to match the Postgres ILIKE behavior
     const lowerName = name.toLowerCase();
     const results: Contact[] = [];
     for (const contact of this.contacts.values()) {
-      if (contact.displayName.toLowerCase() === lowerName) {
+      if (contact.displayName.toLowerCase().includes(lowerName)) {
         results.push(contact);
       }
     }


### PR DESCRIPTION
## **User description**
## Summary

Live testing revealed that Nathan couldn't find a provisional contact by nickname — "Joe Brennan" didn't match "Joseph Brennan" because `findContactByName` used exact match. Nathan also didn't know the contact's email because the lookup didn't return channel identities.

### Changes

- **Partial name search**: `findContactByName` now uses `ILIKE '%name%'` (Postgres) / `.includes()` (InMemory) instead of exact match. "Joe" finds "Joseph Brennan".
- **Identity enrichment**: contact-lookup results now include channel identities (email, phone, etc.) so Nathan can see contact details without a separate lookup.
- **Status in output**: lookup results include contact status (confirmed/provisional/blocked).
- **Prompt update**: Clarifies that dismissing a held message doesn't delete the contact. Nathan should always search contacts before asking the CEO for info they might already have.

## How it was found

Live test: CEO dismissed a held email, then later asked Nathan to follow up with the sender. Nathan couldn't find the contact (exact name mismatch) and didn't know the email address (not in lookup output), so he asked the CEO for info he already had.

## Test plan

- [x] 269 tests passing, typecheck clean
- [ ] Live test: "Joe" finds "Joseph Brennan" with email address in results


___

## **CodeAnt-AI Description**
**Find contacts by partial name and see their contact details in results**

### What Changed
- Contact search by name now matches partial names, so a search like "Joe" finds "Joseph Brennan"
- Contact lookup results now include the contact’s status plus email, phone, and other linked identities
- The assistant is now told to search contacts first before asking the CEO for details, and that dismissing a held message does not delete the contact

### Impact
`✅ Fewer missed contacts from nickname searches`
`✅ Clearer contact lookup results`
`✅ Fewer повторные requests for contact details`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
