### PR TITLE
fix: return 403 immediately when unknown_sender: reject drops HTTP messages

### DIFF
--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -117,6 +117,18 @@ interface MessageHeldPayload {
   subject: string | null;
 }
 
+// MessageRejectedPayload — emitted by the dispatch layer when a message is rejected
+// due to an unknown_sender: reject policy (or a blocked sender). The conversationId
+// is included so the HTTP adapter can immediately resolve the pending response
+// with an error rather than hanging until the 120-second timeout.
+interface MessageRejectedPayload {
+  conversationId: string;
+  channelId: string;
+  senderId: string;
+  /** Why the message was rejected — used by the HTTP adapter to select the status code. */
+  reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender';
+}
+
 // Memory event payloads — used for the knowledge graph audit trail (Phase 6).
 // `source` is a structured provenance string (e.g. "agent:coordinator/task:task-1/channel:cli").
 
@@ -239,6 +251,12 @@ export interface MessageHeldEvent extends BaseEvent {
   payload: MessageHeldPayload;
 }
 
+export interface MessageRejectedEvent extends BaseEvent {
+  type: 'message.rejected';
+  sourceLayer: 'dispatch';
+  payload: MessageRejectedPayload;
+}
+
 // Memory events — emitted by the agent layer whenever the knowledge graph is written to or queried.
 // These form the audit trail for memory operations (Phase 6).
 
@@ -285,6 +303,7 @@ export type BusEvent =
   | ContactResolvedEvent  // Contacts Phase A: sender matched to a known contact
   | ContactUnknownEvent   // Contacts Phase A: sender has no contact record
   | MessageHeldEvent      // Unknown sender policy: message held for CEO review
+  | MessageRejectedEvent  // Unknown sender policy: message rejected, signals HTTP adapter to return 403
   | OutboundBlockedEvent  // Outbound content filter: message blocked before delivery (#38)
   | ScheduleCreatedEvent   // Scheduler: job created
   | ScheduleFiredEvent     // Scheduler: job fired
