### PR TITLE
fix: restore knowledge graph viewport rendering after layout refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Fixed
+- **Knowledge Graph viewport blank after layout refactor** — `#cy` used `height: 100%` inside a flex
+  chain which is unreliable across browsers; switched to `position: absolute; inset: 0` so the canvas
+  always fills its `position: relative` parent. Added `cy.resize()` before layout runs so Cytoscape
+  re-measures the container after `main-app` transitions from `display: none`, and again when
+  navigating back to the KG view.
 - **`calendar-update-event` attendees input type** — declared as bare `array?` which is not a
   valid JSON Schema type; corrected to `object[]?` matching the handler's expected shape
   (`Array<{ email, name? }>`). Caused startup crash after primitive-type validation was added in 0.7.1.

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -270,7 +270,10 @@ function createUiHtml(): string {
     .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 
     /* ── Cytoscape canvas ─────────────────────────────────────────────── */
-    #cy { width: 100%; height: 100%; }
+    /* Use absolute positioning so #cy fills its position:relative parent
+       regardless of whether the flex chain gives the parent a definite height.
+       height:100% on a flex-item child is unreliable across browsers. */
+    #cy { position: absolute; top: 0; left: 0; right: 0; bottom: 0; }
 
     /* ── Subtle scrollbars ───────────────────────────────────────────── */
     ::-webkit-scrollbar       { width: 5px; }
@@ -1015,6 +1018,13 @@ function createUiHtml(): string {
       chatView.style.display = view === 'chat'         ? 'flex' : 'none';
       contactsView.style.display = view === 'contacts' ? 'flex' : 'none';
       tasksView.style.display = view === 'tasks'       ? 'flex' : 'none';
+      // When returning to the KG view, tell Cytoscape to re-measure the container.
+      // The canvas dimensions may be stale if the view was hidden (display:none)
+      // since the last render.
+      if (view === 'kg' && cy) {
+        cy.resize();
+        cy.fit();
+      }
       if (view === 'contacts') {
         loadContacts();
       }
@@ -1100,6 +1110,10 @@ function createUiHtml(): string {
       );
       cy.elements().remove();
       cy.add(elements);
+      // Force Cytoscape to re-measure the container before running layout.
+      // Without this, the canvas may still be sized 0×0 from when main-app was
+      // display:none (e.g. on first load or after navigating away and back).
+      cy.resize();
       cy.layout({ name: 'cose', animate: false, fit: true }).run();
     }
 

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1020,10 +1020,15 @@ function createUiHtml(): string {
       tasksView.style.display = view === 'tasks'       ? 'flex' : 'none';
       // When returning to the KG view, tell Cytoscape to re-measure the container.
       // The canvas dimensions may be stale if the view was hidden (display:none)
-      // since the last render.
+      // since the last render. Defer to requestAnimationFrame so the browser
+      // completes layout on the newly-visible container before we read its
+      // dimensions — calling cy.resize() synchronously after a display change
+      // can still see stale 0x0 values in some browser/flex combinations.
       if (view === 'kg' && cy) {
-        cy.resize();
-        cy.fit();
+        requestAnimationFrame(function() {
+          cy.resize();
+          cy.fit();
+        });
       }
       if (view === 'contacts') {
         loadContacts();


### PR DESCRIPTION
## **User description**
## Summary

- `#cy` used `height: 100%` inside a flex chain where no ancestor had an explicit height, causing Cytoscape to measure a 0×0 canvas at init time (when `main-app` was still `display: none`)
- Fixed by switching `#cy` to `position: absolute; top/right/bottom/left: 0` — the parent wrapper is already `position: relative`, so this fills it reliably without needing height inheritance
- Added `cy.resize()` in `renderGraph()` so Cytoscape re-measures the container before each layout run
- Added `requestAnimationFrame(() => { cy.resize(); cy.fit(); })` in `navigate()` when returning to the KG view — deferred so the browser completes layout on the newly-visible container before geometry is read

## Test plan

- [ ] Load the KG page, click a node — graph renders in the viewport
- [ ] Navigate to Chat or Contacts, then back to Knowledge Graph — previously loaded graph re-appears correctly (pan/zoom may reset to fit, which is acceptable)
- [ ] Resize the browser window while on the KG view — graph stays correctly fitted


___

## **CodeAnt-AI Description**
**Restore Knowledge Graph rendering after navigating or resizing**

### What Changed
- The Knowledge Graph canvas now fills its visible area reliably, so the graph no longer opens or reopens as a blank 0×0 view.
- The graph now re-checks its size before drawing and again when returning to the Knowledge Graph screen, which keeps the layout fitted after navigation.
- The view stays usable after switching away and back, with the graph reappearing correctly instead of needing a refresh.

### Impact
`✅ Fewer blank Knowledge Graph screens`
`✅ Reliable graph display after navigation`
`✅ Better fit after returning to the graph`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
