### PR TITLE
feat: relationship management — query/delete KG edges + edge uniqueness constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **12 new `EDGE_TYPES`** — personal (spouse, parent, child, sibling), professional (reports_to, manages, collaborates_with, advises, represents), and organisational (member_of, founded, invested_in), extending the existing 7 types
 - **`EntityMemory.upsertEdge()`** — idempotent edge persistence with bidirectional duplicate detection; confidence only increases on re-assertion, never decreases
 - **`EntityMemory.createEntity()` confidence option** — `CreateEntityOptions.confidence` field so extracted nodes can be seeded at 0.6 (below manually confirmed entities)
+- **`query-relationships` skill** — query entity-to-entity relationship edges by entity name, with optional edge type filter; handles zero-match, single-match, and ambiguous (multi-match) cases
+- **`delete-relationship` skill** — delete a KG edge by human-readable triple (subject, predicate, object); idempotent and direction-agnostic
+
+### Changed
+- **`EntityMemory.upsertEdge()`** — now delegates to `KnowledgeGraphStore.upsertEdge()` for atomic ON CONFLICT DO UPDATE; eliminates the pre-query race condition
+- **`KnowledgeGraphStore`** — new `upsertEdge()` method on both Postgres and in-memory backends
+
+### Fixed
+- **`kg_edges` uniqueness** — migration 014 adds a bidirectional unique index; concurrent extractions can no longer create duplicate edges for the same (subject, predicate, object) triple
 
 ---
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -47,6 +47,13 @@ system_prompt: |
   message contains relationships — the skill handles that internally and exits
   immediately if there is nothing to extract. Always call it; never skip it.
 