@@ -484,6 +503,21 @@ export function createMessageHeld(
     id: randomUUID(),
     timestamp: new Date(),
     type: 'message.held',
+    sourceLayer: 'dispatch',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createMessageRejected(
+  // parentEventId is required — rejection events must trace back to the inbound event.
+  payload: MessageRejectedPayload & { parentEventId: string },
+): MessageRejectedEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'message.rejected',
     sourceLayer: 'dispatch',
     payload: rest,
     parentEventId,

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -9,18 +9,18 @@ import type { Layer, EventType } from './events.js';
 //                 system layer gets full access for audit logging and monitoring.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message']),
-  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'contact.resolved', 'contact.unknown', 'message.held']),
+  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected']),
   agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query']),
   execution: new Set(['skill.result']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'schedule.created', 'schedule.fired', 'schedule.suspended']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended']),
 };
 
 const subscribeAllowlist: Record<Layer, Set<EventType>> = {
-  channel: new Set(['outbound.message', 'outbound.blocked', 'message.held']),
+  channel: new Set(['outbound.message', 'outbound.blocked', 'message.held', 'message.rejected']),
   dispatch: new Set(['inbound.message', 'agent.response', 'agent.error']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'schedule.created', 'schedule.fired', 'schedule.suspended']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -14,6 +14,22 @@ import type { BusEvent } from '../../bus/events.js';
 import type { Logger } from '../../logger.js';
 import type { ServerResponse } from 'node:http';
 
+/**
+ * Thrown by the event router when the dispatcher rejects a message via the
+ * `unknown_sender: reject` policy. Typed separately from Error so the route
+ * handler can detect the rejection case and return 403 without brittle string
+ * matching on the error message.
+ */
+export class MessageRejectedError extends Error {
+  readonly reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender';
+
+  constructor(reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender') {
+    super(`Message rejected — sender not authorized (${reason})`);
+    this.name = 'MessageRejectedError';
+    this.reason = reason;
+  }
+}
+
 export interface PendingResponse {
   resolve: (content: string) => void;
   reject: (error: Error) => void;
@@ -137,7 +153,7 @@ export class EventRouter {
       if (pending) {
         clearTimeout(pending.timeout);
         this.pendingResponses.delete(convId);
-        pending.reject(new Error(`Message rejected — sender not authorized (${event.payload.reason})`));
+        pending.reject(new MessageRejectedError(event.payload.reason));
       }
 
       // Also broadcast to SSE clients so dashboards can react

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -143,20 +143,23 @@ export class EventRouter {
     // (which has no other way to know the message was dropped).
     bus.subscribe('message.rejected', 'channel', (event: BusEvent) => {
       if (event.type !== 'message.rejected') return;
-      // Only handle rejections for the HTTP channel
-      if (event.payload.channelId !== 'http') return;
 
       const convId = event.payload.conversationId;
 
-      // Reject the pending POST if one is waiting — this unblocks the route handler
-      const pending = this.pendingResponses.get(convId);
-      if (pending) {
-        clearTimeout(pending.timeout);
-        this.pendingResponses.delete(convId);
-        pending.reject(new MessageRejectedError(event.payload.reason));
+      // Only HTTP requests have pending POST promises to reject.
+      // Non-HTTP channels (email, etc.) produce rejection events for audit and SSE,
+      // but have no synchronous caller waiting on a promise.
+      if (event.payload.channelId === 'http') {
+        const pending = this.pendingResponses.get(convId);
+        if (pending) {
+          clearTimeout(pending.timeout);
+          this.pendingResponses.delete(convId);
+          pending.reject(new MessageRejectedError(event.payload.reason));
+        }
       }
 
-      // Also broadcast to SSE clients so dashboards can react
+      // Broadcast to SSE clients for all channels so dashboards have full visibility
+      // into rejection events regardless of which channel the message arrived on.
       const sseData = JSON.stringify({
         type: 'message.rejected',
         conversation_id: convId,

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -121,6 +121,37 @@ export class EventRouter {
       this.broadcastToSseClients(sseData);
     });
 
+    // message.rejected — immediately reject the pending POST promise so the caller
+    // gets a 403 instead of hanging until the 120-second timeout. This is the signal
+    // path between the dispatch layer (where reject policy fires) and the HTTP adapter
+    // (which has no other way to know the message was dropped).
+    bus.subscribe('message.rejected', 'channel', (event: BusEvent) => {
+      if (event.type !== 'message.rejected') return;
+      // Only handle rejections for the HTTP channel
+      if (event.payload.channelId !== 'http') return;
+
+      const convId = event.payload.conversationId;
+
+      // Reject the pending POST if one is waiting — this unblocks the route handler
+      const pending = this.pendingResponses.get(convId);
+      if (pending) {
+        clearTimeout(pending.timeout);
+        this.pendingResponses.delete(convId);
+        pending.reject(new Error(`Message rejected — sender not authorized (${event.payload.reason})`));
+      }
+
+      // Also broadcast to SSE clients so dashboards can react
+      const sseData = JSON.stringify({
+        type: 'message.rejected',
+        conversation_id: convId,
+        channel_id: event.payload.channelId,
+        sender_id: event.payload.senderId,
+        reason: event.payload.reason,
+        timestamp: event.timestamp,
+      });
+      this.broadcastToSseClients(sseData, convId);
+    });
+
     this.logger.info('HTTP event router subscriptions registered');
   }
 

--- a/src/channels/http/routes/messages.ts
+++ b/src/channels/http/routes/messages.ts
@@ -60,8 +60,23 @@ export async function messageRoutes(
       content: body.content,
     });
 
+    // Publish failure: bus.publish() threw synchronously. Cancel our pending entry
+    // (which is still ours at this point — no other request has had a chance to
+    // supersede it) and bail early with a 500.
     try {
       await bus.publish('channel', inboundEvent);
+    } catch (publishErr) {
+      eventRouter.cancelPending(conversationId);
+      const message = publishErr instanceof Error ? publishErr.message : String(publishErr);
+      logger.error({ err: publishErr, conversationId }, 'HTTP message publish failed');
+      return reply.status(500).send({ error: message });
+    }
+
+    // Wait for the agent response. At this point the pending entry may have been
+    // superseded by a concurrent request with the same conversation_id — in that
+    // case our promise already rejected with "Superseded". We must NOT call
+    // cancelPending here because the entry now belongs to the newer request.
+    try {
       const content = await responsePromise;
 
       // TODO: agent_id is hardcoded — OutboundMessagePayload doesn't carry agentId.
@@ -73,14 +88,10 @@ export async function messageRoutes(
         agent_id: 'coordinator',
       });
     } catch (err) {
-      // Safety net: cancel the pending entry if the bus.publish() threw before
-      // the rejection event could clean it up. On the normal rejection path the
-      // EventRouter has already removed the entry, so this is a no-op there.
-      eventRouter.cancelPending(conversationId);
       const message = err instanceof Error ? err.message : String(err);
       logger.error({ err, conversationId }, 'HTTP message handling failed');
 
-      // Distinguish rejection (403), timeout (504), and internal failures (500).
+      // Distinguish rejection (403), timeout (504), superseded/internal failures (500).
       // Use instanceof rather than string matching so a wording change can't
       // silently break the status code.
       const isRejected = err instanceof MessageRejectedError;

--- a/src/channels/http/routes/messages.ts
+++ b/src/channels/http/routes/messages.ts
@@ -13,6 +13,7 @@ import type { EventBus } from '../../../bus/bus.js';
 import { createInboundMessage } from '../../../bus/events.js';
 import type { Logger } from '../../../logger.js';
 import type { EventRouter } from '../event-router.js';
+import { MessageRejectedError } from '../event-router.js';
 
 export interface MessageRouteOptions {
   bus: EventBus;
@@ -72,13 +73,17 @@ export async function messageRoutes(
         agent_id: 'coordinator',
       });
     } catch (err) {
-      // Clean up the pending response if publish failed
+      // Safety net: cancel the pending entry if the bus.publish() threw before
+      // the rejection event could clean it up. On the normal rejection path the
+      // EventRouter has already removed the entry, so this is a no-op there.
       eventRouter.cancelPending(conversationId);
       const message = err instanceof Error ? err.message : String(err);
       logger.error({ err, conversationId }, 'HTTP message handling failed');
 
-      // Distinguish rejection (403), timeout (504), and internal failures (500)
-      const isRejected = message.includes('sender not authorized');
+      // Distinguish rejection (403), timeout (504), and internal failures (500).
+      // Use instanceof rather than string matching so a wording change can't
+      // silently break the status code.
+      const isRejected = err instanceof MessageRejectedError;
       const isTimeout = message.includes('timeout') || message.includes('Timeout');
       const status = isRejected ? 403 : isTimeout ? 504 : 500;
       return reply.status(status).send({ error: message });

--- a/src/channels/http/routes/messages.ts
+++ b/src/channels/http/routes/messages.ts
@@ -77,9 +77,11 @@ export async function messageRoutes(
       const message = err instanceof Error ? err.message : String(err);
       logger.error({ err, conversationId }, 'HTTP message handling failed');
 
-      // Distinguish timeout errors (504) from internal failures (500)
+      // Distinguish rejection (403), timeout (504), and internal failures (500)
+      const isRejected = message.includes('sender not authorized');
       const isTimeout = message.includes('timeout') || message.includes('Timeout');
-      return reply.status(isTimeout ? 504 : 500).send({ error: message });
+      const status = isRejected ? 403 : isTimeout ? 504 : 500;
+      return reply.status(status).send({ error: message });
     }
   });
 

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -1,6 +1,6 @@
 import type { EventBus } from '../bus/bus.js';
 import type { InboundMessageEvent, AgentResponseEvent, AgentErrorEvent } from '../bus/events.js';
-import { createAgentTask, createOutboundMessage, createContactResolved, createContactUnknown, createMessageHeld } from '../bus/events.js';
+import { createAgentTask, createOutboundMessage, createContactResolved, createContactUnknown, createMessageHeld, createMessageRejected } from '../bus/events.js';
 import type { Logger } from '../logger.js';
 import type { ContactResolver } from '../contacts/contact-resolver.js';
 import type { HeldMessageService } from '../contacts/held-messages.js';
@@ -110,6 +110,13 @@ export class Dispatcher {
                   { channel: payload.channelId, senderId: payload.senderId, contactId: senderContext.contactId },
                   'Blocked sender — dropping message',
                 );
+                await this.bus.publish('dispatch', createMessageRejected({
+                  conversationId: payload.conversationId,
+                  channelId: payload.channelId,
+                  senderId: payload.senderId,
+                  reason: 'blocked_sender',
+                  parentEventId: event.id,
+                }));
                 return;
               }
 
@@ -151,6 +158,13 @@ export class Dispatcher {
                   { channel: payload.channelId, senderId: payload.senderId },
                   'Rejected message from provisional sender',
                 );
+                await this.bus.publish('dispatch', createMessageRejected({
+                  conversationId: payload.conversationId,
+                  channelId: payload.channelId,
+                  senderId: payload.senderId,
+                  reason: 'provisional_sender',
+                  parentEventId: event.id,
+                }));
                 return;
               }
             }
@@ -208,7 +222,14 @@ export class Dispatcher {
               { channel: payload.channelId, senderId: payload.senderId },
               'Rejected message from unknown sender',
             );
-            return; // Silently drop
+            await this.bus.publish('dispatch', createMessageRejected({
+              conversationId: payload.conversationId,
+              channelId: payload.channelId,
+              senderId: payload.senderId,
+              reason: 'unknown_sender',
+              parentEventId: event.id,
+            }));
+            return;
           }
 
           // 'allow' policy or no policy configured — fall through to normal routing

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -110,13 +110,23 @@ export class Dispatcher {
                   { channel: payload.channelId, senderId: payload.senderId, contactId: senderContext.contactId },
                   'Blocked sender — dropping message',
                 );
