### PR TITLE
fix: reject non-UUID contact_id in contact-set-role

### DIFF
--- a/skills/contact-set-role/handler.ts
+++ b/skills/contact-set-role/handler.ts
@@ -22,6 +22,17 @@ export class ContactSetRoleHandler implements SkillHandler {
       return { success: false, error: 'Missing required input: role (string)' };
     }
 
+    // Validate contact_id is a UUID — the DB column is UUID type and will
+    // reject slug-style IDs like "contact_joseph_fung" with a cryptic 22P02 error.
+    // The agent must obtain the real UUID via contact-lookup or contact-create first.
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!UUID_RE.test(contact_id)) {
+      return {
+        success: false,
+        error: 'contact_id must be a valid UUID. Use contact-lookup or contact-create to obtain the contact\'s UUID first.',
+      };
+    }
+
     // Input length limit — prevent oversized payloads reaching the DB
     if (role.length > 200) {
       return { success: false, error: 'Role must be 200 characters or fewer' };

--- a/skills/contact-set-role/handler.ts
+++ b/skills/contact-set-role/handler.ts
@@ -51,8 +51,9 @@ export class ContactSetRoleHandler implements SkillHandler {
     try {
       const updated = await ctx.contactService.setRole(contact_id, role);
 
+      // Log both the input ID and the service-returned ID so any discrepancy is visible
       ctx.log.info(
-        { contactId: updated.id, role: updated.role },
+        { inputContactId: contact_id, contactId: updated.id, role: updated.role },
         'Contact role updated',
       );
 
@@ -65,6 +66,15 @@ export class ContactSetRoleHandler implements SkillHandler {
         },
       };
     } catch (err) {
+      // ContactService.setRole() throws "Contact not found: <id>" as a normal
+      // control-flow case. Surface it as a distinct, actionable error so the
+      // agent knows to re-verify the UUID rather than retrying the same call.
+      if (err instanceof Error && err.message.startsWith('Contact not found:')) {
+        return {
+          success: false,
+          error: `No contact exists with id ${contact_id}. Use contact-lookup to verify the UUID, or contact-create to create a new contact.`,
+        };
+      }
       const message = err instanceof Error ? err.message : String(err);
       ctx.log.error({ err, contact_id, role }, 'Failed to set contact role');
       return { success: false, error: `Failed to set contact role: ${message}` };

--- a/skills/contact-set-role/skill.json
+++ b/skills/contact-set-role/skill.json
@@ -1,11 +1,11 @@
 {
   "name": "contact-set-role",
-  "description": "Set or change a contact's role (e.g., CFO, board member, advisor).",
+  "description": "Set or change a contact's role (e.g., CFO, board member, advisor). contact_id must be a UUID obtained from contact-lookup or contact-create — do not invent or infer IDs.",
   "version": "1.0.0",
   "sensitivity": "elevated",
   "infrastructure": true,
   "inputs": {
-    "contact_id": "string",
+    "contact_id": "string (UUID from contact-lookup or contact-create)",
     "role": "string"
   },
   "outputs": {

--- a/tests/unit/skills/contact-set-role.test.ts
+++ b/tests/unit/skills/contact-set-role.test.ts
@@ -55,6 +55,36 @@ describe('ContactSetRoleHandler', () => {
     if (!result.success) expect(result.error).toContain('contactService');
   });
 
+  it('returns actionable message when the contact UUID does not exist', async () => {
+    // ContactService.setRole() throws "Contact not found: <id>" for missing UUIDs.
+    // The handler should surface a distinct error guiding the agent to re-verify,
+    // rather than the same generic message as an infrastructure failure.
+    const contactService = {
+      setRole: vi.fn().mockRejectedValue(new Error(`Contact not found: ${VALID_UUID}`)),
+    };
+    const result = await handler.execute(
+      makeCtx({ contact_id: VALID_UUID, role: 'CFO' }, { contactService: contactService as never }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain(VALID_UUID);
+      expect(result.error).toContain('contact-lookup');
+    }
+  });
+
+  it('returns failure when contactService.setRole throws unexpectedly', async () => {
+    const contactService = {
+      setRole: vi.fn().mockRejectedValue(new Error('connection refused')),
+    };
+    const result = await handler.execute(
+      makeCtx({ contact_id: VALID_UUID, role: 'CFO' }, { contactService: contactService as never }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('connection refused');
+    }
+  });
+
   it('sets the role and returns updated contact details', async () => {
     const contactService = {
       setRole: vi.fn().mockResolvedValue({ id: VALID_UUID, displayName: 'Joseph Fung', role: 'Founder & CEO' }),

--- a/tests/unit/skills/contact-set-role.test.ts
+++ b/tests/unit/skills/contact-set-role.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ContactSetRoleHandler } from '../../../skills/contact-set-role/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  return { input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
+}
+
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('ContactSetRoleHandler', () => {
+  const handler = new ContactSetRoleHandler();
+
+  it('returns failure when contact_id is missing', async () => {
+    const result = await handler.execute(makeCtx({ role: 'CFO' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('contact_id');
+  });
+
+  it('returns failure when role is missing', async () => {
+    const result = await handler.execute(makeCtx({ contact_id: VALID_UUID }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('role');
+  });
+
+  it('returns failure when contact_id is a slug, not a UUID', async () => {
+    // Regression test: agent hallucinated "contact_joseph_fung" style IDs instead of
+    // looking up the real UUID first. This produced an opaque 22P02 DB error.
+    const result = await handler.execute(makeCtx({ contact_id: 'contact_joseph_fung', role: 'Founder & CEO' }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('UUID');
+      expect(result.error).toContain('contact-lookup');
+    }
+  });
+
+  it('returns failure when contact_id is a plain name, not a UUID', async () => {
+    const result = await handler.execute(makeCtx({ contact_id: 'joseph fung', role: 'Founder & CEO' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('UUID');
+  });
+
+  it('returns failure when role exceeds 200 characters', async () => {
+    const result = await handler.execute(makeCtx({ contact_id: VALID_UUID, role: 'x'.repeat(201) }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('200');
+  });
+
+  it('returns failure when contactService is not available', async () => {
+    const result = await handler.execute(makeCtx({ contact_id: VALID_UUID, role: 'CFO' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('contactService');
+  });
+
+  it('sets the role and returns updated contact details', async () => {
+    const contactService = {
+      setRole: vi.fn().mockResolvedValue({ id: VALID_UUID, displayName: 'Joseph Fung', role: 'Founder & CEO' }),
+    };
+    const result = await handler.execute(
+      makeCtx({ contact_id: VALID_UUID, role: 'Founder & CEO' }, { contactService: contactService as never }),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { contact_id: string; display_name: string; role: string };
+      expect(data.contact_id).toBe(VALID_UUID);
+      expect(data.display_name).toBe('Joseph Fung');
+      expect(data.role).toBe('Founder & CEO');
+    }
+    expect(contactService.setRole).toHaveBeenCalledWith(VALID_UUID, 'Founder & CEO');
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause:** Agent hallucinated slug-style IDs (`contact_joseph_fung`) for `contact_id` instead of calling `contact-lookup` first to get the real UUID. The DB column is `uuid` type, so any non-UUID input produced a cryptic `22P02` PostgreSQL error with no guidance on how to fix it.
- **Handler fix:** UUID regex validation added before the DB call. Invalid format returns a clear error directing the agent to use `contact-lookup` or `contact-create`.
- **Manifest fix:** `skill.json` description and input hint now state that `contact_id` must be a UUID — visible to the LLM at tool-selection time.
- **Error clarity:** `Contact not found` (expected, wrong UUID) is now distinguished from infrastructure failures (DB down, etc.) with a separate actionable error message.
- **Test coverage:** New unit test file covers the regression case, missing inputs, role length, missing service, NOT_FOUND throw, unexpected throw, and happy path.

## Side note (out of scope, filed separately)

`contact-lookup/handler.ts` has an empty `catch {}` block in `enrichContact` that silently swallows all identity-lookup errors. Should be a follow-up fix.

## Test plan

- [x] `pnpm test -- tests/unit/skills/contact-set-role.test.ts` — 9 tests, all passing
- [x] Full suite — 571 tests passing, 9 skipped


___

## **CodeAnt-AI Description**
**Reject invalid contact IDs in contact-set-role and show clearer lookup errors**

### What Changed
- `contact-set-role` now rejects non-UUID `contact_id` values up front, so slug-style or plain-name IDs fail with a clear message instead of a database error
- The tool description now tells users to get the contact UUID from `contact-lookup` or `contact-create`
- If the contact UUID does not exist, the tool now returns a specific message that points users back to `contact-lookup` instead of a generic failure
- Added tests for missing inputs, invalid IDs, missing infrastructure, not-found contacts, unexpected failures, and the successful path

### Impact
`✅ Clearer contact role update errors`
`✅ Fewer failed role updates from invalid IDs`
`✅ Safer contact lookup and retry flow`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