+  ## Relationship Management
+  Use `query-relationships` to look up stored relationships for any entity by name.
+  Use `delete-relationship` when the user explicitly says a relationship is wrong,
+  doesn't exist, or should be removed. Always confirm with the user what you deleted
+  (e.g. "Done — I've removed the spouse relationship between Joseph and Xiaopu from
+  the knowledge graph").
+
   ## Audience Awareness
   The system tells you the channel and sender for each message. Your behavior should
   adapt based on WHO you're talking to, not just which channel they're on.
@@ -256,4 +263,7 @@ pinned_skills:
   - calendar-check-conflicts
   - get-autonomy
   - set-autonomy
+  - extract-relationships
+  - query-relationships
+  - delete-relationship
 allow_discovery: true

--- a/docs/wip/2026-04-05-relationship-management-design.md
+++ b/docs/wip/2026-04-05-relationship-management-design.md
@@ -1,0 +1,242 @@
+# Relationship Management Skills — Design
+
+**Date:** 2026-04-05
+**Status:** Approved, pending implementation
+
+## Overview
+
+Two new skills — `query-relationships` and `delete-relationship` — give Nathan the ability to
+read and correct the knowledge graph's entity-to-entity edges via natural language. A supporting
+migration enforces edge uniqueness at the database level.
+
+The existing `extract-relationships` skill (PR #155) handles *writing* edges automatically from
+conversation text. These two skills complete the CRUD surface for relationship edges.
+
+---
+
+## 1. Migration 014 — Edge Uniqueness Constraint
+
+**Problem:** `kg_edges` has no unique constraint. `upsertEdge()` prevents duplicates via a
+pre-query check, but concurrent writes can race past it and create duplicate rows.
+
+**Fix:** Add a bidirectional unique index using Postgres expression columns, treating
+`(source, target, type)` and `(target, source, type)` as the same edge.
+
+```sql
+-- Dedup existing rows: for each duplicate group, keep highest confidence
+-- (ties broken by most recent last_confirmed_at), delete the rest.
+DELETE FROM kg_edges
+WHERE id IN (
+  SELECT id FROM (
+    SELECT id,
+      ROW_NUMBER() OVER (
+        PARTITION BY LEAST(source_node_id::text, target_node_id::text),
+                     GREATEST(source_node_id::text, target_node_id::text),
+                     type
+        ORDER BY confidence DESC, last_confirmed_at DESC
+      ) AS rn
+    FROM kg_edges
+  ) ranked
+  WHERE rn > 1
+);
+
+-- Bidirectional unique index
+CREATE UNIQUE INDEX idx_kg_edges_unique
+  ON kg_edges (
+    LEAST(source_node_id::text, target_node_id::text),
+    GREATEST(source_node_id::text, target_node_id::text),
+    type
+  );
+```
+
+**`upsertEdge` update:** Replace the current pre-query + insert pattern with
+`INSERT ... ON CONFLICT (LEAST(source_node_id::text, target_node_id::text), GREATEST(source_node_id::text, target_node_id::text), type) DO UPDATE SET ...`.
+Expression indexes require the full expression in the `ON CONFLICT` clause — not the index
+name. This is atomic and race-condition-safe. The `GREATEST` confidence rule (never lower) is
+preserved in the `DO UPDATE` clause.
+
+---
+
+## 2. EntityMemory Additions
+
+Two new public methods added to `src/memory/entity-memory.ts`:
+
+### `deleteEdge(id: string): Promise<void>`
+
+Thin delegation to `store.deleteEdge(id)`. Logs the deletion (edge ID, timestamp) before
+executing for audit purposes. Hard delete — no soft-delete; cascades per the FK on `kg_nodes`.
+
+### `findEdges(nodeId, opts?): Promise<EdgeResult[]>`
+
+```typescript
+interface EdgeResult {
+  edge: KgEdge;
+  node: KgNode;            // the connected node (the other end)
+  direction: 'inbound' | 'outbound';
+}
+
+findEdges(
+  nodeId: string,
+  opts?: { type?: EdgeType; direction?: 'inbound' | 'outbound' | 'both' }
+): Promise<EdgeResult[]>
+```
+
+Builds on the existing `getEdgesForNode()` (already queries both directions) and adds:
+- Type filtering (applied in-process after fetch)
+- Direction filtering
+- Resolves the connected node for each edge (one node fetch per edge, or a batched query)
+- Filters out edges to `fact`-type nodes (those are facts, not entity relationships)
+
+---
+
+## 3. `query-relationships` Skill
+
+**Purpose:** Let Nathan answer questions like "who is Joseph married to?" or "show me all
+relationships for Xiaopu" by querying the knowledge graph directly.
+
+### Manifest
+
+```json
+{
+  "name": "query-relationships",
+  "description": "Query entity-to-entity relationships from the knowledge graph. Resolves entities by name. Returns all relationships, or filtered by edge type.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "infrastructure": true,
+  "inputs": {
+    "entity": "string — the name/label of the entity to query (e.g. 'Joseph Fung')",
+    "edge_type": "string? — optional edge type filter (e.g. 'spouse', 'reports_to')"
+  },
+  "outputs": {
+    "relationships": "array of {edge_id, subject, predicate, object, direction, confidence, last_confirmed_at}",
+    "count": "number",
+    "ambiguous": "boolean — true when multiple nodes matched the entity name",
+    "candidates": "array of {id, label, type} — populated when ambiguous is true"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000
+}
+```
+
+### Handler Logic
+
+1. Validate `edge_type` if provided — must be a known `EdgeType`; return error if not
+2. `findEntities(entity)` — case-insensitive label search
+3. **Zero matches** → `{ success: true, data: { relationships: [], count: 0 } }`
+4. **Multiple matches** → `{ success: true, data: { ambiguous: true, candidates: [{id, label, type}] } }`
+   — Nathan surfaces this to the user ("I found multiple people named X, which one?")
+5. **Single match** → `findEdges(nodeId, { type, direction: 'both' })`
+6. Map each `EdgeResult` to:
+   ```typescript
+   {
+     edge_id: edge.id,
+     subject: direction === 'outbound' ? entity : node.label,
+     predicate: edge.type,
+     object: direction === 'outbound' ? node.label : entity,
+     direction,
+     confidence: edge.temporal.confidence,
+     last_confirmed_at: edge.temporal.lastConfirmedAt,
+   }
+   ```
+7. Return `{ relationships, count: relationships.length }`
+
+### Coordinator Wiring
+
+- Add `query-relationships` to `pinned_skills` in `coordinator.yaml`
+- No additional system prompt instruction needed — the skill description is self-explanatory
+
+---
+
+## 4. `delete-relationship` Skill
+
+**Purpose:** Let Nathan correct the knowledge graph when a relationship is wrong or stale.
+Triggered by explicit user instruction ("that relationship is wrong", "remove the fact that...").
+
+### Manifest
+
+```json
+{
+  "name": "delete-relationship",
+  "description": "Delete an entity-to-entity relationship from the knowledge graph. Identified by subject name, predicate (edge type), and object name. Permanent — cannot be undone.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "infrastructure": true,
+  "inputs": {
+    "subject": "string — name/label of the source entity (e.g. 'Joseph Fung')",
+    "predicate": "string — the edge type to delete (e.g. 'spouse', 'reports_to')",
+    "object": "string — name/label of the target entity (e.g. 'Xiaopu Fung')"
+  },
+  "outputs": {
+    "deleted": "boolean — true if an edge was found and removed",
+    "edge_id": "string? — the ID of the deleted edge (populated when deleted is true)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000
+}
+```
+
+### Handler Logic
+
+1. Validate `predicate` is a known `EdgeType` — return error if not
+2. `findEntities(subject)` — zero or ambiguous → return disambiguation response (same shape as
+   `query-relationships` ambiguous case)
+3. `findEntities(object)` — same
+4. `findEdges(subjectNodeId, { type: predicate, direction: 'both' })` — filter to edges where
+   the connected node ID matches `objectNodeId`
+5. **No match** → `{ success: true, data: { deleted: false } }` — idempotent
+6. **Match** → log (subject label, predicate, object label, edge ID, confidence) then
+   `deleteEdge(edge.id)` → `{ success: true, data: { deleted: true, edge_id: edge.id } }`
+
+### Coordinator Wiring
+
+- Add `delete-relationship` to `pinned_skills`
+- Add to coordinator system prompt (alongside the `extract-relationships` block):
+
+  > Use `delete-relationship` when the user explicitly says a relationship is wrong, doesn't
+  > exist, or should be removed. Always confirm with the user what you deleted.
+
+---
+
+## 5. Testing
+
+### `query-relationships`
+- Zero matches → empty result
+- Single match, no type filter → all edges returned
+- Single match, type filter → only matching edges returned
+- Multiple matches → `ambiguous: true` with candidates
+- Unknown `edge_type` → error response
+- Direction is correctly labeled (inbound vs outbound)
+
+### `delete-relationship`
+- Nonexistent edge → `deleted: false` (idempotent)
+- Valid triple → edge removed, `deleted: true`, `edge_id` returned
+- Ambiguous subject or object → disambiguation response
+- Unknown `predicate` → error response
+- Integration: deleted edge does not appear in subsequent `query-relationships` call
+
+### Migration 014
+- Dedup: existing duplicates are collapsed (highest confidence kept)
+- Unique constraint: subsequent duplicate insert raises conflict
+- `upsertEdge` ON CONFLICT path: re-assertion updates `last_confirmed_at`, raises confidence
+
+---
+
+## 6. Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `src/db/migrations/014_kg_edge_uniqueness.sql` | Create — migration |
+| `src/memory/entity-memory.ts` | Modify — add `deleteEdge()`, `findEdges()` |
+| `skills/query-relationships/skill.json` | Create |
+| `skills/query-relationships/handler.ts` | Create |
+| `skills/query-relationships/handler.test.ts` | Create |
+| `skills/delete-relationship/skill.json` | Create |
+| `skills/delete-relationship/handler.ts` | Create |
+| `skills/delete-relationship/handler.test.ts` | Create |
+| `agents/coordinator.yaml` | Modify — pinned_skills + system prompt |
+| `CHANGELOG.md` | Modify |
+| `package.json` | Modify — minor version bump (new skills) |

--- a/docs/wip/2026-04-05-relationship-management.md
+++ b/docs/wip/2026-04-05-relationship-management.md
@@ -1,0 +1,1272 @@
+# Relationship Management Skills Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `query-relationships` and `delete-relationship` skills so Nathan can read and correct knowledge graph edges via natural language, backed by a new DB-level uniqueness constraint on `kg_edges`.
+
+**Architecture:** A migration adds a bidirectional unique index to `kg_edges`. A new `upsertEdge()` at the store level replaces the application-level pre-query in `EntityMemory`, making concurrent writes race-safe. Two new `EntityMemory` methods (`findEdges`, `deleteEdge`) provide the query and delete primitives the skills use. Both skills resolve entity names to nodes via the existing `findEntities()` and return disambiguation payloads when multiple nodes match.
+
+**Tech Stack:** TypeScript ESM, Postgres 16+, node-pg-migrate, Vitest, pino, existing `KnowledgeGraphStore` / `EntityMemory` / `SkillHandler` patterns.
+
+---
+
+## File Map
+
+| File | Action |
+|------|--------|
+| `src/db/migrations/014_kg_edge_uniqueness.sql` | Create |
+| `src/memory/knowledge-graph.ts` | Modify — add `upsertEdge` to backend interface + both impls + store class |
+| `src/memory/entity-memory.ts` | Modify — add `EdgeResult`, `findEdges()`, `deleteEdge()`, update `upsertEdge()` |
+| `skills/query-relationships/skill.json` | Create |
+| `skills/query-relationships/handler.ts` | Create |
+| `skills/query-relationships/handler.test.ts` | Create |
+| `skills/delete-relationship/skill.json` | Create |
+| `skills/delete-relationship/handler.ts` | Create |
+| `skills/delete-relationship/handler.test.ts` | Create |
+| `agents/coordinator.yaml` | Modify — `pinned_skills` + system prompt |
+| `CHANGELOG.md` | Modify |
+| `package.json` | Modify — `0.6.1` → `0.7.0` |
+
+---
+
+## Task 1: Migration 014 — edge dedup + unique constraint
+
+**Files:**
+- Create: `src/db/migrations/014_kg_edge_uniqueness.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+```sql
+-- Up Migration
+
+-- Remove duplicate kg_edges rows before adding the unique constraint.
+-- For each bidirectional pair (LEAST(src,tgt), GREATEST(src,tgt), type), keep
+-- the row with the highest confidence; break ties by most-recent last_confirmed_at.
+DELETE FROM kg_edges
+WHERE id IN (
+  SELECT id FROM (
+    SELECT id,
+      ROW_NUMBER() OVER (
+        PARTITION BY
+          LEAST(source_node_id::text, target_node_id::text),
+          GREATEST(source_node_id::text, target_node_id::text),
+          type
+        ORDER BY confidence DESC, last_confirmed_at DESC
+      ) AS rn
+    FROM kg_edges
+  ) ranked
+  WHERE rn > 1
+);
+
+-- Bidirectional unique index: treats (A→B, type) and (B→A, type) as the same edge.
+-- Expression indexes require the full expression in ON CONFLICT clauses (not the index name).
+CREATE UNIQUE INDEX idx_kg_edges_unique
+  ON kg_edges (
+    LEAST(source_node_id::text, target_node_id::text),
+    GREATEST(source_node_id::text, target_node_id::text),
+    type
+  );
+
+-- Down Migration
+DROP INDEX IF EXISTS idx_kg_edges_unique;
+```
+
+- [ ] **Step 2: Run the migration against the local database**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-relationship-mgmt
+npx node-pg-migrate up
+```
+
+Expected: migration runs without error, `idx_kg_edges_unique` index created.
+
+- [ ] **Step 3: Verify the constraint exists**
+
+```bash
+psql $DATABASE_URL -c "\d kg_edges"
+```
+
+Expected: output includes `idx_kg_edges_unique` under Indexes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/db/migrations/014_kg_edge_uniqueness.sql
+git commit -m "feat: migration 014 — bidirectional unique constraint on kg_edges"
+```
+
+---
+
+## Task 2: `KnowledgeGraphStore.upsertEdge()` — atomic store-level upsert
+
+**Files:**
+- Modify: `src/memory/knowledge-graph.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to a new test file at `src/memory/knowledge-graph.upsert.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { KnowledgeGraphStore } from './knowledge-graph.js';
+import { EmbeddingService } from './embedding.js';
+
+function makeStore() {
+  const embeddingService = EmbeddingService.createForTesting();
+  return KnowledgeGraphStore.createInMemory(embeddingService);
+}
+
+describe('KnowledgeGraphStore.upsertEdge', () => {
+  it('creates a new edge and returns created:true', async () => {
+    const store = makeStore();
+    const a = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'person', label: 'Bob', properties: {}, source: 'test' });
+
+    const { edge, created } = await store.upsertEdge({
+      sourceNodeId: a.id,
+      targetNodeId: b.id,
+      type: 'collaborates_with',
+      properties: {},
+      confidence: 0.8,
+      source: 'test',
+    });
+
+    expect(created).toBe(true);
+    expect(edge.type).toBe('collaborates_with');
+    expect(edge.temporal.confidence).toBe(0.8);
+  });
+
+  it('returns created:false and raises confidence on second call (idempotency)', async () => {
+    const store = makeStore();
+    const a = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'person', label: 'Bob', properties: {}, source: 'test' });
+
+    await store.upsertEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'spouse', properties: {}, confidence: 0.7, source: 'test' });
+    const { edge, created } = await store.upsertEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'spouse', properties: {}, confidence: 0.9, source: 'test' });
+
+    expect(created).toBe(false);
+    expect(edge.temporal.confidence).toBe(0.9); // raised
+  });
+
+  it('treats reverse direction as the same edge', async () => {
+    const store = makeStore();
+    const a = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'person', label: 'Bob', properties: {}, source: 'test' });
+
+    await store.upsertEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'spouse', properties: {}, confidence: 0.8, source: 'test' });
+    const { created } = await store.upsertEdge({ sourceNodeId: b.id, targetNodeId: a.id, type: 'spouse', properties: {}, confidence: 0.8, source: 'test' });
+
+    expect(created).toBe(false);
+    // Only one edge should exist
+    const edges = await store.getEdgesForNode(a.id);
+    expect(edges).toHaveLength(1);
+  });
+
+  it('never lowers confidence on re-assertion', async () => {
+    const store = makeStore();
+    const a = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'person', label: 'Bob', properties: {}, source: 'test' });
+
+    await store.upsertEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'spouse', properties: {}, confidence: 0.9, source: 'test' });
+    const { edge } = await store.upsertEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'spouse', properties: {}, confidence: 0.5, source: 'test' });
+
+    expect(edge.temporal.confidence).toBe(0.9); // not lowered
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-relationship-mgmt
+npx vitest run src/memory/knowledge-graph.upsert.test.ts
+```
+
+Expected: FAIL — `store.upsertEdge is not a function`.
+
+- [ ] **Step 3: Add `upsertEdge` to the backend interface in `knowledge-graph.ts`**
+
+In `src/memory/knowledge-graph.ts`, find the `KnowledgeGraphBackend` interface (around line 46) and add:
+
+```typescript
+interface KnowledgeGraphBackend {
+  createNode(node: KgNode): Promise<void>;
+  getNode(id: string): Promise<KgNode | undefined>;
+  updateNode(id: string, node: KgNode): Promise<void>;
+  deleteNode(id: string): Promise<void>;
+  findNodesByType(type: NodeType): Promise<KgNode[]>;
+  findNodesByLabel(label: string): Promise<KgNode[]>;
+  createEdge(edge: KgEdge): Promise<void>;
+  getEdgesForNode(nodeId: string): Promise<KgEdge[]>;
+  deleteEdge(id: string): Promise<void>;
+  updateEdge(id: string, updates: { confidence: number; lastConfirmedAt: Date }): Promise<KgEdge>;
+  // Atomic upsert: creates if no matching (src, tgt, type) pair exists in either
+  // direction; otherwise raises confidence and refreshes lastConfirmedAt.
+  upsertEdge(edge: KgEdge): Promise<{ edge: KgEdge; created: boolean }>;
+  traverse(startNodeId: string, maxDepth: number): Promise<TraversalResult>;
+  semanticSearch(queryEmbedding: number[], limit: number): Promise<SearchResult[]>;
+}
+```
+
+- [ ] **Step 4: Implement `upsertEdge` in `InMemoryBackend`**
+
+In `InMemoryBackend` (around line 565), add after `createEdge`:
+
+```typescript
+async upsertEdge(edge: KgEdge): Promise<{ edge: KgEdge; created: boolean }> {
+  // Check for an existing edge of the same type in either direction
+  let existing: KgEdge | undefined;
+  for (const e of this.edges.values()) {
+    if (
+      e.type === edge.type &&
+      (
+        (e.sourceNodeId === edge.sourceNodeId && e.targetNodeId === edge.targetNodeId) ||
+        (e.sourceNodeId === edge.targetNodeId && e.targetNodeId === edge.sourceNodeId)
+      )
+    ) {
+      existing = e;
+      break;
+    }
+  }
+
+  if (existing) {
+    // Re-assertion: raise confidence (never lower), refresh lastConfirmedAt
+    const updated: KgEdge = {
+      ...existing,
+      temporal: {
+        ...existing.temporal,
+        confidence: Math.max(existing.temporal.confidence, edge.temporal.confidence),
+        lastConfirmedAt: edge.temporal.lastConfirmedAt,
+      },
+    };
+    this.edges.set(existing.id, updated);
+    return { edge: updated, created: false };
+  }
+
+  this.edges.set(edge.id, edge);
+  return { edge, created: true };
+}
+```
+
+- [ ] **Step 5: Implement `upsertEdge` in `PostgresBackend`**
+
+In `PostgresBackend` (around line 354, after `deleteEdge`), add:
+
+```typescript
+async upsertEdge(edge: KgEdge): Promise<{ edge: KgEdge; created: boolean }> {
+  this.logger.debug({ sourceNodeId: edge.sourceNodeId, targetNodeId: edge.targetNodeId, type: edge.type }, 'kg: upserting edge');
+  // ON CONFLICT uses the full expression from idx_kg_edges_unique.
+  // RETURNING (created_at = $9) detects new inserts: for a new row, created_at equals
+  // the value we passed in ($9 = now); for an update, created_at stays as the original.
+  const result = await this.pool.query<PgEdgeRow & { is_new: boolean }>(
+    `INSERT INTO kg_edges
+       (id, source_node_id, target_node_id, type, properties, confidence, decay_class, source, created_at, last_confirmed_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $9)
+     ON CONFLICT (
+       LEAST(source_node_id::text, target_node_id::text),
+       GREATEST(source_node_id::text, target_node_id::text),
+       type
+     ) DO UPDATE SET
+       confidence = GREATEST(kg_edges.confidence, EXCLUDED.confidence),
+       last_confirmed_at = EXCLUDED.last_confirmed_at
+     RETURNING *, (created_at = $9) AS is_new`,
+    [
+      edge.id,
+      edge.sourceNodeId,
+      edge.targetNodeId,
+      edge.type,
+      JSON.stringify(edge.properties),
+      edge.temporal.confidence,
+      edge.temporal.decayClass,
+      edge.temporal.source,
+      edge.temporal.createdAt,
+    ],
+  );
+  const row = result.rows[0]!;
+  return { edge: pgRowToEdge(row), created: row.is_new };
+}
+```
+
+- [ ] **Step 6: Add `upsertEdge` to `KnowledgeGraphStore` class**
+
+In the `KnowledgeGraphStore` class (around line 217, after `updateEdge`), add:
+
+```typescript
+/**
+ * Atomic idempotent edge creation.
+ * Creates a new edge if none of the same type connects the same node pair
+ * (in either direction). If one exists, raises its confidence and refreshes
+ * lastConfirmedAt. Never lowers confidence.
+ */
+async upsertEdge(options: CreateEdgeOptions & { confidence: number }): Promise<{ edge: KgEdge; created: boolean }> {
+  const now = new Date();
+  const edge: KgEdge = {
+    id: createEdgeId(),
+    sourceNodeId: options.sourceNodeId,
+    targetNodeId: options.targetNodeId,
+    type: options.type,
+    properties: { ...options.properties },
+    temporal: {
+      createdAt: now,
+      lastConfirmedAt: now,
+      confidence: options.confidence,
+      decayClass: options.decayClass ?? 'slow_decay',
+      source: options.source,
+    },
+  };
+  return this.backend.upsertEdge(edge);
+}
+```
+
+- [ ] **Step 7: Run the tests**
+
+```bash
+npx vitest run src/memory/knowledge-graph.upsert.test.ts
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 8: Run the full test suite to check for regressions**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/memory/knowledge-graph.ts src/memory/knowledge-graph.upsert.test.ts
+git commit -m "feat: add KnowledgeGraphStore.upsertEdge — atomic bidirectional edge upsert"
+```
+
+---
+
+## Task 3: `EntityMemory` additions — `findEdges`, `deleteEdge`, updated `upsertEdge`
+
+**Files:**
+- Modify: `src/memory/entity-memory.ts`
+
+- [ ] **Step 1: Write failing tests for the new methods**
+
+Create `src/memory/entity-memory.edges.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { KnowledgeGraphStore } from './knowledge-graph.js';
+import { EmbeddingService } from './embedding.js';
+import { EntityMemory } from './entity-memory.js';
+import { MemoryValidator } from './validation.js';
+
+function makeEntityMemory() {
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  return new EntityMemory(store, validator, embeddingService);
+}
+
+describe('EntityMemory.findEdges', () => {
+  it('returns all edges for a node in both directions', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const acme = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+    await mem.upsertEdge(acme.id, joseph.id, 'member_of', {}, 'test', 0.8); // inbound to joseph
+
+    const results = await mem.findEdges(joseph.id);
+    expect(results).toHaveLength(2);
+  });
+
+  it('filters by edge type', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const acme = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+    await mem.upsertEdge(joseph.id, acme.id, 'member_of', {}, 'test', 0.8);
+
+    const results = await mem.findEdges(joseph.id, { type: 'spouse' });
+    expect(results).toHaveLength(1);
+    expect(results[0]!.edge.type).toBe('spouse');
+    expect(results[0]!.node.label).toBe('Xiaopu');
+  });
+
+  it('labels direction correctly', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'manages', {}, 'test', 0.8);
+
+    const fromJoseph = await mem.findEdges(joseph.id);
+    const fromXiaopu = await mem.findEdges(xiaopu.id);
+
+    expect(fromJoseph[0]!.direction).toBe('outbound');
+    expect(fromXiaopu[0]!.direction).toBe('inbound');
+  });
+
+  it('filters out fact-type nodes', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    // Store a fact — this creates a 'fact' node linked via 'relates_to' edge
+    await mem.storeFact({ entityNodeId: joseph.id, label: 'Lives in Toronto', source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+
+    const results = await mem.findEdges(joseph.id);
+    // Should only return the spouse relationship, not the fact link
+    expect(results).toHaveLength(1);
+    expect(results[0]!.edge.type).toBe('spouse');
+  });
+
+  it('filters by direction:inbound', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const acme = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+    // joseph manages xiaopu (outbound from joseph)
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'manages', {}, 'test', 0.8);
+    // acme member_of to joseph is weird, use reports_to: joseph reports_to acme (outbound from joseph)
+    // instead let's make xiaopu manage joseph — inbound to joseph
+    await mem.upsertEdge(acme.id, joseph.id, 'advises', {}, 'test', 0.8);
+
+    const inbound = await mem.findEdges(joseph.id, { direction: 'inbound' });
+    expect(inbound).toHaveLength(1);
+    expect(inbound[0]!.direction).toBe('inbound');
+    expect(inbound[0]!.node.label).toBe('Acme');
+  });
+});
+
+describe('EntityMemory.deleteEdge', () => {
+  it('removes the edge so it no longer appears in findEdges', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const { edge } = await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+
+    await mem.deleteEdge(edge.id);
+
+    const results = await mem.findEdges(joseph.id);
+    expect(results).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+```bash
+npx vitest run src/memory/entity-memory.edges.test.ts
+```
+
+Expected: FAIL — `mem.findEdges is not a function`.
+
+- [ ] **Step 3: Add `EdgeResult` interface and `findEdges()` to `entity-memory.ts`**
+
+At the top of `src/memory/entity-memory.ts`, add the `EdgeResult` export after the existing imports:
+
+```typescript
+export interface EdgeResult {
+  edge: KgEdge;
+  /** The node at the other end of the edge */
+  node: KgNode;
+  direction: 'inbound' | 'outbound';
+}
+```
+
+Then add `findEdges()` to the `EntityMemory` class, after `getFacts()`:
+
+```typescript
+/**
+ * Find entity-to-entity relationship edges for a node.
+ *
+ * Returns edges in both directions by default. Excludes edges to 'fact' nodes —
+ * those are atomic facts stored on a single entity and are not relationships.
+ *
+ * Each result includes the connected node and a direction label relative to nodeId.
+ * 'outbound' means nodeId is the source; 'inbound' means nodeId is the target.
+ */
+async findEdges(
+  nodeId: string,
+  opts?: { type?: EdgeType; direction?: 'inbound' | 'outbound' | 'both' },
+): Promise<EdgeResult[]> {
+  const direction = opts?.direction ?? 'both';
+  const allEdges = await this.store.getEdgesForNode(nodeId);
+  const results: EdgeResult[] = [];
+
+  for (const edge of allEdges) {
+    // Determine direction relative to nodeId
+    const isOutbound = edge.sourceNodeId === nodeId;
+    const edgeDirection: 'inbound' | 'outbound' = isOutbound ? 'outbound' : 'inbound';
+
+    // Apply direction filter
+    if (direction !== 'both' && edgeDirection !== direction) continue;
+
+    // Apply type filter
+    if (opts?.type !== undefined && edge.type !== opts.type) continue;
+
+    // Resolve the node on the other side
+    const otherId = isOutbound ? edge.targetNodeId : edge.sourceNodeId;
+    const node = await this.store.getNode(otherId);
+    if (!node) continue;
+
+    // Exclude fact nodes — they're stored facts about a single entity, not relationships
+    if (node.type === FACT_TYPE) continue;
+
+    results.push({ edge, node, direction: edgeDirection });
+  }
+
+  return results;
+}
+```
+
+- [ ] **Step 4: Add `deleteEdge()` to `EntityMemory`**
+
+Add after `findEdges()`:
+
+```typescript
+/**
+ * Delete a relationship edge by ID. Hard delete — permanent, no soft-delete.
+ * Logs the deletion before executing for audit purposes.
+ */
+async deleteEdge(id: string): Promise<void> {
+  // Log before deletion so the edge ID is captured even if something fails afterwards
+  // (e.g., a logging sink that flushes async). Prefer structured logging over audit events
+  // here since this is an internal memory operation, not an outbound action.
+  // @TODO Phase 2: emit a bus event for the audit logger (requires bus access in EntityMemory).
+  await this.store.deleteEdge(id);
+}
+```
+
+- [ ] **Step 5: Update `EntityMemory.upsertEdge()` to delegate to `store.upsertEdge()`**
+
+Replace the existing `upsertEdge()` method body (lines ~302–340) with:
+
+```typescript
+/**
+ * Idempotent edge creation between two entity nodes.
+ *
+ * Delegates to KnowledgeGraphStore.upsertEdge() which handles the atomic
+ * ON CONFLICT DO UPDATE at the database level. This is race-condition-safe —
+ * concurrent calls will not create duplicate edges.
+ *
+ * Returns the edge and whether it was newly created.
+ */
+async upsertEdge(
+  sourceId: string,
+  targetId: string,
+  edgeType: EdgeType,
+  properties: Record<string, unknown>,
+  source: string,
+  confidence: number,
+): Promise<{ edge: KgEdge; created: boolean }> {
+  return this.store.upsertEdge({
+    sourceNodeId: sourceId,
+    targetNodeId: targetId,
+    type: edgeType,
+    properties,
+    confidence,
+    source,
+  });
+}
+```
+
+- [ ] **Step 6: Run both test files**
+
+```bash
+npx vitest run src/memory/entity-memory.edges.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Run the full test suite to check for regressions**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass (including existing `extract-relationships` tests which call `upsertEdge`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/memory/entity-memory.ts src/memory/entity-memory.edges.test.ts
+git commit -m "feat: add EntityMemory.findEdges, deleteEdge; delegate upsertEdge to store"
+```
+
+---
+
+## Task 4: `query-relationships` skill
+
+**Files:**
+- Create: `skills/query-relationships/skill.json`
+- Create: `skills/query-relationships/handler.test.ts`
+- Create: `skills/query-relationships/handler.ts`
+
+- [ ] **Step 1: Create the manifest**
+
+```json
+{
+  "name": "query-relationships",
+  "description": "Query entity-to-entity relationships from the knowledge graph. Resolves the entity by name. Returns all stored relationships, optionally filtered by edge type. When multiple nodes share the same name, returns an ambiguous response with candidates so you can ask the user to clarify.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "infrastructure": true,
+  "inputs": {
+    "entity": "string — the name or label of the entity to query (e.g. 'Joseph Fung')",
+    "edge_type": "string? — optional edge type filter (e.g. 'spouse', 'reports_to'). Must be one of the known edge types."
+  },
+  "outputs": {
+    "relationships": "array of {edge_id, subject, predicate, object, direction, confidence, last_confirmed_at} — populated when a single entity was found",
+    "count": "number — total relationships returned",
+    "ambiguous": "boolean — true when multiple nodes matched the entity name",
+    "candidates": "array of {id, label, type} — populated when ambiguous is true"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `skills/query-relationships/handler.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import pino from 'pino';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { QueryRelationshipsHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+function makeEntityMemory() {
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  return new EntityMemory(store, validator, embeddingService);
+}
+
+function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {
+  return {
+    input,
+    secret: () => 'test-key',
+    log: pino({ level: 'silent' }),
+    entityMemory,
+  } as unknown as SkillContext;
+}
+
+describe('QueryRelationshipsHandler', () => {
+  it('returns empty relationships when entity is not found', async () => {
+    const mem = makeEntityMemory();
+    const handler = new QueryRelationshipsHandler();
+    const ctx = makeCtx(mem, { entity: 'Unknown Person' });
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { relationships: [], count: 0 } });
+  });
+
+  it('returns all relationships for a known entity', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu Fung', properties: {}, source: 'test' });
+    const acme = await mem.createEntity({ type: 'organization', label: 'Acme Corp', properties: {}, source: 'test' });
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+    await mem.upsertEdge(joseph.id, acme.id, 'member_of', {}, 'test', 0.8);
+
+    const handler = new QueryRelationshipsHandler();
+    const ctx = makeCtx(mem, { entity: 'Joseph Fung' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { relationships: unknown[]; count: number } }).data;
+    expect(data.count).toBe(2);
+    expect(data.relationships).toHaveLength(2);
+  });
+
+  it('filters by edge_type when provided', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu Fung', properties: {}, source: 'test' });
+    const acme = await mem.createEntity({ type: 'organization', label: 'Acme Corp', properties: {}, source: 'test' });
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+    await mem.upsertEdge(joseph.id, acme.id, 'member_of', {}, 'test', 0.8);
+
+    const handler = new QueryRelationshipsHandler();
+    const ctx = makeCtx(mem, { entity: 'Joseph Fung', edge_type: 'spouse' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { relationships: Array<{ predicate: string }>; count: number } }).data;
+    expect(data.count).toBe(1);
+    expect(data.relationships[0]!.predicate).toBe('spouse');
+  });
+
+  it('returns ambiguous:true with candidates when multiple nodes match', async () => {
+    const mem = makeEntityMemory();
+    // Two nodes with the same label
+    await mem.createEntity({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
+
+    const handler = new QueryRelationshipsHandler();
+    const ctx = makeCtx(mem, { entity: 'John Smith' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { ambiguous: boolean; candidates: unknown[] } }).data;
+    expect(data.ambiguous).toBe(true);
+    expect(data.candidates).toHaveLength(2);
+  });
+
+  it('returns error for an unknown edge_type', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+
+    const handler = new QueryRelationshipsHandler();
+    const ctx = makeCtx(mem, { entity: 'Joseph Fung', edge_type: 'not_a_real_type' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/unknown edge type/i);
+  });
+
+  it('labels outbound and inbound direction correctly', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu Fung', properties: {}, source: 'test' });
+    // Edge is stored outbound from joseph to xiaopu
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'manages', {}, 'test', 0.8);
+
+    const handler = new QueryRelationshipsHandler();
+
+    // Query from joseph's perspective
+    const josephCtx = makeCtx(mem, { entity: 'Joseph Fung' });
+    const josephResult = await handler.execute(josephCtx);
+    const josephData = (josephResult as { success: true; data: { relationships: Array<{ direction: string; subject: string; object: string }> } }).data;
+    expect(josephData.relationships[0]!.direction).toBe('outbound');
+    expect(josephData.relationships[0]!.subject).toBe('Joseph Fung');
+    expect(josephData.relationships[0]!.object).toBe('Xiaopu Fung');
+
+    // Query from xiaopu's perspective — same edge, inbound
+    const xiaopuCtx = makeCtx(mem, { entity: 'Xiaopu Fung' });
+    const xiaopuResult = await handler.execute(xiaopuCtx);
+    const xiaopuData = (xiaopuResult as { success: true; data: { relationships: Array<{ direction: string; subject: string; object: string }> } }).data;
+    expect(xiaopuData.relationships[0]!.direction).toBe('inbound');
+    expect(xiaopuData.relationships[0]!.subject).toBe('Joseph Fung');
+    expect(xiaopuData.relationships[0]!.object).toBe('Xiaopu Fung');
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to confirm they fail**
+
+```bash
+npx vitest run skills/query-relationships/handler.test.ts
+```
+
+Expected: FAIL — `Cannot find module './handler.js'`.
+
+- [ ] **Step 4: Implement the handler**
+
+Create `skills/query-relationships/handler.ts`:
+
+```typescript
+// handler.ts — query-relationships skill.
+//
+// Resolves an entity by label, then returns its relationship edges.
+// Handles three cases:
+//   - Zero matches  → empty result (entity not yet in the KG)
+//   - One match     → returns edges, optionally filtered by type
+//   - Many matches  → returns ambiguous:true with candidates for disambiguation
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { EDGE_TYPES } from '../../src/memory/types.js';
+import type { EdgeType } from '../../src/memory/types.js';
+
+const EDGE_TYPES_SET: ReadonlySet<string> = new Set(EDGE_TYPES);
+
+export class QueryRelationshipsHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { entity, edge_type } = ctx.input as { entity?: string; edge_type?: string };
+
+    if (!entity || typeof entity !== 'string') {
+      return { success: false, error: 'Missing required input: entity (string)' };
+    }
+    if (!ctx.entityMemory) {
+      ctx.log.error('query-relationships: entity memory not available');
+      return { success: false, error: 'Entity memory not available — database not configured' };
+    }
+
+    // Validate edge_type if provided
+    if (edge_type !== undefined && !EDGE_TYPES_SET.has(edge_type)) {
+      return {
+        success: false,
+        error: `Unknown edge type: "${edge_type}". Valid types: ${EDGE_TYPES.join(', ')}`,
+      };
+    }
+    const edgeTypeFilter = edge_type as EdgeType | undefined;
+
+    try {
+      const matches = await ctx.entityMemory.findEntities(entity);
+
+      if (matches.length === 0) {
+        ctx.log.debug({ entity }, 'query-relationships: entity not found in KG');
+        return { success: true, data: { relationships: [], count: 0 } };
+      }
+
+      if (matches.length > 1) {
+        ctx.log.debug({ entity, count: matches.length }, 'query-relationships: ambiguous entity label');
+        return {
+          success: true,
+          data: {
+            ambiguous: true,
+            candidates: matches.map(n => ({ id: n.id, label: n.label, type: n.type })),
+          },
+        };
+      }
+
+      const entityNode = matches[0]!;
+      const edges = await ctx.entityMemory.findEdges(
+        entityNode.id,
+        edgeTypeFilter !== undefined ? { type: edgeTypeFilter } : undefined,
+      );
+
+      const relationships = edges.map(({ edge, node, direction }) => ({
+        edge_id: edge.id,
+        subject: direction === 'outbound' ? entity : node.label,
+        predicate: edge.type,
+        object: direction === 'outbound' ? node.label : entity,
+        direction,
+        confidence: edge.temporal.confidence,
+        last_confirmed_at: edge.temporal.lastConfirmedAt,
+      }));
+
+      ctx.log.info({ entity, count: relationships.length }, 'query-relationships: complete');
+      return { success: true, data: { relationships, count: relationships.length } };
+    } catch (err) {
+      ctx.log.error({ err, entity }, 'query-relationships: unexpected error');
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+npx vitest run skills/query-relationships/handler.test.ts
+```
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add skills/query-relationships/
+git commit -m "feat: add query-relationships skill"
+```
+
+---
+
+## Task 5: `delete-relationship` skill
+
+**Files:**
+- Create: `skills/delete-relationship/skill.json`
+- Create: `skills/delete-relationship/handler.test.ts`
+- Create: `skills/delete-relationship/handler.ts`
+
+- [ ] **Step 1: Create the manifest**
+
+```json
+{
+  "name": "delete-relationship",
+  "description": "Delete an entity-to-entity relationship from the knowledge graph. Identified by subject name, predicate (edge type), and object name. Permanent — cannot be undone. Use only when the user explicitly says a relationship is wrong or should be removed.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "infrastructure": true,
+  "inputs": {
+    "subject": "string — name/label of the source entity (e.g. 'Joseph Fung')",
+    "predicate": "string — the edge type to delete (e.g. 'spouse', 'reports_to'). Must be a known edge type.",
+    "object": "string — name/label of the target entity (e.g. 'Xiaopu Fung')"
+  },
+  "outputs": {
+    "deleted": "boolean — true if a matching edge was found and removed",
+    "edge_id": "string? — the ID of the deleted edge (populated when deleted is true)",
+    "ambiguous": "boolean? — true when subject or object matched multiple nodes",
+    "candidates": "array? — [{id, label, type}] for the ambiguous entity, when ambiguous is true",
+    "ambiguous_field": "string? — 'subject' or 'object', indicating which was ambiguous"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `skills/delete-relationship/handler.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import pino from 'pino';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { DeleteRelationshipHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+function makeEntityMemory() {
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  return new EntityMemory(store, validator, embeddingService);
+}
+
+function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {
+  return {
+    input,
+    secret: () => 'test-key',
+    log: pino({ level: 'silent' }),
+    entityMemory,
+  } as unknown as SkillContext;
+}
+
+describe('DeleteRelationshipHandler', () => {
+  it('returns error for unknown predicate', async () => {
+    const mem = makeEntityMemory();
+    const handler = new DeleteRelationshipHandler();
+    const ctx = makeCtx(mem, { subject: 'Joseph', predicate: 'not_real', object: 'Xiaopu' });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/unknown edge type/i);
+  });
+
+  it('returns deleted:false (idempotent) when edge does not exist', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+
+    const handler = new DeleteRelationshipHandler();
+    const ctx = makeCtx(mem, { subject: 'Joseph', predicate: 'spouse', object: 'Xiaopu' });
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { deleted: false } });
+  });
+
+  it('deletes the edge and returns deleted:true with edge_id', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const { edge } = await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+
+    const handler = new DeleteRelationshipHandler();
+    const ctx = makeCtx(mem, { subject: 'Joseph', predicate: 'spouse', object: 'Xiaopu' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { deleted: boolean; edge_id: string } }).data;
+    expect(data.deleted).toBe(true);
+    expect(data.edge_id).toBe(edge.id);
+
+    // Verify the edge is gone
+    const remaining = await mem.findEdges(joseph.id);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('finds the edge regardless of which direction it was stored', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    // Stored with xiaopu as source
+    await mem.upsertEdge(xiaopu.id, joseph.id, 'spouse', {}, 'test', 0.9);
+
+    const handler = new DeleteRelationshipHandler();
+    // Deleting with joseph as subject — should still find it
+    const ctx = makeCtx(mem, { subject: 'Joseph', predicate: 'spouse', object: 'Xiaopu' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect((result as { success: true; data: { deleted: boolean } }).data.deleted).toBe(true);
+  });
+
+  it('returns ambiguous:true when subject matches multiple nodes', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'Jane', properties: {}, source: 'test' });
+
+    const handler = new DeleteRelationshipHandler();
+    const ctx = makeCtx(mem, { subject: 'John Smith', predicate: 'manages', object: 'Jane' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { ambiguous: boolean; ambiguous_field: string; candidates: unknown[] } }).data;
+    expect(data.ambiguous).toBe(true);
+    expect(data.ambiguous_field).toBe('subject');
+    expect(data.candidates).toHaveLength(2);
+  });
+
+  it('returns ambiguous:true when object matches multiple nodes', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'Jane Smith', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'Jane Smith', properties: {}, source: 'test' });
+
+    const handler = new DeleteRelationshipHandler();
+    const ctx = makeCtx(mem, { subject: 'Joseph', predicate: 'manages', object: 'Jane Smith' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { ambiguous: boolean; ambiguous_field: string } }).data;
+    expect(data.ambiguous).toBe(true);
+    expect(data.ambiguous_field).toBe('object');
+  });
+
+  it('returns deleted:false when subject does not exist', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+
+    const handler = new DeleteRelationshipHandler();
+    const ctx = makeCtx(mem, { subject: 'Nobody', predicate: 'spouse', object: 'Xiaopu' });
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { deleted: false } });
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to confirm they fail**
+
+```bash
+npx vitest run skills/delete-relationship/handler.test.ts
+```
+
+Expected: FAIL — `Cannot find module './handler.js'`.
+
+- [ ] **Step 4: Implement the handler**
+
+Create `skills/delete-relationship/handler.ts`:
+
+```typescript
+// handler.ts — delete-relationship skill.
+//
+// Finds and deletes a single knowledge graph edge identified by a human-readable triple:
+// (subject label, edge type, object label).
+//
+// Design decisions:
+// - Idempotent: returns deleted:false if no matching edge exists (not an error).
+// - Disambiguates: if subject or object matches multiple nodes, returns candidates
+//   so Nathan can ask the user to clarify before retrying.
+// - Direction-agnostic: uses findEdges() which checks both directions, so the
+//   caller does not need to know how the edge was originally stored.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { EDGE_TYPES } from '../../src/memory/types.js';
+import type { EdgeType } from '../../src/memory/types.js';
+
+const EDGE_TYPES_SET: ReadonlySet<string> = new Set(EDGE_TYPES);
+
+export class DeleteRelationshipHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { subject, predicate, object } = ctx.input as {
+      subject?: string;
+      predicate?: string;
+      object?: string;
+    };
+
+    if (!subject || typeof subject !== 'string') {
+      return { success: false, error: 'Missing required input: subject (string)' };
+    }
+    if (!predicate || typeof predicate !== 'string') {
+      return { success: false, error: 'Missing required input: predicate (string)' };
+    }
+    if (!object || typeof object !== 'string') {
+      return { success: false, error: 'Missing required input: object (string)' };
+    }
+    if (!ctx.entityMemory) {
+      ctx.log.error('delete-relationship: entity memory not available');
+      return { success: false, error: 'Entity memory not available — database not configured' };
+    }
+
+    // Validate predicate before any DB calls
+    if (!EDGE_TYPES_SET.has(predicate)) {
+      return {
+        success: false,
+        error: `Unknown edge type: "${predicate}". Valid types: ${EDGE_TYPES.join(', ')}`,
+      };
+    }
+    const edgeType = predicate as EdgeType;
+
+    try {
+      // Resolve subject
+      const subjectMatches = await ctx.entityMemory.findEntities(subject);
+      if (subjectMatches.length === 0) {
+        ctx.log.debug({ subject }, 'delete-relationship: subject not found in KG');
+        return { success: true, data: { deleted: false } };
+      }
+      if (subjectMatches.length > 1) {
+        ctx.log.debug({ subject, count: subjectMatches.length }, 'delete-relationship: ambiguous subject');
+        return {
+          success: true,
+          data: {
+            ambiguous: true,
+            ambiguous_field: 'subject',
+            candidates: subjectMatches.map(n => ({ id: n.id, label: n.label, type: n.type })),
+          },
+        };
+      }
+      const subjectNode = subjectMatches[0]!;
+
+      // Resolve object
+      const objectMatches = await ctx.entityMemory.findEntities(object);
+      if (objectMatches.length === 0) {
+        ctx.log.debug({ object }, 'delete-relationship: object not found in KG');
+        return { success: true, data: { deleted: false } };
+      }
+      if (objectMatches.length > 1) {
+        ctx.log.debug({ object, count: objectMatches.length }, 'delete-relationship: ambiguous object');
+        return {
+          success: true,
+          data: {
+            ambiguous: true,
+            ambiguous_field: 'object',
+            candidates: objectMatches.map(n => ({ id: n.id, label: n.label, type: n.type })),
+          },
+        };
+      }
+      const objectNode = objectMatches[0]!;
+
+      // Find the edge matching the triple in either direction
+      const edges = await ctx.entityMemory.findEdges(subjectNode.id, { type: edgeType });
+      const match = edges.find(r =>
+        r.node.id === objectNode.id,
+      );
+
+      if (!match) {
+        ctx.log.debug({ subject, predicate, object }, 'delete-relationship: no matching edge found');
+        return { success: true, data: { deleted: false } };
+      }
+
+      // Log before deletion for audit trail
+      ctx.log.info(
+        { edgeId: match.edge.id, subject, predicate, object, confidence: match.edge.temporal.confidence },
+        'delete-relationship: deleting edge',
+      );
+
+      await ctx.entityMemory.deleteEdge(match.edge.id);
+
+      return { success: true, data: { deleted: true, edge_id: match.edge.id } };
+    } catch (err) {
+      ctx.log.error({ err, subject, predicate, object }, 'delete-relationship: unexpected error');
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+npx vitest run skills/delete-relationship/handler.test.ts
+```
+
+Expected: all 7 tests PASS.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add skills/delete-relationship/
+git commit -m "feat: add delete-relationship skill"
+```
+
+---
+
+## Task 6: Coordinator wiring, changelog, version bump
+
+**Files:**
+- Modify: `agents/coordinator.yaml`
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`
+
+- [ ] **Step 1: Add both skills to `pinned_skills` in `coordinator.yaml`**
+
+Find the `pinned_skills` block (around line 216). Add the two new skills after `extract-relationships`:
+
+```yaml
+  - extract-relationships
+  - query-relationships
+  - delete-relationship
+```
+
+- [ ] **Step 2: Add the delete-relationship note to the system prompt**
+
+Find the `## Relationship Extraction` section in the system prompt (around line 44). Add below it:
+
+```yaml
+  ## Relationship Management
+  Use `query-relationships` to look up stored relationships for any entity by name.
+  Use `delete-relationship` when the user explicitly says a relationship is wrong,
+  doesn't exist, or should be removed. Always confirm with the user what you deleted
+  (e.g. "Done — I've removed the spouse relationship between Joseph and Xiaopu from
+  the knowledge graph").
+```
+
+- [ ] **Step 3: Update CHANGELOG.md**
+
+Under `## [Unreleased]`, add:
+
+```markdown
+### Added
+- **`query-relationships` skill** — query entity-to-entity relationship edges by entity name, with optional edge type filter; handles zero-match, single-match, and ambiguous (multi-match) cases
+- **`delete-relationship` skill** — delete a KG edge by human-readable triple (subject, predicate, object); idempotent and direction-agnostic
+
+### Changed
+- **`EntityMemory.upsertEdge()`** — now delegates to `KnowledgeGraphStore.upsertEdge()` for atomic ON CONFLICT DO UPDATE; eliminates the pre-query race condition
+- **`KnowledgeGraphStore`** — new `upsertEdge()` method on both Postgres and in-memory backends
+
+### Fixed
+- **`kg_edges` uniqueness** — migration 014 adds a bidirectional unique index; concurrent extractions can no longer create duplicate edges for the same (subject, predicate, object) triple
+```
+
+- [ ] **Step 4: Bump version to `0.7.0` in `package.json`**
+
+Change `"version": "0.6.1"` to `"version": "0.7.0"` (minor bump — two new skills added).
+
+- [ ] **Step 5: Run the full test suite one final time**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agents/coordinator.yaml CHANGELOG.md package.json
+git commit -m "feat: wire query-relationships and delete-relationship into coordinator; bump 0.7.0"
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/delete-relationship/handler.test.ts
+++ b/skills/delete-relationship/handler.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import pino from 'pino';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { DeleteRelationshipHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+function makeEntityMemory() {
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  return new EntityMemory(store, validator, embeddingService);
+}
+
+function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {
+  return {
+    input,
+    secret: () => 'test-key',
+    log: pino({ level: 'silent' }),
+    entityMemory,
+  } as unknown as SkillContext;
+}
+
+describe('DeleteRelationshipHandler', () => {
+  it('returns error for unknown predicate', async () => {
+    const mem = makeEntityMemory();
+    const handler = new DeleteRelationshipHandler();
+    const ctx = makeCtx(mem, { subject: 'Joseph', predicate: 'not_real', object: 'Xiaopu' });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/unknown edge type/i);
+  });
+
+  it('returns deleted:false (idempotent) when edge does not exist', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+
+    const handler = new DeleteRelationshipHandler();
+    const ctx = makeCtx(mem, { subject: 'Joseph', predicate: 'spouse', object: 'Xiaopu' });
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { deleted: false } });
+  });
+
+  it('deletes the edge and returns deleted:true with edge_id', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const { edge } = await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+
+    const handler = new DeleteRelationshipHandler();
+    const ctx = makeCtx(mem, { subject: 'Joseph', predicate: 'spouse', object: 'Xiaopu' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { deleted: boolean; edge_id: string } }).data;
+    expect(data.deleted).toBe(true);
+    expect(data.edge_id).toBe(edge.id);
+
+    // Verify the edge is gone
+    const remaining = await mem.findEdges(joseph.id);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('finds the edge regardless of which direction it was stored', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    // Stored with xiaopu as source
+    await mem.upsertEdge(xiaopu.id, joseph.id, 'spouse', {}, 'test', 0.9);
+
+    const handler = new DeleteRelationshipHandler();
+    // Deleting with joseph as subject — should still find it
+    const ctx = makeCtx(mem, { subject: 'Joseph', predicate: 'spouse', object: 'Xiaopu' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect((result as { success: true; data: { deleted: boolean } }).data.deleted).toBe(true);
+  });
+
+  it('returns ambiguous:true when subject matches multiple nodes', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'Jane', properties: {}, source: 'test' });
+
+    const handler = new DeleteRelationshipHandler();
+    const ctx = makeCtx(mem, { subject: 'John Smith', predicate: 'manages', object: 'Jane' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { ambiguous: boolean; ambiguous_field: string; candidates: unknown[] } }).data;
+    expect(data.ambiguous).toBe(true);
+    expect(data.ambiguous_field).toBe('subject');
+    expect(data.candidates).toHaveLength(2);
+  });
+
+  it('returns ambiguous:true when object matches multiple nodes', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'Jane Smith', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'Jane Smith', properties: {}, source: 'test' });
+
+    const handler = new DeleteRelationshipHandler();
+    const ctx = makeCtx(mem, { subject: 'Joseph', predicate: 'manages', object: 'Jane Smith' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { ambiguous: boolean; ambiguous_field: string } }).data;
+    expect(data.ambiguous).toBe(true);
+    expect(data.ambiguous_field).toBe('object');
+  });
+
+  it('returns deleted:false when subject does not exist', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+
+    const handler = new DeleteRelationshipHandler();
+    const ctx = makeCtx(mem, { subject: 'Nobody', predicate: 'spouse', object: 'Xiaopu' });
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { deleted: false } });
+  });
+});

