### PR TITLE
Add secure Postgres-backed Knowledge Graph web explorer (Cytoscape.js)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ OPENAI_API_KEY=sk-...
 HTTP_PORT=3000
 API_TOKEN=your-secret-token-here
 
+# Knowledge Graph web explorer
+# Secret required by /api/kg/* endpoints (sent as x-kg-secret from the /kg UI).
+# If unset, the knowledge graph explorer API is disabled.
+KG_UI_SECRET=replace-with-a-long-random-secret
+
 # Nylas — unified email, calendar, and contacts API (https://nylas.com).
 # Powers the email channel adapter. Optional: system works without it
 # but email send/receive will be unavailable.

--- a/.env.example
+++ b/.env.example
@@ -24,9 +24,9 @@ HTTP_PORT=3000
 API_TOKEN=your-secret-token-here
 
 # Knowledge Graph web explorer
-# Secret required by /api/kg/* endpoints (sent as x-kg-secret from the /kg UI).
+# Secret required by /api/kg/* endpoints (sent as x-web-bootstrap-secret from the /kg UI).
 # If unset, the knowledge graph explorer API is disabled.
-KG_UI_SECRET=replace-with-a-long-random-secret
+WEB_APP_BOOTSTRAP_SECRET=replace-with-a-long-random-secret
 
 # Nylas — unified email, calendar, and contacts API (https://nylas.com).
 # Powers the email channel adapter. Optional: system works without it

--- a/README.md
+++ b/README.md
@@ -301,12 +301,12 @@ Curia now includes a built-in graph browser at `GET /kg` backed by Postgres `kg_
 
 1. Set `KG_UI_SECRET` in `.env`
 2. Start Curia (`pnpm local`)
-3. Open `http://localhost:3000/kg?secret=YOUR_SECRET`
+3. Open `http://localhost:3000/kg`, enter `KG_UI_SECRET` in the UI, then search/browse.
 
 The explorer supports:
 - node search (`/api/kg/nodes`)
 - neighborhood traversal (`/api/kg/graph`)
-- interactive rendering via Cytoscape.js (open source, MIT)
+- interactive rendering via Cytoscape.js (open source, MIT), served locally by Curia
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -299,9 +299,9 @@ This starts Postgres via Docker, applies any pending migrations, then launches t
 
 Curia now includes a built-in graph browser at `GET /kg` backed by Postgres `kg_nodes` + `kg_edges`.
 
-1. Set `KG_UI_SECRET` in `.env`
+1. Set `WEB_APP_BOOTSTRAP_SECRET` in `.env`
 2. Start Curia (`pnpm local`)
-3. Open `http://localhost:3000/kg`, enter `KG_UI_SECRET` in the UI, then search/browse.
+3. Open `http://localhost:3000/kg`, enter `WEB_APP_BOOTSTRAP_SECRET` in the UI, then search/browse.
 
 The explorer supports:
 - node search (`/api/kg/nodes`)

--- a/README.md
+++ b/README.md
@@ -294,6 +294,20 @@ pnpm local
 
 This starts Postgres via Docker, applies any pending migrations, then launches the Curia stack. Talk to it via CLI immediately; email and HTTP channels activate as configured in `.env`.
 
+
+### Knowledge Graph Web Explorer
+
+Curia now includes a built-in graph browser at `GET /kg` backed by Postgres `kg_nodes` + `kg_edges`.
+
+1. Set `KG_UI_SECRET` in `.env`
+2. Start Curia (`pnpm local`)
+3. Open `http://localhost:3000/kg?secret=YOUR_SECRET`
+
+The explorer supports:
+- node search (`/api/kg/nodes`)
+- neighborhood traversal (`/api/kg/graph`)
+- interactive rendering via Cytoscape.js (open source, MIT)
+
 ---
 
 ## Project Status

--- a/docs/specs/12-knowledge-graph-web-explorer.md
+++ b/docs/specs/12-knowledge-graph-web-explorer.md
@@ -16,12 +16,12 @@ Why Cytoscape.js:
 
 ## Security model
 
-The web explorer is gated by `KG_UI_SECRET` from `.env`:
+The web explorer is gated by `WEB_APP_BOOTSTRAP_SECRET` from `.env`:
 - `GET /kg` serves the UI shell (no graph data).
-- `GET /api/kg/nodes` requires `x-kg-secret`.
-- `GET /api/kg/graph` requires `x-kg-secret`.
+- `GET /api/kg/nodes` requires `x-web-bootstrap-secret`.
+- `GET /api/kg/graph` requires `x-web-bootstrap-secret`.
 
-If `KG_UI_SECRET` is missing, the feature is intentionally disabled.
+If `WEB_APP_BOOTSTRAP_SECRET` is missing, the feature is intentionally disabled.
 
 ## API surface
 

--- a/docs/specs/12-knowledge-graph-web-explorer.md
+++ b/docs/specs/12-knowledge-graph-web-explorer.md
@@ -1,0 +1,38 @@
+# Knowledge Graph Web Explorer
+
+## Goal
+
+Provide a secure browser-based UI for inspecting Curia's knowledge graph directly from the existing Postgres schema (`kg_nodes`, `kg_edges`) without changing storage architecture.
+
+## Visualization layer choice
+
+We selected **Cytoscape.js** as the visualization layer and wrapped it in Curia's Node/Fastify HTTP channel.
+
+Why Cytoscape.js:
+- Mature open-source project (MIT licensed, long maintenance history).
+- Designed for interactive graph analysis (layout, styling, neighborhood-focused exploration).
+- Lightweight to embed in a single-page internal tool.
+- Works with plain JSON node/edge payloads, mapping directly to the Postgres-backed model Curia already has.
+
+## Security model
+
+The web explorer is gated by `KG_UI_SECRET` from `.env`:
+- `GET /kg` requires `?secret=` or `x-kg-secret`.
+- `GET /api/kg/nodes` requires the same secret.
+- `GET /api/kg/graph` requires the same secret.
+
+If `KG_UI_SECRET` is missing, the feature is intentionally disabled.
+
+## API surface
+
+- `GET /api/kg/nodes`
+  - Query params: `query`, `type`, `limit`
+  - Purpose: label/property text search and browsing.
+
+- `GET /api/kg/graph`
+  - Query params: `node_id`, `depth`, `limit`
+  - Purpose: neighborhood traversal for a selected node; falls back to recent nodes when no `node_id` is provided.
+
+## Notes
+
+This design intentionally keeps dependencies minimal and uses the existing Node.js runtime so operational dependencies stay aligned with Curia's current deployment profile.

--- a/docs/specs/12-knowledge-graph-web-explorer.md
+++ b/docs/specs/12-knowledge-graph-web-explorer.md
@@ -6,7 +6,7 @@ Provide a secure browser-based UI for inspecting Curia's knowledge graph directl
 
 ## Visualization layer choice
 
-We selected **Cytoscape.js** as the visualization layer and wrapped it in Curia's Node/Fastify HTTP channel.
+We selected **Cytoscape.js** as the visualization layer and wrapped it in Curia's Node/Fastify HTTP channel, serving the asset locally from `node_modules`.
 
 Why Cytoscape.js:
 - Mature open-source project (MIT licensed, long maintenance history).
@@ -17,9 +17,9 @@ Why Cytoscape.js:
 ## Security model
 
 The web explorer is gated by `KG_UI_SECRET` from `.env`:
-- `GET /kg` requires `?secret=` or `x-kg-secret`.
-- `GET /api/kg/nodes` requires the same secret.
-- `GET /api/kg/graph` requires the same secret.
+- `GET /kg` serves the UI shell (no graph data).
+- `GET /api/kg/nodes` requires `x-kg-secret`.
+- `GET /api/kg/graph` requires `x-kg-secret`.
 
 If `KG_UI_SECRET` is missing, the feature is intentionally disabled.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@anthropic-ai/sdk": "^0.81.0",
         "@fastify/cors": "^11.2.0",
         "cron-parser": "^5.5.0",
+        "cytoscape": "^3.33.1",
         "fastify": "^5.8.4",
         "js-yaml": "^4.1.1",
         "node-pg-migrate": "^8.0.4",
@@ -65,43 +66,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1629,7 +1593,7 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -1639,7 +1603,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -2389,6 +2353,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/dateformat": {
@@ -5042,7 +5015,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/upper-case": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.81.0",
+    "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.2.0",
+    "@fastify/rate-limit": "^10.3.0",
     "cron-parser": "^5.5.0",
     "cytoscape": "^3.33.1",
     "fastify": "^5.8.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@anthropic-ai/sdk": "^0.81.0",
     "@fastify/cors": "^11.2.0",
     "cron-parser": "^5.5.0",
+    "cytoscape": "^3.33.1",
     "fastify": "^5.8.4",
     "js-yaml": "^4.1.1",
     "node-pg-migrate": "^8.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,21 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.81.0
         version: 0.81.0
+      '@fastify/cookie':
+        specifier: ^11.0.2
+        version: 11.0.2
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
+      '@fastify/rate-limit':
+        specifier: ^10.3.0
+        version: 10.3.0
       cron-parser:
         specifier: ^5.5.0
         version: 5.5.0
+      cytoscape:
+        specifier: ^3.33.1
+        version: 3.33.1
       fastify:
         specifier: ^5.8.4
         version: 5.8.4
@@ -298,6 +307,9 @@ packages:
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
+  '@fastify/cookie@11.0.2':
+    resolution: {integrity: sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==}
+
   '@fastify/cors@11.2.0':
     resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
 
