### PR TITLE
refactor: replace autonomy_floor with action_risk on skill manifests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,18 +69,20 @@ Cross-cutting: Audit Logger, Memory Engine, Scheduler.
 
 ### Autonomy Awareness
 
-When adding a new skill, declare its autonomy floor in `skill.json` (this field is not enforced in Phase 1 but is required for Phase 2 gate wiring):
+When adding a new skill, declare its action risk in `skill.json` (this field is not enforced in Phase 1 but is required for Phase 2 gate wiring):
 
 ```json
-"autonomy_floor": "spot-check"
+"action_risk": "medium"
 ```
 
-Floors by capability class:
-- `"full"` — reads, retrieval, summarization (no external effect)
-- `"spot-check"` — outbound communications, internal state writes
-- `"approval-required"` — calendar writes, commitments on behalf of CEO
-- `"draft-only"` — financial actions, high-stakes operations
-- `"restricted"` — irreversible or destructive actions
+Values by capability class:
+- `"none"` — reads, retrieval, summarization (no external effect; min score 0)
+- `"low"` — internal state writes, memory, contacts (min score 60)
+- `"medium"` — outbound communications (min score 70)
+- `"high"` — calendar writes, commitments on behalf of CEO (min score 80)
+- `"critical"` — financial / destructive / irreversible actions (min score 90)
+
+A raw number (0–100) may be used for precision. Numbers outside [0, 100] produce a validation error at skill load time.
 
 When adding a new agent, ensure it receives the autonomy block via the runtime injection mechanism (same pattern as date/timezone injection — pass `autonomyService` in `AgentRuntime` config if the agent needs autonomy awareness). See `docs/superpowers/specs/2026-04-03-autonomy-engine-design.md`.
 

--- a/docs/superpowers/specs/2026-04-03-autonomy-engine-design.md
+++ b/docs/superpowers/specs/2026-04-03-autonomy-engine-design.md
@@ -191,32 +191,44 @@ single-row Postgres read per task — negligible.
 
 ## Guidelines for New Agents & Skills
 
-Every new skill manifest (`skill.json`) should declare an `autonomy_floor` field indicating
-the minimum autonomy band at which this skill is appropriate to run without explicit CEO
-approval:
+Every new skill manifest (`skill.json`) should declare an `action_risk` field indicating
+the minimum autonomy score required before this skill may run without explicit CEO approval:
 
 ```json
 {
   "name": "send-email",
-  "autonomy_floor": "spot-check",
+  "action_risk": "medium",
   ...
 }
 ```
 
+Named labels map to minimum score thresholds:
+
+| Label | Min score | Capability class |
+|---|---|---|
+| `none` | 0 | Read-only, no side effects |
+| `low` | 60 | Internal state writes (memory, contacts) |
+| `medium` | 70 | Outbound communications |
+| `high` | 80 | Calendar writes, commitments |
+| `critical` | 90 | Financial / destructive / irreversible |
+
+A raw number (0–100) may be used for precision (e.g. `75` for a skill that should unlock
+just above approval-required but below spot-check). Numbers outside [0, 100] produce a
+validation error at skill load time.
+
 This field is **not enforced by the execution layer in Phase 1** — it is documentation for
 the developer and for Phase 2's gate wiring. When the execution layer is extended to enforce
-autonomy floors, the field will already be present.
+action risk, the field will already be present.
 
-### Autonomy floor guidelines by capability class
+### Action risk guidelines by capability class
 
-| Capability class | Recommended floor | Rationale |
+| Capability class | Recommended value | Rationale |
 |---|---|---|
-| Read / retrieve / summarize | `full` | No external effect; always safe |
-| Internal state writes (memory, contacts) | `spot-check` | Affects future behavior but reversible |
-| Outbound communications | `spot-check` | External effect; CEO should have visibility |
-| Calendar writes | `approval-required` | Creates commitments on behalf of CEO |
-| Financial actions | `draft-only` | High-stakes; always require explicit instruction |
-| Destructive / irreversible actions | `restricted` | Never autonomous |
+| Read / retrieve / summarize | `none` | No external effect; always safe |
+| Internal state writes (memory, contacts) | `low` | Affects future behavior but reversible |
+| Outbound communications | `medium` | External effect; CEO should have visibility |
+| Calendar writes / commitments on behalf of CEO | `high` | Creates commitments |
+| Financial actions / destructive / irreversible | `critical` | Never autonomous |
 
 ### New agent checklist
 
