### PR TITLE
feat: entity context enrichment platform (spec 11, phase 1)

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -20,6 +20,12 @@ system_prompt: |
   resolve them to specific calendar dates and state the dates explicitly so the
   user can confirm you understood correctly.
 
+  ## Your Identity
+  Your contact ID is ${agent_contact_id}. When someone refers to "you", "your calendar",
+  "your inbox", or anything that refers to you as the agent, use this contact ID for
+  entity-context lookups. This ensures "your calendar" resolves the same way as
+  "Jenna's calendar" — through the entity-context system.
+
   ## Contact Awareness
   You have access to a contact system. The system injects information about who you're
   talking to as a system message — use their name naturally in your response.
@@ -150,6 +156,7 @@ system_prompt: |
     in your own voice. The user should never know multiple agents were involved.
   - Keep responses concise unless detail is requested
 pinned_skills:
+  - entity-context
   - web-fetch
   - delegate
   - contact-create

--- a/skills/entity-context/handler.ts
+++ b/skills/entity-context/handler.ts
@@ -1,0 +1,65 @@
+// skills/entity-context/handler.ts
+//
+// Assembles rich context about one or more entities for the LLM to use.
+// Wraps EntityContextAssembler as a callable skill so agents can inspect
+// entity context interactively (e.g., "what do you know about Jenna?").
+//
+// For automatic pre-enrichment before skill invocation, use the
+// entity_enrichment manifest declaration instead — that runs the same
+// assembler without an extra LLM round-trip.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class EntityContextHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const assembler = ctx.entityContextAssembler;
+    if (!assembler) {
+      return { success: false, error: 'Entity context assembler not available — database not configured' };
+    }
+
+    const { entityIds, contactIds, includeRelationships } = ctx.input as {
+      entityIds?: string[];
+      contactIds?: string[];
+      includeRelationships?: boolean;
+    };
+
+    // Merge contactIds and entityIds into a single list to resolve.
+    // Both contact IDs and KG node IDs are accepted by assembleMany().
+    const ids: string[] = [
+      ...(Array.isArray(contactIds) ? contactIds : []),
+      ...(Array.isArray(entityIds) ? entityIds : []),
+    ];
+
+    // Default: assemble context for the caller when no IDs provided
+    if (ids.length === 0) {
+      const callerId = ctx.caller?.contactId;
+      if (!callerId) {
+        return { success: false, error: 'No entity IDs provided and no caller context available' };
+      }
+      ids.push(callerId);
+    }
+
+    try {
+      const result = await assembler.assembleMany(ids, {
+        includeRelationships: includeRelationships !== false,
+      });
+
+      ctx.log.info(
+        { resolvedCount: result.entities.length, unresolvedCount: result.unresolved.length },
+        'entity-context: assembled context',
+      );
+
+      return {
+        success: true,
+        data: {
+          entities: result.entities,
+          unresolved: result.unresolved,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, ids }, 'entity-context: assembly failed');
+      return { success: false, error: `Failed to assemble entity context: ${message}` };
+    }
+  }
+}

--- a/skills/entity-context/handler.ts
+++ b/skills/entity-context/handler.ts
@@ -57,9 +57,10 @@ export class EntityContextHandler implements SkillHandler {
         },
       };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      // Log the full error server-side but don't expose DB internals (table names,
+      // column names, SQL state codes) to the LLM via the skill result string.
       ctx.log.error({ err, ids }, 'entity-context: assembly failed');
-      return { success: false, error: `Failed to assemble entity context: ${message}` };
+      return { success: false, error: 'Failed to assemble entity context — see server logs for details' };
     }
   }
 }

--- a/skills/entity-context/skill.json
+++ b/skills/entity-context/skill.json
@@ -3,7 +3,6 @@
   "description": "Assemble rich context about one or more entities (people, orgs, events, etc.). Returns known facts, connected accounts, preferences, relationships, and other contextual information. Use contactIds for people; entityIds for any KG node. Omit both to get context for the caller. Use this when you need to know what resources (calendars, email accounts) an entity has, or to retrieve stored facts (timezone, preferences, identifiers).",
   "version": "1.0.0",
   "sensitivity": "normal",
-  "infrastructure": true,
   "inputs": {
     "entityIds": "string[]? (KG node IDs — use for non-person entities like orgs, events, places)",
     "contactIds": "string[]? (contact IDs — convenience alias for person entities, resolved via contacts table)",

--- a/skills/entity-context/skill.json
+++ b/skills/entity-context/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "entity-context",
+  "description": "Assemble rich context about one or more entities (people, orgs, events, etc.). Returns known facts, connected accounts, preferences, relationships, and other contextual information. Use contactIds for people; entityIds for any KG node. Omit both to get context for the caller. Use this when you need to know what resources (calendars, email accounts) an entity has, or to retrieve stored facts (timezone, preferences, identifiers).",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "entityIds": "string[]? (KG node IDs — use for non-person entities like orgs, events, places)",
+    "contactIds": "string[]? (contact IDs — convenience alias for person entities, resolved via contacts table)",
+    "includeRelationships": "boolean? (default true — set false to reduce payload size for simple lookups)"
+  },
+  "outputs": {
+    "entities": "EntityContext[] (assembled context payloads for each resolved entity)",
+    "unresolved": "string[] (IDs that could not be found in the KG or contacts table)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000
+}

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -121,6 +121,7 @@ function interpolatePersona(
  * - ${available_specialists} — list of specialist agents from the agent registry
  * - ${current_date} — today's date in the configured timezone (YYYY-MM-DD, Day)
  * - ${timezone} — the configured IANA timezone name
+ * - ${agent_contact_id} — the agent's own contact ID (seeded at bootstrap)
  *
  * This runs at bootstrap time (after all agents are registered) and is separate
  * from persona interpolation which runs at config load time.
@@ -131,6 +132,7 @@ export function interpolateRuntimeContext(
     availableSpecialists?: string;
     currentDate?: string;
     timezone?: string;
+    agentContactId?: string;
   },
 ): string {
   return systemPrompt
@@ -145,5 +147,9 @@ export function interpolateRuntimeContext(
     .replace(
       /\$\{timezone\}/g,
       context.timezone ?? 'UTC',
+    )
+    .replace(
+      /\$\{agent_contact_id\}/g,
+      context.agentContactId ?? '',
     );
 }

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -2,6 +2,12 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import yaml from 'js-yaml';
 
+// UUID v4 format: 8-4-4-4-12 hex groups separated by hyphens.
+// Used to validate agentContactId before system prompt interpolation —
+// guards against prompt injection if the ID source ever changes from
+// the current gen_random_uuid() call in bootstrap.ts.
+const UUID_FORMAT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * Shape of an agent YAML config file.
  * Fields match what's in agents/*.yaml.
@@ -150,6 +156,11 @@ export function interpolateRuntimeContext(
     )
     .replace(
       /\$\{agent_contact_id\}/g,
-      context.agentContactId ?? '',
+      // Validate UUID format before interpolation — defense-in-depth against
+      // prompt injection if the ID source ever changes from gen_random_uuid().
+      // The current bootstrap always produces a Postgres-generated UUID, but an
+      // explicit check here ensures a future change (env var, config, etc.) can't
+      // accidentally inject arbitrary text into the system prompt.
+      UUID_FORMAT.test(context.agentContactId ?? '') ? (context.agentContactId ?? '') : '',
     );
 }

