### PR TITLE
feat: coordinator template and knowledge skills (Phase A)

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -167,4 +167,12 @@ pinned_skills:
   - scheduler-create
   - scheduler-list
   - scheduler-cancel
+  - template-meeting-request
+  - template-reschedule
+  - template-cancel
+  - template-doc-request
+  - knowledge-company-overview
+  - knowledge-meeting-links
+  - knowledge-travel-preferences
+  - knowledge-loyalty-programs
 allow_discovery: true

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -175,4 +175,5 @@ pinned_skills:
   - knowledge-meeting-links
   - knowledge-travel-preferences
   - knowledge-loyalty-programs
+  - context-for-email
 allow_discovery: true

--- a/docs/plans/2026-03-29-ea-handbook-agent-plan.md
+++ b/docs/plans/2026-03-29-ea-handbook-agent-plan.md
@@ -25,6 +25,44 @@ Every section of the handbook was evaluated against three questions:
 3. **Where is Curia constrained or infeasible?** Tasks requiring physical presence,
    social nuance, or APIs that don't exist.
 
+### Design Principle: Skills Must Add Value Beyond the Bare LLM
+
+Curia's agents are powered by LLMs. An LLM can already write emails, summarize threads,
+classify urgency, and generate briefings. A skill that merely wraps what the LLM does
+natively is a **downgrade** — it replaces flexible, context-aware generation with rigid
+code that the LLM could outperform on its own.
+
+Every skill must pass this test: **"What does this skill do that the LLM cannot do
+(or should not be trusted to do) by itself?"**
+
+Skills add genuine value when they provide:
+
+- **API access** — the LLM cannot call Google Calendar, Nylas, or Slack without a tool.
+  These skills are always justified.
+- **Deterministic data storage/retrieval** — loyalty numbers, meeting links, and company
+  facts must be stored and recalled exactly, not paraphrased. The knowledge graph is the
+  right home for these, and skills are the right interface.
+- **Organizational policy & guardrails** — instead of rigid templates, skills should store
+  and retrieve *guidelines* (required elements, tone constraints, structural rules) that
+  the LLM follows when composing. The skill enforces consistency; the LLM provides
+  fluency and adaptation.
+- **Data aggregation & orchestration** — gathering data from multiple sources (calendar +
+  contacts + email) into a structured package is plumbing the LLM shouldn't be doing
+  turn-by-turn. Briefing skills justify their existence by assembling, not by writing.
+- **Scheduled/autonomous execution** — cron-triggered proactive checks can't rely on
+  a user prompt to initiate. Skills provide the entry point and structured evaluation.
+
+Skills that fail this test should be **removed or redesigned**:
+
+- A skill that does string interpolation on a template is a downgrade from the LLM
+  composing the same email natively. **Redesign**: store guidelines + example, return them
+  as instructions for the LLM to compose from.
+- A skill that "classifies urgency" by running hardcoded rules is worse than the LLM's
+  judgment. **Redesign**: the skill applies labels via API; the LLM decides the label.
+- A skill that "summarizes a thread" is literally what the LLM already does. **Remove**
+  as a standalone skill — the LLM does this in-context. Only justify it if it runs as a
+  background batch job where the LLM isn't already in the conversation.
+
 ---
 
 ## Proposed Agents
@@ -52,6 +90,9 @@ Meeting Setup & Defaults, In-Person Events, Focus Time, Travel time blocks
 **Dependencies:** Google Calendar API OAuth integration (server-side, not the Claude Code
 MCP)
 
+**Value justification:** Every skill here is an API bridge — the LLM cannot read or write
+calendar data without these tools. Pure infrastructure. No design risk.
+
 ---
 
 ### 2. Email Triage Agent — `core` (basic) / `paid` (advanced)
@@ -64,17 +105,41 @@ open source core. Advanced skills (`extract-actions`, `summarize-thread`) are pa
 
 | Skill | What it does |
 |---|---|
