### PR TITLE
fix: coordinator must ALWAYS use contact-lookup, NEVER guess contact IDs

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -21,10 +21,13 @@ system_prompt: |
   user can confirm you understood correctly.
 
   ## Your Identity
-  Your contact ID is ${agent_contact_id}. When someone refers to "you", "your calendar",
-  "your inbox", or anything that refers to you as the agent, use this contact ID for
-  entity-context lookups. This ensures "your calendar" resolves the same way as
-  "Jenna's calendar" — through the entity-context system.
+  Your contact ID is ${agent_contact_id}. Use this when "you" or "your" clearly refers
+  to you as the agent (e.g. "what's your calendar look like?"). This is the ONLY contact
+  ID you should EVER use directly — NEVER derive or guess contact IDs from names.
+
+  For everyone else — the person you're talking to, third parties, other agents — ALWAYS
+  use contact-lookup first to resolve their name to a real contact ID before passing it
+  to any tool. This includes the CEO asking "what's my schedule?" — look them up first.
 
   ## Contact Awareness
   You have access to a contact system. The system injects information about who you're


### PR DESCRIPTION
## **User description**
## Summary

- Rewrites the `## Your Identity` section of the coordinator prompt to make the ID resolution rule unambiguous
- `${agent_contact_id}` is the ONLY ID the coordinator may use directly
- For everyone else (CEO asking "what's my schedule?", Jenna, third parties, Curia itself), it must ALWAYS resolve via `contact-lookup` first
- Removes the implicit pattern where the coordinator saw hardcoded IDs and over-generalized it to deriving slug IDs from names (e.g. `joseph-fung-contact-id`)

## Test plan

- [ ] All 592 unit tests pass
- [ ] Verify in prod: "what's my schedule?" uses contact-lookup before calendar-list-events — no hallucinated IDs in logs
- [ ] Verify: "what's Jenna's schedule?" uses contact-lookup for Jenna before any entity-context call
- [ ] Verify: "what's your schedule?" still uses `${agent_contact_id}` directly


___

## **CodeAnt-AI Description**
**Stop the coordinator from guessing contact IDs**

### What Changed
- The coordinator now uses its own contact ID only when the user clearly means the assistant
- For the CEO, other people, and third parties, it must look up the contact first instead of inventing or guessing an ID
- Requests like “what’s my schedule?” now go through contact lookup before any scheduling action

### Impact
`✅ Fewer wrong-schedule lookups`
`✅ Fewer mistaken contact matches`
`✅ More reliable identity resolution`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
