### PR TITLE
feat: Office Identity Engine

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,17 +1,11 @@
 name: coordinator
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
-persona:
-  display_name: Nathan Curia
-  tone: professional but approachable
-  title: Agent Chief of Staff
 model:
   provider: anthropic
   model: claude-sonnet-4-20250514
 system_prompt: |
-  You are ${persona.display_name}, the ${persona.title}.
-  You are an AI executive assistant serving the CEO.
-  Your communication style is ${persona.tone}.
+  ${office_identity_block}
 
   ## Date & Time
   When interpreting relative dates ("next Friday", "the Monday after"), always
@@ -65,7 +59,7 @@ system_prompt: |
     or "I'll get back to you") — never explain the technical reason.
   - The person should experience you as a competent human assistant, not as software
     with visible internals.
-  - Sign emails professionally as "Nathan Curia, Agent Chief of Staff".
+  - Sign emails professionally using your name and title from the identity block above.
 
   **How to determine the audience**: Check the sender context injected by the system.
   - If the sender's role is "ceo", you're talking to the CEO.
@@ -153,7 +147,7 @@ system_prompt: |
   ${available_specialists}
 
   ## Persona & Communication Style
-  You are Nathan Curia — a person, not a platform. When you talk about yourself:
+  You are a person, not a platform. When you talk about yourself:
   - Say "I have contacts for..." not "I have a contact system that stores..."
   - Say "I can look into that" not "I can use the web-fetch tool"
   - Say "I'll check with my research team" not "I'll delegate to the research-analyst agent"

--- a/config/office-identity.yaml
+++ b/config/office-identity.yaml
@@ -1,0 +1,40 @@
+# Office-level identity for this Curia instance.
+# Changes here take effect on the next coordinator turn (hot reload).
+# All changes are versioned in the database.
+#
+# This file is the default for new deployments. Once the onboarding wizard
+# has been used to update the identity, the DB version takes precedence
+# over this file — edits here will still trigger a hot reload and create a
+# new DB version, but they will not "reset" a wizard-configured identity.
+
+office:
+  assistant:
+    name: "Nathan Curia"
+    title: "Agent Chief of Staff"
+    email_signature: |
+      Nathan Curia
+      Office of the CEO
+
+  tone:
+    baseline:                             # 1–3 words from the predefined set
+      - "warm"
+      - "direct"
+    verbosity: 50                         # 0–100; 0 = tersest, 100 = most thorough
+    directness: 75                        # 0–100; 0 = most hedged, 100 = most direct
+
+  behavioral_preferences:
+    # Free-form guidance compiled into the coordinator system prompt.
+    # Ordered: first item has highest weight.
+    - "Be concise unless detail is explicitly requested"
+    - "Prioritize signal over noise — surface only what's actionable or strategic"
+    - "Escalate ambiguity before taking external action"
+
+  decision_style:
+    external_actions: "conservative"      # conservative | balanced | proactive
+    internal_analysis: "proactive"        # conservative | balanced | proactive
+
+  constraints:
+    # Hard rules. Compiled separately and placed above all other identity content
+    # in the system prompt. Cannot be overridden by overlays or wizard edits.
+    - "Never impersonate the CEO"
+    - "Always identify as an AI assistant when asked directly"

--- a/config/office-identity.yaml
+++ b/config/office-identity.yaml
@@ -9,10 +9,10 @@
 
 office:
   assistant:
-    name: "Nathan Curia"
-    title: "Agent Chief of Staff"
+    name: "Alex Curia"
+    title: "Agent EA"
     email_signature: |
-      Nathan Curia
+      Alex Curia
       Office of the CEO
 
   tone:

--- a/docs/dev/adding-an-agent.md
+++ b/docs/dev/adding-an-agent.md
@@ -50,9 +50,6 @@ system_prompt: |
   Extract amounts, vendors, categories, and dates from receipts.
   Return structured data — never guess at missing fields.
 
-  # Variable interpolation — any persona field is available:
-  # ${persona.display_name}, ${persona.tone}, ${persona.title}
-
 # ------------------------------------------------------------------
 # Skills (optional but almost always needed)
 # ------------------------------------------------------------------
@@ -138,8 +135,8 @@ The optional `fallback` block specifies an alternate provider+model to use if th
 
 The LLM instructions for this agent. Written in plain text. Key points:
 
-- Interpolate persona fields via `${persona.display_name}` etc.
 - The runtime injects additional context automatically (current date/time, autonomy band, memory context) — you do not need to add boilerplate for these
+- The Coordinator's system prompt uses `${office_identity_block}` to receive the compiled identity (name, tone, constraints, etc.) from `OfficeIdentityService`. Specialist agents do not need this — identity is a Coordinator concern.
 - Write for a single-turn task frame. For persistent tasks, the `intent_anchor` is injected separately to prevent drift.
 
 ### `pinned_skills` (optional)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@fastify/cors": "^11.2.0",
     "@fastify/rate-limit": "^10.3.0",
     "@ghostery/adblocker-playwright": "^2.14.1",
+    "chokidar": "^5.0.0",
     "cron-parser": "^5.5.0",
     "cytoscape": "^3.33.1",
     "fastify": "^5.8.4",
@@ -41,6 +42,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/chokidar": "^2.1.7",
     "@types/js-yaml": "^4.0.9",
     "@types/luxon": "^3.7.1",
     "@types/node": "^25.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@ghostery/adblocker-playwright':
         specifier: ^2.14.1
         version: 2.14.1(playwright@1.59.1)
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
       cron-parser:
         specifier: ^5.5.0
         version: 5.5.0
@@ -60,6 +63,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.1.0)
+      '@types/chokidar':
+        specifier: ^2.1.7
+        version: 2.1.7
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -672,6 +678,10 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/chokidar@2.1.7':
+    resolution: {integrity: sha512-A7/MFHf6KF7peCzjEC1BBTF8jpmZTokb3vr/A0NxRGfwRLK3Ws+Hq6ugVn6cJIMfM6wkCak/aplWrxbTcu8oig==}
+    deprecated: This is a stub types definition. chokidar provides its own type definitions, so you do not need this installed.
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -870,6 +880,10 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1546,6 +1560,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
@@ -2292,6 +2310,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/chokidar@2.1.7':
+    dependencies:
+      chokidar: 5.0.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
@@ -2535,6 +2557,10 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
 
   cliui@8.0.1:
     dependencies:
@@ -3202,6 +3228,8 @@ snapshots:
   quick-format-unescaped@4.0.4: {}
 
   readdirp@4.1.2: {}