--- a/src/db/migrations/010_agent_singleton_constraints.sql
+++ b/src/db/migrations/010_agent_singleton_constraints.sql
@@ -1,0 +1,22 @@
+-- Up Migration
+
+-- Ensure at most one agent KG node (is_agent = true) and one agent contact
+-- exist, so bootstrapAgentIdentity() is truly idempotent across concurrent
+-- startup processes.
+--
+-- Without these constraints, ON CONFLICT DO NOTHING in the bootstrap INSERT
+-- has nothing to conflict on (UUID PKs are always unique), and two concurrent
+-- startups would silently create two agent records.
+
+-- Partial unique index on kg_nodes for the agent singleton.
+-- Only one row with properties->>'is_agent' = 'true' may exist.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_kg_nodes_agent_singleton
+  ON kg_nodes ((properties->>'is_agent'))
+  WHERE (properties->>'is_agent') = 'true';
+
+-- Partial unique index on contacts: at most one contact per kg_node_id.
+-- This also guarantees the agent's contact record is a singleton once the
+-- KG node is a singleton.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_contacts_kg_node_unique
+  ON contacts (kg_node_id)
+  WHERE kg_node_id IS NOT NULL;

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -283,7 +283,7 @@ export class EntityContextAssembler {
     );
 
     return result.rows.map((row) => {
-      const props = row.properties as Record<string, unknown>;
+      const props = (row.properties ?? {}) as Record<string, unknown>;
       const factValue = props.value;
       // Log missing value field so operators can detect malformed fact writes
       if (factValue === undefined) {

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -70,8 +70,10 @@ export class EntityContextAssembler {
     const unresolved: string[] = [];
 
     for (const id of ids) {
-      // Check cache first (keyed by input ID to handle both contact and node ID hits)
-      const cached = this.getFromCache(id);
+      // Cache stores full payloads (with relationships) only. Skipping the cache for
+      // includeRelationships=false requests prevents a partial payload from being served
+      // to a later caller that wants the full payload (and vice versa).
+      const cached = includeRelationships ? this.getFromCache(id) : undefined;
       if (cached) {
         entities.push(cached);
         continue;
@@ -80,7 +82,9 @@ export class EntityContextAssembler {
       try {
         const ctx = await this.assembleOne(id, includeRelationships);
         if (ctx) {
-          this.putInCache(id, ctx);
+          if (includeRelationships) {
+            this.putInCache(id, ctx);
+          }
           entities.push(ctx);
         } else {
           this.logger.debug({ entityId: id }, 'entity-context: ID could not be resolved to a KG node');
@@ -200,7 +204,26 @@ export class EntityContextAssembler {
   }
 
   private putInCache(inputId: string, ctx: EntityContext): void {
-    const expiresAt = Date.now() + CACHE_TTL_MS;
+    const now = Date.now();
+    const expiresAt = now + CACHE_TTL_MS;
+
+    // Opportunistic GC: scan for expired entries on every write.
+    // Expired entries are only pruned on direct-key reads (getFromCache), so IDs that
+    // are never looked up again would otherwise accumulate indefinitely in long-lived
+    // processes. The scan is O(n) over the cache size; acceptable because the cache is
+    // bounded to the set of entities touched in a conversation (typically <100).
+    for (const [key, entry] of this.cache.entries()) {
+      if (now > entry.expiresAt) {
+        this.cache.delete(key);
+        const keys = this.entityToCacheKeys.get(entry.context.entityId);
+        if (keys) {
+          keys.delete(key);
+          if (keys.size === 0) {
+            this.entityToCacheKeys.delete(entry.context.entityId);
+          }
+        }
+      }
+    }
 
     // Collect all lookup keys for this entity: the input ID (may be a contact ID
     // or KG node ID), the resolved KG node ID, and — crucially — the contact ID

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -16,6 +16,10 @@
 // skills operate on the same entity in a single conversation. Cache keys are
 // entity/contact IDs; invalidation is handled by clearCacheForEntity() which
 // callers (ContactService, EntityMemory) call after mutations.
+//
+// assembleMany() wraps each per-ID call in its own try/catch so that a DB error
+// on one entity doesn't abort the entire batch — failed IDs are logged and placed
+// in the `unresolved` array rather than propagating.
 
 import type { DbPool } from '../db/connection.js';
 import type { Logger } from '../logger.js';
@@ -36,20 +40,26 @@ interface CacheEntry {
 export class EntityContextAssembler {
   private cache = new Map<string, CacheEntry>();
 
+  // Reverse mapping: entityId -> Set of all cache keys that hold it.
+  // Used by clearCacheForEntity() to ensure stale entries can't be reached
+  // by either the original input ID or the resolved entity ID.
+  private entityToCacheKeys = new Map<string, Set<string>>();
+
   constructor(private pool: DbPool, private logger: Logger) {}
 
   /**
    * Resolve one or more IDs to EntityContext payloads.
    *
    * Resolution priority for each ID:
-   *   1. 'caller' / 'agent' — special aliases; callers must substitute the real
-   *      contactId before calling (the execution layer handles this).
-   *   2. Matches a contacts.id → look up kg_node_id, assemble from that KG node
-   *   3. Matches a kg_nodes.id directly → assemble from that KG node
-   *   4. No match → included in `unresolved` (not a hard error)
+   *   1. Matches a contacts.id → look up kg_node_id, assemble from that KG node
+   *   2. Matches a kg_nodes.id directly → assemble from that KG node
+   *   3. No match → included in `unresolved` (not a hard error)
+   *
+   * Each ID is assembled independently; a DB error on one ID logs a warning and
+   * adds the ID to `unresolved` without aborting the remaining IDs in the batch.
    *
    * @param ids   Array of contact IDs or KG node IDs to resolve.
-   * @param includeRelationships  If false, the relationships field is skipped (reduces payload size).
+   * @param includeRelationships  If false, the relationships field is skipped.
    */
   async assembleMany(
     ids: string[],
@@ -67,16 +77,19 @@ export class EntityContextAssembler {
         continue;
       }
 
-      const ctx = await this.assembleOne(id, includeRelationships);
-      if (ctx) {
-        // Cache under both the input ID and the resolved entity ID so subsequent
-        // lookups by either key hit the cache.
-        this.putInCache(id, ctx);
-        if (id !== ctx.entityId) {
-          this.putInCache(ctx.entityId, ctx);
+      try {
+        const ctx = await this.assembleOne(id, includeRelationships);
+        if (ctx) {
+          this.putInCache(id, ctx);
+          entities.push(ctx);
+        } else {
+          this.logger.debug({ entityId: id }, 'entity-context: ID could not be resolved to a KG node');
+          unresolved.push(id);
         }
-        entities.push(ctx);
-      } else {
+      } catch (err) {
+        // Per-ID failure is non-fatal for the batch — log with full context and
+        // treat as unresolved so the caller gets partial results instead of nothing.
+        this.logger.error({ err, entityId: id }, 'entity-context: assembleOne failed — treating as unresolved');
         unresolved.push(id);
       }
     }
@@ -86,56 +99,91 @@ export class EntityContextAssembler {
 
   /**
    * Resolve a single ID to an EntityContext. Returns undefined if not found.
+   * Throws on DB errors — callers should wrap in try/catch or use assembleMany().
    */
   async assembleOne(id: string, includeRelationships = true): Promise<EntityContext | undefined> {
-    // Step 1: Resolve the input ID to a KG node.
-    // Try contact ID first, then fall back to direct KG node ID.
-    let kgNodeId = await this.resolveKgNodeId(id);
-    if (!kgNodeId) return undefined;
+    try {
+      // Step 1: Resolve the input ID to a KG node.
+      // Try contact ID first, then fall back to direct KG node ID.
+      const kgNodeId = await this.resolveKgNodeId(id);
+      if (!kgNodeId) return undefined;
 
-    // Step 2: Load the KG node
-    const nodeRow = await this.getKgNode(kgNodeId);
-    if (!nodeRow) return undefined;
+      // Step 2: Load the KG node
+      const nodeRow = await this.getKgNode(kgNodeId);
+      if (!nodeRow) return undefined;
 
-    // Steps 3-6: Run assembly pipeline in parallel where safe
-    // Contact lookup + connected accounts depend on each other (need contactId),
-    // so contact lookup must complete before connected accounts.
-    // Facts and relationships are independent of contacts.
-    const [factsResult, contactRow] = await Promise.all([
-      this.getFacts(kgNodeId),
-      this.getContactByKgNodeId(kgNodeId),
-    ]);
+      // Steps 3-6: Run assembly pipeline in parallel where safe.
+      // Contact lookup + connected accounts depend on each other (need contactId),
+      // so contact lookup must complete before connected accounts.
+      // Facts and relationships are independent of contacts.
+      const [factsResult, contactRow] = await Promise.all([
+        this.getFacts(kgNodeId),
+        this.getContactByKgNodeId(kgNodeId),
+      ]);
 
-    // Connected accounts require the contact record's id
-    const connectedAccounts = contactRow
-      ? await this.getConnectedAccounts(contactRow.id)
-      : [];
+      // Connected accounts require the contact record's id
+      const connectedAccounts = contactRow
+        ? await this.getConnectedAccounts(contactRow.id)
+        : [];
 
-    const relationships = includeRelationships
-      ? await this.getRelationships(kgNodeId)
-      : [];
+      const relationships = includeRelationships
+        ? await this.getRelationships(kgNodeId)
+        : [];
 
-    const ctx: EntityContext = {
-      entityId: kgNodeId,
-      entityType: nodeRow.type,
-      label: nodeRow.label,
-      contact: contactRow
-        ? { contactId: contactRow.id, displayName: contactRow.display_name, role: contactRow.role }
-        : null,
-      facts: factsResult,
-      connectedAccounts,
-      relationships,
-    };
+      const ctx: EntityContext = {
+        entityId: kgNodeId,
+        entityType: nodeRow.type,
+        label: nodeRow.label,
+        contact: contactRow
+          ? { contactId: contactRow.id, displayName: contactRow.display_name, role: contactRow.role }
+          : null,
+        facts: factsResult,
+        connectedAccounts,
+        relationships,
+      };
 
-    return ctx;
+      return ctx;
+    } catch (err) {
+      // Re-throw with the entity ID stamped in the error for upstream diagnostic logs.
+      // assembleMany() catches this and logs `{ err, entityId: id }`.
+      this.logger.error({ err, entityId: id }, 'entity-context: pipeline failed');
+      throw err;
+    }
   }
 
   /**
    * Invalidate all cached entries for a given entity or contact ID.
    * Called by ContactService and EntityMemory after mutations.
+   *
+   * Clears all cache keys associated with the entity (both the input ID used to
+   * look it up and the resolved entity ID) to prevent stale hits via either path.
    */
   clearCacheForEntity(id: string): void {
-    this.cache.delete(id);
+    // Collect all keys that reference this entity (input ID and resolved entity ID)
+    const keysToDelete = new Set<string>([id]);
+
+    // If a cached entry under this ID exists, also collect its entityId
+    const entry = this.cache.get(id);
+    if (entry) {
+      keysToDelete.add(entry.context.entityId);
+    }
+
+    // Also collect any keys tracked under the entityId reverse map
+    const relatedKeys = this.entityToCacheKeys.get(id);
+    if (relatedKeys) {
+      for (const k of relatedKeys) keysToDelete.add(k);
+    }
+
+    // Delete all collected keys from both cache and reverse map
+    for (const key of keysToDelete) {
+      const e = this.cache.get(key);
+      if (e) {
+        // Clean up the reverse map for this entity
+        this.entityToCacheKeys.get(e.context.entityId)?.delete(key);
+      }
+      this.cache.delete(key);
+      this.entityToCacheKeys.delete(key);
+    }
   }
 
   // -- Private helpers --
@@ -145,13 +193,30 @@ export class EntityContextAssembler {
     if (!entry) return undefined;
     if (Date.now() > entry.expiresAt) {
       this.cache.delete(id);
+      this.entityToCacheKeys.get(entry.context.entityId)?.delete(id);
       return undefined;
     }
     return entry.context;
   }
 
-  private putInCache(id: string, ctx: EntityContext): void {
-    this.cache.set(id, { context: ctx, expiresAt: Date.now() + CACHE_TTL_MS });
+  private putInCache(inputId: string, ctx: EntityContext): void {
+    const expiresAt = Date.now() + CACHE_TTL_MS;
+
+    // Store under the input ID (may be a contact ID or KG node ID)
+    this.cache.set(inputId, { context: ctx, expiresAt });
+
+    // Also store under the resolved entity ID so subsequent lookups by KG node
+    // ID also hit the cache without a second DB round-trip
+    if (inputId !== ctx.entityId) {
+      this.cache.set(ctx.entityId, { context: ctx, expiresAt });
+    }
+
+    // Track both keys in the reverse map for accurate invalidation
+    if (!this.entityToCacheKeys.has(ctx.entityId)) {
+      this.entityToCacheKeys.set(ctx.entityId, new Set());
+    }
+    this.entityToCacheKeys.get(ctx.entityId)!.add(inputId);
+    this.entityToCacheKeys.get(ctx.entityId)!.add(ctx.entityId);
   }
 
   /**
@@ -217,15 +282,26 @@ export class EntityContextAssembler {
       [entityNodeId],
     );
 
-    return result.rows.map((row) => ({
-      label: row.label,
-      value: (row.properties as Record<string, unknown>).value ?? null,
-      category: String((row.properties as Record<string, unknown>).category ?? 'unknown'),
-      confidence: Number(row.confidence),
-      lastConfirmedAt: row.last_confirmed_at instanceof Date
-        ? row.last_confirmed_at.toISOString()
-        : String(row.last_confirmed_at),
-    }));
+    return result.rows.map((row) => {
+      const props = row.properties as Record<string, unknown>;
+      const factValue = props.value;
+      // Log missing value field so operators can detect malformed fact writes
+      if (factValue === undefined) {
+        this.logger.debug(
+          { label: row.label, entityNodeId },
+          'entity-context: fact node missing properties.value',
+        );
+      }
+      return {
+        label: row.label,
+        value: factValue ?? null,
+        category: String(props.category ?? 'unknown'),
+        confidence: Number(row.confidence),
+        lastConfirmedAt: row.last_confirmed_at instanceof Date
+          ? row.last_confirmed_at.toISOString()
+          : String(row.last_confirmed_at),
+      };
+    });
   }
 
   private async getContactByKgNodeId(kgNodeId: string): Promise<ContactRow | undefined> {

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -1,0 +1,339 @@
+// src/entity-context/assembler.ts
+//
+// EntityContextAssembler: the core assembly pipeline for entity context payloads.
+//
+// For each entity ID, assembles:
+//   1. KG node lookup (type, label, properties)
+//   2. Facts — KG nodes of type 'fact' linked via 'relates_to' edges
+//   3. Contact record lookup (contacts table, by kg_node_id)
+//   4. Connected accounts (contact_calendars today; email/integrations in future)
+//   5. First-degree relationships (kg_edges where one side is the entity, depth=1)
+//
+// All of the above is a database read path — no LLM involvement, no external API
+// calls. Should complete in single-digit milliseconds for typical entities.
+//
+// A simple TTL cache (5-minute default) avoids redundant DB queries when multiple
+// skills operate on the same entity in a single conversation. Cache keys are
+// entity/contact IDs; invalidation is handled by clearCacheForEntity() which
+// callers (ContactService, EntityMemory) call after mutations.
+
+import type { DbPool } from '../db/connection.js';
+import type { Logger } from '../logger.js';
+import type { EntityContext, EntityFact, ConnectedAccount, EntityRelationship } from './types.js';
+
+// TTL for cached entity context payloads (5 minutes per spec).
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  context: EntityContext;
+  expiresAt: number;
+}
+
+/**
+ * Assembles EntityContext payloads from the database.
+ * Holds a simple TTL cache to avoid redundant queries within a conversation.
+ */
+export class EntityContextAssembler {
+  private cache = new Map<string, CacheEntry>();
+
+  constructor(private pool: DbPool, private logger: Logger) {}
+
+  /**
+   * Resolve one or more IDs to EntityContext payloads.
+   *
+   * Resolution priority for each ID:
+   *   1. 'caller' / 'agent' — special aliases; callers must substitute the real
+   *      contactId before calling (the execution layer handles this).
+   *   2. Matches a contacts.id → look up kg_node_id, assemble from that KG node
+   *   3. Matches a kg_nodes.id directly → assemble from that KG node
+   *   4. No match → included in `unresolved` (not a hard error)
+   *
+   * @param ids   Array of contact IDs or KG node IDs to resolve.
+   * @param includeRelationships  If false, the relationships field is skipped (reduces payload size).
+   */
+  async assembleMany(
+    ids: string[],
+    options: { includeRelationships?: boolean } = {},
+  ): Promise<{ entities: EntityContext[]; unresolved: string[] }> {
+    const includeRelationships = options.includeRelationships ?? true;
+    const entities: EntityContext[] = [];
+    const unresolved: string[] = [];
+
+    for (const id of ids) {
+      // Check cache first (keyed by input ID to handle both contact and node ID hits)
+      const cached = this.getFromCache(id);
+      if (cached) {
+        entities.push(cached);
+        continue;
+      }
+
+      const ctx = await this.assembleOne(id, includeRelationships);
+      if (ctx) {
+        // Cache under both the input ID and the resolved entity ID so subsequent
+        // lookups by either key hit the cache.
+        this.putInCache(id, ctx);
+        if (id !== ctx.entityId) {
+          this.putInCache(ctx.entityId, ctx);
+        }
+        entities.push(ctx);
+      } else {
+        unresolved.push(id);
+      }
+    }
+
+    return { entities, unresolved };
+  }
+
+  /**
+   * Resolve a single ID to an EntityContext. Returns undefined if not found.
+   */
+  async assembleOne(id: string, includeRelationships = true): Promise<EntityContext | undefined> {
+    // Step 1: Resolve the input ID to a KG node.
+    // Try contact ID first, then fall back to direct KG node ID.
+    let kgNodeId = await this.resolveKgNodeId(id);
+    if (!kgNodeId) return undefined;
+
+    // Step 2: Load the KG node
+    const nodeRow = await this.getKgNode(kgNodeId);
+    if (!nodeRow) return undefined;
+
+    // Steps 3-6: Run assembly pipeline in parallel where safe
+    // Contact lookup + connected accounts depend on each other (need contactId),
+    // so contact lookup must complete before connected accounts.
+    // Facts and relationships are independent of contacts.
+    const [factsResult, contactRow] = await Promise.all([
+      this.getFacts(kgNodeId),
+      this.getContactByKgNodeId(kgNodeId),
+    ]);
+
+    // Connected accounts require the contact record's id
+    const connectedAccounts = contactRow
+      ? await this.getConnectedAccounts(contactRow.id)
+      : [];
+
+    const relationships = includeRelationships
+      ? await this.getRelationships(kgNodeId)
+      : [];
+
+    const ctx: EntityContext = {
+      entityId: kgNodeId,
+      entityType: nodeRow.type,
+      label: nodeRow.label,
+      contact: contactRow
+        ? { contactId: contactRow.id, displayName: contactRow.display_name, role: contactRow.role }
+        : null,
+      facts: factsResult,
+      connectedAccounts,
+      relationships,
+    };
+
+    return ctx;
+  }
+
+  /**
+   * Invalidate all cached entries for a given entity or contact ID.
+   * Called by ContactService and EntityMemory after mutations.
+   */
+  clearCacheForEntity(id: string): void {
+    this.cache.delete(id);
+  }
+
+  // -- Private helpers --
+
+  private getFromCache(id: string): EntityContext | undefined {
+    const entry = this.cache.get(id);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(id);
+      return undefined;
+    }
+    return entry.context;
+  }
+
+  private putInCache(id: string, ctx: EntityContext): void {
+    this.cache.set(id, { context: ctx, expiresAt: Date.now() + CACHE_TTL_MS });
+  }
+
+  /**
+   * Resolve an input ID to a KG node ID.
+   * Tries contacts.id first, then kg_nodes.id directly.
+   */
+  private async resolveKgNodeId(id: string): Promise<string | undefined> {
+    // Try as a contact ID first
+    const contactResult = await this.pool.query<{ kg_node_id: string | null }>(
+      'SELECT kg_node_id FROM contacts WHERE id = $1',
+      [id],
+    );
+    if (contactResult.rows.length > 0) {
+      const row = contactResult.rows[0];
+      const kgNodeId = row?.kg_node_id;
+      // Contact found but has no linked KG node — return undefined (unresolved)
+      if (!kgNodeId) {
+        this.logger.debug({ contactId: id }, 'entity-context: contact has no linked KG node');
+        return undefined;
+      }
+      return kgNodeId;
+    }
+
+    // Try as a KG node ID directly
+    const nodeResult = await this.pool.query<{ id: string }>(
+      'SELECT id FROM kg_nodes WHERE id = $1',
+      [id],
+    );
+    if (nodeResult.rows.length > 0) {
+      return nodeResult.rows[0]?.id;
+    }
+
+    return undefined;
+  }
+
+  private async getKgNode(id: string): Promise<KgNodeRow | undefined> {
+    const result = await this.pool.query<KgNodeRow>(
+      'SELECT id, type, label, properties FROM kg_nodes WHERE id = $1',
+      [id],
+    );
+    return result.rows[0];
+  }
+
+  /**
+   * Get all fact nodes linked to the entity via 'relates_to' edges.
+   * Fact nodes have type = 'fact' and carry value/category in their properties.
+   */
+  private async getFacts(entityNodeId: string): Promise<EntityFact[]> {
+    const result = await this.pool.query<FactRow>(
+      `SELECT n.label, n.properties, n.confidence, n.last_confirmed_at
+       FROM kg_edges e
+       JOIN kg_nodes n ON n.id = e.target_node_id
+       WHERE e.source_node_id = $1
+         AND e.type = 'relates_to'
+         AND n.type = 'fact'
+       UNION ALL
+       SELECT n.label, n.properties, n.confidence, n.last_confirmed_at
+       FROM kg_edges e
+       JOIN kg_nodes n ON n.id = e.source_node_id
+       WHERE e.target_node_id = $1
+         AND e.type = 'relates_to'
+         AND n.type = 'fact'`,
+      [entityNodeId],
+    );
+
+    return result.rows.map((row) => ({
+      label: row.label,
+      value: (row.properties as Record<string, unknown>).value ?? null,
+      category: String((row.properties as Record<string, unknown>).category ?? 'unknown'),
+      confidence: Number(row.confidence),
+      lastConfirmedAt: row.last_confirmed_at instanceof Date
+        ? row.last_confirmed_at.toISOString()
+        : String(row.last_confirmed_at),
+    }));
+  }
+
+  private async getContactByKgNodeId(kgNodeId: string): Promise<ContactRow | undefined> {
+    const result = await this.pool.query<ContactRow>(
+      'SELECT id, display_name, role FROM contacts WHERE kg_node_id = $1',
+      [kgNodeId],
+    );
+    return result.rows[0];
+  }
+
+  /**
+   * Get all connected accounts for a contact.
+   * Today: contact_calendars only. Future: union with contact_email_accounts, etc.
+   */
+  private async getConnectedAccounts(contactId: string): Promise<ConnectedAccount[]> {
+    const calendarResult = await this.pool.query<CalendarRow>(
+      `SELECT nylas_calendar_id, label, is_primary, read_only, timezone
+       FROM contact_calendars
+       WHERE contact_id = $1`,
+      [contactId],
+    );
+
+    return calendarResult.rows.map((row) => ({
+      type: 'calendar',
+      label: row.label,
+      serviceId: row.nylas_calendar_id,
+      isPrimary: row.is_primary,
+      readOnly: row.read_only,
+      metadata: row.timezone ? { timezone: row.timezone } : {},
+    }));
+  }
+
+  /**
+   * Get first-degree relationships (depth=1) for an entity.
+   * Walks all kg_edges where the entity is source or target, then fetches
+   * the other end's label and type. Excludes 'fact' nodes (those go in the
+   * facts array, not relationships).
+   */
+  private async getRelationships(entityNodeId: string): Promise<EntityRelationship[]> {
+    const result = await this.pool.query<RelationshipRow>(
+      `SELECT
+         e.type AS edge_type,
+         'outbound' AS direction,
+         n.id AS related_id,
+         n.label AS related_label,
+         n.type AS related_type
+       FROM kg_edges e
+       JOIN kg_nodes n ON n.id = e.target_node_id
+       WHERE e.source_node_id = $1
+         AND n.type != 'fact'
+       UNION ALL
+       SELECT
+         e.type AS edge_type,
+         'inbound' AS direction,
+         n.id AS related_id,
+         n.label AS related_label,
+         n.type AS related_type
+       FROM kg_edges e
+       JOIN kg_nodes n ON n.id = e.source_node_id
+       WHERE e.target_node_id = $1
+         AND n.type != 'fact'`,
+      [entityNodeId],
+    );
+
+    return result.rows.map((row) => ({
+      type: row.edge_type,
+      direction: row.direction as 'outbound' | 'inbound',
+      relatedEntityId: row.related_id,
+      relatedEntityLabel: row.related_label,
+      relatedEntityType: row.related_type,
+    }));
+  }
+}
+
+// -- DB row types (internal only) --
+
+interface KgNodeRow {
+  id: string;
+  type: string;
+  label: string;
+  properties: Record<string, unknown>;
+}
+
+interface FactRow {
+  label: string;
+  properties: Record<string, unknown>;
+  confidence: number;
+  last_confirmed_at: Date | string;
+}
+
+interface ContactRow {
+  id: string;
+  display_name: string;
+  role: string | null;
+}
+
+interface CalendarRow {
+  nylas_calendar_id: string;
+  label: string;
+  is_primary: boolean;
+  read_only: boolean;
+  timezone: string | null;
+}
+
+interface RelationshipRow {
+  edge_type: string;
+  direction: string;
+  related_id: string;
+  related_label: string;
+  related_type: string;
+}

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -202,21 +202,30 @@ export class EntityContextAssembler {
   private putInCache(inputId: string, ctx: EntityContext): void {
     const expiresAt = Date.now() + CACHE_TTL_MS;
 
-    // Store under the input ID (may be a contact ID or KG node ID)
-    this.cache.set(inputId, { context: ctx, expiresAt });
-
-    // Also store under the resolved entity ID so subsequent lookups by KG node
-    // ID also hit the cache without a second DB round-trip
-    if (inputId !== ctx.entityId) {
-      this.cache.set(ctx.entityId, { context: ctx, expiresAt });
+    // Collect all lookup keys for this entity: the input ID (may be a contact ID
+    // or KG node ID), the resolved KG node ID, and — crucially — the contact ID
+    // if the entity has one. Registering all three ensures that
+    // clearCacheForEntity() can invalidate the entry no matter which alias was
+    // used to prime the cache. Without the contact ID here, a lookup by KG node
+    // ID would leave no contact-ID → KG-node reverse map entry, so a subsequent
+    // clearCacheForEntity(contactId) call after a mutation would silently miss the
+    // stale KG node entry.
+    const allKeys = new Set([inputId, ctx.entityId]);
+    if (ctx.contact) {
+      allKeys.add(ctx.contact.contactId);
     }
 
-    // Track both keys in the reverse map for accurate invalidation
+    for (const key of allKeys) {
+      this.cache.set(key, { context: ctx, expiresAt });
+    }
+
+    // Register all keys in the reverse map so invalidation can sweep them all
     if (!this.entityToCacheKeys.has(ctx.entityId)) {
       this.entityToCacheKeys.set(ctx.entityId, new Set());
     }
-    this.entityToCacheKeys.get(ctx.entityId)!.add(inputId);
-    this.entityToCacheKeys.get(ctx.entityId)!.add(ctx.entityId);
+    for (const key of allKeys) {
+      this.entityToCacheKeys.get(ctx.entityId)!.add(key);
+    }
   }
 
   /**

--- a/src/entity-context/bootstrap.ts
+++ b/src/entity-context/bootstrap.ts
@@ -46,48 +46,53 @@ export async function bootstrapAgentIdentity(
   // We identify the agent by a special property: is_agent = true.
   // The partial unique index idx_kg_nodes_agent_singleton (migration 010) ensures
   // ON CONFLICT fires when a concurrent INSERT tries to create a second agent node.
-  const nodeResult = await pool.query<{ id: string }>(
-    `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at)
-     VALUES ('person', $1, $2, 1.0, 'permanent', 'bootstrap', now(), now())
-     ON CONFLICT ((properties->>'is_agent')) WHERE (properties->>'is_agent') = 'true'
-     DO UPDATE SET last_confirmed_at = now()
-     RETURNING id`,
-    [
-      displayName,
-      JSON.stringify({ is_agent: true }),
-    ],
-  );
-
-  if (!nodeResult.rows[0]) {
-    throw new Error(
-      `agent-bootstrap: INSERT ... ON CONFLICT returned no rows for displayName="${displayName}" — ` +
-      'check that migration 010 was applied (idx_kg_nodes_agent_singleton must exist)',
+  try {
+    const nodeResult = await pool.query<{ id: string }>(
+      `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at)
+       VALUES ('person', $1, $2, 1.0, 'permanent', 'bootstrap', now(), now())
+       ON CONFLICT ((properties->>'is_agent')) WHERE (properties->>'is_agent') = 'true'
+       DO UPDATE SET last_confirmed_at = now()
+       RETURNING id`,
+      [
+        displayName,
+        JSON.stringify({ is_agent: true }),
+      ],
     );
-  }
-  const kgNodeId = nodeResult.rows[0].id;
-  logger.debug({ kgNodeId, displayName }, 'agent-bootstrap: agent KG node ready');
 
-  // Step 2: Find or create the agent's contact record linked to the KG node.
-  // The partial unique index idx_contacts_kg_node_unique (migration 010) ensures
-  // ON CONFLICT fires when a concurrent INSERT tries to create a second contact for
-  // the same KG node.
-  const contactResult = await pool.query<{ id: string }>(
-    `INSERT INTO contacts (kg_node_id, display_name, role, status, created_at, updated_at)
-     VALUES ($1, $2, 'agent', 'confirmed', now(), now())
-     ON CONFLICT (kg_node_id) WHERE kg_node_id IS NOT NULL
-     DO UPDATE SET updated_at = now()
-     RETURNING id`,
-    [kgNodeId, displayName],
-  );
+    if (!nodeResult.rows[0]) {
+      throw new Error(
+        `agent-bootstrap: INSERT ... ON CONFLICT returned no rows for displayName="${displayName}" — ` +
+        'check that migration 010 was applied (idx_kg_nodes_agent_singleton must exist)',
+      );
+    }
+    const kgNodeId = nodeResult.rows[0].id;
+    logger.debug({ kgNodeId, displayName }, 'agent-bootstrap: agent KG node ready');
 
-  if (!contactResult.rows[0]) {
-    throw new Error(
-      `agent-bootstrap: INSERT ... ON CONFLICT returned no rows for kgNodeId="${kgNodeId}" — ` +
-      'check that migration 010 was applied (idx_contacts_kg_node_unique must exist)',
+    // Step 2: Find or create the agent's contact record linked to the KG node.
+    // The partial unique index idx_contacts_kg_node_unique (migration 010) ensures
+    // ON CONFLICT fires when a concurrent INSERT tries to create a second contact for
+    // the same KG node.
+    const contactResult = await pool.query<{ id: string }>(
+      `INSERT INTO contacts (kg_node_id, display_name, role, status, created_at, updated_at)
+       VALUES ($1, $2, 'agent', 'confirmed', now(), now())
+       ON CONFLICT (kg_node_id) WHERE kg_node_id IS NOT NULL
+       DO UPDATE SET updated_at = now()
+       RETURNING id`,
+      [kgNodeId, displayName],
     );
-  }
-  const contactId = contactResult.rows[0].id;
-  logger.info({ contactId, kgNodeId, displayName }, 'agent-bootstrap: agent identity ready');
 
-  return { kgNodeId, contactId };
+    if (!contactResult.rows[0]) {
+      throw new Error(
+        `agent-bootstrap: INSERT ... ON CONFLICT returned no rows for kgNodeId="${kgNodeId}" — ` +
+        'check that migration 010 was applied (idx_contacts_kg_node_unique must exist)',
+      );
+    }
+    const contactId = contactResult.rows[0].id;
+    logger.info({ contactId, kgNodeId, displayName }, 'agent-bootstrap: agent identity ready');
+
+    return { kgNodeId, contactId };
+  } catch (err) {
+    logger.error({ err, displayName }, 'agent-bootstrap: failed to bootstrap agent identity');
+    throw err;
+  }
 }

--- a/src/entity-context/bootstrap.ts
+++ b/src/entity-context/bootstrap.ts
@@ -76,7 +76,7 @@ export async function bootstrapAgentIdentity(
       `INSERT INTO contacts (kg_node_id, display_name, role, status, created_at, updated_at)
        VALUES ($1, $2, 'agent', 'confirmed', now(), now())
        ON CONFLICT (kg_node_id) WHERE kg_node_id IS NOT NULL
-       DO UPDATE SET updated_at = now()
+       DO UPDATE SET role = 'agent', updated_at = now()
        RETURNING id`,
       [kgNodeId, displayName],
     );

--- a/src/entity-context/bootstrap.ts
+++ b/src/entity-context/bootstrap.ts
@@ -51,7 +51,7 @@ export async function bootstrapAgentIdentity(
       `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at)
        VALUES ('person', $1, $2, 1.0, 'permanent', 'bootstrap', now(), now())
        ON CONFLICT ((properties->>'is_agent')) WHERE (properties->>'is_agent') = 'true'
-       DO UPDATE SET last_confirmed_at = now()
+       DO UPDATE SET label = EXCLUDED.label, last_confirmed_at = now()
        RETURNING id`,
       [
         displayName,

--- a/src/entity-context/bootstrap.ts
+++ b/src/entity-context/bootstrap.ts
@@ -10,6 +10,10 @@
 // and contact record already exist, it verifies them and returns the existing IDs
 // without creating duplicates.
 //
+// Idempotency is guaranteed by two partial unique indexes added in migration 010:
+//   - idx_kg_nodes_agent_singleton on (properties->>'is_agent') WHERE = 'true'
+//   - idx_contacts_kg_node_unique on (kg_node_id) WHERE kg_node_id IS NOT NULL
+//
 // The returned contactId is injected into:
 //   - The coordinator's system prompt (so "you" resolves correctly)
 //   - The ExecutionLayer (for entity_enrichment default='agent')
@@ -25,8 +29,9 @@ export interface AgentIdentity {
 /**
  * Ensure Nathan's KG node and contact record exist, returning their IDs.
  *
- * Idempotent: safe to call on every startup. Uses SELECT + INSERT ... ON CONFLICT
- * to avoid race conditions between concurrent startup attempts.
+ * Idempotent: safe to call on every startup. The INSERT ... ON CONFLICT targets
+ * the partial unique indexes from migration 010 so concurrent startups
+ * cannot create duplicate agent records.
  *
  * @param displayName  The agent's display name (from persona config)
  * @param pool         Postgres connection pool
@@ -39,92 +44,50 @@ export async function bootstrapAgentIdentity(
 ): Promise<AgentIdentity> {
   // Step 1: Find or create the agent's KG node.
   // We identify the agent by a special property: is_agent = true.
-  // Using SELECT first, then INSERT ... ON CONFLICT, so we never overwrite an
-  // existing record even if two processes start simultaneously.
-  const existingNodeResult = await pool.query<{ id: string }>(
-    `SELECT id FROM kg_nodes
-     WHERE type = 'person'
-       AND (properties->>'is_agent')::boolean = true
-     LIMIT 1`,
-    [],
+  // The partial unique index idx_kg_nodes_agent_singleton (migration 010) ensures
+  // ON CONFLICT fires when a concurrent INSERT tries to create a second agent node.
+  const nodeResult = await pool.query<{ id: string }>(
+    `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at)
+     VALUES ('person', $1, $2, 1.0, 'permanent', 'bootstrap', now(), now())
+     ON CONFLICT ((properties->>'is_agent')) WHERE (properties->>'is_agent') = 'true'
+     DO UPDATE SET last_confirmed_at = now()
+     RETURNING id`,
+    [
+      displayName,
+      JSON.stringify({ is_agent: true }),
+    ],
   );
 
-  let kgNodeId: string;
-
-  if (existingNodeResult.rows.length > 0) {
-    kgNodeId = existingNodeResult.rows[0]!.id;
-    logger.debug({ kgNodeId }, 'agent-bootstrap: found existing agent KG node');
-  } else {
-    // Insert a new 'person' node for the agent.
-    // Confidence 1.0 + permanent decay: the agent's identity doesn't change.
-    const insertNodeResult = await pool.query<{ id: string }>(
-      `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at)
-       VALUES ('person', $1, $2, 1.0, 'permanent', 'bootstrap', now(), now())
-       ON CONFLICT DO NOTHING
-       RETURNING id`,
-      [
-        displayName,
-        JSON.stringify({ is_agent: true }),
-      ],
+  if (!nodeResult.rows[0]) {
+    throw new Error(
+      `agent-bootstrap: INSERT ... ON CONFLICT returned no rows for displayName="${displayName}" — ` +
+      'check that migration 010 was applied (idx_kg_nodes_agent_singleton must exist)',
     );
-
-    if (insertNodeResult.rows.length > 0) {
-      kgNodeId = insertNodeResult.rows[0]!.id;
-      logger.info({ kgNodeId, displayName }, 'agent-bootstrap: created agent KG node');
-    } else {
-      // ON CONFLICT fired — another process got there first. Re-read.
-      const retryResult = await pool.query<{ id: string }>(
-        `SELECT id FROM kg_nodes
-         WHERE type = 'person'
-           AND (properties->>'is_agent')::boolean = true
-         LIMIT 1`,
-        [],
-      );
-      if (!retryResult.rows[0]) {
-        throw new Error('agent-bootstrap: failed to find or create agent KG node');
-      }
-      kgNodeId = retryResult.rows[0].id;
-    }
   }
+  const kgNodeId = nodeResult.rows[0].id;
+  logger.debug({ kgNodeId, displayName }, 'agent-bootstrap: agent KG node ready');
 
   // Step 2: Find or create the agent's contact record linked to the KG node.
-  const existingContactResult = await pool.query<{ id: string }>(
-    'SELECT id FROM contacts WHERE kg_node_id = $1 LIMIT 1',
-    [kgNodeId],
+  // The partial unique index idx_contacts_kg_node_unique (migration 010) ensures
+  // ON CONFLICT fires when a concurrent INSERT tries to create a second contact for
+  // the same KG node.
+  const contactResult = await pool.query<{ id: string }>(
+    `INSERT INTO contacts (kg_node_id, display_name, role, status, created_at, updated_at)
+     VALUES ($1, $2, 'agent', 'confirmed', now(), now())
+     ON CONFLICT (kg_node_id) WHERE kg_node_id IS NOT NULL
+     DO UPDATE SET updated_at = now()
+     RETURNING id`,
+    [kgNodeId, displayName],
   );
 
-  let contactId: string;
-
-  if (existingContactResult.rows.length > 0) {
-    contactId = existingContactResult.rows[0]!.id;
-    logger.debug({ contactId, kgNodeId }, 'agent-bootstrap: found existing agent contact');
-  } else {
-    // Insert the contact record.
-    // Status 'confirmed' — the agent is always confirmed.
-    // role 'agent' — distinguishes it from human CEO/staff contacts.
-    const insertContactResult = await pool.query<{ id: string }>(
-      `INSERT INTO contacts (kg_node_id, display_name, role, status, created_at, updated_at)
-       VALUES ($1, $2, 'agent', 'confirmed', now(), now())
-       ON CONFLICT DO NOTHING
-       RETURNING id`,
-      [kgNodeId, displayName],
+  if (!contactResult.rows[0]) {
+    throw new Error(
+      `agent-bootstrap: INSERT ... ON CONFLICT returned no rows for kgNodeId="${kgNodeId}" — ` +
+      'check that migration 010 was applied (idx_contacts_kg_node_unique must exist)',
     );
-
-    if (insertContactResult.rows.length > 0) {
-      contactId = insertContactResult.rows[0]!.id;
-      logger.info({ contactId, kgNodeId, displayName }, 'agent-bootstrap: created agent contact record');
-    } else {
-      // ON CONFLICT fired — re-read.
-      const retryResult = await pool.query<{ id: string }>(
-        'SELECT id FROM contacts WHERE kg_node_id = $1 LIMIT 1',
-        [kgNodeId],
-      );
-      if (!retryResult.rows[0]) {
-        throw new Error('agent-bootstrap: failed to find or create agent contact record');
-      }
-      contactId = retryResult.rows[0].id;
-    }
   }
+  const contactId = contactResult.rows[0].id;
+  logger.info({ contactId, kgNodeId, displayName }, 'agent-bootstrap: agent identity ready');
 
   return { kgNodeId, contactId };
 }

--- a/src/entity-context/bootstrap.ts
+++ b/src/entity-context/bootstrap.ts
@@ -1,0 +1,130 @@
+// src/entity-context/bootstrap.ts
+//
+// Agent self-identity bootstrap.
+//
+// Nathan Curia (the agent) is an entity like any other person — it has a KG node,
+// a contact record, and connected accounts. This lets "your calendar" resolve the
+// same way as "Jenna's calendar" through the entity-context system.
+//
+// This module is called once at startup. It is idempotent: if the agent's KG node
+// and contact record already exist, it verifies them and returns the existing IDs
+// without creating duplicates.
+//
+// The returned contactId is injected into:
+//   - The coordinator's system prompt (so "you" resolves correctly)
+//   - The ExecutionLayer (for entity_enrichment default='agent')
+
+import type { DbPool } from '../db/connection.js';
+import type { Logger } from '../logger.js';
+
+export interface AgentIdentity {
+  kgNodeId: string;
+  contactId: string;
+}
+
+/**
+ * Ensure Nathan's KG node and contact record exist, returning their IDs.
+ *
+ * Idempotent: safe to call on every startup. Uses SELECT + INSERT ... ON CONFLICT
+ * to avoid race conditions between concurrent startup attempts.
+ *
+ * @param displayName  The agent's display name (from persona config)
+ * @param pool         Postgres connection pool
+ * @param logger       Pino logger
+ */
+export async function bootstrapAgentIdentity(
+  displayName: string,
+  pool: DbPool,
+  logger: Logger,
+): Promise<AgentIdentity> {
+  // Step 1: Find or create the agent's KG node.
+  // We identify the agent by a special property: is_agent = true.
+  // Using SELECT first, then INSERT ... ON CONFLICT, so we never overwrite an
+  // existing record even if two processes start simultaneously.
+  const existingNodeResult = await pool.query<{ id: string }>(
+    `SELECT id FROM kg_nodes
+     WHERE type = 'person'
+       AND (properties->>'is_agent')::boolean = true
+     LIMIT 1`,
+    [],
+  );
+
+  let kgNodeId: string;
+
+  if (existingNodeResult.rows.length > 0) {
+    kgNodeId = existingNodeResult.rows[0]!.id;
+    logger.debug({ kgNodeId }, 'agent-bootstrap: found existing agent KG node');
+  } else {
+    // Insert a new 'person' node for the agent.
+    // Confidence 1.0 + permanent decay: the agent's identity doesn't change.
+    const insertNodeResult = await pool.query<{ id: string }>(
+      `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at)
+       VALUES ('person', $1, $2, 1.0, 'permanent', 'bootstrap', now(), now())
+       ON CONFLICT DO NOTHING
+       RETURNING id`,
+      [
+        displayName,
+        JSON.stringify({ is_agent: true }),
+      ],
+    );
+
+    if (insertNodeResult.rows.length > 0) {
+      kgNodeId = insertNodeResult.rows[0]!.id;
+      logger.info({ kgNodeId, displayName }, 'agent-bootstrap: created agent KG node');
+    } else {
+      // ON CONFLICT fired — another process got there first. Re-read.
+      const retryResult = await pool.query<{ id: string }>(
+        `SELECT id FROM kg_nodes
+         WHERE type = 'person'
+           AND (properties->>'is_agent')::boolean = true
+         LIMIT 1`,
+        [],
+      );
+      if (!retryResult.rows[0]) {
+        throw new Error('agent-bootstrap: failed to find or create agent KG node');
+      }
+      kgNodeId = retryResult.rows[0].id;
+    }
+  }
+
+  // Step 2: Find or create the agent's contact record linked to the KG node.
+  const existingContactResult = await pool.query<{ id: string }>(
+    'SELECT id FROM contacts WHERE kg_node_id = $1 LIMIT 1',
+    [kgNodeId],
+  );
+
+  let contactId: string;
+
+  if (existingContactResult.rows.length > 0) {
+    contactId = existingContactResult.rows[0]!.id;
+    logger.debug({ contactId, kgNodeId }, 'agent-bootstrap: found existing agent contact');
+  } else {
+    // Insert the contact record.
+    // Status 'confirmed' — the agent is always confirmed.
+    // role 'agent' — distinguishes it from human CEO/staff contacts.
+    const insertContactResult = await pool.query<{ id: string }>(
+      `INSERT INTO contacts (kg_node_id, display_name, role, status, created_at, updated_at)
+       VALUES ($1, $2, 'agent', 'confirmed', now(), now())
+       ON CONFLICT DO NOTHING
+       RETURNING id`,
+      [kgNodeId, displayName],
+    );
+
+    if (insertContactResult.rows.length > 0) {
+      contactId = insertContactResult.rows[0]!.id;
+      logger.info({ contactId, kgNodeId, displayName }, 'agent-bootstrap: created agent contact record');
+    } else {
+      // ON CONFLICT fired — re-read.
+      const retryResult = await pool.query<{ id: string }>(
+        'SELECT id FROM contacts WHERE kg_node_id = $1 LIMIT 1',
+        [kgNodeId],
+      );
+      if (!retryResult.rows[0]) {
+        throw new Error('agent-bootstrap: failed to find or create agent contact record');
+      }
+      contactId = retryResult.rows[0].id;
+    }
+  }
+
+  return { kgNodeId, contactId };
+}

--- a/src/entity-context/types.ts
+++ b/src/entity-context/types.ts
@@ -1,0 +1,97 @@
+// src/entity-context/types.ts
+//
+// EntityContext payload — the single structured object the entity-context
+// system hands to skills and agents. Assembles KG facts, connected accounts,
+// contact record, and first-degree relationships into one place.
+//
+// Design: context is a hint, not a gate. Missing fields mean the LLM should
+// reason about how to proceed (e.g., search elsewhere), not hard-fail.
+
+/**
+ * Full context payload for a single entity (person, org, event, etc.).
+ * Assembled from the KG, contacts table, and connected-accounts tables.
+ */
+export interface EntityContext {
+  /** The KG node ID for this entity */
+  entityId: string;
+
+  /** KG node type: 'person', 'organization', 'event', etc. */
+  entityType: string;
+
+  /** Human-readable label from the KG node */
+  label: string;
+
+  /** Contact record — only populated for person entities that have a contact record */
+  contact: {
+    contactId: string;
+    displayName: string;
+    role: string | null;
+  } | null;
+
+  /** Known facts from the KG, grouped by category.
+   *  Facts include confidence and freshness metadata so the consumer
+   *  can weigh how much to trust them. */
+  facts: EntityFact[];
+
+  /** Connected accounts: calendars, email accounts, integrations.
+   *  Structured resources with service-level identifiers. */
+  connectedAccounts: ConnectedAccount[];
+
+  /** First-degree KG relationships — useful for understanding context:
+   *  "Jenna works at Acme", "Dreamforce is hosted by Salesforce", etc. */
+  relationships: EntityRelationship[];
+}
+
+/**
+ * A single fact stored in the KG about an entity.
+ * Facts are KG nodes of type 'fact' linked to the entity via 'relates_to' edges.
+ */
+export interface EntityFact {
+  /** Fact label, e.g. "timezone", "Aeroplan number", "scheduling preference" */
+  label: string;
+  /** Fact value — whatever the agent stored in the fact node's properties.value */
+  value: unknown;
+  /** Category for grouping — convention-driven, not an enum.
+   *  Common values: 'preference', 'identifier', 'location', 'biographical',
+   *  'scheduling', 'faith', 'travel', 'financial'. */
+  category: string;
+  /** Confidence score (0–1) from the KG temporal metadata */
+  confidence: number;
+  /** ISO string: when this fact was last confirmed */
+  lastConfirmedAt: string;
+}
+
+/**
+ * A connected account linking an entity to an external service.
+ * Today: contact_calendars. Future: contact_email_accounts, contact_integrations.
+ */
+export interface ConnectedAccount {
+  /** Account type: 'calendar', 'email', 'crm', etc. */
+  type: string;
+  /** Human-readable label, e.g. "Work calendar", "Personal Gmail" */
+  label: string;
+  /** Service-specific identifier (Nylas calendar ID, email address, etc.) */
+  serviceId: string;
+  /** Whether this is the primary account of its type for this entity */
+  isPrimary: boolean;
+  /** Whether the account is read-only */
+  readOnly: boolean;
+  /** Additional metadata: timezone for calendars, signatures for email, etc. */
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * A first-degree KG relationship between the entity and another KG node.
+ */
+export interface EntityRelationship {
+  /** Edge type: 'works_on', 'relates_to', 'attended', etc. */
+  type: string;
+  /** Direction relative to this entity: outbound = this → target; inbound = source → this */
+  direction: 'outbound' | 'inbound';
+  /** The related entity's KG node ID */
+  relatedEntityId: string;
+  /** The related entity's human-readable label */
+  relatedEntityLabel: string;
+  /** The related entity's KG node type */
+  relatedEntityType: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,9 +175,11 @@ async function main(): Promise<void> {
     agentIdentityContactId = agentIdentity.contactId;
     logger.info({ contactId: agentIdentityContactId }, 'Agent self-identity ready');
   } catch (err) {
-    // Non-fatal: warn and continue. Entity enrichment for "your" references will
-    // degrade (return empty context) but won't crash the system.
-    logger.warn({ err }, 'Agent self-identity bootstrap failed — entity_enrichment default=agent will not resolve');
+    // Non-fatal: warn and continue. Three things degrade:
+    // 1. entity_enrichment default='agent' will return no results
+    // 2. The coordinator's ${agent_contact_id} prompt placeholder will be empty
+    // 3. Interactive entity-context lookups for "you"/"your" will fail to resolve
+    logger.warn({ err }, 'Agent self-identity bootstrap failed — entity_enrichment default=agent will not resolve; coordinator system prompt ${agent_contact_id} will be empty');
   }
 
   // Held messages — stores messages from unknown senders pending CEO review.

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,8 @@ import { OutboundContentFilter } from './dispatch/outbound-filter.js';
 import { OutboundGateway } from './skills/outbound-gateway.js';
 import { SchedulerService } from './scheduler/scheduler-service.js';
 import { Scheduler } from './scheduler/scheduler.js';
+import { EntityContextAssembler } from './entity-context/assembler.js';
+import { bootstrapAgentIdentity } from './entity-context/bootstrap.js';
 import type { AgentPersona } from './skills/types.js';
 
 async function main(): Promise<void> {
@@ -156,6 +158,27 @@ async function main(): Promise<void> {
 
   const contactResolver = new ContactResolver(contactService, entityMemory, authService, logger);
   logger.info('Contact system initialized');
+
+  // Entity context assembler — assembles EntityContext payloads from the KG, contacts,
+  // and connected accounts. Created here (after contact system) so it can query the DB
+  // for facts, calendars, and relationships. Passed to ExecutionLayer for pre-enrichment.
+  const entityContextAssembler = new EntityContextAssembler(pool, logger);
+
+  // Agent self-identity — seed Nathan's KG node and contact record at startup.
+  // Idempotent: safe to call every startup (uses INSERT ... ON CONFLICT).
+  // Fatal on failure: without a contactId, "your calendar" cannot be resolved
+  // and entity_enrichment default='agent' would silently produce no results.
+  let agentIdentityContactId: string | undefined;
+  const agentDisplayName = 'Nathan Curia'; // @TODO: read from coordinatorConfig.persona.display_name after agentConfigs are loaded
+  try {
+    const agentIdentity = await bootstrapAgentIdentity(agentDisplayName, pool, logger);
+    agentIdentityContactId = agentIdentity.contactId;
+    logger.info({ contactId: agentIdentityContactId }, 'Agent self-identity ready');
+  } catch (err) {
+    // Non-fatal: warn and continue. Entity enrichment for "your" references will
+    // degrade (return empty context) but won't crash the system.
+    logger.warn({ err }, 'Agent self-identity bootstrap failed — entity_enrichment default=agent will not resolve');
+  }
 
   // Held messages — stores messages from unknown senders pending CEO review.
   const heldMessages = HeldMessageService.createWithPostgres(pool, logger);
@@ -307,7 +330,9 @@ async function main(): Promise<void> {
 
   // Execution layer — now with bus, agent registry, and outbound gateway for
   // infrastructure skills. outboundGateway gives email skills their send path.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient });
+  // entityContextAssembler enables entity_enrichment pre-enrichment and the
+  // entity-context skill. agentContactId enables entity_enrichment default='agent'.
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete
@@ -353,6 +378,7 @@ async function main(): Promise<void> {
         availableSpecialists: agentRegistry.specialistSummary(),
         currentDate,
         timezone: config.timezone,
+        agentContactId: agentIdentityContactId,
       });
     }
 

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -209,6 +209,14 @@ export class ExecutionLayer {
     // Entity enrichment: if the manifest declares entity_enrichment, pre-assemble
     // EntityContext before invoking the handler. This makes enrichment deterministic
     // and invisible to the LLM — it never sees raw calendar IDs or KG node IDs.
+    if (manifest.entity_enrichment && !this.entityContextAssembler) {
+      // A skill declared entity_enrichment but the assembler was not wired in —
+      // this is a configuration mistake, not a designed degradation path.
+      skillLogger.warn(
+        { skillName },
+        'entity_enrichment declared in manifest but EntityContextAssembler not configured — skipping pre-enrichment; ctx.entityContext will be undefined',
+      );
+    }
     if (manifest.entity_enrichment && this.entityContextAssembler) {
       const enrichment = manifest.entity_enrichment;
       const rawIds = input[enrichment.param];

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -199,11 +199,15 @@ export class ExecutionLayer {
       if (this.nylasCalendarClient) {
         ctx.nylasCalendarClient = this.nylasCalendarClient;
       }
-      // entityContextAssembler — available to infrastructure skills for the
-      // entity-context skill and other advanced use cases
-      if (this.entityContextAssembler) {
-        ctx.entityContextAssembler = this.entityContextAssembler;
-      }
+    }
+
+    // entityContextAssembler — available to ALL skills (not just infrastructure).
+    // The assembler is a read-only DB pipeline; granting it unconditionally is no
+    // more privileged than contactService. Keeping it outside the infrastructure
+    // block means the entity-context skill does not need infrastructure: true,
+    // which would otherwise grant it full bus/registry access it doesn't need.
+    if (this.entityContextAssembler) {
+      ctx.entityContextAssembler = this.entityContextAssembler;
     }
 
     // Entity enrichment: if the manifest declares entity_enrichment, pre-assemble

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -243,12 +243,25 @@ export class ExecutionLayer {
 
       if (idsToEnrich.length > 0) {
         try {
-          const { entities, unresolved } = await this.entityContextAssembler.assembleMany(idsToEnrich, { includeRelationships: true });
-          if (unresolved.length > 0) {
-            skillLogger.warn({ skillName, unresolved }, 'entity_enrichment: some IDs could not be resolved');
+          // Run assembleMany under the same timeout budget as the skill itself.
+          // Without this, a hung DB query in the assembler would block indefinitely
+          // because the invocation timeout race (further below) hasn't been set up yet.
+          let enrichmentTimer: NodeJS.Timeout | undefined;
+          const enrichmentResult = await Promise.race([
+            this.entityContextAssembler.assembleMany(idsToEnrich, { includeRelationships: true }),
+            new Promise<never>((_, reject) => {
+              enrichmentTimer = setTimeout(
+                () => reject(new Error(`entity_enrichment timed out after ${manifest.timeout}ms`)),
+                manifest.timeout,
+              );
+            }),
+          ]).finally(() => { clearTimeout(enrichmentTimer); });
+
+          if (enrichmentResult.unresolved.length > 0) {
+            skillLogger.warn({ skillName, unresolved: enrichmentResult.unresolved }, 'entity_enrichment: some IDs could not be resolved');
           }
-          ctx.entityContext = entities;
-          skillLogger.debug({ skillName, enrichedCount: entities.length }, 'entity_enrichment: pre-enrichment complete');
+          ctx.entityContext = enrichmentResult.entities;
+          skillLogger.debug({ skillName, enrichedCount: enrichmentResult.entities.length }, 'entity_enrichment: pre-enrichment complete');
         } catch (err) {
           // Non-fatal: log and continue without ctx.entityContext.
           // The handler should check ctx.entityContext and handle its absence gracefully.

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -11,6 +11,11 @@
 // bus and agent registry access. This effectively grants unrestricted bus
 // publish/subscribe including layer impersonation. Only framework-internal
 // skills like 'delegate' should use this — it is a privileged escape hatch.
+//
+// Entity enrichment (manifest.entity_enrichment): when a skill declares this,
+// the execution layer assembles EntityContext for the declared input parameter
+// before invoking the handler. The handler receives ctx.entityContext[] and
+// never needs to call entity-context itself.
 
 import type { SkillResult, SkillContext, CallerContext, AgentPersona } from './types.js';
 import type { SkillRegistry } from './registry.js';
@@ -24,6 +29,7 @@ import type { HeldMessageService } from '../contacts/held-messages.js';
 import type { SchedulerService } from '../scheduler/scheduler-service.js';
 import type { EntityMemory } from '../memory/entity-memory.js';
 import type { NylasCalendarClient } from '../channels/calendar/nylas-calendar-client.js';
+import type { EntityContextAssembler } from '../entity-context/assembler.js';
 
 // Warn (but don't truncate) when a skill returns more than this many chars.
 // Helps operators spot skills that might blow out the LLM context window.
@@ -41,8 +47,23 @@ export class ExecutionLayer {
   private entityMemory?: EntityMemory;
   private agentPersona?: AgentPersona;
   private nylasCalendarClient?: NylasCalendarClient;
+  private entityContextAssembler?: EntityContextAssembler;
+  /** The agent's own contactId — injected into ctx.agentContactId for entity_enrichment default='agent' */
+  private agentContactId?: string;
 
-  constructor(registry: SkillRegistry, logger: Logger, options?: { bus?: EventBus; agentRegistry?: AgentRegistry; contactService?: ContactService; outboundGateway?: OutboundGateway; heldMessages?: HeldMessageService; schedulerService?: SchedulerService; entityMemory?: EntityMemory; agentPersona?: AgentPersona; nylasCalendarClient?: NylasCalendarClient }) {
+  constructor(registry: SkillRegistry, logger: Logger, options?: {
+    bus?: EventBus;
+    agentRegistry?: AgentRegistry;
+    contactService?: ContactService;
+    outboundGateway?: OutboundGateway;
+    heldMessages?: HeldMessageService;
+    schedulerService?: SchedulerService;
+    entityMemory?: EntityMemory;
+    agentPersona?: AgentPersona;
+    nylasCalendarClient?: NylasCalendarClient;
+    entityContextAssembler?: EntityContextAssembler;
+    agentContactId?: string;
+  }) {
     this.registry = registry;
     this.logger = logger;
     this.bus = options?.bus;
@@ -54,6 +75,16 @@ export class ExecutionLayer {
     this.entityMemory = options?.entityMemory;
     this.agentPersona = options?.agentPersona;
     this.nylasCalendarClient = options?.nylasCalendarClient;
+    this.entityContextAssembler = options?.entityContextAssembler;
+    this.agentContactId = options?.agentContactId;
+  }
+
+  /**
+   * Update the agent's own contactId after bootstrap has seeded it.
+   * Called from index.ts once the agent self-identity is resolved.
+   */
+  setAgentContactId(contactId: string): void {
+    this.agentContactId = contactId;
   }
 
   /**
@@ -62,9 +93,10 @@ export class ExecutionLayer {
    * Steps:
    * 1. Resolve the skill from the registry
    * 2. Build a sandboxed SkillContext with scoped secret access
-   * 3. Execute the handler with a timeout
-   * 4. Sanitize the output (strip injection vectors, redact secrets, truncate)
-   * 5. Return the result
+   * 3. If manifest declares entity_enrichment, pre-assemble EntityContext
+   * 4. Execute the handler with a timeout
+   * 5. Sanitize the output (strip injection vectors, redact secrets, truncate)
+   * 6. Return the result
    *
    * Never throws — always returns a SkillResult.
    */
@@ -123,6 +155,7 @@ export class ExecutionLayer {
       log: skillLogger,
       agentPersona: this.agentPersona,
       caller,
+      agentContactId: this.agentContactId,
       // contactService is available to all skills — read-only contact lookups
       // (calendars, display names, etc.) are not a privilege escalation.
       contactService: this.contactService,
@@ -165,6 +198,50 @@ export class ExecutionLayer {
       // nylasCalendarClient is optional — only calendar skills need it
       if (this.nylasCalendarClient) {
         ctx.nylasCalendarClient = this.nylasCalendarClient;
+      }
+      // entityContextAssembler — available to infrastructure skills for the
+      // entity-context skill and other advanced use cases
+      if (this.entityContextAssembler) {
+        ctx.entityContextAssembler = this.entityContextAssembler;
+      }
+    }
+
+    // Entity enrichment: if the manifest declares entity_enrichment, pre-assemble
+    // EntityContext before invoking the handler. This makes enrichment deterministic
+    // and invisible to the LLM — it never sees raw calendar IDs or KG node IDs.
+    if (manifest.entity_enrichment && this.entityContextAssembler) {
+      const enrichment = manifest.entity_enrichment;
+      const rawIds = input[enrichment.param];
+
+      // Resolve the IDs to enrich: explicit input > default (caller/agent)
+      let idsToEnrich: string[] = [];
+      if (Array.isArray(rawIds) && rawIds.length > 0) {
+        idsToEnrich = rawIds.filter((id): id is string => typeof id === 'string');
+      } else {
+        // Use the declared default
+        if (enrichment.default === 'caller' && caller?.contactId) {
+          idsToEnrich = [caller.contactId];
+        } else if (enrichment.default === 'agent' && this.agentContactId) {
+          idsToEnrich = [this.agentContactId];
+        } else {
+          // No IDs to enrich — log and continue without pre-enrichment
+          skillLogger.debug({ skillName, enrichmentDefault: enrichment.default }, 'entity_enrichment: no IDs to resolve, skipping pre-enrichment');
+        }
+      }
+
+      if (idsToEnrich.length > 0) {
+        try {
+          const { entities, unresolved } = await this.entityContextAssembler.assembleMany(idsToEnrich, { includeRelationships: true });
+          if (unresolved.length > 0) {
+            skillLogger.warn({ skillName, unresolved }, 'entity_enrichment: some IDs could not be resolved');
+          }
+          ctx.entityContext = entities;
+          skillLogger.debug({ skillName, enrichedCount: entities.length }, 'entity_enrichment: pre-enrichment complete');
+        } catch (err) {
+          // Non-fatal: log and continue without ctx.entityContext.
+          // The handler should check ctx.entityContext and handle its absence gracefully.
+          skillLogger.error({ err, skillName }, 'entity_enrichment: pre-enrichment failed, continuing without entity context');
+        }
       }
     }
 

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -31,6 +31,19 @@ export interface SkillManifest {
    *  This grants unrestricted bus publish/subscribe including layer impersonation.
    *  Only for framework-internal skills like 'delegate' — external skills should never set this. */
   infrastructure?: boolean;
+  /** Declares that the execution layer should automatically assemble entity context
+   *  before invoking this skill's handler. The assembled EntityContext[] is injected
+   *  into ctx.entityContext so the handler doesn't need to call entity-context directly.
+   *
+   *  param:    the input key containing the list of contact/entity IDs to enrich.
+   *  default:  what to use when that input is not provided:
+   *              'caller' → ctx.caller.contactId
+   *              'agent'  → the seeded agent contactId (ctx.agentContactId)
+   */
+  entity_enrichment?: {
+    param: string;
+    default: 'caller' | 'agent';
+  };
 }
 
 /**
@@ -106,6 +119,17 @@ export interface SkillContext {
    *  Guaranteed to be defined for elevated skills (execution layer rejects without it).
    *  Available but optional for normal skills. */
   caller?: CallerContext;
+  /** Entity context assembler — available to infrastructure skills.
+   *  Used by the entity-context skill to assemble EntityContext payloads on demand.
+   *  Also used by the execution layer for entity_enrichment pre-enrichment. */
+  entityContextAssembler?: import('../entity-context/assembler.js').EntityContextAssembler;
+  /** Pre-assembled entity context — populated automatically by the execution layer
+   *  when the skill's manifest declares entity_enrichment. Skills that declare
+   *  entity_enrichment receive this instead of calling entity-context themselves. */
+  entityContext?: import('../entity-context/types.js').EntityContext[];
+  /** The agent's own contactId — used by entity_enrichment when default is 'agent'.
+   *  Seeded at bootstrap and injected by the execution layer. */
+  agentContactId?: string;
 }
 
 /**

--- a/tests/unit/entity-context/assembler.test.ts
+++ b/tests/unit/entity-context/assembler.test.ts
@@ -3,7 +3,7 @@
 // Unit tests for EntityContextAssembler.
 // Uses a mock DB pool — no real database required.
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import pino from 'pino';
 import { EntityContextAssembler } from '../../../src/entity-context/assembler.js';
 import type { DbPool } from '../../../src/db/connection.js';
@@ -28,7 +28,12 @@ function makeSequentialPool(responses: Array<{ rows: unknown[] }>): DbPool {
   const pool = makeMockPool();
   let callIndex = 0;
   vi.mocked(pool.query).mockImplementation(() => {
-    const res = responses[callIndex++] ?? { rows: [] };
+    const res = responses[callIndex++];
+    if (!res) {
+      // Throw so tests fail fast when the assembler issues more queries than expected.
+      // A silent empty-rows fallback would mask regressions where extra DB calls are added.
+      throw new Error(`Unexpected query call #${callIndex} — add a response to makeSequentialPool`);
+    }
     return Promise.resolve(res as ReturnType<DbPool['query']>);
   });
   return pool;

--- a/tests/unit/entity-context/assembler.test.ts
+++ b/tests/unit/entity-context/assembler.test.ts
@@ -1,0 +1,340 @@
+// tests/unit/entity-context/assembler.test.ts
+//
+// Unit tests for EntityContextAssembler.
+// Uses a mock DB pool — no real database required.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import pino from 'pino';
+import { EntityContextAssembler } from '../../../src/entity-context/assembler.js';
+import type { DbPool } from '../../../src/db/connection.js';
+
+const logger = pino({ level: 'silent' });
+
+// -- Minimal mock pool --
+// query() is a vi.fn() so tests can stub return values per query.
+
+function makeMockPool(): DbPool {
+  return {
+    query: vi.fn(),
+    end: vi.fn(),
+    connect: vi.fn(),
+    on: vi.fn(),
+  } as unknown as DbPool;
+}
+
+// Helper: build a pool mock that responds to queries in order.
+// Each call to pool.query() returns the next response in the queue.
+function makeSequentialPool(responses: Array<{ rows: unknown[] }>): DbPool {
+  const pool = makeMockPool();
+  let callIndex = 0;
+  vi.mocked(pool.query).mockImplementation(() => {
+    const res = responses[callIndex++] ?? { rows: [] };
+    return Promise.resolve(res as ReturnType<DbPool['query']>);
+  });
+  return pool;
+}
+
+// -- KG node row fixture --
+const personNodeRow = {
+  id: 'node-1',
+  type: 'person',
+  label: 'Jenna Smith',
+  properties: {},
+};
+
+// -- Fact node row fixture --
+const timezoneFactRow = {
+  label: 'timezone',
+  properties: { value: 'America/Vancouver', category: 'scheduling' },
+  confidence: 0.9,
+  last_confirmed_at: new Date('2026-01-01T00:00:00Z'),
+};
+
+// -- Contact row fixture --
+const contactRow = {
+  id: 'contact-1',
+  display_name: 'Jenna Smith',
+  role: null,
+};
+
+// -- Calendar row fixture --
+const calendarRow = {
+  nylas_calendar_id: 'cal-abc',
+  label: 'Work Calendar',
+  is_primary: true,
+  read_only: false,
+  timezone: 'America/Vancouver',
+};
+
+// -- Relationship row fixture --
+const relationshipRow = {
+  edge_type: 'works_on',
+  direction: 'outbound',
+  related_id: 'node-2',
+  related_label: 'Acme Corp',
+  related_type: 'organization',
+};
+
+describe('EntityContextAssembler', () => {
+  describe('assembleOne — person entity via contact ID', () => {
+    it('assembles a full EntityContext for a person with facts and calendars', async () => {
+      // Queries in order:
+      // 1. resolveKgNodeId: contact ID lookup → returns kg_node_id
+      // 2. getKgNode: node lookup
+      // 3. getFacts: two-part UNION (returns 1 fact via first half)
+      // 4. getContactByKgNodeId
+      // 5. getConnectedAccounts (calendars)
+      // 6. getRelationships: two-part UNION (returns 1 relationship)
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: 'node-1' }] },   // resolveKgNodeId: contact found
+        { rows: [personNodeRow] },                // getKgNode
+        { rows: [timezoneFactRow] },              // getFacts (UNION result)
+        { rows: [contactRow] },                   // getContactByKgNodeId
+        { rows: [calendarRow] },                  // getConnectedAccounts
+        { rows: [relationshipRow] },              // getRelationships (UNION result)
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const ctx = await assembler.assembleOne('contact-1');
+
+      expect(ctx).toBeDefined();
+      expect(ctx!.entityId).toBe('node-1');
+      expect(ctx!.entityType).toBe('person');
+      expect(ctx!.label).toBe('Jenna Smith');
+
+      // Contact record
+      expect(ctx!.contact).toEqual({
+        contactId: 'contact-1',
+        displayName: 'Jenna Smith',
+        role: null,
+      });
+
+      // Facts
+      expect(ctx!.facts).toHaveLength(1);
+      expect(ctx!.facts[0].label).toBe('timezone');
+      expect(ctx!.facts[0].value).toBe('America/Vancouver');
+      expect(ctx!.facts[0].category).toBe('scheduling');
+      expect(ctx!.facts[0].confidence).toBe(0.9);
+
+      // Connected accounts
+      expect(ctx!.connectedAccounts).toHaveLength(1);
+      expect(ctx!.connectedAccounts[0].type).toBe('calendar');
+      expect(ctx!.connectedAccounts[0].serviceId).toBe('cal-abc');
+      expect(ctx!.connectedAccounts[0].isPrimary).toBe(true);
+      expect(ctx!.connectedAccounts[0].metadata).toEqual({ timezone: 'America/Vancouver' });
+
+      // Relationships
+      expect(ctx!.relationships).toHaveLength(1);
+      expect(ctx!.relationships[0].type).toBe('works_on');
+      expect(ctx!.relationships[0].direction).toBe('outbound');
+      expect(ctx!.relationships[0].relatedEntityLabel).toBe('Acme Corp');
+    });
+
+    it('returns undefined when the contact has no linked KG node', async () => {
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: null }] }, // contact found, but no KG node
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const ctx = await assembler.assembleOne('contact-1');
+      expect(ctx).toBeUndefined();
+    });
+
+    it('returns undefined when the ID does not match any contact or KG node', async () => {
+      const pool = makeSequentialPool([
+        { rows: [] }, // not a contact
+        { rows: [] }, // not a KG node
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const ctx = await assembler.assembleOne('unknown-id');
+      expect(ctx).toBeUndefined();
+    });
+  });
+
+  describe('assembleOne — entity via KG node ID directly', () => {
+    it('resolves a KG node ID directly when not a contact', async () => {
+      // Non-person entity (org) — no contact record, no connected accounts
+      const orgNodeRow = {
+        id: 'node-org',
+        type: 'organization',
+        label: 'Acme Corp',
+        properties: {},
+      };
+
+      const pool = makeSequentialPool([
+        { rows: [] },            // not a contact
+        { rows: [{ id: 'node-org' }] }, // is a KG node
+        { rows: [orgNodeRow] },  // getKgNode
+        { rows: [] },            // getFacts (empty)
+        { rows: [] },            // getContactByKgNodeId (no contact)
+        // no getConnectedAccounts call since contactRow is undefined
+        { rows: [] },            // getRelationships (empty)
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const ctx = await assembler.assembleOne('node-org');
+
+      expect(ctx).toBeDefined();
+      expect(ctx!.entityId).toBe('node-org');
+      expect(ctx!.entityType).toBe('organization');
+      expect(ctx!.contact).toBeNull();
+      expect(ctx!.connectedAccounts).toHaveLength(0);
+    });
+  });
+
+  describe('assembleMany', () => {
+    it('returns entities and empty unresolved when all IDs resolve', async () => {
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: 'node-1' }] },
+        { rows: [personNodeRow] },
+        { rows: [] },          // facts
+        { rows: [contactRow] },
+        { rows: [] },          // calendars
+        { rows: [] },          // relationships
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities, unresolved } = await assembler.assembleMany(['contact-1']);
+
+      expect(entities).toHaveLength(1);
+      expect(unresolved).toHaveLength(0);
+    });
+
+    it('puts unresolvable IDs into unresolved array', async () => {
+      const pool = makeSequentialPool([
+        { rows: [] }, // not a contact
+        { rows: [] }, // not a KG node
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities, unresolved } = await assembler.assembleMany(['ghost-id']);
+
+      expect(entities).toHaveLength(0);
+      expect(unresolved).toEqual(['ghost-id']);
+    });
+  });
+
+  describe('TTL cache', () => {
+    // Cache is keyed by the input ID in assembleMany. Direct assembleOne()
+    // calls bypass the cache — the cache only applies when going through assembleMany().
+
+    it('returns cached result on second assembleMany call without hitting DB again', async () => {
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: 'node-1' }] },
+        { rows: [personNodeRow] },
+        { rows: [] },
+        { rows: [contactRow] },
+        { rows: [] },
+        { rows: [] },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+
+      // First call — hits DB
+      await assembler.assembleMany(['contact-1']);
+      const callsAfterFirst = vi.mocked(pool.query).mock.calls.length;
+
+      // Second call — should hit cache, no additional DB queries
+      await assembler.assembleMany(['contact-1']);
+      expect(vi.mocked(pool.query).mock.calls.length).toBe(callsAfterFirst);
+    });
+
+    it('clears cache for entity on clearCacheForEntity()', async () => {
+      const pool = makeSequentialPool([
+        // First assembly
+        { rows: [{ kg_node_id: 'node-1' }] },
+        { rows: [personNodeRow] },
+        { rows: [] },
+        { rows: [contactRow] },
+        { rows: [] },
+        { rows: [] },
+        // Second assembly after cache clear
+        { rows: [{ kg_node_id: 'node-1' }] },
+        { rows: [personNodeRow] },
+        { rows: [] },
+        { rows: [contactRow] },
+        { rows: [] },
+        { rows: [] },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+
+      await assembler.assembleMany(['contact-1']);
+      const callsAfterFirst = vi.mocked(pool.query).mock.calls.length;
+
+      assembler.clearCacheForEntity('contact-1');
+
+      // After clearing, next call should hit DB again
+      await assembler.assembleMany(['contact-1']);
+      expect(vi.mocked(pool.query).mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    });
+  });
+
+  describe('includeRelationships=false', () => {
+    it('skips relationship query when includeRelationships is false', async () => {
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: 'node-1' }] },
+        { rows: [personNodeRow] },
+        { rows: [] },          // facts
+        { rows: [contactRow] },
+        { rows: [] },          // calendars
+        // no relationship query
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities } = await assembler.assembleMany(['contact-1'], { includeRelationships: false });
+
+      expect(entities).toHaveLength(1);
+      expect(entities[0].relationships).toHaveLength(0);
+    });
+  });
+
+  describe('fact value extraction', () => {
+    it('extracts value from fact properties', async () => {
+      const factWithComplexValue = {
+        label: 'dietary preferences',
+        properties: { value: ['vegetarian', 'gluten-free'], category: 'preference' },
+        confidence: 0.8,
+        last_confirmed_at: new Date('2026-01-01T00:00:00Z'),
+      };
+
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: 'node-1' }] },
+        { rows: [personNodeRow] },
+        { rows: [factWithComplexValue] },
+        { rows: [contactRow] },
+        { rows: [] },
+        { rows: [] },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const ctx = await assembler.assembleOne('contact-1');
+
+      expect(ctx!.facts[0].value).toEqual(['vegetarian', 'gluten-free']);
+      expect(ctx!.facts[0].category).toBe('preference');
+    });
+
+    it('falls back to "unknown" category when not present', async () => {
+      const factNoCategory = {
+        label: 'loyalty number',
+        properties: { value: 'ABC123' }, // no category field
+        confidence: 1.0,
+        last_confirmed_at: new Date('2026-01-01T00:00:00Z'),
+      };
+
+      const pool = makeSequentialPool([
+        { rows: [{ kg_node_id: 'node-1' }] },
+        { rows: [personNodeRow] },
+        { rows: [factNoCategory] },
+        { rows: [contactRow] },
+        { rows: [] },
+        { rows: [] },
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const ctx = await assembler.assembleOne('contact-1');
+      expect(ctx!.facts[0].category).toBe('unknown');
+    });
+  });
+});

--- a/tests/unit/entity-context/execution-enrichment.test.ts
+++ b/tests/unit/entity-context/execution-enrichment.test.ts
@@ -78,8 +78,8 @@ describe('ExecutionLayer — entity_enrichment', () => {
     await execution.invoke('test-skill', { contacts: ['contact-1'] });
 
     expect(capturedCtx?.entityContext).toBeDefined();
-    expect(capturedCtx!.entityContext).toHaveLength(1);
-    expect(capturedCtx!.entityContext![0].entityId).toBe('node-1');
+    expect(capturedCtx?.entityContext).toHaveLength(1);
+    expect(capturedCtx?.entityContext?.[0]?.entityId).toBe('node-1');
     expect(vi.mocked(assembler.assembleMany)).toHaveBeenCalledWith(['contact-1'], { includeRelationships: true });
   });
 

--- a/tests/unit/entity-context/execution-enrichment.test.ts
+++ b/tests/unit/entity-context/execution-enrichment.test.ts
@@ -1,0 +1,257 @@
+// tests/unit/entity-context/execution-enrichment.test.ts
+//
+// Unit tests for the execution layer entity_enrichment pre-enrichment feature.
+// Verifies that when a manifest declares entity_enrichment, the execution layer
+// assembles EntityContext and injects it into ctx.entityContext before calling
+// the handler.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import pino from 'pino';
+import { ExecutionLayer } from '../../../src/skills/execution.js';
+import { SkillRegistry } from '../../../src/skills/registry.js';
+import type { SkillManifest, SkillHandler, SkillContext } from '../../../src/skills/types.js';
+import type { EntityContextAssembler } from '../../../src/entity-context/assembler.js';
+import type { EntityContext } from '../../../src/entity-context/types.js';
+
+const logger = pino({ level: 'silent' });
+
+function makeManifest(overrides: Partial<SkillManifest> = {}): SkillManifest {
+  return {
+    name: 'test-skill',
+    description: 'A test skill',
+    version: '1.0.0',
+    sensitivity: 'normal',
+    inputs: {},
+    outputs: {},
+    permissions: [],
+    secrets: [],
+    timeout: 5000,
+    ...overrides,
+  };
+}
+
+const sampleEntityContext: EntityContext = {
+  entityId: 'node-1',
+  entityType: 'person',
+  label: 'Jenna Smith',
+  contact: { contactId: 'contact-1', displayName: 'Jenna Smith', role: null },
+  facts: [{ label: 'timezone', value: 'America/Vancouver', category: 'scheduling', confidence: 0.9, lastConfirmedAt: '2026-01-01T00:00:00.000Z' }],
+  connectedAccounts: [{ type: 'calendar', label: 'Work Calendar', serviceId: 'cal-abc', isPrimary: true, readOnly: false, metadata: {} }],
+  relationships: [],
+};
+
+function makeMockAssembler(result: Awaited<ReturnType<EntityContextAssembler['assembleMany']>>): EntityContextAssembler {
+  return {
+    assembleMany: vi.fn().mockResolvedValue(result),
+    assembleOne: vi.fn(),
+    clearCacheForEntity: vi.fn(),
+  } as unknown as EntityContextAssembler;
+}
+
+describe('ExecutionLayer — entity_enrichment', () => {
+  let registry: SkillRegistry;
+
+  beforeEach(() => {
+    registry = new SkillRegistry();
+  });
+
+  it('injects ctx.entityContext when manifest declares entity_enrichment', async () => {
+    let capturedCtx: SkillContext | undefined;
+
+    const handler: SkillHandler = {
+      execute: async (ctx) => {
+        capturedCtx = ctx;
+        return { success: true, data: 'ok' };
+      },
+    };
+
+    const manifest = makeManifest({
+      entity_enrichment: { param: 'contacts', default: 'caller' },
+    });
+    registry.register(manifest, handler);
+
+    const assembler = makeMockAssembler({ entities: [sampleEntityContext], unresolved: [] });
+    const execution = new ExecutionLayer(registry, logger, {
+      entityContextAssembler: assembler,
+    });
+
+    await execution.invoke('test-skill', { contacts: ['contact-1'] });
+
+    expect(capturedCtx?.entityContext).toBeDefined();
+    expect(capturedCtx!.entityContext).toHaveLength(1);
+    expect(capturedCtx!.entityContext![0].entityId).toBe('node-1');
+    expect(vi.mocked(assembler.assembleMany)).toHaveBeenCalledWith(['contact-1'], { includeRelationships: true });
+  });
+
+  it('uses caller contactId as default when param is empty and default=caller', async () => {
+    let capturedCtx: SkillContext | undefined;
+
+    const handler: SkillHandler = {
+      execute: async (ctx) => {
+        capturedCtx = ctx;
+        return { success: true, data: 'ok' };
+      },
+    };
+
+    const manifest = makeManifest({
+      entity_enrichment: { param: 'contacts', default: 'caller' },
+    });
+    registry.register(manifest, handler);
+
+    const assembler = makeMockAssembler({ entities: [sampleEntityContext], unresolved: [] });
+    const execution = new ExecutionLayer(registry, logger, {
+      entityContextAssembler: assembler,
+    });
+
+    const caller = { contactId: 'caller-contact', role: 'ceo', channel: 'cli' };
+    // No 'contacts' in input — should fall back to caller.contactId
+    await execution.invoke('test-skill', {}, caller);
+
+    expect(vi.mocked(assembler.assembleMany)).toHaveBeenCalledWith(['caller-contact'], { includeRelationships: true });
+    expect(capturedCtx?.entityContext).toHaveLength(1);
+  });
+
+  it('uses agentContactId as default when default=agent', async () => {
+    let capturedCtx: SkillContext | undefined;
+
+    const handler: SkillHandler = {
+      execute: async (ctx) => {
+        capturedCtx = ctx;
+        return { success: true, data: 'ok' };
+      },
+    };
+
+    const manifest = makeManifest({
+      entity_enrichment: { param: 'contacts', default: 'agent' },
+    });
+    registry.register(manifest, handler);
+
+    const assembler = makeMockAssembler({ entities: [sampleEntityContext], unresolved: [] });
+    const execution = new ExecutionLayer(registry, logger, {
+      entityContextAssembler: assembler,
+      agentContactId: 'agent-contact-id',
+    });
+
+    // No 'contacts' in input — should fall back to agentContactId
+    await execution.invoke('test-skill', {});
+
+    expect(vi.mocked(assembler.assembleMany)).toHaveBeenCalledWith(['agent-contact-id'], { includeRelationships: true });
+    expect(capturedCtx?.entityContext).toBeDefined();
+  });
+
+  it('skips pre-enrichment when no assembler is configured', async () => {
+    let capturedCtx: SkillContext | undefined;
+
+    const handler: SkillHandler = {
+      execute: async (ctx) => {
+        capturedCtx = ctx;
+        return { success: true, data: 'ok' };
+      },
+    };
+
+    const manifest = makeManifest({
+      entity_enrichment: { param: 'contacts', default: 'caller' },
+    });
+    registry.register(manifest, handler);
+
+    // No assembler passed to ExecutionLayer
+    const execution = new ExecutionLayer(registry, logger);
+    await execution.invoke('test-skill', { contacts: ['contact-1'] });
+
+    // Handler still runs but ctx.entityContext is not populated
+    expect(capturedCtx?.entityContext).toBeUndefined();
+  });
+
+  it('does not call assembler when skill has no entity_enrichment declaration', async () => {
+    const handler: SkillHandler = {
+      execute: async () => ({ success: true, data: 'ok' }),
+    };
+
+    // No entity_enrichment in manifest
+    registry.register(makeManifest(), handler);
+
+    const assembler = makeMockAssembler({ entities: [], unresolved: [] });
+    const execution = new ExecutionLayer(registry, logger, {
+      entityContextAssembler: assembler,
+    });
+
+    await execution.invoke('test-skill', { contacts: ['contact-1'] });
+
+    expect(vi.mocked(assembler.assembleMany)).not.toHaveBeenCalled();
+  });
+
+  it('continues handler invocation when assembler throws (non-fatal)', async () => {
+    let handlerCalled = false;
+
+    const handler: SkillHandler = {
+      execute: async () => {
+        handlerCalled = true;
+        return { success: true, data: 'ok' };
+      },
+    };
+
+    const manifest = makeManifest({
+      entity_enrichment: { param: 'contacts', default: 'caller' },
+    });
+    registry.register(manifest, handler);
+
+    const flakyAssembler = {
+      assembleMany: vi.fn().mockRejectedValue(new Error('DB timeout')),
+      assembleOne: vi.fn(),
+      clearCacheForEntity: vi.fn(),
+    } as unknown as EntityContextAssembler;
+
+    const execution = new ExecutionLayer(registry, logger, {
+      entityContextAssembler: flakyAssembler,
+    });
+
+    const caller = { contactId: 'caller-contact', role: 'ceo', channel: 'cli' };
+    const result = await execution.invoke('test-skill', {}, caller);
+
+    // Handler still runs despite assembler failure
+    expect(handlerCalled).toBe(true);
+    expect(result.success).toBe(true);
+  });
+
+  it('includes unresolved IDs in a debug log but does not fail the skill', async () => {
+    const handler: SkillHandler = {
+      execute: async () => ({ success: true, data: 'ok' }),
+    };
+
+    const manifest = makeManifest({
+      entity_enrichment: { param: 'contacts', default: 'caller' },
+    });
+    registry.register(manifest, handler);
+
+    const assembler = makeMockAssembler({
+      entities: [],
+      unresolved: ['ghost-id'],
+    });
+    const execution = new ExecutionLayer(registry, logger, {
+      entityContextAssembler: assembler,
+    });
+
+    const result = await execution.invoke('test-skill', { contacts: ['ghost-id'] });
+    // Skill should still succeed even if the entity wasn't found
+    expect(result.success).toBe(true);
+  });
+
+  it('exposes agentContactId on ctx for all skills', async () => {
+    let capturedCtx: SkillContext | undefined;
+
+    const handler: SkillHandler = {
+      execute: async (ctx) => {
+        capturedCtx = ctx;
+        return { success: true, data: 'ok' };
+      },
+    };
+    registry.register(makeManifest(), handler);
+
+    const execution = new ExecutionLayer(registry, logger, {
+      agentContactId: 'agent-123',
+    });
+    await execution.invoke('test-skill', {});
+
+    expect(capturedCtx?.agentContactId).toBe('agent-123');
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- **Entity context assembly** (`src/entity-context/`): assembles KG facts, contact records, connected accounts (calendars), and first-degree relationships into a single `EntityContext` payload per entity. Includes a 5-minute TTL cache keyed by input ID.
- **`entity-context` skill**: wraps the assembler as a callable skill for interactive LLM lookups ("what do you know about Jenna?").
- **Execution layer `entity_enrichment`**: manifest declaration triggers automatic pre-enrichment before a skill's handler runs. Handler receives `ctx.entityContext[]` with resolved calendar IDs, timezones, and preferences — no extra LLM round-trip needed.
- **Agent self-identity bootstrap**: seeds Nathan's KG person node and contact record at startup (idempotent via two partial unique indexes in migration 010). The agent's contactId is injected into the coordinator's system prompt so "your calendar" resolves the same way as "Jenna's calendar".

## What this enables (Phase 2 will complete it)

Calendar skills can now declare `entity_enrichment` and receive `ctx.entityContext` instead of asking the LLM to pass raw calendar IDs. Phase 2 (a follow-up PR) will wire the calendar skills to use this.

## Test plan

- [ ] 19 new unit tests: assembler assembly (person, org, unresolved), TTL cache (hit/miss/invalidation), fact value extraction, execution-layer pre-enrichment (all branches: success, caller default, agent default, no assembler, assembler throws, no declaration)
- [ ] Full suite: 581 passing, 9 skipped (integration tests require real DB)
- [ ] TypeScript: no errors
- [ ] Bootstrap idempotency: migration 010 adds partial unique indexes so concurrent startups can't create duplicate agent records
- [ ] Cache invalidation: `clearCacheForEntity()` uses a reverse map to delete both the input ID and resolved entity ID cache entries


___

## **CodeAnt-AI Description**
**Add entity context lookups and automatic enrichment for skills**

### What Changed
- Added a new `entity-context` skill so the assistant can look up rich context for people, organizations, events, and other entities from a single request.
- Skills can now declare entity enrichment and receive preloaded entity context automatically, including fallback to the caller or the agent itself when no IDs are provided.
- The assistant now knows its own contact ID at startup, so phrases like “you” and “your calendar” can resolve through the same entity lookup flow as other contacts.
- Startup now seeds the agent’s identity safely without creating duplicate agent records.

### Impact
`✅ Faster entity lookups`
`✅ Fewer manual ID lookups in skills`
`✅ Reliable "your calendar" resolution`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
