### PR TITLE
fix: resolve cytoscape asset path via createRequire (fixes KG blank viewport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,13 @@ bus event types) are noted explicitly even in the `0.x` range.
   housekeeping task and must not replace the text response; also added a defensive fallback
   in the agent runtime that logs an error and returns a safe message instead of forwarding
   an empty string to the user.
-- **Knowledge Graph viewport blank after layout refactor** — `#cy` used `height: 100%` inside a flex
-  chain which is unreliable across browsers; switched to `position: absolute; inset: 0` so the canvas
-  always fills its `position: relative` parent. Added `cy.resize()` before layout runs so Cytoscape
-  re-measures the container after `main-app` transitions from `display: none`, and again when
-  navigating back to the KG view.
+- **Knowledge Graph viewport blank after layout refactor** — two root causes fixed: (1) `#cy` used
+  `height: 100%` inside a flex chain which is unreliable across browsers; switched to
+  `position: absolute; inset: 0` so the canvas always fills its `position: relative` parent; (2) the
+  `/assets/cytoscape.min.js` route used a `new URL('../../../../node_modules/...')` relative path
+  that breaks when tsup bundles into a flat `dist/index.js` — replaced with `createRequire` +
+  `require.resolve()` so Node's module resolution finds cytoscape correctly in any output structure.
+  Also added `cy.resize()` before layout runs and when navigating back to the KG view.
 - **`calendar-update-event` attendees input type** — declared as bare `array?` which is not a
   valid JSON Schema type; corrected to `object[]?` matching the handler's expected shape
   (`Array<{ email, name? }>`). Caused startup crash after primitive-type validation was added in 0.7.1.

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1,6 +1,6 @@
 import { randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { Pool } from 'pg';
 import type { EventBus } from '../../../bus/bus.js';
@@ -1827,9 +1827,13 @@ export async function knowledgeGraphRoutes(
   });
 
   app.get('/assets/cytoscape.min.js', async (_request, reply) => {
-    const cytoscapePath = fileURLToPath(
-      new URL('../../../../node_modules/cytoscape/dist/cytoscape.min.js', import.meta.url),
-    );
+    // Use createRequire so Node's module resolution finds cytoscape relative to
+    // this source file, not relative to the compiled bundle output path.
+    // The URL-relative approach (new URL('../../../../node_modules/...')) breaks
+    // when tsup bundles everything into a flat dist/index.js — the path walks
+    // above the project root and produces a 500.
+    const require = createRequire(import.meta.url);
+    const cytoscapePath = require.resolve('cytoscape/dist/cytoscape.min.js');
     const source = await readFile(cytoscapePath, 'utf8');
     // Long-lived cache — cytoscape is a pinned dependency; the version never
     // changes without a code change, so immutable caching is safe here.


### PR DESCRIPTION
## **User description**
## Summary

- `/assets/cytoscape.min.js` was returning 500 in production, causing the KG graph to never render
- Root cause: `new URL('../../../../node_modules/cytoscape/dist/cytoscape.min.js', import.meta.url)` worked in dev (source at `src/channels/http/routes/kg.ts`, 4 levels deep) but broke after tsup bundles into a flat `dist/index.js` — the `../../../../` walk goes above the project root and the file isn't found
- Fix: replaced with `createRequire(import.meta.url).resolve('cytoscape/dist/cytoscape.min.js')` which uses Node's standard package resolution — works correctly regardless of bundle output depth

## Test plan

- [ ] Deploy to production and confirm `/assets/cytoscape.min.js` returns 200
- [ ] Click a node in the Knowledge Graph — Cytoscape canvas appears and graph renders
- [ ] Confirmed via Network tab: `cytoscape.min.js` was previously returning 500; should now be 200


___

## **CodeAnt-AI Description**
**Fix the Knowledge Graph script load so the graph renders again**

### What Changed
- The Knowledge Graph now loads Cytoscape through Node’s package resolution, so `/assets/cytoscape.min.js` works in production bundles as well as in development
- This removes the 500 error that left the Knowledge Graph canvas blank
- The changelog now reflects the full Knowledge Graph viewport fix, including the canvas sizing and redraw updates

### Impact
`✅ Fewer blank Knowledge Graph views`
`✅ Fewer production 500s for the graph script`
`✅ More reliable graph rendering after navigation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
