### PR TITLE
chore: backfill action_risk on pre-spec-12 skill manifests

### DIFF
--- a/skills/calendar-check-conflicts/skill.json
+++ b/skills/calendar-check-conflicts/skill.json
@@ -3,6 +3,7 @@
   "description": "Check whether a proposed time slot conflicts with existing events on one or more calendars. Returns conflicting events with details so you can assess severity (hard conflict vs tentative hold).",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "calendarIds": "array",

--- a/skills/calendar-create-event/skill.json
+++ b/skills/calendar-create-event/skill.json
@@ -3,6 +3,7 @@
   "description": "Create a new calendar event with title, time, attendees, and optional description/location/conferencing. Attendees will receive invitation emails automatically.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "high",
   "infrastructure": true,
   "inputs": {
     "calendarId": "string",

--- a/skills/calendar-delete-event/skill.json
+++ b/skills/calendar-delete-event/skill.json
@@ -3,6 +3,7 @@
   "description": "Delete a calendar event. By default, attendees receive cancellation emails. Set notifyAttendees to false to suppress cancellation notifications.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "high",
   "infrastructure": true,
   "inputs": {
     "calendarId": "string",

--- a/skills/calendar-find-free-time/skill.json
+++ b/skills/calendar-find-free-time/skill.json
@@ -3,6 +3,7 @@
   "description": "Find available time windows across one or more calendars. Returns free slots within a date range. Use duration (minutes) to filter to slots at least that long. Supports checking multiple people's availability at once.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "calendarIds": "array",

--- a/skills/calendar-list-calendars/skill.json
+++ b/skills/calendar-list-calendars/skill.json
@@ -3,6 +3,7 @@
   "description": "List all calendars visible to the agent (owned and shared), annotated with which contact each is registered to. Use this to discover new calendars or verify calendar assignments. NOT needed before listing events — calendar-list-events auto-resolves the caller's calendars when calendarId is omitted.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {},
   "outputs": {

--- a/skills/calendar-list-events/skill.json
+++ b/skills/calendar-list-events/skill.json
@@ -3,6 +3,7 @@
   "description": "Fetch events within a date range. Omit calendarId to automatically query all of the caller's registered calendars (preferred — do NOT look up calendar IDs manually). Only pass calendarId when the user explicitly asks about a specific calendar. Supports filtering by text query (title/description) and attendee email.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "calendarId": "string? (omit to auto-query all caller calendars — only pass when targeting a specific calendar)",

--- a/skills/calendar-register/skill.json
+++ b/skills/calendar-register/skill.json
@@ -3,6 +3,7 @@
   "description": "Register a Nylas calendar in the contact registry, linking it to a contact. Use this after calendar-list-calendars identifies an unregistered calendar and the CEO confirms which contact it belongs to. Defaults contact_id to the caller's own contact when omitted — the common case when the CEO is claiming their own calendar.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "low",
   "infrastructure": true,
   "inputs": {
     "nylas_calendar_id": "string",

--- a/skills/calendar-update-event/skill.json
+++ b/skills/calendar-update-event/skill.json
@@ -3,6 +3,7 @@
   "description": "Modify an existing calendar event. Supports partial updates — only provide the fields that need changing (title, time, description, location, attendees, conferencing). Attendee changes trigger invitation updates.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "high",
   "infrastructure": true,
   "inputs": {
     "calendarId": "string",

--- a/skills/contact-create/skill.json
+++ b/skills/contact-create/skill.json
@@ -3,6 +3,7 @@
   "description": "Create a new contact. Provide the person's name and optionally their role, notes, and channel identifiers (email, phone, signal, telegram). Automatically creates a knowledge graph entry.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "low",
   "infrastructure": true,
   "inputs": {
     "name": "string",

--- a/skills/contact-grant-permission/skill.json
+++ b/skills/contact-grant-permission/skill.json
@@ -3,6 +3,7 @@
   "description": "Grant or deny a specific permission for a contact, overriding their role defaults. Use when the CEO says 'Let X do Y' or 'Don't let X do Y'.",
   "version": "1.0.0",
   "sensitivity": "elevated",
+  "action_risk": "low",
   "infrastructure": true,
   "inputs": {
     "contact_id": "string",

--- a/skills/contact-link-identity/skill.json
+++ b/skills/contact-link-identity/skill.json
@@ -3,6 +3,7 @@
   "description": "Add a channel identity (email, phone, Signal, Telegram) to an existing contact.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "low",
   "infrastructure": true,
   "inputs": {
     "contact_id": "string",

--- a/skills/contact-list/skill.json
+++ b/skills/contact-list/skill.json
@@ -3,6 +3,7 @@
   "description": "List all contacts, optionally filtered by role.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "role": "string?"

--- a/skills/contact-lookup/skill.json
+++ b/skills/contact-lookup/skill.json
@@ -3,6 +3,7 @@
   "description": "Look up a contact by name, role, or channel identifier. Returns matching contacts with their details.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "query": "string",

--- a/skills/contact-revoke-permission/skill.json
+++ b/skills/contact-revoke-permission/skill.json
@@ -3,6 +3,7 @@
   "description": "Remove a permission override for a contact, restoring their role's default behavior for that permission.",
   "version": "1.0.0",
   "sensitivity": "elevated",
+  "action_risk": "low",
   "infrastructure": true,
   "inputs": {
     "contact_id": "string",

--- a/skills/contact-set-role/skill.json
+++ b/skills/contact-set-role/skill.json
@@ -3,6 +3,7 @@
   "description": "Set or change a contact's role (e.g., CFO, board member, advisor). contact_id must be a UUID obtained from contact-lookup or contact-create — do not invent or infer IDs.",
   "version": "1.0.0",
   "sensitivity": "elevated",
+  "action_risk": "low",
   "infrastructure": true,
   "inputs": {
     "contact_id": "string (UUID from contact-lookup or contact-create)",

--- a/skills/contact-unlink-identity/skill.json
+++ b/skills/contact-unlink-identity/skill.json
@@ -3,6 +3,7 @@
   "description": "Remove a channel identity from a contact. Use when the CEO says an email/phone is wrong or no longer valid for a contact.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "low",
   "infrastructure": true,
   "inputs": {
     "contact_id": "string",

--- a/skills/context-for-email/skill.json
+++ b/skills/context-for-email/skill.json
@@ -3,6 +3,7 @@
   "description": "Assemble complete context for composing an email in a single call. Given an email type (meeting-request, reschedule, cancel, doc-request) and a recipient name, this skill gathers: (1) the email composing policy/guidelines for that email type, (2) the recipient's contact info and meeting link if on file, (3) the agent signature. Returns everything the LLM needs to compose the email without additional tool calls. Use this instead of calling template and knowledge skills separately.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "email_type": "string (meeting-request | reschedule | cancel | doc-request)",

--- a/skills/delegate/skill.json
+++ b/skills/delegate/skill.json
@@ -3,6 +3,7 @@
   "description": "Delegate a task to a specialist agent. Use this when the user's request requires specialized expertise (research, expense tracking, etc.). Provide the specialist's name and a clear task description.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "agent": "string",

--- a/skills/email-reply/skill.json
+++ b/skills/email-reply/skill.json
@@ -3,6 +3,7 @@
   "description": "Reply to an existing email thread. Provide the Nylas message ID to reply to and the reply body. The reply will be threaded correctly and sent to the original sender.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "medium",
   "infrastructure": true,
   "inputs": {
     "reply_to_message_id": "string",

--- a/skills/email-send/skill.json
+++ b/skills/email-send/skill.json
@@ -3,6 +3,7 @@
   "description": "Send a new email. Provide comma-separated recipient email addresses, subject, and body. Emails are sent from Nathan Curia's email address.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "medium",
   "infrastructure": true,
   "inputs": {
     "to": "string",

--- a/skills/entity-context/skill.json
+++ b/skills/entity-context/skill.json
@@ -3,6 +3,7 @@
   "description": "Assemble rich context about one or more entities (people, orgs, events, etc.). Returns known facts, connected accounts, preferences, relationships, and other contextual information. Use contactIds for people; entityIds for any KG node. Omit both to get context for the caller. Use this when you need to know what resources (calendars, email accounts) an entity has, or to retrieve stored facts (timezone, preferences, identifiers).",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "inputs": {
     "entityIds": "string[]? (KG node IDs — use for non-person entities like orgs, events, places)",
     "contactIds": "string[]? (contact IDs — convenience alias for person entities, resolved via contacts table)",

--- a/skills/held-messages-list/skill.json
+++ b/skills/held-messages-list/skill.json
@@ -3,6 +3,7 @@
   "description": "List messages held from unknown senders awaiting your review. Shows sender, channel, subject, and when it arrived.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "channel": "string?"

--- a/skills/held-messages-process/skill.json
+++ b/skills/held-messages-process/skill.json
@@ -3,6 +3,7 @@
   "description": "Process a held message: identify the sender (create/link contact and replay message), dismiss it, or block the sender.",
   "version": "1.0.0",
   "sensitivity": "elevated",
+  "action_risk": "medium",
   "infrastructure": true,
   "inputs": {
     "held_message_id": "string",

--- a/skills/knowledge-company-overview/skill.json
+++ b/skills/knowledge-company-overview/skill.json
@@ -3,6 +3,7 @@
   "description": "Store or retrieve company overview information in the knowledge graph. Use 'store' to save details like legal name, address, officers, board members, or any other company-level facts. Use 'retrieve' to look up stored company information. Each fact is stored independently, so you can call 'store' multiple times to build up the company profile incrementally.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "action": "string (store | retrieve)",

--- a/skills/knowledge-loyalty-programs/skill.json
+++ b/skills/knowledge-loyalty-programs/skill.json
@@ -3,6 +3,7 @@
   "description": "Store or retrieve loyalty program information (airline frequent flyer numbers, hotel rewards numbers, etc.) in the knowledge graph. Use 'store' to save a loyalty program membership. Use 'retrieve' to look up all stored loyalty programs.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "action": "string (store | retrieve)",

--- a/skills/knowledge-meeting-links/skill.json
+++ b/skills/knowledge-meeting-links/skill.json
@@ -3,6 +3,7 @@
   "description": "Store or retrieve personal meeting links (Zoom, Teams, Google Meet, etc.) in the knowledge graph. Use 'store' to save a meeting link for a specific person (e.g. the CEO's personal Zoom link, a board member's Teams link). Use 'retrieve' to look up stored meeting links, optionally filtered by person name.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "action": "string (store | retrieve)",

--- a/skills/knowledge-travel-preferences/skill.json
+++ b/skills/knowledge-travel-preferences/skill.json
@@ -3,6 +3,7 @@
   "description": "Store or retrieve travel preferences in the knowledge graph. Use 'store' to save preferences like preferred airline, seat preference, hotel chain, dietary restrictions, or any other travel-related preference. Use 'retrieve' to look up all stored travel preferences.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "action": "string (store | retrieve)",

--- a/skills/scheduler-cancel/skill.json
+++ b/skills/scheduler-cancel/skill.json
@@ -3,6 +3,7 @@
   "description": "Cancel a scheduled job by its ID. The job is soft-deleted (status set to cancelled) and preserved for audit history.",
   "version": "1.0.0",
   "sensitivity": "elevated",
+  "action_risk": "low",
   "infrastructure": true,
   "inputs": { "job_id": "string" },
   "outputs": { "cancelled": "boolean" },

--- a/skills/scheduler-create/skill.json
+++ b/skills/scheduler-create/skill.json
@@ -3,6 +3,7 @@
   "description": "Create a scheduled job. Supports cron expressions for recurring jobs and ISO 8601 timestamps for one-shot jobs. Provide intent_anchor to create a persistent multi-burst task.",
   "version": "1.0.0",
   "sensitivity": "elevated",
+  "action_risk": "low",
   "infrastructure": true,
   "inputs": {
     "task": "string",

--- a/skills/scheduler-list/skill.json
+++ b/skills/scheduler-list/skill.json
@@ -3,6 +3,7 @@
   "description": "List scheduled jobs. Optionally filter by status (pending, running, completed, failed, suspended, cancelled) or agent_id.",
   "version": "1.0.0",
   "sensitivity": "elevated",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": { "status": "string?", "agent_id": "string?" },
   "outputs": { "jobs": "array" },

--- a/skills/template-cancel/skill.json
+++ b/skills/template-cancel/skill.json
@@ -3,6 +3,7 @@
   "description": "Retrieve email composing guidelines for meeting cancellations. Returns structured policy that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports four actions: 'generate' retrieves the policy (with any refinements); 'update' accepts a natural-language refinement; 'save' replaces the entire policy; 'reset' reverts to defaults and clears refinements.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "action": "string (generate | update | save | reset)",

--- a/skills/template-doc-request/skill.json
+++ b/skills/template-doc-request/skill.json
@@ -3,6 +3,7 @@
   "description": "Retrieve email composing guidelines for pre-meeting document/materials requests. Returns structured policy that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports four actions: 'generate' retrieves the policy (with any refinements); 'update' accepts a natural-language refinement; 'save' replaces the entire policy; 'reset' reverts to defaults and clears refinements.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "action": "string (generate | update | save | reset)",

--- a/skills/template-meeting-request/skill.json
+++ b/skills/template-meeting-request/skill.json
@@ -3,6 +3,7 @@
   "description": "Retrieve email composing guidelines for meeting requests. Returns structured policy (required elements, tone, structure, constraints, example) that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports four actions: 'generate' retrieves the policy (checks KG for customizations and refinements); 'update' accepts a natural-language refinement (e.g. 'make these less formal', 'always mention my assistant') and stores it as an additive adjustment; 'save' replaces the entire policy; 'reset' reverts to defaults and clears all refinements.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "action": "string (generate | update | save | reset)",

--- a/skills/template-reschedule/skill.json
+++ b/skills/template-reschedule/skill.json
@@ -3,6 +3,7 @@
   "description": "Retrieve email composing guidelines for meeting rescheduling. Returns structured policy that you use as instructions when composing the email — do NOT send the policy itself to the recipient. Supports four actions: 'generate' retrieves the policy (with any refinements); 'update' accepts a natural-language refinement; 'save' replaces the entire policy; 'reset' reverts to defaults and clears refinements.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "action": "string (generate | update | save | reset)",

--- a/skills/web-fetch/skill.json
+++ b/skills/web-fetch/skill.json
@@ -3,6 +3,7 @@
   "description": "Fetch the content of a web page via HTTP GET. Returns the page body as text. Use this to look up information on the web.",
   "version": "1.0.0",
   "sensitivity": "normal",
+  "action_risk": "none",
   "inputs": {
     "url": "string",
     "max_length": "number?"


### PR DESCRIPTION
## **User description**
## Summary

- Adds `action_risk` to all 35 skill manifests that predate spec 12
- Values assigned per the capability class table in `docs/superpowers/specs/2026-04-03-autonomy-engine-design.md`
- All 38 skill manifests now declare `action_risk` (3 were already updated in #136)

**Risk level rationale notes:**
- `held-messages-process = medium` — the skill has a replay path that triggers downstream message delivery, classifying it as outbound-adjacent rather than pure internal state
- `delegate = none` — the wrapper itself has no external effect; the specialist agent's own `action_risk` governs the actual action taken
- `web-browser` (pre-existing `medium`) — uses "outbound communications" as the closest bucket for form submissions; spec doesn't enumerate headless browser as a distinct class

## Test plan

- [x] All 35 skill manifests updated, each with exactly 1 line added
- [x] No existing skill manifest lost formatting or content
- [x] `pnpm test` — 729 passed, 0 failures
- [x] Code review confirmed assignments match spec rubric
- [x] Validation layer confirms bad values fail closed at startup

Closes #141


___

## **CodeAnt-AI Description**
**Add action risk labels to calendar, contact, email, scheduler, knowledge, and utility skills**

### What Changed
- Added a risk label to each affected skill so actions are grouped by how much they can change data or send messages
- Read-only lookups are marked as no-risk, data edits as low-risk, message sending as medium-risk, and calendar changes as high-risk
- Skills that create, update, or remove calendar events now show as high-risk, while email sending and replies are marked medium-risk

### Impact
`✅ Clearer handling of write actions`
`✅ Safer calendar and email operations`
`✅ More accurate action classification`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
