### PR TITLE
feat: add pgAudit for SQL-level audit logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     # Load pgAudit and configure session-level auditing via command args.
     # All pgAudit settings are here (not in the init script) so there's one
     # place to look. The init script only handles CREATE EXTENSION and role setup.
+    # IMPORTANT: shared_preload_libraries is the critical line — without it, the
+    # other pgaudit.* settings are silently accepted but have no effect.
     command: >
       postgres
       -c shared_preload_libraries=pgaudit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,29 @@
 services:
   postgres:
-    image: pgvector/pgvector:pg16
+    build:
+      context: .
+      dockerfile: docker/postgres.Dockerfile
     ports:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+      # pgAudit init script runs on first database creation only
+      - ./docker/postgres-init-pgaudit.sql:/docker-entrypoint-initdb.d/10-pgaudit.sql:ro
     environment:
       POSTGRES_DB: curia
       POSTGRES_USER: ${DB_USER:-curia}
       POSTGRES_PASSWORD: ${DB_PASSWORD:-curia_dev}
+    # Load pgAudit extension and configure session-level auditing.
+    # - shared_preload_libraries: required for pgAudit to function
+    # - pgaudit.log: log all write (INSERT/UPDATE/DELETE) and DDL statements
+    # - pgaudit.log_parameter: include bind parameter values in log output
+    # - pgaudit.log_relation: log each table separately in multi-table queries
+    command: >
+      postgres
+      -c shared_preload_libraries=pgaudit
+      -c pgaudit.log=write,ddl
+      -c pgaudit.log_parameter=on
+      -c pgaudit.log_relation=on
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-curia}"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,17 +13,16 @@ services:
       POSTGRES_DB: curia
       POSTGRES_USER: ${DB_USER:-curia}
       POSTGRES_PASSWORD: ${DB_PASSWORD:-curia_dev}
-    # Load pgAudit extension and configure session-level auditing.
-    # - shared_preload_libraries: required for pgAudit to function
-    # - pgaudit.log: log all write (INSERT/UPDATE/DELETE) and DDL statements
-    # - pgaudit.log_parameter: include bind parameter values in log output
-    # - pgaudit.log_relation: log each table separately in multi-table queries
+    # Load pgAudit and configure session-level auditing via command args.
+    # All pgAudit settings are here (not in the init script) so there's one
+    # place to look. The init script only handles CREATE EXTENSION and role setup.
     command: >
       postgres
       -c shared_preload_libraries=pgaudit
       -c pgaudit.log=write,ddl
       -c pgaudit.log_parameter=on
       -c pgaudit.log_relation=on
+      -c pgaudit.role=pgaudit_role
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-curia}"]
       interval: 5s

--- a/docker/postgres-init-pgaudit.sql
+++ b/docker/postgres-init-pgaudit.sql
@@ -1,11 +1,19 @@
 -- Enable pgAudit extension.
 -- This script runs once on first database initialization (via /docker-entrypoint-initdb.d/).
 -- pgAudit must already be loaded via shared_preload_libraries (set in compose command args).
+--
+-- All pgaudit.* runtime settings (log, log_parameter, log_relation, role) are configured
+-- via compose command args, not ALTER SYSTEM. This keeps configuration in one place.
+--
+-- NOTE: pgaudit.log_parameter=on (set in compose) logs actual SQL bind parameter values.
+-- This may include user messages, email content, or PII. Ensure the Postgres log destination
+-- is secured appropriately. In production, consider disabling this or restricting log access.
 CREATE EXTENSION IF NOT EXISTS pgaudit;
 
 -- Create the audit role used for object-level auditing.
 -- Granting SELECT/INSERT/UPDATE/DELETE on specific tables to this role causes
 -- pgAudit to log all matching statements, regardless of which user executes them.
+-- The role is referenced by pgaudit.role (set in compose command args).
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pgaudit_role') THEN
@@ -14,15 +22,11 @@ BEGIN
 END
 $$;
 
