### PR TITLE
chore: capability expansion design — CEO inbox + web search

### DIFF
--- a/docs/superpowers/plans/2026-04-03-ceo-inbox.md
+++ b/docs/superpowers/plans/2026-04-03-ceo-inbox.md
@@ -1,0 +1,1534 @@
+# CEO Inbox Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Connect Joseph's Gmail as a second Nylas channel so Nathan can read his inbox, fetch full messages, and save draft replies — with no autonomous sending in Phase 1.
+
+**Architecture:** A new `email-ceo` channel adapter polls Joseph's Nylas grant and publishes `inbound.message` events with `channelId: "email-ceo"`. Three account-aware skills (`email-list`, `email-get`, `email-draft-save`) resolve to either Nathan's or Joseph's `NylasClient` based on an `account` param — the same `infrastructure: true` pattern as calendar skills. `NylasClient` gains a `createDraft()` method. The channel trust config, `SkillContext`, and `ExecutionLayer` each get one addition.
+
+**Tech Stack:** Nylas SDK v8 (existing), existing `NylasClient` class (extended), Vitest.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `src/config.ts` | Add `nylasCeoGrantId` and `nylasCeoSelfEmail` |
+| Modify | `src/channels/email/nylas-client.ts` | Add `createDraft()`, extend `ListMessagesOptions`, extend `NylasLike` |
+| Modify | `src/skills/types.ts` | Add `nylasEmailClient` and `nylasCeoEmailClient` to `SkillContext` |
+| Modify | `src/skills/execution.ts` | Inject both clients from constructor, populate ctx for infra skills |
+| Modify | `config/channel-trust.yaml` | Add `email-ceo` channel with `trust: high` |
+| Create | `src/channels/email-ceo/email-ceo-adapter.ts` | Poll CEO inbox, publish `inbound.message` with `channelId: "email-ceo"` |
+| Modify | `src/index.ts` | Construct CEO NylasClient, instantiate + start CEO adapter |
+| Create | `skills/email-list/skill.json` | Manifest for account-aware inbox listing |
+| Create | `skills/email-list/handler.ts` | List messages from any account + folder |
+| Create | `tests/unit/skills/email-list.test.ts` | Unit tests |
+| Create | `skills/email-get/skill.json` | Manifest for fetching full message body |
+| Create | `skills/email-get/handler.ts` | Fetch single message by ID |
+| Create | `tests/unit/skills/email-get.test.ts` | Unit tests |
+| Create | `skills/email-draft-save/skill.json` | Manifest for saving drafts |
+| Create | `skills/email-draft-save/handler.ts` | Create draft via Nylas drafts API |
+| Create | `tests/unit/skills/email-draft-save.test.ts` | Unit tests |
+| Modify | `agents/coordinator.yaml` | Pin three new skills, add CEO inbox persona guidance |
+
+---
+
+### Task 1: Extend config with CEO credentials
+
+**Files:**
+- Modify: `src/config.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+There are no existing config unit tests, so verify by running the app below. First, update the Config interface and `loadConfig()`:
+
+In `src/config.ts`, add two fields to the `Config` interface:
+
+```typescript
+export interface Config {
+  // ... existing fields ...
+  /** Nylas grant ID for Joseph's Gmail (CEO inbox). When set, the email-ceo adapter starts. */
+  nylasCeoGrantId: string | undefined;
+  /** Joseph's own email address — used to filter self-sent messages in the CEO adapter. */
+  nylasCeoSelfEmail: string | undefined;
+}
+```
+
+Add to the `loadConfig()` return object:
+
+```typescript
+return {
+  // ... existing fields ...
+  nylasCeoGrantId: process.env.NYLAS_CEO_GRANT_ID || undefined,
+  nylasCeoSelfEmail: process.env.NYLAS_CEO_SELF_EMAIL?.trim().toLowerCase() || undefined,
+};
+```
+
+- [ ] **Step 2: Run typecheck to confirm no errors**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-ceo-inbox
+npx tsc --noEmit
+```
+
+Expected: passes with no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/config.ts
+git commit -m "feat: add NYLAS_CEO_GRANT_ID and NYLAS_CEO_SELF_EMAIL config fields"
+```
+
+---
+
+### Task 2: Extend NylasClient — createDraft and folder filtering
+
+**Files:**
+- Modify: `src/channels/email/nylas-client.ts`
+
+The existing `NylasClient` wraps `nylas.messages.*`. Drafts are a separate Nylas resource (`nylas.drafts.*`). This task adds `createDraft()` and extends `listMessages()` to support folder/from/subject/searchQueryNative filtering.
+
+- [ ] **Step 1: Extend the import list**
+
+At the top of `nylas-client.ts`, extend the type imports from `'nylas'`:
+
+```typescript
+import type {
+  Message as NylasSdkMessage,
+  ListMessagesQueryParams,
+  NylasResponse,
+  NylasListResponse,
+  SendMessageRequest,
+  CreateDraftRequest,   // ← add
+  Draft as NylasSdkDraft,  // ← add
+} from 'nylas';
+```
+
+- [ ] **Step 2: Extend the NylasLike interface**
+
+Add a `drafts` property to the `NylasLike` interface (immediately after the `messages` block):
+
+```typescript
+interface NylasLike {
+  messages: {
+    list(params: { identifier: string; queryParams?: ListMessagesQueryParams }): Promise<NylasListResponse<NylasSdkMessage>>;
+    find(params: { identifier: string; messageId: string }): Promise<NylasResponse<NylasSdkMessage>>;
+    send(params: { identifier: string; requestBody: SendMessageRequest }): Promise<NylasResponse<NylasSdkMessage>>;
+  };
+  // Drafts are a separate Nylas resource from messages — creating a draft calls
+  // drafts.create() rather than messages.send(), which avoids triggering send.
+  drafts: {
+    create(params: {
+      identifier: string;
+      requestBody: CreateDraftRequest;
+    }): Promise<NylasResponse<NylasSdkDraft>>;
+  };
+}
+```
+
+- [ ] **Step 3: Add NylasDraft export type and extend ListMessagesOptions**
+
+Add `NylasDraft` after the existing `NylasMessage` export, and extend `ListMessagesOptions`:
+
+```typescript
+export interface NylasDraft {
+  id: string;
+  threadId?: string;
+  subject?: string;
+  to: Array<{ name?: string; email: string }>;
+  body?: string;
+}
+
+export interface ListMessagesOptions {
+  /** Unix timestamp — only return messages received after this time */
+  receivedAfter?: number;
+  /** When true, only return unread messages */
+  unread?: boolean;
+  /** Max number of messages to return (default 50, max 200 per Nylas) */
+  limit?: number;
+  /** Filter messages to a specific thread ID */
+  threadId?: string;
+  /** Filter to messages in these folder IDs (maps to Nylas `in` param).
+   *  Standard folders: INBOX, DRAFTS, SENT, TRASH. */
+  folders?: string[];
+  /** Filter to messages from this email address */
+  from?: string;
+  /** Filter to messages with this literal subject */
+  subject?: string;
+  /** Provider-native query string (Gmail search syntax, Outlook KQL) */
+  searchQueryNative?: string;
+}
+```
+
+- [ ] **Step 4: Update listMessages() to pass new params**
+
+In the `listMessages()` method, add the new query param mappings after the existing ones:
+
+```typescript
+async listMessages(options?: ListMessagesOptions): Promise<NylasMessage[]> {
+  const queryParams: ListMessagesQueryParams = {};
+
+  if (options?.receivedAfter !== undefined) queryParams.receivedAfter = options.receivedAfter;
+  if (options?.unread !== undefined) queryParams.unread = options.unread;
+  if (options?.limit !== undefined) queryParams.limit = options.limit;
+  if (options?.threadId !== undefined) queryParams.threadId = options.threadId;
+  // New params:
+  if (options?.folders !== undefined) queryParams.in = options.folders;
+  if (options?.from !== undefined) queryParams.from = [options.from];
+  if (options?.subject !== undefined) queryParams.subject = options.subject;
+  if (options?.searchQueryNative !== undefined) queryParams.searchQueryNative = options.searchQueryNative;
+
+  // ... rest of existing method unchanged ...
+```
+
+- [ ] **Step 5: Add createDraft() method**
+
+Add the new method to `NylasClient` after `sendMessage()`:
+
+```typescript
+/**
+ * Create a draft. The draft is stored in the Nylas drafts resource and
+ * appears in Gmail's Drafts folder. It is NOT sent.
+ * Use sendMessage() when the CEO approves and is ready to send.
+ */
+async createDraft(options: {
+  to: Array<{ name?: string; email: string }>;
+  subject: string;
+  body: string;
+  replyToMessageId?: string;
+}): Promise<NylasDraft> {
+  this.log.debug({ to: options.to, subject: options.subject }, 'creating draft');
+
+  try {
+    const response = await this.nylas.drafts.create({
+      identifier: this.grantId,
+      requestBody: {
+        to: options.to,
+        subject: options.subject,
+        body: options.body,
+        replyToMessageId: options.replyToMessageId,
+      },
+    });
+
+    const d = response.data;
+    return {
+      id: d.id,
+      threadId: d.threadId ?? undefined,
+      subject: d.subject ?? undefined,
+      to: (d.to ?? []).map((p) => ({ name: p.name, email: p.email })),
+      body: d.body ?? undefined,
+    };
+  } catch (err) {
+    this.log.error(
+      { err, grantId: this.grantId, to: options.to, subject: options.subject },
+      'Nylas createDraft failed',
+    );
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 6: Run typecheck**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-ceo-inbox
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/channels/email/nylas-client.ts
+git commit -m "feat: extend NylasClient with createDraft() and folder/search filtering"
+```
+
+---
+
+### Task 3: Add email clients to SkillContext and ExecutionLayer
+
+**Files:**
+- Modify: `src/skills/types.ts`
+- Modify: `src/skills/execution.ts`
+
+Skills need access to two NylasClient instances — one per account. Following the same pattern as `nylasCalendarClient`.
+
+- [ ] **Step 1: Add clients to SkillContext (types.ts)**
+
+In `src/skills/types.ts`, add two fields to `SkillContext` after `nylasCalendarClient`:
+
+```typescript
+/** Nathan's Nylas email client — only available to infrastructure skills.
+ *  Used by account-aware email skills (email-list, email-get, email-draft-save)
+ *  when account is "nathan". */
+nylasEmailClient?: import('../channels/email/nylas-client.js').NylasClient;
+/** CEO's Nylas email client — only available to infrastructure skills.
+ *  Used by account-aware email skills when account is "joseph". */
+nylasCeoEmailClient?: import('../channels/email/nylas-client.js').NylasClient;
+```
+
+- [ ] **Step 2: Add clients to ExecutionLayer constructor (execution.ts)**
+
+In `src/skills/execution.ts`, add two private fields after `nylasCalendarClient`:
+
+```typescript
+private nylasEmailClient?: NylasClient;
+private nylasCeoEmailClient?: NylasClient;
+```
+
+Import the type at the top of the file:
+
+```typescript
+import type { NylasClient } from '../channels/email/nylas-client.js';
+```
+
+Extend the constructor options type:
+
+```typescript
+constructor(registry: SkillRegistry, logger: Logger, options?: {
+  // ... existing fields ...
+  nylasCalendarClient?: NylasCalendarClient;
+  nylasEmailClient?: NylasClient;       // ← add
+  nylasCeoEmailClient?: NylasClient;    // ← add
+  entityContextAssembler?: EntityContextAssembler;
+  agentContactId?: string;
+}) {
+```
+
+Assign them in the constructor body after the existing assignments:
+
+```typescript
+this.nylasEmailClient = options?.nylasEmailClient;
+this.nylasCeoEmailClient = options?.nylasCeoEmailClient;
+```
+
+- [ ] **Step 3: Inject clients into ctx for infrastructure skills (execution.ts)**
+
+In the `if (manifest.infrastructure)` block of `invoke()`, add after the `nylasCalendarClient` block:
+
+```typescript
+// nylasEmailClient — Nathan's email client for account-aware email skills
+if (this.nylasEmailClient) {
+  ctx.nylasEmailClient = this.nylasEmailClient;
+}
+// nylasCeoEmailClient — CEO's email client for account-aware email skills
+if (this.nylasCeoEmailClient) {
+  ctx.nylasCeoEmailClient = this.nylasCeoEmailClient;
+}
+```
+
+- [ ] **Step 4: Run typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/skills/types.ts src/skills/execution.ts
+git commit -m "feat: add nylasEmailClient and nylasCeoEmailClient to SkillContext and ExecutionLayer"
+```
+
+---
+
+### Task 4: Add email-ceo channel to trust config
+
+**Files:**
+- Modify: `config/channel-trust.yaml`
+
+- [ ] **Step 1: Add the entry**
+
+In `config/channel-trust.yaml`, add `email-ceo` after the `email` block:
+
+```yaml
+  email-ceo:
+    trust: high
+    unknown_sender: hold_and_notify
+```
+
+Trust is `high` because this is the CEO's own account — messages from it are authoritative. `hold_and_notify` for unknown senders still applies (anyone who emails Joseph and isn't in contacts yet gets held).
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config/channel-trust.yaml
+git commit -m "feat: add email-ceo channel trust config (high trust, hold_and_notify)"
+```
+
+---
+
+### Task 5: Build the CEO inbox adapter
+
+**Files:**
+- Create: `src/channels/email-ceo/email-ceo-adapter.ts`
+
+This adapter is structurally identical to `src/channels/email/email-adapter.ts` with two differences:
+1. Takes `NylasClient` directly instead of `OutboundGateway` (no outbound in Phase 1)
+2. Publishes with `channelId: 'email-ceo'` and `conversationId: 'email-ceo:{threadId}'`
+
+- [ ] **Step 1: Write the adapter**
+
+```typescript
+// src/channels/email-ceo/email-ceo-adapter.ts
+//
+// CEO inbox channel adapter — polls Joseph's Nylas grant for new inbound emails
+// and publishes them as inbound.message events with channelId 'email-ceo'.
+//
+// Phase 1 only: this adapter reads and publishes. It does NOT send.
+// Outbound (drafts, eventual sends) go through the email skills, not this adapter.
+//
+// The adapter reuses message-converter.ts, html-to-text.ts from the primary email
+// channel — the converted message's channelId is overridden to 'email-ceo' and
+// conversationId prefix changed to 'email-ceo:' so CEO threads have their own
+// working memory scope, separate from Nathan's email threads.
+
+import type { EventBus } from '../../bus/bus.js';
+import type { Logger } from '../../logger.js';
+import type { ContactService } from '../../contacts/contact-service.js';
+import type { NylasClient } from '../email/nylas-client.js';
+import { convertNylasMessage } from '../email/message-converter.js';
+import { createInboundMessage } from '../../bus/events.js';
+import { sanitizeOutput } from '../../skills/sanitize.js';
+
+export interface EmailCeoAdapterConfig {
+  bus: EventBus;
+  logger: Logger;
+  nylasClient: NylasClient;
+  contactService: ContactService;
+  pollingIntervalMs: number;
+  /** Joseph's own email address — used to filter out his own sent messages */
+  selfEmail: string;
+}
+
+export class EmailCeoAdapter {
+  private config: EmailCeoAdapterConfig;
+  private pollTimer?: ReturnType<typeof setInterval>;
+  private lastSeenTimestamp: number = 0;
+  private processing = false;
+
+  constructor(config: EmailCeoAdapterConfig) {
+    this.config = config;
+  }
+
+  async start(): Promise<void> {
+    const { logger, pollingIntervalMs } = this.config;
+    // Initialise high-water mark to now so we only process new emails
+    this.lastSeenTimestamp = Math.floor(Date.now() / 1000);
+    this.pollTimer = setInterval(() => void this.poll(), pollingIntervalMs);
+    logger.info({ pollingIntervalMs }, 'CEO email adapter started — polling Nylas');
+    void this.poll();
+  }
+
+  async stop(): Promise<void> {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = undefined;
+    }
+    this.config.logger.info('CEO email adapter stopped');
+  }
+
+  private async poll(): Promise<void> {
+    if (this.processing) return;
+    this.processing = true;
+
+    let messages;
+    try {
+      messages = await this.config.nylasClient.listMessages({
+        receivedAfter: this.lastSeenTimestamp,
+        unread: true,
+        limit: 25,
+      });
+    } catch (err) {
+      this.config.logger.error({ err }, 'CEO email polling failed — will retry');
+      this.processing = false;
+      return;
+    }
+
+    try {
+      for (const msg of messages) {
+        // Advance high-water mark before processing — a permanently broken message
+        // must never be retried on the next poll cycle.
+        if (msg.date >= this.lastSeenTimestamp) {
+          this.lastSeenTimestamp = msg.date + 1;
+        }
+
+        // Skip emails sent by Joseph himself (self-sent messages, outbox copies)
+        const fromEmail = msg.from[0]?.email;
+        if (fromEmail?.toLowerCase() === this.config.selfEmail.toLowerCase()) continue;
+
+        try {
+          const converted = convertNylasMessage(msg);
+
+          // Override channelId and conversationId — CEO threads get their own scope.
+          // email: prefix → email-ceo: prefix keeps CEO memory separate from Nathan's.
+          const channelId = 'email-ceo' as const;
+          const conversationId = `email-ceo:${msg.threadId}`;
+
+          await this.extractParticipants(converted.metadata.participants);
+
+          const sanitizedContent = sanitizeOutput(converted.content, { maxLength: 60_000 });
+
+          const event = createInboundMessage({
+            conversationId,
+            channelId,
+            senderId: converted.senderId,
+            content: sanitizedContent,
+            metadata: converted.metadata as unknown as Record<string, unknown>,
+          });
+          await this.config.bus.publish('channel', event);
+
+          this.config.logger.info(
+            { from: fromEmail, subject: msg.subject, threadId: msg.threadId },
+            'CEO email received and published to bus',
+          );
+        } catch (err) {
+          this.config.logger.error(
+            { err, messageId: msg.id, threadId: msg.threadId, from: fromEmail },
+            'Failed to process inbound CEO email — skipping message',
+          );
+        }
+      }
+    } finally {
+      this.processing = false;
+    }
+  }
+
+  /**
+   * Auto-create contacts from email participants (From/To/CC).
+   * Uses source 'email_ceo_participant' to distinguish CEO-inbox contacts
+   * from Nathan's own inbox participants. Both merge into the shared contact graph.
+   */
+  private async extractParticipants(
+    participants: Array<{ email: string; name?: string; role: string }>,
+  ): Promise<void> {
+    const { contactService, logger, selfEmail } = this.config;
+
+    for (const p of participants) {
+      if (p.email.toLowerCase() === selfEmail.toLowerCase()) continue;
+
+      try {
+        const existing = await contactService.resolveByChannelIdentity('email', p.email);
+        if (existing) continue;
+
+        const contact = await contactService.createContact({
+          displayName: p.name || p.email,
+          fallbackDisplayName: p.email,
+          source: 'email_ceo_participant',
+          status: 'provisional',
+        });
+        await contactService.linkIdentity({
+          contactId: contact.id,
+          channel: 'email',
+          channelIdentifier: p.email,
+          source: 'email_ceo_participant',
+        });
+
+        logger.info({ email: p.email, name: p.name }, 'Auto-created contact from CEO email participant');
+      } catch (err) {
+        logger.warn({ err, email: p.email }, 'Failed to auto-create contact from CEO email participant');
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/channels/email-ceo/email-ceo-adapter.ts
+git commit -m "feat: add EmailCeoAdapter for Joseph's inbox (Phase 1 — read only)"
+```
+
+---
+
+### Task 6: Wire the CEO adapter into index.ts
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Import the CEO adapter**
+
+Add the import near the existing email imports (around line 46):
+
+```typescript
+import { EmailCeoAdapter } from './channels/email-ceo/email-ceo-adapter.js';
+```
+
+- [ ] **Step 2: Declare the CEO client and adapter variables**
+
+After the `let emailAdapter: EmailAdapter | undefined;` declaration, add:
+
+```typescript
+let nylasCeoClient: NylasClient | undefined;
+let emailCeoAdapter: EmailCeoAdapter | undefined;
+```
+
+- [ ] **Step 3: Construct the CEO client**
+
+After the existing `nylasClient` construction block (around line 233), add:
+
+```typescript
+// CEO inbox channel — optional, requires NYLAS_CEO_GRANT_ID and NYLAS_CEO_SELF_EMAIL.
+// Uses the same Nylas API key as Nathan's account but a separate grant (different OAuth token).
+if (config.nylasCeoGrantId && config.nylasCeoSelfEmail && config.nylasApiKey) {
+  nylasCeoClient = new NylasClient(config.nylasApiKey, config.nylasCeoGrantId, logger);
+  logger.info('CEO Nylas client initialized');
+} else if (config.nylasCeoGrantId) {
+  logger.warn('NYLAS_CEO_GRANT_ID is set but NYLAS_CEO_SELF_EMAIL or NYLAS_API_KEY is missing — CEO inbox disabled');
+}
+```
+
+- [ ] **Step 4: Pass clients to ExecutionLayer**
+
+Find the `new ExecutionLayer(...)` call and add `nylasEmailClient` and `nylasCeoEmailClient`:
+
+```typescript
+const executionLayer = new ExecutionLayer(skillRegistry, logger, {
+  bus,
+  agentRegistry,
+  contactService,
+  outboundGateway,
+  heldMessages,
+  schedulerService,
+  entityMemory,
+  agentPersona,
+  nylasCalendarClient,
+  nylasEmailClient: nylasClient,          // ← add
+  nylasCeoEmailClient: nylasCeoClient,    // ← add
+  entityContextAssembler,
+  agentContactId: agentIdentityContactId,
+});
+```
+
+- [ ] **Step 5: Construct and start the CEO adapter**
+
+After the existing `emailAdapter = new EmailAdapter(...)` block, add:
+
+```typescript
+// Construct CEO inbox adapter — started after dispatcher registration (same ordering
+// constraint as the primary email adapter: inbound.message must have a subscriber).
+if (nylasCeoClient && config.nylasCeoSelfEmail) {
+  emailCeoAdapter = new EmailCeoAdapter({
+    bus,
+    logger,
+    nylasClient: nylasCeoClient,
+    contactService,
+    pollingIntervalMs: config.nylasPollingIntervalMs,
+    selfEmail: config.nylasCeoSelfEmail,
+  });
+}
+```
+
+After the `await emailAdapter.start()` block, add:
+
+```typescript
+if (emailCeoAdapter) {
+  await emailCeoAdapter.start();
+  logger.info('CEO email channel adapter started');
+}
+```
+
+- [ ] **Step 6: Add to graceful shutdown**
+
+In the `shutdown` function, after the `emailAdapter.stop()` block:
+
+```typescript
+if (emailCeoAdapter) {
+  try {
+    await emailCeoAdapter.stop();
+  } catch (err) {
+    logger.error({ err }, 'Error stopping CEO email adapter during shutdown');
+  }
+}
+```
+
+- [ ] **Step 7: Run typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 8: Run full test suite**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: wire EmailCeoAdapter into bootstrap — constructs CEO Nylas client, starts adapter"
+```
+
+---
+
+### Task 7: Write failing tests for the three email skills
+
+**Files:**
+- Create: `tests/unit/skills/email-list.test.ts`
+- Create: `tests/unit/skills/email-get.test.ts`
+- Create: `tests/unit/skills/email-draft-save.test.ts`
+
+- [ ] **Step 1: Write email-list tests**
+
+```typescript
+// tests/unit/skills/email-list.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { EmailListHandler } from '../../../skills/email-list/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+const mockMessage = {
+  id: 'msg-1',
+  threadId: 'thread-1',
+  subject: 'Hello',
+  from: [{ email: 'sender@example.com', name: 'Sender' }],
+  to: [{ email: 'joseph@josephfung.ca' }],
+  cc: [],
+  bcc: [],
+  snippet: 'Hello there...',
+  date: 1700000000,
+  unread: true,
+  body: 'Full body here',
+  folders: ['INBOX'],
+};
+
+function makeCtx(
+  input: Record<string, unknown>,
+  clients?: { nathan?: unknown; joseph?: unknown },
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    nylasEmailClient: clients?.nathan as never,
+    nylasCeoEmailClient: clients?.joseph as never,
+  };
+}
+
+describe('EmailListHandler', () => {
+  const handler = new EmailListHandler();
+
+  it('returns failure when no email client is available', async () => {
+    const result = await handler.execute(makeCtx({}));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('not configured');
+  });
+
+  it('returns failure when account is joseph but CEO client is not available', async () => {
+    const nathanClient = { listMessages: vi.fn() };
+    const result = await handler.execute(makeCtx({ account: 'joseph' }, { nathan: nathanClient }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('CEO inbox not configured');
+  });
+
+  it('defaults to nathan account when account param is omitted', async () => {
+    const nathanClient = { listMessages: vi.fn().mockResolvedValue([mockMessage]) };
+    const result = await handler.execute(makeCtx({}, { nathan: nathanClient }));
+    expect(result.success).toBe(true);
+    expect(nathanClient.listMessages).toHaveBeenCalledOnce();
+  });
+
+  it('uses CEO client when account is joseph', async () => {
+    const josephClient = { listMessages: vi.fn().mockResolvedValue([mockMessage]) };
+    const result = await handler.execute(makeCtx({ account: 'joseph' }, { joseph: josephClient }));
+    expect(result.success).toBe(true);
+    expect(josephClient.listMessages).toHaveBeenCalledOnce();
+  });
+
+  it('passes folder param as folders array to listMessages', async () => {
+    const nathanClient = { listMessages: vi.fn().mockResolvedValue([]) };
+    await handler.execute(makeCtx({ folder: 'DRAFTS' }, { nathan: nathanClient }));
+    expect(nathanClient.listMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ folders: ['DRAFTS'] }),
+    );
+  });
+
+  it('passes unreadOnly param', async () => {
+    const nathanClient = { listMessages: vi.fn().mockResolvedValue([]) };
+    await handler.execute(makeCtx({ unreadOnly: true }, { nathan: nathanClient }));
+    expect(nathanClient.listMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ unread: true }),
+    );
+  });
+
+  it('returns normalised message array', async () => {
+    const nathanClient = { listMessages: vi.fn().mockResolvedValue([mockMessage]) };
+    const result = await handler.execute(makeCtx({}, { nathan: nathanClient }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { messages: unknown[] };
+      expect(data.messages).toHaveLength(1);
+    }
+  });
+
+  it('returns failure on client error', async () => {
+    const nathanClient = { listMessages: vi.fn().mockRejectedValue(new Error('Nylas timeout')) };
+    const result = await handler.execute(makeCtx({}, { nathan: nathanClient }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Failed to list');
+  });
+});
+```
+
+- [ ] **Step 2: Write email-get tests**
+
+```typescript
+// tests/unit/skills/email-get.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { EmailGetHandler } from '../../../skills/email-get/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+const mockMessage = {
+  id: 'msg-1',
+  threadId: 'thread-1',
+  subject: 'Hello',
+  from: [{ email: 'sender@example.com', name: 'Sender' }],
+  to: [{ email: 'joseph@josephfung.ca' }],
+  cc: [],
+  bcc: [],
+  snippet: 'Hello there...',
+  date: 1700000000,
+  unread: true,
+  body: '<p>Full body here</p>',
+  folders: ['INBOX'],
+};
+
+function makeCtx(
+  input: Record<string, unknown>,
+  clients?: { nathan?: unknown; joseph?: unknown },
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    nylasEmailClient: clients?.nathan as never,
+    nylasCeoEmailClient: clients?.joseph as never,
+  };
+}
+
+describe('EmailGetHandler', () => {
+  const handler = new EmailGetHandler();
+
+  it('returns failure when messageId is missing', async () => {
+    const client = { getMessage: vi.fn() };
+    const result = await handler.execute(makeCtx({}, { nathan: client }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('messageId');
+  });
+
+  it('returns failure when no email client is available', async () => {
+    const result = await handler.execute(makeCtx({ messageId: 'msg-1' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('not configured');
+  });
+
+  it('defaults to nathan account', async () => {
+    const nathanClient = { getMessage: vi.fn().mockResolvedValue(mockMessage) };
+    const result = await handler.execute(makeCtx({ messageId: 'msg-1' }, { nathan: nathanClient }));
+    expect(result.success).toBe(true);
+    expect(nathanClient.getMessage).toHaveBeenCalledWith('msg-1');
+  });
+
+  it('uses CEO client when account is joseph', async () => {
+    const josephClient = { getMessage: vi.fn().mockResolvedValue(mockMessage) };
+    const result = await handler.execute(makeCtx({ messageId: 'msg-1', account: 'joseph' }, { joseph: josephClient }));
+    expect(result.success).toBe(true);
+    expect(josephClient.getMessage).toHaveBeenCalledWith('msg-1');
+  });
+
+  it('returns the message object on success', async () => {
+    const nathanClient = { getMessage: vi.fn().mockResolvedValue(mockMessage) };
+    const result = await handler.execute(makeCtx({ messageId: 'msg-1' }, { nathan: nathanClient }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { message: { id: string } };
+      expect(data.message.id).toBe('msg-1');
+    }
+  });
+
+  it('returns failure on client error', async () => {
+    const nathanClient = { getMessage: vi.fn().mockRejectedValue(new Error('Not found')) };
+    const result = await handler.execute(makeCtx({ messageId: 'msg-1' }, { nathan: nathanClient }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Failed to fetch');
+  });
+});
+```
+
+- [ ] **Step 3: Write email-draft-save tests**
+
+```typescript
+// tests/unit/skills/email-draft-save.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { EmailDraftSaveHandler } from '../../../skills/email-draft-save/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(
+  input: Record<string, unknown>,
+  clients?: { nathan?: unknown; joseph?: unknown },
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    nylasEmailClient: clients?.nathan as never,
+    nylasCeoEmailClient: clients?.joseph as never,
+  };
+}
+
+describe('EmailDraftSaveHandler', () => {
+  const handler = new EmailDraftSaveHandler();
+
+  it('returns failure when to is missing', async () => {
+    const client = { createDraft: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      { account: 'joseph', subject: 'Hi', body: 'Hello' },
+      { joseph: client },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('to');
+  });
+
+  it('returns failure when subject is missing', async () => {
+    const client = { createDraft: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      { account: 'joseph', to: 'recipient@example.com', body: 'Hello' },
+      { joseph: client },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('subject');
+  });
+
+  it('returns failure when body is missing', async () => {
+    const client = { createDraft: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      { account: 'joseph', to: 'recipient@example.com', subject: 'Hi' },
+      { joseph: client },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('body');
+  });
+
+  it('returns failure when account is joseph but CEO client unavailable', async () => {
+    const result = await handler.execute(makeCtx(
+      { account: 'joseph', to: 'r@example.com', subject: 'Hi', body: 'Hello' },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('CEO inbox not configured');
+  });
+
+  it('uses CEO client when account is joseph', async () => {
+    const josephClient = { createDraft: vi.fn().mockResolvedValue({ id: 'draft-1' }) };
+    const result = await handler.execute(makeCtx(
+      { account: 'joseph', to: 'r@example.com', subject: 'Hi', body: 'Hello' },
+      { joseph: josephClient },
+    ));
+    expect(result.success).toBe(true);
+    expect(josephClient.createDraft).toHaveBeenCalledOnce();
+  });
+
+  it('uses Nathan client when account is nathan', async () => {
+    const nathanClient = { createDraft: vi.fn().mockResolvedValue({ id: 'draft-2' }) };
+    const result = await handler.execute(makeCtx(
+      { account: 'nathan', to: 'r@example.com', subject: 'Hi', body: 'Hello' },
+      { nathan: nathanClient },
+    ));
+    expect(result.success).toBe(true);
+    expect(nathanClient.createDraft).toHaveBeenCalledOnce();
+  });
+
+  it('returns draftId on success', async () => {
+    const josephClient = { createDraft: vi.fn().mockResolvedValue({ id: 'draft-99' }) };
+    const result = await handler.execute(makeCtx(
+      { account: 'joseph', to: 'r@example.com', subject: 'Hi', body: 'Hello' },
+      { joseph: josephClient },
+    ));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { draftId: string };
+      expect(data.draftId).toBe('draft-99');
+    }
+  });
+
+  it('passes replyToMessageId when provided', async () => {
+    const josephClient = { createDraft: vi.fn().mockResolvedValue({ id: 'draft-1' }) };
+    await handler.execute(makeCtx(
+      { account: 'joseph', to: 'r@example.com', subject: 'Re: Hi', body: 'Hello', replyToMessageId: 'msg-orig' },
+      { joseph: josephClient },
+    ));
+    expect(josephClient.createDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ replyToMessageId: 'msg-orig' }),
+    );
+  });
+
+  it('returns failure on client error', async () => {
+    const josephClient = { createDraft: vi.fn().mockRejectedValue(new Error('Nylas error')) };
+    const result = await handler.execute(makeCtx(
+      { account: 'joseph', to: 'r@example.com', subject: 'Hi', body: 'Hello' },
+      { joseph: josephClient },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Failed to save draft');
+  });
+});
+```
+
+- [ ] **Step 4: Run the tests — confirm they fail**
+
+```bash
+npx vitest run tests/unit/skills/email-list.test.ts tests/unit/skills/email-get.test.ts tests/unit/skills/email-draft-save.test.ts
+```
+
+Expected: all fail with "Cannot find module" — the skill handlers don't exist yet.
+
+- [ ] **Step 5: Commit the test files**
+
+```bash
+git add tests/unit/skills/email-list.test.ts tests/unit/skills/email-get.test.ts tests/unit/skills/email-draft-save.test.ts
+git commit -m "test: add failing tests for email-list, email-get, email-draft-save skills"
+```
+
+---
+
+### Task 8: Implement email-list skill
+
+**Files:**
+- Create: `skills/email-list/skill.json`
+- Create: `skills/email-list/handler.ts`
+
+- [ ] **Step 1: Write the manifest**
+
+```json
+{
+  "name": "email-list",
+  "description": "List email messages from any folder for either account. Use account='joseph' for the CEO's inbox, account='nathan' (default) for Nathan's. Use folder='DRAFTS' to check drafts, 'SENT' for sent mail, 'INBOX' (default) for inbox. Supports filtering by from address, subject, or a native Gmail/Outlook search query. Returns snippets only — use email-get to read the full body of a specific message.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "account": "string?",
+    "folder": "string?",
+    "limit": "number?",
+    "unreadOnly": "boolean?",
+    "from": "string?",
+    "subject": "string?",
+    "searchQueryNative": "string?"
+  },
+  "outputs": {
+    "messages": "array"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}
+```
+
+- [ ] **Step 2: Write the handler**
+
+```typescript
+// handler.ts — email-list skill implementation.
+//
+// Lists messages from any folder for either Nathan's or Joseph's account.
+// Returns metadata + snippet only — not full bodies (use email-get for that).
+// All parameters are optional; defaults are inbox for Nathan's account.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export class EmailListHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { account, folder, limit, unreadOnly, from, subject, searchQueryNative } = ctx.input as {
+      account?: string;
+      folder?: string;
+      limit?: number;
+      unreadOnly?: boolean;
+      from?: string;
+      subject?: string;
+      searchQueryNative?: string;
+    };
+
+    // Resolve which Nylas client to use based on account param
+    const useJoseph = account === 'joseph';
+    const client = useJoseph ? ctx.nylasCeoEmailClient : ctx.nylasEmailClient;
+
+    if (!client && !useJoseph) {
+      return { success: false, error: 'Email not configured — NYLAS_API_KEY/NYLAS_GRANT_ID not set' };
+    }
+    if (!client && useJoseph) {
+      return { success: false, error: 'CEO inbox not configured — NYLAS_CEO_GRANT_ID/NYLAS_CEO_SELF_EMAIL not set' };
+    }
+
+    // Validate from address if provided
+    if (from && !EMAIL_REGEX.test(from)) {
+      return { success: false, error: `Invalid from address: ${from}` };
+    }
+
+    const queryLimit = typeof limit === 'number' ? Math.min(limit, 100) : 20;
+
+    ctx.log.info({ account: account ?? 'nathan', folder: folder ?? 'INBOX', queryLimit }, 'Listing email messages');
+
+    try {
+      const messages = await client!.listMessages({
+        limit: queryLimit,
+        unread: unreadOnly === true ? true : undefined,
+        folders: folder ? [folder] : undefined,
+        from: from ?? undefined,
+        subject: subject ?? undefined,
+        searchQueryNative: searchQueryNative ?? undefined,
+      });
+
+      // Return metadata + snippet — no full bodies (keeps response size manageable)
+      const normalised = messages.map((m) => ({
+        id: m.id,
+        threadId: m.threadId,
+        subject: m.subject,
+        from: m.from,
+        snippet: m.snippet,
+        date: m.date,
+        unread: m.unread,
+        folders: m.folders,
+      }));
+
+      return { success: true, data: { messages: normalised } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, account: account ?? 'nathan' }, 'Failed to list email messages');
+      return { success: false, error: `Failed to list messages: ${message}` };
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Run the email-list tests**
+
+```bash
+npx vitest run tests/unit/skills/email-list.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/email-list/skill.json skills/email-list/handler.ts
+git commit -m "feat: add email-list skill (account-aware, folder + filter support)"
+```
+
+---
+
+### Task 9: Implement email-get skill
+
+**Files:**
+- Create: `skills/email-get/skill.json`
+- Create: `skills/email-get/handler.ts`
+
+- [ ] **Step 1: Write the manifest**
+
+```json
+{
+  "name": "email-get",
+  "description": "Fetch the full body and metadata of a single email message by ID. Use this after email-list to read a specific message before drafting a reply — email-list returns only 100-character snippets which are not enough context for drafting.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "messageId": "string",
+    "account": "string?"
+  },
+  "outputs": {
+    "message": "object"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}
+```
+
+- [ ] **Step 2: Write the handler**
+
+```typescript
+// handler.ts — email-get skill implementation.
+//
+// Fetches a single message by its Nylas message ID, for either account.
+// This is the prerequisite step before drafting — email-list returns snippets
+// only (100 chars), which is not enough context for composing a meaningful reply.
+// Nathan's typical flow: email-list → email-get → email-draft-save.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class EmailGetHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { messageId, account } = ctx.input as {
+      messageId?: string;
+      account?: string;
+    };
+
+    if (!messageId || typeof messageId !== 'string') {
+      return { success: false, error: 'Missing required input: messageId (string)' };
+    }
+
+    const useJoseph = account === 'joseph';
+    const client = useJoseph ? ctx.nylasCeoEmailClient : ctx.nylasEmailClient;
+
+    if (!client && !useJoseph) {
+      return { success: false, error: 'Email not configured — NYLAS_API_KEY/NYLAS_GRANT_ID not set' };
+    }
+    if (!client && useJoseph) {
+      return { success: false, error: 'CEO inbox not configured — NYLAS_CEO_GRANT_ID/NYLAS_CEO_SELF_EMAIL not set' };
+    }
+
+    ctx.log.info({ messageId, account: account ?? 'nathan' }, 'Fetching email message');
+
+    try {
+      const message = await client!.getMessage(messageId);
+      return { success: true, data: { message } };
+    } catch (err) {
+      const errMessage = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, messageId, account: account ?? 'nathan' }, 'Failed to fetch email message');
+      return { success: false, error: `Failed to fetch message: ${errMessage}` };
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Run email-get tests**
+
+```bash
+npx vitest run tests/unit/skills/email-get.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/email-get/skill.json skills/email-get/handler.ts
+git commit -m "feat: add email-get skill (account-aware full message fetch)"
+```
+
+---
+
+### Task 10: Implement email-draft-save skill
+
+**Files:**
+- Create: `skills/email-draft-save/skill.json`
+- Create: `skills/email-draft-save/handler.ts`
+
+- [ ] **Step 1: Write the manifest**
+
+```json
+{
+  "name": "email-draft-save",
+  "description": "Save a draft email to the specified account's Drafts folder. The draft is NOT sent — it waits in Drafts for the account owner to review and send. Use account='joseph' to draft in Joseph's name (for CEO inbox replies). Use account='nathan' to draft in Nathan's own name.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "infrastructure": true,
+  "inputs": {
+    "account": "string",
+    "to": "string",
+    "subject": "string",
+    "body": "string",
+    "replyToMessageId": "string?"
+  },
+  "outputs": {
+    "draftId": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000
+}
+```
+
+- [ ] **Step 2: Write the handler**
+
+```typescript
+// handler.ts — email-draft-save skill implementation.
+//
+// Creates a draft via the Nylas drafts API. This is a separate resource
+// from messages — nylas.drafts.create() stores the draft without sending it.
+// The draft appears in Gmail's Drafts folder for the account owner to review.
+//
+// Sensitivity: elevated — requires CEO role or CLI channel. This prevents
+// any non-CEO agent or channel from saving drafts on Joseph's behalf.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+const MAX_BODY_LENGTH = 50000;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export class EmailDraftSaveHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { account, to, subject, body, replyToMessageId } = ctx.input as {
+      account?: string;
+      to?: string;
+      subject?: string;
+      body?: string;
+      replyToMessageId?: string;
+    };
+
+    // Input validation
+    if (!to || typeof to !== 'string') {
+      return { success: false, error: 'Missing required input: to (string)' };
+    }
+    if (!EMAIL_REGEX.test(to)) {
+      return { success: false, error: `Invalid to address: ${to}` };
+    }
+    if (!subject || typeof subject !== 'string') {
+      return { success: false, error: 'Missing required input: subject (string)' };
+    }
+    if (!body || typeof body !== 'string') {
+      return { success: false, error: 'Missing required input: body (string)' };
+    }
+    if (body.length > MAX_BODY_LENGTH) {
+      return { success: false, error: `body must be ${MAX_BODY_LENGTH} characters or fewer` };
+    }
+
+    const useJoseph = account === 'joseph';
+    const client = useJoseph ? ctx.nylasCeoEmailClient : ctx.nylasEmailClient;
+
+    if (!client && !useJoseph) {
+      return { success: false, error: 'Email not configured — NYLAS_API_KEY/NYLAS_GRANT_ID not set' };
+    }
+    if (!client && useJoseph) {
+      return { success: false, error: 'CEO inbox not configured — NYLAS_CEO_GRANT_ID/NYLAS_CEO_SELF_EMAIL not set' };
+    }
+
+    ctx.log.info({ account: account ?? 'nathan', to, subject }, 'Saving email draft');
+
+    try {
+      const draft = await client!.createDraft({
+        to: [{ email: to }],
+        subject,
+        body,
+        replyToMessageId: replyToMessageId ?? undefined,
+      });
+
+      ctx.log.info({ draftId: draft.id, account: account ?? 'nathan' }, 'Draft saved successfully');
+
+      return { success: true, data: { draftId: draft.id } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, account: account ?? 'nathan', to, subject }, 'Failed to save draft');
+      return { success: false, error: `Failed to save draft: ${message}` };
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Run all three skill tests**
+
+```bash
+npx vitest run tests/unit/skills/email-list.test.ts tests/unit/skills/email-get.test.ts tests/unit/skills/email-draft-save.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/email-draft-save/skill.json skills/email-draft-save/handler.ts
+git commit -m "feat: add email-draft-save skill (creates Nylas draft, elevated sensitivity)"
+```
+
+---
+
+### Task 11: Update coordinator — pin skills and add persona guidance
+
+**Files:**
+- Modify: `agents/coordinator.yaml`
+
+- [ ] **Step 1: Pin the three new skills**
+
+In `agents/coordinator.yaml`, add the three skills to `pinned_skills`:
+
+```yaml
+pinned_skills:
+  - entity-context
+  - web-fetch
+  - delegate
+  - contact-create
+  - contact-lookup
+  # ... existing skills ...
+  - email-send
+  - email-reply
+  - email-list        # ← add
+  - email-get         # ← add
+  - email-draft-save  # ← add
+  # ... rest unchanged ...
+```
+
+- [ ] **Step 2: Expand the Email section in the system prompt**
+
+Find the `## Email` section. Replace it with the expanded version:
+
+```yaml
+  ## Email
+  You have two email accounts: your own (Nathan Curia, nathancuria1@gmail.com) and
+  access to the CEO's inbox (Joseph Fung, joseph@josephfung.ca).
+
+  **Your own email (account: "nathan"):**
+  - When you receive an email and want to respond: ALWAYS use email-reply with the
+    thread_id from the conversation. It replies to the sender automatically.
+  - email-send is ONLY for composing brand new emails when the CEO asks you to email
+    someone. It starts a new thread and requires a "to" address.
+
+  **CEO's inbox (account: "joseph") — Phase 1 rules:**
+  - You can READ Joseph's inbox using email-list and email-get.
+  - Before drafting a reply, ALWAYS call email-get to read the full message body —
+    the snippet from email-list is not enough context.
+  - When drafting a reply on Joseph's behalf: use email-draft-save with account="joseph".
+    Write in Joseph's voice — first person, his tone, no mention of Nathan.
+    The draft will appear in his Drafts folder for him to review and send.
+  - You CANNOT send from Joseph's address in Phase 1. Do not attempt email-send or
+    email-reply with account="joseph" — only drafts are permitted.
+
+  **Daily digest:**
+  Joseph may ask you to set up a recurring reminder if there are pending drafts.
+  Use scheduler-create with a natural-language task string for this.
+```
+
+- [ ] **Step 3: Run typecheck and full test suite**
+
+```bash
+npx tsc --noEmit && npx vitest run
+```
+
+Expected: both pass cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agents/coordinator.yaml
+git commit -m "feat: pin email-list, email-get, email-draft-save; add CEO inbox guidance to coordinator prompt"
+```
+
+---
+
+### Task 12: Configure credentials and smoke test
+
+- [ ] **Step 1: Set up the CEO Nylas grant**
+
+In the Nylas dashboard (https://dashboard.nylas.com):
+1. Go to your application
+2. Click "Add Test Grant" (or use the Nylas CLI: `nylas auth`)
+3. Authenticate with joseph@josephfung.ca (Google OAuth)
+4. Copy the resulting grant ID
+
+- [ ] **Step 2: Add credentials to .env**
+
+```
+NYLAS_CEO_GRANT_ID=<grant-id-from-dashboard>
+NYLAS_CEO_SELF_EMAIL=joseph@josephfung.ca
+```
+
+- [ ] **Step 3: Start Curia and verify the CEO adapter starts**
+
+```bash
+npx tsx src/index.ts
+```
+
+Expected log lines:
+```
+{"msg":"CEO Nylas client initialized"}
+{"msg":"CEO email channel adapter started — polling Nylas"}
+```
+
+- [ ] **Step 4: Send a test email to joseph@josephfung.ca**
+
+Send a test email from any external address to joseph@josephfung.ca with subject "Test inbox integration".
+
+Within 30 seconds, check the logs for:
+```
+{"msg":"CEO email received and published to bus","from":"...","subject":"Test inbox integration"}
+```
+
+- [ ] **Step 5: Ask Nathan to list the CEO inbox**
+
+From the CLI:
+
+```
+Check Joseph's inbox and tell me about any recent emails.
+```
+
+Expected: Nathan calls `email-list(account: "joseph", folder: "INBOX")` and reports back with subjects, senders, and snippets.
+
+- [ ] **Step 6: Ask Nathan to draft a reply**
+
+```
+Draft a reply to the test email — just a brief "got it, thanks."
+```
+
+Expected:
+1. Nathan calls `email-get(account: "joseph", messageId: "...")` to read the full message
+2. Nathan calls `email-draft-save(account: "joseph", to: "...", subject: "Re: Test inbox integration", body: "...")`
+3. Nathan confirms the draft is saved
+4. Open Gmail for joseph@josephfung.ca — the draft should appear in Drafts
+
+- [ ] **Step 7: Set up the daily draft digest**
+
+```
+Keep an eye on my drafts and let me know at 5pm on weekdays if there are any waiting for me.
+```
+
+Expected: Nathan calls `scheduler-create(cron_expr: "0 17 * * 1-5", task: "Check Joseph's Drafts folder...")` and confirms the job is set up.
+
+---
+
+## Verification Checklist
+
+- [ ] `npx tsc --noEmit` — clean
+- [ ] `npx vitest run` — all tests pass (including new email-list, email-get, email-draft-save)
+- [ ] CEO adapter starts when `NYLAS_CEO_GRANT_ID` and `NYLAS_CEO_SELF_EMAIL` are set
+- [ ] CEO adapter does NOT start when credentials are absent (graceful degradation)
+- [ ] Inbound email to joseph@josephfung.ca appears in Nathan's context within 30s
+- [ ] `email-list(account: "joseph")` lists Joseph's inbox
+- [ ] `email-get` returns full message body
+- [ ] `email-draft-save(account: "joseph")` creates a visible draft in Gmail Drafts — NOT in Sent
+- [ ] No email is dispatched from Joseph's address (OutboundGateway never called for CEO account in Phase 1)
+- [ ] Contact from the test email thread appears as a provisional contact
+- [ ] Daily draft digest job created via `scheduler-create`

--- a/docs/superpowers/plans/2026-04-03-web-search.md
+++ b/docs/superpowers/plans/2026-04-03-web-search.md
@@ -1,0 +1,469 @@
+# Web Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `web-search` skill backed by Tavily that lets Nathan run multi-turn searches and synthesise results himself.
+
+**Architecture:** A single `SkillHandler` calls the Tavily HTTP API, normalises and truncates the results, and returns structured data. The existing `web-fetch` skill handles full-page reads; this skill handles search. Both compose naturally in the tool-use loop — Nathan searches to find URLs, then fetches to read them. No pre-synthesis layer: the LLM does all reasoning.
+
+**Tech Stack:** Tavily REST API (`https://api.tavily.com/search`), Node `fetch`, Vitest.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `skills/web-search/skill.json` | Manifest: inputs, outputs, secrets, sensitivity |
+| Create | `skills/web-search/handler.ts` | Tavily call, normalisation, sanitisation |
+| Create | `tests/unit/skills/web-search.test.ts` | Unit tests (mocked fetch) |
+| Modify | `agents/coordinator.yaml` | Pin `web-search`, add research guidance to system prompt |
+
+---
+
+### Task 1: Write the failing tests
+
+**Files:**
+- Create: `tests/unit/skills/web-search.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+```typescript
+// tests/unit/skills/web-search.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WebSearchHandler } from '../../../skills/web-search/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(
+  input: Record<string, unknown>,
+  secretValue = 'tvly-test-key',
+): SkillContext {
+  return {
+    input,
+    secret: (name: string) => {
+      if (name === 'tavily_api_key') return secretValue;
+      throw new Error(`Unexpected secret: ${name}`);
+    },
+    log: logger,
+  };
+}
+
+describe('WebSearchHandler', () => {
+  const handler = new WebSearchHandler();
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns failure when query is missing', async () => {
+    const result = await handler.execute(makeCtx({}));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('query');
+  });
+
+  it('returns failure when query is empty string', async () => {
+    const result = await handler.execute(makeCtx({ query: '' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('query');
+  });
+
+  it('returns failure when API key is missing', async () => {
+    const ctx: SkillContext = {
+      input: { query: 'test' },
+      secret: () => { throw new Error('Secret not set'); },
+      log: logger,
+    };
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('API key');
+  });
+
+  it('returns structured results on success', async () => {
+    const mockResponse = {
+      results: [
+        { title: 'Example', url: 'https://example.com', content: 'Some content', score: 0.9 },
+        { title: 'Other', url: 'https://other.com', content: 'Other content', score: 0.7 },
+      ],
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    }));
+
+    const result = await handler.execute(makeCtx({ query: 'ramen near King and Spadina' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { results: unknown[]; count: number };
+      expect(data.count).toBe(2);
+      expect(data.results).toHaveLength(2);
+    }
+  });
+
+  it('returns empty results array when Tavily returns no results', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    }));
+
+    const result = await handler.execute(makeCtx({ query: 'obscure query' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { results: unknown[]; count: number };
+      expect(data.count).toBe(0);
+      expect(data.results).toHaveLength(0);
+    }
+  });
+
+  it('returns failure on non-OK HTTP response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+    }));
+
+    const result = await handler.execute(makeCtx({ query: 'test' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('401');
+  });
+
+  it('returns failure on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network timeout')));
+
+    const result = await handler.execute(makeCtx({ query: 'test' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Search failed');
+  });
+
+  it('truncates long content fields to 5000 chars', async () => {
+    const longContent = 'x'.repeat(10_000);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [{ title: 'Test', url: 'https://example.com', content: longContent, score: 0.9 }],
+      }),
+    }));
+
+    const result = await handler.execute(makeCtx({ query: 'test', searchDepth: 'advanced' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { results: Array<{ content: string }> };
+      expect(data.results[0]!.content.length).toBeLessThanOrEqual(5000 + '[truncated]'.length);
+    }
+  });
+
+  it('sends correct search_depth to Tavily', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await handler.execute(makeCtx({ query: 'test', searchDepth: 'advanced' }));
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [, options] = mockFetch.mock.calls[0] as [string, { body: string }];
+    const body = JSON.parse(options.body) as { search_depth: string };
+    expect(body.search_depth).toBe('advanced');
+  });
+
+  it('defaults to basic search_depth', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    }); 
+    vi.stubGlobal('fetch', mockFetch);
+
+    await handler.execute(makeCtx({ query: 'test' }));
+
+    const [, options] = mockFetch.mock.calls[0] as [string, { body: string }];
+    const body = JSON.parse(options.body) as { search_depth: string };
+    expect(body.search_depth).toBe('basic');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-web-search
+npx vitest run tests/unit/skills/web-search.test.ts
+```
+
+Expected: all tests fail with "Cannot find module" or similar — the handler doesn't exist yet.
+
+---
+
+### Task 2: Create the skill manifest
+
+**Files:**
+- Create: `skills/web-search/skill.json`
+
+- [ ] **Step 1: Write the manifest**
+
+```json
+{
+  "name": "web-search",
+  "description": "Search the web using Tavily. Returns structured results with title, URL, snippet, and (for advanced depth) extracted page content. For simple lookups, one search is enough. For research tasks, call multiple times with different queries — each covering a different angle — before forming a conclusion.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "inputs": {
+    "query": "string",
+    "maxResults": "number?",
+    "searchDepth": "string?"
+  },
+  "outputs": {
+    "results": "array",
+    "count": "number"
+  },
+  "permissions": ["network:search"],
+  "secrets": ["tavily_api_key"],
+  "timeout": 30000
+}
+```
+
+---
+
+### Task 3: Implement the handler
+
+**Files:**
+- Create: `skills/web-search/handler.ts`
+
+- [ ] **Step 1: Write the handler**
+
+```typescript
+// handler.ts — web-search skill implementation.
+//
+// Calls the Tavily search API and returns structured results for the LLM
+// to synthesise. All synthesis happens in Nathan's LLM — this skill is a
+// data bridge, not an answer generator.
+//
+// Two search depths:
+//   basic    — fast, returns title + snippet only. Good for simple lookups.
+//   advanced — slower, extracts full page content. Good for research tasks.
+//
+// Security: the API key is resolved via ctx.secret() (declared in manifest),
+// never passed through the LLM context. Content is truncated per result to
+// avoid blowing out the LLM context window.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+// Max characters per result's content field — keeps LLM context manageable.
+const MAX_CONTENT_LENGTH = 5000;
+
+const TAVILY_API_URL = 'https://api.tavily.com/search';
+
+interface TavilyResult {
+  title: string;
+  url: string;
+  content: string;
+  raw_content?: string;
+  score: number;
+}
+
+interface TavilyResponse {
+  results: TavilyResult[];
+}
+
+interface NormalisedResult {
+  title: string;
+  url: string;
+  content: string;
+  score: number;
+}
+
+function truncate(text: string): string {
+  if (text.length <= MAX_CONTENT_LENGTH) return text;
+  return text.slice(0, MAX_CONTENT_LENGTH) + '[truncated]';
+}
+
+export class WebSearchHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { query, maxResults, searchDepth } = ctx.input as {
+      query?: string;
+      maxResults?: number;
+      searchDepth?: string;
+    };
+
+    if (!query || typeof query !== 'string' || query.trim() === '') {
+      return { success: false, error: 'Missing required input: query (non-empty string)' };
+    }
+
+    // Resolve API key — declared in manifest so secret() will allow it.
+    // If the env var is not set, secret() throws — we surface that as a
+    // user-readable error rather than letting the exception propagate.
+    let apiKey: string;
+    try {
+      apiKey = ctx.secret('tavily_api_key');
+    } catch {
+      return { success: false, error: 'Tavily API key not configured — set TAVILY_API_KEY in the environment' };
+    }
+
+    const depth = searchDepth === 'advanced' ? 'advanced' : 'basic';
+    const limit = typeof maxResults === 'number' ? Math.min(maxResults, 20) : 5;
+
+    ctx.log.info({ query, depth, limit }, 'Running web search via Tavily');
+
+    let response: Response;
+    try {
+      response = await fetch(TAVILY_API_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          api_key: apiKey,
+          query: query.trim(),
+          max_results: limit,
+          search_depth: depth,
+          // Request raw_content for advanced depth — full extracted page text
+          include_raw_content: depth === 'advanced',
+        }),
+        signal: AbortSignal.timeout(25000),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, query }, 'Tavily request failed');
+      return { success: false, error: `Search failed: ${message}` };
+    }
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `Tavily returned HTTP ${response.status}: ${response.statusText || 'request failed'}`,
+      };
+    }
+
+    let body: TavilyResponse;
+    try {
+      body = await response.json() as TavilyResponse;
+    } catch (err) {
+      return { success: false, error: 'Failed to parse Tavily response as JSON' };
+    }
+
+    // Normalise and truncate — use raw_content when available (advanced depth),
+    // fall back to the snippet content field.
+    const results: NormalisedResult[] = (body.results ?? []).map((r) => ({
+      title: r.title,
+      url: r.url,
+      content: truncate(r.raw_content ?? r.content ?? ''),
+      score: r.score,
+    }));
+
+    ctx.log.info({ query, resultCount: results.length }, 'Web search complete');
+
+    return {
+      success: true,
+      data: { results, count: results.length },
+    };
+  }
+}
+```
+
+- [ ] **Step 2: Run tests — they should now pass**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-web-search
+npx vitest run tests/unit/skills/web-search.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/web-search/skill.json skills/web-search/handler.ts tests/unit/skills/web-search.test.ts
+git commit -m "feat: add web-search skill via Tavily API"
+```
+
+---
+
+### Task 4: Update coordinator — pin skill and add research guidance
+
+**Files:**
+- Modify: `agents/coordinator.yaml`
+
+- [ ] **Step 1: Pin web-search in the skills list**
+
+In `agents/coordinator.yaml`, add `web-search` to the `pinned_skills` list after `web-fetch`:
+
+```yaml
+pinned_skills:
+  - entity-context
+  - web-fetch
+  - web-search   # ← add this line
+  - delegate
+  # ... rest unchanged
+```
+
+- [ ] **Step 2: Add research guidance to the system prompt**
+
+Find the `## Email` section in the system prompt. Add a new `## Research` section directly before it:
+
+```yaml
+  ## Research
+  You can search the web and fetch pages to answer questions and do research.
+  - For simple lookups ("find a restaurant", "what is X"), one search is enough.
+  - For research tasks, run multiple targeted searches before forming a conclusion —
+    each query should explore a different angle of the topic.
+  - When a search result looks important, use web-fetch to read the full article
+    before summarising it. Snippets can mislead.
+  - Cite your sources naturally ("according to [source]...") rather than listing URLs
+    at the end.
+```
+
+- [ ] **Step 3: Run the full test suite to confirm nothing broke**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-web-search
+npx vitest run
+```
+
+Expected: all existing tests pass plus the new web-search tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agents/coordinator.yaml
+git commit -m "feat: pin web-search skill and add research guidance to coordinator prompt"
+```
+
+---
+
+### Task 5: Set the API key and smoke test
+
+- [ ] **Step 1: Add `TAVILY_API_KEY` to the `.env` file**
+
+Sign up at https://tavily.com, copy the API key, and add it to `.env`:
+
+```
+TAVILY_API_KEY=tvly-...
+```
+
+- [ ] **Step 2: Start Curia and run a simple test**
+
+Start the server and send this message from the CLI:
+
+```
+Find me a ramen restaurant near King St and Spadina Ave in Toronto.
+```
+
+Expected: Nathan responds with specific restaurant names, addresses, and hours. If he says he can't search, the skill isn't pinned correctly. If he gives results but no specific details, try `searchDepth: advanced`.
+
+- [ ] **Step 3: Run a research test**
+
+```
+Help me understand the key differences between the geopolitical context surrounding the Apollo moon landings in 1969-1972 versus the Artemis program today. Focus on US-Russia/Soviet dynamics and the role of national prestige.
+```
+
+Expected: Nathan runs 3-5 searches across different angles and synthesises a structured comparison with citations. If he runs only one search, the research guidance in the prompt needs tuning.
+
+---
+
+## Verification Checklist
+
+- [ ] `tests/unit/skills/web-search.test.ts` — all tests pass
+- [ ] `npx vitest run` — full suite passes
+- [ ] Simple lookup works end-to-end (restaurant query)
+- [ ] Deep research query produces multi-search synthesis with citations
+- [ ] `web-search` appears in Nathan's tool use in logs during the smoke tests