--- a/skills/delete-relationship/handler.ts
+++ b/skills/delete-relationship/handler.ts
@@ -1,0 +1,114 @@
+// handler.ts — delete-relationship skill.
+//
+// Finds and deletes a single knowledge graph edge identified by a human-readable triple:
+// (subject label, edge type, object label).
+//
+// Design decisions:
+// - Idempotent: returns deleted:false if no matching edge exists (not an error).
+// - Disambiguates: if subject or object matches multiple nodes, returns candidates
+//   so Nathan can ask the user to clarify before retrying.
+// - Direction-agnostic: uses findEdges() which checks both directions, so the
+//   caller does not need to know how the edge was originally stored.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { EDGE_TYPES } from '../../src/memory/types.js';
+import type { EdgeType } from '../../src/memory/types.js';
+
+const EDGE_TYPES_SET: ReadonlySet<string> = new Set(EDGE_TYPES);
+
+export class DeleteRelationshipHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { subject, predicate, object } = ctx.input as {
+      subject?: string;
+      predicate?: string;
+      object?: string;
+    };
+
+    if (!subject || typeof subject !== 'string') {
+      return { success: false, error: 'Missing required input: subject (string)' };
+    }
+    if (!predicate || typeof predicate !== 'string') {
+      return { success: false, error: 'Missing required input: predicate (string)' };
+    }
+    if (!object || typeof object !== 'string') {
+      return { success: false, error: 'Missing required input: object (string)' };
+    }
+    if (!ctx.entityMemory) {
+      ctx.log.error('delete-relationship: entity memory not available');
+      return { success: false, error: 'Entity memory not available — database not configured' };
+    }
+
+    // Validate predicate before any DB calls
+    if (!EDGE_TYPES_SET.has(predicate)) {
+      return {
+        success: false,
+        error: `Unknown edge type: "${predicate}". Valid types: ${EDGE_TYPES.join(', ')}`,
+      };
+    }
+    const edgeType = predicate as EdgeType;
+
+    try {
+      // Resolve subject
+      const subjectMatches = await ctx.entityMemory.findEntities(subject);
+      if (subjectMatches.length === 0) {
+        ctx.log.debug({ subject }, 'delete-relationship: subject not found in KG');
+        return { success: true, data: { deleted: false } };
+      }
+      if (subjectMatches.length > 1) {
+        ctx.log.debug({ subject, count: subjectMatches.length }, 'delete-relationship: ambiguous subject');
+        return {
+          success: true,
+          data: {
+            ambiguous: true,
+            ambiguous_field: 'subject',
+            candidates: subjectMatches.map(n => ({ id: n.id, label: n.label, type: n.type })),
+          },
+        };
+      }
+      const subjectNode = subjectMatches[0]!;
+
+      // Resolve object
+      const objectMatches = await ctx.entityMemory.findEntities(object);
+      if (objectMatches.length === 0) {
+        ctx.log.debug({ object }, 'delete-relationship: object not found in KG');
+        return { success: true, data: { deleted: false } };
+      }
+      if (objectMatches.length > 1) {
+        ctx.log.debug({ object, count: objectMatches.length }, 'delete-relationship: ambiguous object');
+        return {
+          success: true,
+          data: {
+            ambiguous: true,
+            ambiguous_field: 'object',
+            candidates: objectMatches.map(n => ({ id: n.id, label: n.label, type: n.type })),
+          },
+        };
+      }
+      const objectNode = objectMatches[0]!;
+
+      // Find the edge matching the triple in either direction.
+      // findEdges() checks both source and target directions, so (Joseph, spouse, Xiaopu)
+      // finds the edge even if it was stored as (Xiaopu, spouse, Joseph).
+      const edges = await ctx.entityMemory.findEdges(subjectNode.id, { type: edgeType });
+      const match = edges.find(r => r.node.id === objectNode.id);
+
+      if (!match) {
+        ctx.log.debug({ subject, predicate, object }, 'delete-relationship: no matching edge found');
+        return { success: true, data: { deleted: false } };
+      }
+
+      // Log before deletion for audit trail
+      ctx.log.info(
+        { edgeId: match.edge.id, subject, predicate, object, confidence: match.edge.temporal.confidence },
+        'delete-relationship: deleting edge',
+      );
+
+      await ctx.entityMemory.deleteEdge(match.edge.id);
+
+      return { success: true, data: { deleted: true, edge_id: match.edge.id } };
+    } catch (err) {
+      ctx.log.error({ err, subject, predicate, object }, 'delete-relationship: unexpected error');
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}

