### PR TITLE
feat: auto-resolve caller calendars, expose contactService to all skills

### DIFF
--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -35,25 +35,25 @@ export class CalendarListEventsHandler implements SkillHandler {
       return { success: false, error: 'Missing required input: timeMax' };
     }
 
-    // Resolve which calendar(s) to query.
-    // If the caller provided a specific calendarId, use that.
-    // Otherwise, look up all calendars registered to the caller's contact.
-    let calendarIds: string[];
-
-    if (calendarId && typeof calendarId === 'string') {
-      calendarIds = [calendarId];
-    } else if (ctx.contactService && ctx.caller) {
-      const calendars = await ctx.contactService.getCalendarsForContact(ctx.caller.contactId);
-      if (calendars.length === 0) {
-        return { success: false, error: 'No calendars registered for this contact — register a calendar first' };
-      }
-      calendarIds = calendars.map((c) => c.nylasCalendarId);
-      ctx.log.info({ contactId: ctx.caller.contactId, calendarCount: calendarIds.length }, 'Resolved caller calendars');
-    } else {
-      return { success: false, error: 'Missing required input: calendarId (and unable to resolve caller calendars)' };
-    }
-
     try {
+      // Resolve which calendar(s) to query.
+      // If the caller provided a specific calendarId, use that.
+      // Otherwise, look up all calendars registered to the caller's contact.
+      let calendarIds: string[];
+
+      if (calendarId && typeof calendarId === 'string') {
+        calendarIds = [calendarId];
+      } else if (ctx.contactService && ctx.caller) {
+        const calendars = await ctx.contactService.getCalendarsForContact(ctx.caller.contactId);
+        if (calendars.length === 0) {
+          return { success: false, error: 'No calendars registered for this contact — register a calendar first' };
+        }
+        calendarIds = calendars.map((c) => c.nylasCalendarId);
+        ctx.log.info({ contactId: ctx.caller.contactId, calendarCount: calendarIds.length }, 'Resolved caller calendars');
+      } else {
+        return { success: false, error: 'Missing required input: calendarId (and unable to resolve caller calendars)' };
+      }
+
       // Pass maxResults as the upstream fetch limit so callers asking for >200 events aren't silently capped.
       const fetchLimit = typeof maxResults === 'number' && maxResults > 0 ? { limit: maxResults } : undefined;
 
@@ -93,7 +93,7 @@ export class CalendarListEventsHandler implements SkillHandler {
       return { success: true, data: { events, count: events.length } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err, calendarIds }, 'Failed to list events');
+      ctx.log.error({ err, calendarId }, 'Failed to list events');
       return { success: false, error: `Failed to list events: ${message}` };
     }
   }

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -1,7 +1,13 @@
 // skills/calendar-list-events/handler.ts
 //
-// Fetches events for a date range from a specific calendar, with optional
+// Fetches events for a date range from one or more calendars, with optional
 // client-side filtering by text query or attendee email.
+//
+// When calendarId is provided, queries that single calendar.
+// When omitted, resolves ALL calendars registered to the caller (via
+// contactService) and merges events across them — so "what's my agenda?"
+// works without the LLM needing to know specific calendar IDs.
+//
 // Nylas doesn't support server-side text search on event fields, so
 // the skill fetches all events in range and filters locally.
 
@@ -22,9 +28,6 @@ export class CalendarListEventsHandler implements SkillHandler {
       attendeeEmail?: string;
     };
 
-    if (!calendarId || typeof calendarId !== 'string') {
-      return { success: false, error: 'Missing required input: calendarId' };
-    }
     if (!timeMin || typeof timeMin !== 'string') {
       return { success: false, error: 'Missing required input: timeMin' };
     }
@@ -32,10 +35,36 @@ export class CalendarListEventsHandler implements SkillHandler {
       return { success: false, error: 'Missing required input: timeMax' };
     }
 
