### PR TITLE
fix: remove default truncation, expose contactService, auto-resolve caller calendars

### DIFF
--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -25,6 +25,10 @@ import type { SchedulerService } from '../scheduler/scheduler-service.js';
 import type { EntityMemory } from '../memory/entity-memory.js';
 import type { NylasCalendarClient } from '../channels/calendar/nylas-calendar-client.js';
 
+// Warn (but don't truncate) when a skill returns more than this many chars.
+// Helps operators spot skills that might blow out the LLM context window.
+const LARGE_OUTPUT_THRESHOLD = 50_000;
+
 export class ExecutionLayer {
   private registry: SkillRegistry;
   private logger: Logger;
@@ -181,11 +185,21 @@ export class ExecutionLayer {
         timeoutPromise,
       ]);
 
-      // Sanitize successful output before returning
+      // Sanitize successful output before returning.
+      // No default truncation — sanitizeOutput only strips dangerous tags and
+      // redacts secrets. We log a warning for large outputs so operators can
+      // spot skills that might blow out the LLM context window.
       if (result.success && typeof result.data === 'string') {
-        return { success: true, data: sanitizeOutput(result.data) };
+        const sanitized = sanitizeOutput(result.data);
+        if (sanitized.length > LARGE_OUTPUT_THRESHOLD) {
+          skillLogger.warn({ skillName, outputLength: sanitized.length }, 'Skill output exceeds large-output threshold');
+        }
+        return { success: true, data: sanitized };
       } else if (result.success && result.data !== null && result.data !== undefined) {
         const sanitized = sanitizeOutput(JSON.stringify(result.data));
+        if (sanitized.length > LARGE_OUTPUT_THRESHOLD) {
+          skillLogger.warn({ skillName, outputLength: sanitized.length }, 'Skill output exceeds large-output threshold');
+        }
         try {
           return { success: true, data: JSON.parse(sanitized) };
         } catch (parseErr) {

--- a/src/skills/sanitize.ts
+++ b/src/skills/sanitize.ts
@@ -8,7 +8,7 @@
 // Lesson from Zora: tool outputs without sanitization are a prompt injection vector.
 
 export interface SanitizeOptions {
-  /** Max output length in characters. Default: 10000. */
+  /** Max output length in characters. Default: Infinity (no truncation). */
   maxLength?: number;
   /** If true, wraps the output in <tool_error> tags. */
   isError?: boolean;
@@ -42,14 +42,14 @@ const DANGEROUS_TAG_PATTERN = /<\/?(system|instruction|prompt|role|script|iframe
  * 1. Coerce non-strings to JSON
  * 2. Strip dangerous HTML/XML tag pairs + content, then orphan tags
  * 3. Redact secret patterns
- * 4. Truncate to length limit
+ * 4. Truncate to length limit (only if caller passes maxLength; no limit by default)
  * 5. Wrap errors in <tool_error> tags
  */
 export function sanitizeOutput(
   raw: string | unknown,
   options: SanitizeOptions = {},
 ): string {
-  const { maxLength = 10000, isError = false, extraRedactPatterns = [] } = options;
+  const { maxLength = Infinity, isError = false, extraRedactPatterns = [] } = options;
 
   // 1. Coerce non-strings to JSON so we always work with a string
   let text: string;

--- a/tests/unit/skills/sanitize.test.ts
+++ b/tests/unit/skills/sanitize.test.ts
@@ -39,6 +39,12 @@ describe('sanitizeOutput', () => {
     expect(result).toBe(short);
   });
 
+  it('does not truncate by default (no maxLength)', () => {
+    const long = 'x'.repeat(50000);
+    const result = sanitizeOutput(long);
+    expect(result).toBe(long);
+  });
+
   it('redacts patterns matching common API key formats', () => {
     const input = 'key is sk-ant-api03-abcdefghijk1234567890 and more text';
     const result = sanitizeOutput(input);


### PR DESCRIPTION
## Summary
- Removes the 10k-char default `maxLength` from `sanitizeOutput()` (now `Infinity`), so skill output is sanitized (tag stripping, secret redaction) without being silently truncated. Callers who need a limit still pass one explicitly.
- Adds a warning log in the execution layer when skill output exceeds 50k chars, giving operators visibility without truncating.
- Exposes `contactService` to all skills (previously infrastructure-only) — enables caller-scoped lookups like calendar resolution without requiring the infrastructure flag.
- Makes `calendarId` optional in `calendar-list-events` — when omitted, the handler resolves all calendars registered to the caller and queries them in parallel, merging results chronologically. The LLM no longer needs to guess calendar IDs.

## Test plan
- [x] Sanitize tests pass (33/33) — truncation tests use explicit `maxLength`, new test validates no default truncation
- [x] Execution layer tests pass (15/15)
- [x] All skill tests pass (168/168 across 21 files)
- [ ] Manual: ask the agent for daily agenda without specifying a calendar — should resolve all registered calendars automatically
- [ ] Manual: ask with explicit calendarId — should still work as before