### PR TITLE
feat: calendar skills — 7 Nylas-backed CRUD/free-busy skills pinned to coordinator

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -176,4 +176,11 @@ pinned_skills:
   - knowledge-travel-preferences
   - knowledge-loyalty-programs
   - context-for-email
+  - calendar-list-calendars
+  - calendar-list-events
+  - calendar-create-event
+  - calendar-update-event
+  - calendar-delete-event
+  - calendar-find-free-time
+  - calendar-check-conflicts
 allow_discovery: true

--- a/skills/calendar-check-conflicts/handler.ts
+++ b/skills/calendar-check-conflicts/handler.ts
@@ -43,17 +43,19 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
       }> = [];
 
       for (const result of freeBusyResults) {
+        // Resolve contact name once per calendar result, not once per busy slot — avoids N+1 DB calls.
+        let contactName: string | null = null;
+        if (ctx.contactService) {
+          const registry = await ctx.contactService.resolveCalendar(result.email);
+          if (registry?.contactId) {
+            const contact = await ctx.contactService.getContact(registry.contactId);
+            contactName = contact?.displayName ?? null;
+          }
+        }
+
         for (const slot of result.timeSlots) {
           // Check overlap: busy slot overlaps the proposed range
           if (slot.startTime < proposedEndTs && slot.endTime > proposedStartTs) {
-            let contactName: string | null = null;
-            if (ctx.contactService) {
-              const registry = await ctx.contactService.resolveCalendar(result.email);
-              if (registry?.contactId) {
-                const contact = await ctx.contactService.getContact(registry.contactId);
-                contactName = contact?.displayName ?? null;
-              }
-            }
             conflicts.push({
               calendarId: result.email,
               contactName,

--- a/skills/calendar-check-conflicts/handler.ts
+++ b/skills/calendar-check-conflicts/handler.ts
@@ -1,0 +1,77 @@
+// skills/calendar-check-conflicts/handler.ts
+//
+// Checks whether a proposed time slot conflicts with existing busy periods.
+// Annotates each conflict with the calendar owner's name from the registry.
+// Returns an empty array (clear=true) if the time is free.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class CalendarCheckConflictsHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.nylasCalendarClient) {
+      return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
+    }
+
+    const { calendarIds, proposedStart, proposedEnd } = ctx.input as {
+      calendarIds?: string[];
+      proposedStart?: string;
+      proposedEnd?: string;
+    };
+
+    if (!calendarIds || !Array.isArray(calendarIds) || calendarIds.length === 0) {
+      return { success: false, error: 'Missing required input: calendarIds (must be a non-empty array)' };
+    }
+    if (!proposedStart || typeof proposedStart !== 'string') {
+      return { success: false, error: 'Missing required input: proposedStart' };
+    }
+    if (!proposedEnd || typeof proposedEnd !== 'string') {
+      return { success: false, error: 'Missing required input: proposedEnd' };
+    }
+
+    try {
+      const freeBusyResults = await ctx.nylasCalendarClient.getFreeBusy(calendarIds, proposedStart, proposedEnd);
+
+      const proposedStartTs = Math.floor(new Date(proposedStart).getTime() / 1000);
+      const proposedEndTs = Math.floor(new Date(proposedEnd).getTime() / 1000);
+
+      const conflicts: Array<{
+        calendarId: string;
+        contactName: string | null;
+        startTime: number;
+        endTime: number;
+        status: string;
+      }> = [];
+
+      for (const result of freeBusyResults) {
+        for (const slot of result.timeSlots) {
+          // Check overlap: busy slot overlaps the proposed range
+          if (slot.startTime < proposedEndTs && slot.endTime > proposedStartTs) {
+            let contactName: string | null = null;
+            if (ctx.contactService) {
+              const registry = await ctx.contactService.resolveCalendar(result.email);
+              if (registry?.contactId) {
+                const contact = await ctx.contactService.getContact(registry.contactId);
+                contactName = contact?.displayName ?? null;
+              }
+            }
+            conflicts.push({
+              calendarId: result.email,
+              contactName,
+              startTime: slot.startTime,
+              endTime: slot.endTime,
+              status: slot.status,
+            });
+          }
+        }
+      }
+
+      const clear = conflicts.length === 0;
+      ctx.log.info({ calendarCount: calendarIds.length, conflictCount: conflicts.length }, 'Checked conflicts');
+      return { success: true, data: { conflicts, clear } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to check conflicts');
+      return { success: false, error: `Failed to check conflicts: ${message}` };
+    }
+  }
+}

--- a/skills/calendar-check-conflicts/skill.json
+++ b/skills/calendar-check-conflicts/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "calendar-check-conflicts",
+  "description": "Check whether a proposed time slot conflicts with existing events on one or more calendars. Returns conflicting events with details so you can assess severity (hard conflict vs tentative hold).",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "calendarIds": "array",
+    "proposedStart": "string",
+    "proposedEnd": "string"
+  },
+  "outputs": {
+    "conflicts": "array",
+    "clear": "boolean"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}

--- a/skills/calendar-create-event/handler.ts
+++ b/skills/calendar-create-event/handler.ts
@@ -36,6 +36,18 @@ export class CalendarCreateEventHandler implements SkillHandler {
     if (!end || typeof end !== 'string') {
       return { success: false, error: 'Missing required input: end' };
     }
+    if (isNaN(new Date(start).getTime())) {
+      return { success: false, error: 'Invalid input: start is not a valid date' };
+    }
+    if (isNaN(new Date(end).getTime())) {
+      return { success: false, error: 'Invalid input: end is not a valid date' };
+    }
+    if (new Date(end) <= new Date(start)) {
+      return { success: false, error: 'Invalid input: end must be after start' };
+    }
+    if (attendees !== undefined && !Array.isArray(attendees)) {
+      return { success: false, error: 'Invalid input: attendees must be an array' };
+    }
 
     try {
       // Read-only check: if the calendar is registered and marked read-only, refuse.

--- a/skills/calendar-create-event/handler.ts
+++ b/skills/calendar-create-event/handler.ts
@@ -37,16 +37,17 @@ export class CalendarCreateEventHandler implements SkillHandler {
       return { success: false, error: 'Missing required input: end' };
     }
 
-    // Read-only check: if the calendar is registered and marked read-only, refuse.
-    // Unregistered calendars (null) proceed — Nylas enforces its own permissions.
-    if (ctx.contactService) {
-      const registry = await ctx.contactService.resolveCalendar(calendarId);
-      if (registry?.readOnly) {
-        return { success: false, error: 'Calendar is read-only' };
-      }
-    }
-
     try {
+      // Read-only check: if the calendar is registered and marked read-only, refuse.
+      // Unregistered calendars (null) proceed — Nylas enforces its own permissions.
+      // Moved inside try so DB errors from resolveCalendar are caught with skill-level context.
+      if (ctx.contactService) {
+        const registry = await ctx.contactService.resolveCalendar(calendarId);
+        if (registry?.readOnly) {
+          return { success: false, error: 'Calendar is read-only' };
+        }
+      }
+
       const eventData: CreateEventInput = { title, start, end };
       if (description) eventData.description = description;
       if (location) eventData.location = location;

--- a/skills/calendar-create-event/handler.ts
+++ b/skills/calendar-create-event/handler.ts
@@ -1,0 +1,65 @@
+// skills/calendar-create-event/handler.ts
+//
+// Creates a new calendar event. Checks the read-only flag from the calendar
+// registry before attempting creation. If the calendar is unregistered,
+// proceeds anyway — the Nylas API will enforce its own permissions.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { CreateEventInput } from '../../src/channels/calendar/nylas-calendar-client.js';
+
+export class CalendarCreateEventHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.nylasCalendarClient) {
+      return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
+    }
+
+    const { calendarId, title, start, end, description, location, attendees, conferencing } = ctx.input as {
+      calendarId?: string;
+      title?: string;
+      start?: string;
+      end?: string;
+      description?: string;
+      location?: string;
+      attendees?: Array<{ email: string; name?: string }>;
+      conferencing?: Record<string, unknown>;
+    };
+
+    if (!calendarId || typeof calendarId !== 'string') {
+      return { success: false, error: 'Missing required input: calendarId' };
+    }
+    if (!title || typeof title !== 'string') {
+      return { success: false, error: 'Missing required input: title' };
+    }
+    if (!start || typeof start !== 'string') {
+      return { success: false, error: 'Missing required input: start' };
+    }
+    if (!end || typeof end !== 'string') {
+      return { success: false, error: 'Missing required input: end' };
+    }
+
+    // Read-only check: if the calendar is registered and marked read-only, refuse.
+    // Unregistered calendars (null) proceed — Nylas enforces its own permissions.
+    if (ctx.contactService) {
+      const registry = await ctx.contactService.resolveCalendar(calendarId);
+      if (registry?.readOnly) {
+        return { success: false, error: 'Calendar is read-only' };
+      }
+    }
+
+    try {
+      const eventData: CreateEventInput = { title, start, end };
+      if (description) eventData.description = description;
+      if (location) eventData.location = location;
+      if (attendees) eventData.attendees = attendees;
+      if (conferencing) eventData.conferencing = conferencing;
+
+      const event = await ctx.nylasCalendarClient.createEvent(calendarId, eventData);
+      ctx.log.info({ calendarId, eventId: event.id }, 'Created calendar event');
+      return { success: true, data: { event } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, calendarId }, 'Failed to create event');
+      return { success: false, error: `Failed to create event: ${message}` };
+    }
+  }
+}

--- a/skills/calendar-create-event/skill.json
+++ b/skills/calendar-create-event/skill.json
@@ -1,0 +1,25 @@
+{
+  "name": "calendar-create-event",
+  "description": "Create a new calendar event with title, time, attendees, and optional description/location/conferencing. Attendees will receive invitation emails automatically.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "calendarId": "string",
+    "title": "string",
+    "start": "string",
+    "end": "string",
+    "description": "string?",
+    "location": "string?",
+    "attendees": "array?",
+    "conferencing": "object?",
+    "colorId": "string?",
+    "reminders": "object?"
+  },
+  "outputs": {
+    "event": "object"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/skills/calendar-delete-event/handler.ts
+++ b/skills/calendar-delete-event/handler.ts
@@ -1,0 +1,43 @@
+// skills/calendar-delete-event/handler.ts
+//
+// Deletes a calendar event. Checks read-only flag before attempting deletion.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class CalendarDeleteEventHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.nylasCalendarClient) {
+      return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
+    }
+
+    const { calendarId, eventId } = ctx.input as {
+      calendarId?: string;
+      eventId?: string;
+    };
+
+    if (!calendarId || typeof calendarId !== 'string') {
+      return { success: false, error: 'Missing required input: calendarId' };
+    }
+    if (!eventId || typeof eventId !== 'string') {
+      return { success: false, error: 'Missing required input: eventId' };
+    }
+
+    // Read-only check
+    if (ctx.contactService) {
+      const registry = await ctx.contactService.resolveCalendar(calendarId);
+      if (registry?.readOnly) {
+        return { success: false, error: 'Calendar is read-only' };
+      }
+    }
+
+    try {
+      await ctx.nylasCalendarClient.deleteEvent(calendarId, eventId);
+      ctx.log.info({ calendarId, eventId }, 'Deleted calendar event');
+      return { success: true, data: { deleted: true } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, calendarId, eventId }, 'Failed to delete event');
+      return { success: false, error: `Failed to delete event: ${message}` };
+    }
+  }
+}

--- a/skills/calendar-delete-event/handler.ts
+++ b/skills/calendar-delete-event/handler.ts
@@ -22,15 +22,15 @@ export class CalendarDeleteEventHandler implements SkillHandler {
       return { success: false, error: 'Missing required input: eventId' };
     }
 
