### PR TITLE
feat: autonomy engine — global score, CEO controls, per-task prompt injection (spec 12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,23 @@ Cross-cutting: Audit Logger, Memory Engine, Scheduler.
 2. Declare permissions and secrets in the manifest
 3. Write `handler.test.ts`
 
+### Autonomy Awareness
+
+When adding a new skill, declare its autonomy floor in `skill.json` (this field is not enforced in Phase 1 but is required for Phase 2 gate wiring):
+
+```json
+"autonomy_floor": "spot-check"
+```
+
+Floors by capability class:
+- `"full"` — reads, retrieval, summarization (no external effect)
+- `"spot-check"` — outbound communications, internal state writes
+- `"approval-required"` — calendar writes, commitments on behalf of CEO
+- `"draft-only"` — financial actions, high-stakes operations
+- `"restricted"` — irreversible or destructive actions
+
+When adding a new agent, ensure it receives the autonomy block via the runtime injection mechanism (same pattern as date/timezone injection — pass `autonomyService` in `AgentRuntime` config if the agent needs autonomy awareness). See `docs/superpowers/specs/2026-04-03-autonomy-engine-design.md`.
+
 ### New Agent
 1. Create `agents/<name>.yaml` with required fields (name, description, model, system_prompt)
 2. Optionally add `handler: ./<name>.handler.ts` for custom logic

--- a/README.md
+++ b/README.md
@@ -233,6 +233,28 @@ schedule:
 
 **Dynamic scheduling** — agents can create their own scheduled jobs at runtime. "Remind me every Friday to review the expense report" just works.
 
+## Autonomy Engine
+
+Nathan operates at a configurable autonomy level — a single score from 0 to 100 that determines how independently he acts across all channels and skills.
+
+The score maps to one of five **autonomy bands**:
+
+| Band | Score | What it means |
+|---|---|---|
+| **Full** | 90–100 | Acts independently. Flags only genuinely novel or irreversible actions. |
+| **Spot-check** | 80–89 | Proceeds on routine tasks. Notes consequential actions for CEO visibility. |
+| **Approval Required** | 70–79 | Presents a plan and asks for confirmation before any consequential action. |
+| **Draft Only** | 60–69 | Prepares drafts and plans but does not send or act without explicit instruction. |
+| **Restricted** | < 60 | Advisory only. Takes no independent action whatsoever. |
+
+The current band is injected into Nathan's system prompt on every task, so his self-governance adjusts immediately when the score changes — no restart required.
+
+**CEO controls (via CLI or email):**
+- *"What is your current autonomy score?"* — Nathan reports his score, band, and recent change history
+- *"Set your autonomy score to 85"* — Nathan updates the score and confirms the change
+
+The score defaults to **75 (Approval Required)** on first deployment. Scores are stored in Postgres with a full change history. Future versions will adjust the score automatically based on performance metrics (task success rate, factual correction rate, follow-through).
+
 ---
 
 ## Multi-Provider LLM Support
@@ -289,6 +311,8 @@ This starts Postgres via Docker, applies any pending migrations, then launches t
 | 08 | Operations (deployment, health, monitoring) | Planned |
 | 09 | Contacts & identity (auth, unknown sender policy) | ✅ Implemented |
 | 10 | Audit log hardening (hash-chain, HITL, provenance) | Planned |
+| 11 | Autonomy engine (global score, CEO controls, per-task prompt injection) | ✅ Implemented |
+| 12 | Autonomy engine (global score, CEO controls, per-task prompt injection) | Planned |
 | — | Outbound safety (content filter, gateway, display name sanitization, caller verification) | Partial — deterministic rules done; LLM-as-judge planned |
 | — | Smoke test framework (14 chat-based cases, LLM-as-judge, HTML reports) | ✅ Implemented |
 | — | Web dashboard | Future |

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ This starts Postgres via Docker, applies any pending migrations, then launches t
 | 09 | Contacts & identity (auth, unknown sender policy) | ✅ Implemented |
 | 10 | Audit log hardening (hash-chain, HITL, provenance) | Planned |
 | 11 | Autonomy engine (global score, CEO controls, per-task prompt injection) | ✅ Implemented |
-| 12 | Autonomy engine (global score, CEO controls, per-task prompt injection) | Planned |
+| 12 | Autonomy engine (self-monitoring, measurement, and automatic tuning) | Planned |
 | — | Outbound safety (content filter, gateway, display name sanitization, caller verification) | Partial — deterministic rules done; LLM-as-judge planned |
 | — | Smoke test framework (14 chat-based cases, LLM-as-judge, HTML reports) | ✅ Implemented |
 | — | Web dashboard | Future |

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -194,4 +194,6 @@ pinned_skills:
   - calendar-delete-event
   - calendar-find-free-time
   - calendar-check-conflicts
+  - get-autonomy
+  - set-autonomy
 allow_discovery: true

--- a/docs/superpowers/plans/2026-04-03-autonomy-engine.md
+++ b/docs/superpowers/plans/2026-04-03-autonomy-engine.md
@@ -1,0 +1,1250 @@
+# Autonomy Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a global autonomy score (0–100) for the Nathan Curia instance — stored in Postgres, adjustable by the CEO via two CLI skills, and injected into the coordinator's system prompt on every task so Nathan self-governs accordingly.
+
+**Architecture:** New `AutonomyService` in `src/autonomy/` owns all DB access and the band→description map. `AgentRuntime` reads it per-task and appends the autonomy block to the effective system prompt. `ExecutionLayer` passes it through `SkillContext` so the two new skills (`get-autonomy`, `set-autonomy`) can read and write the score. `set-autonomy` is elevated (CEO-only via the existing CallerContext gate).
+
+**Tech Stack:** TypeScript/ESM, Node 22+, PostgreSQL (node-postgres pool), Vitest, node-pg-migrate (plain SQL migrations). No new dependencies required.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `src/db/migrations/011_create_autonomy.sql` | Schema for `autonomy_config` + `autonomy_history`; seeds default row |
+| Create | `src/autonomy/autonomy-service.ts` | DB reads/writes, band logic, prompt block formatting |
+| Create | `tests/unit/autonomy/autonomy-service.test.ts` | Unit tests for `AutonomyService` |
+| Modify | `src/skills/types.ts` | Add `autonomyService?: AutonomyService` to `SkillContext` |
+| Modify | `src/skills/execution.ts` | Accept + store + inject `autonomyService` in options/context |
+| Modify | `src/agents/runtime.ts` | Add `autonomyService?` to `AgentConfig`; inject per-task in `processTask()` |
+| Modify | `src/index.ts` | Instantiate `AutonomyService`; wire into `ExecutionLayer` and coordinator `AgentRuntime` |
+| Create | `skills/get-autonomy/skill.json` | Skill manifest |
+| Create | `skills/get-autonomy/handler.ts` | Read score + recent history, return human-readable summary |
+| Create | `skills/set-autonomy/skill.json` | Skill manifest (elevated, infrastructure) |
+| Create | `skills/set-autonomy/handler.ts` | Validate score, upsert config, append history |
+| Modify | `agents/coordinator.yaml` | Pin `get-autonomy` and `set-autonomy` |
+| Modify | `README.md` | Add Autonomy Engine section + spec 12 row in Project Status |
+| Modify | `CLAUDE.md` | Add Autonomy Awareness checklist to "Adding Things" |
+
+---
+
+## Task 1: Database Migration
+
+**Files:**
+- Create: `src/db/migrations/011_create_autonomy.sql`
+
+- [ ] **Step 1.1: Write the migration**
+
+```sql
+-- Up Migration
+
+-- Single-row table holding the live autonomy score.
+-- The CONSTRAINT single_row CHECK (id = 1) ensures exactly one row exists —
+-- enforced at the DB level rather than application code.
+CREATE TABLE autonomy_config (
+  id          INTEGER PRIMARY KEY DEFAULT 1,
+  score       INTEGER NOT NULL CHECK (score >= 0 AND score <= 100),
+  band        TEXT NOT NULL,
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by  TEXT NOT NULL,
+  CONSTRAINT single_row CHECK (id = 1)
+);
+
+-- Append-only audit trail — never updated or deleted.
+-- Phase 2 auto-adjustment will also write here (changed_by = 'system').
+CREATE TABLE autonomy_history (
+  id             BIGSERIAL PRIMARY KEY,
+  score          INTEGER NOT NULL,
+  previous_score INTEGER,
+  band           TEXT NOT NULL,
+  changed_by     TEXT NOT NULL,
+  reason         TEXT,
+  changed_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Seed the default starting score (75 = approval-required).
+-- ON CONFLICT DO NOTHING makes this idempotent on existing deployments.
+INSERT INTO autonomy_config (id, score, band, updated_by)
+VALUES (1, 75, 'approval-required', 'system')
+ON CONFLICT (id) DO NOTHING;
+
+-- Seed the corresponding history entry so the audit trail starts complete.
+INSERT INTO autonomy_history (score, previous_score, band, changed_by, reason)
+VALUES (75, NULL, 'approval-required', 'system', 'Initial default score');
+```
+
+- [ ] **Step 1.2: Verify migration runs cleanly**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-autonomy-engine
+pnpm local
+```
+
+Expected: Startup log shows `"Database migrations applied" count=1 migrations=["011_create_autonomy"]`. Then Ctrl+C.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add src/db/migrations/011_create_autonomy.sql
+git commit -m "feat: add autonomy_config and autonomy_history tables (migration 011)"
+```
+
+---
+
+## Task 2: AutonomyService
+
+**Files:**
+- Create: `src/autonomy/autonomy-service.ts`
+
+- [ ] **Step 2.1: Write the service**
+
+```typescript
+// autonomy-service.ts — manages the global autonomy score for the Curia instance.
+//
+// The autonomy score (0–100) determines how independently Nathan operates.
+// It maps to one of five bands, each with a behavioral description that is
+// injected into the coordinator's system prompt on every task.
+//
+// Phase 1: CEO-controlled via get-autonomy / set-autonomy skills.
+// Phase 2: Automatic adjustment based on action log data (future).
+
+import type { Pool } from 'pg';
+import type { Logger } from '../logger.js';
+
+export type AutonomyBand =
+  | 'full'
+  | 'spot-check'
+  | 'approval-required'
+  | 'draft-only'
+  | 'restricted';
+
+export interface AutonomyConfig {
+  score: number;
+  band: AutonomyBand;
+  updatedAt: Date;
+  updatedBy: string;
+}
+
+export interface AutonomyHistoryEntry {
+  id: number;
+  score: number;
+  previousScore: number | null;
+  band: AutonomyBand;
+  changedBy: string;
+  reason: string | null;
+  changedAt: Date;
+}
+
+// Static map of band labels to their behavioral descriptions.
+// These are injected verbatim into the coordinator system prompt.
+const BAND_DESCRIPTIONS: Record<AutonomyBand, string> = {
+  'full':
+    'Act independently. No confirmation needed for standard operations. Flag only genuinely ' +
+    'novel, irreversible, or high-stakes actions — where the downside of acting without ' +
+    'checking outweighs the cost of the pause.',
+  'spot-check':
+    'Proceed on routine tasks. For consequential actions — sending external communications, ' +
+    'creating commitments, or acting on behalf of the CEO — note what you are doing in your ' +
+    'response so the CEO maintains visibility. No need to stop and ask.',
+  'approval-required':
+    'For any consequential action, present your plan and explicitly ask for confirmation ' +
+    'before proceeding. Routine reporting, summarization, and information retrieval can ' +
+    'proceed without approval. When in doubt, draft and ask.',
+  'draft-only':
+    'Prepare drafts, plans, and analysis, but do not send, publish, schedule, or act on ' +
+    'behalf of the CEO without an explicit instruction to do so. Surface your work for review; ' +
+    'execution requires a direct go-ahead.',
+  'restricted':
+    'Present options and analysis only. Take no independent action. All outputs are advisory. ' +
+    'Every step that would have an external effect requires explicit CEO instruction.',
+};
+
+// Human-readable band labels for display.
+const BAND_LABELS: Record<AutonomyBand, string> = {
+  'full': 'Full',
+  'spot-check': 'Spot-check',
+  'approval-required': 'Approval Required',
+  'draft-only': 'Draft Only',
+  'restricted': 'Restricted',
+};
+
+export class AutonomyService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly logger: Logger,
+  ) {}
+
+  /** Derive the autonomy band from a numeric score. */
+  static bandForScore(score: number): AutonomyBand {
+    if (score >= 90) return 'full';
+    if (score >= 80) return 'spot-check';
+    if (score >= 70) return 'approval-required';
+    if (score >= 60) return 'draft-only';
+    return 'restricted';
+  }
+
+  /** Return the behavioral description for a band. */
+  static bandDescription(band: AutonomyBand): string {
+    return BAND_DESCRIPTIONS[band];
+  }
+
+  /**
+   * Format the autonomy block for injection into the coordinator system prompt.
+   * Returns a Markdown section with the current score, band label, and behavioral guidance.
+   */
+  static formatPromptBlock(config: AutonomyConfig): string {
+    const label = BAND_LABELS[config.band];
+    const description = BAND_DESCRIPTIONS[config.band];
+    return [
+      '## Autonomy Level',
+      '',
+      `Your current autonomy score is ${config.score} (${label}).`,
+      '',
+      description,
+    ].join('\n');
+  }
+
+  /** Read the current autonomy config. Returns null if the row does not exist (pre-migration). */
+  async getConfig(): Promise<AutonomyConfig | null> {
+    try {
+      const result = await this.pool.query<{
+        score: number;
+        band: string;
+        updated_at: Date;
+        updated_by: string;
+      }>('SELECT score, band, updated_at, updated_by FROM autonomy_config WHERE id = 1');
+
+      if (result.rows.length === 0) return null;
+
+      const row = result.rows[0]!;
+      return {
+        score: row.score,
+        band: row.band as AutonomyBand,
+        updatedAt: row.updated_at,
+        updatedBy: row.updated_by,
+      };
+    } catch (err) {
+      // Log but don't throw — a missing table (pre-migration) should degrade gracefully.
+      // The coordinator will just run without the autonomy block until the migration runs.
+      this.logger.warn({ err }, 'autonomy-service: failed to read autonomy_config — is migration 011 applied?');
+      return null;
+    }
+  }
+
+  /**
+   * Update the autonomy score. Upserts autonomy_config and appends to autonomy_history.
+   * Throws if score is out of range [0, 100].
+   */
+  async setScore(score: number, changedBy: string, reason?: string): Promise<AutonomyConfig> {
+    if (!Number.isInteger(score) || score < 0 || score > 100) {
+      throw new Error(`Invalid autonomy score: ${score}. Must be an integer between 0 and 100.`);
+    }
+
+    const band = AutonomyService.bandForScore(score);
+
+    // Read the current score before updating so history has previous_score.
+    const current = await this.getConfig();
+    const previousScore = current?.score ?? null;
+
+    // Upsert the live config row.
+    await this.pool.query(
+      `INSERT INTO autonomy_config (id, score, band, updated_at, updated_by)
+       VALUES (1, $1, $2, now(), $3)
+       ON CONFLICT (id) DO UPDATE SET score = $1, band = $2, updated_at = now(), updated_by = $3`,
+      [score, band, changedBy],
+    );
+
+    // Append to the append-only audit trail.
+    await this.pool.query(
+      `INSERT INTO autonomy_history (score, previous_score, band, changed_by, reason)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [score, previousScore, band, changedBy, reason ?? null],
+    );
+
+    this.logger.info({ score, band, changedBy, previousScore }, 'Autonomy score updated');
+
+    return { score, band, updatedAt: new Date(), updatedBy: changedBy };
+  }
+
+  /** Return the most recent history entries, newest first. */
+  async getHistory(limit = 3): Promise<AutonomyHistoryEntry[]> {
+    const result = await this.pool.query<{
+      id: number;
+      score: number;
+      previous_score: number | null;
+      band: string;
+      changed_by: string;
+      reason: string | null;
+      changed_at: Date;
+    }>(
+      'SELECT id, score, previous_score, band, changed_by, reason, changed_at FROM autonomy_history ORDER BY changed_at DESC LIMIT $1',
+      [limit],
+    );
+
+    return result.rows.map(row => ({
+      id: row.id,
+      score: row.score,
+      previousScore: row.previous_score,
+      band: row.band as AutonomyBand,
+      changedBy: row.changed_by,
+      reason: row.reason,
+      changedAt: row.changed_at,
+    }));
+  }
+}
+```
+
+- [ ] **Step 2.2: Commit**
+
+```bash
+git add src/autonomy/autonomy-service.ts
+git commit -m "feat: AutonomyService — score storage, band logic, prompt block formatting"
+```
+
+---
+
+## Task 3: Unit Tests for AutonomyService
+
+**Files:**
+- Create: `tests/unit/autonomy/autonomy-service.test.ts`
+
+- [ ] **Step 3.1: Write the failing tests**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AutonomyService } from '../../../src/autonomy/autonomy-service.js';
+import type { AutonomyBand } from '../../../src/autonomy/autonomy-service.js';
+
+function mockPool() {
+  return { query: vi.fn() };
+}
+
+function mockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+}
+
+describe('AutonomyService', () => {
+  // -- Static helpers --
+
+  describe('bandForScore', () => {
+    const cases: Array<[number, AutonomyBand]> = [
+      [100, 'full'],
+      [90, 'full'],
+      [89, 'spot-check'],
+      [80, 'spot-check'],
+      [79, 'approval-required'],
+      [70, 'approval-required'],
+      [69, 'draft-only'],
+      [60, 'draft-only'],
+      [59, 'restricted'],
+      [0, 'restricted'],
+    ];
+
+    it.each(cases)('score %i → band "%s"', (score, expected) => {
+      expect(AutonomyService.bandForScore(score)).toBe(expected);
+    });
+  });
+
+  describe('formatPromptBlock', () => {
+    it('includes score, band label, and description', () => {
+      const config = {
+        score: 75,
+        band: 'approval-required' as AutonomyBand,
+        updatedAt: new Date(),
+        updatedBy: 'ceo',
+      };
+      const block = AutonomyService.formatPromptBlock(config);
+      expect(block).toContain('## Autonomy Level');
+      expect(block).toContain('75');
+      expect(block).toContain('Approval Required');
+      // Should contain behavioral guidance for this band
+      expect(block).toContain('present your plan');
+    });
+
+    it('produces different text for different bands', () => {
+      const make = (score: number, band: AutonomyBand) =>
+        AutonomyService.formatPromptBlock({ score, band, updatedAt: new Date(), updatedBy: 'ceo' });
+      expect(make(95, 'full')).not.toBe(make(75, 'approval-required'));
+    });
+  });
+
+  // -- getConfig --
+
+  describe('getConfig', () => {
+    let pool: ReturnType<typeof mockPool>;
+    let logger: ReturnType<typeof mockLogger>;
+    let svc: AutonomyService;
+
+    beforeEach(() => {
+      pool = mockPool();
+      logger = mockLogger();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      svc = new AutonomyService(pool as any, logger as any);
+    });
+
+    it('returns the current config when a row exists', async () => {
+      const now = new Date();
+      pool.query.mockResolvedValueOnce({
+        rows: [{ score: 75, band: 'approval-required', updated_at: now, updated_by: 'ceo' }],
+      });
+
+      const config = await svc.getConfig();
+      expect(config).toEqual({ score: 75, band: 'approval-required', updatedAt: now, updatedBy: 'ceo' });
+    });
+
+    it('returns null when no row exists', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      expect(await svc.getConfig()).toBeNull();
+    });
+
+    it('returns null (not throw) when the DB call fails', async () => {
+      pool.query.mockRejectedValueOnce(new Error('relation does not exist'));
+      expect(await svc.getConfig()).toBeNull();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  // -- setScore --
+
+  describe('setScore', () => {
+    let pool: ReturnType<typeof mockPool>;
+    let svc: AutonomyService;
+
+    beforeEach(() => {
+      pool = mockPool();
+      const logger = mockLogger();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      svc = new AutonomyService(pool as any, logger as any);
+    });
+
+    it('throws for out-of-range scores', async () => {
+      await expect(svc.setScore(-1, 'ceo')).rejects.toThrow('Invalid autonomy score');
+      await expect(svc.setScore(101, 'ceo')).rejects.toThrow('Invalid autonomy score');
+    });
+
+    it('throws for non-integer scores', async () => {
+      await expect(svc.setScore(75.5, 'ceo')).rejects.toThrow('Invalid autonomy score');
+    });
+
+    it('upserts config and inserts history, then returns new config', async () => {
+      // getConfig() call (to read previous_score)
+      pool.query.mockResolvedValueOnce({ rows: [{ score: 70, band: 'approval-required', updated_at: new Date(), updated_by: 'ceo' }] });
+      // upsert autonomy_config
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      // insert autonomy_history
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      const result = await svc.setScore(80, 'ceo', 'good week');
+      expect(result.score).toBe(80);
+      expect(result.band).toBe('spot-check');
+      expect(result.updatedBy).toBe('ceo');
+
+      // upsert call
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO autonomy_config'),
+        [80, 'spot-check', 'ceo'],
+      );
+      // history call — includes previous_score and reason
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO autonomy_history'),
+        [80, 70, 'spot-check', 'ceo', 'good week'],
+      );
+    });
+
+    it('passes null previous_score on first write (no existing config)', async () => {
+      // getConfig returns null (no row yet)
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      pool.query.mockResolvedValueOnce({ rows: [] }); // upsert
+      pool.query.mockResolvedValueOnce({ rows: [] }); // history
+
+      await svc.setScore(75, 'system');
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO autonomy_history'),
+        [75, null, 'approval-required', 'system', null],
+      );
+    });
+  });
+});
+```
+
+- [ ] **Step 3.2: Run tests — expect failures**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-autonomy-engine
+pnpm test tests/unit/autonomy/autonomy-service.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../../../src/autonomy/autonomy-service.js'`
+
+- [ ] **Step 3.3: Run tests again now that Task 2 is complete**
+
+```bash
+pnpm test tests/unit/autonomy/autonomy-service.test.ts
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add tests/unit/autonomy/autonomy-service.test.ts
+git commit -m "test: AutonomyService unit tests — band logic, getConfig, setScore"
+```
+
+---
+
+## Task 4: Extend SkillContext
+
+**Files:**
+- Modify: `src/skills/types.ts`
+
+- [ ] **Step 4.1: Add `autonomyService` to `SkillContext`**
+
+In `src/skills/types.ts`, add after the `agentContactId` field (the last field before the closing brace):
+
+```typescript
+  /** Autonomy service — available to infrastructure skills that manage the global
+   *  autonomy score (get-autonomy, set-autonomy). Not available to normal skills. */
+  autonomyService?: import('../autonomy/autonomy-service.js').AutonomyService;
+```
+
+- [ ] **Step 4.2: Run typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add src/skills/types.ts
+git commit -m "feat: add autonomyService to SkillContext"
+```
+
+---
+
+## Task 5: Extend ExecutionLayer
+
+**Files:**
+- Modify: `src/skills/execution.ts`
+
+- [ ] **Step 5.1: Add the import at the top of the imports block**
+
+After the last `import type` line (currently `import type { EntityContextAssembler } ...`), add:
+
+```typescript
+import type { AutonomyService } from '../autonomy/autonomy-service.js';
+```
+
+- [ ] **Step 5.2: Add the private field**
+
+After `private agentContactId?: string;` (line ~52), add:
+
+```typescript
+  private autonomyService?: AutonomyService;
+```
+
+- [ ] **Step 5.3: Add to the constructor options interface and assignment**
+
+In the constructor options object (the parameter type after `options?: {`), add after `agentContactId?: string;`:
+
+```typescript
+    autonomyService?: AutonomyService;
+```
+
+In the constructor body, after `this.agentContactId = options?.agentContactId;`, add:
+
+```typescript
+    this.autonomyService = options?.autonomyService;
+```
+
+- [ ] **Step 5.4: Pass through in `invoke()`**
+
+Find where `SkillContext` is assembled inside `invoke()` (the object passed to `skill.handler.execute(ctx)`). Add `autonomyService: this.autonomyService` alongside the other optional services such as `schedulerService` and `entityMemory`.
+
+- [ ] **Step 5.5: Run typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add src/skills/execution.ts
+git commit -m "feat: thread autonomyService through ExecutionLayer into SkillContext"
+```
+
+---
+
+## Task 6: Per-Task Prompt Injection in AgentRuntime
+
+**Files:**
+- Modify: `src/agents/runtime.ts`
+
+- [ ] **Step 6.1: Add import**
+
+At the top of `src/agents/runtime.ts`, after the existing imports, add:
+
+```typescript
+// Value import (not type-only) — we call AutonomyService.formatPromptBlock() as a static method.
+import { AutonomyService } from '../autonomy/autonomy-service.js';
+```
+
+- [ ] **Step 6.2: Add `autonomyService` to `AgentConfig`**
+
+In the `AgentConfig` interface, after `skillToolDefs?: ToolDefinition[];`, add:
+
+```typescript
+  /** Optional autonomy service — when provided, the autonomy block is injected
+   *  into the effective system prompt on every task. Only the coordinator receives this. */
+  autonomyService?: AutonomyService;
+```
+
+- [ ] **Step 6.3: Inject the autonomy block in `processTask()`**
+
+In `processTask()`, find this line near the top of the method:
+
+```typescript
+const { agentId, systemPrompt, provider, bus, logger, memory, executionLayer, skillToolDefs } = this.config;
+```
+
+Replace it with:
+
+```typescript
+const { agentId, systemPrompt, provider, bus, logger, memory, executionLayer, skillToolDefs, autonomyService } = this.config;
+```
+
+Then, immediately after that destructure line and before `const budget = ...`, add:
+
+```typescript
+    // Load the current autonomy config and append its behavioral block to the
+    // system prompt. This runs per-task (not at startup) so a CEO score change
+    // mid-session takes effect on Nathan's next action without a restart.
+    let effectiveSystemPrompt = systemPrompt;
+    if (autonomyService) {
+      const autonomyConfig = await autonomyService.getConfig();
+      if (autonomyConfig) {
+        effectiveSystemPrompt = systemPrompt + '\n\n' + AutonomyService.formatPromptBlock(autonomyConfig);
+      }
+    }
+```
+
+Then update the `messages` array construction to use `effectiveSystemPrompt` instead of `systemPrompt`:
+
+```typescript
+    const messages: Message[] = [
+      { role: 'system', content: effectiveSystemPrompt },
+      ...history,
+      { role: 'user', content },
+    ];
+```
+
+- [ ] **Step 6.4: Write a test for the injection**
+
+In `tests/unit/agents/runtime.test.ts`, add a new test after the existing tests (inside the `describe('AgentRuntime', ...)` block):
+
+```typescript
+  it('appends the autonomy block to the system prompt when autonomyService is provided', async () => {
+    const mockAutonomyService = {
+      getConfig: vi.fn().mockResolvedValue({
+        score: 75,
+        band: 'approval-required',
+        updatedAt: new Date(),
+        updatedBy: 'system',
+      }),
+    };
+
+    const provider = createMockProvider('OK');
+    const runtime = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'Base prompt.',
+      provider,
+      bus,
+      logger: createLogger('error'),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      autonomyService: mockAutonomyService as any,
+    });
+    runtime.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-auto-1',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Hello',
+      parentEventId: 'parent-auto-1',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(mockAutonomyService.getConfig).toHaveBeenCalledOnce();
+    // The system message sent to the LLM should contain both the base prompt and the autonomy block
+    expect(provider.chat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: 'system',
+            content: expect.stringContaining('Base prompt.'),
+          }),
+          expect.objectContaining({
+            role: 'system',
+            content: expect.stringContaining('Autonomy Level'),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('uses base system prompt unchanged when autonomyService returns null', async () => {
+    const mockAutonomyService = {
+      getConfig: vi.fn().mockResolvedValue(null),
+    };
+
+    const provider = createMockProvider('OK');
+    const runtime = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'Base prompt.',
+      provider,
+      bus,
+      logger: createLogger('error'),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      autonomyService: mockAutonomyService as any,
+    });
+    runtime.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-auto-2',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Hello',
+      parentEventId: 'parent-auto-2',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(provider.chat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          { role: 'system', content: 'Base prompt.' },
+          { role: 'user', content: 'Hello' },
+        ],
+      }),
+    );
+  });
+```
+
+- [ ] **Step 6.5: Run the new tests**
+
+```bash
+pnpm test tests/unit/agents/runtime.test.ts
+```
+
+Expected: all tests PASS (including the two new ones).
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add src/agents/runtime.ts tests/unit/agents/runtime.test.ts
+git commit -m "feat: inject autonomy prompt block per-task in AgentRuntime"
+```
+
+---
+
+## Task 7: Wire into index.ts
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 7.1: Add the import**
+
+After the `import { bootstrapCeoContact }` line, add:
+
+```typescript
+import { AutonomyService } from './autonomy/autonomy-service.js';
+```
+
+- [ ] **Step 7.2: Instantiate AutonomyService after the pool is confirmed healthy**
+
+After the line `logger.info('Database connected');` (inside the try block that verifies connectivity), add immediately after:
+
+```typescript
+  // Autonomy service — manages the global autonomy score (0–100).
+  // Instantiated early (right after DB connect) so it's ready before agents start.
+  const autonomyService = new AutonomyService(pool, logger);
+```
+
+- [ ] **Step 7.3: Pass autonomyService to ExecutionLayer**
+
+Find the `ExecutionLayer` construction line (long options object). Add `autonomyService` to the options:
+
+```typescript
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, {
+    bus, agentRegistry, contactService, outboundGateway, heldMessages,
+    schedulerService, entityMemory, agentPersona, nylasCalendarClient,
+    entityContextAssembler, agentContactId: agentIdentityContactId,
+    autonomyService,  // <-- add this
+  });
+```
+
+- [ ] **Step 7.4: Pass autonomyService to the coordinator AgentRuntime**
+
+In Pass 2 of agent registration, find the block that creates the `AgentRuntime`:
+
+```typescript
+    const agent = new AgentRuntime({
+      agentId: agentConfig.name,
+      systemPrompt,
+      provider: llmProvider,
+      bus,
+      logger,
+      memory,
+      entityMemory,
+      executionLayer,
+      pinnedSkills: agentPinnedSkills,
+      skillToolDefs: agentToolDefs,
+      errorBudget: ...
+    });
+```
+
+Add `autonomyService` conditionally — only the coordinator gets per-task injection:
+
+```typescript
+    const agent = new AgentRuntime({
+      agentId: agentConfig.name,
+      systemPrompt,
+      provider: llmProvider,
+      bus,
+      logger,
+      memory,
+      entityMemory,
+      executionLayer,
+      pinnedSkills: agentPinnedSkills,
+      skillToolDefs: agentToolDefs,
+      // Only the coordinator receives the autonomy service — it's the only agent
+      // that needs per-task autonomy prompt injection and the autonomy skills.
+      autonomyService: agentConfig.role === 'coordinator' ? autonomyService : undefined,
+      errorBudget: agentConfig.error_budget ? {
+        maxTurns: agentConfig.error_budget.max_turns ?? DEFAULT_ERROR_BUDGET.maxTurns,
+        maxConsecutiveErrors: agentConfig.error_budget.max_errors ?? DEFAULT_ERROR_BUDGET.maxConsecutiveErrors,
+      } : undefined,
+    });
+```
+
+- [ ] **Step 7.5: Run typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 7.6: Smoke test — confirm startup and autonomy block appears**
+
+```bash
+pnpm local
+```
+
+Type: `what is your current autonomy level?`
+
+Expected: Nathan describes his score and band (he'll have the autonomy block in context even without the skill, since the prompt injection is now active). Then Ctrl+C.
+
+- [ ] **Step 7.7: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: wire AutonomyService into ExecutionLayer and coordinator AgentRuntime"
+```
+
+---
+
+## Task 8: `get-autonomy` Skill
+
+**Files:**
+- Create: `skills/get-autonomy/skill.json`
+- Create: `skills/get-autonomy/handler.ts`
+
+- [ ] **Step 8.1: Write the manifest**
+
+```json
+{
+  "name": "get-autonomy",
+  "description": "Report Nathan's current global autonomy score, band, and recent change history. Use this when the CEO asks about autonomy level, trust level, or how independently Nathan is operating.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {},
+  "outputs": { "score": "number", "band": "string", "summary": "string" },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000,
+  "autonomy_floor": "full"
+}
+```
+
+- [ ] **Step 8.2: Write the handler**
+
+```typescript
+// handler.ts — get-autonomy skill.
+//
+// Reports the current global autonomy score and band to the CEO.
+// Includes the last 3 history entries so the CEO can see recent changes.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class GetAutonomyHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.autonomyService) {
+      return { success: false, error: 'get-autonomy requires autonomyService in context. Is infrastructure: true set in the manifest?' };
+    }
+
+    try {
+      const [config, history] = await Promise.all([
+        ctx.autonomyService.getConfig(),
+        ctx.autonomyService.getHistory(3),
+      ]);
+
+      if (!config) {
+        return { success: false, error: 'Autonomy config not found — migration 011 may not have run.' };
+      }
+
+      // Format the band label for human display
+      const bandLabels: Record<string, string> = {
+        'full': 'Full',
+        'spot-check': 'Spot-check',
+        'approval-required': 'Approval Required',
+        'draft-only': 'Draft Only',
+        'restricted': 'Restricted',
+      };
+      const bandLabel = bandLabels[config.band] ?? config.band;
+
+      // Build a readable summary
+      const lines: string[] = [
+        `Autonomy score: ${config.score} — ${bandLabel}`,
+        `Last updated: ${config.updatedAt.toISOString().split('T')[0]} by ${config.updatedBy}`,
+      ];
+
+      if (history.length > 0) {
+        lines.push('', 'Recent changes:');
+        for (const entry of history) {
+          const date = entry.changedAt.toISOString().split('T')[0] ?? '';
+          const prev = entry.previousScore !== null ? `${entry.previousScore} → ` : '';
+          const reason = entry.reason ? `  "${entry.reason}"` : '';
+          lines.push(`  ${date}  ${prev}${entry.score} (${entry.band})${reason}  — ${entry.changedBy}`);
+        }
+      }
+
+      return {
+        success: true,
+        data: {
+          score: config.score,
+          band: config.band,
+          summary: lines.join('\n'),
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'get-autonomy failed');
+      return { success: false, error: message };
+    }
+  }
+}
+```
+
+- [ ] **Step 8.3: Run typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git add skills/get-autonomy/
+git commit -m "feat: get-autonomy skill — report current score, band, and history"
+```
+
+---
+
+## Task 9: `set-autonomy` Skill
+
+**Files:**
+- Create: `skills/set-autonomy/skill.json`
+- Create: `skills/set-autonomy/handler.ts`
+
+- [ ] **Step 9.1: Write the manifest**
+
+```json
+{
+  "name": "set-autonomy",
+  "description": "Update Nathan's global autonomy score (0–100). Requires CEO authorization. Lower scores require more approvals before Nathan acts; higher scores allow more independent action. Optionally provide a reason for the change.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "infrastructure": true,
+  "inputs": {
+    "score": "number",
+    "reason": "string?"
+  },
+  "outputs": { "score": "number", "band": "string", "previous_score": "number" },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000,
+  "autonomy_floor": "full"
+}
+```
+
+- [ ] **Step 9.2: Write the handler**
+
+```typescript
+// handler.ts — set-autonomy skill.
+//
+// Updates the global autonomy score. Elevated sensitivity — requires CEO CallerContext.
+// Validated and rejected by the execution layer if the caller is not CEO.
+// Upserts autonomy_config and appends to autonomy_history.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class SetAutonomyHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.autonomyService) {
+      return { success: false, error: 'set-autonomy requires autonomyService in context. Is infrastructure: true set in the manifest?' };
+    }
+
+    const { score, reason } = ctx.input as { score?: unknown; reason?: unknown };
+
+    // Validate score input — the LLM may pass a float or string
+    const parsedScore = typeof score === 'number' ? score : Number(score);
+    if (!Number.isFinite(parsedScore)) {
+      return { success: false, error: `Invalid score: "${score}". Must be a number between 0 and 100.` };
+    }
+
+    // Round to nearest integer — tolerate minor float imprecision from the LLM
+    const intScore = Math.round(parsedScore);
+
+    const changedBy = ctx.caller?.role ?? ctx.caller?.contactId ?? 'ceo';
+    const reasonStr = typeof reason === 'string' && reason.trim() ? reason.trim() : undefined;
+
+    try {
+      const previous = await ctx.autonomyService.getConfig();
+      const previousScore = previous?.score ?? null;
+
+      const updated = await ctx.autonomyService.setScore(intScore, changedBy, reasonStr);
+
+      const bandLabels: Record<string, string> = {
+        'full': 'Full',
+        'spot-check': 'Spot-check',
+        'approval-required': 'Approval Required',
+        'draft-only': 'Draft Only',
+        'restricted': 'Restricted',
+      };
+      const bandLabel = bandLabels[updated.band] ?? updated.band;
+
+      const changeDesc = previousScore !== null
+        ? `${previousScore} → ${updated.score}`
+        : `${updated.score}`;
+
+      return {
+        success: true,
+        data: {
+          score: updated.score,
+          band: updated.band,
+          previous_score: previousScore,
+          summary: `Autonomy score updated: ${changeDesc} (${bandLabel}).${reasonStr ? ` Reason: "${reasonStr}".` : ''}`,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'set-autonomy failed');
+      return { success: false, error: message };
+    }
+  }
+}
+```
+
+- [ ] **Step 9.3: Run typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 9.4: Commit**
+
+```bash
+git add skills/set-autonomy/
+git commit -m "feat: set-autonomy skill — CEO-only score update with history append"
+```
+
+---
+
+## Task 10: Pin Skills to Coordinator
+
+**Files:**
+- Modify: `agents/coordinator.yaml`
+
+- [ ] **Step 10.1: Add the two skills to `pinned_skills`**
+
+At the end of the `pinned_skills` list (currently ending with `calendar-check-conflicts`), add:
+
+```yaml
+  - get-autonomy
+  - set-autonomy
+```
+
+- [ ] **Step 10.2: Smoke test — confirm skills are available**
+
+```bash
+pnpm local
+```
+
+Type: `what is your current autonomy score?`
+
+Expected: Nathan calls `get-autonomy` and reports the score (75, Approval Required) with history. Then Ctrl+C.
+
+Type: `set my autonomy score to 80` (in a new session or continuation)
+
+Expected: Nathan calls `set-autonomy` and confirms the update.
+
+- [ ] **Step 10.3: Commit**
+
+```bash
+git add agents/coordinator.yaml
+git commit -m "feat: pin get-autonomy and set-autonomy to coordinator"
+```
+
+---
+
+## Task 11: Update README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 11.1: Add a new "Autonomy Engine" section after the "Scheduling" section**
+
+Find the line `---` immediately after the Scheduling section ends (before `## Multi-Provider LLM Support`). Insert the new section before it:
+
+```markdown
+## Autonomy Engine
+
+Nathan operates at a configurable autonomy level — a single score from 0 to 100 that determines how independently he acts across all channels and skills.
+
+The score maps to one of five **autonomy bands**:
+
+| Band | Score | What it means |
+|---|---|---|
+| **Full** | 90–100 | Acts independently. Flags only genuinely novel or irreversible actions. |
+| **Spot-check** | 80–89 | Proceeds on routine tasks. Notes consequential actions for CEO visibility. |
+| **Approval Required** | 70–79 | Presents a plan and asks for confirmation before any consequential action. |
+| **Draft Only** | 60–69 | Prepares drafts and plans but does not send or act without explicit instruction. |
+| **Restricted** | < 60 | Advisory only. Takes no independent action whatsoever. |
+
+The current band is injected into Nathan's system prompt on every task, so his self-governance adjusts immediately when the score changes — no restart required.
+
+**CEO controls (via CLI or email):**
+- *"What is your current autonomy score?"* — Nathan reports his score, band, and recent change history
+- *"Set your autonomy score to 85"* — Nathan updates the score and confirms the change
+
+The score defaults to **75 (Approval Required)** on first deployment. Scores are stored in Postgres with a full change history. Future versions will adjust the score automatically based on performance metrics (task success rate, factual correction rate, follow-through).
+
+```
+
+- [ ] **Step 11.2: Add spec 12 to the Project Status table**
+
+Find the end of the Project Status table. Add a new row after the existing `—` rows (Outbound safety and Smoke test):
+
+```markdown
+| 12 | Autonomy engine (global score, CEO controls, per-task prompt injection) | Planned |
+```
+
+- [ ] **Step 11.3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add Autonomy Engine section and spec 12 to README"
+```
+
+---
+
+## Task 12: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 12.1: Add the Autonomy Awareness checklist**
+
+In `CLAUDE.md`, find the `### New Skill` section under `## Adding Things`. After that section's steps, add a new subsection:
+
+```markdown
+### Autonomy Awareness
+
+When adding a new skill, declare its autonomy floor in `skill.json` (this field is not enforced in Phase 1 but is required for Phase 2 gate wiring):
+
+```json
+"autonomy_floor": "spot-check"
+```
+
+Floors by capability class:
+- `"full"` — reads, retrieval, summarization (no external effect)
+- `"spot-check"` — outbound communications, internal state writes
+- `"approval-required"` — calendar writes, commitments on behalf of CEO
+- `"draft-only"` — financial actions, high-stakes operations
+- `"restricted"` — irreversible or destructive actions
+
+When adding a new agent, ensure it receives the autonomy block via the runtime injection mechanism (same pattern as date/timezone injection — pass `autonomyService` in `AgentRuntime` config if the agent needs autonomy awareness). See `docs/specs/12-autonomy-engine.md`.
+```
+
+- [ ] **Step 12.2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add Autonomy Awareness checklist to CLAUDE.md"
+```
+
+---
+
+## Task 13: Full Test Suite
+
+- [ ] **Step 13.1: Run the full test suite**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-autonomy-engine
+pnpm test
+```
+
+Expected: all existing tests plus the new autonomy tests pass. No regressions.
+
+- [ ] **Step 13.2: Run typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 13.3: Final smoke test**
+
+```bash
+pnpm local
+```
+
+Run through the following sequence:
+1. *"What is your current autonomy level?"* → Nathan calls `get-autonomy` and reports 75 / Approval Required
+2. *"Set your autonomy score to 85 — you've been doing well."* → Nathan calls `set-autonomy`, confirms 75 → 85 / Spot-check
+3. *"What is your autonomy score now?"* → Nathan reports 85 / Spot-check with history showing the change
+
+Then Ctrl+C.

