### PR TITLE
Warn when an agent's pinned skill is missing from the registry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -491,6 +491,14 @@ async function main(): Promise<void> {
   for (const agentConfig of agentConfigs) {
     // Build tool definitions from pinned skills
     const agentPinnedSkills = agentConfig.pinned_skills ?? [];
+    for (const skillName of agentPinnedSkills) {
+      if (!skillRegistry.get(skillName)) {
+        logger.warn(
+          { agent: agentConfig.name, skill: skillName },
+          'Pinned skill not found in registry; skipping tool definition',
+        );
+      }
+    }
     const agentToolDefs = skillRegistry.toToolDefinitions(agentPinnedSkills);
 
     // For the coordinator, interpolate runtime context (specialist list, agent contact ID).


### PR DESCRIPTION
## **User description**
### Motivation
- Avoid silent failures when an agent references a pinned skill that isn't registered by emitting a warning so misconfigurations can be detected during startup.

### Description
- Add a pre-check that iterates `agentConfig.pinned_skills` before calling `skillRegistry.toToolDefinitions()` and logs `logger.warn` with `{ agent, skill }` when `skillRegistry.get(skillName)` returns falsy, otherwise behavior is unchanged.

### Testing
- Ran the automated test suite with `npm test` and the linter via `npm run lint`, and both completed successfully.

------
Fixes #https://github.com/josephfung/curia/issues/97
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2f131c72c832389d794a89f641082)


___

## **CodeAnt-AI Description**
Warn when an agent uses a pinned skill that is not registered

### What Changed
- Startup now logs a warning for each pinned skill that cannot be found in the skill registry
- The warning includes the agent name and missing skill so misconfigurations are easier to spot
- Existing behavior for valid skills stays the same

### Impact
`✅ Clearer startup warnings`
`✅ Faster detection of missing skills`
`✅ Fewer silent agent misconfigurations`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