@@ -288,12 +300,12 @@ Add to the "Adding Things" section of `CLAUDE.md`:
 ```markdown
 ### Autonomy Awareness
 
-When adding a new skill, declare its autonomy floor in `skill.json`:
-- `"autonomy_floor": "full"` — safe to run at any autonomy level (reads, retrieval)
-- `"autonomy_floor": "spot-check"` — outbound communications, internal state writes
-- `"autonomy_floor": "approval-required"` — calendar writes, commitments
-- `"autonomy_floor": "draft-only"` — financial actions
-- `"autonomy_floor": "restricted"` — irreversible or destructive actions
+When adding a new skill, declare its action risk in `skill.json`:
+- `"action_risk": "none"` — reads, retrieval, no external effect (always safe)
+- `"action_risk": "low"` — internal state writes (memory, contacts)
+- `"action_risk": "medium"` — outbound communications
+- `"action_risk": "high"` — calendar writes, commitments on behalf of CEO
+- `"action_risk": "critical"` — financial / destructive / irreversible actions
 
 See `docs/specs/12-autonomy-engine.md` for the full guidelines table.
 

--- a/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-03-capability-expansion-design.md
@@ -19,7 +19,7 @@ Two new capabilities that unlock core EA work Curia cannot currently do:
 
 - **Skills Must Add Value Beyond the Bare LLM** — skills are API bridges. No skill contains classification, summarization, or judgment logic. The LLM decides what to draft; the skill saves it to Drafts. The LLM decides what to search for; the skill fetches results.
 - **Future-Proof for LLM Upgrades** — synthesis always stays in Curia's LLM, never in a pre-synthesis API (Perplexity rejected for this reason). As Claude gets smarter, Curia's research quality improves automatically at zero cost.
-- **Autonomy-Score-Aware** — all new skills declare `autonomy_floor` per spec 12 (autonomy engine). The global autonomy score governs which capabilities Curia may exercise independently — no per-channel config flags. Skills that ship now are available at any score; higher-autonomy behaviors (archiving, sending as the CEO) activate as the score increases into the appropriate band.
+- **Autonomy-Score-Aware** — all new skills declare `action_risk` per spec 12 (autonomy engine). The global autonomy score governs which capabilities Curia may exercise independently — no per-channel config flags. Skills that ship now are available at any score; higher-autonomy behaviors (archiving, sending as the CEO) activate as the score increases into the appropriate band.
 
 ---
 
@@ -31,14 +31,14 @@ CEO inbox capabilities map to autonomy bands (spec 12) rather than hard-coded ph
 The global autonomy score governs what Nathan does independently vs. asks first — no
 separate `autonomy_phase` config field.
 
-| Capability | autonomy_floor | Ships when |
+| Capability | action_risk | Ships when |
 |---|---|---|
-| Read inbox, read messages, list drafts | `full` | Now — reads are always safe |
-| Draft replies, save to the CEO's Drafts folder | `full` | Now — no outbound effect; nothing leaves until the CEO manually sends from Gmail |
-| Daily draft digest (scheduler job) | `full` | Now — read + notify, no external write |
-| Archive threads, apply Gmail labels | `spot-check` | When skills are built — Curia proceeds at `spot-check`+, asks at lower bands |
-| Reply as Curia (from nathancuria1@gmail.com) | `spot-check` | When `email-send` account param ships |
-| Reply as the CEO (from joseph@josephfung.ca) | `approval-required` | When `email-send` account param ships — sending on the CEO's behalf requires higher trust |
+| Read inbox, read messages, list drafts | `none` | Now — reads are always safe |
+| Draft replies, save to the CEO's Drafts folder | `none` | Now — no outbound effect; nothing leaves until the CEO manually sends from Gmail |
+| Daily draft digest (scheduler job) | `none` | Now — read + notify, no external write |
+| Archive threads, apply Gmail labels | `low` | When skills are built — Curia proceeds at score ≥ 60, asks at lower bands |
+| Reply as Curia (from nathancuria1@gmail.com) | `medium` | When `email-send` account param ships |
+| Reply as the CEO (from joseph@josephfung.ca) | `high` | When `email-send` account param ships — sending on the CEO's behalf requires higher trust |
 
 The autonomy engine (spec 12) injects the current band's behavioral description into
 every coordinator task. Curia self-governs accordingly without additional gating code
@@ -64,7 +64,7 @@ Skills are **account-aware** rather than account-specific — an optional `accou
   "name": "email-list",
   "sensitivity": "normal",
   "infrastructure": true,
