### PR TITLE
docs: clarify autonomy engine phase numbering, make action_risk required

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Cross-cutting: Audit Logger, Memory Engine, Scheduler.
 
 ### Autonomy Awareness
 
-When adding a new skill, declare its action risk in `skill.json` (this field is not enforced in Phase 1 but is required for Phase 2 gate wiring):
+When adding a new skill, declare its action risk in `skill.json`. This field is **required** — Phase 2 will reject manifests that omit it at startup:
 
 ```json
 "action_risk": "medium"

--- a/docs/dev/adding-a-skill.md
+++ b/docs/dev/adding-a-skill.md
@@ -91,9 +91,9 @@ Use `"elevated"` for skills with serious external effects: sending emails, makin
 
 The elevated check is per-call, not per-agent-pair — there is no stored approval table. Every invocation of an elevated skill is checked against the caller context on the fly.
 
-#### `action_risk` (strongly recommended)
+#### `action_risk` (required)
 
-Declares the risk level of this skill's primary action. Used by the **autonomy engine** in Phase 2 to gate skill execution against the global autonomy score. The field is optional in the schema (manifests that predate spec 12 don't have it), but all new skills should declare it now so the gating system is correctly labeled when it goes live.
+Declares the risk level of this skill's primary action. Used by the **autonomy engine** in Phase 2 to gate skill execution against the global autonomy score. All skills must declare this field — manifests without it will be rejected at startup once Phase 2 gating is wired, and it is required now so skills are correctly labeled when that goes live.
 
 | Value | Min autonomy score | Capability class |
 |---|---|---|
@@ -105,9 +105,9 @@ Declares the risk level of this skill's primary action. Used by the **autonomy e
 
 A raw integer (0–100) may be used for precision when the named levels are too coarse. Values outside `[0, 100]` produce a validation error at skill load time.
 
-**Phase 1 status:** `action_risk` is declared now but not yet enforced at runtime — the gating engine is Phase 2. Declaring it now ensures all skills are correctly labeled when gating goes live.
+**Phase 1 status:** `action_risk` is declared and validated at load time but not yet enforced at runtime — the hard gate is Phase 2 work.
 
-**How Phase 2 gating will work:** When an agent calls a skill, the execution layer will compare the skill's minimum required autonomy score against the live global score from `autonomy_config`. If the score is too low, the skill call is held and the CEO is notified for approval. The autonomy score is CEO-controlled and adjusted via the `set-autonomy` skill. See `docs/superpowers/specs/2026-04-03-autonomy-engine-design.md` for the full design.
+**How Phase 2 gating will work:** When an agent calls a skill, the execution layer compares the skill's minimum required autonomy score against the live global score from `autonomy_config`. If the score is too low, the invocation returns an advisory failure (no throw, same `{ success: false, error }` shape as any other failure) and an audit event is emitted. The autonomy score is CEO-controlled via the `set-autonomy` skill. See `docs/superpowers/specs/2026-04-03-autonomy-engine-design.md` for the full design.
 
 #### `infrastructure` (optional, default: `false`)
 
@@ -441,4 +441,4 @@ When the risk is between two levels, use the higher one. It's easier to lower au
 - [Skills & Execution Spec](../specs/03-skills-and-execution.md) — full execution layer design
 - [Adding an Agent](adding-an-agent.md) — wire your new skill into an agent
 - [Audit & Security](../specs/06-audit-and-security.md) — what gets logged
-- [Autonomy Engine Design](../superpowers/specs/2026-04-03-autonomy-engine-design.md) — how `action_risk` will gate execution in Phase 2
+- [Autonomy Engine Design](../superpowers/specs/2026-04-03-autonomy-engine-design.md) — how `action_risk` gates execution (Phase 2 hard gates, Phase 3 auto-adjustment)

--- a/docs/superpowers/plans/2026-04-03-autonomy-engine.md
+++ b/docs/superpowers/plans/2026-04-03-autonomy-engine.md
@@ -54,7 +54,7 @@ CREATE TABLE autonomy_config (
 );
 
 -- Append-only audit trail — never updated or deleted.
--- Phase 2 auto-adjustment will also write here (changed_by = 'system').
+-- Phase 3 auto-adjustment will also write here (changed_by = 'system').
 CREATE TABLE autonomy_history (
   id             BIGSERIAL PRIMARY KEY,
   score          INTEGER NOT NULL,
@@ -109,7 +109,8 @@ git commit -m "feat: add autonomy_config and autonomy_history tables (migration 
 // injected into the coordinator's system prompt on every task.
 //
 // Phase 1: CEO-controlled via get-autonomy / set-autonomy skills.
-// Phase 2: Automatic adjustment based on action log data (future).
+// Phase 2: Hard gates in the execution layer driven by action_risk vs. live score (future).
+// Phase 3: Automatic adjustment based on action log data (future).
 
 import type { Pool } from 'pg';
 import type { Logger } from '../logger.js';

--- a/docs/superpowers/specs/2026-04-03-autonomy-engine-design.md
+++ b/docs/superpowers/specs/2026-04-03-autonomy-engine-design.md
@@ -14,7 +14,8 @@ Postgres-persisted, and injected into the coordinator's system prompt on every t
 Curia self-governs accordingly.
 
 Phase 1 establishes the score, CEO read/write access, and behavioral prompt injection.
-Phase 2 (future) will add automatic score adjustment driven by an action log.
+Phase 2 (future) will wire hard gates in the execution and outbound layers driven by the live score and each skill's declared `action_risk`.
+Phase 3 (future) will add automatic score adjustment driven by an action log.
 
 ---
 
@@ -23,14 +24,15 @@ Phase 2 (future) will add automatic score adjustment driven by an action log.
 The autonomy framework is derived from Gorick Ng's Competence / Commitment / Compatibility
 model. A composite score maps to one of five autonomy bands, each with explicit behavioral
 guidance. This spec covers the Phase 1 foundation only — the full scoring formula,
-auto-adjustment rules, relationship signals, and gating engine are documented in the
-source spec (to be filed at `docs/specs/designs/office-ceo-agent-scoring-spec.md`) and deferred to Phase 2.
+auto-adjustment rules, and relationship signals are documented in the source spec
+(to be filed at `docs/specs/designs/office-ceo-agent-scoring-spec.md`) and deferred to Phase 3.
+The gating engine is Phase 2.
 
 **Why a single global score rather than per-agent or per-capability scoring?**
 Curia is a single deployed instance — there is no meaningful distinction between "Curia's
 email autonomy" and "Curia's calendar autonomy" at this stage. A global score is
 interpretable, adjustable, and directly tied to the CEO's lived trust in the system. Per-
-capability scoring can be layered on top in Phase 2 once the global baseline is established.
+capability scoring can be layered on top in Phase 2 or later once the global baseline is established.
 
 ---
 
@@ -85,7 +87,7 @@ CREATE TABLE autonomy_config (
   score       INTEGER NOT NULL CHECK (score >= 0 AND score <= 100),
   band        TEXT NOT NULL,        -- derived label stored for query convenience
   updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-  updated_by  TEXT NOT NULL,        -- 'ceo' or 'system' (Phase 2+)
+  updated_by  TEXT NOT NULL,        -- 'ceo' or 'system' (Phase 3+)
   CONSTRAINT single_row CHECK (id = 1)
 );
 ```
