### PR TITLE
feat: add calendar-register skill

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -187,6 +187,7 @@ pinned_skills:
   - knowledge-loyalty-programs
   - context-for-email
   - calendar-list-calendars
+  - calendar-register
   - calendar-list-events
   - calendar-create-event
   - calendar-update-event

--- a/skills/calendar-register/handler.ts
+++ b/skills/calendar-register/handler.ts
@@ -40,6 +40,17 @@ export class CalendarRegisterHandler implements SkillHandler {
     const resolvedContactId: string | null =
       typeof contact_id === 'string' ? contact_id : (ctx.caller?.contactId ?? null);
 
+    // Warn when neither contact_id nor caller context is present — the calendar
+    // will be registered as org-wide (null contact). This is valid for shared
+    // calendars (holidays, rooms) but is probably a routing bug if it happens
+    // during a CEO conversation.
+    if (resolvedContactId === null && typeof contact_id !== 'string') {
+      ctx.log.warn(
+        { nylasCalendarId: nylas_calendar_id },
+        'calendar-register: no contact_id and no caller — registering as org-wide (no contact association)',
+      );
+    }
+
     ctx.log.info(
       { nylasCalendarId: nylas_calendar_id, contactId: resolvedContactId, label, isPrimary: is_primary ?? false },
       'Registering calendar',
@@ -69,6 +80,31 @@ export class CalendarRegisterHandler implements SkillHandler {
         },
       };
     } catch (err) {
+      // Postgres unique_violation (code 23505): translate raw constraint names into
+      // human-readable messages so the LLM can give the CEO actionable feedback.
+      const pgCode = (err as { code?: string }).code;
+      if (pgCode === '23505') {
+        const constraint = (err as { constraint?: string }).constraint ?? '';
+        if (constraint.includes('primary')) {
+          ctx.log.warn(
+            { nylasCalendarId: nylas_calendar_id, contactId: resolvedContactId },
+            'calendar-register: contact already has a primary calendar',
+          );
+          return {
+            success: false,
+            error: `Contact ${resolvedContactId ?? '(none)'} already has a primary calendar. Set is_primary to false, or unregister the existing primary calendar first.`,
+          };
+        }
+        ctx.log.warn(
+          { nylasCalendarId: nylas_calendar_id, contactId: resolvedContactId },
+          'calendar-register: calendar already registered',
+        );
+        return {
+          success: false,
+          error: `Calendar ${nylas_calendar_id} is already registered. Use calendar-list-calendars to see its current mapping.`,
+        };
+      }
+
       const message = err instanceof Error ? err.message : String(err);
       ctx.log.error({ err, nylasCalendarId: nylas_calendar_id, contactId: resolvedContactId }, 'Failed to register calendar');
       return { success: false, error: `Failed to register calendar: ${message}` };

--- a/skills/calendar-register/handler.ts
+++ b/skills/calendar-register/handler.ts
@@ -1,0 +1,77 @@
+// skills/calendar-register/handler.ts
+//
+// Registers a Nylas calendar in the contact registry by linking it to a contact.
+//
+// The typical flow is:
+//   1. calendar-list-calendars surfaces an unregistered calendar
+//   2. The CEO confirms which contact owns it (usually themselves)
+//   3. This skill persists that mapping so calendar-list-events can auto-resolve it
+//
+// contact_id defaults to the caller's own contact when omitted — the common case
+// when the CEO is claiming ownership of their own calendar.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class CalendarRegisterHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.contactService) {
+      return { success: false, error: 'calendar-register requires infrastructure access (contactService)' };
+    }
+
+    const { nylas_calendar_id, label, contact_id, is_primary } = ctx.input as {
+      nylas_calendar_id?: string;
+      label?: string;
+      contact_id?: string;
+      is_primary?: boolean;
+    };
+
+    if (!nylas_calendar_id || typeof nylas_calendar_id !== 'string') {
+      return { success: false, error: 'Missing required input: nylas_calendar_id' };
+    }
+    if (!label || typeof label !== 'string') {
+      return { success: false, error: 'Missing required input: label' };
+    }
+    if (label.length > 200) {
+      return { success: false, error: 'label must be 200 characters or fewer' };
+    }
+
+    // Default to the caller's contact when contact_id is not provided.
+    // This is the most common case: the CEO saying "that calendar is mine."
+    const resolvedContactId: string | null =
+      typeof contact_id === 'string' ? contact_id : (ctx.caller?.contactId ?? null);
+
+    ctx.log.info(
+      { nylasCalendarId: nylas_calendar_id, contactId: resolvedContactId, label, isPrimary: is_primary ?? false },
+      'Registering calendar',
+    );
+
+    try {
+      const calendar = await ctx.contactService.linkCalendar({
+        nylasCalendarId: nylas_calendar_id,
+        contactId: resolvedContactId,
+        label,
+        isPrimary: is_primary ?? false,
+      });
+
+      ctx.log.info(
+        { calendarId: calendar.id, nylasCalendarId: calendar.nylasCalendarId, contactId: calendar.contactId },
+        'Calendar registered successfully',
+      );
+
+      return {
+        success: true,
+        data: {
+          calendar_id: calendar.id,
+          nylas_calendar_id: calendar.nylasCalendarId,
+          contact_id: calendar.contactId,
+          label: calendar.label,
+          is_primary: calendar.isPrimary,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, nylasCalendarId: nylas_calendar_id, contactId: resolvedContactId }, 'Failed to register calendar');
+      return { success: false, error: `Failed to register calendar: ${message}` };
+    }
+  }
+}

