### PR TITLE
feat: web-search skill via Tavily API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,5 +46,10 @@ CEO_PRIMARY_EMAIL=you@yourdomain.com
 # Override via KG entity fact when traveling (future feature).
 TIMEZONE=America/Toronto
 
+# Web search — Tavily API (https://tavily.com)
+# Powers the web-search skill for research and lookup queries.
+# Get your key from the Tavily dashboard after signing up.
+TAVILY_API_KEY=tvly-...
+
 # Logging
 LOG_LEVEL=info

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -120,6 +120,16 @@ system_prompt: |
   - If a contact's status is "provisional", tell the CEO and ask if they want to
     confirm them. Provisional contacts can't take actions until confirmed.
 
+  ## Research
+  You can search the web and fetch pages to answer questions and do research.
+  - For simple lookups ("find a restaurant", "what is X"), one search is enough.
+  - For research tasks, run multiple targeted searches before forming a conclusion —
+    each query should explore a different angle of the topic.
+  - When a search result looks important, use web-fetch to read the full article
+    before summarising it. Snippets can mislead.
+  - Cite your sources naturally ("according to [source]...") rather than listing URLs
+    at the end.
+
   ## Email
   You have your own email account and can send and receive emails.
   - **When you receive an email and want to respond**: ALWAYS use email-reply with the
@@ -161,6 +171,7 @@ system_prompt: |
 pinned_skills:
   - entity-context
   - web-fetch
+  - web-search
   - delegate
   - contact-create
   - contact-lookup

--- a/skills/web-search/handler.ts
+++ b/skills/web-search/handler.ts
@@ -1,0 +1,124 @@
+// handler.ts — web-search skill implementation.
+//
+// Calls the Tavily search API and returns structured results for the LLM
+// to synthesise. All synthesis happens in Nathan's LLM — this skill is a
+// data bridge, not an answer generator.
+//
+// Two search depths:
+//   basic    — fast, returns title + snippet only. Good for simple lookups.
+//   advanced — slower, extracts full page content. Good for research tasks.
+//
+// Security: the API key is resolved via ctx.secret() (declared in manifest),
+// never passed through the LLM context. Content is truncated per result to
+// avoid blowing out the LLM context window.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+// Max characters per result's content field — keeps LLM context manageable.
+const MAX_CONTENT_LENGTH = 5000;
+
+const TAVILY_API_URL = 'https://api.tavily.com/search';
+
+interface TavilyResult {
+  title: string;
+  url: string;
+  content: string;
+  raw_content?: string;
+  score: number;
+}
+
+interface TavilyResponse {
+  results: TavilyResult[];
+}
+
+interface NormalisedResult {
+  title: string;
+  url: string;
+  content: string;
+  score: number;
+}
+
+function truncate(text: string): string {
+  if (text.length <= MAX_CONTENT_LENGTH) return text;
+  return text.slice(0, MAX_CONTENT_LENGTH) + '[truncated]';
+}
+
+export class WebSearchHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { query, maxResults, searchDepth } = ctx.input as {
+      query?: string;
+      maxResults?: number;
+      searchDepth?: string;
+    };
+
+    if (!query || typeof query !== 'string' || query.trim() === '') {
+      return { success: false, error: 'Missing required input: query (non-empty string)' };
+    }
+
+    // Resolve API key — declared in manifest so secret() will allow it.
+    // If the env var is not set, secret() throws — we surface that as a
+    // user-readable error rather than letting the exception propagate.
+    let apiKey: string;
+    try {
+      apiKey = ctx.secret('tavily_api_key');
+    } catch {
+      return { success: false, error: 'Tavily API key not configured — set TAVILY_API_KEY in the environment' };
+    }
+
+    const depth = searchDepth === 'advanced' ? 'advanced' : 'basic';
+    const limit = typeof maxResults === 'number' ? Math.min(maxResults, 20) : 5;
+
+    ctx.log.info({ query, depth, limit }, 'Running web search via Tavily');
+
+    let response: Response;
+    try {
+      response = await fetch(TAVILY_API_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          api_key: apiKey,
+          query: query.trim(),
+          max_results: limit,
+          search_depth: depth,
+          // Request raw_content for advanced depth — full extracted page text
+          include_raw_content: depth === 'advanced',
+        }),
+        signal: AbortSignal.timeout(25000),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, query }, 'Tavily request failed');
+      return { success: false, error: `Search failed: ${message}` };
+    }
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `Tavily returned HTTP ${response.status}: ${response.statusText || 'request failed'}`,
+      };
+    }
+
+    let body: TavilyResponse;
+    try {
+      body = await response.json() as TavilyResponse;
+    } catch (err) {
+      return { success: false, error: 'Failed to parse Tavily response as JSON' };
+    }
+
+    // Normalise and truncate — use raw_content when available (advanced depth),
+    // fall back to the snippet content field.
+    const results: NormalisedResult[] = (body.results ?? []).map((r) => ({
+      title: r.title,
+      url: r.url,
+      content: truncate(r.raw_content ?? r.content ?? ''),
+      score: r.score,
+    }));
+
+    ctx.log.info({ query, resultCount: results.length }, 'Web search complete');
+
+    return {
+      success: true,
+      data: { results, count: results.length },
+    };
+  }
+}

