### PR TITLE
fix: correct bare array types in calendar skill inputs (v0.7.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`calendar-update-event` attendees input type** — declared as bare `array?` which is not a
   valid JSON Schema type; corrected to `object[]?` matching the handler's expected shape
   (`Array<{ email, name? }>`). Caused startup crash after primitive-type validation was added in 0.7.1.
+- **`calendar-find-free-time` and `calendar-check-conflicts` calendarIds input type** — both
+  declared as bare `array` (invalid JSON Schema type); corrected to `string[]` matching the
+  handlers' expected `string[]` shape. Would have caused startup crash on deploy.
 - **Duplicate `extract-relationships` in coordinator `pinned_skills`** — skill appeared twice,
   causing Anthropic to receive two identical tool definitions in the tools array
 - **`query-relationships` and `delete-relationship` skill input schemas** — both skills used

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.7.2",
+  "version": "0.7.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/calendar-check-conflicts/skill.json
+++ b/skills/calendar-check-conflicts/skill.json
@@ -6,7 +6,7 @@
   "action_risk": "none",
   "infrastructure": true,
   "inputs": {
-    "calendarIds": "array",
+    "calendarIds": "string[] (list of calendar IDs to check for conflicts)",
     "proposedStart": "timestamp (start of proposed slot)",
     "proposedEnd": "timestamp (end of proposed slot)"
   },

--- a/skills/calendar-find-free-time/skill.json
+++ b/skills/calendar-find-free-time/skill.json
@@ -6,7 +6,7 @@
   "action_risk": "none",
   "infrastructure": true,
   "inputs": {
-    "calendarIds": "array",
+    "calendarIds": "string[] (list of calendar IDs to check for availability)",
     "timeMin": "timestamp (start of search window, inclusive)",
     "timeMax": "timestamp (end of search window, exclusive)",
     "duration": "number?"


### PR DESCRIPTION
## **User description**
## Summary

- `calendar-find-free-time` and `calendar-check-conflicts` both declared `calendarIds` as `"array"` — bare `array` is not a valid JSON Schema type and causes a startup crash under the primitive-type validation added in v0.7.1
- Both handlers expect `string[]`; corrected to `"string[]"` format
- Also restores the v0.7.2 version bump that was dropped when a suggestion was applied to PR #163

## Test plan

- [ ] Container starts without errors after deploy
- [ ] `calendar-find-free-time` and `calendar-check-conflicts` skills load correctly
- [ ] Existing calendar tests pass


___

## **CodeAnt-AI Description**
Fix calendar skill inputs so the app can start and use them normally

### What Changed
- `calendar-find-free-time` and `calendar-check-conflicts` now accept calendar IDs in the expected list format instead of an invalid bare array value
- This removes a startup failure that could block these calendar skills from loading after deploy

### Impact
`✅ Fewer calendar skill startup crashes`
`✅ Reliable free-time searches`
`✅ Reliable conflict checks`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