-  "autonomy_floor": "full",
+  "action_risk": "none",
   "inputs": {
     "account": "string? (nathan | joseph, default nathan)",
     "folder": "string? (INBOX | DRAFTS | SENT | TRASH | <provider folder id>, default INBOX)",
@@ -86,7 +86,7 @@ Skills are **account-aware** rather than account-specific — an optional `accou
   "name": "email-get",
   "sensitivity": "normal",
   "infrastructure": true,
-  "autonomy_floor": "full",
+  "action_risk": "none",
   "inputs": {
     "account": "string? (nathan | joseph, default nathan)",
     "messageId": "string"
@@ -103,7 +103,7 @@ Skills are **account-aware** rather than account-specific — an optional `accou
   "name": "email-draft-save",
   "sensitivity": "elevated",
   "infrastructure": true,
-  "autonomy_floor": "full",
+  "action_risk": "none",
   "inputs": {
     "account": "string (nathan | joseph)",
     "to": "string",
@@ -118,7 +118,7 @@ Skills are **account-aware** rather than account-specific — an optional `accou
 ```
 
 Elevated sensitivity ensures a human-approval gate the first time the coordinator uses this
-skill. `autonomy_floor: "full"` reflects that saving a draft has no outbound effect — nothing
+skill. `action_risk: "none"` reflects that saving a draft has no outbound effect — nothing
 leaves until Joseph manually reviews and sends it from Gmail.
 
 **Scheduler job (Phase 1):**
@@ -131,17 +131,17 @@ This is set up during first-time onboarding via a CLI prompt like "keep an eye o
 
 **Future skills (not shipped now) — autonomy band triggers:**
 
-- `email-archive` (`autonomy_floor: "spot-check"`) — removes a message from `INBOX` via `UpdateMessageRequest`. Supports `account` param. Nathan should proceed independently at `spot-check`+; at lower bands he surfaces the action and waits for explicit approval.
-- `email-label` (`autonomy_floor: "spot-check"`) — applies Gmail labels to a thread via `UpdateMessageRequest`. Supports `account` param. Same band guidance as `email-archive`.
+- `email-archive` (`action_risk: "low"`) — removes a message from `INBOX` via `UpdateMessageRequest`. Supports `account` param. Nathan should proceed independently at score ≥ 60; at lower scores he surfaces the action and waits for explicit approval.
+- `email-label` (`action_risk: "low"`) — applies Gmail labels to a thread via `UpdateMessageRequest`. Supports `account` param. Same risk guidance as `email-archive`.
 - `email-send` / `email-reply` gain an `account` parameter when the autonomous reply capability ships:
-  - `account: "nathan"` → `autonomy_floor: "spot-check"` — Nathan replying as himself is standard outbound
-  - `account: "joseph"` → `autonomy_floor: "approval-required"` — sending on the CEO's behalf requires higher trust; below this band the OutboundGateway hard-blocks the send and the coordinator saves a draft instead
+  - `account: "nathan"` → `action_risk: "medium"` — Nathan replying as himself is standard outbound
+  - `account: "joseph"` → `action_risk: "high"` — sending on the CEO's behalf requires higher trust; below score 80 the OutboundGateway hard-blocks the send and the coordinator saves a draft instead
 
 ### Outbound Gateway
 
 All writes to the CEO's account (draft saves, eventual sends) route through `OutboundGateway`. Currently only draft saves are implemented — no sends. The gateway's blocked-contact and content-filter checks apply to drafts to prevent Curia from drafting problematic content.
 
-**Future autonomy gate (when `email-send(account: "joseph")` ships):** OutboundGateway will check the current autonomy score against the skill's `autonomy_floor: "approval-required"` (score ≥ 70). Below that threshold, `email-send` with `account: "joseph"` is blocked at the gateway level and the coordinator is instructed to save a draft instead. This is a hard gate — it holds even if the LLM's injected autonomy guidance would otherwise permit the action.
+**Future autonomy gate (when `email-send(account: "joseph")` ships):** OutboundGateway will check the current autonomy score against the skill's `action_risk: "high"` (score ≥ 80). Below that threshold, `email-send` with `account: "joseph"` is blocked at the gateway level and the coordinator is instructed to save a draft instead. This is a hard gate — it holds even if the LLM's injected autonomy guidance would otherwise permit the action.
 
 ### Contact System
 
@@ -213,7 +213,7 @@ Curia decides which to use based on the task. The skill exposes both via an inpu
   "name": "web-search",
   "description": "Search the web using Tavily. Returns structured results with title, URL, snippet, and (for advanced depth) extracted page content. Call multiple times with refined queries for complex research tasks.",
   "sensitivity": "normal",
-  "autonomy_floor": "full",
+  "action_risk": "none",
   "inputs": {
     "query": "string",
     "maxResults": "number? (default 5, max 20)",

--- a/docs/superpowers/specs/2026-04-04-web-browser-skill-design.md
+++ b/docs/superpowers/specs/2026-04-04-web-browser-skill-design.md
@@ -126,7 +126,7 @@ skills/web-browser/handler.ts
   "description": "Control a real web browser to interact with JS-rendered pages, fill forms, navigate multi-step flows, and interact with sites that have no API. Use this instead of web-fetch when a page requires JavaScript, login, or user interaction. Each call performs one action and returns the updated page state. Pass session_id back on subsequent calls to maintain browser context across actions.",
   "version": "1.0.0",
   "sensitivity": "normal",
-  "autonomy_floor": "spot-check",
+  "action_risk": "medium",
   "inputs": {
     "action": "string",
     "url": "string?",
@@ -148,8 +148,9 @@ skills/web-browser/handler.ts
 }
 ```
 
-`autonomy_floor: "spot-check"` — the browser can submit forms and trigger real-world side
-effects, so it must not run at `"full"` autonomy. Actions are logged and reviewable.
+`action_risk: "medium"` — the browser can submit forms and trigger real-world side effects
+(outbound communications class), so it requires a minimum autonomy score of 70. Actions
+are logged and reviewable.
 
 ---
 

--- a/skills/get-autonomy/skill.json
+++ b/skills/get-autonomy/skill.json
@@ -9,5 +9,5 @@
   "permissions": [],
   "secrets": [],
   "timeout": 10000,
-  "autonomy_floor": "full"
+  "action_risk": "none"
 }

--- a/skills/set-autonomy/skill.json
+++ b/skills/set-autonomy/skill.json
@@ -12,5 +12,5 @@
   "permissions": [],
   "secrets": [],
   "timeout": 10000,
-  "autonomy_floor": "approval-required"
+  "action_risk": "high"
 }

--- a/skills/web-browser/skill.json
+++ b/skills/web-browser/skill.json
@@ -3,7 +3,7 @@
   "description": "Control a real web browser to interact with JS-rendered pages, fill forms, navigate multi-step flows, and interact with sites that have no API. Use this instead of web-fetch when a page requires JavaScript, login, or user interaction. Each call performs one action and returns the updated page state. Pass session_id back on subsequent calls to maintain browser context across actions. Actions: navigate (url required), click (selector required), type (selector+text required), select (selector+value required), get_content, screenshot, close_session.",
   "version": "1.0.0",
   "sensitivity": "elevated",
-  "autonomy_floor": "spot-check",
+  "action_risk": "medium",
   "inputs": {
     "action": "string",
     "url": "string?",

--- a/skills/web-search/skill.json
+++ b/skills/web-search/skill.json
@@ -3,7 +3,7 @@
   "description": "Search the web using Tavily. Returns structured results with title, URL, snippet, and (for advanced depth) extracted page content. For simple lookups, one search is enough. For research tasks, call multiple times with different queries — each covering a different angle — before forming a conclusion.",
   "version": "1.0.0",
   "sensitivity": "normal",
-  "autonomy_floor": "full",
+  "action_risk": "none",
   "inputs": {
     "query": "string",
     "maxResults": "number?",

--- a/src/autonomy/autonomy-service.ts
+++ b/src/autonomy/autonomy-service.ts
@@ -9,6 +9,7 @@
 
 import type { Pool } from 'pg';
 import type { Logger } from '../logger.js';
+import type { ActionRisk } from '../skills/types.js';
 
 export type AutonomyBand =
   | 'full'
@@ -72,6 +73,25 @@ export class AutonomyService {
     private readonly pool: Pool,
     private readonly logger: Logger,
   ) {}
+
+  /**
+   * Resolve an action_risk label (or raw number) to the minimum autonomy score
+   * required before that skill may run without explicit CEO approval.
+   *
+   * Used by Phase 2 gate wiring in the execution layer to enforce autonomy-aware
+   * skill access. Callers should validate numeric values are in [0, 100] at
+   * skill load time (see SkillRegistry.register) before calling this.
+   */
+  static minScoreForActionRisk(risk: ActionRisk): number {
+    if (typeof risk === 'number') return risk;
+    switch (risk) {
+      case 'none':     return 0;
+      case 'low':      return 60;
+      case 'medium':   return 70;
+      case 'high':     return 80;
+      case 'critical': return 90;
+    }
+  }
 
   /** Derive the autonomy band from a numeric score. */
   static bandForScore(score: number): AutonomyBand {

--- a/src/autonomy/autonomy-service.ts
+++ b/src/autonomy/autonomy-service.ts
@@ -90,6 +90,9 @@ export class AutonomyService {
       case 'medium':   return 70;
       case 'high':     return 80;
       case 'critical': return 90;
+      // Defense in depth: SkillRegistry.register() should reject unknown labels at load
+      // time, but guard here in case this helper is called outside the registry path.
+      default: throw new Error(`Unknown action_risk label: "${String(risk)}"`);
     }
   }
 

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -10,6 +10,10 @@
 import type { SkillManifest, SkillHandler, RegisteredSkill, ToolDefinition } from './types.js';
 import { describeTimestampInput } from '../time/timestamp.js';
 
+// Valid named action_risk labels — used for runtime validation since manifests
+// are loaded from JSON via a bare cast and TypeScript cannot enforce this at runtime.
+const ACTION_RISK_LABELS = new Set(['none', 'low', 'medium', 'high', 'critical']);
+
 export class SkillRegistry {
   private skills = new Map<string, RegisteredSkill>();
   /** IANA timezone name used to populate timestamp input descriptions in tool schemas. */
@@ -25,19 +29,28 @@ export class SkillRegistry {
    * duplicate names indicate a configuration error that should surface
    * at startup, not silently overwrite.
    *
-   * Also validates action_risk when provided as a number: must be an integer
-   * in [0, 100]. Named labels are validated by TypeScript at compile time.
+   * Also validates action_risk at runtime — manifests are loaded from JSON via
+   * a bare `as SkillManifest` cast, so TypeScript cannot enforce enum correctness.
+   * Invalid values fail closed at skill load time rather than silently producing
+   * undefined thresholds later when autonomy gates are evaluated.
    */
   register(manifest: SkillManifest, handler: SkillHandler): void {
     if (this.skills.has(manifest.name)) {
       throw new Error(`Skill '${manifest.name}' is already registered`);
     }
-    if (typeof manifest.action_risk === 'number') {
+    if (manifest.action_risk !== undefined) {
       const risk = manifest.action_risk;
-      if (!Number.isInteger(risk) || risk < 0 || risk > 100) {
+      if (typeof risk === 'number') {
+        if (!Number.isInteger(risk) || risk < 0 || risk > 100) {
+          throw new Error(
+            `Skill '${manifest.name}' has invalid action_risk: ${risk}. ` +
+            `Numeric action_risk must be an integer between 0 and 100.`,
+          );
+        }
+      } else if (!ACTION_RISK_LABELS.has(risk as string)) {
         throw new Error(
-          `Skill '${manifest.name}' has invalid action_risk: ${risk}. ` +
-          `Numeric action_risk must be an integer between 0 and 100.`,
+          `Skill '${manifest.name}' has invalid action_risk label: "${String(risk)}". ` +
+          `Expected one of: ${[...ACTION_RISK_LABELS].join(', ')}.`,
         );
       }
     }

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -24,10 +24,22 @@ export class SkillRegistry {
    * Throws if a skill with the same name is already registered —
    * duplicate names indicate a configuration error that should surface
    * at startup, not silently overwrite.
+   *
+   * Also validates action_risk when provided as a number: must be an integer
+   * in [0, 100]. Named labels are validated by TypeScript at compile time.
    */
   register(manifest: SkillManifest, handler: SkillHandler): void {
     if (this.skills.has(manifest.name)) {
       throw new Error(`Skill '${manifest.name}' is already registered`);
+    }
+    if (typeof manifest.action_risk === 'number') {
+      const risk = manifest.action_risk;
+      if (!Number.isInteger(risk) || risk < 0 || risk > 100) {
+        throw new Error(
+          `Skill '${manifest.name}' has invalid action_risk: ${risk}. ` +
+          `Numeric action_risk must be an integer between 0 and 100.`,
+        );
+      }
     }
     this.skills.set(manifest.name, { manifest, handler });
   }

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -8,6 +8,23 @@
 import type { Logger } from '../logger.js';
 
 /**
+ * The risk level of a skill's actions, expressed as the minimum autonomy score
+ * required before the skill may run without explicit CEO approval.
+ *
+ * Named labels map to score thresholds:
+ *   none     →  0  — read-only, no side effects (always safe)
+ *   low      → 60  — internal state writes (memory, contacts)
+ *   medium   → 70  — outbound communications
+ *   high     → 80  — calendar writes, commitments on behalf of CEO
+ *   critical → 90  — financial / destructive / irreversible
+ *
+ * A raw number (0–100) may be used for precision (e.g. 75 for a skill that
+ * should unlock just above approval-required but below spot-check).
+ * Numbers outside [0, 100] produce a validation error at skill load time.
+ */
+export type ActionRisk = 'none' | 'low' | 'medium' | 'high' | 'critical' | number;
+
+/**
  * Skill manifest shape — loaded from skill.json files in each skill directory.
  * Declares what the skill does, what it needs, and its security classification.
  */
@@ -17,10 +34,11 @@ export interface SkillManifest {
   version: string;
   /** "normal" = auto-approvable; "elevated" = requires human approval on first use */
   sensitivity: 'normal' | 'elevated';
-  /** Autonomy floor: the minimum autonomy band required to invoke this skill.
-   *  Used by Phase 2 gate wiring to enforce autonomy-aware skill access.
-   *  Optional — existing manifests that predate spec 12 don't have this field. */
-  autonomy_floor?: 'full' | 'spot-check' | 'approval-required' | 'draft-only' | 'restricted';
+  /** Action risk: the minimum autonomy score required to invoke this skill without
+   *  explicit CEO approval. Used by Phase 2 gate wiring to enforce autonomy-aware
+   *  skill access. Optional — existing manifests that predate spec 12 don't have
+   *  this field. See ActionRisk for the named label → score mapping. */
+  action_risk?: ActionRisk;
   /** JSON Schema-ish description of expected inputs */
   inputs: Record<string, string>;
   /** JSON Schema-ish description of outputs */


### PR DESCRIPTION
## **User description**
Closes #136.

## Summary

- `autonomy_floor` borrowed autonomy band names (`full`, `spot-check`, ...) which read backwards — `"full"` looked like the system needed full autonomy before the skill could run, when the intent was the opposite
- `action_risk` replaces it with purpose-built labels tied directly to minimum score thresholds, making the semantics obvious to any developer

## What changed

**`src/skills/types.ts`** — new exported `ActionRisk` type; `SkillManifest.autonomy_floor` → `action_risk`

**`src/autonomy/autonomy-service.ts`** — new `AutonomyService.minScoreForActionRisk()` static helper that resolves any `ActionRisk` value to its minimum score threshold, ready for Phase 2 gate wiring

**`src/skills/registry.ts`** — `SkillRegistry.register()` now validates numeric `action_risk` values at skill load time; throws if outside [0, 100] or non-integer

**4 skill manifests** updated with new field name and values:

| Skill | Old | New | Notes |
|---|---|---|---|
| `web-search` | `full` | `none` | |
| `get-autonomy` | `full` | `none` | |
| `set-autonomy` | `approval-required` | `high` | Gate intentionally tightened: 70 → 80 |
| `web-browser` | `spot-check` | `medium` | Confirmed in issue discussion |

**3 spec docs + CLAUDE.md** updated to match.

## Notes

- `set-autonomy`'s gate tightening (70 → 80) is intentional per the issue proposal — `high` is the correct capability class for a skill that writes the global trust score
- `web-browser: "medium"` (score ≥ 70) was confirmed in issue discussion; the browser can submit forms, putting it in the outbound-communications class
- ~30 older skills still lack `action_risk` — tracked in #141
- Plan docs (`docs/superpowers/plans/`) were left as historical artifacts; only live spec docs were updated


___

## **CodeAnt-AI Description**
**Rename skill safety settings to action risk and validate them at load time**

### What Changed
- Replaced `autonomy_floor` with `action_risk` in skill manifests and docs, with clearer labels tied to minimum autonomy scores
- Updated shipped skills to use the new risk values: web search and autonomy lookup are always allowed, web browser is medium risk, and setting autonomy is high risk
- Skill loading now rejects invalid `action_risk` values, including unknown labels and numbers outside 0–100
- Added a direct way to convert an action risk into the score needed to run a skill without CEO approval

### Impact
`✅ Clearer skill approval rules`
`✅ Fewer invalid skill manifests`
`✅ Safer autonomy gating`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
