### PR TITLE
fix: close unhandledRejection race in delegate skill (#73)

### DIFF
--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -115,9 +115,19 @@ export class DelegateHandler implements SkillHandler {
     // Publish the task to the bus — the specialist will pick it up.
     // We publish as 'dispatch' layer because only dispatch can publish agent.task
     // per the permission model. Infrastructure skills are trusted to impersonate layers.
+    //
+    // IMPORTANT: await both concurrently via Promise.all rather than sequentially.
+    // The EventBus awaits subscriber handlers in sequence, so publish() does not resolve
+    // until the specialist's full processing chain completes (which can take 60–90s).
+    // If we awaited publish() first and then responsePromise, the 90s timeout could fire
+    // while responsePromise had no rejection handler yet — causing an unhandledRejection
+    // that crashes the process. Promise.all attaches handlers to both promises immediately,
+    // closing that window. See: https://github.com/josephfung/curia/issues/73
     try {
-      await ctx.bus.publish('dispatch', taskEvent);
-      const response = await responsePromise;
+      const [response] = await Promise.all([
+        responsePromise,
+        ctx.bus.publish('dispatch', taskEvent),
+      ]);
       ctx.log.info({ targetAgent: agent }, 'Specialist responded');
 
       return {
@@ -132,8 +142,7 @@ export class DelegateHandler implements SkillHandler {
       ctx.log.error({ err, targetAgent: agent }, 'Delegation failed');
       return { success: false, error: message };
     } finally {
-      // Always clean up the timeout — prevents unhandled rejection if publish()
-      // throws before responsePromise is awaited
+      // Always clean up the timeout on any exit path
       clearTimeout(timeoutHandle!);
     }
   }


### PR DESCRIPTION
## **User description**
## Summary

- The `delegate` skill awaited `ctx.bus.publish(taskEvent)` first, then `await responsePromise`. Because the EventBus awaits subscriber handlers sequentially, `publish()` doesn't resolve until the specialist's full processing chain completes (which can take 60–90s).
- This left a window where the 90s `responsePromise` timeout could fire while `responsePromise` had no rejection handler attached, causing an `unhandledRejection` that crashed the Node process mid-suite.
- Fix: replace the two sequential awaits with `Promise.all([responsePromise, publish()])`, which attaches handlers to both promises immediately and eliminates the race.

## Test plan

- [ ] `pnpm typecheck` — passes
- [ ] `pnpm test` — 562 tests pass, 9 skipped, 0 failures
- [ ] Run `pnpm smoke` against the full 34-case suite to confirm no crash at cases 3/14


___

## **CodeAnt-AI Description**
Prevent delegate requests from crashing when a specialist takes a long time to respond

### What Changed
- Delegate now waits for the specialist response and the task publish step at the same time, which removes the timeout race that could crash the process
- Timeout cleanup now runs on every exit path, avoiding leftover timers after failures

### Impact
`✅ Fewer mid-request crashes`
`✅ More reliable long-running delegate calls`
`✅ Safer timeout cleanup`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