--- a/docs/superpowers/specs/2026-04-03-autonomy-engine-design.md
+++ b/docs/superpowers/specs/2026-04-03-autonomy-engine-design.md
@@ -1,0 +1,302 @@
+# Autonomy Engine — Design Spec
+
+**Date:** 2026-04-03
+**Spec:** 12
+**Status:** Draft
+
+---
+
+## Overview
+
+A single global autonomy score (0–100) for the Nathan Curia instance that governs how
+independently Nathan operates across all agents and skills. The score is CEO-controlled,
+Postgres-persisted, and injected into the coordinator's system prompt on every task so
+Nathan self-governs accordingly.
+
+Phase 1 establishes the score, CEO read/write access, and behavioral prompt injection.
+Phase 2 (future) will add automatic score adjustment driven by an action log.
+
+---
+
+## Background
+
+The autonomy framework is derived from Gorick Ng's Competence / Commitment / Compatibility
+model. A composite score maps to one of five autonomy bands, each with explicit behavioral
+guidance. This spec covers the Phase 1 foundation only — the full scoring formula,
+auto-adjustment rules, relationship signals, and gating engine are documented in the
+source spec (to be filed at `docs/specs/designs/office-ceo-agent-scoring-spec.md`) and deferred to Phase 2.
+
+**Why a single global score rather than per-agent or per-capability scoring?**
+Nathan is a single deployed instance — there is no meaningful distinction between "Nathan's
+email autonomy" and "Nathan's calendar autonomy" at this stage. A global score is
+interpretable, adjustable, and directly tied to the CEO's lived trust in the system. Per-
+capability scoring can be layered on top in Phase 2 once the global baseline is established.
+
+---
+
+## Autonomy Bands
+
+| Band | Score Range | Label |
+|---|---|---|
+| Full | 90–100 | `full` |
+| Spot-check | 80–89 | `spot-check` |
+| Approval Required | 70–79 | `approval-required` |
+| Draft Only | 60–69 | `draft-only` |
+| Restricted | < 60 | `restricted` |
+
+### Band Behavioral Descriptions
+
+These descriptions are injected verbatim into the coordinator system prompt. They define
+Nathan's self-governance posture at each band.
+
+**Full (90–100)**
+> Act independently. No confirmation needed for standard operations. Flag only genuinely
+> novel, irreversible, or high-stakes actions — where the downside of acting without
+> checking outweighs the cost of the pause.
+
+**Spot-check (80–89)**
+> Proceed on routine tasks. For consequential actions — sending external communications,
+> creating commitments, or acting on behalf of the CEO — note what you're doing in your
+> response so the CEO maintains visibility. No need to stop and ask.
+
+**Approval Required (70–79)**
+> For any consequential action, present your plan and explicitly ask for confirmation
+> before proceeding. Routine reporting, summarization, and information retrieval can
+> proceed without approval. When in doubt, draft and ask.
+
+**Draft Only (60–69)**
+> Prepare drafts, plans, and analysis, but do not send, publish, schedule, or act on
+> behalf of the CEO without an explicit instruction to do so. Surface your work for review;
+> execution requires a direct go-ahead.
+
+**Restricted (< 60)**
+> Present options and analysis only. Take no independent action. All outputs are advisory.
+> Every step that would have an external effect requires explicit CEO instruction.
+
+---
+
+## Data Model
+
+### `autonomy_config` — live state (single row)
+
+```sql
+CREATE TABLE autonomy_config (
+  id          INTEGER PRIMARY KEY DEFAULT 1,
+  score       INTEGER NOT NULL CHECK (score >= 0 AND score <= 100),
+  band        TEXT NOT NULL,        -- derived label stored for query convenience
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by  TEXT NOT NULL,        -- 'ceo' or 'system' (Phase 2+)
+  CONSTRAINT single_row CHECK (id = 1)
+);
+```
+
+The `CONSTRAINT single_row CHECK (id = 1)` enforces exactly one row at the database level.
+Upserts use `ON CONFLICT (id) DO UPDATE`.
+
+The `band` label is derived from `score` at write time and stored for readability — no need
+to recompute on every read.
+
+**Default starting value:** 75 (`approval-required`). This is a conservative starting point
+that requires Nathan to confirm consequential actions. The CEO adjusts from here as trust
+is established.
+
+### `autonomy_history` — append-only audit trail
+
+```sql
+CREATE TABLE autonomy_history (
+  id             BIGSERIAL PRIMARY KEY,
+  score          INTEGER NOT NULL,
+  previous_score INTEGER,           -- NULL on first write
+  band           TEXT NOT NULL,
+  changed_by     TEXT NOT NULL,
+  reason         TEXT,              -- optional CEO note
+  changed_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+Every write to `autonomy_config` appends a row here. This table is never updated or
+deleted. It is the foundation Phase 2's auto-adjustment will write to when recording
+score changes from the action log.
+
+---
+
+## Skills
+
+Both skills are pinned to the coordinator agent only. They are not available to other agents.
+
+### `get-autonomy`
+
+- **Sensitivity:** normal
+- **Inputs:** none
+- **Behavior:** Queries `autonomy_config` for the current score and band, plus the last
+  3 rows from `autonomy_history`. Returns a human-readable summary Nathan relays to
+  the CEO.
+- **Example output:**
+  ```
+  Autonomy score: 75 — Approval Required
+
+  At this level, I'll confirm before taking consequential actions like sending email
+  or creating commitments, but can proceed independently on research and summarization.
+
+  Recent changes:
+    2026-04-03  75  (approval-required)  "starting point"  — ceo
+  ```
+
+### `set-autonomy`
+
+- **Sensitivity:** elevated (requires `CallerContext` with `role: "ceo"`)
+- **Inputs:** `score` (integer 0–100), `reason` (string, optional)
+- **Behavior:**
+  1. Validates `score` is in range [0, 100]
+  2. Reads current score from `autonomy_config`
+  3. Derives new `band` label from `score`
+  4. Upserts `autonomy_config`
+  5. Appends to `autonomy_history` with `previous_score`, `changed_by: "ceo"`, and
+     the optional `reason`
+  6. Returns confirmation with old score → new score and band label
+- **Caller verification:** Uses the same elevated-skill gate from PR #65. Any invocation
+  without a valid CEO `CallerContext` fails closed.
+
+---
+
+## Prompt Injection
+
+The autonomy score is loaded from Postgres and injected into the coordinator's system prompt
+**on every task**, following the same runtime enrichment pattern established in PR #32
+(date/timezone injection).
+
+### Injection mechanism
+
+During the coordinator's context assembly phase, before the LLM call:
+
+1. Read `autonomy_config` (single row, fast)
+2. Look up the band's behavioral description (static map, keyed by `band`)
+3. Append a structured block to the system prompt:
+
+```
+## Autonomy Level
+
+Your current autonomy score is {score} ({band-label}).
+
+{band-behavioral-description}
+```
+
+### Why per-task (not once at startup)
+
+The CEO may change the score mid-session. Loading per-task ensures a `set-autonomy` call
+takes effect on Nathan's next action without requiring a process restart. The cost is one
+single-row Postgres read per task — negligible.
+
+---
+
+## Guidelines for New Agents & Skills
+
+Every new skill manifest (`skill.json`) should declare an `autonomy_floor` field indicating
+the minimum autonomy band at which this skill is appropriate to run without explicit CEO
+approval:
+
+```json
+{
+  "name": "send-email",
+  "autonomy_floor": "spot-check",
+  ...
+}
+```
+
+This field is **not enforced by the execution layer in Phase 1** — it is documentation for
+the developer and for Phase 2's gate wiring. When the execution layer is extended to enforce
+autonomy floors, the field will already be present.
+
+### Autonomy floor guidelines by capability class
+
+| Capability class | Recommended floor | Rationale |
+|---|---|---|
+| Read / retrieve / summarize | `full` | No external effect; always safe |
+| Internal state writes (memory, contacts) | `spot-check` | Affects future behavior but reversible |
+| Outbound communications | `spot-check` | External effect; CEO should have visibility |
+| Calendar writes | `approval-required` | Creates commitments on behalf of CEO |
+| Financial actions | `draft-only` | High-stakes; always require explicit instruction |
+| Destructive / irreversible actions | `restricted` | Never autonomous |
+
+### New agent checklist
+
+When adding a new agent:
+
+1. Ensure it receives the autonomy block via the standard prompt injection mechanism
+   (coordinator does this automatically; standalone agents need explicit wiring)
+2. Review pinned skills against the floor guidelines above
+3. If the agent has capabilities that cross band boundaries, document which capabilities
+   apply at which floor in the agent YAML comments
+
+---
+
+## Intended Future Hard Gates (Phase 2)
+
+These gates are deferred to Phase 2 but documented here as the intended target. When
+wiring, these are the first candidates:
+
+| Condition | Gate |
+|---|---|
+| `score < 70` | `outbound-gateway` requires an explicit approval event before dispatching any email |
+| `score < 60` | All skill invocations in `agent.task` context return early with an advisory message |
+| `score >= 90` | Elevated skills (sensitivity: `elevated`) are callable without per-action confirmation from CEO |
+
+The outbound gateway (`OutboundGateway`) is already a natural choke point — adding an
+autonomy check there in Phase 2 requires no architectural change.
+
+---
+
+## Phase 2: Auto-Adjustment (Future)
+
+Phase 2 will implement automatic score adjustment based on an action log. The formula from
+the source spec:
+
+```
+Capability Score =
+  0.45 × Competence +
+  0.35 × Commitment +
+  0.20 × Compatibility
+```
+
+Key constraints from the spec:
+- Minimum 30 actions before any automatic adjustment
+- Time-decay weighting applied (recent actions weighted more heavily)
+- Autonomy cannot increase if factual error rate is high or overconfidence penalty is active
+- All automatic adjustments write to `autonomy_history` with `changed_by: "system"`
+
+The `autonomy_history` table designed in Phase 1 is the exact foundation Phase 2 writes to.
+
+The full Phase 2 schema (action log, relationship signals, confidence model) is in the
+source spec. Phase 2 gets its own design doc when the time comes.
+
+---
+
+## README Update
+
+Add to the Project Status table:
+
+| Spec | Area | Status |
+|---|---|---|
+| 12 | Autonomy engine (score, CEO controls, prompt injection) | Planned |
+
+---
+
+## CLAUDE.md Addition
+
+Add to the "Adding Things" section of `CLAUDE.md`:
+
+```markdown
+### Autonomy Awareness
+
+When adding a new skill, declare its autonomy floor in `skill.json`:
+- `"autonomy_floor": "full"` — safe to run at any autonomy level (reads, retrieval)
+- `"autonomy_floor": "spot-check"` — outbound communications, internal state writes
+- `"autonomy_floor": "approval-required"` — calendar writes, commitments
+- `"autonomy_floor": "draft-only"` — financial actions
+- `"autonomy_floor": "restricted"` — irreversible or destructive actions
+
+See `docs/specs/12-autonomy-engine.md` for the full guidelines table.
+
+When adding a new agent, ensure it receives the autonomy prompt block via the runtime
+injection mechanism (same pattern as date/timezone injection — see spec 12 for details).
+```

--- a/skills/get-autonomy/handler.ts
+++ b/skills/get-autonomy/handler.ts
@@ -12,13 +12,18 @@ export class GetAutonomyHandler implements SkillHandler {
     }
 
     try {
-      const [config, history] = await Promise.all([
-        ctx.autonomyService.getConfig(),
-        ctx.autonomyService.getHistory(3),
-      ]);
+      const config = await ctx.autonomyService.getConfig();
 
       if (!config) {
         return { success: false, error: 'Autonomy config not found — migration 011 may not have run.' };
+      }
+
+      // History is supplementary — a failure here should not block showing the current score.
+      let history: import('../../src/autonomy/autonomy-service.js').AutonomyHistoryEntry[] = [];
+      try {
+        history = await ctx.autonomyService.getHistory(3);
+      } catch (err) {
+        ctx.log.warn({ err }, 'get-autonomy: could not load history — showing current score only');
       }
 
       // Format the band label for human display

--- a/skills/get-autonomy/handler.ts
+++ b/skills/get-autonomy/handler.ts
@@ -1,0 +1,64 @@
+// handler.ts — get-autonomy skill.
+//
+// Reports the current global autonomy score and band to the CEO.
+// Includes the last 3 history entries so the CEO can see recent changes.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class GetAutonomyHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.autonomyService) {
+      return { success: false, error: 'get-autonomy requires autonomyService in context. Is infrastructure: true set in the manifest?' };
+    }
+
+    try {
+      const [config, history] = await Promise.all([
+        ctx.autonomyService.getConfig(),
+        ctx.autonomyService.getHistory(3),
+      ]);
+
+      if (!config) {
+        return { success: false, error: 'Autonomy config not found — migration 011 may not have run.' };
+      }
+
+      // Format the band label for human display
+      const bandLabels: Record<string, string> = {
+        'full': 'Full',
+        'spot-check': 'Spot-check',
+        'approval-required': 'Approval Required',
+        'draft-only': 'Draft Only',
+        'restricted': 'Restricted',
+      };
+      const bandLabel = bandLabels[config.band] ?? config.band;
+
+      // Build a readable summary
+      const lines: string[] = [
+        `Autonomy score: ${config.score} — ${bandLabel}`,
+        `Last updated: ${config.updatedAt.toISOString().split('T')[0]} by ${config.updatedBy}`,
+      ];
+
+      if (history.length > 0) {
+        lines.push('', 'Recent changes:');
+        for (const entry of history) {
+          const date = entry.changedAt.toISOString().split('T')[0] ?? '';
+          const prev = entry.previousScore !== null ? `${entry.previousScore} → ` : '';
+          const reason = entry.reason ? `  "${entry.reason}"` : '';
+          lines.push(`  ${date}  ${prev}${entry.score} (${entry.band})${reason}  — ${entry.changedBy}`);
+        }
+      }
+
+      return {
+        success: true,
+        data: {
+          score: config.score,
+          band: config.band,
+          summary: lines.join('\n'),
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'get-autonomy failed');
+      return { success: false, error: message };
+    }
+  }
+}

--- a/skills/get-autonomy/skill.json
+++ b/skills/get-autonomy/skill.json
@@ -1,0 +1,13 @@
+{
+  "name": "get-autonomy",
+  "description": "Report Nathan's current global autonomy score, band, and recent change history. Use this when the CEO asks about autonomy level, trust level, or how independently Nathan is operating.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "infrastructure": true,
+  "inputs": {},
+  "outputs": { "score": "number", "band": "string", "summary": "string" },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000,
+  "autonomy_floor": "full"
+}

--- a/skills/set-autonomy/handler.ts
+++ b/skills/set-autonomy/handler.ts
@@ -25,7 +25,7 @@ export class SetAutonomyHandler implements SkillHandler {
 
     // Prefer the caller's role as the audit identifier; fall back to contactId.
     // CallerContext.role is string | null, so we guard against null explicitly.
-    const changedBy = ctx.caller?.role ?? ctx.caller?.contactId ?? 'ceo';
+    const changedBy = ctx.caller?.role ?? ctx.caller?.contactId ?? 'system';
     const reasonStr = typeof reason === 'string' && reason.trim() ? reason.trim() : undefined;
 
     try {

--- a/skills/set-autonomy/handler.ts
+++ b/skills/set-autonomy/handler.ts
@@ -23,10 +23,12 @@ export class SetAutonomyHandler implements SkillHandler {
     // Round to nearest integer — tolerate minor float imprecision from the LLM
     const intScore = Math.round(parsedScore);
 
-    // Prefer the caller's role as the audit identifier; fall back to contactId.
-    // CallerContext.role is string | null, so we guard against null explicitly.
-    const changedBy = ctx.caller?.role ?? ctx.caller?.contactId ?? 'system';
-    const reasonStr = typeof reason === 'string' && reason.trim() ? reason.trim() : undefined;
+    // Prefer contactId over role for the audit identifier — contactId is a unique, stable
+    // identifier while role is a broad category (multiple callers can share a role).
+    const changedBy = ctx.caller?.contactId ?? ctx.caller?.role ?? 'system';
+    const reasonStr = typeof reason === 'string' && reason.trim()
+      ? reason.trim().slice(0, 500)  // Cap at 500 chars to prevent context-stuffing
+      : undefined;
 
     try {
       // setScore returns previousScore atomically (captured inside the CTE), so we don't

--- a/skills/set-autonomy/handler.ts
+++ b/skills/set-autonomy/handler.ts
@@ -14,8 +14,12 @@ export class SetAutonomyHandler implements SkillHandler {
 
     const { score, reason } = ctx.input as { score?: unknown; reason?: unknown };
 
-    // Validate score input — the LLM may pass a float or string
-    const parsedScore = typeof score === 'number' ? score : Number(score);
+    // Validate score input — the LLM may pass a numeric string; reject other types
+    // explicitly (null, boolean, arrays all coerce to 0 via Number(), which would silently
+    // reset the score to Restricted without any validation error).
+    const parsedScore = typeof score === 'number'
+      ? score
+      : (typeof score === 'string' && score.trim() !== '' ? Number(score) : NaN);
     if (!Number.isFinite(parsedScore)) {
       return { success: false, error: `Invalid score: "${score}". Must be a number between 0 and 100.` };
     }

--- a/skills/set-autonomy/handler.ts
+++ b/skills/set-autonomy/handler.ts
@@ -29,10 +29,10 @@ export class SetAutonomyHandler implements SkillHandler {
     const reasonStr = typeof reason === 'string' && reason.trim() ? reason.trim() : undefined;
 
     try {
-      const previous = await ctx.autonomyService.getConfig();
-      const previousScore = previous?.score ?? null;
-
+      // setScore returns previousScore atomically (captured inside the CTE), so we don't
+      // need a separate getConfig() call that could race with a concurrent write.
       const updated = await ctx.autonomyService.setScore(intScore, changedBy, reasonStr);
+      const { previousScore } = updated;
 
       const bandLabels: Record<string, string> = {
         'full': 'Full',

--- a/skills/set-autonomy/handler.ts
+++ b/skills/set-autonomy/handler.ts
@@ -1,0 +1,65 @@
+// handler.ts — set-autonomy skill.
+//
+// Updates the global autonomy score. Elevated sensitivity — requires CEO CallerContext.
+// Validated and rejected by the execution layer if the caller is not CEO.
+// Upserts autonomy_config and appends to autonomy_history.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class SetAutonomyHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.autonomyService) {
+      return { success: false, error: 'set-autonomy requires autonomyService in context. Is infrastructure: true set in the manifest?' };
+    }
+
+    const { score, reason } = ctx.input as { score?: unknown; reason?: unknown };
+
+    // Validate score input — the LLM may pass a float or string
+    const parsedScore = typeof score === 'number' ? score : Number(score);
+    if (!Number.isFinite(parsedScore)) {
+      return { success: false, error: `Invalid score: "${score}". Must be a number between 0 and 100.` };
+    }
+
+    // Round to nearest integer — tolerate minor float imprecision from the LLM
+    const intScore = Math.round(parsedScore);
+
+    // Prefer the caller's role as the audit identifier; fall back to contactId.
+    // CallerContext.role is string | null, so we guard against null explicitly.
+    const changedBy = ctx.caller?.role ?? ctx.caller?.contactId ?? 'ceo';
+    const reasonStr = typeof reason === 'string' && reason.trim() ? reason.trim() : undefined;
+
+    try {
+      const previous = await ctx.autonomyService.getConfig();
+      const previousScore = previous?.score ?? null;
+
+      const updated = await ctx.autonomyService.setScore(intScore, changedBy, reasonStr);
+
+      const bandLabels: Record<string, string> = {
+        'full': 'Full',
+        'spot-check': 'Spot-check',
+        'approval-required': 'Approval Required',
+        'draft-only': 'Draft Only',
+        'restricted': 'Restricted',
+      };
+      const bandLabel = bandLabels[updated.band] ?? updated.band;
+
+      const changeDesc = previousScore !== null
+        ? `${previousScore} → ${updated.score}`
+        : `${updated.score}`;
+
+      return {
+        success: true,
+        data: {
+          score: updated.score,
+          band: updated.band,
+          previous_score: previousScore,
+          summary: `Autonomy score updated: ${changeDesc} (${bandLabel}).${reasonStr ? ` Reason: "${reasonStr}".` : ''}`,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'set-autonomy failed');
+      return { success: false, error: message };
+    }
+  }
+}

--- a/skills/set-autonomy/skill.json
+++ b/skills/set-autonomy/skill.json
@@ -12,5 +12,5 @@
   "permissions": [],
   "secrets": [],
   "timeout": 10000,
-  "autonomy_floor": "full"
+  "autonomy_floor": "approval-required"
 }

--- a/skills/set-autonomy/skill.json
+++ b/skills/set-autonomy/skill.json
@@ -1,0 +1,16 @@
+{
+  "name": "set-autonomy",
+  "description": "Update Nathan's global autonomy score (0–100). Requires CEO authorization. Lower scores require more approvals before Nathan acts; higher scores allow more independent action. Optionally provide a reason for the change.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "infrastructure": true,
+  "inputs": {
+    "score": "number",
+    "reason": "string?"
+  },
+  "outputs": { "score": "number", "band": "string", "previous_score": "number" },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000,
+  "autonomy_floor": "full"
+}

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -123,9 +123,16 @@ export class AgentRuntime {
     // mid-session takes effect on Nathan's next action without a restart.
     let effectiveSystemPrompt = systemPrompt;
     if (autonomyService) {
-      const autonomyConfig = await autonomyService.getConfig();
-      if (autonomyConfig) {
-        effectiveSystemPrompt = systemPrompt + '\n\n' + AutonomyService.formatPromptBlock(autonomyConfig);
+      try {
+        const autonomyConfig = await autonomyService.getConfig();
+        if (autonomyConfig) {
+          effectiveSystemPrompt = systemPrompt + '\n\n' + AutonomyService.formatPromptBlock(autonomyConfig);
+        }
+      } catch (err) {
+        // An unexpected DB error loading the autonomy config should not abort the task entirely.
+        // Log at error level (operator signal) and proceed with the base system prompt.
+        logger.error({ err, agentId }, 'Failed to load autonomy config — proceeding with base system prompt');
+        // effectiveSystemPrompt remains as systemPrompt.
       }
     }
 

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -9,6 +9,8 @@ import type { CallerContext } from '../skills/types.js';
 import { sanitizeOutput } from '../skills/sanitize.js';
 import { classifySkillError, formatTaskError } from '../errors/classify.js';
 import { DEFAULT_ERROR_BUDGET, type AgentError, type ErrorBudget } from '../errors/types.js';
+// Value import (not type-only) — we call AutonomyService.formatPromptBlock() as a static method.
+import { AutonomyService } from '../autonomy/autonomy-service.js';
 
 export interface AgentConfig {
   agentId: string;
@@ -26,6 +28,9 @@ export interface AgentConfig {
   pinnedSkills?: string[];
   /** Pre-built tool definitions for the LLM (from SkillRegistry.toToolDefinitions). */
   skillToolDefs?: ToolDefinition[];
+  /** Optional autonomy service — when provided, the autonomy block is injected
+   *  into the effective system prompt on every task. Only the coordinator receives this. */
+  autonomyService?: AutonomyService;
   /** Error budget config — turn and consecutive error limits per task.
    * maxTurns is checked at the start of each tool-use iteration, so
    * the effective number of tool-calling rounds is maxTurns - 1. */
@@ -110,8 +115,19 @@ export class AgentRuntime {
   }
 
   private async processTask(taskEvent: AgentTaskEvent): Promise<void> {
-    const { agentId, systemPrompt, provider, bus, logger, memory, executionLayer, skillToolDefs } = this.config;
+    const { agentId, systemPrompt, provider, bus, logger, memory, executionLayer, skillToolDefs, autonomyService } = this.config;
     const { content, conversationId } = taskEvent.payload;
+
+    // Load the current autonomy config and append its behavioral block to the
+    // system prompt. This runs per-task (not at startup) so a CEO score change
+    // mid-session takes effect on Nathan's next action without a restart.
+    let effectiveSystemPrompt = systemPrompt;
+    if (autonomyService) {
+      const autonomyConfig = await autonomyService.getConfig();
+      if (autonomyConfig) {
+        effectiveSystemPrompt = systemPrompt + '\n\n' + AutonomyService.formatPromptBlock(autonomyConfig);
+      }
+    }
 
     // Initialize the error budget for this task.
     // Config values override defaults; budget tracks runtime counters.
@@ -130,7 +146,7 @@ export class AgentRuntime {
 
     // Assemble initial LLM context
     const messages: Message[] = [
-      { role: 'system', content: systemPrompt },
+      { role: 'system', content: effectiveSystemPrompt },
       ...history,
       { role: 'user', content },
     ];

--- a/src/autonomy/autonomy-service.ts
+++ b/src/autonomy/autonomy-service.ts
@@ -133,8 +133,11 @@ export class AutonomyService {
   /**
    * Update the autonomy score. Upserts autonomy_config and appends to autonomy_history.
    * Throws if score is out of range [0, 100].
+   *
+   * Returns the new config plus the atomically-captured previousScore — the value
+   * actually written to autonomy_history, not a separate pre-read that could diverge.
    */
-  async setScore(score: number, changedBy: string, reason?: string): Promise<AutonomyConfig> {
+  async setScore(score: number, changedBy: string, reason?: string): Promise<AutonomyConfig & { previousScore: number | null }> {
     if (!Number.isInteger(score) || score < 0 || score > 100) {
       throw new Error(`Invalid autonomy score: ${score}. Must be an integer between 0 and 100.`);
     }
@@ -142,8 +145,8 @@ export class AutonomyService {
     const band = AutonomyService.bandForScore(score);
 
     // Atomic: read previous score, upsert config, and write history in a single query.
-    // Uses a CTE with FOR UPDATE to prevent concurrent writes from recording a stale previous_score.
-    await this.pool.query(
+    // RETURNING previous_score gives us the atomically-captured old value for the response.
+    const result = await this.pool.query<{ previous_score: number | null }>(
       `WITH locked AS (
          SELECT score AS previous_score
          FROM autonomy_config
@@ -164,13 +167,16 @@ export class AutonomyService {
        FROM locked
        UNION ALL
        SELECT $1, NULL, $2, $3, $4
-       WHERE NOT EXISTS (SELECT 1 FROM locked)`,
+       WHERE NOT EXISTS (SELECT 1 FROM locked)
+       RETURNING previous_score`,
       [score, band, changedBy, reason ?? null],
     );
 
-    this.logger.info({ score, band, changedBy }, 'Autonomy score updated');
+    const previousScore = result.rows[0]?.previous_score ?? null;
 
-    return { score, band, updatedAt: new Date(), updatedBy: changedBy };
+    this.logger.info({ score, band, changedBy, previousScore }, 'Autonomy score updated');
+
+    return { score, band, updatedAt: new Date(), updatedBy: changedBy, previousScore };
   }
 
   /** Return the most recent history entries, newest first. */