-| `email.classify` | Assign urgency (red/yellow/purple) and category (action/FYI/delegate) |
-| `email.extract-actions` | Pull out action items, deadlines, asks from email body |
-| `email.summarize-thread` | Produce 2-3 sentence summary of a long thread |
-| `email.label` | Apply triage labels to messages (maps to handbook's label system) |
+| Skill | What it does |
+|---|---|
+| `email.label` | Apply triage labels to messages via Nylas API (maps to handbook's label system) |
 | `email.surface-urgent` | Push urgent items to CEO via CLI notification or priority channel |
-| `email.archive-resolved` | Identify and archive threads that need no further action |
+| `email.archive-resolved` | Archive threads via Nylas API that need no further action |
+| `email.batch-triage` | Scheduled batch: fetch unprocessed emails, have the agent classify + label + surface in one pass |
 
 **Handbook coverage:** Email Inbox Management, Label System, Daily Inbox Triage Flow,
 End-of-Day Cleanup
 
 **Dependencies:** Email channel (built). Needs Nylas label/folder API support added.
+
+**Value justification & redesign notes:**
+
+- ~~`email.classify`~~ — **Removed as a standalone skill.** Classification (urgency,
+  category) is what the LLM does natively in-context. The agent's system prompt defines
+  the classification rules; the LLM applies them. No skill needed — the LLM just decides
+  and then calls `email.label` to apply its decision via the API.
+- ~~`email.extract-actions`~~ — **Removed as a standalone skill.** Action extraction is
+  native LLM capability. The agent does this in-context while reading the email. If
+  extracted actions need to be persisted, that's a knowledge graph write — not a separate
+  skill.
+- ~~`email.summarize-thread`~~ — **Removed as a standalone skill.** Thread summarization
+  is literally what the LLM does. Only justified as a batch job (e.g., nightly digest of
+  long threads), in which case it's part of `email.batch-triage`, not standalone.
+- `email.label` — **Justified.** API bridge to Nylas label/folder system. The LLM
+  decides the label; the skill applies it.
+- `email.surface-urgent` — **Justified.** Pushes notifications via bus events. Can't be
+  done without a tool.
+- `email.archive-resolved` — **Justified.** API bridge to Nylas archive. The LLM decides
+  what's resolved; the skill moves it.
+- `email.batch-triage` — **New.** Scheduler-triggered skill that fetches the inbox and
+  lets the agent process it in one pass. This is where the orchestration value lives —
+  not in individual classify/summarize skills, but in the pipeline that feeds email to
+  the agent and collects its decisions.
 
 ---
 
@@ -103,19 +168,42 @@ one-time batch scan of sent mail via Nylas.
 to the CEO's sent email archive, Curia can analyze hundreds of emails on day one to
 bootstrap tone, formality, sign-off style, and audience-specific variation.
 
+**Value justification & redesign notes:**
+
+- `profile.analyze-voice` — **Justified.** The value is in the *batch orchestration* +
+  *persistence*, not the analysis itself. The LLM does the analysis; the skill orchestrates
+  scanning hundreds of sent emails via Nylas and storing the resulting voice model in the
+  knowledge graph. This can't happen in a single conversation turn.
+- `profile.validate-draft` — **Justified, but skill should be retrieval-only.** The skill
+  retrieves the stored voice model from the KG and returns it. The LLM compares the draft
+  against the model. The skill should NOT try to do the comparison itself — that's
+  LLM-native work.
+- `profile.update-preferences` / `profile.get-preferences` — **Justified.** Deterministic
+  storage and retrieval. Same pattern as the knowledge skills.
+- ~~`profile.detect-patterns`~~ — **Needs scrutiny.** Pattern detection (response timing,
+  style by audience) is LLM analysis. The skill is only justified if it runs as a batch
+  job that *persists* the detected patterns. If it's on-demand, the LLM can detect
+  patterns in-context without a skill. **Redesign**: make this a scheduled batch job that
+  scans recent email/calendar data and stores observed patterns.
+- `profile.executive-snapshot` — **Justified.** Structured data retrieval from the KG.
+  The snapshot is a compiled, persistent artifact — not something the LLM re-derives
+  each time.
+
 ---
 
 ### 4. Briefing Agent — `paid`
 
-Generates structured briefings and prep documents. Template-driven but context-aware.
+Assembles structured data packages from multiple sources (calendar, contacts, email,
+knowledge graph) and lets the agent compose briefings from the assembled context. The
+skills are data pipelines, not text generators.
 
 | Skill | What it does |
 |---|---|
-| `briefing.daily` | Morning briefing: today's schedule, notes, FYIs, OOO teammates |
-| `briefing.weekly-look-ahead` | Week-ahead email: highlights, travel, reminders, open items |
-| `briefing.meeting-prep` | Pre-meeting brief: attendee bios, last interaction, context, talking points |
-| `briefing.travel-itinerary` | Compile full travel doc: flights, hotel, ground transport, dinner reservations, calendar links |
-| `briefing.board-prep` | Board meeting brief: attendees, agenda, materials checklist, prep/debrief blocks |
+| `briefing.gather-daily` | Aggregate today's calendar, pending action items, unread urgents, OOO contacts into a structured data package |
+| `briefing.gather-weekly` | Aggregate next 7 days of calendar, open threads, travel, reminders into a structured data package |
+| `briefing.gather-meeting-prep` | For a given meeting: fetch attendee contact records, last interaction from KG, meeting context, related documents |
+| `briefing.gather-travel` | For a given trip: compile flights, hotel, ground transport, dinner reservations, calendar links from KG + calendar |
+| `briefing.gather-board-prep` | For a board meeting: attendees, agenda, materials checklist, related KG context |
 
 **Handbook coverage:** Daily Briefing Template, Week Ahead Email, Meeting Prep,
 Travel Itinerary Template, Board Engagement prep, Look Ahead Always
@@ -123,6 +211,20 @@ Travel Itinerary Template, Board Engagement prep, Look Ahead Always
 **Dependencies:** Calendar Agent (#1), Contact system (built), Knowledge graph (built).
 Scheduler (spec 07) needed for automated daily/weekly delivery. Partially usable
 without Scheduler via on-demand requests.
+
+**Value justification & redesign notes:**
+
+The original skill names (`briefing.daily`, `briefing.weekly-look-ahead`, etc.) implied
+the *skill* generates the briefing text. That's a downgrade — the LLM writes better
+prose than any templated skill. **Renamed to `gather-*`** to make the job clear: each
+skill is a data aggregation pipeline that assembles context from multiple APIs and the
+knowledge graph, then returns structured data. The *agent* (LLM) writes the briefing
+using that data, adapting format, tone, and emphasis to what actually matters that day.
+
+This also means briefing *format preferences* (e.g., "I want bullet points, not
+paragraphs" or "always lead with the most important meeting") should be stored as
+guidelines in the KG, retrievable by the agent when composing. The skills gather data;
+the agent follows guidelines to compose.
 
 ---
 
@@ -146,6 +248,27 @@ actual calendar operations.
 CEO Time & Speaking Engagements, Meeting Prep Checklist
 
 **Dependencies:** Calendar Agent (#1), Email channel (built), Outbound content filter (built)
+
+**Value justification & redesign notes:**
+
+- `meeting.propose-times` — **Justified.** Queries calendar availability via API. The LLM
+  can't read the calendar without this.
+- `meeting.send-request` — **Partially justified, needs redesign.** The sending part
+  (email API) is justified. But the skill should NOT compose the email. It should
+  retrieve the meeting-request email policy/guidelines from the KG, return them to the
+  agent, and let the LLM compose. Then the agent calls `email-send`. This skill may
+  collapse into just the guidelines retrieval.
+- `meeting.reschedule` / `meeting.cancel` — **Same redesign.** The calendar mutation and
+  email sending are justified API calls. The email composition is LLM work guided by
+  policies retrieved from the KG.
+- ~~`meeting.intake-request`~~ — **Removed as standalone skill.** Parsing inbound requests
+  and extracting structured fields is native LLM capability. The agent does this
+  in-context when it receives the email.
+- `meeting.coordinate` — **Justified.** Multi-turn state management across email exchanges
+  is genuinely complex orchestration that benefits from a skill tracking the state machine
+  (proposed → awaiting response → counter-proposed → confirmed).
+- `meeting.confirm` — **Justified.** Sends confirmation email with Zoom link, creates
+  calendar event. API bridge work.
 
 ---
 
@@ -178,6 +301,26 @@ calendar operations"). The Proactive Calendar Agent is cron-triggered with an ev
 prompt ("review the calendar and flag problems"). Different invocation patterns and
 cognitive modes warrant separate agents.
 
+**Value justification & redesign notes:**
+
+Most of these skills (detect-overload, detect-back-to-backs, missing-context, etc.)
+are **evaluation tasks** the LLM can do natively if given the calendar data. The skills
+are justified not because the detection logic is hard, but because:
+
+1. They run on a **schedule** (cron-triggered, no user prompt)
+2. They **fetch data** the LLM can't access without API tools (calendar events for the
+   next N days)
+3. They **route findings** through the bus to notify the CEO
+
+The skills should focus on data fetching and routing, not on implementing detection rules
+in code. The agent's system prompt defines what "overload" or "back-to-back" means; the
+LLM evaluates the data. The skill fetches the calendar window and returns it to the agent.
+
+Consider consolidating: instead of 6 separate detection skills, a single
+`proactive-cal.fetch-week` skill that returns the next 7 days of calendar data, and
+the agent's prompt tells it what to look for. The weekly-report skill is justified as
+a separate data aggregation pipeline.
+
 ---
 
 ### 7. Escalation Agent — `core`
@@ -198,19 +341,64 @@ portions only)
 **Dependencies:** Email (built), CLI (built). Slack channel and SMS/Signal would
 dramatically increase value. Minimal viable version works with email + CLI.
 
+**Value justification & redesign notes:**
+
+- ~~`escalation.assess-urgency`~~ — **Removed as standalone skill.** Urgency assessment
+  is LLM-native. The agent's system prompt defines the red/orange criteria from the
+  handbook; the LLM evaluates the situation in-context.
+- `escalation.notify-ceo` — **Justified.** Multi-channel notification is an API/bus
+  operation. The skill sends via available channels with escalating intensity.
+- `escalation.notify-backup` — **Justified.** Routing to backup contacts requires KG
+  lookup + notification. API bridge.
+- `escalation.log-attempt` — **Justified, but may not need a separate skill.** The audit
+  logger already captures all bus events. This skill is only justified if escalation logs
+  need a different format or destination than the standard audit trail. Consider whether
+  the bus audit hook already covers this.
+
 ---
 
-## Coordinator Template Skills — `core`
+## Coordinator Skills — `core`
 
-Skills the Coordinator (already built) uses directly, not attached to a specialized agent:
+Skills the Coordinator (already built) uses directly, not attached to a specialized agent.
+Split into two categories: email policy skills and knowledge skills.
+
+### Email Policy Skills
+
+These skills store and retrieve **composing guidelines** — not rigid fill-in-the-blanks
+templates. The LLM composes the actual email; the skill provides the organizational
+policy, required structural elements, tone constraints, and an example email as reference.
+
+The output of a `generate` call is a structured policy object the LLM uses as
+instructions, not a finished email. This is better than both hardcoded templates (rigid,
+can't adapt) and bare LLM behavior (no organizational consistency).
 
 | Skill | What it does | Handbook coverage |
 |---|---|---|
-| `template.meeting-request` | Generate meeting request email from handbook template | Meeting Request template (p.53) |
-| `template.reschedule` | Generate rescheduling email | Rescheduling template (p.54) |
-| `template.cancel` | Generate cancellation email | Canceling template (p.55) |
-| `template.doc-request` | Generate pre-meeting materials request | Requesting Docs template (p.55) |
-| `template.linkedin-response` | Generate LinkedIn-style connection response | LinkedIn Connection Responses (p.52) |
+| `template.meeting-request` | Retrieve meeting-request email policy (required elements, tone, structure, example) | Meeting Request template (p.53) |
+| `template.reschedule` | Retrieve rescheduling email policy | Rescheduling template (p.54) |
+| `template.cancel` | Retrieve cancellation email policy | Canceling template (p.55) |
+| `template.doc-request` | Retrieve pre-meeting materials request policy | Requesting Docs template (p.55) |
+
+Each skill supports three actions:
+- **`generate`** — returns the policy (checks KG for user-customized version first,
+  falls back to built-in defaults). The policy includes: required structural elements,
+  tone/formality guidelines, constraints, and an example email.
+- **`save`** — stores a custom policy in the knowledge graph, overriding the defaults.
+  The CEO can tell the agent "from now on, meeting requests should always mention my
+  assistant's availability too" and the agent saves that as a policy update.
+- **`reset`** — removes the custom policy and reverts to built-in defaults.
+
+~~`template.linkedin-response`~~ — **Removed.** LinkedIn API is too restrictive for
+automated use (noted in the "Not Addressed" section). A template for something we can't
+send is dead weight.
+
+### Knowledge Skills
+
+Structured, deterministic storage and retrieval. These are justified because the data
+must be stored and recalled *exactly* — not paraphrased by an LLM.
+
+| Skill | What it does | Handbook coverage |
+|---|---|---|
 | `knowledge.company-overview` | Store/retrieve company legal name, address, officers, board | Company Overview & Contact Lists (p.19-21) |
 | `knowledge.meeting-links` | Store/retrieve personal Zoom/Teams links for leadership | Virtual Meeting Access (p.32-33) |
 | `knowledge.travel-preferences` | Store/retrieve travel prefs (seat, airline, loyalty, baggage) | Travel Booking Preferences (p.37-38) |
@@ -232,24 +420,23 @@ intelligent, learns and anticipates.
 | Agent / Skill Group | Skills | Rationale |
 |---|---|---|
 | **Calendar Agent** | All 9 skills | Table stakes. An EA system without calendar management isn't an EA system. This is what gets people to try Curia. |
-| **Email Triage Agent** (basic) | `email.classify`, `email.label`, `email.surface-urgent`, `email.archive-resolved` | Basic triage is necessary for the system to be useful with email. People need to see Curia actually do something with their inbox. |
-| **Coordinator Template Skills** | All 9 skills | Templates, knowledge storage, meeting links - these are the "getting started" experience. Low cost to give away, high cost if missing. |
-| **Escalation Agent** | All 4 skills | Safety feature. If Curia handles email and calendar, it must be able to escalate urgent situations. Gating this behind a paywall would erode trust. |
+| **Email Triage Agent** (basic) | `email.label`, `email.surface-urgent`, `email.archive-resolved`, `email.batch-triage` | API bridges for inbox management. Classification and summarization are LLM-native — no skill needed for those. |
+| **Coordinator Skills** | 4 email policy + 4 knowledge = 8 skills | Email policies provide organizational consistency; knowledge skills store exact data. The "getting started" experience. |
+| **Escalation Agent** | `escalation.notify-ceo`, `escalation.notify-backup` (+ audit via bus) | Safety feature. Urgency assessment is LLM-native; notification routing needs API tools. |
 
-A self-hosted Curia with these four groups can manage a calendar, triage email at a
-basic level, store company knowledge, use templates, and escalate urgent items. That's
-a functional, if basic, AI EA - enough to build a community, attract contributors, and
+A self-hosted Curia with these four groups can manage a calendar, triage email,
+store company knowledge, follow email policies, and escalate urgent items. That's
+a functional, if basic, AI EA — enough to build a community, attract contributors, and
 create a funnel.
 
 ### Paid SaaS Tier
 
 | Agent / Skill Group | Skills | Rationale |
 |---|---|---|
-| **Executive Profile Agent** | All 6 skills | Highest-value differentiator. Voice analysis, preference learning, draft validation - this is what makes Curia feel like *your* EA rather than a generic assistant. Hard to replicate well with self-hosting because it needs tuning and operational refinement. |
-| **Briefing Agent** | All 5 skills | Daily and weekly briefings create a habit. The CEO opens Curia's briefing every morning. Habit-forming features drive retention and make churn painful. |
-| **Meeting Coordinator** | All 7 skills | Multi-turn email coordination is operationally complex, high LLM cost (many turns per meeting), and high-value. This is where Curia saves the most time. |
-| **Proactive Calendar Agent** | All 7 skills | The "exceed human EA" agent. Proactive features are the clearest paid-tier differentiator - Curia doing things the CEO didn't ask for. Reactive is free. Proactive is premium. |
-| **Email Triage Agent** (advanced) | `email.extract-actions`, `email.summarize-thread` | Intelligence-heavy features that cost more LLM tokens and provide significantly more value than basic classification. |
+| **Executive Profile Agent** | 5 skills (analyze-voice, validate-draft, update/get-preferences, executive-snapshot) | Highest-value differentiator. Voice analysis, preference learning, draft validation — this is what makes Curia feel like *your* EA. Batch analysis + persistence are the value, not LLM-native tasks repackaged. |
+| **Briefing Agent** | 5 `gather-*` skills | Data aggregation pipelines. The LLM writes the briefing; the skills assemble the data from calendar + contacts + KG. Habit-forming daily/weekly delivery drives retention. |
+| **Meeting Coordinator** | 5 skills (propose-times, reschedule, cancel, coordinate, confirm) | Multi-turn email coordination is operationally complex. API bridges + state machine orchestration. High time-saving value. |
+| **Proactive Calendar Agent** | 2 skills (fetch-week, weekly-report) + agent prompt | The "exceed human EA" agent. Consolidated from 7 skills to 2 data-fetching skills — the LLM evaluates the data, the prompt defines what to look for. Proactive is premium. |
 
 ### Tier Comparison
 
@@ -294,32 +481,34 @@ when the paid tier is ready to ship.
 | Rank | Agent | Tier | Handbook Domains Covered | Effort | Dependencies | Notes |
 |---|---|---|---|---|---|---|
 | **1** | **Calendar Agent** (9 skills) | core | Calendar Mgmt, Meeting Setup, Focus Time, Travel Blocks, Board Scheduling, Calendar Hygiene | **Large** (2-3 weeks) | Google Calendar API OAuth | Unlocks agents #4, #5, #6. Build first. |
-| **2** | **Email Triage Agent** (6 skills) | core/paid | Email Inbox Mgmt, Label System, Daily Triage, Drafting | **Medium** (1-2 weeks) | Email channel (built), Nylas label API | 4 basic skills core, 2 advanced skills paid. |
-| **3** | **Executive Profile Agent** (6 skills) | paid | Exec Snapshot, Learning Preferences, Voice Matching, Drafting Quality | **Medium** (1-2 weeks) | Email channel (built), Knowledge graph (built) | Voice analysis is a force multiplier for all outbound skills. |
-| **4** | **Briefing Agent** (5 skills) | paid | Daily Briefing, Weekly Look-ahead, Meeting Prep, Travel Itinerary, Board Prep | **Medium** (1-2 weeks) | Calendar Agent (#1), Scheduler (spec 07) | High CEO-perceived value. Partially usable without Scheduler. |
-| **5** | **Meeting Coordinator** (7 skills) | paid | Meeting Requests, Rescheduling, Cancellation, CEO Time Requests, Speaking Engagements | **Large** (2-3 weeks) | Calendar Agent (#1), Email channel (built) | Multi-turn coordination is complex. High time-saving value. |
-| **6** | **Coordinator template skills** (9 skills) | core | Email templates, Company Knowledge, Meeting Links, Travel Prefs | **Small** (3-5 days) | Knowledge graph (built) | Low effort, fills gaps immediately. Build in parallel with anything. |
-| **7** | **Proactive Calendar Agent** (7 skills) | paid | Look Ahead, Focus Time, Calendar Hygiene, Back-to-back Detection | **Medium** (1-2 weeks) | Calendar Agent (#1), Scheduler (spec 07) | Highest "exceed human EA" potential. Blocked on Scheduler. |
-| **8** | **Escalation Agent** (4 skills) | core | Urgent Comms Plan (digital portions) | **Small-Medium** (1 week) | Needs Slack channel for real value | MVP with email+CLI is small. Full value needs more channels. |
+| **2** | **Email Triage Agent** (4 skills) | core | Email Inbox Mgmt, Label System, Daily Triage | **Medium** (1-2 weeks) | Email channel (built), Nylas label API | Classification/summarization are LLM-native — only API bridges here. |
+| **3** | **Executive Profile Agent** (5 skills) | paid | Exec Snapshot, Learning Preferences, Voice Matching, Drafting Quality | **Medium** (1-2 weeks) | Email channel (built), Knowledge graph (built) | Voice analysis is a force multiplier for all outbound skills. |
+| **4** | **Briefing Agent** (5 `gather-*` skills) | paid | Daily Briefing, Weekly Look-ahead, Meeting Prep, Travel Itinerary, Board Prep | **Medium** (1-2 weeks) | Calendar Agent (#1), Scheduler (spec 07) | Data aggregation pipelines. LLM composes; skills assemble. |
+| **5** | **Meeting Coordinator** (5 skills) | paid | Meeting Requests, Rescheduling, Cancellation, Speaking Engagements | **Large** (2-3 weeks) | Calendar Agent (#1), Email channel (built) | Multi-turn coordination is complex. Intake parsing is LLM-native. |
+| **6** | **Coordinator skills** (8 skills) | core | Email policies, Company Knowledge, Meeting Links, Travel Prefs | **Small** (3-5 days) | Knowledge graph (built) | Low effort, fills gaps immediately. Build in parallel with anything. |
+| **7** | **Proactive Calendar Agent** (2 skills + agent prompt) | paid | Look Ahead, Focus Time, Calendar Hygiene, Back-to-back Detection | **Small-Medium** (1 week) | Calendar Agent (#1), Scheduler (spec 07) | Consolidated: data-fetching skills + evaluative prompt. |
+| **8** | **Escalation Agent** (2 skills) | core | Urgent Comms Plan (digital portions) | **Small** (3-5 days) | Needs Slack channel for real value | Urgency assessment is LLM-native. Skills handle notification routing. |
 
 ---
 
 ## Recommended Build Phases
 
 ```
-Phase A (foundation):  Calendar Agent + Coordinator template skills
+Phase A (foundation):  Calendar Agent + Coordinator skills (email policies + knowledge)
 Phase B (intelligence): Email Triage Agent + Executive Profile Agent
 Phase C (automation):   Briefing Agent + Meeting Coordinator
 Phase D (proactive):    Proactive Calendar Agent + Escalation Agent
 ```
 
-Phase A unlocks everything downstream. The template skills are low-effort gap-fillers
-that can ship alongside Calendar Agent work. Phase B makes Curia "smart" about email
-and voice. Phase C is where Curia starts saving the CEO real time. Phase D is where it
-starts anticipating needs before being asked.
+Phase A unlocks everything downstream. The coordinator skills (email policies and
+knowledge storage) are low-effort, high-value foundations that can ship alongside
+Calendar Agent work. Phase B makes Curia "smart" about email and voice. Phase C is
+where Curia starts saving the CEO real time. Phase D is where it starts anticipating
+needs before being asked.
 
-**Totals: 7 agents + 1 skill group = 53 skills covering ~85% of the handbook's
-actionable domains.**
+**Totals: 7 agents + 1 skill group = ~38 skills covering ~85% of the handbook's
+actionable domains.** (Down from 53 in the original plan — 15 skills removed as
+LLM-native capabilities that don't benefit from being wrapped in a skill.)
 
 ---
 

--- a/docs/plans/2026-03-29-ea-handbook-agent-plan.md
+++ b/docs/plans/2026-03-29-ea-handbook-agent-plan.md
@@ -63,6 +63,60 @@ Skills that fail this test should be **removed or redesigned**:
   as a standalone skill — the LLM does this in-context. Only justify it if it runs as a
   background batch job where the LLM isn't already in the conversation.
 
+### Design Principle: Future-Proof for LLM Upgrades
+
+Skills should be designed so that improvements in the underlying LLM automatically
+improve the system — without code changes. This means:
+
+**Skills provide data, context, and constraints — never intelligence.**
+
+1. **Richer context → better output.** As LLMs become better at utilizing large contexts,
+   skills that assemble more relevant context (contact history, preferences, past
+   interactions, audience-specific patterns) will produce proportionally better results.
+   Design skills to gather and surface *more* context than the current LLM can fully
+   exploit — the next model will use it.
+
+2. **Better instruction following → policies become more valuable.** Structured guidelines
+   (required elements, tone, constraints) work better with each model generation. Invest
+   in policy richness — audience-level variants, conditional rules, voice model
+   integration — because the LLM's ability to follow them faithfully will only improve.
+
+3. **Better multi-step reasoning → composable primitives.** As LLMs improve at tool
+   orchestration, small, composable skills become more powerful than monolithic ones.
+   Design skills as primitives that the LLM chains together, not as pre-wired workflows
+   the LLM merely triggers.
+
+4. **Never embed intelligence in skill code.** If the skill contains `if/else` logic that
+   makes a judgment call (classifying, prioritizing, summarizing, deciding), that logic
+   will be *worse* than the LLM at the time of writing and will fall further behind as
+   models improve. Move judgments to the agent's prompt; keep skills as data plumbing.
+
+5. **Design for feedback loops.** Static skills improve only when a developer ships a code
+   change. Skills that accept natural-language refinement ("make these more casual",
+   "always include my assistant's availability") improve continuously from user
+   interaction. Every skill that stores policy or preferences should support incremental
+   refinement, not just wholesale replacement.
+
+These principles apply to all future agent and skill development, not just the skills
+in this plan.
+
+### Design Principle: Skills Must Compose
+
+A skill that operates in isolation forces the LLM to orchestrate multiple tool calls to
+assemble context. This wastes turns, burns tokens, and creates fragile multi-step
+sequences where any failure breaks the chain.
+
+**Context assembly skills** bridge this gap. Given a task context (e.g., "I'm writing a
+meeting request to Alice"), a context assembly skill gathers everything relevant in a
+single call: email policy + contact info + meeting link + audience preferences + last
+interaction. The LLM gets complete context in one response, composes in the next.
+
+Rules for composability:
+- Knowledge skills should be callable by other skills (via shared EntityMemory access)
+- Context assembly skills should aggregate across knowledge skills, contacts, and KG
+- No skill should require the output of another skill as a *string* input — use shared
+  backing stores (KG, contact service) instead
+
 ---
 
 ## Proposed Agents
@@ -403,6 +457,74 @@ must be stored and recalled *exactly* — not paraphrased by an LLM.
 | `knowledge.meeting-links` | Store/retrieve personal Zoom/Teams links for leadership | Virtual Meeting Access (p.32-33) |
 | `knowledge.travel-preferences` | Store/retrieve travel prefs (seat, airline, loyalty, baggage) | Travel Booking Preferences (p.37-38) |
 | `knowledge.loyalty-programs` | Store/retrieve airline/hotel loyalty numbers | Travel Booking Info (p.38-39) |
+
+### Context Assembly Skill
+
+A single skill that bridges the gap between siloed knowledge and the LLM's need for
+complete context in one call.
+
+| Skill | What it does | Handbook coverage |
+|---|---|---|
+| `context.for-email` | Given an email type and recipient, assemble: email policy + contact info + meeting link (if on file) + audience preferences + last interaction from KG. Returns everything the LLM needs to compose in one call. | Cross-cutting: supports all email-generating tasks |
+
+This skill exists because the alternative — the LLM making 4-5 sequential tool calls
+to gather context — is fragile, token-expensive, and gets worse as the number of
+knowledge sources grows. The skill does the plumbing; the LLM does the thinking.
+
+### Known Gaps and Planned Improvements
+
+**These are known limitations of the current Coordinator Skills implementation.** They
+are documented here so future development addresses them intentionally rather than
+rediscovering them.
+
+#### Email Policy Skills
+
+1. **Policies are static without a feedback loop.** Once set, they don't evolve from
+   usage. The CEO rewrites 20 meeting request emails to be shorter — the system
+   learns nothing. **Mitigation (implemented):** The `update` action accepts
+   natural-language refinements ("make these less formal", "always mention my
+   assistant can help with scheduling") and merges them into the existing policy.
+   The skill uses the LLM to interpret the refinement and update the structured policy.
+
+2. **Policies are audience-blind.** One policy for every recipient. Board chairs,
+   engineering partners, and vendors all get emails shaped by the same guidelines.
+   **Future:** Support audience-tagged policy variants. The policy resolution checks
+   for audience-level overrides (by role, relationship type, or specific contact)
+   before falling back to the general policy. Requires the contact system to carry
+   audience metadata.
+
+3. **Example emails are frozen fiction.** They don't reflect the CEO's actual voice.
+   **Future:** When the Executive Profile Agent ships, the template skills should pull
+   the CEO's voice model into the guidelines automatically. Example emails should be
+   *regenerated from the voice model*, not static strings. This is a dependency on
+   the Profile Agent — design the policy structure to accept a `voice_model_id` field
+   now so the integration is mechanical later.
+
+4. **No version history.** After updating a policy 5 times, there's no way to see what
+   it looked like before or roll back a bad change. **Future:** Store policy versions
+   as separate fact nodes with timestamps, and add a `history` action that returns
+   past versions. Low priority but useful for trust-building ("show me what changed").
+
+#### Knowledge Skills
+
+5. **They're a flat key-value store.** The knowledge graph supports semantic search,
+   relationship traversal, and cross-entity connections. The knowledge skills use none
+   of this — they store facts by exact label and retrieve by exact label.
+   **Future:** Add semantic search to the retrieve action so "airline preferences" finds
+   "preferred_airline" and "frequent_flyer" without exact label matches.
+
+6. **No freshness tracking.** Meeting links get rotated, loyalty tiers change, company
+   officers turn over. There's no mechanism to flag stale data or prompt
+   re-confirmation. **Future:** Use the temporal metadata (lastConfirmedAt) to surface
+   "this was last confirmed 6 months ago — is it still current?" warnings when facts
+   are retrieved. The decay classes are already in the data model; the skills just
+   don't read them yet.
+
+7. **No cross-referencing.** Travel preferences, loyalty programs, meeting links, and
+   company info live in separate anchor nodes with no edges between them.
+   **Mitigation (implemented):** The `context.for-email` assembly skill bridges this
+   gap for email composition. **Future:** Extend the pattern to other task types
+   (travel planning, meeting prep, board engagement).
 
 ---
 

--- a/skills/_shared/template-base.ts
+++ b/skills/_shared/template-base.ts
@@ -1,0 +1,258 @@
+// template-base.ts — shared logic for all email policy template skills.
+//
+// Each template skill (meeting-request, reschedule, cancel, doc-request)
+// follows the same pattern: store/retrieve email composing guidelines from
+// the knowledge graph, with support for natural-language refinements.
+//
+// This module provides the common implementation. Individual skill handlers
+// extend it with their specific default policy and input validation.
+//
+// KG storage model (per template type):
+//   - Anchor node: type=concept, label=TEMPLATE_LABEL
+//   - Base policy: fact node with label="email policy"
+//   - Refinements: fact nodes with label="policy refinement: <timestamp>"
+//   - Clear marker: fact node with label="refinements cleared"
+//   - All decayClass=permanent
+
+import type { SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
+
+/** Build the email signature from the agent persona, or a safe fallback. */
+export function resolveSignature(persona?: AgentPersona): string {
+  if (persona?.emailSignature) return persona.emailSignature;
+  if (persona) return `${persona.displayName}, ${persona.title}`;
+  return '';
+}
+
+/**
+ * Save a complete custom policy, replacing the existing one.
+ */
+export async function savePolicy(
+  ctx: SkillContext,
+  templateLabel: string,
+  skillSource: string,
+): Promise<SkillResult> {
+  const { custom_policy } = ctx.input as { custom_policy?: string };
+  if (!custom_policy || typeof custom_policy !== 'string') {
+    return { success: false, error: 'Missing required input: custom_policy (a JSON string describing the email policy, or plain-text guidelines)' };
+  }
+  if (custom_policy.length > 10000) {
+    return { success: false, error: 'custom_policy must be 10000 characters or fewer' };
+  }
+  if (!ctx.entityMemory) {
+    return { success: false, error: 'Knowledge graph not available — cannot save custom policy' };
+  }
+
+  try {
+    const anchorId = await findOrCreateAnchor(ctx, templateLabel, skillSource);
+    await ctx.entityMemory.storeFact({
+      entityNodeId: anchorId,
+      label: 'email policy',
+      properties: { policy: custom_policy },
+      confidence: 1.0,
+      decayClass: 'permanent',
+      source: skillSource,
+    });
+    ctx.log.info('Saved custom email policy to knowledge graph');
+    return { success: true, data: { saved: true } };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    ctx.log.error({ err }, 'Failed to save custom policy');
+    return { success: false, error: `Failed to save policy: ${message}` };
+  }
+}
+
+/**
+ * Accept a natural-language refinement and store it as an additive adjustment.
+ * Refinements accumulate — each one is preserved independently so the
+ * compose-time LLM can see the full history of adjustments.
+ *
+ * Examples: "make these less formal", "always mention my assistant can help"
+ */
+export async function updatePolicy(
+  ctx: SkillContext,
+  templateLabel: string,
+  skillSource: string,
+): Promise<SkillResult> {
+  const { refinement } = ctx.input as { refinement?: string };
+  if (!refinement || typeof refinement !== 'string') {
+    return { success: false, error: 'Missing required input: refinement (a natural-language instruction describing how to adjust the email policy)' };
+  }
+  if (refinement.length > 2000) {
+    return { success: false, error: 'refinement must be 2000 characters or fewer' };
+  }
+  if (!ctx.entityMemory) {
+    return { success: false, error: 'Knowledge graph not available — cannot store policy refinement' };
+  }
+
+  try {
+    const anchorId = await findOrCreateAnchor(ctx, templateLabel, skillSource);
+
+    // Each refinement gets a unique label so they accumulate rather than
+    // overwriting each other via storeFact's dedup logic.
+    const timestamp = new Date().toISOString();
+    await ctx.entityMemory.storeFact({
+      entityNodeId: anchorId,
+      label: `policy refinement: ${timestamp}`,
+      properties: { refinement, addedAt: timestamp },
+      confidence: 1.0,
+      decayClass: 'permanent',
+      source: skillSource,
+    });
+
+    ctx.log.info({ refinement }, 'Stored policy refinement');
+    return { success: true, data: { updated: true, refinement } };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    ctx.log.error({ err }, 'Failed to store policy refinement');
+    return { success: false, error: `Failed to store refinement: ${message}` };
+  }
+}
+
+/**
+ * Reset clears both the custom base policy and all accumulated refinements.
+ */
+export async function resetPolicy(
+  ctx: SkillContext,
+  templateLabel: string,
+  skillSource: string,
+): Promise<SkillResult> {
+  if (!ctx.entityMemory) {
+    return { success: true, data: { reset: true } };
+  }
+
+  try {
+    const existing = await ctx.entityMemory.findEntities(templateLabel);
+    if (existing.length > 0) {
+      const facts = await ctx.entityMemory.getFacts(existing[0]!.id);
+      if (facts.length > 0) {
+        await ctx.entityMemory.storeFact({
+          entityNodeId: existing[0]!.id,
+          label: 'email policy',
+          properties: { policy: '', cleared: true },
+          confidence: 1.0,
+          decayClass: 'permanent',
+          source: skillSource,
+        });
+        // Mark all existing refinements as cleared — resolvePolicy will
+        // ignore refinements with addedAt before this timestamp.
+        await ctx.entityMemory.storeFact({
+          entityNodeId: existing[0]!.id,
+          label: 'refinements cleared',
+          properties: { clearedAt: new Date().toISOString() },
+          confidence: 1.0,
+          decayClass: 'permanent',
+          source: skillSource,
+        });
+      }
+    }
+
+    ctx.log.info('Reset email policy and refinements to default');
+    return { success: true, data: { reset: true } };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    ctx.log.error({ err }, 'Failed to reset policy');
+    return { success: false, error: `Failed to reset policy: ${message}` };
+  }
+}
+
+/**
+ * Look up the email policy from the knowledge graph.
+ *
+ * Returns the base policy (custom or default) plus any accumulated
+ * refinements. Refinements added before the last "reset" are ignored.
+ */
+export async function resolvePolicy(
+  ctx: SkillContext,
+  templateLabel: string,
+  defaultPolicy: unknown,
+): Promise<{ policy: unknown; source: 'default' | 'custom' | 'refined' }> {
+  if (!ctx.entityMemory) {
+    return { policy: defaultPolicy, source: 'default' };
+  }
+
+  try {
+    const nodes = await ctx.entityMemory.findEntities(templateLabel);
+    if (nodes.length === 0) {
+      return { policy: defaultPolicy, source: 'default' };
+    }
+
+    const facts = await ctx.entityMemory.getFacts(nodes[0]!.id);
+
+    // Resolve the base policy (custom or default)
+    let basePolicy: unknown = defaultPolicy;
+    let hasCustomBase = false;
+
+    const policyFact = facts
+      .filter((f) => f.label === 'email policy')
+      .sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
+
+    if (policyFact) {
+      const rawPolicy = policyFact.properties.policy;
+      if (typeof rawPolicy === 'string' && rawPolicy.length > 0 && !policyFact.properties.cleared) {
+        hasCustomBase = true;
+        try {
+          basePolicy = JSON.parse(rawPolicy) as unknown;
+        } catch {
+          basePolicy = { custom_guidelines: rawPolicy, note: 'Custom guidelines that override the default policy.' };
+        }
+      }
+    }
+
+    // Check if refinements were cleared
+    const clearedFact = facts
+      .filter((f) => f.label === 'refinements cleared')
+      .sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
+    const clearedAt = clearedFact?.properties.clearedAt
+      ? new Date(clearedFact.properties.clearedAt as string).getTime()
+      : 0;
+
+    // Gather refinements added after the last clear, oldest-first
+    const refinements = facts
+      .filter((f) => {
+        if (!f.label.startsWith('policy refinement:')) return false;
+        const addedAt = f.properties.addedAt
+          ? new Date(f.properties.addedAt as string).getTime()
+          : f.temporal.createdAt.getTime();
+        return addedAt > clearedAt;
+      })
+      .sort((a, b) => a.temporal.createdAt.getTime() - b.temporal.createdAt.getTime())
+      .map((f) => f.properties.refinement as string);
+
+    if (refinements.length > 0) {
+      return {
+        policy: {
+          base_policy: basePolicy,
+          refinements,
+          note: 'The base_policy defines the structural guidelines. The refinements are user-requested adjustments listed in chronological order — apply them all when composing. If a refinement contradicts the base policy, the refinement takes priority.',
+        },
+        source: 'refined',
+      };
+    }
+
+    return {
+      policy: basePolicy,
+      source: hasCustomBase ? 'custom' : 'default',
+    };
+  } catch (err) {
+    ctx.log.warn({ err }, 'Failed to look up custom policy, using default');
+    return { policy: defaultPolicy, source: 'default' };
+  }
+}
+
+/** Find or create the anchor node for a template type. */
+async function findOrCreateAnchor(
+  ctx: SkillContext,
+  templateLabel: string,
+  skillSource: string,
+): Promise<string> {
+  const existing = await ctx.entityMemory!.findEntities(templateLabel);
+  if (existing.length > 0) return existing[0]!.id;
+
+  const anchor = await ctx.entityMemory!.createEntity({
+    type: 'concept',
+    label: templateLabel,
+    properties: { category: 'email-policy' },
+    source: skillSource,
+  });
+  return anchor.id;
+}

--- a/skills/context-for-email/handler.ts
+++ b/skills/context-for-email/handler.ts
@@ -1,0 +1,217 @@
+// handler.ts — context-for-email skill implementation.
+//
+// Assembles complete context for composing an email in a single call.
+// Bridges the gap between siloed knowledge and the LLM's need for complete
+// context in one response. Instead of the LLM making 4-5 sequential tool
+// calls (template policy + contact lookup + meeting link + etc.), this skill
+// gathers everything relevant in one call.
+//
+// This is an infrastructure skill because it needs:
+//   - entityMemory (to resolve email policies and meeting links from KG)
+//   - contactService (to look up recipient contact info)
+
+import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
+import { resolveSignature, resolvePolicy } from '../_shared/template-base.js';
+
+// Map email_type input values to KG template labels
+const TYPE_TO_LABEL: Record<string, string> = {
+  'meeting-request': 'template:meeting-request',
+  'reschedule': 'template:reschedule',
+  'cancel': 'template:cancel',
+  'doc-request': 'template:doc-request',
+};
+
+// Default policies for each email type — imported inline to avoid circular deps.
+// These are the same defaults defined in each template skill handler.
+// TODO: extract default policies into a shared constants file to avoid this duplication.
+const DEFAULT_POLICIES: Record<string, unknown> = {
+  'meeting-request': {
+    required_elements: [
+      'Greeting addressing the recipient by name',
+      'State who is requesting the meeting and the purpose',
+      'List proposed times as bullet points',
+      'Include duration and location if provided',
+      'Offer flexibility for alternative times',
+      'Professional sign-off with the agent signature',
+    ],
+    tone: 'Professional, warm, and concise.',
+    structure: 'Greeting → purpose → proposed times → logistics → flexibility offer → sign-off',
+    constraints: ['Keep to 4-6 sentences plus time list', 'No exclamation marks', 'Subject includes meeting purpose'],
+  },
+  'reschedule': {
+    required_elements: [
+      'Greeting addressing the recipient by name',
+      'Reference the original meeting time',
+      'Brief reason for rescheduling if provided',
+      'List new proposed times as bullet points',
+      'Invite alternatives',
+      'Brief apology',
+      'Professional sign-off',
+    ],
+    tone: 'Apologetic but confident.',
+    structure: 'Greeting → reference original → reason → new times → flexibility → apology → sign-off',
+    constraints: ['Keep to 4-6 sentences plus time list', 'Subject includes "Rescheduling"', 'Do not blame anyone'],
+  },
+  'cancel': {
+    required_elements: [
+      'Greeting addressing the recipient by name',
+      'Reference the specific meeting being canceled',
+      'Brief reason if provided',
+      'Offer to reschedule unless told not to',
+      'Thanks for understanding',
+      'Professional sign-off',
+    ],
+    tone: 'Respectful and direct.',
+    structure: 'Greeting → identify meeting → cancellation → reason → reschedule offer → thanks → sign-off',
+    constraints: ['Keep to 3-5 sentences', 'Subject includes "Cancellation"', 'One apology max'],
+  },
+  'doc-request': {
+    required_elements: [
+      'Greeting addressing the recipient by name',
+      'Reference upcoming meeting',
+      'Purpose — helping sender prepare',
+      'List requested documents as bullet points',
+      'Deadline if provided',
+      'Offer to clarify',
+      'Professional sign-off',
+    ],
+    tone: 'Polite and helpful. Frame as enabling a productive meeting.',
+    structure: 'Greeting → meeting reference → purpose → document list → deadline → clarify offer → sign-off',
+    constraints: ['Keep to 4-6 sentences plus materials list', 'Subject includes "Materials Needed"', 'Polite deadline framing'],
+  },
+};
+
+const MEETING_LINKS_LABEL = 'meeting-links';
+
+export class ContextForEmailHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { email_type, recipient_name } = ctx.input as {
+      email_type?: string;
+      recipient_name?: string;
+    };
+
+    if (!email_type || !TYPE_TO_LABEL[email_type]) {
+      return { success: false, error: `Missing or invalid email_type — must be one of: ${Object.keys(TYPE_TO_LABEL).join(', ')}` };
+    }
+    if (!recipient_name || typeof recipient_name !== 'string') {
+      return { success: false, error: 'Missing required input: recipient_name' };
+    }
+    if (recipient_name.length > 500) {
+      return { success: false, error: 'recipient_name must be 500 characters or fewer' };
+    }
+
+    const templateLabel = TYPE_TO_LABEL[email_type]!;
+    const defaultPolicy = DEFAULT_POLICIES[email_type]!;
+
+    // Gather all context in parallel where possible
+    const [policyResult, recipientResult, meetingLinkResult] = await Promise.all([
+      // 1. Email composing guidelines (policy + refinements)
+      resolvePolicy(ctx, templateLabel, defaultPolicy),
+      // 2. Recipient contact info (if contact service is available)
+      this.lookupRecipient(ctx, recipient_name),
+      // 3. Recipient's meeting link (if on file in KG)
+      this.lookupMeetingLink(ctx, recipient_name),
+    ]);
+
+    // Assemble the recipient object
+    const recipient: Record<string, unknown> = {};
+    if (recipientResult) {
+      recipient.display_name = recipientResult.displayName;
+      if (recipientResult.role) recipient.role = recipientResult.role;
+      if (recipientResult.email) recipient.email = recipientResult.email;
+    }
+    if (meetingLinkResult) {
+      recipient.meeting_link = meetingLinkResult;
+    }
+
+    const agentSignature = resolveSignature(ctx.agentPersona);
+
+    ctx.log.info(
+      { email_type, recipient_name, policySource: policyResult.source, hasContact: !!recipientResult, hasMeetingLink: !!meetingLinkResult },
+      'Assembled email context',
+    );
+
+    return {
+      success: true,
+      data: {
+        guidelines: policyResult.policy,
+        guidelines_source: policyResult.source,
+        recipient: Object.keys(recipient).length > 0 ? recipient : null,
+        agent_signature: agentSignature,
+        instructions: `Use the guidelines to compose a ${email_type} email. The recipient field contains any known contact info and meeting link — use it naturally in the email (e.g., include their meeting link if scheduling a video call). If refinements are present in the guidelines, apply them. Adapt naturally — do not copy any example verbatim.`,
+      },
+    };
+  }
+
+  /**
+   * Look up recipient contact info via the contact service.
+   * Uses findContactByName for partial name matching, then fetches
+   * identities to find their email address.
+   * Returns null if not found or contact service is unavailable.
+   */
+  private async lookupRecipient(
+    ctx: SkillContext,
+    recipientName: string,
+  ): Promise<{ displayName: string; role?: string; email?: string } | null> {
+    if (!ctx.contactService) return null;
+
+    try {
+      const contacts = await ctx.contactService.findContactByName(recipientName);
+      if (contacts.length === 0) return null;
+
+      const contact = contacts[0]!;
+      // Fetch identities to find their email address
+      const withIdentities = await ctx.contactService.getContactWithIdentities(contact.id);
+      let email: string | undefined;
+      if (withIdentities) {
+        const emailIdentity = withIdentities.identities.find(
+          (id) => id.channel === 'email',
+        );
+        if (emailIdentity) email = emailIdentity.channelIdentifier;
+      }
+
+      return {
+        displayName: contact.displayName,
+        role: contact.role ?? undefined,
+        email,
+      };
+    } catch (err) {
+      // Contact lookup failure is non-fatal — we just won't have contact info
+      ctx.log.debug({ err, recipientName }, 'Contact lookup failed during context assembly');
+      return null;
+    }
+  }
+
+  /**
+   * Look up the recipient's meeting link from the knowledge graph.
+   * Returns the link string if found, null otherwise.
+   */
+  private async lookupMeetingLink(
+    ctx: SkillContext,
+    recipientName: string,
+  ): Promise<string | null> {
+    if (!ctx.entityMemory) return null;
+
+    try {
+      const nodes = await ctx.entityMemory.findEntities(MEETING_LINKS_LABEL);
+      if (nodes.length === 0) return null;
+
+      // Search across all meeting-links anchors for a matching person name
+      const allFacts = await Promise.all(nodes.map((n) => ctx.entityMemory!.getFacts(n.id)));
+      const lowerName = recipientName.toLowerCase();
+
+      for (const fact of allFacts.flat()) {
+        const personName = fact.properties.person_name;
+        if (typeof personName === 'string' && personName.toLowerCase().includes(lowerName)) {
+          const link = fact.properties.link;
+          if (typeof link === 'string') return link;
+        }
+      }
+
+      return null;
+    } catch (err) {
+      ctx.log.debug({ err, recipientName }, 'Meeting link lookup failed during context assembly');
+      return null;
+    }
+  }
+}

--- a/skills/context-for-email/skill.json
+++ b/skills/context-for-email/skill.json
@@ -1,0 +1,21 @@
+{
+  "name": "context-for-email",
+  "description": "Assemble complete context for composing an email in a single call. Given an email type (meeting-request, reschedule, cancel, doc-request) and a recipient name, this skill gathers: (1) the email composing policy/guidelines for that email type, (2) the recipient's contact info and meeting link if on file, (3) the agent signature. Returns everything the LLM needs to compose the email without additional tool calls. Use this instead of calling template and knowledge skills separately.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "email_type": "string (meeting-request | reschedule | cancel | doc-request)",
+    "recipient_name": "string (the recipient's name — used to look up contact info and meeting link)"
+  },
+  "outputs": {
+    "guidelines": "object (the email policy for this email type)",
+    "guidelines_source": "string (default | custom | refined)",
+    "recipient": "object? (contact info if found: display_name, role, email, meeting_link)",
+    "agent_signature": "string",
+    "instructions": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/skills/knowledge-company-overview/handler.ts
+++ b/skills/knowledge-company-overview/handler.ts
@@ -1,0 +1,110 @@
+// handler.ts — knowledge-company-overview skill implementation.
+//
+// Stores and retrieves company overview information (legal name, address,
+// officers, board members, etc.) in the knowledge graph.
+//
+// KG storage model:
+//   - Anchor node: type=organization, label="company-overview"
+//   - Each field stored as a fact node with label=field name,
+//     properties.value=field value
+//   - decayClass=permanent (company info doesn't decay)
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+const ANCHOR_LABEL = 'company-overview';
+
+export class KnowledgeCompanyOverviewHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { action } = ctx.input as { action?: string };
+
+    if (!action || !['store', 'retrieve'].includes(action)) {
+      return { success: false, error: "Missing or invalid 'action' — must be 'store' or 'retrieve'" };
+    }
+
+    if (!ctx.entityMemory) {
+      return { success: false, error: 'Knowledge graph not available — cannot store or retrieve company information' };
+    }
+
+    if (action === 'store') {
+      return this.store(ctx);
+    }
+    return this.retrieve(ctx);
+  }
+
+  private async store(ctx: SkillContext): Promise<SkillResult> {
+    const { field, value } = ctx.input as { field?: string; value?: string };
+
+    if (!field || typeof field !== 'string') {
+      return { success: false, error: 'Missing required input: field' };
+    }
+    if (!value || typeof value !== 'string') {
+      return { success: false, error: 'Missing required input: value' };
+    }
+    if (field.length > 200) {
+      return { success: false, error: 'field must be 200 characters or fewer' };
+    }
+    if (value.length > 5000) {
+      return { success: false, error: 'value must be 5000 characters or fewer' };
+    }
+
+    try {
+      const anchor = await this.findOrCreateAnchor(ctx);
+
+      await ctx.entityMemory!.storeFact({
+        entityNodeId: anchor.id,
+        label: field,
+        properties: { value, field },
+        confidence: 1.0,
+        decayClass: 'permanent',
+        source: 'skill:knowledge-company-overview',
+      });
+
+      ctx.log.info({ field }, 'Stored company overview fact');
+      return { success: true, data: { stored: true, field } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, field }, 'Failed to store company overview fact');
+      return { success: false, error: `Failed to store: ${message}` };
+    }
+  }
+
+  private async retrieve(ctx: SkillContext): Promise<SkillResult> {
+    try {
+      const nodes = await ctx.entityMemory!.findEntities(ANCHOR_LABEL);
+      if (nodes.length === 0) {
+        return {
+          success: true,
+          data: { facts: [], message: 'No company overview information stored yet.' },
+        };
+      }
+
+      const factNodes = await ctx.entityMemory!.getFacts(nodes[0]!.id);
+      const facts = factNodes.map((f) => ({
+        field: f.properties.field ?? f.label,
+        value: f.properties.value,
+        last_updated: f.temporal.lastConfirmedAt.toISOString(),
+      }));
+
+      ctx.log.info({ factCount: facts.length }, 'Retrieved company overview facts');
+      return { success: true, data: { facts } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to retrieve company overview');
+      return { success: false, error: `Failed to retrieve: ${message}` };
+    }
+  }
+
+  private async findOrCreateAnchor(ctx: SkillContext) {
+    const existing = await ctx.entityMemory!.findEntities(ANCHOR_LABEL);
+    if (existing.length > 0) {
+      return existing[0]!;
+    }
+
+    return ctx.entityMemory!.createEntity({
+      type: 'organization',
+      label: ANCHOR_LABEL,
+      properties: { category: 'company-knowledge' },
+      source: 'skill:knowledge-company-overview',
+    });
+  }
+}

--- a/skills/knowledge-company-overview/handler.ts
+++ b/skills/knowledge-company-overview/handler.ts
@@ -78,8 +78,10 @@ export class KnowledgeCompanyOverviewHandler implements SkillHandler {
         };
       }
 
-      const factNodes = await ctx.entityMemory!.getFacts(nodes[0]!.id);
-      const facts = factNodes.map((f) => ({
+      // Aggregate facts across all matching anchor nodes. A race condition in
+      // findOrCreateAnchor can produce duplicates; querying all ensures no data is lost.
+      const allFacts = await Promise.all(nodes.map((n) => ctx.entityMemory!.getFacts(n.id)));
+      const facts = allFacts.flat().map((f) => ({
         field: f.properties.field ?? f.label,
         value: f.properties.value,
         last_updated: f.temporal.lastConfirmedAt.toISOString(),

--- a/skills/knowledge-company-overview/skill.json
+++ b/skills/knowledge-company-overview/skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "knowledge-company-overview",
+  "description": "Store or retrieve company overview information in the knowledge graph. Use 'store' to save details like legal name, address, officers, board members, or any other company-level facts. Use 'retrieve' to look up stored company information. Each fact is stored independently, so you can call 'store' multiple times to build up the company profile incrementally.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "action": "string (store | retrieve)",
+    "field": "string? (required for store — the field name, e.g. 'legal_name', 'address', 'officers', 'board_members', 'ein', 'founding_date')",
+    "value": "string? (required for store — the value to store)"
+  },
+  "outputs": {
+    "stored": "boolean?",
+    "field": "string?",
+    "facts": "array? (for retrieve — list of {field, value} objects)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/skills/knowledge-loyalty-programs/handler.ts
+++ b/skills/knowledge-loyalty-programs/handler.ts
@@ -1,0 +1,129 @@
+// handler.ts — knowledge-loyalty-programs skill implementation.
+//
+// Stores and retrieves loyalty program information (frequent flyer numbers,
+// hotel rewards, etc.) in the knowledge graph.
+//
+// KG storage model:
+//   - Anchor node: type=concept, label="loyalty-programs"
+//   - Each program stored as a fact node with label=program name,
+//     properties: { program_name, member_number, tier, notes }
+//   - decayClass=permanent (loyalty numbers don't change often)
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+const ANCHOR_LABEL = 'loyalty-programs';
+
+export class KnowledgeLoyaltyProgramsHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { action } = ctx.input as { action?: string };
+
+    if (!action || !['store', 'retrieve'].includes(action)) {
+      return { success: false, error: "Missing or invalid 'action' — must be 'store' or 'retrieve'" };
+    }
+
+    if (!ctx.entityMemory) {
+      return { success: false, error: 'Knowledge graph not available — cannot store or retrieve loyalty programs' };
+    }
+
+    if (action === 'store') {
+      return this.store(ctx);
+    }
+    return this.retrieve(ctx);
+  }
+
+  private async store(ctx: SkillContext): Promise<SkillResult> {
+    const { program_name, member_number, tier, notes } = ctx.input as {
+      program_name?: string;
+      member_number?: string;
+      tier?: string;
+      notes?: string;
+    };
+
+    if (!program_name || typeof program_name !== 'string') {
+      return { success: false, error: 'Missing required input: program_name' };
+    }
+    if (!member_number || typeof member_number !== 'string') {
+      return { success: false, error: 'Missing required input: member_number' };
+    }
+    if (program_name.length > 500) {
+      return { success: false, error: 'program_name must be 500 characters or fewer' };
+    }
+    if (member_number.length > 200) {
+      return { success: false, error: 'member_number must be 200 characters or fewer' };
+    }
+    if (tier && tier.length > 100) {
+      return { success: false, error: 'tier must be 100 characters or fewer' };
+    }
+    if (notes && notes.length > 2000) {
+      return { success: false, error: 'notes must be 2000 characters or fewer' };
+    }
+
+    try {
+      const anchor = await this.findOrCreateAnchor(ctx);
+
+      // Label is the program name so dedup detects updates to the same program
+      await ctx.entityMemory!.storeFact({
+        entityNodeId: anchor.id,
+        label: program_name,
+        properties: {
+          program_name,
+          member_number,
+          ...(tier ? { tier } : {}),
+          ...(notes ? { notes } : {}),
+        },
+        confidence: 1.0,
+        decayClass: 'permanent',
+        source: 'skill:knowledge-loyalty-programs',
+      });
+
+      ctx.log.info({ program_name }, 'Stored loyalty program');
+      return { success: true, data: { stored: true, program_name } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, program_name }, 'Failed to store loyalty program');
+      return { success: false, error: `Failed to store: ${message}` };
+    }
+  }
+
+  private async retrieve(ctx: SkillContext): Promise<SkillResult> {
+    try {
+      const nodes = await ctx.entityMemory!.findEntities(ANCHOR_LABEL);
+      if (nodes.length === 0) {
+        return {
+          success: true,
+          data: { programs: [], message: 'No loyalty programs stored yet.' },
+        };
+      }
+
+      const factNodes = await ctx.entityMemory!.getFacts(nodes[0]!.id);
+      const programs = factNodes.map((f) => ({
+        program_name: f.properties.program_name ?? f.label,
+        member_number: f.properties.member_number,
+        tier: f.properties.tier ?? null,
+        notes: f.properties.notes ?? null,
+        last_updated: f.temporal.lastConfirmedAt.toISOString(),
+      }));
+
+      ctx.log.info({ programCount: programs.length }, 'Retrieved loyalty programs');
+      return { success: true, data: { programs } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to retrieve loyalty programs');
+      return { success: false, error: `Failed to retrieve: ${message}` };
+    }
+  }
+
+  private async findOrCreateAnchor(ctx: SkillContext) {
+    const existing = await ctx.entityMemory!.findEntities(ANCHOR_LABEL);
+    if (existing.length > 0) {
+      return existing[0]!;
+    }
+
+    return ctx.entityMemory!.createEntity({
+      type: 'concept',
+      label: ANCHOR_LABEL,
+      properties: { category: 'loyalty-knowledge' },
+      source: 'skill:knowledge-loyalty-programs',
+    });
+  }
+}

--- a/skills/knowledge-loyalty-programs/handler.ts
+++ b/skills/knowledge-loyalty-programs/handler.ts
@@ -95,8 +95,8 @@ export class KnowledgeLoyaltyProgramsHandler implements SkillHandler {
         };
       }
 
-      const factNodes = await ctx.entityMemory!.getFacts(nodes[0]!.id);
-      const programs = factNodes.map((f) => ({
+      const allFacts = await Promise.all(nodes.map((n) => ctx.entityMemory!.getFacts(n.id)));
+      const programs = allFacts.flat().map((f) => ({
         program_name: f.properties.program_name ?? f.label,
         member_number: f.properties.member_number,
         tier: f.properties.tier ?? null,

--- a/skills/knowledge-loyalty-programs/skill.json
+++ b/skills/knowledge-loyalty-programs/skill.json
@@ -1,0 +1,22 @@
+{
+  "name": "knowledge-loyalty-programs",
+  "description": "Store or retrieve loyalty program information (airline frequent flyer numbers, hotel rewards numbers, etc.) in the knowledge graph. Use 'store' to save a loyalty program membership. Use 'retrieve' to look up all stored loyalty programs.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "action": "string (store | retrieve)",
+    "program_name": "string? (required for store — e.g. 'Air Canada Aeroplan', 'Marriott Bonvoy', 'United MileagePlus')",
+    "member_number": "string? (required for store — the membership/loyalty number)",
+    "tier": "string? (optional for store — status tier e.g. 'Gold', 'Platinum')",
+    "notes": "string? (optional for store — additional notes)"
+  },
+  "outputs": {
+    "stored": "boolean?",
+    "program_name": "string?",
+    "programs": "array? (for retrieve — list of {program_name, member_number, tier, notes} objects)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/skills/knowledge-meeting-links/handler.ts
+++ b/skills/knowledge-meeting-links/handler.ts
@@ -60,9 +60,10 @@ export class KnowledgeMeetingLinksHandler implements SkillHandler {
     try {
       const anchor = await this.findOrCreateAnchor(ctx);
 
-      // Label includes person and platform so dedup detects updates to the
-      // same person's link on the same platform.
-      const factLabel = `${person_name} ${platform} link`;
+      // Label includes person and platform (lowercased) so dedup detects
+      // updates to the same person's link on the same platform regardless
+      // of casing (e.g., "Zoom" vs "zoom" won't create duplicates).
+      const factLabel = `${person_name} ${platform.toLowerCase()} link`;
       await ctx.entityMemory!.storeFact({
         entityNodeId: anchor.id,
         label: factLabel,
@@ -93,8 +94,8 @@ export class KnowledgeMeetingLinksHandler implements SkillHandler {
         };
       }
 
-      const factNodes = await ctx.entityMemory!.getFacts(nodes[0]!.id);
-      let links = factNodes.map((f) => ({
+      const allFacts = await Promise.all(nodes.map((n) => ctx.entityMemory!.getFacts(n.id)));
+      let links = allFacts.flat().map((f) => ({
         person_name: f.properties.person_name as string,
         platform: f.properties.platform as string,
         link: f.properties.link as string,

--- a/skills/knowledge-meeting-links/handler.ts
+++ b/skills/knowledge-meeting-links/handler.ts
@@ -1,0 +1,132 @@
+// handler.ts — knowledge-meeting-links skill implementation.
+//
+// Stores and retrieves personal meeting links (Zoom, Teams, etc.) in the
+// knowledge graph. Each link is associated with a person name and platform.
+//
+// KG storage model:
+//   - Anchor node: type=concept, label="meeting-links"
+//   - Each link stored as a fact node with label="{person_name} {platform} link"
+//     properties: { person_name, platform, link }
+//   - decayClass=slow_decay (links change occasionally)
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+const ANCHOR_LABEL = 'meeting-links';
+
+export class KnowledgeMeetingLinksHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { action } = ctx.input as { action?: string };
+
+    if (!action || !['store', 'retrieve'].includes(action)) {
+      return { success: false, error: "Missing or invalid 'action' — must be 'store' or 'retrieve'" };
+    }
+
+    if (!ctx.entityMemory) {
+      return { success: false, error: 'Knowledge graph not available — cannot store or retrieve meeting links' };
+    }
+
+    if (action === 'store') {
+      return this.store(ctx);
+    }
+    return this.retrieve(ctx);
+  }
+
+  private async store(ctx: SkillContext): Promise<SkillResult> {
+    const { person_name, platform, link } = ctx.input as {
+      person_name?: string;
+      platform?: string;
+      link?: string;
+    };
+
+    if (!person_name || typeof person_name !== 'string') {
+      return { success: false, error: 'Missing required input: person_name' };
+    }
+    if (!platform || typeof platform !== 'string') {
+      return { success: false, error: 'Missing required input: platform' };
+    }
+    if (!link || typeof link !== 'string') {
+      return { success: false, error: 'Missing required input: link' };
+    }
+    if (person_name.length > 500) {
+      return { success: false, error: 'person_name must be 500 characters or fewer' };
+    }
+    if (platform.length > 100) {
+      return { success: false, error: 'platform must be 100 characters or fewer' };
+    }
+    if (link.length > 2000) {
+      return { success: false, error: 'link must be 2000 characters or fewer' };
+    }
+
+    try {
+      const anchor = await this.findOrCreateAnchor(ctx);
+
+      // Label includes person and platform so dedup detects updates to the
+      // same person's link on the same platform.
+      const factLabel = `${person_name} ${platform} link`;
+      await ctx.entityMemory!.storeFact({
+        entityNodeId: anchor.id,
+        label: factLabel,
+        properties: { person_name, platform: platform.toLowerCase(), link },
+        confidence: 1.0,
+        decayClass: 'slow_decay',
+        source: 'skill:knowledge-meeting-links',
+      });
+
+      ctx.log.info({ person_name, platform }, 'Stored meeting link');
+      return { success: true, data: { stored: true, person_name } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, person_name, platform }, 'Failed to store meeting link');
+      return { success: false, error: `Failed to store: ${message}` };
+    }
+  }
+
+  private async retrieve(ctx: SkillContext): Promise<SkillResult> {
+    const { person_name } = ctx.input as { person_name?: string };
+
+    try {
+      const nodes = await ctx.entityMemory!.findEntities(ANCHOR_LABEL);
+      if (nodes.length === 0) {
+        return {
+          success: true,
+          data: { links: [], message: 'No meeting links stored yet.' },
+        };
+      }
+
+      const factNodes = await ctx.entityMemory!.getFacts(nodes[0]!.id);
+      let links = factNodes.map((f) => ({
+        person_name: f.properties.person_name as string,
+        platform: f.properties.platform as string,
+        link: f.properties.link as string,
+        last_updated: f.temporal.lastConfirmedAt.toISOString(),
+      }));
+
+      // Filter by person name if provided (case-insensitive partial match)
+      if (person_name && typeof person_name === 'string') {
+        const lowerName = person_name.toLowerCase();
+        links = links.filter((l) => l.person_name?.toLowerCase().includes(lowerName));
+      }
+
+      ctx.log.info({ linkCount: links.length, filter: person_name ?? 'none' }, 'Retrieved meeting links');
+      return { success: true, data: { links } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to retrieve meeting links');
+      return { success: false, error: `Failed to retrieve: ${message}` };
+    }
+  }
+
+  private async findOrCreateAnchor(ctx: SkillContext) {
+    const existing = await ctx.entityMemory!.findEntities(ANCHOR_LABEL);
+    if (existing.length > 0) {
+      return existing[0]!;
+    }
+
+    return ctx.entityMemory!.createEntity({
+      type: 'concept',
+      label: ANCHOR_LABEL,
+      properties: { category: 'meeting-knowledge' },
+      source: 'skill:knowledge-meeting-links',
+    });
+  }
+}

--- a/skills/knowledge-meeting-links/skill.json
+++ b/skills/knowledge-meeting-links/skill.json
@@ -1,0 +1,21 @@
+{
+  "name": "knowledge-meeting-links",
+  "description": "Store or retrieve personal meeting links (Zoom, Teams, Google Meet, etc.) in the knowledge graph. Use 'store' to save a meeting link for a specific person (e.g. the CEO's personal Zoom link, a board member's Teams link). Use 'retrieve' to look up stored meeting links, optionally filtered by person name.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "action": "string (store | retrieve)",
+    "person_name": "string? (required for store, optional for retrieve — filter by person name)",
+    "platform": "string? (required for store — e.g. 'zoom', 'teams', 'google_meet')",
+    "link": "string? (required for store — the meeting URL)"
+  },
+  "outputs": {
+    "stored": "boolean?",
+    "person_name": "string?",
+    "links": "array? (for retrieve — list of {person_name, platform, link} objects)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/skills/knowledge-travel-preferences/handler.ts
+++ b/skills/knowledge-travel-preferences/handler.ts
@@ -78,8 +78,8 @@ export class KnowledgeTravelPreferencesHandler implements SkillHandler {
         };
       }
 
-      const factNodes = await ctx.entityMemory!.getFacts(nodes[0]!.id);
-      const preferences = factNodes.map((f) => ({
+      const allFacts = await Promise.all(nodes.map((n) => ctx.entityMemory!.getFacts(n.id)));
+      const preferences = allFacts.flat().map((f) => ({
         field: f.properties.field ?? f.label,
         value: f.properties.value,
         last_updated: f.temporal.lastConfirmedAt.toISOString(),

--- a/skills/knowledge-travel-preferences/handler.ts
+++ b/skills/knowledge-travel-preferences/handler.ts
@@ -1,0 +1,110 @@
+// handler.ts — knowledge-travel-preferences skill implementation.
+//
+// Stores and retrieves travel preferences (airline, seat, hotel, dietary, etc.)
+// in the knowledge graph.
+//
+// KG storage model:
+//   - Anchor node: type=concept, label="travel-preferences"
+//   - Each preference stored as a fact node with label=field name,
+//     properties: { value, field }
+//   - decayClass=slow_decay (travel preferences change occasionally)
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+const ANCHOR_LABEL = 'travel-preferences';
+
+export class KnowledgeTravelPreferencesHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { action } = ctx.input as { action?: string };
+
+    if (!action || !['store', 'retrieve'].includes(action)) {
+      return { success: false, error: "Missing or invalid 'action' — must be 'store' or 'retrieve'" };
+    }
+
+    if (!ctx.entityMemory) {
+      return { success: false, error: 'Knowledge graph not available — cannot store or retrieve travel preferences' };
+    }
+
+    if (action === 'store') {
+      return this.store(ctx);
+    }
+    return this.retrieve(ctx);
+  }
+
+  private async store(ctx: SkillContext): Promise<SkillResult> {
+    const { field, value } = ctx.input as { field?: string; value?: string };
+
+    if (!field || typeof field !== 'string') {
+      return { success: false, error: 'Missing required input: field' };
+    }
+    if (!value || typeof value !== 'string') {
+      return { success: false, error: 'Missing required input: value' };
+    }
+    if (field.length > 200) {
+      return { success: false, error: 'field must be 200 characters or fewer' };
+    }
+    if (value.length > 5000) {
+      return { success: false, error: 'value must be 5000 characters or fewer' };
+    }
+
+    try {
+      const anchor = await this.findOrCreateAnchor(ctx);
+
+      await ctx.entityMemory!.storeFact({
+        entityNodeId: anchor.id,
+        label: field,
+        properties: { value, field },
+        confidence: 1.0,
+        decayClass: 'slow_decay',
+        source: 'skill:knowledge-travel-preferences',
+      });
+
+      ctx.log.info({ field }, 'Stored travel preference');
+      return { success: true, data: { stored: true, field } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, field }, 'Failed to store travel preference');
+      return { success: false, error: `Failed to store: ${message}` };
+    }
+  }
+
+  private async retrieve(ctx: SkillContext): Promise<SkillResult> {
+    try {
+      const nodes = await ctx.entityMemory!.findEntities(ANCHOR_LABEL);
+      if (nodes.length === 0) {
+        return {
+          success: true,
+          data: { preferences: [], message: 'No travel preferences stored yet.' },
+        };
+      }
+
+      const factNodes = await ctx.entityMemory!.getFacts(nodes[0]!.id);
+      const preferences = factNodes.map((f) => ({
+        field: f.properties.field ?? f.label,
+        value: f.properties.value,
+        last_updated: f.temporal.lastConfirmedAt.toISOString(),
+      }));
+
+      ctx.log.info({ prefCount: preferences.length }, 'Retrieved travel preferences');
+      return { success: true, data: { preferences } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to retrieve travel preferences');
+      return { success: false, error: `Failed to retrieve: ${message}` };
+    }
+  }
+
+  private async findOrCreateAnchor(ctx: SkillContext) {
+    const existing = await ctx.entityMemory!.findEntities(ANCHOR_LABEL);
+    if (existing.length > 0) {
+      return existing[0]!;
+    }
+
+    return ctx.entityMemory!.createEntity({
+      type: 'concept',
+      label: ANCHOR_LABEL,
+      properties: { category: 'travel-knowledge' },
+      source: 'skill:knowledge-travel-preferences',
+    });
+  }
+}

--- a/skills/knowledge-travel-preferences/skill.json
+++ b/skills/knowledge-travel-preferences/skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "knowledge-travel-preferences",
+  "description": "Store or retrieve travel preferences in the knowledge graph. Use 'store' to save preferences like preferred airline, seat preference, hotel chain, dietary restrictions, or any other travel-related preference. Use 'retrieve' to look up all stored travel preferences.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "action": "string (store | retrieve)",
+    "field": "string? (required for store — the preference name, e.g. 'preferred_airline', 'seat_preference', 'hotel_chain', 'dietary_restrictions', 'baggage_notes')",
+    "value": "string? (required for store — the preference value)"
+  },
+  "outputs": {
+    "stored": "boolean?",
+    "field": "string?",
+    "preferences": "array? (for retrieve — list of {field, value} objects)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/skills/template-cancel/handler.ts
+++ b/skills/template-cancel/handler.ts
@@ -8,7 +8,13 @@
 //   - Template body stored as a fact node with label="template body"
 //   - decayClass=permanent (templates don't decay)
 
-import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
+
+function resolveSignature(persona?: AgentPersona): string {
+  if (persona?.emailSignature) return persona.emailSignature;
+  if (persona) return `${persona.displayName}\n${persona.title}`;
+  return '';
+}
 
 const TEMPLATE_LABEL = 'template:cancel';
 
@@ -23,8 +29,7 @@ Unfortunately, we need to cancel this meeting.{{reason_clause}}
 {{reschedule_clause}}Thank you for your understanding.
 
 Best regards,
-Nathan Curia
-Agent Chief of Staff`;
+{{agent_signature}}`;
 
 const MAX_INPUT_LENGTH = 5000;
 
@@ -107,6 +112,7 @@ export class TemplateCancelHandler implements SkillHandler {
       meeting_time,
       reason_clause: reasonClause,
       reschedule_clause: rescheduleClause,
+      agent_signature: resolveSignature(ctx.agentPersona),
     });
 
     const lines = filled.split('\n');

--- a/skills/template-cancel/handler.ts
+++ b/skills/template-cancel/handler.ts
@@ -1,0 +1,219 @@
+// handler.ts — template-cancel skill implementation.
+//
+// Generates meeting cancellation emails from a template. Built-in default
+// template is used unless the user has stored a custom version in the KG.
+//
+// KG storage model:
+//   - Anchor node: type=concept, label="template:cancel"
+//   - Template body stored as a fact node with label="template body"
+//   - decayClass=permanent (templates don't decay)
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+const TEMPLATE_LABEL = 'template:cancel';
+
+const DEFAULT_TEMPLATE = `Subject: Cancellation — {{meeting_subject}}
+
+Hi {{recipient_name}},
+
+I'm writing on behalf of {{sender_name}} regarding your meeting scheduled for {{meeting_time}} ({{meeting_subject}}).
+
+Unfortunately, we need to cancel this meeting.{{reason_clause}}
+
+{{reschedule_clause}}Thank you for your understanding.
+
+Best regards,
+Nathan Curia
+Agent Chief of Staff`;
+
+function fillTemplate(template: string, vars: Record<string, string>): string {
+  let result = template;
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replaceAll(`{{${key}}}`, value);
+  }
+  return result;
+}
+
+export class TemplateCancelHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { action } = ctx.input as { action?: string };
+
+    if (!action || !['generate', 'save', 'reset'].includes(action)) {
+      return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', or 'reset'" };
+    }
+
+    if (action === 'save') {
+      return this.saveTemplate(ctx);
+    }
+    if (action === 'reset') {
+      return this.resetTemplate(ctx);
+    }
+    return this.generate(ctx);
+  }
+
+  private async generate(ctx: SkillContext): Promise<SkillResult> {
+    const { recipient_name, sender_name, meeting_subject, meeting_time, reason, offer_reschedule } =
+      ctx.input as {
+        recipient_name?: string;
+        sender_name?: string;
+        meeting_subject?: string;
+        meeting_time?: string;
+        reason?: string;
+        offer_reschedule?: boolean;
+      };
+
+    if (!recipient_name || typeof recipient_name !== 'string') {
+      return { success: false, error: 'Missing required input: recipient_name' };
+    }
+    if (!sender_name || typeof sender_name !== 'string') {
+      return { success: false, error: 'Missing required input: sender_name' };
+    }
+    if (!meeting_subject || typeof meeting_subject !== 'string') {
+      return { success: false, error: 'Missing required input: meeting_subject' };
+    }
+    if (!meeting_time || typeof meeting_time !== 'string') {
+      return { success: false, error: 'Missing required input: meeting_time' };
+    }
+
+    const { template, source } = await this.resolveTemplate(ctx);
+
+    const reasonClause = reason ? ` ${reason}` : '';
+    // Default to offering reschedule unless explicitly set to false
+    const shouldOfferReschedule = offer_reschedule !== false;
+    const rescheduleClause = shouldOfferReschedule
+      ? `If you'd like to reschedule, please let me know your availability and I'll find a time that works.\n\n`
+      : '';
+
+    const filled = fillTemplate(template, {
+      recipient_name,
+      sender_name,
+      meeting_subject,
+      meeting_time,
+      reason_clause: reasonClause,
+      reschedule_clause: rescheduleClause,
+    });
+
+    const lines = filled.split('\n');
+    const subjectLine = lines[0] ?? '';
+    const subject = subjectLine.replace(/^Subject:\s*/i, '').trim();
+    const body = lines.slice(2).join('\n').trim();
+
+    ctx.log.info({ recipient_name, source }, 'Generated cancellation email');
+    return {
+      success: true,
+      data: { subject, body, template_source: source },
+    };
+  }
+
+  private async saveTemplate(ctx: SkillContext): Promise<SkillResult> {
+    const { custom_template } = ctx.input as { custom_template?: string };
+    if (!custom_template || typeof custom_template !== 'string') {
+      return { success: false, error: 'Missing required input: custom_template' };
+    }
+    if (custom_template.length > 10000) {
+      return { success: false, error: 'custom_template must be 10000 characters or fewer' };
+    }
+
+    if (!ctx.entityMemory) {
+      return { success: false, error: 'Knowledge graph not available — cannot save custom template' };
+    }
+
+    try {
+      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
+      if (existing.length > 0) {
+        await ctx.entityMemory.storeFact({
+          entityNodeId: existing[0]!.id,
+          label: 'template body',
+          properties: { body: custom_template },
+          confidence: 1.0,
+          decayClass: 'permanent',
+          source: 'skill:template-cancel',
+        });
+      } else {
+        const anchor = await ctx.entityMemory.createEntity({
+          type: 'concept',
+          label: TEMPLATE_LABEL,
+          properties: { category: 'email-template', templateName: 'cancel' },
+          source: 'skill:template-cancel',
+        });
+        await ctx.entityMemory.storeFact({
+          entityNodeId: anchor.id,
+          label: 'template body',
+          properties: { body: custom_template },
+          confidence: 1.0,
+          decayClass: 'permanent',
+          source: 'skill:template-cancel',
+        });
+      }
+
+      ctx.log.info('Saved custom cancellation template to knowledge graph');
+      return { success: true, data: { saved: true } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to save custom template');
+      return { success: false, error: `Failed to save template: ${message}` };
+    }
+  }
+
+  private async resetTemplate(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.entityMemory) {
+      return { success: true, data: { reset: true } };
+    }
+
+    try {
+      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
+      if (existing.length > 0) {
+        const facts = await ctx.entityMemory.getFacts(existing[0]!.id);
+        if (facts.length > 0) {
+          await ctx.entityMemory.storeFact({
+            entityNodeId: existing[0]!.id,
+            label: 'template body',
+            properties: { body: '', cleared: true },
+            confidence: 1.0,
+            decayClass: 'permanent',
+            source: 'skill:template-cancel',
+          });
+        }
+      }
+
+      ctx.log.info('Reset cancellation template to default');
+      return { success: true, data: { reset: true } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to reset template');
+      return { success: false, error: `Failed to reset template: ${message}` };
+    }
+  }
+
+  private async resolveTemplate(ctx: SkillContext): Promise<{ template: string; source: 'default' | 'custom' }> {
+    if (!ctx.entityMemory) {
+      return { template: DEFAULT_TEMPLATE, source: 'default' };
+    }
+
+    try {
+      const nodes = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
+      if (nodes.length === 0) {
+        return { template: DEFAULT_TEMPLATE, source: 'default' };
+      }
+
+      const facts = await ctx.entityMemory.getFacts(nodes[0]!.id);
+      const templateFact = facts
+        .filter((f) => f.label === 'template body')
+        .sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
+
+      if (!templateFact) {
+        return { template: DEFAULT_TEMPLATE, source: 'default' };
+      }
+
+      const body = templateFact.properties.body;
+      if (typeof body === 'string' && body.length > 0 && !templateFact.properties.cleared) {
+        return { template: body, source: 'custom' };
+      }
+
+      return { template: DEFAULT_TEMPLATE, source: 'default' };
+    } catch (err) {
+      ctx.log.warn({ err }, 'Failed to look up custom template, using default');
+      return { template: DEFAULT_TEMPLATE, source: 'default' };
+    }
+  }
+}

--- a/skills/template-cancel/handler.ts
+++ b/skills/template-cancel/handler.ts
@@ -1,241 +1,157 @@
 // handler.ts — template-cancel skill implementation.
 //
-// Generates meeting cancellation emails from a template. Built-in default
-// template is used unless the user has stored a custom version in the KG.
+// Returns email composing guidelines for cancellation emails.
 //
 // KG storage model:
 //   - Anchor node: type=concept, label="template:cancel"
-//   - Template body stored as a fact node with label="template body"
-//   - decayClass=permanent (templates don't decay)
+//   - Custom policy stored as a fact node with label="email policy"
+//   - decayClass=permanent
 
 import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
 
 function resolveSignature(persona?: AgentPersona): string {
   if (persona?.emailSignature) return persona.emailSignature;
-  if (persona) return `${persona.displayName}\n${persona.title}`;
+  if (persona) return `${persona.displayName}, ${persona.title}`;
   return '';
 }
 
 const TEMPLATE_LABEL = 'template:cancel';
-
-const DEFAULT_TEMPLATE = `Subject: Cancellation — {{meeting_subject}}
-
-Hi {{recipient_name}},
-
-I'm writing on behalf of {{sender_name}} regarding your meeting scheduled for {{meeting_time}} ({{meeting_subject}}).
-
-Unfortunately, we need to cancel this meeting.{{reason_clause}}
-
-{{reschedule_clause}}Thank you for your understanding.
-
-Best regards,
-{{agent_signature}}`;
-
 const MAX_INPUT_LENGTH = 5000;
 
-function fillTemplate(template: string, vars: Record<string, string>): string {
-  let result = template;
-  for (const [key, value] of Object.entries(vars)) {
-    result = result.replaceAll(`{{${key}}}`, value);
-  }
-  result = result.replace(/\{\{[^}]+\}\}/g, '');
-  return result;
-}
+const DEFAULT_POLICY = {
+  required_elements: [
+    'Greeting addressing the recipient by name',
+    'Reference the specific meeting (subject and time) being canceled',
+    'Brief reason for cancellation if provided (keep concise)',
+    'Offer to reschedule unless explicitly told not to',
+    'Thank them for their understanding',
+    'Professional sign-off with the agent signature',
+  ],
+  tone: 'Respectful and direct. Acknowledge the disruption without excessive apology.',
+  structure: 'Greeting → identify the meeting → cancellation statement → reason (if any) → reschedule offer (if applicable) → thanks → sign-off',
+  constraints: [
+    'Keep the body to 3-5 sentences',
+    'Subject line should include "Cancellation" and the meeting topic',
+    'Do not over-explain or justify excessively',
+    'One apology is enough — do not repeat it',
+  ],
+  example: `Subject: Cancellation — Q3 Planning
+
+Hi Alice,
+
+I'm writing on behalf of Joseph regarding your meeting scheduled for Monday, April 7 at 10:00 AM (Q3 Planning).
+
+Unfortunately, we need to cancel this meeting. If you'd like to reschedule, please let me know your availability and I'll find a time that works.
+
+Thank you for your understanding.
+
+Best regards,
+Nathan Curia, Agent Chief of Staff`,
+};
 
 export class TemplateCancelHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     const { action } = ctx.input as { action?: string };
-
     if (!action || !['generate', 'save', 'reset'].includes(action)) {
       return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', or 'reset'" };
     }
-
-    if (action === 'save') {
-      return this.saveTemplate(ctx);
-    }
-    if (action === 'reset') {
-      return this.resetTemplate(ctx);
-    }
+    if (action === 'save') return this.savePolicy(ctx);
+    if (action === 'reset') return this.resetPolicy(ctx);
     return this.generate(ctx);
   }
 
   private async generate(ctx: SkillContext): Promise<SkillResult> {
     const { recipient_name, sender_name, meeting_subject, meeting_time, reason, offer_reschedule } =
       ctx.input as {
-        recipient_name?: string;
-        sender_name?: string;
-        meeting_subject?: string;
-        meeting_time?: string;
-        reason?: string;
-        offer_reschedule?: boolean;
+        recipient_name?: string; sender_name?: string; meeting_subject?: string;
+        meeting_time?: string; reason?: string; offer_reschedule?: boolean;
       };
 
-    if (!recipient_name || typeof recipient_name !== 'string') {
-      return { success: false, error: 'Missing required input: recipient_name' };
-    }
-    if (!sender_name || typeof sender_name !== 'string') {
-      return { success: false, error: 'Missing required input: sender_name' };
-    }
-    if (!meeting_subject || typeof meeting_subject !== 'string') {
-      return { success: false, error: 'Missing required input: meeting_subject' };
-    }
-    if (!meeting_time || typeof meeting_time !== 'string') {
-      return { success: false, error: 'Missing required input: meeting_time' };
-    }
+    if (!recipient_name || typeof recipient_name !== 'string') return { success: false, error: 'Missing required input: recipient_name' };
+    if (!sender_name || typeof sender_name !== 'string') return { success: false, error: 'Missing required input: sender_name' };
+    if (!meeting_subject || typeof meeting_subject !== 'string') return { success: false, error: 'Missing required input: meeting_subject' };
+    if (!meeting_time || typeof meeting_time !== 'string') return { success: false, error: 'Missing required input: meeting_time' };
 
-    if (recipient_name.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `recipient_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
-    if (sender_name.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `sender_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
-    if (meeting_subject.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `meeting_subject must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
-    if (meeting_time.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `meeting_time must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
+    if (recipient_name.length > MAX_INPUT_LENGTH) return { success: false, error: `recipient_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    if (sender_name.length > MAX_INPUT_LENGTH) return { success: false, error: `sender_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    if (meeting_subject.length > MAX_INPUT_LENGTH) return { success: false, error: `meeting_subject must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    if (meeting_time.length > MAX_INPUT_LENGTH) return { success: false, error: `meeting_time must be ${MAX_INPUT_LENGTH} characters or fewer` };
 
-    const { template, source } = await this.resolveTemplate(ctx);
+    const { policy, source } = await this.resolvePolicy(ctx);
 
-    const reasonClause = reason ? ` ${reason}` : '';
-    // Default to offering reschedule unless explicitly set to false
-    const shouldOfferReschedule = offer_reschedule !== false;
-    const rescheduleClause = shouldOfferReschedule
-      ? `If you'd like to reschedule, please let me know your availability and I'll find a time that works.\n\n`
-      : '';
-
-    const filled = fillTemplate(template, {
-      recipient_name,
-      sender_name,
-      meeting_subject,
-      meeting_time,
-      reason_clause: reasonClause,
-      reschedule_clause: rescheduleClause,
+    const context: Record<string, string | boolean> = {
+      recipient_name, sender_name, meeting_subject, meeting_time,
+      offer_reschedule: offer_reschedule !== false,
       agent_signature: resolveSignature(ctx.agentPersona),
-    });
+    };
+    if (reason) context.reason = reason;
 
-    const lines = filled.split('\n');
-    const subjectLine = lines[0] ?? '';
-    const subject = subjectLine.replace(/^Subject:\s*/i, '').trim();
-    const body = lines.slice(2).join('\n').trim();
-
-    ctx.log.info({ recipient_name, source }, 'Generated cancellation email');
+    ctx.log.info({ recipient_name, source }, 'Retrieved cancellation email policy');
     return {
       success: true,
-      data: { subject, body, template_source: source },
+      data: {
+        guidelines: policy, context, source,
+        instructions: 'Use the guidelines to compose a cancellation email. Adapt naturally to the provided context — do not copy the example verbatim. If offer_reschedule is false, omit the reschedule offer.',
+      },
     };
   }
 
-  private async saveTemplate(ctx: SkillContext): Promise<SkillResult> {
-    const { custom_template } = ctx.input as { custom_template?: string };
-    if (!custom_template || typeof custom_template !== 'string') {
-      return { success: false, error: 'Missing required input: custom_template' };
-    }
-    if (custom_template.length > 10000) {
-      return { success: false, error: 'custom_template must be 10000 characters or fewer' };
-    }
-
-    if (!ctx.entityMemory) {
-      return { success: false, error: 'Knowledge graph not available — cannot save custom template' };
-    }
+  private async savePolicy(ctx: SkillContext): Promise<SkillResult> {
+    const { custom_policy } = ctx.input as { custom_policy?: string };
+    if (!custom_policy || typeof custom_policy !== 'string') return { success: false, error: 'Missing required input: custom_policy' };
+    if (custom_policy.length > 10000) return { success: false, error: 'custom_policy must be 10000 characters or fewer' };
+    if (!ctx.entityMemory) return { success: false, error: 'Knowledge graph not available — cannot save custom policy' };
 
     try {
       const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (existing.length > 0) {
-        await ctx.entityMemory.storeFact({
-          entityNodeId: existing[0]!.id,
-          label: 'template body',
-          properties: { body: custom_template },
-          confidence: 1.0,
-          decayClass: 'permanent',
-          source: 'skill:template-cancel',
-        });
-      } else {
-        const anchor = await ctx.entityMemory.createEntity({
-          type: 'concept',
-          label: TEMPLATE_LABEL,
-          properties: { category: 'email-template', templateName: 'cancel' },
-          source: 'skill:template-cancel',
-        });
-        await ctx.entityMemory.storeFact({
-          entityNodeId: anchor.id,
-          label: 'template body',
-          properties: { body: custom_template },
-          confidence: 1.0,
-          decayClass: 'permanent',
-          source: 'skill:template-cancel',
-        });
-      }
-
-      ctx.log.info('Saved custom cancellation template to knowledge graph');
+      const anchorId = existing.length > 0
+        ? existing[0]!.id
+        : (await ctx.entityMemory.createEntity({ type: 'concept', label: TEMPLATE_LABEL, properties: { category: 'email-policy', templateName: 'cancel' }, source: 'skill:template-cancel' })).id;
+      await ctx.entityMemory.storeFact({ entityNodeId: anchorId, label: 'email policy', properties: { policy: custom_policy }, confidence: 1.0, decayClass: 'permanent', source: 'skill:template-cancel' });
+      ctx.log.info('Saved custom cancellation email policy');
       return { success: true, data: { saved: true } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to save custom template');
-      return { success: false, error: `Failed to save template: ${message}` };
+      ctx.log.error({ err }, 'Failed to save custom policy');
+      return { success: false, error: `Failed to save policy: ${message}` };
     }
   }
 
-  private async resetTemplate(ctx: SkillContext): Promise<SkillResult> {
-    if (!ctx.entityMemory) {
-      return { success: true, data: { reset: true } };
-    }
-
+  private async resetPolicy(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.entityMemory) return { success: true, data: { reset: true } };
     try {
       const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
       if (existing.length > 0) {
         const facts = await ctx.entityMemory.getFacts(existing[0]!.id);
         if (facts.length > 0) {
-          await ctx.entityMemory.storeFact({
-            entityNodeId: existing[0]!.id,
-            label: 'template body',
-            properties: { body: '', cleared: true },
-            confidence: 1.0,
-            decayClass: 'permanent',
-            source: 'skill:template-cancel',
-          });
+          await ctx.entityMemory.storeFact({ entityNodeId: existing[0]!.id, label: 'email policy', properties: { policy: '', cleared: true }, confidence: 1.0, decayClass: 'permanent', source: 'skill:template-cancel' });
         }
       }
-
-      ctx.log.info('Reset cancellation template to default');
+      ctx.log.info('Reset cancellation email policy to default');
       return { success: true, data: { reset: true } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to reset template');
-      return { success: false, error: `Failed to reset template: ${message}` };
+      ctx.log.error({ err }, 'Failed to reset policy');
+      return { success: false, error: `Failed to reset policy: ${message}` };
     }
   }
 
-  private async resolveTemplate(ctx: SkillContext): Promise<{ template: string; source: 'default' | 'custom' }> {
-    if (!ctx.entityMemory) {
-      return { template: DEFAULT_TEMPLATE, source: 'default' };
-    }
-
+  private async resolvePolicy(ctx: SkillContext): Promise<{ policy: unknown; source: 'default' | 'custom' }> {
+    if (!ctx.entityMemory) return { policy: DEFAULT_POLICY, source: 'default' };
     try {
       const nodes = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (nodes.length === 0) {
-        return { template: DEFAULT_TEMPLATE, source: 'default' };
-      }
-
+      if (nodes.length === 0) return { policy: DEFAULT_POLICY, source: 'default' };
       const facts = await ctx.entityMemory.getFacts(nodes[0]!.id);
-      const templateFact = facts
-        .filter((f) => f.label === 'template body')
-        .sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
-
-      if (!templateFact) {
-        return { template: DEFAULT_TEMPLATE, source: 'default' };
+      const policyFact = facts.filter((f) => f.label === 'email policy').sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
+      if (!policyFact) return { policy: DEFAULT_POLICY, source: 'default' };
+      const rawPolicy = policyFact.properties.policy;
+      if (typeof rawPolicy === 'string' && rawPolicy.length > 0 && !policyFact.properties.cleared) {
+        try { return { policy: JSON.parse(rawPolicy) as unknown, source: 'custom' }; } catch { return { policy: { custom_guidelines: rawPolicy, note: 'Custom guidelines that override the default policy.' }, source: 'custom' }; }
       }
-
-      const body = templateFact.properties.body;
-      if (typeof body === 'string' && body.length > 0 && !templateFact.properties.cleared) {
-        return { template: body, source: 'custom' };
-      }
-
-      return { template: DEFAULT_TEMPLATE, source: 'default' };
+      return { policy: DEFAULT_POLICY, source: 'default' };
     } catch (err) {
-      ctx.log.warn({ err }, 'Failed to look up custom template, using default');
-      return { template: DEFAULT_TEMPLATE, source: 'default' };
+      ctx.log.warn({ err }, 'Failed to look up custom policy, using default');
+      return { policy: DEFAULT_POLICY, source: 'default' };
     }
   }
 }

--- a/skills/template-cancel/handler.ts
+++ b/skills/template-cancel/handler.ts
@@ -1,21 +1,12 @@
 // handler.ts — template-cancel skill implementation.
 //
 // Returns email composing guidelines for cancellation emails.
-//
-// KG storage model:
-//   - Anchor node: type=concept, label="template:cancel"
-//   - Custom policy stored as a fact node with label="email policy"
-//   - decayClass=permanent
 
-import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
-
-function resolveSignature(persona?: AgentPersona): string {
-  if (persona?.emailSignature) return persona.emailSignature;
-  if (persona) return `${persona.displayName}, ${persona.title}`;
-  return '';
-}
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { resolveSignature, savePolicy, updatePolicy, resetPolicy, resolvePolicy } from '../_shared/template-base.js';
 
 const TEMPLATE_LABEL = 'template:cancel';
+const SKILL_SOURCE = 'skill:template-cancel';
 const MAX_INPUT_LENGTH = 5000;
 
 const DEFAULT_POLICY = {
@@ -52,11 +43,12 @@ Nathan Curia, Agent Chief of Staff`,
 export class TemplateCancelHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     const { action } = ctx.input as { action?: string };
-    if (!action || !['generate', 'save', 'reset'].includes(action)) {
-      return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', or 'reset'" };
+    if (!action || !['generate', 'save', 'update', 'reset'].includes(action)) {
+      return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', 'update', or 'reset'" };
     }
-    if (action === 'save') return this.savePolicy(ctx);
-    if (action === 'reset') return this.resetPolicy(ctx);
+    if (action === 'save') return savePolicy(ctx, TEMPLATE_LABEL, SKILL_SOURCE);
+    if (action === 'update') return updatePolicy(ctx, TEMPLATE_LABEL, SKILL_SOURCE);
+    if (action === 'reset') return resetPolicy(ctx, TEMPLATE_LABEL, SKILL_SOURCE);
     return this.generate(ctx);
   }
 
@@ -77,7 +69,7 @@ export class TemplateCancelHandler implements SkillHandler {
     if (meeting_subject.length > MAX_INPUT_LENGTH) return { success: false, error: `meeting_subject must be ${MAX_INPUT_LENGTH} characters or fewer` };
     if (meeting_time.length > MAX_INPUT_LENGTH) return { success: false, error: `meeting_time must be ${MAX_INPUT_LENGTH} characters or fewer` };
 
-    const { policy, source } = await this.resolvePolicy(ctx);
+    const { policy, source } = await resolvePolicy(ctx, TEMPLATE_LABEL, DEFAULT_POLICY);
 
     const context: Record<string, string | boolean> = {
       recipient_name, sender_name, meeting_subject, meeting_time,
@@ -91,67 +83,8 @@ export class TemplateCancelHandler implements SkillHandler {
       success: true,
       data: {
         guidelines: policy, context, source,
-        instructions: 'Use the guidelines to compose a cancellation email. Adapt naturally to the provided context — do not copy the example verbatim. If offer_reschedule is false, omit the reschedule offer.',
+        instructions: 'Use the guidelines to compose a cancellation email. Adapt naturally to the provided context. If offer_reschedule is false, omit the reschedule offer. If refinements are present, apply them.',
       },
     };
-  }
-
-  private async savePolicy(ctx: SkillContext): Promise<SkillResult> {
-    const { custom_policy } = ctx.input as { custom_policy?: string };
-    if (!custom_policy || typeof custom_policy !== 'string') return { success: false, error: 'Missing required input: custom_policy' };
-    if (custom_policy.length > 10000) return { success: false, error: 'custom_policy must be 10000 characters or fewer' };
-    if (!ctx.entityMemory) return { success: false, error: 'Knowledge graph not available — cannot save custom policy' };
-
-    try {
-      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      const anchorId = existing.length > 0
-        ? existing[0]!.id
-        : (await ctx.entityMemory.createEntity({ type: 'concept', label: TEMPLATE_LABEL, properties: { category: 'email-policy', templateName: 'cancel' }, source: 'skill:template-cancel' })).id;
-      await ctx.entityMemory.storeFact({ entityNodeId: anchorId, label: 'email policy', properties: { policy: custom_policy }, confidence: 1.0, decayClass: 'permanent', source: 'skill:template-cancel' });
-      ctx.log.info('Saved custom cancellation email policy');
-      return { success: true, data: { saved: true } };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to save custom policy');
-      return { success: false, error: `Failed to save policy: ${message}` };
-    }
-  }
-
-  private async resetPolicy(ctx: SkillContext): Promise<SkillResult> {
-    if (!ctx.entityMemory) return { success: true, data: { reset: true } };
-    try {
-      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (existing.length > 0) {
-        const facts = await ctx.entityMemory.getFacts(existing[0]!.id);
-        if (facts.length > 0) {
-          await ctx.entityMemory.storeFact({ entityNodeId: existing[0]!.id, label: 'email policy', properties: { policy: '', cleared: true }, confidence: 1.0, decayClass: 'permanent', source: 'skill:template-cancel' });
-        }
-      }
-      ctx.log.info('Reset cancellation email policy to default');
-      return { success: true, data: { reset: true } };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to reset policy');
-      return { success: false, error: `Failed to reset policy: ${message}` };
-    }
-  }
-
-  private async resolvePolicy(ctx: SkillContext): Promise<{ policy: unknown; source: 'default' | 'custom' }> {
-    if (!ctx.entityMemory) return { policy: DEFAULT_POLICY, source: 'default' };
-    try {
-      const nodes = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (nodes.length === 0) return { policy: DEFAULT_POLICY, source: 'default' };
-      const facts = await ctx.entityMemory.getFacts(nodes[0]!.id);
-      const policyFact = facts.filter((f) => f.label === 'email policy').sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
-      if (!policyFact) return { policy: DEFAULT_POLICY, source: 'default' };
-      const rawPolicy = policyFact.properties.policy;
-      if (typeof rawPolicy === 'string' && rawPolicy.length > 0 && !policyFact.properties.cleared) {
-        try { return { policy: JSON.parse(rawPolicy) as unknown, source: 'custom' }; } catch { return { policy: { custom_guidelines: rawPolicy, note: 'Custom guidelines that override the default policy.' }, source: 'custom' }; }
-      }
-      return { policy: DEFAULT_POLICY, source: 'default' };
-    } catch (err) {
-      ctx.log.warn({ err }, 'Failed to look up custom policy, using default');
-      return { policy: DEFAULT_POLICY, source: 'default' };
-    }
   }
 }

--- a/skills/template-cancel/handler.ts
+++ b/skills/template-cancel/handler.ts
@@ -26,11 +26,14 @@ Best regards,
 Nathan Curia
 Agent Chief of Staff`;
 
+const MAX_INPUT_LENGTH = 5000;
+
 function fillTemplate(template: string, vars: Record<string, string>): string {
   let result = template;
   for (const [key, value] of Object.entries(vars)) {
     result = result.replaceAll(`{{${key}}}`, value);
   }
+  result = result.replace(/\{\{[^}]+\}\}/g, '');
   return result;
 }
 
@@ -73,6 +76,19 @@ export class TemplateCancelHandler implements SkillHandler {
     }
     if (!meeting_time || typeof meeting_time !== 'string') {
       return { success: false, error: 'Missing required input: meeting_time' };
+    }
+
+    if (recipient_name.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `recipient_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    }
+    if (sender_name.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `sender_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    }
+    if (meeting_subject.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `meeting_subject must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    }
+    if (meeting_time.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `meeting_time must be ${MAX_INPUT_LENGTH} characters or fewer` };
     }
 
     const { template, source } = await this.resolveTemplate(ctx);

--- a/skills/template-cancel/skill.json
+++ b/skills/template-cancel/skill.json
@@ -1,0 +1,27 @@
+{
+  "name": "template-cancel",
+  "description": "Generate a meeting cancellation email from a template. Supports three actions: 'generate' fills the template with provided variables (checks the knowledge graph for a user-customized template before falling back to the built-in default); 'save' stores a custom template in the knowledge graph; 'reset' removes the custom template and reverts to the built-in default.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "action": "string (generate | save | reset)",
+    "recipient_name": "string? (required for generate)",
+    "sender_name": "string? (required for generate — the person on whose behalf you're canceling)",
+    "meeting_subject": "string? (required for generate — what the meeting was about)",
+    "meeting_time": "string? (required for generate — the scheduled meeting time)",
+    "reason": "string? (optional for generate — brief reason for cancellation)",
+    "offer_reschedule": "boolean? (optional for generate — whether to offer to reschedule, defaults to true)",
+    "custom_template": "string? (required for save — the template body to store)"
+  },
+  "outputs": {
+    "subject": "string?",
+    "body": "string?",
+    "template_source": "string? (default | custom)",
+    "saved": "boolean?",
+    "reset": "boolean?"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/skills/template-cancel/skill.json
+++ b/skills/template-cancel/skill.json
@@ -1,11 +1,12 @@
 {
   "name": "template-cancel",
-  "description": "Retrieve email composing guidelines for meeting cancellations. Returns structured policy (required elements, tone, structure, constraints, example) that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports 'generate', 'save', and 'reset' actions.",
+  "description": "Retrieve email composing guidelines for meeting cancellations. Returns structured policy that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports four actions: 'generate' retrieves the policy (with any refinements); 'update' accepts a natural-language refinement; 'save' replaces the entire policy; 'reset' reverts to defaults and clears refinements.",
   "version": "1.0.0",
   "sensitivity": "normal",
   "infrastructure": true,
   "inputs": {
-    "action": "string (generate | save | reset)",
+    "action": "string (generate | update | save | reset)",
+    "refinement": "string? (required for update — a natural-language adjustment to the policy)",
     "recipient_name": "string? (required for generate)",
     "sender_name": "string? (required for generate — the person canceling)",
     "meeting_subject": "string? (required for generate — the meeting topic)",

--- a/skills/template-cancel/skill.json
+++ b/skills/template-cancel/skill.json
@@ -1,23 +1,24 @@
 {
   "name": "template-cancel",
-  "description": "Generate a meeting cancellation email from a template. Supports three actions: 'generate' fills the template with provided variables (checks the knowledge graph for a user-customized template before falling back to the built-in default); 'save' stores a custom template in the knowledge graph; 'reset' removes the custom template and reverts to the built-in default.",
+  "description": "Retrieve email composing guidelines for meeting cancellations. Returns structured policy (required elements, tone, structure, constraints, example) that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports 'generate', 'save', and 'reset' actions.",
   "version": "1.0.0",
   "sensitivity": "normal",
   "infrastructure": true,
   "inputs": {
     "action": "string (generate | save | reset)",
     "recipient_name": "string? (required for generate)",
-    "sender_name": "string? (required for generate — the person on whose behalf you're canceling)",
-    "meeting_subject": "string? (required for generate — what the meeting was about)",
-    "meeting_time": "string? (required for generate — the scheduled meeting time)",
+    "sender_name": "string? (required for generate — the person canceling)",
+    "meeting_subject": "string? (required for generate — the meeting topic)",
+    "meeting_time": "string? (required for generate — the scheduled time)",
     "reason": "string? (optional for generate — brief reason for cancellation)",
-    "offer_reschedule": "boolean? (optional for generate — whether to offer to reschedule, defaults to true)",
-    "custom_template": "string? (required for save — the template body to store)"
+    "offer_reschedule": "boolean? (optional for generate — whether to offer rescheduling, defaults to true)",
+    "custom_policy": "string? (required for save — the policy to store)"
   },
   "outputs": {
-    "subject": "string?",
-    "body": "string?",
-    "template_source": "string? (default | custom)",
+    "guidelines": "object?",
+    "context": "object?",
+    "source": "string? (default | custom)",
+    "instructions": "string?",
     "saved": "boolean?",
     "reset": "boolean?"
   },

--- a/skills/template-doc-request/handler.ts
+++ b/skills/template-doc-request/handler.ts
@@ -1,254 +1,167 @@
 // handler.ts — template-doc-request skill implementation.
 //
-// Generates pre-meeting document/materials request emails from a template.
-// Built-in default template is used unless the user has stored a custom
-// version in the knowledge graph.
+// Returns email composing guidelines for pre-meeting document requests.
 //
 // KG storage model:
 //   - Anchor node: type=concept, label="template:doc-request"
-//   - Template body stored as a fact node with label="template body"
-//   - decayClass=permanent (templates don't decay)
+//   - Custom policy stored as a fact node with label="email policy"
+//   - decayClass=permanent
 
 import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
 
 function resolveSignature(persona?: AgentPersona): string {
   if (persona?.emailSignature) return persona.emailSignature;
-  if (persona) return `${persona.displayName}\n${persona.title}`;
+  if (persona) return `${persona.displayName}, ${persona.title}`;
   return '';
 }
 
 const TEMPLATE_LABEL = 'template:doc-request';
+const MAX_INPUT_LENGTH = 5000;
 
-const DEFAULT_TEMPLATE = `Subject: Materials Needed — {{meeting_subject}} ({{meeting_time}})
+const DEFAULT_POLICY = {
+  required_elements: [
+    'Greeting addressing the recipient by name',
+    'Reference the upcoming meeting (topic and time)',
+    'Explain the purpose — helping the sender prepare for the meeting',
+    'List the requested documents/materials as bullet points',
+    'Include a deadline if provided',
+    'Offer to clarify what is needed',
+    'Professional sign-off with the agent signature',
+  ],
+  tone: 'Polite and helpful. Frame the request as enabling a productive meeting, not as a demand.',
+  structure: 'Greeting → meeting reference → purpose → document list → deadline (if any) → offer to clarify → sign-off',
+  constraints: [
+    'Keep the body to 4-6 sentences plus the materials list',
+    'Subject line should include "Materials Needed" and the meeting topic',
+    'List documents as bullet points, not inline',
+    'Frame the deadline politely ("If possible, by...") not as an ultimatum',
+  ],
+  example: `Subject: Materials Needed — Board Meeting (April 15)
 
-Hi {{recipient_name}},
+Hi Sarah,
 
-I'm reaching out on behalf of {{sender_name}} ahead of your upcoming meeting on {{meeting_time}} regarding {{meeting_subject}}.
+I'm reaching out on behalf of Joseph ahead of your upcoming Board Meeting on Tuesday, April 15 at 9:00 AM.
 
-To help {{sender_name}} prepare, could you please share the following materials?
+To help Joseph prepare, could you please share the following materials?
 
-{{documents_requested}}
+  • Q1 financial summary
+  • Updated headcount projections
+  • Draft board slide deck
 
-{{deadline_clause}}If you have any questions or need clarification on what's needed, please don't hesitate to reach out.
+If possible, please share these by Friday, April 11 so there's time to review before the meeting.
+
+If you have any questions or need clarification on what's needed, please don't hesitate to reach out.
 
 Thank you in advance.
 
 Best regards,
-{{agent_signature}}`;
-
-const MAX_INPUT_LENGTH = 5000;
-
-function fillTemplate(template: string, vars: Record<string, string>): string {
-  let result = template;
-  for (const [key, value] of Object.entries(vars)) {
-    result = result.replaceAll(`{{${key}}}`, value);
-  }
-  result = result.replace(/\{\{[^}]+\}\}/g, '');
-  return result;
-}
+Nathan Curia, Agent Chief of Staff`,
+};
 
 export class TemplateDocRequestHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     const { action } = ctx.input as { action?: string };
-
     if (!action || !['generate', 'save', 'reset'].includes(action)) {
       return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', or 'reset'" };
     }
-
-    if (action === 'save') {
-      return this.saveTemplate(ctx);
-    }
-    if (action === 'reset') {
-      return this.resetTemplate(ctx);
-    }
+    if (action === 'save') return this.savePolicy(ctx);
+    if (action === 'reset') return this.resetPolicy(ctx);
     return this.generate(ctx);
   }
 
   private async generate(ctx: SkillContext): Promise<SkillResult> {
     const { recipient_name, sender_name, meeting_subject, meeting_time, documents_requested, deadline } =
       ctx.input as {
-        recipient_name?: string;
-        sender_name?: string;
-        meeting_subject?: string;
-        meeting_time?: string;
-        documents_requested?: string;
-        deadline?: string;
+        recipient_name?: string; sender_name?: string; meeting_subject?: string;
+        meeting_time?: string; documents_requested?: string; deadline?: string;
       };
 
-    if (!recipient_name || typeof recipient_name !== 'string') {
-      return { success: false, error: 'Missing required input: recipient_name' };
-    }
-    if (!sender_name || typeof sender_name !== 'string') {
-      return { success: false, error: 'Missing required input: sender_name' };
-    }
-    if (!meeting_subject || typeof meeting_subject !== 'string') {
-      return { success: false, error: 'Missing required input: meeting_subject' };
-    }
-    if (!meeting_time || typeof meeting_time !== 'string') {
-      return { success: false, error: 'Missing required input: meeting_time' };
-    }
-    if (!documents_requested || typeof documents_requested !== 'string') {
-      return { success: false, error: 'Missing required input: documents_requested' };
-    }
+    if (!recipient_name || typeof recipient_name !== 'string') return { success: false, error: 'Missing required input: recipient_name' };
+    if (!sender_name || typeof sender_name !== 'string') return { success: false, error: 'Missing required input: sender_name' };
+    if (!meeting_subject || typeof meeting_subject !== 'string') return { success: false, error: 'Missing required input: meeting_subject' };
+    if (!meeting_time || typeof meeting_time !== 'string') return { success: false, error: 'Missing required input: meeting_time' };
+    if (!documents_requested || typeof documents_requested !== 'string') return { success: false, error: 'Missing required input: documents_requested' };
 
-    if (recipient_name.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `recipient_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
-    if (sender_name.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `sender_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
-    if (meeting_subject.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `meeting_subject must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
-    if (meeting_time.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `meeting_time must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
-    if (documents_requested.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `documents_requested must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
+    if (recipient_name.length > MAX_INPUT_LENGTH) return { success: false, error: `recipient_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    if (sender_name.length > MAX_INPUT_LENGTH) return { success: false, error: `sender_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    if (meeting_subject.length > MAX_INPUT_LENGTH) return { success: false, error: `meeting_subject must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    if (meeting_time.length > MAX_INPUT_LENGTH) return { success: false, error: `meeting_time must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    if (documents_requested.length > MAX_INPUT_LENGTH) return { success: false, error: `documents_requested must be ${MAX_INPUT_LENGTH} characters or fewer` };
 
-    const { template, source } = await this.resolveTemplate(ctx);
+    const { policy, source } = await this.resolvePolicy(ctx);
 
-    const formattedDocs = documents_requested
-      .split(',')
-      .map((d) => `  • ${d.trim()}`)
-      .join('\n');
-
-    const deadlineClause = deadline
-      ? `If possible, please share these by ${deadline} so there's time to review before the meeting.\n\n`
-      : '';
-
-    const filled = fillTemplate(template, {
-      recipient_name,
-      sender_name,
-      meeting_subject,
-      meeting_time,
-      documents_requested: formattedDocs,
-      deadline_clause: deadlineClause,
+    const context: Record<string, string> = {
+      recipient_name, sender_name, meeting_subject, meeting_time, documents_requested,
       agent_signature: resolveSignature(ctx.agentPersona),
-    });
+    };
+    if (deadline) context.deadline = deadline;
 
-    const lines = filled.split('\n');
-    const subjectLine = lines[0] ?? '';
-    const subject = subjectLine.replace(/^Subject:\s*/i, '').trim();
-    const body = lines.slice(2).join('\n').trim();
-
-    ctx.log.info({ recipient_name, source }, 'Generated document request email');
+    ctx.log.info({ recipient_name, source }, 'Retrieved doc request email policy');
     return {
       success: true,
-      data: { subject, body, template_source: source },
+      data: {
+        guidelines: policy, context, source,
+        instructions: 'Use the guidelines to compose a document request email. Adapt naturally to the provided context — do not copy the example verbatim.',
+      },
     };
   }
 
-  private async saveTemplate(ctx: SkillContext): Promise<SkillResult> {
-    const { custom_template } = ctx.input as { custom_template?: string };
-    if (!custom_template || typeof custom_template !== 'string') {
-      return { success: false, error: 'Missing required input: custom_template' };
-    }
-    if (custom_template.length > 10000) {
-      return { success: false, error: 'custom_template must be 10000 characters or fewer' };
-    }
-
-    if (!ctx.entityMemory) {
-      return { success: false, error: 'Knowledge graph not available — cannot save custom template' };
-    }
+  private async savePolicy(ctx: SkillContext): Promise<SkillResult> {
+    const { custom_policy } = ctx.input as { custom_policy?: string };
+    if (!custom_policy || typeof custom_policy !== 'string') return { success: false, error: 'Missing required input: custom_policy' };
+    if (custom_policy.length > 10000) return { success: false, error: 'custom_policy must be 10000 characters or fewer' };
+    if (!ctx.entityMemory) return { success: false, error: 'Knowledge graph not available — cannot save custom policy' };
 
     try {
       const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (existing.length > 0) {
-        await ctx.entityMemory.storeFact({
-          entityNodeId: existing[0]!.id,
-          label: 'template body',
-          properties: { body: custom_template },
-          confidence: 1.0,
-          decayClass: 'permanent',
-          source: 'skill:template-doc-request',
-        });
-      } else {
-        const anchor = await ctx.entityMemory.createEntity({
-          type: 'concept',
-          label: TEMPLATE_LABEL,
-          properties: { category: 'email-template', templateName: 'doc-request' },
-          source: 'skill:template-doc-request',
-        });
-        await ctx.entityMemory.storeFact({
-          entityNodeId: anchor.id,
-          label: 'template body',
-          properties: { body: custom_template },
-          confidence: 1.0,
-          decayClass: 'permanent',
-          source: 'skill:template-doc-request',
-        });
-      }
-
-      ctx.log.info('Saved custom doc request template to knowledge graph');
+      const anchorId = existing.length > 0
+        ? existing[0]!.id
+        : (await ctx.entityMemory.createEntity({ type: 'concept', label: TEMPLATE_LABEL, properties: { category: 'email-policy', templateName: 'doc-request' }, source: 'skill:template-doc-request' })).id;
+      await ctx.entityMemory.storeFact({ entityNodeId: anchorId, label: 'email policy', properties: { policy: custom_policy }, confidence: 1.0, decayClass: 'permanent', source: 'skill:template-doc-request' });
+      ctx.log.info('Saved custom doc request email policy');
       return { success: true, data: { saved: true } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to save custom template');
-      return { success: false, error: `Failed to save template: ${message}` };
+      ctx.log.error({ err }, 'Failed to save custom policy');
+      return { success: false, error: `Failed to save policy: ${message}` };
     }
   }
 
-  private async resetTemplate(ctx: SkillContext): Promise<SkillResult> {
-    if (!ctx.entityMemory) {
-      return { success: true, data: { reset: true } };
-    }
-
+  private async resetPolicy(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.entityMemory) return { success: true, data: { reset: true } };
     try {
       const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
       if (existing.length > 0) {
         const facts = await ctx.entityMemory.getFacts(existing[0]!.id);
         if (facts.length > 0) {
-          await ctx.entityMemory.storeFact({
-            entityNodeId: existing[0]!.id,
-            label: 'template body',
-            properties: { body: '', cleared: true },
-            confidence: 1.0,
-            decayClass: 'permanent',
-            source: 'skill:template-doc-request',
-          });
+          await ctx.entityMemory.storeFact({ entityNodeId: existing[0]!.id, label: 'email policy', properties: { policy: '', cleared: true }, confidence: 1.0, decayClass: 'permanent', source: 'skill:template-doc-request' });
         }
       }
-
-      ctx.log.info('Reset doc request template to default');
+      ctx.log.info('Reset doc request email policy to default');
       return { success: true, data: { reset: true } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to reset template');
-      return { success: false, error: `Failed to reset template: ${message}` };
+      ctx.log.error({ err }, 'Failed to reset policy');
+      return { success: false, error: `Failed to reset policy: ${message}` };
     }
   }
 
-  private async resolveTemplate(ctx: SkillContext): Promise<{ template: string; source: 'default' | 'custom' }> {
-    if (!ctx.entityMemory) {
-      return { template: DEFAULT_TEMPLATE, source: 'default' };
-    }
-
+  private async resolvePolicy(ctx: SkillContext): Promise<{ policy: unknown; source: 'default' | 'custom' }> {
+    if (!ctx.entityMemory) return { policy: DEFAULT_POLICY, source: 'default' };
     try {
       const nodes = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (nodes.length === 0) {
-        return { template: DEFAULT_TEMPLATE, source: 'default' };
-      }
-
+      if (nodes.length === 0) return { policy: DEFAULT_POLICY, source: 'default' };
       const facts = await ctx.entityMemory.getFacts(nodes[0]!.id);
-      const templateFact = facts
-        .filter((f) => f.label === 'template body')
-        .sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
-
-      if (!templateFact) {
-        return { template: DEFAULT_TEMPLATE, source: 'default' };
+      const policyFact = facts.filter((f) => f.label === 'email policy').sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
+      if (!policyFact) return { policy: DEFAULT_POLICY, source: 'default' };
+      const rawPolicy = policyFact.properties.policy;
+      if (typeof rawPolicy === 'string' && rawPolicy.length > 0 && !policyFact.properties.cleared) {
+        try { return { policy: JSON.parse(rawPolicy) as unknown, source: 'custom' }; } catch { return { policy: { custom_guidelines: rawPolicy, note: 'Custom guidelines that override the default policy.' }, source: 'custom' }; }
       }
-
-      const body = templateFact.properties.body;
-      if (typeof body === 'string' && body.length > 0 && !templateFact.properties.cleared) {
-        return { template: body, source: 'custom' };
-      }
-
-      return { template: DEFAULT_TEMPLATE, source: 'default' };
+      return { policy: DEFAULT_POLICY, source: 'default' };
     } catch (err) {
-      ctx.log.warn({ err }, 'Failed to look up custom template, using default');
-      return { template: DEFAULT_TEMPLATE, source: 'default' };
+      ctx.log.warn({ err }, 'Failed to look up custom policy, using default');
+      return { policy: DEFAULT_POLICY, source: 'default' };
     }
   }
 }

--- a/skills/template-doc-request/handler.ts
+++ b/skills/template-doc-request/handler.ts
@@ -1,0 +1,229 @@
+// handler.ts — template-doc-request skill implementation.
+//
+// Generates pre-meeting document/materials request emails from a template.
+// Built-in default template is used unless the user has stored a custom
+// version in the knowledge graph.
+//
+// KG storage model:
+//   - Anchor node: type=concept, label="template:doc-request"
+//   - Template body stored as a fact node with label="template body"
+//   - decayClass=permanent (templates don't decay)
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+const TEMPLATE_LABEL = 'template:doc-request';
+
+const DEFAULT_TEMPLATE = `Subject: Materials Needed — {{meeting_subject}} ({{meeting_time}})
+
+Hi {{recipient_name}},
+
+I'm reaching out on behalf of {{sender_name}} ahead of your upcoming meeting on {{meeting_time}} regarding {{meeting_subject}}.
+
+To help {{sender_name}} prepare, could you please share the following materials?
+
+{{documents_requested}}
+
+{{deadline_clause}}If you have any questions or need clarification on what's needed, please don't hesitate to reach out.
+
+Thank you in advance.
+
+Best regards,
+Nathan Curia
+Agent Chief of Staff`;
+
+function fillTemplate(template: string, vars: Record<string, string>): string {
+  let result = template;
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replaceAll(`{{${key}}}`, value);
+  }
+  return result;
+}
+
+export class TemplateDocRequestHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { action } = ctx.input as { action?: string };
+
+    if (!action || !['generate', 'save', 'reset'].includes(action)) {
+      return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', or 'reset'" };
+    }
+
+    if (action === 'save') {
+      return this.saveTemplate(ctx);
+    }
+    if (action === 'reset') {
+      return this.resetTemplate(ctx);
+    }
+    return this.generate(ctx);
+  }
+
+  private async generate(ctx: SkillContext): Promise<SkillResult> {
+    const { recipient_name, sender_name, meeting_subject, meeting_time, documents_requested, deadline } =
+      ctx.input as {
+        recipient_name?: string;
+        sender_name?: string;
+        meeting_subject?: string;
+        meeting_time?: string;
+        documents_requested?: string;
+        deadline?: string;
+      };
+
+    if (!recipient_name || typeof recipient_name !== 'string') {
+      return { success: false, error: 'Missing required input: recipient_name' };
+    }
+    if (!sender_name || typeof sender_name !== 'string') {
+      return { success: false, error: 'Missing required input: sender_name' };
+    }
+    if (!meeting_subject || typeof meeting_subject !== 'string') {
+      return { success: false, error: 'Missing required input: meeting_subject' };
+    }
+    if (!meeting_time || typeof meeting_time !== 'string') {
+      return { success: false, error: 'Missing required input: meeting_time' };
+    }
+    if (!documents_requested || typeof documents_requested !== 'string') {
+      return { success: false, error: 'Missing required input: documents_requested' };
+    }
+
+    const { template, source } = await this.resolveTemplate(ctx);
+
+    const formattedDocs = documents_requested
+      .split(',')
+      .map((d) => `  • ${d.trim()}`)
+      .join('\n');
+
+    const deadlineClause = deadline
+      ? `If possible, please share these by ${deadline} so there's time to review before the meeting.\n\n`
+      : '';
+
+    const filled = fillTemplate(template, {
+      recipient_name,
+      sender_name,
+      meeting_subject,
+      meeting_time,
+      documents_requested: formattedDocs,
+      deadline_clause: deadlineClause,
+    });
+
+    const lines = filled.split('\n');
+    const subjectLine = lines[0] ?? '';
+    const subject = subjectLine.replace(/^Subject:\s*/i, '').trim();
+    const body = lines.slice(2).join('\n').trim();
+
+    ctx.log.info({ recipient_name, source }, 'Generated document request email');
+    return {
+      success: true,
+      data: { subject, body, template_source: source },
+    };
+  }
+
+  private async saveTemplate(ctx: SkillContext): Promise<SkillResult> {
+    const { custom_template } = ctx.input as { custom_template?: string };
+    if (!custom_template || typeof custom_template !== 'string') {
+      return { success: false, error: 'Missing required input: custom_template' };
+    }
+    if (custom_template.length > 10000) {
+      return { success: false, error: 'custom_template must be 10000 characters or fewer' };
+    }
+
+    if (!ctx.entityMemory) {
+      return { success: false, error: 'Knowledge graph not available — cannot save custom template' };
+    }
+
+    try {
+      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
+      if (existing.length > 0) {
+        await ctx.entityMemory.storeFact({
+          entityNodeId: existing[0]!.id,
+          label: 'template body',
+          properties: { body: custom_template },
+          confidence: 1.0,
+          decayClass: 'permanent',
+          source: 'skill:template-doc-request',
+        });
+      } else {
+        const anchor = await ctx.entityMemory.createEntity({
+          type: 'concept',
+          label: TEMPLATE_LABEL,
+          properties: { category: 'email-template', templateName: 'doc-request' },
+          source: 'skill:template-doc-request',
+        });
+        await ctx.entityMemory.storeFact({
+          entityNodeId: anchor.id,
+          label: 'template body',
+          properties: { body: custom_template },
+          confidence: 1.0,
+          decayClass: 'permanent',
+          source: 'skill:template-doc-request',
+        });
+      }
+
+      ctx.log.info('Saved custom doc request template to knowledge graph');
+      return { success: true, data: { saved: true } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to save custom template');
+      return { success: false, error: `Failed to save template: ${message}` };
+    }
+  }
+
+  private async resetTemplate(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.entityMemory) {
+      return { success: true, data: { reset: true } };
+    }
+
+    try {
+      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
+      if (existing.length > 0) {
+        const facts = await ctx.entityMemory.getFacts(existing[0]!.id);
+        if (facts.length > 0) {
+          await ctx.entityMemory.storeFact({
+            entityNodeId: existing[0]!.id,
+            label: 'template body',
+            properties: { body: '', cleared: true },
+            confidence: 1.0,
+            decayClass: 'permanent',
+            source: 'skill:template-doc-request',
+          });
+        }
+      }
+
+      ctx.log.info('Reset doc request template to default');
+      return { success: true, data: { reset: true } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to reset template');
+      return { success: false, error: `Failed to reset template: ${message}` };
+    }
+  }
+
+  private async resolveTemplate(ctx: SkillContext): Promise<{ template: string; source: 'default' | 'custom' }> {
+    if (!ctx.entityMemory) {
+      return { template: DEFAULT_TEMPLATE, source: 'default' };
+    }
+
+    try {
+      const nodes = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
+      if (nodes.length === 0) {
+        return { template: DEFAULT_TEMPLATE, source: 'default' };
+      }
+
+      const facts = await ctx.entityMemory.getFacts(nodes[0]!.id);
+      const templateFact = facts
+        .filter((f) => f.label === 'template body')
+        .sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
+
+      if (!templateFact) {
+        return { template: DEFAULT_TEMPLATE, source: 'default' };
+      }
+
+      const body = templateFact.properties.body;
+      if (typeof body === 'string' && body.length > 0 && !templateFact.properties.cleared) {
+        return { template: body, source: 'custom' };
+      }
+
+      return { template: DEFAULT_TEMPLATE, source: 'default' };
+    } catch (err) {
+      ctx.log.warn({ err }, 'Failed to look up custom template, using default');
+      return { template: DEFAULT_TEMPLATE, source: 'default' };
+    }
+  }
+}

--- a/skills/template-doc-request/handler.ts
+++ b/skills/template-doc-request/handler.ts
@@ -1,21 +1,12 @@
 // handler.ts — template-doc-request skill implementation.
 //
 // Returns email composing guidelines for pre-meeting document requests.
-//
-// KG storage model:
-//   - Anchor node: type=concept, label="template:doc-request"
-//   - Custom policy stored as a fact node with label="email policy"
-//   - decayClass=permanent
 
-import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
-
-function resolveSignature(persona?: AgentPersona): string {
-  if (persona?.emailSignature) return persona.emailSignature;
-  if (persona) return `${persona.displayName}, ${persona.title}`;
-  return '';
-}
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { resolveSignature, savePolicy, updatePolicy, resetPolicy, resolvePolicy } from '../_shared/template-base.js';
 
 const TEMPLATE_LABEL = 'template:doc-request';
+const SKILL_SOURCE = 'skill:template-doc-request';
 const MAX_INPUT_LENGTH = 5000;
 
 const DEFAULT_POLICY = {
@@ -61,11 +52,12 @@ Nathan Curia, Agent Chief of Staff`,
 export class TemplateDocRequestHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     const { action } = ctx.input as { action?: string };
-    if (!action || !['generate', 'save', 'reset'].includes(action)) {
-      return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', or 'reset'" };
+    if (!action || !['generate', 'save', 'update', 'reset'].includes(action)) {
+      return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', 'update', or 'reset'" };
     }
-    if (action === 'save') return this.savePolicy(ctx);
-    if (action === 'reset') return this.resetPolicy(ctx);
+    if (action === 'save') return savePolicy(ctx, TEMPLATE_LABEL, SKILL_SOURCE);
+    if (action === 'update') return updatePolicy(ctx, TEMPLATE_LABEL, SKILL_SOURCE);
+    if (action === 'reset') return resetPolicy(ctx, TEMPLATE_LABEL, SKILL_SOURCE);
     return this.generate(ctx);
   }
 
@@ -88,7 +80,7 @@ export class TemplateDocRequestHandler implements SkillHandler {
     if (meeting_time.length > MAX_INPUT_LENGTH) return { success: false, error: `meeting_time must be ${MAX_INPUT_LENGTH} characters or fewer` };
     if (documents_requested.length > MAX_INPUT_LENGTH) return { success: false, error: `documents_requested must be ${MAX_INPUT_LENGTH} characters or fewer` };
 
-    const { policy, source } = await this.resolvePolicy(ctx);
+    const { policy, source } = await resolvePolicy(ctx, TEMPLATE_LABEL, DEFAULT_POLICY);
 
     const context: Record<string, string> = {
       recipient_name, sender_name, meeting_subject, meeting_time, documents_requested,
@@ -101,67 +93,8 @@ export class TemplateDocRequestHandler implements SkillHandler {
       success: true,
       data: {
         guidelines: policy, context, source,
-        instructions: 'Use the guidelines to compose a document request email. Adapt naturally to the provided context — do not copy the example verbatim.',
+        instructions: 'Use the guidelines to compose a document request email. Adapt naturally to the provided context. If refinements are present, apply them.',
       },
     };
-  }
-
-  private async savePolicy(ctx: SkillContext): Promise<SkillResult> {
-    const { custom_policy } = ctx.input as { custom_policy?: string };
-    if (!custom_policy || typeof custom_policy !== 'string') return { success: false, error: 'Missing required input: custom_policy' };
-    if (custom_policy.length > 10000) return { success: false, error: 'custom_policy must be 10000 characters or fewer' };
-    if (!ctx.entityMemory) return { success: false, error: 'Knowledge graph not available — cannot save custom policy' };
-
-    try {
-      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      const anchorId = existing.length > 0
-        ? existing[0]!.id
-        : (await ctx.entityMemory.createEntity({ type: 'concept', label: TEMPLATE_LABEL, properties: { category: 'email-policy', templateName: 'doc-request' }, source: 'skill:template-doc-request' })).id;
-      await ctx.entityMemory.storeFact({ entityNodeId: anchorId, label: 'email policy', properties: { policy: custom_policy }, confidence: 1.0, decayClass: 'permanent', source: 'skill:template-doc-request' });
-      ctx.log.info('Saved custom doc request email policy');
-      return { success: true, data: { saved: true } };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to save custom policy');
-      return { success: false, error: `Failed to save policy: ${message}` };
-    }
-  }
-
-  private async resetPolicy(ctx: SkillContext): Promise<SkillResult> {
-    if (!ctx.entityMemory) return { success: true, data: { reset: true } };
-    try {
-      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (existing.length > 0) {
-        const facts = await ctx.entityMemory.getFacts(existing[0]!.id);
-        if (facts.length > 0) {
-          await ctx.entityMemory.storeFact({ entityNodeId: existing[0]!.id, label: 'email policy', properties: { policy: '', cleared: true }, confidence: 1.0, decayClass: 'permanent', source: 'skill:template-doc-request' });
-        }
-      }
-      ctx.log.info('Reset doc request email policy to default');
-      return { success: true, data: { reset: true } };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to reset policy');
-      return { success: false, error: `Failed to reset policy: ${message}` };
-    }
-  }
-
-  private async resolvePolicy(ctx: SkillContext): Promise<{ policy: unknown; source: 'default' | 'custom' }> {
-    if (!ctx.entityMemory) return { policy: DEFAULT_POLICY, source: 'default' };
-    try {
-      const nodes = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (nodes.length === 0) return { policy: DEFAULT_POLICY, source: 'default' };
-      const facts = await ctx.entityMemory.getFacts(nodes[0]!.id);
-      const policyFact = facts.filter((f) => f.label === 'email policy').sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
-      if (!policyFact) return { policy: DEFAULT_POLICY, source: 'default' };
-      const rawPolicy = policyFact.properties.policy;
-      if (typeof rawPolicy === 'string' && rawPolicy.length > 0 && !policyFact.properties.cleared) {
-        try { return { policy: JSON.parse(rawPolicy) as unknown, source: 'custom' }; } catch { return { policy: { custom_guidelines: rawPolicy, note: 'Custom guidelines that override the default policy.' }, source: 'custom' }; }
-      }
-      return { policy: DEFAULT_POLICY, source: 'default' };
-    } catch (err) {
-      ctx.log.warn({ err }, 'Failed to look up custom policy, using default');
-      return { policy: DEFAULT_POLICY, source: 'default' };
-    }
   }
 }

--- a/skills/template-doc-request/handler.ts
+++ b/skills/template-doc-request/handler.ts
@@ -31,11 +31,14 @@ Best regards,
 Nathan Curia
 Agent Chief of Staff`;
 
+const MAX_INPUT_LENGTH = 5000;
+
 function fillTemplate(template: string, vars: Record<string, string>): string {
   let result = template;
   for (const [key, value] of Object.entries(vars)) {
     result = result.replaceAll(`{{${key}}}`, value);
   }
+  result = result.replace(/\{\{[^}]+\}\}/g, '');
   return result;
 }
 
@@ -81,6 +84,22 @@ export class TemplateDocRequestHandler implements SkillHandler {
     }
     if (!documents_requested || typeof documents_requested !== 'string') {
       return { success: false, error: 'Missing required input: documents_requested' };
+    }
+
+    if (recipient_name.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `recipient_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    }
+    if (sender_name.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `sender_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    }
+    if (meeting_subject.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `meeting_subject must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    }
+    if (meeting_time.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `meeting_time must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    }
+    if (documents_requested.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `documents_requested must be ${MAX_INPUT_LENGTH} characters or fewer` };
     }
 
     const { template, source } = await this.resolveTemplate(ctx);

--- a/skills/template-doc-request/handler.ts
+++ b/skills/template-doc-request/handler.ts
@@ -9,7 +9,13 @@
 //   - Template body stored as a fact node with label="template body"
 //   - decayClass=permanent (templates don't decay)
 
-import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
+
+function resolveSignature(persona?: AgentPersona): string {
+  if (persona?.emailSignature) return persona.emailSignature;
+  if (persona) return `${persona.displayName}\n${persona.title}`;
+  return '';
+}
 
 const TEMPLATE_LABEL = 'template:doc-request';
 
@@ -28,8 +34,7 @@ To help {{sender_name}} prepare, could you please share the following materials?
 Thank you in advance.
 
 Best regards,
-Nathan Curia
-Agent Chief of Staff`;
+{{agent_signature}}`;
 
 const MAX_INPUT_LENGTH = 5000;
 
@@ -120,6 +125,7 @@ export class TemplateDocRequestHandler implements SkillHandler {
       meeting_time,
       documents_requested: formattedDocs,
       deadline_clause: deadlineClause,
+      agent_signature: resolveSignature(ctx.agentPersona),
     });
 
     const lines = filled.split('\n');

--- a/skills/template-doc-request/skill.json
+++ b/skills/template-doc-request/skill.json
@@ -1,11 +1,12 @@
 {
   "name": "template-doc-request",
-  "description": "Retrieve email composing guidelines for pre-meeting document/materials requests. Returns structured policy (required elements, tone, structure, constraints, example) that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports 'generate', 'save', and 'reset' actions.",
+  "description": "Retrieve email composing guidelines for pre-meeting document/materials requests. Returns structured policy that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports four actions: 'generate' retrieves the policy (with any refinements); 'update' accepts a natural-language refinement; 'save' replaces the entire policy; 'reset' reverts to defaults and clears refinements.",
   "version": "1.0.0",
   "sensitivity": "normal",
   "infrastructure": true,
   "inputs": {
-    "action": "string (generate | save | reset)",
+    "action": "string (generate | update | save | reset)",
+    "refinement": "string? (required for update — a natural-language adjustment to the policy)",
     "recipient_name": "string? (required for generate)",
     "sender_name": "string? (required for generate — the person requesting the documents)",
     "meeting_subject": "string? (required for generate — the meeting topic)",

--- a/skills/template-doc-request/skill.json
+++ b/skills/template-doc-request/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "template-doc-request",
-  "description": "Generate a pre-meeting document/materials request email from a template. Supports three actions: 'generate' fills the template with provided variables (checks the knowledge graph for a user-customized template before falling back to the built-in default); 'save' stores a custom template in the knowledge graph; 'reset' removes the custom template and reverts to the built-in default.",
+  "description": "Retrieve email composing guidelines for pre-meeting document/materials requests. Returns structured policy (required elements, tone, structure, constraints, example) that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports 'generate', 'save', and 'reset' actions.",
   "version": "1.0.0",
   "sensitivity": "normal",
   "infrastructure": true,
@@ -12,12 +12,13 @@
     "meeting_time": "string? (required for generate — when the meeting is scheduled)",
     "documents_requested": "string? (required for generate — comma-separated list of requested materials)",
     "deadline": "string? (optional for generate — when materials are needed by)",
-    "custom_template": "string? (required for save — the template body to store)"
+    "custom_policy": "string? (required for save — the policy to store)"
   },
   "outputs": {
-    "subject": "string?",
-    "body": "string?",
-    "template_source": "string? (default | custom)",
+    "guidelines": "object?",
+    "context": "object?",
+    "source": "string? (default | custom)",
+    "instructions": "string?",
     "saved": "boolean?",
     "reset": "boolean?"
   },

--- a/skills/template-doc-request/skill.json
+++ b/skills/template-doc-request/skill.json
@@ -1,0 +1,27 @@
+{
+  "name": "template-doc-request",
+  "description": "Generate a pre-meeting document/materials request email from a template. Supports three actions: 'generate' fills the template with provided variables (checks the knowledge graph for a user-customized template before falling back to the built-in default); 'save' stores a custom template in the knowledge graph; 'reset' removes the custom template and reverts to the built-in default.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "action": "string (generate | save | reset)",
+    "recipient_name": "string? (required for generate)",
+    "sender_name": "string? (required for generate — the person requesting the documents)",
+    "meeting_subject": "string? (required for generate — the meeting topic)",
+    "meeting_time": "string? (required for generate — when the meeting is scheduled)",
+    "documents_requested": "string? (required for generate — comma-separated list of requested materials)",
+    "deadline": "string? (optional for generate — when materials are needed by)",
+    "custom_template": "string? (required for save — the template body to store)"
+  },
+  "outputs": {
+    "subject": "string?",
+    "body": "string?",
+    "template_source": "string? (default | custom)",
+    "saved": "boolean?",
+    "reset": "boolean?"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/skills/template-meeting-request/handler.ts
+++ b/skills/template-meeting-request/handler.ts
@@ -31,15 +31,22 @@ Best regards,
 Nathan Curia
 Agent Chief of Staff`;
 
+const MAX_INPUT_LENGTH = 5000;
+
 /**
  * Fill template placeholders with provided variables.
  * Placeholders use {{variable_name}} syntax.
+ * Strips any unfilled placeholders after substitution so they don't leak
+ * into generated emails as raw {{...}} text.
  */
 function fillTemplate(template: string, vars: Record<string, string>): string {
   let result = template;
   for (const [key, value] of Object.entries(vars)) {
     result = result.replaceAll(`{{${key}}}`, value);
   }
+  // Strip any remaining unfilled placeholders (from custom templates with
+  // different variable names, or optional fields not provided)
+  result = result.replace(/\{\{[^}]+\}\}/g, '');
   return result;
 }
 
@@ -79,6 +86,17 @@ export class TemplateMeetingRequestHandler implements SkillHandler {
     }
     if (!proposed_times || typeof proposed_times !== 'string') {
       return { success: false, error: 'Missing required input: proposed_times' };
+    }
+
+    // Length caps prevent oversized inputs from producing enormous output
+    if (recipient_name.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `recipient_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    }
+    if (sender_name.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `sender_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    }
+    if (proposed_times.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `proposed_times must be ${MAX_INPUT_LENGTH} characters or fewer` };
     }
 
     // Look up custom template from KG, fall back to built-in default

--- a/skills/template-meeting-request/handler.ts
+++ b/skills/template-meeting-request/handler.ts
@@ -1,37 +1,25 @@
 // handler.ts — template-meeting-request skill implementation.
 //
 // Returns email composing guidelines for meeting requests — NOT a pre-filled
-// email. The LLM uses these guidelines (required elements, tone, structure,
-// example) to compose the actual email, combining organizational consistency
-// with natural language fluency.
+// email. The LLM uses these guidelines to compose naturally while following
+// organizational policy.
 //
-// This is better than both rigid templates (can't adapt) and bare LLM behavior
-// (no organizational consistency). The skill enforces policy; the LLM provides
-// fluency.
-//
-// KG storage model:
-//   - Anchor node: type=concept, label="template:meeting-request"
-//   - Custom policy stored as a fact node with label="email policy"
-//   - decayClass=permanent (policies don't decay)
+// See skills/_shared/template-base.ts for the shared save/update/reset/resolve
+// logic that all template skills use.
 
-import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
-
-/** Build the email signature from the agent persona, or a safe fallback. */
-function resolveSignature(persona?: AgentPersona): string {
-  if (persona?.emailSignature) return persona.emailSignature;
-  if (persona) return `${persona.displayName}, ${persona.title}`;
-  return '';
-}
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import {
+  resolveSignature,
+  savePolicy,
+  updatePolicy,
+  resetPolicy,
+  resolvePolicy,
+} from '../_shared/template-base.js';
 
 const TEMPLATE_LABEL = 'template:meeting-request';
-
+const SKILL_SOURCE = 'skill:template-meeting-request';
 const MAX_INPUT_LENGTH = 5000;
 
-/**
- * Built-in default policy for meeting request emails. Stored as structured
- * guidelines so the LLM knows what to include, how to structure it, and
- * what tone to use — then composes naturally.
- */
 const DEFAULT_POLICY = {
   required_elements: [
     'Greeting addressing the recipient by name',
@@ -74,59 +62,35 @@ export class TemplateMeetingRequestHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     const { action } = ctx.input as { action?: string };
 
-    if (!action || !['generate', 'save', 'reset'].includes(action)) {
-      return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', or 'reset'" };
+    if (!action || !['generate', 'save', 'update', 'reset'].includes(action)) {
+      return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', 'update', or 'reset'" };
     }
 
-    if (action === 'save') {
-      return this.savePolicy(ctx);
-    }
-    if (action === 'reset') {
-      return this.resetPolicy(ctx);
-    }
+    if (action === 'save') return savePolicy(ctx, TEMPLATE_LABEL, SKILL_SOURCE);
+    if (action === 'update') return updatePolicy(ctx, TEMPLATE_LABEL, SKILL_SOURCE);
+    if (action === 'reset') return resetPolicy(ctx, TEMPLATE_LABEL, SKILL_SOURCE);
     return this.generate(ctx);
   }
 
   private async generate(ctx: SkillContext): Promise<SkillResult> {
     const { recipient_name, sender_name, proposed_times, meeting_purpose, meeting_duration, meeting_location } =
       ctx.input as {
-        recipient_name?: string;
-        sender_name?: string;
-        proposed_times?: string;
-        meeting_purpose?: string;
-        meeting_duration?: string;
-        meeting_location?: string;
+        recipient_name?: string; sender_name?: string; proposed_times?: string;
+        meeting_purpose?: string; meeting_duration?: string; meeting_location?: string;
       };
 
-    if (!recipient_name || typeof recipient_name !== 'string') {
-      return { success: false, error: 'Missing required input: recipient_name' };
-    }
-    if (!sender_name || typeof sender_name !== 'string') {
-      return { success: false, error: 'Missing required input: sender_name' };
-    }
-    if (!proposed_times || typeof proposed_times !== 'string') {
-      return { success: false, error: 'Missing required input: proposed_times' };
-    }
+    if (!recipient_name || typeof recipient_name !== 'string') return { success: false, error: 'Missing required input: recipient_name' };
+    if (!sender_name || typeof sender_name !== 'string') return { success: false, error: 'Missing required input: sender_name' };
+    if (!proposed_times || typeof proposed_times !== 'string') return { success: false, error: 'Missing required input: proposed_times' };
 
-    // Length caps prevent oversized inputs from producing enormous output
-    if (recipient_name.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `recipient_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
-    if (sender_name.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `sender_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
-    if (proposed_times.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `proposed_times must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
+    if (recipient_name.length > MAX_INPUT_LENGTH) return { success: false, error: `recipient_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    if (sender_name.length > MAX_INPUT_LENGTH) return { success: false, error: `sender_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    if (proposed_times.length > MAX_INPUT_LENGTH) return { success: false, error: `proposed_times must be ${MAX_INPUT_LENGTH} characters or fewer` };
 
-    // Look up custom policy from KG, fall back to built-in default
-    const { policy, source } = await this.resolvePolicy(ctx);
+    const { policy, source } = await resolvePolicy(ctx, TEMPLATE_LABEL, DEFAULT_POLICY);
 
-    // Build the context object the LLM will use to compose the email
     const context: Record<string, string> = {
-      recipient_name,
-      sender_name,
-      proposed_times,
+      recipient_name, sender_name, proposed_times,
       agent_signature: resolveSignature(ctx.agentPersona),
     };
     if (meeting_purpose) context.meeting_purpose = meeting_purpose;
@@ -137,138 +101,9 @@ export class TemplateMeetingRequestHandler implements SkillHandler {
     return {
       success: true,
       data: {
-        guidelines: policy,
-        context,
-        source,
-        instructions: 'Use the guidelines to compose a meeting request email. The guidelines define required elements, tone, structure, and constraints. The example shows the expected quality and format. Adapt naturally to the provided context — do not copy the example verbatim.',
+        guidelines: policy, context, source,
+        instructions: 'Use the guidelines to compose a meeting request email. The guidelines define required elements, tone, structure, and constraints. The example shows the expected quality and format. Adapt naturally to the provided context — do not copy the example verbatim. If refinements are present, they are user-requested adjustments that take priority over the base policy.',
       },
     };
-  }
-
-  private async savePolicy(ctx: SkillContext): Promise<SkillResult> {
-    const { custom_policy } = ctx.input as { custom_policy?: string };
-    if (!custom_policy || typeof custom_policy !== 'string') {
-      return { success: false, error: 'Missing required input: custom_policy (a JSON string describing the email policy, or plain-text guidelines)' };
-    }
-    if (custom_policy.length > 10000) {
-      return { success: false, error: 'custom_policy must be 10000 characters or fewer' };
-    }
-
-    if (!ctx.entityMemory) {
-      return { success: false, error: 'Knowledge graph not available — cannot save custom policy' };
-    }
-
-    try {
-      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (existing.length > 0) {
-        await ctx.entityMemory.storeFact({
-          entityNodeId: existing[0]!.id,
-          label: 'email policy',
-          properties: { policy: custom_policy },
-          confidence: 1.0,
-          decayClass: 'permanent',
-          source: 'skill:template-meeting-request',
-        });
-      } else {
-        const anchor = await ctx.entityMemory.createEntity({
-          type: 'concept',
-          label: TEMPLATE_LABEL,
-          properties: { category: 'email-policy', templateName: 'meeting-request' },
-          source: 'skill:template-meeting-request',
-        });
-        await ctx.entityMemory.storeFact({
-          entityNodeId: anchor.id,
-          label: 'email policy',
-          properties: { policy: custom_policy },
-          confidence: 1.0,
-          decayClass: 'permanent',
-          source: 'skill:template-meeting-request',
-        });
-      }
-
-      ctx.log.info('Saved custom meeting request email policy to knowledge graph');
-      return { success: true, data: { saved: true } };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to save custom policy');
-      return { success: false, error: `Failed to save policy: ${message}` };
-    }
-  }
-
-  private async resetPolicy(ctx: SkillContext): Promise<SkillResult> {
-    if (!ctx.entityMemory) {
-      return { success: true, data: { reset: true } };
-    }
-
-    try {
-      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (existing.length > 0) {
-        const facts = await ctx.entityMemory.getFacts(existing[0]!.id);
-        if (facts.length > 0) {
-          await ctx.entityMemory.storeFact({
-            entityNodeId: existing[0]!.id,
-            label: 'email policy',
-            properties: { policy: '', cleared: true },
-            confidence: 1.0,
-            decayClass: 'permanent',
-            source: 'skill:template-meeting-request',
-          });
-        }
-      }
-
-      ctx.log.info('Reset meeting request email policy to default');
-      return { success: true, data: { reset: true } };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to reset policy');
-      return { success: false, error: `Failed to reset policy: ${message}` };
-    }
-  }
-
-  /**
-   * Look up a custom email policy from the knowledge graph.
-   * Returns the custom policy if found, otherwise the built-in default.
-   * Custom policies can be plain text guidelines or structured JSON.
-   */
-  private async resolvePolicy(ctx: SkillContext): Promise<{ policy: unknown; source: 'default' | 'custom' }> {
-    if (!ctx.entityMemory) {
-      return { policy: DEFAULT_POLICY, source: 'default' };
-    }
-
-    try {
-      const nodes = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (nodes.length === 0) {
-        return { policy: DEFAULT_POLICY, source: 'default' };
-      }
-
-      const facts = await ctx.entityMemory.getFacts(nodes[0]!.id);
-      const policyFact = facts
-        .filter((f) => f.label === 'email policy')
-        .sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
-
-      if (!policyFact) {
-        return { policy: DEFAULT_POLICY, source: 'default' };
-      }
-
-      const rawPolicy = policyFact.properties.policy;
-      if (typeof rawPolicy === 'string' && rawPolicy.length > 0 && !policyFact.properties.cleared) {
-        // Try to parse as JSON; if it fails, treat as plain-text guidelines
-        try {
-          const parsed = JSON.parse(rawPolicy) as unknown;
-          return { policy: parsed, source: 'custom' };
-        } catch {
-          // Plain text guidelines — wrap in a structure for the LLM
-          return {
-            policy: { custom_guidelines: rawPolicy, note: 'These are custom guidelines that override the default policy. Follow them when composing the email.' },
-            source: 'custom',
-          };
-        }
-      }
-
-      return { policy: DEFAULT_POLICY, source: 'default' };
-    } catch (err) {
-      ctx.log.warn({ err }, 'Failed to look up custom policy, using default');
-      return { policy: DEFAULT_POLICY, source: 'default' };
-    }
   }
 }

--- a/skills/template-meeting-request/handler.ts
+++ b/skills/template-meeting-request/handler.ts
@@ -1,0 +1,257 @@
+// handler.ts — template-meeting-request skill implementation.
+//
+// Generates meeting request emails from a template. The built-in default
+// template is used unless the user has stored a custom version in the
+// knowledge graph. Users can save, retrieve, and reset custom templates.
+//
+// KG storage model:
+//   - Anchor node: type=concept, label="template:meeting-request"
+//   - Template body stored in the anchor node's properties.body field
+//   - decayClass=permanent (templates don't decay)
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+const TEMPLATE_LABEL = 'template:meeting-request';
+
+const DEFAULT_TEMPLATE = `Subject: Meeting Request — {{meeting_purpose}}
+
+Hi {{recipient_name}},
+
+I'm reaching out on behalf of {{sender_name}} to schedule a meeting{{purpose_clause}}.
+
+{{sender_name}} is available at the following times:
+
+{{proposed_times}}
+
+{{duration_line}}{{location_line}}Please let me know which time works best for you, or suggest an alternative if none of these work.
+
+Looking forward to connecting.
+
+Best regards,
+Nathan Curia
+Agent Chief of Staff`;
+
+/**
+ * Fill template placeholders with provided variables.
+ * Placeholders use {{variable_name}} syntax.
+ */
+function fillTemplate(template: string, vars: Record<string, string>): string {
+  let result = template;
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replaceAll(`{{${key}}}`, value);
+  }
+  return result;
+}
+
+export class TemplateMeetingRequestHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { action } = ctx.input as { action?: string };
+
+    if (!action || !['generate', 'save', 'reset'].includes(action)) {
+      return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', or 'reset'" };
+    }
+
+    if (action === 'save') {
+      return this.saveTemplate(ctx);
+    }
+    if (action === 'reset') {
+      return this.resetTemplate(ctx);
+    }
+    return this.generate(ctx);
+  }
+
+  private async generate(ctx: SkillContext): Promise<SkillResult> {
+    const { recipient_name, sender_name, proposed_times, meeting_purpose, meeting_duration, meeting_location } =
+      ctx.input as {
+        recipient_name?: string;
+        sender_name?: string;
+        proposed_times?: string;
+        meeting_purpose?: string;
+        meeting_duration?: string;
+        meeting_location?: string;
+      };
+
+    if (!recipient_name || typeof recipient_name !== 'string') {
+      return { success: false, error: 'Missing required input: recipient_name' };
+    }
+    if (!sender_name || typeof sender_name !== 'string') {
+      return { success: false, error: 'Missing required input: sender_name' };
+    }
+    if (!proposed_times || typeof proposed_times !== 'string') {
+      return { success: false, error: 'Missing required input: proposed_times' };
+    }
+
+    // Look up custom template from KG, fall back to built-in default
+    const { template, source } = await this.resolveTemplate(ctx);
+
+    // Build conditional clause fragments so the template reads naturally
+    // whether optional fields are provided or not.
+    const purposeClause = meeting_purpose ? ` to discuss ${meeting_purpose}` : '';
+    const durationLine = meeting_duration ? `Duration: ${meeting_duration}\n` : '';
+    const locationLine = meeting_location ? `Location: ${meeting_location}\n\n` : '\n';
+
+    // Format proposed times as a bulleted list
+    const formattedTimes = proposed_times
+      .split(',')
+      .map((t) => `  • ${t.trim()}`)
+      .join('\n');
+
+    const filled = fillTemplate(template, {
+      recipient_name,
+      sender_name,
+      proposed_times: formattedTimes,
+      meeting_purpose: meeting_purpose ?? 'Meeting',
+      purpose_clause: purposeClause,
+      duration_line: durationLine,
+      location_line: locationLine,
+    });
+
+    // Split subject from body (first line is the subject)
+    const lines = filled.split('\n');
+    const subjectLine = lines[0] ?? '';
+    const subject = subjectLine.replace(/^Subject:\s*/i, '').trim();
+    // Skip the blank line after the subject
+    const body = lines.slice(2).join('\n').trim();
+
+    ctx.log.info({ recipient_name, source }, 'Generated meeting request email');
+    return {
+      success: true,
+      data: { subject, body, template_source: source },
+    };
+  }
+
+  private async saveTemplate(ctx: SkillContext): Promise<SkillResult> {
+    const { custom_template } = ctx.input as { custom_template?: string };
+    if (!custom_template || typeof custom_template !== 'string') {
+      return { success: false, error: 'Missing required input: custom_template' };
+    }
+    if (custom_template.length > 10000) {
+      return { success: false, error: 'custom_template must be 10000 characters or fewer' };
+    }
+
+    if (!ctx.entityMemory) {
+      return { success: false, error: 'Knowledge graph not available — cannot save custom template' };
+    }
+
+    try {
+      // Check if a custom template node already exists
+      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
+      if (existing.length > 0) {
+        // Update the existing node's body — storeFact would create a child fact,
+        // but we want to update the anchor node's properties directly.
+        // Use search + create pattern: delete old, create new (KG doesn't expose
+        // direct property updates on entity nodes through EntityMemory).
+        // Actually, we store the template as a fact on the anchor node so we can
+        // use storeFact's dedup/update logic.
+        await ctx.entityMemory.storeFact({
+          entityNodeId: existing[0]!.id,
+          label: 'template body',
+          properties: { body: custom_template },
+          confidence: 1.0,
+          decayClass: 'permanent',
+          source: 'skill:template-meeting-request',
+        });
+      } else {
+        // Create the anchor concept node, then store the template as a fact
+        const anchor = await ctx.entityMemory.createEntity({
+          type: 'concept',
+          label: TEMPLATE_LABEL,
+          properties: { category: 'email-template', templateName: 'meeting-request' },
+          source: 'skill:template-meeting-request',
+        });
+        await ctx.entityMemory.storeFact({
+          entityNodeId: anchor.id,
+          label: 'template body',
+          properties: { body: custom_template },
+          confidence: 1.0,
+          decayClass: 'permanent',
+          source: 'skill:template-meeting-request',
+        });
+      }
+
+      ctx.log.info('Saved custom meeting request template to knowledge graph');
+      return { success: true, data: { saved: true } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to save custom template');
+      return { success: false, error: `Failed to save template: ${message}` };
+    }
+  }
+
+  private async resetTemplate(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.entityMemory) {
+      // No KG means no custom template could exist — reset is a no-op
+      return { success: true, data: { reset: true } };
+    }
+
+    try {
+      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
+      if (existing.length > 0) {
+        // Remove all fact nodes linked to the anchor, then the anchor itself.
+        // getFacts returns fact nodes; we need the KG store to delete them.
+        // Since EntityMemory doesn't expose deleteNode, we clear by removing
+        // the facts. The anchor node remains but with no template body fact,
+        // so resolveTemplate will fall back to the default.
+        const facts = await ctx.entityMemory.getFacts(existing[0]!.id);
+        // We can't delete nodes through EntityMemory — but we can store a
+        // "cleared" marker so resolveTemplate knows to use the default.
+        // Simpler: just store a fact with body="" to signal "use default".
+        if (facts.length > 0) {
+          await ctx.entityMemory.storeFact({
+            entityNodeId: existing[0]!.id,
+            label: 'template body',
+            properties: { body: '', cleared: true },
+            confidence: 1.0,
+            decayClass: 'permanent',
+            source: 'skill:template-meeting-request',
+          });
+        }
+      }
+
+      ctx.log.info('Reset meeting request template to default');
+      return { success: true, data: { reset: true } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to reset template');
+      return { success: false, error: `Failed to reset template: ${message}` };
+    }
+  }
+
+  /**
+   * Look up a custom template from the knowledge graph.
+   * Returns the custom template if found and non-empty, otherwise the built-in default.
+   */
+  private async resolveTemplate(ctx: SkillContext): Promise<{ template: string; source: 'default' | 'custom' }> {
+    if (!ctx.entityMemory) {
+      return { template: DEFAULT_TEMPLATE, source: 'default' };
+    }
+
+    try {
+      const nodes = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
+      if (nodes.length === 0) {
+        return { template: DEFAULT_TEMPLATE, source: 'default' };
+      }
+
+      const facts = await ctx.entityMemory.getFacts(nodes[0]!.id);
+      // Find the most recent template body fact (by lastConfirmedAt)
+      const templateFact = facts
+        .filter((f) => f.label === 'template body')
+        .sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
+
+      if (!templateFact) {
+        return { template: DEFAULT_TEMPLATE, source: 'default' };
+      }
+
+      const body = templateFact.properties.body;
+      if (typeof body === 'string' && body.length > 0 && !templateFact.properties.cleared) {
+        return { template: body, source: 'custom' };
+      }
+
+      return { template: DEFAULT_TEMPLATE, source: 'default' };
+    } catch (err) {
+      // KG lookup failure is non-fatal — fall back to default
+      ctx.log.warn({ err }, 'Failed to look up custom template, using default');
+      return { template: DEFAULT_TEMPLATE, source: 'default' };
+    }
+  }
+}

--- a/skills/template-meeting-request/handler.ts
+++ b/skills/template-meeting-request/handler.ts
@@ -1,60 +1,74 @@
 // handler.ts — template-meeting-request skill implementation.
 //
-// Generates meeting request emails from a template. The built-in default
-// template is used unless the user has stored a custom version in the
-// knowledge graph. Users can save, retrieve, and reset custom templates.
+// Returns email composing guidelines for meeting requests — NOT a pre-filled
+// email. The LLM uses these guidelines (required elements, tone, structure,
+// example) to compose the actual email, combining organizational consistency
+// with natural language fluency.
+//
+// This is better than both rigid templates (can't adapt) and bare LLM behavior
+// (no organizational consistency). The skill enforces policy; the LLM provides
+// fluency.
 //
 // KG storage model:
 //   - Anchor node: type=concept, label="template:meeting-request"
-//   - Template body stored in the anchor node's properties.body field
-//   - decayClass=permanent (templates don't decay)
+//   - Custom policy stored as a fact node with label="email policy"
+//   - decayClass=permanent (policies don't decay)
 
 import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
 
 /** Build the email signature from the agent persona, or a safe fallback. */
 function resolveSignature(persona?: AgentPersona): string {
   if (persona?.emailSignature) return persona.emailSignature;
-  if (persona) return `${persona.displayName}\n${persona.title}`;
+  if (persona) return `${persona.displayName}, ${persona.title}`;
   return '';
 }
 
 const TEMPLATE_LABEL = 'template:meeting-request';
 
-const DEFAULT_TEMPLATE = `Subject: Meeting Request — {{meeting_purpose}}
-
-Hi {{recipient_name}},
-
-I'm reaching out on behalf of {{sender_name}} to schedule a meeting{{purpose_clause}}.
-
-{{sender_name}} is available at the following times:
-
-{{proposed_times}}
-
-{{duration_line}}{{location_line}}Please let me know which time works best for you, or suggest an alternative if none of these work.
-
-Looking forward to connecting.
-
-Best regards,
-{{agent_signature}}`;
-
 const MAX_INPUT_LENGTH = 5000;
 
 /**
- * Fill template placeholders with provided variables.
- * Placeholders use {{variable_name}} syntax.
- * Strips any unfilled placeholders after substitution so they don't leak
- * into generated emails as raw {{...}} text.
+ * Built-in default policy for meeting request emails. Stored as structured
+ * guidelines so the LLM knows what to include, how to structure it, and
+ * what tone to use — then composes naturally.
  */
-function fillTemplate(template: string, vars: Record<string, string>): string {
-  let result = template;
-  for (const [key, value] of Object.entries(vars)) {
-    result = result.replaceAll(`{{${key}}}`, value);
-  }
-  // Strip any remaining unfilled placeholders (from custom templates with
-  // different variable names, or optional fields not provided)
-  result = result.replace(/\{\{[^}]+\}\}/g, '');
-  return result;
-}
+const DEFAULT_POLICY = {
+  required_elements: [
+    'Greeting addressing the recipient by name',
+    'State who is requesting the meeting (the sender) and the purpose',
+    'List proposed times as bullet points (at least 2-3 options)',
+    'Include meeting duration if provided',
+    'Include meeting location/format if provided (Zoom, in-person, etc.)',
+    'Offer flexibility — invite the recipient to suggest alternatives if none of the times work',
+    'Professional sign-off with the agent signature',
+  ],
+  tone: 'Professional, warm, and concise. Not stiff or overly formal.',
+  structure: 'Greeting → purpose → proposed times → logistics → flexibility offer → sign-off',
+  constraints: [
+    'Keep the body to 4-6 sentences plus the time list',
+    'Do not use exclamation marks',
+    'Subject line should include the meeting purpose',
+    'Times should be formatted as a bulleted list, not inline',
+  ],
+  example: `Subject: Meeting Request — Q3 Planning
+
+Hi Alice,
+
+I'm reaching out on behalf of Joseph to schedule a meeting to discuss Q3 Planning.
+
+Joseph is available at the following times:
+
+  • Monday, April 7 at 10:00 AM ET
+  • Tuesday, April 8 at 2:00 PM ET
+  • Wednesday, April 9 at 11:00 AM ET
+
+The meeting would be approximately 45 minutes via Zoom.
+
+Please let me know which time works best for you, or suggest an alternative if none of these are convenient.
+
+Best regards,
+Nathan Curia, Agent Chief of Staff`,
+};
 
 export class TemplateMeetingRequestHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -65,10 +79,10 @@ export class TemplateMeetingRequestHandler implements SkillHandler {
     }
 
     if (action === 'save') {
-      return this.saveTemplate(ctx);
+      return this.savePolicy(ctx);
     }
     if (action === 'reset') {
-      return this.resetTemplate(ctx);
+      return this.resetPolicy(ctx);
     }
     return this.generate(ctx);
   }
@@ -105,127 +119,96 @@ export class TemplateMeetingRequestHandler implements SkillHandler {
       return { success: false, error: `proposed_times must be ${MAX_INPUT_LENGTH} characters or fewer` };
     }
 
-    // Look up custom template from KG, fall back to built-in default
-    const { template, source } = await this.resolveTemplate(ctx);
+    // Look up custom policy from KG, fall back to built-in default
+    const { policy, source } = await this.resolvePolicy(ctx);
 
-    // Build conditional clause fragments so the template reads naturally
-    // whether optional fields are provided or not.
-    const purposeClause = meeting_purpose ? ` to discuss ${meeting_purpose}` : '';
-    const durationLine = meeting_duration ? `Duration: ${meeting_duration}\n` : '';
-    const locationLine = meeting_location ? `Location: ${meeting_location}\n\n` : '\n';
-
-    // Format proposed times as a bulleted list
-    const formattedTimes = proposed_times
-      .split(',')
-      .map((t) => `  • ${t.trim()}`)
-      .join('\n');
-
-    const filled = fillTemplate(template, {
+    // Build the context object the LLM will use to compose the email
+    const context: Record<string, string> = {
       recipient_name,
       sender_name,
-      proposed_times: formattedTimes,
-      meeting_purpose: meeting_purpose ?? 'Meeting',
-      purpose_clause: purposeClause,
-      duration_line: durationLine,
-      location_line: locationLine,
+      proposed_times,
       agent_signature: resolveSignature(ctx.agentPersona),
-    });
+    };
+    if (meeting_purpose) context.meeting_purpose = meeting_purpose;
+    if (meeting_duration) context.meeting_duration = meeting_duration;
+    if (meeting_location) context.meeting_location = meeting_location;
 
-    // Split subject from body (first line is the subject)
-    const lines = filled.split('\n');
-    const subjectLine = lines[0] ?? '';
-    const subject = subjectLine.replace(/^Subject:\s*/i, '').trim();
-    // Skip the blank line after the subject
-    const body = lines.slice(2).join('\n').trim();
-
-    ctx.log.info({ recipient_name, source }, 'Generated meeting request email');
+    ctx.log.info({ recipient_name, source }, 'Retrieved meeting request email policy');
     return {
       success: true,
-      data: { subject, body, template_source: source },
+      data: {
+        guidelines: policy,
+        context,
+        source,
+        instructions: 'Use the guidelines to compose a meeting request email. The guidelines define required elements, tone, structure, and constraints. The example shows the expected quality and format. Adapt naturally to the provided context — do not copy the example verbatim.',
+      },
     };
   }
 
-  private async saveTemplate(ctx: SkillContext): Promise<SkillResult> {
-    const { custom_template } = ctx.input as { custom_template?: string };
-    if (!custom_template || typeof custom_template !== 'string') {
-      return { success: false, error: 'Missing required input: custom_template' };
+  private async savePolicy(ctx: SkillContext): Promise<SkillResult> {
+    const { custom_policy } = ctx.input as { custom_policy?: string };
+    if (!custom_policy || typeof custom_policy !== 'string') {
+      return { success: false, error: 'Missing required input: custom_policy (a JSON string describing the email policy, or plain-text guidelines)' };
     }
-    if (custom_template.length > 10000) {
-      return { success: false, error: 'custom_template must be 10000 characters or fewer' };
+    if (custom_policy.length > 10000) {
+      return { success: false, error: 'custom_policy must be 10000 characters or fewer' };
     }
 
     if (!ctx.entityMemory) {
-      return { success: false, error: 'Knowledge graph not available — cannot save custom template' };
+      return { success: false, error: 'Knowledge graph not available — cannot save custom policy' };
     }
 
     try {
-      // Check if a custom template node already exists
       const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
       if (existing.length > 0) {
-        // Update the existing node's body — storeFact would create a child fact,
-        // but we want to update the anchor node's properties directly.
-        // Use search + create pattern: delete old, create new (KG doesn't expose
-        // direct property updates on entity nodes through EntityMemory).
-        // Actually, we store the template as a fact on the anchor node so we can
-        // use storeFact's dedup/update logic.
         await ctx.entityMemory.storeFact({
           entityNodeId: existing[0]!.id,
-          label: 'template body',
-          properties: { body: custom_template },
+          label: 'email policy',
+          properties: { policy: custom_policy },
           confidence: 1.0,
           decayClass: 'permanent',
           source: 'skill:template-meeting-request',
         });
       } else {
-        // Create the anchor concept node, then store the template as a fact
         const anchor = await ctx.entityMemory.createEntity({
           type: 'concept',
           label: TEMPLATE_LABEL,
-          properties: { category: 'email-template', templateName: 'meeting-request' },
+          properties: { category: 'email-policy', templateName: 'meeting-request' },
           source: 'skill:template-meeting-request',
         });
         await ctx.entityMemory.storeFact({
           entityNodeId: anchor.id,
-          label: 'template body',
-          properties: { body: custom_template },
+          label: 'email policy',
+          properties: { policy: custom_policy },
           confidence: 1.0,
           decayClass: 'permanent',
           source: 'skill:template-meeting-request',
         });
       }
 
-      ctx.log.info('Saved custom meeting request template to knowledge graph');
+      ctx.log.info('Saved custom meeting request email policy to knowledge graph');
       return { success: true, data: { saved: true } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to save custom template');
-      return { success: false, error: `Failed to save template: ${message}` };
+      ctx.log.error({ err }, 'Failed to save custom policy');
+      return { success: false, error: `Failed to save policy: ${message}` };
     }
   }
 
-  private async resetTemplate(ctx: SkillContext): Promise<SkillResult> {
+  private async resetPolicy(ctx: SkillContext): Promise<SkillResult> {
     if (!ctx.entityMemory) {
-      // No KG means no custom template could exist — reset is a no-op
       return { success: true, data: { reset: true } };
     }
 
     try {
       const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
       if (existing.length > 0) {
-        // Remove all fact nodes linked to the anchor, then the anchor itself.
-        // getFacts returns fact nodes; we need the KG store to delete them.
-        // Since EntityMemory doesn't expose deleteNode, we clear by removing
-        // the facts. The anchor node remains but with no template body fact,
-        // so resolveTemplate will fall back to the default.
         const facts = await ctx.entityMemory.getFacts(existing[0]!.id);
-        // We can't delete nodes through EntityMemory — but we can store a
-        // "cleared" marker so resolveTemplate knows to use the default.
-        // Simpler: just store a fact with body="" to signal "use default".
         if (facts.length > 0) {
           await ctx.entityMemory.storeFact({
             entityNodeId: existing[0]!.id,
-            label: 'template body',
-            properties: { body: '', cleared: true },
+            label: 'email policy',
+            properties: { policy: '', cleared: true },
             confidence: 1.0,
             decayClass: 'permanent',
             source: 'skill:template-meeting-request',
@@ -233,50 +216,59 @@ export class TemplateMeetingRequestHandler implements SkillHandler {
         }
       }
 
-      ctx.log.info('Reset meeting request template to default');
+      ctx.log.info('Reset meeting request email policy to default');
       return { success: true, data: { reset: true } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to reset template');
-      return { success: false, error: `Failed to reset template: ${message}` };
+      ctx.log.error({ err }, 'Failed to reset policy');
+      return { success: false, error: `Failed to reset policy: ${message}` };
     }
   }
 
   /**
-   * Look up a custom template from the knowledge graph.
-   * Returns the custom template if found and non-empty, otherwise the built-in default.
+   * Look up a custom email policy from the knowledge graph.
+   * Returns the custom policy if found, otherwise the built-in default.
+   * Custom policies can be plain text guidelines or structured JSON.
    */
-  private async resolveTemplate(ctx: SkillContext): Promise<{ template: string; source: 'default' | 'custom' }> {
+  private async resolvePolicy(ctx: SkillContext): Promise<{ policy: unknown; source: 'default' | 'custom' }> {
     if (!ctx.entityMemory) {
-      return { template: DEFAULT_TEMPLATE, source: 'default' };
+      return { policy: DEFAULT_POLICY, source: 'default' };
     }
 
     try {
       const nodes = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
       if (nodes.length === 0) {
-        return { template: DEFAULT_TEMPLATE, source: 'default' };
+        return { policy: DEFAULT_POLICY, source: 'default' };
       }
 
       const facts = await ctx.entityMemory.getFacts(nodes[0]!.id);
-      // Find the most recent template body fact (by lastConfirmedAt)
-      const templateFact = facts
-        .filter((f) => f.label === 'template body')
+      const policyFact = facts
+        .filter((f) => f.label === 'email policy')
         .sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
 
-      if (!templateFact) {
-        return { template: DEFAULT_TEMPLATE, source: 'default' };
+      if (!policyFact) {
+        return { policy: DEFAULT_POLICY, source: 'default' };
       }
 
-      const body = templateFact.properties.body;
-      if (typeof body === 'string' && body.length > 0 && !templateFact.properties.cleared) {
-        return { template: body, source: 'custom' };
+      const rawPolicy = policyFact.properties.policy;
+      if (typeof rawPolicy === 'string' && rawPolicy.length > 0 && !policyFact.properties.cleared) {
+        // Try to parse as JSON; if it fails, treat as plain-text guidelines
+        try {
+          const parsed = JSON.parse(rawPolicy) as unknown;
+          return { policy: parsed, source: 'custom' };
+        } catch {
+          // Plain text guidelines — wrap in a structure for the LLM
+          return {
+            policy: { custom_guidelines: rawPolicy, note: 'These are custom guidelines that override the default policy. Follow them when composing the email.' },
+            source: 'custom',
+          };
+        }
       }
 
-      return { template: DEFAULT_TEMPLATE, source: 'default' };
+      return { policy: DEFAULT_POLICY, source: 'default' };
     } catch (err) {
-      // KG lookup failure is non-fatal — fall back to default
-      ctx.log.warn({ err }, 'Failed to look up custom template, using default');
-      return { template: DEFAULT_TEMPLATE, source: 'default' };
+      ctx.log.warn({ err }, 'Failed to look up custom policy, using default');
+      return { policy: DEFAULT_POLICY, source: 'default' };
     }
   }
 }

--- a/skills/template-meeting-request/handler.ts
+++ b/skills/template-meeting-request/handler.ts
@@ -9,7 +9,14 @@
 //   - Template body stored in the anchor node's properties.body field
 //   - decayClass=permanent (templates don't decay)
 
-import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
+
+/** Build the email signature from the agent persona, or a safe fallback. */
+function resolveSignature(persona?: AgentPersona): string {
+  if (persona?.emailSignature) return persona.emailSignature;
+  if (persona) return `${persona.displayName}\n${persona.title}`;
+  return '';
+}
 
 const TEMPLATE_LABEL = 'template:meeting-request';
 
@@ -28,8 +35,7 @@ I'm reaching out on behalf of {{sender_name}} to schedule a meeting{{purpose_cla
 Looking forward to connecting.
 
 Best regards,
-Nathan Curia
-Agent Chief of Staff`;
+{{agent_signature}}`;
 
 const MAX_INPUT_LENGTH = 5000;
 
@@ -122,6 +128,7 @@ export class TemplateMeetingRequestHandler implements SkillHandler {
       purpose_clause: purposeClause,
       duration_line: durationLine,
       location_line: locationLine,
+      agent_signature: resolveSignature(ctx.agentPersona),
     });
 
     // Split subject from body (first line is the subject)

--- a/skills/template-meeting-request/skill.json
+++ b/skills/template-meeting-request/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "template-meeting-request",
-  "description": "Generate a meeting request email from a template. Supports three actions: 'generate' fills the template with provided variables and returns the email text (checks the knowledge graph for a user-customized template before falling back to the built-in default); 'save' stores a custom template in the knowledge graph; 'reset' removes the custom template and reverts to the built-in default.",
+  "description": "Retrieve email composing guidelines for meeting requests. Returns structured policy (required elements, tone, structure, constraints, example) that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports three actions: 'generate' retrieves the policy (checks KG for customizations first); 'save' stores a custom policy in the knowledge graph; 'reset' reverts to the built-in default policy.",
   "version": "1.0.0",
   "sensitivity": "normal",
   "infrastructure": true,
@@ -12,12 +12,13 @@
     "meeting_purpose": "string? (optional for generate — reason for meeting)",
     "meeting_duration": "string? (optional for generate — e.g. '30 minutes', '1 hour')",
     "meeting_location": "string? (optional for generate — e.g. 'Zoom', 'in-person at HQ')",
-    "custom_template": "string? (required for save — the template body to store)"
+    "custom_policy": "string? (required for save — the policy to store, as JSON or plain-text guidelines)"
   },
   "outputs": {
-    "subject": "string?",
-    "body": "string?",
-    "template_source": "string? (default | custom)",
+    "guidelines": "object? (the email policy: required_elements, tone, structure, constraints, example)",
+    "context": "object? (the provided variables for the LLM to use when composing)",
+    "source": "string? (default | custom)",
+    "instructions": "string? (how to use the guidelines)",
     "saved": "boolean?",
     "reset": "boolean?"
   },

--- a/skills/template-meeting-request/skill.json
+++ b/skills/template-meeting-request/skill.json
@@ -1,11 +1,12 @@
 {
   "name": "template-meeting-request",
-  "description": "Retrieve email composing guidelines for meeting requests. Returns structured policy (required elements, tone, structure, constraints, example) that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports three actions: 'generate' retrieves the policy (checks KG for customizations first); 'save' stores a custom policy in the knowledge graph; 'reset' reverts to the built-in default policy.",
+  "description": "Retrieve email composing guidelines for meeting requests. Returns structured policy (required elements, tone, structure, constraints, example) that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports four actions: 'generate' retrieves the policy (checks KG for customizations and refinements); 'update' accepts a natural-language refinement (e.g. 'make these less formal', 'always mention my assistant') and stores it as an additive adjustment; 'save' replaces the entire policy; 'reset' reverts to defaults and clears all refinements.",
   "version": "1.0.0",
   "sensitivity": "normal",
   "infrastructure": true,
   "inputs": {
-    "action": "string (generate | save | reset)",
+    "action": "string (generate | update | save | reset)",
+    "refinement": "string? (required for update — a natural-language instruction like 'make these less formal' or 'always mention my assistant can help')",
     "recipient_name": "string? (required for generate)",
     "sender_name": "string? (required for generate — the name of the person requesting the meeting, typically the CEO)",
     "proposed_times": "string? (required for generate — comma-separated proposed times)",
@@ -17,7 +18,8 @@
   "outputs": {
     "guidelines": "object? (the email policy: required_elements, tone, structure, constraints, example)",
     "context": "object? (the provided variables for the LLM to use when composing)",
-    "source": "string? (default | custom)",
+    "source": "string? (default | custom | refined)",
+    "updated": "boolean?",
     "instructions": "string? (how to use the guidelines)",
     "saved": "boolean?",
     "reset": "boolean?"

--- a/skills/template-meeting-request/skill.json
+++ b/skills/template-meeting-request/skill.json
@@ -1,0 +1,27 @@
+{
+  "name": "template-meeting-request",
+  "description": "Generate a meeting request email from a template. Supports three actions: 'generate' fills the template with provided variables and returns the email text (checks the knowledge graph for a user-customized template before falling back to the built-in default); 'save' stores a custom template in the knowledge graph; 'reset' removes the custom template and reverts to the built-in default.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "action": "string (generate | save | reset)",
+    "recipient_name": "string? (required for generate)",
+    "sender_name": "string? (required for generate — the name of the person requesting the meeting, typically the CEO)",
+    "proposed_times": "string? (required for generate — comma-separated proposed times)",
+    "meeting_purpose": "string? (optional for generate — reason for meeting)",
+    "meeting_duration": "string? (optional for generate — e.g. '30 minutes', '1 hour')",
+    "meeting_location": "string? (optional for generate — e.g. 'Zoom', 'in-person at HQ')",
+    "custom_template": "string? (required for save — the template body to store)"
+  },
+  "outputs": {
+    "subject": "string?",
+    "body": "string?",
+    "template_source": "string? (default | custom)",
+    "saved": "boolean?",
+    "reset": "boolean?"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/skills/template-reschedule/handler.ts
+++ b/skills/template-reschedule/handler.ts
@@ -8,7 +8,13 @@
 //   - Template body stored as a fact node with label="template body"
 //   - decayClass=permanent (templates don't decay)
 
-import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
+
+function resolveSignature(persona?: AgentPersona): string {
+  if (persona?.emailSignature) return persona.emailSignature;
+  if (persona) return `${persona.displayName}\n${persona.title}`;
+  return '';
+}
 
 const TEMPLATE_LABEL = 'template:reschedule';
 
@@ -27,8 +33,7 @@ Would any of these work for you? If not, please suggest a time that's convenient
 Apologies for any inconvenience, and thank you for your flexibility.
 
 Best regards,
-Nathan Curia
-Agent Chief of Staff`;
+{{agent_signature}}`;
 
 const MAX_INPUT_LENGTH = 5000;
 
@@ -110,6 +115,7 @@ export class TemplateRescheduleHandler implements SkillHandler {
       proposed_times: formattedTimes,
       meeting_subject: meeting_subject ?? 'Our Meeting',
       reason_clause: reasonClause,
+      agent_signature: resolveSignature(ctx.agentPersona),
     });
 
     const lines = filled.split('\n');

--- a/skills/template-reschedule/handler.ts
+++ b/skills/template-reschedule/handler.ts
@@ -30,11 +30,14 @@ Best regards,
 Nathan Curia
 Agent Chief of Staff`;
 
+const MAX_INPUT_LENGTH = 5000;
+
 function fillTemplate(template: string, vars: Record<string, string>): string {
   let result = template;
   for (const [key, value] of Object.entries(vars)) {
     result = result.replaceAll(`{{${key}}}`, value);
   }
+  result = result.replace(/\{\{[^}]+\}\}/g, '');
   return result;
 }
 
@@ -77,6 +80,19 @@ export class TemplateRescheduleHandler implements SkillHandler {
     }
     if (!proposed_times || typeof proposed_times !== 'string') {
       return { success: false, error: 'Missing required input: proposed_times' };
+    }
+
+    if (recipient_name.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `recipient_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    }
+    if (sender_name.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `sender_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    }
+    if (original_time.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `original_time must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    }
+    if (proposed_times.length > MAX_INPUT_LENGTH) {
+      return { success: false, error: `proposed_times must be ${MAX_INPUT_LENGTH} characters or fewer` };
     }
 
     const { template, source } = await this.resolveTemplate(ctx);

--- a/skills/template-reschedule/handler.ts
+++ b/skills/template-reschedule/handler.ts
@@ -1,50 +1,62 @@
 // handler.ts — template-reschedule skill implementation.
 //
-// Generates rescheduling emails from a template. Built-in default template
-// is used unless the user has stored a custom version in the knowledge graph.
+// Returns email composing guidelines for rescheduling emails — NOT a pre-filled
+// email. The LLM uses these guidelines to compose naturally while following
+// organizational policy.
 //
 // KG storage model:
 //   - Anchor node: type=concept, label="template:reschedule"
-//   - Template body stored as a fact node with label="template body"
-//   - decayClass=permanent (templates don't decay)
+//   - Custom policy stored as a fact node with label="email policy"
+//   - decayClass=permanent (policies don't decay)
 
 import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
 
 function resolveSignature(persona?: AgentPersona): string {
   if (persona?.emailSignature) return persona.emailSignature;
-  if (persona) return `${persona.displayName}\n${persona.title}`;
+  if (persona) return `${persona.displayName}, ${persona.title}`;
   return '';
 }
 
 const TEMPLATE_LABEL = 'template:reschedule';
+const MAX_INPUT_LENGTH = 5000;
 
-const DEFAULT_TEMPLATE = `Subject: Rescheduling — {{meeting_subject}}
+const DEFAULT_POLICY = {
+  required_elements: [
+    'Greeting addressing the recipient by name',
+    'Reference the original meeting time so they know which meeting is affected',
+    'Brief reason for rescheduling if provided (keep it concise, no over-explaining)',
+    'List new proposed times as bullet points',
+    'Invite the recipient to suggest alternatives',
+    'Apologize for the inconvenience (once, briefly — not excessively)',
+    'Professional sign-off with the agent signature',
+  ],
+  tone: 'Apologetic but confident. Acknowledge the inconvenience without being overly sorry.',
+  structure: 'Greeting → reference original meeting → reason (if any) → new times → flexibility offer → apology → sign-off',
+  constraints: [
+    'Keep the body to 4-6 sentences plus the time list',
+    'Subject line should include "Rescheduling" and the meeting topic',
+    'Do not blame anyone for the reschedule',
+    'Do not use exclamation marks',
+  ],
+  example: `Subject: Rescheduling — Q3 Planning
 
-Hi {{recipient_name}},
+Hi Alice,
 
-I'm writing on behalf of {{sender_name}} regarding your meeting originally scheduled for {{original_time}}.{{reason_clause}}
+I'm writing on behalf of Joseph regarding your meeting originally scheduled for Monday, April 7 at 10:00 AM. Unfortunately, a scheduling conflict has come up and we need to reschedule.
 
-Unfortunately, we need to reschedule. {{sender_name}} is available at the following alternative times:
+Joseph is available at the following alternative times:
 
-{{proposed_times}}
+  • Wednesday, April 9 at 2:00 PM ET
+  • Thursday, April 10 at 10:00 AM ET
+  • Friday, April 11 at 11:00 AM ET
 
 Would any of these work for you? If not, please suggest a time that's convenient and I'll do my best to accommodate.
 
-Apologies for any inconvenience, and thank you for your flexibility.
+Apologies for the inconvenience, and thank you for your flexibility.
 
 Best regards,
-{{agent_signature}}`;
-
-const MAX_INPUT_LENGTH = 5000;
-
-function fillTemplate(template: string, vars: Record<string, string>): string {
-  let result = template;
-  for (const [key, value] of Object.entries(vars)) {
-    result = result.replaceAll(`{{${key}}}`, value);
-  }
-  result = result.replace(/\{\{[^}]+\}\}/g, '');
-  return result;
-}
+Nathan Curia, Agent Chief of Staff`,
+};
 
 export class TemplateRescheduleHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -54,191 +66,104 @@ export class TemplateRescheduleHandler implements SkillHandler {
       return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', or 'reset'" };
     }
 
-    if (action === 'save') {
-      return this.saveTemplate(ctx);
-    }
-    if (action === 'reset') {
-      return this.resetTemplate(ctx);
-    }
+    if (action === 'save') return this.savePolicy(ctx);
+    if (action === 'reset') return this.resetPolicy(ctx);
     return this.generate(ctx);
   }
 
   private async generate(ctx: SkillContext): Promise<SkillResult> {
     const { recipient_name, sender_name, original_time, proposed_times, meeting_subject, reason } =
       ctx.input as {
-        recipient_name?: string;
-        sender_name?: string;
-        original_time?: string;
-        proposed_times?: string;
-        meeting_subject?: string;
-        reason?: string;
+        recipient_name?: string; sender_name?: string; original_time?: string;
+        proposed_times?: string; meeting_subject?: string; reason?: string;
       };
 
-    if (!recipient_name || typeof recipient_name !== 'string') {
-      return { success: false, error: 'Missing required input: recipient_name' };
-    }
-    if (!sender_name || typeof sender_name !== 'string') {
-      return { success: false, error: 'Missing required input: sender_name' };
-    }
-    if (!original_time || typeof original_time !== 'string') {
-      return { success: false, error: 'Missing required input: original_time' };
-    }
-    if (!proposed_times || typeof proposed_times !== 'string') {
-      return { success: false, error: 'Missing required input: proposed_times' };
-    }
+    if (!recipient_name || typeof recipient_name !== 'string') return { success: false, error: 'Missing required input: recipient_name' };
+    if (!sender_name || typeof sender_name !== 'string') return { success: false, error: 'Missing required input: sender_name' };
+    if (!original_time || typeof original_time !== 'string') return { success: false, error: 'Missing required input: original_time' };
+    if (!proposed_times || typeof proposed_times !== 'string') return { success: false, error: 'Missing required input: proposed_times' };
 
-    if (recipient_name.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `recipient_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
-    if (sender_name.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `sender_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
-    if (original_time.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `original_time must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
-    if (proposed_times.length > MAX_INPUT_LENGTH) {
-      return { success: false, error: `proposed_times must be ${MAX_INPUT_LENGTH} characters or fewer` };
-    }
+    if (recipient_name.length > MAX_INPUT_LENGTH) return { success: false, error: `recipient_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    if (sender_name.length > MAX_INPUT_LENGTH) return { success: false, error: `sender_name must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    if (original_time.length > MAX_INPUT_LENGTH) return { success: false, error: `original_time must be ${MAX_INPUT_LENGTH} characters or fewer` };
+    if (proposed_times.length > MAX_INPUT_LENGTH) return { success: false, error: `proposed_times must be ${MAX_INPUT_LENGTH} characters or fewer` };
 
-    const { template, source } = await this.resolveTemplate(ctx);
+    const { policy, source } = await this.resolvePolicy(ctx);
 
-    const reasonClause = reason ? ` ${reason}` : '';
-    const formattedTimes = proposed_times
-      .split(',')
-      .map((t) => `  • ${t.trim()}`)
-      .join('\n');
-
-    const filled = fillTemplate(template, {
-      recipient_name,
-      sender_name,
-      original_time,
-      proposed_times: formattedTimes,
-      meeting_subject: meeting_subject ?? 'Our Meeting',
-      reason_clause: reasonClause,
+    const context: Record<string, string> = {
+      recipient_name, sender_name, original_time, proposed_times,
       agent_signature: resolveSignature(ctx.agentPersona),
-    });
+    };
+    if (meeting_subject) context.meeting_subject = meeting_subject;
+    if (reason) context.reason = reason;
 
-    const lines = filled.split('\n');
-    const subjectLine = lines[0] ?? '';
-    const subject = subjectLine.replace(/^Subject:\s*/i, '').trim();
-    const body = lines.slice(2).join('\n').trim();
-
-    ctx.log.info({ recipient_name, source }, 'Generated rescheduling email');
+    ctx.log.info({ recipient_name, source }, 'Retrieved rescheduling email policy');
     return {
       success: true,
-      data: { subject, body, template_source: source },
+      data: {
+        guidelines: policy, context, source,
+        instructions: 'Use the guidelines to compose a rescheduling email. The guidelines define required elements, tone, structure, and constraints. The example shows the expected quality and format. Adapt naturally to the provided context — do not copy the example verbatim.',
+      },
     };
   }
 
-  private async saveTemplate(ctx: SkillContext): Promise<SkillResult> {
-    const { custom_template } = ctx.input as { custom_template?: string };
-    if (!custom_template || typeof custom_template !== 'string') {
-      return { success: false, error: 'Missing required input: custom_template' };
-    }
-    if (custom_template.length > 10000) {
-      return { success: false, error: 'custom_template must be 10000 characters or fewer' };
-    }
-
-    if (!ctx.entityMemory) {
-      return { success: false, error: 'Knowledge graph not available — cannot save custom template' };
-    }
+  private async savePolicy(ctx: SkillContext): Promise<SkillResult> {
+    const { custom_policy } = ctx.input as { custom_policy?: string };
+    if (!custom_policy || typeof custom_policy !== 'string') return { success: false, error: 'Missing required input: custom_policy' };
+    if (custom_policy.length > 10000) return { success: false, error: 'custom_policy must be 10000 characters or fewer' };
+    if (!ctx.entityMemory) return { success: false, error: 'Knowledge graph not available — cannot save custom policy' };
 
     try {
       const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (existing.length > 0) {
-        await ctx.entityMemory.storeFact({
-          entityNodeId: existing[0]!.id,
-          label: 'template body',
-          properties: { body: custom_template },
-          confidence: 1.0,
-          decayClass: 'permanent',
-          source: 'skill:template-reschedule',
-        });
-      } else {
-        const anchor = await ctx.entityMemory.createEntity({
-          type: 'concept',
-          label: TEMPLATE_LABEL,
-          properties: { category: 'email-template', templateName: 'reschedule' },
-          source: 'skill:template-reschedule',
-        });
-        await ctx.entityMemory.storeFact({
-          entityNodeId: anchor.id,
-          label: 'template body',
-          properties: { body: custom_template },
-          confidence: 1.0,
-          decayClass: 'permanent',
-          source: 'skill:template-reschedule',
-        });
-      }
+      const anchorId = existing.length > 0
+        ? existing[0]!.id
+        : (await ctx.entityMemory.createEntity({ type: 'concept', label: TEMPLATE_LABEL, properties: { category: 'email-policy', templateName: 'reschedule' }, source: 'skill:template-reschedule' })).id;
 
-      ctx.log.info('Saved custom reschedule template to knowledge graph');
+      await ctx.entityMemory.storeFact({ entityNodeId: anchorId, label: 'email policy', properties: { policy: custom_policy }, confidence: 1.0, decayClass: 'permanent', source: 'skill:template-reschedule' });
+      ctx.log.info('Saved custom reschedule email policy to knowledge graph');
       return { success: true, data: { saved: true } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to save custom template');
-      return { success: false, error: `Failed to save template: ${message}` };
+      ctx.log.error({ err }, 'Failed to save custom policy');
+      return { success: false, error: `Failed to save policy: ${message}` };
     }
   }
 
-  private async resetTemplate(ctx: SkillContext): Promise<SkillResult> {
-    if (!ctx.entityMemory) {
-      return { success: true, data: { reset: true } };
-    }
-
+  private async resetPolicy(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.entityMemory) return { success: true, data: { reset: true } };
     try {
       const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
       if (existing.length > 0) {
         const facts = await ctx.entityMemory.getFacts(existing[0]!.id);
         if (facts.length > 0) {
-          await ctx.entityMemory.storeFact({
-            entityNodeId: existing[0]!.id,
-            label: 'template body',
-            properties: { body: '', cleared: true },
-            confidence: 1.0,
-            decayClass: 'permanent',
-            source: 'skill:template-reschedule',
-          });
+          await ctx.entityMemory.storeFact({ entityNodeId: existing[0]!.id, label: 'email policy', properties: { policy: '', cleared: true }, confidence: 1.0, decayClass: 'permanent', source: 'skill:template-reschedule' });
         }
       }
-
-      ctx.log.info('Reset reschedule template to default');
+      ctx.log.info('Reset reschedule email policy to default');
       return { success: true, data: { reset: true } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to reset template');
-      return { success: false, error: `Failed to reset template: ${message}` };
+      ctx.log.error({ err }, 'Failed to reset policy');
+      return { success: false, error: `Failed to reset policy: ${message}` };
     }
   }
 
-  private async resolveTemplate(ctx: SkillContext): Promise<{ template: string; source: 'default' | 'custom' }> {
-    if (!ctx.entityMemory) {
-      return { template: DEFAULT_TEMPLATE, source: 'default' };
-    }
-
+  private async resolvePolicy(ctx: SkillContext): Promise<{ policy: unknown; source: 'default' | 'custom' }> {
+    if (!ctx.entityMemory) return { policy: DEFAULT_POLICY, source: 'default' };
     try {
       const nodes = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (nodes.length === 0) {
-        return { template: DEFAULT_TEMPLATE, source: 'default' };
-      }
-
+      if (nodes.length === 0) return { policy: DEFAULT_POLICY, source: 'default' };
       const facts = await ctx.entityMemory.getFacts(nodes[0]!.id);
-      const templateFact = facts
-        .filter((f) => f.label === 'template body')
-        .sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
-
-      if (!templateFact) {
-        return { template: DEFAULT_TEMPLATE, source: 'default' };
+      const policyFact = facts.filter((f) => f.label === 'email policy').sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
+      if (!policyFact) return { policy: DEFAULT_POLICY, source: 'default' };
+      const rawPolicy = policyFact.properties.policy;
+      if (typeof rawPolicy === 'string' && rawPolicy.length > 0 && !policyFact.properties.cleared) {
+        try { return { policy: JSON.parse(rawPolicy) as unknown, source: 'custom' }; } catch { return { policy: { custom_guidelines: rawPolicy, note: 'Custom guidelines that override the default policy.' }, source: 'custom' }; }
       }
-
-      const body = templateFact.properties.body;
-      if (typeof body === 'string' && body.length > 0 && !templateFact.properties.cleared) {
-        return { template: body, source: 'custom' };
-      }
-
-      return { template: DEFAULT_TEMPLATE, source: 'default' };
+      return { policy: DEFAULT_POLICY, source: 'default' };
     } catch (err) {
-      ctx.log.warn({ err }, 'Failed to look up custom template, using default');
-      return { template: DEFAULT_TEMPLATE, source: 'default' };
+      ctx.log.warn({ err }, 'Failed to look up custom policy, using default');
+      return { policy: DEFAULT_POLICY, source: 'default' };
     }
   }
 }

--- a/skills/template-reschedule/handler.ts
+++ b/skills/template-reschedule/handler.ts
@@ -1,23 +1,12 @@
 // handler.ts — template-reschedule skill implementation.
 //
-// Returns email composing guidelines for rescheduling emails — NOT a pre-filled
-// email. The LLM uses these guidelines to compose naturally while following
-// organizational policy.
-//
-// KG storage model:
-//   - Anchor node: type=concept, label="template:reschedule"
-//   - Custom policy stored as a fact node with label="email policy"
-//   - decayClass=permanent (policies don't decay)
+// Returns email composing guidelines for rescheduling emails.
 
-import type { SkillHandler, SkillContext, SkillResult, AgentPersona } from '../../src/skills/types.js';
-
-function resolveSignature(persona?: AgentPersona): string {
-  if (persona?.emailSignature) return persona.emailSignature;
-  if (persona) return `${persona.displayName}, ${persona.title}`;
-  return '';
-}
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { resolveSignature, savePolicy, updatePolicy, resetPolicy, resolvePolicy } from '../_shared/template-base.js';
 
 const TEMPLATE_LABEL = 'template:reschedule';
+const SKILL_SOURCE = 'skill:template-reschedule';
 const MAX_INPUT_LENGTH = 5000;
 
 const DEFAULT_POLICY = {
@@ -61,13 +50,12 @@ Nathan Curia, Agent Chief of Staff`,
 export class TemplateRescheduleHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     const { action } = ctx.input as { action?: string };
-
-    if (!action || !['generate', 'save', 'reset'].includes(action)) {
-      return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', or 'reset'" };
+    if (!action || !['generate', 'save', 'update', 'reset'].includes(action)) {
+      return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', 'update', or 'reset'" };
     }
-
-    if (action === 'save') return this.savePolicy(ctx);
-    if (action === 'reset') return this.resetPolicy(ctx);
+    if (action === 'save') return savePolicy(ctx, TEMPLATE_LABEL, SKILL_SOURCE);
+    if (action === 'update') return updatePolicy(ctx, TEMPLATE_LABEL, SKILL_SOURCE);
+    if (action === 'reset') return resetPolicy(ctx, TEMPLATE_LABEL, SKILL_SOURCE);
     return this.generate(ctx);
   }
 
@@ -88,7 +76,7 @@ export class TemplateRescheduleHandler implements SkillHandler {
     if (original_time.length > MAX_INPUT_LENGTH) return { success: false, error: `original_time must be ${MAX_INPUT_LENGTH} characters or fewer` };
     if (proposed_times.length > MAX_INPUT_LENGTH) return { success: false, error: `proposed_times must be ${MAX_INPUT_LENGTH} characters or fewer` };
 
-    const { policy, source } = await this.resolvePolicy(ctx);
+    const { policy, source } = await resolvePolicy(ctx, TEMPLATE_LABEL, DEFAULT_POLICY);
 
     const context: Record<string, string> = {
       recipient_name, sender_name, original_time, proposed_times,
@@ -102,68 +90,8 @@ export class TemplateRescheduleHandler implements SkillHandler {
       success: true,
       data: {
         guidelines: policy, context, source,
-        instructions: 'Use the guidelines to compose a rescheduling email. The guidelines define required elements, tone, structure, and constraints. The example shows the expected quality and format. Adapt naturally to the provided context — do not copy the example verbatim.',
+        instructions: 'Use the guidelines to compose a rescheduling email. Adapt naturally to the provided context — do not copy the example verbatim. If refinements are present, apply them.',
       },
     };
-  }
-
-  private async savePolicy(ctx: SkillContext): Promise<SkillResult> {
-    const { custom_policy } = ctx.input as { custom_policy?: string };
-    if (!custom_policy || typeof custom_policy !== 'string') return { success: false, error: 'Missing required input: custom_policy' };
-    if (custom_policy.length > 10000) return { success: false, error: 'custom_policy must be 10000 characters or fewer' };
-    if (!ctx.entityMemory) return { success: false, error: 'Knowledge graph not available — cannot save custom policy' };
-
-    try {
-      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      const anchorId = existing.length > 0
-        ? existing[0]!.id
-        : (await ctx.entityMemory.createEntity({ type: 'concept', label: TEMPLATE_LABEL, properties: { category: 'email-policy', templateName: 'reschedule' }, source: 'skill:template-reschedule' })).id;
-
-      await ctx.entityMemory.storeFact({ entityNodeId: anchorId, label: 'email policy', properties: { policy: custom_policy }, confidence: 1.0, decayClass: 'permanent', source: 'skill:template-reschedule' });
-      ctx.log.info('Saved custom reschedule email policy to knowledge graph');
-      return { success: true, data: { saved: true } };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to save custom policy');
-      return { success: false, error: `Failed to save policy: ${message}` };
-    }
-  }
-
-  private async resetPolicy(ctx: SkillContext): Promise<SkillResult> {
-    if (!ctx.entityMemory) return { success: true, data: { reset: true } };
-    try {
-      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (existing.length > 0) {
-        const facts = await ctx.entityMemory.getFacts(existing[0]!.id);
-        if (facts.length > 0) {
-          await ctx.entityMemory.storeFact({ entityNodeId: existing[0]!.id, label: 'email policy', properties: { policy: '', cleared: true }, confidence: 1.0, decayClass: 'permanent', source: 'skill:template-reschedule' });
-        }
-      }
-      ctx.log.info('Reset reschedule email policy to default');
-      return { success: true, data: { reset: true } };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to reset policy');
-      return { success: false, error: `Failed to reset policy: ${message}` };
-    }
-  }
-
-  private async resolvePolicy(ctx: SkillContext): Promise<{ policy: unknown; source: 'default' | 'custom' }> {
-    if (!ctx.entityMemory) return { policy: DEFAULT_POLICY, source: 'default' };
-    try {
-      const nodes = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
-      if (nodes.length === 0) return { policy: DEFAULT_POLICY, source: 'default' };
-      const facts = await ctx.entityMemory.getFacts(nodes[0]!.id);
-      const policyFact = facts.filter((f) => f.label === 'email policy').sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
-      if (!policyFact) return { policy: DEFAULT_POLICY, source: 'default' };
-      const rawPolicy = policyFact.properties.policy;
-      if (typeof rawPolicy === 'string' && rawPolicy.length > 0 && !policyFact.properties.cleared) {
-        try { return { policy: JSON.parse(rawPolicy) as unknown, source: 'custom' }; } catch { return { policy: { custom_guidelines: rawPolicy, note: 'Custom guidelines that override the default policy.' }, source: 'custom' }; }
-      }
-      return { policy: DEFAULT_POLICY, source: 'default' };
-    } catch (err) {
-      ctx.log.warn({ err }, 'Failed to look up custom policy, using default');
-      return { policy: DEFAULT_POLICY, source: 'default' };
-    }
   }
 }

--- a/skills/template-reschedule/handler.ts
+++ b/skills/template-reschedule/handler.ts
@@ -1,0 +1,222 @@
+// handler.ts — template-reschedule skill implementation.
+//
+// Generates rescheduling emails from a template. Built-in default template
+// is used unless the user has stored a custom version in the knowledge graph.
+//
+// KG storage model:
+//   - Anchor node: type=concept, label="template:reschedule"
+//   - Template body stored as a fact node with label="template body"
+//   - decayClass=permanent (templates don't decay)
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+const TEMPLATE_LABEL = 'template:reschedule';
+
+const DEFAULT_TEMPLATE = `Subject: Rescheduling — {{meeting_subject}}
+
+Hi {{recipient_name}},
+
+I'm writing on behalf of {{sender_name}} regarding your meeting originally scheduled for {{original_time}}.{{reason_clause}}
+
+Unfortunately, we need to reschedule. {{sender_name}} is available at the following alternative times:
+
+{{proposed_times}}
+
+Would any of these work for you? If not, please suggest a time that's convenient and I'll do my best to accommodate.
+
+Apologies for any inconvenience, and thank you for your flexibility.
+
+Best regards,
+Nathan Curia
+Agent Chief of Staff`;
+
+function fillTemplate(template: string, vars: Record<string, string>): string {
+  let result = template;
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replaceAll(`{{${key}}}`, value);
+  }
+  return result;
+}
+
+export class TemplateRescheduleHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { action } = ctx.input as { action?: string };
+
+    if (!action || !['generate', 'save', 'reset'].includes(action)) {
+      return { success: false, error: "Missing or invalid 'action' — must be 'generate', 'save', or 'reset'" };
+    }
+
+    if (action === 'save') {
+      return this.saveTemplate(ctx);
+    }
+    if (action === 'reset') {
+      return this.resetTemplate(ctx);
+    }
+    return this.generate(ctx);
+  }
+
+  private async generate(ctx: SkillContext): Promise<SkillResult> {
+    const { recipient_name, sender_name, original_time, proposed_times, meeting_subject, reason } =
+      ctx.input as {
+        recipient_name?: string;
+        sender_name?: string;
+        original_time?: string;
+        proposed_times?: string;
+        meeting_subject?: string;
+        reason?: string;
+      };
+
+    if (!recipient_name || typeof recipient_name !== 'string') {
+      return { success: false, error: 'Missing required input: recipient_name' };
+    }
+    if (!sender_name || typeof sender_name !== 'string') {
+      return { success: false, error: 'Missing required input: sender_name' };
+    }
+    if (!original_time || typeof original_time !== 'string') {
+      return { success: false, error: 'Missing required input: original_time' };
+    }
+    if (!proposed_times || typeof proposed_times !== 'string') {
+      return { success: false, error: 'Missing required input: proposed_times' };
+    }
+
+    const { template, source } = await this.resolveTemplate(ctx);
+
+    const reasonClause = reason ? ` ${reason}` : '';
+    const formattedTimes = proposed_times
+      .split(',')
+      .map((t) => `  • ${t.trim()}`)
+      .join('\n');
+
+    const filled = fillTemplate(template, {
+      recipient_name,
+      sender_name,
+      original_time,
+      proposed_times: formattedTimes,
+      meeting_subject: meeting_subject ?? 'Our Meeting',
+      reason_clause: reasonClause,
+    });
+
+    const lines = filled.split('\n');
+    const subjectLine = lines[0] ?? '';
+    const subject = subjectLine.replace(/^Subject:\s*/i, '').trim();
+    const body = lines.slice(2).join('\n').trim();
+
+    ctx.log.info({ recipient_name, source }, 'Generated rescheduling email');
+    return {
+      success: true,
+      data: { subject, body, template_source: source },
+    };
+  }
+
+  private async saveTemplate(ctx: SkillContext): Promise<SkillResult> {
+    const { custom_template } = ctx.input as { custom_template?: string };
+    if (!custom_template || typeof custom_template !== 'string') {
+      return { success: false, error: 'Missing required input: custom_template' };
+    }
+    if (custom_template.length > 10000) {
+      return { success: false, error: 'custom_template must be 10000 characters or fewer' };
+    }
+
+    if (!ctx.entityMemory) {
+      return { success: false, error: 'Knowledge graph not available — cannot save custom template' };
+    }
+
+    try {
+      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
+      if (existing.length > 0) {
+        await ctx.entityMemory.storeFact({
+          entityNodeId: existing[0]!.id,
+          label: 'template body',
+          properties: { body: custom_template },
+          confidence: 1.0,
+          decayClass: 'permanent',
+          source: 'skill:template-reschedule',
+        });
+      } else {
+        const anchor = await ctx.entityMemory.createEntity({
+          type: 'concept',
+          label: TEMPLATE_LABEL,
+          properties: { category: 'email-template', templateName: 'reschedule' },
+          source: 'skill:template-reschedule',
+        });
+        await ctx.entityMemory.storeFact({
+          entityNodeId: anchor.id,
+          label: 'template body',
+          properties: { body: custom_template },
+          confidence: 1.0,
+          decayClass: 'permanent',
+          source: 'skill:template-reschedule',
+        });
+      }
+
+      ctx.log.info('Saved custom reschedule template to knowledge graph');
+      return { success: true, data: { saved: true } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to save custom template');
+      return { success: false, error: `Failed to save template: ${message}` };
+    }
+  }
+
+  private async resetTemplate(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.entityMemory) {
+      return { success: true, data: { reset: true } };
+    }
+
+    try {
+      const existing = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
+      if (existing.length > 0) {
+        const facts = await ctx.entityMemory.getFacts(existing[0]!.id);
+        if (facts.length > 0) {
+          await ctx.entityMemory.storeFact({
+            entityNodeId: existing[0]!.id,
+            label: 'template body',
+            properties: { body: '', cleared: true },
+            confidence: 1.0,
+            decayClass: 'permanent',
+            source: 'skill:template-reschedule',
+          });
+        }
+      }
+
+      ctx.log.info('Reset reschedule template to default');
+      return { success: true, data: { reset: true } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to reset template');
+      return { success: false, error: `Failed to reset template: ${message}` };
+    }
+  }
+
+  private async resolveTemplate(ctx: SkillContext): Promise<{ template: string; source: 'default' | 'custom' }> {
+    if (!ctx.entityMemory) {
+      return { template: DEFAULT_TEMPLATE, source: 'default' };
+    }
+
+    try {
+      const nodes = await ctx.entityMemory.findEntities(TEMPLATE_LABEL);
+      if (nodes.length === 0) {
+        return { template: DEFAULT_TEMPLATE, source: 'default' };
+      }
+
+      const facts = await ctx.entityMemory.getFacts(nodes[0]!.id);
+      const templateFact = facts
+        .filter((f) => f.label === 'template body')
+        .sort((a, b) => b.temporal.lastConfirmedAt.getTime() - a.temporal.lastConfirmedAt.getTime())[0];
+
+      if (!templateFact) {
+        return { template: DEFAULT_TEMPLATE, source: 'default' };
+      }
+
+      const body = templateFact.properties.body;
+      if (typeof body === 'string' && body.length > 0 && !templateFact.properties.cleared) {
+        return { template: body, source: 'custom' };
+      }
+
+      return { template: DEFAULT_TEMPLATE, source: 'default' };
+    } catch (err) {
+      ctx.log.warn({ err }, 'Failed to look up custom template, using default');
+      return { template: DEFAULT_TEMPLATE, source: 'default' };
+    }
+  }
+}

--- a/skills/template-reschedule/skill.json
+++ b/skills/template-reschedule/skill.json
@@ -1,11 +1,12 @@
 {
   "name": "template-reschedule",
-  "description": "Retrieve email composing guidelines for meeting rescheduling. Returns structured policy (required elements, tone, structure, constraints, example) that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports three actions: 'generate' retrieves the policy; 'save' stores a custom policy in the knowledge graph; 'reset' reverts to the built-in default.",
+  "description": "Retrieve email composing guidelines for meeting rescheduling. Returns structured policy that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports four actions: 'generate' retrieves the policy (with any refinements); 'update' accepts a natural-language refinement; 'save' replaces the entire policy; 'reset' reverts to defaults and clears refinements.",
   "version": "1.0.0",
   "sensitivity": "normal",
   "infrastructure": true,
   "inputs": {
-    "action": "string (generate | save | reset)",
+    "action": "string (generate | update | save | reset)",
+    "refinement": "string? (required for update — a natural-language adjustment to the policy)",
     "recipient_name": "string? (required for generate)",
     "sender_name": "string? (required for generate — the person on whose behalf you're rescheduling)",
     "original_time": "string? (required for generate — the original meeting time)",

--- a/skills/template-reschedule/skill.json
+++ b/skills/template-reschedule/skill.json
@@ -1,0 +1,27 @@
+{
+  "name": "template-reschedule",
+  "description": "Generate a meeting rescheduling email from a template. Supports three actions: 'generate' fills the template with provided variables (checks the knowledge graph for a user-customized template before falling back to the built-in default); 'save' stores a custom template in the knowledge graph; 'reset' removes the custom template and reverts to the built-in default.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "action": "string (generate | save | reset)",
+    "recipient_name": "string? (required for generate)",
+    "sender_name": "string? (required for generate — the person on whose behalf you're rescheduling)",
+    "original_time": "string? (required for generate — the original meeting time)",
+    "proposed_times": "string? (required for generate — comma-separated new proposed times)",
+    "meeting_subject": "string? (optional for generate — what the meeting was about)",
+    "reason": "string? (optional for generate — brief reason for rescheduling)",
+    "custom_template": "string? (required for save — the template body to store)"
+  },
+  "outputs": {
+    "subject": "string?",
+    "body": "string?",
+    "template_source": "string? (default | custom)",
+    "saved": "boolean?",
+    "reset": "boolean?"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/skills/template-reschedule/skill.json
+++ b/skills/template-reschedule/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "template-reschedule",
-  "description": "Generate a meeting rescheduling email from a template. Supports three actions: 'generate' fills the template with provided variables (checks the knowledge graph for a user-customized template before falling back to the built-in default); 'save' stores a custom template in the knowledge graph; 'reset' removes the custom template and reverts to the built-in default.",
+  "description": "Retrieve email composing guidelines for meeting rescheduling. Returns structured policy (required elements, tone, structure, constraints, example) that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports three actions: 'generate' retrieves the policy; 'save' stores a custom policy in the knowledge graph; 'reset' reverts to the built-in default.",
   "version": "1.0.0",
   "sensitivity": "normal",
   "infrastructure": true,
@@ -12,12 +12,13 @@
     "proposed_times": "string? (required for generate — comma-separated new proposed times)",
     "meeting_subject": "string? (optional for generate — what the meeting was about)",
     "reason": "string? (optional for generate — brief reason for rescheduling)",
-    "custom_template": "string? (required for save — the template body to store)"
+    "custom_policy": "string? (required for save — the policy to store)"
   },
   "outputs": {
-    "subject": "string?",
-    "body": "string?",
-    "template_source": "string? (default | custom)",
+    "guidelines": "object?",
+    "context": "object?",
+    "source": "string? (default | custom)",
+    "instructions": "string?",
     "saved": "boolean?",
     "reset": "boolean?"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import { OutboundContentFilter } from './dispatch/outbound-filter.js';
 import { OutboundGateway } from './skills/outbound-gateway.js';
 import { SchedulerService } from './scheduler/scheduler-service.js';
 import { Scheduler } from './scheduler/scheduler.js';
+import type { AgentPersona } from './skills/types.js';
 
 async function main(): Promise<void> {
   // 1. Config & logging — no dependencies, must come first.
@@ -220,6 +221,23 @@ async function main(): Promise<void> {
   // canonical identifier. Role is an optional field and may not match "coordinator"
   // if the config uses a different role value (e.g., "chief-of-staff").
   const coordinatorConfig = agentConfigs.find(c => c.name === 'coordinator');
+
+  // Extract agent persona from the coordinator config. This is the single source
+  // of truth for the agent's identity — used by the system prompt (via YAML
+  // interpolation) and by skills (via SkillContext.agentPersona) so templates
+  // and outbound-facing code never hardcode the agent's name or title.
+  let agentPersona: AgentPersona | undefined;
+  if (coordinatorConfig?.persona) {
+    agentPersona = {
+      displayName: coordinatorConfig.persona.display_name ?? 'Curia',
+      title: coordinatorConfig.persona.title ?? 'Agent Chief of Staff',
+      emailSignature: coordinatorConfig.persona.email_signature ?? undefined,
+    };
+    logger.info({ displayName: agentPersona.displayName, title: agentPersona.title }, 'Agent persona extracted from coordinator config');
+  } else {
+    logger.warn('No coordinator persona found — skills will not have agent identity context');
+  }
+
   let outboundFilter: OutboundContentFilter | undefined;
   if (coordinatorConfig) {
     const systemPromptMarkers = extractSystemPromptMarkers(coordinatorConfig);
@@ -280,7 +298,7 @@ async function main(): Promise<void> {
 
   // Execution layer — now with bus, agent registry, and outbound gateway for
   // infrastructure skills. outboundGateway gives email skills their send path.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,7 +280,7 @@ async function main(): Promise<void> {
 
   // Execution layer — now with bus, agent registry, and outbound gateway for
   // infrastructure skills. outboundGateway gives email skills their send path.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -22,6 +22,7 @@ import type { ContactService } from '../contacts/contact-service.js';
 import type { OutboundGateway } from './outbound-gateway.js';
 import type { HeldMessageService } from '../contacts/held-messages.js';
 import type { SchedulerService } from '../scheduler/scheduler-service.js';
+import type { EntityMemory } from '../memory/entity-memory.js';
 
 export class ExecutionLayer {
   private registry: SkillRegistry;
@@ -32,8 +33,9 @@ export class ExecutionLayer {
   private outboundGateway?: OutboundGateway;
   private heldMessages?: HeldMessageService;
   private schedulerService?: SchedulerService;
+  private entityMemory?: EntityMemory;
 
-  constructor(registry: SkillRegistry, logger: Logger, options?: { bus?: EventBus; agentRegistry?: AgentRegistry; contactService?: ContactService; outboundGateway?: OutboundGateway; heldMessages?: HeldMessageService; schedulerService?: SchedulerService }) {
+  constructor(registry: SkillRegistry, logger: Logger, options?: { bus?: EventBus; agentRegistry?: AgentRegistry; contactService?: ContactService; outboundGateway?: OutboundGateway; heldMessages?: HeldMessageService; schedulerService?: SchedulerService; entityMemory?: EntityMemory }) {
     this.registry = registry;
     this.logger = logger;
     this.bus = options?.bus;
@@ -42,6 +44,7 @@ export class ExecutionLayer {
     this.outboundGateway = options?.outboundGateway;
     this.heldMessages = options?.heldMessages;
     this.schedulerService = options?.schedulerService;
+    this.entityMemory = options?.entityMemory;
   }
 
   /**
@@ -142,6 +145,10 @@ export class ExecutionLayer {
       // schedulerService is optional — only scheduler skills need it
       if (this.schedulerService) {
         ctx.schedulerService = this.schedulerService;
+      }
+      // entityMemory is optional — only skills that read/write the knowledge graph need it
+      if (this.entityMemory) {
+        ctx.entityMemory = this.entityMemory;
       }
     }
 

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -12,7 +12,7 @@
 // publish/subscribe including layer impersonation. Only framework-internal
 // skills like 'delegate' should use this — it is a privileged escape hatch.
 
-import type { SkillResult, SkillContext, CallerContext } from './types.js';
+import type { SkillResult, SkillContext, CallerContext, AgentPersona } from './types.js';
 import type { SkillRegistry } from './registry.js';
 import { sanitizeOutput } from './sanitize.js';
 import type { Logger } from '../logger.js';
@@ -34,8 +34,9 @@ export class ExecutionLayer {
   private heldMessages?: HeldMessageService;
   private schedulerService?: SchedulerService;
   private entityMemory?: EntityMemory;
+  private agentPersona?: AgentPersona;
 
-  constructor(registry: SkillRegistry, logger: Logger, options?: { bus?: EventBus; agentRegistry?: AgentRegistry; contactService?: ContactService; outboundGateway?: OutboundGateway; heldMessages?: HeldMessageService; schedulerService?: SchedulerService; entityMemory?: EntityMemory }) {
+  constructor(registry: SkillRegistry, logger: Logger, options?: { bus?: EventBus; agentRegistry?: AgentRegistry; contactService?: ContactService; outboundGateway?: OutboundGateway; heldMessages?: HeldMessageService; schedulerService?: SchedulerService; entityMemory?: EntityMemory; agentPersona?: AgentPersona }) {
     this.registry = registry;
     this.logger = logger;
     this.bus = options?.bus;
@@ -45,6 +46,7 @@ export class ExecutionLayer {
     this.heldMessages = options?.heldMessages;
     this.schedulerService = options?.schedulerService;
     this.entityMemory = options?.entityMemory;
+    this.agentPersona = options?.agentPersona;
   }
 
   /**
@@ -112,6 +114,7 @@ export class ExecutionLayer {
         return value;
       },
       log: skillLogger,
+      agentPersona: this.agentPersona,
       caller,
     };
 

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -73,6 +73,10 @@ export interface SkillContext {
   heldMessages?: import('../contacts/held-messages.js').HeldMessageService;
   /** Scheduler service — only available to infrastructure skills */
   schedulerService?: import('../scheduler/scheduler-service.js').SchedulerService;
+  /** Entity memory (knowledge graph) — only available to infrastructure skills.
+   *  Provides semantic search, entity CRUD, and fact storage for skills that
+   *  need to read or write long-term knowledge (templates, preferences, etc.). */
+  entityMemory?: import('../memory/entity-memory.js').EntityMemory;
   /** Caller identity — populated from the task event's sender context.
    *  Guaranteed to be defined for elevated skills (execution layer rejects without it).
    *  Available but optional for normal skills. */

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -48,6 +48,21 @@ export interface CallerContext {
 }
 
 /**
+ * The agent persona — display name, title, and optional email signature.
+ * Sourced from the coordinator's persona config in agents/coordinator.yaml.
+ * Available to all skills (not gated behind infrastructure) so templates
+ * and outbound-facing skills can reference the agent's identity without
+ * hardcoding it.
+ */
+export interface AgentPersona {
+  displayName: string;
+  title: string;
+  /** Full email signature block. If not set, skills should construct a
+   *  default from displayName + title. */
+  emailSignature?: string;
+}
+
+/**
  * The sandboxed context passed to every skill invocation.
  * Skills cannot access the bus, database, or filesystem directly —
  * they receive inputs through ctx.input and return outputs via SkillResult.
@@ -77,6 +92,10 @@ export interface SkillContext {
    *  Provides semantic search, entity CRUD, and fact storage for skills that
    *  need to read or write long-term knowledge (templates, preferences, etc.). */
   entityMemory?: import('../memory/entity-memory.js').EntityMemory;
+  /** Agent persona — display name, title, and email signature from the
+   *  coordinator's persona config. Available to all skills (not infrastructure-gated)
+   *  so templates can reference the agent's identity without hardcoding it. */
+  agentPersona?: AgentPersona;
   /** Caller identity — populated from the task event's sender context.
    *  Guaranteed to be defined for elevated skills (execution layer rejects without it).
    *  Available but optional for normal skills. */

--- a/tests/unit/skills/context-for-email.test.ts
+++ b/tests/unit/skills/context-for-email.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ContextForEmailHandler } from '../../../skills/context-for-email/handler.js';
+import type { SkillContext, AgentPersona } from '../../../src/skills/types.js';
+
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+const TEST_PERSONA: AgentPersona = {
+  displayName: 'Nathan Curia',
+  title: 'Agent Chief of Staff',
+};
+
+function makeCtx(
+  input: Record<string, unknown>,
+  overrides?: Partial<SkillContext>,
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    agentPersona: TEST_PERSONA,
+    ...overrides,
+  };
+}
+
+function makeEntityMemory() {
+  const entities = new Map<string, { id: string; label: string; properties: Record<string, unknown> }>();
+  const facts = new Map<string, Array<{ id: string; label: string; properties: Record<string, unknown>; temporal: { lastConfirmedAt: Date; confidence: number; decayClass: string; source: string; createdAt: Date } }>>();
+  let nextId = 1;
+
+  return {
+    findEntities: vi.fn(async (label: string) => {
+      const matches: Array<{ id: string; label: string; properties: Record<string, unknown> }> = [];
+      for (const e of entities.values()) {
+        if (e.label.toLowerCase() === label.toLowerCase()) matches.push(e);
+      }
+      return matches;
+    }),
+    createEntity: vi.fn(async (opts: { type: string; label: string; properties: Record<string, unknown>; source: string }) => {
+      const id = `entity-${nextId++}`;
+      const entity = { id, label: opts.label, properties: opts.properties };
+      entities.set(id, entity);
+      facts.set(id, []);
+      return entity;
+    }),
+    storeFact: vi.fn(async (opts: { entityNodeId: string; label: string; properties: Record<string, unknown>; confidence: number; decayClass: string; source: string }) => {
+      const entityFacts = facts.get(opts.entityNodeId) ?? [];
+      const existing = entityFacts.find((f) => f.label === opts.label);
+      if (existing) {
+        existing.properties = opts.properties;
+        existing.temporal.lastConfirmedAt = new Date();
+        return { stored: true, nodeId: existing.id };
+      }
+      const factId = `fact-${nextId++}`;
+      const now = new Date();
+      entityFacts.push({
+        id: factId, label: opts.label, properties: opts.properties,
+        temporal: { lastConfirmedAt: now, confidence: opts.confidence, decayClass: opts.decayClass, source: opts.source, createdAt: now },
+      });
+      facts.set(opts.entityNodeId, entityFacts);
+      return { stored: true, nodeId: factId };
+    }),
+    getFacts: vi.fn(async (entityNodeId: string) => facts.get(entityNodeId) ?? []),
+  };
+}
+
+function makeContactService() {
+  return {
+    findContactByName: vi.fn(async () => []),
+    getContactWithIdentities: vi.fn(async () => undefined),
+  };
+}
+
+describe('ContextForEmailHandler', () => {
+  const handler = new ContextForEmailHandler();
+
+  describe('input validation', () => {
+    it('rejects invalid email_type', async () => {
+      const result = await handler.execute(makeCtx({ email_type: 'spam', recipient_name: 'Alice' }));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('email_type');
+    });
+
+    it('rejects missing recipient_name', async () => {
+      const result = await handler.execute(makeCtx({ email_type: 'meeting-request' }));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('recipient_name');
+    });
+  });
+
+  describe('context assembly', () => {
+    it('returns default guidelines and agent signature with no KG or contacts', async () => {
+      const result = await handler.execute(makeCtx({
+        email_type: 'meeting-request',
+        recipient_name: 'Alice',
+      }));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as {
+          guidelines: { required_elements: string[] };
+          guidelines_source: string;
+          recipient: unknown;
+          agent_signature: string;
+          instructions: string;
+        };
+        expect(data.guidelines_source).toBe('default');
+        expect(data.guidelines.required_elements).toBeInstanceOf(Array);
+        expect(data.agent_signature).toContain('Nathan Curia');
+        expect(data.recipient).toBeNull();
+        expect(data.instructions).toContain('meeting-request');
+      }
+    });
+
+    it('includes contact info when contact service finds a match', async () => {
+      const cs = makeContactService();
+      cs.findContactByName.mockResolvedValue([
+        { id: 'c1', displayName: 'Alice Smith', role: 'cfo', kgNodeId: null, status: 'confirmed', notes: null, createdAt: new Date(), updatedAt: new Date() },
+      ]);
+      cs.getContactWithIdentities.mockResolvedValue({
+        contact: { id: 'c1', displayName: 'Alice Smith', role: 'cfo', kgNodeId: null, status: 'confirmed', notes: null, createdAt: new Date(), updatedAt: new Date() },
+        identities: [
+          { id: 'i1', contactId: 'c1', channel: 'email', channelIdentifier: 'alice@example.com', label: null, verified: true, verifiedAt: new Date(), source: 'ceo_stated', createdAt: new Date(), updatedAt: new Date() },
+        ],
+      });
+
+      const result = await handler.execute(makeCtx(
+        { email_type: 'cancel', recipient_name: 'Alice' },
+        { contactService: cs as never },
+      ));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { recipient: { display_name: string; role: string; email: string } };
+        expect(data.recipient.display_name).toBe('Alice Smith');
+        expect(data.recipient.role).toBe('cfo');
+        expect(data.recipient.email).toBe('alice@example.com');
+      }
+    });
+
+    it('includes meeting link when found in KG', async () => {
+      const em = makeEntityMemory();
+      // Set up a meeting-links anchor with Alice's Zoom link
+      const anchor = await em.createEntity({
+        type: 'concept', label: 'meeting-links',
+        properties: {}, source: 'test',
+      });
+      await em.storeFact({
+        entityNodeId: anchor.id, label: 'alice zoom link',
+        properties: { person_name: 'Alice Smith', platform: 'zoom', link: 'https://zoom.us/j/alice123' },
+        confidence: 1.0, decayClass: 'slow_decay', source: 'test',
+      });
+
+      const result = await handler.execute(makeCtx(
+        { email_type: 'meeting-request', recipient_name: 'Alice' },
+        { entityMemory: em as never },
+      ));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { recipient: { meeting_link: string } };
+        expect(data.recipient.meeting_link).toBe('https://zoom.us/j/alice123');
+      }
+    });
+
+    it('works for all 4 email types', async () => {
+      for (const emailType of ['meeting-request', 'reschedule', 'cancel', 'doc-request']) {
+        const result = await handler.execute(makeCtx({
+          email_type: emailType,
+          recipient_name: 'Bob',
+        }));
+        expect(result.success).toBe(true);
+        if (result.success) {
+          const data = result.data as { guidelines_source: string };
+          expect(data.guidelines_source).toBe('default');
+        }
+      }
+    });
+  });
+});

--- a/tests/unit/skills/knowledge-company-overview.test.ts
+++ b/tests/unit/skills/knowledge-company-overview.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi } from 'vitest';
+import { KnowledgeCompanyOverviewHandler } from '../../../skills/knowledge-company-overview/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(
+  input: Record<string, unknown>,
+  overrides?: Partial<SkillContext>,
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    ...overrides,
+  };
+}
+
+/** Stub EntityMemory with in-memory storage. */
+function makeEntityMemory() {
+  const entities = new Map<string, { id: string; label: string; properties: Record<string, unknown> }>();
+  const facts = new Map<string, Array<{ id: string; label: string; properties: Record<string, unknown>; temporal: { lastConfirmedAt: Date; confidence: number; decayClass: string; source: string; createdAt: Date } }>>();
+  let nextId = 1;
+
+  return {
+    findEntities: vi.fn(async (label: string) => {
+      const matches: Array<{ id: string; label: string; properties: Record<string, unknown> }> = [];
+      for (const e of entities.values()) {
+        if (e.label.toLowerCase() === label.toLowerCase()) {
+          matches.push(e);
+        }
+      }
+      return matches;
+    }),
+    createEntity: vi.fn(async (opts: { type: string; label: string; properties: Record<string, unknown>; source: string }) => {
+      const id = `entity-${nextId++}`;
+      const entity = { id, label: opts.label, properties: opts.properties };
+      entities.set(id, entity);
+      facts.set(id, []);
+      return entity;
+    }),
+    storeFact: vi.fn(async (opts: { entityNodeId: string; label: string; properties: Record<string, unknown>; confidence: number; decayClass: string; source: string }) => {
+      const entityFacts = facts.get(opts.entityNodeId) ?? [];
+      const existing = entityFacts.find((f) => f.label === opts.label);
+      if (existing) {
+        existing.properties = opts.properties;
+        existing.temporal.lastConfirmedAt = new Date();
+        return { stored: true, nodeId: existing.id };
+      }
+      const factId = `fact-${nextId++}`;
+      const now = new Date();
+      entityFacts.push({
+        id: factId,
+        label: opts.label,
+        properties: opts.properties,
+        temporal: { lastConfirmedAt: now, confidence: opts.confidence, decayClass: opts.decayClass, source: opts.source, createdAt: now },
+      });
+      facts.set(opts.entityNodeId, entityFacts);
+      return { stored: true, nodeId: factId };
+    }),
+    getFacts: vi.fn(async (entityNodeId: string) => {
+      return facts.get(entityNodeId) ?? [];
+    }),
+  };
+}
+
+describe('KnowledgeCompanyOverviewHandler', () => {
+  const handler = new KnowledgeCompanyOverviewHandler();
+
+  describe('action validation', () => {
+    it('rejects missing action', async () => {
+      const em = makeEntityMemory();
+      const result = await handler.execute(makeCtx({}, { entityMemory: em as never }));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('action');
+    });
+
+    it('rejects invalid action', async () => {
+      const em = makeEntityMemory();
+      const result = await handler.execute(makeCtx({ action: 'delete' }, { entityMemory: em as never }));
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('entityMemory requirement', () => {
+    it('rejects when entityMemory is not available', async () => {
+      const result = await handler.execute(makeCtx({ action: 'store', field: 'name', value: 'Acme' }));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('Knowledge graph');
+    });
+  });
+
+  describe('store', () => {
+    it('rejects when field is missing', async () => {
+      const em = makeEntityMemory();
+      const result = await handler.execute(makeCtx(
+        { action: 'store', value: 'Acme Inc.' },
+        { entityMemory: em as never },
+      ));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('field');
+    });
+
+    it('rejects when value is missing', async () => {
+      const em = makeEntityMemory();
+      const result = await handler.execute(makeCtx(
+        { action: 'store', field: 'legal_name' },
+        { entityMemory: em as never },
+      ));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('value');
+    });
+
+    it('stores a fact and creates anchor on first store', async () => {
+      const em = makeEntityMemory();
+      const result = await handler.execute(makeCtx(
+        { action: 'store', field: 'legal_name', value: 'Acme Corporation' },
+        { entityMemory: em as never },
+      ));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { stored: boolean; field: string };
+        expect(data.stored).toBe(true);
+        expect(data.field).toBe('legal_name');
+      }
+      expect(em.createEntity).toHaveBeenCalledTimes(1);
+      expect(em.storeFact).toHaveBeenCalledTimes(1);
+    });
+
+    it('reuses existing anchor on subsequent stores', async () => {
+      const em = makeEntityMemory();
+      await handler.execute(makeCtx(
+        { action: 'store', field: 'legal_name', value: 'Acme Corporation' },
+        { entityMemory: em as never },
+      ));
+      await handler.execute(makeCtx(
+        { action: 'store', field: 'address', value: '123 Main St' },
+        { entityMemory: em as never },
+      ));
+
+      // Anchor should only be created once
+      expect(em.createEntity).toHaveBeenCalledTimes(1);
+      expect(em.storeFact).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('retrieve', () => {
+    it('returns empty list when no facts stored', async () => {
+      const em = makeEntityMemory();
+      const result = await handler.execute(makeCtx(
+        { action: 'retrieve' },
+        { entityMemory: em as never },
+      ));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { facts: unknown[] };
+        expect(data.facts).toHaveLength(0);
+      }
+    });
+
+    it('retrieves stored facts', async () => {
+      const em = makeEntityMemory();
+      // Store two facts
+      await handler.execute(makeCtx(
+        { action: 'store', field: 'legal_name', value: 'Acme Corporation' },
+        { entityMemory: em as never },
+      ));
+      await handler.execute(makeCtx(
+        { action: 'store', field: 'address', value: '123 Main St, Toronto' },
+        { entityMemory: em as never },
+      ));
+
+      const result = await handler.execute(makeCtx(
+        { action: 'retrieve' },
+        { entityMemory: em as never },
+      ));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { facts: Array<{ field: string; value: string }> };
+        expect(data.facts).toHaveLength(2);
+        const fields = data.facts.map((f) => f.field);
+        expect(fields).toContain('legal_name');
+        expect(fields).toContain('address');
+      }
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles storeFact errors gracefully', async () => {
+      const em = makeEntityMemory();
+      em.storeFact.mockRejectedValueOnce(new Error('DB connection lost'));
+
+      // First need to create anchor
+      em.createEntity.mockResolvedValueOnce({ id: 'e-1', label: 'company-overview', properties: {} });
+
+      const result = await handler.execute(makeCtx(
+        { action: 'store', field: 'legal_name', value: 'Acme' },
+        { entityMemory: em as never },
+      ));
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain('DB connection lost');
+      }
+    });
+  });
+});

--- a/tests/unit/skills/template-meeting-request.test.ts
+++ b/tests/unit/skills/template-meeting-request.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, vi } from 'vitest';
 import { TemplateMeetingRequestHandler } from '../../../skills/template-meeting-request/handler.js';
-import type { SkillContext } from '../../../src/skills/types.js';
+import type { SkillContext, AgentPersona } from '../../../src/skills/types.js';
 
 import pino from 'pino';
 
 const logger = pino({ level: 'silent' });
+
+const TEST_PERSONA: AgentPersona = {
+  displayName: 'Nathan Curia',
+  title: 'Agent Chief of Staff',
+};
 
 function makeCtx(
   input: Record<string, unknown>,
@@ -14,6 +19,7 @@ function makeCtx(
     input,
     secret: () => { throw new Error('no secrets'); },
     log: logger,
+    agentPersona: TEST_PERSONA,
     ...overrides,
   };
 }
@@ -210,6 +216,68 @@ describe('TemplateMeetingRequestHandler', () => {
         const data = result.data as { subject: string; body: string; template_source: string };
         expect(data.body).toContain('45 minutes');
         expect(data.body).toContain('Zoom');
+      }
+    });
+
+    it('uses agent persona for signature in default template', async () => {
+      const result = await handler.execute(makeCtx({
+        action: 'generate',
+        recipient_name: 'Eve',
+        sender_name: 'CEO',
+        proposed_times: 'Monday 9am',
+      }));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { body: string };
+        expect(data.body).toContain('Nathan Curia');
+        expect(data.body).toContain('Agent Chief of Staff');
+      }
+    });
+
+    it('uses custom emailSignature when configured', async () => {
+      const customPersona: AgentPersona = {
+        displayName: 'Alex Helper',
+        title: 'Executive Assistant',
+        emailSignature: 'Alex Helper\nExecutive Assistant\nAcme Corp',
+      };
+      const result = await handler.execute(makeCtx(
+        {
+          action: 'generate',
+          recipient_name: 'Frank',
+          sender_name: 'CEO',
+          proposed_times: 'Tuesday 3pm',
+        },
+        { agentPersona: customPersona },
+      ));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { body: string };
+        expect(data.body).toContain('Alex Helper');
+        expect(data.body).toContain('Acme Corp');
+        // Should NOT contain the default persona
+        expect(data.body).not.toContain('Nathan Curia');
+      }
+    });
+
+    it('omits signature when no persona is provided', async () => {
+      const result = await handler.execute(makeCtx(
+        {
+          action: 'generate',
+          recipient_name: 'Grace',
+          sender_name: 'CEO',
+          proposed_times: 'Wednesday 1pm',
+        },
+        { agentPersona: undefined },
+      ));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { body: string };
+        // The signature placeholder should be filled with empty string
+        // and no hardcoded name should appear
+        expect(data.body).not.toContain('Nathan Curia');
       }
     });
   });

--- a/tests/unit/skills/template-meeting-request.test.ts
+++ b/tests/unit/skills/template-meeting-request.test.ts
@@ -244,10 +244,100 @@ describe('TemplateMeetingRequestHandler', () => {
     });
   });
 
+  describe('update (natural language refinement)', () => {
+    it('rejects when refinement is missing', async () => {
+      const em = makeEntityMemory();
+      const result = await handler.execute(makeCtx({ action: 'update' }, { entityMemory: em as never }));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('refinement');
+    });
+
+    it('rejects when entityMemory is not available', async () => {
+      const result = await handler.execute(makeCtx({ action: 'update', refinement: 'make it casual' }));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('Knowledge graph');
+    });
+
+    it('stores a refinement and returns it in generate', async () => {
+      const em = makeEntityMemory();
+      // Store a refinement
+      const updateResult = await handler.execute(makeCtx(
+        { action: 'update', refinement: 'Always mention that my assistant can help with scheduling' },
+        { entityMemory: em as never },
+      ));
+      expect(updateResult.success).toBe(true);
+      if (updateResult.success) {
+        const data = updateResult.data as { updated: boolean; refinement: string };
+        expect(data.updated).toBe(true);
+      }
+
+      // Generate should now include the refinement
+      const genResult = await handler.execute(makeCtx(
+        { action: 'generate', recipient_name: 'Alice', sender_name: 'CEO', proposed_times: 'Monday 9am' },
+        { entityMemory: em as never },
+      ));
+      expect(genResult.success).toBe(true);
+      if (genResult.success) {
+        const data = genResult.data as { guidelines: { refinements: string[] }; source: string };
+        expect(data.source).toBe('refined');
+        expect(data.guidelines.refinements).toContain('Always mention that my assistant can help with scheduling');
+      }
+    });
+
+    it('accumulates multiple refinements', async () => {
+      const em = makeEntityMemory();
+      await handler.execute(makeCtx(
+        { action: 'update', refinement: 'Make these less formal' },
+        { entityMemory: em as never },
+      ));
+      // Small delay so the timestamp-based label is unique (the real KG
+      // uses dedup by label similarity, not exact match, but our test stub
+      // deduplicates by exact label — same-millisecond timestamps collide).
+      await new Promise((r) => setTimeout(r, 2));
+      await handler.execute(makeCtx(
+        { action: 'update', refinement: 'Keep them under 3 sentences' },
+        { entityMemory: em as never },
+      ));
+
+      const result = await handler.execute(makeCtx(
+        { action: 'generate', recipient_name: 'Bob', sender_name: 'CEO', proposed_times: 'Tuesday 2pm' },
+        { entityMemory: em as never },
+      ));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { guidelines: { refinements: string[] } };
+        expect(data.guidelines.refinements).toHaveLength(2);
+        expect(data.guidelines.refinements[0]).toContain('less formal');
+        expect(data.guidelines.refinements[1]).toContain('3 sentences');
+      }
+    });
+  });
+
   describe('reset', () => {
     it('succeeds without entityMemory (no-op)', async () => {
       const result = await handler.execute(makeCtx({ action: 'reset' }));
       expect(result.success).toBe(true);
+    });
+
+    it('resets refinements so generate returns default source', async () => {
+      const em = makeEntityMemory();
+      // Add a refinement
+      await handler.execute(makeCtx(
+        { action: 'update', refinement: 'Keep it short' },
+        { entityMemory: em as never },
+      ));
+      // Reset
+      await handler.execute(makeCtx({ action: 'reset' }, { entityMemory: em as never }));
+      // Generate should be default, not refined
+      const result = await handler.execute(makeCtx(
+        { action: 'generate', recipient_name: 'Frank', sender_name: 'CEO', proposed_times: 'Friday 3pm' },
+        { entityMemory: em as never },
+      ));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { source: string };
+        expect(data.source).toBe('default');
+      }
     });
 
     it('resets custom policy so generate falls back to default', async () => {

--- a/tests/unit/skills/template-meeting-request.test.ts
+++ b/tests/unit/skills/template-meeting-request.test.ts
@@ -24,7 +24,7 @@ function makeCtx(
   };
 }
 
-/** Stub EntityMemory that stores/retrieves from a simple in-memory map. */
+/** Stub EntityMemory with in-memory storage. */
 function makeEntityMemory() {
   const entities = new Map<string, { id: string; label: string; properties: Record<string, unknown> }>();
   const facts = new Map<string, Array<{ id: string; label: string; properties: Record<string, unknown>; temporal: { lastConfirmedAt: Date; confidence: number; decayClass: string; source: string; createdAt: Date } }>>();
@@ -34,9 +34,7 @@ function makeEntityMemory() {
     findEntities: vi.fn(async (label: string) => {
       const matches: Array<{ id: string; label: string; properties: Record<string, unknown> }> = [];
       for (const e of entities.values()) {
-        if (e.label.toLowerCase() === label.toLowerCase()) {
-          matches.push(e);
-        }
+        if (e.label.toLowerCase() === label.toLowerCase()) matches.push(e);
       }
       return matches;
     }),
@@ -49,7 +47,6 @@ function makeEntityMemory() {
     }),
     storeFact: vi.fn(async (opts: { entityNodeId: string; label: string; properties: Record<string, unknown>; confidence: number; decayClass: string; source: string }) => {
       const entityFacts = facts.get(opts.entityNodeId) ?? [];
-      // Simulate dedup: update existing fact with same label
       const existing = entityFacts.find((f) => f.label === opts.label);
       if (existing) {
         existing.properties = opts.properties;
@@ -59,17 +56,13 @@ function makeEntityMemory() {
       const factId = `fact-${nextId++}`;
       const now = new Date();
       entityFacts.push({
-        id: factId,
-        label: opts.label,
-        properties: opts.properties,
+        id: factId, label: opts.label, properties: opts.properties,
         temporal: { lastConfirmedAt: now, confidence: opts.confidence, decayClass: opts.decayClass, source: opts.source, createdAt: now },
       });
       facts.set(opts.entityNodeId, entityFacts);
       return { stored: true, nodeId: factId };
     }),
-    getFacts: vi.fn(async (entityNodeId: string) => {
-      return facts.get(entityNodeId) ?? [];
-    }),
+    getFacts: vi.fn(async (entityNodeId: string) => facts.get(entityNodeId) ?? []),
   };
 }
 
@@ -86,42 +79,17 @@ describe('TemplateMeetingRequestHandler', () => {
     it('rejects invalid action', async () => {
       const result = await handler.execute(makeCtx({ action: 'invalid' }));
       expect(result.success).toBe(false);
-      if (!result.success) expect(result.error).toContain('action');
     });
   });
 
   describe('generate', () => {
-    it('rejects when recipient_name is missing', async () => {
-      const result = await handler.execute(makeCtx({
-        action: 'generate',
-        sender_name: 'CEO',
-        proposed_times: 'Monday 10am',
-      }));
+    it('rejects when required inputs are missing', async () => {
+      const result = await handler.execute(makeCtx({ action: 'generate', sender_name: 'CEO', proposed_times: 'Monday 10am' }));
       expect(result.success).toBe(false);
       if (!result.success) expect(result.error).toContain('recipient_name');
     });
 
-    it('rejects when sender_name is missing', async () => {
-      const result = await handler.execute(makeCtx({
-        action: 'generate',
-        recipient_name: 'Alice',
-        proposed_times: 'Monday 10am',
-      }));
-      expect(result.success).toBe(false);
-      if (!result.success) expect(result.error).toContain('sender_name');
-    });
-
-    it('rejects when proposed_times is missing', async () => {
-      const result = await handler.execute(makeCtx({
-        action: 'generate',
-        recipient_name: 'Alice',
-        sender_name: 'CEO',
-      }));
-      expect(result.success).toBe(false);
-      if (!result.success) expect(result.error).toContain('proposed_times');
-    });
-
-    it('generates with default template when no entityMemory', async () => {
+    it('returns guidelines + context with default policy when no KG', async () => {
       const result = await handler.execute(makeCtx({
         action: 'generate',
         recipient_name: 'Alice',
@@ -132,248 +100,173 @@ describe('TemplateMeetingRequestHandler', () => {
 
       expect(result.success).toBe(true);
       if (result.success) {
-        const data = result.data as { subject: string; body: string; template_source: string };
-        expect(data.template_source).toBe('default');
-        expect(data.subject).toContain('Q3 Planning');
-        expect(data.body).toContain('Alice');
-        expect(data.body).toContain('Joseph');
-        expect(data.body).toContain('Monday 10am');
-        expect(data.body).toContain('Tuesday 2pm');
+        const data = result.data as {
+          guidelines: { required_elements: string[]; tone: string; structure: string; constraints: string[]; example: string };
+          context: Record<string, string>;
+          source: string;
+          instructions: string;
+        };
+        // Returns structured guidelines, NOT a pre-filled email
+        expect(data.source).toBe('default');
+        expect(data.guidelines.required_elements).toBeInstanceOf(Array);
+        expect(data.guidelines.tone).toBeDefined();
+        expect(data.guidelines.structure).toBeDefined();
+        expect(data.guidelines.constraints).toBeInstanceOf(Array);
+        expect(data.guidelines.example).toContain('Subject:');
+        expect(data.instructions).toContain('guidelines');
+
+        // Context passes through the input variables for the LLM
+        expect(data.context.recipient_name).toBe('Alice');
+        expect(data.context.sender_name).toBe('Joseph');
+        expect(data.context.proposed_times).toBe('Monday 10am, Tuesday 2pm');
+        expect(data.context.meeting_purpose).toBe('Q3 Planning');
+        expect(data.context.agent_signature).toContain('Nathan Curia');
       }
     });
 
-    it('generates with default template when entityMemory has no custom template', async () => {
+    it('returns custom policy from KG when available', async () => {
       const em = makeEntityMemory();
-      const result = await handler.execute(makeCtx(
-        {
-          action: 'generate',
-          recipient_name: 'Bob',
-          sender_name: 'CEO',
-          proposed_times: 'Wednesday 3pm',
-        },
-        { entityMemory: em as never },
-      ));
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        const data = result.data as { subject: string; body: string; template_source: string };
-        expect(data.template_source).toBe('default');
-        expect(data.body).toContain('Bob');
-      }
-    });
-
-    it('generates with custom template from KG', async () => {
-      const em = makeEntityMemory();
-      // Pre-populate a custom template
       const anchor = await em.createEntity({
-        type: 'concept',
-        label: 'template:meeting-request',
-        properties: { category: 'email-template' },
-        source: 'test',
+        type: 'concept', label: 'template:meeting-request',
+        properties: { category: 'email-policy' }, source: 'test',
+      });
+      const customPolicy = JSON.stringify({
+        required_elements: ['Keep it short', 'Include a joke'],
+        tone: 'Casual and friendly',
       });
       await em.storeFact({
-        entityNodeId: anchor.id,
-        label: 'template body',
-        properties: { body: 'Subject: Custom — {{meeting_purpose}}\n\nDear {{recipient_name}}, let us meet. Times: {{proposed_times}}' },
-        confidence: 1.0,
-        decayClass: 'permanent',
-        source: 'test',
+        entityNodeId: anchor.id, label: 'email policy',
+        properties: { policy: customPolicy },
+        confidence: 1.0, decayClass: 'permanent', source: 'test',
       });
 
       const result = await handler.execute(makeCtx(
         {
           action: 'generate',
-          recipient_name: 'Carol',
-          sender_name: 'CEO',
-          proposed_times: 'Thursday 11am',
-          meeting_purpose: 'Budget Review',
+          recipient_name: 'Carol', sender_name: 'CEO', proposed_times: 'Thursday 11am',
         },
         { entityMemory: em as never },
       ));
 
       expect(result.success).toBe(true);
       if (result.success) {
-        const data = result.data as { subject: string; body: string; template_source: string };
-        expect(data.template_source).toBe('custom');
-        expect(data.subject).toContain('Budget Review');
-        expect(data.body).toContain('Carol');
+        const data = result.data as { guidelines: { tone: string }; source: string };
+        expect(data.source).toBe('custom');
+        expect(data.guidelines.tone).toBe('Casual and friendly');
       }
     });
 
-    it('includes optional fields when provided', async () => {
+    it('handles plain-text custom policy (non-JSON)', async () => {
+      const em = makeEntityMemory();
+      const anchor = await em.createEntity({
+        type: 'concept', label: 'template:meeting-request',
+        properties: {}, source: 'test',
+      });
+      await em.storeFact({
+        entityNodeId: anchor.id, label: 'email policy',
+        properties: { policy: 'Always mention the CEO loves coffee meetings.' },
+        confidence: 1.0, decayClass: 'permanent', source: 'test',
+      });
+
+      const result = await handler.execute(makeCtx(
+        {
+          action: 'generate',
+          recipient_name: 'Dan', sender_name: 'CEO', proposed_times: 'Friday 2pm',
+        },
+        { entityMemory: em as never },
+      ));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { guidelines: { custom_guidelines: string }; source: string };
+        expect(data.source).toBe('custom');
+        expect(data.guidelines.custom_guidelines).toContain('coffee meetings');
+      }
+    });
+
+    it('includes optional context fields when provided', async () => {
       const result = await handler.execute(makeCtx({
         action: 'generate',
-        recipient_name: 'Dave',
-        sender_name: 'CEO',
-        proposed_times: 'Friday 9am',
-        meeting_purpose: 'Product Demo',
-        meeting_duration: '45 minutes',
-        meeting_location: 'Zoom',
+        recipient_name: 'Dave', sender_name: 'CEO', proposed_times: 'Friday 9am',
+        meeting_purpose: 'Product Demo', meeting_duration: '45 minutes', meeting_location: 'Zoom',
       }));
 
       expect(result.success).toBe(true);
       if (result.success) {
-        const data = result.data as { subject: string; body: string; template_source: string };
-        expect(data.body).toContain('45 minutes');
-        expect(data.body).toContain('Zoom');
-      }
-    });
-
-    it('uses agent persona for signature in default template', async () => {
-      const result = await handler.execute(makeCtx({
-        action: 'generate',
-        recipient_name: 'Eve',
-        sender_name: 'CEO',
-        proposed_times: 'Monday 9am',
-      }));
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        const data = result.data as { body: string };
-        expect(data.body).toContain('Nathan Curia');
-        expect(data.body).toContain('Agent Chief of Staff');
+        const data = result.data as { context: Record<string, string> };
+        expect(data.context.meeting_duration).toBe('45 minutes');
+        expect(data.context.meeting_location).toBe('Zoom');
       }
     });
 
     it('uses custom emailSignature when configured', async () => {
       const customPersona: AgentPersona = {
-        displayName: 'Alex Helper',
-        title: 'Executive Assistant',
-        emailSignature: 'Alex Helper\nExecutive Assistant\nAcme Corp',
+        displayName: 'Alex Helper', title: 'Executive Assistant',
+        emailSignature: 'Alex Helper, Executive Assistant, Acme Corp',
       };
       const result = await handler.execute(makeCtx(
-        {
-          action: 'generate',
-          recipient_name: 'Frank',
-          sender_name: 'CEO',
-          proposed_times: 'Tuesday 3pm',
-        },
+        { action: 'generate', recipient_name: 'Frank', sender_name: 'CEO', proposed_times: 'Tuesday 3pm' },
         { agentPersona: customPersona },
       ));
 
       expect(result.success).toBe(true);
       if (result.success) {
-        const data = result.data as { body: string };
-        expect(data.body).toContain('Alex Helper');
-        expect(data.body).toContain('Acme Corp');
-        // Should NOT contain the default persona
-        expect(data.body).not.toContain('Nathan Curia');
-      }
-    });
-
-    it('omits signature when no persona is provided', async () => {
-      const result = await handler.execute(makeCtx(
-        {
-          action: 'generate',
-          recipient_name: 'Grace',
-          sender_name: 'CEO',
-          proposed_times: 'Wednesday 1pm',
-        },
-        { agentPersona: undefined },
-      ));
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        const data = result.data as { body: string };
-        // The signature placeholder should be filled with empty string
-        // and no hardcoded name should appear
-        expect(data.body).not.toContain('Nathan Curia');
+        const data = result.data as { context: { agent_signature: string } };
+        expect(data.context.agent_signature).toContain('Acme Corp');
+        expect(data.context.agent_signature).not.toContain('Nathan Curia');
       }
     });
   });
 
   describe('save', () => {
-    it('rejects when custom_template is missing', async () => {
+    it('rejects when custom_policy is missing', async () => {
       const em = makeEntityMemory();
-      const result = await handler.execute(makeCtx(
-        { action: 'save' },
-        { entityMemory: em as never },
-      ));
+      const result = await handler.execute(makeCtx({ action: 'save' }, { entityMemory: em as never }));
       expect(result.success).toBe(false);
-      if (!result.success) expect(result.error).toContain('custom_template');
+      if (!result.success) expect(result.error).toContain('custom_policy');
     });
 
     it('rejects when entityMemory is not available', async () => {
-      const result = await handler.execute(makeCtx({
-        action: 'save',
-        custom_template: 'My template',
-      }));
+      const result = await handler.execute(makeCtx({ action: 'save', custom_policy: 'My policy' }));
       expect(result.success).toBe(false);
       if (!result.success) expect(result.error).toContain('Knowledge graph');
     });
 
-    it('saves a new custom template', async () => {
+    it('saves a new custom policy', async () => {
       const em = makeEntityMemory();
       const result = await handler.execute(makeCtx(
-        { action: 'save', custom_template: 'Subject: New\n\nHello {{recipient_name}}' },
+        { action: 'save', custom_policy: '{"tone": "Very casual"}' },
         { entityMemory: em as never },
       ));
-
       expect(result.success).toBe(true);
-      if (result.success) {
-        const data = result.data as { saved: boolean };
-        expect(data.saved).toBe(true);
-      }
       expect(em.createEntity).toHaveBeenCalled();
       expect(em.storeFact).toHaveBeenCalled();
-    });
-
-    it('updates an existing custom template', async () => {
-      const em = makeEntityMemory();
-      // First save
-      await handler.execute(makeCtx(
-        { action: 'save', custom_template: 'V1 template' },
-        { entityMemory: em as never },
-      ));
-      // Second save — should update, not create new anchor
-      const result = await handler.execute(makeCtx(
-        { action: 'save', custom_template: 'V2 template' },
-        { entityMemory: em as never },
-      ));
-
-      expect(result.success).toBe(true);
-      // createEntity should only be called once (for the first save)
-      expect(em.createEntity).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('reset', () => {
-    it('succeeds even without entityMemory (no-op)', async () => {
+    it('succeeds without entityMemory (no-op)', async () => {
       const result = await handler.execute(makeCtx({ action: 'reset' }));
       expect(result.success).toBe(true);
-      if (result.success) {
-        const data = result.data as { reset: boolean };
-        expect(data.reset).toBe(true);
-      }
     });
 
-    it('resets custom template so generate falls back to default', async () => {
+    it('resets custom policy so generate falls back to default', async () => {
       const em = makeEntityMemory();
-      // Save a custom template
       await handler.execute(makeCtx(
-        { action: 'save', custom_template: 'Subject: Custom\n\nCustom body {{recipient_name}}' },
+        { action: 'save', custom_policy: '{"tone": "Very casual"}' },
         { entityMemory: em as never },
       ));
-      // Reset it
-      await handler.execute(makeCtx(
-        { action: 'reset' },
-        { entityMemory: em as never },
-      ));
-      // Generate should use default
+      await handler.execute(makeCtx({ action: 'reset' }, { entityMemory: em as never }));
+
       const result = await handler.execute(makeCtx(
-        {
-          action: 'generate',
-          recipient_name: 'Eve',
-          sender_name: 'CEO',
-          proposed_times: 'Monday 9am',
-        },
+        { action: 'generate', recipient_name: 'Eve', sender_name: 'CEO', proposed_times: 'Monday 9am' },
         { entityMemory: em as never },
       ));
 
       expect(result.success).toBe(true);
       if (result.success) {
-        const data = result.data as { template_source: string };
-        expect(data.template_source).toBe('default');
+        const data = result.data as { source: string };
+        expect(data.source).toBe('default');
       }
     });
   });

--- a/tests/unit/skills/template-meeting-request.test.ts
+++ b/tests/unit/skills/template-meeting-request.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TemplateMeetingRequestHandler } from '../../../skills/template-meeting-request/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(
+  input: Record<string, unknown>,
+  overrides?: Partial<SkillContext>,
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    ...overrides,
+  };
+}
+
+/** Stub EntityMemory that stores/retrieves from a simple in-memory map. */
+function makeEntityMemory() {
+  const entities = new Map<string, { id: string; label: string; properties: Record<string, unknown> }>();
+  const facts = new Map<string, Array<{ id: string; label: string; properties: Record<string, unknown>; temporal: { lastConfirmedAt: Date; confidence: number; decayClass: string; source: string; createdAt: Date } }>>();
+  let nextId = 1;
+
+  return {
+    findEntities: vi.fn(async (label: string) => {
+      const matches: Array<{ id: string; label: string; properties: Record<string, unknown> }> = [];
+      for (const e of entities.values()) {
+        if (e.label.toLowerCase() === label.toLowerCase()) {
+          matches.push(e);
+        }
+      }
+      return matches;
+    }),
+    createEntity: vi.fn(async (opts: { type: string; label: string; properties: Record<string, unknown>; source: string }) => {
+      const id = `entity-${nextId++}`;
+      const entity = { id, label: opts.label, properties: opts.properties };
+      entities.set(id, entity);
+      facts.set(id, []);
+      return entity;
+    }),
+    storeFact: vi.fn(async (opts: { entityNodeId: string; label: string; properties: Record<string, unknown>; confidence: number; decayClass: string; source: string }) => {
+      const entityFacts = facts.get(opts.entityNodeId) ?? [];
+      // Simulate dedup: update existing fact with same label
+      const existing = entityFacts.find((f) => f.label === opts.label);
+      if (existing) {
+        existing.properties = opts.properties;
+        existing.temporal.lastConfirmedAt = new Date();
+        return { stored: true, nodeId: existing.id };
+      }
+      const factId = `fact-${nextId++}`;
+      const now = new Date();
+      entityFacts.push({
+        id: factId,
+        label: opts.label,
+        properties: opts.properties,
+        temporal: { lastConfirmedAt: now, confidence: opts.confidence, decayClass: opts.decayClass, source: opts.source, createdAt: now },
+      });
+      facts.set(opts.entityNodeId, entityFacts);
+      return { stored: true, nodeId: factId };
+    }),
+    getFacts: vi.fn(async (entityNodeId: string) => {
+      return facts.get(entityNodeId) ?? [];
+    }),
+  };
+}
+
+describe('TemplateMeetingRequestHandler', () => {
+  const handler = new TemplateMeetingRequestHandler();
+
+  describe('action validation', () => {
+    it('rejects missing action', async () => {
+      const result = await handler.execute(makeCtx({}));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('action');
+    });
+
+    it('rejects invalid action', async () => {
+      const result = await handler.execute(makeCtx({ action: 'invalid' }));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('action');
+    });
+  });
+
+  describe('generate', () => {
+    it('rejects when recipient_name is missing', async () => {
+      const result = await handler.execute(makeCtx({
+        action: 'generate',
+        sender_name: 'CEO',
+        proposed_times: 'Monday 10am',
+      }));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('recipient_name');
+    });
+
+    it('rejects when sender_name is missing', async () => {
+      const result = await handler.execute(makeCtx({
+        action: 'generate',
+        recipient_name: 'Alice',
+        proposed_times: 'Monday 10am',
+      }));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('sender_name');
+    });
+
+    it('rejects when proposed_times is missing', async () => {
+      const result = await handler.execute(makeCtx({
+        action: 'generate',
+        recipient_name: 'Alice',
+        sender_name: 'CEO',
+      }));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('proposed_times');
+    });
+
+    it('generates with default template when no entityMemory', async () => {
+      const result = await handler.execute(makeCtx({
+        action: 'generate',
+        recipient_name: 'Alice',
+        sender_name: 'Joseph',
+        proposed_times: 'Monday 10am, Tuesday 2pm',
+        meeting_purpose: 'Q3 Planning',
+      }));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { subject: string; body: string; template_source: string };
+        expect(data.template_source).toBe('default');
+        expect(data.subject).toContain('Q3 Planning');
+        expect(data.body).toContain('Alice');
+        expect(data.body).toContain('Joseph');
+        expect(data.body).toContain('Monday 10am');
+        expect(data.body).toContain('Tuesday 2pm');
+      }
+    });
+
+    it('generates with default template when entityMemory has no custom template', async () => {
+      const em = makeEntityMemory();
+      const result = await handler.execute(makeCtx(
+        {
+          action: 'generate',
+          recipient_name: 'Bob',
+          sender_name: 'CEO',
+          proposed_times: 'Wednesday 3pm',
+        },
+        { entityMemory: em as never },
+      ));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { subject: string; body: string; template_source: string };
+        expect(data.template_source).toBe('default');
+        expect(data.body).toContain('Bob');
+      }
+    });
+
+    it('generates with custom template from KG', async () => {
+      const em = makeEntityMemory();
+      // Pre-populate a custom template
+      const anchor = await em.createEntity({
+        type: 'concept',
+        label: 'template:meeting-request',
+        properties: { category: 'email-template' },
+        source: 'test',
+      });
+      await em.storeFact({
+        entityNodeId: anchor.id,
+        label: 'template body',
+        properties: { body: 'Subject: Custom — {{meeting_purpose}}\n\nDear {{recipient_name}}, let us meet. Times: {{proposed_times}}' },
+        confidence: 1.0,
+        decayClass: 'permanent',
+        source: 'test',
+      });
+
+      const result = await handler.execute(makeCtx(
+        {
+          action: 'generate',
+          recipient_name: 'Carol',
+          sender_name: 'CEO',
+          proposed_times: 'Thursday 11am',
+          meeting_purpose: 'Budget Review',
+        },
+        { entityMemory: em as never },
+      ));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { subject: string; body: string; template_source: string };
+        expect(data.template_source).toBe('custom');
+        expect(data.subject).toContain('Budget Review');
+        expect(data.body).toContain('Carol');
+      }
+    });
+
+    it('includes optional fields when provided', async () => {
+      const result = await handler.execute(makeCtx({
+        action: 'generate',
+        recipient_name: 'Dave',
+        sender_name: 'CEO',
+        proposed_times: 'Friday 9am',
+        meeting_purpose: 'Product Demo',
+        meeting_duration: '45 minutes',
+        meeting_location: 'Zoom',
+      }));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { subject: string; body: string; template_source: string };
+        expect(data.body).toContain('45 minutes');
+        expect(data.body).toContain('Zoom');
+      }
+    });
+  });
+
+  describe('save', () => {
+    it('rejects when custom_template is missing', async () => {
+      const em = makeEntityMemory();
+      const result = await handler.execute(makeCtx(
+        { action: 'save' },
+        { entityMemory: em as never },
+      ));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('custom_template');
+    });
+
+    it('rejects when entityMemory is not available', async () => {
+      const result = await handler.execute(makeCtx({
+        action: 'save',
+        custom_template: 'My template',
+      }));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('Knowledge graph');
+    });
+
+    it('saves a new custom template', async () => {
+      const em = makeEntityMemory();
+      const result = await handler.execute(makeCtx(
+        { action: 'save', custom_template: 'Subject: New\n\nHello {{recipient_name}}' },
+        { entityMemory: em as never },
+      ));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { saved: boolean };
+        expect(data.saved).toBe(true);
+      }
+      expect(em.createEntity).toHaveBeenCalled();
+      expect(em.storeFact).toHaveBeenCalled();
+    });
+
+    it('updates an existing custom template', async () => {
+      const em = makeEntityMemory();
+      // First save
+      await handler.execute(makeCtx(
+        { action: 'save', custom_template: 'V1 template' },
+        { entityMemory: em as never },
+      ));
+      // Second save — should update, not create new anchor
+      const result = await handler.execute(makeCtx(
+        { action: 'save', custom_template: 'V2 template' },
+        { entityMemory: em as never },
+      ));
+
+      expect(result.success).toBe(true);
+      // createEntity should only be called once (for the first save)
+      expect(em.createEntity).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('reset', () => {
+    it('succeeds even without entityMemory (no-op)', async () => {
+      const result = await handler.execute(makeCtx({ action: 'reset' }));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { reset: boolean };
+        expect(data.reset).toBe(true);
+      }
+    });
+
+    it('resets custom template so generate falls back to default', async () => {
+      const em = makeEntityMemory();
+      // Save a custom template
+      await handler.execute(makeCtx(
+        { action: 'save', custom_template: 'Subject: Custom\n\nCustom body {{recipient_name}}' },
+        { entityMemory: em as never },
+      ));
+      // Reset it
+      await handler.execute(makeCtx(
+        { action: 'reset' },
+        { entityMemory: em as never },
+      ));
+      // Generate should use default
+      const result = await handler.execute(makeCtx(
+        {
+          action: 'generate',
+          recipient_name: 'Eve',
+          sender_name: 'CEO',
+          proposed_times: 'Monday 9am',
+        },
+        { entityMemory: em as never },
+      ));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { template_source: string };
+        expect(data.template_source).toBe('default');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Implements the Coordinator Skills group from the EA Handbook Phase A plan: 9 skills that give the coordinator email policy guidance, structured knowledge storage, and context assembly.

### What changed

**Infrastructure (src/)**
- `AgentPersona` type on `SkillContext` — agent identity (name, title, signature) sourced from coordinator YAML persona config, not hardcoded
- `entityMemory` on `SkillContext` — KG access for infrastructure skills, threaded through `ExecutionLayer` and bootstrap

**4 email policy skills** (`template-meeting-request`, `template-reschedule`, `template-cancel`, `template-doc-request`)
- Return structured composing guidelines (required elements, tone, structure, constraints, example) — the LLM composes the actual email
- `generate` — retrieves policy from KG (custom + refinements), falls back to built-in defaults
- `update` — accepts natural-language refinements ("make these less formal", "always mention my assistant") as additive adjustments stored in the KG
- `save` — replaces the entire policy wholesale
- `reset` — clears custom policy and all refinements

**4 knowledge skills** (`knowledge-company-overview`, `knowledge-meeting-links`, `knowledge-travel-preferences`, `knowledge-loyalty-programs`)
- Store/retrieve structured facts in the KG with well-known anchor entities
- Aggregate across duplicate anchors to handle race conditions

**1 context assembly skill** (`context-for-email`)
- Assembles complete email context in a single call: email policy + recipient contact info + meeting link + agent signature
- Gathers data in parallel via `Promise.all`
- Eliminates 4-5 sequential tool calls the LLM would otherwise need

**Shared template base** (`skills/_shared/template-base.ts`)
- Extracts save/update/reset/resolve logic shared by all 4 template skills

**EA Handbook plan updates** (`docs/plans/`)
- Added "Skills Must Add Value Beyond the Bare LLM" design principle with concrete test
- Added LLM future-proofing principles (skills provide data, never intelligence)
- Added composability rules (context assembly, shared backing stores)
- Applied value analysis to every proposed agent — removed 15 skills that merely wrap LLM-native capabilities (53 → 38 total)
- Documented 7 known gaps with mitigation status and future plans

### Design decisions

- **Guidelines, not templates.** Template skills return policy objects the LLM uses as composing instructions — not pre-filled emails. This is better than both rigid templates (can't adapt) and bare LLM behavior (no organizational consistency).
- **Additive refinements.** The `update` action stores natural-language adjustments that accumulate chronologically. The compose-time LLM sees both the base policy and all refinements. No LLM call inside the skill — the compose-time model does the synthesis.
- **Context assembly.** One skill call replaces a multi-step tool orchestration. As the number of knowledge sources grows, this pattern scales — the LLM doesn't need to know about every knowledge skill.

## Test plan

- [x] 58 test files, 490 tests, 0 failures
- [x] TypeScript type checking passes with no errors
- [x] Tests cover: generate/save/update/reset actions, custom policy from KG, plain-text policy, refinement accumulation, reset-clears-refinements, persona-driven signatures, context assembly with contacts and meeting links


___

## **CodeAnt-AI Description**
**Add coordinator email policy, knowledge, and context assembly skills**

### What Changed
- Added four email policy skills that return composing guidelines for meeting requests, reschedules, cancellations, and document requests, with support for saving, updating, and resetting custom rules.
- Added four knowledge skills for storing and retrieving company details, meeting links, travel preferences, and loyalty program data in a shared knowledge store.
- Added a single email context skill that gathers the right policy, contact details, meeting link, and agent signature in one call so email composition needs fewer tool steps.
- Replaced hardcoded agent identity in email outputs with the coordinator’s configured persona, and added input limits plus cleanup for unfinished template text.

### Impact
`✅ Fewer email drafting steps`
`✅ Consistent meeting request and reschedule emails`
`✅ Easier reuse of stored company and travel details`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
