### PR TITLE
fix: use camelCase field names when reading Nylas SDK event responses

### DIFF
--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -61,15 +61,19 @@ export interface NylasCalendarLike {
 }
 
 // -- Raw Nylas SDK types (subset we use) --
+//
+// The Nylas SDK v8 runs objKeysToCamelCase() on all API responses before returning
+// them, so runtime objects use camelCase — not the snake_case of the raw REST API.
+// These interfaces must match the *SDK output*, not the wire format.
 
 interface NylasRawCalendar {
   id: string;
   name?: string;
   description?: string;
   timezone?: string;
-  is_primary?: boolean;
-  read_only?: boolean;
-  is_owned_by_user?: boolean;
+  isPrimary?: boolean;
+  readOnly?: boolean;
+  isOwnedByUser?: boolean;
 }
 
 interface NylasRawEvent {
@@ -77,11 +81,17 @@ interface NylasRawEvent {
   title?: string;
   description?: string;
   location?: string;
+  // 'when' is a discriminated union (Timespan | Time | Date | Datespan).
+  // All field names are camelCase after the SDK's objKeysToCamelCase transform.
   when?: {
-    start_time?: number;
-    end_time?: number;
-    start_date?: string;
-    end_date?: string;
+    // Timespan — regular timed events
+    startTime?: number;
+    endTime?: number;
+    // Date — single all-day events
+    date?: string;
+    // Datespan — multi-day all-day events
+    startDate?: string;
+    endDate?: string;
     object?: string;
   };
   participants?: Array<{
@@ -91,16 +101,16 @@ interface NylasRawEvent {
   }>;
   conferencing?: Record<string, unknown>;
   status?: string;
-  calendar_id?: string;
+  calendarId?: string;
   busy?: boolean;
   metadata?: Record<string, string>;
 }
 
 interface NylasRawFreeBusy {
   email: string;
-  time_slots?: Array<{
-    start_time: number;
-    end_time: number;
+  timeSlots?: Array<{
+    startTime: number;
+    endTime: number;
     status: string;
   }>;
 }
@@ -350,9 +360,9 @@ export class NylasCalendarClient {
       });
       return (response?.data ?? []).map((fb) => ({
         email: fb.email,
-        timeSlots: (fb.time_slots ?? []).map((ts) => ({
-          startTime: ts.start_time,
-          endTime: ts.end_time,
+        timeSlots: (fb.timeSlots ?? []).map((ts) => ({
+          startTime: ts.startTime,
+          endTime: ts.endTime,
           status: ts.status,
         })),
       }));
@@ -381,9 +391,9 @@ export class NylasCalendarClient {
       name: cal.name ?? '',
       description: cal.description ?? '',
       timezone: cal.timezone ?? '',
-      isPrimary: cal.is_primary ?? false,
-      readOnly: cal.read_only ?? false,
-      isOwnedByUser: cal.is_owned_by_user ?? true,
+      isPrimary: cal.isPrimary ?? false,
+      readOnly: cal.readOnly ?? false,
+      isOwnedByUser: cal.isOwnedByUser ?? true,
     };
   }
 
@@ -393,10 +403,11 @@ export class NylasCalendarClient {
       title: evt.title ?? '',
       description: evt.description ?? '',
       location: evt.location ?? '',
-      startTime: evt.when?.start_time ?? null,
-      endTime: evt.when?.end_time ?? null,
-      startDate: evt.when?.start_date ?? null,
-      endDate: evt.when?.end_date ?? null,
+      startTime: evt.when?.startTime ?? null,
+      endTime: evt.when?.endTime ?? null,
+      // For single all-day events (Date type), expose the date as both startDate and endDate
+      startDate: evt.when?.startDate ?? evt.when?.date ?? null,
+      endDate: evt.when?.endDate ?? evt.when?.date ?? null,
       participants: (evt.participants ?? []).map((p) => ({
         email: p.email,
         name: p.name ?? '',
@@ -404,7 +415,7 @@ export class NylasCalendarClient {
       })),
       conferencing: evt.conferencing ?? null,
       status: evt.status ?? 'confirmed',
-      calendarId: evt.calendar_id ?? '',
+      calendarId: evt.calendarId ?? '',
       busy: evt.busy ?? true,
     };
   }

--- a/tests/unit/channels/nylas-calendar-client.test.ts
+++ b/tests/unit/channels/nylas-calendar-client.test.ts
@@ -53,15 +53,17 @@ describe('NylasCalendarClient', () => {
     });
 
     it('returns normalized calendar objects', async () => {
+      // Mock data uses camelCase — the Nylas SDK v8 runs objKeysToCamelCase() on
+      // all API responses before returning them, so runtime objects are camelCase.
       (sdk.calendars.list as ReturnType<typeof vi.fn>).mockResolvedValue({
         data: [{
           id: 'cal-1',
           name: 'Joseph Work',
           description: 'Main calendar',
           timezone: 'America/Toronto',
-          is_primary: true,
-          read_only: false,
-          is_owned_by_user: false,
+          isPrimary: true,
+          readOnly: false,
+          isOwnedByUser: false,
         }],
       });
 
@@ -98,6 +100,65 @@ describe('NylasCalendarClient', () => {
     it('throws on invalid date strings', async () => {
       await expect(client.listEvents('cal-1', 'not-a-date', '2026-04-02T00:00:00Z'))
         .rejects.toThrow(/Invalid timeMin timestamp/);
+    });
+
+    it('returns normalized event objects with timestamps from SDK camelCase response', async () => {
+      // The Nylas SDK v8 transforms all response keys to camelCase before returning.
+      // startTime/endTime on 'when' come back camelCase, not start_time/end_time.
+      (sdk.events.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: [{
+          id: 'evt-abc',
+          title: 'Karen — Capacity Canada',
+          calendarId: 'cal-1',
+          status: 'confirmed',
+          busy: true,
+          when: {
+            startTime: 1744027500, // 2026-04-07T18:45:00Z
+            endTime: 1744029300,   // 2026-04-07T19:15:00Z
+            object: 'timespan',
+          },
+          participants: [{ email: 'karen@capacity.ca', name: 'Karen', status: 'yes' }],
+        }],
+      });
+
+      const events = await client.listEvents('cal-1', '2026-04-07T00:00:00Z', '2026-04-08T00:00:00Z');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        id: 'evt-abc',
+        title: 'Karen — Capacity Canada',
+        calendarId: 'cal-1',
+        startTime: 1744027500,
+        endTime: 1744029300,
+        startDate: null,
+        endDate: null,
+      });
+    });
+
+    it('returns normalized all-day event with startDate/endDate', async () => {
+      (sdk.events.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: [{
+          id: 'evt-allday',
+          title: 'Company Holiday',
+          calendarId: 'cal-1',
+          status: 'confirmed',
+          busy: false,
+          when: {
+            startDate: '2026-04-10',
+            endDate: '2026-04-10',
+            object: 'datespan',
+          },
+        }],
+      });
+
+      const events = await client.listEvents('cal-1', '2026-04-07T00:00:00Z', '2026-04-14T00:00:00Z');
+
+      expect(events[0]).toMatchObject({
+        startTime: null,
+        endTime: null,
+        startDate: '2026-04-10',
+        endDate: '2026-04-10',
+      });
     });
   });
 
@@ -164,6 +225,26 @@ describe('NylasCalendarClient', () => {
           end_time: Math.floor(new Date('2026-04-02T00:00:00Z').getTime() / 1000),
           emails: ['cal-1', 'cal-2'],
         },
+      });
+    });
+
+    it('returns normalized free-busy slots from camelCase SDK response', async () => {
+      // The Nylas SDK v8 camelCases the response — timeSlots, startTime, endTime.
+      (sdk.calendars_free_busy.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: [{
+          email: 'cal-1',
+          timeSlots: [
+            { startTime: 1744027500, endTime: 1744029300, status: 'busy' },
+          ],
+        }],
+      });
+
+      const result = await client.getFreeBusy(['cal-1'], '2026-04-01T00:00:00Z', '2026-04-02T00:00:00Z');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        email: 'cal-1',
+        timeSlots: [{ startTime: 1744027500, endTime: 1744029300, status: 'busy' }],
       });
     });
   });