--- a/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
@@ -1,0 +1,245 @@
+# Capability Expansion: CEO Inbox & Web Search
+
+**Date:** 2026-04-03
+**Status:** Proposed
+
+## Overview
+
+Two new capabilities that unlock core EA work Nathan cannot currently do:
+
+1. **CEO Inbox** — Nathan monitors and acts on Joseph's Gmail (joseph@josephfung.ca). Currently Nathan only has access to his own address (nathancuria1@gmail.com). Without inbox access, email triage, drafting replies on Joseph's behalf, and inbox filing are impossible.
+
+2. **Web Search** — Nathan cannot look things up. This blocks simple queries ("find a restaurant near my meeting") and deep research tasks ("compare the geopolitical context of 1972 Apollo vs 2025 Artemis"). Web search is also a force-multiplier for inbox work — Nathan can research context before drafting a reply.
+
+### What This Defers
+
+- **Google Docs/Drive** — document storage, ongoing research files, expense receipt filing. Deferred until MCP support is implemented in the framework (spec 03). At that point, `@modelcontextprotocol/server-gdrive` is the likely approach.
+
+### Design Principles Applied
+
+- **Skills Must Add Value Beyond the Bare LLM** — skills are API bridges. No skill contains classification, summarization, or judgment logic. The LLM decides what to draft; the skill saves it to Drafts. The LLM decides what to search for; the skill fetches results.
+- **Future-Proof for LLM Upgrades** — synthesis always stays in Nathan's LLM, never in a pre-synthesis API (Perplexity rejected for this reason). As Claude gets smarter, Nathan's research quality improves automatically at zero cost.
+- **Phase-Gated Autonomy** — the CEO inbox integration is designed for three levels of autonomy. Only Phase 1 ships now. Phases 2 and 3 are config-flag additions, not architectural changes.
+
+---
+
+## Capability 1: CEO Inbox
+
+### Autonomy Phases
+
+The inbox integration supports three phases of autonomy, each a superset of the last:
+
+| Phase | What Nathan does | Ships when |
+|---|---|---|
+| **1 — Monitor & Draft** | Reads inbox, drafts replies, saves to Joseph's Drafts folder. Daily digest notifies Joseph if drafts are pending. | Now |
+| **2 — Archive & File** | Archives threads, applies Gmail labels. Builds on Joseph's existing filters. | Later |
+| **3 — Autonomous Reply** | Replies as Joseph (or from nathancuria1@gmail.com) for threads Nathan can handle independently. | Later |
+
+A `autonomy_phase` config field in `config/default.yaml` controls which behaviors are active.
+
+### Architecture
+
+**New Nylas grant:** Joseph's Gmail (joseph@josephfung.ca) connected to Nylas as a separate grant. Credential: `NYLAS_CEO_GRANT_ID`. The existing Nathan grant (`NYLAS_GRANT_ID`) is unchanged.
+
+**New channel adapter:** `src/channels/email-ceo/`
+
+- `email-ceo-adapter.ts` — polls Joseph's Nylas grant. Same polling pattern as `email-adapter.ts` (high-water timestamp, duplicate suppression). Publishes `inbound.message` with `channel_id: "email-ceo"`. Trust level: `high` (it is the CEO's own account).
+- `nylas-ceo-client.ts` — thin wrapper around the Nylas SDK, parameterized by `NYLAS_CEO_GRANT_ID` and `NYLAS_CEO_EMAIL`. Mirrors `nylas-client.ts` in structure.
+- Reuses `message-converter.ts`, `html-to-text.ts`, `markdown-to-html.ts` from `src/channels/email/` without modification.
+
+**New skills (Phase 1):**
+
+`email-ceo-list` — lists recent threads from Joseph's inbox.
+```json
+{
+  "name": "email-ceo-list",
+  "sensitivity": "normal",
+  "inputs": { "limit": "number? (default 20)", "unreadOnly": "boolean? (default false)" },
+  "outputs": { "threads": "array" },
+  "permissions": ["network:nylas"],
+  "secrets": ["nylas_ceo_grant_id"]
+}
+```
+
+`email-ceo-draft-save` — writes a draft to Joseph's Gmail Drafts folder.
+```json
+{
+  "name": "email-ceo-draft-save",
+  "sensitivity": "elevated",
+  "inputs": {
+    "to": "string",
+    "subject": "string",
+    "body": "string",
+    "replyToThreadId": "string?"
+  },
+  "outputs": { "draftId": "string" },
+  "permissions": ["network:nylas"],
+  "secrets": ["nylas_ceo_grant_id"]
+}
+```
+
+Elevated sensitivity ensures a human-approval gate the first time the coordinator uses this skill.
+
+`email-ceo-draft-list` — lists drafts currently in Joseph's Drafts folder. Used by the scheduler job to check if notification is needed.
+```json
+{
+  "name": "email-ceo-draft-list",
+  "sensitivity": "normal",
+  "outputs": { "drafts": "array", "count": "number" },
+  "permissions": ["network:nylas"],
+  "secrets": ["nylas_ceo_grant_id"]
+}
+```
+
+**Scheduler job (Phase 1):**
+
+A daily one-shot job at 5pm (configurable) checks `email-ceo-draft-list`. If `count > 0`, it sends a CLI notification listing draft subjects and recipients. Joseph can then open Gmail, review, and send or discard. The job is registered in `agents/coordinator.yaml` as a startup scheduled task, or seeded via the bootstrap.
+
+**New skills (Phase 2, not shipped now):**
+
+- `email-ceo-archive` — archives a thread, optionally applies a label
+- `email-ceo-label` — applies one or more Gmail labels to a thread
+
+**New skills (Phase 3, not shipped now):**
+
+- `email-ceo-send` — sends from Joseph's address. Requires `autonomyPhase ≥ 3` gate in OutboundGateway. Elevated sensitivity.
+
+### Outbound Gateway
+
+All writes to Joseph's account (draft saves, eventual sends) route through `OutboundGateway`. Phase 1 only writes drafts — no sends. The gateway's blocked-contact and content-filter checks still apply to drafts to prevent Nathan from drafting problematic content.
+
+A new autonomy gate is added to OutboundGateway for Phase 3: if `autonomyPhase < 3`, attempts to call `email-ceo-send` are blocked and the coordinator is told to save a draft instead.
+
+### Contact System
+
+Participants extracted from Joseph's inbox threads are auto-created as `provisional` contacts with source `email_ceo_participant`. Same flow as the primary email adapter. This enriches the shared contact graph — a contact who has emailed both Nathan and Joseph is the same contact record.
+
+### Persona Guidance
+
+When Nathan is drafting a reply for Joseph's Drafts folder, he is writing *in Joseph's voice*, not his own. The coordinator prompt is updated to clarify:
+
+- When acting on `email-ceo` threads, Nathan writes as Joseph — first person, Joseph's tone, no references to Nathan as a person
+- When replying as himself (Phase 3, `channel_id: "email"`), Nathan writes as Nathan
+
+### Configuration
+
+```yaml
+# config/default.yaml additions
+channels:
+  email-ceo:
+    enabled: true
+    pollingIntervalMs: 30000
+    autonomyPhase: 1       # 1 = monitor+draft, 2 = +archive, 3 = +send
+
+scheduler:
+  jobs:
+    - name: ceo-draft-digest
+      schedule: "0 17 * * 1-5"   # 5pm weekdays
+      task: check-ceo-drafts-and-notify
+```
+
+### Files to Create/Modify
+
+| Action | Path |
+|---|---|
+| Create | `src/channels/email-ceo/email-ceo-adapter.ts` |
+| Create | `src/channels/email-ceo/nylas-ceo-client.ts` |
+| Create | `skills/email-ceo-list/skill.json` + `handler.ts` + `handler.test.ts` |
+| Create | `skills/email-ceo-draft-save/skill.json` + `handler.ts` + `handler.test.ts` |
+| Create | `skills/email-ceo-draft-list/skill.json` + `handler.ts` + `handler.test.ts` |
+| Modify | `config/default.yaml` — add `email-ceo` channel config and scheduler job |
+| Modify | `agents/coordinator.yaml` — pin new skills, add persona guidance |
+| Modify | `src/index.ts` (or channel bootstrap) — register `email-ceo-adapter` |
+| Modify | `src/skills/outbound-gateway.ts` — autonomy phase gate (Phase 3 prep) |
+
+---
+
+## Capability 2: Web Search
+
+### Approach
+
+Two composable skills — Nathan calls them as many times as needed in the tool-use loop:
+
+- `web-search` (new) — calls Tavily API, returns structured results per URL: title, URL, snippet, extracted content. Nathan issues multiple targeted queries for complex research.
+- `web-fetch` (exists) — fetches full page content for a specific URL. Nathan uses this for articles identified as important in search results.
+
+The LLM orchestrates all synthesis. No pre-synthesis API layer.
+
+### Why Tavily
+
+Tavily is purpose-built for AI agents. Unlike raw search APIs (Brave, SerpAPI), Tavily performs content extraction alongside the search — returning clean text from the page, not just a snippet. This is critical for the deep research use case where Nathan needs actual article content, not just headlines. The provider is swappable; it is just a skill.
+
+### Search Depth
+
+Tavily's `search_depth` parameter maps to the query's complexity:
+
+- `"basic"` — fast, snippet-only. Suitable for "find me a ramen restaurant" queries.
+- `"advanced"` — slower, full content extraction. Suitable for research tasks.
+
+Nathan decides which to use based on the task. The skill exposes both via an input parameter.
+
+### Skill Design
+
+`skills/web-search/skill.json`:
+```json
+{
+  "name": "web-search",
+  "description": "Search the web using Tavily. Returns structured results with title, URL, snippet, and (for advanced depth) extracted page content. Call multiple times with refined queries for complex research tasks.",
+  "sensitivity": "normal",
+  "inputs": {
+    "query": "string",
+    "maxResults": "number? (default 5, max 20)",
+    "searchDepth": "string? (basic | advanced, default basic)"
+  },
+  "outputs": {
+    "results": "array of { title, url, snippet, content?, score }",
+    "count": "number"
+  },
+  "permissions": ["network:search"],
+  "secrets": ["tavily_api_key"],
+  "timeout": 30000
+}
+```
+
+`skills/web-search/handler.ts` — calls `https://api.tavily.com/search`, returns normalized results. Sanitizes returned content (HTML stripped, max 5KB per result) before it reaches the LLM.
+
+### Coordinator Guidance
+
+System prompt addition (paraphrased — written in Nathan's voice per persona rules):
+
+> For simple lookups, one search is enough. For research tasks, run multiple targeted searches before forming a conclusion — each query should explore a different angle. When a search result looks important, use web-fetch to read the full article before summarizing it.
+
+### Files to Create/Modify
+
+| Action | Path |
+|---|---|
+| Create | `skills/web-search/skill.json` |
+| Create | `skills/web-search/handler.ts` |
+| Create | `skills/web-search/handler.test.ts` |
+| Modify | `agents/coordinator.yaml` — pin `web-search`, add research guidance |
+| Modify | `config/default.yaml` — add `TAVILY_API_KEY` secret reference |
+
+---
+
+## Implementation Sequence
+
+**Ship web search first.** It is a smaller lift (one skill, no channel setup), and it immediately makes Nathan smarter for inbox triage — he can research context before drafting a reply. Inbox work starts in a better position with web search already available.
+
+1. `feat/web-search` — `web-search` skill + coordinator pin
+2. `feat/ceo-inbox` — `email-ceo` adapter + Phase 1 skills + scheduler job
+
+---
+
+## Verification
+
+### Web Search
+- Nathan answers "find me a ramen restaurant near King and Spadina" with real, specific results
+- Nathan produces a structured synthesis with citations for a multi-angle research query
+- `handler.test.ts` covers: valid query returns results, empty results, API error, missing API key, content sanitization
+
+### CEO Inbox (Phase 1)
+- Sending a test email to joseph@josephfung.ca causes it to appear in Nathan's context within one polling interval
+- Nathan drafts a reply → it appears in Joseph's Gmail Drafts folder, not in Sent
+- No email is dispatched from Joseph's address in Phase 1 — OutboundGateway blocks it
+- Scheduler job fires at 5pm and sends a CLI notification listing pending draft subjects
+- Contact extracted from the test email thread appears as a provisional contact in the contact system

--- a/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
@@ -51,7 +51,7 @@ A `autonomy_phase` config field in `config/default.yaml` controls which behavior
 
 Skills are **account-aware** rather than account-specific — an optional `account: "nathan" | "joseph"` parameter determines which Nylas client is used. This mirrors the existing `email-send` pattern: `infrastructure: true`, credentials resolved by the handler via the injected Nylas client registry, never exposed to the LLM. One skill, two accounts, no parallel skill maintenance.
 
-`email-list` — lists messages from any folder, for either account. The `folder` param maps to the Nylas `in` query parameter, which filters by folder ID. Nylas uses `INBOX`, `DRAFTS`, `SENT`, and `TRASH` as standard folder IDs across providers (Gmail and others). This means `email-list(account: "joseph", folder: "DRAFTS")` replaces what would have been a separate `email-draft-list` skill — no additional skill needed for listing drafts.
+`email-list` — lists messages from any folder, for either account. The `folder` param maps to the Nylas `in` query parameter. Nylas uses `INBOX`, `DRAFTS`, `SENT`, and `TRASH` as standard folder IDs across providers. Additional filter params (`from`, `subject`, `searchQueryNative`) support triage queries like "find all emails from john@example.com about the Q1 report." This means `email-list(account: "joseph", folder: "DRAFTS")` also handles draft listing — no separate skill needed. Returns snippets (100 chars) per message, not full bodies — use `email-get` to read a specific message in full.
 ```json
 {
   "name": "email-list",
@@ -61,9 +61,28 @@ Skills are **account-aware** rather than account-specific — an optional `accou
     "account": "string? (nathan | joseph, default nathan)",
     "folder": "string? (INBOX | DRAFTS | SENT | TRASH | <provider folder id>, default INBOX)",
     "limit": "number? (default 20)",
-    "unreadOnly": "boolean? (default false)"
+    "unreadOnly": "boolean? (default false)",
+    "from": "string?",
+    "subject": "string?",
+    "searchQueryNative": "string? (Gmail/Outlook native query, e.g. 'from:john subject:Q1')"
   },
