### PR TITLE
fix: resolve CLI caller to real CEO UUID, guard assembler against non-UUID IDs

### DIFF
--- a/src/contacts/contact-resolver.ts
+++ b/src/contacts/contact-resolver.ts
@@ -33,9 +33,36 @@ export class ContactResolver {
    * CLI and smoke-test channels always resolve as the primary user (CEO).
    */
   async resolve(channel: string, senderId: string): Promise<InboundSenderContext> {
-    // CLI and smoke-test are always the primary user — no resolution needed.
-    // kgNodeId is null here because synthetic IDs have no KG node.
+    // CLI and smoke-test are always the primary user (CEO).
+    // Look up the real CEO contact in the DB so downstream skills (calendar, entity-context)
+    // get a proper UUID — passing the synthetic 'primary-user' string to UUID columns causes
+    // PostgreSQL errors. Fall back to the synthetic ID only if no CEO contact exists yet.
     if (channel === 'cli' || channel === 'smoke-test') {
+      try {
+        const ceoContacts = await this.contactService.findContactByRole('ceo');
+        const ceo = ceoContacts[0];
+        if (ceo) {
+          return {
+            resolved: true,
+            contactId: ceo.id,
+            displayName: ceo.displayName,
+            role: 'ceo',
+            status: 'confirmed' as const,
+            verified: true,
+            kgNodeId: ceo.kgNodeId,
+            knowledgeSummary: '',
+            authorization: null,
+          };
+        }
+      } catch (err) {
+        // DB lookup failure must not break the CLI — fall through to the synthetic ID
+        this.logger.warn({ err }, 'contact-resolver: failed to look up CEO contact, falling back to synthetic ID');
+      }
+
+      // No CEO contact in DB yet (e.g., fresh install before seeding) — use the synthetic ID.
+      // Skills that need a real UUID (calendar, entity-context) will return empty results,
+      // which is the best we can do without a real contact record.
+      this.logger.warn({ channel }, 'contact-resolver: no CEO contact found in DB, using synthetic primary-user ID');
       return {
         resolved: true,
         contactId: 'primary-user',

--- a/src/contacts/contact-resolver.ts
+++ b/src/contacts/contact-resolver.ts
@@ -54,15 +54,14 @@ export class ContactResolver {
             authorization: null,
           };
         }
+        // DB call succeeded but no CEO contact row exists yet (fresh install before seeding).
+        // Skills that need a real UUID will return empty results — best we can do.
+        this.logger.warn({ channel }, 'contact-resolver: no CEO contact found in DB, using synthetic primary-user ID');
       } catch (err) {
-        // DB lookup failure must not break the CLI — fall through to the synthetic ID
+        // DB lookup failure must not break the CLI — fall through to the synthetic ID.
+        // Don't re-log "no CEO contact found" here; the issue is a DB error, not a missing row.
         this.logger.warn({ err }, 'contact-resolver: failed to look up CEO contact, falling back to synthetic ID');
       }
-
-      // No CEO contact in DB yet (e.g., fresh install before seeding) — use the synthetic ID.
-      // Skills that need a real UUID (calendar, entity-context) will return empty results,
-      // which is the best we can do without a real contact record.
-      this.logger.warn({ channel }, 'contact-resolver: no CEO contact found in DB, using synthetic primary-user ID');
       return {
         resolved: true,
         contactId: 'primary-user',

--- a/src/contacts/contact-resolver.ts
+++ b/src/contacts/contact-resolver.ts
@@ -58,9 +58,16 @@ export class ContactResolver {
         // Skills that need a real UUID will return empty results — best we can do.
         this.logger.warn({ channel }, 'contact-resolver: no CEO contact found in DB, using synthetic primary-user ID');
       } catch (err) {
-        // DB lookup failure must not break the CLI — fall through to the synthetic ID.
-        // Don't re-log "no CEO contact found" here; the issue is a DB error, not a missing row.
-        this.logger.warn({ err }, 'contact-resolver: failed to look up CEO contact, falling back to synthetic ID');
+        // Only suppress errors that look like DB-layer errors (pg driver attaches a .code).
+        // Anything else (TypeError, programming bug in findContactByRole, etc.) should propagate
+        // so it is not silently misclassified as a transient DB blip.
+        const isDbError = err !== null && typeof err === 'object' && 'code' in err;
+        if (!isDbError) {
+          throw err;
+        }
+        // DB error: log at error level so Sentry captures it, then fall through to synthetic ID.
+        // The CLI continuing to work in degraded mode is acceptable; operators still need to know.
+        this.logger.error({ err }, 'contact-resolver: DB error looking up CEO contact — falling back to synthetic ID');
       }
       return {
         resolved: true,

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -498,7 +498,7 @@ class PostgresContactBackend implements ContactServiceBackend {
       updated_at: Date;
     }>(
       `SELECT id, kg_node_id, display_name, role, status, notes, created_at, updated_at
-       FROM contacts WHERE role = $1`,
+       FROM contacts WHERE role = $1 ORDER BY created_at ASC`,
       [role],
     );
 

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -294,7 +294,10 @@ export class EntityContextAssembler {
         'code' in err &&
         (err as { code: string }).code === '22P02'
       ) {
-        this.logger.debug({ id }, 'entity-context: non-UUID id passed to resolveKgNodeId — treating as unresolved');
+        // Warn rather than debug: after the contact-resolver fix ships, this path should be
+        // unreachable in production. If it fires, something upstream is still leaking a
+        // synthetic/hallucinated ID and operators need a searchable signal to trace it.
+        this.logger.warn({ id }, 'entity-context: non-UUID id passed to resolveKgNodeId — treating as unresolved');
         return undefined;
       }
       throw err;

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -256,32 +256,49 @@ export class EntityContextAssembler {
    * Tries contacts.id first, then kg_nodes.id directly.
    */
   private async resolveKgNodeId(id: string): Promise<string | undefined> {
-    // Try as a contact ID first
-    const contactResult = await this.pool.query<{ kg_node_id: string | null }>(
-      'SELECT kg_node_id FROM contacts WHERE id = $1',
-      [id],
-    );
-    if (contactResult.rows.length > 0) {
-      const row = contactResult.rows[0];
-      const kgNodeId = row?.kg_node_id;
-      // Contact found but has no linked KG node — return undefined (unresolved)
-      if (!kgNodeId) {
-        this.logger.debug({ contactId: id }, 'entity-context: contact has no linked KG node');
+    try {
+      // Try as a contact ID first
+      const contactResult = await this.pool.query<{ kg_node_id: string | null }>(
+        'SELECT kg_node_id FROM contacts WHERE id = $1',
+        [id],
+      );
+      if (contactResult.rows.length > 0) {
+        const row = contactResult.rows[0];
+        const kgNodeId = row?.kg_node_id;
+        // Contact found but has no linked KG node — return undefined (unresolved)
+        if (!kgNodeId) {
+          this.logger.debug({ contactId: id }, 'entity-context: contact has no linked KG node');
+          return undefined;
+        }
+        return kgNodeId;
+      }
+
+      // Try as a KG node ID directly
+      const nodeResult = await this.pool.query<{ id: string }>(
+        'SELECT id FROM kg_nodes WHERE id = $1',
+        [id],
+      );
+      if (nodeResult.rows.length > 0) {
+        return nodeResult.rows[0]?.id;
+      }
+
+      return undefined;
+    } catch (err) {
+      // PostgreSQL error 22P02 = invalid_text_representation: the ID is not a valid UUID.
+      // This happens when the LLM passes a hallucinated or synthetic string (e.g.
+      // 'joseph-fung-contact-id', 'primary-user') to a UUID column. Treat as unresolved
+      // rather than letting the error bubble up and surface to the caller.
+      if (
+        err !== null &&
+        typeof err === 'object' &&
+        'code' in err &&
+        (err as { code: string }).code === '22P02'
+      ) {
+        this.logger.debug({ id }, 'entity-context: non-UUID id passed to resolveKgNodeId — treating as unresolved');
         return undefined;
       }
-      return kgNodeId;
+      throw err;
     }
-
-    // Try as a KG node ID directly
-    const nodeResult = await this.pool.query<{ id: string }>(
-      'SELECT id FROM kg_nodes WHERE id = $1',
-      [id],
-    );
-    if (nodeResult.rows.length > 0) {
-      return nodeResult.rows[0]?.id;
-    }
-
-    return undefined;
   }
 
   private async getKgNode(id: string): Promise<KgNodeRow | undefined> {


### PR DESCRIPTION
## **User description**
## Summary

- **`contact-resolver.ts`**: CLI/smoke-test channels now look up the real CEO contact via `findContactByRole('ceo')` and return its UUID instead of the synthetic `'primary-user'` string. This was causing `invalid input syntax for type uuid` errors whenever `calendar-list-events` or `entity-context` tried to query UUID columns with that string — forcing the LLM to take 4 extra turns to recover calendar data.
- **`assembler.ts` `resolveKgNodeId`**: Catches PostgreSQL error `22P02` (invalid_text_representation) and returns `undefined` instead of throwing. Handles LLM-hallucinated IDs like `'joseph-fung-contact-id'`. Logs at `warn` level so synthetic ID leakage is visible in production after this fix ships.
- Narrow the CEO catch block to only suppress DB-shaped errors (pg driver `.code` present); re-throws anything else so programming bugs aren't silently downgraded to a warn.

## Test plan

- [ ] All 592 existing unit tests pass
- [ ] Verify in prod: `what's my schedule today?` resolves calendars on turn 1 without UUID errors in logs
- [ ] Verify: entity-context with a hallucinated ID logs a `warn` and returns `unresolved`, not an error


___

## **CodeAnt-AI Description**
Use the real CEO contact ID in CLI flows and ignore non-UUID IDs instead of failing

### What Changed
- CLI and smoke-test requests now resolve to the actual CEO contact when one exists, so downstream features receive a valid UUID instead of the synthetic `primary-user` value
- If no CEO contact is available yet, the system falls back to the synthetic ID and logs a warning
- Entity context lookups now treat invalid or hallucinated IDs as unresolved instead of returning a database error
- Unexpected non-database errors still surface normally

### Impact
`✅ Fewer UUID errors in CLI calendar and entity lookups`
`✅ Faster first-turn answers for schedule and context questions`
`✅ Clearer handling of invalid IDs from assistant output`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