--- a/skills/calendar-register/skill.json
+++ b/skills/calendar-register/skill.json
@@ -1,0 +1,23 @@
+{
+  "name": "calendar-register",
+  "description": "Register a Nylas calendar in the contact registry, linking it to a contact. Use this after calendar-list-calendars identifies an unregistered calendar and the CEO confirms which contact it belongs to. Defaults contact_id to the caller's own contact when omitted — the common case when the CEO is claiming their own calendar.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "nylas_calendar_id": "string",
+    "label": "string",
+    "contact_id": "string?",
+    "is_primary": "boolean?"
+  },
+  "outputs": {
+    "calendar_id": "string",
+    "nylas_calendar_id": "string",
+    "contact_id": "string | null",
+    "label": "string",
+    "is_primary": "boolean"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}

--- a/tests/unit/skills/calendar-register.test.ts
+++ b/tests/unit/skills/calendar-register.test.ts
@@ -105,7 +105,7 @@ describe('CalendarRegisterHandler', () => {
         { nylas_calendar_id: 'cal-1', label: 'Personal', is_primary: true },
         {
           contactService: contactService as never,
-          caller: { contactId: 'caller-contact', channel: 'email', identifier: 'joseph@josephfung.ca' },
+          caller: { contactId: 'caller-contact', role: 'ceo', channel: 'email' },
         },
       ),
     );
@@ -143,10 +143,27 @@ describe('CalendarRegisterHandler', () => {
     );
   });
 
