### PR TITLE
fix: guard CLI adapter on stdin TTY, fix SIGINT and message.held gaps

### DIFF
--- a/src/channels/cli/cli-adapter.ts
+++ b/src/channels/cli/cli-adapter.ts
@@ -61,13 +61,9 @@ export class CliAdapter {
       // which just emits 'close' — we want a clean shutdown sequence
     });
 
-    // Handle Ctrl+C — process SIGINT directly since readline can swallow it
-    process.on('SIGINT', () => {
-      process.stdout.write('\n');
-      this.stop();
-    });
-
-    // Handle readline close (e.g., stdin EOF)
+    // Handle readline close (e.g., /quit or Ctrl+C).
+    // SIGINT is handled at the process level in index.ts (unconditionally), so
+    // there is no separate listener here — it would fire shutdown() twice.
     this.rl.on('close', () => {
       this.logger.info('CLI closed');
       if (this.onExit) {

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -103,6 +103,24 @@ export class EventRouter {
       this.broadcastToSseClients(sseData, event.payload.conversationId);
     });
 
+    // message.held — broadcast to all SSE clients so dashboards and API consumers
+    // are notified when an unknown sender's message is held for CEO review.
+    // Previously this notification only reached the CLI adapter; with the CLI
+    // skipped in non-TTY (production) environments, the EventRouter must carry it.
+    bus.subscribe('message.held', 'channel', (event: BusEvent) => {
+      if (event.type !== 'message.held') return;
+      const sseData = JSON.stringify({
+        type: 'message.held',
+        held_message_id: event.payload.heldMessageId,
+        channel: event.payload.channel,
+        sender_id: event.payload.senderId,
+        subject: event.payload.subject,
+        timestamp: event.timestamp,
+      });
+      // Not filtered by conversationId — held-message notifications are system-wide
+      this.broadcastToSseClients(sseData);
+    });
+
     this.logger.info('HTTP event router subscriptions registered');
   }
 

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -159,22 +159,29 @@ export class EventRouter {
   }
 
   /**
-   * Send an SSE payload to all matching clients. Wraps each write in try/catch
+   * Send an SSE payload to matching clients. Wraps each write in try/catch
    * so a dead client (TCP reset between close event and write) doesn't abort
    * delivery to remaining clients in this dispatch cycle.
+   *
+   * When `conversationId` is provided, only clients with no filter OR whose
+   * filter matches are written to. When omitted, ALL clients receive the event
+   * (system-wide notifications like message.held).
    */
   private broadcastToSseClients(sseData: string, conversationId?: string): void {
     for (const client of this.sseClients) {
-      if (!client.conversationId || client.conversationId === conversationId) {
-        try {
-          client.res.write(`data: ${sseData}\n\n`);
-        } catch {
-          // Client connection is dead — remove it. The 'close' event handler
-          // will also fire eventually, but cleaning up here prevents repeated
-          // failed writes for subsequent events in this tick.
-          this.sseClients.delete(client);
-          this.logger.debug({ conversationId: client.conversationId }, 'Removed dead SSE client');
-        }
+      // Skip filtered clients unless the filter matches OR this is a system-wide broadcast
+      const shouldSend = conversationId === undefined
+        || !client.conversationId
+        || client.conversationId === conversationId;
+      if (!shouldSend) continue;
+      try {
+        client.res.write(`data: ${sseData}\n\n`);
+      } catch {
+        // Client connection is dead — remove it. The 'close' event handler
+        // will also fire eventually, but cleaning up here prevents repeated
+        // failed writes for subsequent events in this tick.
+        this.sseClients.delete(client);
+        this.logger.debug({ conversationId: client.conversationId }, 'Removed dead SSE client');
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -495,16 +495,18 @@ async function main(): Promise<void> {
 
   process.on('SIGTERM', () => void shutdown());
 
-  // 8. CLI channel — the last thing to start, since opening readline
-  // immediately prompts for user input. Everything upstream must be
-  // fully wired before the user can type their first message.
-  // The onExit callback handles both /quit and Ctrl+C.
-  const cli = new CliAdapter(bus, logger, () => void shutdown());
-  cli.start();
-
-  // Print welcome directly to stdout (logger writes to curia.log in dev mode)
-  process.stdout.write('\nCuria is ready. Type a message, /quit to exit, or Ctrl+C.\n\n');
-  cli.prompt();
+  // 8. CLI channel — only started when stdin is an interactive TTY (i.e., local dev).
+  // In Docker / production, stdin is closed or a pipe: readline receives EOF
+  // immediately and would fire onExit, triggering shutdown before any work is done.
+  // Guarding on isTTY means the HTTP API and email channel handle all production
+  // input while the CLI remains available for local development sessions.
+  if (process.stdin.isTTY) {
+    const cli = new CliAdapter(bus, logger, () => void shutdown());
+    cli.start();
+    // Print welcome directly to stdout (logger writes to curia.log in dev mode)
+    process.stdout.write('\nCuria is ready. Type a message, /quit to exit, or Ctrl+C.\n\n');
+    cli.prompt();
+  }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -494,6 +494,12 @@ async function main(): Promise<void> {
   };
 
   process.on('SIGTERM', () => void shutdown());
+  // Handle SIGINT unconditionally here rather than inside CliAdapter.start().
+  // Previously SIGINT was only caught when the CLI adapter was running; with
+  // the TTY guard above, non-TTY (Docker/production) deployments had no SIGINT
+  // handler and would terminate uncleanly without draining the DB pool, stopping
+  // the scheduler, or gracefully closing the HTTP server.
+  process.on('SIGINT', () => void shutdown());
 
   // 8. CLI channel — only started when stdin is an interactive TTY (i.e., local dev).
   // In Docker / production, stdin is closed or a pipe: readline receives EOF


### PR DESCRIPTION
## **User description**
## Summary

- Guard `CliAdapter.start()` with `process.stdin.isTTY` — in Docker/production, stdin is closed so readline gets EOF immediately, fires `onExit`, and triggers a crashloop. HTTP API and email channel handle all production input; the CLI is only needed in interactive dev sessions.
- Move `process.on('SIGINT', ...)` from `CliAdapter.start()` to `index.ts` alongside SIGTERM so graceful shutdown (DB pool, HTTP server, scheduler) always runs regardless of whether the CLI is active.
- Add `message.held` subscriber to `EventRouter.setupSubscriptions()` so SSE clients receive held-message notifications in production (the CLI adapter was previously the only subscriber).

## Root cause

The immediate production crashloop was caused by the container being started without the production compose overlay (`compose.production.yaml`), so the `stdin_open: true` workaround was not applied. This PR fixes the underlying code so the service is resilient regardless of how Docker is invoked.

## Test plan

- [ ] 592 existing tests pass
- [ ] Verify `process.stdin.isTTY` guard: run `node dist/index.js < /dev/null` — should not crashloop (HTTP API stays up)
- [ ] Verify CLI still works in TTY: run `npm run dev` interactively — prompt appears as before
- [ ] Verify SSE clients receive `message.held` events after deploy


___

## **CodeAnt-AI Description**
**Stop non-interactive deployments from shutting down early and restore held-message alerts**

### What Changed
- The CLI now starts only in interactive terminal sessions, so Docker and production no longer exit immediately when stdin is closed.
- Ctrl+C shutdown now works even when the CLI is not running, so the service still closes cleanly in non-TTY environments.
- Held-message notifications now reach SSE clients, including system-wide updates that are not tied to one conversation.

### Impact
`✅ Fewer production crashloops`
`✅ Clean shutdowns in Docker and other non-interactive runs`
`✅ Held-message alerts in dashboards and API clients`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