-                await this.bus.publish('dispatch', createMessageRejected({
-                  conversationId: payload.conversationId,
-                  channelId: payload.channelId,
-                  senderId: payload.senderId,
-                  reason: 'blocked_sender',
-                  parentEventId: event.id,
-                }));
+                // Wrapped in its own try/catch so a publish failure (e.g. audit hook throws)
+                // cannot escape to the outer resolver catch and fall through to coordinator
+                // routing. The return below is unconditional — fail-closed regardless.
+                try {
+                  await this.bus.publish('dispatch', createMessageRejected({
+                    conversationId: payload.conversationId,
+                    channelId: payload.channelId,
+                    senderId: payload.senderId,
+                    reason: 'blocked_sender',
+                    parentEventId: event.id,
+                  }));
+                } catch (publishErr) {
+                  this.logger.error(
+                    { err: publishErr, channel: payload.channelId, senderId: payload.senderId },
+                    'Failed to publish blocked-sender rejection event — dropping (fail-closed)',
+                  );
+                }
                 return;
               }
 
@@ -158,13 +168,20 @@ export class Dispatcher {
                   { channel: payload.channelId, senderId: payload.senderId },
                   'Rejected message from provisional sender',
                 );
-                await this.bus.publish('dispatch', createMessageRejected({
-                  conversationId: payload.conversationId,
-                  channelId: payload.channelId,
-                  senderId: payload.senderId,
-                  reason: 'provisional_sender',
-                  parentEventId: event.id,
-                }));
+                try {
+                  await this.bus.publish('dispatch', createMessageRejected({
+                    conversationId: payload.conversationId,
+                    channelId: payload.channelId,
+                    senderId: payload.senderId,
+                    reason: 'provisional_sender',
+                    parentEventId: event.id,
+                  }));
+                } catch (publishErr) {
+                  this.logger.error(
+                    { err: publishErr, channel: payload.channelId, senderId: payload.senderId },
+                    'Failed to publish provisional-sender rejection event — dropping (fail-closed)',
+                  );
+                }
                 return;
               }
             }
