### PR TITLE
fix: use non-whitespace placeholder in recovery assistant turn

### DIFF
--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -417,10 +417,10 @@ export class AgentRuntime {
           'LLM returned empty text after tool use — attempting recovery prompt',
         );
 
-        // Append the empty assistant turn so the conversation structure stays valid
-        // (Anthropic rejects empty string content, so use a single space as a stand-in),
-        // then ask the LLM to write the text reply it skipped.
-        messages.push({ role: 'assistant', content: ' ' });
+        // Append a minimal assistant turn to maintain valid turn alternation.
+        // Anthropic rejects both empty strings AND whitespace-only strings, so we
+        // use a non-whitespace ellipsis as a stand-in for "ran tools, no text produced".
+        messages.push({ role: 'assistant', content: '…' });
         messages.push({ role: 'user', content: 'Please write your response to the user.' });
 
         // Count the recovery call against the turn budget — it is a real LLM round-trip.


### PR DESCRIPTION
## **User description**
## Summary

- Follow-up to #172: the single-space placeholder (`' '`) used in the recovery assistant turn is also rejected by the Anthropic API with `400: text content blocks must contain non-whitespace text`
- Every recovery attempt was hitting this 400, causing `chatWithRetry` to return `null` and fall straight through to the error fallback — making #172 a no-op in production
- Fix: use `'…'` (unicode ellipsis) as the placeholder — valid non-whitespace, accepted by the API

## Root cause (from production logs)

```
messages: text content blocks must contain non-whitespace text
```

The recovery path appended `{ role: 'assistant', content: ' ' }` before the nudge turn. Anthropic rejects both `''` and `' '` alike.

## Test plan

- [ ] All 809 tests pass (CI green)
- [ ] Deploy and verify responses come through for KG queries and simple questions
- [ ] Confirm `info: Empty-response recovery succeeded` log appears rather than the fallback error


___

## **CodeAnt-AI Description**
**Fix recovery after the model returns no text**

### What Changed
- When the model finishes a tool-based response without any text, the app now uses a non-whitespace placeholder so the retry path can continue.
- Recovery no longer fails immediately because the placeholder is accepted by the API.
- Users are more likely to receive a normal answer instead of falling through to the error fallback after an empty response.

### Impact
`✅ Fewer empty-response fallbacks`
`✅ More recovered answers after tool use`
`✅ Fewer failed retry attempts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