-    // Read-only check
-    if (ctx.contactService) {
-      const registry = await ctx.contactService.resolveCalendar(calendarId);
-      if (registry?.readOnly) {
-        return { success: false, error: 'Calendar is read-only' };
-      }
-    }
-
     try {
+      // Read-only check — moved inside try so DB errors from resolveCalendar are caught with skill-level context.
+      if (ctx.contactService) {
+        const registry = await ctx.contactService.resolveCalendar(calendarId);
+        if (registry?.readOnly) {
+          return { success: false, error: 'Calendar is read-only' };
+        }
+      }
+
       await ctx.nylasCalendarClient.deleteEvent(calendarId, eventId);
       ctx.log.info({ calendarId, eventId }, 'Deleted calendar event');
       return { success: true, data: { deleted: true } };

--- a/skills/calendar-delete-event/handler.ts
+++ b/skills/calendar-delete-event/handler.ts
@@ -10,9 +10,10 @@ export class CalendarDeleteEventHandler implements SkillHandler {
       return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
     }
 
-    const { calendarId, eventId } = ctx.input as {
+    const { calendarId, eventId, notifyAttendees } = ctx.input as {
       calendarId?: string;
       eventId?: string;
+      notifyAttendees?: boolean;
     };
 
     if (!calendarId || typeof calendarId !== 'string') {
@@ -31,7 +32,7 @@ export class CalendarDeleteEventHandler implements SkillHandler {
         }
       }
 
-      await ctx.nylasCalendarClient.deleteEvent(calendarId, eventId);
+      await ctx.nylasCalendarClient.deleteEvent(calendarId, eventId, notifyAttendees);
       ctx.log.info({ calendarId, eventId }, 'Deleted calendar event');
       return { success: true, data: { deleted: true } };
     } catch (err) {

--- a/skills/calendar-delete-event/skill.json
+++ b/skills/calendar-delete-event/skill.json
@@ -1,0 +1,18 @@
+{
+  "name": "calendar-delete-event",
+  "description": "Delete a calendar event. By default, attendees receive cancellation emails. Set notifyAttendees to false to suppress cancellation notifications.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "calendarId": "string",
+    "eventId": "string",
+    "notifyAttendees": "boolean?"
+  },
+  "outputs": {
+    "deleted": "boolean"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}

--- a/skills/calendar-find-free-time/handler.ts
+++ b/skills/calendar-find-free-time/handler.ts
@@ -1,0 +1,89 @@
+// skills/calendar-find-free-time/handler.ts
+//
+// Finds free time windows across one or more calendars by inverting
+// the busy periods returned by the Nylas free/busy API.
+//
+// NOTE: the `duration` input is in seconds (not minutes). The skill.json
+// description says "minutes" for user-facing clarity (most humans think in
+// minutes), but the implementation treats the raw number as seconds so that
+// callers can be precise without floating-point conversion. Revisit if the
+// LLM consistently passes minute values — a unit conversion layer may be needed.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class CalendarFindFreeTimeHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.nylasCalendarClient) {
+      return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
+    }
+
+    const { calendarIds, timeMin, timeMax, duration } = ctx.input as {
+      calendarIds?: string[];
+      timeMin?: string;
+      timeMax?: string;
+      duration?: number;
+    };
+
+    if (!calendarIds || !Array.isArray(calendarIds) || calendarIds.length === 0) {
+      return { success: false, error: 'Missing required input: calendarIds (must be a non-empty array)' };
+    }
+    if (!timeMin || typeof timeMin !== 'string') {
+      return { success: false, error: 'Missing required input: timeMin' };
+    }
+    if (!timeMax || typeof timeMax !== 'string') {
+      return { success: false, error: 'Missing required input: timeMax' };
+    }
+
+    try {
+      const freeBusyResults = await ctx.nylasCalendarClient.getFreeBusy(calendarIds, timeMin, timeMax);
+
+      // Collect all busy periods across all calendars
+      const allBusy: Array<{ start: number; end: number }> = [];
+      for (const result of freeBusyResults) {
+        for (const slot of result.timeSlots) {
+          allBusy.push({ start: slot.startTime, end: slot.endTime });
+        }
+      }
+
+      // Sort and merge overlapping busy periods so inversion is clean
+      allBusy.sort((a, b) => a.start - b.start);
+      const merged: Array<{ start: number; end: number }> = [];
+      for (const slot of allBusy) {
+        if (merged.length > 0 && slot.start <= merged[merged.length - 1].end) {
+          merged[merged.length - 1].end = Math.max(merged[merged.length - 1].end, slot.end);
+        } else {
+          merged.push({ ...slot });
+        }
+      }
+
+      // Invert: compute free windows within the requested range
+      const rangeStart = Math.floor(new Date(timeMin).getTime() / 1000);
+      const rangeEnd = Math.floor(new Date(timeMax).getTime() / 1000);
+
+      const freeWindows: Array<{ start: number; end: number }> = [];
+      let cursor = rangeStart;
+      for (const busy of merged) {
+        if (busy.start > cursor) {
+          freeWindows.push({ start: cursor, end: busy.start });
+        }
+        cursor = Math.max(cursor, busy.end);
+      }
+      if (cursor < rangeEnd) {
+        freeWindows.push({ start: cursor, end: rangeEnd });
+      }
+
+      // Filter by minimum duration (duration is in seconds)
+      const minSeconds = typeof duration === 'number' ? duration : 0;
+      const filtered = minSeconds > 0
+        ? freeWindows.filter((w) => w.end - w.start >= minSeconds)
+        : freeWindows;
+
+      ctx.log.info({ calendarCount: calendarIds.length, freeWindowCount: filtered.length }, 'Found free time');
+      return { success: true, data: { freeWindows: filtered } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to find free time');
+      return { success: false, error: `Failed to find free time: ${message}` };
+    }
+  }
+}

--- a/skills/calendar-find-free-time/handler.ts
+++ b/skills/calendar-find-free-time/handler.ts
@@ -27,6 +27,15 @@ export class CalendarFindFreeTimeHandler implements SkillHandler {
     if (!timeMax || typeof timeMax !== 'string') {
       return { success: false, error: 'Missing required input: timeMax' };
     }
+    if (isNaN(new Date(timeMin).getTime())) {
+      return { success: false, error: 'Invalid input: timeMin is not a valid date' };
+    }
+    if (isNaN(new Date(timeMax).getTime())) {
+      return { success: false, error: 'Invalid input: timeMax is not a valid date' };
+    }
+    if (new Date(timeMax) <= new Date(timeMin)) {
+      return { success: false, error: 'Invalid input: timeMax must be after timeMin' };
+    }
 
     try {
       const freeBusyResults = await ctx.nylasCalendarClient.getFreeBusy(calendarIds, timeMin, timeMax);

--- a/skills/calendar-find-free-time/handler.ts
+++ b/skills/calendar-find-free-time/handler.ts
@@ -2,12 +2,6 @@
 //
 // Finds free time windows across one or more calendars by inverting
 // the busy periods returned by the Nylas free/busy API.
-//
-// NOTE: the `duration` input is in seconds (not minutes). The skill.json
-// description says "minutes" for user-facing clarity (most humans think in
-// minutes), but the implementation treats the raw number as seconds so that
-// callers can be precise without floating-point conversion. Revisit if the
-// LLM consistently passes minute values — a unit conversion layer may be needed.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 
@@ -72,8 +66,8 @@ export class CalendarFindFreeTimeHandler implements SkillHandler {
         freeWindows.push({ start: cursor, end: rangeEnd });
       }
 
-      // Filter by minimum duration (duration is in seconds)
-      const minSeconds = typeof duration === 'number' ? duration : 0;
+      // Filter by minimum duration (duration input is in minutes, convert to seconds for comparison)
+      const minSeconds = typeof duration === 'number' ? duration * 60 : 0;
       const filtered = minSeconds > 0
         ? freeWindows.filter((w) => w.end - w.start >= minSeconds)
         : freeWindows;

--- a/skills/calendar-find-free-time/skill.json
+++ b/skills/calendar-find-free-time/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "calendar-find-free-time",
+  "description": "Find available time windows across one or more calendars. Returns free slots within a date range. Use duration (minutes) to filter to slots at least that long. Supports checking multiple people's availability at once.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "calendarIds": "array",
+    "timeMin": "string",
+    "timeMax": "string",
+    "duration": "number?"
+  },
+  "outputs": {
+    "freeWindows": "array"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}

--- a/skills/calendar-list-calendars/handler.ts
+++ b/skills/calendar-list-calendars/handler.ts
@@ -1,0 +1,56 @@
+// skills/calendar-list-calendars/handler.ts
+//
+// Lists all calendars visible to the Nylas grant, annotated with
+// registration status from the contact system calendar registry.
+// Unregistered calendars are flagged so the agent can ask the CEO
+// who they belong to.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class CalendarListCalendarsHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.nylasCalendarClient) {
+      return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
+    }
+    if (!ctx.contactService) {
+      return { success: false, error: 'calendar-list-calendars requires infrastructure access (contactService)' };
+    }
+
+    try {
+      const nylasCalendars = await ctx.nylasCalendarClient.listCalendars();
+
+      const calendars = await Promise.all(
+        nylasCalendars.map(async (cal) => {
+          const registry = await ctx.contactService!.resolveCalendar(cal.id);
+
+          let contactName: string | undefined;
+          if (registry?.contactId) {
+            const contact = await ctx.contactService!.getContact(registry.contactId);
+            contactName = contact?.displayName;
+          }
+
+          return {
+            id: cal.id,
+            name: cal.name,
+            description: cal.description,
+            timezone: cal.timezone,
+            isPrimary: cal.isPrimary,
+            readOnly: cal.readOnly,
+            isOwnedByUser: cal.isOwnedByUser,
+            registered: registry !== null,
+            contactId: registry?.contactId ?? null,
+            contactName: contactName ?? null,
+            registryLabel: registry?.label ?? null,
+          };
+        }),
+      );
+
+      ctx.log.info({ count: calendars.length }, 'Listed calendars');
+      return { success: true, data: { calendars } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'Failed to list calendars');
+      return { success: false, error: `Failed to list calendars: ${message}` };
+    }
+  }
+}

--- a/skills/calendar-list-calendars/handler.ts
+++ b/skills/calendar-list-calendars/handler.ts
@@ -16,8 +16,11 @@ export class CalendarListCalendarsHandler implements SkillHandler {
       return { success: false, error: 'calendar-list-calendars requires infrastructure access (contactService)' };
     }
 
+    // Hoisted so the catch block can reference the partial result for log context.
+    let nylasCalendars: Awaited<ReturnType<typeof ctx.nylasCalendarClient.listCalendars>> | undefined;
+
     try {
-      const nylasCalendars = await ctx.nylasCalendarClient.listCalendars();
+      nylasCalendars = await ctx.nylasCalendarClient.listCalendars();
 
       const calendars = await Promise.all(
         nylasCalendars.map(async (cal) => {
@@ -49,7 +52,7 @@ export class CalendarListCalendarsHandler implements SkillHandler {
       return { success: true, data: { calendars } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err }, 'Failed to list calendars');
+      ctx.log.error({ err, calendarCount: nylasCalendars?.length ?? 'unknown' }, 'Failed to list calendars');
       return { success: false, error: `Failed to list calendars: ${message}` };
     }
   }

--- a/skills/calendar-list-calendars/skill.json
+++ b/skills/calendar-list-calendars/skill.json
@@ -1,0 +1,14 @@
+{
+  "name": "calendar-list-calendars",
+  "description": "List all calendars visible to the agent (owned and shared), annotated with which contact each is registered to. Use this to discover new calendars or verify calendar assignments.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {},
+  "outputs": {
+    "calendars": "array"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -1,0 +1,69 @@
+// skills/calendar-list-events/handler.ts
+//
+// Fetches events for a date range from a specific calendar, with optional
+// client-side filtering by text query or attendee email.
+// Nylas doesn't support server-side text search on event fields, so
+// the skill fetches all events in range and filters locally.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class CalendarListEventsHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.nylasCalendarClient) {
+      return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
+    }
+
+    const { calendarId, timeMin, timeMax, maxResults, query, attendeeEmail } = ctx.input as {
+      calendarId?: string;
+      timeMin?: string;
+      timeMax?: string;
+      maxResults?: number;
+      query?: string;
+      attendeeEmail?: string;
+    };
+
+    if (!calendarId || typeof calendarId !== 'string') {
+      return { success: false, error: 'Missing required input: calendarId' };
+    }
+    if (!timeMin || typeof timeMin !== 'string') {
+      return { success: false, error: 'Missing required input: timeMin' };
+    }
+    if (!timeMax || typeof timeMax !== 'string') {
+      return { success: false, error: 'Missing required input: timeMax' };
+    }
+
+    try {
+      let events = await ctx.nylasCalendarClient.listEvents(calendarId, timeMin, timeMax);
+
+      // Client-side filtering: query matches title or description (case-insensitive)
+      if (query && typeof query === 'string') {
+        const lowerQuery = query.toLowerCase();
+        events = events.filter(
+          (evt) =>
+            evt.title.toLowerCase().includes(lowerQuery) ||
+            evt.description.toLowerCase().includes(lowerQuery),
+        );
+      }
+
+      // Client-side filtering: attendee email
+      if (attendeeEmail && typeof attendeeEmail === 'string') {
+        const lowerEmail = attendeeEmail.toLowerCase();
+        events = events.filter(
+          (evt) => evt.participants.some((p) => p.email.toLowerCase() === lowerEmail),
+        );
+      }
+
+      // Truncate if maxResults is set
+      if (typeof maxResults === 'number' && maxResults > 0) {
+        events = events.slice(0, maxResults);
+      }
+
+      ctx.log.info({ calendarId, count: events.length }, 'Listed events');
+      return { success: true, data: { events, count: events.length } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, calendarId }, 'Failed to list events');
+      return { success: false, error: `Failed to list events: ${message}` };
+    }
+  }
+}

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -33,7 +33,9 @@ export class CalendarListEventsHandler implements SkillHandler {
     }
 
     try {
-      let events = await ctx.nylasCalendarClient.listEvents(calendarId, timeMin, timeMax);
+      // Pass maxResults as the upstream fetch limit so callers asking for >200 events aren't silently capped.
+      const fetchLimit = typeof maxResults === 'number' && maxResults > 0 ? { limit: maxResults } : undefined;
+      let events = await ctx.nylasCalendarClient.listEvents(calendarId, timeMin, timeMax, fetchLimit);
 
       // Client-side filtering: query matches title or description (case-insensitive)
       if (query && typeof query === 'string') {

--- a/skills/calendar-list-events/skill.json
+++ b/skills/calendar-list-events/skill.json
@@ -1,0 +1,22 @@
+{
+  "name": "calendar-list-events",
+  "description": "Fetch events from a calendar within a date range. Supports filtering by text query (title/description) and attendee email. Use for checking schedules, finding specific appointments, or reviewing upcoming events.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "calendarId": "string",
+    "timeMin": "string",
+    "timeMax": "string",
+    "maxResults": "number?",
+    "query": "string?",
+    "attendeeEmail": "string?"
+  },
+  "outputs": {
+    "events": "array",
+    "count": "number"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/skills/calendar-update-event/handler.ts
+++ b/skills/calendar-update-event/handler.ts
@@ -1,0 +1,60 @@
+// skills/calendar-update-event/handler.ts
+//
+// Updates an existing calendar event with partial field changes.
+// Checks the read-only flag before attempting the update.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class CalendarUpdateEventHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.nylasCalendarClient) {
+      return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
+    }
+
+    const { calendarId, eventId, title, start, end, description, location, attendees, conferencing } = ctx.input as {
+      calendarId?: string;
+      eventId?: string;
+      title?: string;
+      start?: string;
+      end?: string;
+      description?: string;
+      location?: string;
+      attendees?: Array<{ email: string; name?: string }>;
+      conferencing?: Record<string, unknown>;
+    };
+
+    if (!calendarId || typeof calendarId !== 'string') {
+      return { success: false, error: 'Missing required input: calendarId' };
+    }
+    if (!eventId || typeof eventId !== 'string') {
+      return { success: false, error: 'Missing required input: eventId' };
+    }
+
+    // Read-only check
+    if (ctx.contactService) {
+      const registry = await ctx.contactService.resolveCalendar(calendarId);
+      if (registry?.readOnly) {
+        return { success: false, error: 'Calendar is read-only' };
+      }
+    }
+
+    try {
+      const changes: Record<string, unknown> = {};
+      if (title !== undefined) changes.title = title;
+      if (start !== undefined) changes.start = start;
+      if (end !== undefined) changes.end = end;
+      if (description !== undefined) changes.description = description;
+      if (location !== undefined) changes.location = location;
+      if (attendees !== undefined) changes.attendees = attendees;
+      if (conferencing !== undefined) changes.conferencing = conferencing;
+
+      const event = await ctx.nylasCalendarClient.updateEvent(calendarId, eventId, changes);
+      ctx.log.info({ calendarId, eventId }, 'Updated calendar event');
+      return { success: true, data: { event } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, calendarId, eventId }, 'Failed to update event');
+      return { success: false, error: `Failed to update event: ${message}` };
+    }
+  }
+}

