### PR TITLE
feat: add Dockerfile for self-contained deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,4 +10,7 @@ tests
 coverage
 *.md
 !README.md
-docker/
+docker/*
+!docker/postgres.Dockerfile
+!docker/postgres-init-pgaudit.sql
+!docker/postgres-verify-pgaudit.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+dist
+.env
+.env.*
+*.log
+.git
+.github
+docs
+tests
+coverage
+*.md
+!README.md
+docker/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# Build stage: compile TypeScript and install dependencies
+FROM node:22-slim AS build
+
+WORKDIR /app
+
+# Enable pnpm via corepack (ships with Node 22)
+RUN corepack enable
+
+# Install dependencies first (layer caching — deps change less often than src)
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Copy source and build
+COPY src/ ./src/
+COPY tsconfig.json ./
+# Skip --dts: type declarations are for library consumers, not the runtime image.
+# tsup's DTS build also trips a TS 6.0 deprecation error on any tsconfig with baseUrl.
+RUN pnpm exec tsup src/index.ts --format esm --no-dts
+
+# Production stage: minimal runtime image
+FROM node:22-slim
+
+# curl is needed for the HEALTHCHECK command
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+RUN corepack enable
+
+# Copy manifest and lockfile, then install production deps only
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile --prod
+
+# Copy compiled output from build stage
+COPY --from=build /app/dist ./dist
+
+# Copy runtime data files loaded at startup (agents, skills, config, migrations)
+COPY agents/ ./agents/
+COPY skills/ ./skills/
+COPY config/ ./config/
+COPY src/db/migrations/ ./src/db/migrations/
+
+EXPOSE 3000
+
+# Health check matches the Fastify /api/health route
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD curl -f http://localhost:3000/api/health || exit 1
+
+CMD ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,5 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD curl -f http://localhost:3000/api/health || exit 1
 
-CMD ["node", "dist/index.js"]
+# --experimental-strip-types: skill handlers are .ts files loaded via dynamic import()
+CMD ["node", "--experimental-strip-types", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,5 +31,24 @@ services:
       timeout: 5s
       retries: 5
 
+  curia:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: curia
+    restart: unless-stopped
+    ports:
+      - "${HTTP_PORT:-3000}:3000"
+    env_file: .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+
 volumes:
   pgdata:


### PR DESCRIPTION
## **User description**
## Summary
- Adds multi-stage Dockerfile (build + production) for the curia app
- Adds curia service to docker-compose.yml alongside existing postgres service
- Adds .dockerignore for clean build context
- Uses `--no-dts` in Docker build (type declarations unnecessary in runtime image, and tsup's DTS worker has a TS 6.0 compatibility issue)

## Test plan
- [x] `docker build -t curia-test .` succeeds
- [ ] `docker compose up` starts both postgres and curia, health endpoint responds


___

## **CodeAnt-AI Description**
Run the app and database together with Docker Compose

### What Changed
- Added a production Docker image so the app can run in a container with only the files it needs at startup
- Added the app service to Docker Compose, with automatic start after the database is healthy and a health check for the app endpoint
- Kept build files out of the Docker context while still including the Postgres-specific Docker files needed for the database setup
- Fixed runtime loading of TypeScript skill handlers in the container

### Impact
`✅ One-command local startup`
`✅ Fewer app startup failures before the database is ready`
`✅ Reliable container startup for dynamic skills`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
