### PR TITLE
fix: default isOwnedByUser to false when missing in normalizeCalendar

### DIFF
--- a/src/channels/calendar/nylas-calendar-client.ts
+++ b/src/channels/calendar/nylas-calendar-client.ts
@@ -386,6 +386,11 @@ export class NylasCalendarClient {
   // -- Normalizers --
 
   private normalizeCalendar(cal: NylasRawCalendar): NylasCalendar {
+    // Warn if isOwnedByUser is absent — default to false (safe side) to avoid
+    // granting write access to calendars the user may not own.
+    if (cal.isOwnedByUser === undefined) {
+      this.log.warn({ calendarId: cal.id }, 'normalizeCalendar: isOwnedByUser missing — defaulting to false');
+    }
     return {
       id: cal.id,
       name: cal.name ?? '',
@@ -393,7 +398,7 @@ export class NylasCalendarClient {
       timezone: cal.timezone ?? '',
       isPrimary: cal.isPrimary ?? false,
       readOnly: cal.readOnly ?? false,
-      isOwnedByUser: cal.isOwnedByUser ?? true,
+      isOwnedByUser: cal.isOwnedByUser ?? false,
     };
   }
 

--- a/tests/unit/channels/nylas-calendar-client.test.ts
+++ b/tests/unit/channels/nylas-calendar-client.test.ts
@@ -80,6 +80,25 @@ describe('NylasCalendarClient', () => {
         isOwnedByUser: false,
       });
     });
+
+    it('defaults isOwnedByUser to false when missing from SDK response', async () => {
+      // Safety-side default: absent isOwnedByUser must NOT grant write access.
+      (sdk.calendars.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: [{
+          id: 'cal-unknown',
+          name: 'Mystery Calendar',
+          description: '',
+          timezone: 'UTC',
+          isPrimary: false,
+          readOnly: false,
+          // isOwnedByUser intentionally absent
+        }],
+      });
+
+      const calendars = await client.listCalendars();
+
+      expect(calendars[0].isOwnedByUser).toBe(false);
+    });
   });
 
   describe('listEvents', () => {


### PR DESCRIPTION
## **User description**
## Summary

- `normalizeCalendar()` was defaulting `isOwnedByUser` to `true` when the field was absent from the Nylas SDK response
- This could silently grant write access to calendars the user does not own
- Fixed to default to `false` (safe side) and emit a `warn` log when the field is missing

## Test plan

- [x] New unit test: `defaults isOwnedByUser to false when missing from SDK response`
- [x] All 632 existing tests continue to pass

Closes #106


___

## **CodeAnt-AI Description**
**Treat missing calendar ownership as not owned by the user**

### What Changed
- Calendars that arrive without an ownership value now default to not owned by the user, which avoids showing write access where it should not exist
- A warning is logged when that value is missing so the issue is easier to spot
- Added a test to confirm missing ownership stays false

### Impact
`✅ Fewer calendars shown with write access`
`✅ Safer calendar permissions`
`✅ Clearer missing-data warnings`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