-  "outputs": { "threads": "array" },
+  "outputs": { "messages": "array of { id, threadId, subject, from, snippet, date, unread }" },
+  "permissions": [],
+  "secrets": []
+}
+```
+
+`email-get` — fetches the full body and metadata of a single message by ID. **Required prerequisite for drafting** — `email-list` returns only 100-character snippets, which is not enough context to write a meaningful reply. Nathan calls `email-list` to find the message, then `email-get` to read it before drafting.
+```json
+{
+  "name": "email-get",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {
+    "account": "string? (nathan | joseph, default nathan)",
+    "messageId": "string"
+  },
+  "outputs": { "message": "object (id, threadId, subject, from, to, cc, body, date, unread, folders)" },
   "permissions": [],
   "secrets": []
 }
@@ -92,16 +111,17 @@ Elevated sensitivity ensures a human-approval gate the first time the coordinato
 
 **Scheduler job (Phase 1):**
 
-A daily one-shot job at 5pm (configurable) calls `email-list` with `account: "joseph"` and `folder: "DRAFTS"`. If any drafts are returned, it sends a CLI notification listing subjects and recipients. Joseph can then open Gmail, review, and send or discard. The job is registered in `agents/coordinator.yaml` as a startup scheduled task, or seeded via the bootstrap.
+A daily one-shot job at 5pm (configurable) calls `email-list` with `account: "joseph"` and `folder: "DRAFTS"`. If any messages are returned, it sends a CLI notification listing subjects and recipients. Joseph can then open Gmail, review, and send or discard. The job is registered in `agents/coordinator.yaml` as a startup scheduled task, or seeded via the bootstrap.
 
 **New skills (Phase 2, not shipped now):**
 
