### PR TITLE
chore: align capability expansion spec/plans with autonomy engine

### DIFF
--- a/docs/superpowers/plans/2026-04-03-ceo-inbox.md
+++ b/docs/superpowers/plans/2026-04-03-ceo-inbox.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Connect Joseph's Gmail as a second Nylas channel so Nathan can read his inbox, fetch full messages, and save draft replies — with no autonomous sending in Phase 1.
+**Goal:** Connect Joseph's Gmail as a second Nylas channel so Nathan can read his inbox, fetch full messages, and save draft replies — with no autonomous sending until the autonomy score warrants it.
 
 **Architecture:** A new `email-ceo` channel adapter polls Joseph's Nylas grant and publishes `inbound.message` events with `channelId: "email-ceo"`. Three account-aware skills (`email-list`, `email-get`, `email-draft-save`) resolve to either Nathan's or Joseph's `NylasClient` based on an `account` param — the same `infrastructure: true` pattern as calendar skills. `NylasClient` gains a `createDraft()` method. The channel trust config, `SkillContext`, and `ExecutionLayer` each get one addition.
 
@@ -377,7 +377,7 @@ git commit -m "feat: add email-ceo channel trust config (high trust, hold_and_no
 - Create: `src/channels/email-ceo/email-ceo-adapter.ts`
 
 This adapter is structurally identical to `src/channels/email/email-adapter.ts` with two differences:
-1. Takes `NylasClient` directly instead of `OutboundGateway` (no outbound in Phase 1)
+1. Takes `NylasClient` directly instead of `OutboundGateway` (no outbound — this adapter reads only)
 2. Publishes with `channelId: 'email-ceo'` and `conversationId: 'email-ceo:{threadId}'`
 
 - [ ] **Step 1: Write the adapter**
@@ -388,7 +388,7 @@ This adapter is structurally identical to `src/channels/email/email-adapter.ts` 
 // CEO inbox channel adapter — polls Joseph's Nylas grant for new inbound emails
 // and publishes them as inbound.message events with channelId 'email-ceo'.
 //
-// Phase 1 only: this adapter reads and publishes. It does NOT send.
+// This adapter reads and publishes only. It does NOT send.
 // Outbound (drafts, eventual sends) go through the email skills, not this adapter.
 //
 // The adapter reuses message-converter.ts, html-to-text.ts from the primary email
@@ -558,7 +558,7 @@ Expected: no errors.
 
 ```bash
 git add src/channels/email-ceo/email-ceo-adapter.ts
-git commit -m "feat: add EmailCeoAdapter for Joseph's inbox (Phase 1 — read only)"
+git commit -m "feat: add EmailCeoAdapter for Joseph's inbox (read-only channel adapter)"
 ```
 
 ---
@@ -1041,6 +1041,7 @@ git commit -m "test: add failing tests for email-list, email-get, email-draft-sa
   "version": "1.0.0",
   "sensitivity": "normal",
   "infrastructure": true,