--- a/skills/calendar-update-event/handler.ts
+++ b/skills/calendar-update-event/handler.ts
@@ -30,15 +30,15 @@ export class CalendarUpdateEventHandler implements SkillHandler {
       return { success: false, error: 'Missing required input: eventId' };
     }
 
-    // Read-only check
-    if (ctx.contactService) {
-      const registry = await ctx.contactService.resolveCalendar(calendarId);
-      if (registry?.readOnly) {
-        return { success: false, error: 'Calendar is read-only' };
-      }
-    }
-
     try {
+      // Read-only check — moved inside try so DB errors from resolveCalendar are caught with skill-level context.
+      if (ctx.contactService) {
+        const registry = await ctx.contactService.resolveCalendar(calendarId);
+        if (registry?.readOnly) {
+          return { success: false, error: 'Calendar is read-only' };
+        }
+      }
+
       const changes: Record<string, unknown> = {};
       if (title !== undefined) changes.title = title;
       if (start !== undefined) changes.start = start;
@@ -47,6 +47,11 @@ export class CalendarUpdateEventHandler implements SkillHandler {
       if (location !== undefined) changes.location = location;
       if (attendees !== undefined) changes.attendees = attendees;
       if (conferencing !== undefined) changes.conferencing = conferencing;
+
+      // Guard against silent no-ops — require at least one field to update.
+      if (Object.keys(changes).length === 0) {
+        return { success: false, error: 'No fields provided to update — at least one of title, start, end, description, location, attendees, or conferencing is required' };
+      }
 
       const event = await ctx.nylasCalendarClient.updateEvent(calendarId, eventId, changes);
       ctx.log.info({ calendarId, eventId }, 'Updated calendar event');

--- a/skills/calendar-update-event/handler.ts
+++ b/skills/calendar-update-event/handler.ts
@@ -41,11 +41,20 @@ export class CalendarUpdateEventHandler implements SkillHandler {
 
       const changes: Record<string, unknown> = {};
       if (title !== undefined) changes.title = title;
-      if (start !== undefined) changes.start = start;
-      if (end !== undefined) changes.end = end;
+      if (start !== undefined) {
+        if (!start) return { success: false, error: 'Invalid input: start must be a non-empty string' };
+        changes.start = start;
+      }
+      if (end !== undefined) {
+        if (!end) return { success: false, error: 'Invalid input: end must be a non-empty string' };
+        changes.end = end;
+      }
       if (description !== undefined) changes.description = description;
       if (location !== undefined) changes.location = location;
-      if (attendees !== undefined) changes.attendees = attendees;
+      if (attendees !== undefined) {
+        if (!Array.isArray(attendees)) return { success: false, error: 'Invalid input: attendees must be an array' };
+        changes.attendees = attendees;
+      }
       if (conferencing !== undefined) changes.conferencing = conferencing;
 
       // Guard against silent no-ops — require at least one field to update.

--- a/skills/calendar-update-event/skill.json
+++ b/skills/calendar-update-event/skill.json
@@ -1,0 +1,26 @@
+{
+  "name": "calendar-update-event",
+  "description": "Modify an existing calendar event. Supports partial updates — only provide the fields that need changing (title, time, description, location, attendees, conferencing). Attendee changes trigger invitation updates.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "calendarId": "string",
+    "eventId": "string",
+    "title": "string?",
+    "start": "string?",
+    "end": "string?",
+    "description": "string?",
+    "location": "string?",
+    "attendees": "array?",
+    "conferencing": "object?",
+    "colorId": "string?",
+    "reminders": "object?"
+  },
+  "outputs": {
+    "event": "object"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}

--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -1,0 +1,380 @@
+// src/channels/calendar/nylas-calendar-client.ts
+//
+// Thin wrapper around the Nylas SDK's calendar endpoints.
+// Same constructor pattern as NylasClient (email) — takes apiKey, grantId, logger.
+// Uses the same Nylas SDK with the same workaround for CJS type declarations.
+//
+// Provider-agnostic: works with Google Calendar, Microsoft 365/Outlook, or
+// any other provider connected through Nylas.
+
+import NylasDefault from 'nylas';
+import type { Logger } from '../../logger.js';
+
+/**
+ * Minimal typed interface for the Nylas SDK calendar surface.
+ * We only declare the subset we use — keeps the CJS workaround small.
+ */
+export interface NylasCalendarLike {
+  calendars: {
+    list(params: {
+      identifier: string;
+    }): Promise<{ data: NylasRawCalendar[] }>;
+
+    find(params: {
+      identifier: string;
+      calendarId: string;
+    }): Promise<{ data: NylasRawCalendar }>;
+  };
+
+  events: {
+    list(params: {
+      identifier: string;
+      queryParams?: Record<string, unknown>;
+    }): Promise<{ data: NylasRawEvent[] }>;
+
+    create(params: {
+      identifier: string;
+      queryParams?: Record<string, unknown>;
+      requestBody: Record<string, unknown>;
+    }): Promise<{ data: NylasRawEvent }>;
+
+    update(params: {
+      identifier: string;
+      eventId: string;
+      queryParams?: Record<string, unknown>;
+      requestBody: Record<string, unknown>;
+    }): Promise<{ data: NylasRawEvent }>;
+
+    destroy(params: {
+      identifier: string;
+      eventId: string;
+      queryParams?: Record<string, unknown>;
+    }): Promise<void>;
+  };
+
+  calendars_free_busy: {
+    list(params: {
+      identifier: string;
+      requestBody: Record<string, unknown>;
+    }): Promise<{ data: NylasRawFreeBusy[] }>;
+  };
+}
+
+// -- Raw Nylas SDK types (subset we use) --
+
+interface NylasRawCalendar {
+  id: string;
+  name?: string;
+  description?: string;
+  timezone?: string;
+  is_primary?: boolean;
+  read_only?: boolean;
+  is_owned_by_user?: boolean;
+}
+
+interface NylasRawEvent {
+  id: string;
+  title?: string;
+  description?: string;
+  location?: string;
+  when?: {
+    start_time?: number;
+    end_time?: number;
+    start_date?: string;
+    end_date?: string;
+    object?: string;
+  };
+  participants?: Array<{
+    email: string;
+    name?: string;
+    status?: string;
+  }>;
+  conferencing?: Record<string, unknown>;
+  status?: string;
+  calendar_id?: string;
+  busy?: boolean;
+  metadata?: Record<string, string>;
+}
+
+interface NylasRawFreeBusy {
+  email: string;
+  time_slots?: Array<{
+    start_time: number;
+    end_time: number;
+    status: string;
+  }>;
+}
+
+// -- Normalized types --
+
+export interface NylasCalendar {
+  id: string;
+  name: string;
+  description: string;
+  timezone: string;
+  isPrimary: boolean;
+  readOnly: boolean;
+  isOwnedByUser: boolean;
+}
+
+export interface NylasCalendarEvent {
+  id: string;
+  title: string;
+  description: string;
+  location: string;
+  startTime: number | null;
+  endTime: number | null;
+  startDate: string | null;
+  endDate: string | null;
+  participants: Array<{ email: string; name: string; status: string }>;
+  conferencing: Record<string, unknown> | null;
+  status: string;
+  calendarId: string;
+  busy: boolean;
+}
+
+export interface NylasFreeBusyResult {
+  email: string;
+  timeSlots: Array<{
+    startTime: number;
+    endTime: number;
+    status: string;
+  }>;
+}
+
+export interface CreateEventInput {
+  title: string;
+  start: string;
+  end: string;
+  description?: string;
+  location?: string;
+  attendees?: Array<{ email: string; name?: string }>;
+  conferencing?: Record<string, unknown>;
+}
+
+// -- SDK constructor workaround (same as email NylasClient) --
+// The Nylas SDK v8's type declarations resolve as CJS under TypeScript's nodenext
+// module resolution. We work around this by importing the default and casting once.
+// TODO: Remove if Nylas ships proper ESM type declarations.
+
+const NylasSDK = NylasDefault as unknown as new (config: { apiKey: string }) => NylasCalendarLike;
+
+// ---------------------------------------------------------------------------
+// NylasCalendarClient
+// ---------------------------------------------------------------------------
+
+export class NylasCalendarClient {
+  private readonly nylas: NylasCalendarLike;
+  private readonly grantId: string;
+  private readonly log: Logger;
+
+  constructor(apiKey: string, grantId: string, logger: Logger) {
+    this.nylas = new NylasSDK({ apiKey });
+    this.grantId = grantId;
+    this.log = logger.child({ component: 'nylas-calendar-client' });
+  }
+
+  /** Create an instance with a pre-built SDK (for testing). */
+  static createWithSdk(sdk: NylasCalendarLike, grantId: string, logger: Logger): NylasCalendarClient {
+    const instance = Object.create(NylasCalendarClient.prototype) as NylasCalendarClient;
+    // Bypass the constructor to inject the mock SDK
+    Object.assign(instance, {
+      nylas: sdk,
+      grantId,
+      log: logger.child({ component: 'nylas-calendar-client' }),
+    });
+    return instance;
+  }
+
+  /** List all calendars visible to this grant (owned + shared). */
+  async listCalendars(): Promise<NylasCalendar[]> {
+    this.log.debug('Listing calendars');
+    try {
+      const response = await this.nylas.calendars.list({
+        identifier: this.grantId,
+      });
+      return response.data.map((cal) => this.normalizeCalendar(cal));
+    } catch (err) {
+      this.log.error({ err }, 'Nylas listCalendars failed');
+      throw err;
+    }
+  }
+
+  /** List events for a calendar within a time range. */
+  async listEvents(
+    calendarId: string,
+    timeMin: string,
+    timeMax: string,
+    opts?: { limit?: number },
+  ): Promise<NylasCalendarEvent[]> {
+    this.log.debug({ calendarId, timeMin, timeMax }, 'Listing events');
+    try {
+      const response = await this.nylas.events.list({
+        identifier: this.grantId,
+        queryParams: {
+          calendar_id: calendarId,
+          start: timeMin,
+          end: timeMax,
+          limit: opts?.limit ?? 200,
+        },
+      });
+      return response.data.map((evt) => this.normalizeEvent(evt));
+    } catch (err) {
+      this.log.error({ err, calendarId }, 'Nylas listEvents failed');
+      throw err;
+    }
+  }
+
+  /** Create a new event on a calendar. */
+  async createEvent(calendarId: string, event: CreateEventInput): Promise<NylasCalendarEvent> {
+    this.log.debug({ calendarId, title: event.title }, 'Creating event');
+    try {
+      const requestBody: Record<string, unknown> = {
+        title: event.title,
+        when: {
+          start_time: Math.floor(new Date(event.start).getTime() / 1000),
+          end_time: Math.floor(new Date(event.end).getTime() / 1000),
+        },
+      };
+      if (event.description) requestBody.description = event.description;
+      if (event.location) requestBody.location = event.location;
+      if (event.attendees) {
+        requestBody.participants = event.attendees.map((a) => ({
+          email: a.email,
+          name: a.name ?? '',
+        }));
+      }
+      if (event.conferencing) requestBody.conferencing = event.conferencing;
+
+      const response = await this.nylas.events.create({
+        identifier: this.grantId,
+        queryParams: { calendar_id: calendarId },
+        requestBody,
+      });
+      return this.normalizeEvent(response.data);
+    } catch (err) {
+      this.log.error({ err, calendarId }, 'Nylas createEvent failed');
+      throw err;
+    }
+  }
+
+  /** Update an existing event. */
+  async updateEvent(
+    calendarId: string,
+    eventId: string,
+    changes: Partial<CreateEventInput>,
+  ): Promise<NylasCalendarEvent> {
+    this.log.debug({ calendarId, eventId }, 'Updating event');
+    try {
+      const requestBody: Record<string, unknown> = {};
+      if (changes.title !== undefined) requestBody.title = changes.title;
+      if (changes.description !== undefined) requestBody.description = changes.description;
+      if (changes.location !== undefined) requestBody.location = changes.location;
+      if (changes.start !== undefined || changes.end !== undefined) {
+        requestBody.when = {
+          ...(changes.start ? { start_time: Math.floor(new Date(changes.start).getTime() / 1000) } : {}),
+          ...(changes.end ? { end_time: Math.floor(new Date(changes.end).getTime() / 1000) } : {}),
+        };
+      }
+      if (changes.attendees) {
+        requestBody.participants = changes.attendees.map((a) => ({
+          email: a.email,
+          name: a.name ?? '',
+        }));
+      }
+      if (changes.conferencing !== undefined) requestBody.conferencing = changes.conferencing;
+
+      const response = await this.nylas.events.update({
+        identifier: this.grantId,
+        eventId,
+        queryParams: { calendar_id: calendarId },
+        requestBody,
+      });
+      return this.normalizeEvent(response.data);
+    } catch (err) {
+      this.log.error({ err, calendarId, eventId }, 'Nylas updateEvent failed');
+      throw err;
+    }
+  }
+
+  /** Delete an event. */
+  async deleteEvent(calendarId: string, eventId: string): Promise<void> {
+    this.log.debug({ calendarId, eventId }, 'Deleting event');
+    try {
+      await this.nylas.events.destroy({
+        identifier: this.grantId,
+        eventId,
+        queryParams: { calendar_id: calendarId },
+      });
+    } catch (err) {
+      this.log.error({ err, calendarId, eventId }, 'Nylas deleteEvent failed');
+      throw err;
+    }
+  }
+
+  /** Get free/busy data for one or more calendar IDs across a time range. */
+  async getFreeBusy(
+    calendarIds: string[],
+    timeMin: string,
+    timeMax: string,
+  ): Promise<NylasFreeBusyResult[]> {
+    this.log.debug({ calendarIds, timeMin, timeMax }, 'Getting free/busy');
+    try {
+      const response = await this.nylas.calendars_free_busy.list({
+        identifier: this.grantId,
+        requestBody: {
+          start_time: timeMin,
+          end_time: timeMax,
+          emails: calendarIds,
+        },
+      });
+      return response.data.map((fb) => ({
+        email: fb.email,
+        timeSlots: (fb.time_slots ?? []).map((ts) => ({
+          startTime: ts.start_time,
+          endTime: ts.end_time,
+          status: ts.status,
+        })),
+      }));
+    } catch (err) {
+      this.log.error({ err, calendarIds }, 'Nylas getFreeBusy failed');
+      throw err;
+    }
+  }
+
+  // -- Normalizers --
+
+  private normalizeCalendar(cal: NylasRawCalendar): NylasCalendar {
+    return {
+      id: cal.id,
+      name: cal.name ?? '',
+      description: cal.description ?? '',
+      timezone: cal.timezone ?? '',
+      isPrimary: cal.is_primary ?? false,
+      readOnly: cal.read_only ?? false,
+      isOwnedByUser: cal.is_owned_by_user ?? true,
+    };
+  }
+
+  private normalizeEvent(evt: NylasRawEvent): NylasCalendarEvent {
+    return {
+      id: evt.id,
+      title: evt.title ?? '',
+      description: evt.description ?? '',
+      location: evt.location ?? '',
+      startTime: evt.when?.start_time ?? null,
+      endTime: evt.when?.end_time ?? null,
+      startDate: evt.when?.start_date ?? null,
+      endDate: evt.when?.end_date ?? null,
+      participants: (evt.participants ?? []).map((p) => ({
+        email: p.email,
+        name: p.name ?? '',
+        status: p.status ?? 'noreply',
+      })),
+      conferencing: evt.conferencing ?? null,
+      status: evt.status ?? 'confirmed',
+      calendarId: evt.calendar_id ?? '',
+      busy: evt.busy ?? true,
+    };
+  }
+}

--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -297,14 +297,19 @@ export class NylasCalendarClient {
     }
   }
 
-  /** Delete an event. */
-  async deleteEvent(calendarId: string, eventId: string): Promise<void> {
-    this.log.debug({ calendarId, eventId }, 'Deleting event');
+  /** Delete an event. Pass notifyAttendees=false to suppress Nylas cancellation emails. */
+  async deleteEvent(calendarId: string, eventId: string, notifyAttendees?: boolean): Promise<void> {
+    this.log.debug({ calendarId, eventId, notifyAttendees }, 'Deleting event');
     try {
+      const queryParams: Record<string, unknown> = { calendar_id: calendarId };
+      // Nylas sends cancellation emails by default; only override when explicitly suppressed.
+      if (notifyAttendees === false) {
+        queryParams.notify_event_creator = false;
+      }
       await this.nylas.events.destroy({
         identifier: this.grantId,
         eventId,
-        queryParams: { calendar_id: calendarId },
+        queryParams,
       });
     } catch (err) {
       this.log.error({ err, calendarId, eventId }, 'Nylas deleteEvent failed');

--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -323,8 +323,9 @@ export class NylasCalendarClient {
       const response = await this.nylas.calendars_free_busy.list({
         identifier: this.grantId,
         requestBody: {
-          start_time: timeMin,
-          end_time: timeMax,
+          // Nylas expects Unix timestamps (seconds), not ISO strings
+          start_time: Math.floor(new Date(timeMin).getTime() / 1000),
+          end_time: Math.floor(new Date(timeMax).getTime() / 1000),
           emails: calendarIds,
         },
       });

--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -193,7 +193,7 @@ export class NylasCalendarClient {
       const response = await this.nylas.calendars.list({
         identifier: this.grantId,
       });
-      return response.data.map((cal) => this.normalizeCalendar(cal));
+      return (response?.data ?? []).map((cal) => this.normalizeCalendar(cal));
     } catch (err) {
       this.log.error({ err }, 'Nylas listCalendars failed');
       throw err;
@@ -218,7 +218,7 @@ export class NylasCalendarClient {
           limit: opts?.limit ?? 200,
         },
       });
-      return response.data.map((evt) => this.normalizeEvent(evt));
+      return (response?.data ?? []).map((evt) => this.normalizeEvent(evt));
     } catch (err) {
       this.log.error({ err, calendarId }, 'Nylas listEvents failed');
       throw err;
@@ -329,7 +329,7 @@ export class NylasCalendarClient {
           emails: calendarIds,
         },
       });
-      return response.data.map((fb) => ({
+      return (response?.data ?? []).map((fb) => ({
         email: fb.email,
         timeSlots: (fb.time_slots ?? []).map((ts) => ({
           startTime: ts.start_time,

--- a/src/contacts/calendar-types.ts
+++ b/src/contacts/calendar-types.ts
@@ -25,3 +25,11 @@ export interface CreateCalendarLinkOptions {
   readOnly?: boolean;
   timezone?: string;
 }
+
+/** Resolved registry entry for a Nylas calendar ID. Returned by resolveCalendar(). */
+export interface ResolvedCalendar {
+  contactId: string | null;
+  label: string;
+  isPrimary: boolean;
+  readOnly: boolean;
+}

--- a/src/contacts/calendar-types.ts
+++ b/src/contacts/calendar-types.ts
@@ -1,0 +1,27 @@
+// src/contacts/calendar-types.ts
+//
+// Types for the calendar registry — maps Nylas calendar IDs to contacts.
+// A contact can have multiple calendars (work, personal, etc.).
+// Org-wide calendars (holidays, rooms) have null contact_id.
+
+export interface ContactCalendar {
+  id: string;
+  nylasCalendarId: string;
+  contactId: string | null;
+  label: string;
+  isPrimary: boolean;
+  readOnly: boolean;
+  timezone: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateCalendarLinkOptions {
+  nylasCalendarId: string;
+  /** null for org-wide calendars (holidays, conference rooms) */
+  contactId: string | null;
+  label: string;
+  isPrimary?: boolean;
+  readOnly?: boolean;
+  timezone?: string;
+}

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -24,7 +24,7 @@ import type {
   ResolvedSender,
   IdentitySource,
 } from './types.js';
-import type { ContactCalendar, CreateCalendarLinkOptions } from './calendar-types.js';
+import type { ContactCalendar, CreateCalendarLinkOptions, ResolvedCalendar } from './calendar-types.js';
 
 // -- Backend interface --
 
@@ -45,7 +45,7 @@ interface ContactServiceBackend {
   createCalendarLink(calendar: ContactCalendar): Promise<void>;
   deleteCalendarLink(nylasCalendarId: string): Promise<boolean>;
   getCalendarsForContact(contactId: string): Promise<ContactCalendar[]>;
-  resolveCalendar(nylasCalendarId: string): Promise<{ contactId: string | null; label: string; isPrimary: boolean; readOnly: boolean } | null>;
+  resolveCalendar(nylasCalendarId: string): Promise<ResolvedCalendar | null>;
   getPrimaryCalendar(contactId: string): Promise<ContactCalendar | null>;
 }
 
@@ -364,7 +364,7 @@ export class ContactService {
   }
 
   /** Resolve a Nylas calendar ID to its registry entry. Returns null if unregistered. */
-  async resolveCalendar(nylasCalendarId: string): Promise<{ contactId: string | null; label: string; isPrimary: boolean; readOnly: boolean } | null> {
+  async resolveCalendar(nylasCalendarId: string): Promise<ResolvedCalendar | null> {
     return this.backend.resolveCalendar(nylasCalendarId);
   }
 
@@ -651,7 +651,7 @@ class PostgresContactBackend implements ContactServiceBackend {
     return result.rows.map((row) => this.rowToCalendar(row));
   }
 
-  async resolveCalendar(nylasCalendarId: string): Promise<{ contactId: string | null; label: string; isPrimary: boolean; readOnly: boolean } | null> {
+  async resolveCalendar(nylasCalendarId: string): Promise<ResolvedCalendar | null> {
     const result = await this.pool.query<{
       contact_id: string | null;
       label: string;
@@ -942,7 +942,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return results;
   }
 
-  async resolveCalendar(nylasCalendarId: string): Promise<{ contactId: string | null; label: string; isPrimary: boolean; readOnly: boolean } | null> {
+  async resolveCalendar(nylasCalendarId: string): Promise<ResolvedCalendar | null> {
     for (const cal of this.calendars.values()) {
       if (cal.nylasCalendarId === nylasCalendarId) {
         return {

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -24,6 +24,7 @@ import type {
   ResolvedSender,
   IdentitySource,
 } from './types.js';
+import type { ContactCalendar, CreateCalendarLinkOptions } from './calendar-types.js';
 
 // -- Backend interface --
 
@@ -41,6 +42,11 @@ interface ContactServiceBackend {
   getAuthOverrides(contactId: string): Promise<Array<{ permission: string; granted: boolean }>>;
   createAuthOverride(override: AuthOverride): Promise<void>;
   revokeAuthOverride(contactId: string, permission: string): Promise<boolean>;
+  createCalendarLink(calendar: ContactCalendar): Promise<void>;
+  deleteCalendarLink(nylasCalendarId: string): Promise<boolean>;
+  getCalendarsForContact(contactId: string): Promise<ContactCalendar[]>;
+  resolveCalendar(nylasCalendarId: string): Promise<{ contactId: string | null; label: string; isPrimary: boolean; readOnly: boolean } | null>;
+  getPrimaryCalendar(contactId: string): Promise<ContactCalendar | null>;
 }
 
 // -- Auto-verification sources --
@@ -315,6 +321,57 @@ export class ContactService {
   async revokePermission(contactId: string, permission: string): Promise<boolean> {
     return this.backend.revokeAuthOverride(contactId, permission);
   }
+
+  /**
+   * Link a calendar to a contact (or null for org-wide calendars).
+   * Validates the contact exists (if contactId is non-null) and enforces
+   * uniqueness on nylas_calendar_id and at-most-one-primary-per-contact.
+   */
+  async linkCalendar(options: CreateCalendarLinkOptions): Promise<ContactCalendar> {
+    // Validate the contact exists if a contactId is provided
+    if (options.contactId !== null) {
+      const contact = await this.backend.getContact(options.contactId);
+      if (!contact) {
+        throw new Error(`Contact not found: ${options.contactId}`);
+      }
+    }
+
+    const now = new Date();
+    const calendar: ContactCalendar = {
+      id: randomUUID(),
+      nylasCalendarId: options.nylasCalendarId,
+      contactId: options.contactId,
+      label: options.label,
+      isPrimary: options.isPrimary ?? false,
+      readOnly: options.readOnly ?? false,
+      timezone: options.timezone ?? null,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.backend.createCalendarLink(calendar);
+    return calendar;
+  }
+
+  /** Remove a calendar association by its Nylas calendar ID. */
+  async unlinkCalendar(nylasCalendarId: string): Promise<boolean> {
+    return this.backend.deleteCalendarLink(nylasCalendarId);
+  }
+
+  /** Get all calendars linked to a contact. */
+  async getCalendarsForContact(contactId: string): Promise<ContactCalendar[]> {
+    return this.backend.getCalendarsForContact(contactId);
+  }
+
+  /** Resolve a Nylas calendar ID to its registry entry. Returns null if unregistered. */
+  async resolveCalendar(nylasCalendarId: string): Promise<{ contactId: string | null; label: string; isPrimary: boolean; readOnly: boolean } | null> {
+    return this.backend.resolveCalendar(nylasCalendarId);
+  }
+
+  /** Get the primary calendar for a contact. Returns null if no primary is set. */
+  async getPrimaryCalendar(contactId: string): Promise<ContactCalendar | null> {
+    return this.backend.getPrimaryCalendar(contactId);
+  }
 }
 
 // -- Postgres backend --
@@ -557,6 +614,85 @@ class PostgresContactBackend implements ContactServiceBackend {
     return (result.rowCount ?? 0) > 0;
   }
 
+  async createCalendarLink(calendar: ContactCalendar): Promise<void> {
+    this.logger.debug({ calendarId: calendar.id, nylasCalendarId: calendar.nylasCalendarId }, 'contacts: linking calendar');
+    await this.pool.query(
+      `INSERT INTO contact_calendars (id, nylas_calendar_id, contact_id, label, is_primary, read_only, timezone, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+      [calendar.id, calendar.nylasCalendarId, calendar.contactId, calendar.label, calendar.isPrimary, calendar.readOnly, calendar.timezone, calendar.createdAt, calendar.updatedAt],
+    );
+  }
+
+  async deleteCalendarLink(nylasCalendarId: string): Promise<boolean> {
+    this.logger.debug({ nylasCalendarId }, 'contacts: unlinking calendar');
+    const result = await this.pool.query(
+      'DELETE FROM contact_calendars WHERE nylas_calendar_id = $1',
+      [nylasCalendarId],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async getCalendarsForContact(contactId: string): Promise<ContactCalendar[]> {
+    const result = await this.pool.query<{
+      id: string;
+      nylas_calendar_id: string;
+      contact_id: string | null;
+      label: string;
+      is_primary: boolean;
+      read_only: boolean;
+      timezone: string | null;
+      created_at: Date;
+      updated_at: Date;
+    }>(
+      `SELECT id, nylas_calendar_id, contact_id, label, is_primary, read_only, timezone, created_at, updated_at
+       FROM contact_calendars WHERE contact_id = $1 ORDER BY created_at ASC`,
+      [contactId],
+    );
+    return result.rows.map((row) => this.rowToCalendar(row));
+  }
+
+  async resolveCalendar(nylasCalendarId: string): Promise<{ contactId: string | null; label: string; isPrimary: boolean; readOnly: boolean } | null> {
+    const result = await this.pool.query<{
+      contact_id: string | null;
+      label: string;
+      is_primary: boolean;
+      read_only: boolean;
+    }>(
+      `SELECT contact_id, label, is_primary, read_only
+       FROM contact_calendars WHERE nylas_calendar_id = $1`,
+      [nylasCalendarId],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    return {
+      contactId: row.contact_id,
+      label: row.label,
+      isPrimary: row.is_primary,
+      readOnly: row.read_only,
+    };
+  }
+
+  async getPrimaryCalendar(contactId: string): Promise<ContactCalendar | null> {
+    const result = await this.pool.query<{
+      id: string;
+      nylas_calendar_id: string;
+      contact_id: string | null;
+      label: string;
+      is_primary: boolean;
+      read_only: boolean;
+      timezone: string | null;
+      created_at: Date;
+      updated_at: Date;
+    }>(
+      `SELECT id, nylas_calendar_id, contact_id, label, is_primary, read_only, timezone, created_at, updated_at
+       FROM contact_calendars WHERE contact_id = $1 AND is_primary = true`,
+      [contactId],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    return this.rowToCalendar(row);
+  }
+
   // -- Row mapping helpers --
 
   private rowToContact(row: {
@@ -606,6 +742,30 @@ class PostgresContactBackend implements ContactServiceBackend {
       updatedAt: row.updated_at,
     };
   }
+
+  private rowToCalendar(row: {
+    id: string;
+    nylas_calendar_id: string;
+    contact_id: string | null;
+    label: string;
+    is_primary: boolean;
+    read_only: boolean;
+    timezone: string | null;
+    created_at: Date;
+    updated_at: Date;
+  }): ContactCalendar {
+    return {
+      id: row.id,
+      nylasCalendarId: row.nylas_calendar_id,
+      contactId: row.contact_id,
+      label: row.label,
+      isPrimary: row.is_primary,
+      readOnly: row.read_only,
+      timezone: row.timezone,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
 }
 
 // -- In-memory backend --
@@ -618,6 +778,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
   private contacts = new Map<string, Contact>();
   private identities = new Map<string, ChannelIdentity>();
   private overrides = new Map<string, AuthOverride>();
+  private calendars = new Map<string, ContactCalendar>();
 
   async createContact(contact: Contact): Promise<void> {
     this.contacts.set(contact.id, contact);
@@ -741,5 +902,66 @@ class InMemoryContactBackend implements ContactServiceBackend {
       }
     }
     return false;
+  }
+
+  async createCalendarLink(calendar: ContactCalendar): Promise<void> {
+    // Enforce UNIQUE(nylas_calendar_id)
+    for (const existing of this.calendars.values()) {
+      if (existing.nylasCalendarId === calendar.nylasCalendarId) {
+        throw new Error(`Calendar already registered: ${calendar.nylasCalendarId}`);
+      }
+    }
+    // Enforce at-most-one-primary per contact
+    if (calendar.isPrimary && calendar.contactId !== null) {
+      for (const existing of this.calendars.values()) {
+        if (existing.contactId === calendar.contactId && existing.isPrimary) {
+          throw new Error(`Contact ${calendar.contactId} already has a primary calendar`);
+        }
+      }
+    }
+    this.calendars.set(calendar.id, calendar);
+  }
+
+  async deleteCalendarLink(nylasCalendarId: string): Promise<boolean> {
+    for (const [id, cal] of this.calendars) {
+      if (cal.nylasCalendarId === nylasCalendarId) {
+        this.calendars.delete(id);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  async getCalendarsForContact(contactId: string): Promise<ContactCalendar[]> {
+    const results: ContactCalendar[] = [];
+    for (const cal of this.calendars.values()) {
+      if (cal.contactId === contactId) {
+        results.push(cal);
+      }
+    }
+    return results;
+  }
+
+  async resolveCalendar(nylasCalendarId: string): Promise<{ contactId: string | null; label: string; isPrimary: boolean; readOnly: boolean } | null> {
+    for (const cal of this.calendars.values()) {
+      if (cal.nylasCalendarId === nylasCalendarId) {
+        return {
+          contactId: cal.contactId,
+          label: cal.label,
+          isPrimary: cal.isPrimary,
+          readOnly: cal.readOnly,
+        };
+      }
+    }
+    return null;
+  }
+
+  async getPrimaryCalendar(contactId: string): Promise<ContactCalendar | null> {
+    for (const cal of this.calendars.values()) {
+      if (cal.contactId === contactId && cal.isPrimary) {
+        return cal;
+      }
+    }
+    return null;
   }
 }

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -165,3 +165,6 @@ export interface ChannelPolicyConfig {
   trust: TrustLevel;
   unknownSender: UnknownSenderPolicy;
 }
+
+// -- Calendar registry types --
+export type { ContactCalendar, CreateCalendarLinkOptions } from './calendar-types.js';

--- a/src/db/migrations/009_create_contact_calendars.sql
+++ b/src/db/migrations/009_create_contact_calendars.sql
@@ -1,0 +1,25 @@
+-- Up Migration
+
+-- Calendar registry: maps Nylas calendar IDs to contacts.
+-- A contact can have multiple calendars (work, personal, etc.).
+-- Nullable contact_id supports org-wide calendars (holidays, rooms).
+CREATE TABLE contact_calendars (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  nylas_calendar_id TEXT NOT NULL UNIQUE,
+  contact_id        UUID REFERENCES contacts(id) ON DELETE CASCADE,
+  label             TEXT NOT NULL,
+  is_primary        BOOLEAN NOT NULL DEFAULT false,
+  read_only         BOOLEAN NOT NULL DEFAULT false,
+  timezone          TEXT,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- At most one primary calendar per contact.
+-- Partial unique index: only rows where is_primary = true participate.
+CREATE UNIQUE INDEX idx_contact_calendars_primary
+  ON contact_calendars (contact_id) WHERE is_primary = true;
+
+-- Fast lookup by contact for "get calendars for this person" queries.
+CREATE INDEX idx_contact_calendars_contact
+  ON contact_calendars (contact_id) WHERE contact_id IS NOT NULL;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { loadSkillsFromDirectory } from './skills/loader.js';
 import { ContactService } from './contacts/contact-service.js';
 import { ContactResolver } from './contacts/contact-resolver.js';
 import { NylasClient } from './channels/email/nylas-client.js';
+import { NylasCalendarClient } from './channels/calendar/nylas-calendar-client.js';
 import { EmailAdapter } from './channels/email/email-adapter.js';
 import { loadAuthConfig } from './contacts/config-loader.js';
 import { AuthorizationService } from './contacts/authorization.js';
@@ -175,6 +176,14 @@ async function main(): Promise<void> {
     logger.warn('NYLAS_API_KEY/NYLAS_GRANT_ID not set — email channel disabled');
   }
 
+  // Calendar client — uses the same Nylas credentials as email.
+  // Independent instance, no shared state with the email client.
+  let nylasCalendarClient: NylasCalendarClient | undefined;
+  if (config.nylasApiKey && config.nylasGrantId) {
+    nylasCalendarClient = new NylasCalendarClient(config.nylasApiKey, config.nylasGrantId, logger);
+    logger.info('Nylas calendar client initialized');
+  }
+
   // Skill registry — loads all skills from the skills/ directory.
   // Skills are the framework's extension mechanism; agents invoke them
   // via the LLM's tool-use API through the execution layer.
@@ -298,7 +307,7 @@ async function main(): Promise<void> {
 
   // Execution layer — now with bus, agent registry, and outbound gateway for
   // infrastructure skills. outboundGateway gives email skills their send path.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -23,6 +23,7 @@ import type { OutboundGateway } from './outbound-gateway.js';
 import type { HeldMessageService } from '../contacts/held-messages.js';
 import type { SchedulerService } from '../scheduler/scheduler-service.js';
 import type { EntityMemory } from '../memory/entity-memory.js';
+import type { NylasCalendarClient } from '../channels/calendar/nylas-calendar-client.js';
 
 export class ExecutionLayer {
   private registry: SkillRegistry;
@@ -35,8 +36,9 @@ export class ExecutionLayer {
   private schedulerService?: SchedulerService;
   private entityMemory?: EntityMemory;
   private agentPersona?: AgentPersona;
+  private nylasCalendarClient?: NylasCalendarClient;
 
-  constructor(registry: SkillRegistry, logger: Logger, options?: { bus?: EventBus; agentRegistry?: AgentRegistry; contactService?: ContactService; outboundGateway?: OutboundGateway; heldMessages?: HeldMessageService; schedulerService?: SchedulerService; entityMemory?: EntityMemory; agentPersona?: AgentPersona }) {
+  constructor(registry: SkillRegistry, logger: Logger, options?: { bus?: EventBus; agentRegistry?: AgentRegistry; contactService?: ContactService; outboundGateway?: OutboundGateway; heldMessages?: HeldMessageService; schedulerService?: SchedulerService; entityMemory?: EntityMemory; agentPersona?: AgentPersona; nylasCalendarClient?: NylasCalendarClient }) {
     this.registry = registry;
     this.logger = logger;
     this.bus = options?.bus;
@@ -47,6 +49,7 @@ export class ExecutionLayer {
     this.schedulerService = options?.schedulerService;
     this.entityMemory = options?.entityMemory;
     this.agentPersona = options?.agentPersona;
+    this.nylasCalendarClient = options?.nylasCalendarClient;
   }
 
   /**
@@ -152,6 +155,10 @@ export class ExecutionLayer {
       // entityMemory is optional — only skills that read/write the knowledge graph need it
       if (this.entityMemory) {
         ctx.entityMemory = this.entityMemory;
+      }
+      // nylasCalendarClient is optional — only calendar skills need it
+      if (this.nylasCalendarClient) {
+        ctx.nylasCalendarClient = this.nylasCalendarClient;
       }
     }
 

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -96,6 +96,10 @@ export interface SkillContext {
    *  coordinator's persona config. Available to all skills (not infrastructure-gated)
    *  so templates can reference the agent's identity without hardcoding it. */
   agentPersona?: AgentPersona;
+  /** Nylas calendar client — only available to infrastructure skills.
+   *  Provides CRUD operations on calendar events and free/busy queries
+   *  via the Nylas unified API (provider-agnostic). */
+  nylasCalendarClient?: import('../channels/calendar/nylas-calendar-client.js').NylasCalendarClient;
   /** Caller identity — populated from the task event's sender context.
    *  Guaranteed to be defined for elevated skills (execution layer rejects without it).
    *  Available but optional for normal skills. */

--- a/tests/unit/channels/nylas-calendar-client.test.ts
+++ b/tests/unit/channels/nylas-calendar-client.test.ts
@@ -1,0 +1,164 @@
+// tests/unit/channels/nylas-calendar-client.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import pino from 'pino';
+
+// We test via the public interface, mocking the Nylas SDK at the instance level.
+// The NylasCalendarClient constructor creates a Nylas SDK instance internally,
+// so we test by constructing the client and then overriding the internal SDK.
+// Since the SDK is a private field, we test through the public methods and
+// verify behavior via the mock SDK's method calls.
+
+// For testability, NylasCalendarClient accepts an optional NylasLike override
+// (same pattern as the email NylasClient could use, but we add it fresh here).
+
+import { NylasCalendarClient } from '../../../src/channels/calendar/nylas-calendar-client.js';
+import type { NylasCalendarLike } from '../../../src/channels/calendar/nylas-calendar-client.js';
+
+const logger = pino({ level: 'silent' });
+
+function makeMockSdk(): NylasCalendarLike {
+  return {
+    calendars: {
+      list: vi.fn().mockResolvedValue({ data: [] }),
+      find: vi.fn(),
+    },
+    events: {
+      list: vi.fn().mockResolvedValue({ data: [] }),
+      create: vi.fn().mockResolvedValue({ data: { id: 'evt-1' } }),
+      update: vi.fn().mockResolvedValue({ data: { id: 'evt-1' } }),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    },
+    calendars_free_busy: {
+      list: vi.fn().mockResolvedValue({ data: [] }),
+    },
+  };
+}
+
+describe('NylasCalendarClient', () => {
+  let client: NylasCalendarClient;
+  let sdk: NylasCalendarLike;
+
+  beforeEach(() => {
+    sdk = makeMockSdk();
+    client = NylasCalendarClient.createWithSdk(sdk, 'grant-123', logger);
+  });
+
+  describe('listCalendars', () => {
+    it('calls SDK calendars.list with correct grant identifier', async () => {
+      await client.listCalendars();
+
+      expect(sdk.calendars.list).toHaveBeenCalledWith({
+        identifier: 'grant-123',
+      });
+    });
+
+    it('returns normalized calendar objects', async () => {
+      (sdk.calendars.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: [{
+          id: 'cal-1',
+          name: 'Joseph Work',
+          description: 'Main calendar',
+          timezone: 'America/Toronto',
+          is_primary: true,
+          read_only: false,
+          is_owned_by_user: false,
+        }],
+      });
+
+      const calendars = await client.listCalendars();
+
+      expect(calendars).toHaveLength(1);
+      expect(calendars[0]).toEqual({
+        id: 'cal-1',
+        name: 'Joseph Work',
+        description: 'Main calendar',
+        timezone: 'America/Toronto',
+        isPrimary: true,
+        readOnly: false,
+        isOwnedByUser: false,
+      });
+    });
+  });
+
+  describe('listEvents', () => {
+    it('calls SDK events.list with correct params', async () => {
+      await client.listEvents('cal-1', '2026-04-01T00:00:00Z', '2026-04-02T00:00:00Z');
+
+      expect(sdk.events.list).toHaveBeenCalledWith({
+        identifier: 'grant-123',
+        queryParams: {
+          calendar_id: 'cal-1',
+          start: '2026-04-01T00:00:00Z',
+          end: '2026-04-02T00:00:00Z',
+          limit: 200,
+        },
+      });
+    });
+  });
+
+  describe('createEvent', () => {
+    it('calls SDK events.create with calendarId and event data', async () => {
+      const eventData = {
+        title: 'Team Standup',
+        start: '2026-04-01T09:00:00Z',
+        end: '2026-04-01T09:30:00Z',
+      };
+
+      await client.createEvent('cal-1', eventData);
+
+      expect(sdk.events.create).toHaveBeenCalledWith({
+        identifier: 'grant-123',
+        queryParams: { calendar_id: 'cal-1' },
+        requestBody: expect.objectContaining({
+          title: 'Team Standup',
+        }),
+      });
+    });
+  });
+
+  describe('updateEvent', () => {
+    it('calls SDK events.update with eventId and changes', async () => {
+      await client.updateEvent('cal-1', 'evt-1', { title: 'Updated' });
+
+      expect(sdk.events.update).toHaveBeenCalledWith({
+        identifier: 'grant-123',
+        eventId: 'evt-1',
+        queryParams: { calendar_id: 'cal-1' },
+        requestBody: expect.objectContaining({
+          title: 'Updated',
+        }),
+      });
+    });
+  });
+
+  describe('deleteEvent', () => {
+    it('calls SDK events.destroy with eventId', async () => {
+      await client.deleteEvent('cal-1', 'evt-1');
+
+      expect(sdk.events.destroy).toHaveBeenCalledWith({
+        identifier: 'grant-123',
+        eventId: 'evt-1',
+        queryParams: { calendar_id: 'cal-1' },
+      });
+    });
+  });
+
+  describe('getFreeBusy', () => {
+    it('calls SDK free-busy endpoint with calendar IDs and time range', async () => {
+      await client.getFreeBusy(
+        ['cal-1', 'cal-2'],
+        '2026-04-01T00:00:00Z',
+        '2026-04-02T00:00:00Z',
+      );
+
+      expect(sdk.calendars_free_busy.list).toHaveBeenCalledWith({
+        identifier: 'grant-123',
+        requestBody: {
+          start_time: '2026-04-01T00:00:00Z',
+          end_time: '2026-04-02T00:00:00Z',
+          emails: ['cal-1', 'cal-2'],
+        },
+      });
+    });
+  });
+});

--- a/tests/unit/channels/nylas-calendar-client.test.ts
+++ b/tests/unit/channels/nylas-calendar-client.test.ts
@@ -151,11 +151,12 @@ describe('NylasCalendarClient', () => {
         '2026-04-02T00:00:00Z',
       );
 
+      // Nylas expects Unix timestamps (seconds), not ISO strings — assert the converted values.
       expect(sdk.calendars_free_busy.list).toHaveBeenCalledWith({
         identifier: 'grant-123',
         requestBody: {
-          start_time: '2026-04-01T00:00:00Z',
-          end_time: '2026-04-02T00:00:00Z',
+          start_time: Math.floor(new Date('2026-04-01T00:00:00Z').getTime() / 1000),
+          end_time: Math.floor(new Date('2026-04-02T00:00:00Z').getTime() / 1000),
           emails: ['cal-1', 'cal-2'],
         },
       });

--- a/tests/unit/contacts/contact-calendar-service.test.ts
+++ b/tests/unit/contacts/contact-calendar-service.test.ts
@@ -1,0 +1,221 @@
+// tests/unit/contacts/contact-calendar-service.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ContactService } from '../../../src/contacts/contact-service.js';
+import { KnowledgeGraphStore } from '../../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../../src/memory/embedding.js';
+import { EntityMemory } from '../../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../../src/memory/validation.js';
+import type { Contact } from '../../../src/contacts/types.js';
+
+describe('ContactService — calendar methods', () => {
+  let service: ContactService;
+  let ceoContact: Contact;
+
+  beforeEach(async () => {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    const entityMemory = new EntityMemory(store, validator, embeddingService);
+    service = ContactService.createInMemory(entityMemory);
+
+    ceoContact = await service.createContact({
+      displayName: 'Joseph Fung',
+      role: 'ceo',
+      source: 'test',
+    });
+  });
+
+  describe('linkCalendar', () => {
+    it('links a calendar to a contact', async () => {
+      const cal = await service.linkCalendar({
+        nylasCalendarId: 'nylas-cal-123',
+        contactId: ceoContact.id,
+        label: 'Work',
+      });
+
+      expect(cal.id).toBeDefined();
+      expect(cal.nylasCalendarId).toBe('nylas-cal-123');
+      expect(cal.contactId).toBe(ceoContact.id);
+      expect(cal.label).toBe('Work');
+      expect(cal.isPrimary).toBe(false);
+      expect(cal.readOnly).toBe(false);
+    });
+
+    it('links a calendar with isPrimary flag', async () => {
+      const cal = await service.linkCalendar({
+        nylasCalendarId: 'nylas-cal-123',
+        contactId: ceoContact.id,
+        label: 'Work',
+        isPrimary: true,
+      });
+
+      expect(cal.isPrimary).toBe(true);
+    });
+
+    it('links an org-wide calendar with null contactId', async () => {
+      const cal = await service.linkCalendar({
+        nylasCalendarId: 'nylas-cal-holidays',
+        contactId: null,
+        label: 'Company Holidays',
+      });
+
+      expect(cal.contactId).toBeNull();
+      expect(cal.label).toBe('Company Holidays');
+    });
+
+    it('rejects duplicate nylas_calendar_id', async () => {
+      await service.linkCalendar({
+        nylasCalendarId: 'nylas-cal-123',
+        contactId: ceoContact.id,
+        label: 'Work',
+      });
+
+      await expect(
+        service.linkCalendar({
+          nylasCalendarId: 'nylas-cal-123',
+          contactId: ceoContact.id,
+          label: 'Duplicate',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('enforces at most one primary per contact', async () => {
+      await service.linkCalendar({
+        nylasCalendarId: 'nylas-cal-1',
+        contactId: ceoContact.id,
+        label: 'Work',
+        isPrimary: true,
+      });
+
+      await expect(
+        service.linkCalendar({
+          nylasCalendarId: 'nylas-cal-2',
+          contactId: ceoContact.id,
+          label: 'Personal',
+          isPrimary: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects link to nonexistent contact', async () => {
+      await expect(
+        service.linkCalendar({
+          nylasCalendarId: 'nylas-cal-999',
+          contactId: 'nonexistent-uuid',
+          label: 'Ghost',
+        }),
+      ).rejects.toThrow('Contact not found');
+    });
+  });
+
+  describe('unlinkCalendar', () => {
+    it('removes a calendar association', async () => {
+      await service.linkCalendar({
+        nylasCalendarId: 'nylas-cal-123',
+        contactId: ceoContact.id,
+        label: 'Work',
+      });
+
+      const removed = await service.unlinkCalendar('nylas-cal-123');
+      expect(removed).toBe(true);
+
+      const calendars = await service.getCalendarsForContact(ceoContact.id);
+      expect(calendars).toHaveLength(0);
+    });
+
+    it('returns false for unknown calendar ID', async () => {
+      const removed = await service.unlinkCalendar('nonexistent');
+      expect(removed).toBe(false);
+    });
+  });
+
+  describe('getCalendarsForContact', () => {
+    it('returns all calendars for a contact', async () => {
+      await service.linkCalendar({
+        nylasCalendarId: 'nylas-cal-work',
+        contactId: ceoContact.id,
+        label: 'Work',
+        isPrimary: true,
+      });
+      await service.linkCalendar({
+        nylasCalendarId: 'nylas-cal-personal',
+        contactId: ceoContact.id,
+        label: 'Personal',
+      });
+
+      const calendars = await service.getCalendarsForContact(ceoContact.id);
+      expect(calendars).toHaveLength(2);
+      expect(calendars.map(c => c.label).sort()).toEqual(['Personal', 'Work']);
+    });
+
+    it('returns empty array for contact with no calendars', async () => {
+      const calendars = await service.getCalendarsForContact(ceoContact.id);
+      expect(calendars).toHaveLength(0);
+    });
+  });
+
+  describe('resolveCalendar', () => {
+    it('returns the contact for a registered calendar', async () => {
+      await service.linkCalendar({
+        nylasCalendarId: 'nylas-cal-123',
+        contactId: ceoContact.id,
+        label: 'Work',
+      });
+
+      const result = await service.resolveCalendar('nylas-cal-123');
+      expect(result).toBeDefined();
+      expect(result!.contactId).toBe(ceoContact.id);
+      expect(result!.label).toBe('Work');
+    });
+
+    it('returns null for unregistered calendar', async () => {
+      const result = await service.resolveCalendar('unknown-cal');
+      expect(result).toBeNull();
+    });
+
+    it('returns null contactId for org-wide calendar', async () => {
+      await service.linkCalendar({
+        nylasCalendarId: 'nylas-cal-holidays',
+        contactId: null,
+        label: 'Company Holidays',
+      });
+
+      const result = await service.resolveCalendar('nylas-cal-holidays');
+      expect(result).toBeDefined();
+      expect(result!.contactId).toBeNull();
+      expect(result!.label).toBe('Company Holidays');
+    });
+  });
+
+  describe('getPrimaryCalendar', () => {
+    it('returns the primary calendar for a contact', async () => {
+      await service.linkCalendar({
+        nylasCalendarId: 'nylas-cal-secondary',
+        contactId: ceoContact.id,
+        label: 'Personal',
+      });
+      await service.linkCalendar({
+        nylasCalendarId: 'nylas-cal-primary',
+        contactId: ceoContact.id,
+        label: 'Work',
+        isPrimary: true,
+      });
+
+      const primary = await service.getPrimaryCalendar(ceoContact.id);
+      expect(primary).toBeDefined();
+      expect(primary!.nylasCalendarId).toBe('nylas-cal-primary');
+      expect(primary!.label).toBe('Work');
+    });
+
+    it('returns null when no primary is set', async () => {
+      await service.linkCalendar({
+        nylasCalendarId: 'nylas-cal-123',
+        contactId: ceoContact.id,
+        label: 'Work',
+      });
+
+      const primary = await service.getPrimaryCalendar(ceoContact.id);
+      expect(primary).toBeNull();
+    });
+  });
+});

--- a/tests/unit/skills/calendar-check-conflicts.test.ts
+++ b/tests/unit/skills/calendar-check-conflicts.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CalendarCheckConflictsHandler } from '../../../skills/calendar-check-conflicts/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  return { input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
+}
+
+describe('CalendarCheckConflictsHandler', () => {
+  const handler = new CalendarCheckConflictsHandler();
+
+  it('returns failure when nylasCalendarClient is not available', async () => {
+    const result = await handler.execute(makeCtx({ calendarIds: ['cal-1'], proposedStart: 'a', proposedEnd: 'b' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Calendar not configured');
+  });
+
+  it('returns failure when required inputs are missing', async () => {
+    const nylasCalendarClient = { getFreeBusy: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'] },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('proposedStart');
+  });
+
+  it('returns clear=true and empty conflicts when no busy periods', async () => {
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([{ email: 'cal-1', timeSlots: [] }]),
+    };
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'], proposedStart: '2026-04-01T09:00:00Z', proposedEnd: '2026-04-01T10:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { conflicts: unknown[]; clear: boolean };
+      expect(data.clear).toBe(true);
+      expect(data.conflicts).toHaveLength(0);
+    }
+  });
+
+  it('returns conflicts when busy periods overlap proposed time', async () => {
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([{
+        email: 'cal-1',
+        timeSlots: [
+          { startTime: 1000, endTime: 2000, status: 'busy' },
+        ],
+      }]),
+    };
+    const contactService = {
+      resolveCalendar: vi.fn().mockResolvedValue({ contactId: 'c1', label: 'Work', isPrimary: true, readOnly: false }),
+      getContact: vi.fn().mockResolvedValue({ id: 'c1', displayName: 'Joseph Fung' }),
+    };
+
+    // Proposed time overlaps with the busy period
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'], proposedStart: '1970-01-01T00:00:00Z', proposedEnd: '1970-01-01T01:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never, contactService: contactService as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { conflicts: Array<{ calendarId: string; contactName: string | null }>; clear: boolean };
+      expect(data.clear).toBe(false);
+      expect(data.conflicts).toHaveLength(1);
+      expect(data.conflicts[0].contactName).toBe('Joseph Fung');
+    }
+  });
+
+  it('returns clear=true when no overlap', async () => {
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([{
+        email: 'cal-1',
+        // Busy from 0 to 100 — proposed time is 200-300, no overlap
+        timeSlots: [{ startTime: 0, endTime: 100, status: 'busy' }],
+      }]),
+    };
+    const result = await handler.execute(makeCtx(
+      // These ISO strings translate to times WAY after timestamp 100
+      { calendarIds: ['cal-1'], proposedStart: '2026-04-01T09:00:00Z', proposedEnd: '2026-04-01T10:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { clear: boolean };
+      expect(data.clear).toBe(true);
+    }
+  });
+});

--- a/tests/unit/skills/calendar-create-event.test.ts
+++ b/tests/unit/skills/calendar-create-event.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CalendarCreateEventHandler } from '../../../skills/calendar-create-event/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  return { input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
+}
+
+describe('CalendarCreateEventHandler', () => {
+  const handler = new CalendarCreateEventHandler();
+
+  it('returns failure when nylasCalendarClient is not available', async () => {
+    const result = await handler.execute(makeCtx({ calendarId: 'cal-1', title: 'Test', start: '2026-04-01T09:00:00Z', end: '2026-04-01T10:00:00Z' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Calendar not configured');
+  });
+
+  it('returns failure when required inputs are missing', async () => {
+    const nylasCalendarClient = { createEvent: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', title: 'Test' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('start');
+  });
+
+  it('rejects creation on read-only calendar', async () => {
+    const nylasCalendarClient = { createEvent: vi.fn() };
+    const contactService = {
+      resolveCalendar: vi.fn().mockResolvedValue({ contactId: 'c1', label: 'Work', isPrimary: true, readOnly: true }),
+    };
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', title: 'Test', start: '2026-04-01T09:00:00Z', end: '2026-04-01T10:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never, contactService: contactService as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('read-only');
+    expect(nylasCalendarClient.createEvent).not.toHaveBeenCalled();
+  });
+
+  it('creates event successfully when calendar is writable', async () => {
+    const createdEvent = { id: 'evt-new', title: 'Team Meeting', description: '', location: '', startTime: 1000, endTime: 2000, startDate: null, endDate: null, participants: [], conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true };
+    const nylasCalendarClient = { createEvent: vi.fn().mockResolvedValue(createdEvent) };
+    const contactService = {
+      resolveCalendar: vi.fn().mockResolvedValue(null), // unregistered = proceed
+    };
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', title: 'Team Meeting', start: '2026-04-01T09:00:00Z', end: '2026-04-01T10:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never, contactService: contactService as never },
+    ));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { event: { id: string } };
+      expect(data.event.id).toBe('evt-new');
+    }
+  });
+
+  it('creates event without contactService check when not provided', async () => {
+    const createdEvent = { id: 'evt-new', title: 'Test', description: '', location: '', startTime: 1000, endTime: 2000, startDate: null, endDate: null, participants: [], conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true };
+    const nylasCalendarClient = { createEvent: vi.fn().mockResolvedValue(createdEvent) };
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', title: 'Test', start: '2026-04-01T09:00:00Z', end: '2026-04-01T10:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/unit/skills/calendar-create-event.test.ts
+++ b/tests/unit/skills/calendar-create-event.test.ts
@@ -42,11 +42,11 @@ describe('CalendarCreateEventHandler', () => {
     expect(nylasCalendarClient.createEvent).not.toHaveBeenCalled();
   });
 
-  it('creates event successfully when calendar is writable', async () => {
+  it('creates event successfully when calendar is unregistered (null from resolveCalendar)', async () => {
     const createdEvent = { id: 'evt-new', title: 'Team Meeting', description: '', location: '', startTime: 1000, endTime: 2000, startDate: null, endDate: null, participants: [], conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true };
     const nylasCalendarClient = { createEvent: vi.fn().mockResolvedValue(createdEvent) };
     const contactService = {
-      resolveCalendar: vi.fn().mockResolvedValue(null), // unregistered = proceed
+      resolveCalendar: vi.fn().mockResolvedValue(null), // unregistered calendar — proceeds without read-only check
     };
     const result = await handler.execute(makeCtx(
       { calendarId: 'cal-1', title: 'Team Meeting', start: '2026-04-01T09:00:00Z', end: '2026-04-01T10:00:00Z' },
@@ -57,6 +57,20 @@ describe('CalendarCreateEventHandler', () => {
       const data = result.data as { event: { id: string } };
       expect(data.event.id).toBe('evt-new');
     }
+  });
+
+  it('creates event successfully when calendar is registered and writable (readOnly: false)', async () => {
+    const createdEvent = { id: 'evt-new', title: 'Team Meeting', description: '', location: '', startTime: 1000, endTime: 2000, startDate: null, endDate: null, participants: [], conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true };
+    const nylasCalendarClient = { createEvent: vi.fn().mockResolvedValue(createdEvent) };
+    const contactService = {
+      resolveCalendar: vi.fn().mockResolvedValue({ contactId: 'c1', label: 'Work', isPrimary: true, readOnly: false }),
+    };
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', title: 'Team Meeting', start: '2026-04-01T09:00:00Z', end: '2026-04-01T10:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never, contactService: contactService as never },
+    ));
+    expect(result.success).toBe(true);
+    expect(nylasCalendarClient.createEvent).toHaveBeenCalled();
   });
 
   it('creates event without contactService check when not provided', async () => {

--- a/tests/unit/skills/calendar-delete-event.test.ts
+++ b/tests/unit/skills/calendar-delete-event.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CalendarDeleteEventHandler } from '../../../skills/calendar-delete-event/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  return { input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
+}
+
+describe('CalendarDeleteEventHandler', () => {
+  const handler = new CalendarDeleteEventHandler();
+
+  it('returns failure when nylasCalendarClient is not available', async () => {
+    const result = await handler.execute(makeCtx({ calendarId: 'cal-1', eventId: 'evt-1' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Calendar not configured');
+  });
+
+  it('returns failure when required inputs are missing', async () => {
+    const nylasCalendarClient = { deleteEvent: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('eventId');
+  });
+
+  it('rejects deletion on read-only calendar', async () => {
+    const nylasCalendarClient = { deleteEvent: vi.fn() };
+    const contactService = {
+      resolveCalendar: vi.fn().mockResolvedValue({ contactId: 'c1', label: 'Shared', isPrimary: false, readOnly: true }),
+    };
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', eventId: 'evt-1' },
+      { nylasCalendarClient: nylasCalendarClient as never, contactService: contactService as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('read-only');
+    expect(nylasCalendarClient.deleteEvent).not.toHaveBeenCalled();
+  });
+
+  it('deletes event successfully', async () => {
+    const nylasCalendarClient = { deleteEvent: vi.fn().mockResolvedValue(undefined) };
+    const contactService = { resolveCalendar: vi.fn().mockResolvedValue(null) };
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', eventId: 'evt-1' },
+      { nylasCalendarClient: nylasCalendarClient as never, contactService: contactService as never },
+    ));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { deleted: boolean };
+      expect(data.deleted).toBe(true);
+    }
+  });
+});

--- a/tests/unit/skills/calendar-find-free-time.test.ts
+++ b/tests/unit/skills/calendar-find-free-time.test.ts
@@ -71,18 +71,18 @@ describe('CalendarFindFreeTimeHandler', () => {
     };
 
     // With a range of 0-1000 and busy at 100-200, free windows are 0-100 (100s) and 200-1000 (800s)
-    // With duration filter of 300s, only the 200-1000 window qualifies
+    // With duration filter of 5 minutes (300 seconds), only the 200-1000 window qualifies
     const result = await handler.execute(makeCtx(
-      { calendarIds: ['cal-1'], timeMin: '1970-01-01T00:00:00Z', timeMax: '1970-01-01T00:16:40Z', duration: 300 },
+      { calendarIds: ['cal-1'], timeMin: '1970-01-01T00:00:00Z', timeMax: '1970-01-01T00:16:40Z', duration: 5 * 60 },
       { nylasCalendarClient: nylasCalendarClient as never },
     ));
 
     expect(result.success).toBe(true);
     if (result.success) {
       const data = result.data as { freeWindows: Array<{ start: number; end: number }> };
-      // All windows should be at least 300 seconds long
+      // All windows should be at least 5 minutes (300 seconds) long
       for (const w of data.freeWindows) {
-        expect(w.end - w.start).toBeGreaterThanOrEqual(300);
+        expect(w.end - w.start).toBeGreaterThanOrEqual(5 * 60);
       }
     }
   });

--- a/tests/unit/skills/calendar-find-free-time.test.ts
+++ b/tests/unit/skills/calendar-find-free-time.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CalendarFindFreeTimeHandler } from '../../../skills/calendar-find-free-time/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  return { input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
+}
+
+// Times as Unix timestamps (seconds)
+// Range: 9am-5pm = 32400-61200 seconds (relative, for test purposes we use small numbers)
+// Busy: 10-11am = 36000-39600
+const mockFreeBusy = [
+  {
+    email: 'cal-1',
+    timeSlots: [
+      { startTime: 200, endTime: 400, status: 'busy' }, // busy 200-400
+      { startTime: 700, endTime: 900, status: 'busy' }, // busy 700-900
+    ],
+  },
+];
+
+describe('CalendarFindFreeTimeHandler', () => {
+  const handler = new CalendarFindFreeTimeHandler();
+
+  it('returns failure when nylasCalendarClient is not available', async () => {
+    const result = await handler.execute(makeCtx({ calendarIds: ['cal-1'], timeMin: 'a', timeMax: 'b' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Calendar not configured');
+  });
+
+  it('returns failure when required inputs are missing', async () => {
+    const nylasCalendarClient = { getFreeBusy: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'] },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('timeMin');
+  });
+
+  it('returns free windows by inverting busy periods', async () => {
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue(mockFreeBusy),
+    };
+
+    // Range is 0-1000, busy at 200-400 and 700-900
+    // Free windows: 0-200, 400-700, 900-1000
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'], timeMin: '1970-01-01T00:00:00Z', timeMax: '1970-01-01T00:16:40Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { freeWindows: Array<{ start: number; end: number }> };
+      expect(data.freeWindows.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('filters by minimum duration', async () => {
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([{
+        email: 'cal-1',
+        timeSlots: [
+          { startTime: 100, endTime: 200, status: 'busy' },
+        ],
+      }]),
+    };
+
+    // With a range of 0-1000 and busy at 100-200, free windows are 0-100 (100s) and 200-1000 (800s)
+    // With duration filter of 300s, only the 200-1000 window qualifies
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'], timeMin: '1970-01-01T00:00:00Z', timeMax: '1970-01-01T00:16:40Z', duration: 300 },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { freeWindows: Array<{ start: number; end: number }> };
+      // All windows should be at least 300 seconds long
+      for (const w of data.freeWindows) {
+        expect(w.end - w.start).toBeGreaterThanOrEqual(300);
+      }
+    }
+  });
+});

--- a/tests/unit/skills/calendar-find-free-time.test.ts
+++ b/tests/unit/skills/calendar-find-free-time.test.ts
@@ -71,9 +71,9 @@ describe('CalendarFindFreeTimeHandler', () => {
     };
 
     // With a range of 0-1000 and busy at 100-200, free windows are 0-100 (100s) and 200-1000 (800s)
-    // With duration filter of 300 seconds (5 minutes) minimum, only the 200-1000 window qualifies
+    // With duration filter of 5 minutes minimum (converted to 300 seconds), only the 200-1000 window qualifies
     const result = await handler.execute(makeCtx(
-      { calendarIds: ['cal-1'], timeMin: '1970-01-01T00:00:00Z', timeMax: '1970-01-01T00:16:40Z', duration: 300 },
+      { calendarIds: ['cal-1'], timeMin: '1970-01-01T00:00:00Z', timeMax: '1970-01-01T00:16:40Z', duration: 5 },
       { nylasCalendarClient: nylasCalendarClient as never },
     ));
 

--- a/tests/unit/skills/calendar-find-free-time.test.ts
+++ b/tests/unit/skills/calendar-find-free-time.test.ts
@@ -71,18 +71,19 @@ describe('CalendarFindFreeTimeHandler', () => {
     };
 
     // With a range of 0-1000 and busy at 100-200, free windows are 0-100 (100s) and 200-1000 (800s)
-    // With duration filter of 5 minutes (300 seconds), only the 200-1000 window qualifies
+    // With duration filter of 300 seconds (5 minutes) minimum, only the 200-1000 window qualifies
     const result = await handler.execute(makeCtx(
-      { calendarIds: ['cal-1'], timeMin: '1970-01-01T00:00:00Z', timeMax: '1970-01-01T00:16:40Z', duration: 5 * 60 },
+      { calendarIds: ['cal-1'], timeMin: '1970-01-01T00:00:00Z', timeMax: '1970-01-01T00:16:40Z', duration: 300 },
       { nylasCalendarClient: nylasCalendarClient as never },
     ));
 
     expect(result.success).toBe(true);
     if (result.success) {
       const data = result.data as { freeWindows: Array<{ start: number; end: number }> };
-      // All windows should be at least 5 minutes (300 seconds) long
+      expect(data.freeWindows).toHaveLength(1);
+      // The window should be at least 300 seconds long
       for (const w of data.freeWindows) {
-        expect(w.end - w.start).toBeGreaterThanOrEqual(5 * 60);
+        expect(w.end - w.start).toBeGreaterThanOrEqual(300);
       }
     }
   });

--- a/tests/unit/skills/calendar-find-free-time.test.ts
+++ b/tests/unit/skills/calendar-find-free-time.test.ts
@@ -56,7 +56,12 @@ describe('CalendarFindFreeTimeHandler', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       const data = result.data as { freeWindows: Array<{ start: number; end: number }> };
-      expect(data.freeWindows.length).toBeGreaterThan(0);
+      // Range 0-1000, busy 200-400 and 700-900 → free windows: 0-200, 400-700, 900-1000
+      expect(data.freeWindows).toEqual([
+        { start: 0, end: 200 },
+        { start: 400, end: 700 },
+        { start: 900, end: 1000 },
+      ]);
     }
   });
 
@@ -80,11 +85,7 @@ describe('CalendarFindFreeTimeHandler', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       const data = result.data as { freeWindows: Array<{ start: number; end: number }> };
-      expect(data.freeWindows).toHaveLength(1);
-      // The window should be at least 300 seconds long
-      for (const w of data.freeWindows) {
-        expect(w.end - w.start).toBeGreaterThanOrEqual(300);
-      }
+      expect(data.freeWindows).toEqual([{ start: 200, end: 1000 }]);
     }
   });
 });

--- a/tests/unit/skills/calendar-list-calendars.test.ts
+++ b/tests/unit/skills/calendar-list-calendars.test.ts
@@ -1,0 +1,76 @@
+// tests/unit/skills/calendar-list-calendars.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { CalendarListCalendarsHandler } from '../../../skills/calendar-list-calendars/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(
+  input: Record<string, unknown>,
+  overrides?: Partial<SkillContext>,
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    ...overrides,
+  };
+}
+
+describe('CalendarListCalendarsHandler', () => {
+  const handler = new CalendarListCalendarsHandler();
+
+  it('returns failure when nylasCalendarClient is not available', async () => {
+    const result = await handler.execute(makeCtx({}));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Calendar not configured');
+    }
+  });
+
+  it('returns calendars annotated with registry info', async () => {
+    const nylasCalendarClient = {
+      listCalendars: vi.fn().mockResolvedValue([
+        { id: 'cal-1', name: 'CEO Work', description: '', timezone: 'America/Toronto', isPrimary: true, readOnly: false, isOwnedByUser: false },
+        { id: 'cal-2', name: 'Holidays', description: 'Company holidays', timezone: 'America/Toronto', isPrimary: false, readOnly: true, isOwnedByUser: false },
+      ]),
+    };
+    const contactService = {
+      resolveCalendar: vi.fn()
+        .mockResolvedValueOnce({ contactId: 'contact-1', label: 'Work', isPrimary: true, readOnly: false })
+        .mockResolvedValueOnce(null),
+      getContact: vi.fn().mockResolvedValue({ id: 'contact-1', displayName: 'Joseph Fung' }),
+    };
+
+    const result = await handler.execute(makeCtx(
+      {},
+      { nylasCalendarClient: nylasCalendarClient as never, contactService: contactService as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { calendars: Array<{ id: string; registered: boolean; contactName?: string }> };
+      expect(data.calendars).toHaveLength(2);
+      expect(data.calendars[0].registered).toBe(true);
+      expect(data.calendars[0].contactName).toBe('Joseph Fung');
+      expect(data.calendars[1].registered).toBe(false);
+    }
+  });
+
+  it('handles Nylas API errors gracefully', async () => {
+    const nylasCalendarClient = {
+      listCalendars: vi.fn().mockRejectedValue(new Error('Nylas 500')),
+    };
+
+    const result = await handler.execute(makeCtx(
+      {},
+      { nylasCalendarClient: nylasCalendarClient as never, contactService: {} as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Nylas 500');
+    }
+  });
+});

--- a/tests/unit/skills/calendar-list-events.test.ts
+++ b/tests/unit/skills/calendar-list-events.test.ts
@@ -28,8 +28,9 @@ describe('CalendarListEventsHandler', () => {
   const handler = new CalendarListEventsHandler();
 
   it('returns failure when nylasCalendarClient is not available', async () => {
-    const result = await handler.execute(makeCtx({ calendarId: 'cal-1', timeMin: 'a', timeMax: 'b' }));
+    const result = await handler.execute(makeCtx({ calendarId: 'cal-1', timeMin: '2026-04-01T00:00:00Z', timeMax: '2026-04-02T00:00:00Z' }));
     expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Calendar not configured');
   });
 
   it('returns failure when required inputs are missing', async () => {
@@ -58,6 +59,7 @@ describe('CalendarListEventsHandler', () => {
       expect(data.events).toHaveLength(3);
       expect(data.count).toBe(3);
     }
+    expect(nylasCalendarClient.listEvents).toHaveBeenCalledWith('cal-1', '2026-04-01T00:00:00Z', '2026-04-02T00:00:00Z', undefined);
   });
 
   it('filters by query (case-insensitive substring on title)', async () => {
@@ -66,7 +68,7 @@ describe('CalendarListEventsHandler', () => {
     };
 
     const result = await handler.execute(makeCtx(
-      { calendarId: 'cal-1', timeMin: 'a', timeMax: 'b', query: 'chiropractor' },
+      { calendarId: 'cal-1', timeMin: '2026-04-01T00:00:00Z', timeMax: '2026-04-02T00:00:00Z', query: 'chiropractor' },
       { nylasCalendarClient: nylasCalendarClient as never },
     ));
 
@@ -84,7 +86,7 @@ describe('CalendarListEventsHandler', () => {
     };
 
     const result = await handler.execute(makeCtx(
-      { calendarId: 'cal-1', timeMin: 'a', timeMax: 'b', query: 'daily sync' },
+      { calendarId: 'cal-1', timeMin: '2026-04-01T00:00:00Z', timeMax: '2026-04-02T00:00:00Z', query: 'daily sync' },
       { nylasCalendarClient: nylasCalendarClient as never },
     ));
 
@@ -102,7 +104,7 @@ describe('CalendarListEventsHandler', () => {
     };
 
     const result = await handler.execute(makeCtx(
-      { calendarId: 'cal-1', timeMin: 'a', timeMax: 'b', attendeeEmail: 'bob@co.com' },
+      { calendarId: 'cal-1', timeMin: '2026-04-01T00:00:00Z', timeMax: '2026-04-02T00:00:00Z', attendeeEmail: 'bob@co.com' },
       { nylasCalendarClient: nylasCalendarClient as never },
     ));
 
@@ -120,7 +122,7 @@ describe('CalendarListEventsHandler', () => {
     };
 
     const result = await handler.execute(makeCtx(
-      { calendarId: 'cal-1', timeMin: 'a', timeMax: 'b', maxResults: 2 },
+      { calendarId: 'cal-1', timeMin: '2026-04-01T00:00:00Z', timeMax: '2026-04-02T00:00:00Z', maxResults: 2 },
       { nylasCalendarClient: nylasCalendarClient as never },
     ));
 

--- a/tests/unit/skills/calendar-list-events.test.ts
+++ b/tests/unit/skills/calendar-list-events.test.ts
@@ -1,0 +1,134 @@
+// tests/unit/skills/calendar-list-events.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { CalendarListEventsHandler } from '../../../skills/calendar-list-events/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(
+  input: Record<string, unknown>,
+  overrides?: Partial<SkillContext>,
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    ...overrides,
+  };
+}
+
+const mockEvents = [
+  { id: 'evt-1', title: 'Team Standup', description: 'Daily sync', participants: [{ email: 'alice@co.com', name: 'Alice', status: 'accepted' }], startTime: 1000, endTime: 2000, startDate: null, endDate: null, location: '', conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true },
+  { id: 'evt-2', title: 'Chiropractor', description: 'Appointment at 2pm', participants: [], startTime: 3000, endTime: 4000, startDate: null, endDate: null, location: '123 Main St', conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true },
+  { id: 'evt-3', title: 'Board Meeting', description: '', participants: [{ email: 'bob@co.com', name: 'Bob', status: 'accepted' }], startTime: 5000, endTime: 6000, startDate: null, endDate: null, location: '', conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true },
+];
+
+describe('CalendarListEventsHandler', () => {
+  const handler = new CalendarListEventsHandler();
+
+  it('returns failure when nylasCalendarClient is not available', async () => {
+    const result = await handler.execute(makeCtx({ calendarId: 'cal-1', timeMin: 'a', timeMax: 'b' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('returns failure when required inputs are missing', async () => {
+    const nylasCalendarClient = { listEvents: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('timeMin');
+  });
+
+  it('returns all events in range when no filters provided', async () => {
+    const nylasCalendarClient = {
+      listEvents: vi.fn().mockResolvedValue(mockEvents),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', timeMin: '2026-04-01T00:00:00Z', timeMax: '2026-04-02T00:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: unknown[]; count: number };
+      expect(data.events).toHaveLength(3);
+      expect(data.count).toBe(3);
+    }
+  });
+
+  it('filters by query (case-insensitive substring on title)', async () => {
+    const nylasCalendarClient = {
+      listEvents: vi.fn().mockResolvedValue(mockEvents),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', timeMin: 'a', timeMax: 'b', query: 'chiropractor' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: Array<{ id: string }>; count: number };
+      expect(data.events).toHaveLength(1);
+      expect(data.events[0].id).toBe('evt-2');
+    }
+  });
+
+  it('filters by query matching description', async () => {
+    const nylasCalendarClient = {
+      listEvents: vi.fn().mockResolvedValue(mockEvents),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', timeMin: 'a', timeMax: 'b', query: 'daily sync' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: Array<{ id: string }> };
+      expect(data.events).toHaveLength(1);
+      expect(data.events[0].id).toBe('evt-1');
+    }
+  });
+
+  it('filters by attendeeEmail', async () => {
+    const nylasCalendarClient = {
+      listEvents: vi.fn().mockResolvedValue(mockEvents),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', timeMin: 'a', timeMax: 'b', attendeeEmail: 'bob@co.com' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: Array<{ id: string }> };
+      expect(data.events).toHaveLength(1);
+      expect(data.events[0].id).toBe('evt-3');
+    }
+  });
+
+  it('respects maxResults limit', async () => {
+    const nylasCalendarClient = {
+      listEvents: vi.fn().mockResolvedValue(mockEvents),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', timeMin: 'a', timeMax: 'b', maxResults: 2 },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: unknown[]; count: number };
+      expect(data.events).toHaveLength(2);
+      expect(data.count).toBe(2);
+    }
+  });
+});

--- a/tests/unit/skills/calendar-update-event.test.ts
+++ b/tests/unit/skills/calendar-update-event.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CalendarUpdateEventHandler } from '../../../skills/calendar-update-event/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  return { input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
+}
+
+describe('CalendarUpdateEventHandler', () => {
+  const handler = new CalendarUpdateEventHandler();
+
+  it('returns failure when nylasCalendarClient is not available', async () => {
+    const result = await handler.execute(makeCtx({ calendarId: 'cal-1', eventId: 'evt-1' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Calendar not configured');
+  });
+
+  it('returns failure when required inputs are missing', async () => {
+    const nylasCalendarClient = { updateEvent: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('eventId');
+  });
+
+  it('rejects update on read-only calendar', async () => {
+    const nylasCalendarClient = { updateEvent: vi.fn() };
+    const contactService = {
+      resolveCalendar: vi.fn().mockResolvedValue({ contactId: 'c1', label: 'Shared', isPrimary: false, readOnly: true }),
+    };
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', eventId: 'evt-1', title: 'New Title' },
+      { nylasCalendarClient: nylasCalendarClient as never, contactService: contactService as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('read-only');
+    expect(nylasCalendarClient.updateEvent).not.toHaveBeenCalled();
+  });
+
+  it('updates event successfully', async () => {
+    const updatedEvent = { id: 'evt-1', title: 'Updated', description: '', location: '', startTime: 1000, endTime: 2000, startDate: null, endDate: null, participants: [], conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true };
+    const nylasCalendarClient = { updateEvent: vi.fn().mockResolvedValue(updatedEvent) };
+    const contactService = { resolveCalendar: vi.fn().mockResolvedValue(null) };
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', eventId: 'evt-1', title: 'Updated' },
+      { nylasCalendarClient: nylasCalendarClient as never, contactService: contactService as never },
+    ));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { event: { id: string } };
+      expect(data.event.id).toBe('evt-1');
+    }
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- Adds a `NylasCalendarClient` wrapping the Nylas SDK calendar endpoints (same credentials as email, independent instance)
- Adds a `contact_calendars` registry table linking Nylas calendar IDs to contacts, with new `ContactService` methods (`linkCalendar`, `unlinkCalendar`, `getCalendarsForContact`, `resolveCalendar`, `getPrimaryCalendar`)
- Adds 7 infrastructure skills pinned to the Coordinator: `calendar-list-calendars`, `calendar-list-events`, `calendar-create-event`, `calendar-update-event`, `calendar-delete-event`, `calendar-find-free-time`, `calendar-check-conflicts`
- Write skills (create/update/delete) check the `read_only` flag from the registry before calling Nylas; unregistered calendars fall through to Nylas's own permission enforcement
- 32 new tests, 544 total passing

## Test Plan

- [ ] `npx tsc --noEmit` — clean
- [ ] `npx vitest run` — 544 passing, 0 failures
- [ ] Manual: run `npx tsx src/index.ts` and verify startup logs show 7 new calendar skills loaded
- [ ] Manual: send "what calendars do I have?" to the coordinator and confirm `calendar-list-calendars` is invoked


___

## **CodeAnt-AI Description**
**Add calendar discovery, event management, and availability checks**

### What Changed
- Added calendar skills to list calendars and events, create, update, and delete events, find free time, and check schedule conflicts
- Calendar results now show which contact each calendar belongs to, and shared or unregistered calendars are clearly marked
- Calendar event changes now respect read-only calendars and reject updates when no fields are provided
- Free-time and conflict checks now use the correct time format, so availability checks work reliably
- Calendar skills are pinned to the Coordinator so they can be used directly in calendar-related requests

### Impact
`✅ Easier calendar discovery`
`✅ Fewer failed availability checks`
`✅ Safer event edits on shared calendars`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
