### PR TITLE
chore: add ADR directory with 12 backfilled decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+- **Architecture Decision Records** — `docs/adr/` directory with template, index, and 12 backfilled ADRs covering: Postgres over SQLite, message bus over direct calls, YAML agent config with TypeScript escape hatch, pgvector over dedicated vector DB, node-pg-migrate over Knex, custom framework over existing agent frameworks, Anthropic as primary LLM with provider-agnostic interface, OpenAI embeddings for knowledge graph, Nylas for email, Signal over Telegram, score-based autonomy engine, and LLM-as-judge evaluation (closes #7)
+- **ADR reminder in CLAUDE.md** — guidance on when to write an ADR when implementing specs with major architectural decisions
+
 ### Fixed
 - **Empty-response recovery** — when the LLM ends a turn with no text (e.g. after calling
   `extract-relationships` as its last action), the agent runtime now attempts one recovery:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,25 @@ When adding a new agent, ensure it receives the autonomy block via the runtime i
 1. Create `agents/<name>.yaml` with required fields (name, description, model, system_prompt)
 2. Optionally add `handler: ./<name>.handler.ts` for custom logic
 
+## Architecture Decision Records (ADRs)
+
+ADRs live in `docs/adr/`. Each ADR documents a significant architectural decision — the context, the choice made, and the consequences.
+
+**When to write an ADR:** If the spec or plan you're working on contains a major architectural decision — a choice between fundamentally different approaches, a new external dependency that shapes the system, or a deliberate trade-off with long-term consequences — write an ADR before or alongside the implementation. Use `docs/adr/template.md`.
+
+Examples that warrant an ADR:
+- Choosing one technology over another (database engine, external API, messaging pattern)
+- A new design pattern or abstraction that other components will follow
+- Explicitly rejecting an approach that seems obvious (document why)
+- A breaking change to a public API surface with a stated rationale
+
+Examples that do NOT need an ADR:
+- Adding a new skill or agent using existing patterns
+- Bug fixes
+- Routine dependency updates
+
+Add a row to `docs/adr/README.md` for every new ADR.
+
 ## WIP Artifacts (Plans & Designs)
 
 All timestamped work artifacts — implementation plans and design specs — live in `docs/wip/`. This overrides the default superpowers skill behavior:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,19 @@ Curia uses a message bus architecture with five layers — four domain layers wi
 
 Each layer has strict bus permissions. See [architecture overview](docs/specs/00-overview.md) for details.
 
+### Architecture Decision Records
+
+Significant architectural decisions are documented in [`docs/adr/`](docs/adr/). Read these before proposing changes — they explain *why* the system is the way it is, and which trade-offs were deliberately accepted.
+
+**If your change involves a major architectural decision, write an ADR before or alongside the implementation.** This includes:
+
+- Choosing one technology or pattern over another
+- Introducing a new external dependency that shapes the system
+- Deliberately rejecting an approach that might seem obvious
+- A breaking change to a public API surface with a stated rationale
+
+Use [`docs/adr/template.md`](docs/adr/template.md) and add a row to the index in [`docs/adr/README.md`](docs/adr/README.md). ADRs should be included in the same PR as the implementation, not filed separately after the fact.
+
 ## Developer Guides
 
 Step-by-step guides for common extension tasks — more detail than the quick references below:

--- a/docs/adr/001-postgres-over-sqlite.md
+++ b/docs/adr/001-postgres-over-sqlite.md
@@ -1,0 +1,33 @@
+# ADR-001: Postgres over SQLite
+
+Date: 2026-02-05
+Status: Accepted
+
+## Context
+
+Curia is a long-running, VPS-hosted executive assistant that needs persistent storage for:
+- Structured data (contacts, audit log, scheduled jobs, identity records)
+- Vector embeddings for the knowledge graph (pgvector)
+- Write-ahead audit logging with at-least-once delivery guarantees
+- Concurrent access from multiple async layers (bus, agent runtime, skill execution)
+
+SQLite was the simplest option for a single-user system deployed on a single VPS. However, the project also needed native vector similarity search and concurrent writer safety.
+
+## Decision
+
+Use PostgreSQL 16+ as the primary database.
+
+Postgres was chosen over SQLite because:
+- **pgvector** — native vector similarity search (HNSW index) is a first-class Postgres extension. SQLite's vector support is bolted-on and immature.
+- **Concurrent writes** — Postgres handles concurrent writers from multiple async processes safely. SQLite's write lock model is fragile under high-concurrency async workloads.
+- **Audit log guarantees** — write-ahead logging and transaction semantics ensure the audit record is durable before in-process delivery continues.
+- **Deployment familiarity** — the existing `ceo-deploy` infrastructure (Hetzner VPS, Docker Compose) already runs Postgres for other services.
+
+The single-tenant deployment model means Postgres doesn't need to scale horizontally — a single Postgres container is sufficient and simpler to operate.
+
+## Consequences
+
+- Vector similarity search and pgvector HNSW indexes are available natively.
+- Integration tests require a running Postgres instance (Docker); no in-memory fallback for tests.
+- The `pg` driver is used directly (no ORM) to keep SQL transparent and auditable.
+- Horizontal scaling would require read replicas or connection pooling (pgBouncer) — accepted as out of scope for the single-tenant use case.

--- a/docs/adr/002-message-bus-over-direct-calls.md
+++ b/docs/adr/002-message-bus-over-direct-calls.md
@@ -1,0 +1,32 @@
+# ADR-002: Message bus over direct calls
+
+Date: 2026-02-05
+Status: Accepted
+
+## Context
+
+The system has five distinct layers (Channel, Dispatch, Agent, Execution, System) that need to communicate. The two obvious implementation patterns were:
+
+1. **Direct calls** — each layer imports and calls the next layer's functions directly
+2. **Message bus** — all communication flows through a central typed event bus backed by Postgres
+
+Direct calls are simpler to implement and debug. However, Curia has strict requirements around security boundaries, auditability, and restart safety that pull strongly toward the bus pattern.
+
+## Decision
+
+All inter-layer communication flows through a central in-process message bus backed by Postgres for persistence.
+
+Key aspects of the decision:
+- **Typed event registry** — all event types are defined as a TypeScript discriminated union. No `any` payloads, no stringly-typed event names without compile-time checking.
+- **Hard security boundaries** — the bus validates publisher authorization at registration time. A layer registered as `"channel"` cannot publish `skill.invoke`. This is architectural enforcement, not policy.
+- **Write-ahead audit logging** — the audit logger writes events to Postgres *before* delivering to other subscribers. This gives at-least-once delivery guarantees even across restarts.
+- **System layer** — trusted infrastructure (audit logger, memory engine, scheduler) registers with full pub/sub access. All other layers have a restrictive allowlist.
+
+The alternative — direct calls with post-hoc audit logging — was rejected because it requires all callers to remember to log, makes security boundaries organizational rather than enforced, and doesn't provide restart-safe delivery guarantees.
+
+## Consequences
+
+- Adding a new capability (new event type) requires updating the discriminated union and the permissions map — intentional friction that prevents undocumented side-channels.
+- The bus is currently in-process; true distributed messaging (e.g., Redis Streams) would require replacing the bus layer without changing the interfaces.
+- Write-ahead audit logging means every event incurs a Postgres write before in-process delivery. This is an intentional latency trade-off for durability.
+- Debugging requires reading the audit log rather than stepping through a call stack — observability tooling is more important than in direct-call architectures.

--- a/docs/adr/003-yaml-agent-config-with-typescript-escape-hatch.md
+++ b/docs/adr/003-yaml-agent-config-with-typescript-escape-hatch.md
@@ -1,0 +1,29 @@
+# ADR-003: YAML agent config with TypeScript escape hatch
+
+Date: 2026-02-20
+Status: Accepted
+
+## Context
+
+Agent definitions need to capture: identity (name, description, model), system prompt, pinned skills, memory scopes, schedule, and error budget. These are primarily static configuration that doesn't change per-request.
+
+Options considered:
+1. **TypeScript only** — agents defined entirely in code; maximum flexibility, but no declarative overview
+2. **YAML only** — fully declarative; inspectable without running code, but no escape hatch for custom logic
+3. **YAML with optional TypeScript handler** — declarative baseline with a `handler:` field pointing to a `.ts` file for agents that need custom dispatch logic
+
+## Decision
+
+Agent definitions are YAML files (`agents/*.yaml`) with an optional `handler:` field pointing to a TypeScript module.
+
+The YAML layer captures what's universally declarative: identity, model selection, system prompt, pinned skills, memory scopes, schedule, and error budget. This can be read and understood without running the system.
+
+The TypeScript escape hatch (`handler: ./coordinator.handler.ts`) is available for agents with non-trivial routing logic (e.g., the Coordinator, which dynamically selects agents based on message content). Standard specialist agents need no handler — the runtime's default execution path is sufficient.
+
+## Consequences
+
+- Agents can be inspected, audited, and diffed as plain text without code execution.
+- New agents for standard use cases require no TypeScript — just a YAML file.
+- Custom agents (like the Coordinator) can express arbitrary dispatch logic in the handler without polluting the base runtime.
+- The YAML schema is a public API surface — changes are breaking and must be called out in the changelog even in the `0.x` range.
+- Schema validation runs at startup; malformed agent files crash early rather than failing silently at runtime.

--- a/docs/adr/004-pgvector-over-dedicated-vector-db.md
+++ b/docs/adr/004-pgvector-over-dedicated-vector-db.md
@@ -1,0 +1,30 @@
+# ADR-004: pgvector over dedicated vector DB
+
+Date: 2026-02-20
+Status: Accepted
+
+## Context
+
+The knowledge graph needs vector similarity search for entity lookup and relationship queries. A dedicated vector database (Pinecone, Weaviate, Qdrant, Chroma) would provide purpose-built indexing and approximate nearest-neighbor search at scale. However, the system already depends on Postgres for all other persistence.
+
+Options considered:
+1. **Dedicated vector DB** (Pinecone, Qdrant, Chroma) — optimized for vector search; separate service to operate
+2. **pgvector** — Postgres extension; same database, same connection pool, same backup strategy
+
+## Decision
+
+Use the pgvector Postgres extension with an HNSW index for vector similarity search.
+
+Running a separate vector database was rejected because:
+- **Operational overhead** — a second stateful service to deploy, monitor, backup, and keep in sync with Postgres. For a single-tenant system on a single VPS, this cost is not justified.
+- **Consistency** — entity records and their embeddings live in the same Postgres transaction. A separate vector DB would require dual writes with failure modes (entity saved, embedding not; embedding updated, entity stale).
+- **Scale** — at the expected volume (thousands to tens of thousands of entities for a single executive), pgvector's HNSW index is fast enough and requires no special tuning.
+
+pgvector's HNSW index provides approximate nearest-neighbor search at sub-millisecond latency for this data scale. Exact k-NN is available as a fallback for correctness-sensitive queries.
+
+## Consequences
+
+- Entity embeddings and structured entity data are always consistent (same transaction).
+- No additional service to deploy or monitor beyond what's already required.
+- If the system ever needs to scale to millions of entities or serve many concurrent users, migrating to a dedicated vector DB would require a data migration and dual-write period.
+- HNSW index build time grows with dataset size — at very large scale, index maintenance would need tuning. Accepted as a future concern.

--- a/docs/adr/005-node-pg-migrate-over-knex.md
+++ b/docs/adr/005-node-pg-migrate-over-knex.md
@@ -1,0 +1,31 @@
+# ADR-005: node-pg-migrate over Knex for migrations
+
+Date: 2026-02-20
+Status: Accepted
+
+## Context
+
+The system needs a database migration strategy for evolving the Postgres schema over time. The main options considered were:
+
+1. **Knex** — query builder that includes a migration system; migrations written in JavaScript/TypeScript using a fluent API
+2. **node-pg-migrate** — migration runner only; migrations are plain SQL files with an optional JS/TS wrapper
+3. **Prisma** — full ORM with its own migration system and schema language
+
+## Decision
+
+Use node-pg-migrate with plain SQL migration files.
+
+Knex and Prisma were rejected because:
+- **ORM coupling** — Knex's migration API encourages using Knex's query builder in migrations. If Knex is later replaced or upgraded, migrations become a liability. Plain SQL has no coupling.
+- **Readability** — SQL migrations are readable by any database engineer without framework knowledge. Knex migrations require understanding the Knex fluent API to audit.
+- **Debuggability** — a plain SQL migration can be run directly in `psql` for inspection or manual correction. A Knex migration cannot.
+- **Prisma overhead** — Prisma's schema language and migration system add significant abstraction that isn't needed when queries are written directly with `pg`.
+
+node-pg-migrate is a thin runner: it tracks which migrations have run, executes them in order, and handles `up`/`down` transitions. The migrations themselves are plain SQL, which gives maximum portability and auditability.
+
+## Consequences
+
+- Any database engineer can read and audit the migration history without framework knowledge.
+- Migrations can be tested by running them directly in `psql` before deploying.
+- Complex operations (e.g., data backfills alongside schema changes) require raw SQL, which is more verbose than a query builder but more explicit.
+- There is no ORM — all queries are written with parameterized `pg` calls. This is a deliberate choice (see design principle: "everything is auditable") but means more boilerplate than an ORM would produce.

--- a/docs/adr/006-custom-framework-over-existing-agents.md
+++ b/docs/adr/006-custom-framework-over-existing-agents.md
@@ -1,0 +1,33 @@
+# ADR-006: Build custom framework over adopting existing agent frameworks
+
+Date: 2026-02-05
+Status: Accepted
+
+## Context
+
+Building a production AI agent system requires a foundation. The obvious question was whether to adopt an existing open-source agent framework or build a purpose-built one. Four candidates were evaluated:
+
+- **agentsystems** — single maintainer, no code review, thin tests, immature architecture
+- **Daemora** — same risk profile as agentsystems
+- **ForgeAI** — same risk profile
+- **Edict** — same risk profile
+
+All four were assessed as high-risk for production use: they lacked code review processes, had minimal test coverage, and were architected for demo use cases rather than long-running production systems.
+
+The alternative was to build a minimal custom framework ("Curia") purpose-built for a long-running, VPS-hosted executive assistant.
+
+## Decision
+
+Build a custom framework from scratch rather than adopting an existing open-source agent framework.
+
+The custom framework is scoped to exactly what the system needs: a typed message bus, a layered security model, a skill execution layer, and a knowledge graph. It does not try to be general-purpose.
+
+The existing `ceo-deploy` infrastructure (Hetzner VPS, Docker Compose, Caddy) is reused. The Zora dependency is replaced entirely — no data migration, because Zora was an evaluation system, not a production system with accumulated data worth preserving.
+
+## Consequences
+
+- No inherited technical debt or surprise breaking changes from upstream maintainers.
+- Every architectural decision is intentional and documented (this ADR directory).
+- The maintenance burden falls entirely on this project — there is no upstream community to fix security issues or add capabilities.
+- New contributors cannot rely on prior framework knowledge; they must learn Curia's patterns from its docs and code.
+- The framework is deliberately minimal — capabilities are added when needed, not speculatively. This keeps the surface area small and the codebase auditable.

--- a/docs/adr/007-anthropic-primary-llm-provider-agnostic-interface.md
+++ b/docs/adr/007-anthropic-primary-llm-provider-agnostic-interface.md
@@ -1,0 +1,31 @@
+# ADR-007: Anthropic as primary LLM with provider-agnostic interface
+
+Date: 2026-02-05
+Status: Accepted
+
+## Context
+
+The system needs an LLM provider for agent reasoning and tool use. The primary candidates at design time were Anthropic (Claude), OpenAI (GPT-4), and self-hosted models (Ollama). The decision had two parts: which provider to use by default, and whether to abstract the provider behind an interface.
+
+## Decision
+
+Anthropic (Claude) is the primary LLM provider. The `AgentRuntime` uses a provider-agnostic interface so that OpenAI and Ollama implementations can be registered alongside the Anthropic default.
+
+**Why Anthropic as primary:**
+- Claude's tool use (function calling) API is the most ergonomic for multi-step agent workflows at the time of design.
+- Claude has stronger documented safety properties for an executive assistant use case — reduced likelihood of prompt injection following through to harmful actions.
+- The existing `ceo-deploy` infrastructure already had Anthropic API credentials.
+
+**Why a provider-agnostic interface:**
+- Vendor lock-in at the architecture level is a significant long-term risk. Prices, quality, and API availability change.
+- Different agents may benefit from different providers (e.g., a fast cheap model for classification, a capable model for complex reasoning).
+- The interface cost is low — a thin adapter per provider, all conforming to the same `LLMProvider` contract.
+
+The SDK list in `package.json` includes `@anthropic-ai/sdk`, `openai`, and `ollama` — all three are available for registration.
+
+## Consequences
+
+- Switching the primary provider or running agents on different providers requires only a config change, not code changes.
+- Each new provider requires a thin adapter implementing the `LLMProvider` interface.
+- The system is not fully provider-neutral — capabilities like tool use and streaming must be supported by whichever provider is used for a given agent.
+- Anthropic API rate limits and pricing are a live operational concern; the interface makes it easy to add fallback providers if needed.

--- a/docs/adr/008-openai-embeddings-for-knowledge-graph.md
+++ b/docs/adr/008-openai-embeddings-for-knowledge-graph.md
@@ -1,0 +1,33 @@
+# ADR-008: OpenAI text-embedding-3-small for knowledge graph embeddings
+
+Date: 2026-02-20
+Status: Accepted
+
+## Context
+
+The knowledge graph stores entity embeddings to support vector similarity search (e.g., "find entities similar to this name or description"). An embedding model is needed to generate these vectors.
+
+Options considered:
+1. **Anthropic embeddings** — not available; Anthropic does not offer an embeddings API
+2. **OpenAI text-embedding-3-small** — 1536-dimensional vectors, low cost, high quality at this dimension count
+3. **OpenAI text-embedding-3-large** — 3072-dimensional vectors, higher quality, higher cost and storage
+4. **Self-hosted (Ollama + nomic-embed-text)** — no API cost, privacy-preserving, but requires GPU or CPU inference infrastructure
+
+## Decision
+
+Use OpenAI `text-embedding-3-small` (1536 dimensions) with a pgvector HNSW index.
+
+`text-embedding-3-small` was chosen because:
+- **Quality at scale** — 1536 dimensions provides strong semantic similarity for entity names, descriptions, and relationship text at the expected data volume.
+- **Cost** — `text-embedding-3-small` is significantly cheaper per token than `text-embedding-3-large` or `ada-002`, and the quality delta is not meaningful at this scale.
+- **Latency** — API call latency is acceptable for offline embedding generation (contact creation, relationship extraction). It is not on the user-facing critical path.
+- **Operational simplicity** — no self-hosted inference infrastructure required.
+
+Anthropic was already the primary LLM provider, so using OpenAI for embeddings introduces a second vendor dependency. This is accepted because Anthropic offers no embedding API, and the embedding call is isolated behind an interface that could be swapped for a self-hosted model later.
+
+## Consequences
+
+- A second vendor API key (OpenAI) is required in addition to Anthropic.
+- Embedding generation costs are incurred at contact creation and relationship extraction time — not on the read path.
+- Changing the embedding model in the future would require re-embedding all existing entities (migration of the `kg_nodes.embedding` column). The HNSW index dimensions are fixed at creation time.
+- pgvector stores embeddings as `vector(1536)` — the dimension is baked into the schema.

--- a/docs/adr/009-nylas-for-email.md
+++ b/docs/adr/009-nylas-for-email.md
@@ -1,0 +1,30 @@
+# ADR-009: Nylas as email integration layer
+
+Date: 2026-03-10
+Status: Accepted
+
+## Context
+
+The email channel needs to send and receive email on behalf of the executive. Options considered:
+
+1. **Direct SMTP/IMAP** — implement the raw email protocols; maximum control, but significant implementation complexity (auth, TLS, bounces, MIME parsing, attachment handling, threading)
+2. **SendGrid / Postmark** — outbound-only transactional email APIs; no inbound support
+3. **Nylas** — unified email API supporting both inbound webhooks and outbound sending across Gmail, Outlook, and others
+
+## Decision
+
+Use Nylas as the email integration layer.
+
+Nylas was chosen because:
+- **Unified API** — inbound and outbound in a single integration. Direct SMTP/IMAP would require maintaining two separate integrations (IMAP for receive, SMTP for send) with all the reconnection, TLS, and authentication complexity that entails.
+- **Multi-provider** — Nylas abstracts over Gmail, Outlook, and other providers. The executive's email provider can change without touching Curia's channel adapter.
+- **MIME and threading** — Nylas handles MIME parsing, attachment decoding, thread reconstruction, and reply-chain management. These are non-trivial to implement correctly and are not Curia's core competency.
+- **Webhooks** — inbound email arrives via webhook push, not polling. This is more reliable and lower-latency than IMAP IDLE.
+- **HTML formatting** — Nylas supports sending HTML bodies natively, which the outbound formatter uses to produce readable formatted emails.
+
+## Consequences
+
+- Nylas is a paid third-party service; the integration depends on Nylas's API availability and pricing.
+- All email content (subject, body, sender metadata) is processed by Nylas before reaching Curia. This is an accepted privacy trade-off for the integration simplicity it provides.
+- Switching email providers (e.g., from Nylas to direct IMAP) would require rewriting the channel adapter but would not affect the bus events or agent layer.
+- Nylas API credentials are required in addition to Anthropic and OpenAI credentials.

--- a/docs/adr/010-signal-over-telegram.md
+++ b/docs/adr/010-signal-over-telegram.md
@@ -1,6 +1,6 @@
 # ADR-010: Signal as high-trust messaging channel, rejecting Telegram
 
-Date: 2026-05-05
+Date: 2026-04-05
 Status: Accepted
 
 ## Context

--- a/docs/adr/010-signal-over-telegram.md
+++ b/docs/adr/010-signal-over-telegram.md
@@ -1,0 +1,31 @@
+# ADR-010: Signal as high-trust messaging channel, rejecting Telegram
+
+Date: 2026-05-05
+Status: Accepted
+
+## Context
+
+The system needed a high-trust, low-friction messaging channel for the executive to communicate with the agent — one where messages can trigger high-autonomy actions (setting autonomy scores, managing contacts, initiating outbound communication on their behalf).
+
+Two candidates were considered for this channel: Signal and Telegram.
+
+Both are mobile-first messaging apps with bot/API support. The question was which to adopt as the high-trust channel, given that messages on this channel bypass the provisional sender queue and can invoke skills with elevated `action_risk` levels.
+
+## Decision
+
+Signal is adopted as the high-trust messaging channel. Telegram support was removed from the planned channel list.
+
+Signal was chosen because:
+- **End-to-end encryption by default** — Signal's protocol (the Signal Protocol) encrypts all messages end-to-end with no server-side access. Telegram uses client-server encryption by default; end-to-end is only available in "Secret Chats" and is not available in group chats or bots.
+- **Trust alignment** — the high-trust channel carries messages that can authorize high-autonomy actions. The security properties of that channel must match the trust level it implies.
+- **No cloud storage of messages** — Telegram stores message history on Telegram's servers by default. Signal does not. For an executive assistant with access to sensitive business context, server-side message retention is a meaningful risk.
+- **Operational simplicity** — maintaining two messaging channels with similar trust levels adds complexity without proportional value.
+
+Telegram remains a technically viable channel for lower-trust, higher-volume use cases (e.g., public-facing bots) — it is not globally rejected, only rejected as the high-trust executive channel.
+
+## Consequences
+
+- Signal is the only high-trust messaging channel at launch.
+- The Signal channel adapter requires the `signal-cli` integration or an equivalent Signal API bridge (Signal does not offer an official bot API).
+- Telegram-based workflows planned in early design documents are deprecated.
+- If Telegram support is added in the future, it should be as a lower-trust channel, not a peer to Signal.

--- a/docs/adr/011-score-based-autonomy-engine.md
+++ b/docs/adr/011-score-based-autonomy-engine.md
@@ -13,9 +13,10 @@ The agent system needs a mechanism for the executive to control how autonomously
 
 ## Decision
 
-Use a single score (0–100) with five named bands: Minimal (0–19), Supervised (20–39), Standard (40–59), Elevated (60–79), Full (80–100).
+Every skill manifest must declare an `action_risk` field indicating the minimum autonomy score at which this skill may run without explicit CEO confirmation.
 
-Each skill declares its minimum required score as an `action_risk` field in `skill.json`. The execution layer checks the current score against the skill's minimum before invoking it.
+Use a single score (0–100) with five named bands: none (0–59), low (60–69), medium (70–79), high (80–89), critical (90–100). Each skills `action_risk` can have a numeric value, or a named band as a shortcut.
+
 
 Score-based was chosen over capability-based because:
 - **Cognitive simplicity** — one number is easier to reason about than a permission matrix. The executive can say "I want supervised mode today" rather than managing a list of allowed capabilities.
@@ -23,7 +24,7 @@ Score-based was chosen over capability-based because:
 - **Natural language alignment** — "set autonomy to 60" maps cleanly to a Coordinator instruction. A permission matrix would require natural language parsing to determine which capabilities to toggle.
 - **Consistent enforcement** — the gate is in the execution layer, not the agent layer. Skills cannot bypass it, regardless of what the LLM requests.
 
-The five band names (Minimal, Supervised, Standard, Elevated, Full) are human-readable aliases for score ranges, documented in `docs/specs/14-autonomy-engine.md`.
+The five band names  are human-readable aliases for score ranges, documented in `docs/specs/14-autonomy-engine.md`.
 
 ## Consequences
 

--- a/docs/adr/011-score-based-autonomy-engine.md
+++ b/docs/adr/011-score-based-autonomy-engine.md
@@ -1,0 +1,34 @@
+# ADR-011: Score-based autonomy engine over capability-based permissions
+
+Date: 2026-03-28
+Status: Accepted
+
+## Context
+
+The agent system needs a mechanism for the executive to control how autonomously the system acts. Two design approaches were considered:
+
+1. **Capability-based permissions** — a set of boolean flags or allowlists (e.g., "allow: email, calendar; deny: financial"). The executive grants or revokes specific capabilities.
+
+2. **Score-based autonomy** — a single integer (0–100) representing global autonomy level. Skills declare a minimum score required to invoke them (`action_risk`). The executive sets the score; skills gate themselves.
+
+## Decision
+
+Use a single score (0–100) with five named bands: Minimal (0–19), Supervised (20–39), Standard (40–59), Elevated (60–79), Full (80–100).
+
+Each skill declares its minimum required score as an `action_risk` field in `skill.json`. The execution layer checks the current score against the skill's minimum before invoking it.
+
+Score-based was chosen over capability-based because:
+- **Cognitive simplicity** — one number is easier to reason about than a permission matrix. The executive can say "I want supervised mode today" rather than managing a list of allowed capabilities.
+- **Graceful degradation** — as the score increases, more skills become available without the executive needing to explicitly grant each one. Decreasing the score progressively restricts capability.
+- **Natural language alignment** — "set autonomy to 60" maps cleanly to a Coordinator instruction. A permission matrix would require natural language parsing to determine which capabilities to toggle.
+- **Consistent enforcement** — the gate is in the execution layer, not the agent layer. Skills cannot bypass it, regardless of what the LLM requests.
+
+The five band names (Minimal, Supervised, Standard, Elevated, Full) are human-readable aliases for score ranges, documented in `docs/specs/14-autonomy-engine.md`.
+
+## Consequences
+
+- The executive manages autonomy through a single slider, not a permission matrix. This trades expressiveness for simplicity.
+- Skills must declare their `action_risk` at manifest load time — it cannot be dynamic. This is a deliberate constraint that makes the authorization model auditable.
+- A skill that needs to perform actions across multiple risk levels must be split into multiple skills (one per risk tier).
+- Phase 2 (per-skill and per-contact overrides) can add more granularity without changing the core score-based model.
+- The `action_risk` field is part of the skill manifest public API — renaming it or changing its semantics is a breaking change.

--- a/docs/adr/012-llm-as-judge-evaluation.md
+++ b/docs/adr/012-llm-as-judge-evaluation.md
@@ -1,0 +1,30 @@
+# ADR-012: LLM-as-judge for outbound safety and smoke test evaluation
+
+Date: 2026-03-10
+Status: Accepted
+
+## Context
+
+Two distinct evaluation problems emerged during development:
+
+1. **Smoke tests** — integration tests that submit real chat inputs and check whether the agent's response is correct. "Correct" is hard to define with deterministic assertions because LLM responses vary in phrasing.
+
+2. **Outbound safety** — before sending an email or other outbound message on behalf of the executive, the system should check whether the content is appropriate (no prompt injection leakage, no internal structure exposure, no PII exfiltration).
+
+Classic approaches for both: string matching, regex, keyword lists. These are fast and deterministic but brittle — they miss paraphrased problems and produce false positives on legitimate content.
+
+## Decision
+
+Use an LLM-as-judge approach for both smoke test evaluation and outbound safety review (Stage 2).
+
+**Smoke tests:** Each test case provides a rubric and the judge LLM scores the agent's response against it. Results are aggregated into an HTML report. This allows tests to verify semantic correctness ("did the agent find the right contact?") rather than surface form ("did the response contain the word 'found'?").
+
+**Outbound safety:** Stage 1 is a deterministic filter (regex patterns for system prompt fragments, known secret patterns, contact data exfiltration). Stage 2 — planned, not yet shipped — will use a local LLM instance running a different model from the main agent to evaluate borderline cases that Stage 1 passes. Using a *different* model provides independence: the same prompt injection that manipulates the main agent is unlikely to manipulate a different model evaluating its output.
+
+## Consequences
+
+- Smoke test evaluation is non-deterministic — the same response may receive slightly different scores on repeated runs. Rubrics must be written carefully to produce consistent judgments.
+- LLM-as-judge adds latency and cost to the smoke test suite. Tests are run manually or in CI, not on every commit — this cost is accepted.
+- Stage 2 outbound safety (LLM judge) requires a second model inference per outbound message. The local/different-model requirement means it cannot use the same Anthropic Claude instance that generated the outbound content.
+- The deterministic Stage 1 filter runs first — Stage 2 is only invoked for content that passes Stage 1. This limits the latency impact to edge cases.
+- This is a two-stage defense: Stage 1 catches known patterns fast; Stage 2 catches novel or subtle violations. Neither stage provides absolute guarantees.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,43 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the Curia project.
+
+ADRs document the reasoning behind key technical decisions — who made them, why, and what trade-offs were accepted. They prevent relitigating settled decisions and give future contributors context that isn't visible in the code.
+
+## Format
+
+Each ADR follows the [Nygard format](https://adr.github.io/):
+
+- **Context** — what problem or question prompted the decision
+- **Decision** — what was chosen and why
+- **Consequences** — what becomes easier or harder as a result
+
+## Status values
+
+- **Accepted** — in force; the current approach
+- **Deprecated** — no longer relevant but kept for historical record
+- **Superseded by ADR-NNN** — replaced by a later decision
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [001](001-postgres-over-sqlite.md) | Postgres over SQLite | Accepted |
+| [002](002-message-bus-over-direct-calls.md) | Message bus over direct calls | Accepted |
+| [003](003-yaml-agent-config-with-typescript-escape-hatch.md) | YAML agent config with TypeScript escape hatch | Accepted |
+| [004](004-pgvector-over-dedicated-vector-db.md) | pgvector over dedicated vector DB | Accepted |
+| [005](005-node-pg-migrate-over-knex.md) | node-pg-migrate over Knex for migrations | Accepted |
+| [006](006-custom-framework-over-existing-agents.md) | Build custom framework over adopting existing agent frameworks | Accepted |
+| [007](007-anthropic-primary-llm-provider-agnostic-interface.md) | Anthropic as primary LLM with provider-agnostic interface | Accepted |
+| [008](008-openai-embeddings-for-knowledge-graph.md) | OpenAI text-embedding-3-small for knowledge graph embeddings | Accepted |
+| [009](009-nylas-for-email.md) | Nylas as email integration layer | Accepted |
+| [010](010-signal-over-telegram.md) | Signal as high-trust messaging channel, rejecting Telegram | Accepted |
+| [011](011-score-based-autonomy-engine.md) | Score-based autonomy engine over capability-based permissions | Accepted |
+| [012](012-llm-as-judge-evaluation.md) | LLM-as-judge for outbound safety and smoke test evaluation | Accepted |
+
+## Adding new ADRs
+
+1. Copy `template.md` to `NNN-short-title.md` (zero-pad to three digits)
+2. Fill in Context, Decision, and Consequences
+3. Add a row to the index above
+4. If the ADR supersedes an earlier one, update the earlier ADR's status

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,16 @@
+# ADR-NNN: Short title
+
+Date: YYYY-MM-DD
+Status: Accepted
+
+## Context
+
+What is the issue, requirement, or question that motivated this decision? Include the alternatives that were considered.
+
+## Decision
+
+What was chosen and why? Be specific about the rationale — what made this option better than the alternatives in this context?
+
+## Consequences
+
+What becomes easier or more difficult as a result of this decision? Include both positive outcomes and accepted trade-offs or risks.


### PR DESCRIPTION
## **User description**
## Summary

- Creates `docs/adr/` with a template, index README, and 12 ADRs backfilled from the CHANGELOG and architecture specs
- Adds an ADR reminder section to `CLAUDE.md` so future specs with major architectural decisions get documented
- Closes #7

**ADRs included:**
| # | Decision |
|---|----------|
| 001 | Postgres over SQLite |
| 002 | Message bus over direct calls |
| 003 | YAML agent config with TypeScript escape hatch |
| 004 | pgvector over dedicated vector DB |
| 005 | node-pg-migrate over Knex for migrations |
| 006 | Build custom framework over existing agent frameworks |
| 007 | Anthropic as primary LLM with provider-agnostic interface |
| 008 | OpenAI text-embedding-3-small for knowledge graph |
| 009 | Nylas as email integration layer |
| 010 | Signal as high-trust channel, rejecting Telegram |
| 011 | Score-based autonomy engine over capability-based permissions |
| 012 | LLM-as-judge for outbound safety and smoke test evaluation |

## Test plan

- [ ] Review each ADR for accuracy against the specs and CHANGELOG
- [ ] Verify the README index links resolve to the correct files
- [ ] Confirm the CLAUDE.md ADR reminder is clear and actionable


___

## **CodeAnt-AI Description**
**Add ADR guidance and backfill the project’s architectural decisions**

### What Changed
- Added an ADR section to `CLAUDE.md` explaining when major architecture choices should be documented before or alongside implementation
- Created an ADR home in `docs/adr/` with a template, index, and 12 accepted records covering the project’s main design decisions
- Linked each ADR in the index so decisions are easier to find and review later

### Impact
`✅ Clearer architecture decisions`
`✅ Fewer undocumented design changes`
`✅ Easier onboarding for future contributors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