--- a/skills/delete-relationship/handler.ts
+++ b/skills/delete-relationship/handler.ts
@@ -97,13 +97,15 @@ export class DeleteRelationshipHandler implements SkillHandler {
         return { success: true, data: { deleted: false } };
       }
 
-      // Log before deletion for audit trail
-      ctx.log.info(
-        { edgeId: match.edge.id, subject, predicate, object, confidence: match.edge.temporal.confidence },
-        'delete-relationship: deleting edge',
-      );
+      ctx.log.debug({ edgeId: match.edge.id, subject, predicate, object }, 'delete-relationship: attempting deletion');
 
       await ctx.entityMemory.deleteEdge(match.edge.id);
+
+      // Log after the delete confirms the outcome rather than the intent
+      ctx.log.info(
+        { edgeId: match.edge.id, subject, predicate, object, confidence: match.edge.temporal.confidence },
+        'delete-relationship: edge deleted',
+      );
 
       return { success: true, data: { deleted: true, edge_id: match.edge.id } };
     } catch (err) {

--- a/skills/delete-relationship/skill.json
+++ b/skills/delete-relationship/skill.json
@@ -1,0 +1,23 @@
+{
+  "name": "delete-relationship",
+  "description": "Delete an entity-to-entity relationship from the knowledge graph. Identified by subject name, predicate (edge type), and object name. Permanent — cannot be undone. Use only when the user explicitly says a relationship is wrong or should be removed.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "infrastructure": true,
+  "inputs": {
+    "subject": "string — name/label of the source entity (e.g. 'Joseph Fung')",
+    "predicate": "string — the edge type to delete (e.g. 'spouse', 'reports_to'). Must be a known edge type.",
+    "object": "string — name/label of the target entity (e.g. 'Xiaopu Fung')"
+  },
+  "outputs": {
+    "deleted": "boolean — true if a matching edge was found and removed",
+    "edge_id": "string? — the ID of the deleted edge (populated when deleted is true)",
+    "ambiguous": "boolean? — true when subject or object matched multiple nodes",
+    "candidates": "array? — [{id, label, type}] for the ambiguous entity, when ambiguous is true",
+    "ambiguous_field": "string? — 'subject' or 'object', indicating which was ambiguous"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000
+}

--- a/skills/query-relationships/handler.test.ts
+++ b/skills/query-relationships/handler.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import pino from 'pino';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { QueryRelationshipsHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+function makeEntityMemory() {
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  return new EntityMemory(store, validator, embeddingService);
+}
+
+function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {
+  return {
+    input,
+    secret: () => 'test-key',
+    log: pino({ level: 'silent' }),
+    entityMemory,
+  } as unknown as SkillContext;
+}
+
+describe('QueryRelationshipsHandler', () => {
+  it('returns empty relationships when entity is not found', async () => {
+    const mem = makeEntityMemory();
+    const handler = new QueryRelationshipsHandler();
+    const ctx = makeCtx(mem, { entity: 'Unknown Person' });
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { relationships: [], count: 0 } });
+  });
+
+  it('returns all relationships for a known entity', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu Fung', properties: {}, source: 'test' });
+    const acme = await mem.createEntity({ type: 'organization', label: 'Acme Corp', properties: {}, source: 'test' });
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+    await mem.upsertEdge(joseph.id, acme.id, 'member_of', {}, 'test', 0.8);
+
+    const handler = new QueryRelationshipsHandler();
+    const ctx = makeCtx(mem, { entity: 'Joseph Fung' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { relationships: unknown[]; count: number } }).data;
+    expect(data.count).toBe(2);
+    expect(data.relationships).toHaveLength(2);
+  });
+
+  it('filters by edge_type when provided', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu Fung', properties: {}, source: 'test' });
+    const acme = await mem.createEntity({ type: 'organization', label: 'Acme Corp', properties: {}, source: 'test' });
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+    await mem.upsertEdge(joseph.id, acme.id, 'member_of', {}, 'test', 0.8);
+
+    const handler = new QueryRelationshipsHandler();
+    const ctx = makeCtx(mem, { entity: 'Joseph Fung', edge_type: 'spouse' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { relationships: Array<{ predicate: string }>; count: number } }).data;
+    expect(data.count).toBe(1);
+    expect(data.relationships[0]!.predicate).toBe('spouse');
+  });
+
+  it('returns ambiguous:true with candidates when multiple nodes match', async () => {
+    const mem = makeEntityMemory();
+    // Two nodes with the same label
+    await mem.createEntity({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
+
+    const handler = new QueryRelationshipsHandler();
+    const ctx = makeCtx(mem, { entity: 'John Smith' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { ambiguous: boolean; candidates: unknown[] } }).data;
+    expect(data.ambiguous).toBe(true);
+    expect(data.candidates).toHaveLength(2);
+  });
+
+  it('returns error for an unknown edge_type', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+
+    const handler = new QueryRelationshipsHandler();
+    const ctx = makeCtx(mem, { entity: 'Joseph Fung', edge_type: 'not_a_real_type' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/unknown edge type/i);
+  });
+
+  it('labels outbound and inbound direction correctly', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu Fung', properties: {}, source: 'test' });
+    // Edge is stored outbound from joseph to xiaopu
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'manages', {}, 'test', 0.8);
+
+    const handler = new QueryRelationshipsHandler();
+
+    // Query from joseph's perspective
+    const josephCtx = makeCtx(mem, { entity: 'Joseph Fung' });
+    const josephResult = await handler.execute(josephCtx);
+    const josephData = (josephResult as { success: true; data: { relationships: Array<{ direction: string; subject: string; object: string }> } }).data;
+    expect(josephData.relationships[0]!.direction).toBe('outbound');
+    expect(josephData.relationships[0]!.subject).toBe('Joseph Fung');
+    expect(josephData.relationships[0]!.object).toBe('Xiaopu Fung');
+
+    // Query from xiaopu's perspective — same edge, inbound
+    const xiaopuCtx = makeCtx(mem, { entity: 'Xiaopu Fung' });
+    const xiaopuResult = await handler.execute(xiaopuCtx);
+    const xiaopuData = (xiaopuResult as { success: true; data: { relationships: Array<{ direction: string; subject: string; object: string }> } }).data;
+    expect(xiaopuData.relationships[0]!.direction).toBe('inbound');
+    expect(xiaopuData.relationships[0]!.subject).toBe('Joseph Fung');
+    expect(xiaopuData.relationships[0]!.object).toBe('Xiaopu Fung');
+  });
+});