--- a/src/autonomy/autonomy-service.ts
+++ b/src/autonomy/autonomy-service.ts
@@ -94,6 +94,10 @@ export class AutonomyService {
   static formatPromptBlock(config: AutonomyConfig): string {
     const label = BAND_LABELS[config.band];
     const description = BAND_DESCRIPTIONS[config.band];
+    if (!label || !description) {
+      // Unknown band — fail safe rather than injecting 'undefined' into the system prompt.
+      throw new Error(`Unknown autonomy band: '${config.band}'`);
+    }
     return [
       '## Autonomy Level',
       '',

--- a/src/autonomy/autonomy-service.ts
+++ b/src/autonomy/autonomy-service.ts
@@ -1,0 +1,193 @@
+// autonomy-service.ts — manages the global autonomy score for the Curia instance.
+//
+// The autonomy score (0–100) determines how independently Nathan operates.
+// It maps to one of five bands, each with a behavioral description that is
+// injected into the coordinator's system prompt on every task.
+//
+// Phase 1: CEO-controlled via get-autonomy / set-autonomy skills.
+// Phase 2: Automatic adjustment based on action log data (future).
+
+import type { Pool } from 'pg';
+import type { Logger } from '../logger.js';
+
+export type AutonomyBand =
+  | 'full'
+  | 'spot-check'
+  | 'approval-required'
+  | 'draft-only'
+  | 'restricted';
+
+export interface AutonomyConfig {
+  score: number;
+  band: AutonomyBand;
+  updatedAt: Date;
+  updatedBy: string;
+}
+
+export interface AutonomyHistoryEntry {
+  id: number;
+  score: number;
+  previousScore: number | null;
+  band: AutonomyBand;
+  changedBy: string;
+  reason: string | null;
+  changedAt: Date;
+}
+
+// Static map of band labels to their behavioral descriptions.
+// These are injected verbatim into the coordinator system prompt.
+const BAND_DESCRIPTIONS: Record<AutonomyBand, string> = {
+  'full':
+    'Act independently. No confirmation needed for standard operations. Flag only genuinely ' +
+    'novel, irreversible, or high-stakes actions — where the downside of acting without ' +
+    'checking outweighs the cost of the pause.',
+  'spot-check':
+    'Proceed on routine tasks. For consequential actions — sending external communications, ' +
+    'creating commitments, or acting on behalf of the CEO — note what you are doing in your ' +
+    'response so the CEO maintains visibility. No need to stop and ask.',
+  'approval-required':
+    'For any consequential action, present your plan and explicitly ask for confirmation ' +
+    'before proceeding. Routine reporting, summarization, and information retrieval can ' +
+    'proceed without approval. When in doubt, draft and ask.',
+  'draft-only':
+    'Prepare drafts, plans, and analysis, but do not send, publish, schedule, or act on ' +
+    'behalf of the CEO without an explicit instruction to do so. Surface your work for review; ' +
+    'execution requires a direct go-ahead.',
+  'restricted':
+    'Present options and analysis only. Take no independent action. All outputs are advisory. ' +
+    'Every step that would have an external effect requires explicit CEO instruction.',
+};
+
+// Human-readable band labels for display.
+const BAND_LABELS: Record<AutonomyBand, string> = {
+  'full': 'Full',
+  'spot-check': 'Spot-check',
+  'approval-required': 'Approval Required',
+  'draft-only': 'Draft Only',
+  'restricted': 'Restricted',
+};
+
+export class AutonomyService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly logger: Logger,
+  ) {}
+
+  /** Derive the autonomy band from a numeric score. */
+  static bandForScore(score: number): AutonomyBand {
+    if (score >= 90) return 'full';
+    if (score >= 80) return 'spot-check';
+    if (score >= 70) return 'approval-required';
+    if (score >= 60) return 'draft-only';
+    return 'restricted';
+  }
+
+  /** Return the behavioral description for a band. */
+  static bandDescription(band: AutonomyBand): string {
+    return BAND_DESCRIPTIONS[band];
+  }
+
+  /**
+   * Format the autonomy block for injection into the coordinator system prompt.
+   * Returns a Markdown section with the current score, band label, and behavioral guidance.
+   */
+  static formatPromptBlock(config: AutonomyConfig): string {
+    const label = BAND_LABELS[config.band];
+    const description = BAND_DESCRIPTIONS[config.band];
+    return [
+      '## Autonomy Level',
+      '',
+      `Your current autonomy score is ${config.score} (${label}).`,
+      '',
+      description,
+    ].join('\n');
+  }
+
+  /** Read the current autonomy config. Returns null if the row does not exist (pre-migration). */
+  async getConfig(): Promise<AutonomyConfig | null> {
+    try {
+      const result = await this.pool.query<{
+        score: number;
+        band: string;
+        updated_at: Date;
+        updated_by: string;
+      }>('SELECT score, band, updated_at, updated_by FROM autonomy_config WHERE id = 1');
+
+      if (result.rows.length === 0) return null;
+
+      const row = result.rows[0]!;
+      return {
+        score: row.score,
+        band: row.band as AutonomyBand,
+        updatedAt: row.updated_at,
+        updatedBy: row.updated_by,
+      };
+    } catch (err) {
+      // Log but don't throw — a missing table (pre-migration) should degrade gracefully.
+      // The coordinator will just run without the autonomy block until the migration runs.
+      this.logger.warn({ err }, 'autonomy-service: failed to read autonomy_config — is migration 011 applied?');
+      return null;
+    }
+  }
+
+  /**
+   * Update the autonomy score. Upserts autonomy_config and appends to autonomy_history.
+   * Throws if score is out of range [0, 100].
+   */
+  async setScore(score: number, changedBy: string, reason?: string): Promise<AutonomyConfig> {
+    if (!Number.isInteger(score) || score < 0 || score > 100) {
+      throw new Error(`Invalid autonomy score: ${score}. Must be an integer between 0 and 100.`);
+    }
+
+    const band = AutonomyService.bandForScore(score);
+
+    // Read the current score before updating so history has previous_score.
+    const current = await this.getConfig();
+    const previousScore = current?.score ?? null;
+
+    // Upsert the live config row.
+    await this.pool.query(
+      `INSERT INTO autonomy_config (id, score, band, updated_at, updated_by)
+       VALUES (1, $1, $2, now(), $3)
+       ON CONFLICT (id) DO UPDATE SET score = $1, band = $2, updated_at = now(), updated_by = $3`,
+      [score, band, changedBy],
+    );
+
+    // Append to the append-only audit trail.
+    await this.pool.query(
+      `INSERT INTO autonomy_history (score, previous_score, band, changed_by, reason)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [score, previousScore, band, changedBy, reason ?? null],
+    );
+
+    this.logger.info({ score, band, changedBy, previousScore }, 'Autonomy score updated');
+
+    return { score, band, updatedAt: new Date(), updatedBy: changedBy };
+  }
+
+  /** Return the most recent history entries, newest first. */
+  async getHistory(limit = 3): Promise<AutonomyHistoryEntry[]> {
+    const result = await this.pool.query<{
+      id: number;
+      score: number;
+      previous_score: number | null;
+      band: string;
+      changed_by: string;
+      reason: string | null;
+      changed_at: Date;
+    }>(
+      'SELECT id, score, previous_score, band, changed_by, reason, changed_at FROM autonomy_history ORDER BY changed_at DESC LIMIT $1',
+      [limit],
+    );
+
+    return result.rows.map(row => ({
+      id: row.id,
+      score: row.score,
+      previousScore: row.previous_score,
+      band: row.band as AutonomyBand,
+      changedBy: row.changed_by,
+      reason: row.reason,
+      changedAt: row.changed_at,
+    }));
+  }
+}

--- a/src/autonomy/autonomy-service.ts
+++ b/src/autonomy/autonomy-service.ts
@@ -123,10 +123,17 @@ export class AutonomyService {
         updatedBy: row.updated_by,
       };
     } catch (err) {
-      // Log but don't throw — a missing table (pre-migration) should degrade gracefully.
-      // The coordinator will just run without the autonomy block until the migration runs.
-      this.logger.warn({ err }, 'autonomy-service: failed to read autonomy_config — is migration 011 applied?');
-      return null;
+      // Only swallow missing-table errors (pg code 42P01) — the expected pre-migration state.
+      // All other errors (connection failure, query timeout, data corruption) are re-thrown
+      // so the caller can decide how to handle them. The coordinator's processTask() has its
+      // own catch that degrades gracefully rather than aborting the task.
+      const pgCode = (err as { code?: string }).code;
+      if (pgCode === '42P01') {
+        this.logger.warn({ err }, 'autonomy-service: autonomy_config table not found — is migration 011 applied?');
+        return null;
+      }
+      this.logger.error({ err }, 'autonomy-service: unexpected error reading autonomy_config');
+      throw err;
     }
   }
 
@@ -146,6 +153,8 @@ export class AutonomyService {
 
     // Atomic: read previous score, upsert config, and write history in a single query.
     // RETURNING previous_score gives us the atomically-captured old value for the response.
+    // @TODO Phase 2: If setScore is ever split into separate queries (e.g., for two-step
+    // update flows), wrap in explicit BEGIN/COMMIT to preserve atomicity guarantees.
     const result = await this.pool.query<{ previous_score: number | null }>(
       `WITH locked AS (
          SELECT score AS previous_score

--- a/src/autonomy/autonomy-service.ts
+++ b/src/autonomy/autonomy-service.ts
@@ -141,26 +141,34 @@ export class AutonomyService {
 
     const band = AutonomyService.bandForScore(score);
 
-    // Read the current score before updating so history has previous_score.
-    const current = await this.getConfig();
-    const previousScore = current?.score ?? null;
-
-    // Upsert the live config row.
+    // Atomic: read previous score, upsert config, and write history in a single query.
+    // Uses a CTE with FOR UPDATE to prevent concurrent writes from recording a stale previous_score.
     await this.pool.query(
-      `INSERT INTO autonomy_config (id, score, band, updated_at, updated_by)
-       VALUES (1, $1, $2, now(), $3)
-       ON CONFLICT (id) DO UPDATE SET score = $1, band = $2, updated_at = now(), updated_by = $3`,
-      [score, band, changedBy],
+      `WITH locked AS (
+         SELECT score AS previous_score
+         FROM autonomy_config
+         WHERE id = 1
+         FOR UPDATE
+       ),
+       upserted AS (
+         INSERT INTO autonomy_config (id, score, band, updated_at, updated_by)
+         VALUES (1, $1, $2, now(), $3)
+         ON CONFLICT (id) DO UPDATE
+           SET score = EXCLUDED.score,
+               band = EXCLUDED.band,
+               updated_at = EXCLUDED.updated_at,
+               updated_by = EXCLUDED.updated_by
+       )
+       INSERT INTO autonomy_history (score, previous_score, band, changed_by, reason)
+       SELECT $1, locked.previous_score, $2, $3, $4
+       FROM locked
+       UNION ALL
+       SELECT $1, NULL, $2, $3, $4
+       WHERE NOT EXISTS (SELECT 1 FROM locked)`,
+      [score, band, changedBy, reason ?? null],
     );
 
-    // Append to the append-only audit trail.
-    await this.pool.query(
-      `INSERT INTO autonomy_history (score, previous_score, band, changed_by, reason)
-       VALUES ($1, $2, $3, $4, $5)`,
-      [score, previousScore, band, changedBy, reason ?? null],
-    );
-
-    this.logger.info({ score, band, changedBy, previousScore }, 'Autonomy score updated');
+    this.logger.info({ score, band, changedBy }, 'Autonomy score updated');
 
     return { score, band, updatedAt: new Date(), updatedBy: changedBy };
   }

--- a/src/db/migrations/011_create_autonomy.sql
+++ b/src/db/migrations/011_create_autonomy.sql
@@ -6,7 +6,7 @@
 CREATE TABLE autonomy_config (
   id          INTEGER PRIMARY KEY DEFAULT 1,
   score       INTEGER NOT NULL CHECK (score >= 0 AND score <= 100),
-  band        TEXT NOT NULL,
+  band        TEXT NOT NULL CHECK (band IN ('full', 'spot-check', 'approval-required', 'draft-only', 'restricted')),
   updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_by  TEXT NOT NULL,
   CONSTRAINT single_row CHECK (id = 1)
@@ -18,7 +18,7 @@ CREATE TABLE autonomy_history (
   id             BIGSERIAL PRIMARY KEY,
   score          INTEGER NOT NULL,
   previous_score INTEGER,
-  band           TEXT NOT NULL,
+  band           TEXT NOT NULL CHECK (band IN ('full', 'spot-check', 'approval-required', 'draft-only', 'restricted')),
   changed_by     TEXT NOT NULL,
   reason         TEXT,
   changed_at     TIMESTAMPTZ NOT NULL DEFAULT now()

--- a/src/db/migrations/011_create_autonomy.sql
+++ b/src/db/migrations/011_create_autonomy.sql
@@ -1,0 +1,35 @@
+-- Up Migration
+
+-- Single-row table holding the live autonomy score.
+-- The CONSTRAINT single_row CHECK (id = 1) ensures exactly one row exists —
+-- enforced at the DB level rather than application code.
+CREATE TABLE autonomy_config (
+  id          INTEGER PRIMARY KEY DEFAULT 1,
+  score       INTEGER NOT NULL CHECK (score >= 0 AND score <= 100),
+  band        TEXT NOT NULL,
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by  TEXT NOT NULL,
+  CONSTRAINT single_row CHECK (id = 1)
+);
+
+-- Append-only audit trail — never updated or deleted.
+-- Phase 2 auto-adjustment will also write here (changed_by = 'system').
+CREATE TABLE autonomy_history (
+  id             BIGSERIAL PRIMARY KEY,
+  score          INTEGER NOT NULL,
+  previous_score INTEGER,
+  band           TEXT NOT NULL,
+  changed_by     TEXT NOT NULL,
+  reason         TEXT,
+  changed_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Seed the default starting score (75 = approval-required).
+-- ON CONFLICT DO NOTHING makes this idempotent on existing deployments.
+INSERT INTO autonomy_config (id, score, band, updated_by)
+VALUES (1, 75, 'approval-required', 'system')
+ON CONFLICT (id) DO NOTHING;
+
+-- Seed the corresponding history entry so the audit trail starts complete.
+INSERT INTO autonomy_history (score, previous_score, band, changed_by, reason)
+VALUES (75, NULL, 'approval-required', 'system', 'Initial default score');

--- a/src/index.ts
+++ b/src/index.ts
@@ -440,7 +440,8 @@ async function main(): Promise<void> {
       skillToolDefs: agentToolDefs,
       // Only the coordinator receives the autonomy service — it's the only agent
       // that needs per-task autonomy prompt injection and the autonomy skills.
-      autonomyService: agentConfig.role === 'coordinator' ? autonomyService : undefined,
+      // Use name (not role) — role is optional in agent YAML and may not be set.
+      autonomyService: agentConfig.name === 'coordinator' ? autonomyService : undefined,
       // Map YAML snake_case fields to AgentConfig camelCase, falling back to
       // DEFAULT_ERROR_BUDGET values for any omitted fields.
       errorBudget: agentConfig.error_budget ? {

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ import { Scheduler } from './scheduler/scheduler.js';
 import { EntityContextAssembler } from './entity-context/assembler.js';
 import { bootstrapAgentIdentity } from './entity-context/bootstrap.js';
 import { bootstrapCeoContact } from './contacts/ceo-bootstrap.js';
+import { AutonomyService } from './autonomy/autonomy-service.js';
 import type { AgentPersona } from './skills/types.js';
 
 async function main(): Promise<void> {
@@ -76,6 +77,10 @@ async function main(): Promise<void> {
     logger.fatal({ err }, 'Database connection failed');
     process.exit(1);
   }
+
+  // Autonomy service — manages the global autonomy score (0–100).
+  // Instantiated early (right after DB connect) so it's ready before agents start.
+  const autonomyService = new AutonomyService(pool, logger);
 
   // Run pending migrations so the schema is always current when the process starts.
   // Uses node-pg-migrate's programmatic runner with the same DATABASE_URL.
@@ -372,7 +377,7 @@ async function main(): Promise<void> {
   // infrastructure skills. outboundGateway gives email skills their send path.
   // entityContextAssembler enables entity_enrichment pre-enrichment and the
   // entity-context skill. agentContactId enables entity_enrichment default='agent'.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete
@@ -433,6 +438,9 @@ async function main(): Promise<void> {
       executionLayer,
       pinnedSkills: agentPinnedSkills,
       skillToolDefs: agentToolDefs,
+      // Only the coordinator receives the autonomy service — it's the only agent
+      // that needs per-task autonomy prompt injection and the autonomy skills.
+      autonomyService: agentConfig.role === 'coordinator' ? autonomyService : undefined,
       // Map YAML snake_case fields to AgentConfig camelCase, falling back to
       // DEFAULT_ERROR_BUDGET values for any omitted fields.
       errorBudget: agentConfig.error_budget ? {

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -203,10 +203,12 @@ export class ExecutionLayer {
       if (this.nylasCalendarClient) {
         ctx.nylasCalendarClient = this.nylasCalendarClient;
       }
-      // autonomyService is optional — only infrastructure skills that manage the global autonomy score need it
-      if (this.autonomyService) {
-        ctx.autonomyService = this.autonomyService;
-      }
+    }
+
+    // autonomyService is scoped to the autonomy skills only — not granted to all infrastructure skills.
+    // Limiting access here reduces blast radius if any other infrastructure skill is ever compromised.
+    if (this.autonomyService && (manifest.name === 'get-autonomy' || manifest.name === 'set-autonomy')) {
+      ctx.autonomyService = this.autonomyService;
     }
 
     // entityContextAssembler — available to ALL skills (not just infrastructure).

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -30,6 +30,7 @@ import type { SchedulerService } from '../scheduler/scheduler-service.js';
 import type { EntityMemory } from '../memory/entity-memory.js';
 import type { NylasCalendarClient } from '../channels/calendar/nylas-calendar-client.js';
 import type { EntityContextAssembler } from '../entity-context/assembler.js';
+import type { AutonomyService } from '../autonomy/autonomy-service.js';
 
 // Warn (but don't truncate) when a skill returns more than this many chars.
 // Helps operators spot skills that might blow out the LLM context window.
@@ -48,6 +49,7 @@ export class ExecutionLayer {
   private agentPersona?: AgentPersona;
   private nylasCalendarClient?: NylasCalendarClient;
   private entityContextAssembler?: EntityContextAssembler;
+  private autonomyService?: AutonomyService;
   /** The agent's own contactId — injected into ctx.agentContactId for entity_enrichment default='agent' */
   private agentContactId?: string;
 
@@ -62,6 +64,7 @@ export class ExecutionLayer {
     agentPersona?: AgentPersona;
     nylasCalendarClient?: NylasCalendarClient;
     entityContextAssembler?: EntityContextAssembler;
+    autonomyService?: AutonomyService;
     agentContactId?: string;
   }) {
     this.registry = registry;
@@ -76,6 +79,7 @@ export class ExecutionLayer {
     this.agentPersona = options?.agentPersona;
     this.nylasCalendarClient = options?.nylasCalendarClient;
     this.entityContextAssembler = options?.entityContextAssembler;
+    this.autonomyService = options?.autonomyService;
     this.agentContactId = options?.agentContactId;
   }
 
@@ -198,6 +202,10 @@ export class ExecutionLayer {
       // nylasCalendarClient is optional — only calendar skills need it
       if (this.nylasCalendarClient) {
         ctx.nylasCalendarClient = this.nylasCalendarClient;
+      }
+      // autonomyService is optional — only infrastructure skills that manage the global autonomy score need it
+      if (this.autonomyService) {
+        ctx.autonomyService = this.autonomyService;
       }
     }
 

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -130,6 +130,9 @@ export interface SkillContext {
   /** The agent's own contactId — used by entity_enrichment when default is 'agent'.
    *  Seeded at bootstrap and injected by the execution layer. */
   agentContactId?: string;
+  /** Autonomy service — available to infrastructure skills that manage the global
+   *  autonomy score (get-autonomy, set-autonomy). Not available to normal skills. */
+  autonomyService?: import('../autonomy/autonomy-service.js').AutonomyService;
 }
 
 /**

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -252,6 +252,79 @@ describe('AgentRuntime', () => {
     expect(history[0]).toEqual({ role: 'user', content: 'Hello' });
     expect(history[1]).toEqual({ role: 'assistant', content: 'Bot reply' });
   });
+
+  it('appends the autonomy block to the system prompt when autonomyService is provided', async () => {
+    const mockAutonomyService = {
+      getConfig: vi.fn().mockResolvedValue({
+        score: 75,
+        band: 'approval-required',
+        updatedAt: new Date(),
+        updatedBy: 'system',
+      }),
+    };
+
+    const provider = createMockProvider('OK');
+    const runtime = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'Base prompt.',
+      provider,
+      bus,
+      logger: createLogger('error'),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      autonomyService: mockAutonomyService as any,
+    });
+    runtime.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-auto-1',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Hello',
+      parentEventId: 'parent-auto-1',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(mockAutonomyService.getConfig).toHaveBeenCalledOnce();
+    // The system message sent to the LLM should contain both the base prompt and the autonomy block
+    const callArgs = provider.chat.mock.calls[0]?.[0] as { messages: Array<{ role: string; content: string }> };
+    const systemMsg = callArgs?.messages?.[0];
+    expect(systemMsg?.role).toBe('system');
+    expect(systemMsg?.content).toContain('Base prompt.');
+    expect(systemMsg?.content).toContain('Autonomy Level');
+  });
+
+  it('uses base system prompt unchanged when autonomyService returns null', async () => {
+    const mockAutonomyService = {
+      getConfig: vi.fn().mockResolvedValue(null),
+    };
+
+    const provider = createMockProvider('OK');
+    const runtime = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'Base prompt.',
+      provider,
+      bus,
+      logger: createLogger('error'),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      autonomyService: mockAutonomyService as any,
+    });
+    runtime.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-auto-2',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Hello',
+      parentEventId: 'parent-auto-2',
+    });
+    await bus.publish('dispatch', task);
+
+    const callArgs = provider.chat.mock.calls[0]?.[0] as { messages: Array<{ role: string; content: string }> };
+    const systemMsg = callArgs?.messages?.[0];
+    expect(systemMsg?.content).toBe('Base prompt.');
+  });
 });
 
 // Helper: mock LLM that returns tool_use on first call, text on second

--- a/tests/unit/autonomy/autonomy-service.test.ts
+++ b/tests/unit/autonomy/autonomy-service.test.ts
@@ -119,12 +119,8 @@ describe('AutonomyService', () => {
       await expect(svc.setScore(75.5, 'ceo')).rejects.toThrow('Invalid autonomy score');
     });
 
-    it('upserts config and inserts history, then returns new config', async () => {
-      // getConfig() call (to read previous_score)
-      pool.query.mockResolvedValueOnce({ rows: [{ score: 70, band: 'approval-required', updated_at: new Date(), updated_by: 'ceo' }] });
-      // upsert autonomy_config
-      pool.query.mockResolvedValueOnce({ rows: [] });
-      // insert autonomy_history
+    it('upserts config and inserts history atomically, then returns new config', async () => {
+      // Single atomic CTE query
       pool.query.mockResolvedValueOnce({ rows: [] });
 
       const result = await svc.setScore(80, 'ceo', 'good week');
@@ -132,29 +128,32 @@ describe('AutonomyService', () => {
       expect(result.band).toBe('spot-check');
       expect(result.updatedBy).toBe('ceo');
 
-      // upsert call
+      expect(pool.query).toHaveBeenCalledTimes(1);
       expect(pool.query).toHaveBeenCalledWith(
         expect.stringContaining('INSERT INTO autonomy_config'),
-        [80, 'spot-check', 'ceo'],
+        [80, 'spot-check', 'ceo', 'good week'],
       );
-      // history call — includes previous_score and reason
       expect(pool.query).toHaveBeenCalledWith(
         expect.stringContaining('INSERT INTO autonomy_history'),
-        [80, 70, 'spot-check', 'ceo', 'good week'],
+        [80, 'spot-check', 'ceo', 'good week'],
       );
     });
 
-    it('passes null previous_score on first write (no existing config)', async () => {
-      // getConfig returns null (no row yet)
+    it('passes null reason when not provided', async () => {
       pool.query.mockResolvedValueOnce({ rows: [] });
-      pool.query.mockResolvedValueOnce({ rows: [] }); // upsert
-      pool.query.mockResolvedValueOnce({ rows: [] }); // history
-
       await svc.setScore(75, 'system');
       expect(pool.query).toHaveBeenCalledWith(
-        expect.stringContaining('INSERT INTO autonomy_history'),
-        [75, null, 'approval-required', 'system', null],
+        expect.any(String),
+        [75, 'approval-required', 'system', null],
       );
+    });
+
+    it('throws for NaN', async () => {
+      await expect(svc.setScore(NaN, 'ceo')).rejects.toThrow('Invalid autonomy score');
+    });
+
+    it('throws for Infinity', async () => {
+      await expect(svc.setScore(Infinity, 'ceo')).rejects.toThrow('Invalid autonomy score');
     });
   });
 });

--- a/tests/unit/autonomy/autonomy-service.test.ts
+++ b/tests/unit/autonomy/autonomy-service.test.ts
@@ -90,10 +90,21 @@ describe('AutonomyService', () => {
       expect(await svc.getConfig()).toBeNull();
     });
 
-    it('returns null (not throw) when the DB call fails', async () => {
-      pool.query.mockRejectedValueOnce(new Error('relation does not exist'));
+    it('returns null (not throw) when the table is missing (pg code 42P01)', async () => {
+      // 42P01 is the expected pre-migration state — should degrade gracefully.
+      const missingTableErr = Object.assign(new Error('relation "autonomy_config" does not exist'), { code: '42P01' });
+      pool.query.mockRejectedValueOnce(missingTableErr);
       expect(await svc.getConfig()).toBeNull();
       expect(logger.warn).toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('re-throws unexpected DB errors (not 42P01)', async () => {
+      // Connection failures, timeouts, etc. should surface to the caller.
+      const connectionErr = Object.assign(new Error('connection refused'), { code: '08006' });
+      pool.query.mockRejectedValueOnce(connectionErr);
+      await expect(svc.getConfig()).rejects.toThrow('connection refused');
+      expect(logger.error).toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/autonomy/autonomy-service.test.ts
+++ b/tests/unit/autonomy/autonomy-service.test.ts
@@ -120,13 +120,14 @@ describe('AutonomyService', () => {
     });
 
     it('upserts config and inserts history atomically, then returns new config', async () => {
-      // Single atomic CTE query
-      pool.query.mockResolvedValueOnce({ rows: [] });
+      // Single atomic CTE query — RETURNING previous_score gives us the old value
+      pool.query.mockResolvedValueOnce({ rows: [{ previous_score: 70 }] });
 
       const result = await svc.setScore(80, 'ceo', 'good week');
       expect(result.score).toBe(80);
       expect(result.band).toBe('spot-check');
       expect(result.updatedBy).toBe('ceo');
+      expect(result.previousScore).toBe(70);
 
       expect(pool.query).toHaveBeenCalledTimes(1);
       expect(pool.query).toHaveBeenCalledWith(
@@ -140,8 +141,9 @@ describe('AutonomyService', () => {
     });
 
     it('passes null reason when not provided', async () => {
-      pool.query.mockResolvedValueOnce({ rows: [] });
-      await svc.setScore(75, 'system');
+      pool.query.mockResolvedValueOnce({ rows: [{ previous_score: null }] });
+      const result = await svc.setScore(75, 'system');
+      expect(result.previousScore).toBeNull();
       expect(pool.query).toHaveBeenCalledWith(
         expect.any(String),
         [75, 'approval-required', 'system', null],

--- a/tests/unit/autonomy/autonomy-service.test.ts
+++ b/tests/unit/autonomy/autonomy-service.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AutonomyService } from '../../../src/autonomy/autonomy-service.js';
+import type { AutonomyBand } from '../../../src/autonomy/autonomy-service.js';
+
+function mockPool() {
+  return { query: vi.fn() };
+}
+
+function mockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+}
+
+describe('AutonomyService', () => {
+  // -- Static helpers --
+
+  describe('bandForScore', () => {
+    const cases: Array<[number, AutonomyBand]> = [
+      [100, 'full'],
+      [90, 'full'],
+      [89, 'spot-check'],
+      [80, 'spot-check'],
+      [79, 'approval-required'],
+      [70, 'approval-required'],
+      [69, 'draft-only'],
+      [60, 'draft-only'],
+      [59, 'restricted'],
+      [0, 'restricted'],
+    ];
+
+    it.each(cases)('score %i → band "%s"', (score, expected) => {
+      expect(AutonomyService.bandForScore(score)).toBe(expected);
+    });
+  });
+
+  describe('formatPromptBlock', () => {
+    it('includes score, band label, and description', () => {
+      const config = {
+        score: 75,
+        band: 'approval-required' as AutonomyBand,
+        updatedAt: new Date(),
+        updatedBy: 'ceo',
+      };
+      const block = AutonomyService.formatPromptBlock(config);
+      expect(block).toContain('## Autonomy Level');
+      expect(block).toContain('75');
+      expect(block).toContain('Approval Required');
+      // Should contain behavioral guidance for this band
+      expect(block).toContain('present your plan');
+    });
+
+    it('produces different text for different bands', () => {
+      const make = (score: number, band: AutonomyBand) =>
+        AutonomyService.formatPromptBlock({ score, band, updatedAt: new Date(), updatedBy: 'ceo' });
+      expect(make(95, 'full')).not.toBe(make(75, 'approval-required'));
+    });
+  });
+
+  // -- getConfig --
+
+  describe('getConfig', () => {
+    let pool: ReturnType<typeof mockPool>;
+    let logger: ReturnType<typeof mockLogger>;
+    let svc: AutonomyService;
+
+    beforeEach(() => {
+      pool = mockPool();
+      logger = mockLogger();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      svc = new AutonomyService(pool as any, logger as any);
+    });
+
+    it('returns the current config when a row exists', async () => {
+      const now = new Date();
+      pool.query.mockResolvedValueOnce({
+        rows: [{ score: 75, band: 'approval-required', updated_at: now, updated_by: 'ceo' }],
+      });
+
+      const config = await svc.getConfig();
+      expect(config).toEqual({ score: 75, band: 'approval-required', updatedAt: now, updatedBy: 'ceo' });
+    });
+
+    it('returns null when no row exists', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      expect(await svc.getConfig()).toBeNull();
+    });
+
+    it('returns null (not throw) when the DB call fails', async () => {
+      pool.query.mockRejectedValueOnce(new Error('relation does not exist'));
+      expect(await svc.getConfig()).toBeNull();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  // -- setScore --
+
+  describe('setScore', () => {
+    let pool: ReturnType<typeof mockPool>;
+    let svc: AutonomyService;
+
+    beforeEach(() => {
+      pool = mockPool();
+      const logger = mockLogger();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      svc = new AutonomyService(pool as any, logger as any);
+    });
+
+    it('throws for out-of-range scores', async () => {
+      await expect(svc.setScore(-1, 'ceo')).rejects.toThrow('Invalid autonomy score');
+      await expect(svc.setScore(101, 'ceo')).rejects.toThrow('Invalid autonomy score');
+    });
+
+    it('throws for non-integer scores', async () => {
+      await expect(svc.setScore(75.5, 'ceo')).rejects.toThrow('Invalid autonomy score');
+    });
+
+    it('upserts config and inserts history, then returns new config', async () => {
+      // getConfig() call (to read previous_score)
+      pool.query.mockResolvedValueOnce({ rows: [{ score: 70, band: 'approval-required', updated_at: new Date(), updated_by: 'ceo' }] });
+      // upsert autonomy_config
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      // insert autonomy_history
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      const result = await svc.setScore(80, 'ceo', 'good week');
+      expect(result.score).toBe(80);
+      expect(result.band).toBe('spot-check');
+      expect(result.updatedBy).toBe('ceo');
+
+      // upsert call
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO autonomy_config'),
+        [80, 'spot-check', 'ceo'],
+      );
+      // history call — includes previous_score and reason
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO autonomy_history'),
+        [80, 70, 'spot-check', 'ceo', 'good week'],
+      );
+    });
+
+    it('passes null previous_score on first write (no existing config)', async () => {
+      // getConfig returns null (no row yet)
+      pool.query.mockResolvedValueOnce({ rows: [] });
+      pool.query.mockResolvedValueOnce({ rows: [] }); // upsert
+      pool.query.mockResolvedValueOnce({ rows: [] }); // history
+
+      await svc.setScore(75, 'system');
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO autonomy_history'),
+        [75, null, 'approval-required', 'system', null],
+      );
+    });
+  });
+});

--- a/tests/unit/autonomy/autonomy-service.test.ts
+++ b/tests/unit/autonomy/autonomy-service.test.ts
@@ -59,6 +59,16 @@ describe('AutonomyService', () => {
         AutonomyService.formatPromptBlock({ score, band, updatedAt: new Date(), updatedBy: 'ceo' });
       expect(make(95, 'full')).not.toBe(make(75, 'approval-required'));
     });
+
+    it('throws for an unknown band value', () => {
+      const config = {
+        score: 75,
+        band: 'invalid-band' as AutonomyBand,
+        updatedAt: new Date(),
+        updatedBy: 'ceo',
+      };
+      expect(() => AutonomyService.formatPromptBlock(config)).toThrow("Unknown autonomy band: 'invalid-band'");
+    });
   });
 
   // -- getConfig --


### PR DESCRIPTION
## **User description**
## Summary

- Adds a global autonomy score (0–100) for the Nathan Curia instance, stored in Postgres
- Score maps to one of five bands (Full, Spot-check, Approval Required, Draft Only, Restricted), each with behavioral guidance injected into the coordinator's system prompt **per-task** — so a CEO score change takes effect on Nathan's next action without restart
- Two CEO-controlled skills: `get-autonomy` (read score + history) and `set-autonomy` (update score, CEO-only via elevated sensitivity gate)
- Full audit trail via append-only `autonomy_history` table; config stored in single-row `autonomy_config`

## What's in this PR

**Schema (migration 011):**
- `autonomy_config` — single-row live state (score, band, updated_at, updated_by)
- `autonomy_history` — append-only audit trail; foundation for Phase 2 auto-adjustment
- Default seed: score=75, band=approval-required

**Service (`src/autonomy/autonomy-service.ts`):**
- `AutonomyService` with static band logic, prompt block formatting, and DB methods
- `setScore` is atomic via a single CTE with `FOR UPDATE` — no race condition on previous_score capture
- `getConfig` degrades gracefully on missing-table (42P01 only); other DB errors propagate with error-level log

**Wiring:**
- `SkillContext` extended with `autonomyService?` (infra-gated)
- `ExecutionLayer` threads it through to infrastructure skills only
- `AgentRuntime` injects the autonomy block per-task; wrapped in try/catch so a DB blip doesn't abort the task

**Skills:**
- `get-autonomy` (normal sensitivity) — reports score, band, and last 3 history entries
- `set-autonomy` (elevated, CEO-only) — validates + rounds score, records reason, returns atomic previous→new summary
- Both pinned to coordinator only

**Docs:**
- README: new Autonomy Engine section with band table and CEO usage examples
- CLAUDE.md: Autonomy Awareness checklist for new skills/agents
- Spec 12 added to Project Status table

## Test plan

- [ ] Run `pnpm test` — 663 tests pass, 0 failures
- [ ] Run `pnpm typecheck` — clean
- [ ] Start `pnpm local` and ask Nathan: *"What is your current autonomy score?"* → should call `get-autonomy` and report 75 / Approval Required
- [ ] Ask Nathan: *"Set your autonomy score to 85 — you've been doing well."* → should call `set-autonomy` and confirm 75 → 85 / Spot-check
- [ ] Ask Nathan: *"What is your autonomy level?"* in the same session → should report 85 with history showing the change


___

## **CodeAnt-AI Description**
**Add a global autonomy score with CEO controls and per-task guidance**

### What Changed
- The coordinator now reads the current autonomy score before each task and includes the matching guidance in its system prompt
- Two new coordinator-only skills let the CEO check the current score and update it, with the change history shown in the status output
- Autonomy changes are saved with a running history, and the starting score is set to 75 so new installs begin in Approval Required mode
- Added tests for score bands, prompt text, score updates, and prompt injection; updated the README and developer notes with the new autonomy rules

### Impact
`✅ Immediate autonomy changes without restart`
`✅ Clearer CEO control over Nathan's approval level`
`✅ Audit trail for autonomy changes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
