### PR TITLE
fix: skill input schema format breaks all chat (production outage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Fixed
+- **Duplicate `extract-relationships` in coordinator `pinned_skills`** — skill appeared twice,
+  causing Anthropic to receive two identical tool definitions in the tools array
 - **`query-relationships` and `delete-relationship` skill input schemas** — both skills used
   `"string — description"` shorthand in `inputs`, which the manifest parser misreads as the
   type token, producing invalid JSON Schema types that caused Anthropic to reject every chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Fixed
+- **`query-relationships` and `delete-relationship` skill input schemas** — both skills used
+  `"string — description"` shorthand in `inputs`, which the manifest parser misreads as the
+  type token, producing invalid JSON Schema types that caused Anthropic to reject every chat
+  request with a 400 `invalid_request_error`; corrected to `"string (description)"` format
 - **`extract-relationships` not available to coordinator** — skill was missing from `pinned_skills`
   in `coordinator.yaml`, so the LLM was instructed to call it but never received the tool definition;
   tool calls silently failed and the agent hallucinated that the skill didn't exist

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -263,7 +263,6 @@ pinned_skills:
   - calendar-check-conflicts
   - get-autonomy
   - set-autonomy
-  - extract-relationships
   - query-relationships
   - delete-relationship
 allow_discovery: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/delete-relationship/skill.json
+++ b/skills/delete-relationship/skill.json
@@ -6,9 +6,9 @@
   "action_risk": "low",
   "infrastructure": true,
   "inputs": {
-    "subject": "string — name/label of the source entity (e.g. 'Joseph Fung')",
-    "predicate": "string — the edge type to delete (e.g. 'spouse', 'reports_to'). Must be a known edge type.",
-    "object": "string — name/label of the target entity (e.g. 'Xiaopu Fung')"
+    "subject": "string (name or label of the source entity, e.g. 'Joseph Fung')",
+    "predicate": "string (the edge type to delete, e.g. 'spouse' or 'reports_to'. Must be a known edge type.)",
+    "object": "string (name or label of the target entity, e.g. 'Xiaopu Fung')"
   },
   "outputs": {
     "deleted": "boolean — true if a matching edge was found and removed",

--- a/skills/query-relationships/skill.json
+++ b/skills/query-relationships/skill.json
@@ -6,8 +6,8 @@
   "action_risk": "none",
   "infrastructure": true,
   "inputs": {
-    "entity": "string — the name or label of the entity to query (e.g. 'Joseph Fung')",
-    "edge_type": "string? — optional edge type filter (e.g. 'spouse', 'reports_to'). Must be one of the known edge types."
+    "entity": "string (the name or label of the entity to query, e.g. 'Joseph Fung')",
+    "edge_type": "string? (optional edge type filter, e.g. 'spouse' or 'reports_to'. Must be a known edge type.)"
   },
   "outputs": {
     "relationships": "array of {edge_id, subject, predicate, object, direction, confidence, last_confirmed_at} — populated when a single entity was found",

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -143,6 +143,17 @@ export class SkillRegistry {
           }
           properties[key] = { type: 'array', items: { type: itemType }, ...(description ? { description } : {}) };
         } else {
+          // Validate against JSON Schema primitive types so a manifest typo like
+          // "string — description" fails loudly at startup rather than silently
+          // emitting an invalid schema that causes an opaque API 400 at call time.
+          // (This is the same pattern as the array-item validation above.)
+          const VALID_PRIMITIVE_TYPES = new Set(['string', 'number', 'integer', 'boolean', 'object', 'null']);
+          if (!VALID_PRIMITIVE_TYPES.has(baseType)) {
+            throw new Error(
+              `Skill '${name}' input '${key}': invalid type '${baseType}' in '${typeStr}'. ` +
+              `Expected one of: ${[...VALID_PRIMITIVE_TYPES].join(', ')}, or an array type (e.g. string[]).`,
+            );
+          }
           properties[key] = { type: baseType, ...(description ? { description } : {}) };
         }
 

--- a/tests/unit/skills/registry.test.ts
+++ b/tests/unit/skills/registry.test.ts
@@ -143,6 +143,19 @@ describe('SkillRegistry', () => {
     expect(tools[0].input_schema.required).toEqual(['ids']);
   });
 
+  it('throws on invalid primitive type in skill manifest (e.g. em-dash format)', () => {
+    // Regression test: "string — description" was the format that caused a production
+    // outage — the em-dash made the parser capture "string — description" as the type
+    // token, which is not a valid JSON Schema type. This must fail at startup.
+    registry.register(makeManifest({
+      name: 'bad-type-skill',
+      description: 'Bad manifest',
+      inputs: { entity: 'string — the entity name' },
+    }), stubHandler);
+    expect(() => registry.toToolDefinitions(['bad-type-skill']))
+      .toThrow(/invalid type/);
+  });
+
   it('throws on invalid array item type in skill manifest', () => {
     registry.register(makeManifest({
       name: 'bad-array-skill',


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause:** `query-relationships` and `delete-relationship` both used `"string — description"` (em-dash) in their `inputs` fields. The manifest parser regex captures the part before the parenthetical as the JSON Schema `type`, so the em-dash landed in the type token — producing `type: "string — description"` instead of `type: "string"`. Anthropic rejected every chat request with a 400 `invalid_request_error`, giving users "I'm sorry, I was unable to process that request."
- **Immediate fix:** Corrected both skill manifests to use `"string (description)"` format.
- **Hardening:** Added primitive type validation to the `else` branch in `toToolDefinitions()` so the same class of bug throws at startup rather than failing silently at the Anthropic API boundary. Also added a regression test covering the em-dash format specifically.
- **Cleanup:** Removed duplicate `extract-relationships` entry from `coordinator.yaml` `pinned_skills`.

## Test plan

- [x] All 807 unit tests pass (`pnpm test`)
- [ ] Verify chat works after deploy (screenshot from issue should resolve)
- [ ] Confirm no duplicate `extract-relationships` in coordinator tool list


___

## **CodeAnt-AI Description**
**Prevent chat failures caused by invalid skill input formats**

### What Changed
- Skill inputs that used `string — description` now fail fast at startup instead of reaching chat with an invalid type
- `query-relationships` and `delete-relationship` now use the correct `string (description)` format, so their tools can load and run normally
- Removed the duplicate `extract-relationships` entry from the coordinator tool list

### Impact
`✅ Fewer chat request failures`
`✅ Clearer startup errors for broken skill manifests`
`✅ No duplicate tool definitions in coordinator chats`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