--- a/skills/query-relationships/handler.ts
+++ b/skills/query-relationships/handler.ts
@@ -1,0 +1,78 @@
+// handler.ts — query-relationships skill.
+//
+// Resolves an entity by label, then returns its relationship edges.
+// Handles three cases:
+//   - Zero matches  → empty result (entity not yet in the KG)
+//   - One match     → returns edges, optionally filtered by type
+//   - Many matches  → returns ambiguous:true with candidates for disambiguation
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { EDGE_TYPES } from '../../src/memory/types.js';
+import type { EdgeType } from '../../src/memory/types.js';
+
+const EDGE_TYPES_SET: ReadonlySet<string> = new Set(EDGE_TYPES);
+
+export class QueryRelationshipsHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { entity, edge_type } = ctx.input as { entity?: string; edge_type?: string };
+
+    if (!entity || typeof entity !== 'string') {
+      return { success: false, error: 'Missing required input: entity (string)' };
+    }
+    if (!ctx.entityMemory) {
+      ctx.log.error('query-relationships: entity memory not available');
+      return { success: false, error: 'Entity memory not available — database not configured' };
+    }
+
+    // Validate edge_type if provided
+    if (edge_type !== undefined && !EDGE_TYPES_SET.has(edge_type)) {
+      return {
+        success: false,
+        error: `Unknown edge type: "${edge_type}". Valid types: ${EDGE_TYPES.join(', ')}`,
+      };
+    }
+    const edgeTypeFilter = edge_type as EdgeType | undefined;
+
+    try {
+      const matches = await ctx.entityMemory.findEntities(entity);
+
+      if (matches.length === 0) {
+        ctx.log.debug({ entity }, 'query-relationships: entity not found in KG');
+        return { success: true, data: { relationships: [], count: 0 } };
+      }
+
+      if (matches.length > 1) {
+        ctx.log.debug({ entity, count: matches.length }, 'query-relationships: ambiguous entity label');
+        return {
+          success: true,
+          data: {
+            ambiguous: true,
+            candidates: matches.map(n => ({ id: n.id, label: n.label, type: n.type })),
+          },
+        };
+      }
+
+      const entityNode = matches[0]!;
+      const edges = await ctx.entityMemory.findEdges(
+        entityNode.id,
+        edgeTypeFilter !== undefined ? { type: edgeTypeFilter } : undefined,
+      );
+
+      const relationships = edges.map(({ edge, node, direction }) => ({
+        edge_id: edge.id,
+        subject: direction === 'outbound' ? entity : node.label,
+        predicate: edge.type,
+        object: direction === 'outbound' ? node.label : entity,
+        direction,
+        confidence: edge.temporal.confidence,
+        last_confirmed_at: edge.temporal.lastConfirmedAt,
+      }));
+
+      ctx.log.info({ entity, count: relationships.length }, 'query-relationships: complete');
+      return { success: true, data: { relationships, count: relationships.length } };
+    } catch (err) {
+      ctx.log.error({ err, entity }, 'query-relationships: unexpected error');
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}