-- `email-archive` — archives a thread. Supports `account` param.
-- `email-label` — applies Gmail labels to a thread. Supports `account` param.
+- `email-archive` — removes a message from `INBOX` by updating its folders via `UpdateMessageRequest`. Supports `account` param.
+- `email-label` — applies Gmail labels to a thread via `UpdateMessageRequest`. Supports `account` param.
 
-**New skills (Phase 3, not shipped now):**
+**New skills / modifications (Phase 3, not shipped now):**
 
 - `email-send` gains an `account` parameter. When `account: "joseph"`, routes through a new `email-ceo` OutboundGateway path that enforces `autonomyPhase ≥ 3`. Elevated sensitivity.
+- `email-reply` gains an `account` parameter with the same gating.
 
 ### Outbound Gateway
 
@@ -144,6 +164,7 @@ scheduler:
 | Create | `src/channels/email-ceo/email-ceo-adapter.ts` |
 | Create | `src/channels/email-ceo/nylas-ceo-client.ts` |
 | Create | `skills/email-list/skill.json` + `handler.ts` + `handler.test.ts` |
+| Create | `skills/email-get/skill.json` + `handler.ts` + `handler.test.ts` |
 | Create | `skills/email-draft-save/skill.json` + `handler.ts` + `handler.test.ts` |
 | Modify | `config/default.yaml` — add `email-ceo` channel config and scheduler job |
 | Modify | `agents/coordinator.yaml` — pin new skills, add persona guidance |
