### PR TITLE
fix: prevent blank KG chat replies when extract-relationships runs last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Fixed
+- **KG chat blank reply** — after `extract-relationships` ran as the last tool call, the LLM
+  produced `end_turn` with no text blocks, delivering an empty reply to the user. Fixed by
+  clarifying in the coordinator system prompt that `extract-relationships` is a background
+  housekeeping task and must not replace the text response; also added a defensive fallback
+  in the agent runtime that logs an error and returns a safe message instead of forwarding
+  an empty string to the user.
 - **Knowledge Graph viewport blank after layout refactor** — `#cy` used `height: 100%` inside a flex
   chain which is unreliable across browsers; switched to `position: absolute; inset: 0` so the canvas
   always fills its `position: relative` parent. Added `cy.resize()` before layout runs so Cytoscape

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -47,6 +47,12 @@ system_prompt: |
   message contains relationships — the skill handles that internally and exits
   immediately if there is nothing to extract. Always call it; never skip it.
 
+  IMPORTANT: `extract-relationships` is a silent background housekeeping task.
+  It must never replace your text response to the user. Always write your reply
+  to the user first, then call `extract-relationships` as a follow-up step.
+  If you have nothing else to say, write a brief acknowledgement before calling it.
+  The user must always receive a non-empty text response from you.
+
   ## Relationship Management
   Use `query-relationships` to look up stored relationships for any entity by name.
   Use `delete-relationship` when the user explicitly says a relationship is wrong,

