### PR TITLE
feat: relationship edge extraction and entity linking (issue #128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Bus events** — `contact.duplicate_detected` and `contact.merged` published by the dispatch
   layer; reason strings are privacy-safe (no PII / identifier values)
 - Coordinator workflow guidance for dedup review and weekly scan; both new skills pinned
+- **`extract-relationships` skill** — self-classifying two-stage LLM pipeline (haiku classifier gate + sonnet extractor) that extracts entity-to-entity relationship triples from text and persists them to the knowledge graph; coordinator calls it after every message (spec: `docs/wip/2026-04-05-relationship-extraction-design.md`)
+- **12 new `EDGE_TYPES`** — personal (spouse, parent, child, sibling), professional (reports_to, manages, collaborates_with, advises, represents), and organisational (member_of, founded, invested_in), extending the existing 7 types
+- **`EntityMemory.upsertEdge()`** — idempotent edge persistence with bidirectional duplicate detection; confidence only increases on re-assertion, never decreases
+- **`EntityMemory.createEntity()` confidence option** — `CreateEntityOptions.confidence` field so extracted nodes can be seeded at 0.6 (below manually confirmed entities)
 
 ---
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -41,6 +41,12 @@ system_prompt: |
   When an email arrives from someone not yet in contacts, the system auto-creates
   a contact. You can enrich it with contact-set-role if you learn their role.
 
+  ## Relationship Extraction
+  After every message, call `extract-relationships` with the full message text
+  and your current task source string. You do not need to decide whether the
+  message contains relationships — the skill handles that internally and exits
+  immediately if there is nothing to extract. Always call it; never skip it.
+
   ## Audience Awareness
   The system tells you the channel and sender for each message. Your behavior should
   adapt based on WHO you're talking to, not just which channel they're on.

--- a/docs/wip/2026-04-05-relationship-extraction-design.md
+++ b/docs/wip/2026-04-05-relationship-extraction-design.md
@@ -1,0 +1,217 @@
+# Design: Relationship Edge Extraction & Entity Linking
+
+**Date:** 2026-04-05
+**Issue:** josephfung/curia#128
+**Status:** Approved
+
+---
+
+## Background
+
+The `kg_nodes` and `kg_edges` tables exist and the persistence layer (`KnowledgeGraphStore.createEdge`, `EntityMemory.link`) is implemented and tested. The entity-context enrichment pipeline (spec 11 / `EntityContextAssembler`) already reads first-degree edges to assemble context for the coordinator — but with zero edges in the database, that assembly is always empty.
+
+No production code path creates edges between entity nodes. Every relationship mentioned in conversation ("Xiaopu Fung is my wife", "Ada is the lead on Project Orion") is silently lost.
+
+---
+
+## Scope
+
+This spec covers:
+
+1. Extended edge type vocabulary in `EDGE_TYPES`
+2. The `extract-relationships` skill (self-classifying, idempotent)
+3. Coordinator integration (unconditional invocation)
+4. Unit and integration tests
+
+**Out of scope:**
+- Automatic fact extraction (attributes of a single entity — see josephfung/curia#151)
+- Edge decay / expiry (memory decay engine — issue #27)
+- Bulk import of relationships from external sources
+- UI for manually editing edges
+
+---
+
+## Section 1 — Edge Type Vocabulary
+
+Add 12 new types to `EDGE_TYPES` in `src/memory/types.ts`:
+
+**Personal relationships:**
+- `spouse`
+- `parent`
+- `child`
+- `sibling`
+
+**Professional relationships:**
+- `reports_to`
+- `manages`
+- `collaborates_with`
+- `advises`
+- `represents`
+
+**Organisational membership:**
+- `member_of`
+- `founded`
+- `invested_in`
+
+The 7 existing types (`works_on`, `decided`, `attended`, `relates_to`, `belongs_to`, `authored`, `mentioned_in`) remain unchanged. `relates_to` is the generic fallback used when no specific type fits.
+
+**No edge type is exclusive.** A person can have multiple `spouse` edges (ex-spouses, polyamorous situations) and multiple `reports_to` edges (multiple jobs). There are no cardinality constraints — this simplifies the model and avoids false conflicts.
+
+---
+
+## Section 2 — The `extract-relationships` Skill
+
+### Location
+
+```
+skills/extract-relationships/
+  skill.json
+  handler.ts
+  handler.test.ts
+```
+
+### Manifest (`skill.json`)
+
+```json
+{
+  "name": "extract-relationships",
+  "description": "Extract entity-to-entity relationships from a passage of text and persist them as knowledge graph edges. Self-classifies internally — always safe to call; exits early if no relationships are found.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "infrastructure": true,
+  "inputs": {
+    "text": "string (the message or turn text to extract relationships from)",
+    "source": "string (provenance string, e.g. 'agent:coordinator/task:abc123/channel:cli')"
+  },
+  "outputs": {
+    "extracted": "number (new edges created)",
+    "confirmed": "number (existing edges re-asserted and updated)",
+    "skipped": "boolean (true if the classifier gate determined no relationships were present)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}
+```
+
+### Internal Flow
+
+#### Step 1 — Classifier gate
+
+A cheap haiku call with a binary prompt:
+
+> "Does the following text assert a relationship or connection between two or more people or organisations? Answer only 'yes' or 'no'.\n\n{text}"
+
+If the answer is `no`, return immediately:
+```json
+{ "extracted": 0, "confirmed": 0, "skipped": true }
+```
+
+This gate keeps the skill cost-neutral on the vast majority of coordinator turns (scheduling, email, etc.).
+
+#### Step 2 — Extraction prompt
+
+A sonnet call with the full `EDGE_TYPES` vocabulary in the prompt. The prompt instructs the model to return a JSON array of triples:
+
+```typescript
+interface ExtractedTriple {
+  subject: string;           // name or label of the source entity
+  subjectType: NodeType;     // 'person', 'organization', 'project', etc.
+  predicate: EdgeType;       // from EDGE_TYPES; use 'relates_to' if no specific type fits
+  object: string;            // name or label of the target entity
+  objectType: NodeType;      // 'person', 'organization', 'project', etc.
+  confidence: number;        // 0–1, how confident the model is in this extraction
+}
+```
+
+The prompt explicitly instructs the model to **ignore facts** (attributes of a single entity, e.g. "Joseph lives in Toronto" — those are for a future `extract-facts` skill).
+
+#### Step 3 — Node resolution
+
+For each triple's `subject` and `object`:
+
+1. Call `store.findNodesByLabel(name)` (case-insensitive)
+2. If found: use the existing node ID
+3. If not found: call `entityMemory.createEntity()` with:
+   - `type`: taken directly from `subjectType` / `objectType` in the extracted triple (the LLM provides this)
+   - `confidence: 0.6` (lower than a manually confirmed entity)
+   - `decayClass: 'slow_decay'`
+   - `source`: the skill's `source` input
+
+#### Step 4 — Idempotency check + edge upsert
+
+For each resolved triple:
+
+1. Query `kg_edges` for an existing edge matching `type` where either:
+   - `source_node_id = A AND target_node_id = B`, OR
+   - `source_node_id = B AND target_node_id = A`
+
+   Checking both directions prevents bidirectional duplicates (e.g. extracting "Joseph and Xiaopu are married" twice from different phrasings doesn't create two `spouse` edges).
+
+2. If found: `UPDATE kg_edges SET last_confirmed_at = now(), confidence = $newConfidence WHERE id = $edgeId` — count as `confirmed`
+3. If not found: call `EntityMemory.link()` to insert the new edge — count as `extracted`
+
+The updated confidence on confirmation is `max(existing_confidence, extracted_confidence)` — re-assertion can only raise confidence, never lower it.
+
+---
+
+## Section 3 — Coordinator Integration
+
+### System prompt addition
+
+Add a new block to `agents/coordinator.yaml` after the "Contact Awareness" section:
+
+```
+## Relationship Extraction
+After every message, call `extract-relationships` with the full message text and
+your current task source string. You do not need to decide whether the message
+contains relationships — the skill handles that internally and exits immediately
+if there is nothing to extract. Always call it; never skip it.
+```
+
+**Rationale for "always call it":** Making extraction unconditional avoids silent misses and keeps the instruction simple. The haiku gate inside the skill keeps the cost to a single cheap API call on unrelated messages. This design is also easy to improve later — the haiku gate can be replaced by a local LLM without changing the coordinator or skill interface.
+
+### Entity context — no changes needed
+
+`EntityContextAssembler` already queries `kg_edges` for first-degree relationships. Once edges start being created, the coordinator will automatically receive richer entity context on subsequent turns. No wiring changes required.
+
+---
+
+## Section 4 — Testing
+
+### Unit tests (`skills/extract-relationships/handler.test.ts`)
+
+Uses the in-memory KG backend (no Postgres required).
+
+| Test | Assertion |
+|---|---|
+| Classifier gate fires on unrelated text | Returns `{ skipped: true, extracted: 0, confirmed: 0 }` |
+| Single relationship extracted | Edge persisted, `extracted: 1` |
+| Idempotency — same triple twice | Second call: `confirmed: 1, extracted: 0`; `lastConfirmedAt` updated |
+| Unknown subject/object creates new nodes | Two new `person` nodes created alongside the edge |
+| Acceptance criterion | "Xiaopu Fung is Joseph's wife" → `spouse` edge between two person nodes |
+| Generic fallback | Ambiguous relationship uses `relates_to` edge type |
+
+### Integration test (`tests/integration/extract-relationships.test.ts`)
+
+Uses real Postgres (Docker, same pattern as existing integration tests).
+
+Full round-trip:
+1. Call skill with "Xiaopu Fung is Joseph's wife"
+2. Assert edge exists in `kg_edges` with type `spouse`
+3. Call `entity-context` skill for Joseph's KG node ID
+4. Assert the response includes Xiaopu as a relationship
+
+This verifies the end-to-end acceptance criterion from josephfung/curia#128.
+
+---
+
+## Acceptance Criteria (from issue)
+
+- [ ] `EDGE_TYPES` extended with personal, professional, and organisational relationship types
+- [ ] `extract-relationships` skill: LLM-powered, takes text, returns typed triples, resolves to existing nodes (or creates new ones), calls `EntityMemory.link()`
+- [ ] Skill is idempotent — duplicate triple confirms existing edge, does not insert
+- [ ] Coordinator prompt updated to invoke extraction after every message
+- [ ] Integration test: full round-trip — message in → edges in DB → entity context includes relationship on next turn
+- [ ] "Xiaopu Fung is Joseph's wife" creates a `spouse` edge between their two person nodes

--- a/docs/wip/2026-04-05-relationship-extraction-plan.md
+++ b/docs/wip/2026-04-05-relationship-extraction-plan.md
@@ -1,0 +1,976 @@
+# Relationship Edge Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add automatic relationship extraction from conversation — detecting entity-to-entity relationships (e.g. "Xiaopu is Joseph's wife") and persisting them as `kg_edges` so the coordinator's entity context becomes progressively richer.
+
+**Architecture:** A self-classifying `extract-relationships` skill runs a cheap haiku gate first (exits early on non-relational messages), then uses sonnet to extract typed triples, resolves/creates entity nodes by label, and calls a new `EntityMemory.upsertEdge()` for idempotent edge persistence. The coordinator calls it unconditionally after every message.
+
+**Tech Stack:** TypeScript ESM, `@anthropic-ai/sdk` (already a project dependency), Vitest, Postgres via pgvector, in-memory KG backend for unit tests.
+
+---
+
+## File Map
+
+| Action | Path | Purpose |
+|--------|------|---------|
+| Modify | `src/memory/types.ts` | Add 12 new edge types |
+| Modify | `src/memory/knowledge-graph.ts` | Add `updateEdge` to interface + both backends + public method |
+| Modify | `src/memory/entity-memory.ts` | Add `upsertEdge` method |
+| Modify | `vitest.config.ts` | Include `skills/**/*.test.ts` in test discovery |
+| Create | `skills/extract-relationships/skill.json` | Skill manifest |
+| Create | `skills/extract-relationships/handler.ts` | Skill handler with classifier gate + extraction |
+| Create | `skills/extract-relationships/handler.test.ts` | Unit tests (in-memory KG, mock Anthropic) |
+| Modify | `agents/coordinator.yaml` | Add Relationship Extraction section to system prompt |
+| Create | `tests/integration/extract-relationships.test.ts` | Integration test (real Postgres, mock Anthropic) |
+
+---
+
+### Task 1: Extend EDGE_TYPES
+
+**Files:**
+- Modify: `src/memory/types.ts:16-24`
+
+- [ ] **Step 1: Replace the EDGE_TYPES array**
+
+In `src/memory/types.ts`, replace the existing `EDGE_TYPES` constant (lines 16–24) with:
+
+```typescript
+// -- Edge types from spec (01-memory-system.md line 72) --
+// Original 7 types preserved; 12 new relationship types added per issue #128.
+export const EDGE_TYPES = [
+  // Structural / generic (original)
+  'works_on',
+  'decided',
+  'attended',
+  'relates_to',    // generic fallback — use when no specific type fits
+  'belongs_to',
+  'authored',
+  'mentioned_in',
+  // Personal relationships
+  'spouse',
+  'parent',
+  'child',
+  'sibling',
+  // Professional relationships
+  'reports_to',
+  'manages',
+  'collaborates_with',
+  'advises',
+  'represents',
+  // Organisational membership
+  'member_of',
+  'founded',
+  'invested_in',
+] as const;
+export type EdgeType = (typeof EDGE_TYPES)[number];
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-relationship-extraction
+npm run build 2>&1 | head -30
+```
+
+Expected: no errors (the new types are additive; nothing uses an exhaustive check on `EDGE_TYPES`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/memory/types.ts
+git commit -m "feat: extend EDGE_TYPES with personal, professional, and organisational relationships"
+```
+
+---
+
+### Task 2: Add `updateEdge` to KnowledgeGraphStore
+
+The idempotency logic in `EntityMemory.upsertEdge` (Task 3) needs to bump `confidence` and `lastConfirmedAt` on an existing edge. `KnowledgeGraphStore` currently has no update path for edges.
+
+**Files:**
+- Modify: `src/memory/knowledge-graph.ts`
+
+- [ ] **Step 1: Add `updateEdge` to the `KnowledgeGraphBackend` private interface**
+
+In `src/memory/knowledge-graph.ts`, find the `KnowledgeGraphBackend` interface (around line 46) and add one method after `deleteEdge`:
+
+```typescript
+  updateEdge(id: string, updates: { confidence: number; lastConfirmedAt: Date }): Promise<KgEdge>;
+```
+
+- [ ] **Step 2: Implement `updateEdge` in `PostgresBackend`**
+
+In the `PostgresBackend` class, add after `deleteEdge`:
+
+```typescript
+  async updateEdge(id: string, updates: { confidence: number; lastConfirmedAt: Date }): Promise<KgEdge> {
+    this.logger.debug({ edgeId: id }, 'kg: updating edge');
+    const result = await this.pool.query<PgEdgeRow>(
+      `UPDATE kg_edges SET confidence = $1, last_confirmed_at = $2 WHERE id = $3 RETURNING *`,
+      [updates.confidence, updates.lastConfirmedAt, id],
+    );
+    const row = result.rows[0];
+    if (!row) throw new Error(`Edge not found: ${id}`);
+    return pgRowToEdge(row);
+  }
+```
+
+- [ ] **Step 3: Implement `updateEdge` in `InMemoryBackend`**
+
+In the `InMemoryBackend` class, add after `deleteEdge`:
+
+```typescript
+  async updateEdge(id: string, updates: { confidence: number; lastConfirmedAt: Date }): Promise<KgEdge> {
+    const edge = this.edges.get(id);
+    if (!edge) throw new Error(`Edge not found: ${id}`);
+    const updated: KgEdge = {
+      ...edge,
+      temporal: {
+        ...edge.temporal,
+        confidence: updates.confidence,
+        lastConfirmedAt: updates.lastConfirmedAt,
+      },
+    };
+    this.edges.set(id, updated);
+    return updated;
+  }
+```
+
+- [ ] **Step 4: Add public method to `KnowledgeGraphStore`**
+
+In the `KnowledgeGraphStore` class, add after `deleteEdge`:
+
+```typescript
+  /** Update an edge's confidence and lastConfirmedAt. Used by upsertEdge for idempotency. */
+  async updateEdge(id: string, updates: { confidence: number; lastConfirmedAt: Date }): Promise<KgEdge> {
+    return this.backend.updateEdge(id, updates);
+  }
+```
+
+- [ ] **Step 5: Verify build**
+
+```bash
+npm run build 2>&1 | head -30
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Run existing KG integration test to confirm nothing broke**
+
+```bash
+DATABASE_URL=$(grep DATABASE_URL .env | cut -d= -f2-) npx vitest run tests/integration/knowledge-graph.test.ts 2>&1 | tail -20
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/memory/knowledge-graph.ts
+git commit -m "feat: add updateEdge to KnowledgeGraphStore for edge confidence/timestamp updates"
+```
+
+---
+
+### Task 3: Add `upsertEdge` to EntityMemory
+
+**Files:**
+- Modify: `src/memory/entity-memory.ts`
+
+- [ ] **Step 1: Add the `upsertEdge` method**
+
+In `src/memory/entity-memory.ts`, add this method after `link()`:
+
+```typescript
+  /**
+   * Idempotent edge creation between two entity nodes.
+   *
+   * Checks for an existing edge of the same type connecting the same pair of nodes
+   * in either direction. If found, bumps lastConfirmedAt and raises confidence
+   * (never lowers it). If not found, creates a new edge.
+   *
+   * The bidirectional check prevents duplicate edges when the same relationship
+   * is expressed from different angles ("A is B's spouse" vs "B is A's spouse").
+   *
+   * Returns the edge and whether it was newly created.
+   */
+  async upsertEdge(
+    sourceId: string,
+    targetId: string,
+    edgeType: EdgeType,
+    properties: Record<string, unknown>,
+    source: string,
+    confidence: number,
+  ): Promise<{ edge: KgEdge; created: boolean }> {
+    // getEdgesForNode returns edges where sourceId is on EITHER side of the edge,
+    // so a single call covers the bidirectional duplicate check.
+    const existingEdges = await this.store.getEdgesForNode(sourceId);
+    const match = existingEdges.find(e =>
+      e.type === edgeType &&
+      (
+        (e.sourceNodeId === sourceId && e.targetNodeId === targetId) ||
+        (e.sourceNodeId === targetId && e.targetNodeId === sourceId)
+      ),
+    );
+
+    if (match) {
+      // Re-assertion: raise confidence if the new extraction is more confident,
+      // and refresh the lastConfirmedAt timestamp.
+      const updated = await this.store.updateEdge(match.id, {
+        confidence: Math.max(match.temporal.confidence, confidence),
+        lastConfirmedAt: new Date(),
+      });
+      return { edge: updated, created: false };
+    }
+
+    const edge = await this.store.createEdge({
+      sourceNodeId: sourceId,
+      targetNodeId: targetId,
+      type: edgeType,
+      properties,
+      confidence,
+      source,
+    });
+    return { edge, created: true };
+  }
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+npm run build 2>&1 | head -30
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/memory/entity-memory.ts
+git commit -m "feat: add upsertEdge to EntityMemory for idempotent edge creation"
+```
+
+---
+
+### Task 4: Enable skill test discovery and create skill manifest
+
+**Files:**
+- Modify: `vitest.config.ts`
+- Create: `skills/extract-relationships/skill.json`
+
+- [ ] **Step 1: Add skills to vitest test discovery**
+
+In `vitest.config.ts`, update the `include` array:
+
+```typescript
+include: ['tests/**/*.test.ts', 'src/**/*.test.ts', 'skills/**/*.test.ts'],
+```
+
+- [ ] **Step 2: Create `skills/extract-relationships/skill.json`**
+
+```json
+{
+  "name": "extract-relationships",
+  "description": "Extract entity-to-entity relationships from a passage of text and persist them as knowledge graph edges. Self-classifies internally — always safe to call; exits early if no relationships are found.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "infrastructure": true,
+  "inputs": {
+    "text": "string (the message or turn text to extract relationships from)",
+    "source": "string (provenance string, e.g. 'agent:coordinator/task:abc123/channel:cli')"
+  },
+  "outputs": {
+    "extracted": "number (new edges created)",
+    "confirmed": "number (existing edges re-asserted and updated)",
+    "skipped": "boolean (true if the classifier gate determined no relationships were present)"
+  },
+  "permissions": [],
+  "secrets": ["ANTHROPIC_API_KEY"],
+  "timeout": 15000
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add vitest.config.ts skills/extract-relationships/skill.json
+git commit -m "chore: add extract-relationships skill manifest and enable skill test discovery"
+```
+
+---
+
+### Task 5: Write failing handler tests
+
+**Files:**
+- Create: `skills/extract-relationships/handler.test.ts`
+- Create: `skills/extract-relationships/handler.ts` (stub — enough to import, not to pass)
+
+- [ ] **Step 1: Create a stub handler so tests can import it**
+
+Create `skills/extract-relationships/handler.ts`:
+
+```typescript
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class ExtractRelationshipsHandler implements SkillHandler {
+  async execute(_ctx: SkillContext): Promise<SkillResult> {
+    return { success: false, error: 'not implemented' };
+  }
+}
+```
+
+- [ ] **Step 2: Create the test file**
+
+Create `skills/extract-relationships/handler.test.ts`:
+
+```typescript
+// handler.test.ts — unit tests for extract-relationships skill.
+//
+// Uses an in-memory KG backend (no Postgres) and a mock Anthropic client
+// injected via the handler constructor, so no real API calls are made.
+
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { ExtractRelationshipsHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+// -- Test helpers --
+
+function makeEntityMemory(): EntityMemory {
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  return new EntityMemory(store, validator, embeddingService);
+}
+
+function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {
+  return {
+    input,
+    secret: () => 'test-api-key',
+    log: pino({ level: 'silent' }),
+    entityMemory,
+  } as unknown as SkillContext;
+}
+
+// Creates a mock Anthropic client that returns a scripted sequence of responses.
+// First call is the classifier gate; second call (if triggered) is extraction.
+function makeMockAnthropicClient(responses: string[]) {
+  let callIndex = 0;
+  return {
+    messages: {
+      create: vi.fn().mockImplementation(() => {
+        const text = responses[callIndex++] ?? 'no';
+        return Promise.resolve({ content: [{ type: 'text', text }] });
+      }),
+    },
+  };
+}
+
+// -- Tests --
+
+describe('ExtractRelationshipsHandler', () => {
+  it('returns skipped:true when classifier gate fires on unrelated text', async () => {
+    const entityMemory = makeEntityMemory();
+    const anthropic = makeMockAnthropicClient(['no']);
+    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const ctx = makeCtx(entityMemory, {
+      text: 'Please schedule a call with the engineering team for Thursday.',
+      source: 'test',
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { extracted: 0, confirmed: 0, skipped: true } });
+    // Classifier was called; extraction was not (only 1 API call made)
+    expect(anthropic.messages.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('extracts a single relationship and persists the edge', async () => {
+    const entityMemory = makeEntityMemory();
+    const triple = JSON.stringify([
+      { subject: 'Ada Lovelace', subjectType: 'person', predicate: 'manages', object: 'Project Orion', objectType: 'project', confidence: 0.9 },
+    ]);
+    const anthropic = makeMockAnthropicClient(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const ctx = makeCtx(entityMemory, {
+      text: 'Ada Lovelace is the lead on Project Orion.',
+      source: 'test',
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { extracted: 1, confirmed: 0, skipped: false } });
+
+    // Verify the edge exists in the KG
+    const adaNodes = await entityMemory.findEntities('Ada Lovelace');
+    expect(adaNodes).toHaveLength(1);
+    const orionNodes = await entityMemory.findEntities('Project Orion');
+    expect(orionNodes).toHaveLength(1);
+
+    const queryResult = await entityMemory.query(adaNodes[0]!.id);
+    expect(queryResult.relationships).toHaveLength(1);
+    expect(queryResult.relationships[0]!.edge.type).toBe('manages');
+  });
+
+  it('confirms an existing edge on second call (idempotency)', async () => {
+    const entityMemory = makeEntityMemory();
+    const triple = JSON.stringify([
+      { subject: 'Joseph Fung', subjectType: 'person', predicate: 'spouse', object: 'Xiaopu Fung', objectType: 'person', confidence: 0.95 },
+    ]);
+
+    // First invocation — creates the edge
+    const anthropic1 = makeMockAnthropicClient(['yes', triple]);
+    const handler1 = new ExtractRelationshipsHandler(anthropic1 as never);
+    const ctx1 = makeCtx(entityMemory, { text: 'Xiaopu Fung is Joseph\'s wife.', source: 'test' });
+    await handler1.execute(ctx1);
+
+    // Second invocation with same text — should confirm, not duplicate
+    const anthropic2 = makeMockAnthropicClient(['yes', triple]);
+    const handler2 = new ExtractRelationshipsHandler(anthropic2 as never);
+    const ctx2 = makeCtx(entityMemory, { text: 'Xiaopu Fung is Joseph\'s wife.', source: 'test' });
+    const result = await handler2.execute(ctx2);
+
+    expect(result).toEqual({ success: true, data: { extracted: 0, confirmed: 1, skipped: false } });
+
+    // Exactly two person nodes, one edge — no duplicate
+    const josephNodes = await entityMemory.findEntities('Joseph Fung');
+    const xiaopuNodes = await entityMemory.findEntities('Xiaopu Fung');
+    expect(josephNodes).toHaveLength(1);
+    expect(xiaopuNodes).toHaveLength(1);
+
+    const queryResult = await entityMemory.query(josephNodes[0]!.id);
+    expect(queryResult.relationships).toHaveLength(1);
+  });
+
+  it('creates new nodes for unknown entities', async () => {
+    const entityMemory = makeEntityMemory();
+    const triple = JSON.stringify([
+      { subject: 'New Person A', subjectType: 'person', predicate: 'collaborates_with', object: 'New Person B', objectType: 'person', confidence: 0.8 },
+    ]);
+    const anthropic = makeMockAnthropicClient(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const ctx = makeCtx(entityMemory, {
+      text: 'New Person A is collaborating with New Person B.',
+      source: 'test',
+    });
+
+    await handler.execute(ctx);
+
+    const aNodes = await entityMemory.findEntities('New Person A');
+    const bNodes = await entityMemory.findEntities('New Person B');
+    expect(aNodes).toHaveLength(1);
+    expect(bNodes).toHaveLength(1);
+    expect(aNodes[0]!.type).toBe('person');
+    expect(bNodes[0]!.type).toBe('person');
+    // New nodes created by extraction get a lower confidence (0.6)
+    expect(aNodes[0]!.temporal.confidence).toBe(0.6);
+  });
+
+  it('acceptance criterion: "Xiaopu Fung is Joseph\'s wife" creates a spouse edge', async () => {
+    const entityMemory = makeEntityMemory();
+    const triple = JSON.stringify([
+      { subject: 'Xiaopu Fung', subjectType: 'person', predicate: 'spouse', object: 'Joseph Fung', objectType: 'person', confidence: 0.95 },
+    ]);
+    const anthropic = makeMockAnthropicClient(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const ctx = makeCtx(entityMemory, {
+      text: 'Xiaopu Fung is Joseph\'s wife.',
+      source: 'test',
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { extracted: 1, confirmed: 0, skipped: false } });
+
+    const xiaopuNodes = await entityMemory.findEntities('Xiaopu Fung');
+    const josephNodes = await entityMemory.findEntities('Joseph Fung');
+    expect(xiaopuNodes).toHaveLength(1);
+    expect(josephNodes).toHaveLength(1);
+
+    const queryResult = await entityMemory.query(xiaopuNodes[0]!.id);
+    const spouseRel = queryResult.relationships.find(r => r.edge.type === 'spouse');
+    expect(spouseRel).toBeDefined();
+    expect(spouseRel!.node.label).toBe('Joseph Fung');
+  });
+
+  it('falls back to relates_to for an unknown predicate in the extraction output', async () => {
+    const entityMemory = makeEntityMemory();
+    // LLM returns an edge type not in EDGE_TYPES — should be normalised to relates_to
+    const triple = JSON.stringify([
+      { subject: 'Alice', subjectType: 'person', predicate: 'knows_well', object: 'Bob', objectType: 'person', confidence: 0.7 },
+    ]);
+    const anthropic = makeMockAnthropicClient(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const ctx = makeCtx(entityMemory, { text: 'Alice knows Bob well.', source: 'test' });
+
+    await handler.execute(ctx);
+
+    const aliceNodes = await entityMemory.findEntities('Alice');
+    const queryResult = await entityMemory.query(aliceNodes[0]!.id);
+    expect(queryResult.relationships[0]!.edge.type).toBe('relates_to');
+  });
+});
+```
+
+- [ ] **Step 3: Run tests and confirm they fail**
+
+```bash
+npx vitest run skills/extract-relationships/handler.test.ts 2>&1 | tail -20
+```
+
+Expected: tests fail with "not implemented" errors.
+
+- [ ] **Step 4: Commit the stub and tests**
+
+```bash
+git add skills/extract-relationships/handler.ts skills/extract-relationships/handler.test.ts
+git commit -m "test: add failing handler tests for extract-relationships skill"
+```
+
+---
+
+### Task 6: Implement the handler
+
+**Files:**
+- Modify: `skills/extract-relationships/handler.ts`
+
+- [ ] **Step 1: Replace the stub with the full implementation**
+
+Replace `skills/extract-relationships/handler.ts` entirely:
+
+```typescript
+// handler.ts — extract-relationships skill.
+//
+// Self-classifying: runs a cheap haiku gate first and exits early when the
+// message contains no entity-to-entity relationships. Only fires the full
+// extraction prompt (sonnet) when the classifier says yes.
+//
+// Idempotent: calling it twice with the same triple confirms the existing
+// edge rather than inserting a duplicate, and may raise its confidence.
+
+import Anthropic from '@anthropic-ai/sdk';
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { EDGE_TYPES, NODE_TYPES } from '../../src/memory/types.js';
+import type { EdgeType, NodeType } from '../../src/memory/types.js';
+
+// Shape of each triple returned by the LLM extraction prompt.
+interface ExtractedTriple {
+  subject: string;
+  subjectType: NodeType;
+  predicate: EdgeType;
+  object: string;
+  objectType: NodeType;
+  confidence: number;
+}
+
+const EDGE_TYPES_LIST = EDGE_TYPES.join(', ');
+const NODE_TYPES_LIST = NODE_TYPES.join(', ');
+
+export class ExtractRelationshipsHandler implements SkillHandler {
+  // Optional Anthropic client injection for testing.
+  // In production the skill registry instantiates with no args and the
+  // handler creates its own client from ctx.secret('ANTHROPIC_API_KEY').
+  constructor(private readonly anthropicClient?: Anthropic) {}
+
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { text, source } = ctx.input as { text?: string; source?: string };
+
+    if (!text || typeof text !== 'string') {
+      return { success: false, error: 'Missing required input: text (string)' };
+    }
+    if (!source || typeof source !== 'string') {
+      return { success: false, error: 'Missing required input: source (string)' };
+    }
+    if (!ctx.entityMemory) {
+      return { success: false, error: 'Entity memory not available — database not configured' };
+    }
+
+    const client = this.anthropicClient ?? new Anthropic({ apiKey: ctx.secret('ANTHROPIC_API_KEY') });
+
+    // -- Step 1: Classifier gate --
+    // Cheap haiku call — exits early on the majority of messages (scheduling,
+    // email drafts, lookups) that contain no entity-to-entity relationships.
+    const classifierResponse = await client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 10,
+      messages: [{
+        role: 'user',
+        content: `Does the following text assert a relationship or connection between two or more people or organisations? Answer only 'yes' or 'no'.\n\n${text}`,
+      }],
+    });
+
+    const classifierAnswer = (classifierResponse.content[0] as { type: string; text: string }).text
+      .toLowerCase()
+      .trim();
+
+    if (!classifierAnswer.startsWith('yes')) {
+      ctx.log.debug({ textPreview: text.slice(0, 80) }, 'extract-relationships: classifier gate — no relationships, skipping');
+      return { success: true, data: { extracted: 0, confirmed: 0, skipped: true } };
+    }
+
+    // -- Step 2: Extraction prompt --
+    // Sonnet call with the full EDGE_TYPES vocabulary. Returns JSON triples.
+    const extractionResponse = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 1000,
+      messages: [{
+        role: 'user',
+        content: `Extract entity-to-entity relationships from the text below. Return a JSON array of relationship triples.
+
+Available edge types: ${EDGE_TYPES_LIST}
+Available node types: ${NODE_TYPES_LIST}
+
+Rules:
+- Only extract relationships between two distinct entities (person, organization, project, etc.)
+- Do NOT extract facts about a single entity (e.g. "Joseph lives in Toronto" is a fact about one entity, not a relationship)
+- Use 'relates_to' as predicate if no specific edge type fits
+- Set confidence between 0.0 and 1.0 based on how explicitly the relationship is stated
+- Return ONLY valid JSON, no explanation or markdown fences
+
+Format:
+[{"subject":"<name>","subjectType":"<nodeType>","predicate":"<edgeType>","object":"<name>","objectType":"<nodeType>","confidence":<number>}]
+
+Text:
+${text}`,
+      }],
+    });
+
+    // Strip optional markdown code fences the model may include despite instructions
+    const rawText = (extractionResponse.content[0] as { type: string; text: string }).text.trim();
+    const jsonText = rawText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+
+    let triples: ExtractedTriple[];
+    try {
+      const parsed = JSON.parse(jsonText) as unknown;
+      if (!Array.isArray(parsed)) {
+        ctx.log.warn({ rawText }, 'extract-relationships: extraction returned non-array, treating as empty');
+        return { success: true, data: { extracted: 0, confirmed: 0, skipped: false } };
+      }
+      triples = parsed as ExtractedTriple[];
+    } catch (err) {
+      ctx.log.warn({ err, rawText }, 'extract-relationships: failed to parse extraction JSON, treating as empty');
+      return { success: true, data: { extracted: 0, confirmed: 0, skipped: false } };
+    }
+
+    // -- Steps 3 & 4: Node resolution + edge upsert --
+    let extracted = 0;
+    let confirmed = 0;
+
+    for (const triple of triples) {
+      // Normalise predicate — fall back to 'relates_to' for unknown types
+      const predicate: EdgeType = (EDGE_TYPES as readonly string[]).includes(triple.predicate)
+        ? triple.predicate as EdgeType
+        : 'relates_to';
+
+      // Normalise node types — fall back to 'person' for unknown types
+      const subjectType: NodeType = (NODE_TYPES as readonly string[]).includes(triple.subjectType)
+        ? triple.subjectType as NodeType
+        : 'person';
+      const objectType: NodeType = (NODE_TYPES as readonly string[]).includes(triple.objectType)
+        ? triple.objectType as NodeType
+        : 'person';
+
+      // Resolve subject — find existing node by label or create a new one.
+      // New nodes get confidence 0.6 (lower than manually confirmed entities).
+      const subjectMatches = await ctx.entityMemory.findEntities(triple.subject);
+      const subjectNode = subjectMatches[0] ?? await ctx.entityMemory.createEntity({
+        type: subjectType,
+        label: triple.subject,
+        properties: {},
+        source,
+      });
+
+      // Resolve object — same pattern
+      const objectMatches = await ctx.entityMemory.findEntities(triple.object);
+      const objectNode = objectMatches[0] ?? await ctx.entityMemory.createEntity({
+        type: objectType,
+        label: triple.object,
+        properties: {},
+        source,
+      });
+
+      // Clamp confidence to [0, 1] in case the LLM returns an out-of-range value
+      const confidence = typeof triple.confidence === 'number'
+        ? Math.min(1, Math.max(0, triple.confidence))
+        : 0.7;
+
+      const { created } = await ctx.entityMemory.upsertEdge(
+        subjectNode.id,
+        objectNode.id,
+        predicate,
+        {},
+        source,
+        confidence,
+      );
+
+      if (created) {
+        extracted++;
+      } else {
+        confirmed++;
+      }
+    }
+
+    ctx.log.info({ extracted, confirmed }, 'extract-relationships: complete');
+    return { success: true, data: { extracted, confirmed, skipped: false } };
+  }
+}
+```
+
+- [ ] **Step 2: Run tests and confirm they all pass**
+
+```bash
+npx vitest run skills/extract-relationships/handler.test.ts 2>&1 | tail -20
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/extract-relationships/handler.ts
+git commit -m "feat: implement extract-relationships skill handler"
+```
+
+---
+
+### Task 7: Update coordinator system prompt
+
+**Files:**
+- Modify: `agents/coordinator.yaml`
+
+- [ ] **Step 1: Add the Relationship Extraction section**
+
+In `agents/coordinator.yaml`, find the end of the `## Contact Awareness` section (just before `## Audience Awareness`). Insert the following block between them:
+
+```yaml
+  ## Relationship Extraction
+  After every message, call `extract-relationships` with the full message text
+  and your current task source string. You do not need to decide whether the
+  message contains relationships — the skill handles that internally and exits
+  immediately if there is nothing to extract. Always call it; never skip it.
+```
+
+The section in the file should look like this after the edit (showing surrounding context):
+
+```
+  When an email arrives from someone not yet in contacts, the system auto-creates
+  a contact. You can enrich it with contact-set-role if you learn their role.
+
+  ## Relationship Extraction
+  After every message, call `extract-relationships` with the full message text
+  and your current task source string. You do not need to decide whether the
+  message contains relationships — the skill handles that internally and exits
+  immediately if there is nothing to extract. Always call it; never skip it.
+
+  ## Audience Awareness
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+```bash
+node -e "import('js-yaml').then(m => { m.default.load(require('fs').readFileSync('agents/coordinator.yaml','utf8')); console.log('valid'); }).catch(e => console.error(e))" 2>/dev/null || npx js-yaml agents/coordinator.yaml > /dev/null && echo "valid YAML"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add agents/coordinator.yaml
+git commit -m "feat: add relationship extraction instruction to coordinator system prompt"
+```
+
+---
+
+### Task 8: Integration test
+
+**Files:**
+- Create: `tests/integration/extract-relationships.test.ts`
+
+- [ ] **Step 1: Create the integration test**
+
+Create `tests/integration/extract-relationships.test.ts`:
+
+```typescript
+// Integration test: extract-relationships full round-trip.
+//
+// Uses real Postgres (DATABASE_URL must be set) and a mock Anthropic client
+// so no real LLM API calls are made. Tests that:
+// 1. The skill persists edges to kg_edges via real SQL
+// 2. EntityContextAssembler reads those edges back on the next turn
+//
+// This verifies the acceptance criterion from issue #128.
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { EntityContextAssembler } from '../../src/entity-context/assembler.js';
+import { ExtractRelationshipsHandler } from '../../skills/extract-relationships/handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+const { Pool } = pg;
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+function makeCtx(entityMemory: EntityMemory, text: string): SkillContext {
+  return {
+    input: { text, source: 'integration-test' },
+    secret: () => 'test-api-key',
+    log: pino({ level: 'silent' }),
+    entityMemory,
+  } as unknown as SkillContext;
+}
+
+function makeMockAnthropicClient(responses: string[]) {
+  let callIndex = 0;
+  return {
+    messages: {
+      create: vi.fn().mockImplementation(() => {
+        const text = responses[callIndex++] ?? 'no';
+        return Promise.resolve({ content: [{ type: 'text', text }] });
+      }),
+    },
+  };
+}
+
+describeIf('extract-relationships integration', () => {
+  let pool: pg.Pool;
+  let entityMemory: EntityMemory;
+  let assembler: EntityContextAssembler;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    const logger = pino({ level: 'silent' });
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(store, embeddingService);
+    entityMemory = new EntityMemory(store, validator, embeddingService);
+    assembler = new EntityContextAssembler(pool, logger);
+
+    await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
+  });
+
+  afterAll(async () => {
+    await pool.query("DELETE FROM kg_edges WHERE source = 'integration-test'");
+    await pool.query("DELETE FROM kg_nodes WHERE source = 'integration-test'");
+    await pool.end();
+  });
+
+  it('persists a spouse edge to Postgres and surfaces it via entity context', async () => {
+    const triple = JSON.stringify([
+      {
+        subject: 'Xiaopu Fung',
+        subjectType: 'person',
+        predicate: 'spouse',
+        object: 'Joseph Fung',
+        objectType: 'person',
+        confidence: 0.95,
+      },
+    ]);
+    const anthropic = makeMockAnthropicClient(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const ctx = makeCtx(entityMemory, 'Xiaopu Fung is Joseph\'s wife.');
+
+    const result = await handler.execute(ctx);
+
+    // Edge was created
+    expect(result).toMatchObject({ success: true, data: { extracted: 1, confirmed: 0, skipped: false } });
+
+    // Verify edge exists in Postgres directly
+    const josephNodes = await entityMemory.findEntities('Joseph Fung');
+    expect(josephNodes).toHaveLength(1);
+    const josephId = josephNodes[0]!.id;
+
+    const edgeResult = await pool.query(
+      `SELECT type FROM kg_edges WHERE (source_node_id = $1 OR target_node_id = $1) AND type = 'spouse'`,
+      [josephId],
+    );
+    expect(edgeResult.rows).toHaveLength(1);
+    expect(edgeResult.rows[0]!.type).toBe('spouse');
+
+    // Round-trip: entity context assembler includes the relationship on the next turn
+    const assembled = await assembler.assembleMany([josephId], { includeRelationships: true });
+    expect(assembled.entities).toHaveLength(1);
+    const josephCtx = assembled.entities[0]!;
+    // EntityRelationship uses .type and .relatedEntityLabel (see src/entity-context/types.ts)
+    const spouseRel = josephCtx.relationships.find(r => r.type === 'spouse');
+    expect(spouseRel).toBeDefined();
+    expect(spouseRel!.relatedEntityLabel).toBe('Xiaopu Fung');
+  });
+
+  it('is idempotent — second call with same triple confirms the edge, not duplicates it', async () => {
+    const triple = JSON.stringify([
+      {
+        subject: 'Idempotency Person A',
+        subjectType: 'person',
+        predicate: 'reports_to',
+        object: 'Idempotency Person B',
+        objectType: 'person',
+        confidence: 0.8,
+      },
+    ]);
+
+    const anthropic1 = makeMockAnthropicClient(['yes', triple]);
+    const handler1 = new ExtractRelationshipsHandler(anthropic1 as never);
+    await handler1.execute(makeCtx(entityMemory, 'Person A reports to Person B.'));
+
+    const anthropic2 = makeMockAnthropicClient(['yes', triple]);
+    const handler2 = new ExtractRelationshipsHandler(anthropic2 as never);
+    const result2 = await handler2.execute(makeCtx(entityMemory, 'Person A reports to Person B.'));
+
+    expect(result2).toMatchObject({ success: true, data: { extracted: 0, confirmed: 1, skipped: false } });
+
+    const aNodes = await entityMemory.findEntities('Idempotency Person A');
+    const edgeResult = await pool.query(
+      `SELECT COUNT(*)::int AS cnt FROM kg_edges WHERE (source_node_id = $1 OR target_node_id = $1) AND type = 'reports_to'`,
+      [aNodes[0]!.id],
+    );
+    expect(edgeResult.rows[0]!.cnt).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the integration test**
+
+```bash
+DATABASE_URL=$(grep DATABASE_URL .env | cut -d= -f2-) npx vitest run tests/integration/extract-relationships.test.ts 2>&1 | tail -30
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 3: Run the full test suite to confirm nothing regressed**
+
+```bash
+DATABASE_URL=$(grep DATABASE_URL .env | cut -d= -f2-) npx vitest run 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/extract-relationships.test.ts
+git commit -m "test: add integration test for extract-relationships round-trip"
+```
+
+---
+
+## Done
+
+All acceptance criteria from issue #128 are now met:
+
+- [x] `EDGE_TYPES` extended with personal, professional, and organisational relationship types (Task 1)
+- [x] `extract-relationships` skill: LLM-powered, takes text, returns typed triples, resolves to existing nodes (or creates new ones), calls `EntityMemory.upsertEdge()` (Tasks 4–6)
+- [x] Skill is idempotent — duplicate triple confirms existing edge, does not insert (Task 3 + 6)
+- [x] Coordinator prompt updated to invoke extraction after every message (Task 7)
+- [x] Integration test: full round-trip — message in → edges in DB → entity context includes relationship on next turn (Task 8)
+- [x] "Xiaopu Fung is Joseph's wife" creates a `spouse` edge between their two person nodes (Task 6 unit test + Task 8 integration test)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^11.2.0",
         "@fastify/rate-limit": "^10.3.0",
+        "@ghostery/adblocker-playwright": "^2.14.1",
         "cron-parser": "^5.5.0",
         "cytoscape": "^3.33.1",
         "fastify": "^5.8.4",
@@ -22,7 +23,8 @@
         "nylas": "^8.0.5",
         "pg": "^8.20.0",
         "pgvector": "^0.2.1",
-        "pino": "^10.3.1"
+        "pino": "^10.3.1",
+        "playwright": "^1.59.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -823,6 +825,59 @@
         "toad-cache": "^3.7.0"
       }
     },
+    "node_modules/@ghostery/adblocker": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.14.1.tgz",
+      "integrity": "sha512-/cQTMJRd4/7zpgFHWqe+9wqiRPGTy+BhqfkxplvejPgq8d6spBjC6bSJV61rVHJZw5F4KOO5ReKOvuguaKG28A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ghostery/adblocker-content": "^2.14.1",
+        "@ghostery/adblocker-extended-selectors": "^2.14.1",
+        "@ghostery/url-parser": "^1.3.1",
+        "@remusao/guess-url-type": "^2.1.0",
+        "@remusao/small": "^2.1.0",
+        "@remusao/smaz": "^2.2.0",
+        "tldts-experimental": "^7.0.23"
+      }
+    },
+    "node_modules/@ghostery/adblocker-content": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.14.1.tgz",
+      "integrity": "sha512-hDE6RAL9xgQonJQiK1knOHy527PEwlAuvKaha4snE0XO6Vmtk0HThce1M2JFVRxGayWR3nTxoWbvEfGWXU7O/A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ghostery/adblocker-extended-selectors": "^2.14.1"
+      }
+    },
+    "node_modules/@ghostery/adblocker-extended-selectors": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.14.1.tgz",
+      "integrity": "sha512-3RARO2ukDrfwDqVEMD+HKZIwsM9QjjII+U1zqxhLXZ0dZRHjbtUHlZCsokqfjZ1JAa3ZVKcZrF0nZv5SA2LgyA==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@ghostery/adblocker-playwright": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-playwright/-/adblocker-playwright-2.14.1.tgz",
+      "integrity": "sha512-ODNTIVuhBslpehelujprYv4X2Iu0yXKTGk5TEy1aii5m4M0D884KU2htrcOg5GexQ0xoSf4guldsM899f1uEJA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ghostery/adblocker": "^2.14.1",
+        "@ghostery/adblocker-content": "^2.14.1",
+        "tldts-experimental": "^7.0.23"
+      },
+      "peerDependencies": {
+        "playwright": "^1.x"
+      }
+    },
+    "node_modules/@ghostery/url-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/url-parser/-/url-parser-1.3.1.tgz",
+      "integrity": "sha512-QKqGi+7aDQ4RcyHyCwgEk6B9vWnsBP4Q7htaN0zPJV3ATqTKEQDtSTb9c/AN586oJUDs24YXKcwFYwNweY/YjQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "tldts-experimental": "^7.0.8"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -966,6 +1021,49 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@remusao/guess-url-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/guess-url-type/-/guess-url-type-2.1.0.tgz",
+      "integrity": "sha512-zI3dlTUxpjvx2GCxp9nLOSK5yEIqDCpxlAVGwb2Y49RKkS72oeNaxxo+VWS5+XQ5+Mf8Zfp9ZXIlk+G5eoEN8A==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@remusao/small": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/small/-/small-2.1.0.tgz",
+      "integrity": "sha512-Y1kyjZp7JU7dXdyOdxHVNfoTr1XLZJTyQP36/esZUU/WRWq9XY0PV2HsE3CsIHuaTf4pvgWv2pvzvnZ//UHIJQ==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@remusao/smaz": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz/-/smaz-2.2.0.tgz",
+      "integrity": "sha512-eSd3Qs0ELP/e7tU1SI5RWXcCn9KjDgvBY+KtWbL4i2QvvHhJOfdIt4v0AA3S5BbLWAr5dCEC7C4LUfogDm6q/Q==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@remusao/smaz-compress": "^2.2.0",
+        "@remusao/smaz-decompress": "^2.2.0"
+      }
+    },
+    "node_modules/@remusao/smaz-compress": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz-compress/-/smaz-compress-2.2.0.tgz",
+      "integrity": "sha512-TXpTPgILRUYOt2rEe0+9PC12xULPvBqeMpmipzB9A7oM4fa9Ztvy9lLYzPTd7tiQEeoNa1pmxihpKfJtsxnM/w==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@remusao/trie": "^2.1.0"
+      }
+    },
+    "node_modules/@remusao/smaz-decompress": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz-decompress/-/smaz-decompress-2.2.0.tgz",
+      "integrity": "sha512-ERAPwxPaA0/yg4hkNU7T2S+lnp9jj1sApcQMtOyROvOQyo+Zuh6Hn/oRcXr8mmjlYzyRaC7E6r3mT1nrdHR6pg==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/@remusao/trie": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/trie/-/trie-2.1.0.tgz",
+      "integrity": "sha512-Er3Q8q0/2OcCJPQYJOPLmCuqO0wu7cav3SPtpjlxSbjFi1x+A1pZkkLD6c9q2rGEkGW/tkrRzfrhNMt8VQjzXg==",
+      "license": "MPL-2.0"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.12",
@@ -4269,6 +4367,50 @@
         "pathe": "^2.0.1"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -4912,6 +5054,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "license": "MIT"
+    },
+    "node_modules/tldts-experimental": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.28.tgz",
+      "integrity": "sha512-z000DWdcayJ6TctJCb50BtJb89aeXw7WVUp5OREZZrkg56jEwLT18ySbSB28bJvEcNQ4D3JG5SLS/eSViGlRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
       }
     },
     "node_modules/toad-cache": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/extract-relationships/handler.test.ts
+++ b/skills/extract-relationships/handler.test.ts
@@ -1,0 +1,190 @@
+// handler.test.ts — unit tests for extract-relationships skill.
+//
+// Uses an in-memory KG backend (no Postgres) and a mock Anthropic client
+// injected via the handler constructor, so no real API calls are made.
+
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { ExtractRelationshipsHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+// -- Test helpers --
+
+function makeEntityMemory(): EntityMemory {
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  return new EntityMemory(store, validator, embeddingService);
+}
+
+function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {
+  return {
+    input,
+    secret: () => 'test-api-key',
+    log: pino({ level: 'silent' }),
+    entityMemory,
+  } as unknown as SkillContext;
+}
+
+// Creates a mock Anthropic client that returns a scripted sequence of responses.
+// First call is the classifier gate; second call (if triggered) is extraction.
+function makeMockAnthropicClient(responses: string[]) {
+  let callIndex = 0;
+  return {
+    messages: {
+      create: vi.fn().mockImplementation(() => {
+        const text = responses[callIndex++] ?? 'no';
+        return Promise.resolve({ content: [{ type: 'text', text }] });
+      }),
+    },
+  };
+}
+
+// -- Tests --
+
+describe('ExtractRelationshipsHandler', () => {
+  it('returns skipped:true when classifier gate fires on unrelated text', async () => {
+    const entityMemory = makeEntityMemory();
+    const anthropic = makeMockAnthropicClient(['no']);
+    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const ctx = makeCtx(entityMemory, {
+      text: 'Please schedule a call with the engineering team for Thursday.',
+      source: 'test',
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { extracted: 0, confirmed: 0, skipped: true } });
+    // Classifier was called; extraction was not (only 1 API call made)
+    expect(anthropic.messages.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('extracts a single relationship and persists the edge', async () => {
+    const entityMemory = makeEntityMemory();
+    const triple = JSON.stringify([
+      { subject: 'Ada Lovelace', subjectType: 'person', predicate: 'manages', object: 'Project Orion', objectType: 'project', confidence: 0.9 },
+    ]);
+    const anthropic = makeMockAnthropicClient(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const ctx = makeCtx(entityMemory, {
+      text: 'Ada Lovelace is the lead on Project Orion.',
+      source: 'test',
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { extracted: 1, confirmed: 0, skipped: false } });
+
+    // Verify the edge exists in the KG
+    const adaNodes = await entityMemory.findEntities('Ada Lovelace');
+    expect(adaNodes).toHaveLength(1);
+    const orionNodes = await entityMemory.findEntities('Project Orion');
+    expect(orionNodes).toHaveLength(1);
+
+    const queryResult = await entityMemory.query(adaNodes[0]!.id);
+    expect(queryResult.relationships).toHaveLength(1);
+    expect(queryResult.relationships[0]!.edge.type).toBe('manages');
+  });
+
+  it('confirms an existing edge on second call (idempotency)', async () => {
+    const entityMemory = makeEntityMemory();
+    const triple = JSON.stringify([
+      { subject: 'Joseph Fung', subjectType: 'person', predicate: 'spouse', object: 'Xiaopu Fung', objectType: 'person', confidence: 0.95 },
+    ]);
+
+    // First invocation — creates the edge
+    const anthropic1 = makeMockAnthropicClient(['yes', triple]);
+    const handler1 = new ExtractRelationshipsHandler(anthropic1 as never);
+    const ctx1 = makeCtx(entityMemory, { text: 'Xiaopu Fung is Joseph\'s wife.', source: 'test' });
+    await handler1.execute(ctx1);
+
+    // Second invocation with same text — should confirm, not duplicate
+    const anthropic2 = makeMockAnthropicClient(['yes', triple]);
+    const handler2 = new ExtractRelationshipsHandler(anthropic2 as never);
+    const ctx2 = makeCtx(entityMemory, { text: 'Xiaopu Fung is Joseph\'s wife.', source: 'test' });
+    const result = await handler2.execute(ctx2);
+
+    expect(result).toEqual({ success: true, data: { extracted: 0, confirmed: 1, skipped: false } });
+
+    // Exactly two person nodes, one edge — no duplicate
+    const josephNodes = await entityMemory.findEntities('Joseph Fung');
+    const xiaopuNodes = await entityMemory.findEntities('Xiaopu Fung');
+    expect(josephNodes).toHaveLength(1);
+    expect(xiaopuNodes).toHaveLength(1);
+
+    const queryResult = await entityMemory.query(josephNodes[0]!.id);
+    expect(queryResult.relationships).toHaveLength(1);
+  });
+
+  it('creates new nodes for unknown entities', async () => {
+    const entityMemory = makeEntityMemory();
+    const triple = JSON.stringify([
+      { subject: 'New Person A', subjectType: 'person', predicate: 'collaborates_with', object: 'New Person B', objectType: 'person', confidence: 0.8 },
+    ]);
+    const anthropic = makeMockAnthropicClient(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const ctx = makeCtx(entityMemory, {
+      text: 'New Person A is collaborating with New Person B.',
+      source: 'test',
+    });
+
+    await handler.execute(ctx);
+
+    const aNodes = await entityMemory.findEntities('New Person A');
+    const bNodes = await entityMemory.findEntities('New Person B');
+    expect(aNodes).toHaveLength(1);
+    expect(bNodes).toHaveLength(1);
+    expect(aNodes[0]!.type).toBe('person');
+    expect(bNodes[0]!.type).toBe('person');
+    // New nodes created by extraction get a lower confidence (0.6)
+    expect(aNodes[0]!.temporal.confidence).toBe(0.6);
+  });
+
+  it('acceptance criterion: "Xiaopu Fung is Joseph\'s wife" creates a spouse edge', async () => {
+    const entityMemory = makeEntityMemory();
+    const triple = JSON.stringify([
+      { subject: 'Xiaopu Fung', subjectType: 'person', predicate: 'spouse', object: 'Joseph Fung', objectType: 'person', confidence: 0.95 },
+    ]);
+    const anthropic = makeMockAnthropicClient(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const ctx = makeCtx(entityMemory, {
+      text: 'Xiaopu Fung is Joseph\'s wife.',
+      source: 'test',
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { extracted: 1, confirmed: 0, skipped: false } });
+
+    const xiaopuNodes = await entityMemory.findEntities('Xiaopu Fung');
+    const josephNodes = await entityMemory.findEntities('Joseph Fung');
+    expect(xiaopuNodes).toHaveLength(1);
+    expect(josephNodes).toHaveLength(1);
+
+    const queryResult = await entityMemory.query(xiaopuNodes[0]!.id);
+    const spouseRel = queryResult.relationships.find(r => r.edge.type === 'spouse');
+    expect(spouseRel).toBeDefined();
+    expect(spouseRel!.node.label).toBe('Joseph Fung');
+  });
+
+  it('falls back to relates_to for an unknown predicate in the extraction output', async () => {
+    const entityMemory = makeEntityMemory();
+    // LLM returns an edge type not in EDGE_TYPES — should be normalised to relates_to
+    const triple = JSON.stringify([
+      { subject: 'Alice', subjectType: 'person', predicate: 'knows_well', object: 'Bob', objectType: 'person', confidence: 0.7 },
+    ]);
+    const anthropic = makeMockAnthropicClient(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const ctx = makeCtx(entityMemory, { text: 'Alice knows Bob well.', source: 'test' });
+
+    await handler.execute(ctx);
+
+    const aliceNodes = await entityMemory.findEntities('Alice');
+    const queryResult = await entityMemory.query(aliceNodes[0]!.id);
+    expect(queryResult.relationships[0]!.edge.type).toBe('relates_to');
+  });
+});

--- a/skills/extract-relationships/handler.test.ts
+++ b/skills/extract-relationships/handler.test.ts
@@ -77,7 +77,7 @@ describe('ExtractRelationshipsHandler', () => {
 
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { extracted: 1, confirmed: 0, skipped: false } });
+    expect(result).toEqual({ success: true, data: { extracted: 1, confirmed: 0, failed: 0, skipped: false } });
 
     // Verify the edge exists in the KG
     const adaNodes = await entityMemory.findEntities('Ada Lovelace');
@@ -108,7 +108,7 @@ describe('ExtractRelationshipsHandler', () => {
     const ctx2 = makeCtx(entityMemory, { text: 'Xiaopu Fung is Joseph\'s wife.', source: 'test' });
     const result = await handler2.execute(ctx2);
 
-    expect(result).toEqual({ success: true, data: { extracted: 0, confirmed: 1, skipped: false } });
+    expect(result).toEqual({ success: true, data: { extracted: 0, confirmed: 1, failed: 0, skipped: false } });
 
     // Exactly two person nodes, one edge — no duplicate
     const josephNodes = await entityMemory.findEntities('Joseph Fung');
@@ -158,7 +158,7 @@ describe('ExtractRelationshipsHandler', () => {
 
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { extracted: 1, confirmed: 0, skipped: false } });
+    expect(result).toEqual({ success: true, data: { extracted: 1, confirmed: 0, failed: 0, skipped: false } });
 
     const xiaopuNodes = await entityMemory.findEntities('Xiaopu Fung');
     const josephNodes = await entityMemory.findEntities('Joseph Fung');

--- a/skills/extract-relationships/handler.test.ts
+++ b/skills/extract-relationships/handler.test.ts
@@ -184,6 +184,7 @@ describe('ExtractRelationshipsHandler', () => {
     await handler.execute(ctx);
 
     const aliceNodes = await entityMemory.findEntities('Alice');
+    expect(aliceNodes).toHaveLength(1);
     const queryResult = await entityMemory.query(aliceNodes[0]!.id);
     expect(queryResult.relationships[0]!.edge.type).toBe('relates_to');
   });

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -1,0 +1,12 @@
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class ExtractRelationshipsHandler implements SkillHandler {
+  // _client is accepted here so the constructor signature is compatible with
+  // Task 6, which will inject a real (or mock) Anthropic client. The stub
+  // ignores it and just returns "not implemented".
+  constructor(private readonly _client?: unknown) {}
+
+  async execute(_ctx: SkillContext): Promise<SkillResult> {
+    return { success: false, error: 'not implemented' };
+  }
+}

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -50,6 +50,7 @@ export class ExtractRelationshipsHandler implements SkillHandler {
 
     const client = this.anthropicClient ?? new Anthropic({ apiKey: ctx.secret('ANTHROPIC_API_KEY') });
 
+    try {
     // -- Step 1: Classifier gate --
     // Cheap haiku call — exits early on the majority of messages (scheduling,
     // email drafts, lookups) that contain no entity-to-entity relationships.
@@ -193,5 +194,12 @@ ${text}`,
 
     ctx.log.info({ extracted, confirmed }, 'extract-relationships: complete');
     return { success: true, data: { extracted, confirmed, skipped: false } };
+    } catch (err) {
+      // Top-level catch for Anthropic API errors (rate limits, auth, timeouts, 5xx).
+      // Skills must never throw — return a failure result so the execution layer
+      // can audit and surface the error to the caller.
+      ctx.log.error({ err }, 'extract-relationships: unexpected error');
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
   }
 }

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -1,12 +1,177 @@
+// handler.ts — extract-relationships skill.
+//
+// Self-classifying: runs a cheap haiku gate first and exits early when the
+// message contains no entity-to-entity relationships. Only fires the full
+// extraction prompt (sonnet) when the classifier says yes.
+//
+// Idempotent: calling it twice with the same triple confirms the existing
+// edge rather than inserting a duplicate, and may raise its confidence.
+
+import Anthropic from '@anthropic-ai/sdk';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { EDGE_TYPES, NODE_TYPES } from '../../src/memory/types.js';
+import type { EdgeType, NodeType } from '../../src/memory/types.js';
+
+// Shape of each triple returned by the LLM extraction prompt.
+interface ExtractedTriple {
+  subject: string;
+  subjectType: NodeType;
+  predicate: EdgeType;
+  object: string;
+  objectType: NodeType;
+  confidence: number;
+}
+
+const EDGE_TYPES_LIST = EDGE_TYPES.join(', ');
+const NODE_TYPES_LIST = NODE_TYPES.join(', ');
 
 export class ExtractRelationshipsHandler implements SkillHandler {
-  // _client is accepted here so the constructor signature is compatible with
-  // Task 6, which will inject a real (or mock) Anthropic client. The stub
-  // ignores it and just returns "not implemented".
-  constructor(private readonly _client?: unknown) {}
+  // Optional Anthropic client injection for testing.
+  // In production the skill registry instantiates with no args and the
+  // handler creates its own client from ctx.secret('ANTHROPIC_API_KEY').
+  constructor(private readonly anthropicClient?: Anthropic) {}
 
-  async execute(_ctx: SkillContext): Promise<SkillResult> {
-    return { success: false, error: 'not implemented' };
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { text, source } = ctx.input as { text?: string; source?: string };
+
+    if (!text || typeof text !== 'string') {
+      return { success: false, error: 'Missing required input: text (string)' };
+    }
+    if (!source || typeof source !== 'string') {
+      return { success: false, error: 'Missing required input: source (string)' };
+    }
+    if (!ctx.entityMemory) {
+      return { success: false, error: 'Entity memory not available — database not configured' };
+    }
+
+    const client = this.anthropicClient ?? new Anthropic({ apiKey: ctx.secret('ANTHROPIC_API_KEY') });
+
+    // -- Step 1: Classifier gate --
+    // Cheap haiku call — exits early on the majority of messages (scheduling,
+    // email drafts, lookups) that contain no entity-to-entity relationships.
+    const classifierResponse = await client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 10,
+      messages: [{
+        role: 'user',
+        content: `Does the following text assert a relationship or connection between two or more people or organisations? Answer only 'yes' or 'no'.\n\n${text}`,
+      }],
+    });
+
+    const classifierAnswer = (classifierResponse.content[0] as { type: string; text: string }).text
+      .toLowerCase()
+      .trim();
+
+    if (!classifierAnswer.startsWith('yes')) {
+      ctx.log.debug({ textPreview: text.slice(0, 80) }, 'extract-relationships: classifier gate — no relationships, skipping');
+      return { success: true, data: { extracted: 0, confirmed: 0, skipped: true } };
+    }
+
+    // -- Step 2: Extraction prompt --
+    // Sonnet call with the full EDGE_TYPES vocabulary. Returns JSON triples.
+    const extractionResponse = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 1000,
+      messages: [{
+        role: 'user',
+        content: `Extract entity-to-entity relationships from the text below. Return a JSON array of relationship triples.
+
+Available edge types: ${EDGE_TYPES_LIST}
+Available node types: ${NODE_TYPES_LIST}
+
+Rules:
+- Only extract relationships between two distinct entities (person, organization, project, etc.)
+- Do NOT extract facts about a single entity (e.g. "Joseph lives in Toronto" is a fact about one entity, not a relationship)
+- Use 'relates_to' as predicate if no specific edge type fits
+- Set confidence between 0.0 and 1.0 based on how explicitly the relationship is stated
+- Return ONLY valid JSON, no explanation or markdown fences
+
+Format:
+[{"subject":"<name>","subjectType":"<nodeType>","predicate":"<edgeType>","object":"<name>","objectType":"<nodeType>","confidence":<number>}]
+
+Text:
+${text}`,
+      }],
+    });
+
+    // Strip optional markdown code fences the model may include despite instructions
+    const rawText = (extractionResponse.content[0] as { type: string; text: string }).text.trim();
+    const jsonText = rawText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+
+    let triples: ExtractedTriple[];
+    try {
+      const parsed = JSON.parse(jsonText) as unknown;
+      if (!Array.isArray(parsed)) {
+        ctx.log.warn({ rawText }, 'extract-relationships: extraction returned non-array, treating as empty');
+        return { success: true, data: { extracted: 0, confirmed: 0, skipped: false } };
+      }
+      triples = parsed as ExtractedTriple[];
+    } catch (err) {
+      ctx.log.warn({ err, rawText }, 'extract-relationships: failed to parse extraction JSON, treating as empty');
+      return { success: true, data: { extracted: 0, confirmed: 0, skipped: false } };
+    }
+
+    // -- Steps 3 & 4: Node resolution + edge upsert --
+    let extracted = 0;
+    let confirmed = 0;
+
+    for (const triple of triples) {
+      // Normalise predicate — fall back to 'relates_to' for unknown types
+      const predicate: EdgeType = (EDGE_TYPES as readonly string[]).includes(triple.predicate)
+        ? triple.predicate as EdgeType
+        : 'relates_to';
+
+      // Normalise node types — fall back to 'person' for unknown types
+      const subjectType: NodeType = (NODE_TYPES as readonly string[]).includes(triple.subjectType)
+        ? triple.subjectType as NodeType
+        : 'person';
+      const objectType: NodeType = (NODE_TYPES as readonly string[]).includes(triple.objectType)
+        ? triple.objectType as NodeType
+        : 'person';
+
+      // Resolve subject — find existing node by label or create a new one.
+      // New nodes from extraction get confidence 0.6 (lower than manually confirmed entities).
+      const subjectMatches = await ctx.entityMemory.findEntities(triple.subject);
+      const subjectNode = subjectMatches[0] ?? await ctx.entityMemory.createEntity({
+        type: subjectType,
+        label: triple.subject,
+        properties: {},
+        source,
+        confidence: 0.6,
+      });
+
+      // Resolve object — same pattern
+      const objectMatches = await ctx.entityMemory.findEntities(triple.object);
+      const objectNode = objectMatches[0] ?? await ctx.entityMemory.createEntity({
+        type: objectType,
+        label: triple.object,
+        properties: {},
+        source,
+        confidence: 0.6,
+      });
+
+      // Clamp confidence to [0, 1] in case the LLM returns an out-of-range value
+      const confidence = typeof triple.confidence === 'number'
+        ? Math.min(1, Math.max(0, triple.confidence))
+        : 0.7;
+
+      const { created } = await ctx.entityMemory.upsertEdge(
+        subjectNode.id,
+        objectNode.id,
+        predicate,
+        {},
+        source,
+        confidence,
+      );
+
+      if (created) {
+        extracted++;
+      } else {
+        confirmed++;
+      }
+    }
+
+    ctx.log.info({ extracted, confirmed }, 'extract-relationships: complete');
+    return { success: true, data: { extracted, confirmed, skipped: false } };
   }
 }

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -12,6 +12,10 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 import { EDGE_TYPES, NODE_TYPES } from '../../src/memory/types.js';
 import type { EdgeType, NodeType } from '../../src/memory/types.js';
 
+// Model constants — update here when model IDs rotate
+const CLASSIFIER_MODEL = 'claude-haiku-4-5-20251001';
+const EXTRACTION_MODEL = 'claude-sonnet-4-6';
+
 // Shape of each triple returned by the LLM extraction prompt.
 interface ExtractedTriple {
   subject: string;
@@ -50,7 +54,7 @@ export class ExtractRelationshipsHandler implements SkillHandler {
     // Cheap haiku call — exits early on the majority of messages (scheduling,
     // email drafts, lookups) that contain no entity-to-entity relationships.
     const classifierResponse = await client.messages.create({
-      model: 'claude-haiku-4-5-20251001',
+      model: CLASSIFIER_MODEL,
       max_tokens: 10,
       messages: [{
         role: 'user',
@@ -58,9 +62,14 @@ export class ExtractRelationshipsHandler implements SkillHandler {
       }],
     });
 
-    const classifierAnswer = (classifierResponse.content[0] as { type: string; text: string }).text
-      .toLowerCase()
-      .trim();
+    const classifierTextBlock = classifierResponse.content.find(
+      (c): c is { type: 'text'; text: string } => c.type === 'text',
+    );
+    if (!classifierTextBlock) {
+      ctx.log.warn({ textPreview: text.slice(0, 80) }, 'extract-relationships: classifier returned no text block, skipping');
+      return { success: true, data: { extracted: 0, confirmed: 0, skipped: true } };
+    }
+    const classifierAnswer = classifierTextBlock.text.toLowerCase().trim();
 
     if (!classifierAnswer.startsWith('yes')) {
       ctx.log.debug({ textPreview: text.slice(0, 80) }, 'extract-relationships: classifier gate — no relationships, skipping');
@@ -70,7 +79,7 @@ export class ExtractRelationshipsHandler implements SkillHandler {
     // -- Step 2: Extraction prompt --
     // Sonnet call with the full EDGE_TYPES vocabulary. Returns JSON triples.
     const extractionResponse = await client.messages.create({
-      model: 'claude-sonnet-4-6',
+      model: EXTRACTION_MODEL,
       max_tokens: 1000,
       messages: [{
         role: 'user',
@@ -94,8 +103,15 @@ ${text}`,
       }],
     });
 
+    const extractionTextBlock = extractionResponse.content.find(
+      (c): c is { type: 'text'; text: string } => c.type === 'text',
+    );
+    if (!extractionTextBlock) {
+      ctx.log.warn('extract-relationships: extraction returned no text block, treating as empty');
+      return { success: true, data: { extracted: 0, confirmed: 0, skipped: false } };
+    }
     // Strip optional markdown code fences the model may include despite instructions
-    const rawText = (extractionResponse.content[0] as { type: string; text: string }).text.trim();
+    const rawText = extractionTextBlock.text.trim();
     const jsonText = rawText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
 
     let triples: ExtractedTriple[];
@@ -116,58 +132,62 @@ ${text}`,
     let confirmed = 0;
 
     for (const triple of triples) {
-      // Normalise predicate — fall back to 'relates_to' for unknown types
-      const predicate: EdgeType = (EDGE_TYPES as readonly string[]).includes(triple.predicate)
-        ? triple.predicate as EdgeType
-        : 'relates_to';
+      try {
+        // Normalise predicate — fall back to 'relates_to' for unknown types
+        const predicate: EdgeType = (EDGE_TYPES as readonly string[]).includes(triple.predicate)
+          ? triple.predicate as EdgeType
+          : 'relates_to';
 
-      // Normalise node types — fall back to 'person' for unknown types
-      const subjectType: NodeType = (NODE_TYPES as readonly string[]).includes(triple.subjectType)
-        ? triple.subjectType as NodeType
-        : 'person';
-      const objectType: NodeType = (NODE_TYPES as readonly string[]).includes(triple.objectType)
-        ? triple.objectType as NodeType
-        : 'person';
+        // Normalise node types — fall back to 'person' for unknown types
+        const subjectType: NodeType = (NODE_TYPES as readonly string[]).includes(triple.subjectType)
+          ? triple.subjectType as NodeType
+          : 'person';
+        const objectType: NodeType = (NODE_TYPES as readonly string[]).includes(triple.objectType)
+          ? triple.objectType as NodeType
+          : 'person';
 
-      // Resolve subject — find existing node by label or create a new one.
-      // New nodes from extraction get confidence 0.6 (lower than manually confirmed entities).
-      const subjectMatches = await ctx.entityMemory.findEntities(triple.subject);
-      const subjectNode = subjectMatches[0] ?? await ctx.entityMemory.createEntity({
-        type: subjectType,
-        label: triple.subject,
-        properties: {},
-        source,
-        confidence: 0.6,
-      });
+        // Resolve subject — find existing node by label or create a new one.
+        // New nodes from extraction get confidence 0.6 (lower than manually confirmed entities).
+        const subjectMatches = await ctx.entityMemory.findEntities(triple.subject);
+        const subjectNode = subjectMatches[0] ?? await ctx.entityMemory.createEntity({
+          type: subjectType,
+          label: triple.subject,
+          properties: {},
+          source,
+          confidence: 0.6,
+        });
 
-      // Resolve object — same pattern
-      const objectMatches = await ctx.entityMemory.findEntities(triple.object);
-      const objectNode = objectMatches[0] ?? await ctx.entityMemory.createEntity({
-        type: objectType,
-        label: triple.object,
-        properties: {},
-        source,
-        confidence: 0.6,
-      });
+        // Resolve object — same pattern
+        const objectMatches = await ctx.entityMemory.findEntities(triple.object);
+        const objectNode = objectMatches[0] ?? await ctx.entityMemory.createEntity({
+          type: objectType,
+          label: triple.object,
+          properties: {},
+          source,
+          confidence: 0.6,
+        });
 
-      // Clamp confidence to [0, 1] in case the LLM returns an out-of-range value
-      const confidence = typeof triple.confidence === 'number'
-        ? Math.min(1, Math.max(0, triple.confidence))
-        : 0.7;
+        // Clamp confidence to [0, 1] in case the LLM returns an out-of-range value
+        const confidence = typeof triple.confidence === 'number'
+          ? Math.min(1, Math.max(0, triple.confidence))
+          : 0.7;
 
-      const { created } = await ctx.entityMemory.upsertEdge(
-        subjectNode.id,
-        objectNode.id,
-        predicate,
-        {},
-        source,
-        confidence,
-      );
+        const { created } = await ctx.entityMemory.upsertEdge(
+          subjectNode.id,
+          objectNode.id,
+          predicate,
+          {},
+          source,
+          confidence,
+        );
 
-      if (created) {
-        extracted++;
-      } else {
-        confirmed++;
+        if (created) {
+          extracted++;
+        } else {
+          confirmed++;
+        }
+      } catch (err) {
+        ctx.log.warn({ err, subject: triple.subject, object: triple.object }, 'extract-relationships: failed to persist triple, skipping');
       }
     }
 

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -114,9 +114,10 @@ ${text}`,
       ctx.log.warn('extract-relationships: extraction returned no text block, treating as empty');
       return { success: true, data: { extracted: 0, confirmed: 0, skipped: false } };
     }
-    // Strip optional markdown code fences the model may include despite instructions
+    // Strip optional markdown code fences the model may include despite instructions.
+    // Case-insensitive to handle ```JSON as well as ```json.
     const rawText = extractionTextBlock.text.trim();
-    const jsonText = rawText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+    const jsonText = rawText.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
 
     let triples: ExtractedTriple[];
     try {
@@ -136,41 +137,77 @@ ${text}`,
     let confirmed = 0;
     let failed = 0;
 
+    // Entity types that are valid relationship endpoints. 'fact' is excluded —
+    // facts describe a single entity and should not appear as nodes in a
+    // subject↔object relationship (that's the extract-facts skill's domain).
+    const ENTITY_NODE_TYPES: ReadonlySet<string> = new Set(
+      NODE_TYPES.filter(t => t !== 'fact'),
+    );
+
     for (const triple of triples) {
       try {
+        // Guard: skip malformed triples where required string fields are absent.
+        // The LLM may return null/undefined for subject or object on edge cases.
+        if (
+          !triple ||
+          typeof triple.subject !== 'string' ||
+          typeof triple.object !== 'string' ||
+          typeof triple.predicate !== 'string'
+        ) {
+          ctx.log.warn({ triple }, 'extract-relationships: skipping malformed triple');
+          failed++;
+          continue;
+        }
+
         // Normalise predicate — fall back to 'relates_to' for unknown types
         const predicate: EdgeType = (EDGE_TYPES as readonly string[]).includes(triple.predicate)
           ? triple.predicate as EdgeType
           : 'relates_to';
 
-        // Normalise node types — fall back to 'person' for unknown types
-        const subjectType: NodeType = (NODE_TYPES as readonly string[]).includes(triple.subjectType)
+        // Normalise node types — fall back to 'person' for unknown or non-entity types.
+        // 'fact' is intentionally excluded: relationship edges must connect entity nodes.
+        const subjectType: NodeType = ENTITY_NODE_TYPES.has(triple.subjectType)
           ? triple.subjectType as NodeType
           : 'person';
-        const objectType: NodeType = (NODE_TYPES as readonly string[]).includes(triple.objectType)
+        const objectType: NodeType = ENTITY_NODE_TYPES.has(triple.objectType)
           ? triple.objectType as NodeType
           : 'person';
 
-        // Resolve subject — find existing node by label or create a new one.
-        // New nodes from extraction get confidence 0.6 (lower than manually confirmed entities).
+        // Resolve subject — prefer a node whose type matches the extraction.
+        // Falling back to the first match handles cases where a node was previously
+        // created under a different type; creating a new node is the last resort.
         const subjectMatches = await ctx.entityMemory.findEntities(triple.subject);
-        const subjectNode = subjectMatches[0] ?? await ctx.entityMemory.createEntity({
-          type: subjectType,
-          label: triple.subject,
-          properties: {},
-          source,
-          confidence: 0.6,
-        });
+        const subjectNode =
+          subjectMatches.find(n => n.type === subjectType) ??
+          subjectMatches[0] ??
+          await ctx.entityMemory.createEntity({
+            type: subjectType,
+            label: triple.subject,
+            properties: {},
+            source,
+            confidence: 0.6,
+          });
 
         // Resolve object — same pattern
         const objectMatches = await ctx.entityMemory.findEntities(triple.object);
-        const objectNode = objectMatches[0] ?? await ctx.entityMemory.createEntity({
-          type: objectType,
-          label: triple.object,
-          properties: {},
-          source,
-          confidence: 0.6,
-        });
+        const objectNode =
+          objectMatches.find(n => n.type === objectType) ??
+          objectMatches[0] ??
+          await ctx.entityMemory.createEntity({
+            type: objectType,
+            label: triple.object,
+            properties: {},
+            source,
+            confidence: 0.6,
+          });
+
+        // Skip self-loops — subject and object resolved to the same node.
+        // The extraction prompt asks for two distinct entities but the LLM can still
+        // produce a triple like ("Joseph", "knows", "Joseph") on malformed input.
+        if (subjectNode.id === objectNode.id) {
+          ctx.log.warn({ subject: triple.subject, object: triple.object }, 'extract-relationships: skipping self-loop triple');
+          continue;
+        }
 
         // Clamp confidence to [0, 1] in case the LLM returns an out-of-range value
         const confidence = typeof triple.confidence === 'number'

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -39,12 +39,15 @@ export class ExtractRelationshipsHandler implements SkillHandler {
     const { text, source } = ctx.input as { text?: string; source?: string };
 
     if (!text || typeof text !== 'string') {
+      ctx.log.error({ input: ctx.input }, 'extract-relationships: missing required input "text"');
       return { success: false, error: 'Missing required input: text (string)' };
     }
     if (!source || typeof source !== 'string') {
+      ctx.log.error({ input: ctx.input }, 'extract-relationships: missing required input "source"');
       return { success: false, error: 'Missing required input: source (string)' };
     }
     if (!ctx.entityMemory) {
+      ctx.log.error('extract-relationships: entity memory not available — is the database configured?');
       return { success: false, error: 'Entity memory not available — database not configured' };
     }
 
@@ -131,6 +134,7 @@ ${text}`,
     // -- Steps 3 & 4: Node resolution + edge upsert --
     let extracted = 0;
     let confirmed = 0;
+    let failed = 0;
 
     for (const triple of triples) {
       try {
@@ -188,12 +192,17 @@ ${text}`,
           confirmed++;
         }
       } catch (err) {
-        ctx.log.warn({ err, subject: triple.subject, object: triple.object }, 'extract-relationships: failed to persist triple, skipping');
+        // Log at error (not warn) — persistence failures are infrastructure errors
+        // (DB outage, connection loss) that must surface in Sentry, not soft warnings.
+        // The skill still returns success so the coordinator can continue, but the
+        // failed count lets callers see that triples were dropped.
+        ctx.log.error({ err, subject: triple.subject, object: triple.object }, 'extract-relationships: failed to persist triple, skipping');
+        failed++;
       }
     }
 
-    ctx.log.info({ extracted, confirmed }, 'extract-relationships: complete');
-    return { success: true, data: { extracted, confirmed, skipped: false } };
+    ctx.log.info({ extracted, confirmed, failed }, 'extract-relationships: complete');
+    return { success: true, data: { extracted, confirmed, failed, skipped: false } };
     } catch (err) {
       // Top-level catch for Anthropic API errors (rate limits, auth, timeouts, 5xx).
       // Skills must never throw — return a failure result so the execution layer

--- a/skills/extract-relationships/skill.json
+++ b/skills/extract-relationships/skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "extract-relationships",
+  "description": "Extract entity-to-entity relationships from a passage of text and persist them as knowledge graph edges. Self-classifies internally — always safe to call; exits early if no relationships are found.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "infrastructure": true,
+  "inputs": {
+    "text": "string (the message or turn text to extract relationships from)",
+    "source": "string (provenance string, e.g. 'agent:coordinator/task:abc123/channel:cli')"
+  },
+  "outputs": {
+    "extracted": "number (new edges created)",
+    "confirmed": "number (existing edges re-asserted and updated)",
+    "skipped": "boolean (true if the classifier gate determined no relationships were present)"
+  },
+  "permissions": [],
+  "secrets": ["ANTHROPIC_API_KEY"],
+  "timeout": 15000
+}

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -282,6 +282,58 @@ export class EntityMemory {
   }
 
   /**
+   * Idempotent edge creation between two entity nodes.
+   *
+   * Checks for an existing edge of the same type connecting the same pair of nodes
+   * in either direction. If found, bumps lastConfirmedAt and raises confidence
+   * (never lowers it). If not found, creates a new edge.
+   *
+   * The bidirectional check prevents duplicate edges when the same relationship
+   * is expressed from different angles ("A is B's spouse" vs "B is A's spouse").
+   *
+   * Returns the edge and whether it was newly created.
+   */
+  async upsertEdge(
+    sourceId: string,
+    targetId: string,
+    edgeType: EdgeType,
+    properties: Record<string, unknown>,
+    source: string,
+    confidence: number,
+  ): Promise<{ edge: KgEdge; created: boolean }> {
+    // getEdgesForNode returns edges where sourceId is on EITHER side of the edge,
+    // so a single call covers the bidirectional duplicate check.
+    const existingEdges = await this.store.getEdgesForNode(sourceId);
+    const match = existingEdges.find(e =>
+      e.type === edgeType &&
+      (
+        (e.sourceNodeId === sourceId && e.targetNodeId === targetId) ||
+        (e.sourceNodeId === targetId && e.targetNodeId === sourceId)
+      ),
+    );
+
+    if (match) {
+      // Re-assertion: raise confidence if the new extraction is more confident,
+      // and refresh the lastConfirmedAt timestamp.
+      const updated = await this.store.updateEdge(match.id, {
+        confidence: Math.max(match.temporal.confidence, confidence),
+        lastConfirmedAt: new Date(),
+      });
+      return { edge: updated, created: false };
+    }
+
+    const edge = await this.store.createEdge({
+      sourceNodeId: sourceId,
+      targetNodeId: targetId,
+      type: edgeType,
+      properties,
+      confidence,
+      source,
+    });
+    return { edge, created: true };
+  }
+
+  /**
    * Reset rate limit counters for a given agent+task key.
    * Delegates to the validator so the runtime doesn't need a direct validator reference.
    *

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -21,6 +21,10 @@ export interface CreateEntityOptions {
   label: string;
   properties: Record<string, unknown>;
   source: string;
+  // Optional confidence override; defaults to 0.7 (the store default).
+  // Pass a lower value (e.g. 0.6) when creating nodes from LLM extraction
+  // output, where the entity may be a first-time mention with no prior context.
+  confidence?: number;
 }
 
 export interface StoreFactResult {
@@ -73,6 +77,8 @@ export class EntityMemory {
       label: options.label,
       properties: options.properties,
       source: options.source,
+      // Thread through the optional confidence override
+      confidence: options.confidence,
     });
   }
 

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -53,6 +53,7 @@ interface KnowledgeGraphBackend {
   createEdge(edge: KgEdge): Promise<void>;
   getEdgesForNode(nodeId: string): Promise<KgEdge[]>;
   deleteEdge(id: string): Promise<void>;
+  updateEdge(id: string, updates: { confidence: number; lastConfirmedAt: Date }): Promise<KgEdge>;
   traverse(startNodeId: string, maxDepth: number): Promise<TraversalResult>;
   semanticSearch(queryEmbedding: number[], limit: number): Promise<SearchResult[]>;
 }
@@ -213,6 +214,11 @@ export class KnowledgeGraphStore {
     await this.backend.deleteEdge(id);
   }
 
+  /** Update an edge's confidence and lastConfirmedAt. Used by upsertEdge for idempotency. */
+  async updateEdge(id: string, updates: { confidence: number; lastConfirmedAt: Date }): Promise<KgEdge> {
+    return this.backend.updateEdge(id, updates);
+  }
+
   /**
    * BFS traversal from a start node, depth-limited and cycle-safe.
    * Returns all reachable nodes within the depth limit and the edges between them.
@@ -348,6 +354,17 @@ class PostgresBackend implements KnowledgeGraphBackend {
   async deleteEdge(id: string): Promise<void> {
     this.logger.debug({ edgeId: id }, 'kg: deleting edge');
     await this.pool.query('DELETE FROM kg_edges WHERE id = $1', [id]);
+  }
+
+  async updateEdge(id: string, updates: { confidence: number; lastConfirmedAt: Date }): Promise<KgEdge> {
+    this.logger.debug({ edgeId: id }, 'kg: updating edge');
+    const result = await this.pool.query<PgEdgeRow>(
+      `UPDATE kg_edges SET confidence = $1, last_confirmed_at = $2 WHERE id = $3 RETURNING *`,
+      [updates.confidence, updates.lastConfirmedAt, id],
+    );
+    const row = result.rows[0];
+    if (!row) throw new Error(`Edge not found: ${id}`);
+    return pgRowToEdge(row);
   }
 
   async traverse(startNodeId: string, maxDepth: number): Promise<TraversalResult> {
@@ -556,6 +573,21 @@ class InMemoryBackend implements KnowledgeGraphBackend {
 
   async deleteEdge(id: string): Promise<void> {
     this.edges.delete(id);
+  }
+
+  async updateEdge(id: string, updates: { confidence: number; lastConfirmedAt: Date }): Promise<KgEdge> {
+    const edge = this.edges.get(id);
+    if (!edge) throw new Error(`Edge not found: ${id}`);
+    const updated: KgEdge = {
+      ...edge,
+      temporal: {
+        ...edge.temporal,
+        confidence: updates.confidence,
+        lastConfirmedAt: updates.lastConfirmedAt,
+      },
+    };
+    this.edges.set(id, updated);
+    return updated;
   }
 
   /**

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -358,12 +358,17 @@ class PostgresBackend implements KnowledgeGraphBackend {
 
   async updateEdge(id: string, updates: { confidence: number; lastConfirmedAt: Date }): Promise<KgEdge> {
     this.logger.debug({ edgeId: id }, 'kg: updating edge');
+    // Use GREATEST so confidence is monotonically non-decreasing even if two concurrent
+    // re-assertions both read the same prior value (lost-update race condition).
     const result = await this.pool.query<PgEdgeRow>(
-      `UPDATE kg_edges SET confidence = $1, last_confirmed_at = $2 WHERE id = $3 RETURNING *`,
+      `UPDATE kg_edges SET confidence = GREATEST(confidence, $1), last_confirmed_at = $2 WHERE id = $3 RETURNING *`,
       [updates.confidence, updates.lastConfirmedAt, id],
     );
     const row = result.rows[0];
-    if (!row) throw new Error(`Edge not found: ${id}`);
+    if (!row) {
+      this.logger.error({ edgeId: id }, 'kg: updateEdge — edge not found in database');
+      throw new Error(`Edge not found: ${id}`);
+    }
     return pgRowToEdge(row);
   }
 

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -13,14 +13,31 @@ export const NODE_TYPES = [
 export type NodeType = (typeof NODE_TYPES)[number];
 
 // -- Edge types from spec (01-memory-system.md line 72) --
+// Original 7 types preserved; 12 new relationship types added per issue #128.
 export const EDGE_TYPES = [
+  // Structural / generic (original)
   'works_on',
   'decided',
   'attended',
-  'relates_to',
+  'relates_to',    // generic fallback — use when no specific type fits
   'belongs_to',
   'authored',
   'mentioned_in',
+  // Personal relationships
+  'spouse',
+  'parent',
+  'child',
+  'sibling',
+  // Professional relationships
+  'reports_to',
+  'manages',
+  'collaborates_with',
+  'advises',
+  'represents',
+  // Organisational membership
+  'member_of',
+  'founded',
+  'invested_in',
 ] as const;
 export type EdgeType = (typeof EDGE_TYPES)[number];
 

--- a/tests/integration/extract-relationships.test.ts
+++ b/tests/integration/extract-relationships.test.ts
@@ -59,6 +59,11 @@ describeIf('extract-relationships integration', () => {
     assembler = new EntityContextAssembler(pool, logger);
 
     await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
+
+    // Clean any stale rows from previous runs that crashed before teardown.
+    // Without this, leftover 'integration-test' rows cause flaky toHaveLength(1) failures.
+    await pool.query("DELETE FROM kg_edges WHERE source = 'integration-test'");
+    await pool.query("DELETE FROM kg_nodes WHERE source = 'integration-test'");
   });
 
   afterAll(async () => {
@@ -132,6 +137,7 @@ describeIf('extract-relationships integration', () => {
     expect(result2).toMatchObject({ success: true, data: { extracted: 0, confirmed: 1, skipped: false } });
 
     const aNodes = await entityMemory.findEntities('Idempotency Person A');
+    expect(aNodes).toHaveLength(1);
     const edgeResult = await pool.query(
       `SELECT COUNT(*)::int AS cnt FROM kg_edges WHERE (source_node_id = $1 OR target_node_id = $1) AND type = 'reports_to'`,
       [aNodes[0]!.id],

--- a/tests/integration/extract-relationships.test.ts
+++ b/tests/integration/extract-relationships.test.ts
@@ -1,0 +1,141 @@
+// Integration test: extract-relationships full round-trip.
+//
+// Uses real Postgres (DATABASE_URL must be set) and a mock Anthropic client
+// so no real LLM API calls are made. Tests that:
+// 1. The skill persists edges to kg_edges via real SQL
+// 2. EntityContextAssembler reads those edges back on the next turn
+//
+// This verifies the acceptance criterion from issue #128.
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import pino from 'pino';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { EntityContextAssembler } from '../../src/entity-context/assembler.js';
+import { ExtractRelationshipsHandler } from '../../skills/extract-relationships/handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+const { Pool } = pg;
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+function makeCtx(entityMemory: EntityMemory, text: string): SkillContext {
+  return {
+    input: { text, source: 'integration-test' },
+    secret: () => 'test-api-key',
+    log: pino({ level: 'silent' }),
+    entityMemory,
+  } as unknown as SkillContext;
+}
+
+function makeMockAnthropicClient(responses: string[]) {
+  let callIndex = 0;
+  return {
+    messages: {
+      create: vi.fn().mockImplementation(() => {
+        const text = responses[callIndex++] ?? 'no';
+        return Promise.resolve({ content: [{ type: 'text', text }] });
+      }),
+    },
+  };
+}
+
+describeIf('extract-relationships integration', () => {
+  let pool: pg.Pool;
+  let entityMemory: EntityMemory;
+  let assembler: EntityContextAssembler;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    const logger = pino({ level: 'silent' });
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(store, embeddingService);
+    entityMemory = new EntityMemory(store, validator, embeddingService);
+    assembler = new EntityContextAssembler(pool, logger);
+
+    await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
+  });
+
+  afterAll(async () => {
+    await pool.query("DELETE FROM kg_edges WHERE source = 'integration-test'");
+    await pool.query("DELETE FROM kg_nodes WHERE source = 'integration-test'");
+    await pool.end();
+  });
+
+  it('persists a spouse edge to Postgres and surfaces it via entity context', async () => {
+    const triple = JSON.stringify([
+      {
+        subject: 'Xiaopu Fung',
+        subjectType: 'person',
+        predicate: 'spouse',
+        object: 'Joseph Fung',
+        objectType: 'person',
+        confidence: 0.95,
+      },
+    ]);
+    const anthropic = makeMockAnthropicClient(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const ctx = makeCtx(entityMemory, 'Xiaopu Fung is Joseph\'s wife.');
+
+    const result = await handler.execute(ctx);
+
+    // Edge was created
+    expect(result).toMatchObject({ success: true, data: { extracted: 1, confirmed: 0, skipped: false } });
+
+    // Verify edge exists in Postgres directly
+    const josephNodes = await entityMemory.findEntities('Joseph Fung');
+    expect(josephNodes).toHaveLength(1);
+    const josephId = josephNodes[0]!.id;
+
+    const edgeResult = await pool.query(
+      `SELECT type FROM kg_edges WHERE (source_node_id = $1 OR target_node_id = $1) AND type = 'spouse'`,
+      [josephId],
+    );
+    expect(edgeResult.rows).toHaveLength(1);
+    expect(edgeResult.rows[0]!.type).toBe('spouse');
+
+    // Round-trip: entity context assembler includes the relationship on the next turn
+    const assembled = await assembler.assembleMany([josephId], { includeRelationships: true });
+    expect(assembled.entities).toHaveLength(1);
+    const josephCtx = assembled.entities[0]!;
+    // EntityRelationship uses .type and .relatedEntityLabel (see src/entity-context/types.ts)
+    const spouseRel = josephCtx.relationships.find(r => r.type === 'spouse');
+    expect(spouseRel).toBeDefined();
+    expect(spouseRel!.relatedEntityLabel).toBe('Xiaopu Fung');
+  });
+
+  it('is idempotent — second call with same triple confirms the edge, not duplicates it', async () => {
+    const triple = JSON.stringify([
+      {
+        subject: 'Idempotency Person A',
+        subjectType: 'person',
+        predicate: 'reports_to',
+        object: 'Idempotency Person B',
+        objectType: 'person',
+        confidence: 0.8,
+      },
+    ]);
+
+    const anthropic1 = makeMockAnthropicClient(['yes', triple]);
+    const handler1 = new ExtractRelationshipsHandler(anthropic1 as never);
+    await handler1.execute(makeCtx(entityMemory, 'Person A reports to Person B.'));
+
+    const anthropic2 = makeMockAnthropicClient(['yes', triple]);
+    const handler2 = new ExtractRelationshipsHandler(anthropic2 as never);
+    const result2 = await handler2.execute(makeCtx(entityMemory, 'Person A reports to Person B.'));
+
+    expect(result2).toMatchObject({ success: true, data: { extracted: 0, confirmed: 1, skipped: false } });
+
+    const aNodes = await entityMemory.findEntities('Idempotency Person A');
+    const edgeResult = await pool.query(
+      `SELECT COUNT(*)::int AS cnt FROM kg_edges WHERE (source_node_id = $1 OR target_node_id = $1) AND type = 'reports_to'`,
+      [aNodes[0]!.id],
+    );
+    expect(edgeResult.rows[0]!.cnt).toBe(1);
+  });
+});

--- a/tests/unit/memory/entity-memory.test.ts
+++ b/tests/unit/memory/entity-memory.test.ts
@@ -379,4 +379,79 @@ describe('EntityMemory', () => {
       await expect(entityMemory.query('non-existent-id')).rejects.toThrow();
     });
   });
+
+  describe('upsertEdge', () => {
+    it('creates a new edge when none exists', async () => {
+      const a = await entityMemory.createEntity({ type: 'person', label: 'Upsert-A', properties: {}, source: 'test' });
+      const b = await entityMemory.createEntity({ type: 'person', label: 'Upsert-B', properties: {}, source: 'test' });
+
+      const result = await entityMemory.upsertEdge(a.id, b.id, 'spouse', {}, 'test', 0.8);
+
+      expect(result.created).toBe(true);
+      expect(result.edge.type).toBe('spouse');
+      expect(result.edge.temporal.confidence).toBe(0.8);
+    });
+
+    it('confirms an existing edge when called again with same direction', async () => {
+      const a = await entityMemory.createEntity({ type: 'person', label: 'Upsert-C', properties: {}, source: 'test' });
+      const b = await entityMemory.createEntity({ type: 'person', label: 'Upsert-D', properties: {}, source: 'test' });
+      await entityMemory.upsertEdge(a.id, b.id, 'manages', {}, 'test', 0.7);
+
+      const result = await entityMemory.upsertEdge(a.id, b.id, 'manages', {}, 'test', 0.7);
+
+      expect(result.created).toBe(false);
+      // Exactly one edge, not two
+      const queryResult = await entityMemory.query(a.id);
+      expect(queryResult.relationships).toHaveLength(1);
+    });
+
+    it('confirms an existing edge when called with reversed direction (bidirectional check)', async () => {
+      const a = await entityMemory.createEntity({ type: 'person', label: 'Upsert-E', properties: {}, source: 'test' });
+      const b = await entityMemory.createEntity({ type: 'person', label: 'Upsert-F', properties: {}, source: 'test' });
+      await entityMemory.upsertEdge(a.id, b.id, 'spouse', {}, 'test', 0.8);
+
+      // Call with reversed order — should confirm the existing edge, not create a duplicate
+      const result = await entityMemory.upsertEdge(b.id, a.id, 'spouse', {}, 'test', 0.8);
+
+      expect(result.created).toBe(false);
+      const queryResult = await entityMemory.query(a.id);
+      expect(queryResult.relationships).toHaveLength(1);
+    });
+
+    it('raises confidence when re-assertion has higher confidence', async () => {
+      const a = await entityMemory.createEntity({ type: 'person', label: 'Upsert-G', properties: {}, source: 'test' });
+      const b = await entityMemory.createEntity({ type: 'person', label: 'Upsert-H', properties: {}, source: 'test' });
+      await entityMemory.upsertEdge(a.id, b.id, 'reports_to', {}, 'test', 0.6);
+
+      const result = await entityMemory.upsertEdge(a.id, b.id, 'reports_to', {}, 'test', 0.9);
+
+      expect(result.created).toBe(false);
+      expect(result.edge.temporal.confidence).toBe(0.9);
+    });
+
+    it('does not lower confidence when re-assertion has lower confidence', async () => {
+      const a = await entityMemory.createEntity({ type: 'person', label: 'Upsert-I', properties: {}, source: 'test' });
+      const b = await entityMemory.createEntity({ type: 'person', label: 'Upsert-J', properties: {}, source: 'test' });
+      await entityMemory.upsertEdge(a.id, b.id, 'sibling', {}, 'test', 0.9);
+
+      const result = await entityMemory.upsertEdge(a.id, b.id, 'sibling', {}, 'test', 0.3);
+
+      expect(result.created).toBe(false);
+      // Confidence stays at 0.9, not lowered to 0.3
+      expect(result.edge.temporal.confidence).toBe(0.9);
+    });
+
+    it('refreshes lastConfirmedAt on re-assertion', async () => {
+      const a = await entityMemory.createEntity({ type: 'person', label: 'Upsert-K', properties: {}, source: 'test' });
+      const b = await entityMemory.createEntity({ type: 'person', label: 'Upsert-L', properties: {}, source: 'test' });
+      const first = await entityMemory.upsertEdge(a.id, b.id, 'advises', {}, 'test', 0.7);
+      const firstConfirmedAt = first.edge.temporal.lastConfirmedAt;
+
+      // Small delay to ensure timestamp differs
+      await new Promise(resolve => setTimeout(resolve, 5));
+      const second = await entityMemory.upsertEdge(a.id, b.id, 'advises', {}, 'test', 0.7);
+
+      expect(second.edge.temporal.lastConfirmedAt.getTime()).toBeGreaterThanOrEqual(firstConfirmedAt.getTime());
+    });
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['tests/**/*.test.ts', 'src/**/*.test.ts'],
+    include: ['tests/**/*.test.ts', 'src/**/*.test.ts', 'skills/**/*.test.ts'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## **User description**
## Summary

- **`extract-relationships` skill** — self-classifying two-stage LLM pipeline (haiku classifier gate + sonnet extractor) that extracts entity-to-entity relationship triples from text and persists them to the knowledge graph. The coordinator calls it after every message; the internal classifier exits in ~10 tokens on messages with no relationships.
- **12 new `EDGE_TYPES`** — personal (spouse, parent, child, sibling), professional (reports_to, manages, collaborates_with, advises, represents), and organisational (member_of, founded, invested_in), extending the existing 7.
- **`EntityMemory.upsertEdge()`** — idempotent edge persistence with bidirectional duplicate detection; confidence only increases on re-assertion, never decreases.
- **`EntityMemory.createEntity()` confidence option** — new nodes discovered during extraction are seeded with confidence 0.6 (lower than manually confirmed entities).
- **Coordinator instruction** — coordinator always calls `extract-relationships`; the skill handles the no-op case internally so the coordinator prompt stays unconditional.

Closes #128

## Test Plan

- [x] 6 handler unit tests: classifier gate (exits early), single extraction, idempotency (re-assertion confirms, doesn't duplicate), new node creation (confidence 0.6), acceptance criterion (`"Xiaopu Fung is Joseph's wife"` → spouse edge), unknown predicate fallback → `relates_to`
- [x] 6 `upsertEdge` unit tests: new edge, same-direction idempotency, reversed-direction idempotency, confidence raised, confidence not lowered, `lastConfirmedAt` refreshed
- [x] Integration test: real Postgres + mock Anthropic — creates spouse edge, round-trips via `EntityContextAssembler` returning `EntityRelationship` with `.type === 'spouse'` and `.relatedEntityLabel === 'Xiaopu Fung'`; idempotency verified with `COUNT(*) = 1`
- [x] Full test suite: 741 tests passing


___

## **CodeAnt-AI Description**
**Extract relationship edges from messages and add them to the knowledge graph**

### What Changed
- Added a new relationship-extraction skill that scans each message, skips unrelated text, and turns stated relationships into graph edges.
- Expanded the relationship vocabulary to cover family, work, and organization links such as spouse, reports_to, and member_of.
- When a relationship is seen again, the existing edge is confirmed instead of duplicated, and its confidence can increase.
- New entities found during extraction are created with lower confidence so they can be refined later.
- Updated the coordinator to call relationship extraction after every message, so relevant links are captured automatically.
- Added unit and integration tests covering skipped messages, new edge creation, repeated confirmations, fallback handling, and the full database round trip.

### Impact
`✅ More relationships captured from chat`
`✅ Fewer duplicate edges in the knowledge graph`
`✅ Richer entity context on later turns`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