@@ -222,13 +239,20 @@ export class Dispatcher {
               { channel: payload.channelId, senderId: payload.senderId },
               'Rejected message from unknown sender',
             );
-            await this.bus.publish('dispatch', createMessageRejected({
-              conversationId: payload.conversationId,
-              channelId: payload.channelId,
-              senderId: payload.senderId,
-              reason: 'unknown_sender',
-              parentEventId: event.id,
-            }));
+            try {
+              await this.bus.publish('dispatch', createMessageRejected({
+                conversationId: payload.conversationId,
+                channelId: payload.channelId,
+                senderId: payload.senderId,
+                reason: 'unknown_sender',
+                parentEventId: event.id,
+              }));
+            } catch (publishErr) {
+              this.logger.error(
+                { err: publishErr, channel: payload.channelId, senderId: payload.senderId },
+                'Failed to publish unknown-sender rejection event — dropping (fail-closed)',
+              );
+            }
             return;
           }
 

--- a/tests/integration/http-api.test.ts
+++ b/tests/integration/http-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import Fastify from 'fastify';
 import { EventBus } from '../../src/bus/bus.js';
 import { AgentRuntime } from '../../src/agents/runtime.js';
@@ -9,6 +9,8 @@ import { healthRoutes } from '../../src/channels/http/routes/health.js';
 import { agentRoutes } from '../../src/channels/http/routes/agents.js';
 import { Dispatcher } from '../../src/dispatch/dispatcher.js';
 import type { LLMProvider } from '../../src/agents/llm/provider.js';
