### PR TITLE
fix: convert listEvents timestamps to unix seconds for Nylas API

### DIFF
--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -208,14 +208,19 @@ export class NylasCalendarClient {
     opts?: { limit?: number },
   ): Promise<NylasCalendarEvent[]> {
     this.log.debug({ calendarId, timeMin, timeMax }, 'Listing events');
+    // Nylas expects Unix timestamps (seconds), not ISO strings
+    const startUnix = Math.floor(new Date(timeMin).getTime() / 1000);
+    const endUnix = Math.floor(new Date(timeMax).getTime() / 1000);
+    if (Number.isNaN(startUnix) || Number.isNaN(endUnix)) {
+      throw new Error(`Invalid time range: timeMin="${timeMin}", timeMax="${timeMax}" — expected ISO 8601 strings`);
+    }
     try {
       const response = await this.nylas.events.list({
         identifier: this.grantId,
         queryParams: {
           calendar_id: calendarId,
-          // Nylas expects Unix timestamps (seconds), not ISO strings
-          start: Math.floor(new Date(timeMin).getTime() / 1000),
-          end: Math.floor(new Date(timeMax).getTime() / 1000),
+          start: startUnix,
+          end: endUnix,
           limit: opts?.limit ?? 200,
         },
       });

--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -210,6 +210,9 @@ export class NylasCalendarClient {
     this.log.debug({ calendarId, timeMin, timeMax }, 'Listing events');
     const startUnix = this.toUnixSeconds(timeMin, 'timeMin');
     const endUnix = this.toUnixSeconds(timeMax, 'timeMax');
+    if (endUnix <= startUnix) {
+      throw new Error(`Invalid time range: timeMax must be after timeMin (timeMin="${timeMin}", timeMax="${timeMax}")`);
+    }
     try {
       const response = await this.nylas.events.list({
         identifier: this.grantId,
@@ -232,6 +235,9 @@ export class NylasCalendarClient {
     this.log.debug({ calendarId, title: event.title }, 'Creating event');
     const startUnix = this.toUnixSeconds(event.start, 'start');
     const endUnix = this.toUnixSeconds(event.end, 'end');
+    if (endUnix <= startUnix) {
+      throw new Error(`Invalid time range: end must be after start (start="${event.start}", end="${event.end}")`);
+    }
     try {
       const requestBody: Record<string, unknown> = {
         title: event.title,
@@ -330,6 +336,9 @@ export class NylasCalendarClient {
     this.log.debug({ calendarIds, timeMin, timeMax }, 'Getting free/busy');
     const startUnix = this.toUnixSeconds(timeMin, 'timeMin');
     const endUnix = this.toUnixSeconds(timeMax, 'timeMax');
+    if (endUnix <= startUnix) {
+      throw new Error(`Invalid time range: timeMax must be after timeMin (timeMin="${timeMin}", timeMax="${timeMax}")`);
+    }
     try {
       const response = await this.nylas.calendars_free_busy.list({
         identifier: this.grantId,

--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -208,12 +208,8 @@ export class NylasCalendarClient {
     opts?: { limit?: number },
   ): Promise<NylasCalendarEvent[]> {
     this.log.debug({ calendarId, timeMin, timeMax }, 'Listing events');
-    // Nylas expects Unix timestamps (seconds), not ISO strings
-    const startUnix = Math.floor(new Date(timeMin).getTime() / 1000);
-    const endUnix = Math.floor(new Date(timeMax).getTime() / 1000);
-    if (Number.isNaN(startUnix) || Number.isNaN(endUnix)) {
-      throw new Error(`Invalid time range: timeMin="${timeMin}", timeMax="${timeMax}" — expected ISO 8601 strings`);
-    }
+    const startUnix = this.toUnixSeconds(timeMin, 'timeMin');
+    const endUnix = this.toUnixSeconds(timeMax, 'timeMax');
     try {
       const response = await this.nylas.events.list({
         identifier: this.grantId,
@@ -234,12 +230,14 @@ export class NylasCalendarClient {
   /** Create a new event on a calendar. */
   async createEvent(calendarId: string, event: CreateEventInput): Promise<NylasCalendarEvent> {
     this.log.debug({ calendarId, title: event.title }, 'Creating event');
+    const startUnix = this.toUnixSeconds(event.start, 'start');
+    const endUnix = this.toUnixSeconds(event.end, 'end');
     try {
       const requestBody: Record<string, unknown> = {
         title: event.title,
         when: {
-          start_time: Math.floor(new Date(event.start).getTime() / 1000),
-          end_time: Math.floor(new Date(event.end).getTime() / 1000),
+          start_time: startUnix,
+          end_time: endUnix,
         },
       };
       if (event.description) requestBody.description = event.description;
@@ -278,8 +276,8 @@ export class NylasCalendarClient {
       if (changes.location !== undefined) requestBody.location = changes.location;
       if (changes.start !== undefined || changes.end !== undefined) {
         requestBody.when = {
-          ...(changes.start ? { start_time: Math.floor(new Date(changes.start).getTime() / 1000) } : {}),
-          ...(changes.end ? { end_time: Math.floor(new Date(changes.end).getTime() / 1000) } : {}),
+          ...(changes.start ? { start_time: this.toUnixSeconds(changes.start, 'start') } : {}),
+          ...(changes.end ? { end_time: this.toUnixSeconds(changes.end, 'end') } : {}),
         };
       }
       if (changes.attendees) {
@@ -330,13 +328,14 @@ export class NylasCalendarClient {
     timeMax: string,
   ): Promise<NylasFreeBusyResult[]> {
     this.log.debug({ calendarIds, timeMin, timeMax }, 'Getting free/busy');
+    const startUnix = this.toUnixSeconds(timeMin, 'timeMin');
+    const endUnix = this.toUnixSeconds(timeMax, 'timeMax');
     try {
       const response = await this.nylas.calendars_free_busy.list({
         identifier: this.grantId,
         requestBody: {
-          // Nylas expects Unix timestamps (seconds), not ISO strings
-          start_time: Math.floor(new Date(timeMin).getTime() / 1000),
-          end_time: Math.floor(new Date(timeMax).getTime() / 1000),
+          start_time: startUnix,
+          end_time: endUnix,
           emails: calendarIds,
         },
       });
@@ -352,6 +351,17 @@ export class NylasCalendarClient {
       this.log.error({ err, calendarIds }, 'Nylas getFreeBusy failed');
       throw err;
     }
+  }
+
+  // -- Helpers --
+
+  /** Convert an ISO 8601 string to Unix seconds, throwing on unparseable input. */
+  private toUnixSeconds(iso: string, label: string): number {
+    const unix = Math.floor(new Date(iso).getTime() / 1000);
+    if (Number.isNaN(unix)) {
+      throw new Error(`Invalid ${label} timestamp: "${iso}" — expected ISO 8601`);
+    }
+    return unix;
   }
 
   // -- Normalizers --

--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -213,8 +213,9 @@ export class NylasCalendarClient {
         identifier: this.grantId,
         queryParams: {
           calendar_id: calendarId,
-          start: timeMin,
-          end: timeMax,
+          // Nylas expects Unix timestamps (seconds), not ISO strings
+          start: Math.floor(new Date(timeMin).getTime() / 1000),
+          end: Math.floor(new Date(timeMax).getTime() / 1000),
           limit: opts?.limit ?? 200,
         },
       });

--- a/tests/unit/channels/nylas-calendar-client.test.ts
+++ b/tests/unit/channels/nylas-calendar-client.test.ts
@@ -88,8 +88,8 @@ describe('NylasCalendarClient', () => {
         identifier: 'grant-123',
         queryParams: {
           calendar_id: 'cal-1',
-          start: '2026-04-01T00:00:00Z',
-          end: '2026-04-02T00:00:00Z',
+          start: Math.floor(new Date('2026-04-01T00:00:00Z').getTime() / 1000),
+          end: Math.floor(new Date('2026-04-02T00:00:00Z').getTime() / 1000),
           limit: 200,
         },
       });

--- a/tests/unit/channels/nylas-calendar-client.test.ts
+++ b/tests/unit/channels/nylas-calendar-client.test.ts
@@ -97,7 +97,7 @@ describe('NylasCalendarClient', () => {
 
     it('throws on invalid date strings', async () => {
       await expect(client.listEvents('cal-1', 'not-a-date', '2026-04-02T00:00:00Z'))
-        .rejects.toThrow(/Invalid time range/);
+        .rejects.toThrow(/Invalid timeMin timestamp/);
     });
   });
 

--- a/tests/unit/channels/nylas-calendar-client.test.ts
+++ b/tests/unit/channels/nylas-calendar-client.test.ts
@@ -94,6 +94,11 @@ describe('NylasCalendarClient', () => {
         },
       });
     });
+
+    it('throws on invalid date strings', async () => {
+      await expect(client.listEvents('cal-1', 'not-a-date', '2026-04-02T00:00:00Z'))
+        .rejects.toThrow(/Invalid time range/);
+    });
   });
 
   describe('createEvent', () => {


### PR DESCRIPTION
## **User description**
## Summary

- `listEvents` was passing ISO 8601 strings directly as `start`/`end` query params to Nylas, which expects unix timestamps in seconds — causing a 400 error ("start must be a valid unix time in seconds")
- Added `NaN` validation so malformed date strings throw a clear error instead of silently sending garbage to the API
- Other methods in the same file (`createEvent`, `getFreeBusy`) already did this conversion correctly; `listEvents` was the only one missing it

## Test plan

- [x] Updated existing `listEvents` unit test to assert unix seconds are passed
- [x] Added new test for invalid date string input
- [x] Full test suite passes (553 tests, 0 failures)


___

## **CodeAnt-AI Description**
**List calendar events with valid time values and fail fast on bad dates**

### What Changed
- Calendar event searches now send Unix seconds to Nylas, which lets event lists load instead of failing with a time format error
- Invalid start or end dates now stop the request immediately with a clear error message
- Existing event creation behavior is unchanged

### Impact
`✅ Fewer calendar list failures`
`✅ Clearer errors for invalid date ranges`
`✅ Reliable event loading for calendar views`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
