### PR TITLE
fix: steer LLM toward calendar auto-resolve

### DIFF
--- a/skills/calendar-list-calendars/skill.json
+++ b/skills/calendar-list-calendars/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar-list-calendars",
-  "description": "List all calendars visible to the agent (owned and shared), annotated with which contact each is registered to. Use this to discover new calendars or verify calendar assignments.",
+  "description": "List all calendars visible to the agent (owned and shared), annotated with which contact each is registered to. Use this to discover new calendars or verify calendar assignments. NOT needed before listing events — calendar-list-events auto-resolves the caller's calendars when calendarId is omitted.",
   "version": "1.0.0",
   "sensitivity": "normal",
   "infrastructure": true,

--- a/skills/calendar-list-events/skill.json
+++ b/skills/calendar-list-events/skill.json
@@ -1,11 +1,11 @@
 {
   "name": "calendar-list-events",
-  "description": "Fetch events from a calendar within a date range. Supports filtering by text query (title/description) and attendee email. Use for checking schedules, finding specific appointments, or reviewing upcoming events. When calendarId is omitted, automatically queries all calendars registered to the caller.",
+  "description": "Fetch events within a date range. Omit calendarId to automatically query all of the caller's registered calendars (preferred — do NOT look up calendar IDs manually). Only pass calendarId when the user explicitly asks about a specific calendar. Supports filtering by text query (title/description) and attendee email.",
   "version": "1.0.0",
   "sensitivity": "normal",
   "infrastructure": true,
   "inputs": {
-    "calendarId": "string?",
+    "calendarId": "string? (omit to auto-query all caller calendars — only pass when targeting a specific calendar)",
     "timeMin": "string",
     "timeMax": "string",
     "maxResults": "number?",


### PR DESCRIPTION
## **User description**
## Summary
- Updates `calendar-list-events` description to explicitly tell the LLM to **omit calendarId** and let the skill auto-resolve (preferred path), only passing it when the user asks about a specific calendar
- Adds a parenthetical description on the `calendarId` input reinforcing this
- Updates `calendar-list-calendars` description to note it's NOT needed before listing events

## Context
PR #89 added auto-resolve logic, but the LLM was still calling `calendar-list-calendars` first and passing explicit calendarIds — sometimes guessing wrong gmail addresses that don't exist in Nylas, causing 404s. The auto-resolve code path was never being hit because the descriptions didn't steer the LLM toward it.

## Test plan
- [ ] Manual: ask the agent for daily agenda — should call calendar-list-events without calendarId, hitting the auto-resolve path ("Resolved caller calendars" in logs)
- [ ] Manual: ask "what's on my work calendar?" — should still allow explicit calendarId


___

## **CodeAnt-AI Description**
**Guide calendar searches to use automatic calendar matching**

### What Changed
- `calendar-list-events` now tells the agent to leave out `calendarId` by default so it can search across the caller’s calendars automatically
- The event lookup instructions now say to use a specific `calendarId` only when the user asks about one calendar
- `calendar-list-calendars` now says it is not needed before listing events, reducing unnecessary calendar lookup steps

### Impact
`✅ Fewer wrong calendar lookups`
`✅ Fewer 404s when checking schedules`
`✅ Faster access to upcoming events`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