@@ -315,6 +327,9 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/rate-limit@10.3.0':
+    resolution: {integrity: sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -348,6 +363,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
 
   '@napi-rs/wasm-runtime@1.1.2':
     resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
@@ -396,36 +415,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
     resolution: {integrity: sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==}
@@ -487,66 +512,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -825,6 +863,10 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  cytoscape@3.33.1:
+    resolution: {integrity: sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==}
+    engines: {node: '>=0.10'}
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
@@ -1137,24 +1179,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1919,6 +1965,11 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-uri: 3.1.0
 
+  '@fastify/cookie@11.0.2':
+    dependencies:
+      cookie: 1.1.1
+      fastify-plugin: 5.1.0
+
   '@fastify/cors@11.2.0':
     dependencies:
       fastify-plugin: 5.1.0
@@ -1940,6 +1991,12 @@ snapshots:
     dependencies:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
+
+  '@fastify/rate-limit@10.3.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      fastify-plugin: 5.1.0
+      toad-cache: 3.7.0
 
   '@humanfs/core@0.19.1': {}
 
@@ -1967,6 +2024,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lukeed/ms@2.0.2': {}
 
   '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
     dependencies:
@@ -2399,6 +2458,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  cytoscape@3.33.1: {}
 
   dateformat@4.6.3: {}
 

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -28,6 +28,7 @@ import { healthRoutes } from './routes/health.js';
 import { agentRoutes } from './routes/agents.js';
 import { jobRoutes } from './routes/jobs.js';
 import { messageRoutes } from './routes/messages.js';
+import { knowledgeGraphRoutes } from './routes/kg.js';
 
 export interface HttpAdapterConfig {
   bus: EventBus;
@@ -36,6 +37,7 @@ export interface HttpAdapterConfig {
   agentRegistry: AgentRegistry;
   port: number;
   apiToken: string | undefined;
+  knowledgeGraphUiSecret: string | undefined;
   agentNames: string[];
   skillNames: string[];
   schedulerService?: SchedulerService;
@@ -56,7 +58,17 @@ export class HttpAdapter {
   }
 
   async start(): Promise<void> {
-    const { bus, logger, pool, agentRegistry, port, apiToken, agentNames, skillNames } = this.config;
+    const {
+      bus,
+      logger,
+      pool,
+      agentRegistry,
+      port,
+      apiToken,
+      agentNames,
+      skillNames,
+      knowledgeGraphUiSecret,
+    } = this.config;
 
     // Register shared bus subscriptions BEFORE starting the server.
     // One subscriber per event type, dispatches to HTTP clients via Maps/Sets.
@@ -69,7 +81,9 @@ export class HttpAdapter {
     this.app.addHook('onRequest', async (request, reply) => {
       // Skip auth for health endpoint — it's used by load balancers and monitors.
       // Use routeOptions.url (the registered pattern) so query strings don't break the match.
-      if (request.routeOptions.url === '/api/health') return;
+      const routeUrl = request.routeOptions.url ?? '';
+      if (routeUrl === '/api/health') return;
+      if (routeUrl.startsWith('/kg') || routeUrl.startsWith('/api/kg')) return;
 
       if (!validateBearerToken(request.headers.authorization, apiToken)) {
         return reply.status(401).send({ error: 'Unauthorized — provide a valid Bearer token' });
@@ -84,6 +98,12 @@ export class HttpAdapter {
     if (this.config.schedulerService) {
       await this.app.register(jobRoutes, { schedulerService: this.config.schedulerService });
     }
+
+    await this.app.register(knowledgeGraphRoutes, {
+      pool,
+      logger,
+      knowledgeGraphUiSecret,
+    });
 
     // Start listening
     await this.app.listen({ port, host: '0.0.0.0' });

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -83,7 +83,9 @@ export class HttpAdapter {
       // Use routeOptions.url (the registered pattern) so query strings don't break the match.
       const routeUrl = request.routeOptions.url ?? '';
       if (routeUrl === '/api/health') return;
-      if (routeUrl.startsWith('/kg') || routeUrl.startsWith('/api/kg')) return;
+      // KG web app and its API — the app shell and assets need no bearer token,
+      // and the /api/kg/* routes enforce their own secret via assertSecret().
+      if (routeUrl === '/' || routeUrl.startsWith('/assets') || routeUrl.startsWith('/api/kg')) return;
 
       if (!validateBearerToken(request.headers.authorization, apiToken)) {
         return reply.status(401).send({ error: 'Unauthorized — provide a valid Bearer token' });

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -99,11 +99,15 @@ export class HttpAdapter {
       await this.app.register(jobRoutes, { schedulerService: this.config.schedulerService });
     }
 
-    await this.app.register(knowledgeGraphRoutes, {
-      pool,
-      logger,
-      webAppBootstrapSecret,
-    });
+    // Only register KG routes when the secret is configured — if unset, the routes
+    // don't exist at all (404) rather than leaking a 503 that reveals the feature exists.
+    if (webAppBootstrapSecret) {
+      await this.app.register(knowledgeGraphRoutes, {
+        pool,
+        logger,
+        webAppBootstrapSecret,
+      });
+    }
 
     // Start listening
     await this.app.listen({ port, host: '0.0.0.0' });

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -17,6 +17,8 @@
 
 import Fastify, { type FastifyInstance } from 'fastify';
 import cors from '@fastify/cors';
+import cookie from '@fastify/cookie';
+import rateLimit from '@fastify/rate-limit';
 import type { EventBus } from '../../bus/bus.js';
 import type { Logger } from '../../logger.js';
 import type { Pool } from 'pg';
@@ -38,6 +40,7 @@ export interface HttpAdapterConfig {
   port: number;
   apiToken: string | undefined;
   webAppBootstrapSecret: string | undefined;
+  appOrigin: string | undefined;
   agentNames: string[];
   skillNames: string[];
   schedulerService?: SchedulerService;
@@ -68,14 +71,30 @@ export class HttpAdapter {
       agentNames,
       skillNames,
       webAppBootstrapSecret,
+      appOrigin,
     } = this.config;
 
     // Register shared bus subscriptions BEFORE starting the server.
     // One subscriber per event type, dispatches to HTTP clients via Maps/Sets.
     this.eventRouter.setupSubscriptions(bus);
 
-    // CORS — allow all origins in dev, restrict in production later
-    await this.app.register(cors, { origin: true });
+    // Cookie parsing — required for the KG session cookie auth flow.
+    await this.app.register(cookie);
+
+    // Rate limiting — global baseline, with tighter per-route overrides on auth endpoints.
+    // Prevents brute-force against the bootstrap secret and general DoS.
+    await this.app.register(rateLimit, {
+      max: 200,
+      timeWindow: '1 minute',
+    });
+
+    // CORS — restricted to APP_ORIGIN in production; disabled (no ACAO header) in dev.
+    // 'origin: false' means Fastify sends no Access-Control-Allow-Origin header,
+    // which is safe for same-origin browser requests on localhost.
+    await this.app.register(cors, {
+      origin: appOrigin ?? false,
+      credentials: true, // needed so the browser sends the session cookie cross-origin
+    });
 
     // Auth hook — runs before every request
     this.app.addHook('onRequest', async (request, reply) => {
@@ -83,9 +102,14 @@ export class HttpAdapter {
       // Use routeOptions.url (the registered pattern) so query strings don't break the match.
       const routeUrl = request.routeOptions.url ?? '';
       if (routeUrl === '/api/health') return;
-      // KG web app and its API — the app shell and assets need no bearer token,
-      // and the /api/kg/* routes enforce their own secret via assertSecret().
-      if (routeUrl === '/' || routeUrl.startsWith('/assets') || routeUrl.startsWith('/api/kg')) return;
+      // KG web app routes bypass bearer auth — the app shell, static assets, and
+      // /auth exchange need no token; /api/kg/* routes enforce their own session/secret.
+      if (
+        routeUrl === '/' ||
+        routeUrl === '/auth' ||
+        routeUrl.startsWith('/assets') ||
+        routeUrl.startsWith('/api/kg')
+      ) return;
 
       if (!validateBearerToken(request.headers.authorization, apiToken)) {
         return reply.status(401).send({ error: 'Unauthorized — provide a valid Bearer token' });
@@ -104,10 +128,15 @@ export class HttpAdapter {
     // Only register KG routes when the secret is configured — if unset, the routes
     // don't exist at all (404) rather than leaking a 503 that reveals the feature exists.
     if (webAppBootstrapSecret) {
+      // secureCookies: true only when serving over HTTPS (i.e. APP_ORIGIN is https://).
+      // In local dev (no APP_ORIGIN), cookies are set without the Secure flag so they
+      // work on plain http://localhost.
+      const secureCookies = appOrigin?.startsWith('https://') ?? false;
       await this.app.register(knowledgeGraphRoutes, {
         pool,
         logger,
         webAppBootstrapSecret,
+        secureCookies,
       });
     }
 

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -37,7 +37,7 @@ export interface HttpAdapterConfig {
   agentRegistry: AgentRegistry;
   port: number;
   apiToken: string | undefined;
-  knowledgeGraphUiSecret: string | undefined;
+  webAppBootstrapSecret: string | undefined;
   agentNames: string[];
   skillNames: string[];
   schedulerService?: SchedulerService;
@@ -67,7 +67,7 @@ export class HttpAdapter {
       apiToken,
       agentNames,
       skillNames,
-      knowledgeGraphUiSecret,
+      webAppBootstrapSecret,
     } = this.config;
 
     // Register shared bus subscriptions BEFORE starting the server.
@@ -102,7 +102,7 @@ export class HttpAdapter {
     await this.app.register(knowledgeGraphRoutes, {
       pool,
       logger,
-      knowledgeGraphUiSecret,
+      webAppBootstrapSecret,
     });
 
     // Start listening

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -7,7 +7,7 @@ import type { Logger } from '../../../logger.js';
 export interface KnowledgeGraphRouteOptions {
   pool: Pool;
   logger: Logger;
-  knowledgeGraphUiSecret: string | undefined;
+  webAppBootstrapSecret: string | undefined;
 }
 
 interface KgNodeRow {
@@ -48,15 +48,15 @@ function assertSecret(
 ): boolean {
   if (!configuredSecret) {
     reply.status(503).send({
-      error: 'Knowledge graph web UI is disabled. Set KG_UI_SECRET in .env to enable it.',
+      error: 'Knowledge graph web UI is disabled. Set WEB_APP_BOOTSTRAP_SECRET in .env to enable it.',
     });
     return false;
   }
 
-  const provided = request.headers['x-kg-secret'];
+  const provided = request.headers['x-web-bootstrap-secret'];
   if (typeof provided !== 'string' || provided !== configuredSecret) {
     reply.status(401).send({
-      error: 'Unauthorized. Provide KG_UI_SECRET via the x-kg-secret header.',
+      error: 'Unauthorized. Provide WEB_APP_BOOTSTRAP_SECRET via the x-web-bootstrap-secret header.',
     });
     return false;
   }
@@ -89,7 +89,7 @@ function createUiHtml(): string {
 <body>
   <header>
     <strong>Knowledge Graph Explorer</strong>
-    <input id="secret" type="password" placeholder="KG_UI_SECRET" style="width: 220px" />
+    <input id="secret" type="password" placeholder="WEB_APP_BOOTSTRAP_SECRET" style="width: 220px" />
     <button id="saveSecret">Use Secret</button>
     <input id="search" placeholder="Search label or properties..." style="width: 360px" />
     <button id="searchBtn">Search</button>
@@ -111,7 +111,7 @@ function createUiHtml(): string {
     const secretInput = document.getElementById('secret');
     const saveSecretBtn = document.getElementById('saveSecret');
 
-    secretInput.value = sessionStorage.getItem('kg_ui_secret') || '';
+    secretInput.value = sessionStorage.getItem('web_app_bootstrap_secret') || '';
 
     const cy = cytoscape({
       container: document.getElementById('graph'),
@@ -137,7 +137,7 @@ function createUiHtml(): string {
 
     async function fetchJson(url) {
       const secret = getSecret();
-      const headers = secret ? { 'x-kg-secret': secret } : {};
+      const headers = secret ? { 'x-web-bootstrap-secret': secret } : {};
       const response = await fetch(url, { headers });
       if (!response.ok) throw new Error(await response.text());
       return response.json();
@@ -192,7 +192,7 @@ function createUiHtml(): string {
     }
 
     saveSecretBtn.addEventListener('click', () => {
-      sessionStorage.setItem('kg_ui_secret', getSecret());
+      sessionStorage.setItem('web_app_bootstrap_secret', getSecret());
       setStatus('Secret stored in this browser session.');
     });
 
@@ -208,7 +208,7 @@ export async function knowledgeGraphRoutes(
   app: FastifyInstance,
   options: KnowledgeGraphRouteOptions,
 ): Promise<void> {
-  const { pool, logger, knowledgeGraphUiSecret } = options;
+  const { pool, logger, webAppBootstrapSecret } = options;
 
   app.get('/kg', async (_request, reply) => {
     reply.type('text/html; charset=utf-8').send(createUiHtml());
@@ -223,7 +223,7 @@ export async function knowledgeGraphRoutes(
   });
 
   app.get('/api/kg/nodes', async (request, reply) => {
-    if (!assertSecret(request, reply, knowledgeGraphUiSecret)) return;
+    if (!assertSecret(request, reply, webAppBootstrapSecret)) return;
 
     const query = request.query as {
       query?: string;
@@ -265,7 +265,7 @@ export async function knowledgeGraphRoutes(
   });
 
   app.get('/api/kg/graph', async (request, reply) => {
-    if (!assertSecret(request, reply, knowledgeGraphUiSecret)) return;
+    if (!assertSecret(request, reply, webAppBootstrapSecret)) return;
 
     const query = request.query as {
       node_id?: string;

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
@@ -54,7 +55,14 @@ function assertSecret(
   }
 
   const provided = request.headers['x-web-bootstrap-secret'];
-  if (typeof provided !== 'string' || provided !== configuredSecret) {
+  // Reject non-string values (e.g. Fastify coerces duplicate headers to string[]).
+  // Then use a timing-safe comparison to avoid leaking how many leading characters
+  // matched — same pattern as validateBearerToken() in auth.ts.
+  if (
+    typeof provided !== 'string' ||
+    provided.length !== configuredSecret.length ||
+    !timingSafeEqual(Buffer.from(provided), Buffer.from(configuredSecret))
+  ) {
     reply.status(401).send({
       error: 'Unauthorized. Provide WEB_APP_BOOTSTRAP_SECRET via the x-web-bootstrap-secret header.',
     });
@@ -610,7 +618,13 @@ export async function knowledgeGraphRoutes(
   const { pool, logger, webAppBootstrapSecret } = options;
 
   app.get('/', async (_request, reply) => {
-    reply.type('text/html; charset=utf-8').send(createUiHtml());
+    reply
+      .type('text/html; charset=utf-8')
+      // Prevent the page from being embedded in an iframe (clickjacking defence).
+      .header('X-Frame-Options', 'DENY')
+      // Stop browsers from MIME-sniffing the response away from text/html.
+      .header('X-Content-Type-Options', 'nosniff')
+      .send(createUiHtml());
   });
 
   app.get('/assets/cytoscape.min.js', async (_request, reply) => {
@@ -618,7 +632,12 @@ export async function knowledgeGraphRoutes(
       new URL('../../../../node_modules/cytoscape/dist/cytoscape.min.js', import.meta.url),
     );
     const source = await readFile(cytoscapePath, 'utf8');
-    reply.type('application/javascript; charset=utf-8').send(source);
+    // Long-lived cache — cytoscape is a pinned dependency; the version never
+    // changes without a code change, so immutable caching is safe here.
+    reply
+      .type('application/javascript; charset=utf-8')
+      .header('Cache-Control', 'public, max-age=31536000, immutable')
+      .send(source);
   });
 
   app.get('/api/kg/nodes', async (request, reply) => {

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1,0 +1,339 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import type { Pool } from 'pg';
+import type { Logger } from '../../../logger.js';
+
+export interface KnowledgeGraphRouteOptions {
+  pool: Pool;
+  logger: Logger;
+  knowledgeGraphUiSecret: string | undefined;
+}
+
+interface KgNodeRow {
+  id: string;
+  type: string;
+  label: string;
+  properties: Record<string, unknown>;
+  confidence: number;
+  decay_class: string;
+  source: string;
+  created_at: string;
+  last_confirmed_at: string;
+}
+
+interface KgEdgeRow {
+  id: string;
+  source_node_id: string;
+  target_node_id: string;
+  type: string;
+  properties: Record<string, unknown>;
+  confidence: number;
+  decay_class: string;
+  source: string;
+  created_at: string;
+  last_confirmed_at: string;
+}
+
+function normalizeLimit(raw: string | undefined, fallback: number, max: number): number {
+  const parsed = Number.parseInt(raw ?? '', 10);
+  if (Number.isNaN(parsed)) return fallback;
+  return Math.max(1, Math.min(parsed, max));
+}
+
+function getSecretFromRequest(request: FastifyRequest): string | undefined {
+  const fromHeader = request.headers['x-kg-secret'];
+  if (typeof fromHeader === 'string' && fromHeader.length > 0) return fromHeader;
+
+  const query = request.query as { secret?: string } | undefined;
+  if (query?.secret && query.secret.length > 0) return query.secret;
+
+  return undefined;
+}
+
+function assertSecret(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  configuredSecret: string | undefined,
+): boolean {
+  if (!configuredSecret) {
+    reply.status(503).send({
+      error: 'Knowledge graph web UI is disabled. Set KG_UI_SECRET in .env to enable it.',
+    });
+    return false;
+  }
+
+  const provided = getSecretFromRequest(request);
+  if (provided !== configuredSecret) {
+    reply.status(401).send({
+      error: 'Unauthorized. Provide the configured secret via ?secret=... or x-kg-secret header.',
+    });
+    return false;
+  }
+
+  return true;
+}
+
+function createUiHtml(): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Curia Knowledge Graph Explorer</title>
+  <style>
+    :root { color-scheme: dark; }
+    body { margin: 0; font-family: Inter, system-ui, sans-serif; background: #111827; color: #f3f4f6; }
+    header { padding: 1rem; border-bottom: 1px solid #374151; display: flex; gap: .5rem; align-items: center; }
+    input, button { border-radius: .5rem; border: 1px solid #4b5563; background: #1f2937; color: #f9fafb; padding: .5rem .75rem; }
+    button { cursor: pointer; }
+    #layout { display: grid; grid-template-columns: 320px 1fr; min-height: calc(100vh - 70px); }
+    #sidebar { border-right: 1px solid #374151; padding: 1rem; overflow: auto; }
+    #graph { width: 100%; height: calc(100vh - 70px); }
+    .node-result { padding: .6rem; border: 1px solid #374151; border-radius: .5rem; margin-bottom: .5rem; cursor: pointer; }
+    .node-result:hover { border-color: #60a5fa; }
+    .meta { color: #9ca3af; font-size: .85rem; }
+    #status { color: #93c5fd; min-height: 1.2rem; }
+  </style>
+</head>
+<body>
+  <header>
+    <strong>Knowledge Graph Explorer</strong>
+    <input id="search" placeholder="Search label or properties..." style="width: 420px" />
+    <button id="searchBtn">Search</button>
+    <span id="status"></span>
+  </header>
+  <div id="layout">
+    <aside id="sidebar">
+      <h3>Nodes</h3>
+      <div id="results"></div>
+    </aside>
+    <main><div id="graph"></div></main>
+  </div>
+
+  <script src="https://unpkg.com/cytoscape@3.33.1/dist/cytoscape.min.js"></script>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const secret = params.get('secret') || '';
+    const statusEl = document.getElementById('status');
+    const resultsEl = document.getElementById('results');
+    const searchInput = document.getElementById('search');
+
+    const cy = cytoscape({
+      container: document.getElementById('graph'),
+      elements: [],
+      style: [
+        { selector: 'node', style: { label: 'data(label)', 'background-color': '#3b82f6', color: '#f8fafc', 'text-valign': 'center', 'text-halign': 'center', 'font-size': 10, width: 30, height: 30 } },
+        { selector: 'node[type="person"]', style: { 'background-color': '#10b981' } },
+        { selector: 'node[type="organization"]', style: { 'background-color': '#f59e0b' } },
+        { selector: 'node[type="project"]', style: { 'background-color': '#8b5cf6' } },
+        { selector: 'edge', style: { width: 2, 'line-color': '#6b7280', 'curve-style': 'bezier', 'target-arrow-shape': 'triangle', 'target-arrow-color': '#6b7280', label: 'data(label)', 'font-size': 9, color: '#d1d5db' } }
+      ],
+      layout: { name: 'cose', animate: false }
+    });
+
+    function setStatus(message, isError = false) {
+      statusEl.textContent = message;
+      statusEl.style.color = isError ? '#fca5a5' : '#93c5fd';
+    }
+
+    async function fetchJson(url) {
+      const headers = secret ? { 'x-kg-secret': secret } : {};
+      const response = await fetch(url, { headers });
+      if (!response.ok) throw new Error(await response.text());
+      return response.json();
+    }
+
+    function renderResults(nodes) {
+      resultsEl.innerHTML = '';
+      if (nodes.length === 0) {
+        resultsEl.innerHTML = '<p class="meta">No matching nodes.</p>';
+        return;
+      }
+
+      nodes.forEach((node) => {
+        const card = document.createElement('div');
+        card.className = 'node-result';
+        card.innerHTML = '<strong>' + node.label + '</strong><div class="meta">' + node.type + ' · confidence ' + node.confidence.toFixed(2) + '</div>';
+        card.addEventListener('click', () => loadNeighborhood(node.id));
+        resultsEl.appendChild(card);
+      });
+    }
+
+    function renderGraph(payload) {
+      const elements = [];
+      payload.nodes.forEach((n) => elements.push({ data: { id: n.id, label: n.label, type: n.type } }));
+      payload.edges.forEach((e) => elements.push({ data: { id: e.id, source: e.sourceNodeId, target: e.targetNodeId, label: e.type } }));
+      cy.elements().remove();
+      cy.add(elements);
+      cy.layout({ name: 'cose', animate: false, fit: true }).run();
+    }
+
+    async function search() {
+      try {
+        setStatus('Searching...');
+        const q = encodeURIComponent(searchInput.value.trim());
+        const data = await fetchJson('/api/kg/nodes?query=' + q + '&limit=100' + (secret ? '&secret=' + encodeURIComponent(secret) : ''));
+        renderResults(data.nodes);
+        setStatus('Found ' + data.nodes.length + ' nodes');
+      } catch (error) {
+        setStatus(String(error), true);
+      }
+    }
+
+    async function loadNeighborhood(nodeId) {
+      try {
+        setStatus('Loading neighborhood...');
+        const data = await fetchJson('/api/kg/graph?node_id=' + encodeURIComponent(nodeId) + '&depth=2' + (secret ? '&secret=' + encodeURIComponent(secret) : ''));
+        renderGraph(data);
+        setStatus('Loaded ' + data.nodes.length + ' nodes and ' + data.edges.length + ' edges');
+      } catch (error) {
+        setStatus(String(error), true);
+      }
+    }
+
+    document.getElementById('searchBtn').addEventListener('click', search);
+    searchInput.addEventListener('keydown', (event) => { if (event.key === 'Enter') search(); });
+    search();
+  </script>
+</body>
+</html>`;
+}
+
+export async function knowledgeGraphRoutes(
+  app: FastifyInstance,
+  options: KnowledgeGraphRouteOptions,
+): Promise<void> {
+  const { pool, logger, knowledgeGraphUiSecret } = options;
+
+  app.get('/kg', async (request, reply) => {
+    if (!assertSecret(request, reply, knowledgeGraphUiSecret)) return;
+    reply.type('text/html; charset=utf-8').send(createUiHtml());
+  });
+
+  app.get('/api/kg/nodes', async (request, reply) => {
+    if (!assertSecret(request, reply, knowledgeGraphUiSecret)) return;
+
+    const query = request.query as {
+      query?: string;
+      type?: string;
+      limit?: string;
+    };
+
+    const limit = normalizeLimit(query.limit, 50, 250);
+    const searchQuery = query.query?.trim();
+    const typeFilter = query.type?.trim();
+
+    const result = await pool.query<KgNodeRow>(
+      `SELECT id, type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at
+       FROM kg_nodes
+       WHERE ($1::text IS NULL OR type = $1)
+         AND (
+           $2::text IS NULL
+           OR label ILIKE '%' || $2 || '%'
+           OR properties::text ILIKE '%' || $2 || '%'
+         )
+       ORDER BY last_confirmed_at DESC
+       LIMIT $3`,
+      [typeFilter || null, searchQuery || null, limit],
+    );
+
+    return reply.send({
+      nodes: result.rows.map((row) => ({
+        id: row.id,
+        type: row.type,
+        label: row.label,
+        properties: row.properties,
+        confidence: row.confidence,
+        decayClass: row.decay_class,
+        source: row.source,
+        createdAt: row.created_at,
+        lastConfirmedAt: row.last_confirmed_at,
+      })),
+    });
+  });
+
+  app.get('/api/kg/graph', async (request, reply) => {
+    if (!assertSecret(request, reply, knowledgeGraphUiSecret)) return;
+
+    const query = request.query as {
+      node_id?: string;
+      depth?: string;
+      limit?: string;
+    };
+
+    const nodeId = query.node_id?.trim();
+    const depth = normalizeLimit(query.depth, 2, 4);
+    const limit = normalizeLimit(query.limit, 100, 300);
+
+    const nodeResult = nodeId
+      ? await pool.query<KgNodeRow>(
+        `WITH RECURSIVE traversal AS (
+          SELECT id, 0 AS depth
+          FROM kg_nodes
+          WHERE id = $1::uuid
+          UNION
+          SELECT
+            CASE WHEN e.source_node_id = t.id THEN e.target_node_id ELSE e.source_node_id END AS id,
+            t.depth + 1 AS depth
+          FROM traversal t
+          JOIN kg_edges e ON e.source_node_id = t.id OR e.target_node_id = t.id
+          WHERE t.depth < $2
+        )
+        SELECT DISTINCT n.id, n.type, n.label, n.properties, n.confidence, n.decay_class, n.source, n.created_at, n.last_confirmed_at
+        FROM traversal t
+        JOIN kg_nodes n ON n.id = t.id
+        ORDER BY n.last_confirmed_at DESC
+        LIMIT $3`,
+        [nodeId, depth, limit],
+      )
+      : await pool.query<KgNodeRow>(
+        `SELECT id, type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at
+         FROM kg_nodes
+         ORDER BY last_confirmed_at DESC
+         LIMIT $1`,
+        [limit],
+      );
+
+    if (nodeResult.rows.length === 0) {
+      return reply.send({ nodes: [], edges: [] });
+    }
+
+    const nodeIds = nodeResult.rows.map((row) => row.id);
+    const edgeResult = await pool.query<KgEdgeRow>(
+      `SELECT id, source_node_id, target_node_id, type, properties, confidence, decay_class, source, created_at, last_confirmed_at
+       FROM kg_edges
+       WHERE source_node_id = ANY($1::uuid[])
+         AND target_node_id = ANY($1::uuid[])
+       ORDER BY last_confirmed_at DESC
+       LIMIT 1000`,
+      [nodeIds],
+    );
+
+    logger.debug({ nodes: nodeResult.rowCount, edges: edgeResult.rowCount }, 'kg: graph query served');
+
+    return reply.send({
+      nodes: nodeResult.rows.map((row) => ({
+        id: row.id,
+        type: row.type,
+        label: row.label,
+        properties: row.properties,
+        confidence: row.confidence,
+        decayClass: row.decay_class,
+        source: row.source,
+        createdAt: row.created_at,
+        lastConfirmedAt: row.last_confirmed_at,
+      })),
+      edges: edgeResult.rows.map((row) => ({
+        id: row.id,
+        sourceNodeId: row.source_node_id,
+        targetNodeId: row.target_node_id,
+        type: row.type,
+        properties: row.properties,
+        confidence: row.confidence,
+        decayClass: row.decay_class,
+        source: row.source,
+        createdAt: row.created_at,
+        lastConfirmedAt: row.last_confirmed_at,
+      })),
+    });
+  });
+}

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -64,160 +64,540 @@ function assertSecret(
   return true;
 }
 
+// Design tokens — dark mode, from the Curia design system (theme.md).
+// Keeping them here as a reference makes it easy to update the palette in one place
+// without hunting through inline styles.
 function createUiHtml(): string {
   return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Curia Knowledge Graph Explorer</title>
+  <title>Curia</title>
+
+  <!-- Manrope (body/UI) + Lora (headings/wordmark) from Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Lora:wght@500&display=swap" rel="stylesheet" />
+
+  <!-- Tailwind CSS browser runtime — layout utilities only; colours come from CSS vars below -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        fontFamily: {
+          sans: ['Manrope', 'system-ui', 'sans-serif'],
+          serif: ['Lora', 'Georgia', 'serif'],
+        },
+        extend: {},
+      },
+    };
+  </script>
+
   <style>
-    :root { color-scheme: dark; }
-    body { margin: 0; font-family: Inter, system-ui, sans-serif; background: #111827; color: #f3f4f6; }
-    header { padding: 1rem; border-bottom: 1px solid #374151; display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
-    input, button { border-radius: .5rem; border: 1px solid #4b5563; background: #1f2937; color: #f9fafb; padding: .5rem .75rem; }
-    button { cursor: pointer; }
-    #layout { display: grid; grid-template-columns: 320px 1fr; min-height: calc(100vh - 78px); }
-    #sidebar { border-right: 1px solid #374151; padding: 1rem; overflow: auto; }
-    #graph { width: 100%; height: calc(100vh - 78px); }
-    .node-result { padding: .6rem; border: 1px solid #374151; border-radius: .5rem; margin-bottom: .5rem; cursor: pointer; }
-    .node-result:hover { border-color: #60a5fa; }
-    .meta { color: #9ca3af; font-size: .85rem; }
-    #status { color: #93c5fd; min-height: 1.2rem; }
+    /* ── Design tokens (dark mode) ──────────────────────────────────── */
+    :root {
+      --bg:           #111111;   /* oklch(0.145 0 0) */
+      --card:         #1E1E1E;   /* oklch(0.205 0 0) */
+      --sidebar-bg:   #1E1E1E;
+      --muted:        #373737;   /* oklch(0.269 0 0) */
+      --accent:       #555555;   /* oklch(0.371 0 0) — hover bg */
+      --border:       rgba(255,255,255,0.10);
+      --input-border: rgba(255,255,255,0.15);
+      --primary:      #DEDEDE;   /* oklch(0.87 0 0) */
+      --primary-fg:   #1E1E1E;
+      --fg:           #FAFAFA;   /* oklch(0.985 0 0) */
+      --fg-muted:     #ADADAD;   /* oklch(0.708 0 0) */
+      --destructive:  #E86040;   /* oklch(0.704 0.191 22.216) */
+      --teal:         #478189;   /* accent: active indicators */
+      --chart-2:      #4174C8;   /* default node colour */
+      --chart-1:      #6BAED6;   /* organization node */
+
+      --radius-sm: 6px;
+      --radius-md: 8px;
+      --radius-lg: 10px;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; overflow: hidden; }
+
+    body {
+      background: var(--bg);
+      color: var(--fg);
+      font-family: 'Manrope', system-ui, sans-serif;
+      font-size: 14px;
+    }
+
+    /* ── Sidebar nav items ──────────────────────────────────────────── */
+    .nav-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      padding: 6px 10px;
+      border-radius: var(--radius-md);
+      border: none;
+      background: none;
+      color: var(--fg-muted);
+      font-family: inherit;
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+      text-align: left;
+      transition: background 0.12s, color 0.12s;
+    }
+    .nav-item:hover  { background: var(--accent); color: var(--fg); }
+    .nav-item.active { background: var(--muted);  color: var(--fg); }
+
+    /* Sub-items are inset to sit under their parent */
+    .nav-sub-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      padding: 5px 10px 5px 28px;
+      border-radius: var(--radius-md);
+      border: none;
+      background: none;
+      color: var(--fg-muted);
+      font-family: inherit;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      text-align: left;
+      transition: background 0.12s, color 0.12s;
+    }
+    .nav-sub-item:hover  { background: var(--accent); color: var(--fg); }
+    .nav-sub-item.active { background: var(--muted);  color: var(--fg); }
+
+    /* ── Node cards in the result list ──────────────────────────────── */
+    .node-card {
+      padding: 8px 10px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      margin-bottom: 4px;
+      cursor: pointer;
+      transition: border-color 0.12s, background 0.12s;
+    }
+    .node-card:hover {
+      border-color: var(--teal);
+      background: rgba(71,129,137,0.08);
+    }
+
+    /* ── Form elements ───────────────────────────────────────────────── */
+    input[type="text"],
+    input[type="password"] {
+      background: var(--muted);
+      border: 1px solid var(--input-border);
+      border-radius: var(--radius-md);
+      color: var(--fg);
+      font-family: inherit;
+      font-size: 0.875rem;
+      padding: 8px 12px;
+      outline: none;
+      width: 100%;
+      transition: border-color 0.12s;
+    }
+    input[type="text"]:focus,
+    input[type="password"]:focus { border-color: var(--teal); }
+
+    /* ── Buttons ─────────────────────────────────────────────────────── */
+    .btn-primary {
+      background: var(--primary);
+      color: var(--primary-fg);
+      border: none;
+      border-radius: var(--radius-md);
+      font-family: inherit;
+      font-size: 0.875rem;
+      font-weight: 600;
+      padding: 8px 16px;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: opacity 0.12s;
+    }
+    .btn-primary:hover    { opacity: 0.88; }
+    .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    /* ── Cytoscape canvas ─────────────────────────────────────────────── */
+    #cy { width: 100%; height: 100%; }
+
+    /* ── Subtle scrollbars ───────────────────────────────────────────── */
+    ::-webkit-scrollbar       { width: 5px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: var(--accent); border-radius: 99px; }
+
+    /* ── Chevron rotation for expand/collapse ──────────────────────── */
+    .chevron               { transition: transform 0.2s; }
+    .chevron.collapsed     { transform: rotate(-90deg); }
   </style>
 </head>
 <body>
-  <header>
-    <strong>Knowledge Graph Explorer</strong>
-    <input id="secret" type="password" placeholder="WEB_APP_BOOTSTRAP_SECRET" style="width: 220px" />
-    <button id="saveSecret">Use Secret</button>
-    <input id="search" placeholder="Search label or properties..." style="width: 360px" />
-    <button id="searchBtn">Search</button>
-    <span id="status"></span>
-  </header>
-  <div id="layout">
-    <aside id="sidebar">
-      <h3>Nodes</h3>
-      <div id="results"></div>
-    </aside>
-    <main><div id="graph"></div></main>
+
+  <!-- ================================================================
+       AUTH WALL — shown until the correct access key is supplied.
+       Blocks the entire viewport; dismissed via JS once validated.
+  ================================================================= -->
+  <div id="auth-wall" style="position: fixed; inset: 0; z-index: 50; display: flex; align-items: center; justify-content: center; background: var(--bg);">
+    <div style="width: 100%; max-width: 360px; margin: 0 1rem; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 2rem;">
+      <div style="text-align: center; margin-bottom: 1.75rem;">
+        <div style="font-family: 'Lora', Georgia, serif; font-size: 1.375rem; font-weight: 500; letter-spacing: 0.06em; color: var(--fg); margin-bottom: 0.375rem;">CURIA</div>
+        <div style="font-size: 0.8125rem; color: var(--fg-muted);">Enter your access key to continue</div>
+      </div>
+      <form id="auth-form">
+        <input id="auth-input" type="password" placeholder="Access key" autocomplete="current-password" style="margin-bottom: 0.75rem;" />
+        <button type="submit" class="btn-primary" style="width: 100%; padding: 10px;">Enter</button>
+        <div id="auth-error" style="display: none; margin-top: 0.75rem; font-size: 0.75rem; text-align: center; color: var(--destructive);">
+          Invalid access key — please try again.
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- ================================================================
+       MAIN APP — revealed after successful authentication.
+  ================================================================= -->
+  <div id="main-app" style="display: none; height: 100vh; flex-direction: row; overflow: hidden;">
+
+    <!-- ── Left sidebar ─────────────────────────────────────────────── -->
+    <nav style="flex: none; width: 220px; display: flex; flex-direction: column; padding: 16px 10px; background: var(--sidebar-bg); border-right: 1px solid var(--border); overflow-y: auto;">
+
+      <!-- Wordmark — placeholder for logo -->
+      <div style="padding: 4px 10px 20px;">
+        <span style="font-family: 'Lora', Georgia, serif; font-size: 1.125rem; font-weight: 500; letter-spacing: 0.06em; color: var(--fg);">CURIA</span>
+      </div>
+
+      <!-- Nav tree -->
+      <div style="display: flex; flex-direction: column; gap: 2px;">
+
+        <!-- Chat -->
+        <button id="nav-chat" class="nav-item" onclick="navigate('coming-soon', 'Chat', 'nav-chat')">
+          <!-- speech-bubble icon -->
+          <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M13 9.5A1.5 1.5 0 0 1 11.5 11H4L1.5 13.5V3A1.5 1.5 0 0 1 3 1.5h8.5A1.5 1.5 0 0 1 13 3v6.5z"/>
+          </svg>
+          Chat
+        </button>
+
+        <!-- Memory (expandable section) -->
+        <div>
+          <button class="nav-item" id="memory-toggle" onclick="toggleMemory()">
+            <!-- database-stack icon -->
+            <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <ellipse cx="7.5" cy="4" rx="5.5" ry="2.5"/>
+              <path d="M2 4v3.5C2 9.157 4.462 10.5 7.5 10.5S13 9.157 13 7.5V4"/>
+              <path d="M2 7.5v3C2 12.157 4.462 13.5 7.5 13.5S13 12.157 13 10.5v-3"/>
+            </svg>
+            Memory
+            <!-- chevron rotates when the section collapses -->
+            <svg id="memory-chevron" class="chevron" style="margin-left: auto;" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M3 4.5L6 7.5L9 4.5"/>
+            </svg>
+          </button>
+
+          <div id="memory-submenu" style="display: flex; flex-direction: column; gap: 2px; margin-top: 2px;">
+            <!-- Knowledge Graph — active by default -->
+            <button id="nav-kg" class="nav-sub-item active" onclick="navigate('kg', 'Knowledge Graph', 'nav-kg')">
+              <!-- nodes-and-edges icon -->
+              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="6.5" cy="6.5" r="1.5"/>
+                <circle cx="2"   cy="3.5" r="1.5"/>
+                <circle cx="11"  cy="3.5" r="1.5"/>
+                <circle cx="2"   cy="9.5" r="1.5"/>
+                <circle cx="11"  cy="9.5" r="1.5"/>
+                <line x1="3.5"  y1="4.5"  x2="5"   y2="5.5"/>
+                <line x1="8"    y1="5.5"  x2="9.5"  y2="4.5"/>
+                <line x1="5"    y1="7.5"  x2="3.5"  y2="8.5"/>
+                <line x1="9.5"  y1="8.5"  x2="8"    y2="7.5"/>
+              </svg>
+              Knowledge Graph
+            </button>
+
+            <button id="nav-contacts" class="nav-sub-item" onclick="navigate('coming-soon', 'Contacts', 'nav-contacts')">
+              <!-- person icon -->
+              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="6.5" cy="4" r="2.5"/>
+                <path d="M1 12c0-3.038 2.462-5.5 5.5-5.5S12 8.962 12 12"/>
+              </svg>
+              Contacts
+            </button>
+
+            <button id="nav-tasks" class="nav-sub-item" onclick="navigate('coming-soon', 'Tasks', 'nav-tasks')">
+              <!-- checklist icon -->
+              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="1.5" y="1.5" width="10" height="10" rx="1.5"/>
+                <path d="M4 6.5L5.5 8L9 4.5"/>
+              </svg>
+              Tasks
+            </button>
+          </div>
+        </div>
+
+      </div>
+    </nav>
+
+    <!-- ── Main content area ─────────────────────────────────────────── -->
+    <main style="flex: 1; display: flex; flex-direction: column; overflow: hidden; background: var(--bg);">
+
+      <!-- Knowledge Graph view -->
+      <div id="view-kg" style="height: 100%; display: flex; flex-direction: column;">
+
+        <!-- Toolbar: search + status -->
+        <div style="flex: none; display: flex; align-items: center; gap: 10px; padding: 10px 16px; border-bottom: 1px solid var(--border);">
+          <input id="search-input" type="text" placeholder="Search nodes by label or properties…" style="max-width: 400px;" />
+          <button id="search-btn" class="btn-primary">Search</button>
+          <span id="status" style="font-size: 0.75rem; color: var(--fg-muted); margin-left: 4px;"></span>
+        </div>
+
+        <!-- Split: node list panel | graph canvas -->
+        <div style="flex: 1; display: flex; overflow: hidden;">
+
+          <!-- Node list -->
+          <div style="flex: none; width: 240px; overflow-y: auto; padding: 12px; border-right: 1px solid var(--border);">
+            <div style="font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--fg-muted); margin-bottom: 10px;">Nodes</div>
+            <div id="results"></div>
+          </div>
+
+          <!-- Cytoscape graph -->
+          <div style="flex: 1; position: relative; overflow: hidden;">
+            <div id="cy"></div>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- Coming Soon view (shared by Chat, Contacts, Tasks) -->
+      <div id="view-coming-soon" style="display: none; height: 100%; flex-direction: column; align-items: center; justify-content: center;">
+        <p style="font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.15em; color: var(--fg-muted); margin: 0 0 8px;">Coming Soon</p>
+        <h2 id="coming-soon-title" style="font-family: 'Lora', Georgia, serif; font-size: 2rem; font-weight: 500; color: var(--fg); margin: 0;"></h2>
+      </div>
+
+    </main>
   </div>
 
   <script src="/kg/assets/cytoscape.min.js"></script>
   <script>
-    const statusEl = document.getElementById('status');
-    const resultsEl = document.getElementById('results');
-    const searchInput = document.getElementById('search');
-    const searchBtn = document.getElementById('searchBtn');
-    const secretInput = document.getElementById('secret');
-    const saveSecretBtn = document.getElementById('saveSecret');
-    const graphEl = document.getElementById('graph');
+    // ── State ──────────────────────────────────────────────────────────
+    var cy = null;           // Cytoscape instance (lazy-initialised on first login)
+    var memoryOpen = true;   // Memory nav section expanded by default
+    var activeNavId = 'nav-kg';
 
-    // Guard against missing DOM elements — all are defined in the HTML above, but this
-    // catches template/script divergence early with a readable error instead of a
-    // cryptic null-dereference later.
-    if (!statusEl || !resultsEl || !searchInput || !searchBtn || !secretInput || !saveSecretBtn || !graphEl) {
-      throw new Error('KG Explorer: required DOM element missing — check template integrity.');
+    // ── Element refs ───────────────────────────────────────────────────
+    var authWall      = document.getElementById('auth-wall');
+    var mainApp       = document.getElementById('main-app');
+    var authForm      = document.getElementById('auth-form');
+    var authInput     = document.getElementById('auth-input');
+    var authError     = document.getElementById('auth-error');
+    var statusEl      = document.getElementById('status');
+    var resultsEl     = document.getElementById('results');
+    var searchInput   = document.getElementById('search-input');
+    var searchBtn     = document.getElementById('search-btn');
+    var memoryCaret   = document.getElementById('memory-chevron');
+    var memorySubmenu = document.getElementById('memory-submenu');
+
+    // Catch template/script divergence early rather than producing cryptic null errors
+    if (!authWall || !mainApp || !authForm || !authInput || !authError ||
+        !statusEl || !resultsEl || !searchInput || !searchBtn ||
+        !memoryCaret || !memorySubmenu) {
+      throw new Error('Curia KG: required DOM element missing — check template integrity.');
     }
 
-    secretInput.value = sessionStorage.getItem('web_app_bootstrap_secret') || '';
+    // ── Auth ───────────────────────────────────────────────────────────
+    function getSecret() {
+      return sessionStorage.getItem('web_app_bootstrap_secret') || '';
+    }
 
-    const cy = cytoscape({
-      container: graphEl,
-      elements: [],
-      style: [
-        { selector: 'node', style: { label: 'data(label)', 'background-color': '#3b82f6', color: '#f8fafc', 'text-valign': 'center', 'text-halign': 'center', 'font-size': 10, width: 30, height: 30 } },
-        { selector: 'node[type="person"]', style: { 'background-color': '#10b981' } },
-        { selector: 'node[type="organization"]', style: { 'background-color': '#f59e0b' } },
-        { selector: 'node[type="project"]', style: { 'background-color': '#8b5cf6' } },
-        { selector: 'edge', style: { width: 2, 'line-color': '#6b7280', 'curve-style': 'bezier', 'target-arrow-shape': 'triangle', 'target-arrow-color': '#6b7280', label: 'data(label)', 'font-size': 9, color: '#d1d5db' } }
-      ],
-      layout: { name: 'cose', animate: false }
+    function showMain() {
+      authWall.style.display = 'none';
+      mainApp.style.display  = 'flex';
+      initCytoscape();
+      search(); // auto-load all nodes on entry
+    }
+
+    authForm.addEventListener('submit', function(e) {
+      e.preventDefault();
+      var secret = authInput.value.trim();
+      if (!secret) return;
+
+      var btn = authForm.querySelector('button[type="submit"]');
+      btn.textContent = 'Checking\u2026';
+      btn.disabled = true;
+      authError.style.display = 'none';
+
+      // Validate secret against the server before storing it — gives immediate
+      // feedback if the key is wrong rather than letting errors surface in the search.
+      fetch('/api/kg/nodes?limit=1', { headers: { 'x-web-bootstrap-secret': secret } })
+        .then(function(res) {
+          if (res.status === 401) {
+            authError.style.display = 'block';
+            btn.textContent = 'Enter';
+            btn.disabled = false;
+            return;
+          }
+          sessionStorage.setItem('web_app_bootstrap_secret', secret);
+          showMain();
+        })
+        .catch(function() {
+          // Network error — store and proceed; subsequent API calls will surface issues.
+          sessionStorage.setItem('web_app_bootstrap_secret', secret);
+          showMain();
+        });
     });
 
-    function getSecret() {
-      return secretInput.value.trim();
+    // Auto-unlock when a valid key is already stored in this session
+    if (getSecret()) showMain();
+
+    // ── Cytoscape ──────────────────────────────────────────────────────
+    function initCytoscape() {
+      if (cy) return;
+      cy = cytoscape({
+        container: document.getElementById('cy'),
+        elements: [],
+        style: [
+          {
+            selector: 'node',
+            style: {
+              label: 'data(label)',
+              'background-color': '#4174C8',  // --chart-2
+              color: '#FAFAFA',
+              'text-valign': 'center',
+              'text-halign': 'center',
+              'font-size': 10,
+              'font-family': 'Manrope, system-ui, sans-serif',
+              width: 32,
+              height: 32,
+            },
+          },
+          { selector: 'node[type="person"]',       style: { 'background-color': '#478189' } }, // teal accent
+          { selector: 'node[type="organization"]',  style: { 'background-color': '#6BAED6' } }, // --chart-1
+          { selector: 'node[type="project"]',       style: { 'background-color': '#555555' } }, // --accent
+          {
+            selector: 'edge',
+            style: {
+              width: 1.5,
+              'line-color': 'rgba(255,255,255,0.15)',
+              'curve-style': 'bezier',
+              'target-arrow-shape': 'triangle',
+              'target-arrow-color': 'rgba(255,255,255,0.15)',
+              label: 'data(label)',
+              'font-size': 9,
+              'font-family': 'Manrope, system-ui, sans-serif',
+              color: '#ADADAD',
+            },
+          },
+        ],
+        layout: { name: 'cose', animate: false },
+      });
     }
 
-    function setStatus(message, isError = false) {
-      statusEl.textContent = message;
-      statusEl.style.color = isError ? '#fca5a5' : '#93c5fd';
+    // ── Navigation ─────────────────────────────────────────────────────
+    function navigate(view, title, navId) {
+      var kgView = document.getElementById('view-kg');
+      var csView = document.getElementById('view-coming-soon');
+
+      kgView.style.display = view === 'kg'           ? 'flex' : 'none';
+      csView.style.display = view === 'coming-soon'  ? 'flex' : 'none';
+
+      if (view === 'coming-soon') {
+        document.getElementById('coming-soon-title').textContent = title;
+      }
+
+      // Update active highlight
+      if (activeNavId) {
+        var prev = document.getElementById(activeNavId);
+        if (prev) prev.classList.remove('active');
+      }
+      if (navId) {
+        var curr = document.getElementById(navId);
+        if (curr) curr.classList.add('active');
+        activeNavId = navId;
+      }
     }
 
-    async function fetchJson(url) {
-      const secret = getSecret();
-      const headers = secret ? { 'x-web-bootstrap-secret': secret } : {};
-      const response = await fetch(url, { headers });
-      if (!response.ok) throw new Error(await response.text());
-      return response.json();
+    function toggleMemory() {
+      memoryOpen = !memoryOpen;
+      memorySubmenu.style.display = memoryOpen ? 'flex' : 'none';
+      memoryCaret.classList.toggle('collapsed', !memoryOpen);
+    }
+
+    // ── KG API helpers ─────────────────────────────────────────────────
+    function setStatus(msg, isError) {
+      statusEl.textContent = msg;
+      statusEl.style.color = isError ? 'var(--destructive)' : 'var(--fg-muted)';
+    }
+
+    function fetchJson(url) {
+      var secret = getSecret();
+      var headers = secret ? { 'x-web-bootstrap-secret': secret } : {};
+      return fetch(url, { headers: headers }).then(function(res) {
+        if (!res.ok) return res.text().then(function(t) { throw new Error(t); });
+        return res.json();
+      });
     }
 
     function renderResults(nodes) {
       resultsEl.replaceChildren();
       if (nodes.length === 0) {
-        const empty = document.createElement('p');
-        empty.className = 'meta';
-        empty.textContent = 'No matching nodes.';
-        resultsEl.appendChild(empty);
+        var p = document.createElement('p');
+        p.style.cssText = 'font-size: 0.8125rem; color: var(--fg-muted); margin: 0;';
+        p.textContent = 'No matching nodes.';
+        resultsEl.appendChild(p);
         return;
       }
 
-      nodes.forEach((node) => {
-        const card = document.createElement('div');
-        card.className = 'node-result';
-        // Use textContent (not innerHTML) to prevent stored XSS — node labels and types
-        // come from the database and could contain HTML/JS payloads from imported sources.
-        const title = document.createElement('strong');
-        title.textContent = node.label;
-        const meta = document.createElement('div');
-        meta.className = 'meta';
-        meta.textContent = node.type + ' · confidence ' + node.confidence.toFixed(2);
-        card.append(title, meta);
-        card.addEventListener('click', () => loadNeighborhood(node.id));
+      nodes.forEach(function(node) {
+        var card = document.createElement('div');
+        card.className = 'node-card';
+
+        // Use textContent (not innerHTML) to prevent stored XSS — labels come from the DB
+        // and could carry HTML/JS payloads injected through imported data sources.
+        var label = document.createElement('div');
+        label.style.cssText = 'font-size: 0.8125rem; font-weight: 600; color: var(--fg); margin-bottom: 2px;';
+        label.textContent = node.label;
+
+        var meta = document.createElement('div');
+        meta.style.cssText = 'font-size: 0.75rem; color: var(--fg-muted);';
+        meta.textContent = node.type + ' \u00B7 ' + node.confidence.toFixed(2);
+
+        card.append(label, meta);
+        card.addEventListener('click', function() { loadNeighborhood(node.id); });
         resultsEl.appendChild(card);
       });
     }
 
     function renderGraph(payload) {
-      const elements = [];
-      payload.nodes.forEach((n) => elements.push({ data: { id: n.id, label: n.label, type: n.type } }));
-      payload.edges.forEach((e) => elements.push({ data: { id: e.id, source: e.sourceNodeId, target: e.targetNodeId, label: e.type } }));
+      if (!cy) return;
+      var elements = [].concat(
+        payload.nodes.map(function(n) { return { data: { id: n.id, label: n.label, type: n.type } }; }),
+        payload.edges.map(function(e) { return { data: { id: e.id, source: e.sourceNodeId, target: e.targetNodeId, label: e.type } }; })
+      );
       cy.elements().remove();
       cy.add(elements);
       cy.layout({ name: 'cose', animate: false, fit: true }).run();
     }
 
-    async function search() {
-      try {
-        setStatus('Searching...');
-        const q = encodeURIComponent(searchInput.value.trim());
-        const data = await fetchJson('/api/kg/nodes?query=' + q + '&limit=100');
-        renderResults(data.nodes);
-        setStatus('Found ' + data.nodes.length + ' nodes');
-      } catch (error) {
-        setStatus(String(error), true);
-      }
+    function search() {
+      setStatus('Searching\u2026');
+      var q = encodeURIComponent(searchInput.value.trim());
+      fetchJson('/api/kg/nodes?query=' + q + '&limit=100')
+        .then(function(data) {
+          renderResults(data.nodes);
+          setStatus(data.nodes.length + ' node' + (data.nodes.length === 1 ? '' : 's'));
+        })
+        .catch(function(err) { setStatus(String(err), true); });
     }
 
-    async function loadNeighborhood(nodeId) {
-      try {
-        setStatus('Loading neighborhood...');
-        const data = await fetchJson('/api/kg/graph?node_id=' + encodeURIComponent(nodeId) + '&depth=2');
-        renderGraph(data);
-        setStatus('Loaded ' + data.nodes.length + ' nodes and ' + data.edges.length + ' edges');
-      } catch (error) {
-        setStatus(String(error), true);
-      }
+    function loadNeighborhood(nodeId) {
+      setStatus('Loading\u2026');
+      fetchJson('/api/kg/graph?node_id=' + encodeURIComponent(nodeId) + '&depth=2')
+        .then(function(data) {
+          renderGraph(data);
+          setStatus(data.nodes.length + ' nodes \u00B7 ' + data.edges.length + ' edges');
+        })
+        .catch(function(err) { setStatus(String(err), true); });
     }
-
-    saveSecretBtn.addEventListener('click', () => {
-      sessionStorage.setItem('web_app_bootstrap_secret', getSecret());
-      setStatus('Secret stored in this browser session.');
-    });
 
     searchBtn.addEventListener('click', search);
-    searchInput.addEventListener('keydown', (event) => { if (event.key === 'Enter') search(); });
-    if (getSecret()) search();
+    searchInput.addEventListener('keydown', function(e) { if (e.key === 'Enter') search(); });
   </script>
 </body>
 </html>`;

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -374,7 +374,7 @@ function createUiHtml(): string {
     </main>
   </div>
 
-  <script src="/kg/assets/cytoscape.min.js"></script>
+  <script src="/assets/cytoscape.min.js"></script>
   <script>
     // ── State ──────────────────────────────────────────────────────────
     var cy = null;           // Cytoscape instance (lazy-initialised on first login)
@@ -609,11 +609,11 @@ export async function knowledgeGraphRoutes(
 ): Promise<void> {
   const { pool, logger, webAppBootstrapSecret } = options;
 
-  app.get('/kg', async (_request, reply) => {
+  app.get('/', async (_request, reply) => {
     reply.type('text/html; charset=utf-8').send(createUiHtml());
   });
 
-  app.get('/kg/assets/cytoscape.min.js', async (_request, reply) => {
+  app.get('/assets/cytoscape.min.js', async (_request, reply) => {
     const cytoscapePath = fileURLToPath(
       new URL('../../../../node_modules/cytoscape/dist/cytoscape.min.js', import.meta.url),
     );

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { Pool } from 'pg';
 import type { Logger } from '../../../logger.js';
@@ -39,16 +41,6 @@ function normalizeLimit(raw: string | undefined, fallback: number, max: number):
   return Math.max(1, Math.min(parsed, max));
 }
 
-function getSecretFromRequest(request: FastifyRequest): string | undefined {
-  const fromHeader = request.headers['x-kg-secret'];
-  if (typeof fromHeader === 'string' && fromHeader.length > 0) return fromHeader;
-
-  const query = request.query as { secret?: string } | undefined;
-  if (query?.secret && query.secret.length > 0) return query.secret;
-
-  return undefined;
-}
-
 function assertSecret(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -61,10 +53,10 @@ function assertSecret(
     return false;
   }
 
-  const provided = getSecretFromRequest(request);
-  if (provided !== configuredSecret) {
+  const provided = request.headers['x-kg-secret'];
+  if (typeof provided !== 'string' || provided !== configuredSecret) {
     reply.status(401).send({
-      error: 'Unauthorized. Provide the configured secret via ?secret=... or x-kg-secret header.',
+      error: 'Unauthorized. Provide KG_UI_SECRET via the x-kg-secret header.',
     });
     return false;
   }
@@ -82,12 +74,12 @@ function createUiHtml(): string {
   <style>
     :root { color-scheme: dark; }
     body { margin: 0; font-family: Inter, system-ui, sans-serif; background: #111827; color: #f3f4f6; }
-    header { padding: 1rem; border-bottom: 1px solid #374151; display: flex; gap: .5rem; align-items: center; }
+    header { padding: 1rem; border-bottom: 1px solid #374151; display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
     input, button { border-radius: .5rem; border: 1px solid #4b5563; background: #1f2937; color: #f9fafb; padding: .5rem .75rem; }
     button { cursor: pointer; }
-    #layout { display: grid; grid-template-columns: 320px 1fr; min-height: calc(100vh - 70px); }
+    #layout { display: grid; grid-template-columns: 320px 1fr; min-height: calc(100vh - 78px); }
     #sidebar { border-right: 1px solid #374151; padding: 1rem; overflow: auto; }
-    #graph { width: 100%; height: calc(100vh - 70px); }
+    #graph { width: 100%; height: calc(100vh - 78px); }
     .node-result { padding: .6rem; border: 1px solid #374151; border-radius: .5rem; margin-bottom: .5rem; cursor: pointer; }
     .node-result:hover { border-color: #60a5fa; }
     .meta { color: #9ca3af; font-size: .85rem; }
@@ -97,7 +89,9 @@ function createUiHtml(): string {
 <body>
   <header>
     <strong>Knowledge Graph Explorer</strong>
-    <input id="search" placeholder="Search label or properties..." style="width: 420px" />
+    <input id="secret" type="password" placeholder="KG_UI_SECRET" style="width: 220px" />
+    <button id="saveSecret">Use Secret</button>
+    <input id="search" placeholder="Search label or properties..." style="width: 360px" />
     <button id="searchBtn">Search</button>
     <span id="status"></span>
   </header>
@@ -109,13 +103,15 @@ function createUiHtml(): string {
     <main><div id="graph"></div></main>
   </div>
 
-  <script src="https://unpkg.com/cytoscape@3.33.1/dist/cytoscape.min.js"></script>
+  <script src="/kg/assets/cytoscape.min.js"></script>
   <script>
-    const params = new URLSearchParams(window.location.search);
-    const secret = params.get('secret') || '';
     const statusEl = document.getElementById('status');
     const resultsEl = document.getElementById('results');
     const searchInput = document.getElementById('search');
+    const secretInput = document.getElementById('secret');
+    const saveSecretBtn = document.getElementById('saveSecret');
+
+    secretInput.value = sessionStorage.getItem('kg_ui_secret') || '';
 
     const cy = cytoscape({
       container: document.getElementById('graph'),
@@ -130,12 +126,17 @@ function createUiHtml(): string {
       layout: { name: 'cose', animate: false }
     });
 
+    function getSecret() {
+      return secretInput.value.trim();
+    }
+
     function setStatus(message, isError = false) {
       statusEl.textContent = message;
       statusEl.style.color = isError ? '#fca5a5' : '#93c5fd';
     }
 
     async function fetchJson(url) {
+      const secret = getSecret();
       const headers = secret ? { 'x-kg-secret': secret } : {};
       const response = await fetch(url, { headers });
       if (!response.ok) throw new Error(await response.text());
@@ -171,7 +172,7 @@ function createUiHtml(): string {
       try {
         setStatus('Searching...');
         const q = encodeURIComponent(searchInput.value.trim());
-        const data = await fetchJson('/api/kg/nodes?query=' + q + '&limit=100' + (secret ? '&secret=' + encodeURIComponent(secret) : ''));
+        const data = await fetchJson('/api/kg/nodes?query=' + q + '&limit=100');
         renderResults(data.nodes);
         setStatus('Found ' + data.nodes.length + ' nodes');
       } catch (error) {
@@ -182,7 +183,7 @@ function createUiHtml(): string {
     async function loadNeighborhood(nodeId) {
       try {
         setStatus('Loading neighborhood...');
-        const data = await fetchJson('/api/kg/graph?node_id=' + encodeURIComponent(nodeId) + '&depth=2' + (secret ? '&secret=' + encodeURIComponent(secret) : ''));
+        const data = await fetchJson('/api/kg/graph?node_id=' + encodeURIComponent(nodeId) + '&depth=2');
         renderGraph(data);
         setStatus('Loaded ' + data.nodes.length + ' nodes and ' + data.edges.length + ' edges');
       } catch (error) {
@@ -190,9 +191,14 @@ function createUiHtml(): string {
       }
     }
 
+    saveSecretBtn.addEventListener('click', () => {
+      sessionStorage.setItem('kg_ui_secret', getSecret());
+      setStatus('Secret stored in this browser session.');
+    });
+
     document.getElementById('searchBtn').addEventListener('click', search);
     searchInput.addEventListener('keydown', (event) => { if (event.key === 'Enter') search(); });
-    search();
+    if (getSecret()) search();
   </script>
 </body>
 </html>`;
@@ -204,9 +210,16 @@ export async function knowledgeGraphRoutes(
 ): Promise<void> {
   const { pool, logger, knowledgeGraphUiSecret } = options;
 
-  app.get('/kg', async (request, reply) => {
-    if (!assertSecret(request, reply, knowledgeGraphUiSecret)) return;
+  app.get('/kg', async (_request, reply) => {
     reply.type('text/html; charset=utf-8').send(createUiHtml());
+  });
+
+  app.get('/kg/assets/cytoscape.min.js', async (_request, reply) => {
+    const cytoscapePath = fileURLToPath(
+      new URL('../../../../node_modules/cytoscape/dist/cytoscape.min.js', import.meta.url),
+    );
+    const source = await readFile(cytoscapePath, 'utf8');
+    reply.type('application/javascript; charset=utf-8').send(source);
   });
 
   app.get('/api/kg/nodes', async (request, reply) => {
@@ -266,32 +279,32 @@ export async function knowledgeGraphRoutes(
 
     const nodeResult = nodeId
       ? await pool.query<KgNodeRow>(
-        `WITH RECURSIVE traversal AS (
-          SELECT id, 0 AS depth
-          FROM kg_nodes
-          WHERE id = $1::uuid
-          UNION
-          SELECT
-            CASE WHEN e.source_node_id = t.id THEN e.target_node_id ELSE e.source_node_id END AS id,
-            t.depth + 1 AS depth
-          FROM traversal t
-          JOIN kg_edges e ON e.source_node_id = t.id OR e.target_node_id = t.id
-          WHERE t.depth < $2
+          `WITH RECURSIVE traversal AS (
+             SELECT id, 0 AS depth
+             FROM kg_nodes
+             WHERE id = $1::uuid
+             UNION
+             SELECT
+               CASE WHEN e.source_node_id = t.id THEN e.target_node_id ELSE e.source_node_id END AS id,
+               t.depth + 1 AS depth
+             FROM traversal t
+             JOIN kg_edges e ON e.source_node_id = t.id OR e.target_node_id = t.id
+             WHERE t.depth < $2
+           )
+           SELECT DISTINCT n.id, n.type, n.label, n.properties, n.confidence, n.decay_class, n.source, n.created_at, n.last_confirmed_at
+           FROM traversal t
+           JOIN kg_nodes n ON n.id = t.id
+           ORDER BY n.last_confirmed_at DESC
+           LIMIT $3`,
+          [nodeId, depth, limit],
         )
-        SELECT DISTINCT n.id, n.type, n.label, n.properties, n.confidence, n.decay_class, n.source, n.created_at, n.last_confirmed_at
-        FROM traversal t
-        JOIN kg_nodes n ON n.id = t.id
-        ORDER BY n.last_confirmed_at DESC
-        LIMIT $3`,
-        [nodeId, depth, limit],
-      )
       : await pool.query<KgNodeRow>(
-        `SELECT id, type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at
-         FROM kg_nodes
-         ORDER BY last_confirmed_at DESC
-         LIMIT $1`,
-        [limit],
-      );
+          `SELECT id, type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at
+           FROM kg_nodes
+           ORDER BY last_confirmed_at DESC
+           LIMIT $1`,
+          [limit],
+        );
 
     if (nodeResult.rows.length === 0) {
       return reply.send({ nodes: [], edges: [] });

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from 'node:crypto';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
@@ -9,7 +9,14 @@ export interface KnowledgeGraphRouteOptions {
   pool: Pool;
   logger: Logger;
   webAppBootstrapSecret: string | undefined;
+  // True when APP_ORIGIN is https:// — causes Set-Cookie to include the Secure flag.
+  // False in local dev so cookies work on http://localhost without browser rejection.
+  secureCookies: boolean;
 }
+
+// Session token → expiry timestamp (ms). Scoped to the route registration
+// lifetime (process lifetime for production). Single-tenant tool: memory is fine.
+type SessionStore = Map<string, number>;
 
 interface KgNodeRow {
   id: string;
@@ -46,6 +53,7 @@ function assertSecret(
   request: FastifyRequest,
   reply: FastifyReply,
   configuredSecret: string | undefined,
+  sessions: SessionStore,
 ): boolean {
   if (!configuredSecret) {
     reply.status(503).send({
@@ -54,17 +62,27 @@ function assertSecret(
     return false;
   }
 
+  // Primary path: browser session cookie set by POST /auth.
+  // @fastify/cookie augments FastifyRequest with .cookies at runtime.
+  const cookies = (request as unknown as { cookies?: Record<string, string | undefined> }).cookies;
+  const sessionToken = cookies?.['curia_session'];
+  if (sessionToken) {
+    const expiresAt = sessions.get(sessionToken);
+    if (expiresAt !== undefined && Date.now() < expiresAt) return true;
+    // Expired or unknown token — fall through to header check below.
+  }
+
+  // Fallback: direct header (programmatic API access via curl / scripts).
+  // Reject non-string values (Fastify coerces duplicate headers to string[]).
+  // Use timing-safe comparison to prevent character-by-character brute force.
   const provided = request.headers['x-web-bootstrap-secret'];
-  // Reject non-string values (e.g. Fastify coerces duplicate headers to string[]).
-  // Then use a timing-safe comparison to avoid leaking how many leading characters
-  // matched — same pattern as validateBearerToken() in auth.ts.
   if (
     typeof provided !== 'string' ||
     provided.length !== configuredSecret.length ||
     !timingSafeEqual(Buffer.from(provided), Buffer.from(configuredSecret))
   ) {
     reply.status(401).send({
-      error: 'Unauthorized. Provide WEB_APP_BOOTSTRAP_SECRET via the x-web-bootstrap-secret header.',
+      error: 'Unauthorized. Authenticate via POST /auth or provide the x-web-bootstrap-secret header.',
     });
     return false;
   }
@@ -410,15 +428,19 @@ function createUiHtml(): string {
     }
 
     // ── Auth ───────────────────────────────────────────────────────────
-    function getSecret() {
-      return sessionStorage.getItem('web_app_bootstrap_secret') || '';
-    }
+    // Session is maintained by an HttpOnly cookie set by POST /auth.
+    // The secret never lives in JS-land after the exchange.
 
     function showMain() {
       authWall.style.display = 'none';
       mainApp.style.display  = 'flex';
       initCytoscape();
       search(); // auto-load all nodes on entry
+    }
+
+    function showAuthError(msg) {
+      authError.textContent = msg || 'Invalid access key \u2014 please try again.';
+      authError.style.display = 'block';
     }
 
     authForm.addEventListener('submit', function(e) {
@@ -431,28 +453,45 @@ function createUiHtml(): string {
       btn.disabled = true;
       authError.style.display = 'none';
 
-      // Validate secret against the server before storing it — gives immediate
-      // feedback if the key is wrong rather than letting errors surface in the search.
-      fetch('/api/kg/nodes?limit=1', { headers: { 'x-web-bootstrap-secret': secret } })
+      // Exchange the secret for an HttpOnly session cookie via POST /auth.
+      // The secret travels in a JSON body (not a header or query string) and
+      // is never stored in JS-accessible storage.
+      fetch('/auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ secret: secret }),
+      })
         .then(function(res) {
           if (res.status === 401) {
-            authError.style.display = 'block';
+            showAuthError('Invalid access key \u2014 please try again.');
             btn.textContent = 'Enter';
             btn.disabled = false;
             return;
           }
-          sessionStorage.setItem('web_app_bootstrap_secret', secret);
+          if (res.status === 429) {
+            showAuthError('Too many attempts \u2014 please wait before trying again.');
+            btn.textContent = 'Enter';
+            btn.disabled = false;
+            return;
+          }
+          // Cookie is now set by the server. Clear the input so the secret
+          // doesn't linger in the DOM longer than necessary.
+          authInput.value = '';
           showMain();
         })
         .catch(function() {
-          // Network error — store and proceed; subsequent API calls will surface issues.
-          sessionStorage.setItem('web_app_bootstrap_secret', secret);
-          showMain();
+          // Network error — do not grant access. Show an error so the user can retry.
+          showAuthError('Could not reach server \u2014 please check your connection and try again.');
+          btn.textContent = 'Enter';
+          btn.disabled = false;
         });
     });
 
-    // Auto-unlock when a valid key is already stored in this session
-    if (getSecret()) showMain();
+    // On page load, probe the API to check whether a valid session cookie already
+    // exists (e.g. page refresh within a live session). If so, skip the auth wall.
+    fetch('/api/kg/nodes?limit=1')
+      .then(function(res) { if (res.ok) showMain(); })
+      .catch(function() { /* network error — stay on auth wall */ });
 
     // ── Cytoscape ──────────────────────────────────────────────────────
     function initCytoscape() {
@@ -534,9 +573,9 @@ function createUiHtml(): string {
     }
 
     function fetchJson(url) {
-      var secret = getSecret();
-      var headers = secret ? { 'x-web-bootstrap-secret': secret } : {};
-      return fetch(url, { headers: headers }).then(function(res) {
+      // No explicit auth header needed — the browser sends the HttpOnly session
+      // cookie automatically with every same-origin request.
+      return fetch(url).then(function(res) {
         if (!res.ok) return res.text().then(function(t) { throw new Error(t); });
         return res.json();
       });
@@ -615,7 +654,21 @@ export async function knowledgeGraphRoutes(
   app: FastifyInstance,
   options: KnowledgeGraphRouteOptions,
 ): Promise<void> {
-  const { pool, logger, webAppBootstrapSecret } = options;
+  const { pool, logger, webAppBootstrapSecret, secureCookies } = options;
+
+  // In-memory session store: token → expiry timestamp (ms).
+  // Single-tenant tool — no DB persistence needed; sessions reset on server restart.
+  const sessions: SessionStore = new Map();
+
+  // Prune expired sessions every minute so the Map doesn't grow unboundedly.
+  const pruneInterval = setInterval(() => {
+    const now = Date.now();
+    for (const [token, expiresAt] of sessions) {
+      if (now > expiresAt) sessions.delete(token);
+    }
+  }, 60_000);
+  // Unref so the interval doesn't prevent process exit during tests.
+  pruneInterval.unref();
 
   app.get('/', async (_request, reply) => {
     reply
@@ -625,6 +678,41 @@ export async function knowledgeGraphRoutes(
       // Stop browsers from MIME-sniffing the response away from text/html.
       .header('X-Content-Type-Options', 'nosniff')
       .send(createUiHtml());
+  });
+
+  // POST /auth — exchanges the bootstrap secret for an HttpOnly session cookie.
+  // Tighter rate limit than the global default: 10 attempts per 15 minutes per IP,
+  // preventing online brute-force against the secret.
+  app.post('/auth', {
+    config: { rateLimit: { max: 10, timeWindow: '15 minutes' } },
+  }, async (request, reply) => {
+    if (!webAppBootstrapSecret) {
+      return reply.status(503).send({ error: 'KG web UI is disabled.' });
+    }
+
+    const body = request.body as { secret?: unknown };
+    const provided = typeof body?.secret === 'string' ? body.secret : '';
+
+    if (
+      provided.length !== webAppBootstrapSecret.length ||
+      !timingSafeEqual(Buffer.from(provided), Buffer.from(webAppBootstrapSecret))
+    ) {
+      return reply.status(401).send({ error: 'Invalid access key.' });
+    }
+
+    // Issue a 256-bit random session token. The secret itself never goes in the cookie.
+    const token = randomBytes(32).toString('hex');
+    sessions.set(token, Date.now() + 24 * 60 * 60 * 1000); // expires in 24 hours
+
+    reply.setCookie('curia_session', token, {
+      httpOnly: true,
+      secure: secureCookies,  // true in prod (https://), false for http://localhost
+      sameSite: 'strict',
+      path: '/',
+      maxAge: 86400,          // 24 hours in seconds
+    });
+
+    return reply.status(200).send({ ok: true });
   });
 
   app.get('/assets/cytoscape.min.js', async (_request, reply) => {
@@ -641,7 +729,7 @@ export async function knowledgeGraphRoutes(
   });
 
   app.get('/api/kg/nodes', async (request, reply) => {
-    if (!assertSecret(request, reply, webAppBootstrapSecret)) return;
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
 
     const query = request.query as {
       query?: string;
@@ -683,7 +771,7 @@ export async function knowledgeGraphRoutes(
   });
 
   app.get('/api/kg/graph', async (request, reply) => {
-    if (!assertSecret(request, reply, webAppBootstrapSecret)) return;
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
 
     const query = request.query as {
       node_id?: string;

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -108,13 +108,22 @@ function createUiHtml(): string {
     const statusEl = document.getElementById('status');
     const resultsEl = document.getElementById('results');
     const searchInput = document.getElementById('search');
+    const searchBtn = document.getElementById('searchBtn');
     const secretInput = document.getElementById('secret');
     const saveSecretBtn = document.getElementById('saveSecret');
+    const graphEl = document.getElementById('graph');
+
+    // Guard against missing DOM elements — all are defined in the HTML above, but this
+    // catches template/script divergence early with a readable error instead of a
+    // cryptic null-dereference later.
+    if (!statusEl || !resultsEl || !searchInput || !searchBtn || !secretInput || !saveSecretBtn || !graphEl) {
+      throw new Error('KG Explorer: required DOM element missing — check template integrity.');
+    }
 
     secretInput.value = sessionStorage.getItem('web_app_bootstrap_secret') || '';
 
     const cy = cytoscape({
-      container: document.getElementById('graph'),
+      container: graphEl,
       elements: [],
       style: [
         { selector: 'node', style: { label: 'data(label)', 'background-color': '#3b82f6', color: '#f8fafc', 'text-valign': 'center', 'text-halign': 'center', 'font-size': 10, width: 30, height: 30 } },
@@ -144,16 +153,26 @@ function createUiHtml(): string {
     }
 
     function renderResults(nodes) {
-      resultsEl.innerHTML = '';
+      resultsEl.replaceChildren();
       if (nodes.length === 0) {
-        resultsEl.innerHTML = '<p class="meta">No matching nodes.</p>';
+        const empty = document.createElement('p');
+        empty.className = 'meta';
+        empty.textContent = 'No matching nodes.';
+        resultsEl.appendChild(empty);
         return;
       }
 
       nodes.forEach((node) => {
         const card = document.createElement('div');
         card.className = 'node-result';
-        card.innerHTML = '<strong>' + node.label + '</strong><div class="meta">' + node.type + ' · confidence ' + node.confidence.toFixed(2) + '</div>';
+        // Use textContent (not innerHTML) to prevent stored XSS — node labels and types
+        // come from the database and could contain HTML/JS payloads from imported sources.
+        const title = document.createElement('strong');
+        title.textContent = node.label;
+        const meta = document.createElement('div');
+        meta.className = 'meta';
+        meta.textContent = node.type + ' · confidence ' + node.confidence.toFixed(2);
+        card.append(title, meta);
         card.addEventListener('click', () => loadNeighborhood(node.id));
         resultsEl.appendChild(card);
       });
@@ -196,7 +215,7 @@ function createUiHtml(): string {
       setStatus('Secret stored in this browser session.');
     });
 
-    document.getElementById('searchBtn').addEventListener('click', search);
+    searchBtn.addEventListener('click', search);
     searchInput.addEventListener('keydown', (event) => { if (event.key === 'Enter') search(); });
     if (getSecret()) search();
   </script>
@@ -277,19 +296,31 @@ export async function knowledgeGraphRoutes(
     const depth = normalizeLimit(query.depth, 2, 4);
     const limit = normalizeLimit(query.limit, 100, 300);
 
+    // Reject malformed UUIDs before they reach SQL — Postgres would throw a cast error
+    // and surface as a 500 rather than a useful 400 for the caller.
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    if (nodeId && !UUID_RE.test(nodeId)) {
+      return reply.status(400).send({ error: 'Invalid node_id: must be a valid UUID.' });
+    }
+
     const nodeResult = nodeId
       ? await pool.query<KgNodeRow>(
+          // visited tracks the set of node IDs already expanded, preventing the same
+          // node from being re-expanded when reached at a different depth (which UNION
+          // alone can't prevent because depth is part of each row's identity).
           `WITH RECURSIVE traversal AS (
-             SELECT id, 0 AS depth
+             SELECT id, 0 AS depth, ARRAY[id] AS visited
              FROM kg_nodes
              WHERE id = $1::uuid
-             UNION
+             UNION ALL
              SELECT
                CASE WHEN e.source_node_id = t.id THEN e.target_node_id ELSE e.source_node_id END AS id,
-               t.depth + 1 AS depth
+               t.depth + 1,
+               t.visited || CASE WHEN e.source_node_id = t.id THEN e.target_node_id ELSE e.source_node_id END
              FROM traversal t
              JOIN kg_edges e ON e.source_node_id = t.id OR e.target_node_id = t.id
              WHERE t.depth < $2
+               AND NOT (CASE WHEN e.source_node_id = t.id THEN e.target_node_id ELSE e.source_node_id END = ANY(t.visited))
            )
            SELECT DISTINCT n.id, n.type, n.label, n.properties, n.confidence, n.decay_class, n.source, n.created_at, n.last_confirmed_at
            FROM traversal t

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export interface Config {
   logLevel: string;
   httpPort: number;
   apiToken: string | undefined;
+  knowledgeGraphUiSecret: string | undefined;
   timezone: string;
   nylasApiKey: string | undefined;
   nylasGrantId: string | undefined;
@@ -40,6 +41,7 @@ export function loadConfig(): Config {
     logLevel: process.env.LOG_LEVEL ?? 'info',
     httpPort,
     apiToken: process.env.API_TOKEN,
+    knowledgeGraphUiSecret: process.env.KG_UI_SECRET,
     timezone: process.env.TIMEZONE ?? 'America/Toronto',
     nylasApiKey: process.env.NYLAS_API_KEY,
     nylasGrantId: process.env.NYLAS_GRANT_ID,

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,10 @@ export interface Config {
   httpPort: number;
   apiToken: string | undefined;
   webAppBootstrapSecret: string | undefined;
+  // Public origin of the app (e.g. "https://curia.example.com"). Used to restrict
+  // CORS to a single origin and to set the Secure flag on session cookies.
+  // Leave unset in local development — CORS is disabled and cookies are HTTP-only.
+  appOrigin: string | undefined;
   timezone: string;
   nylasApiKey: string | undefined;
   nylasGrantId: string | undefined;
@@ -42,6 +46,7 @@ export function loadConfig(): Config {
     httpPort,
     apiToken: process.env.API_TOKEN,
     webAppBootstrapSecret: process.env.WEB_APP_BOOTSTRAP_SECRET,
+    appOrigin: process.env.APP_ORIGIN || undefined,
     timezone: process.env.TIMEZONE ?? 'America/Toronto',
     nylasApiKey: process.env.NYLAS_API_KEY,
     nylasGrantId: process.env.NYLAS_GRANT_ID,

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ export interface Config {
   logLevel: string;
   httpPort: number;
   apiToken: string | undefined;
-  knowledgeGraphUiSecret: string | undefined;
+  webAppBootstrapSecret: string | undefined;
   timezone: string;
   nylasApiKey: string | undefined;
   nylasGrantId: string | undefined;
@@ -41,7 +41,7 @@ export function loadConfig(): Config {
     logLevel: process.env.LOG_LEVEL ?? 'info',
     httpPort,
     apiToken: process.env.API_TOKEN,
-    knowledgeGraphUiSecret: process.env.KG_UI_SECRET,
+    webAppBootstrapSecret: process.env.WEB_APP_BOOTSTRAP_SECRET,
     timezone: process.env.TIMEZONE ?? 'America/Toronto',
     nylasApiKey: process.env.NYLAS_API_KEY,
     nylasGrantId: process.env.NYLAS_GRANT_ID,

--- a/src/index.ts
+++ b/src/index.ts
@@ -500,7 +500,7 @@ async function main(): Promise<void> {
     agentRegistry,
     port: config.httpPort,
     apiToken: config.apiToken,
-    knowledgeGraphUiSecret: config.knowledgeGraphUiSecret,
+    webAppBootstrapSecret: config.webAppBootstrapSecret,
     agentNames: agentConfigs.map(c => c.name),
     skillNames: skillRegistry.list().map(s => s.manifest.name),
     schedulerService,

--- a/src/index.ts
+++ b/src/index.ts
@@ -500,6 +500,7 @@ async function main(): Promise<void> {
     agentRegistry,
     port: config.httpPort,
     apiToken: config.apiToken,
+    knowledgeGraphUiSecret: config.knowledgeGraphUiSecret,
     agentNames: agentConfigs.map(c => c.name),
     skillNames: skillRegistry.list().map(s => s.manifest.name),
     schedulerService,

--- a/src/index.ts
+++ b/src/index.ts
@@ -501,6 +501,7 @@ async function main(): Promise<void> {
     port: config.httpPort,
     apiToken: config.apiToken,
     webAppBootstrapSecret: config.webAppBootstrapSecret,
+    appOrigin: config.appOrigin,
     agentNames: agentConfigs.map(c => c.name),
     skillNames: skillRegistry.list().map(s => s.manifest.name),
     schedulerService,

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -86,7 +86,7 @@ describe('knowledgeGraphRoutes', () => {
 
     const response = await app.inject({ method: 'GET', url: '/kg' });
     expect(response.statusCode).toBe(200);
-    expect(response.body).toContain('Knowledge Graph Explorer');
+    expect(response.body).toContain('Knowledge Graph');
 
     await app.close();
   });

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -30,6 +30,7 @@ describe('knowledgeGraphRoutes', () => {
       pool,
       logger: createLogger(),
       webAppBootstrapSecret: 'secret-1',
+      secureCookies: false,
     });
 
     const response = await app.inject({ method: 'GET', url: '/api/kg/nodes' });
@@ -60,6 +61,7 @@ describe('knowledgeGraphRoutes', () => {
       pool,
       logger: createLogger(),
       webAppBootstrapSecret: 'secret-1',
+      secureCookies: false,
     });
 
     const response = await app.inject({
@@ -82,6 +84,7 @@ describe('knowledgeGraphRoutes', () => {
       pool,
       logger: createLogger(),
       webAppBootstrapSecret: 'secret-1',
+      secureCookies: false,
     });
 
     const response = await app.inject({ method: 'GET', url: '/' });
@@ -97,6 +100,7 @@ describe('knowledgeGraphRoutes', () => {
       pool,
       logger: createLogger(),
       webAppBootstrapSecret: 'secret-1',
+      secureCookies: false,
     });
 
     const response = await app.inject({
@@ -122,6 +126,7 @@ describe('knowledgeGraphRoutes', () => {
       pool,
       logger: createLogger(),
       webAppBootstrapSecret: undefined,
+      secureCookies: false,
     });
 
     const response = await app.inject({ method: 'GET', url: '/api/kg/nodes' });

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -90,4 +90,43 @@ describe('knowledgeGraphRoutes', () => {
 
     await app.close();
   });
+
+  it('returns 400 for a malformed node_id UUID', async () => {
+    const app = Fastify();
+    await app.register(knowledgeGraphRoutes, {
+      pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: 'secret-1',
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/kg/graph?node_id=not-a-uuid',
+      headers: { 'x-web-bootstrap-secret': 'secret-1' },
+    });
+
+    // Should be rejected before touching the DB — pool.query must not be called.
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toMatch(/Invalid node_id/);
+    expect(pool.query).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it('returns 503 when the secret is not configured', async () => {
+    // This exercises the defensive assertSecret path. In normal operation the
+    // http-adapter does not register the routes when the secret is absent, but
+    // the guard is kept inside the route handler as a belt-and-suspenders check.
+    const app = Fastify();
+    await app.register(knowledgeGraphRoutes, {
+      pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: undefined,
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/kg/nodes' });
+    expect(response.statusCode).toBe(503);
+
+    await app.close();
+  });
 });

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -24,12 +24,12 @@ describe('knowledgeGraphRoutes', () => {
     vi.clearAllMocks();
   });
 
-  it('rejects API requests without x-kg-secret', async () => {
+  it('rejects API requests without x-web-bootstrap-secret', async () => {
     const app = Fastify();
     await app.register(knowledgeGraphRoutes, {
       pool,
       logger: createLogger(),
-      knowledgeGraphUiSecret: 'secret-1',
+      webAppBootstrapSecret: 'secret-1',
     });
 
     const response = await app.inject({ method: 'GET', url: '/api/kg/nodes' });
@@ -59,13 +59,13 @@ describe('knowledgeGraphRoutes', () => {
     await app.register(knowledgeGraphRoutes, {
       pool,
       logger: createLogger(),
-      knowledgeGraphUiSecret: 'secret-1',
+      webAppBootstrapSecret: 'secret-1',
     });
 
     const response = await app.inject({
       method: 'GET',
       url: '/api/kg/nodes?query=ada',
-      headers: { 'x-kg-secret': 'secret-1' },
+      headers: { 'x-web-bootstrap-secret': 'secret-1' },
     });
 
     expect(response.statusCode).toBe(200);
@@ -81,7 +81,7 @@ describe('knowledgeGraphRoutes', () => {
     await app.register(knowledgeGraphRoutes, {
       pool,
       logger: createLogger(),
-      knowledgeGraphUiSecret: 'secret-1',
+      webAppBootstrapSecret: 'secret-1',
     });
 
     const response = await app.inject({ method: 'GET', url: '/kg' });

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -1,0 +1,93 @@
+import Fastify from 'fastify';
+import type { Pool } from 'pg';
+import type { Logger } from '../../../../src/logger.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { knowledgeGraphRoutes } from '../../../../src/channels/http/routes/kg.js';
+
+function createLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(),
+  } as unknown as Logger;
+}
+
+describe('knowledgeGraphRoutes', () => {
+  const pool = {
+    query: vi.fn(),
+  } as unknown as Pick<Pool, 'query'>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects API requests without x-kg-secret', async () => {
+    const app = Fastify();
+    await app.register(knowledgeGraphRoutes, {
+      pool,
+      logger: createLogger(),
+      knowledgeGraphUiSecret: 'secret-1',
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/api/kg/nodes' });
+    expect(response.statusCode).toBe(401);
+
+    await app.close();
+  });
+
+  it('returns node results when authenticated', async () => {
+    pool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: '11111111-1111-1111-1111-111111111111',
+          type: 'person',
+          label: 'Ada Lovelace',
+          properties: { role: 'founder' },
+          confidence: 0.9,
+          decay_class: 'slow_decay',
+          source: 'seed',
+          created_at: '2026-01-01T00:00:00.000Z',
+          last_confirmed_at: '2026-01-02T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const app = Fastify();
+    await app.register(knowledgeGraphRoutes, {
+      pool,
+      logger: createLogger(),
+      knowledgeGraphUiSecret: 'secret-1',
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/kg/nodes?query=ada',
+      headers: { 'x-kg-secret': 'secret-1' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json();
+    expect(payload.nodes).toHaveLength(1);
+    expect(payload.nodes[0].label).toBe('Ada Lovelace');
+
+    await app.close();
+  });
+
+  it('serves the UI shell', async () => {
+    const app = Fastify();
+    await app.register(knowledgeGraphRoutes, {
+      pool,
+      logger: createLogger(),
+      knowledgeGraphUiSecret: 'secret-1',
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/kg' });
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain('Knowledge Graph Explorer');
+
+    await app.close();
+  });
+});

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -84,7 +84,7 @@ describe('knowledgeGraphRoutes', () => {
       webAppBootstrapSecret: 'secret-1',
     });
 
-    const response = await app.inject({ method: 'GET', url: '/kg' });
+    const response = await app.inject({ method: 'GET', url: '/' });
     expect(response.statusCode).toBe(200);
     expect(response.body).toContain('Knowledge Graph');
 


### PR DESCRIPTION
## **User description**
### Motivation

- Provide a secure, browser-based UI to browse and search the existing knowledge graph stored in Postgres (`kg_nodes`, `kg_edges`) without changing storage architecture.
- Use a high-quality, stable open-source visualization layer to allow interactive exploration with minimal additional dependencies.

### Description

- Add a new Fastify route module `src/channels/http/routes/kg.ts` that serves a single-page UI at `GET /kg` and JSON APIs at `GET /api/kg/nodes` and `GET /api/kg/graph` for node search and neighborhood traversal.
- Protect the UI and APIs with a dedicated secret `KG_UI_SECRET` (accepted via `?secret=` query or `x-kg-secret` header) and disable the feature entirely when the secret is not set.
- Wire configuration plumbing (`knowledgeGraphUiSecret`) into `src/config.ts`, the HTTP adapter (`src/channels/http/http-adapter.ts`), and bootstrapping in `src/index.ts`, and exempt the `/kg` and `/api/kg/*` routes from the global bearer-token hook so they use the KG secret flow.
- Use Cytoscape.js (loaded from unpkg in the embedded page) as the visualization layer; the UI maps Postgres rows directly to Cytoscape node/edge payloads and requires no schema changes.
- Add documentation: README entry and `docs/specs/12-knowledge-graph-web-explorer.md` describing design, security model, API surface, and rationale.

### Testing

- Ran static type checking with `npm run typecheck` (TypeScript `tsc --noEmit`) which passed.
- Ran linter `npx eslint src/channels/http/http-adapter.ts src/channels/http/routes/kg.ts src/config.ts src/index.ts` which completed (no blocking errors reported).
- Ran unit tests `npx vitest run tests/unit/config.test.ts tests/unit/channels/http/auth.test.ts` and both test files passed (all tests green).

[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d146adaf708323bc1b85a96f250e3f)


___

## **CodeAnt-AI Description**
**Add a secured web explorer for the knowledge graph**

### What Changed
- Added a browser-based knowledge graph page with search and clickable node browsing.
- The graph view now requires a secret to open, and API calls are blocked unless the same secret is sent from the page.
- The explorer now refuses malformed node IDs with a clear client error instead of failing on the server.
- The page now renders database content as plain text, reducing the risk of script injection from stored labels.
- If the knowledge graph secret is not set, the feature is hidden instead of exposing a disabled endpoint.

### Impact
`✅ Safer graph browsing`
`✅ Clearer access control`
`✅ Fewer server errors from bad graph links`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