### PR DESCRIPTION
## **User description**
## Summary

- Nylas SDK v8 runs `objKeysToCamelCase()` on all API responses before returning them — runtime objects are camelCase, not snake_case
- `NylasRawEvent.when` was declaring `start_time`/`end_time`/`start_date`/`end_date` (snake_case), so `normalizeEvent()` read `undefined` for every timestamp field and returned `null` for `startTime`, `endTime`, `startDate`, and `endDate`
- Same bug hit `NylasRawCalendar` (`is_primary`/`read_only`/`is_owned_by_user`) and `NylasRawFreeBusy` (`time_slots`/`start_time`/`end_time`)
- Fix: update all three raw interfaces to camelCase; update all three normalizers; add test coverage for event and free-busy response normalization

Also handles the Nylas `Date` when-type (single all-day events with just a `date` field) — exposes it as both `startDate` and `endDate` for consistency.

## Test plan

- [ ] `pnpm test tests/unit/channels/nylas-calendar-client.test.ts` — 11 tests pass (includes 3 new response-normalization tests)
- [ ] `pnpm typecheck` — clean
- [ ] Full suite: 622 tests pass, 9 skipped


___

## **CodeAnt-AI Description**
**Fix calendar event and free-busy data coming back empty or missing timestamps**

### What Changed
- Calendar events now read the field names that the Nylas SDK actually returns, so start/end times and calendar IDs are preserved instead of coming back empty.
- Single all-day events now show the same date for both start and end, so they display consistently.
- Free-busy results now keep their time slots when returned from the SDK.
- Added coverage for timed events, all-day events, and free-busy results using the SDK’s camelCase response shape.

### Impact
`✅ Correct event times in calendar views`
`✅ Proper display of all-day events`
`✅ Reliable free-busy availability results`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