--- Set the pgAudit role so object-level auditing is active.
-ALTER SYSTEM SET pgaudit.role = 'pgaudit_role';
-
 -- After the audit_log table is created by Curia's migrations, run:
 --   GRANT ALL ON audit_log TO pgaudit_role;
 -- This tells pgAudit to log every SQL statement that touches audit_log,
 -- providing a DB-level tamper detection layer independent of the application.
 --
 -- We don't grant here because the table doesn't exist yet (migrations run at app startup).
--- See docker/postgres-grant-pgaudit.sql for a helper script, or run the GRANT manually
--- after the first successful migration.
-SELECT pg_reload_conf();
+-- Run the GRANT manually after the first successful migration, or add it as a
+-- post-migration step in the application bootstrap.

--- a/docker/postgres-init-pgaudit.sql
+++ b/docker/postgres-init-pgaudit.sql
@@ -1,0 +1,28 @@
+-- Enable pgAudit extension.
+-- This script runs once on first database initialization (via /docker-entrypoint-initdb.d/).
+-- pgAudit must already be loaded via shared_preload_libraries (set in compose command args).
+CREATE EXTENSION IF NOT EXISTS pgaudit;
+
+-- Create the audit role used for object-level auditing.
+-- Granting SELECT/INSERT/UPDATE/DELETE on specific tables to this role causes
+-- pgAudit to log all matching statements, regardless of which user executes them.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pgaudit_role') THEN
+    CREATE ROLE pgaudit_role NOLOGIN;
+  END IF;
+END
+$$;
+
+-- Set the pgAudit role so object-level auditing is active.
+ALTER SYSTEM SET pgaudit.role = 'pgaudit_role';
+
+-- After the audit_log table is created by Curia's migrations, run:
+--   GRANT ALL ON audit_log TO pgaudit_role;
+-- This tells pgAudit to log every SQL statement that touches audit_log,
+-- providing a DB-level tamper detection layer independent of the application.
+--
+-- We don't grant here because the table doesn't exist yet (migrations run at app startup).
+-- See docker/postgres-grant-pgaudit.sql for a helper script, or run the GRANT manually
+-- after the first successful migration.
+SELECT pg_reload_conf();

--- a/docker/postgres-verify-pgaudit.sh
+++ b/docker/postgres-verify-pgaudit.sh
@@ -10,6 +10,11 @@ set -e
 docker-entrypoint.sh "$@" &
 PG_PID=$!
 
+# This script is PID 1 in the container, so docker stop sends SIGTERM here,
+# not to Postgres. Forward termination signals to ensure clean DB shutdown.
+trap 'kill -TERM "$PG_PID"' TERM INT
+trap 'kill -QUIT "$PG_PID"' QUIT
+
 # Wait for Postgres to be ready (up to 30s)
 for i in $(seq 1 30); do
   if pg_isready -U "${POSTGRES_USER:-curia}" -q 2>/dev/null; then

--- a/docker/postgres-verify-pgaudit.sh
+++ b/docker/postgres-verify-pgaudit.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Verify pgAudit is correctly set up on every Postgres startup — not just first init.
+# docker-entrypoint-initdb.d/ scripts only run on a fresh data directory, so existing
+# volumes silently skip pgAudit setup. This script catches that.
+#
+# Runs as a wrapper around the standard Postgres Docker entrypoint.
+set -e
+
+# Start Postgres via the standard entrypoint (in the background for the check)
+docker-entrypoint.sh "$@" &
+PG_PID=$!
+
+# Wait for Postgres to be ready (up to 30s)
+for i in $(seq 1 30); do
+  if pg_isready -U "${POSTGRES_USER:-curia}" -q 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+if ! pg_isready -U "${POSTGRES_USER:-curia}" -q 2>/dev/null; then
+  echo "ERROR: Postgres did not become ready in 30s" >&2
+  exit 1
+fi
+
+# Verify pgAudit setup. If anything is missing, create it (idempotent).
+# This handles the existing-volume case where initdb.d scripts were skipped.
+psql -U "${POSTGRES_USER:-curia}" -d "${POSTGRES_DB:-curia}" -v ON_ERROR_STOP=1 <<'SQL'
+  -- Ensure extension exists (safe to run repeatedly)
+  CREATE EXTENSION IF NOT EXISTS pgaudit;
+
+  -- Ensure audit role exists
+  DO $$
+  BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pgaudit_role') THEN
+      CREATE ROLE pgaudit_role NOLOGIN;
+      RAISE NOTICE 'pgaudit_role created (was missing — likely an existing volume)';
+    END IF;
+  END
+  $$;
+
+  -- Verify pgAudit is actually loaded (shared_preload_libraries included it)
+  DO $$
+  BEGIN
+    IF current_setting('pgaudit.log', true) IS NULL THEN
+      RAISE EXCEPTION 'AUDIT SAFETY CHECK FAILED: pgAudit is not loaded. '
+        'Ensure shared_preload_libraries includes pgaudit in the compose command args.';
+    END IF;
+  END
+  $$;
+SQL
+
+echo "pgAudit verification passed"
+
+# Bring Postgres back to foreground
+wait $PG_PID