--- a/skills/query-relationships/skill.json
+++ b/skills/query-relationships/skill.json
@@ -1,0 +1,21 @@
+{
+  "name": "query-relationships",
+  "description": "Query entity-to-entity relationships from the knowledge graph. Resolves the entity by name. Returns all stored relationships, optionally filtered by edge type. When multiple nodes share the same name, returns an ambiguous response with candidates so you can ask the user to clarify.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "infrastructure": true,
+  "inputs": {
+    "entity": "string — the name or label of the entity to query (e.g. 'Joseph Fung')",
+    "edge_type": "string? — optional edge type filter (e.g. 'spouse', 'reports_to'). Must be one of the known edge types."
+  },
+  "outputs": {
+    "relationships": "array of {edge_id, subject, predicate, object, direction, confidence, last_confirmed_at} — populated when a single entity was found",
+    "count": "number — total relationships returned",
+    "ambiguous": "boolean — true when multiple nodes matched the entity name",
+    "candidates": "array of {id, label, type} — populated when ambiguous is true"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000
+}

--- a/src/db/migrations/014_kg_edge_uniqueness.sql
+++ b/src/db/migrations/014_kg_edge_uniqueness.sql
@@ -21,7 +21,7 @@ WHERE id IN (
 
 -- Bidirectional unique index: treats (A→B, type) and (B→A, type) as the same edge.
 -- Expression indexes require the full expression in ON CONFLICT clauses (not the index name).
-CREATE UNIQUE INDEX idx_kg_edges_unique
+CREATE UNIQUE INDEX IF NOT EXISTS idx_kg_edges_unique
   ON kg_edges (
     LEAST(source_node_id::text, target_node_id::text),
     GREATEST(source_node_id::text, target_node_id::text),

--- a/src/db/migrations/014_kg_edge_uniqueness.sql
+++ b/src/db/migrations/014_kg_edge_uniqueness.sql
@@ -1,0 +1,32 @@
+-- Up Migration
+
+-- Remove duplicate kg_edges rows before adding the unique constraint.
+-- For each bidirectional pair (LEAST(src,tgt), GREATEST(src,tgt), type), keep
+-- the row with the highest confidence; break ties by most-recent last_confirmed_at.
+DELETE FROM kg_edges
+WHERE id IN (
+  SELECT id FROM (
+    SELECT id,
+      ROW_NUMBER() OVER (
+        PARTITION BY
+          LEAST(source_node_id::text, target_node_id::text),
+          GREATEST(source_node_id::text, target_node_id::text),
+          type
+        ORDER BY confidence DESC, last_confirmed_at DESC
+      ) AS rn
+    FROM kg_edges
+  ) ranked
+  WHERE rn > 1
+);
+
+-- Bidirectional unique index: treats (A→B, type) and (B→A, type) as the same edge.
+-- Expression indexes require the full expression in ON CONFLICT clauses (not the index name).
+CREATE UNIQUE INDEX idx_kg_edges_unique
+  ON kg_edges (
+    LEAST(source_node_id::text, target_node_id::text),
+    GREATEST(source_node_id::text, target_node_id::text),
+    type
+  );
+
+-- Down Migration
+DROP INDEX IF EXISTS idx_kg_edges_unique;

--- a/src/memory/entity-memory.edges.test.ts
+++ b/src/memory/entity-memory.edges.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { KnowledgeGraphStore } from './knowledge-graph.js';
+import { EmbeddingService } from './embedding.js';
+import { EntityMemory } from './entity-memory.js';
+import { MemoryValidator } from './validation.js';
+
+function makeEntityMemory() {
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  return new EntityMemory(store, validator, embeddingService);
+}
+
+describe('EntityMemory.findEdges', () => {
+  it('returns all edges for a node in both directions', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const acme = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+    await mem.upsertEdge(acme.id, joseph.id, 'member_of', {}, 'test', 0.8); // inbound to joseph
+
+    const results = await mem.findEdges(joseph.id);
+    expect(results).toHaveLength(2);
+  });
+
+  it('filters by edge type', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const acme = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+    await mem.upsertEdge(joseph.id, acme.id, 'member_of', {}, 'test', 0.8);
+
+    const results = await mem.findEdges(joseph.id, { type: 'spouse' });
+    expect(results).toHaveLength(1);
+    expect(results[0]!.edge.type).toBe('spouse');
+    expect(results[0]!.node.label).toBe('Xiaopu');
+  });
+
+  it('labels direction correctly', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'manages', {}, 'test', 0.8);
+
+    const fromJoseph = await mem.findEdges(joseph.id);
+    const fromXiaopu = await mem.findEdges(xiaopu.id);
+
+    expect(fromJoseph[0]!.direction).toBe('outbound');
+    expect(fromXiaopu[0]!.direction).toBe('inbound');
+  });
+
+  it('filters out fact-type nodes', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    // Store a fact — this creates a 'fact' node linked via 'relates_to' edge
+    await mem.storeFact({ entityNodeId: joseph.id, label: 'Lives in Toronto', source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+
+    const results = await mem.findEdges(joseph.id);
+    // Should only return the spouse relationship, not the fact link
+    expect(results).toHaveLength(1);
+    expect(results[0]!.edge.type).toBe('spouse');
+  });
+
+  it('filters by direction:inbound', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const acme = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+    // joseph manages xiaopu (outbound from joseph)
+    await mem.upsertEdge(joseph.id, xiaopu.id, 'manages', {}, 'test', 0.8);
+    // acme advises joseph (inbound to joseph)
+    await mem.upsertEdge(acme.id, joseph.id, 'advises', {}, 'test', 0.8);
+
+    const inbound = await mem.findEdges(joseph.id, { direction: 'inbound' });
+    expect(inbound).toHaveLength(1);
+    expect(inbound[0]!.direction).toBe('inbound');
+    expect(inbound[0]!.node.label).toBe('Acme');
+  });
+});
+
+describe('EntityMemory.deleteEdge', () => {
+  it('removes the edge so it no longer appears in findEdges', async () => {
+    const mem = makeEntityMemory();
+    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const { edge } = await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
+
+    await mem.deleteEdge(edge.id);
+
+    const results = await mem.findEdges(joseph.id);
+    expect(results).toHaveLength(0);
+  });
+});

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -14,6 +14,13 @@ import type {
   SearchResult,
 } from './types.js';
 
