### PR TITLE
feat: auto-run database migrations on startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
  * Initializes all services in dependency order:
  * 1. Config + logging (no dependencies)
  * 2. Database connection (needs config)
+ * 2b. Migrations (needs DB connection — runs automatically on startup)
  * 3. Audit logger (needs DB)
  * 4. Message bus (needs logger, audit hook)
  * 5. LLM provider (needs config)
@@ -17,6 +18,7 @@
  */
 
 import * as path from 'node:path';
+import { runner } from 'node-pg-migrate';
 import { loadConfig } from './config.js';
 import { createLogger } from './logger.js';
 import { HttpAdapter } from './channels/http/http-adapter.js';
@@ -70,8 +72,28 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // TODO: Run node-pg-migrate programmatically on startup so the schema is
-  // always current when the process starts (no manual migration step required).
+  // Run pending migrations so the schema is always current when the process starts.
+  // Uses node-pg-migrate's programmatic runner with the same DATABASE_URL.
+  // This is safe for single-process deployments; node-pg-migrate acquires an
+  // advisory lock to prevent concurrent migration runs.
+  try {
+    const migrationsDir = path.resolve(import.meta.dirname, 'db/migrations');
+    const applied = await runner({
+      databaseUrl: config.databaseUrl,
+      dir: migrationsDir,
+      migrationsTable: 'pgmigrations',
+      direction: 'up',
+      log: (msg: string) => logger.debug({ migration: true }, msg),
+    });
+    if (applied.length > 0) {
+      logger.info({ count: applied.length, migrations: applied.map(m => m.name) }, 'Database migrations applied');
+    } else {
+      logger.debug('Database schema up to date');
+    }
+  } catch (err) {
+    logger.fatal({ err }, 'Database migration failed');
+    process.exit(1);
+  }
 
   // 3. Audit logger — must be ready before the bus starts accepting events.
   // The bus's write-ahead hook calls auditLogger.log() synchronously before

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,9 @@ async function main(): Promise<void> {
   // This is safe for single-process deployments; node-pg-migrate acquires an
   // advisory lock to prevent concurrent migration runs.
   try {
-    const migrationsDir = path.resolve(import.meta.dirname, 'db/migrations');
+    // Resolve from the project root (one level up from src/ or dist/) so the
+    // path works both in dev (tsx src/index.ts) and production (node dist/index.js).
+    const migrationsDir = path.resolve(import.meta.dirname, '..', 'src', 'db', 'migrations');
     const applied = await runner({
       databaseUrl: config.databaseUrl,
       dir: migrationsDir,


### PR DESCRIPTION
## **User description**
## Summary

- Replaces the manual `pnpm migrate` step with automatic migration on startup
- Uses node-pg-migrate's programmatic `runner()` API, called after DB connection is confirmed and before any services initialize
- Advisory locking (built into node-pg-migrate) prevents concurrent migration runs
- Fatal on failure — process won't start with a stale schema
- The `pnpm migrate` script is preserved for manual use if needed

## Test plan

- [ ] Start Curia with a pending migration — verify it applies automatically and logs the migration name
- [ ] Start Curia with no pending migrations — verify it logs "schema up to date" at debug level
- [ ] Start Curia with an invalid migration — verify it exits with a fatal error


___

## **CodeAnt-AI Description**
Run database migrations automatically when the app starts

### What Changed
- The app now applies pending database migrations during startup after confirming the database connection
- Startup stops with a clear failure if migrations cannot be applied, avoiding runs with an outdated schema
- When migrations run, the app logs which ones were applied; if none are needed, it logs that the schema is up to date

### Impact
`✅ No manual migration step before startup`
`✅ Fewer failures from stale database schemas`
`✅ Clearer startup status for database updates`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