--- a/docker/postgres.Dockerfile
+++ b/docker/postgres.Dockerfile
@@ -7,3 +7,9 @@ FROM pgvector/pgvector:pg16
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-16-pgaudit \
     && rm -rf /var/lib/apt/lists/*
+
+# Startup verification script ensures pgAudit is correctly set up on every boot,
+# not just on first init. Handles the existing-volume case where initdb.d scripts
+# were skipped because the data directory already existed.
+COPY docker/postgres-verify-pgaudit.sh /usr/local/bin/verify-pgaudit.sh
+ENTRYPOINT ["verify-pgaudit.sh"]

--- a/docker/postgres.Dockerfile
+++ b/docker/postgres.Dockerfile
@@ -1,0 +1,9 @@
+# Extends the pgvector image with pgAudit for SQL-level audit logging.
+# pgAudit captures INSERT/UPDATE/DELETE/DDL statements at the database level,
+# providing a tamper-independent audit trail alongside Curia's application-level
+# audit_log table. See docs/specs/10-audit-log-hardening.md.
+FROM pgvector/pgvector:pg16
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-16-pgaudit \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## **User description**
## Summary

- Extends the Postgres Docker image with pgAudit 16.1 for SQL-level audit logging (INSERT/UPDATE/DELETE/DDL)
- Provides a tamper-independent audit trail alongside Curia's application-level audit_log, per NIST 800-92 and SOC 2 CC7.2 recommendations
- Custom Dockerfile installs `postgresql-16-pgaudit` on top of `pgvector/pgvector:pg16`
- Compose command args configure session-level auditing (all pgAudit config in one place)
- Init script creates the `pgaudit_role` for future object-level auditing on the `audit_log` table
- Always-run `verify-pgaudit.sh` wrapper entrypoint ensures pgAudit is correctly set up on every boot (handles existing volumes where initdb.d scripts are skipped)

After merging, run `GRANT ALL ON audit_log TO pgaudit_role;` post-migration to enable object-level auditing on the audit_log table specifically.

## Test plan

- [x] Docker image builds successfully with pgAudit 16.1
- [x] pgAudit extension loads and logs DDL/write statements
- [x] Verification script creates extension and role on existing volumes
- [x] Verification script fails loudly if shared_preload_libraries is missing
- [x] Existing test suite passes (269 tests, 42 files)


___

## **CodeAnt-AI Description**
**Add pgAudit setup and startup checks for Postgres**

### What Changed
- Postgres now starts with pgAudit enabled so database writes and schema changes can be recorded at the SQL level.
- Audit settings are loaded on startup, and a dedicated audit role is created for table-level logging.
- A startup check now verifies pgAudit is actually active every time Postgres boots, so existing databases do not silently miss audit setup.
- If pgAudit is not loaded, Postgres now fails with a clear error instead of continuing without audit logging.

### Impact
`✅ Database writes and schema changes are logged`
`✅ Existing Postgres volumes keep audit logging enabled`
`✅ Fewer silent audit setup failures`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