--- a/src/agents/llm/anthropic.ts
+++ b/src/agents/llm/anthropic.ts
@@ -156,7 +156,10 @@ export class AnthropicProvider implements LLMProvider {
       );
       const content = textContent?.text ?? '';
       if (!content) {
-        this.logger.warn({ model, stopReason: response.stop_reason }, 'LLM returned empty text response');
+        // Log at error level — an empty text response means the user will receive a blank reply.
+        // The runtime catches this and returns a fallback message, but this event indicates
+        // the model ended its turn (stop_reason) without producing any user-facing text.
+        this.logger.error({ model, stopReason: response.stop_reason }, 'LLM returned empty text response');
       }
       return {
         type: 'text',

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -407,7 +407,7 @@ export class AgentRuntime {
         { agentId, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens },
         'Agent task completed',
       );
-      if (!response.content) {
+      if (response.content === '') {
         // The LLM returned end_turn with no text blocks — this happens when the model
         // considers its tool calls (e.g. extract-relationships) to be the full response
         // and produces an empty content array. Surface as an error so we don't silently

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -407,7 +407,19 @@ export class AgentRuntime {
         { agentId, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens },
         'Agent task completed',
       );
-      responseContent = response.content;
+      if (!response.content) {
+        // The LLM returned end_turn with no text blocks — this happens when the model
+        // considers its tool calls (e.g. extract-relationships) to be the full response
+        // and produces an empty content array. Surface as an error so we don't silently
+        // deliver a blank reply; the system prompt instructs the agent to always write text.
+        logger.error(
+          { agentId, conversationId, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens },
+          'LLM returned empty text response after tool use — agent did not produce a user-facing reply',
+        );
+        responseContent = "I'm sorry, I wasn't able to formulate a response. Please try again.";
+      } else {
+        responseContent = response.content;
+      }
     } else {
       // Shouldn't reach here — chatWithRetry handles errors — but be safe
       logger.error({ agentId, error: response.error }, 'LLM call failed after retries');

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -407,7 +407,7 @@ export class AgentRuntime {
         { agentId, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens },
         'Agent task completed',
       );
-      if (response.content === '') {
+      if (response.content.trim() === '') {
         // The LLM returned end_turn with no text blocks — this happens when the model
         // considers its tool calls (e.g. extract-relationships) to be the full response
         // and produces an empty content array. Surface as an error so we don't silently

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -500,6 +500,69 @@ describe('AgentRuntime tool-use loop', () => {
     expect(responseContent).toContain('formulate a response');
   });
 
+  it('returns fallback message when LLM produces whitespace-only text after tool use', async () => {
+    // Whitespace-only responses (e.g. '\n') are visually blank and must be treated
+    // the same as an empty string — trim() === '' catches both cases.
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    let chatCallCount = 0;
+    const whitespaceTextProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn(async () => {
+        chatCallCount++;
+        if (chatCallCount === 1) {
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{ id: 'call-extract-2', name: 'extract-relationships', input: { text: 'Hello', source: 'test' } }],
+            usage: { inputTokens: 100, outputTokens: 20 },
+          };
+        }
+        return {
+          type: 'text' as const,
+          content: '\n',
+          usage: { inputTokens: 150, outputTokens: 1 },
+        };
+      }),
+    };
+
+    const mockExecution = {
+      invoke: vi.fn().mockResolvedValue({ success: true, data: { extracted: 0, confirmed: 0, skipped: true } }),
+    } as unknown as ExecutionLayer;
+
+    let responseContent = '';
+    bus.subscribe('agent.response', 'dispatch', async (event) => {
+      if (event.type === 'agent.response') {
+        responseContent = event.payload.content;
+      }
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider: whitespaceTextProvider,
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      skillToolDefs: [{ name: 'extract-relationships', description: 'Extract relationships', input_schema: { type: 'object' as const, properties: {}, required: [] } }],
+    });
+    agent.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-whitespace-text',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Hello',
+      parentEventId: 'inbound-whitespace',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(responseContent).not.toBe('');
+    expect(responseContent).not.toBe('\n');
+    expect(responseContent).toContain('formulate a response');
+  });
+
   it('stops after budget maxTurns is exceeded to prevent infinite loops', async () => {
     const logger = createLogger('error');
     const bus = new EventBus(logger);

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -435,6 +435,71 @@ describe('AgentRuntime tool-use loop', () => {
     expect(responseContent).toBeTruthy();
   });
 
+  it('returns fallback message when LLM produces empty text after tool use', async () => {
+    // Regression test: the coordinator calls extract-relationships after every message.
+    // When it runs last, the LLM can return stop_reason=end_turn with an empty content
+    // array, delivering a blank reply. The runtime must detect this and return a fallback.
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    let chatCallCount = 0;
+    const emptyTextProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn(async () => {
+        chatCallCount++;
+        if (chatCallCount === 1) {
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{ id: 'call-extract-1', name: 'extract-relationships', input: { text: 'Hello', source: 'test' } }],
+            usage: { inputTokens: 100, outputTokens: 20 },
+          };
+        }
+        // Second call: LLM returns end_turn with empty content array
+        return {
+          type: 'text' as const,
+          content: '',
+          usage: { inputTokens: 150, outputTokens: 0 },
+        };
+      }),
+    };
+
+    const mockExecution = {
+      invoke: vi.fn().mockResolvedValue({ success: true, data: { extracted: 0, confirmed: 0, skipped: true } }),
+    } as unknown as ExecutionLayer;
+
+    let responseContent = '';
+    bus.subscribe('agent.response', 'dispatch', async (event) => {
+      if (event.type === 'agent.response') {
+        responseContent = event.payload.content;
+      }
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider: emptyTextProvider,
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      skillToolDefs: [{ name: 'extract-relationships', description: 'Extract relationships', input_schema: { type: 'object' as const, properties: {}, required: [] } }],
+    });
+    agent.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-empty-text',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Hello',
+      parentEventId: 'inbound-empty',
+    });
+    await bus.publish('dispatch', task);
+
+    // Must not deliver an empty reply — fallback message expected
+    expect(responseContent).not.toBe('');
+    expect(responseContent).toContain('formulate a response');
+  });
+
   it('stops after budget maxTurns is exceeded to prevent infinite loops', async () => {
     const logger = createLogger('error');
     const bus = new EventBus(logger);


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause**: The coordinator system prompt instructs the agent to call `extract-relationships` after every message. When it ran as the *last* tool call (e.g. after `query-relationships`), the LLM would produce `stop_reason=end_turn` with an empty content array, delivering a `{"reply":""}` to the user.

- **Prompt fix** (`agents/coordinator.yaml`): Clarifies that `extract-relationships` is a silent background housekeeping task that must not replace the user-facing text response. Instructs the agent to always write its reply first.

- **Runtime fix** (`src/agents/runtime.ts`): Defensive fallback — detects `content === ''` after tool use, logs an `error`, and returns a safe message instead of forwarding the empty string.

- **Provider fix** (`src/agents/llm/anthropic.ts`): Elevates the empty-text log from `warn` to `error` so the `stop_reason` is visible at the right severity when correlated in production logs.

- **Regression test** (`tests/unit/agents/runtime.test.ts`): Simulates `tool_use → empty text` sequence; asserts fallback is delivered.

## Test plan

- [ ] All unit tests pass (`npx vitest run tests/unit/agents/runtime.test.ts`)
- [ ] Manually ask the KG chat "What relationships do you know about X?" and verify a non-empty reply is returned
- [ ] Check server logs confirm `extract-relationships` no longer causes blank replies


___

## **CodeAnt-AI Description**
**Prevent blank KG chat replies after relationship extraction runs**

### What Changed
- KG chat now returns a safe fallback message instead of an empty reply when the assistant finishes a turn without any user-facing text after running `extract-relationships`.
- The coordinator instructions now make it clear that relationship extraction is a background step and must not replace the reply shown to the user.
- Empty text responses after tool use are now treated as errors in logs, and a regression test covers the blank-reply case.

### Impact
`✅ Fewer blank KG chat replies`
`✅ Clearer KG chat failures`
`✅ More reliable relationship extraction handling`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
