### PR TITLE
fix: Docker runtime fixes for skill handler loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,13 @@ RUN pnpm add tsx
 # Copy compiled output from build stage
 COPY --from=build /app/dist ./dist
 
-# Copy runtime data files loaded at startup (agents, skills, config, migrations)
+# Copy runtime data files loaded at startup
+# Full src/ is needed because skill handlers import from src/ (e.g., bus/events.ts)
+# and tsx resolves these at runtime
 COPY agents/ ./agents/
 COPY skills/ ./skills/
 COPY config/ ./config/
-COPY src/db/migrations/ ./src/db/migrations/
+COPY src/ ./src/
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,12 @@ RUN corepack enable
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --prod
 
+# tsx is needed at runtime: skill handlers are .ts files loaded via dynamic
+# import(), and they use ESM .js extension mapping (e.g., import from './foo.js'
+# resolving to foo.ts). Node's --experimental-strip-types doesn't handle this;
+# tsx does, and it's already used for dev (pnpm dev).
+RUN pnpm add tsx
+
 # Copy compiled output from build stage
 COPY --from=build /app/dist ./dist
 
@@ -46,5 +52,7 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD curl -f http://localhost:3000/api/health || exit 1
 
-# --experimental-strip-types: skill handlers are .ts files loaded via dynamic import()
-CMD ["node", "--experimental-strip-types", "dist/index.js"]
+# tsx handles dynamic .ts skill imports with ESM .js→.ts extension resolution.
+# The compiled dist/index.js is the entrypoint, but it dynamically imports
+# raw .ts skill handlers at runtime.
+CMD ["pnpm", "exec", "tsx", "dist/index.js"]


### PR DESCRIPTION
## **User description**
## Summary
Follow-up fixes discovered during first production deploy (after #82 merged):

- **Use tsx instead of node --experimental-strip-types**: Skill handlers use ESM `.js`→`.ts` extension mapping (e.g., `import from './foo.js'` resolving to `foo.ts`). Node's `--experimental-strip-types` doesn't handle this; tsx does, and it's already used for dev (`pnpm dev`).
- **Copy full `src/` into Docker image**: Skill handlers import from `src/` (e.g., `src/bus/events.ts`). Only copying `src/db/migrations/` left those imports unresolvable at runtime.

## Test plan
- [ ] `docker build -t curia-test .` succeeds
- [ ] `docker compose up` — all skills load without ERR_MODULE_NOT_FOUND


___

## **CodeAnt-AI Description**
**Fix Docker startup so skill handlers load correctly at runtime**

### What Changed
- Docker now starts the app with the runtime needed to load TypeScript skill handlers correctly.
- The image now includes the full `src/` folder, so startup imports used by skills can be found.
- This removes the previous startup failures caused by missing runtime files and unsupported module resolution.

### Impact
`✅ Fewer Docker startup failures`
`✅ Skill handlers load reliably in production containers`
`✅ Fewer missing-file errors at launch`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