+
+  readdirp@5.0.0: {}
 
   real-require@0.2.0: {}
 

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -124,6 +124,7 @@ function interpolatePersona(
 /**
  * Interpolate runtime context placeholders in the system prompt.
  * Currently supports:
+ * - ${office_identity_block} — compiled identity block from OfficeIdentityService
  * - ${available_specialists} — list of specialist agents from the agent registry
  * - ${current_date} — today's date in the configured timezone (YYYY-MM-DD, Day)
  * - ${timezone} — the configured IANA timezone name
@@ -137,9 +138,18 @@ export function interpolateRuntimeContext(
   context: {
     availableSpecialists?: string;
     agentContactId?: string;
+    officeIdentityBlock?: string;
   },
 ): string {
   return systemPrompt
+    .replace(
+      /\$\{office_identity_block\}/g,
+      // The identity block is compiled by OfficeIdentityService.compileSystemPromptBlock().
+      // It must be injected before persona tokens so constraints always appear first.
+      // If the service is not yet initialized, leave the placeholder as-is so the
+      // misconfiguration is visible rather than silently producing an empty block.
+      context.officeIdentityBlock ?? '${office_identity_block}',
+    )
     .replace(
       /\$\{available_specialists\}/g,
       context.availableSpecialists ?? 'No specialists available yet.',

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -12,6 +12,7 @@ import { DEFAULT_ERROR_BUDGET, type AgentError, type ErrorBudget } from '../erro
 // Value import (not type-only) — we call AutonomyService.formatPromptBlock() as a static method.
 import { AutonomyService } from '../autonomy/autonomy-service.js';
 import { formatTimeContextBlock } from '../time/time-context.js';
+import type { OfficeIdentityService } from '../identity/service.js';
 
 export interface AgentConfig {
   agentId: string;
@@ -32,6 +33,11 @@ export interface AgentConfig {
   /** Optional autonomy service — when provided, the autonomy block is injected
    *  into the effective system prompt on every task. Only the coordinator receives this. */
   autonomyService?: AutonomyService;
+  /** Optional identity service — when provided, ${office_identity_block} in the system
+   *  prompt is replaced with the freshly-compiled identity block on every task turn.
+   *  This enables hot-reload: identity changes via the API or file watcher take effect
+   *  on the very next coordinator turn without a restart. Only the coordinator uses this. */
+  officeIdentityService?: OfficeIdentityService;
   /** IANA timezone name (e.g. "America/Toronto"). When provided, the current date/time
    *  block is appended to the system prompt on every task so the date is always fresh.
    *  If omitted, no time block is injected. */
@@ -120,13 +126,31 @@ export class AgentRuntime {
   }
 
   private async processTask(taskEvent: AgentTaskEvent): Promise<void> {
-    const { agentId, systemPrompt, provider, bus, logger, memory, executionLayer, skillToolDefs, autonomyService } = this.config;
+    const { agentId, systemPrompt, provider, bus, logger, memory, executionLayer, skillToolDefs, autonomyService, officeIdentityService } = this.config;
     const { content, conversationId } = taskEvent.payload;
+
+    // Replace the ${office_identity_block} placeholder with the freshly-compiled
+    // identity block. This runs per-task (not at startup) so identity changes via
+    // the API or file watcher take effect on the next coordinator turn without a restart.
+    // The token stays literal in the stored systemPrompt; we substitute it here each turn.
+    let effectiveSystemPrompt = systemPrompt;
+    if (officeIdentityService) {
+      try {
+        effectiveSystemPrompt = effectiveSystemPrompt.replace(
+          '${office_identity_block}',
+          officeIdentityService.compileSystemPromptBlock(),
+        );
+      } catch (err) {
+        // A compile failure should not abort the task. Log at error (operator signal)
+        // and proceed with the placeholder literal visible — the misconfiguration will
+        // be obvious in the LLM's response if the block is structurally broken.
+        logger.error({ err, agentId }, 'Failed to compile identity block — ${office_identity_block} placeholder left in prompt');
+      }
+    }
 
     // Load the current autonomy config and append its behavioral block to the
     // system prompt. This runs per-task (not at startup) so a CEO score change
     // mid-session takes effect on Curia's next action without a restart.
-    let effectiveSystemPrompt = systemPrompt;
     if (autonomyService) {
       try {
         const autonomyConfig = await autonomyService.getConfig();

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -173,6 +173,18 @@ interface ScheduleSuspendedPayload {
   consecutiveFailures: number;
 }
 
+// ConfigChangePayload — emitted by the System layer whenever a config object changes.
+// Currently only used by OfficeIdentityService (config_type: 'office_identity').
+// The diff_summary is a human-readable description of what changed; it is not machine-parseable.
+interface ConfigChangePayload {
+  config_type: string;          // e.g. 'office_identity'
+  version: number;              // new version number
+  previous_version: number;     // previous version number (0 if this is the first)
+  changed_by: string;           // 'wizard' | 'api' | 'file_load'
+  note?: string;                // optional human-readable reason
+  diff_summary: string;         // human-readable summary of what changed
+}
+
 // -- Discriminated union --
 // The `type` field is the discriminant; `sourceLayer` records which layer emitted the event.
 
@@ -290,6 +302,12 @@ export interface ScheduleSuspendedEvent extends BaseEvent {
   payload: ScheduleSuspendedPayload;
 }
 
+export interface ConfigChangeEvent extends BaseEvent {
+  type: 'config.change';
+  sourceLayer: 'system';
+  payload: ConfigChangePayload;
+}
+
 export type BusEvent =
   | InboundMessageEvent
   | AgentTaskEvent
@@ -307,7 +325,8 @@ export type BusEvent =
   | OutboundBlockedEvent  // Outbound content filter: message blocked before delivery (#38)
   | ScheduleCreatedEvent   // Scheduler: job created
   | ScheduleFiredEvent     // Scheduler: job fired
-  | ScheduleSuspendedEvent; // Scheduler: job auto-suspended
+  | ScheduleSuspendedEvent  // Scheduler: job auto-suspended
+  | ConfigChangeEvent;      // System: config object changed (office identity, etc.)
 
 // Convenience alias for use in handler maps / switch statements.
 export type EventType = BusEvent['type'];
@@ -560,6 +579,20 @@ export function createScheduleSuspended(
     id: randomUUID(),
     timestamp: new Date(),
     type: 'schedule.suspended',
+    sourceLayer: 'system',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createConfigChange(
+  payload: ConfigChangePayload & { parentEventId?: string },
+): ConfigChangeEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'config.change',
     sourceLayer: 'system',
     payload: rest,
     parentEventId,

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -12,7 +12,7 @@ const publishAllowlist: Record<Layer, Set<EventType>> = {
   dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected']),
   agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query']),
   execution: new Set(['skill.result']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'config.change']),
 };
 
 const subscribeAllowlist: Record<Layer, Set<EventType>> = {
@@ -20,7 +20,7 @@ const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   dispatch: new Set(['inbound.message', 'agent.response', 'agent.error']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'config.change']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -31,6 +31,8 @@ import { agentRoutes } from './routes/agents.js';
 import { jobRoutes } from './routes/jobs.js';
 import { messageRoutes } from './routes/messages.js';
 import { knowledgeGraphRoutes } from './routes/kg.js';
+import { identityRoutes } from './routes/identity.js';
+import type { OfficeIdentityService } from '../../identity/service.js';
 
 export interface HttpAdapterConfig {
   bus: EventBus;
@@ -44,6 +46,7 @@ export interface HttpAdapterConfig {
   agentNames: string[];
   skillNames: string[];
   schedulerService?: SchedulerService;
+  identityService?: OfficeIdentityService;
 }
 
 export class HttpAdapter {
@@ -104,11 +107,13 @@ export class HttpAdapter {
       if (routeUrl === '/api/health') return;
       // KG web app routes bypass bearer auth — the app shell, static assets, and
       // /auth exchange need no token; /api/kg/* routes enforce their own session/secret.
+      // Identity routes bypass bearer auth — they enforce their own bootstrap secret auth.
       if (
         routeUrl === '/' ||
         routeUrl === '/auth' ||
         routeUrl.startsWith('/assets') ||
-        routeUrl.startsWith('/api/kg')
+        routeUrl.startsWith('/api/kg') ||
+        routeUrl.startsWith('/api/identity')
       ) return;
 
       if (!validateBearerToken(request.headers.authorization, apiToken)) {
@@ -123,6 +128,15 @@ export class HttpAdapter {
 
     if (this.config.schedulerService) {
       await this.app.register(jobRoutes, { schedulerService: this.config.schedulerService });
+    }
+
+    // Identity routes — only registered when the bootstrap secret is configured.
+    // Uses the same auth pattern as KG routes (x-web-bootstrap-secret header).
+    if (webAppBootstrapSecret && this.config.identityService) {
+      await this.app.register(identityRoutes, {
+        identityService: this.config.identityService,
+        webAppBootstrapSecret,
+      });
     }
 
     // Only register KG routes when the secret is configured — if unset, the routes

--- a/src/channels/http/routes/identity.ts
+++ b/src/channels/http/routes/identity.ts
@@ -19,14 +19,23 @@ export interface IdentityRouteOptions {
   webAppBootstrapSecret: string;
 }
 
-/** Validate the x-web-bootstrap-secret header. Uses timing-safe comparison. */
+/** Validate the x-web-bootstrap-secret header. Uses timing-safe comparison.
+ *
+ * We compare buffer byte lengths — not JavaScript string char lengths — before
+ * calling timingSafeEqual. timingSafeEqual throws ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH
+ * when the two buffers have different byte lengths. A multi-byte UTF-8 header could
+ * have the same char count as the configured secret but a different byte count,
+ * triggering an unhandled 500 without this guard.
+ */
 function validateBootstrapSecret(
   provided: unknown,
   configured: string,
 ): boolean {
   if (typeof provided !== 'string') return false;
-  if (provided.length !== configured.length) return false;
-  return timingSafeEqual(Buffer.from(provided), Buffer.from(configured));
+  const providedBuf = Buffer.from(provided);
+  const configuredBuf = Buffer.from(configured);
+  if (providedBuf.length !== configuredBuf.length) return false;
+  return timingSafeEqual(providedBuf, configuredBuf);
 }
 
 export async function identityRoutes(

--- a/src/channels/http/routes/identity.ts
+++ b/src/channels/http/routes/identity.ts
@@ -134,8 +134,8 @@ export async function identityRoutes(
       await identityService.reload();
       const identity = identityService.get();
       return reply.send({ identity, reloaded: true });
-    } catch (err) {
-      // Do not forward err.message — reload failures surface DB internals (table names,
+    } catch (_err) {
+      // Do not forward _err.message — reload failures surface DB internals (table names,
       // migration identifiers, constraint names) that should not reach API callers.
       // The error is already logged by reload() before rethrowing.
       return reply.status(500).send({ error: 'Failed to reload identity due to a server error. Check server logs.' });

--- a/src/channels/http/routes/identity.ts
+++ b/src/channels/http/routes/identity.ts
@@ -87,6 +87,11 @@ export async function identityRoutes(
       return reply.status(400).send({ error: 'Request body must include an "identity" object' });
     }
 
+    // @TODO: The constraints field in the identity object is currently not protected —
+    // callers can omit or alter constraints, weakening the non-negotiable rules.
+    // The wizard PR will enforce constraint immutability via a separate UI flow
+    // (explicit confirmation step, separate from tone/persona edits).
+
     try {
       await identityService.update(body.identity, 'api', body.note);
       const updated = identityService.get();

--- a/src/channels/http/routes/identity.ts
+++ b/src/channels/http/routes/identity.ts
@@ -134,8 +134,8 @@ export async function identityRoutes(
       await identityService.reload();
       const identity = identityService.get();
       return reply.send({ identity, reloaded: true });
-    } catch (_err) {
-      // Do not forward _err.message — reload failures surface DB internals (table names,
+    } catch {
+      // Do not forward the error message — reload failures surface DB internals (table names,
       // migration identifiers, constraint names) that should not reach API callers.
       // The error is already logged by reload() before rethrowing.
       return reply.status(500).send({ error: 'Failed to reload identity due to a server error. Check server logs.' });

--- a/src/channels/http/routes/identity.ts
+++ b/src/channels/http/routes/identity.ts
@@ -135,8 +135,10 @@ export async function identityRoutes(
       const identity = identityService.get();
       return reply.send({ identity, reloaded: true });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to reload identity';
-      return reply.status(500).send({ error: message });
+      // Do not forward err.message — reload failures surface DB internals (table names,
+      // migration identifiers, constraint names) that should not reach API callers.
+      // The error is already logged by reload() before rethrowing.
+      return reply.status(500).send({ error: 'Failed to reload identity due to a server error. Check server logs.' });
     }
   });
 }

--- a/src/channels/http/routes/identity.ts
+++ b/src/channels/http/routes/identity.ts
@@ -1,0 +1,121 @@
+// identity.ts — HTTP routes for the Office Identity API.
+//
+// All routes require x-web-bootstrap-secret authentication (same as the KG explorer).
+// Routes are only registered when webAppBootstrapSecret is configured.
+//
+// Endpoints:
+//   GET  /api/identity         — return the current active identity config
+//   PUT  /api/identity         — save a new version and trigger hot reload
+//   GET  /api/identity/history — return all versions, newest first
+//   POST /api/identity/reload  — force a reload from DB (used post-wizard)
+
+import { timingSafeEqual } from 'node:crypto';
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import type { OfficeIdentityService } from '../../../identity/service.js';
+import type { OfficeIdentity } from '../../../identity/types.js';
+
+export interface IdentityRouteOptions {
+  identityService: OfficeIdentityService;
+  webAppBootstrapSecret: string;
+}
+
+/** Validate the x-web-bootstrap-secret header. Uses timing-safe comparison. */
+function validateBootstrapSecret(
+  provided: unknown,
+  configured: string,
+): boolean {
+  if (typeof provided !== 'string') return false;
+  if (provided.length !== configured.length) return false;
+  return timingSafeEqual(Buffer.from(provided), Buffer.from(configured));
+}
+
+export async function identityRoutes(
+  app: FastifyInstance,
+  options: IdentityRouteOptions,
+): Promise<void> {
+  const { identityService, webAppBootstrapSecret } = options;
+
+  // Auth helper — validates the bootstrap secret on every request to these routes.
+  function requireBootstrapSecret(
+    headers: Record<string, string | string[] | undefined>,
+    reply: FastifyReply,
+  ): boolean {
+    const provided = headers['x-web-bootstrap-secret'];
+    if (!validateBootstrapSecret(provided, webAppBootstrapSecret)) {
+      void reply.status(401).send({
+        error: 'Unauthorized. Provide a valid x-web-bootstrap-secret header.',
+      });
+      return false;
+    }
+    return true;
+  }
+
+  // -- GET /api/identity — return current identity config --
+
+  app.get('/api/identity', async (request, reply) => {
+    if (!requireBootstrapSecret(request.headers as Record<string, string | string[] | undefined>, reply)) return;
+
+    try {
+      const identity = identityService.get();
+      return reply.send({ identity });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to get identity';
+      return reply.status(500).send({ error: message });
+    }
+  });
+
+  // -- PUT /api/identity — save a new version and trigger hot reload --
+
+  app.put('/api/identity', async (request, reply) => {
+    if (!requireBootstrapSecret(request.headers as Record<string, string | string[] | undefined>, reply)) return;
+
+    const body = request.body as {
+      identity?: OfficeIdentity;
+      note?: string;
+    };
+
+    if (!body?.identity) {
+      return reply.status(400).send({ error: 'Request body must include an "identity" object' });
+    }
+
+    try {
+      await identityService.update(body.identity, 'api', body.note);
+      const updated = identityService.get();
+      return reply.send({ identity: updated, updated: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update identity';
+      return reply.status(400).send({ error: message });
+    }
+  });
+
+  // -- GET /api/identity/history — return all versions, newest first --
+
+  app.get('/api/identity/history', async (request, reply) => {
+    if (!requireBootstrapSecret(request.headers as Record<string, string | string[] | undefined>, reply)) return;
+
+    try {
+      const history = await identityService.history();
+      return reply.send({ history });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to get identity history';
+      return reply.status(500).send({ error: message });
+    }
+  });
+
+  // -- POST /api/identity/reload — force a reload from DB --
+  // Used by the wizard after saving, to ensure the latest DB version is reflected
+  // in the in-memory cache before the next coordinator turn.
+
+  app.post('/api/identity/reload', async (request, reply) => {
+    if (!requireBootstrapSecret(request.headers as Record<string, string | string[] | undefined>, reply)) return;
+
+    try {
+      await identityService.reload();
+      const identity = identityService.get();
+      return reply.send({ identity, reloaded: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to reload identity';
+      return reply.status(500).send({ error: message });
+    }
+  });
+}

--- a/src/channels/http/routes/identity.ts
+++ b/src/channels/http/routes/identity.ts
@@ -83,6 +83,13 @@ export async function identityRoutes(
       const updated = identityService.get();
       return reply.send({ identity: updated, updated: true });
     } catch (err) {
+      // Validation errors from validateIdentity() are plain Error instances with descriptive
+      // messages — return 400 so the wizard UI can surface them to the user.
+      // DB / infrastructure errors carry a Postgres error code — return 500.
+      const pgCode = (err as { code?: string }).code;
+      if (pgCode !== undefined) {
+        return reply.status(500).send({ error: 'Failed to save identity due to a server error. Check server logs.' });
+      }
       const message = err instanceof Error ? err.message : 'Failed to update identity';
       return reply.status(400).send({ error: message });
     }

--- a/src/db/migrations/013_office_identity.sql
+++ b/src/db/migrations/013_office_identity.sql
@@ -4,7 +4,7 @@
 -- Append-only — rows are never updated or deleted.
 CREATE TABLE office_identity_versions (
   id          BIGSERIAL PRIMARY KEY,
-  version     INTEGER NOT NULL,           -- monotonically increasing per-change counter
+  version     INTEGER NOT NULL UNIQUE,     -- monotonically increasing per-change counter; UNIQUE enforces no duplicate versions
   config      JSONB NOT NULL,             -- full OfficeIdentity config snapshot at time of change
   changed_by  TEXT NOT NULL,              -- 'file_load' | 'wizard' | 'api'
   note        TEXT,                       -- optional human-readable reason for change
@@ -17,6 +17,6 @@ CREATE TABLE office_identity_versions (
 -- with singleton = FALSE, closing the gap the PK alone would leave open.
 CREATE TABLE office_identity_current (
   singleton   BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton = TRUE),
-  version_id  INTEGER NOT NULL REFERENCES office_identity_versions(id),
+  version_id  BIGINT NOT NULL REFERENCES office_identity_versions(id),
   updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/src/db/migrations/013_office_identity.sql
+++ b/src/db/migrations/013_office_identity.sql
@@ -1,0 +1,22 @@
+-- Up Migration
+
+-- Full version history of every office identity change.
+-- Append-only — rows are never updated or deleted.
+CREATE TABLE office_identity_versions (
+  id          BIGSERIAL PRIMARY KEY,
+  version     INTEGER NOT NULL,           -- monotonically increasing per-change counter
+  config      JSONB NOT NULL,             -- full OfficeIdentity config snapshot at time of change
+  changed_by  TEXT NOT NULL,              -- 'file_load' | 'wizard' | 'api'
+  note        TEXT,                       -- optional human-readable reason for change
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Single-row table pointing to the active version.
+-- The singleton PRIMARY KEY constraint ensures only one row can ever exist.
+-- The CHECK (singleton = TRUE) makes it impossible to insert a second row
+-- with singleton = FALSE, closing the gap the PK alone would leave open.
+CREATE TABLE office_identity_current (
+  singleton   BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton = TRUE),
+  version_id  INTEGER NOT NULL REFERENCES office_identity_versions(id),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/src/db/migrations/013_office_identity.sql
+++ b/src/db/migrations/013_office_identity.sql
@@ -2,8 +2,11 @@
 
 -- Full version history of every office identity change.
 -- Append-only — rows are never updated or deleted.
+-- SERIAL/INTEGER (not BIGSERIAL/BIGINT) because node-postgres returns int8 columns as
+-- JavaScript strings by default, breaking our TypeScript `id: number` contract.
+-- Identity versions will never approach 2 billion rows in practice.
 CREATE TABLE office_identity_versions (
-  id          BIGSERIAL PRIMARY KEY,
+  id          SERIAL PRIMARY KEY,
   version     INTEGER NOT NULL UNIQUE,     -- monotonically increasing per-change counter; UNIQUE enforces no duplicate versions
   config      JSONB NOT NULL,             -- full OfficeIdentity config snapshot at time of change
   changed_by  TEXT NOT NULL,              -- 'file_load' | 'wizard' | 'api'
@@ -17,6 +20,6 @@ CREATE TABLE office_identity_versions (
 -- with singleton = FALSE, closing the gap the PK alone would leave open.
 CREATE TABLE office_identity_current (
   singleton   BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton = TRUE),
-  version_id  BIGINT NOT NULL REFERENCES office_identity_versions(id),
+  version_id  INTEGER NOT NULL REFERENCES office_identity_versions(id),
   updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/src/identity/service.ts
+++ b/src/identity/service.ts
@@ -201,7 +201,12 @@ export class OfficeIdentityService {
          RETURNING id`,
         [nextVersion, JSON.stringify(config), changedBy, note ?? null],
       );
-      const newVersionId = insertResult.rows[0]!.id;
+      // INSERT ... RETURNING always yields exactly one row on success, but an explicit
+      // check is clearer than a non-null assertion and makes the failure mode obvious.
+      if (!insertResult.rows[0]) {
+        throw new Error('Failed to persist office identity version: INSERT returned no rows');
+      }
+      const newVersionId = insertResult.rows[0].id;
 
       // Upsert the current pointer to point at the new version.
       await client.query(

--- a/src/identity/service.ts
+++ b/src/identity/service.ts
@@ -253,7 +253,13 @@ export class OfficeIdentityService {
    * The new identity takes effect on the next turn.
    */
   async reload(): Promise<void> {
-    const identity = await this.loadFromDb();
+    let identity: OfficeIdentity | null;
+    try {
+      identity = await this.loadFromDb();
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to load office identity from DB during reload');
+      throw err;
+    }
     if (!identity) {
       // After initialize() completes successfully, office_identity_current always has a record.
       // A null return here indicates DB inconsistency (missing pointer row) or a failed prior
@@ -362,9 +368,18 @@ export class OfficeIdentityService {
    */
   async stop(): Promise<void> {
     if (this.watcher) {
-      await this.watcher.close();
-      this.watcher = null;
-      this.logger.debug('Office identity file watcher stopped');
+      try {
+        await this.watcher.close();
+        this.logger.debug('Office identity file watcher stopped');
+      } catch (err) {
+        this.logger.error({ err }, 'Error closing office identity file watcher');
+        // Don't rethrow — callers (shutdown handler, tests) must be able to proceed
+        // even if the watcher close fails. The process is going away anyway.
+      } finally {
+        // Null out even if close() throws so repeated stop() calls don't try to
+        // close an already-errored watcher.
+        this.watcher = null;
+      }
     }
   }
 

--- a/src/identity/service.ts
+++ b/src/identity/service.ts
@@ -163,43 +163,73 @@ export class OfficeIdentityService {
   /**
    * Saves a new version to the DB, updates the in-memory cache, emits a config.change audit event.
    * changedBy: 'wizard' | 'api' | 'file_load'
+   *
+   * The DB write is fully atomic: version number computation, row insert, and current-pointer
+   * upsert all happen inside a single transaction. The UNIQUE constraint on `version` provides
+   * a last-resort guard against duplicate version numbers if two callers race.
    */
   async update(config: OfficeIdentity, changedBy: string, note?: string): Promise<void> {
     this.validateIdentity(config);
 
-    // Capture previous version for the audit diff before overwriting the cache.
-    const previousVersion = await this.getCurrentVersionNumber();
+    // Snapshot the previous config before writing — used for the diff summary.
     const previousConfig = this.cached;
 
-    // Get the next version number.
-    const nextVersion = (previousVersion ?? 0) + 1;
+    const client = await this.pool.connect();
+    let nextVersion: number;
+    let previousVersion: number;
 
-    // Insert the new version row.
-    const insertResult = await this.pool.query<{ id: number }>(
-      `INSERT INTO office_identity_versions (version, config, changed_by, note)
-       VALUES ($1, $2, $3, $4)
-       RETURNING id`,
-      [nextVersion, JSON.stringify(config), changedBy, note ?? null],
-    );
+    try {
+      await client.query('BEGIN');
 
-    const newVersionId = insertResult.rows[0]!.id;
+      // Compute the next version atomically: lock the current pointer row to prevent
+      // two concurrent callers from both computing the same nextVersion.
+      // If no current record exists (first seed), the FOR UPDATE returns 0 rows and
+      // we start at version 1.
+      const lockResult = await client.query<{ version: number }>(
+        `SELECT v.version
+         FROM office_identity_current c
+         JOIN office_identity_versions v ON v.id = c.version_id
+         FOR UPDATE OF c`,
+      );
+      previousVersion = lockResult.rows[0]?.version ?? 0;
+      nextVersion = previousVersion + 1;
 
-    // Upsert the current pointer.
-    await this.pool.query(
-      `INSERT INTO office_identity_current (singleton, version_id, updated_at)
-       VALUES (TRUE, $1, now())
-       ON CONFLICT (singleton) DO UPDATE
-         SET version_id = EXCLUDED.version_id,
-             updated_at = EXCLUDED.updated_at`,
-      [newVersionId],
-    );
+      // Insert the new version row.
+      const insertResult = await client.query<{ id: number }>(
+        `INSERT INTO office_identity_versions (version, config, changed_by, note)
+         VALUES ($1, $2, $3, $4)
+         RETURNING id`,
+        [nextVersion, JSON.stringify(config), changedBy, note ?? null],
+      );
+      const newVersionId = insertResult.rows[0]!.id;
 
-    // Update the in-memory cache.
+      // Upsert the current pointer to point at the new version.
+      await client.query(
+        `INSERT INTO office_identity_current (singleton, version_id, updated_at)
+         VALUES (TRUE, $1, now())
+         ON CONFLICT (singleton) DO UPDATE
+           SET version_id = EXCLUDED.version_id,
+               updated_at = EXCLUDED.updated_at`,
+        [newVersionId],
+      );
+
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK').catch((rollbackErr: unknown) => {
+        this.logger.error({ err: rollbackErr }, 'Failed to roll back office identity update transaction');
+      });
+      throw err;
+    } finally {
+      client.release();
+    }
+
+    // Update the in-memory cache only after the transaction commits.
     this.cached = config;
 
     this.logger.info({ version: nextVersion, changedBy }, 'Office identity updated');
 
     // Emit config.change audit event on the bus.
+    // Best-effort — don't fail the update if the bus event fails.
     const diffSummary = previousConfig
       ? buildDiffSummary(previousConfig, config)
       : 'Initial identity loaded';
@@ -207,12 +237,11 @@ export class OfficeIdentityService {
     const event = createConfigChange({
       config_type: 'office_identity',
       version: nextVersion,
-      previous_version: previousVersion ?? 0,
+      previous_version: previousVersion,
       changed_by: changedBy,
       note,
       diff_summary: diffSummary,
     });
-    // Best-effort publish — don't fail the update if the bus event fails.
     this.bus.publish('system', event).catch((err: unknown) => {
       this.logger.error({ err }, 'Failed to publish config.change event for office identity update');
     });
@@ -226,8 +255,16 @@ export class OfficeIdentityService {
   async reload(): Promise<void> {
     const identity = await this.loadFromDb();
     if (!identity) {
-      this.logger.warn('Office identity reload: no DB record found — keeping existing cached identity');
-      return;
+      // After initialize() completes successfully, office_identity_current always has a record.
+      // A null return here indicates DB inconsistency (missing pointer row) or a failed prior
+      // update(). Throwing rather than silently keeping the stale cache ensures the HTTP route
+      // returns 500 instead of 200 with the wrong identity — callers (e.g. the wizard) must
+      // not believe a reload succeeded when the cache was not actually refreshed.
+      throw new Error(
+        'Office identity reload failed: no record found in office_identity_current. ' +
+        'This indicates a DB inconsistency — check that migration 013 was applied and ' +
+        'that the most recent update() call completed successfully.',
+      );
     }
     this.cached = identity;
     this.logger.info('Office identity reloaded from DB');
@@ -237,27 +274,32 @@ export class OfficeIdentityService {
    * Returns all historical versions, newest first.
    */
   async history(): Promise<OfficeIdentityVersion[]> {
-    const result = await this.pool.query<{
-      id: number;
-      version: number;
-      config: unknown;
-      changed_by: string;
-      note: string | null;
-      created_at: Date;
-    }>(
-      `SELECT id, version, config, changed_by, note, created_at
-       FROM office_identity_versions
-       ORDER BY version DESC`,
-    );
+    try {
+      const result = await this.pool.query<{
+        id: number;
+        version: number;
+        config: unknown;
+        changed_by: string;
+        note: string | null;
+        created_at: Date;
+      }>(
+        `SELECT id, version, config, changed_by, note, created_at
+         FROM office_identity_versions
+         ORDER BY version DESC`,
+      );
 
-    return result.rows.map(row => ({
-      id: row.id,
-      version: row.version,
-      config: row.config as OfficeIdentity,
-      changedBy: row.changed_by,
-      note: row.note ?? undefined,
-      createdAt: row.created_at,
-    }));
+      return result.rows.map(row => ({
+        id: row.id,
+        version: row.version,
+        config: row.config as OfficeIdentity,
+        changedBy: row.changed_by,
+        note: row.note ?? undefined,
+        createdAt: row.created_at,
+      }));
+    } catch (err) {
+      this.logger.error({ err }, 'Failed to query office identity history');
+      throw err;
+    }
   }
 
   /**
@@ -438,16 +480,6 @@ export class OfficeIdentityService {
     }
   }
 
-  /** Return the current version number from the DB, or null if no record exists. */
-  private async getCurrentVersionNumber(): Promise<number | null> {
-    const result = await this.pool.query<{ version: number }>(
-      `SELECT v.version
-       FROM office_identity_current c
-       JOIN office_identity_versions v ON v.id = c.version_id`,
-    );
-    return result.rows[0]?.version ?? null;
-  }
-
   /** Start watching the config file for changes. Writes a new DB version on change. */
   private startFileWatcher(): void {
     // chokidar watches the config file and triggers a reload on any change.
@@ -462,15 +494,34 @@ export class OfficeIdentityService {
 
     this.watcher.on('change', () => {
       this.logger.info({ path: this.configFilePath }, 'Office identity file changed — reloading');
-      // Parse the new file, write to DB, then reload from DB.
-      // Errors are logged but don't crash the process.
+      // Two-step: parse the file first, then write to DB.
+      // Separated so parse errors (operator-fixable by editing the file again) are
+      // distinguished from DB write errors (infrastructure failure requiring separate attention).
       Promise.resolve()
         .then(async () => {
-          const newIdentity = this.loadFromFile();
+          // Step 1: parse the updated YAML.
+          // On failure (bad YAML, missing required fields), log and abort. The existing
+          // in-memory identity is kept. The operator can fix the file and save again.
+          let newIdentity: OfficeIdentity;
+          try {
+            newIdentity = this.loadFromFile();
+          } catch (err: unknown) {
+            this.logger.error(
+              { err, path: this.configFilePath },
+              'Failed to parse office identity YAML — keeping existing identity. Fix the file and save again to retry.',
+            );
+            return;
+          }
+
+          // Step 2: persist to DB. This is a more serious failure — the file was valid
+          // but we couldn't commit the new version. Likely a DB connectivity issue.
           await this.update(newIdentity, 'file_load', 'Hot reload from config/office-identity.yaml');
         })
         .catch((err: unknown) => {
-          this.logger.error({ err }, 'Failed to reload office identity from file — keeping existing identity');
+          this.logger.error(
+            { err },
+            'Failed to write office identity to DB during hot reload — keeping existing identity. Check database connectivity.',
+          );
         });
     });
 

--- a/src/identity/service.ts
+++ b/src/identity/service.ts
@@ -474,6 +474,12 @@ export class OfficeIdentityService {
     if (!config.assistant?.name) {
       throw new Error('Office identity requires assistant.name');
     }
+    // Guard nested fields before dereferencing — API payloads are not guaranteed
+    // to match the TypeScript shape at runtime, and a null/missing tone would
+    // throw a TypeError rather than a controlled validation error.
+    if (!config.tone || !Array.isArray(config.tone.baseline)) {
+      throw new Error('Office identity requires tone.baseline to be an array of 1–3 words');
+    }
     if (config.tone.baseline.length > 3) {
       throw new Error(`tone.baseline may contain at most 3 words; got ${config.tone.baseline.length}`);
     }

--- a/src/identity/service.ts
+++ b/src/identity/service.ts
@@ -1,0 +1,483 @@
+// service.ts — OfficeIdentityService
+//
+// System-layer service that owns the Curia instance identity (name, tone, constraints, etc.).
+// Initialized before the coordinator boots so ${office_identity_block} is always available.
+//
+// Load precedence at startup (initialize()):
+//   1. If office_identity_current exists in DB → load from DB (runtime edits take precedence)
+//   2. If no DB record → load from config/office-identity.yaml and seed as version 1
+//   3. If neither exists → fail fast with a clear error message
+//
+// Hot reload is triggered by:
+//   - chokidar file watcher on config/office-identity.yaml (writes a new DB version, then calls reload())
+//   - POST /api/identity/reload endpoint
+//
+// Every identity change emits a config.change bus event via the audit trail.
+
+import * as fs from 'node:fs';
+import yaml from 'js-yaml';
+import chokidar, { type FSWatcher } from 'chokidar';
+import type { Pool } from 'pg';
+import type { Logger } from '../logger.js';
+import type { EventBus } from '../bus/bus.js';
+import { createConfigChange } from '../bus/events.js';
+import { type OfficeIdentity, type OfficeIdentityVersion, BASELINE_TONE_OPTIONS } from './types.js';
+
+// Raw YAML shape from config/office-identity.yaml.
+// Kept separate from OfficeIdentity so we control the snake_case → camelCase mapping explicitly.
+interface RawOfficeIdentityYaml {
+  office?: {
+    assistant?: {
+      name?: string;
+      title?: string;
+      email_signature?: string;
+    };
+    tone?: {
+      baseline?: string[];
+      verbosity?: number;
+      directness?: number;
+    };
+    behavioral_preferences?: string[];
+    decision_style?: {
+      external_actions?: string;
+      internal_analysis?: string;
+    };
+    constraints?: string[];
+  };
+}
+
+// Map verbosity score to prose guidance.
+// Bands are approximate — these are guidelines, not hard cutoffs.
+function verbosityGuidance(score: number): string {
+  if (score <= 25) return 'Keep responses as brief as possible; omit context unless asked.';
+  if (score <= 50) return 'Default to concise responses; expand when detail is clearly needed.';
+  if (score <= 75) return 'Adapt response length to what the situation calls for.';
+  return 'Default to thorough explanations; err toward more context.';
+}
+
+// Map directness score to prose guidance.
+function directnessGuidance(score: number): string {
+  if (score <= 25) return 'Be measured; acknowledge uncertainty with appropriate qualification.';
+  if (score <= 50) return 'Lean toward directness but hedge where genuinely uncertain.';
+  if (score <= 75) return 'Be direct; minimize unnecessary hedging and qualification.';
+  return 'State positions plainly; avoid softening language.';
+}
+
+// Map decision_style enum to a human-readable prose phrase.
+function decisionStylePhrase(style: 'conservative' | 'balanced' | 'proactive', domain: 'external' | 'internal'): string {
+  if (domain === 'external') {
+    if (style === 'conservative') return 'For external actions, be conservative — verify before acting.';
+    if (style === 'balanced') return 'For external actions, use balanced judgment — act when confidence is high.';
+    return 'For external actions, be proactive — act on good information without waiting for confirmation.';
+  } else {
+    if (style === 'conservative') return 'For internal analysis, be conservative — surface only well-supported conclusions.';
+    if (style === 'balanced') return 'For internal analysis, use balanced judgment — share insights with appropriate confidence levels.';
+    return 'For internal analysis, be proactive — surface insights without being asked.';
+  }
+}
+
+// Build a human-readable diff summary for the audit event.
+// Compares only the top-level shape to keep the summary concise and readable.
+function buildDiffSummary(prev: OfficeIdentity, next: OfficeIdentity): string {
+  const changes: string[] = [];
+
+  if (prev.assistant.name !== next.assistant.name) {
+    changes.push(`name: "${prev.assistant.name}" → "${next.assistant.name}"`);
+  }
+  if (prev.assistant.title !== next.assistant.title) {
+    changes.push(`title: "${prev.assistant.title}" → "${next.assistant.title}"`);
+  }
+  if (prev.assistant.emailSignature !== next.assistant.emailSignature) {
+    changes.push('email_signature updated');
+  }
+  if (JSON.stringify(prev.tone.baseline) !== JSON.stringify(next.tone.baseline)) {
+    changes.push(`tone.baseline: [${prev.tone.baseline.join(', ')}] → [${next.tone.baseline.join(', ')}]`);
+  }
+  if (prev.tone.verbosity !== next.tone.verbosity) {
+    changes.push(`tone.verbosity: ${prev.tone.verbosity} → ${next.tone.verbosity}`);
+  }
+  if (prev.tone.directness !== next.tone.directness) {
+    changes.push(`tone.directness: ${prev.tone.directness} → ${next.tone.directness}`);
+  }
+  if (prev.decisionStyle.externalActions !== next.decisionStyle.externalActions) {
+    changes.push(`decision_style.external_actions: ${prev.decisionStyle.externalActions} → ${next.decisionStyle.externalActions}`);
+  }
+  if (prev.decisionStyle.internalAnalysis !== next.decisionStyle.internalAnalysis) {
+    changes.push(`decision_style.internal_analysis: ${prev.decisionStyle.internalAnalysis} → ${next.decisionStyle.internalAnalysis}`);
+  }
+  if (JSON.stringify(prev.behavioralPreferences) !== JSON.stringify(next.behavioralPreferences)) {
+    changes.push('behavioral_preferences updated');
+  }
+  if (JSON.stringify(prev.constraints) !== JSON.stringify(next.constraints)) {
+    changes.push('constraints updated');
+  }
+
+  return changes.length > 0 ? changes.join('; ') : 'no changes detected';
+}
+
+export class OfficeIdentityService {
+  // In-memory cached identity — populated during initialize(), refreshed via reload().
+  private cached: OfficeIdentity | null = null;
+  private watcher: FSWatcher | null = null;
+
+  constructor(
+    private readonly pool: Pool,
+    private readonly logger: Logger,
+    private readonly bus: EventBus,
+    // Absolute path to config/office-identity.yaml (resolved in index.ts).
+    private readonly configFilePath: string,
+  ) {}
+
+  /**
+   * Initialize the service: load identity from DB or YAML, start file watcher.
+   * Must be called before the coordinator boots.
+   */
+  async initialize(): Promise<void> {
+    // Try to load from DB first — DB takes precedence over the file.
+    const dbIdentity = await this.loadFromDb();
+    if (dbIdentity) {
+      this.cached = dbIdentity;
+      this.logger.info('Office identity loaded from DB');
+    } else {
+      // No DB record — seed from YAML file as version 1.
+      const fileIdentity = this.loadFromFile();
+      await this.update(fileIdentity, 'file_load', 'Initial load from config/office-identity.yaml');
+      this.logger.info('Office identity seeded from config/office-identity.yaml (version 1)');
+    }
+
+    // Start the file watcher so YAML edits take effect on the next coordinator turn.
+    this.startFileWatcher();
+  }
+
+  /**
+   * Returns the currently active identity (cached in memory after initialize()).
+   * Throws if initialize() has not been called.
+   */
+  get(): OfficeIdentity {
+    if (!this.cached) {
+      throw new Error('OfficeIdentityService not initialized — call initialize() before get()');
+    }
+    return this.cached;
+  }
+
+  /**
+   * Saves a new version to the DB, updates the in-memory cache, emits a config.change audit event.
+   * changedBy: 'wizard' | 'api' | 'file_load'
+   */
+  async update(config: OfficeIdentity, changedBy: string, note?: string): Promise<void> {
+    this.validateIdentity(config);
+
+    // Capture previous version for the audit diff before overwriting the cache.
+    const previousVersion = await this.getCurrentVersionNumber();
+    const previousConfig = this.cached;
+
+    // Get the next version number.
+    const nextVersion = (previousVersion ?? 0) + 1;
+
+    // Insert the new version row.
+    const insertResult = await this.pool.query<{ id: number }>(
+      `INSERT INTO office_identity_versions (version, config, changed_by, note)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id`,
+      [nextVersion, JSON.stringify(config), changedBy, note ?? null],
+    );
+
+    const newVersionId = insertResult.rows[0]!.id;
+
+    // Upsert the current pointer.
+    await this.pool.query(
+      `INSERT INTO office_identity_current (singleton, version_id, updated_at)
+       VALUES (TRUE, $1, now())
+       ON CONFLICT (singleton) DO UPDATE
+         SET version_id = EXCLUDED.version_id,
+             updated_at = EXCLUDED.updated_at`,
+      [newVersionId],
+    );
+
+    // Update the in-memory cache.
+    this.cached = config;
+
+    this.logger.info({ version: nextVersion, changedBy }, 'Office identity updated');
+
+    // Emit config.change audit event on the bus.
+    const diffSummary = previousConfig
+      ? buildDiffSummary(previousConfig, config)
+      : 'Initial identity loaded';
+
+    const event = createConfigChange({
+      config_type: 'office_identity',
+      version: nextVersion,
+      previous_version: previousVersion ?? 0,
+      changed_by: changedBy,
+      note,
+      diff_summary: diffSummary,
+    });
+    // Best-effort publish — don't fail the update if the bus event fails.
+    this.bus.publish('system', event).catch((err: unknown) => {
+      this.logger.error({ err }, 'Failed to publish config.change event for office identity update');
+    });
+  }
+
+  /**
+   * Forces a reload from DB (used by hot reload after file write).
+   * In-flight coordinator turns complete with the previous identity.
+   * The new identity takes effect on the next turn.
+   */
+  async reload(): Promise<void> {
+    const identity = await this.loadFromDb();
+    if (!identity) {
+      this.logger.warn('Office identity reload: no DB record found — keeping existing cached identity');
+      return;
+    }
+    this.cached = identity;
+    this.logger.info('Office identity reloaded from DB');
+  }
+
+  /**
+   * Returns all historical versions, newest first.
+   */
+  async history(): Promise<OfficeIdentityVersion[]> {
+    const result = await this.pool.query<{
+      id: number;
+      version: number;
+      config: unknown;
+      changed_by: string;
+      note: string | null;
+      created_at: Date;
+    }>(
+      `SELECT id, version, config, changed_by, note, created_at
+       FROM office_identity_versions
+       ORDER BY version DESC`,
+    );
+
+    return result.rows.map(row => ({
+      id: row.id,
+      version: row.version,
+      config: row.config as OfficeIdentity,
+      changedBy: row.changed_by,
+      note: row.note ?? undefined,
+      createdAt: row.created_at,
+    }));
+  }
+
+  /**
+   * Compiles the identity config into a system prompt block.
+   *
+   * Output order (constraints-first, per spec):
+   *   1. Hard constraints (labeled section, placed first)
+   *   2. Identity header (name, title)
+   *   3. Tone guidance (baseline + verbosity + directness)
+   *   4. Decision style guidance
+   *   5. Behavioral preferences (ordered list)
+   */
+  compileSystemPromptBlock(): string {
+    const id = this.get();
+    const lines: string[] = [];
+
+    lines.push('## Identity & Communication Contract');
+    lines.push('');
+
+    // 1. Hard constraints — first, labeled, non-negotiable.
+    lines.push('**Hard constraints (non-negotiable):**');
+    for (const constraint of id.constraints) {
+      lines.push(`- ${constraint}`);
+    }
+    lines.push('');
+
+    // 2. Identity header.
+    lines.push('**Who you are:**');
+    lines.push(`You are ${id.assistant.name}, ${id.assistant.title}.`);
+    lines.push('');
+
+    // 3. Tone guidance.
+    lines.push('**Communication style:**');
+    // Join baseline words with " and " — matches the spec example output.
+    const tonePhrase = id.tone.baseline.length > 0
+      ? id.tone.baseline.join(' and ')
+      : 'professional';
+    lines.push(`Your tone is ${tonePhrase}.`);
+    lines.push(verbosityGuidance(id.tone.verbosity));
+    lines.push(directnessGuidance(id.tone.directness));
+    lines.push('');
+
+    // 4. Decision style.
+    lines.push('**Decision posture:**');
+    lines.push(decisionStylePhrase(id.decisionStyle.externalActions, 'external'));
+    lines.push(decisionStylePhrase(id.decisionStyle.internalAnalysis, 'internal'));
+    lines.push('');
+
+    // 5. Behavioral preferences.
+    lines.push('**Behavioral preferences:**');
+    for (const pref of id.behavioralPreferences) {
+      lines.push(`- ${pref}`);
+    }
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Stop the file watcher. Called during graceful shutdown.
+   */
+  async stop(): Promise<void> {
+    if (this.watcher) {
+      await this.watcher.close();
+      this.watcher = null;
+      this.logger.debug('Office identity file watcher stopped');
+    }
+  }
+
+  // -- Private helpers --
+
+  /** Load the active identity from the DB. Returns null if no record exists. */
+  private async loadFromDb(): Promise<OfficeIdentity | null> {
+    try {
+      const result = await this.pool.query<{ config: unknown }>(
+        `SELECT v.config
+         FROM office_identity_current c
+         JOIN office_identity_versions v ON v.id = c.version_id`,
+      );
+      if (result.rows.length === 0) return null;
+      return result.rows[0]!.config as OfficeIdentity;
+    } catch (err) {
+      // Table doesn't exist yet (pre-migration) — treat as no record.
+      const pgCode = (err as { code?: string }).code;
+      if (pgCode === '42P01') {
+        this.logger.warn('office_identity tables not found — is migration 013 applied?');
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  /** Load the identity config from the YAML file. Throws if file is missing or invalid. */
+  private loadFromFile(): OfficeIdentity {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.configFilePath, 'utf-8');
+    } catch (err) {
+      throw new Error(
+        `Cannot read office identity config at ${this.configFilePath}: ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        'Create config/office-identity.yaml to configure the office identity.',
+      );
+    }
+
+    let parsed: RawOfficeIdentityYaml;
+    try {
+      parsed = yaml.load(raw) as RawOfficeIdentityYaml;
+    } catch (err) {
+      throw new Error(
+        `Invalid YAML in ${this.configFilePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    return this.mapYamlToIdentity(parsed);
+  }
+
+  /** Map the raw YAML shape to the normalized OfficeIdentity interface. */
+  private mapYamlToIdentity(raw: RawOfficeIdentityYaml): OfficeIdentity {
+    const o = raw?.office;
+    if (!o) {
+      throw new Error('config/office-identity.yaml is missing the top-level "office:" key');
+    }
+    if (!o.assistant?.name) {
+      throw new Error('config/office-identity.yaml is missing office.assistant.name');
+    }
+
+    const externalActions = (o.decision_style?.external_actions ?? 'conservative') as 'conservative' | 'balanced' | 'proactive';
+    const internalAnalysis = (o.decision_style?.internal_analysis ?? 'proactive') as 'conservative' | 'balanced' | 'proactive';
+
+    return {
+      assistant: {
+        name: o.assistant.name,
+        title: o.assistant.title ?? '',
+        emailSignature: o.assistant.email_signature ?? '',
+      },
+      tone: {
+        baseline: o.tone?.baseline ?? [],
+        verbosity: o.tone?.verbosity ?? 50,
+        directness: o.tone?.directness ?? 75,
+      },
+      behavioralPreferences: o.behavioral_preferences ?? [],
+      decisionStyle: {
+        externalActions,
+        internalAnalysis,
+      },
+      constraints: o.constraints ?? [],
+    };
+  }
+
+  /** Validate that the identity config is well-formed before persisting. */
+  private validateIdentity(config: OfficeIdentity): void {
+    if (!config.assistant?.name) {
+      throw new Error('Office identity requires assistant.name');
+    }
+    if (config.tone.baseline.length > 3) {
+      throw new Error(`tone.baseline may contain at most 3 words; got ${config.tone.baseline.length}`);
+    }
+    for (const word of config.tone.baseline) {
+      if (!(BASELINE_TONE_OPTIONS as readonly string[]).includes(word)) {
+        throw new Error(
+          `tone.baseline word "${word}" is not in BASELINE_TONE_OPTIONS. ` +
+          `Valid options: ${BASELINE_TONE_OPTIONS.join(', ')}`,
+        );
+      }
+    }
+    if (!Number.isInteger(config.tone.verbosity) || config.tone.verbosity < 0 || config.tone.verbosity > 100) {
+      throw new Error(`tone.verbosity must be an integer between 0 and 100; got ${config.tone.verbosity}`);
+    }
+    if (!Number.isInteger(config.tone.directness) || config.tone.directness < 0 || config.tone.directness > 100) {
+      throw new Error(`tone.directness must be an integer between 0 and 100; got ${config.tone.directness}`);
+    }
+    const validDecisionStyles = ['conservative', 'balanced', 'proactive'];
+    if (!validDecisionStyles.includes(config.decisionStyle.externalActions)) {
+      throw new Error(`decision_style.external_actions must be conservative | balanced | proactive`);
+    }
+    if (!validDecisionStyles.includes(config.decisionStyle.internalAnalysis)) {
+      throw new Error(`decision_style.internal_analysis must be conservative | balanced | proactive`);
+    }
+  }
+
+  /** Return the current version number from the DB, or null if no record exists. */
+  private async getCurrentVersionNumber(): Promise<number | null> {
+    const result = await this.pool.query<{ version: number }>(
+      `SELECT v.version
+       FROM office_identity_current c
+       JOIN office_identity_versions v ON v.id = c.version_id`,
+    );
+    return result.rows[0]?.version ?? null;
+  }
+
+  /** Start watching the config file for changes. Writes a new DB version on change. */
+  private startFileWatcher(): void {
+    // chokidar watches the config file and triggers a reload on any change.
+    // The write-then-reload sequence ensures the DB is always authoritative:
+    // the file change writes a new DB version, then reload() reads from DB.
+    this.watcher = chokidar.watch(this.configFilePath, {
+      // Ignore initial add event — we've already loaded the file.
+      ignoreInitial: true,
+      // Stabilization delay to avoid multiple rapid events from a single save.
+      awaitWriteFinish: { stabilityThreshold: 300, pollInterval: 100 },
+    });
+
+    this.watcher.on('change', () => {
+      this.logger.info({ path: this.configFilePath }, 'Office identity file changed — reloading');
+      // Parse the new file, write to DB, then reload from DB.
+      // Errors are logged but don't crash the process.
+      Promise.resolve()
+        .then(async () => {
+          const newIdentity = this.loadFromFile();
+          await this.update(newIdentity, 'file_load', 'Hot reload from config/office-identity.yaml');
+        })
+        .catch((err: unknown) => {
+          this.logger.error({ err }, 'Failed to reload office identity from file — keeping existing identity');
+        });
+    });
+
+    this.watcher.on('error', (err: unknown) => {
+      this.logger.error({ err }, 'Office identity file watcher error');
+    });
+
+    this.logger.debug({ path: this.configFilePath }, 'Office identity file watcher started');
+  }
+}

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -1,0 +1,54 @@
+// types.ts — Office Identity types for the Curia instance.
+//
+// These types define the shape of the identity config that is stored in the DB,
+// loaded from config/office-identity.yaml on first startup, and injected into
+// the coordinator system prompt via the ${office_identity_block} token.
+
+export interface OfficeIdentity {
+  assistant: {
+    name: string;
+    title: string;
+    emailSignature: string;
+  };
+  tone: {
+    // 1–3 words from BASELINE_TONE_OPTIONS. Validated at the application layer.
+    // Not a DB enum — extend BASELINE_TONE_OPTIONS without a migration.
+    baseline: string[];
+    verbosity: number;    // 0–100; 0 = tersest, 100 = most thorough
+    directness: number;   // 0–100; 0 = most hedged, 100 = most direct
+  };
+  behavioralPreferences: string[];
+  decisionStyle: {
+    externalActions: 'conservative' | 'balanced' | 'proactive';
+    internalAnalysis: 'conservative' | 'balanced' | 'proactive';
+  };
+  constraints: string[];
+}
+
+export interface OfficeIdentityVersion {
+  id: number;
+  version: number;
+  config: OfficeIdentity;
+  changedBy: string;
+  note?: string;
+  createdAt: Date;
+}
+
+// Predefined set for tone.baseline. Validated at the application layer.
+// To add a new word: extend this constant and bump the app — no migration needed.
+export const BASELINE_TONE_OPTIONS = [
+  // Warmth / Relationship
+  'warm', 'friendly', 'approachable', 'personable', 'empathetic',
+  'encouraging', 'gracious', 'caring',
+  // Efficiency / Edge
+  'direct', 'blunt', 'candid', 'frank', 'matter-of-fact', 'no-nonsense',
+  // Energy / Register
+  'energetic', 'calm', 'composed', 'enthusiastic', 'steady', 'measured',
+  // Personality / Color
+  'playful', 'witty', 'dry', 'charming', 'diplomatic', 'tactful',
+  'thoughtful', 'curious',
+  // Authority / Gravitas
+  'confident', 'assured', 'polished', 'authoritative', 'professional',
+] as const;
+
+export type BaselineToneOption = typeof BASELINE_TONE_OPTIONS[number];

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ import { bootstrapAgentIdentity } from './entity-context/bootstrap.js';
 import { bootstrapCeoContact } from './contacts/ceo-bootstrap.js';
 import { AutonomyService } from './autonomy/autonomy-service.js';
 import { BrowserService } from './browser/browser-service.js';
+import { OfficeIdentityService } from './identity/service.js';
 import type { AgentPersona } from './skills/types.js';
 
 async function main(): Promise<void> {
@@ -118,6 +119,20 @@ async function main(): Promise<void> {
   // than slowing down delivery, hence the synchronous-before-fanout design.
   const bus = new EventBus(logger, (event) => auditLogger.log(event));
 
+  // 4b. Office identity — System-layer service that owns the instance persona.
+  // Must be initialized after migrations (schema) and bus (emits config.change events),
+  // and before agents boot (coordinator needs ${office_identity_block}).
+  // Fatal on failure: without an identity, the coordinator system prompt is incomplete.
+  const identityConfigPath = path.resolve(import.meta.dirname, '../config/office-identity.yaml');
+  const officeIdentityService = new OfficeIdentityService(pool, logger, bus, identityConfigPath);
+  try {
+    await officeIdentityService.initialize();
+    logger.info({ name: officeIdentityService.get().assistant.name }, 'Office identity initialized');
+  } catch (err) {
+    logger.fatal({ err }, 'Failed to initialize office identity service');
+    process.exit(1);
+  }
+
   // 5. LLM provider — hard fail early rather than discovering the missing
   // key only when the first user message arrives.
   if (!config.anthropicApiKey) {
@@ -176,7 +191,8 @@ async function main(): Promise<void> {
   // Fatal on failure: without a contactId, "your calendar" cannot be resolved
   // and entity_enrichment default='agent' would silently produce no results.
   let agentIdentityContactId: string | undefined;
-  const agentDisplayName = 'Curia'; // @TODO: read from coordinatorConfig.persona.display_name after agentConfigs are loaded
+  // Read display name from the identity service — now the single source of truth.
+  const agentDisplayName = officeIdentityService.get().assistant.name;
   try {
     const agentIdentity = await bootstrapAgentIdentity(agentDisplayName, pool, logger);
     agentIdentityContactId = agentIdentity.contactId;
@@ -326,31 +342,26 @@ async function main(): Promise<void> {
   // if the config uses a different role value (e.g., "chief-of-staff").
   const coordinatorConfig = agentConfigs.find(c => c.name === 'coordinator');
 
-  // Extract agent persona from the coordinator config. This is the single source
-  // of truth for the agent's identity — used by the system prompt (via YAML
-  // interpolation) and by skills (via SkillContext.agentPersona) so templates
-  // and outbound-facing code never hardcode the agent's name or title.
-  let agentPersona: AgentPersona | undefined;
-  if (coordinatorConfig?.persona) {
-    agentPersona = {
-      displayName: coordinatorConfig.persona.display_name ?? 'Curia',
-      title: coordinatorConfig.persona.title ?? 'Agent Chief of Staff',
-      emailSignature: coordinatorConfig.persona.email_signature ?? undefined,
-    };
-    logger.info({ displayName: agentPersona.displayName, title: agentPersona.title }, 'Agent persona extracted from coordinator config');
-  } else {
-    logger.warn('No coordinator persona found — skills will not have agent identity context');
-  }
+  // Extract agent persona from the identity service — the single source of truth
+  // for the agent's identity. Used by skills (via SkillContext.agentPersona) so
+  // templates and outbound-facing code never hardcode the agent's name or title.
+  const officeIdentity = officeIdentityService.get();
+  const agentPersona: AgentPersona = {
+    displayName: officeIdentity.assistant.name,
+    title: officeIdentity.assistant.title,
+    emailSignature: officeIdentity.assistant.emailSignature || undefined,
+  };
+  logger.info({ displayName: agentPersona.displayName, title: agentPersona.title }, 'Agent persona loaded from office identity service');
 
   let outboundFilter: OutboundContentFilter | undefined;
   if (coordinatorConfig) {
-    const systemPromptMarkers = extractSystemPromptMarkers(coordinatorConfig);
+    const systemPromptMarkers = extractIdentityMarkers(officeIdentity);
     const ceoEmail = config.nylasSelfEmail ?? '';
     if (!ceoEmail) {
       logger.warn('Outbound content filter initialized without CEO email — contact-data-leak rule may produce false positives');
     }
     if (systemPromptMarkers.length === 0) {
-      logger.warn('No system prompt markers extracted — system-prompt-fragment rule will not detect prompt leakage. Check that coordinator has persona.display_name and persona.tone configured.');
+      logger.warn('No system prompt markers extracted — system-prompt-fragment rule will not detect prompt leakage. Check that office identity has a name and title configured.');
     }
     outboundFilter = new OutboundContentFilter({
       systemPromptMarkers,
@@ -439,6 +450,7 @@ async function main(): Promise<void> {
     let systemPrompt = agentConfig.system_prompt;
     if (agentConfig.role === 'coordinator') {
       systemPrompt = interpolateRuntimeContext(systemPrompt, {
+        officeIdentityBlock: officeIdentityService.compileSystemPromptBlock(),
         availableSpecialists: agentRegistry.specialistSummary(),
         agentContactId: agentIdentityContactId,
       });
@@ -527,6 +539,7 @@ async function main(): Promise<void> {
     agentNames: agentConfigs.map(c => c.name),
     skillNames: skillRegistry.list().map(s => s.manifest.name),
     schedulerService,
+    identityService: officeIdentityService,
   });
 
   try {
@@ -545,6 +558,11 @@ async function main(): Promise<void> {
       } catch (err) {
         logger.error({ err }, 'Error stopping email adapter during shutdown');
       }
+    }
+    try {
+      await officeIdentityService.stop();
+    } catch (err) {
+      logger.error({ err }, 'Error stopping office identity file watcher during shutdown');
     }
     try {
       await httpAdapter.stop();
@@ -594,26 +612,27 @@ async function main(): Promise<void> {
 }
 
 /**
- * Extract distinctive marker phrases from the coordinator config that would
+ * Extract distinctive marker phrases from the office identity that would
  * indicate system prompt leakage if they appeared in an outbound email.
- * These are persona-specific strings that wouldn't occur in normal business writing.
+ * These are identity-specific strings that wouldn't occur in normal business writing.
+ *
+ * @TODO: The current markers only cover name and title. The full system prompt contains
+ * many more distinctive instruction phrases, but extracting arbitrary sentences risks
+ * false positives. This gap is intentionally left for the Stage 2 LLM-as-judge to cover.
  */
-function extractSystemPromptMarkers(
-  config: import('./agents/loader.js').AgentYamlConfig,
+function extractIdentityMarkers(
+  identity: import('./identity/types.js').OfficeIdentity,
 ): string[] {
   const markers: string[] = [];
 
   // Full instruction phrases — distinctive enough to not appear in business email.
-  // We use the full instruction form ("You are X") rather than just the name/title
+  // We use the full instruction form ("You are X") rather than just the name
   // to avoid false positives on email signatures.
-  if (config.persona?.display_name) {
-    markers.push(`You are ${config.persona.display_name}`);
+  if (identity.assistant.name) {
+    markers.push(`You are ${identity.assistant.name}`);
   }
-  if (config.persona?.display_name && config.persona?.title) {
-    markers.push(`${config.persona.display_name}, the ${config.persona.title}`);
-  }
-  if (config.persona?.tone) {
-    markers.push(config.persona.tone);
+  if (identity.assistant.name && identity.assistant.title) {
+    markers.push(`${identity.assistant.name}, ${identity.assistant.title}`);
   }
 
   return markers;

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ import { AutonomyService } from './autonomy/autonomy-service.js';
 import { BrowserService } from './browser/browser-service.js';
 import { OfficeIdentityService } from './identity/service.js';
 import type { AgentPersona } from './skills/types.js';
+import type { ConfigChangeEvent } from './bus/events.js';
 
 async function main(): Promise<void> {
   // 1. Config & logging — no dependencies, must come first.
@@ -353,6 +354,21 @@ async function main(): Promise<void> {
   };
   logger.info({ displayName: agentPersona.displayName, title: agentPersona.title }, 'Agent persona loaded from office identity service');
 
+  // Keep agentPersona in sync with hot-reloaded identity changes.
+  // ExecutionLayer holds a reference to the agentPersona object (not a snapshot),
+  // so mutating its properties in-place propagates to all future skill invocations —
+  // skills always see the current name/title/signature without any restart.
+  bus.subscribe('config.change', 'system', (event) => {
+    const configEvent = event as ConfigChangeEvent;
+    if (configEvent.payload.config_type === 'office_identity') {
+      const updated = officeIdentityService.get();
+      agentPersona.displayName = updated.assistant.name;
+      agentPersona.title = updated.assistant.title;
+      agentPersona.emailSignature = updated.assistant.emailSignature || undefined;
+      logger.info({ displayName: agentPersona.displayName }, 'Agent persona updated from identity hot-reload');
+    }
+  });
+
   let outboundFilter: OutboundContentFilter | undefined;
   if (coordinatorConfig) {
     const systemPromptMarkers = extractIdentityMarkers(officeIdentity);
@@ -449,8 +465,10 @@ async function main(): Promise<void> {
     // This runs in pass 2 so all specialists are already in the registry.
     let systemPrompt = agentConfig.system_prompt;
     if (agentConfig.role === 'coordinator') {
+      // Do NOT pass officeIdentityBlock here — leave ${office_identity_block}
+      // as a literal placeholder. It is replaced per-turn in AgentRuntime.processTask()
+      // by the officeIdentityService passed below, enabling hot-reload without a restart.
       systemPrompt = interpolateRuntimeContext(systemPrompt, {
-        officeIdentityBlock: officeIdentityService.compileSystemPromptBlock(),
         availableSpecialists: agentRegistry.specialistSummary(),
         agentContactId: agentIdentityContactId,
       });
@@ -476,6 +494,11 @@ async function main(): Promise<void> {
       // always current. Specialist agents don't need this — they work with
       // structured data, not user-facing time references.
       timezone: agentConfig.role === 'coordinator' ? config.timezone : undefined,
+      // The coordinator gets per-turn identity block injection via officeIdentityService.
+      // This replaces the ${office_identity_block} placeholder in the system prompt on
+      // every task, so identity hot-reloads (file watcher or API PUT) take effect on the
+      // next turn without a restart.
+      officeIdentityService: agentConfig.role === 'coordinator' ? officeIdentityService : undefined,
       // Map YAML snake_case fields to AgentConfig camelCase, falling back to
       // DEFAULT_ERROR_BUDGET values for any omitted fields.
       errorBudget: agentConfig.error_budget ? {

--- a/tests/unit/agents/loader.test.ts
+++ b/tests/unit/agents/loader.test.ts
@@ -12,15 +12,20 @@ describe('loadAgentConfig', () => {
     expect(config.name).toBe('coordinator');
     expect(config.role).toBe('coordinator');
     expect(config.model.provider).toBe('anthropic');
-    expect(config.system_prompt).toContain('executive assistant');
+    // The identity block token is present — system prompt is meaningful.
+    expect(config.system_prompt).toContain('${office_identity_block}');
   });
 
-  it('interpolates persona fields into system_prompt', () => {
+  it('uses office_identity_block token instead of persona fields', () => {
+    // Since the identity block migration (issue #139), the coordinator no longer has
+    // inline persona fields. Identity is injected at runtime via ${office_identity_block}.
     const config = loadAgentConfig(path.join(agentsDir, 'coordinator.yaml'));
-    expect(config.system_prompt).toContain('Curia');
+    // The runtime token is present — will be replaced at startup by OfficeIdentityService.
+    expect(config.system_prompt).toContain('${office_identity_block}');
+    // No legacy persona tokens remain in the YAML.
     expect(config.system_prompt).not.toContain('${persona.display_name}');
-    expect(config.system_prompt).toContain('professional but approachable');
     expect(config.system_prompt).not.toContain('${persona.tone}');
+    expect(config.system_prompt).not.toContain('${persona.title}');
   });
 
   it('throws on nonexistent file', () => {


### PR DESCRIPTION
## **User description**
## Summary

Implements the Office Identity system as defined in `docs/specs/13-office-identity.md` (closes #139).

- **New `config/office-identity.yaml`** — instance-level identity config (name, title, email signature, tone, behavioral preferences, decision style, hard constraints). Hot-reloaded by chokidar on save.
- **New `OfficeIdentityService`** (`src/identity/`) — System-layer service with in-memory cache, fully atomic DB versioning (single transaction with row-level lock), file watcher, and `compileSystemPromptBlock()` for coordinator injection. Load precedence: DB record over YAML file after first startup.
- **DB migration 013** — `office_identity_versions` (append-only version history) + `office_identity_current` (singleton active pointer, with UNIQUE version constraint).
- **New `config.change` bus event** — emitted by the system layer on every identity change with version number and diff summary; automatically captured by the audit logger.
- **HTTP API** — `GET/PUT /api/identity`, `GET /api/identity/history`, `POST /api/identity/reload` — authenticated via `x-web-bootstrap-secret` (same as KG explorer).
- **Coordinator integration** — `${office_identity_block}` token replaces the removed `persona.*` fields in `agents/coordinator.yaml`; identity is compiled and injected at startup.
- **`agentPersona`** for skills now reads from `OfficeIdentityService` instead of `coordinator.yaml`.

## Test plan

- [ ] All 729 existing tests pass (`pnpm test`)
- [ ] TypeScript compiles clean (`pnpm typecheck`)
- [ ] On fresh DB: startup seeds version 1 from YAML, `office_identity_current` is created
- [ ] On restart with existing DB: identity is loaded from DB (not re-seeded from YAML)
- [ ] `GET /api/identity` returns active identity with correct auth
- [ ] `PUT /api/identity` saves a new version; `GET /api/identity/history` shows it
- [ ] `POST /api/identity/reload` refreshes the cache from DB
- [ ] Editing `config/office-identity.yaml` triggers hot reload (creates a new DB version, coordinator picks up the new identity on next turn)
- [ ] Coordinator system prompt begins with the compiled identity block (constraints first)
- [ ] Outbound email signatures use the identity name/title from the service


___

## **CodeAnt-AI Description**
**Add a versioned office identity that can be edited from the API and takes effect on the next coordinator turn**

### What Changed
- The coordinator now uses a shared office identity block instead of inline persona fields, so its name, title, tone, and rules come from one central identity source.
- Identity updates can be viewed, saved, and reloaded through new `/api/identity` endpoints, with each change stored as a new version and available in history.
- Editing the identity file now updates the saved version and refreshes the running assistant without a restart.
- Skills now use the current office identity, so outgoing messages and assistant references stay aligned after updates.
- Invalid identity edits now surface clear errors instead of silently keeping the old identity.

### Impact
`✅ Faster identity updates`
`✅ Fewer restarts after office copy changes`
`✅ Clearer identity edit errors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
