### PR TITLE
fix: bootstrap CEO contact as confirmed before email adapter starts polling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,12 @@ NYLAS_SELF_EMAIL=nathan@yourdomain.com
 # Polling interval in milliseconds (default: 30000 = 30 seconds)
 # NYLAS_POLL_INTERVAL_MS=30000
 
+# CEO's primary email address. Required for email channel deployments.
+# At startup, Curia ensures this contact exists as confirmed + verified so the
+# CEO's messages are never held. Without this, the first inbound email from the
+# CEO auto-creates them as provisional, causing their messages to be held.
+CEO_PRIMARY_EMAIL=you@yourdomain.com
+
 # Timezone — IANA timezone for the CEO's default location.
 # Used to resolve relative dates ("next Friday") in agent prompts.
 # Override via KG entity fact when traveling (future feature).

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,6 @@ export function loadConfig(): Config {
     nylasGrantId: process.env.NYLAS_GRANT_ID,
     nylasPollingIntervalMs,
     nylasSelfEmail: process.env.NYLAS_SELF_EMAIL ?? '',
-    ceoPrimaryEmail: process.env.CEO_PRIMARY_EMAIL?.trim() || undefined,
+    ceoPrimaryEmail: process.env.CEO_PRIMARY_EMAIL?.trim().toLowerCase() || undefined,
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,11 @@ export interface Config {
   nylasGrantId: string | undefined;
   nylasPollingIntervalMs: number;
   nylasSelfEmail: string;
+  // CEO's primary email address. When set, the startup bootstrap ensures this
+  // contact exists with status=confirmed and verified=true before any email arrives.
+  // Without this, the first inbound email from the CEO creates them as provisional,
+  // causing their messages to be held.
+  ceoPrimaryEmail: string | undefined;
 }
 
 export function loadConfig(): Config {
@@ -40,5 +45,6 @@ export function loadConfig(): Config {
     nylasGrantId: process.env.NYLAS_GRANT_ID,
     nylasPollingIntervalMs,
     nylasSelfEmail: process.env.NYLAS_SELF_EMAIL ?? '',
+    ceoPrimaryEmail: process.env.CEO_PRIMARY_EMAIL?.trim() || undefined,
   };
 }

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -82,6 +82,11 @@ export async function bootstrapCeoContact(
 
   // No existing record — create contact and link the email identity in a single
   // transaction so a partial failure cannot leave an orphaned contacts row.
+  //
+  // If two instances start simultaneously and both reach this point, one will win
+  // and the other will hit a 23505 unique constraint violation on channel_identifier.
+  // In that case we re-query for the winning row and return it as-is — the CEO contact
+  // exists and is correct, so this is an idempotent success, not an error.
   const contactId = randomUUID();
   const client = await pool.connect();
   try {
@@ -100,6 +105,20 @@ export async function bootstrapCeoContact(
     await client.query('COMMIT');
   } catch (err) {
     await client.query('ROLLBACK');
+    // 23505 = unique_violation: another instance won the race and already created the
+    // identity. Re-query for the winning row and treat as idempotent success.
+    const pgCode = (err as { code?: string }).code;
+    if (pgCode === '23505') {
+      const winner = await pool.query<{ contact_id: string }>(
+        `SELECT contact_id FROM contact_channel_identities
+         WHERE channel = 'email' AND channel_identifier = $1`,
+        [ceoPrimaryEmail],
+      );
+      if (winner.rows[0]) {
+        logger.info({ contactId: winner.rows[0].contact_id, email: ceoPrimaryEmail }, 'ceo-bootstrap: concurrent startup race resolved — existing CEO contact used');
+        return { contactId: winner.rows[0].contact_id, alreadyExisted: true };
+      }
+    }
     throw err;
   } finally {
     client.release();

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -1,0 +1,110 @@
+// src/contacts/ceo-bootstrap.ts
+//
+// CEO contact bootstrap.
+//
+// Ensures the CEO's primary email is linked to a confirmed, verified contact
+// before the email adapter starts polling. Without this, the first inbound email
+// from the CEO triggers auto-creation via extractParticipants(), which always
+// creates contacts as provisional — causing their messages to be held.
+//
+// This module is called once at startup. It is idempotent under serial execution
+// (safe for single-process deployments, consistent with the migration runner).
+// Handles three cases:
+//   1. Contact + identity already exist as confirmed/verified → no-op
+//   2. Contact + identity exist as provisional/unverified → promote in-place
+//   3. Neither exists → create fresh contact + identity (in a transaction)
+
+import { randomUUID } from 'crypto';
+import type { DbPool } from '../db/connection.js';
+import type { Logger } from '../logger.js';
+
+export interface CeoContactBootstrapResult {
+  contactId: string;
+  /** true if the contact already existed (possibly promoted), false if newly created */
+  alreadyExisted: boolean;
+}
+
+/**
+ * Ensure the CEO's primary email contact exists and is confirmed + verified.
+ *
+ * @param ceoPrimaryEmail  The CEO's primary email address (from CEO_PRIMARY_EMAIL env)
+ * @param displayName      Display name to use if creating a new contact (defaults to "CEO")
+ * @param pool             Postgres connection pool
+ * @param logger           Pino logger
+ */
+export async function bootstrapCeoContact(
+  ceoPrimaryEmail: string,
+  displayName: string,
+  pool: DbPool,
+  logger: Logger,
+): Promise<CeoContactBootstrapResult> {
+  // Look up by channel identity first — this is the authoritative key for email senders.
+  const existing = await pool.query<{ contact_id: string; contact_status: string; identity_verified: boolean }>(
+    `SELECT ci.contact_id, c.status AS contact_status, ci.verified AS identity_verified
+     FROM contact_channel_identities ci
+     JOIN contacts c ON c.id = ci.contact_id
+     WHERE ci.channel = 'email' AND ci.channel_identifier = $1`,
+    [ceoPrimaryEmail],
+  );
+
+  if (existing.rows[0]) {
+    const { contact_id, contact_status, identity_verified } = existing.rows[0];
+
+    // Already confirmed + verified — nothing to do.
+    if (contact_status === 'confirmed' && identity_verified) {
+      logger.info({ contactId: contact_id, email: ceoPrimaryEmail }, 'ceo-bootstrap: CEO contact already confirmed and verified');
+      return { contactId: contact_id, alreadyExisted: true };
+    }
+
+    // Promote in-place: update contact status and/or identity verified flag.
+    // Two separate updates so each is independently auditable.
+    if (contact_status !== 'confirmed') {
+      await pool.query(
+        `UPDATE contacts SET status = 'confirmed', updated_at = now() WHERE id = $1`,
+        [contact_id],
+      );
+    }
+    if (!identity_verified) {
+      await pool.query(
+        `UPDATE contact_channel_identities
+         SET verified = true, verified_at = now(), updated_at = now()
+         WHERE channel = 'email' AND channel_identifier = $1`,
+        [ceoPrimaryEmail],
+      );
+    }
+
+    logger.info(
+      { contactId: contact_id, email: ceoPrimaryEmail, wasStatus: contact_status, wasVerified: identity_verified },
+      'ceo-bootstrap: CEO contact promoted to confirmed + verified',
+    );
+    return { contactId: contact_id, alreadyExisted: true };
+  }
+
+  // No existing record — create contact and link the email identity in a single
+  // transaction so a partial failure cannot leave an orphaned contacts row.
+  const contactId = randomUUID();
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `INSERT INTO contacts (id, display_name, role, status, created_at, updated_at)
+       VALUES ($1, $2, 'ceo', 'confirmed', now(), now())`,
+      [contactId, displayName],
+    );
+    await client.query(
+      `INSERT INTO contact_channel_identities
+         (id, contact_id, channel, channel_identifier, verified, verified_at, source, created_at, updated_at)
+       VALUES ($1, $2, 'email', $3, true, now(), 'bootstrap', now(), now())`,
+      [randomUUID(), contactId, ceoPrimaryEmail],
+    );
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+
+  logger.info({ contactId, email: ceoPrimaryEmail }, 'ceo-bootstrap: CEO contact created');
+  return { contactId, alreadyExisted: false };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ import { SchedulerService } from './scheduler/scheduler-service.js';
 import { Scheduler } from './scheduler/scheduler.js';
 import { EntityContextAssembler } from './entity-context/assembler.js';
 import { bootstrapAgentIdentity } from './entity-context/bootstrap.js';
+import { bootstrapCeoContact } from './contacts/ceo-bootstrap.js';
 import type { AgentPersona } from './skills/types.js';
 
 async function main(): Promise<void> {
@@ -180,6 +181,43 @@ async function main(): Promise<void> {
     // 2. The coordinator's ${agent_contact_id} prompt placeholder will be empty
     // 3. Interactive entity-context lookups for "you"/"your" will fail to resolve
     logger.warn({ err }, 'Agent self-identity bootstrap failed — entity_enrichment default=agent will not resolve; coordinator system prompt ${agent_contact_id} will be empty');
+  }
+
+  // CEO contact bootstrap — ensures the CEO's primary email contact exists with
+  // status=confirmed and verified=true before the email adapter starts polling.
+  // Without this, the first inbound email from the CEO auto-creates them as
+  // provisional (the extractParticipants default), causing their messages to be held.
+  if (config.ceoPrimaryEmail) {
+    try {
+      await bootstrapCeoContact(config.ceoPrimaryEmail, 'CEO', pool, logger);
+    } catch (err) {
+      // Non-fatal: log and continue. Severity depends on whether the email adapter is active:
+      // - With email configured: the CEO's first message will be held if the contact doesn't
+      //   exist yet — escalate to error so it shows up in log aggregators.
+      // - Without email: no adapter polls, so the risk is deferred and a warn suffices.
+      // A unique constraint violation (23505) indicates inconsistent DB state (e.g. a
+      // channel identity row with no matching contact), not a transient failure — flag it
+      // separately so operators know to inspect contact_channel_identities directly.
+      const pgCode = (err as { code?: string }).code;
+      if (pgCode === '23505') {
+        logger.error(
+          { err, ceoPrimaryEmail: config.ceoPrimaryEmail },
+          'CEO contact bootstrap failed with unique constraint violation — possible inconsistent DB state. Inspect contact_channel_identities for orphaned rows.',
+        );
+      } else if (config.nylasApiKey && config.nylasGrantId) {
+        logger.error(
+          { err, ceoPrimaryEmail: config.ceoPrimaryEmail },
+          'CEO contact bootstrap failed with email adapter active — CEO emails WILL be held if contact does not exist',
+        );
+      } else {
+        logger.warn(
+          { err, ceoPrimaryEmail: config.ceoPrimaryEmail },
+          'CEO contact bootstrap failed — CEO emails may be held if contact is provisional',
+        );
+      }
+    }
+  } else {
+    logger.warn('CEO_PRIMARY_EMAIL not set — CEO contact bootstrap skipped. Set this to prevent CEO emails from being held on first contact.');
   }
 
   // Held messages — stores messages from unknown senders pending CEO review.


### PR DESCRIPTION
## **User description**
## Summary

- Adds `CEO_PRIMARY_EMAIL` env var (and `ceoPrimaryEmail` config field)
- At startup, `bootstrapCeoContact()` ensures that email address exists as a `confirmed`+`verified` contact before the email adapter begins polling
- If the contact already exists as `provisional`, it is promoted in-place; if neither contact nor channel identity exist, both are created in a transaction
- Logs escalate to `error` (not `warn`) when the email adapter is active and bootstrap fails, since a held CEO email is an operational incident

## Root cause

`extractParticipants()` in the email adapter always creates auto-discovered contacts as `provisional`. There was no setup step to pre-seed the CEO contact, so the first inbound email from the CEO triggered auto-creation as provisional → held. This caused joseph@josephfung.ca's first email to be silently held with the log line `[Held] Unknown sender on email`.

## Pre-merge notes

The production contact was already manually promoted to `confirmed` as an immediate fix. `CEO_PRIMARY_EMAIL=joseph@josephfung.ca` has been added to the production `.env` and the fix has been deployed. This PR makes the protection automatic on every startup.


___

## **CodeAnt-AI Description**
Prevent the CEO’s first email from being held

### What Changed
- At startup, the app now makes sure the CEO’s primary email is set up as a confirmed, verified contact before email polling begins
- If that email already exists but is not fully confirmed, it is promoted in place instead of being left provisional
- If no record exists, the contact and email link are created together so the setup cannot be left half-finished
- When the setup is missing or fails, startup logs now call out the risk of held CEO emails more clearly

### Impact
`✅ Fewer held CEO emails`
`✅ Safer first-contact handling`
`✅ Clearer startup warnings for email deployments`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