-  it('surfaces errors from linkCalendar (e.g. duplicate calendar)', async () => {
-    const contactService = {
-      linkCalendar: vi.fn().mockRejectedValue(new Error('duplicate key value violates unique constraint')),
-    };
+  it('returns failure when label exceeds 200 characters', async () => {
+    const contactService = { linkCalendar: vi.fn() };
+    const result = await handler.execute(
+      makeCtx(
+        { nylas_calendar_id: 'cal-1', label: 'x'.repeat(201) },
+        { contactService: contactService as never },
+      ),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('200 characters');
+    }
+  });
+
+  it('returns a readable error when the calendar is already registered (Postgres 23505)', async () => {
+    // Simulate the Postgres unique_violation error for the nylas_calendar_id constraint.
+    const pgError = Object.assign(new Error('duplicate key value violates unique constraint'), {
+      code: '23505',
+      constraint: 'contact_calendars_nylas_calendar_id_key',
+    });
+    const contactService = { linkCalendar: vi.fn().mockRejectedValue(pgError) };
 
     const result = await handler.execute(
       makeCtx(
@@ -157,14 +174,18 @@ describe('CalendarRegisterHandler', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toContain('duplicate key');
+      expect(result.error).toContain('already registered');
+      expect(result.error).toContain('cal-1');
     }
   });
 
-  it('surfaces errors when contact already has a primary calendar', async () => {
-    const contactService = {
-      linkCalendar: vi.fn().mockRejectedValue(new Error('Contact contact-abc already has a primary calendar')),
-    };
+  it('returns a readable error when contact already has a primary calendar (Postgres 23505)', async () => {
+    // Simulate the partial unique index violation for is_primary = true.
+    const pgError = Object.assign(new Error('duplicate key value violates unique constraint'), {
+      code: '23505',
+      constraint: 'idx_contact_calendars_primary',
+    });
+    const contactService = { linkCalendar: vi.fn().mockRejectedValue(pgError) };
 
     const result = await handler.execute(
       makeCtx(
@@ -176,6 +197,25 @@ describe('CalendarRegisterHandler', () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error).toContain('already has a primary calendar');
+      expect(result.error).toContain('contact-abc');
+    }
+  });
+
+  it('falls through to generic error for non-23505 failures', async () => {
+    const contactService = {
+      linkCalendar: vi.fn().mockRejectedValue(new Error('connection refused')),
+    };
+
+    const result = await handler.execute(
+      makeCtx(
+        { nylas_calendar_id: 'cal-1', label: 'Work' },
+        { contactService: contactService as never },
+      ),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('connection refused');
     }
   });
 });

--- a/tests/unit/skills/calendar-register.test.ts
+++ b/tests/unit/skills/calendar-register.test.ts
@@ -1,0 +1,181 @@
+// tests/unit/skills/calendar-register.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { CalendarRegisterHandler } from '../../../skills/calendar-register/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(
+  input: Record<string, unknown>,
+  overrides?: Partial<SkillContext>,
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    ...overrides,
+  };
+}
+
+describe('CalendarRegisterHandler', () => {
+  const handler = new CalendarRegisterHandler();
+
+  it('returns failure when contactService is not available', async () => {
+    const result = await handler.execute(makeCtx({ nylas_calendar_id: 'cal-1', label: 'Work' }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('infrastructure access');
+    }
+  });
+
+  it('returns failure when nylas_calendar_id is missing', async () => {
+    const contactService = { linkCalendar: vi.fn() };
+    const result = await handler.execute(
+      makeCtx({ label: 'Work' }, { contactService: contactService as never }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('nylas_calendar_id');
+    }
+  });
+
+  it('returns failure when label is missing', async () => {
+    const contactService = { linkCalendar: vi.fn() };
+    const result = await handler.execute(
+      makeCtx({ nylas_calendar_id: 'cal-1' }, { contactService: contactService as never }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('label');
+    }
+  });
+
+  it('registers a calendar linked to an explicit contact_id', async () => {
+    const linkedCalendar = {
+      id: 'link-uuid',
+      nylasCalendarId: 'cal-1',
+      contactId: 'contact-abc',
+      label: 'Work',
+      isPrimary: false,
+      readOnly: false,
+      timezone: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const contactService = { linkCalendar: vi.fn().mockResolvedValue(linkedCalendar) };
+
+    const result = await handler.execute(
+      makeCtx(
+        { nylas_calendar_id: 'cal-1', label: 'Work', contact_id: 'contact-abc' },
+        { contactService: contactService as never },
+      ),
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        nylas_calendar_id: 'cal-1',
+        contact_id: 'contact-abc',
+        label: 'Work',
+        is_primary: false,
+      });
+    }
+    expect(contactService.linkCalendar).toHaveBeenCalledWith(
+      expect.objectContaining({ nylasCalendarId: 'cal-1', contactId: 'contact-abc', label: 'Work' }),
+    );
+  });
+
+  it('defaults contact_id to the caller when not provided', async () => {
+    const linkedCalendar = {
+      id: 'link-uuid',
+      nylasCalendarId: 'cal-1',
+      contactId: 'caller-contact',
+      label: 'Personal',
+      isPrimary: true,
+      readOnly: false,
+      timezone: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const contactService = { linkCalendar: vi.fn().mockResolvedValue(linkedCalendar) };
+
+    const result = await handler.execute(
+      makeCtx(
+        { nylas_calendar_id: 'cal-1', label: 'Personal', is_primary: true },
+        {
+          contactService: contactService as never,
+          caller: { contactId: 'caller-contact', channel: 'email', identifier: 'joseph@josephfung.ca' },
+        },
+      ),
+    );
+
+    expect(result.success).toBe(true);
+    expect(contactService.linkCalendar).toHaveBeenCalledWith(
+      expect.objectContaining({ contactId: 'caller-contact', isPrimary: true }),
+    );
+  });
+
+  it('uses null contact_id when no contact_id and no caller', async () => {
+    const linkedCalendar = {
+      id: 'link-uuid',
+      nylasCalendarId: 'cal-holidays',
+      contactId: null,
+      label: 'Holidays',
+      isPrimary: false,
+      readOnly: true,
+      timezone: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const contactService = { linkCalendar: vi.fn().mockResolvedValue(linkedCalendar) };
+
+    const result = await handler.execute(
+      makeCtx(
+        { nylas_calendar_id: 'cal-holidays', label: 'Holidays' },
+        { contactService: contactService as never },
+      ),
+    );
+
+    expect(result.success).toBe(true);
+    expect(contactService.linkCalendar).toHaveBeenCalledWith(
+      expect.objectContaining({ contactId: null }),
+    );
+  });
+
+  it('surfaces errors from linkCalendar (e.g. duplicate calendar)', async () => {
+    const contactService = {
+      linkCalendar: vi.fn().mockRejectedValue(new Error('duplicate key value violates unique constraint')),
+    };
+
+    const result = await handler.execute(
+      makeCtx(
+        { nylas_calendar_id: 'cal-1', label: 'Work' },
+        { contactService: contactService as never },
+      ),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('duplicate key');
+    }
+  });
+
+  it('surfaces errors when contact already has a primary calendar', async () => {
+    const contactService = {
+      linkCalendar: vi.fn().mockRejectedValue(new Error('Contact contact-abc already has a primary calendar')),
+    };
+
+    const result = await handler.execute(
+      makeCtx(
+        { nylas_calendar_id: 'cal-1', label: 'Work', contact_id: 'contact-abc', is_primary: true },
+        { contactService: contactService as never },
+      ),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('already has a primary calendar');
+    }
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- Adds `calendar-register` skill — wraps `contactService.linkCalendar()` so the LLM can persist calendar ownership after the CEO confirms which Nylas calendar is theirs
- Pins the skill to the coordinator agent so it's available in every conversation
- Translates Postgres `23505` constraint violations into human-readable messages (`already registered`, `already has a primary calendar`) instead of surfacing raw constraint names
- Defaults `contact_id` to the caller's contact when omitted — the common case when the CEO says "that calendar is mine"

**Root cause fixed:** `calendar-list-calendars` could show unregistered calendars and prompt the CEO to confirm ownership, but there was no tool to write the answer anywhere. The LLM would say "I'll remember" and immediately forget.

## Test plan

- [ ] 10 new unit tests covering: missing inputs, explicit contact_id, caller defaulting, null/org-wide path, label-length validation, Postgres 23505 duplicate-calendar, Postgres 23505 duplicate-primary, generic errors
- [ ] Full suite: 619 passing, 9 skipped
- [ ] On production: email Curia asking about your calendar; when it lists calendars and asks to confirm, it should now persist the answer and not ask again


___

## **CodeAnt-AI Description**
**Add calendar registration and make duplicate calendar errors readable**

### What Changed
- Added a way to save a confirmed calendar ownership to the contact registry so a calendar can be recognized on later requests.
- When no contact is provided, the calendar now defaults to the caller’s contact; if there is no caller, it can be registered as an org-wide calendar.
- Duplicate calendar and duplicate primary-calendar errors now return plain-language messages instead of raw database constraint text.
- Added checks for missing calendar ID, missing label, and labels that are too long.

### Impact
`✅ Fewer repeat calendar confirmations`
`✅ Clearer calendar registration errors`
`✅ Shorter setup for personal calendars`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