+    // Resolve which calendar(s) to query.
+    // If the caller provided a specific calendarId, use that.
+    // Otherwise, look up all calendars registered to the caller's contact.
+    let calendarIds: string[];
+
+    if (calendarId && typeof calendarId === 'string') {
+      calendarIds = [calendarId];
+    } else if (ctx.contactService && ctx.caller) {
+      const calendars = await ctx.contactService.getCalendarsForContact(ctx.caller.contactId);
+      if (calendars.length === 0) {
+        return { success: false, error: 'No calendars registered for this contact — register a calendar first' };
+      }
+      calendarIds = calendars.map((c) => c.nylasCalendarId);
+      ctx.log.info({ contactId: ctx.caller.contactId, calendarCount: calendarIds.length }, 'Resolved caller calendars');
+    } else {
+      return { success: false, error: 'Missing required input: calendarId (and unable to resolve caller calendars)' };
+    }
+
     try {
       // Pass maxResults as the upstream fetch limit so callers asking for >200 events aren't silently capped.
       const fetchLimit = typeof maxResults === 'number' && maxResults > 0 ? { limit: maxResults } : undefined;
-      let events = await ctx.nylasCalendarClient.listEvents(calendarId, timeMin, timeMax, fetchLimit);
+
+      // Fetch events from all resolved calendars in parallel, then merge.
+      const perCalendarResults = await Promise.all(
+        calendarIds.map((cid) => ctx.nylasCalendarClient!.listEvents(cid, timeMin, timeMax, fetchLimit)),
+      );
+      let events = perCalendarResults.flat();
+
+      // Sort merged events by start time so the agenda reads chronologically
+      events.sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
 
       // Client-side filtering: query matches title or description (case-insensitive)
       if (query && typeof query === 'string') {
@@ -60,11 +89,11 @@ export class CalendarListEventsHandler implements SkillHandler {
         events = events.slice(0, maxResults);
       }
 
-      ctx.log.info({ calendarId, count: events.length }, 'Listed events');
+      ctx.log.info({ calendarIds, count: events.length }, 'Listed events');
       return { success: true, data: { events, count: events.length } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err, calendarId }, 'Failed to list events');
+      ctx.log.error({ err, calendarIds }, 'Failed to list events');
       return { success: false, error: `Failed to list events: ${message}` };
     }
   }

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -15,7 +15,8 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 
 export class CalendarListEventsHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    if (!ctx.nylasCalendarClient) {
+    const calendarClient = ctx.nylasCalendarClient;
+    if (!calendarClient) {
       return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
     }
 
@@ -58,10 +59,32 @@ export class CalendarListEventsHandler implements SkillHandler {
       const fetchLimit = typeof maxResults === 'number' && maxResults > 0 ? { limit: maxResults } : undefined;
 
       // Fetch events from all resolved calendars in parallel, then merge.
-      const perCalendarResults = await Promise.all(
-        calendarIds.map((cid) => ctx.nylasCalendarClient!.listEvents(cid, timeMin, timeMax, fetchLimit)),
+      // Use allSettled so one bad calendar (stale grant, revoked access) doesn't
+      // poison the entire result — return partial results and log failures.
+      const settled = await Promise.allSettled(
+        calendarIds.map((cid) => calendarClient.listEvents(cid, timeMin, timeMax, fetchLimit)),
       );
-      let events = perCalendarResults.flat();
+
+      const failedCalendarIds: string[] = [];
+      const successfulEvents: Array<typeof settled[0] extends PromiseFulfilledResult<infer T> ? T : never> = [];
+      for (let i = 0; i < settled.length; i++) {
+        const result = settled[i];
+        if (result.status === 'fulfilled') {
+          successfulEvents.push(result.value);
+        } else {
+          failedCalendarIds.push(calendarIds[i]);
+          ctx.log.error({ err: result.reason, calendarId: calendarIds[i] }, 'Failed to fetch events for calendar');
+        }
+      }
+
+      if (successfulEvents.length === 0) {
+        const message = failedCalendarIds.length > 0
+          ? `Failed to list events from any calendar (${failedCalendarIds.length} failed: ${failedCalendarIds.join(', ')})`
+          : 'No events found';
+        return { success: false, error: message };
+      }
+
+      let events = successfulEvents.flat();
 
       // Sort merged events by start time so the agenda reads chronologically
       events.sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
@@ -89,8 +112,13 @@ export class CalendarListEventsHandler implements SkillHandler {
         events = events.slice(0, maxResults);
       }
 
-      ctx.log.info({ calendarIds, count: events.length }, 'Listed events');
-      return { success: true, data: { events, count: events.length } };
+      ctx.log.info({ calendarIds, count: events.length, failedCalendarIds }, 'Listed events');
+      const data: Record<string, unknown> = { events, count: events.length };
+      // Surface partial failures so the LLM can inform the user
+      if (failedCalendarIds.length > 0) {
+        data.warnings = [`Failed to fetch events from ${failedCalendarIds.length} calendar(s): ${failedCalendarIds.join(', ')}`];
+      }
+      return { success: true, data };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       ctx.log.error({ err, calendarId }, 'Failed to list events');

--- a/skills/calendar-list-events/skill.json
+++ b/skills/calendar-list-events/skill.json
@@ -1,11 +1,11 @@
 {
   "name": "calendar-list-events",
-  "description": "Fetch events from a calendar within a date range. Supports filtering by text query (title/description) and attendee email. Use for checking schedules, finding specific appointments, or reviewing upcoming events.",
+  "description": "Fetch events from a calendar within a date range. Supports filtering by text query (title/description) and attendee email. Use for checking schedules, finding specific appointments, or reviewing upcoming events. When calendarId is omitted, automatically queries all calendars registered to the caller.",
   "version": "1.0.0",
   "sensitivity": "normal",
   "infrastructure": true,
   "inputs": {
-    "calendarId": "string",
+    "calendarId": "string?",
     "timeMin": "string",
     "timeMax": "string",
     "maxResults": "number?",

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -123,6 +123,9 @@ export class ExecutionLayer {
       log: skillLogger,
       agentPersona: this.agentPersona,
       caller,
+      // contactService is available to all skills — read-only contact lookups
+      // (calendars, display names, etc.) are not a privilege escalation.
+      contactService: this.contactService,
     };
 
     // Infrastructure skills get bus and agent registry access.
@@ -141,7 +144,6 @@ export class ExecutionLayer {
       }
       ctx.bus = this.bus;
       ctx.agentRegistry = this.agentRegistry;
-      ctx.contactService = this.contactService;
       // outboundGateway is optional — only skills that send external messages need it.
       // All outbound communication goes through the gateway, which enforces contact
       // blocked checks and content filtering before dispatch.

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -78,7 +78,9 @@ export interface SkillContext {
   bus?: import('../bus/bus.js').EventBus;
   /** Agent registry — only available to infrastructure skills */
   agentRegistry?: import('../agents/agent-registry.js').AgentRegistry;
-  /** Contact service — only available to infrastructure skills */
+  /** Contact service — available to all skills for caller-scoped lookups
+   *  (e.g., resolving a caller's registered calendars, looking up contacts).
+   *  Populated whenever the ExecutionLayer has a contactService instance. */
   contactService?: import('../contacts/contact-service.js').ContactService;
   /** Outbound gateway — only available to infrastructure skills. All external
    *  communication (email, future Signal/Telegram) goes through the gateway,

--- a/tests/unit/skills/calendar-list-events.test.ts
+++ b/tests/unit/skills/calendar-list-events.test.ts
@@ -116,6 +116,124 @@ describe('CalendarListEventsHandler', () => {
     }
   });
 
+  // -- Auto-resolve caller calendars (no calendarId provided) --
+
+  it('resolves caller calendars when calendarId is omitted', async () => {
+    const nylasCalendarClient = {
+      listEvents: vi.fn().mockResolvedValue([mockEvents[0]]),
+    };
+    const contactService = {
+      getCalendarsForContact: vi.fn().mockResolvedValue([
+        { nylasCalendarId: 'cal-work' },
+        { nylasCalendarId: 'cal-personal' },
+      ]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { timeMin: '2026-04-01T00:00:00Z', timeMax: '2026-04-02T00:00:00Z' },
+      {
+        nylasCalendarClient: nylasCalendarClient as never,
+        contactService: contactService as never,
+        caller: { contactId: 'primary-user', role: 'ceo', channel: 'cli' },
+      },
+    ));
+
+    expect(result.success).toBe(true);
+    // Should have queried both calendars
+    expect(nylasCalendarClient.listEvents).toHaveBeenCalledTimes(2);
+    expect(nylasCalendarClient.listEvents).toHaveBeenCalledWith('cal-work', '2026-04-01T00:00:00Z', '2026-04-02T00:00:00Z', undefined);
+    expect(nylasCalendarClient.listEvents).toHaveBeenCalledWith('cal-personal', '2026-04-01T00:00:00Z', '2026-04-02T00:00:00Z', undefined);
+    expect(contactService.getCalendarsForContact).toHaveBeenCalledWith('primary-user');
+  });
+
+  it('merges and sorts events from multiple calendars chronologically', async () => {
+    const workEvents = [
+      { ...mockEvents[1], id: 'work-1', startTime: '2026-04-01T14:00:00Z' },
+    ];
+    const personalEvents = [
+      { ...mockEvents[0], id: 'personal-1', startTime: '2026-04-01T09:00:00Z' },
+    ];
+    const nylasCalendarClient = {
+      listEvents: vi.fn()
+        .mockResolvedValueOnce(workEvents)
+        .mockResolvedValueOnce(personalEvents),
+    };
+    const contactService = {
+      getCalendarsForContact: vi.fn().mockResolvedValue([
+        { nylasCalendarId: 'cal-work' },
+        { nylasCalendarId: 'cal-personal' },
+      ]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { timeMin: '2026-04-01T00:00:00Z', timeMax: '2026-04-02T00:00:00Z' },
+      {
+        nylasCalendarClient: nylasCalendarClient as never,
+        contactService: contactService as never,
+        caller: { contactId: 'primary-user', role: 'ceo', channel: 'cli' },
+      },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: Array<{ id: string }> };
+      expect(data.events).toHaveLength(2);
+      // personal-1 (09:00) should sort before work-1 (14:00)
+      expect(data.events[0].id).toBe('personal-1');
+      expect(data.events[1].id).toBe('work-1');
+    }
+  });
+
+  it('returns failure when no calendars are registered for caller', async () => {
+    const nylasCalendarClient = { listEvents: vi.fn() };
+    const contactService = {
+      getCalendarsForContact: vi.fn().mockResolvedValue([]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { timeMin: '2026-04-01T00:00:00Z', timeMax: '2026-04-02T00:00:00Z' },
+      {
+        nylasCalendarClient: nylasCalendarClient as never,
+        contactService: contactService as never,
+        caller: { contactId: 'primary-user', role: 'ceo', channel: 'cli' },
+      },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('No calendars registered');
+  });
+
+  it('returns failure when no calendarId and no contactService', async () => {
+    const nylasCalendarClient = { listEvents: vi.fn() };
+
+    const result = await handler.execute(makeCtx(
+      { timeMin: '2026-04-01T00:00:00Z', timeMax: '2026-04-02T00:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('calendarId');
+  });
+
+  it('returns failure (not throws) when getCalendarsForContact rejects', async () => {
+    const nylasCalendarClient = { listEvents: vi.fn() };
+    const contactService = {
+      getCalendarsForContact: vi.fn().mockRejectedValue(new Error('DB connection lost')),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { timeMin: '2026-04-01T00:00:00Z', timeMax: '2026-04-02T00:00:00Z' },
+      {
+        nylasCalendarClient: nylasCalendarClient as never,
+        contactService: contactService as never,
+        caller: { contactId: 'primary-user', role: 'ceo', channel: 'cli' },
+      },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('DB connection lost');
+  });
+
   it('respects maxResults limit', async () => {
     const nylasCalendarClient = {
       listEvents: vi.fn().mockResolvedValue(mockEvents),

--- a/tests/unit/skills/calendar-list-events.test.ts
+++ b/tests/unit/skills/calendar-list-events.test.ts
@@ -234,6 +234,61 @@ describe('CalendarListEventsHandler', () => {
     if (!result.success) expect(result.error).toContain('DB connection lost');
   });
 
+  it('returns partial results with warnings when one calendar fails', async () => {
+    const nylasCalendarClient = {
+      listEvents: vi.fn()
+        .mockResolvedValueOnce([mockEvents[0]])
+        .mockRejectedValueOnce(new Error('Not Found')),
+    };
+    const contactService = {
+      getCalendarsForContact: vi.fn().mockResolvedValue([
+        { nylasCalendarId: 'cal-work' },
+        { nylasCalendarId: 'cal-stale' },
+      ]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { timeMin: '2026-04-01T00:00:00Z', timeMax: '2026-04-02T00:00:00Z' },
+      {
+        nylasCalendarClient: nylasCalendarClient as never,
+        contactService: contactService as never,
+        caller: { contactId: 'primary-user', role: 'ceo', channel: 'cli' },
+      },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: unknown[]; count: number; warnings?: string[] };
+      expect(data.events).toHaveLength(1);
+      expect(data.warnings).toBeDefined();
+      expect(data.warnings![0]).toContain('cal-stale');
+    }
+  });
+
+  it('returns failure when all calendars fail', async () => {
+    const nylasCalendarClient = {
+      listEvents: vi.fn().mockRejectedValue(new Error('Not Found')),
+    };
+    const contactService = {
+      getCalendarsForContact: vi.fn().mockResolvedValue([
+        { nylasCalendarId: 'cal-1' },
+        { nylasCalendarId: 'cal-2' },
+      ]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { timeMin: '2026-04-01T00:00:00Z', timeMax: '2026-04-02T00:00:00Z' },
+      {
+        nylasCalendarClient: nylasCalendarClient as never,
+        contactService: contactService as never,
+        caller: { contactId: 'primary-user', role: 'ceo', channel: 'cli' },
+      },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Failed to list events from any calendar');
+  });
+
   it('respects maxResults limit', async () => {
     const nylasCalendarClient = {
       listEvents: vi.fn().mockResolvedValue(mockEvents),


### PR DESCRIPTION
## **User description**
## Summary
- Exposes `contactService` to all skills (previously infrastructure-only) — enables caller-scoped lookups like calendar resolution without requiring the infrastructure flag.
- Makes `calendarId` optional in `calendar-list-events` — when omitted, the handler looks up all calendars registered to the caller via `contactService.getCalendarsForContact()` and queries them in parallel.
- Uses `Promise.allSettled` so a single bad calendar (stale grant, revoked access) doesn't fail the entire agenda — partial results are returned with warnings surfaced for the LLM.
- Events from multiple calendars are merged and sorted chronologically.

## Test plan
- [x] All skill tests pass (175/175 across 21 files)
- [x] New tests: multi-calendar resolution, chronological merge, zero-calendars error, missing contactService fallback, DB failure during lookup, partial failure (one calendar fails), total failure (all calendars fail)
- [ ] Manual: ask the agent for daily agenda without specifying a calendar — should resolve all registered calendars automatically
- [ ] Manual: ask with explicit calendarId — should still work as before


___

## **CodeAnt-AI Description**
**Let callers view all of their calendars without naming one**

### What Changed
- `calendar-list-events` can now run without a calendar ID and will fetch events from every calendar linked to the caller.
- Events from multiple calendars are combined and shown in time order, so agenda results read chronologically.
- If one calendar fails, the skill still returns the rest of the events and adds a warning instead of failing the whole request.
- If no calendars are linked, or no calendar can be resolved, the skill returns a clear error.
- `contactService` is now available to all skills, allowing caller-based lookups like calendar resolution.

### Impact
`✅ Shorter agenda lookup`
`✅ Fewer failed calendar requests`
`✅ Clearer partial-result warnings`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
