### PR TITLE
fix: convert array type inputs to valid JSON Schema

### DIFF
--- a/skills/calendar-create-event/skill.json
+++ b/skills/calendar-create-event/skill.json
@@ -11,7 +11,7 @@
     "end": "string",
     "description": "string?",
     "location": "string?",
-    "attendees": "array?",
+    "attendees": "object[]?",
     "conferencing": "object?",
     "colorId": "string?",
     "reminders": "object?"

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -82,9 +82,19 @@ export class SkillRegistry {
         const isOptional = typePart.endsWith('?');
         const baseType = isOptional ? typePart.slice(0, -1) : typePart;
 
-        // "string[]", "number[]", etc. → JSON Schema array type with items
+        // "string[]", "object[]", etc. → JSON Schema array type with items.
+        // itemType is validated against the JSON Schema primitive type allowlist so
+        // a manifest typo like "foo[]" fails loudly at startup rather than silently
+        // emitting an invalid schema that causes an opaque API error at call time.
         if (baseType.endsWith('[]')) {
           const itemType = baseType.slice(0, -2);
+          const VALID_ITEM_TYPES = new Set(['string', 'number', 'integer', 'boolean', 'object', 'null']);
+          if (!itemType || !VALID_ITEM_TYPES.has(itemType)) {
+            throw new Error(
+              `Skill '${name}' input '${key}': invalid array item type '${itemType}' in '${typeStr}'. ` +
+              `Expected one of: ${[...VALID_ITEM_TYPES].join(', ')}.`,
+            );
+          }
           properties[key] = { type: 'array', items: { type: itemType }, ...(description ? { description } : {}) };
         } else {
           properties[key] = { type: baseType, ...(description ? { description } : {}) };

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -63,7 +63,7 @@ export class SkillRegistry {
       const skill = this.skills.get(name);
       if (!skill) continue;
 
-      const properties: Record<string, { type: string; description?: string }> = {};
+      const properties: ToolDefinition['input_schema']['properties'] = {};
       const required: string[] = [];
 
       for (const [key, typeStr] of Object.entries(skill.manifest.inputs)) {
@@ -73,6 +73,7 @@ export class SkillRegistry {
         //   "string (generate | update | save | reset)" → type "string", desc "generate | update | save | reset"
         //   "string? (required for generate)" → type "string", optional, desc "required for generate"
         //   "boolean?" → type "boolean", optional, no desc
+        //   "string[]?" → array of strings, optional
         const parenMatch = typeStr.match(/^(.+?)\s*\((.+)\)$/);
         // When the regex matches, groups [1] and [2] are always present
         const typePart = parenMatch ? parenMatch[1]! : typeStr;
@@ -81,7 +82,14 @@ export class SkillRegistry {
         const isOptional = typePart.endsWith('?');
         const baseType = isOptional ? typePart.slice(0, -1) : typePart;
 
-        properties[key] = { type: baseType, ...(description ? { description } : {}) };
+        // "string[]", "number[]", etc. → JSON Schema array type with items
+        if (baseType.endsWith('[]')) {
+          const itemType = baseType.slice(0, -2);
+          properties[key] = { type: 'array', items: { type: itemType }, ...(description ? { description } : {}) };
+        } else {
+          properties[key] = { type: baseType, ...(description ? { description } : {}) };
+        }
+
         if (!isOptional) {
           required.push(key);
         }

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -172,7 +172,7 @@ export interface ToolDefinition {
   description: string;
   input_schema: {
     type: 'object';
-    properties: Record<string, { type: string; description?: string }>;
+    properties: Record<string, { type: string; description?: string } | { type: 'array'; items: { type: string }; description?: string }>;
     required: string[];
   };
 }

--- a/tests/unit/skills/registry.test.ts
+++ b/tests/unit/skills/registry.test.ts
@@ -143,6 +143,16 @@ describe('SkillRegistry', () => {
     expect(tools[0].input_schema.required).toEqual(['ids']);
   });
 
+  it('throws on invalid array item type in skill manifest', () => {
+    registry.register(makeManifest({
+      name: 'bad-array-skill',
+      description: 'Bad manifest',
+      inputs: { ids: 'foo[]' },
+    }), stubHandler);
+    expect(() => registry.toToolDefinitions(['bad-array-skill']))
+      .toThrow(/invalid array item type 'foo'/);
+  });
+
   it('toToolDefinitions ignores unknown skill names', () => {
     const tools = registry.toToolDefinitions(['nonexistent']);
     expect(tools).toHaveLength(0);

--- a/tests/unit/skills/registry.test.ts
+++ b/tests/unit/skills/registry.test.ts
@@ -123,6 +123,26 @@ describe('SkillRegistry', () => {
     expect(props.count).toEqual({ type: 'number' });
   });
 
+  it('converts array type inputs to JSON Schema array with items', () => {
+    registry.register(makeManifest({
+      name: 'array-skill',
+      description: 'Takes arrays',
+      inputs: {
+        ids: 'string[]',
+        tags: 'string[]? (optional list of tags)',
+      },
+    }), stubHandler);
+    const tools = registry.toToolDefinitions(['array-skill']);
+    const props = tools[0].input_schema.properties;
+
+    // Required string array
+    expect(props.ids).toEqual({ type: 'array', items: { type: 'string' } });
+    // Optional string array with description
+    expect(props.tags).toEqual({ type: 'array', items: { type: 'string' }, description: 'optional list of tags' });
+    // ids is required, tags is not
+    expect(tools[0].input_schema.required).toEqual(['ids']);
+  });
+
   it('toToolDefinitions ignores unknown skill names', () => {
     const tools = registry.toToolDefinitions(['nonexistent']);
     expect(tools).toHaveLength(0);


### PR DESCRIPTION
## **User description**
## Summary

- `toToolDefinitions` was passing `"string[]"` verbatim as the JSON Schema `type`, which Anthropic's API rejects as invalid (requires draft 2020-12). The coordinator's `entity-context` skill (first in `pinned_skills`) has two `string[]?` inputs, so every message hit this error.
- Fixes the parser to convert `T[]` → `{ type: "array", items: { type: "T" } }`
- Validates the item type against the JSON Schema primitive allowlist at startup so manifest typos fail loudly rather than producing opaque API errors at call time
- Updates `calendar-create-event/skill.json` to use `"object[]?"` for `attendees` (was bare `"array?"`, which predated the `T[]` notation)
- Widens `ToolDefinition.properties` type to reflect the array schema shape

## Test plan

- [ ] New unit tests in `registry.test.ts` cover: required array, optional array with description, `required` membership, and invalid item type throws
- [ ] Full test suite passes (592 tests)
- [ ] Deploy and verify coordinator responds in CLI


___

## **CodeAnt-AI Description**
Fix array inputs in skill manifests so tools can be created without schema errors

### What Changed
- Array-style inputs now become valid JSON Schema arrays, so skills with inputs like `string[]` or `object[]` can be used normally
- Invalid array item types fail immediately with a clear startup error that points to the affected skill and input
- The calendar event skill now marks attendees as a list of attendee objects, matching how event invitations are sent
- Added tests for array inputs, optional array descriptions, required fields, and invalid array types

### Impact
`✅ Fewer tool setup failures`
`✅ Clearer manifest errors at startup`
`✅ Reliable calendar event invitations`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