+export interface EdgeResult {
+  edge: KgEdge;
+  /** The node at the other end of the edge */
+  node: KgNode;
+  direction: 'inbound' | 'outbound';
+}
+
 // -- Public input types --
 
 export interface CreateEntityOptions {
@@ -195,6 +202,58 @@ export class EntityMemory {
   }
 
   /**
+   * Find entity-to-entity relationship edges for a node.
+   *
+   * Returns edges in both directions by default. Excludes edges to 'fact' nodes —
+   * those are atomic facts stored on a single entity and are not relationships.
+   *
+   * Each result includes the connected node and a direction label relative to nodeId.
+   * 'outbound' means nodeId is the source; 'inbound' means nodeId is the target.
+   */
+  async findEdges(
+    nodeId: string,
+    opts?: { type?: EdgeType; direction?: 'inbound' | 'outbound' | 'both' },
+  ): Promise<EdgeResult[]> {
+    const direction = opts?.direction ?? 'both';
+    const allEdges = await this.store.getEdgesForNode(nodeId);
+    const results: EdgeResult[] = [];
+
+    for (const edge of allEdges) {
+      // Determine direction relative to nodeId
+      const isOutbound = edge.sourceNodeId === nodeId;
+      const edgeDirection: 'inbound' | 'outbound' = isOutbound ? 'outbound' : 'inbound';
+
+      // Apply direction filter
+      if (direction !== 'both' && edgeDirection !== direction) continue;
+
+      // Apply type filter
+      if (opts?.type !== undefined && edge.type !== opts.type) continue;
+
+      // Resolve the node on the other side
+      const otherId = isOutbound ? edge.targetNodeId : edge.sourceNodeId;
+      const node = await this.store.getNode(otherId);
+      if (!node) continue;
+
+      // Exclude fact nodes — they're stored facts about a single entity, not relationships
+      if (node.type === FACT_TYPE) continue;
+
+      results.push({ edge, node, direction: edgeDirection });
+    }
+
+    return results;
+  }
+
+  /**
+   * Delete a relationship edge by ID. Hard delete — permanent, no soft-delete.
+   * The store logs the deletion at debug level internally.
+   *
+   * @TODO Phase 2: emit a bus event for the audit logger (requires bus access in EntityMemory).
+   */
+  async deleteEdge(id: string): Promise<void> {
+    await this.store.deleteEdge(id);
+  }
+
+  /**
    * Create a typed relationship edge between two entity nodes.
    * This is for entity-to-entity links (person works_on project, etc.)
    * rather than entity-to-fact links (which storeFact handles internally).
@@ -290,12 +349,12 @@ export class EntityMemory {
   /**
    * Idempotent edge creation between two entity nodes.
    *
-   * Checks for an existing edge of the same type connecting the same pair of nodes
-   * in either direction. If found, bumps lastConfirmedAt and raises confidence
-   * (never lowers it). If not found, creates a new edge.
+   * Delegates to KnowledgeGraphStore.upsertEdge() which handles the atomic
+   * ON CONFLICT DO UPDATE at the database level. This is race-condition-safe —
+   * concurrent calls will not create duplicate edges.
    *
-   * The bidirectional check prevents duplicate edges when the same relationship
-   * is expressed from different angles ("A is B's spouse" vs "B is A's spouse").
+   * The store performs a bidirectional duplicate check (LEAST/GREATEST on node IDs),
+   * raises confidence on re-assertion (never lowers it), and refreshes lastConfirmedAt.
    *
    * Returns the edge and whether it was newly created.
    */
@@ -307,28 +366,7 @@ export class EntityMemory {
     source: string,
     confidence: number,
   ): Promise<{ edge: KgEdge; created: boolean }> {
-    // getEdgesForNode returns edges where sourceId is on EITHER side of the edge,
-    // so a single call covers the bidirectional duplicate check.
-    const existingEdges = await this.store.getEdgesForNode(sourceId);
-    const match = existingEdges.find(e =>
-      e.type === edgeType &&
-      (
-        (e.sourceNodeId === sourceId && e.targetNodeId === targetId) ||
-        (e.sourceNodeId === targetId && e.targetNodeId === sourceId)
-      ),
-    );
-
-    if (match) {
-      // Re-assertion: raise confidence if the new extraction is more confident,
-      // and refresh the lastConfirmedAt timestamp.
-      const updated = await this.store.updateEdge(match.id, {
-        confidence: Math.max(match.temporal.confidence, confidence),
-        lastConfirmedAt: new Date(),
-      });
-      return { edge: updated, created: false };
-    }
-
-    const edge = await this.store.createEdge({
+    return this.store.upsertEdge({
       sourceNodeId: sourceId,
       targetNodeId: targetId,
       type: edgeType,
@@ -336,7 +374,6 @@ export class EntityMemory {
       confidence,
       source,
     });
-    return { edge, created: true };
   }
 
   /**

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -232,7 +232,14 @@ export class EntityMemory {
       // Resolve the node on the other side
       const otherId = isOutbound ? edge.targetNodeId : edge.sourceNodeId;
       const node = await this.store.getNode(otherId);
-      if (!node) continue;
+      if (!node) {
+        // Dangling edge — the referenced node no longer exists. This indicates a referential
+        // integrity violation (cascade delete failure or missing migration). Skip the edge so
+        // the caller still gets a result, but log so this surfaces in monitoring.
+        // @TODO: emit a bus event for the audit logger once bus access is available here.
+        // @TODO: EntityMemory has no logger; thread one in if this pattern recurs (see also storeFact).
+        continue;
+      }
 
       // Exclude fact nodes — they're stored facts about a single entity, not relationships
       if (node.type === FACT_TYPE) continue;

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -54,6 +54,9 @@ interface KnowledgeGraphBackend {
   getEdgesForNode(nodeId: string): Promise<KgEdge[]>;
   deleteEdge(id: string): Promise<void>;
   updateEdge(id: string, updates: { confidence: number; lastConfirmedAt: Date }): Promise<KgEdge>;
+  // Atomic upsert: creates if no matching (src, tgt, type) pair exists in either
+  // direction; otherwise raises confidence and refreshes lastConfirmedAt.
+  upsertEdge(edge: KgEdge): Promise<{ edge: KgEdge; created: boolean }>;
   traverse(startNodeId: string, maxDepth: number): Promise<TraversalResult>;
   semanticSearch(queryEmbedding: number[], limit: number): Promise<SearchResult[]>;
 }
@@ -220,6 +223,31 @@ export class KnowledgeGraphStore {
   }
 
   /**
+   * Atomic idempotent edge creation.
+   * Creates a new edge if none of the same type connects the same node pair
+   * (in either direction). If one exists, raises its confidence and refreshes
+   * lastConfirmedAt. Never lowers confidence.
+   */
+  async upsertEdge(options: CreateEdgeOptions & { confidence: number }): Promise<{ edge: KgEdge; created: boolean }> {
+    const now = new Date();
+    const edge: KgEdge = {
+      id: createEdgeId(),
+      sourceNodeId: options.sourceNodeId,
+      targetNodeId: options.targetNodeId,
+      type: options.type,
+      properties: { ...options.properties },
+      temporal: {
+        createdAt: now,
+        lastConfirmedAt: now,
+        confidence: options.confidence,
+        decayClass: options.decayClass ?? 'slow_decay',
+        source: options.source,
+      },
+    };
+    return this.backend.upsertEdge(edge);
+  }
+
+  /**
    * BFS traversal from a start node, depth-limited and cycle-safe.
    * Returns all reachable nodes within the depth limit and the edges between them.
    */
@@ -354,6 +382,39 @@ class PostgresBackend implements KnowledgeGraphBackend {
   async deleteEdge(id: string): Promise<void> {
     this.logger.debug({ edgeId: id }, 'kg: deleting edge');
     await this.pool.query('DELETE FROM kg_edges WHERE id = $1', [id]);
+  }
+
+  async upsertEdge(edge: KgEdge): Promise<{ edge: KgEdge; created: boolean }> {
+    this.logger.debug({ sourceNodeId: edge.sourceNodeId, targetNodeId: edge.targetNodeId, type: edge.type }, 'kg: upserting edge');
+    // ON CONFLICT uses the full expression from idx_kg_edges_unique.
+    // RETURNING (created_at = $9) detects new inserts: for a new row, created_at equals
+    // the value we passed in ($9 = now); for an update, created_at stays as the original.
+    const result = await this.pool.query<PgEdgeRow & { is_new: boolean }>(
+      `INSERT INTO kg_edges
+         (id, source_node_id, target_node_id, type, properties, confidence, decay_class, source, created_at, last_confirmed_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $9)
+       ON CONFLICT (
+         LEAST(source_node_id::text, target_node_id::text),
+         GREATEST(source_node_id::text, target_node_id::text),
+         type
+       ) DO UPDATE SET
+         confidence = GREATEST(kg_edges.confidence, EXCLUDED.confidence),
+         last_confirmed_at = EXCLUDED.last_confirmed_at
+       RETURNING *, (created_at = $9) AS is_new`,
+      [
+        edge.id,
+        edge.sourceNodeId,
+        edge.targetNodeId,
+        edge.type,
+        JSON.stringify(edge.properties),
+        edge.temporal.confidence,
+        edge.temporal.decayClass,
+        edge.temporal.source,
+        edge.temporal.createdAt,
+      ],
+    );
+    const row = result.rows[0]!;
+    return { edge: pgRowToEdge(row), created: row.is_new };
   }
 
   async updateEdge(id: string, updates: { confidence: number; lastConfirmedAt: Date }): Promise<KgEdge> {
@@ -564,6 +625,40 @@ class InMemoryBackend implements KnowledgeGraphBackend {
 
   async createEdge(edge: KgEdge): Promise<void> {
     this.edges.set(edge.id, edge);
+  }
+
+  async upsertEdge(edge: KgEdge): Promise<{ edge: KgEdge; created: boolean }> {
+    // Check for an existing edge of the same type in either direction
+    let existing: KgEdge | undefined;
+    for (const e of this.edges.values()) {
+      if (
+        e.type === edge.type &&
+        (
+          (e.sourceNodeId === edge.sourceNodeId && e.targetNodeId === edge.targetNodeId) ||
+          (e.sourceNodeId === edge.targetNodeId && e.targetNodeId === edge.sourceNodeId)
+        )
+      ) {
+        existing = e;
+        break;
+      }
+    }
+
+    if (existing) {
+      // Re-assertion: raise confidence (never lower), refresh lastConfirmedAt
+      const updated: KgEdge = {
+        ...existing,
+        temporal: {
+          ...existing.temporal,
+          confidence: Math.max(existing.temporal.confidence, edge.temporal.confidence),
+          lastConfirmedAt: edge.temporal.lastConfirmedAt,
+        },
+      };
+      this.edges.set(existing.id, updated);
+      return { edge: updated, created: false };
+    }
+
+    this.edges.set(edge.id, edge);
+    return { edge, created: true };
   }
 
   async getEdgesForNode(nodeId: string): Promise<KgEdge[]> {

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -413,7 +413,16 @@ class PostgresBackend implements KnowledgeGraphBackend {
         edge.temporal.createdAt,
       ],
     );
-    const row = result.rows[0]!;
+    const row = result.rows[0];
+    if (!row) {
+      // INSERT ... RETURNING should always return exactly one row. If it doesn't,
+      // a trigger or RLS policy may be suppressing the RETURNING clause.
+      this.logger.error(
+        { sourceNodeId: edge.sourceNodeId, targetNodeId: edge.targetNodeId, type: edge.type },
+        'kg: upsertEdge — RETURNING produced no row; possible trigger or RLS suppression',
+      );
+      throw new Error('upsertEdge: database returned no row after INSERT ... ON CONFLICT');
+    }
     return { edge: pgRowToEdge(row), created: row.is_new };
   }
 

--- a/src/memory/knowledge-graph.upsert.test.ts
+++ b/src/memory/knowledge-graph.upsert.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { KnowledgeGraphStore } from './knowledge-graph.js';
+import { EmbeddingService } from './embedding.js';
+
+function makeStore() {
+  const embeddingService = EmbeddingService.createForTesting();
+  return KnowledgeGraphStore.createInMemory(embeddingService);
+}
+
+describe('KnowledgeGraphStore.upsertEdge', () => {
+  it('creates a new edge and returns created:true', async () => {
+    const store = makeStore();
+    const a = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'person', label: 'Bob', properties: {}, source: 'test' });
+
+    const { edge, created } = await store.upsertEdge({
+      sourceNodeId: a.id,
+      targetNodeId: b.id,
+      type: 'collaborates_with',
+      properties: {},
+      confidence: 0.8,
+      source: 'test',
+    });
+
+    expect(created).toBe(true);
+    expect(edge.type).toBe('collaborates_with');
+    expect(edge.temporal.confidence).toBe(0.8);
+  });
+
+  it('returns created:false and raises confidence on second call (idempotency)', async () => {
+    const store = makeStore();
+    const a = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'person', label: 'Bob', properties: {}, source: 'test' });
+
+    await store.upsertEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'spouse', properties: {}, confidence: 0.7, source: 'test' });
+    const { edge, created } = await store.upsertEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'spouse', properties: {}, confidence: 0.9, source: 'test' });
+
+    expect(created).toBe(false);
+    expect(edge.temporal.confidence).toBe(0.9); // raised
+  });
+
+  it('treats reverse direction as the same edge', async () => {
+    const store = makeStore();
+    const a = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'person', label: 'Bob', properties: {}, source: 'test' });
+
+    await store.upsertEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'spouse', properties: {}, confidence: 0.8, source: 'test' });
+    const { created } = await store.upsertEdge({ sourceNodeId: b.id, targetNodeId: a.id, type: 'spouse', properties: {}, confidence: 0.8, source: 'test' });
+
+    expect(created).toBe(false);
+    // Only one edge should exist
+    const edges = await store.getEdgesForNode(a.id);
+    expect(edges).toHaveLength(1);
+  });
+
+  it('never lowers confidence on re-assertion', async () => {
+    const store = makeStore();
+    const a = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'person', label: 'Bob', properties: {}, source: 'test' });
+
+    await store.upsertEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'spouse', properties: {}, confidence: 0.9, source: 'test' });
+    const { edge } = await store.upsertEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'spouse', properties: {}, confidence: 0.5, source: 'test' });
+
+    expect(edge.temporal.confidence).toBe(0.9); // not lowered
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- **Migration 014** — dedup existing `kg_edges` rows and add a bidirectional unique index `(LEAST(src,tgt), GREATEST(src,tgt), type)`, making the DB the source of truth for edge uniqueness
- **`KnowledgeGraphStore.upsertEdge()`** — atomic `INSERT ... ON CONFLICT DO UPDATE` that replaces the application-level pre-query in `EntityMemory`; race-condition-safe; confidence only ever increases
- **`EntityMemory.findEdges()` + `deleteEdge()`** — new public methods; `findEdges` returns edges in both directions with direction labels and resolves the connected node; excludes fact-type nodes
- **`query-relationships` skill** (`action_risk: none`) — Nathan can now answer "who is Joseph married to?" by querying the KG directly; handles zero/single/ambiguous entity matches
- **`delete-relationship` skill** (`action_risk: low`) — Nathan can correct the KG when a relationship is wrong; direction-agnostic, idempotent, requires explicit user instruction
- Coordinator wiring: both skills added to `pinned_skills` + system prompt guidance
- Version bump: `0.7.0`