+import type { ContactResolver } from '../../src/contacts/contact-resolver.js';
+import type { InboundSenderContext } from '../../src/contacts/types.js';
 import type { Pool } from 'pg';
 import pino from 'pino';
 
@@ -113,5 +115,66 @@ describe('HTTP API integration', () => {
     expect(body.agents).toHaveLength(1);
     expect(body.agents[0].name).toBe('coordinator');
     expect(body.agents[0].role).toBe('coordinator');
+  });
+});
+
+// Issue #47: HTTP callers hang on rejected unknown-sender messages.
+// This suite verifies that the reject policy returns 403 immediately
+// instead of hanging until the 120-second response timeout (504).
+describe('HTTP API — unknown_sender: reject policy', () => {
+  const app = Fastify();
+  const bus = new EventBus(logger);
+  const eventRouter = new EventRouter(logger);
+
+  const mockPool = {
+    query: async () => ({ rows: [{ '?column?': 1 }] }),
+  } as unknown as Pool;
+
+  beforeAll(async () => {
+    eventRouter.setupSubscriptions(bus);
+
+    // Resolver always returns unknown sender
+    const mockResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: false,
+        channel: 'http',
+        senderId: 'stranger',
+      } satisfies InboundSenderContext),
+    } as unknown as ContactResolver;
+
+    // Dispatcher configured with reject policy for the http channel
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: mockResolver,
+      channelPolicies: { http: { trust: 'low', unknownSender: 'reject' } },
+    });
+    dispatcher.register();
+
+    app.register(messageRoutes, { bus, logger, eventRouter });
+    app.register(healthRoutes, { pool: mockPool, logger, agentNames: [], skillNames: [] });
+
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /api/messages returns 403 immediately when sender is rejected', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/messages',
+      payload: {
+        content: 'Hello from unknown sender',
+        conversation_id: 'reject-test-conv-1',
+        sender_id: 'stranger',
+      },
+    });
+
+    // Must be 403, not 504 (timeout) — the response should come immediately
+    expect(response.statusCode).toBe(403);
+    const body = JSON.parse(response.body);
+    expect(body.error).toContain('sender not authorized');
   });
 });

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
 import { EventBus } from '../../../src/bus/bus.js';
 import { AgentRuntime } from '../../../src/agents/runtime.js';
-import { createInboundMessage, createAgentError, type OutboundMessageEvent } from '../../../src/bus/events.js';
+import { createInboundMessage, createAgentError, type OutboundMessageEvent, type MessageRejectedEvent } from '../../../src/bus/events.js';
 import type { LLMProvider } from '../../../src/agents/llm/provider.js';
