### PR TITLE
fix: calendar-update-event attendees input crashes startup (0.7.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Fixed
+- **`calendar-update-event` attendees input type** — declared as bare `array?` which is not a
+  valid JSON Schema type; corrected to `object[]?` matching the handler's expected shape
+  (`Array<{ email, name? }>`). Caused startup crash after primitive-type validation was added in 0.7.1.
 - **Duplicate `extract-relationships` in coordinator `pinned_skills`** — skill appeared twice,
   causing Anthropic to receive two identical tool definitions in the tools array
 - **`query-relationships` and `delete-relationship` skill input schemas** — both skills used

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.7.2",
+  "version": "0.7.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/calendar-update-event/skill.json
+++ b/skills/calendar-update-event/skill.json
@@ -13,7 +13,7 @@
     "end": "timestamp? (new event end time)",
     "description": "string?",
     "location": "string?",
-    "attendees": "array?",
+    "attendees": "object[]? (list of attendees to set, each with email and optional name)",
     "conferencing": "object?",
     "colorId": "string?",
     "reminders": "object?"


### PR DESCRIPTION
## **User description**
## Summary

- `attendees` in `calendar-update-event/skill.json` was typed as `array?` — bare `array` is not a valid JSON Schema primitive, so the new startup validation added in #162 correctly rejects it and the container fails health check immediately
- Changed to `object[]?` which matches the handler's `Array<{ email: string; name?: string }>` signature
- Version bump 0.7.1 → 0.7.2

## Test plan

- [ ] All 807 unit tests pass (`pnpm test`)
- [ ] Container starts healthy after deploy


___

## **CodeAnt-AI Description**
**Fix calendar event updates from crashing at startup**

### What Changed
- The `calendar-update-event` skill now accepts attendee lists in the expected format, so startup validation no longer rejects it.
- Updating event attendees works with a list of attendee objects, each with an email and optional name.
- The release version was bumped to 0.7.2.

### Impact
`✅ Fewer startup failures`
`✅ Reliable calendar event updates`
`✅ Faster recovery after deploy`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