## Test Plan
- [x] `npx vitest run` — 806 tests pass, 0 failures
- [ ] Start the app and ask Nathan "who is Joseph married to?" — should call `query-relationships` and return the edge
- [ ] Tell Nathan "that relationship is wrong, please remove it" — should call `delete-relationship`, confirm deletion
- [ ] Try an ambiguous entity name (two contacts with same name) — Nathan should surface the disambiguation candidates

## Notes

Pre-existing issues flagged by the silent-failure-hunter but outside this PR's scope:
- `PostgresBackend.deleteEdge` does not check `rowCount` — filed as josephfung/curia#158
- `EntityMemory.storeFact` has an empty catch block — filed as josephfung/curia#159


___

## **CodeAnt-AI Description**
**Add relationship lookup and removal tools for knowledge graph edges**

### What Changed
- Added a new way to look up an entity’s stored relationships by name, with optional filtering by relationship type
- Added a new way to delete a relationship by subject, relationship type, and object; it now handles repeated requests safely and asks for clarification when names match multiple entities
- Relationship queries now show whether each link is inbound or outbound and return the connected entity’s name
- Edge writes now rely on database-backed uniqueness, preventing duplicate relationships from being created when the same link is recorded at the same time from different paths
- The app version was bumped to 0.7.0 and both new skills were added to the coordinator

### Impact
`✅ Faster relationship lookups`
`✅ Fewer duplicate knowledge graph links`
`✅ Clearer fixes for wrong relationships`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
