### PR TITLE
feat(kg-ui): add Chat view to KG explorer web app

### DIFF
--- a/docs/superpowers/plans/2026-04-04-kg-chat-ui.md
+++ b/docs/superpowers/plans/2026-04-04-kg-chat-ui.md
@@ -1,0 +1,749 @@
+# KG Chat UI Integration Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Integrate a functional chat UI pane into the KG explorer web app by editing `createUiHtml()` in `src/channels/http/routes/kg.ts`.
+
+**Architecture:** Add a `#view-chat` section (hidden by default, revealed by the existing `navigate()` dispatcher) with a split-pane layout: conversation list on the left, message thread + input form on the right. Messages are sent via `POST /api/kg/chat/messages`; intermediate agent events (skill invocations) are streamed via `GET /api/kg/chat/stream?conversationId=…` using `EventSource.onmessage`.
+
+**Tech Stack:** Vanilla JS inside a server-rendered HTML string (no build step). Tailwind CSS browser runtime (already loaded). CSS custom properties already defined in the design system. Fetch API for POST; EventSource API for SSE.
+
+---
+
+## File to modify
+
+- Modify: `src/channels/http/routes/kg.ts` — `createUiHtml()` function only
+  - Add chat CSS to the `<style>` block (line ~123)
+  - Add `#view-chat` HTML after `#view-coming-soon` (line ~398)
+  - Update the `nav-chat` button's onclick (line ~299)
+  - Add chat JS to the `<script>` block (line ~404)
+  - Update `navigate()` to handle the `'chat'` view (line ~540)
+
+- Test: `tests/unit/channels/http/kg-chat-routes.test.ts`
+  - Add one test verifying the UI shell contains a Chat nav button
+
+---
+
+### Task 1: Add chat CSS to the `<style>` block
+
+The `<style>` block ends with the `.chevron` rule near line 258. Add chat-specific styles immediately before the closing `</style>` tag.
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts` (style block, ~line 255)
+
+- [ ] **Step 1: Add the CSS**
+
+  In `createUiHtml()`, find the line:
+
+  ```css
+      .chevron               { transition: transform 0.2s; }
+      .chevron.collapsed     { transform: rotate(-90deg); }
+    </style>
+  ```
+
+  Replace it with:
+
+  ```css
+      .chevron               { transition: transform 0.2s; }
+      .chevron.collapsed     { transform: rotate(-90deg); }
+
+      /* ── Chat view ───────────────────────────────────────────────────── */
+
+      /* Sidebar: conversation list */
+      .chat-sidebar {
+        flex: none;
+        width: 220px;
+        border-right: 1px solid var(--border);
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+
+      /* Thread column: messages + input bar */
+      .chat-thread {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+
+      /* Scrollable message area */
+      .chat-messages {
+        flex: 1;
+        overflow-y: auto;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+
+      /* Input bar at the bottom of the thread */
+      .chat-input-bar {
+        flex: none;
+        padding: 12px 16px;
+        border-top: 1px solid var(--border);
+        display: flex;
+        align-items: flex-end;
+        gap: 8px;
+      }
+
+      /* Resizable textarea */
+      textarea.chat-textarea {
+        flex: 1;
+        resize: none;
+        min-height: 56px;
+        max-height: 120px;
+        background: var(--muted);
+        border: 1px solid var(--input-border);
+        border-radius: var(--radius-md);
+        color: var(--fg);
+        font-family: inherit;
+        font-size: 0.875rem;
+        padding: 8px 12px;
+        outline: none;
+        transition: border-color 0.12s;
+      }
+      textarea.chat-textarea:focus { border-color: var(--teal); }
+
+      /* Message bubbles */
+      .msg-bubble {
+        max-width: 80%;
+        padding: 8px 12px;
+        border-radius: var(--radius-lg);
+        font-size: 0.875rem;
+        line-height: 1.5;
+        word-wrap: break-word;
+        white-space: pre-wrap;
+      }
+      .msg-bubble.user {
+        align-self: flex-end;
+        background: var(--teal);
+        color: var(--fg);
+        border-bottom-right-radius: 2px;
+      }
+      .msg-bubble.agent {
+        align-self: flex-start;
+        background: var(--card);
+        border: 1px solid var(--border);
+        color: var(--fg);
+        border-bottom-left-radius: 2px;
+      }
+      /* Status messages: skill.invoke notifications, "thinking…" indicator */
+      .msg-bubble.status {
+        align-self: center;
+        background: none;
+        color: var(--fg-muted);
+        font-size: 0.75rem;
+        font-style: italic;
+        padding: 2px 8px;
+        max-width: 100%;
+      }
+      .msg-bubble.error {
+        align-self: flex-start;
+        background: rgba(232,96,64,0.12);
+        border: 1px solid rgba(232,96,64,0.30);
+        color: var(--destructive);
+        border-bottom-left-radius: 2px;
+      }
+
+      /* Conversation list items */
+      .conv-item {
+        padding: 7px 10px;
+        border-radius: var(--radius-md);
+        font-size: 0.8125rem;
+        color: var(--fg-muted);
+        cursor: pointer;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        transition: background 0.12s, color 0.12s;
+      }
+      .conv-item:hover  { background: var(--accent); color: var(--fg); }
+      .conv-item.active { background: var(--muted);  color: var(--fg); }
+    </style>
+  ```
+
+- [ ] **Step 2: Run tests to confirm no regressions**
+
+  ```bash
+  pnpm test --run
+  ```
+
+  Expected: all tests pass (no changes to logic yet).
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add src/channels/http/routes/kg.ts
+  git commit -m "feat(kg-ui): add chat view CSS to style block"
+  ```
+
+---
+
+### Task 2: Add `#view-chat` HTML and update nav button
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts` (HTML template, ~lines 299 and 398)
+
+- [ ] **Step 1: Update the Chat nav button onclick**
+
+  Find the existing nav-chat button (line ~299):
+
+  ```html
+          <button id="nav-chat" class="nav-item" onclick="navigate('coming-soon', 'Chat', 'nav-chat')">
+  ```
+
+  Change it to:
+
+  ```html
+          <button id="nav-chat" class="nav-item" onclick="navigate('chat', 'Chat', 'nav-chat')">
+  ```
+
+- [ ] **Step 2: Add `#view-chat` HTML after `#view-coming-soon`**
+
+  Find the coming-soon view div and the closing `</main>` (lines ~394–400):
+
+  ```html
+        <!-- Coming Soon view (shared by Chat, Contacts, Tasks) -->
+        <div id="view-coming-soon" style="display: none; height: 100%; flex-direction: column; align-items: center; justify-content: center;">
+          <p style="font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.15em; color: var(--fg-muted); margin: 0 0 8px;">Coming Soon</p>
+          <h2 id="coming-soon-title" style="font-family: 'Lora', Georgia, serif; font-size: 2rem; font-weight: 500; color: var(--fg); margin: 0;"></h2>
+        </div>
+
+      </main>
+  ```
+
+  Replace it with:
+
+  ```html
+        <!-- Coming Soon view (shared by Contacts, Tasks) -->
+        <div id="view-coming-soon" style="display: none; height: 100%; flex-direction: column; align-items: center; justify-content: center;">
+          <p style="font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.15em; color: var(--fg-muted); margin: 0 0 8px;">Coming Soon</p>
+          <h2 id="coming-soon-title" style="font-family: 'Lora', Georgia, serif; font-size: 2rem; font-weight: 500; color: var(--fg); margin: 0;"></h2>
+        </div>
+
+        <!-- Chat view — hidden until user clicks the Chat nav item -->
+        <div id="view-chat" style="display: none; height: 100%; flex-direction: row;">
+
+          <!-- Left: conversation list -->
+          <div class="chat-sidebar">
+            <div style="padding: 10px 8px; border-bottom: 1px solid var(--border);">
+              <button class="btn-primary" style="width: 100%;" onclick="newConversation()">+ New Chat</button>
+            </div>
+            <div id="chat-conv-list" style="flex: 1; overflow-y: auto; padding: 6px; display: flex; flex-direction: column; gap: 2px;"></div>
+          </div>
+
+          <!-- Right: message thread + input -->
+          <div class="chat-thread">
+            <div id="chat-messages" class="chat-messages"></div>
+            <div class="chat-input-bar">
+              <form id="chat-form" style="display: contents;">
+                <textarea id="chat-textarea" class="chat-textarea" placeholder="Message Curia\u2026" rows="2"></textarea>
+                <button type="submit" id="chat-send-btn" class="btn-primary" style="padding: 8px 16px;">Send</button>
+              </form>
+            </div>
+          </div>
+
+        </div>
+
+      </main>
+  ```
+
+- [ ] **Step 3: Run tests**
+
+  ```bash
+  pnpm test --run
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add src/channels/http/routes/kg.ts
+  git commit -m "feat(kg-ui): add #view-chat HTML and wire Chat nav button"
+  ```
+
+---
+
+### Task 3: Add JS — chat state, DOM refs, and navigate() update
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts` (script block, ~lines 405–561)
+
+- [ ] **Step 1: Add chat state variables after the existing state block**
+
+  Find the state block (lines ~405–408):
+
+  ```javascript
+    // ── State ──────────────────────────────────────────────────────────
+    var cy = null;           // Cytoscape instance (lazy-initialised on first login)
+    var memoryOpen = true;   // Memory nav section expanded by default
+    var activeNavId = 'nav-kg';
+  ```
+
+  Replace it with:
+
+  ```javascript
+    // ── State ──────────────────────────────────────────────────────────
+    var cy = null;           // Cytoscape instance (lazy-initialised on first login)
+    var memoryOpen = true;   // Memory nav section expanded by default
+    var activeNavId = 'nav-kg';
+
+    // ── Chat state ─────────────────────────────────────────────────────
+    // Active EventSource for SSE — one per conversation, null when idle.
+    var chatStream = null;
+    // Active conversation UUID — set when the user sends their first message
+    // in a new conversation, or when switching between past conversations.
+    var chatConversationId = null;
+    // Tracks whether the agent reply has been rendered for the current round-trip
+    // to prevent the SSE outbound.message and the POST response from both appending
+    // the same text (whichever fires first wins; the other is a no-op).
+    var chatReplyRendered = false;
+    // In-session conversation list. Each entry: { id, label, messages: [] }
+    // where messages are { role: 'user'|'agent'|'status'|'error', text: string }.
+    var chatConversations = [];
+    // Index of the currently active conversation, or -1 if none.
+    var chatActiveConvIdx = -1;
+  ```
+
+- [ ] **Step 2: Add chat DOM refs after the existing element refs block**
+
+  Find the element refs block ending with:
+
+  ```javascript
+    var memoryCaret   = document.getElementById('memory-chevron');
+    var memorySubmenu = document.getElementById('memory-submenu');
+  ```
+
+  Replace it with:
+
+  ```javascript
+    var memoryCaret   = document.getElementById('memory-chevron');
+    var memorySubmenu = document.getElementById('memory-submenu');
+
+    // Chat DOM refs
+    var chatMessagesEl = document.getElementById('chat-messages');
+    var chatConvListEl = document.getElementById('chat-conv-list');
+    var chatForm       = document.getElementById('chat-form');
+    var chatTextarea   = document.getElementById('chat-textarea');
+    var chatSendBtn    = document.getElementById('chat-send-btn');
+  ```
+
+- [ ] **Step 3: Extend the null-check guard to include the new elements**
+
+  Find the existing null-check (lines ~424–428):
+
+  ```javascript
+    if (!authWall || !mainApp || !authForm || !authInput || !authError ||
+        !statusEl || !resultsEl || !searchInput || !searchBtn ||
+        !memoryCaret || !memorySubmenu) {
+      throw new Error('Curia KG: required DOM element missing — check template integrity.');
+    }
+  ```
+
+  Replace it with:
+
+  ```javascript
+    if (!authWall || !mainApp || !authForm || !authInput || !authError ||
+        !statusEl || !resultsEl || !searchInput || !searchBtn ||
+        !memoryCaret || !memorySubmenu ||
+        !chatMessagesEl || !chatConvListEl || !chatForm || !chatTextarea || !chatSendBtn) {
+      throw new Error('Curia KG: required DOM element missing — check template integrity.');
+    }
+  ```
+
+- [ ] **Step 4: Update `navigate()` to handle the `'chat'` view**
+
+  Find the entire `navigate` function (lines ~540–561):
+
+  ```javascript
+    function navigate(view, title, navId) {
+      var kgView = document.getElementById('view-kg');
+      var csView = document.getElementById('view-coming-soon');
+
+      kgView.style.display = view === 'kg'           ? 'flex' : 'none';
+      csView.style.display = view === 'coming-soon'  ? 'flex' : 'none';
+
+      if (view === 'coming-soon') {
+        document.getElementById('coming-soon-title').textContent = title;
+      }
+
+      // Update active highlight
+      if (activeNavId) {
+        var prev = document.getElementById(activeNavId);
+        if (prev) prev.classList.remove('active');
+      }
+      if (navId) {
+        var curr = document.getElementById(navId);
+        if (curr) curr.classList.add('active');
+        activeNavId = navId;
+      }
+    }
+  ```
+
+  Replace it with:
+
+  ```javascript
+    function navigate(view, title, navId) {
+      var kgView   = document.getElementById('view-kg');
+      var chatView = document.getElementById('view-chat');
+      var csView   = document.getElementById('view-coming-soon');
+
+      kgView.style.display   = view === 'kg'           ? 'flex' : 'none';
+      chatView.style.display = view === 'chat'         ? 'flex' : 'none';
+      csView.style.display   = view === 'coming-soon'  ? 'flex' : 'none';
+
+      if (view === 'coming-soon') {
+        document.getElementById('coming-soon-title').textContent = title;
+      }
+
+      // Open the SSE stream lazily on first entry into the Chat view.
+      // If a conversation is already active, reuse its stream.
+      if (view === 'chat' && chatActiveConvIdx === -1 && chatConversations.length === 0) {
+        // No conversations yet — show empty state, ready for first message.
+        chatMessagesEl.replaceChildren();
+      }
+
+      // Update active highlight
+      if (activeNavId) {
+        var prev = document.getElementById(activeNavId);
+        if (prev) prev.classList.remove('active');
+      }
+      if (navId) {
+        var curr = document.getElementById(navId);
+        if (curr) curr.classList.add('active');
+        activeNavId = navId;
+      }
+    }
+  ```
+
+- [ ] **Step 5: Run tests**
+
+  ```bash
+  pnpm test --run
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add src/channels/http/routes/kg.ts
+  git commit -m "feat(kg-ui): add chat state, DOM refs, and navigate() chat view support"
+  ```
+
+---
+
+### Task 4: Add JS — chat logic (openChatStream, sendMessage, renderMessage, form handler)
+
+This is the core chat implementation. All code goes inside the `<script>` block in `createUiHtml()`, after the `searchInput.addEventListener` wiring at the bottom.
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts` (~line 646, before `</script>`)
+
+- [ ] **Step 1: Add the chat functions before the `</script>` closing tag**
+
+  Find the last line of the script block:
+
+  ```javascript
+    searchBtn.addEventListener('click', search);
+    searchInput.addEventListener('keydown', function(e) { if (e.key === 'Enter') search(); });
+  </script>
+  ```
+
+  Replace it with:
+
+  ```javascript
+    searchBtn.addEventListener('click', search);
+    searchInput.addEventListener('keydown', function(e) { if (e.key === 'Enter') search(); });
+
+    // ── Chat ───────────────────────────────────────────────────────────
+
+    // Appends a message bubble to the thread panel and scrolls to bottom.
+    // Also persists the message to the in-memory conversation store so it
+    // survives switching between conversations.
+    // role: 'user' | 'agent' | 'status' | 'error'
+    function renderMessage(role, text) {
+      var bubble = document.createElement('div');
+      bubble.className = 'msg-bubble ' + role;
+      // textContent prevents stored XSS — messages come from the agent/user
+      // and could include characters that look like HTML.
+      bubble.textContent = text;
+      chatMessagesEl.appendChild(bubble);
+      chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
+
+      // Persist to current conversation store (skip ephemeral status messages).
+      if (role !== 'status' && chatActiveConvIdx >= 0) {
+        chatConversations[chatActiveConvIdx].messages.push({ role: role, text: text });
+      }
+    }
+
+    // Opens an SSE stream for the given conversationId.
+    // Closes any previously open stream first to avoid leaking connections.
+    function openChatStream(convId) {
+      if (chatStream) {
+        chatStream.close();
+        chatStream = null;
+      }
+
+      var url = '/api/kg/chat/stream?conversationId=' + encodeURIComponent(convId);
+      chatStream = new EventSource(url);
+
+      chatStream.onmessage = function(event) {
+        var payload;
+        try {
+          payload = JSON.parse(event.data);
+        } catch {
+          // Malformed frame — ignore. The SSE spec allows comment frames (:ping)
+          // which EventSource silently drops, but custom parsers might not.
+          return;
+        }
+
+        if (payload.type === 'skill.invoke') {
+          // Show a transient status bubble so the user knows work is in progress.
+          var skillName = payload.skill || payload.skillId || 'skill';
+          renderMessage('status', 'Using ' + skillName + '\u2026');
+        } else if (payload.type === 'outbound.message') {
+          // Agent reply arrived via SSE — render it only if the POST response
+          // hasn't already rendered it (race: whichever fires first wins).
+          if (!chatReplyRendered) {
+            chatReplyRendered = true;
+            var content = (typeof payload.content === 'string') ? payload.content
+                        : (typeof payload.message === 'string') ? payload.message
+                        : JSON.stringify(payload);
+            renderMessage('agent', content);
+            chatSendBtn.disabled = false;
+          }
+        }
+        // skill.result: not rendered — it's internal bookkeeping for the agent layer.
+      };
+
+      chatStream.onerror = function() {
+        // Network interruption — the browser will try to reconnect automatically.
+        // Don't surface an error bubble here to avoid noise on transient drops.
+      };
+    }
+
+    // Creates a new in-session conversation, resets the thread panel,
+    // and updates the conversation list in the sidebar.
+    function newConversation() {
+      // Close the current SSE stream — a fresh one will open on the next send.
+      if (chatStream) {
+        chatStream.close();
+        chatStream = null;
+      }
+      chatConversationId = null;
+      chatActiveConvIdx = -1;
+      chatReplyRendered = false;
+      chatMessagesEl.replaceChildren();
+    }
+
+    // Renders the sidebar conversation list, highlighting the active entry.
+    function renderConvList() {
+      chatConvListEl.replaceChildren();
+      chatConversations.forEach(function(conv, idx) {
+        var item = document.createElement('div');
+        item.className = 'conv-item' + (idx === chatActiveConvIdx ? ' active' : '');
+        item.textContent = conv.label;
+        item.title = conv.label;
+        item.addEventListener('click', function() { switchConversation(idx); });
+        chatConvListEl.appendChild(item);
+      });
+    }
+
+    // Switches the active conversation: restores its messages in the thread panel
+    // and reopens the SSE stream for that conversationId.
+    function switchConversation(idx) {
+      if (idx === chatActiveConvIdx) return;
+      chatActiveConvIdx = idx;
+      chatConversationId = chatConversations[idx].id;
+      chatReplyRendered = false;
+
+      // Restore message history for the selected conversation.
+      chatMessagesEl.replaceChildren();
+      chatConversations[idx].messages.forEach(function(msg) {
+        var bubble = document.createElement('div');
+        bubble.className = 'msg-bubble ' + msg.role;
+        bubble.textContent = msg.text;
+        chatMessagesEl.appendChild(bubble);
+      });
+      chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
+
+      // Reopen SSE for future messages in this conversation.
+      openChatStream(chatConversationId);
+      renderConvList();
+    }
+
+    // Handles the chat form submit: validates input, creates a conversation if needed,
+    // sends the message, and renders the reply (via POST response or SSE, whichever fires first).
+    function sendChatMessage(e) {
+      e.preventDefault();
+      var text = chatTextarea.value.trim();
+      if (!text) return;
+      chatTextarea.value = '';
+
+      // First message in a new conversation — generate a conversationId and create
+      // the conversation entry. crypto.randomUUID() is available in all modern browsers.
+      if (!chatConversationId) {
+        var newId = 'kg-web-' + crypto.randomUUID();
+        chatConversationId = newId;
+        // Truncate label to ~40 chars for the sidebar.
+        var label = text.length > 40 ? text.slice(0, 40) + '\u2026' : text;
+        chatConversations.push({ id: newId, label: label, messages: [] });
+        chatActiveConvIdx = chatConversations.length - 1;
+        renderConvList();
+        // Open SSE for this conversation BEFORE posting so no events are missed.
+        openChatStream(newId);
+      }
+
+      chatReplyRendered = false;
+      renderMessage('user', text);
+      chatSendBtn.disabled = true;
+
+      var convId = chatConversationId;
+
+      fetch('/api/kg/chat/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text, conversationId: convId }),
+      })
+        .then(function(res) {
+          return res.json().then(function(body) {
+            // Surface structured backend errors (400/401/403/504/500 all return { error: "..." }).
+            if (!res.ok) throw new Error(body.error || ('HTTP ' + res.status));
+            return body;
+          });
+        })
+        .then(function(data) {
+          // Render the reply unless the SSE outbound.message already did so.
+          if (!chatReplyRendered) {
+            chatReplyRendered = true;
+            renderMessage('agent', data.reply);
+          }
+          chatSendBtn.disabled = false;
+        })
+        .catch(function(err) {
+          renderMessage('error', err.message || 'Something went wrong. Please try again.');
+          chatSendBtn.disabled = false;
+        });
+    }
+
+    // Allow Shift+Enter for newlines; plain Enter submits the form.
+    chatTextarea.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        sendChatMessage(e);
+      }
+    });
+
+    chatForm.addEventListener('submit', sendChatMessage);
+  </script>
+  ```
+
+- [ ] **Step 2: Run tests**
+
+  ```bash
+  pnpm test --run
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add src/channels/http/routes/kg.ts
+  git commit -m "feat(kg-ui): add chat JS — openChatStream, sendChatMessage, conversation list"
+  ```
+
+---
+
+### Task 5: Add test — UI shell contains the Chat nav element
+
+The existing `kg-chat-routes.test.ts` tests the backend routes. Add one test that verifies `createUiHtml()` output contains the Chat nav button and `#view-chat` — a simple smoke test that catches template regressions.
+
+**Files:**
+- Modify: `tests/unit/channels/http/kg-chat-routes.test.ts`
+
+- [ ] **Step 1: Add the imports and test**
+
+  The test file already imports `knowledgeGraphRoutes`. Add a new `describe` block at the bottom for UI shell assertions. The route handler serves the HTML via `GET /` so we can `app.inject({ method: 'GET', url: '/' })` to get the body without needing auth (the HTML is public).
+
+  Find the end of `kg-chat-routes.test.ts` (after the last `});`):
+
+  ```typescript
+  });
+  ```
+
+  Replace the final `});` with:
+
+  ```typescript
+  });
+
+  describe('KG web UI shell', () => {
+    it('GET / — response contains Chat nav button and #view-chat section', async () => {
+      const app = Fastify();
+      await app.register(cookie);
+      await app.register(knowledgeGraphRoutes, {
+        pool: createPool() as Pool,
+        logger: createLogger(),
+        webAppBootstrapSecret: 'test-secret',
+        secureCookies: false,
+        bus: createMockBus(),
+        eventRouter: createMockEventRouter(),
+      });
+
+      const response = await app.inject({ method: 'GET', url: '/' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toMatch(/text\/html/);
+      expect(response.body).toContain('id="nav-chat"');
+      expect(response.body).toContain('id="view-chat"');
+      // Confirm the nav button routes to 'chat' (not 'coming-soon').
+      expect(response.body).toContain("navigate('chat'");
+
+      await app.close();
+    });
+  });
+  ```
+
+- [ ] **Step 2: Run tests**
+
+  ```bash
+  pnpm test --run
+  ```
+
+  Expected: all tests pass including the new UI shell test.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add tests/unit/channels/http/kg-chat-routes.test.ts
+  git commit -m "test(kg-ui): verify HTML shell contains Chat nav and #view-chat section"
+  ```
+
+---
+
+## Self-review checklist
+
+**Spec coverage:**
+- [x] `#view-chat` section added (Task 2, Step 2)
+- [x] Conversation list panel (left column) added (Task 2, Step 2)
+- [x] Message thread panel (right column) added (Task 2, Step 2)
+- [x] `#chat-form` textarea + submit button added (Task 2, Step 2)
+- [x] SSE stream via `new EventSource('/api/kg/chat/stream?conversationId=...')` (Task 4, Step 1 — `openChatStream()`)
+- [x] "Chat" nav button wired into `navigate()` (Task 2, Step 1 + Task 3, Step 4)
+- [x] `navigate()` updated to handle `'chat'` view (Task 3, Step 4)
+- [x] All fetch calls wrapped in try/catch (Task 4, Step 1 — `sendChatMessage`)
+- [x] Backend `{ error }` field surfaced to user (Task 4, Step 1 — `!res.ok` branch)
+- [x] `stream.onmessage` used (not named event listeners) (Task 4, Step 1 — `chatStream.onmessage`)
+- [x] Branches on `payload.type` (`outbound.message`, `skill.invoke`) (Task 4, Step 1)
+- [x] No `__ping__` session probe added (not present anywhere)
+- [x] No sender ID passed from UI (Task 4, Step 1 — body only has `message` and `conversationId`)
+- [x] Test coverage for UI shell (Task 5)
+- [x] Only `createUiHtml()` is modified — no other functions/routes touched
+
+**Type consistency:**
+- `renderMessage(role, text)` is called with `role` values `'user'`, `'agent'`, `'status'`, `'error'` — CSS classes `.msg-bubble.user/.agent/.status/.error` are all defined in Task 1.
+- `chatConversations[idx]` structure is `{ id, label, messages }` — consistent across `switchConversation`, `renderConvList`, and `sendChatMessage`.
+- `chatReplyRendered` flag is reset to `false` in `newConversation()`, `switchConversation()`, and at the start of each `sendChatMessage()` call.

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -66,8 +66,10 @@ export class EventRouter {
     // outbound.message — dispatches to pending POST resolvers and SSE clients
     bus.subscribe('outbound.message', 'channel', (event: BusEvent) => {
       if (event.type !== 'outbound.message') return;
-      // Only handle messages for the HTTP channel
-      if (event.payload.channelId !== 'http') return;
+      // Handle messages for channels that use synchronous POST/wait (http and web).
+      // Other channels (email, telegram) process replies asynchronously and have no
+      // pending promise waiting here.
+      if (event.payload.channelId !== 'http' && event.payload.channelId !== 'web') return;
 
       const convId = event.payload.conversationId;
 
@@ -146,10 +148,10 @@ export class EventRouter {
 
       const convId = event.payload.conversationId;
 
-      // Only HTTP requests have pending POST promises to reject.
-      // Non-HTTP channels (email, etc.) produce rejection events for audit and SSE,
-      // but have no synchronous caller waiting on a promise.
-      if (event.payload.channelId === 'http') {
+      // HTTP and web channel requests both have synchronous POST promises to reject.
+      // Other channels (email, telegram, etc.) produce rejection events for audit
+      // and SSE but have no synchronous caller waiting on a promise.
+      if (event.payload.channelId === 'http' || event.payload.channelId === 'web') {
         const pending = this.pendingResponses.get(convId);
         if (pending) {
           clearTimeout(pending.timeout);

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -70,6 +70,11 @@ export class EventRouter {
       // Other channels (email, telegram) process replies asynchronously and have no
       // pending promise waiting here.
       if (event.payload.channelId !== 'http' && event.payload.channelId !== 'web') return;
+      // @TODO: The sseClients Set is shared across all SSE endpoints. A client connected
+      // to /api/messages/stream with no conversationId filter will receive web-channel
+      // events after this change. Both endpoints require the same bootstrap-secret auth
+      // (contained for now), but the clean fix is to tag SseClient with channelId and
+      // filter in broadcastToSseClients. Track as a follow-up improvement.
 
       const convId = event.payload.conversationId;
 

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -573,10 +573,12 @@ function createUiHtml(): string {
     // Active conversation UUID — set when the user sends their first message
     // in a new conversation, or when switching between past conversations.
     var chatConversationId = null;
-    // Tracks whether the agent reply has been rendered for the current round-trip
-    // to prevent the SSE 'message' event and the POST response from both appending
-    // the same text (whichever fires first wins; the other is a no-op).
-    var chatReplyRendered = false;
+    // Tracks which conversationIds have had their agent reply rendered this round-trip,
+    // preventing both the SSE 'message' event and the POST response from appending the
+    // same text (whichever fires first wins; the other is a no-op).
+    // Keyed by conversationId so the guard is correctly scoped even when the user
+    // switches conversations while a POST is in-flight.
+    var chatRepliesDelivered = new Set();
     // In-session conversation list. Each entry: { id, label, messages: [] }
     // where messages are { role: 'user'|'agent'|'status'|'error', text: string }.
     var chatConversations = [];
@@ -888,8 +890,8 @@ function createUiHtml(): string {
         } else if (payload.type === 'message') {
           // Agent reply arrived via SSE — render it only if the POST response
           // hasn't already rendered it (race: whichever fires first wins).
-          if (!chatReplyRendered) {
-            chatReplyRendered = true;
+          if (!chatRepliesDelivered.has(convId)) {
+            chatRepliesDelivered.add(convId);
             var content = (typeof payload.content === 'string') ? payload.content
                         : JSON.stringify(payload);
             renderMessage('agent', content);
@@ -919,7 +921,6 @@ function createUiHtml(): string {
       }
       chatConversationId = null;
       chatActiveConvIdx = -1;
-      chatReplyRendered = false;
       chatSendBtn.disabled = false;
       chatMessagesEl.replaceChildren();
       // Re-render the conversation list to clear the active highlight.
@@ -945,7 +946,6 @@ function createUiHtml(): string {
       if (idx === chatActiveConvIdx) return;
       chatActiveConvIdx = idx;
       chatConversationId = chatConversations[idx].id;
-      chatReplyRendered = false;
 
       // Restore message history for the selected conversation.
       chatMessagesEl.replaceChildren();
@@ -987,11 +987,12 @@ function createUiHtml(): string {
         openChatStream(newId);
       }
 
-      chatReplyRendered = false;
+      // Capture convId before clearing the reply-delivered flag so the delete
+      // is keyed to the right conversation (chatConversationId was just set above).
+      var convId = chatConversationId;
+      chatRepliesDelivered.delete(convId);
       renderMessage('user', text);
       chatSendBtn.disabled = true;
-
-      var convId = chatConversationId;
 
       fetch('/api/kg/chat/messages', {
         method: 'POST',
@@ -1006,14 +1007,32 @@ function createUiHtml(): string {
           });
         })
         .then(function(data) {
-          // Render the reply unless the SSE already did so.
-          if (!chatReplyRendered) {
-            chatReplyRendered = true;
-            renderMessage('agent', data.reply || '(no reply)');
+          // Render the reply unless the SSE already did so (race: whichever fires first wins).
+          // Use the closure-captured convId to route to the correct conversation even if
+          // the user switched threads while this request was in-flight.
+          if (!chatRepliesDelivered.has(convId)) {
+            chatRepliesDelivered.add(convId);
+            var replyText = data.reply || '(no reply)';
+            var targetIdx = chatConversations.findIndex(function(c) { return c.id === convId; });
+            if (targetIdx >= 0) {
+              if (chatActiveConvIdx === targetIdx) {
+                // Still on the originating conversation — render to DOM.
+                renderMessage('agent', replyText);
+              } else {
+                // User switched away — persist to the correct history without rendering.
+                chatConversations[targetIdx].messages.push({ role: 'agent', text: replyText });
+              }
+            }
           }
-          chatSendBtn.disabled = false;
+          // Re-enable send only if the user is still in the originating conversation.
+          if (chatConversationId === convId) {
+            chatSendBtn.disabled = false;
+          }
         })
         .catch(function(err) {
+          // If the user switched conversations while this request was in-flight, swallow
+          // the error silently — surfacing a stale error in the new thread is confusing.
+          if (chatConversationId !== convId) return;
           var msg = err.message || '';
           var userMsg;
           // Network-level failure (no response at all)

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -432,7 +432,7 @@ function createUiHtml(): string {
       <div style="display: flex; flex-direction: column; gap: 2px;">
 
         <!-- Chat -->
-        <button id="nav-chat" class="nav-item" onclick="navigate('coming-soon', 'Chat', 'nav-chat')">
+        <button id="nav-chat" class="nav-item" onclick="navigate('chat', 'Chat', 'nav-chat')">
           <!-- speech-bubble icon -->
           <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <path d="M13 9.5A1.5 1.5 0 0 1 11.5 11H4L1.5 13.5V3A1.5 1.5 0 0 1 3 1.5h8.5A1.5 1.5 0 0 1 13 3v6.5z"/>
@@ -527,10 +527,34 @@ function createUiHtml(): string {
         </div>
       </div>
 
-      <!-- Coming Soon view (shared by Chat, Contacts, Tasks) -->
+      <!-- Coming Soon view (shared by Contacts, Tasks) -->
       <div id="view-coming-soon" style="display: none; height: 100%; flex-direction: column; align-items: center; justify-content: center;">
         <p style="font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.15em; color: var(--fg-muted); margin: 0 0 8px;">Coming Soon</p>
         <h2 id="coming-soon-title" style="font-family: 'Lora', Georgia, serif; font-size: 2rem; font-weight: 500; color: var(--fg); margin: 0;"></h2>
+      </div>
+
+      <!-- Chat view — hidden until user clicks the Chat nav item -->
+      <div id="view-chat" style="display: none; height: 100%; flex-direction: row;">
+
+        <!-- Left: conversation list -->
+        <div class="chat-sidebar">
+          <div style="padding: 10px 8px; border-bottom: 1px solid var(--border);">
+            <button class="btn-primary" style="width: 100%;" onclick="newConversation()">+ New Chat</button>
+          </div>
+          <div id="chat-conv-list" style="flex: 1; overflow-y: auto; padding: 6px; display: flex; flex-direction: column; gap: 2px;"></div>
+        </div>
+
+        <!-- Right: message thread + input -->
+        <div class="chat-thread">
+          <div id="chat-messages" class="chat-messages"></div>
+          <div class="chat-input-bar">
+            <form id="chat-form" style="display: contents;">
+              <textarea id="chat-textarea" class="chat-textarea" placeholder="Message Curia\u2026" rows="2"></textarea>
+              <button type="submit" id="chat-send-btn" class="btn-primary" style="padding: 8px 16px;">Send</button>
+            </form>
+          </div>
+        </div>
+
       </div>
 
     </main>

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -916,6 +916,7 @@ function createUiHtml(): string {
       chatConversationId = null;
       chatActiveConvIdx = -1;
       chatReplyRendered = false;
+      chatSendBtn.disabled = false;
       chatMessagesEl.replaceChildren();
       // Re-render the conversation list to clear the active highlight.
       renderConvList();
@@ -953,6 +954,9 @@ function createUiHtml(): string {
       chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
 
       // Reopen SSE for future messages in this conversation.
+      // @TODO: if a POST is in-flight for the previous conversation when the user
+      // switches, the reply will render into this new conversation's thread instead.
+      // Fix: track the active convId per-request and skip render if it doesn't match.
       openChatStream(chatConversationId);
       renderConvList();
     }

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -900,8 +900,12 @@ function createUiHtml(): string {
       };
 
       chatStream.onerror = function() {
-        // Network interruption — the browser will try to reconnect automatically.
-        // Don't surface an error bubble here to avoid noise on transient drops.
+        // CLOSED means a permanent failure (401, 500, etc.) — browser will not retry.
+        // CONNECTING means auto-reconnect is in progress — no user action needed.
+        if (chatStream && chatStream.readyState === EventSource.CLOSED) {
+          renderMessage('error',
+            'Live connection lost. Replies will still arrive, but reload the page if updates stop appearing.');
+        }
       };
     }
 
@@ -1010,7 +1014,18 @@ function createUiHtml(): string {
           chatSendBtn.disabled = false;
         })
         .catch(function(err) {
-          renderMessage('error', err.message || 'Something went wrong. Please try again.');
+          var msg = err.message || '';
+          var userMsg;
+          // Network-level failure (no response at all)
+          if (!msg || msg.toLowerCase().includes('failed to fetch') || msg.includes('NetworkError')) {
+            userMsg = 'Could not reach the server. Check your connection and try again.';
+          // Non-JSON response body (e.g. HTML 502 from a load balancer)
+          } else if (msg.includes('JSON') || msg.toLowerCase().includes('unexpected token')) {
+            userMsg = 'Unexpected response from the server. Try reloading the page.';
+          } else {
+            userMsg = msg;
+          }
+          renderMessage('error', userMsg);
           chatSendBtn.disabled = false;
         });
     }
@@ -1350,8 +1365,13 @@ export async function knowledgeGraphRoutes(
     const heartbeat = setInterval(() => {
       try {
         reply.raw.write(':ping\n\n');
-      } catch {
+      } catch (err) {
+        // Write failed — client likely disconnected without a clean TCP close.
+        // Clear the interval and explicitly remove the SSE client to prevent a leak
+        // in the case where the 'close' event on request.raw doesn't fire.
+        logger.debug({ err, conversationId: query.conversationId }, 'KG chat SSE heartbeat write failed — removing client');
         clearInterval(heartbeat);
+        cleanup();
       }
     }, 30_000);
 

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -734,8 +734,8 @@ function createUiHtml(): string {
         document.getElementById('coming-soon-title').textContent = title;
       }
 
-      // Open the SSE stream lazily on first entry into the Chat view.
-      // If a conversation is already active, reuse its stream.
+      // On first entry into the Chat view with no conversations yet, ensure
+      // the thread panel is empty (defensive reset in case it has stale content).
       if (view === 'chat' && chatActiveConvIdx === -1 && chatConversations.length === 0) {
         // No conversations yet — show empty state, ready for first message.
         chatMessagesEl.replaceChildren();

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -567,6 +567,22 @@ function createUiHtml(): string {
     var memoryOpen = true;   // Memory nav section expanded by default
     var activeNavId = 'nav-kg';
 
+    // ── Chat state ─────────────────────────────────────────────────────
+    // Active EventSource for SSE — one per conversation, null when idle.
+    var chatStream = null;
+    // Active conversation UUID — set when the user sends their first message
+    // in a new conversation, or when switching between past conversations.
+    var chatConversationId = null;
+    // Tracks whether the agent reply has been rendered for the current round-trip
+    // to prevent the SSE outbound.message and the POST response from both appending
+    // the same text (whichever fires first wins; the other is a no-op).
+    var chatReplyRendered = false;
+    // In-session conversation list. Each entry: { id, label, messages: [] }
+    // where messages are { role: 'user'|'agent'|'status'|'error', text: string }.
+    var chatConversations = [];
+    // Index of the currently active conversation, or -1 if none.
+    var chatActiveConvIdx = -1;
+
     // ── Element refs ───────────────────────────────────────────────────
     var authWall      = document.getElementById('auth-wall');
     var mainApp       = document.getElementById('main-app');
@@ -580,10 +596,18 @@ function createUiHtml(): string {
     var memoryCaret   = document.getElementById('memory-chevron');
     var memorySubmenu = document.getElementById('memory-submenu');
 
+    // Chat DOM refs
+    var chatMessagesEl = document.getElementById('chat-messages');
+    var chatConvListEl = document.getElementById('chat-conv-list');
+    var chatForm       = document.getElementById('chat-form');
+    var chatTextarea   = document.getElementById('chat-textarea');
+    var chatSendBtn    = document.getElementById('chat-send-btn');
+
     // Catch template/script divergence early rather than producing cryptic null errors
     if (!authWall || !mainApp || !authForm || !authInput || !authError ||
         !statusEl || !resultsEl || !searchInput || !searchBtn ||
-        !memoryCaret || !memorySubmenu) {
+        !memoryCaret || !memorySubmenu ||
+        !chatMessagesEl || !chatConvListEl || !chatForm || !chatTextarea || !chatSendBtn) {
       throw new Error('Curia KG: required DOM element missing — check template integrity.');
     }
 
@@ -698,14 +722,23 @@ function createUiHtml(): string {
 
     // ── Navigation ─────────────────────────────────────────────────────
     function navigate(view, title, navId) {
-      var kgView = document.getElementById('view-kg');
-      var csView = document.getElementById('view-coming-soon');
+      var kgView   = document.getElementById('view-kg');
+      var chatView = document.getElementById('view-chat');
+      var csView   = document.getElementById('view-coming-soon');
 
-      kgView.style.display = view === 'kg'           ? 'flex' : 'none';
-      csView.style.display = view === 'coming-soon'  ? 'flex' : 'none';
+      kgView.style.display   = view === 'kg'           ? 'flex' : 'none';
+      chatView.style.display = view === 'chat'         ? 'flex' : 'none';
+      csView.style.display   = view === 'coming-soon'  ? 'flex' : 'none';
 
       if (view === 'coming-soon') {
         document.getElementById('coming-soon-title').textContent = title;
+      }
+
+      // Open the SSE stream lazily on first entry into the Chat view.
+      // If a conversation is already active, reuse its stream.
+      if (view === 'chat' && chatActiveConvIdx === -1 && chatConversations.length === 0) {
+        // No conversations yet — show empty state, ready for first message.
+        chatMessagesEl.replaceChildren();
       }
 
       // Update active highlight

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -838,6 +838,187 @@ function createUiHtml(): string {
 
     searchBtn.addEventListener('click', search);
     searchInput.addEventListener('keydown', function(e) { if (e.key === 'Enter') search(); });
+
+    // ── Chat ───────────────────────────────────────────────────────────
+
+    // Appends a message bubble to the thread panel and scrolls to bottom.
+    // Also persists the message to the in-memory conversation store so it
+    // survives switching between conversations.
+    // role: 'user' | 'agent' | 'status' | 'error'
+    function renderMessage(role, text) {
+      var bubble = document.createElement('div');
+      bubble.className = 'msg-bubble ' + role;
+      // textContent prevents stored XSS — messages come from the agent/user
+      // and could include characters that look like HTML.
+      bubble.textContent = text;
+      chatMessagesEl.appendChild(bubble);
+      chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
+
+      // Persist to current conversation store (skip ephemeral status messages).
+      if (role !== 'status' && chatActiveConvIdx >= 0) {
+        chatConversations[chatActiveConvIdx].messages.push({ role: role, text: text });
+      }
+    }
+
+    // Opens an SSE stream for the given conversationId.
+    // Closes any previously open stream first to avoid leaking connections.
+    function openChatStream(convId) {
+      if (chatStream) {
+        chatStream.close();
+        chatStream = null;
+      }
+
+      var url = '/api/kg/chat/stream?conversationId=' + encodeURIComponent(convId);
+      chatStream = new EventSource(url);
+
+      chatStream.onmessage = function(event) {
+        var payload;
+        try {
+          payload = JSON.parse(event.data);
+        } catch {
+          // Malformed frame — ignore. The SSE spec allows comment frames (:ping)
+          // which EventSource silently drops, but custom parsers might not.
+          return;
+        }
+
+        if (payload.type === 'skill.invoke') {
+          // Show a transient status bubble so the user knows work is in progress.
+          var skillName = payload.skill || payload.skillId || 'skill';
+          renderMessage('status', 'Using ' + skillName + '\u2026');
+        } else if (payload.type === 'outbound.message') {
+          // Agent reply arrived via SSE — render it only if the POST response
+          // hasn't already rendered it (race: whichever fires first wins).
+          if (!chatReplyRendered) {
+            chatReplyRendered = true;
+            var content = (typeof payload.content === 'string') ? payload.content
+                        : (typeof payload.message === 'string') ? payload.message
+                        : JSON.stringify(payload);
+            renderMessage('agent', content);
+            chatSendBtn.disabled = false;
+          }
+        }
+        // skill.result: not rendered — it's internal bookkeeping for the agent layer.
+      };
+
+      chatStream.onerror = function() {
+        // Network interruption — the browser will try to reconnect automatically.
+        // Don't surface an error bubble here to avoid noise on transient drops.
+      };
+    }
+
+    // Creates a new in-session conversation, resets the thread panel,
+    // and updates the conversation list in the sidebar.
+    function newConversation() {
+      // Close the current SSE stream — a fresh one will open on the next send.
+      if (chatStream) {
+        chatStream.close();
+        chatStream = null;
+      }
+      chatConversationId = null;
+      chatActiveConvIdx = -1;
+      chatReplyRendered = false;
+      chatMessagesEl.replaceChildren();
+    }
+
+    // Renders the sidebar conversation list, highlighting the active entry.
+    function renderConvList() {
+      chatConvListEl.replaceChildren();
+      chatConversations.forEach(function(conv, idx) {
+        var item = document.createElement('div');
+        item.className = 'conv-item' + (idx === chatActiveConvIdx ? ' active' : '');
+        item.textContent = conv.label;
+        item.title = conv.label;
+        item.addEventListener('click', function() { switchConversation(idx); });
+        chatConvListEl.appendChild(item);
+      });
+    }
+
+    // Switches the active conversation: restores its messages in the thread panel
+    // and reopens the SSE stream for that conversationId.
+    function switchConversation(idx) {
+      if (idx === chatActiveConvIdx) return;
+      chatActiveConvIdx = idx;
+      chatConversationId = chatConversations[idx].id;
+      chatReplyRendered = false;
+
+      // Restore message history for the selected conversation.
+      chatMessagesEl.replaceChildren();
+      chatConversations[idx].messages.forEach(function(msg) {
+        var bubble = document.createElement('div');
+        bubble.className = 'msg-bubble ' + msg.role;
+        bubble.textContent = msg.text;
+        chatMessagesEl.appendChild(bubble);
+      });
+      chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
+
+      // Reopen SSE for future messages in this conversation.
+      openChatStream(chatConversationId);
+      renderConvList();
+    }
+
+    // Handles the chat form submit: validates input, creates a conversation if needed,
+    // sends the message, and renders the reply (via POST response or SSE, whichever fires first).
+    function sendChatMessage(e) {
+      e.preventDefault();
+      var text = chatTextarea.value.trim();
+      if (!text) return;
+      chatTextarea.value = '';
+
+      // First message in a new conversation — generate a conversationId and create
+      // the conversation entry. crypto.randomUUID() is available in all modern browsers.
+      if (!chatConversationId) {
+        var newId = 'kg-web-' + crypto.randomUUID();
+        chatConversationId = newId;
+        // Truncate label to ~40 chars for the sidebar.
+        var label = text.length > 40 ? text.slice(0, 40) + '\u2026' : text;
+        chatConversations.push({ id: newId, label: label, messages: [] });
+        chatActiveConvIdx = chatConversations.length - 1;
+        renderConvList();
+        // Open SSE for this conversation BEFORE posting so no events are missed.
+        openChatStream(newId);
+      }
+
+      chatReplyRendered = false;
+      renderMessage('user', text);
+      chatSendBtn.disabled = true;
+
+      var convId = chatConversationId;
+
+      fetch('/api/kg/chat/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text, conversationId: convId }),
+      })
+        .then(function(res) {
+          return res.json().then(function(body) {
+            // Surface structured backend errors (400/401/403/504/500 all return { error: "..." }).
+            if (!res.ok) throw new Error(body.error || ('HTTP ' + res.status));
+            return body;
+          });
+        })
+        .then(function(data) {
+          // Render the reply unless the SSE outbound.message already did so.
+          if (!chatReplyRendered) {
+            chatReplyRendered = true;
+            renderMessage('agent', data.reply);
+          }
+          chatSendBtn.disabled = false;
+        })
+        .catch(function(err) {
+          renderMessage('error', err.message || 'Something went wrong. Please try again.');
+          chatSendBtn.disabled = false;
+        });
+    }
+
+    // Allow Shift+Enter for newlines; plain Enter submits the form.
+    chatTextarea.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        sendChatMessage(e);
+      }
+    });
+
+    chatForm.addEventListener('submit', sendChatMessage);
   </script>
 </body>
 </html>`;

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -574,7 +574,7 @@ function createUiHtml(): string {
     // in a new conversation, or when switching between past conversations.
     var chatConversationId = null;
     // Tracks whether the agent reply has been rendered for the current round-trip
-    // to prevent the SSE outbound.message and the POST response from both appending
+    // to prevent the SSE 'message' event and the POST response from both appending
     // the same text (whichever fires first wins; the other is a no-op).
     var chatReplyRendered = false;
     // In-session conversation list. Each entry: { id, label, messages: [] }

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -277,6 +277,120 @@ function createUiHtml(): string {
     /* ── Chevron rotation for expand/collapse ──────────────────────── */
     .chevron               { transition: transform 0.2s; }
     .chevron.collapsed     { transform: rotate(-90deg); }
+
+    /* ── Chat view ───────────────────────────────────────────────────── */
+
+    /* Sidebar: conversation list */
+    .chat-sidebar {
+      flex: none;
+      width: 220px;
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    /* Thread column: messages + input bar */
+    .chat-thread {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    /* Scrollable message area */
+    .chat-messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    /* Input bar at the bottom of the thread */
+    .chat-input-bar {
+      flex: none;
+      padding: 12px 16px;
+      border-top: 1px solid var(--border);
+      display: flex;
+      align-items: flex-end;
+      gap: 8px;
+    }
+
+    /* Resizable textarea */
+    textarea.chat-textarea {
+      flex: 1;
+      resize: none;
+      min-height: 56px;
+      max-height: 120px;
+      background: var(--muted);
+      border: 1px solid var(--input-border);
+      border-radius: var(--radius-md);
+      color: var(--fg);
+      font-family: inherit;
+      font-size: 0.875rem;
+      padding: 8px 12px;
+      outline: none;
+      transition: border-color 0.12s;
+    }
+    textarea.chat-textarea:focus { border-color: var(--teal); }
+
+    /* Message bubbles */
+    .msg-bubble {
+      max-width: 80%;
+      padding: 8px 12px;
+      border-radius: var(--radius-lg);
+      font-size: 0.875rem;
+      line-height: 1.5;
+      word-wrap: break-word;
+      white-space: pre-wrap;
+    }
+    .msg-bubble.user {
+      align-self: flex-end;
+      background: var(--teal);
+      color: var(--fg);
+      border-bottom-right-radius: 2px;
+    }
+    .msg-bubble.agent {
+      align-self: flex-start;
+      background: var(--card);
+      border: 1px solid var(--border);
+      color: var(--fg);
+      border-bottom-left-radius: 2px;
+    }
+    /* Status messages: skill.invoke notifications, "thinking…" indicator */
+    .msg-bubble.status {
+      align-self: center;
+      background: none;
+      color: var(--fg-muted);
+      font-size: 0.75rem;
+      font-style: italic;
+      padding: 2px 8px;
+      max-width: 100%;
+    }
+    .msg-bubble.error {
+      align-self: flex-start;
+      background: rgba(232,96,64,0.12);
+      border: 1px solid rgba(232,96,64,0.30);
+      color: var(--destructive);
+      border-bottom-left-radius: 2px;
+    }
+
+    /* Conversation list items */
+    .conv-item {
+      padding: 7px 10px;
+      border-radius: var(--radius-md);
+      font-size: 0.8125rem;
+      color: var(--fg-muted);
+      cursor: pointer;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      transition: background 0.12s, color 0.12s;
+    }
+    .conv-item:hover  { background: var(--accent); color: var(--fg); }
+    .conv-item.active { background: var(--muted);  color: var(--fg); }
   </style>
 </head>
 <body>

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -885,13 +885,12 @@ function createUiHtml(): string {
           // Show a transient status bubble so the user knows work is in progress.
           var skillName = payload.skill || payload.skillId || 'skill';
           renderMessage('status', 'Using ' + skillName + '\u2026');
-        } else if (payload.type === 'outbound.message') {
+        } else if (payload.type === 'message') {
           // Agent reply arrived via SSE — render it only if the POST response
           // hasn't already rendered it (race: whichever fires first wins).
           if (!chatReplyRendered) {
             chatReplyRendered = true;
             var content = (typeof payload.content === 'string') ? payload.content
-                        : (typeof payload.message === 'string') ? payload.message
                         : JSON.stringify(payload);
             renderMessage('agent', content);
             chatSendBtn.disabled = false;
@@ -918,6 +917,8 @@ function createUiHtml(): string {
       chatActiveConvIdx = -1;
       chatReplyRendered = false;
       chatMessagesEl.replaceChildren();
+      // Re-render the conversation list to clear the active highlight.
+      renderConvList();
     }
 
     // Renders the sidebar conversation list, highlighting the active entry.
@@ -997,10 +998,10 @@ function createUiHtml(): string {
           });
         })
         .then(function(data) {
-          // Render the reply unless the SSE outbound.message already did so.
+          // Render the reply unless the SSE already did so.
           if (!chatReplyRendered) {
             chatReplyRendered = true;
-            renderMessage('agent', data.reply);
+            renderMessage('agent', data.reply || '(no reply)');
           }
           chatSendBtn.disabled = false;
         })
@@ -1014,7 +1015,9 @@ function createUiHtml(): string {
     chatTextarea.addEventListener('keydown', function(e) {
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
-        sendChatMessage(e);
+        // Guard against concurrent submits — the button is disabled while a POST
+        // is in flight, but the keydown fires before the DOM repaint reflects that.
+        if (!chatSendBtn.disabled) sendChatMessage(e);
       }
     });
 

--- a/tests/unit/channels/http/kg-chat-routes.test.ts
+++ b/tests/unit/channels/http/kg-chat-routes.test.ts
@@ -218,3 +218,29 @@ describe('KG chat routes', () => {
     await app.close();
   });
 });
+
+describe('KG web UI shell', () => {
+  it('GET / — response contains Chat nav button and #view-chat section', async () => {
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(knowledgeGraphRoutes, {
+      pool: createPool() as Pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: 'test-secret',
+      secureCookies: false,
+      bus: createMockBus(),
+      eventRouter: createMockEventRouter(),
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toMatch(/text\/html/);
+    expect(response.body).toContain('id="nav-chat"');
+    expect(response.body).toContain('id="view-chat"');
+    // Confirm the nav button routes to 'chat' (not 'coming-soon').
+    expect(response.body).toContain("navigate('chat'");
+
+    await app.close();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- Adds a functional Chat pane to the KG explorer web app (`#view-chat` split-panel layout) wired into the existing `navigate()` sidebar system
- Integrates `POST /api/kg/chat/messages` and `GET /api/kg/chat/stream` (SSE via `EventSource.onmessage`) — the backend endpoints from PR #127
- Fixes a critical bug in `event-router.ts` where the `outbound.message` and `message.rejected` subscribers filtered out `channelId: 'web'`, causing every chat message to time out with 504 instead of delivering a reply

## What's in the UI

- Left panel: in-session conversation list with "+ New Chat" button
- Right panel: message thread (user/agent/status/error bubbles) + textarea + send button
- Shift+Enter for newlines, plain Enter to send
- SSE stream per conversation for live skill-invoke status messages
- Race guard (`chatReplyRendered`) prevents SSE and POST response from both rendering the same reply

## Test Plan

- [x] All 686 unit tests pass (`pnpm test --run`)
- [ ] Navigate to the KG explorer, click "Chat" in the sidebar — chat view appears
- [ ] Send a message — user bubble appears, agent reply arrives
- [ ] Start a new chat via "+ New Chat" — thread clears, new conversation created
- [ ] Disconnect from network mid-session — reconnect error bubble appears on permanent failure
- [ ] `POST /api/kg/chat/messages` with no auth → 401; with valid session → 200


___

## **CodeAnt-AI Description**
**Add a usable Chat view to the KG explorer and make web chat replies deliver correctly**

### What Changed
- Added a dedicated Chat screen with a conversation list, message thread, message input, and a New Chat button
- Chat is now opened from the sidebar and keeps each conversation’s messages when switching between chats
- Live reply updates and status messages now appear in the chat thread while a reply is being processed
- Fixed web chat delivery so replies and rejection errors are handled for the web channel instead of timing out
- Added a smoke test that checks the page still includes the Chat navigation item and Chat view container

### Impact
`✅ Web chat opens from the sidebar`
`✅ Fewer chat timeouts for web users`
`✅ Persistent in-session chat threads`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