@@ -224,7 +245,7 @@ System prompt addition (paraphrased — written in Nathan's voice per persona ru
 **Ship web search first.** It is a smaller lift (one skill, no channel setup), and it immediately makes Nathan smarter for inbox triage — he can research context before drafting a reply. Inbox work starts in a better position with web search already available.
 
 1. `feat/web-search` — `web-search` skill + coordinator pin
-2. `feat/ceo-inbox` — `email-ceo` adapter + `email-list` / `email-draft-save` skills + scheduler job
+2. `feat/ceo-inbox` — `email-ceo` adapter + `email-list` / `email-get` / `email-draft-save` skills + scheduler job
 
 ---
 
@@ -237,7 +258,7 @@ System prompt addition (paraphrased — written in Nathan's voice per persona ru
 
 ### CEO Inbox (Phase 1)
 - Sending a test email to joseph@josephfung.ca causes it to appear in Nathan's context within one polling interval
-- Nathan drafts a reply → it appears in Joseph's Gmail Drafts folder, not in Sent
+- Nathan calls `email-get` on a thread message then drafts a reply → it appears in Joseph's Gmail Drafts folder, not in Sent
 - No email is dispatched from Joseph's address in Phase 1 — OutboundGateway blocks it
 - Scheduler job fires at 5pm and sends a CLI notification listing pending draft subjects
 - Contact extracted from the test email thread appears as a provisional contact in the contact system

--- a/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
@@ -49,66 +49,77 @@ A `autonomy_phase` config field in `config/default.yaml` controls which behavior
 
 **New skills (Phase 1):**
 
-`email-ceo-list` — lists recent threads from Joseph's inbox.
+Skills are **account-aware** rather than account-specific — an optional `account: "nathan" | "joseph"` parameter determines which Nylas client is used. This mirrors the existing `email-send` pattern: `infrastructure: true`, credentials resolved by the handler via the injected Nylas client registry, never exposed to the LLM. One skill, two accounts, no parallel skill maintenance.
+
+`email-list` — lists recent inbox threads. Works for both accounts.
 ```json
 {
-  "name": "email-ceo-list",
+  "name": "email-list",
   "sensitivity": "normal",
-  "inputs": { "limit": "number? (default 20)", "unreadOnly": "boolean? (default false)" },
+  "infrastructure": true,
+  "inputs": {
+    "account": "string? (nathan | joseph, default nathan)",
+    "limit": "number? (default 20)",
+    "unreadOnly": "boolean? (default false)"
+  },
   "outputs": { "threads": "array" },
-  "permissions": ["network:nylas"],
-  "secrets": ["nylas_ceo_grant_id"]
+  "permissions": [],
+  "secrets": []
 }
 ```
 
-`email-ceo-draft-save` — writes a draft to Joseph's Gmail Drafts folder.
+`email-draft-save` — writes a draft to the specified account's Drafts folder.
 ```json
 {
-  "name": "email-ceo-draft-save",
+  "name": "email-draft-save",
   "sensitivity": "elevated",
+  "infrastructure": true,
   "inputs": {
+    "account": "string (nathan | joseph)",
     "to": "string",
     "subject": "string",
     "body": "string",
     "replyToThreadId": "string?"
   },
   "outputs": { "draftId": "string" },
-  "permissions": ["network:nylas"],
-  "secrets": ["nylas_ceo_grant_id"]
+  "permissions": [],
+  "secrets": []
 }
 ```
 
 Elevated sensitivity ensures a human-approval gate the first time the coordinator uses this skill.
 
-`email-ceo-draft-list` — lists drafts currently in Joseph's Drafts folder. Used by the scheduler job to check if notification is needed.
+`email-draft-list` — lists drafts in the specified account's Drafts folder. Used by the scheduler job.
 ```json
 {
-  "name": "email-ceo-draft-list",
+  "name": "email-draft-list",
   "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": { "account": "string? (nathan | joseph, default joseph)" },
   "outputs": { "drafts": "array", "count": "number" },
-  "permissions": ["network:nylas"],
-  "secrets": ["nylas_ceo_grant_id"]
+  "permissions": [],
+  "secrets": []
 }
 ```
 
 **Scheduler job (Phase 1):**
 
-A daily one-shot job at 5pm (configurable) checks `email-ceo-draft-list`. If `count > 0`, it sends a CLI notification listing draft subjects and recipients. Joseph can then open Gmail, review, and send or discard. The job is registered in `agents/coordinator.yaml` as a startup scheduled task, or seeded via the bootstrap.
+A daily one-shot job at 5pm (configurable) calls `email-draft-list` with `account: "joseph"`. If `count > 0`, it sends a CLI notification listing draft subjects and recipients. Joseph can then open Gmail, review, and send or discard. The job is registered in `agents/coordinator.yaml` as a startup scheduled task, or seeded via the bootstrap.
 
 **New skills (Phase 2, not shipped now):**
 
-- `email-ceo-archive` — archives a thread, optionally applies a label
-- `email-ceo-label` — applies one or more Gmail labels to a thread
+- `email-archive` — archives a thread. Supports `account` param.
+- `email-label` — applies Gmail labels to a thread. Supports `account` param.
 
 **New skills (Phase 3, not shipped now):**
 
-- `email-ceo-send` — sends from Joseph's address. Requires `autonomyPhase ≥ 3` gate in OutboundGateway. Elevated sensitivity.
+- `email-send` gains an `account` parameter. When `account: "joseph"`, routes through a new `email-ceo` OutboundGateway path that enforces `autonomyPhase ≥ 3`. Elevated sensitivity.
 
 ### Outbound Gateway
 
 All writes to Joseph's account (draft saves, eventual sends) route through `OutboundGateway`. Phase 1 only writes drafts — no sends. The gateway's blocked-contact and content-filter checks still apply to drafts to prevent Nathan from drafting problematic content.
 
-A new autonomy gate is added to OutboundGateway for Phase 3: if `autonomyPhase < 3`, attempts to call `email-ceo-send` are blocked and the coordinator is told to save a draft instead.
+A new autonomy gate is added to OutboundGateway for Phase 3: if `autonomyPhase < 3`, attempts by `email-send` with `account: "joseph"` are blocked and the coordinator is told to save a draft instead.
 
 ### Contact System
 
@@ -144,9 +155,9 @@ scheduler:
 |---|---|
 | Create | `src/channels/email-ceo/email-ceo-adapter.ts` |
 | Create | `src/channels/email-ceo/nylas-ceo-client.ts` |
-| Create | `skills/email-ceo-list/skill.json` + `handler.ts` + `handler.test.ts` |
-| Create | `skills/email-ceo-draft-save/skill.json` + `handler.ts` + `handler.test.ts` |
-| Create | `skills/email-ceo-draft-list/skill.json` + `handler.ts` + `handler.test.ts` |
+| Create | `skills/email-list/skill.json` + `handler.ts` + `handler.test.ts` |
+| Create | `skills/email-draft-save/skill.json` + `handler.ts` + `handler.test.ts` |
+| Create | `skills/email-draft-list/skill.json` + `handler.ts` + `handler.test.ts` |
 | Modify | `config/default.yaml` — add `email-ceo` channel config and scheduler job |
 | Modify | `agents/coordinator.yaml` — pin new skills, add persona guidance |
 | Modify | `src/index.ts` (or channel bootstrap) — register `email-ceo-adapter` |
@@ -226,7 +237,7 @@ System prompt addition (paraphrased — written in Nathan's voice per persona ru
 **Ship web search first.** It is a smaller lift (one skill, no channel setup), and it immediately makes Nathan smarter for inbox triage — he can research context before drafting a reply. Inbox work starts in a better position with web search already available.
 
 1. `feat/web-search` — `web-search` skill + coordinator pin
-2. `feat/ceo-inbox` — `email-ceo` adapter + Phase 1 skills + scheduler job
+2. `feat/ceo-inbox` — `email-ceo` adapter + `email-list` / `email-draft-save` / `email-draft-list` skills + scheduler job
 
 ---
 

--- a/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
@@ -111,7 +111,11 @@ Elevated sensitivity ensures a human-approval gate the first time the coordinato
 
 **Scheduler job (Phase 1):**
 
-A daily one-shot job at 5pm (configurable) calls `email-list` with `account: "joseph"` and `folder: "DRAFTS"`. If any messages are returned, it sends a CLI notification listing subjects and recipients. Joseph can then open Gmail, review, and send or discard. The job is registered in `agents/coordinator.yaml` as a startup scheduled task, or seeded via the bootstrap.
+A recurring job at 5pm weekdays: Nathan calls `email-list(account: "joseph", folder: "DRAFTS")` and, if any drafts are present, sends a CLI notification summarising who they're addressed to and what they're about. Joseph can then open Gmail, review, and send or discard.
+
+No new infrastructure. The job is created by Nathan via `scheduler-create` with a natural-language `task` string — the same way any recurring task is set up via chat. The scheduler fires it daily, the coordinator receives it as a normal prompt, and handles it with the skills it already has. The job persists in the Postgres-backed scheduler table across restarts.
+
+This is set up during first-time onboarding via a CLI prompt like "keep an eye on my drafts and let me know at 5pm if there's anything waiting" — Nathan decides to create the job himself, exactly as if he'd been asked.
 
 **New skills (Phase 2, not shipped now):**
 

--- a/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
@@ -153,12 +153,6 @@ channels:
     enabled: true
     pollingIntervalMs: 30000
     autonomyPhase: 1       # 1 = monitor+draft, 2 = +archive, 3 = +send
-
-scheduler:
-  jobs:
-    - name: ceo-draft-digest
-      schedule: "0 17 * * 1-5"   # 5pm weekdays
-      task: check-ceo-drafts-and-notify
 ```
 
 ### Files to Create/Modify

--- a/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
@@ -51,7 +51,7 @@ A `autonomy_phase` config field in `config/default.yaml` controls which behavior
 
 Skills are **account-aware** rather than account-specific — an optional `account: "nathan" | "joseph"` parameter determines which Nylas client is used. This mirrors the existing `email-send` pattern: `infrastructure: true`, credentials resolved by the handler via the injected Nylas client registry, never exposed to the LLM. One skill, two accounts, no parallel skill maintenance.
 
-`email-list` — lists recent inbox threads. Works for both accounts.
+`email-list` — lists messages from any folder, for either account. The `folder` param maps to the Nylas `in` query parameter, which filters by folder ID. Nylas uses `INBOX`, `DRAFTS`, `SENT`, and `TRASH` as standard folder IDs across providers (Gmail and others). This means `email-list(account: "joseph", folder: "DRAFTS")` replaces what would have been a separate `email-draft-list` skill — no additional skill needed for listing drafts.
 ```json
 {
   "name": "email-list",
@@ -59,6 +59,7 @@ Skills are **account-aware** rather than account-specific — an optional `accou
   "infrastructure": true,
   "inputs": {
     "account": "string? (nathan | joseph, default nathan)",
+    "folder": "string? (INBOX | DRAFTS | SENT | TRASH | <provider folder id>, default INBOX)",
     "limit": "number? (default 20)",
     "unreadOnly": "boolean? (default false)"
   },
@@ -68,7 +69,7 @@ Skills are **account-aware** rather than account-specific — an optional `accou
 }
 ```
 
-`email-draft-save` — writes a draft to the specified account's Drafts folder.
+`email-draft-save` — creates a draft via the Nylas drafts API (`nylas.drafts.create()`). This is a separate Nylas resource from messages — not a message saved to a folder. The name reflects what actually happens at the API level: a draft object is created, which appears in Gmail's Drafts folder.
 ```json
 {
   "name": "email-draft-save",
@@ -79,7 +80,7 @@ Skills are **account-aware** rather than account-specific — an optional `accou
     "to": "string",
     "subject": "string",
     "body": "string",
-    "replyToThreadId": "string?"
+    "replyToMessageId": "string?"
   },
   "outputs": { "draftId": "string" },
   "permissions": [],
@@ -89,22 +90,9 @@ Skills are **account-aware** rather than account-specific — an optional `accou
 
 Elevated sensitivity ensures a human-approval gate the first time the coordinator uses this skill.
 
-`email-draft-list` — lists drafts in the specified account's Drafts folder. Used by the scheduler job.
-```json
-{
-  "name": "email-draft-list",
-  "sensitivity": "normal",
-  "infrastructure": true,
-  "inputs": { "account": "string? (nathan | joseph, default joseph)" },
-  "outputs": { "drafts": "array", "count": "number" },
-  "permissions": [],
-  "secrets": []
-}
-```
-
 **Scheduler job (Phase 1):**
 
-A daily one-shot job at 5pm (configurable) calls `email-draft-list` with `account: "joseph"`. If `count > 0`, it sends a CLI notification listing draft subjects and recipients. Joseph can then open Gmail, review, and send or discard. The job is registered in `agents/coordinator.yaml` as a startup scheduled task, or seeded via the bootstrap.
+A daily one-shot job at 5pm (configurable) calls `email-list` with `account: "joseph"` and `folder: "DRAFTS"`. If any drafts are returned, it sends a CLI notification listing subjects and recipients. Joseph can then open Gmail, review, and send or discard. The job is registered in `agents/coordinator.yaml` as a startup scheduled task, or seeded via the bootstrap.
 
 **New skills (Phase 2, not shipped now):**
 
@@ -157,7 +145,6 @@ scheduler:
 | Create | `src/channels/email-ceo/nylas-ceo-client.ts` |
 | Create | `skills/email-list/skill.json` + `handler.ts` + `handler.test.ts` |
 | Create | `skills/email-draft-save/skill.json` + `handler.ts` + `handler.test.ts` |
-| Create | `skills/email-draft-list/skill.json` + `handler.ts` + `handler.test.ts` |
 | Modify | `config/default.yaml` — add `email-ceo` channel config and scheduler job |
 | Modify | `agents/coordinator.yaml` — pin new skills, add persona guidance |
 | Modify | `src/index.ts` (or channel bootstrap) — register `email-ceo-adapter` |
@@ -237,7 +224,7 @@ System prompt addition (paraphrased — written in Nathan's voice per persona ru
 **Ship web search first.** It is a smaller lift (one skill, no channel setup), and it immediately makes Nathan smarter for inbox triage — he can research context before drafting a reply. Inbox work starts in a better position with web search already available.
 
 1. `feat/web-search` — `web-search` skill + coordinator pin
-2. `feat/ceo-inbox` — `email-ceo` adapter + `email-list` / `email-draft-save` / `email-draft-list` skills + scheduler job
+2. `feat/ceo-inbox` — `email-ceo` adapter + `email-list` / `email-draft-save` skills + scheduler job
 
 ---
 


### PR DESCRIPTION
## **User description**
## Summary

- Design spec for two new Nathan capabilities: Joseph's Gmail inbox access and web search via Tavily
- Implementation plan for `web-search` skill (5 tasks: TDD, manifest, handler, coordinator update, smoke test)
- Implementation plan for CEO inbox (12 tasks: config, channel adapter, three account-aware skills, coordinator update, smoke test)

## What's in this branch

**`docs/superpowers/specs/2026-04-03-capability-expansion-design.md`**
Full design spec covering:
- CEO inbox architecture: separate Nylas grant (`NYLAS_CEO_GRANT_ID`), new `email-ceo` channel adapter, three account-aware skills (`email-list`, `email-get`, `email-draft-save`) rather than account-specific duplicate skills
- Three autonomy phases (Phase 1 ships now: monitor + draft; Phases 2/3 deferred)
- Daily draft digest via existing `scheduler-create` skill — Nathan sets this up himself during onboarding, no hardcoded infrastructure
- Web search: Tavily API, `search_depth: basic | advanced`, synthesis entirely in Nathan's LLM (not pre-synthesized)

**`docs/superpowers/plans/2026-04-03-web-search.md`** — 5-task TDD plan
**`docs/superpowers/plans/2026-04-03-ceo-inbox.md`** — 12-task TDD plan

## Test plan

- [ ] Review spec for architectural consistency with existing codebase patterns
- [ ] Confirm skill account-aware design matches the `infrastructure: true` injection pattern in `src/skills/execution.ts`
- [ ] Confirm Nylas draft creation path (`nylas.drafts.create()`) is separate from message API (it is — verified in SDK types)


___

## **CodeAnt-AI Description**
Define the CEO inbox and web search rollout plan

### What Changed
- Adds a full plan for connecting Joseph’s Gmail as a second inbox, including read access, draft replies, and a separate CEO inbox channel
- Introduces account-aware email tools for listing messages, reading full emails, and saving drafts for either Nathan or Joseph
- Adds the web search plan using Tavily, with guidance for simple lookups versus deeper research
- Updates coordinator guidance and setup steps so the new capabilities can be enabled and tested end to end

### Impact
`✅ Clearer CEO inbox setup`
`✅ Faster inbox triage`
`✅ Shorter research workflows`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
