### PR TITLE
fix: recover from empty LLM response after tool use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Fixed
+- **Empty-response recovery** — when the LLM ends a turn with no text (e.g. after calling
+  `extract-relationships` as its last action), the agent runtime now attempts one recovery:
+  it appends a nudge turn and retries without tools to force a text reply. Only if the
+  recovery also fails does it fall back to the "unable to formulate a response" message.
 - **KG chat blank reply** — after `extract-relationships` ran as the last tool call, the LLM
   produced `end_turn` with no text blocks, delivering an empty reply to the user. Fixed by
   clarifying in the coordinator system prompt that `extract-relationships` is a background

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.0.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.0.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.81.0",
@@ -14,6 +14,7 @@
         "@fastify/cors": "^11.2.0",
         "@fastify/rate-limit": "^10.3.0",
         "@ghostery/adblocker-playwright": "^2.14.1",
+        "chokidar": "^5.0.0",
         "cron-parser": "^5.5.0",
         "cytoscape": "^3.33.1",
         "fastify": "^5.8.4",
@@ -28,6 +29,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/chokidar": "^2.1.7",
         "@types/js-yaml": "^4.0.9",
         "@types/luxon": "^3.7.1",
         "@types/node": "^25.5.0",
@@ -1706,6 +1708,17 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/chokidar": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-2.1.7.tgz",
+      "integrity": "sha512-A7/MFHf6KF7peCzjEC1BBTF8jpmZTokb3vr/A0NxRGfwRLK3Ws+Hq6ugVn6cJIMfM6wkCak/aplWrxbTcu8oig==",
+      "deprecated": "This is a stub types definition. chokidar provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2376,16 +2389,15 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -4576,13 +4588,12 @@
       "license": "MIT"
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -5173,6 +5184,36 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsup/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/tsup/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -408,15 +408,32 @@ export class AgentRuntime {
         'Agent task completed',
       );
       if (response.content.trim() === '') {
-        // The LLM returned end_turn with no text blocks — this happens when the model
-        // considers its tool calls (e.g. extract-relationships) to be the full response
-        // and produces an empty content array. Surface as an error so we don't silently
-        // deliver a blank reply; the system prompt instructs the agent to always write text.
-        logger.error(
-          { agentId, conversationId, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens },
-          'LLM returned empty text response after tool use — agent did not produce a user-facing reply',
+        // The LLM returned end_turn with no text — this happens when the model considers
+        // its tool calls (e.g. extract-relationships) to be the full response and produces
+        // an empty content array. Attempt one recovery: append the empty turn + a nudge,
+        // then call the LLM again without tools to force it to write the text reply.
+        logger.warn(
+          { agentId, conversationId },
+          'LLM returned empty text after tool use — attempting recovery prompt',
         );
-        responseContent = "I'm sorry, I wasn't able to formulate a response. Please try again.";
+
+        // Append the empty assistant turn so the conversation structure stays valid,
+        // then ask the LLM to write the text reply it skipped.
+        messages.push({ role: 'assistant', content: '' });
+        messages.push({ role: 'user', content: 'Please write your response to the user.' });
+
+        // Call without tools — the LLM must produce text, it cannot call more tools.
+        const recovery = await this.chatWithRetry(provider, { messages }, budget, taskEvent);
+        if (recovery?.type === 'text' && recovery.content.trim() !== '') {
+          responseContent = recovery.content;
+          logger.info({ agentId, conversationId }, 'Empty-response recovery succeeded');
+        } else {
+          logger.error(
+            { agentId, conversationId, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens },
+            'LLM returned empty text response after tool use — recovery also failed, sending fallback',
+          );
+          responseContent = "I'm sorry, I wasn't able to formulate a response. Please try again.";
+        }
       } else {
         responseContent = response.content;
       }

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -413,23 +413,42 @@ export class AgentRuntime {
         // an empty content array. Attempt one recovery: append the empty turn + a nudge,
         // then call the LLM again without tools to force it to write the text reply.
         logger.warn(
-          { agentId, conversationId },
+          { agentId, conversationId, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens },
           'LLM returned empty text after tool use — attempting recovery prompt',
         );
 
-        // Append the empty assistant turn so the conversation structure stays valid,
+        // Append the empty assistant turn so the conversation structure stays valid
+        // (Anthropic rejects empty string content, so use a single space as a stand-in),
         // then ask the LLM to write the text reply it skipped.
-        messages.push({ role: 'assistant', content: '' });
+        messages.push({ role: 'assistant', content: ' ' });
         messages.push({ role: 'user', content: 'Please write your response to the user.' });
+
+        // Count the recovery call against the turn budget — it is a real LLM round-trip.
+        budget.turnsUsed++;
+        if (budget.turnsUsed >= budget.maxTurns) {
+          await this.handleBudgetExceeded(budget, taskEvent, 'maxTurns');
+          return;
+        }
 
         // Call without tools — the LLM must produce text, it cannot call more tools.
         const recovery = await this.chatWithRetry(provider, { messages }, budget, taskEvent);
-        if (recovery?.type === 'text' && recovery.content.trim() !== '') {
+        // chatWithRetry returns null when it has already published error events and sent an
+        // error response — bail out here to avoid double-publishing a second response event
+        // and writing a phantom turn to working memory.
+        if (!recovery) return;
+
+        if (recovery.type === 'text' && recovery.content.trim() !== '') {
           responseContent = recovery.content;
           logger.info({ agentId, conversationId }, 'Empty-response recovery succeeded');
         } else {
           logger.error(
-            { agentId, conversationId, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens },
+            {
+              agentId,
+              conversationId,
+              recoveryType: recovery.type,
+              inputTokens: response.usage.inputTokens,
+              outputTokens: response.usage.outputTokens,
+            },
             'LLM returned empty text response after tool use — recovery also failed, sending fallback',
           );
           responseContent = "I'm sorry, I wasn't able to formulate a response. Please try again.";


### PR DESCRIPTION
## **User description**
## Summary

- When Claude ends a turn with no text (e.g. after calling `extract-relationships` as its last action), the agent runtime now attempts one recovery: appends a nudge turn and retries **without tools**, forcing the LLM to produce the text reply it skipped
- Only if the recovery also fails does it fall back to the "unable to formulate a response" message
- Fixes the production regression introduced by PR #170, where the defensive fallback made the problem visible to users instead of recovering from it

## Root cause

`claude-sonnet-4-20250514` consistently ends turns with empty content after calling background tools, ignoring the system prompt instruction to "write your reply first." The system prompt fix in PR #170 was insufficient — the runtime now handles it structurally.

## Review findings addressed

- `content: ''` → `' '`: Anthropic API rejects empty string assistant content with a 400
- Guard `recovery === null`: without this, `chatWithRetry` null (already-sent error) caused double-published response events and phantom working memory turns
- Recovery call counted against `budget.turnsUsed` + maxTurns checked before calling
- Token usage logged on warn path; `recovery.type` logged in fallback branch to distinguish failure modes

## Test plan

- [ ] All 809 existing tests pass
- [ ] Deploy to production and verify responses come through for KG queries and simple questions like "What's the day today?"
- [ ] Confirm `warn` log appears when recovery is triggered, and `info` appears on success


___

## **CodeAnt-AI Description**
**Recover from empty AI replies after tool use**

### What Changed
- When the AI finishes with no text after using tools, the agent now tries once more to get a normal reply instead of showing the fallback error message right away
- If the retry still produces no usable text, the user still gets the same apology message as before
- The retry counts toward the turn limit, so long-running requests can still stop when they hit their budget

### Impact
`✅ Fewer blank AI replies`
`✅ Fewer “unable to formulate a response” fallbacks`
`✅ More complete answers after tool-based queries`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