+import type { ContactResolver } from '../../../src/contacts/contact-resolver.js';
+import type { InboundSenderContext } from '../../../src/contacts/types.js';
 import { createLogger } from '../../../src/logger.js';
 
 describe('Dispatcher', () => {
@@ -58,6 +60,147 @@ describe('Dispatcher', () => {
     expect(outbound).toHaveLength(1);
     expect(outbound[0]?.payload.content).toBe('Response from Coordinator');
     expect(outbound[0]?.payload.channelId).toBe('cli');
+  });
+});
+
+describe('Dispatcher unknown_sender: reject policy', () => {
+  it('publishes message.rejected for unknown sender with reject policy', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    // Resolver returns unknown sender
+    const mockResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: false,
+        channel: 'http',
+        senderId: 'stranger',
+      } satisfies InboundSenderContext),
+    } as unknown as ContactResolver;
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: mockResolver,
+      channelPolicies: { http: { trust: 'low', unknownSender: 'reject' } },
+    });
+    dispatcher.register();
+
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('message.rejected', 'channel', (event) => {
+      rejected.push(event as MessageRejectedEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'conv-reject-1',
+      channelId: 'http',
+      senderId: 'stranger',
+      content: 'Hello',
+    });
+    await bus.publish('channel', event);
+
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.payload.conversationId).toBe('conv-reject-1');
+    expect(rejected[0]?.payload.reason).toBe('unknown_sender');
+    expect(rejected[0]?.payload.channelId).toBe('http');
+  });
+
+  it('publishes message.rejected for blocked sender', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    // Resolver returns a blocked contact
+    const mockResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: true,
+        contactId: 'blocked-contact-id',
+        displayName: 'Bad Actor',
+        role: null,
+        status: 'blocked',
+        verified: false,
+        kgNodeId: null,
+        knowledgeSummary: '',
+        authorization: null,
+      } satisfies InboundSenderContext),
+    } as unknown as ContactResolver;
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: mockResolver,
+    });
+    dispatcher.register();
+
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('message.rejected', 'channel', (event) => {
+      rejected.push(event as MessageRejectedEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'conv-blocked-1',
+      channelId: 'http',
+      senderId: 'bad-actor',
+      content: 'Hello',
+    });
+    await bus.publish('channel', event);
+
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.payload.conversationId).toBe('conv-blocked-1');
+    expect(rejected[0]?.payload.reason).toBe('blocked_sender');
+  });
+
+  it('does not publish message.rejected when policy is allow', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const mockResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: false,
+        channel: 'http',
+        senderId: 'stranger',
+      } satisfies InboundSenderContext),
+    } as unknown as ContactResolver;
+
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'OK',
+        usage: { inputTokens: 1, outputTokens: 1 },
+      }),
+    };
+
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a helpful assistant.',
+      provider: mockProvider,
+      bus,
+      logger,
+    });
+    coordinator.register();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: mockResolver,
+      channelPolicies: { http: { trust: 'low', unknownSender: 'allow' } },
+    });
+    dispatcher.register();
+
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('message.rejected', 'channel', (event) => {
+      rejected.push(event as MessageRejectedEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'conv-allow-1',
+      channelId: 'http',
+      senderId: 'stranger',
+      content: 'Hello',
+    });
+    await bus.publish('channel', event);
+
+    // Unknown sender with 'allow' policy — message routes through, no rejection
+    expect(rejected).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## **User description**
## Summary

- The dispatcher was silently dropping rejected messages (`unknown_sender: reject`, blocked sender, provisional sender) with no bus event, leaving `EventRouter.waitForResponse()` blocked until the 120-second timeout → 504.
- Adds a `message.rejected` bus event (parallel to `message.held`) that the dispatcher publishes at all three rejection sites.
- The HTTP `EventRouter` subscribes to `message.rejected` and immediately rejects the pending promise with a typed `MessageRejectedError`.
- The route handler maps `MessageRejectedError instanceof` → 403.

## What changed

| File | Change |
|---|---|
| `src/bus/events.ts` | New `MessageRejectedEvent` type + `createMessageRejected` factory |
| `src/bus/permissions.ts` | Added `message.rejected` to dispatch publish, channel subscribe, system allowlists |
| `src/dispatch/dispatcher.ts` | Publish `message.rejected` at blocked/provisional/unknown reject sites |
| `src/channels/http/event-router.ts` | Subscribe to `message.rejected`; export typed `MessageRejectedError` class |
| `src/channels/http/routes/messages.ts` | Detect `MessageRejectedError instanceof` → 403 (not string matching) |

## Test plan

- [x] `tests/unit/dispatch/dispatcher.test.ts` — 3 new cases: unknown_sender reject, blocked sender, allow policy (no rejection event)
- [x] `tests/integration/http-api.test.ts` — POST with reject policy returns 403 immediately (not 504)
- [x] All 635 tests passing

## Follow-up (not in this PR)

- Add `provisional_sender` unit test case for symmetry
- Consider surfacing `message.rejected` signal in non-HTTP channels (email bounce, CLI notification)

Closes #47


___

## **CodeAnt-AI Description**
**Return 403 right away when a message is rejected**

### What Changed
- Rejected incoming HTTP messages now fail immediately with 403 instead of waiting until the request times out.
- Messages rejected because the sender is unknown, provisional, or blocked now produce a rejection event instead of being dropped silently.
- The HTTP response path now uses a typed rejection error, so the status code stays tied to rejection behavior.

### Impact
`✅ Immediate 403s for rejected messages`
`✅ Fewer 504 timeout responses on denied sends`
`✅ Clearer rejection handling for HTTP callers`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
