### PR TITLE
fix: harden smoke evaluator against silent scoring failures

### DIFF
--- a/tests/smoke/evaluator.ts
+++ b/tests/smoke/evaluator.ts
@@ -197,6 +197,9 @@ export function parseJudgeResponse(
     return scores;
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
+    // Always warn so the operator knows a parse failure occurred, even when
+    // fallbackBehaviors is absent (without this the caller receives [] silently).
+    process.stderr.write(`  [WARN] Failed to parse judge response: ${detail}\n`);
     if (!fallbackBehaviors) return [];
     return fallbackBehaviors.map(b => ({
       behaviorId: b.id,
@@ -227,11 +230,13 @@ export function computeWeightedScore(
     if (score) {
       earnedWeight += w * RATING_VALUES[score.rating];
     } else {
-      // Warn so operators know the 0 came from a missing score, not a genuine MISS.
-      // This most commonly happens when the judge reformats IDs (e.g. classify_urgent
-      // vs classify-urgent) and parseJudgeResponse's validation was bypassed or skipped.
+      // Backstop warn: no score entry for this behavior — counts as 0.
+      // parseJudgeResponse will have already identified the specific cause (ID mismatch,
+      // dropped behavior, etc.) when it was given the expected behaviors. This warning
+      // fires regardless, so the score impact is always surfaced even if parsing was called
+      // without fallbackBehaviors.
       process.stderr.write(
-        `  [WARN] No score returned for behavior '${b.id}' — judge may have reformatted the ID (counts as 0)\n`,
+        `  [WARN] No score entry for behavior '${b.id}' — counting as 0\n`,
       );
     }
   }

--- a/tests/smoke/evaluator.ts
+++ b/tests/smoke/evaluator.ts
@@ -150,6 +150,11 @@ Rate each behavior. Respond with JSON only.`;
  * Parse the judge's JSON response into BehaviorScore[].
  * Falls back to all-MISS (using fallbackBehaviors) if parsing fails.
  * If fallbackBehaviors is omitted and parsing fails, returns an empty array.
+ *
+ * When fallbackBehaviors is provided, also validates the returned IDs against
+ * the expected set and warns on any mismatch (extra or missing IDs). This
+ * catches cases where the judge reformats IDs (e.g. underscores vs hyphens)
+ * before they silently zero-score in computeWeightedScore.
  */
 export function parseJudgeResponse(
   raw: string,
@@ -160,11 +165,36 @@ export function parseJudgeResponse(
     if (!Array.isArray(parsed.scores)) throw new Error('Missing scores array');
 
     // Normalize any unrecognized rating values to MISS for safety
-    return parsed.scores.map(s => ({
+    const scores = parsed.scores.map(s => ({
       behaviorId: s.behaviorId,
       rating: (['PASS', 'PARTIAL', 'MISS'].includes(s.rating) ? s.rating : 'MISS') as BehaviorRating,
       justification: s.justification ?? '',
     }));
+
+    // Validate returned IDs against expected set when we have one.
+    // IDs the judge invented won't be matched by computeWeightedScore;
+    // IDs the judge dropped will silently score 0. Both are surfaced here.
+    if (fallbackBehaviors) {
+      const expectedIds = new Set(fallbackBehaviors.map(b => b.id));
+      const returnedIds = new Set(scores.map(s => s.behaviorId));
+
+      for (const id of returnedIds) {
+        if (!expectedIds.has(id)) {
+          process.stderr.write(
+            `  [WARN] Judge returned unexpected behavior ID '${id}' — not in expected set, will be ignored by scorer\n`,
+          );
+        }
+      }
+      for (const id of expectedIds) {
+        if (!returnedIds.has(id)) {
+          process.stderr.write(
+            `  [WARN] Judge did not return a score for expected behavior '${id}' — will score as 0\n`,
+          );
+        }
+      }
+    }
+
+    return scores;
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     if (!fallbackBehaviors) return [];
@@ -196,8 +226,14 @@ export function computeWeightedScore(
     const score = scoreMap.get(b.id);
     if (score) {
       earnedWeight += w * RATING_VALUES[score.rating];
+    } else {
+      // Warn so operators know the 0 came from a missing score, not a genuine MISS.
+      // This most commonly happens when the judge reformats IDs (e.g. classify_urgent
+      // vs classify-urgent) and parseJudgeResponse's validation was bypassed or skipped.
+      process.stderr.write(
+        `  [WARN] No score returned for behavior '${b.id}' — judge may have reformatted the ID (counts as 0)\n`,
+      );
     }
-    // If a behavior has no corresponding score entry, it counts as 0 earned weight
   }
 
   // Guard against degenerate empty-behaviors case

--- a/tests/smoke/loader.ts
+++ b/tests/smoke/loader.ts
@@ -83,14 +83,17 @@ export function loadTestCases(
 
   // Enforce unique names before applying tag filtering so duplicates are caught
   // regardless of which tags are in use.
+  // Normalize to lowercase so duplicate detection matches CLI --case filter semantics,
+  // which uses case-insensitive substring matching (see cli.ts line 34).
   const seen = new Set<string>();
   for (const tc of cases) {
-    if (seen.has(tc.name)) {
+    const normalizedName = tc.name.trim().toLowerCase();
+    if (seen.has(normalizedName)) {
       throw new Error(
         `Duplicate test case name '${tc.name}' found in ${dirPath} — each test case must have a unique name`,
       );
     }
-    seen.add(tc.name);
+    seen.add(normalizedName);
   }
 
   if (options?.tags && options.tags.length > 0) {

--- a/tests/smoke/loader.ts
+++ b/tests/smoke/loader.ts
@@ -68,6 +68,8 @@ export function loadTestCase(filePath: string): TestCase {
  * Load all YAML test cases from a directory.
  * Files are sorted alphabetically for a stable, predictable load order.
  * Optionally filter to only cases that have at least one of the given tags.
+ * Throws if any two files share the same case name — duplicates would cause
+ * the --case CLI filter to match multiple cases silently.
  */
 export function loadTestCases(
   dirPath: string,
@@ -77,11 +79,23 @@ export function loadTestCases(
     .filter(f => f.endsWith('.yaml') || f.endsWith('.yml'))
     .sort();
 
-  let cases = files.map(f => loadTestCase(path.join(dirPath, f)));
+  const cases = files.map(f => loadTestCase(path.join(dirPath, f)));
+
+  // Enforce unique names before applying tag filtering so duplicates are caught
+  // regardless of which tags are in use.
+  const seen = new Set<string>();
+  for (const tc of cases) {
+    if (seen.has(tc.name)) {
+      throw new Error(
+        `Duplicate test case name '${tc.name}' found in ${dirPath} — each test case must have a unique name`,
+      );
+    }
+    seen.add(tc.name);
+  }
 
   if (options?.tags && options.tags.length > 0) {
     const filterTags = new Set(options.tags);
-    cases = cases.filter(tc => tc.tags.some(t => filterTags.has(t)));
+    return cases.filter(tc => tc.tags.some(t => filterTags.has(t)));
   }
 
   return cases;

--- a/tests/unit/smoke/evaluator.test.ts
+++ b/tests/unit/smoke/evaluator.test.ts
@@ -1,9 +1,19 @@
 // tests/unit/smoke/evaluator.test.ts
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { parseJudgeResponse, computeWeightedScore } from '../../smoke/evaluator.js';
 import type { ExpectedBehavior, BehaviorScore } from '../../smoke/types.js';
 
 describe('Evaluator', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
   describe('parseJudgeResponse', () => {
     it('parses a well-formed judge JSON response', () => {
       const raw = JSON.stringify({
@@ -29,6 +39,47 @@ describe('Evaluator', () => {
       const scores = parseJudgeResponse('not valid json', behaviors);
       expect(scores).toHaveLength(2);
       expect(scores.every(s => s.rating === 'MISS')).toBe(true);
+    });
+
+    it('warns when judge returns an unexpected behavior ID', () => {
+      const behaviors: ExpectedBehavior[] = [
+        { id: 'classify-urgent', description: 'test', weight: 'critical' },
+      ];
+      // Judge returns underscore variant — a common reformatting mistake
+      const raw = JSON.stringify({
+        scores: [{ behaviorId: 'classify_urgent', rating: 'PASS', justification: 'ok' }],
+      });
+      parseJudgeResponse(raw, behaviors);
+
+      const output = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(output).toContain("unexpected behavior ID 'classify_urgent'");
+      expect(output).toContain("'classify-urgent'");
+    });
+
+    it('warns when judge omits a score for an expected behavior', () => {
+      const behaviors: ExpectedBehavior[] = [
+        { id: 'a', description: 'test', weight: 'important' },
+        { id: 'b', description: 'test', weight: 'important' },
+      ];
+      const raw = JSON.stringify({
+        scores: [{ behaviorId: 'a', rating: 'PASS', justification: 'ok' }],
+      });
+      parseJudgeResponse(raw, behaviors);
+
+      const output = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(output).toContain("did not return a score for expected behavior 'b'");
+    });
+
+    it('does not warn when returned IDs match expected set exactly', () => {
+      const behaviors: ExpectedBehavior[] = [
+        { id: 'a', description: 'test', weight: 'important' },
+      ];
+      const raw = JSON.stringify({
+        scores: [{ behaviorId: 'a', rating: 'PASS', justification: 'ok' }],
+      });
+      parseJudgeResponse(raw, behaviors);
+
+      expect(stderrSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -66,6 +117,33 @@ describe('Evaluator', () => {
         { behaviorId: 'b', rating: 'MISS', justification: '' },
       ];
       expect(computeWeightedScore(behaviors, scores)).toBeCloseTo(0.75);
+    });
+
+    it('warns when an expected behavior has no score entry', () => {
+      const behaviors: ExpectedBehavior[] = [
+        { id: 'a', description: '', weight: 'critical' },
+        { id: 'b', description: '', weight: 'important' },
+      ];
+      // 'b' is missing from scores — simulates judge reformatting the ID
+      const scores: BehaviorScore[] = [
+        { behaviorId: 'a', rating: 'PASS', justification: '' },
+      ];
+      computeWeightedScore(behaviors, scores);
+
+      const output = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(output).toContain("No score returned for behavior 'b'");
+    });
+
+    it('does not warn when all expected behaviors have scores', () => {
+      const behaviors: ExpectedBehavior[] = [
+        { id: 'a', description: '', weight: 'critical' },
+      ];
+      const scores: BehaviorScore[] = [
+        { behaviorId: 'a', rating: 'PASS', justification: '' },
+      ];
+      computeWeightedScore(behaviors, scores);
+
+      expect(stderrSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/smoke/evaluator.test.ts
+++ b/tests/unit/smoke/evaluator.test.ts
@@ -41,6 +41,15 @@ describe('Evaluator', () => {
       expect(scores.every(s => s.rating === 'MISS')).toBe(true);
     });
 
+    it('warns on parse failure even when fallbackBehaviors is absent', () => {
+      // Without this, a caller omitting fallbackBehaviors would silently receive []
+      // with no indication that the parse failed.
+      parseJudgeResponse('not valid json');
+
+      const output = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(output).toContain('Failed to parse judge response');
+    });
+
     it('warns when judge returns an unexpected behavior ID', () => {
       const behaviors: ExpectedBehavior[] = [
         { id: 'classify-urgent', description: 'test', weight: 'critical' },
@@ -131,7 +140,7 @@ describe('Evaluator', () => {
       computeWeightedScore(behaviors, scores);
 
       const output = stderrSpy.mock.calls.map(c => String(c[0])).join('');
-      expect(output).toContain("No score returned for behavior 'b'");
+      expect(output).toContain("No score entry for behavior 'b'");
     });
 
     it('does not warn when all expected behaviors have scores', () => {

--- a/tests/unit/smoke/loader.test.ts
+++ b/tests/unit/smoke/loader.test.ts
@@ -1,8 +1,17 @@
-import { describe, it, expect } from 'vitest';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { loadTestCases, loadTestCase } from '../../smoke/loader.js';
+
+// Track temp dirs created in this suite for cleanup
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 // Minimal valid YAML test case content
 function minimalYaml(name: string): string {
@@ -52,6 +61,7 @@ describe('Smoke test loader', () => {
 
   it('throws on duplicate test case names across files', () => {
     const dir = mkdtempSync(join(tmpdir(), 'curia-smoke-test-'));
+    tempDirs.push(dir);
     writeFileSync(join(dir, 'a.yaml'), minimalYaml('Duplicate Name'));
     writeFileSync(join(dir, 'b.yaml'), minimalYaml('Duplicate Name'));
 
@@ -60,6 +70,7 @@ describe('Smoke test loader', () => {
 
   it('does not throw when all test case names are unique', () => {
     const dir = mkdtempSync(join(tmpdir(), 'curia-smoke-test-'));
+    tempDirs.push(dir);
     writeFileSync(join(dir, 'a.yaml'), minimalYaml('Case A'));
     writeFileSync(join(dir, 'b.yaml'), minimalYaml('Case B'));
 

--- a/tests/unit/smoke/loader.test.ts
+++ b/tests/unit/smoke/loader.test.ts
@@ -1,5 +1,21 @@
 import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { loadTestCases, loadTestCase } from '../../smoke/loader.js';
+
+// Minimal valid YAML test case content
+function minimalYaml(name: string): string {
+  return [
+    `name: ${name}`,
+    'turns:',
+    '  - content: hello',
+    'expected_behaviors:',
+    '  - id: respond',
+    '    description: Responds to user',
+    '    weight: important',
+  ].join('\n');
+}
 
 describe('Smoke test loader', () => {
   it('loads a single YAML test case', () => {
@@ -32,5 +48,21 @@ describe('Smoke test loader', () => {
     for (const tc of filtered) {
       expect(tc.tags).toContain('inference');
     }
+  });
+
+  it('throws on duplicate test case names across files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'curia-smoke-test-'));
+    writeFileSync(join(dir, 'a.yaml'), minimalYaml('Duplicate Name'));
+    writeFileSync(join(dir, 'b.yaml'), minimalYaml('Duplicate Name'));
+
+    expect(() => loadTestCases(dir)).toThrow(/Duplicate test case name 'Duplicate Name'/);
+  });
+
+  it('does not throw when all test case names are unique', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'curia-smoke-test-'));
+    writeFileSync(join(dir, 'a.yaml'), minimalYaml('Case A'));
+    writeFileSync(join(dir, 'b.yaml'), minimalYaml('Case B'));
+
+    expect(() => loadTestCases(dir)).not.toThrow();
   });
 });

--- a/tests/unit/smoke/loader.test.ts
+++ b/tests/unit/smoke/loader.test.ts
@@ -68,6 +68,17 @@ describe('Smoke test loader', () => {
     expect(() => loadTestCases(dir)).toThrow(/Duplicate test case name 'Duplicate Name'/);
   });
 
+  it('throws on case-insensitive duplicate names to match CLI --case filter semantics', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'curia-smoke-test-'));
+    tempDirs.push(dir);
+    // 'Invoice' and 'invoice' are distinct to a case-sensitive Set but both match
+    // `--case invoice` in the CLI, so we treat them as duplicates.
+    writeFileSync(join(dir, 'a.yaml'), minimalYaml('Invoice'));
+    writeFileSync(join(dir, 'b.yaml'), minimalYaml('invoice'));
+
+    expect(() => loadTestCases(dir)).toThrow(/Duplicate test case name/);
+  });
+
   it('does not throw when all test case names are unique', () => {
     const dir = mkdtempSync(join(tmpdir(), 'curia-smoke-test-'));
     tempDirs.push(dir);


### PR DESCRIPTION
## **User description**
## Summary

Fixes all three issues from #72:

- **`computeWeightedScore`**: warns to stderr when an expected behavior has no matching score entry — catches judge ID reformatting (e.g. `classify_urgent` vs `classify-urgent`) before it silently zeros a run
- **`parseJudgeResponse`**: when `fallbackBehaviors` is provided, validates returned IDs against the expected set and warns on both extra IDs (invented by judge) and missing IDs (dropped by judge)
- **`loadTestCases`**: throws on duplicate test case names across YAML files, preventing `--case` filter from silently matching multiple cases

## Test plan

- [ ] `parseJudgeResponse` warns on unexpected judge-returned ID
- [ ] `parseJudgeResponse` warns when judge omits a score for an expected behavior
- [ ] `parseJudgeResponse` does not warn when IDs match exactly
- [ ] `computeWeightedScore` warns when a behavior has no score entry
- [ ] `computeWeightedScore` does not warn when all behaviors have scores
- [ ] `loadTestCases` throws on duplicate case names
- [ ] `loadTestCases` passes when all names are unique
- [ ] All 16 smoke unit tests pass

## Notes

Two reviewer findings not addressed (pre-existing scope):

1. **`process.stderr.write` vs pino**: CLAUDE.md prefers pino, but the existing `judgeCase` fallback (line 139, pre-existing) already uses `process.stderr.write` with the same `[WARN]` prefix pattern. Switching to pino requires wiring a logger into the smoke harness — a separate refactor.
2. **Double warnings on missing IDs**: When a behavior ID is absent from the judge response, both `parseJudgeResponse` and `computeWeightedScore` emit a warning. This is intentional defense-in-depth per the issue spec, but can produce two messages for the same root cause. Can be tightened in a follow-up if noisy in practice.

Closes #72


___

## **CodeAnt-AI Description**
**Harden smoke checks so missing or mismatched judge scores are surfaced instead of silently counting as zero**

### What Changed
- The smoke evaluator now warns when the judge returns an unexpected behavior ID or skips an expected one, making ID mismatches visible during runs.
- Weighted scoring now warns when a behavior has no score entry, instead of failing quietly.
- Loading smoke test cases now fails if two files use the same case name, preventing the `--case` filter from matching multiple cases without notice.
- Added tests for the new warnings and duplicate-name check.

### Impact
`✅ Fewer silent zero-score runs`
`✅ Clearer judge mismatch warnings`
`✅ Safer smoke case filtering`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