+  "autonomy_floor": "full",
   "inputs": {
     "account": "string?",
     "folder": "string?",
@@ -1168,6 +1169,7 @@ git commit -m "feat: add email-list skill (account-aware, folder + filter suppor
   "version": "1.0.0",
   "sensitivity": "normal",
   "infrastructure": true,
+  "autonomy_floor": "full",
   "inputs": {
     "messageId": "string",
     "account": "string?"
@@ -1260,6 +1262,7 @@ git commit -m "feat: add email-get skill (account-aware full message fetch)"
   "version": "1.0.0",
   "sensitivity": "elevated",
   "infrastructure": true,
+  "autonomy_floor": "spot-check",
   "inputs": {
     "account": "string",
     "to": "string",
@@ -1417,15 +1420,18 @@ Find the `## Email` section. Replace it with the expanded version:
   - email-send is ONLY for composing brand new emails when the CEO asks you to email
     someone. It starts a new thread and requires a "to" address.
 
-  **CEO's inbox (account: "joseph") — Phase 1 rules:**
+  **CEO's inbox (account: "joseph"):**
   - You can READ Joseph's inbox using email-list and email-get.
   - Before drafting a reply, ALWAYS call email-get to read the full message body —
     the snippet from email-list is not enough context.
   - When drafting a reply on Joseph's behalf: use email-draft-save with account="joseph".
     Write in Joseph's voice — first person, his tone, no mention of Nathan.
     The draft will appear in his Drafts folder for him to review and send.
-  - You CANNOT send from Joseph's address in Phase 1. Do not attempt email-send or
-    email-reply with account="joseph" — only drafts are permitted.
+  - Sending directly from Joseph's address is not yet implemented. Do not attempt
+    email-send or email-reply with account="joseph" — save drafts only.
+    (Your current autonomy level is injected separately and governs how independently
+    you act — follow that guidance when deciding whether to draft proactively or wait
+    for explicit instruction.)
 
   **Daily digest:**
   Joseph may ask you to set up a recurring reminder if there are pending drafts.
@@ -1529,6 +1535,6 @@ Expected: Nathan calls `scheduler-create(cron_expr: "0 17 * * 1-5", task: "Check
 - [ ] `email-list(account: "joseph")` lists Joseph's inbox
 - [ ] `email-get` returns full message body
 - [ ] `email-draft-save(account: "joseph")` creates a visible draft in Gmail Drafts — NOT in Sent
-- [ ] No email is dispatched from Joseph's address (OutboundGateway never called for CEO account in Phase 1)
+- [ ] No email is dispatched from Joseph's address (email-send with account="joseph" is not implemented; OutboundGateway is not called)
 - [ ] Contact from the test email thread appears as a provisional contact
 - [ ] Daily draft digest job created via `scheduler-create`

--- a/docs/superpowers/plans/2026-04-03-ceo-inbox.md
+++ b/docs/superpowers/plans/2026-04-03-ceo-inbox.md
@@ -1262,7 +1262,7 @@ git commit -m "feat: add email-get skill (account-aware full message fetch)"
   "version": "1.0.0",
   "sensitivity": "elevated",
   "infrastructure": true,
-  "autonomy_floor": "spot-check",
+  "autonomy_floor": "full",
   "inputs": {
     "account": "string",
     "to": "string",

--- a/docs/superpowers/plans/2026-04-03-web-search.md
+++ b/docs/superpowers/plans/2026-04-03-web-search.md
@@ -209,6 +209,7 @@ Expected: all tests fail with "Cannot find module" or similar — the handler do
   "description": "Search the web using Tavily. Returns structured results with title, URL, snippet, and (for advanced depth) extracted page content. For simple lookups, one search is enough. For research tasks, call multiple times with different queries — each covering a different angle — before forming a conclusion.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "autonomy_floor": "full",
   "inputs": {
     "query": "string",
     "maxResults": "number?",

--- a/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
@@ -1,7 +1,7 @@
 # Capability Expansion: CEO Inbox & Web Search
 
 **Date:** 2026-04-03
-**Status:** Proposed
+**Status:** Updated — autonomy engine (spec 12) supersedes autonomy_phase
 
 ## Overview
 
@@ -19,23 +19,30 @@ Two new capabilities that unlock core EA work Nathan cannot currently do:
 
 - **Skills Must Add Value Beyond the Bare LLM** — skills are API bridges. No skill contains classification, summarization, or judgment logic. The LLM decides what to draft; the skill saves it to Drafts. The LLM decides what to search for; the skill fetches results.
 - **Future-Proof for LLM Upgrades** — synthesis always stays in Nathan's LLM, never in a pre-synthesis API (Perplexity rejected for this reason). As Claude gets smarter, Nathan's research quality improves automatically at zero cost.
-- **Phase-Gated Autonomy** — the CEO inbox integration is designed for three levels of autonomy. Only Phase 1 ships now. Phases 2 and 3 are config-flag additions, not architectural changes.
+- **Autonomy-Score-Aware** — all new skills declare `autonomy_floor` per spec 12 (autonomy engine). The global autonomy score governs which capabilities Nathan may exercise independently — no per-channel config flags. Skills that ship now are available at any score; higher-autonomy behaviors (archiving, sending as Joseph) activate as the score increases into the appropriate band.
 
 ---
 
 ## Capability 1: CEO Inbox
 
-### Autonomy Phases
+### Autonomy Band Mapping
 
-The inbox integration supports three phases of autonomy, each a superset of the last:
+CEO inbox capabilities map to autonomy bands (spec 12) rather than hard-coded phases.
+The global autonomy score governs what Nathan does independently vs. asks first — no
+separate `autonomy_phase` config field.
 
-| Phase | What Nathan does | Ships when |
+| Capability | autonomy_floor | Ships when |
 |---|---|---|
-| **1 — Monitor & Draft** | Reads inbox, drafts replies, saves to Joseph's Drafts folder. Daily digest notifies Joseph if drafts are pending. | Now |
-| **2 — Archive & File** | Archives threads, applies Gmail labels. Builds on Joseph's existing filters. | Later |
-| **3 — Autonomous Reply** | Replies as Joseph (or from nathancuria1@gmail.com) for threads Nathan can handle independently. | Later |
+| Read inbox, read messages, list drafts | `full` | Now — reads are always safe |
+| Draft replies, save to Joseph's Drafts folder | `spot-check` | Now — skill ships regardless of band; at lower bands Nathan confirms intent before saving |
+| Daily draft digest (scheduler job) | `full` | Now — read + notify, no external write |
+| Archive threads, apply Gmail labels | `spot-check` | When skills are built — Nathan proceeds at `spot-check`+, asks at lower bands |
+| Reply as Nathan (from nathancuria1@gmail.com) | `spot-check` | When `email-send` account param ships |
+| Reply as Joseph (from joseph@josephfung.ca) | `approval-required` | When `email-send` account param ships — sending on Joseph's behalf requires higher trust |
 
-A `autonomy_phase` config field in `config/default.yaml` controls which behaviors are active.
+The autonomy engine (spec 12) injects the current band's behavioral description into
+every coordinator task. Nathan self-governs accordingly without additional gating code
+until Phase 2 hard gates are wired in `OutboundGateway`.
 
 ### Architecture
 
@@ -57,6 +64,7 @@ Skills are **account-aware** rather than account-specific — an optional `accou
   "name": "email-list",
   "sensitivity": "normal",
   "infrastructure": true,
+  "autonomy_floor": "full",
   "inputs": {
     "account": "string? (nathan | joseph, default nathan)",
     "folder": "string? (INBOX | DRAFTS | SENT | TRASH | <provider folder id>, default INBOX)",
@@ -78,6 +86,7 @@ Skills are **account-aware** rather than account-specific — an optional `accou
   "name": "email-get",
   "sensitivity": "normal",
   "infrastructure": true,
+  "autonomy_floor": "full",
   "inputs": {
     "account": "string? (nathan | joseph, default nathan)",
     "messageId": "string"
@@ -94,6 +103,7 @@ Skills are **account-aware** rather than account-specific — an optional `accou
   "name": "email-draft-save",
   "sensitivity": "elevated",
   "infrastructure": true,
+  "autonomy_floor": "spot-check",
   "inputs": {
     "account": "string (nathan | joseph)",
     "to": "string",
@@ -107,7 +117,10 @@ Skills are **account-aware** rather than account-specific — an optional `accou
 }
 ```
 
-Elevated sensitivity ensures a human-approval gate the first time the coordinator uses this skill.
+Elevated sensitivity ensures a human-approval gate the first time the coordinator uses this
+skill. `autonomy_floor: "spot-check"` documents that saving a draft on someone's behalf is
+an outbound-effect action; at lower bands Nathan should surface the draft for review rather
+than saving it silently.
 
 **Scheduler job (Phase 1):**
 
@@ -117,21 +130,19 @@ No new infrastructure. The job is created by Nathan via `scheduler-create` with 
 
 This is set up during first-time onboarding via a CLI prompt like "keep an eye on my drafts and let me know at 5pm if there's anything waiting" — Nathan decides to create the job himself, exactly as if he'd been asked.
 
-**New skills (Phase 2, not shipped now):**
+**Future skills (not shipped now) — autonomy band triggers:**
 
-- `email-archive` — removes a message from `INBOX` by updating its folders via `UpdateMessageRequest`. Supports `account` param.
-- `email-label` — applies Gmail labels to a thread via `UpdateMessageRequest`. Supports `account` param.
-
-**New skills / modifications (Phase 3, not shipped now):**
-
-- `email-send` gains an `account` parameter. When `account: "joseph"`, routes through a new `email-ceo` OutboundGateway path that enforces `autonomyPhase ≥ 3`. Elevated sensitivity.
-- `email-reply` gains an `account` parameter with the same gating.
+- `email-archive` (`autonomy_floor: "spot-check"`) — removes a message from `INBOX` via `UpdateMessageRequest`. Supports `account` param. Nathan should proceed independently at `spot-check`+; at lower bands he surfaces the action and waits for explicit approval.
+- `email-label` (`autonomy_floor: "spot-check"`) — applies Gmail labels to a thread via `UpdateMessageRequest`. Supports `account` param. Same band guidance as `email-archive`.
+- `email-send` / `email-reply` gain an `account` parameter when the autonomous reply capability ships:
+  - `account: "nathan"` → `autonomy_floor: "spot-check"` — Nathan replying as himself is standard outbound
+  - `account: "joseph"` → `autonomy_floor: "approval-required"` — sending on the CEO's behalf requires higher trust; below this band the OutboundGateway hard-blocks the send and the coordinator saves a draft instead
 
 ### Outbound Gateway
 
-All writes to Joseph's account (draft saves, eventual sends) route through `OutboundGateway`. Phase 1 only writes drafts — no sends. The gateway's blocked-contact and content-filter checks still apply to drafts to prevent Nathan from drafting problematic content.
+All writes to Joseph's account (draft saves, eventual sends) route through `OutboundGateway`. Currently only draft saves are implemented — no sends. The gateway's blocked-contact and content-filter checks apply to drafts to prevent Nathan from drafting problematic content.
 
-A new autonomy gate is added to OutboundGateway for Phase 3: if `autonomyPhase < 3`, attempts by `email-send` with `account: "joseph"` are blocked and the coordinator is told to save a draft instead.
+**Future autonomy gate (when `email-send(account: "joseph")` ships):** OutboundGateway will check the current autonomy score against the skill's `autonomy_floor: "approval-required"` (score ≥ 70). Below that threshold, `email-send` with `account: "joseph"` is blocked at the gateway level and the coordinator is instructed to save a draft instead. This is a hard gate — it holds even if the LLM's injected autonomy guidance would otherwise permit the action.
 
 ### Contact System
 
@@ -152,7 +163,8 @@ channels:
   email-ceo:
     enabled: true
     pollingIntervalMs: 30000
-    autonomyPhase: 1       # 1 = monitor+draft, 2 = +archive, 3 = +send
+    # No autonomy_phase field — autonomy is governed globally by the autonomy engine (spec 12).
+    # Autonomy score is set via the set-autonomy skill and persisted in Postgres.
 ```
 
 ### Files to Create/Modify
@@ -164,10 +176,9 @@ channels:
 | Create | `skills/email-list/skill.json` + `handler.ts` + `handler.test.ts` |
 | Create | `skills/email-get/skill.json` + `handler.ts` + `handler.test.ts` |
 | Create | `skills/email-draft-save/skill.json` + `handler.ts` + `handler.test.ts` |
-| Modify | `config/default.yaml` — add `email-ceo` channel config and scheduler job |
+| Modify | `config/default.yaml` — add `email-ceo` channel config |
 | Modify | `agents/coordinator.yaml` — pin new skills, add persona guidance |
 | Modify | `src/index.ts` (or channel bootstrap) — register `email-ceo-adapter` |
-| Modify | `src/skills/outbound-gateway.ts` — autonomy phase gate (Phase 3 prep) |
 
 ---
 
@@ -203,6 +214,7 @@ Nathan decides which to use based on the task. The skill exposes both via an inp
   "name": "web-search",
   "description": "Search the web using Tavily. Returns structured results with title, URL, snippet, and (for advanced depth) extracted page content. Call multiple times with refined queries for complex research tasks.",
   "sensitivity": "normal",
+  "autonomy_floor": "full",
   "inputs": {
     "query": "string",
     "maxResults": "number? (default 5, max 20)",

--- a/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
@@ -34,7 +34,7 @@ separate `autonomy_phase` config field.
 | Capability | autonomy_floor | Ships when |
 |---|---|---|
 | Read inbox, read messages, list drafts | `full` | Now — reads are always safe |
-| Draft replies, save to Joseph's Drafts folder | `spot-check` | Now — skill ships regardless of band; at lower bands Nathan confirms intent before saving |
+| Draft replies, save to Joseph's Drafts folder | `full` | Now — no outbound effect; nothing leaves until Joseph manually sends from Gmail |
 | Daily draft digest (scheduler job) | `full` | Now — read + notify, no external write |
 | Archive threads, apply Gmail labels | `spot-check` | When skills are built — Nathan proceeds at `spot-check`+, asks at lower bands |
 | Reply as Nathan (from nathancuria1@gmail.com) | `spot-check` | When `email-send` account param ships |
@@ -103,7 +103,7 @@ Skills are **account-aware** rather than account-specific — an optional `accou
   "name": "email-draft-save",
   "sensitivity": "elevated",
   "infrastructure": true,
-  "autonomy_floor": "spot-check",
+  "autonomy_floor": "full",
   "inputs": {
     "account": "string (nathan | joseph)",
     "to": "string",
@@ -118,9 +118,8 @@ Skills are **account-aware** rather than account-specific — an optional `accou
 ```
 
 Elevated sensitivity ensures a human-approval gate the first time the coordinator uses this
-skill. `autonomy_floor: "spot-check"` documents that saving a draft on someone's behalf is
-an outbound-effect action; at lower bands Nathan should surface the draft for review rather
-than saving it silently.
+skill. `autonomy_floor: "full"` reflects that saving a draft has no outbound effect — nothing
+leaves until Joseph manually reviews and sends it from Gmail.
 
 **Scheduler job (Phase 1):**
 


### PR DESCRIPTION
## **User description**
## Summary

- Replaces the per-channel `autonomy_phase` config field with the global autonomy score system from spec 12
- Adds `autonomy_floor` to all new skill manifests (email-list, email-get, email-draft-save, web-search)
- Updates the "Autonomy Phases" table to an "Autonomy Band Mapping" table that references score bands instead of numbered phases
- Removes `autonomyPhase: 1` from the `email-ceo` config block
- Updates OutboundGateway future gating description to reference `autonomy_floor: "approval-required"` threshold
- Removes Phase 1/2/3 language from plan comments and coordinator prompt guidance; references the injected autonomy block instead

## autonomy_floor assignments

| Skill | Floor | Rationale |
|---|---|---|
| `email-list` | `full` | Read-only; no external effect |
| `email-get` | `full` | Read-only; no external effect |
| `email-draft-save` | `spot-check` | Outbound effect (writes to external account's Drafts) |
| `web-search` | `full` | Read-only; no external effect |
| `email-archive` (future) | `spot-check` | Modifies external account state |
| `email-label` (future) | `spot-check` | Modifies external account state |
| `email-send(account:joseph)` (future) | `approval-required` | Sends on CEO's behalf — higher trust required |

## Test plan

- [ ] Review that no `autonomy_phase` references remain in the spec or plans
- [ ] Confirm `autonomy_floor` values follow the spec 12 guidelines table


___

## **CodeAnt-AI Description**
**Align CEO inbox and web search plans with score-based autonomy**

### What Changed
- Replaces phase-based autonomy wording with the global autonomy score model across the CEO inbox and web search plans
- Marks read-only skills and draft saving as available now, while keeping CEO sending blocked until the higher-trust path exists
- Updates the CEO inbox guidance to say replies should be saved as drafts, not sent, and removes Phase 1/2/3 references

### Impact
`✅ Clearer draft-only CEO replies`
`✅ Fewer outdated autonomy rules in plans`
`✅ Safer guidance for future CEO sending`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