@@ -115,7 +117,7 @@ CREATE TABLE autonomy_history (
 ```
 
 Every write to `autonomy_config` appends a row here. This table is never updated or
-deleted. It is the foundation Phase 2's auto-adjustment will write to when recording
+deleted. It is the foundation Phase 3's auto-adjustment will write to when recording
 score changes from the action log.
 
 ---
@@ -216,9 +218,9 @@ A raw number (0–100) may be used for precision (e.g. `75` for a skill that sho
 just above approval-required but below spot-check). Numbers outside [0, 100] produce a
 validation error at skill load time.
 
-This field is **not enforced by the execution layer in Phase 1** — it is documentation for
-the developer and for Phase 2's gate wiring. When the execution layer is extended to enforce
-action risk, the field will already be present.
+This field is **required** in all skill manifests. It is not enforced at runtime in Phase 1,
+but Phase 2 will gate skill execution against it. The field must be present and valid at
+skill load time — `SkillRegistry.register` will reject manifests that omit it (Phase 2).
 
 ### Action risk guidelines by capability class
 
@@ -242,10 +244,9 @@ When adding a new agent:
 
 ---
 
-## Intended Future Hard Gates (Phase 2)
+## Phase 2: Hard Gates (Future)
 
-These gates are deferred to Phase 2 but documented here as the intended target. When
-wiring, these are the first candidates:
+These gates are deferred to Phase 2. When wiring, these are the first candidates:
 
 | Condition | Gate |
 |---|---|
@@ -258,9 +259,9 @@ autonomy check there in Phase 2 requires no architectural change.
 
 ---
 
-## Phase 2: Auto-Adjustment (Future)
+## Phase 3: Auto-Adjustment (Future)
 
-Phase 2 will implement automatic score adjustment based on an action log. The formula from
+Phase 3 will implement automatic score adjustment based on an action log. The formula from
 the source spec:
 
 ```
@@ -276,10 +277,10 @@ Key constraints from the spec:
 - Autonomy cannot increase if factual error rate is high or overconfidence penalty is active
 - All automatic adjustments write to `autonomy_history` with `changed_by: "system"`
 
-The `autonomy_history` table designed in Phase 1 is the exact foundation Phase 2 writes to.
+The `autonomy_history` table designed in Phase 1 is the exact foundation Phase 3 writes to.
 
-The full Phase 2 schema (action log, relationship signals, confidence model) is in the
-source spec. Phase 2 gets its own design doc when the time comes.
+The full Phase 3 schema (action log, relationship signals, confidence model) is in the
+source spec. Phase 3 gets its own design doc when the time comes.
 
 ---
 

--- a/src/autonomy/autonomy-service.ts
+++ b/src/autonomy/autonomy-service.ts
@@ -5,7 +5,8 @@
 // injected into the coordinator's system prompt on every task.
 //
 // Phase 1: CEO-controlled via get-autonomy / set-autonomy skills.
-// Phase 2: Automatic adjustment based on action log data (future).
+// Phase 2: Hard gates in the execution layer driven by action_risk vs. live score (future).
+// Phase 3: Automatic adjustment based on action log data (future).
 
 import type { Pool } from 'pg';
 import type { Logger } from '../logger.js';
@@ -180,7 +181,7 @@ export class AutonomyService {
 
     // Atomic: read previous score, upsert config, and write history in a single query.
     // RETURNING previous_score gives us the atomically-captured old value for the response.
-    // @TODO Phase 2: If setScore is ever split into separate queries (e.g., for two-step
+    // @TODO Phase 3: If setScore is ever split into separate queries (e.g., for two-step
     // update flows), wrap in explicit BEGIN/COMMIT to preserve atomicity guarantees.
     const result = await this.pool.query<{ previous_score: number | null }>(
       `WITH locked AS (

--- a/src/db/migrations/011_create_autonomy.sql
+++ b/src/db/migrations/011_create_autonomy.sql
@@ -13,7 +13,7 @@ CREATE TABLE autonomy_config (
 );
 
 -- Append-only audit trail — never updated or deleted.
--- Phase 2 auto-adjustment will also write here (changed_by = 'system').
+-- Phase 3 auto-adjustment will also write here (changed_by = 'system').
 CREATE TABLE autonomy_history (
   id             BIGSERIAL PRIMARY KEY,
   score          INTEGER NOT NULL,

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -35,10 +35,10 @@ export interface SkillManifest {
   /** "normal" = auto-approvable; "elevated" = requires human approval on first use */
   sensitivity: 'normal' | 'elevated';
   /** Action risk: the minimum autonomy score required to invoke this skill without
-   *  explicit CEO approval. Used by Phase 2 gate wiring to enforce autonomy-aware
-   *  skill access. Optional — existing manifests that predate spec 12 don't have
-   *  this field. See ActionRisk for the named label → score mapping. */
-  action_risk?: ActionRisk;
+   *  explicit CEO approval. Required on all new manifests — Phase 2 will enforce this
+   *  at load time (SkillRegistry.register will reject manifests that omit it).
+   *  See ActionRisk for the named label → score mapping. */
+  action_risk: ActionRisk;
   /** JSON Schema-ish description of expected inputs */
   inputs: Record<string, string>;
   /** JSON Schema-ish description of outputs */


### PR DESCRIPTION
## **User description**
## Summary

Phase 2 was overloaded — "Intended Future Hard Gates" and "Auto-Adjustment" were both called Phase 2. This PR disambiguates:

- **Phase 2** = Hard gates (action_risk enforcement, outbound gateway gate, full-restriction gate) — tracked in #147
- **Phase 3** = Auto-adjustment (action log, LLM-as-judge, score formula) — tracked in #148

Also upgrades `action_risk` from "strongly recommended" to required:
- `SkillManifest.action_risk` is now non-optional in TypeScript (compile-time enforcement for new skills)
- All existing skills already declare it — no breakage
- Runtime rejection at load time is Phase 2 (#147) work

## Files changed

- `docs/superpowers/specs/2026-04-03-autonomy-engine-design.md` — phase renaming throughout
- `docs/superpowers/plans/2026-04-03-autonomy-engine.md` — plan snapshots updated
- `docs/dev/adding-a-skill.md` — action_risk mandatory, Phase 2 gating description updated
- `src/skills/types.ts` — `action_risk?: ActionRisk` → `action_risk: ActionRisk`
- `src/db/migrations/011_create_autonomy.sql` — Phase 2 → Phase 3 in comment
- `src/autonomy/autonomy-service.ts` — file header and @TODO comment updated
- `CLAUDE.md` — action_risk language updated

## Test plan

- [ ] Verify all existing skills in `skills/` still load (all already have `action_risk` — confirmed by grep)
- [ ] No TypeScript errors introduced by the `action_risk` type change (pre-existing errors in worktree are missing-deps, unrelated)


___

## **CodeAnt-AI Description**
**Clarify autonomy phases and require `action_risk` on new skills**

### What Changed
- Re-labels the autonomy roadmap so Phase 2 covers hard execution gates and Phase 3 covers automatic score adjustment
- Makes `action_risk` a required part of new skill manifests, so missing values are rejected at load time
- Updates the skill-adding guide and autonomy docs to explain the new requirement and when gating will apply

### Impact
`✅ Clearer autonomy rollout`
`✅ Fewer invalid skill manifests`
`✅ Earlier feedback when new skills miss required risk labels`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