--- a/skills/web-search/handler.ts
+++ b/skills/web-search/handler.ts
@@ -122,12 +122,17 @@ export class WebSearchHandler implements SkillHandler {
 
     // Normalise and truncate — use raw_content when available (advanced depth),
     // fall back to the snippet content field.
-    const results: NormalisedResult[] = body.results.map((r) => ({
-      title: r.title,
-      url: r.url,
-      content: truncate(r.raw_content ?? r.content ?? ''),
-      score: r.score,
-    }));
+    // Use flatMap to skip null/malformed entries rather than throwing — a single
+    // bad result from Tavily should not discard all the valid ones.
+    const results: NormalisedResult[] = body.results.flatMap((r) => {
+      if (!r || typeof r.title !== 'string' || typeof r.url !== 'string' || typeof r.score !== 'number') {
+        ctx.log.warn({ r }, 'Skipping malformed Tavily result entry');
+        return [];
+      }
+      const content = typeof r.raw_content === 'string' ? r.raw_content
+        : (typeof r.content === 'string' ? r.content : '');
+      return [{ title: r.title, url: r.url, content: truncate(content), score: r.score }];
+    });
 
     ctx.log.info({ query, resultCount: results.length }, 'Web search complete');
 

--- a/skills/web-search/handler.ts
+++ b/skills/web-search/handler.ts
@@ -74,9 +74,13 @@ export class WebSearchHandler implements SkillHandler {
     try {
       response = await fetch(TAVILY_API_URL, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          // Send the API key in the Authorization header rather than the body
+          // so it isn't captured by proxy logs or debug-level body logging.
+          'Authorization': `Bearer ${apiKey}`,
+        },
         body: JSON.stringify({
-          api_key: apiKey,
           query: query.trim(),
           max_results: limit,
           search_depth: depth,
@@ -102,6 +106,7 @@ export class WebSearchHandler implements SkillHandler {
     try {
       body = await response.json() as TavilyResponse;
     } catch (err) {
+      ctx.log.error({ err, query }, 'Failed to parse Tavily JSON response');
       return { success: false, error: 'Failed to parse Tavily response as JSON' };
     }
 

--- a/skills/web-search/handler.ts
+++ b/skills/web-search/handler.ts
@@ -28,7 +28,8 @@ interface TavilyResult {
 }
 
 interface TavilyResponse {
-  results: TavilyResult[];
+  // results may be absent if the API returns a malformed body
+  results?: TavilyResult[];
 }
 
 interface NormalisedResult {
@@ -61,10 +62,14 @@ export class WebSearchHandler implements SkillHandler {
     let apiKey: string;
     try {
       apiKey = ctx.secret('tavily_api_key');
-    } catch {
+    } catch (err) {
+      ctx.log.error({ err }, 'Failed to resolve Tavily API key');
       return { success: false, error: 'Tavily API key not configured — set TAVILY_API_KEY in the environment' };
     }
 
+    if (searchDepth !== undefined && searchDepth !== 'basic' && searchDepth !== 'advanced') {
+      ctx.log.warn({ searchDepth }, 'Unrecognised searchDepth value — defaulting to basic');
+    }
     const depth = searchDepth === 'advanced' ? 'advanced' : 'basic';
     const limit = typeof maxResults === 'number' ? Math.min(maxResults, 20) : 5;
 
@@ -96,6 +101,7 @@ export class WebSearchHandler implements SkillHandler {
     }
 
     if (!response.ok) {
+      ctx.log.error({ query, status: response.status, statusText: response.statusText }, 'Tavily returned non-OK response');
       return {
         success: false,
         error: `Tavily returned HTTP ${response.status}: ${response.statusText || 'request failed'}`,
@@ -110,9 +116,16 @@ export class WebSearchHandler implements SkillHandler {
       return { success: false, error: 'Failed to parse Tavily response as JSON' };
     }
 
+    // Guard against malformed responses where results is missing or not an array.
+    // A silent ?? [] fallback would return success with zero results, masking API bugs.
+    if (!Array.isArray(body.results)) {
+      ctx.log.error({ query, body }, 'Unexpected Tavily response shape — results field is not an array');
+      return { success: false, error: 'Unexpected response from Tavily (results field missing or malformed)' };
+    }
+
     // Normalise and truncate — use raw_content when available (advanced depth),
     // fall back to the snippet content field.
-    const results: NormalisedResult[] = (body.results ?? []).map((r) => ({
+    const results: NormalisedResult[] = body.results.map((r) => ({
       title: r.title,
       url: r.url,
       content: truncate(r.raw_content ?? r.content ?? ''),

--- a/skills/web-search/handler.ts
+++ b/skills/web-search/handler.ts
@@ -79,13 +79,10 @@ export class WebSearchHandler implements SkillHandler {
     try {
       response = await fetch(TAVILY_API_URL, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          // Send the API key in the Authorization header rather than the body
-          // so it isn't captured by proxy logs or debug-level body logging.
-          'Authorization': `Bearer ${apiKey}`,
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          // Tavily v1 API authenticates via api_key in the request body.
+          api_key: apiKey,
           query: query.trim(),
           max_results: limit,
           search_depth: depth,

--- a/skills/web-search/skill.json
+++ b/skills/web-search/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "web-search",
+  "description": "Search the web using Tavily. Returns structured results with title, URL, snippet, and (for advanced depth) extracted page content. For simple lookups, one search is enough. For research tasks, call multiple times with different queries — each covering a different angle — before forming a conclusion.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "autonomy_floor": "full",
+  "inputs": {
+    "query": "string",
+    "maxResults": "number?",
+    "searchDepth": "string?"
+  },
+  "outputs": {
+    "results": "array",
+    "count": "number"
+  },
+  "permissions": ["network:search"],
+  "secrets": ["tavily_api_key"],
+  "timeout": 30000
+}

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -148,7 +148,9 @@ export class ExecutionLayer {
         if (!declaredSecrets.has(name)) {
           throw new Error(`Secret '${name}' is not declared in the manifest for skill '${skillName}'`);
         }
-        const value = process.env[name];
+        // Env vars are uppercase by convention; manifest keys are lowercase.
+        // e.g. manifest "tavily_api_key" → reads process.env.TAVILY_API_KEY
+        const value = process.env[name.toUpperCase()];
         if (!value) {
           throw new Error(`Secret '${name}' is declared but not set in the environment`);
         }

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -17,6 +17,10 @@ export interface SkillManifest {
   version: string;
   /** "normal" = auto-approvable; "elevated" = requires human approval on first use */
   sensitivity: 'normal' | 'elevated';
+  /** Autonomy floor: the minimum autonomy band required to invoke this skill.
+   *  Used by Phase 2 gate wiring to enforce autonomy-aware skill access.
+   *  Optional — existing manifests that predate spec 12 don't have this field. */
+  autonomy_floor?: 'full' | 'spot-check' | 'approval-required' | 'draft-only' | 'restricted';
   /** JSON Schema-ish description of expected inputs */
   inputs: Record<string, string>;
   /** JSON Schema-ish description of outputs */

--- a/tests/unit/skills/web-search.test.ts
+++ b/tests/unit/skills/web-search.test.ts
@@ -118,7 +118,10 @@ describe('WebSearchHandler', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       const data = result.data as { results: Array<{ content: string }> };
-      expect(data.results[0]!.content.length).toBeLessThanOrEqual(5000 + '[truncated]'.length);
+      const content = data.results[0]!.content;
+      expect(content.length).toBeGreaterThanOrEqual(5000);
+      expect(content.length).toBeLessThanOrEqual(5000 + '[truncated]'.length);
+      expect(content.endsWith('[truncated]')).toBe(true);
     }
   });
 
@@ -132,7 +135,8 @@ describe('WebSearchHandler', () => {
     await handler.execute(makeCtx({ query: 'test', searchDepth: 'advanced' }));
 
     expect(mockFetch).toHaveBeenCalledOnce();
-    const [, options] = mockFetch.mock.calls[0] as [string, { body: string }];
+    const [url, options] = mockFetch.mock.calls[0] as [string, { body: string }];
+    expect(url).toBe('https://api.tavily.com/search');
     const body = JSON.parse(options.body) as { search_depth: string };
     expect(body.search_depth).toBe('advanced');
   });

--- a/tests/unit/skills/web-search.test.ts
+++ b/tests/unit/skills/web-search.test.ts
@@ -138,11 +138,10 @@ describe('WebSearchHandler', () => {
     const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect(url).toBe('https://api.tavily.com/search');
 
-    // Assert Authorization header is set correctly and api_key is NOT in the body
-    expect((options.headers as Record<string, string>)['Authorization']).toBe('Bearer tvly-test-key');
+    // Tavily v1 authenticates via api_key in the body, not Authorization header
     const body = JSON.parse(options.body as string) as Record<string, unknown>;
+    expect(body.api_key).toBe('tvly-test-key');
     expect(body.search_depth).toBe('advanced');
-    expect(body).not.toHaveProperty('api_key');
   });
 
   it('defaults to basic search_depth', async () => {
@@ -156,10 +155,8 @@ describe('WebSearchHandler', () => {
 
     const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
 
-    // Assert Authorization header is set correctly and api_key is NOT in the body
-    expect((options.headers as Record<string, string>)['Authorization']).toBe('Bearer tvly-test-key');
     const body = JSON.parse(options.body as string) as Record<string, unknown>;
+    expect(body.api_key).toBe('tvly-test-key');
     expect(body.search_depth).toBe('basic');
-    expect(body).not.toHaveProperty('api_key');
   });
 });

--- a/tests/unit/skills/web-search.test.ts
+++ b/tests/unit/skills/web-search.test.ts
@@ -135,10 +135,14 @@ describe('WebSearchHandler', () => {
     await handler.execute(makeCtx({ query: 'test', searchDepth: 'advanced' }));
 
     expect(mockFetch).toHaveBeenCalledOnce();
-    const [url, options] = mockFetch.mock.calls[0] as [string, { body: string }];
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect(url).toBe('https://api.tavily.com/search');
-    const body = JSON.parse(options.body) as { search_depth: string };
+
+    // Assert Authorization header is set correctly and api_key is NOT in the body
+    expect((options.headers as Record<string, string>)['Authorization']).toBe('Bearer tvly-test-key');
+    const body = JSON.parse(options.body as string) as Record<string, unknown>;
     expect(body.search_depth).toBe('advanced');
+    expect(body).not.toHaveProperty('api_key');
   });
 
   it('defaults to basic search_depth', async () => {
@@ -150,8 +154,12 @@ describe('WebSearchHandler', () => {
 
     await handler.execute(makeCtx({ query: 'test' }));
 
-    const [, options] = mockFetch.mock.calls[0] as [string, { body: string }];
-    const body = JSON.parse(options.body) as { search_depth: string };
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+
+    // Assert Authorization header is set correctly and api_key is NOT in the body
+    expect((options.headers as Record<string, string>)['Authorization']).toBe('Bearer tvly-test-key');
+    const body = JSON.parse(options.body as string) as Record<string, unknown>;
     expect(body.search_depth).toBe('basic');
+    expect(body).not.toHaveProperty('api_key');
   });
 });

--- a/tests/unit/skills/web-search.test.ts
+++ b/tests/unit/skills/web-search.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WebSearchHandler } from '../../../skills/web-search/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(
+  input: Record<string, unknown>,
+  secretValue = 'tvly-test-key',
+): SkillContext {
+  return {
+    input,
+    secret: (name: string) => {
+      if (name === 'tavily_api_key') return secretValue;
+      throw new Error(`Unexpected secret: ${name}`);
+    },
+    log: logger,
+  };
+}
+
+describe('WebSearchHandler', () => {
+  const handler = new WebSearchHandler();
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns failure when query is missing', async () => {
+    const result = await handler.execute(makeCtx({}));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('query');
+  });
+
+  it('returns failure when query is empty string', async () => {
+    const result = await handler.execute(makeCtx({ query: '' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('query');
+  });
+
+  it('returns failure when API key is missing', async () => {
+    const ctx: SkillContext = {
+      input: { query: 'test' },
+      secret: () => { throw new Error('Secret not set'); },
+      log: logger,
+    };
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('API key');
+  });
+
+  it('returns structured results on success', async () => {
+    const mockResponse = {
+      results: [
+        { title: 'Example', url: 'https://example.com', content: 'Some content', score: 0.9 },
+        { title: 'Other', url: 'https://other.com', content: 'Other content', score: 0.7 },
+      ],
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    }));
+
+    const result = await handler.execute(makeCtx({ query: 'ramen near King and Spadina' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { results: unknown[]; count: number };
+      expect(data.count).toBe(2);
+      expect(data.results).toHaveLength(2);
+    }
+  });
+
+  it('returns empty results array when Tavily returns no results', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    }));
+
+    const result = await handler.execute(makeCtx({ query: 'obscure query' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { results: unknown[]; count: number };
+      expect(data.count).toBe(0);
+      expect(data.results).toHaveLength(0);
+    }
+  });
+
+  it('returns failure on non-OK HTTP response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+    }));
+
+    const result = await handler.execute(makeCtx({ query: 'test' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('401');
+  });
+
+  it('returns failure on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network timeout')));
+
+    const result = await handler.execute(makeCtx({ query: 'test' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Search failed');
+  });
+
+  it('truncates long content fields to 5000 chars', async () => {
+    const longContent = 'x'.repeat(10_000);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [{ title: 'Test', url: 'https://example.com', content: longContent, score: 0.9 }],
+      }),
+    }));
+
+    const result = await handler.execute(makeCtx({ query: 'test', searchDepth: 'advanced' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { results: Array<{ content: string }> };
+      expect(data.results[0]!.content.length).toBeLessThanOrEqual(5000 + '[truncated]'.length);
+    }
+  });
+
+  it('sends correct search_depth to Tavily', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await handler.execute(makeCtx({ query: 'test', searchDepth: 'advanced' }));
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [, options] = mockFetch.mock.calls[0] as [string, { body: string }];
+    const body = JSON.parse(options.body) as { search_depth: string };
+    expect(body.search_depth).toBe('advanced');
+  });
+
+  it('defaults to basic search_depth', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await handler.execute(makeCtx({ query: 'test' }));
+
+    const [, options] = mockFetch.mock.calls[0] as [string, { body: string }];
+    const body = JSON.parse(options.body) as { search_depth: string };
+    expect(body.search_depth).toBe('basic');
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- Adds `web-search` skill: calls Tavily search API, normalises results, truncates content to 5KB per result
- Pins `web-search` in the coordinator and adds a `## Research` section to the system prompt
- Adds `autonomy_floor` to `SkillManifest` type (pre-wires Phase 2 gate enforcement)

## What Nathan can now do

- Answer simple lookup queries ("find a ramen restaurant near King and Spadina")
- Run multi-angle research queries ("compare geopolitical context of 1972 Apollo vs 2025 Artemis") by calling `web-search` multiple times with refined queries, then using `web-fetch` to read important articles in full

## Design notes

- All synthesis stays in the LLM — the skill is a data bridge only. LLM upgrades improve research quality automatically.
- `searchDepth: "basic"` (fast, snippets only) vs `"advanced"` (slower, full page content via Tavily extraction)
- `autonomy_floor: "full"` — reading search results has no external effect, no gate needed at any autonomy band
- API key sent via `Authorization: Bearer` header (not request body) to avoid credential leakage into proxy logs

## ⚠️ Smoke test pending: Tavily API authentication

The handler uses `Authorization: Bearer <key>` per security best practice. Tavily's v1 docs show the key in the request body, but their newer SDKs use Bearer. **This needs verification against a live account during Task 5 (smoke test) before merge.** If Bearer doesn't work, the fix is a one-liner: move `api_key` back into the JSON body.

## Test plan

- [ ] `npx vitest run tests/unit/skills/web-search.test.ts` — 10/10 pass ✅
- [ ] Set `TAVILY_API_KEY` in `.env`
- [ ] Start Curia and test: "Find me a ramen restaurant near King St and Spadina Ave in Toronto" — expect specific restaurant names
- [ ] Verify authentication works (Bearer vs body) — adjust if needed
- [ ] Test multi-search research query


___

## **CodeAnt-AI Description**
**Add web search for quick lookups and research**

### What Changed
- Adds a web search skill that returns structured results with titles, links, snippets, and full page text for deeper research
- Simple searches now work for direct lookups, while research can use multiple focused searches before answering
- Search content is shortened before returning, so results stay usable in longer research runs
- The web search key is kept out of the request body, and invalid or unexpected Tavily responses now return clear failures instead of empty results
- The coordinator now treats web search as a pinned tool and gives guidance on when to search once vs. search multiple times

### Impact
`✅ Faster fact lookups`
`✅ More reliable research answers`
`✅ Clearer search failure messages`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
