### PR TITLE
chore: add CHANGELOG, bump to v0.5.0, add versioning guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Error recovery** — error budgets (`max_turns`, `max_cost_usd`, `max_errors`), failure pattern
   detection, state continuity across restarts (spec 5)
 - **Outbound content filter** — deterministic Stage 1 rules: system prompt fragments, internal
-  structure leakage, known secret patterns, contact data exfiltration (spec 15 partial)
+  structure leakage, known secret patterns, contact data exfiltration (later formalized as
+  spec 15; Stage 2 LLM-as-judge is planned)
 - **Smoke test framework** — 14 chat-based cases, LLM-as-judge evaluation, HTML reports
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,118 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to Curia are documented here.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Pre-1.0: minor bumps introduce new capabilities; patch bumps fix bugs. Breaking changes
+to public API surfaces (skill manifest schema, `SkillContext` interface, agent YAML schema,
+bus event types) are noted explicitly even in the `0.x` range.
+
+---
 
 ## [Unreleased]
 
+---
+
+## [0.5.0] — 2026-04-05
+
 ### Added
-- Project README with architecture overview and security narrative
-- Architecture specification documents (docs/specs/00 through 08)
-- Contributor documentation (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
-- Project structure with agents/, skills/, config/ directories
-- CI workflow with structure verification
+- **Office Identity Engine** — runtime-configurable persona (name, title, email, tone, pronouns)
+  stored in Postgres with a `GET/PUT /api/identity` HTTP API; persona fields interpolated into
+  agent system prompts at task time (spec 13)
+- **`action_risk` on skill manifests** — required field declaring each skill's minimum autonomy
+  score; validated at startup; Phase 2 will enforce the gate at invocation time
+- **Developer guides** — `docs/dev/adding-a-skill.md` and `docs/dev/adding-an-agent.md`
+- **Specs 14 & 15** — Autonomy Engine (full) and Outbound Safety (stub with TODO)
+- **Smoke test contributor guide** — `docs/dev/smoke-tests.md` with YAML schema, worked examples,
+  and tag reference
+
+### Changed
+- Docs reorganized: timestamped work artifacts consolidated into `docs/wip/`; removed redundant
+  `docs/plans/`, `docs/specs/designs/`, and `docs/superpowers/` directories
+- Telegram removed as a planned channel (Signal remains the high-trust messaging channel)
+
+---
+
+## [0.4.0] — 2026-03-28
+
+### Added
+- **Autonomy Engine Phase 1** — global score (0–100), five bands, CEO controls via
+  `get-autonomy` / `set-autonomy` skills, per-task prompt injection into Coordinator
+- **Entity context enrichment** — KG-backed sender/entity profiles injected into inbound
+  messages before agent dispatch (spec 11)
+- **Web search skill** — Tavily-backed `web-search` with ranked results
+- **Web browser skill** — Playwright-based `web-browser` for JS-rendered pages;
+  warm browser instance managed by `BrowserService`
+- **KG web explorer** — browser UI for inspecting the knowledge graph (Cytoscape.js,
+  served from `node_modules`, gated by `WEB_APP_BOOTSTRAP_SECRET`; spec 12)
+- **Timezone-aware scheduling** — per-job timezone flows through `SchedulerService`;
+  `scheduler-create` skill exposes `timezone` input; `ExecutionLayer` normalizes
+  `timestamp` inputs to UTC before dispatch
+- **Calendar skills** — `calendar-register`, `calendar-list-events`, `calendar-create-event`,
+  `calendar-update-event`, `calendar-delete-event`, `calendar-find-free-time`,
+  `calendar-check-conflicts`, `calendar-list-calendars`
+
+### Changed
+- `autonomy_floor` renamed to `action_risk` on skill manifests (breaking change to manifest
+  schema; all built-in skills updated)
+
+---
+
+## [0.3.0] — 2026-03-10
+
+### Added
+- **Email channel** — Nylas-backed inbound/outbound email; HTML formatting for outbound bodies
+- **Contacts & identity service** — contact creation, lookup, role assignment, permission grants,
+  identity linking across channels (spec 9)
+- **Unknown sender policy** — hold-for-review queue, provisional senders, configurable policy
+  per channel
+- **Error recovery** — error budgets (`max_turns`, `max_cost_usd`, `max_errors`), failure pattern
+  detection, state continuity across restarts (spec 5)
+- **Outbound content filter** — deterministic Stage 1 rules: system prompt fragments, internal
+  structure leakage, known secret patterns, contact data exfiltration (spec 15 partial)
+- **Smoke test framework** — 14 chat-based cases, LLM-as-judge evaluation, HTML reports
+
+### Changed
+- Coordinator prompt tuned for contact-aware routing
+
+---
+
+## [0.2.0] — 2026-02-20
+
+### Added
+- **Skills & execution layer** — local skill manifests (`skill.json`), `SkillHandler` interface,
+  `SkillContext` with secrets access, input validation, output sanitization, per-invocation
+  timeout enforcement (spec 3)
+- **Multi-agent delegation** — `delegate` skill; agents can hand off tasks to named specialists
+- **HTTP API channel** — REST endpoints for web-based task submission
+- **Knowledge graph** — `kg_nodes` / `kg_edges` Postgres schema with pgvector embeddings;
+  entity memory reads/writes via `EntityMemory` (spec 1 partial)
+- **Scheduler** — cron and one-shot job support; persistent across restarts (spec 7)
+- **Agent YAML config** — declarative agent definition with `pinned_skills`, `memory.scopes`,
+  `schedule`, `error_budget` (spec 2)
+- **Working memory** — in-memory and Postgres backends for conversation persistence
+
+---
+
+## [0.1.0] — 2026-02-05
+
+### Added
+- **EventBus** — typed event definitions (discriminated union in `src/bus/events.ts`),
+  layer-enforced publish/subscribe permissions (`src/bus/permissions.ts`)
+- **Audit logger** — structured Postgres audit log; every event and agent decision recorded
+- **LLM provider interface** — Anthropic implementation; provider-agnostic `AgentRuntime`
+- **Agent runtime** — bus-integrated LLM execution with multi-turn conversation support
+- **CLI channel adapter** — readline I/O for local development and testing
+- **Dispatcher** — routes all inbound messages to the Coordinator agent
+- **Prompt injection defense** — sender auth, exfiltration protection, security layer
+- **Bootstrap orchestrator** — `src/index.ts` wires all layers in dependency order
+- Architecture specs 00–08, contributor docs (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
+
+[Unreleased]: https://github.com/josephfung/curia/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/josephfung/curia/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/josephfung/curia/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/josephfung/curia/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/josephfung/curia/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/josephfung/curia/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,11 @@ Do **not** create `docs/superpowers/`, `docs/plans/`, or `docs/specs/designs/` �
 
 ### Every PR must update CHANGELOG.md
 
-Add entries under `## [Unreleased]` before creating the PR. Use these sections as needed:
+Add entries under `## [Unreleased]` before creating the PR. Exception: PRs that are
+solely bumping the version and moving `[Unreleased]` to a release heading (like this one)
+don't need a separate entry — the release heading itself is the record.
+
+Use these sections as needed:
 - **Added** — new skills, agents, channels, specs, or features
 - **Changed** — behavior changes to existing functionality
 - **Fixed** — bug fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,42 @@ All timestamped work artifacts — implementation plans and design specs — liv
 
 Do **not** create `docs/superpowers/`, `docs/plans/`, or `docs/specs/designs/` — those directories no longer exist. All new WIP artifacts go directly in `docs/wip/`.
 
+## Changelog & Versioning
+
+### Every PR must update CHANGELOG.md
+
+Add entries under `## [Unreleased]` before creating the PR. Use these sections as needed:
+- **Added** — new skills, agents, channels, specs, or features
+- **Changed** — behavior changes to existing functionality
+- **Fixed** — bug fixes
+- **Removed** — deleted features or files
+- **Security** — security fixes or hardening
+
+One bullet per logical change. Lead with the **feature name in bold**, then a brief description.
+Reference spec numbers where relevant (e.g. "spec 14").
+
+### When to bump the version number
+
+Bump `package.json` version in the same PR as the changelog entry. Use this table:
+
+| Change type | Bump | Examples |
+|---|---|---|
+| New skill, agent, or channel | **minor** (`0.X.0`) | Adding `web-search`, adding Signal channel |
+| Completed spec / major feature | **minor** (`0.X.0`) | Autonomy engine shipped, entity context enrichment |
+| Bug fix, small improvement, doc-only | **patch** (`0.x.Y`) | Fixing a skill error path, updating a guide |
+| Breaking change to public API surface | **minor** + note in changelog | Renaming a `SkillContext` field, changing `skill.json` schema |
+
+**Public API surfaces** (changes here must be called out explicitly in the changelog even pre-1.0):
+- `skill.json` manifest schema (fields, types, required/optional)
+- `SkillHandler` / `SkillContext` / `SkillResult` TypeScript interfaces
+- Agent YAML schema (`agents/*.yaml` fields)
+- Bus event type definitions (`src/bus/events.ts`)
+- Channel adapter interface
+
+**1.0.0** is reserved for when these surfaces are stable enough to commit to — do not bump to
+1.0.0 without explicit discussion. The milestone is API stability + production deployment,
+not just "it works."
+
 ## Scope Discipline
 
 - Fix what was asked. Don't refactor surrounding code.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.0.1",
+  "version": "0.5.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## **User description**
## Summary

- Retroactive `CHANGELOG.md` with entries for v0.1.0 through v0.5.0 (Keep a Changelog format)
- `package.json` version bumped from `0.0.1` to `0.5.0`
- `CLAUDE.md` — new **Changelog & Versioning** section with:
  - Rule: every PR must add entries under `[Unreleased]` (with carve-out for release PRs themselves)
  - Decision table for when to use patch vs minor bump
  - Explicit list of public API surfaces (breaking changes to these must be called out)
  - `1.0.0` gate: API stability + production deployment, not just "it works"

## Why now

Curia will be open-sourced when it reaches minimum viable security + functionality. External consumers need a changelog and predictable versioning from the start — retrofitting this later is harder.

## Test plan

- [ ] Confirm `package.json` reads `"version": "0.5.0"`
- [ ] Confirm CHANGELOG entries are present and correctly formatted
- [ ] Read through CLAUDE.md versioning section to confirm the guidance is clear and actionable

After merge: tag `main` as `v0.5.0` and create a GitHub Release with the v0.5.0 changelog section as the body.


___

## **CodeAnt-AI Description**
**Add release notes and versioning guidance for the v0.5.0 release**

### What Changed
- Added a full changelog with entries for versions 0.1.0 through 0.5.0, including the v0.5.0 release notes
- Bumped the package version to 0.5.0
- Added clear changelog and versioning rules for future PRs, including when to use patch vs. minor bumps and which public API changes must be called out
- Clarified that release-only PRs can use the release heading as the changelog entry

### Impact
`✅ Clearer release notes`
`✅ Consistent version bumps`
`✅ Fewer missed changelog updates`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
