### PR TITLE
feat: onboarding wizard (spec 13 follow-on)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+- **Onboarding wizard** — multi-step full-screen wizard guides new users through configuring the office identity (assistant name, tone, communication style, decision posture) on first run. Re-enterable from Settings → Setup Wizard. Requires the identity service (spec 13) to be configured.
+- **Settings nav** — new collapsible Settings section in the sidebar with Setup Wizard sub-item.
+- **`configured` flag on `GET /api/identity`** — returns `false` until the wizard or API has saved an identity explicitly; used for first-run detection in the browser without client-side state.
+
+### Changed
+- **Default landing screen** — the app now lands on Chat instead of Knowledge Graph after login.
+- **Session auth refactor** — `assertSecret()` extracted to `src/channels/http/session-auth.ts`; sessions store lifted to `HttpAdapter` so identity routes now accept the `curia_session` cookie in addition to the `x-web-bootstrap-secret` header.
+
 ---
 
 ## [0.8.0] — 2026-04-06

--- a/docs/wip/2026-04-06-onboarding-wizard-design.md
+++ b/docs/wip/2026-04-06-onboarding-wizard-design.md
@@ -1,0 +1,280 @@
+# Onboarding Wizard — Design Spec
+
+**Date:** 2026-04-06
+**Status:** Draft
+**Issue:** josephfung/curia#140
+**Branch:** `feat/onboarding-wizard`
+
+---
+
+## Overview
+
+A multi-step onboarding wizard in the Curia web app that guides a new user through configuring their office identity on first run. The wizard can also be re-entered from a Settings nav item to update the identity at any time.
+
+The wizard depends on the Office Identity Engine (spec 13). It assumes `GET /api/identity`, `PUT /api/identity`, and `POST /api/identity/reload` are available.
+
+---
+
+## Design Decisions
+
+### Wizard container: full-screen overlay
+
+The wizard is a `position: fixed; inset: 0; z-index: 60` overlay — the same layering pattern used by the auth wall. It sits above the main app layout (sidebar + content area), so the sidebar is never visible during setup. This gives a focused, mobile-friendly onboarding moment distinct from the main app.
+
+The overlay is dismissed (not navigated away from) when setup completes or when re-entering from Settings.
+
+### Layout: full-bleed with top bar
+
+Each step uses the full screen width with a `max-width: 520px` content column centered horizontally. A thin top bar carries the wordmark and step progress dots. The content area scrolls independently on small screens.
+
+This layout was chosen over a centered card specifically because Step 2 has 30 tone pills that need room to wrap naturally without feeling cramped.
+
+### First-run detection: server-authoritative `configured` flag
+
+`GET /api/identity` gains a `configured: boolean` field in its response:
+
+- `false` — all identity versions in the DB have `changed_by = 'file_load'` (never explicitly configured)
+- `true` — at least one version has `changed_by = 'wizard'` or `changed_by = 'api'`
+
+This is a single extra query on the existing `office_identity_versions` table — no schema change needed. It is server-authoritative (works across devices/browsers) and does not require a separate tracking mechanism.
+
+### Default landing screen: Chat
+
+On successful auth, if `configured: true`, the app navigates to Chat (not Knowledge Graph, which was the previous default). The wizard also lands on Chat with a success banner on completion.
+
+---
+
+## API Changes
+
+### `GET /api/identity` — add `configured` flag
+
+**Current response:**
+```json
+{ "identity": { ... } }
+```
+
+**New response:**
+```json
+{ "identity": { ... }, "configured": false }
+```
+
+Implementation: add a single query inside the `GET /api/identity` route handler:
+
+```sql
+SELECT EXISTS (
+  SELECT 1 FROM office_identity_versions
+  WHERE changed_by IN ('wizard', 'api')
+) AS configured
+```
+
+No new tables, no migrations.
+
+---
+
+## Navigation Changes
+
+A new top-level **Settings** nav item is added to the sidebar at the same level as Chat and Memory. It is collapsible (same pattern as Memory) and starts expanded by default.
+
+```
+Chat
+Memory  ▾
+  ├ Knowledge Graph
+  ├ Contacts
+  ├ Tasks
+  └ Scheduled Jobs
+Settings  ▾
+  └ Setup Wizard
+```
+
+Clicking **Setup Wizard** from the nav calls `navigate('wizard')`, which shows the wizard overlay and sets the active nav highlight on `nav-wizard`. Whether it's a first-run entry or a re-entry, the wizard always opens the same way — the difference is whether fields are pre-filled (re-entry) or at defaults (first run, though defaults match the current identity since it's loaded from the YAML).
+
+---
+
+## Wizard Flow
+
+### Entry points
+
+1. **First run** — after auth wall clears, the app calls `GET /api/identity`. If `configured: false`, the wizard overlay is shown immediately. The main app (sidebar + views) is never shown to the user before they complete setup.
+2. **Re-entry** — Settings → Setup Wizard. The wizard opens with all fields pre-filled from the current identity.
+
+### Exit
+
+On successful save:
+1. `PUT /api/identity` with `{ identity: <compiled config>, note: 'Saved via onboarding wizard' }`
+2. `POST /api/identity/reload` — refreshes the in-memory cache so the new identity is live for the very next coordinator turn
+3. Dismiss the wizard overlay
+4. `navigate('chat')` — land on the Chat view
+5. Show a teal success banner at the top of the Chat view: **"Your assistant is ready."** (auto-dismisses after 4 seconds)
+
+The reload happens *before* the redirect so the identity is guaranteed live when the user sends their first message.
+
+---
+
+## Wizard Steps
+
+### Step 1 — Name your assistant
+
+**Heading:** "What should your assistant be called?"
+
+Fields:
+- **Assistant name** — text input, pre-filled with current `assistant.name` (default: "Alex Curia")
+- **Title** — text input, pre-filled with current `assistant.title` (default: "Executive Assistant to the CEO")
+- **Email signature** — textarea, pre-filled with current `assistant.emailSignature`
+
+All fields required except email signature. Validation: assistant name must not be empty.
+
+---
+
+### Step 2 — Communication style
+
+**Heading:** "How should your assistant communicate?"
+
+#### Tone (pill grid)
+
+All 30 words from `BASELINE_TONE_OPTIONS` displayed as a scrollable pill grid. Pills are ungrouped visually — the natural wrapping provides enough scannable structure without category headers adding density.
+
+- Minimum 1 selection, maximum 3
+- At 3 selections, all unselected pills are visually dimmed and non-interactive, with a hint below the grid: "Pick up to 3"
+- Selected pills render with `background: var(--primary); color: var(--primary-fg)` (same as active buttons)
+- Unselected pills render with `border: 1px solid var(--accent); color: var(--fg-muted)`
+- Default selection: `['warm', 'direct']`
+- Live preview sentence below the grid updates as selections change: **"Your tone is warm and direct."**
+
+#### Detail level (slider)
+
+- Range: 0–100, default 50
+- Left label: "Brief" — right label: "Thorough"
+- Maps to `tone.verbosity`
+- Live preview: a short sample sentence in an italic blockquote updates as the slider moves, drawn from the same band table used by `compileSystemPromptBlock()`:
+  - 0–25: *"Here's the short answer."*
+  - 26–50: *"Happy to help — let me know if you'd like more detail."*
+  - 51–75: *"Here's what you need to know, plus a bit of context."*
+  - 76–100: *"Let me walk you through this thoroughly."*
+
+#### Directness (slider)
+
+- Range: 0–100, default 75
+- Left label: "Measured" — right label: "Direct"
+- Maps to `tone.directness`
+- Live preview sample sentences:
+  - 0–25: *"There are a few things worth considering here — it's hard to say definitively."*
+  - 26–50: *"I'd lean toward option A, though it depends on your priorities."*
+  - 51–75: *"Thursday works. I'll send the invite."*
+  - 76–100: *"Do it. The risk is low and the upside is clear."*
+
+#### Decision posture
+
+Three pill/card selectors (not a dropdown) for `decision_style.external_actions`:
+- **Conservative** *(default)* — "Verify before acting; flag ambiguity"
+- **Balanced** — "Act when confident, flag when uncertain"
+- **Proactive** — "Bias toward action; less checking in"
+
+Note: `decision_style.internal_analysis` is not surfaced in the wizard — it stays at the `'proactive'` default from the YAML. The wizard only exposes the external actions posture, which is what users need to reason about.
+
+---
+
+### Step 3 — Anything else?
+
+**Heading:** "Is there anything else we should know?"
+
+- Single optional textarea, large, generous whitespace
+- Helper text: *"E.g., 'Always include agenda items in meeting requests' or 'Flag emails from investors as high priority'"*
+- The user's input is **appended** to `behavioral_preferences` as a new entry — it does not overwrite the defaults from the YAML. If the textarea is empty, `behavioral_preferences` is left unchanged.
+- **On re-entry:** the textarea is always blank. Re-entering text appends a new entry rather than editing the previous one. This keeps the implementation simple and avoids the complexity of mapping a flat string back to a specific array position.
+
+---
+
+### Step 4 — Review & confirm
+
+A summary card showing all selections as plain English:
+
+- Assistant name and title
+- Tone: "Your tone is warm and direct."
+- Detail: "You prefer concise responses."
+- Directness: "Positions are stated directly."
+- Posture: "The assistant will verify before taking external actions."
+- Freeform preferences (if any): shown as a blockquote
+
+Two actions: **← Back** / **Confirm & save**
+
+On "Confirm & save":
+1. Button shows a loading state ("Saving…", disabled)
+2. `PUT /api/identity` with the compiled identity config
+3. `POST /api/identity/reload`
+4. Dismiss overlay → navigate to Chat → show success banner
+5. On API error: show inline error message, re-enable the button
+
+---
+
+## Step Navigation
+
+- **Next** validates the current step before advancing (name field non-empty on Step 1; at least 1 tone word on Step 2)
+- **Back** never validates — always permitted
+- State is preserved across Back/Next traversals within a session
+- Step progress dots in the top bar reflect completed steps
+
+---
+
+## Implementation Scope
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `src/channels/http/routes/kg.ts` | Main changes — see below |
+| `src/channels/http/routes/identity.ts` | Add `configured` flag to `GET /api/identity` response |
+
+### `kg.ts` changes
+
+1. **`createUiHtml()` — CSS additions:**
+   - Wizard overlay styles (full-screen fixed layer, scroll container)
+   - Tone pill active/disabled states
+   - Slider preview blockquote style
+   - Decision posture card selected state
+   - Settings nav section (mirrors Memory section styles — no new CSS classes needed)
+   - Success banner style
+
+2. **`createUiHtml()` — HTML additions:**
+   - Wizard overlay div (`id="view-wizard"`, `position: fixed; inset: 0; z-index: 60; display: none`)
+   - Settings nav section with Setup Wizard sub-item (after the Memory section)
+   - Success banner div (`id="chat-success-banner"`, hidden by default, shown post-wizard)
+
+3. **`createUiHtml()` — JS additions:**
+   - `wizardState` object holding form values across steps
+   - `showWizard()` / `hideWizard()` — show/hide the overlay, populate fields from current identity on re-entry
+   - `navigateWizardStep(n)` — show the correct step, update progress dots
+   - Tone pill click handler — enforces 1–3 selection, updates live preview sentence
+   - Slider input handlers — update live preview sample sentences
+   - Decision posture click handler
+   - `validateWizardStep(n)` — returns true/false for Next button
+   - `submitWizard()` — compiles state into identity payload, calls PUT then reload, handles loading/error states
+   - Update `showMain()` to check `configured` flag and call `showWizard()` if false
+   - Update `navigate()` to handle `'wizard'` case
+   - Change default landing view from `'kg'` to `'chat'`
+
+4. **`knowledgeGraphRoutes` — update `GET /` route:** After auth check passes, `showMain()` now also fetches `GET /api/identity` to determine first-run state. This fetch uses the session cookie (no extra auth header needed).
+
+### `identity.ts` changes
+
+`GET /api/identity` handler: add a second query to check for any `wizard` or `api` versions before returning.
+
+### Auth refactor — shared sessions store
+
+**Problem:** The wizard JS runs in the browser with only the session cookie set by `POST /auth`. The identity routes currently only accept the `x-web-bootstrap-secret` header (they do not check the session cookie). The KG routes work because their internal `assertSecret()` checks both. The wizard cannot call `GET /api/identity` or `PUT /api/identity` from the browser as-is.
+
+**Fix:** Lift the `sessions` Map (currently scoped inside `knowledgeGraphRoutes`) up to the `HttpAdapter` level. Pass it as an option to both `knowledgeGraphRoutes` and `identityRoutes`. Update `identityRoutes` to accept either:
+- A valid `x-web-bootstrap-secret` header, OR
+- A valid `curia_session` cookie (verified against the shared sessions store)
+
+This mirrors the existing `assertSecret()` logic in `kg.ts` and requires no new security mechanism — it reuses the same token store.
+
+Files additionally affected: `src/channels/http/http-adapter.ts` (sessions Map construction + passing), `src/channels/http/routes/identity.ts` (updated auth helper).
+
+---
+
+## Non-Goals
+
+- The `constraints` field is not editable in the wizard (noted in `identity.ts` with a `@TODO` — deferred)
+- `decision_style.internal_analysis` is not surfaced (stays at YAML default)
+- Channel or contact tone overlays (deferred per spec 13)
+- Multi-step wizard progress persistence across page refreshes (in-memory state only — if the user refreshes mid-wizard on first run, they start over)

--- a/docs/wip/2026-04-06-onboarding-wizard.md
+++ b/docs/wip/2026-04-06-onboarding-wizard.md
@@ -1,0 +1,1733 @@
+# Onboarding Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a multi-step onboarding wizard to the Curia web app that captures office identity config on first run and is accessible via Settings → Setup Wizard for re-entry.
+
+**Architecture:** Full-screen overlay inside the existing `createUiHtml()` HTML template in `kg.ts`. Backend changes: (1) extract the session auth helper to a shared module so both KG and identity routes accept session cookies; (2) add a `configured` boolean to `GET /api/identity` to drive first-run detection without client-side state.
+
+**Tech Stack:** Fastify, vanilla JS, CSS custom properties (already in use), Vitest for unit tests.
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|------|--------|--------------|
+| `src/channels/http/session-auth.ts` | **Create** | `SessionStore` type + `assertSecret()` function extracted from kg.ts |
+| `src/channels/http/http-adapter.ts` | **Modify** | Create sessions Map here; pass to both KG and identity routes |
+| `src/channels/http/routes/kg.ts` | **Modify** | Import `assertSecret` from session-auth; accept sessions via options; add Settings nav, wizard overlay, wizard JS, update `showMain()` and `navigate()` |
+| `src/channels/http/routes/identity.ts` | **Modify** | Accept sessions + pool in options; use `assertSecret` for cookie+header auth; add `configured` flag to `GET /api/identity` |
+| `tests/unit/channels/http/identity-routes.test.ts` | **Create** | Unit tests for updated identity route auth and `configured` flag |
+| `tests/unit/channels/http/session-auth.test.ts` | **Create** | Unit tests for extracted `assertSecret` helper |
+| `CHANGELOG.md` | **Modify** | Add unreleased entry |
+| `package.json` | **Modify** | Minor version bump |
+
+---
+
+## Task 1: Extract session auth to shared module
+
+The `assertSecret()` function and `SessionStore` type currently live inside `knowledgeGraphRoutes` in `kg.ts`. Identity routes need the same logic. Extract them into `src/channels/http/session-auth.ts` so both route files can share them.
+
+**Files:**
+- Create: `src/channels/http/session-auth.ts`
+- Create: `tests/unit/channels/http/session-auth.test.ts`
+
+- [ ] **Step 1.1: Write the failing test**
+
+Create `tests/unit/channels/http/session-auth.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { assertSecret, type SessionStore } from '../../../../src/channels/http/session-auth.js';
+
+// Helper: build a minimal FastifyRequest with optional session cookie and optional secret header.
+function makeRequest(opts: {
+  secretHeader?: string;
+  sessionToken?: string;
+}): FastifyRequest {
+  return {
+    headers: opts.secretHeader ? { 'x-web-bootstrap-secret': opts.secretHeader } : {},
+    cookies: opts.sessionToken ? { curia_session: opts.sessionToken } : undefined,
+  } as unknown as FastifyRequest;
+}
+
+function makeReply(): FastifyReply & { statusCode: number; body: unknown } {
+  const reply = { statusCode: 0, body: undefined as unknown };
+  (reply as unknown as FastifyReply).status = (n: number) => ({
+    send: (b: unknown) => { reply.statusCode = n; reply.body = b; },
+  }) as unknown as FastifyReply;
+  return reply as unknown as FastifyReply & { statusCode: number; body: unknown };
+}
+
+describe('assertSecret', () => {
+  const configuredSecret = 'correct-secret';
+  let sessions: SessionStore;
+
+  beforeEach(() => {
+    sessions = new Map();
+  });
+
+  it('accepts a valid x-web-bootstrap-secret header', () => {
+    const request = makeRequest({ secretHeader: 'correct-secret' });
+    const reply = makeReply();
+    expect(assertSecret(request, reply as unknown as FastifyReply, configuredSecret, sessions)).toBe(true);
+  });
+
+  it('rejects an invalid x-web-bootstrap-secret header', () => {
+    const request = makeRequest({ secretHeader: 'wrong-secret' });
+    const reply = makeReply();
+    expect(assertSecret(request, reply as unknown as FastifyReply, configuredSecret, sessions)).toBe(false);
+    expect(reply.statusCode).toBe(401);
+  });
+
+  it('accepts a valid session cookie', () => {
+    const token = 'valid-token-abc';
+    sessions.set(token, Date.now() + 60_000);
+    const request = makeRequest({ sessionToken: token });
+    const reply = makeReply();
+    expect(assertSecret(request, reply as unknown as FastifyReply, configuredSecret, sessions)).toBe(true);
+  });
+
+  it('rejects an expired session cookie', () => {
+    const token = 'expired-token';
+    sessions.set(token, Date.now() - 1000);
+    const request = makeRequest({ sessionToken: token });
+    const reply = makeReply();
+    expect(assertSecret(request, reply as unknown as FastifyReply, configuredSecret, sessions)).toBe(false);
+    expect(reply.statusCode).toBe(401);
+  });
+
+  it('rejects an unknown session cookie', () => {
+    const request = makeRequest({ sessionToken: 'unknown-token' });
+    const reply = makeReply();
+    expect(assertSecret(request, reply as unknown as FastifyReply, configuredSecret, sessions)).toBe(false);
+    expect(reply.statusCode).toBe(401);
+  });
+
+  it('returns 503 when no configured secret is provided', () => {
+    const request = makeRequest({ secretHeader: 'anything' });
+    const reply = makeReply();
+    expect(assertSecret(request, reply as unknown as FastifyReply, undefined, sessions)).toBe(false);
+    expect(reply.statusCode).toBe(503);
+  });
+});
+```
+
+- [ ] **Step 1.2: Run the test to confirm it fails**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-onboarding-wizard
+pnpm test -- tests/unit/channels/http/session-auth.test.ts
+```
+
+Expected: fails with `Cannot find module '../../../../src/channels/http/session-auth.js'`
+
+- [ ] **Step 1.3: Create `src/channels/http/session-auth.ts`**
+
+```typescript
+// session-auth.ts — Shared session authentication helper for HTTP routes.
+//
+// Both the KG routes and the identity routes accept authentication via either:
+//   1. A valid `curia_session` HttpOnly cookie (set by POST /auth)
+//   2. A valid `x-web-bootstrap-secret` request header (for programmatic access)
+//
+// The sessions Map is created in HttpAdapter and passed to both route registrations.
+
+import { timingSafeEqual } from 'node:crypto';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+
+// token → expiry timestamp in ms. Lives in HttpAdapter, shared across route registrations.
+export type SessionStore = Map<string, number>;
+
+/**
+ * Verify that the request is authenticated via session cookie or bootstrap secret header.
+ *
+ * Returns true if authenticated. Returns false and sends an error response if not.
+ *
+ * Why timingSafeEqual: prevents character-by-character brute force against the secret.
+ * We compare byte lengths before calling it because timingSafeEqual throws if buffers
+ * differ in length.
+ */
+export function assertSecret(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  configuredSecret: string | undefined,
+  sessions: SessionStore,
+): boolean {
+  if (!configuredSecret) {
+    reply.status(503).send({
+      error: 'Web UI is disabled. Set WEB_APP_BOOTSTRAP_SECRET in .env to enable it.',
+    });
+    return false;
+  }
+
+  // Primary path: browser session cookie set by POST /auth.
+  // @fastify/cookie augments FastifyRequest with .cookies at runtime.
+  const cookies = (request as unknown as { cookies?: Record<string, string | undefined> }).cookies;
+  const sessionToken = cookies?.['curia_session'];
+  if (sessionToken) {
+    const expiresAt = sessions.get(sessionToken);
+    if (expiresAt !== undefined && Date.now() < expiresAt) return true;
+    // Expired or unknown token — fall through to header check below.
+  }
+
+  // Fallback: direct header (programmatic access via curl / scripts).
+  // Reject non-string values (Fastify coerces duplicate headers to string[]).
+  const provided = request.headers['x-web-bootstrap-secret'];
+  if (
+    typeof provided !== 'string' ||
+    provided.length !== configuredSecret.length ||
+    !timingSafeEqual(Buffer.from(provided), Buffer.from(configuredSecret))
+  ) {
+    reply.status(401).send({
+      error: 'Unauthorized. Authenticate via POST /auth or provide the x-web-bootstrap-secret header.',
+    });
+    return false;
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 1.4: Run the test to confirm it passes**
+
+```bash
+pnpm test -- tests/unit/channels/http/session-auth.test.ts
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 1.5: Update `kg.ts` to import from `session-auth.ts`**
+
+In `src/channels/http/routes/kg.ts`:
+
+Add the import after the existing imports at the top of the file:
+```typescript
+import { assertSecret, type SessionStore } from '../session-auth.js';
+```
+
+Remove the local `type SessionStore = Map<string, number>;` declaration (around line 44).
+
+Remove the local `function assertSecret(...)` declaration (lines ~77–116). The function is now imported.
+
+All existing `assertSecret(request, reply, webAppBootstrapSecret, sessions)` call sites remain unchanged — the signature is identical.
+
+- [ ] **Step 1.6: Run the full test suite to confirm nothing broke**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add src/channels/http/session-auth.ts tests/unit/channels/http/session-auth.test.ts src/channels/http/routes/kg.ts
+git commit -m "refactor: extract session auth helper to shared module"
+```
+
+---
+
+## Task 2: Lift sessions store to HttpAdapter
+
+The `sessions` Map is currently created inside `knowledgeGraphRoutes`. It needs to be accessible to `identityRoutes` too. Move its creation to `HttpAdapter` and pass it in via route options.
+
+**Files:**
+- Modify: `src/channels/http/http-adapter.ts`
+- Modify: `src/channels/http/routes/kg.ts`
+- Modify: `src/channels/http/routes/identity.ts`
+
+- [ ] **Step 2.1: Add `sessions` to `KnowledgeGraphRouteOptions` in `kg.ts`**
+
+Update the `KnowledgeGraphRouteOptions` interface:
+
+```typescript
+export interface KnowledgeGraphRouteOptions {
+  pool: Pool;
+  logger: Logger;
+  webAppBootstrapSecret: string | undefined;
+  secureCookies: boolean;
+  bus: EventBus;
+  eventRouter: EventRouter;
+  contactService: ContactService;
+  // Shared session store — created in HttpAdapter, passed to both KG and identity routes
+  // so both can accept the curia_session cookie for authentication.
+  sessions: SessionStore;
+}
+```
+
+- [ ] **Step 2.2: Remove sessions Map creation from `knowledgeGraphRoutes`**
+
+Inside `knowledgeGraphRoutes` (around line 2140), remove:
+
+```typescript
+  // In-memory session store: token → expiry timestamp (ms).
+  // Single-tenant tool — no DB persistence needed; sessions reset on server restart.
+  const sessions: SessionStore = new Map();
+
+  // Prune expired sessions every minute so the Map doesn't grow unboundedly.
+  const pruneInterval = setInterval(() => {
+    const now = Date.now();
+    for (const [token, expiresAt] of sessions) {
+      if (now > expiresAt) sessions.delete(token);
+    }
+  }, 60_000);
+  // Unref so the interval doesn't prevent process exit during tests.
+  pruneInterval.unref();
+```
+
+Destructure `sessions` from options at the top of `knowledgeGraphRoutes`:
+
+```typescript
+export async function knowledgeGraphRoutes(
+  app: FastifyInstance,
+  options: KnowledgeGraphRouteOptions,
+): Promise<void> {
+  const { pool, logger, webAppBootstrapSecret, secureCookies, bus, eventRouter, contactService, sessions } = options;
+  // sessions is managed by HttpAdapter — no local Map creation needed here.
+```
+
+- [ ] **Step 2.3: Update `IdentityRouteOptions` in `identity.ts` to accept sessions and pool**
+
+```typescript
+import { timingSafeEqual } from 'node:crypto';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import type { Pool } from 'pg';
+import type { OfficeIdentityService } from '../../../identity/service.js';
+import type { OfficeIdentity } from '../../../identity/types.js';
+import { assertSecret, type SessionStore } from '../session-auth.js';
+
+export interface IdentityRouteOptions {
+  identityService: OfficeIdentityService;
+  webAppBootstrapSecret: string;
+  // Shared session store from HttpAdapter — allows browser sessions (cookie auth)
+  // to call identity routes without the raw bootstrap secret being stored in JS.
+  sessions: SessionStore;
+  // Required for the configured flag query on GET /api/identity.
+  pool: Pool;
+}
+```
+
+Replace the local `validateBootstrapSecret` function and `requireBootstrapSecret` helper entirely. The new `identityRoutes` function body opens with:
+
+```typescript
+export async function identityRoutes(
+  app: FastifyInstance,
+  options: IdentityRouteOptions,
+): Promise<void> {
+  const { identityService, webAppBootstrapSecret, sessions, pool } = options;
+
+  // Auth helper — validates session cookie or bootstrap secret on every request.
+  function requireAuth(request: FastifyRequest, reply: FastifyReply): boolean {
+    return assertSecret(request, reply, webAppBootstrapSecret, sessions);
+  }
+```
+
+Update all four route handlers to call `requireAuth(request, reply)`:
+- `GET /api/identity` → `if (!requireAuth(request, reply)) return;`
+- `PUT /api/identity` → `if (!requireAuth(request, reply)) return;`
+- `GET /api/identity/history` → `if (!requireAuth(request, reply)) return;`
+- `POST /api/identity/reload` → `if (!requireAuth(request, reply)) return;`
+
+- [ ] **Step 2.4: Update `GET /api/identity` to include the `configured` flag**
+
+Replace the `GET /api/identity` handler body:
+
+```typescript
+  app.get('/api/identity', async (request, reply) => {
+    if (!requireAuth(request, reply)) return;
+
+    try {
+      const identity = identityService.get();
+
+      // Determine whether the identity has ever been explicitly configured via the wizard
+      // or API. A fresh deployment (only file_load versions) returns configured: false,
+      // which triggers the first-run wizard in the browser.
+      const configuredResult = await pool.query<{ configured: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1 FROM office_identity_versions
+           WHERE changed_by IN ('wizard', 'api')
+         ) AS configured`,
+      );
+      const configured = configuredResult.rows[0]?.configured ?? false;
+
+      return reply.send({ identity, configured });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to get identity';
+      return reply.status(500).send({ error: message });
+    }
+  });
+```
+
+- [ ] **Step 2.5: Update `HttpAdapter` to create sessions + pass to both routes**
+
+Add the import at the top of `src/channels/http/http-adapter.ts`:
+```typescript
+import { type SessionStore } from './session-auth.js';
+```
+
+In the `start()` method, after registering cors and rateLimit but before registering routes, add:
+
+```typescript
+    // Shared session store — used by both KG and identity routes to validate browser sessions.
+    // Sessions are set by POST /auth (KG routes) and verified by both route registrations.
+    const sessions: SessionStore = new Map();
+    const pruneInterval = setInterval(() => {
+      const now = Date.now();
+      for (const [token, expiresAt] of sessions) {
+        if (now > expiresAt) sessions.delete(token);
+      }
+    }, 60_000);
+    pruneInterval.unref();
+```
+
+Update the identity routes registration:
+```typescript
+    if (webAppBootstrapSecret && this.config.identityService) {
+      await this.app.register(identityRoutes, {
+        identityService: this.config.identityService,
+        webAppBootstrapSecret,
+        sessions,
+        pool,
+      });
+    }
+```
+
+Update the KG routes registration:
+```typescript
+    if (webAppBootstrapSecret) {
+      const secureCookies = appOrigin?.startsWith('https://') ?? false;
+      await this.app.register(knowledgeGraphRoutes, {
+        pool,
+        logger,
+        webAppBootstrapSecret,
+        secureCookies,
+        bus,
+        eventRouter: this.eventRouter,
+        contactService: this.config.contactService,
+        sessions,
+      });
+    }
+```
+
+- [ ] **Step 2.6: Update existing kg-routes unit tests to pass sessions**
+
+In `tests/unit/channels/http/kg-routes.test.ts`, add `sessions: new Map()` to every `knowledgeGraphRoutes` registration:
+
+```typescript
+await app.register(knowledgeGraphRoutes, {
+  pool,
+  logger: createLogger(),
+  webAppBootstrapSecret: 'secret-1',
+  secureCookies: false,
+  sessions: new Map(),
+});
+```
+
+Apply to all registrations in the file.
+
+- [ ] **Step 2.7: Run the full test suite**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2.8: Commit**
+
+```bash
+git add src/channels/http/session-auth.ts src/channels/http/http-adapter.ts src/channels/http/routes/kg.ts src/channels/http/routes/identity.ts tests/unit/channels/http/kg-routes.test.ts
+git commit -m "refactor: lift sessions store to HttpAdapter; identity routes now accept session cookie and configured flag"
+```
+
+---
+
+## Task 3: Identity routes unit tests
+
+Write unit tests for the updated identity route behaviours: session cookie auth and the `configured` flag.
+
+**Files:**
+- Create: `tests/unit/channels/http/identity-routes.test.ts`
+
+- [ ] **Step 3.1: Write the tests**
+
+Create `tests/unit/channels/http/identity-routes.test.ts`:
+
+```typescript
+import Fastify from 'fastify';
+import cookie from '@fastify/cookie';
+import type { Pool } from 'pg';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { identityRoutes } from '../../../../src/channels/http/routes/identity.js';
+import type { OfficeIdentityService } from '../../../../src/identity/service.js';
+import type { OfficeIdentity } from '../../../../src/identity/types.js';
+
+const MOCK_IDENTITY: OfficeIdentity = {
+  assistant: { name: 'Alex Curia', title: 'Executive Assistant', emailSignature: 'Alex Curia\nOffice of the CEO' },
+  tone: { baseline: ['warm', 'direct'], verbosity: 50, directness: 75 },
+  behavioralPreferences: ['Be concise'],
+  decisionStyle: { externalActions: 'conservative', internalAnalysis: 'proactive' },
+  constraints: ['Never impersonate the CEO'],
+};
+
+function createMockIdentityService(): OfficeIdentityService {
+  return {
+    get: vi.fn().mockReturnValue(MOCK_IDENTITY),
+    update: vi.fn().mockResolvedValue(undefined),
+    reload: vi.fn().mockResolvedValue(undefined),
+    history: vi.fn().mockResolvedValue([]),
+    compileSystemPromptBlock: vi.fn().mockReturnValue(''),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+  } as unknown as OfficeIdentityService;
+}
+
+const SECRET = 'test-bootstrap-secret';
+
+describe('GET /api/identity — configured flag', () => {
+  const sessions = new Map<string, number>();
+
+  beforeEach(() => sessions.clear());
+
+  it('returns configured: false when only file_load versions exist', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ configured: false }] }),
+    } as unknown as Pool;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(identityRoutes, {
+      identityService: createMockIdentityService(),
+      webAppBootstrapSecret: SECRET,
+      sessions,
+      pool,
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/identity',
+      headers: { 'x-web-bootstrap-secret': SECRET },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.configured).toBe(false);
+    expect(body.identity.assistant.name).toBe('Alex Curia');
+
+    await app.close();
+  });
+
+  it('returns configured: true when a wizard version exists', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ configured: true }] }),
+    } as unknown as Pool;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(identityRoutes, {
+      identityService: createMockIdentityService(),
+      webAppBootstrapSecret: SECRET,
+      sessions,
+      pool,
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/identity',
+      headers: { 'x-web-bootstrap-secret': SECRET },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().configured).toBe(true);
+
+    await app.close();
+  });
+
+  it('accepts a valid session cookie in place of the header', async () => {
+    const token = 'valid-session-token';
+    sessions.set(token, Date.now() + 60_000);
+
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ configured: true }] }),
+    } as unknown as Pool;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(identityRoutes, {
+      identityService: createMockIdentityService(),
+      webAppBootstrapSecret: SECRET,
+      sessions,
+      pool,
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/identity',
+      headers: { cookie: `curia_session=${token}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    await app.close();
+  });
+
+  it('rejects requests with no auth', async () => {
+    const pool = { query: vi.fn() } as unknown as Pool;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(identityRoutes, {
+      identityService: createMockIdentityService(),
+      webAppBootstrapSecret: SECRET,
+      sessions,
+      pool,
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/identity' });
+
+    expect(res.statusCode).toBe(401);
+
+    await app.close();
+  });
+});
+
+describe('PUT /api/identity — session cookie auth', () => {
+  const sessions = new Map<string, number>();
+
+  beforeEach(() => sessions.clear());
+
+  it('accepts PUT with a valid session cookie', async () => {
+    const token = 'put-session-token';
+    sessions.set(token, Date.now() + 60_000);
+
+    const pool = { query: vi.fn() } as unknown as Pool;
+    const identityService = createMockIdentityService();
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(identityRoutes, {
+      identityService,
+      webAppBootstrapSecret: SECRET,
+      sessions,
+      pool,
+    });
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/identity',
+      headers: { cookie: `curia_session=${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ identity: MOCK_IDENTITY }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(identityService.update).toHaveBeenCalledWith(MOCK_IDENTITY, 'api', undefined);
+
+    await app.close();
+  });
+});
+```
+
+- [ ] **Step 3.2: Run the tests**
+
+```bash
+pnpm test -- tests/unit/channels/http/identity-routes.test.ts
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 3.3: Run the full test suite**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add tests/unit/channels/http/identity-routes.test.ts
+git commit -m "test: add identity route unit tests for configured flag and session cookie auth"
+```
+
+---
+
+## Task 4: Settings nav + navigate('wizard') + default landing → Chat
+
+Add the Settings nav section and update JS to handle the wizard view and the new default landing screen.
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts`
+
+- [ ] **Step 4.1: Add Settings nav HTML to the sidebar**
+
+In `createUiHtml()`, find the line that closes the nav tree div (the `</div>` just before `</nav>`):
+
+```html
+      </div>
+    </nav>
+```
+
+Add the Settings section immediately before that closing `</div>`:
+
+```html
+        <!-- Settings (expandable section) -->
+        <div>
+          <button class="nav-item" id="settings-toggle" onclick="toggleSettings()">
+            <!-- gear icon -->
+            <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="7.5" cy="7.5" r="2"/>
+              <path d="M7.5 1v1.5M7.5 12.5V14M14 7.5h-1.5M2.5 7.5H1M12.07 2.93l-1.06 1.06M4 11l-1.06 1.06M12.07 12.07l-1.06-1.06M4 4l-1.06-1.06"/>
+            </svg>
+            Settings
+            <svg id="settings-chevron" class="chevron" style="margin-left: auto;" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M3 4.5L6 7.5L9 4.5"/>
+            </svg>
+          </button>
+
+          <div id="settings-submenu" style="display: flex; flex-direction: column; gap: 2px; margin-top: 2px;">
+            <button id="nav-wizard" class="nav-sub-item" onclick="navigate('wizard', 'Setup Wizard', 'nav-wizard')">
+              <!-- wand icon -->
+              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M2 11L8 5"/>
+                <path d="M9.5 1.5l.5.5-.5.5-.5-.5z"/>
+                <path d="M5.5 2.5l.5.5-.5.5-.5-.5z"/>
+                <path d="M10.5 5.5l.5.5-.5.5-.5-.5z"/>
+                <path d="M8 5l3.5-3.5"/>
+              </svg>
+              Setup Wizard
+            </button>
+          </div>
+        </div>
+```
+
+- [ ] **Step 4.2: Add Settings JS state, DOM refs, and `toggleSettings()`**
+
+In the JS block, after `var memoryOpen = true;`, add:
+```javascript
+    var settingsOpen = true; // Settings nav section expanded by default
+```
+
+After the `memorySubmenu` and `memoryCaret` DOM ref assignments, add:
+```javascript
+    var settingsSubmenu = document.getElementById('settings-submenu');
+    var settingsCaret   = document.getElementById('settings-chevron');
+```
+
+Add `!settingsSubmenu || !settingsCaret ||` to the null-check guard.
+
+After `toggleMemory()`, add:
+```javascript
+    function toggleSettings() {
+      settingsOpen = !settingsOpen;
+      settingsSubmenu.style.display = settingsOpen ? 'flex' : 'none';
+      settingsCaret.classList.toggle('collapsed', !settingsOpen);
+    }
+```
+
+- [ ] **Step 4.3: Update `navigate()` to handle `'wizard'`**
+
+Find `navigate()`. Add `viewWizard` to the local vars and display switching, and add the wizard fetch-and-show block:
+
+```javascript
+    function navigate(view, title, navId) {
+      var kgView            = document.getElementById('view-kg');
+      var chatView          = document.getElementById('view-chat');
+      var contactsView      = document.getElementById('view-contacts');
+      var tasksView         = document.getElementById('view-tasks');
+      var scheduledJobsView = document.getElementById('view-scheduled-jobs');
+      var viewWizard        = document.getElementById('view-wizard');
+
+      // When navigating to the wizard, fetch the current identity to pre-fill fields,
+      // then delegate to showWizard(). Return early — the wizard has its own overlay.
+      if (view === 'wizard') {
+        fetch('/api/identity')
+          .then(function(res) { return res.json(); })
+          .then(function(data) { showWizard(data.identity); })
+          .catch(function() {
+            showWizard({
+              assistant: { name: '', title: '', emailSignature: '' },
+              tone: { baseline: ['warm', 'direct'], verbosity: 50, directness: 75 },
+              decisionStyle: { externalActions: 'conservative' },
+            });
+          });
+        return;
+      }
+
+      kgView.style.display            = view === 'kg'             ? 'flex' : 'none';
+      chatView.style.display          = view === 'chat'           ? 'flex' : 'none';
+      contactsView.style.display      = view === 'contacts'       ? 'flex' : 'none';
+      tasksView.style.display         = view === 'tasks'          ? 'flex' : 'none';
+      scheduledJobsView.style.display = view === 'scheduled-jobs' ? 'flex' : 'none';
+      if (viewWizard) viewWizard.style.display = 'none'; // always hide when navigating elsewhere
+```
+
+(Keep the rest of `navigate()` — KG resize, contacts/tasks/jobs load, chat init, nav highlight — unchanged.)
+
+- [ ] **Step 4.4: Change default landing from KG to Chat in `showMain()`**
+
+Find `showMain()`:
+
+```javascript
+    function showMain() {
+      authWall.style.display = 'none';
+      mainApp.style.display  = 'flex';
+      initCytoscape();
+      search(); // auto-load all nodes on entry
+    }
+```
+
+Replace with:
+
+```javascript
+    function showMain() {
+      authWall.style.display = 'none';
+      // Check whether identity has been configured via the wizard. If not, show the
+      // wizard overlay. Main app stays hidden until wizard completes (or identity check fails).
+      fetch('/api/identity')
+        .then(function(res) { return res.json(); })
+        .then(function(data) {
+          if (!data.configured) {
+            showWizard(data.identity);
+          } else {
+            mainApp.style.display = 'flex';
+            navigate('chat', 'Chat', 'nav-chat');
+            initCytoscape();
+          }
+        })
+        .catch(function() {
+          // Identity service not available or check failed — fall back to main app.
+          mainApp.style.display = 'flex';
+          navigate('chat', 'Chat', 'nav-chat');
+          initCytoscape();
+        });
+    }
+```
+
+- [ ] **Step 4.5: Run the full test suite**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add src/channels/http/routes/kg.ts
+git commit -m "feat: Settings nav, wizard navigate case, Chat as default landing"
+```
+
+---
+
+## Task 5: Wizard overlay HTML + CSS
+
+Add the full wizard overlay structure (all 4 steps) and all required CSS.
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts`
+
+- [ ] **Step 5.1: Add wizard CSS**
+
+In `createUiHtml()`, find the closing `</style>` tag and add the following immediately before it:
+
+```css
+    /* ── Wizard overlay ─────────────────────────────────────────────── */
+    #view-wizard {
+      position: fixed;
+      inset: 0;
+      z-index: 60;
+      background: var(--bg);
+      display: none;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .wizard-topbar {
+      flex: none;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px 24px;
+      border-bottom: 1px solid var(--border);
+    }
+    .wizard-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 32px 24px 40px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .wizard-content {
+      width: 100%;
+      max-width: 520px;
+      display: flex;
+      flex-direction: column;
+    }
+    .wizard-heading {
+      font-family: 'Lora', Georgia, serif;
+      font-size: 1.375rem;
+      font-weight: 500;
+      color: var(--fg);
+      margin-bottom: 6px;
+    }
+    .wizard-subheading {
+      font-size: 0.8125rem;
+      color: var(--fg-muted);
+      margin-bottom: 28px;
+    }
+    .wizard-label {
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--fg-muted);
+      margin-bottom: 10px;
+    }
+    .wizard-field { margin-bottom: 20px; }
+    .wizard-field label {
+      display: block;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      color: var(--fg-muted);
+      margin-bottom: 6px;
+    }
+    .wizard-field textarea {
+      background: var(--muted);
+      border: 1px solid var(--input-border);
+      border-radius: var(--radius-md);
+      color: var(--fg);
+      font-family: inherit;
+      font-size: 0.875rem;
+      padding: 10px 12px;
+      outline: none;
+      width: 100%;
+      resize: vertical;
+      min-height: 90px;
+      transition: border-color 0.12s;
+    }
+    .wizard-field textarea:focus { border-color: var(--teal); }
+    .wizard-progress { display: flex; gap: 6px; align-items: center; }
+    .wizard-dot {
+      width: 28px;
+      height: 4px;
+      border-radius: 2px;
+      background: var(--muted);
+      transition: background 0.2s;
+    }
+    .wizard-dot.done { background: var(--primary); }
+    .tone-pill {
+      padding: 6px 14px;
+      border-radius: 99px;
+      border: 1px solid var(--accent);
+      background: none;
+      color: var(--fg-muted);
+      font-family: inherit;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.1s, color 0.1s, border-color 0.1s, opacity 0.1s;
+    }
+    .tone-pill.selected {
+      background: var(--primary);
+      color: var(--primary-fg);
+      border-color: var(--primary);
+    }
+    .tone-pill.disabled { opacity: 0.35; cursor: not-allowed; pointer-events: none; }
+    .wizard-preview {
+      font-size: 0.8125rem;
+      color: var(--teal);
+      min-height: 18px;
+      margin-bottom: 24px;
+    }
+    .wizard-sample {
+      font-size: 0.8125rem;
+      font-style: italic;
+      color: var(--fg-muted);
+      padding: 10px 14px;
+      background: var(--card);
+      border-radius: var(--radius-md);
+      border-left: 2px solid var(--muted);
+      margin-bottom: 24px;
+    }
+    .slider-labels {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.6875rem;
+      color: var(--accent);
+      margin-bottom: 8px;
+    }
+    .posture-grid { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 28px; }
+    .posture-card {
+      flex: 1;
+      min-width: 120px;
+      padding: 12px 14px;
+      border-radius: var(--radius-md);
+      border: 1px solid var(--muted);
+      background: none;
+      color: var(--fg-muted);
+      font-family: inherit;
+      text-align: left;
+      cursor: pointer;
+      transition: border-color 0.12s, background 0.12s;
+    }
+    .posture-card:hover { border-color: var(--accent); }
+    .posture-card.selected {
+      border-color: var(--primary);
+      background: rgba(222,222,222,0.06);
+      color: var(--fg);
+    }
+    .posture-card-title { font-size: 0.8125rem; font-weight: 600; margin-bottom: 3px; }
+    .posture-card-desc  { font-size: 0.75rem; }
+    .review-card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: 20px;
+      margin-bottom: 28px;
+    }
+    .review-row {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 10px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .review-row:last-child { border-bottom: none; }
+    .review-row-label {
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--fg-muted);
+    }
+    .review-row-value { font-size: 0.875rem; color: var(--fg); }
+    .wizard-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 8px;
+      margin-top: 8px;
+    }
+    .btn-wizard-back {
+      padding: 10px 20px;
+      border-radius: var(--radius-md);
+      border: 1px solid var(--muted);
+      background: none;
+      color: var(--fg-muted);
+      font-family: inherit;
+      font-size: 0.875rem;
+      cursor: pointer;
+      transition: border-color 0.12s, color 0.12s;
+    }
+    .btn-wizard-back:hover { border-color: var(--accent); color: var(--fg); }
+    .btn-wizard-next {
+      padding: 10px 24px;
+      border-radius: var(--radius-md);
+      background: var(--primary);
+      color: var(--primary-fg);
+      font-family: inherit;
+      font-size: 0.875rem;
+      font-weight: 600;
+      border: none;
+      cursor: pointer;
+      transition: opacity 0.12s;
+    }
+    .btn-wizard-next:hover    { opacity: 0.88; }
+    .btn-wizard-next:disabled { opacity: 0.5; cursor: not-allowed; }
+    #chat-success-banner {
+      display: none;
+      background: rgba(71,129,137,0.15);
+      border-bottom: 1px solid rgba(71,129,137,0.35);
+      color: var(--teal);
+      font-size: 0.8125rem;
+      font-weight: 500;
+      padding: 10px 16px;
+      text-align: center;
+      flex: none;
+    }
+```
+
+- [ ] **Step 5.2: Add wizard overlay HTML**
+
+In `createUiHtml()`, find the closing `</main>` tag. Add the wizard overlay immediately before it:
+
+```html
+      <!-- ============================================================
+           WIZARD OVERLAY — full-screen, z-index 60.
+           Shown on first run (configured: false) or via Settings nav.
+      ============================================================= -->
+      <div id="view-wizard">
+
+        <!-- Top bar: wordmark + progress dots + step counter -->
+        <div class="wizard-topbar">
+          <span style="font-family: 'Lora', Georgia, serif; font-size: 1.125rem; font-weight: 500; letter-spacing: 0.06em; color: var(--fg);">CURIA</span>
+          <div class="wizard-progress">
+            <div class="wizard-dot" id="wdot-1"></div>
+            <div class="wizard-dot" id="wdot-2"></div>
+            <div class="wizard-dot" id="wdot-3"></div>
+            <div class="wizard-dot" id="wdot-4"></div>
+          </div>
+          <span id="wizard-step-label" style="font-size: 0.75rem; color: var(--fg-muted);">Step 1 of 4</span>
+        </div>
+
+        <div class="wizard-body">
+
+          <!-- Step 1 — Name your assistant -->
+          <div id="wstep-1" class="wizard-content" style="display: none;">
+            <div class="wizard-heading">What should your assistant be called?</div>
+            <div class="wizard-subheading">You can change these at any time from Settings.</div>
+            <div class="wizard-field">
+              <label for="w-name">Assistant name</label>
+              <input id="w-name" type="text" placeholder="Alex Curia" />
+            </div>
+            <div class="wizard-field">
+              <label for="w-title">Title</label>
+              <input id="w-title" type="text" placeholder="Executive Assistant to the CEO" />
+            </div>
+            <div class="wizard-field">
+              <label for="w-signature">Email signature <span style="font-weight:400;color:var(--fg-muted);">(optional)</span></label>
+              <textarea id="w-signature" placeholder="Alex Curia&#10;Office of the CEO"></textarea>
+            </div>
+            <div id="wstep1-error" style="display:none;color:var(--destructive);font-size:0.8125rem;margin-bottom:12px;"></div>
+            <div class="wizard-nav">
+              <span></span>
+              <button class="btn-wizard-next" onclick="wizardNext()">Next →</button>
+            </div>
+          </div>
+
+          <!-- Step 2 — Communication style -->
+          <div id="wstep-2" class="wizard-content" style="display: none;">
+            <div class="wizard-heading">How should your assistant communicate?</div>
+            <div class="wizard-subheading">Pick 1–3 words that describe the tone you want.</div>
+            <div class="wizard-label">Tone <span style="font-weight:400;text-transform:none;letter-spacing:0;">(pick up to 3)</span></div>
+            <div id="tone-pill-grid" style="display:flex;flex-wrap:wrap;gap:7px;margin-bottom:10px;"></div>
+            <div id="tone-preview" class="wizard-preview"></div>
+            <div class="wizard-label" style="margin-top:4px;">Detail level</div>
+            <input id="w-verbosity" type="range" min="0" max="100" value="50"
+              style="width:100%;accent-color:var(--primary);margin-bottom:6px;" oninput="updateVerbosityPreview()" />
+            <div class="slider-labels"><span>Brief</span><span>Thorough</span></div>
+            <div id="verbosity-preview" class="wizard-sample"></div>
+            <div class="wizard-label">Directness</div>
+            <input id="w-directness" type="range" min="0" max="100" value="75"
+              style="width:100%;accent-color:var(--primary);margin-bottom:6px;" oninput="updateDirectnessPreview()" />
+            <div class="slider-labels"><span>Measured</span><span>Direct</span></div>
+            <div id="directness-preview" class="wizard-sample"></div>
+            <div class="wizard-label">Decision posture <span style="font-weight:400;text-transform:none;letter-spacing:0;color:var(--accent);">(for external actions)</span></div>
+            <div class="posture-grid">
+              <button class="posture-card" data-posture="conservative" onclick="selectPosture('conservative')">
+                <div class="posture-card-title">Conservative</div>
+                <div class="posture-card-desc">Verify before acting; flag ambiguity</div>
+              </button>
+              <button class="posture-card" data-posture="balanced" onclick="selectPosture('balanced')">
+                <div class="posture-card-title">Balanced</div>
+                <div class="posture-card-desc">Act when confident, flag when uncertain</div>
+              </button>
+              <button class="posture-card" data-posture="proactive" onclick="selectPosture('proactive')">
+                <div class="posture-card-title">Proactive</div>
+                <div class="posture-card-desc">Bias toward action; less checking in</div>
+              </button>
+            </div>
+            <div class="wizard-nav">
+              <button class="btn-wizard-back" onclick="wizardBack()">← Back</button>
+              <button class="btn-wizard-next" onclick="wizardNext()">Next →</button>
+            </div>
+          </div>
+
+          <!-- Step 3 — Anything else? -->
+          <div id="wstep-3" class="wizard-content" style="display: none;">
+            <div class="wizard-heading">Is there anything else we should know?</div>
+            <div class="wizard-subheading">Optional — any specific preferences you'd like your assistant to follow.</div>
+            <div class="wizard-field">
+              <textarea id="w-preferences" style="min-height:140px;"
+                placeholder="E.g., 'Always include agenda items in meeting requests' or 'Flag emails from investors as high priority'"></textarea>
+            </div>
+            <div class="wizard-nav">
+              <button class="btn-wizard-back" onclick="wizardBack()">← Back</button>
+              <button class="btn-wizard-next" onclick="wizardNext()">Review →</button>
+            </div>
+          </div>
+
+          <!-- Step 4 — Review & confirm -->
+          <div id="wstep-4" class="wizard-content" style="display: none;">
+            <div class="wizard-heading">Does everything look right?</div>
+            <div class="wizard-subheading">Go back to change anything, or save to get started.</div>
+            <div class="review-card" id="review-card"></div>
+            <div id="wizard-error" style="display:none;color:var(--destructive);font-size:0.8125rem;margin-bottom:12px;"></div>
+            <div class="wizard-nav">
+              <button class="btn-wizard-back" onclick="wizardBack()">← Back</button>
+              <button id="wizard-save-btn" class="btn-wizard-next" onclick="submitWizard()">Confirm &amp; save</button>
+            </div>
+          </div>
+
+        </div><!-- /.wizard-body -->
+      </div><!-- /#view-wizard -->
+```
+
+- [ ] **Step 5.3: Add success banner to the chat thread**
+
+In `createUiHtml()`, find the `.chat-thread` div inside `#view-chat`. At the very top of `.chat-thread` (before `.chat-messages`), add:
+
+```html
+            <!-- Success banner — shown briefly after wizard completes -->
+            <div id="chat-success-banner">Your assistant is ready.</div>
+```
+
+- [ ] **Step 5.4: Run the full test suite**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add src/channels/http/routes/kg.ts
+git commit -m "feat: wizard overlay HTML and CSS"
+```
+
+---
+
+## Task 6: Wizard JS — state, step navigation, validation
+
+Wire up the wizard's state object, step navigator, and validation.
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts`
+
+- [ ] **Step 6.1: Add `wizardState`, `TONE_OPTIONS`, and DOM refs**
+
+In the JS block, after `var settingsOpen = true;`, add:
+
+```javascript
+    // ── Wizard state ───────────────────────────────────────────────────
+    var wizardState = {
+      step: 1,
+      name: '',
+      title: '',
+      signature: '',
+      toneBaseline: ['warm', 'direct'],
+      verbosity: 50,
+      directness: 75,
+      posture: 'conservative',
+      preferences: '',
+    };
+
+    // All valid tone words — mirrors BASELINE_TONE_OPTIONS in src/identity/types.ts.
+    var TONE_OPTIONS = [
+      'warm','friendly','approachable','personable','empathetic','encouraging','gracious','caring',
+      'direct','blunt','candid','frank','matter-of-fact','no-nonsense',
+      'energetic','calm','composed','enthusiastic','steady','measured',
+      'playful','witty','dry','charming','diplomatic','tactful','thoughtful','curious',
+      'confident','assured','polished','authoritative','professional',
+    ];
+```
+
+After the existing DOM ref assignments, add:
+
+```javascript
+    var wstep1El         = document.getElementById('wstep-1');
+    var wstep2El         = document.getElementById('wstep-2');
+    var wstep3El         = document.getElementById('wstep-3');
+    var wstep4El         = document.getElementById('wstep-4');
+    var wDots            = [
+      document.getElementById('wdot-1'),
+      document.getElementById('wdot-2'),
+      document.getElementById('wdot-3'),
+      document.getElementById('wdot-4'),
+    ];
+    var wizardStepLabel  = document.getElementById('wizard-step-label');
+    var wNameInput       = document.getElementById('w-name');
+    var wTitleInput      = document.getElementById('w-title');
+    var wSignatureInput  = document.getElementById('w-signature');
+    var wVerbosityInput  = document.getElementById('w-verbosity');
+    var wDirectnessInput = document.getElementById('w-directness');
+    var wPrefsInput      = document.getElementById('w-preferences');
+    var wstep1Error      = document.getElementById('wstep1-error');
+    var wizardError      = document.getElementById('wizard-error');
+    var wizardSaveBtn    = document.getElementById('wizard-save-btn');
+    var chatSuccessBanner = document.getElementById('chat-success-banner');
+```
+
+Add all new refs to the null-check guard.
+
+- [ ] **Step 6.2: Add `navigateWizardStep()`, `showWizard()`, `hideWizard()`**
+
+After `toggleSettings()`, add:
+
+```javascript
+    // ── Wizard step management ─────────────────────────────────────────
+
+    function navigateWizardStep(n) {
+      wstep1El.style.display = n === 1 ? 'flex' : 'none';
+      wstep2El.style.display = n === 2 ? 'flex' : 'none';
+      wstep3El.style.display = n === 3 ? 'flex' : 'none';
+      wstep4El.style.display = n === 4 ? 'flex' : 'none';
+      // Dots for steps before n are filled; current and future are empty.
+      wDots.forEach(function(dot, i) { dot.classList.toggle('done', i < n); });
+      wizardStepLabel.textContent = 'Step ' + n + ' of 4';
+      wizardState.step = n;
+      if (n === 2) {
+        buildTonePills();
+        syncPostureSelection();
+        updateVerbosityPreview();
+        updateDirectnessPreview();
+      }
+      if (n === 4) { renderReview(); }
+    }
+
+    function showWizard(identity) {
+      wizardState.name      = (identity.assistant && identity.assistant.name)      || '';
+      wizardState.title     = (identity.assistant && identity.assistant.title)     || '';
+      wizardState.signature = (identity.assistant && identity.assistant.emailSignature) || '';
+      wizardState.toneBaseline = (identity.tone && identity.tone.baseline && identity.tone.baseline.length)
+        ? identity.tone.baseline.slice() : ['warm', 'direct'];
+      wizardState.verbosity  = (identity.tone && identity.tone.verbosity  != null) ? identity.tone.verbosity  : 50;
+      wizardState.directness = (identity.tone && identity.tone.directness != null) ? identity.tone.directness : 75;
+      wizardState.posture    = (identity.decisionStyle && identity.decisionStyle.externalActions)
+        ? identity.decisionStyle.externalActions : 'conservative';
+      wizardState.preferences = '';
+
+      wNameInput.value       = wizardState.name;
+      wTitleInput.value      = wizardState.title;
+      wSignatureInput.value  = wizardState.signature;
+      wVerbosityInput.value  = String(wizardState.verbosity);
+      wDirectnessInput.value = String(wizardState.directness);
+      wPrefsInput.value      = '';
+
+      // Reset pill grid so it rebuilds with the new selection state.
+      var grid = document.getElementById('tone-pill-grid');
+      if (grid) grid.replaceChildren();
+
+      document.getElementById('view-wizard').style.display = 'flex';
+      wstep1Error.style.display = 'none';
+      wizardError.style.display = 'none';
+      navigateWizardStep(1);
+    }
+
+    function hideWizard() {
+      document.getElementById('view-wizard').style.display = 'none';
+    }
+```
+
+- [ ] **Step 6.3: Add `validateWizardStep()`, `wizardNext()`, `wizardBack()`**
+
+```javascript
+    function validateWizardStep(n) {
+      if (n === 1) {
+        var name = wNameInput.value.trim();
+        if (!name) {
+          wstep1Error.textContent = 'Assistant name is required.';
+          wstep1Error.style.display = 'block';
+          return false;
+        }
+        wstep1Error.style.display = 'none';
+        wizardState.name      = name;
+        wizardState.title     = wTitleInput.value.trim();
+        wizardState.signature = wSignatureInput.value.trim();
+        return true;
+      }
+      if (n === 2) {
+        if (wizardState.toneBaseline.length === 0) return false;
+        wizardState.verbosity  = Number(wVerbosityInput.value);
+        wizardState.directness = Number(wDirectnessInput.value);
+        return true;
+      }
+      if (n === 3) {
+        wizardState.preferences = wPrefsInput.value.trim();
+        return true;
+      }
+      return true;
+    }
+
+    function wizardNext() {
+      if (!validateWizardStep(wizardState.step)) return;
+      if (wizardState.step < 4) navigateWizardStep(wizardState.step + 1);
+    }
+
+    function wizardBack() {
+      if (wizardState.step > 1) navigateWizardStep(wizardState.step - 1);
+    }
+```
+
+- [ ] **Step 6.4: Run the full test suite**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add src/channels/http/routes/kg.ts
+git commit -m "feat: wizard JS — state, step navigation, validation"
+```
+
+---
+
+## Task 7: Wizard JS — tone pills, sliders, posture picker
+
+Wire up Step 2's interactive elements.
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts`
+
+- [ ] **Step 7.1: Add tone pill functions**
+
+After `wizardBack()`, add:
+
+```javascript
+    // ── Tone pills ─────────────────────────────────────────────────────
+
+    function buildTonePills() {
+      var grid = document.getElementById('tone-pill-grid');
+      // Rebuild on each entry so the selection syncs with current wizardState.
+      if (grid.children.length > 0) {
+        syncPillSelections();
+        updateTonePreview();
+        return;
+      }
+      TONE_OPTIONS.forEach(function(word) {
+        var btn = document.createElement('button');
+        btn.className = 'tone-pill';
+        btn.textContent = word;
+        btn.dataset.word = word;
+        btn.addEventListener('click', function() { toggleTonePill(btn, word); });
+        grid.appendChild(btn);
+      });
+      syncPillSelections();
+      updateTonePreview();
+    }
+
+    function syncPillSelections() {
+      var grid = document.getElementById('tone-pill-grid');
+      var atMax = wizardState.toneBaseline.length >= 3;
+      Array.from(grid.children).forEach(function(btn) {
+        var word = btn.dataset.word;
+        var isSelected = wizardState.toneBaseline.indexOf(word) !== -1;
+        btn.classList.toggle('selected', isSelected);
+        btn.classList.toggle('disabled', atMax && !isSelected);
+        btn.disabled = atMax && !isSelected;
+      });
+    }
+
+    function toggleTonePill(btn, word) {
+      var idx = wizardState.toneBaseline.indexOf(word);
+      if (idx !== -1) {
+        // Minimum 1: prevent deselecting the last word.
+        if (wizardState.toneBaseline.length <= 1) return;
+        wizardState.toneBaseline.splice(idx, 1);
+      } else {
+        if (wizardState.toneBaseline.length >= 3) return;
+        wizardState.toneBaseline.push(word);
+      }
+      syncPillSelections();
+      updateTonePreview();
+    }
+
+    function updateTonePreview() {
+      var words = wizardState.toneBaseline;
+      var phrase = words.length === 1 ? words[0]
+        : words.length === 2 ? words[0] + ' and ' + words[1]
+        : words[0] + ', ' + words[1] + ' and ' + words[2];
+      var suffix = words.length >= 3 ? ' (Pick up to 3)' : '';
+      document.getElementById('tone-preview').textContent =
+        words.length > 0 ? 'Your tone is ' + phrase + '.' + suffix : '';
+    }
+```
+
+- [ ] **Step 7.2: Add slider preview functions**
+
+```javascript
+    // ── Slider previews ────────────────────────────────────────────────
+
+    function verbosityBand(v) {
+      if (v <= 25) return '\u201cHere\u2019s the short answer.\u201d';
+      if (v <= 50) return '\u201cHappy to help \u2014 let me know if you\u2019d like more detail.\u201d';
+      if (v <= 75) return '\u201cHere\u2019s what you need to know, plus a bit of context.\u201d';
+      return '\u201cLet me walk you through this thoroughly.\u201d';
+    }
+
+    function directnessBand(v) {
+      if (v <= 25) return '\u201cThere are a few things worth considering here \u2014 it\u2019s hard to say definitively.\u201d';
+      if (v <= 50) return '\u201cI\u2019d lean toward option A, though it depends on your priorities.\u201d';
+      if (v <= 75) return '\u201cThursday works. I\u2019ll send the invite.\u201d';
+      return '\u201cDo it. The risk is low and the upside is clear.\u201d';
+    }
+
+    function updateVerbosityPreview() {
+      document.getElementById('verbosity-preview').textContent = verbosityBand(Number(wVerbosityInput.value));
+    }
+
+    function updateDirectnessPreview() {
+      document.getElementById('directness-preview').textContent = directnessBand(Number(wDirectnessInput.value));
+    }
+```
+
+- [ ] **Step 7.3: Add posture picker functions**
+
+```javascript
+    // ── Posture picker ─────────────────────────────────────────────────
+
+    function selectPosture(value) {
+      wizardState.posture = value;
+      document.querySelectorAll('.posture-card').forEach(function(card) {
+        card.classList.toggle('selected', card.dataset.posture === value);
+      });
+    }
+
+    function syncPostureSelection() {
+      selectPosture(wizardState.posture);
+    }
+```
+
+- [ ] **Step 7.4: Run the full test suite**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add src/channels/http/routes/kg.ts
+git commit -m "feat: wizard JS — tone pills, sliders, posture picker"
+```
+
+---
+
+## Task 8: Wizard JS — review step, submit flow, success banner
+
+Implement the Review step renderer and submit function.
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts`
+
+- [ ] **Step 8.1: Add `renderReview()` using safe DOM construction**
+
+The review card is built entirely with `textContent` and DOM methods — no `innerHTML` — to eliminate XSS risk from user-supplied wizard inputs.
+
+```javascript
+    // ── Review & submit ────────────────────────────────────────────────
+
+    function renderReview() {
+      var card = document.getElementById('review-card');
+      // Remove all existing child nodes safely (no innerHTML).
+      while (card.firstChild) card.removeChild(card.firstChild);
+
+      var v = wizardState.verbosity;
+      var verbosityDesc = v <= 25 ? 'Very brief responses — just the essentials.'
+        : v <= 50 ? 'Concise responses by default.'
+        : v <= 75 ? 'Adapts length to the situation.'
+        : 'Thorough by default — full context included.';
+
+      var d = wizardState.directness;
+      var directnessDesc = d <= 25 ? 'Measured — acknowledges uncertainty carefully.'
+        : d <= 50 ? 'Leans direct but hedges where uncertain.'
+        : d <= 75 ? 'Direct — minimal unnecessary hedging.'
+        : 'States positions plainly; no softening.';
+
+      var postureMap = {
+        conservative: 'Verifies before acting on external requests.',
+        balanced:     'Acts when confident; flags when uncertain.',
+        proactive:    'Biases toward action with less checking in.',
+      };
+      var postureDesc = postureMap[wizardState.posture] || '';
+
+      var words = wizardState.toneBaseline;
+      var tonePhrase = words.length === 1 ? words[0]
+        : words.length === 2 ? words[0] + ' and ' + words[1]
+        : words[0] + ', ' + words[1] + ' and ' + words[2];
+
+      var rows = [
+        { label: 'Assistant', value: wizardState.name + (wizardState.title ? ' \u2014 ' + wizardState.title : '') },
+        { label: 'Tone',      value: 'Your tone is ' + tonePhrase + '.' },
+        { label: 'Detail',    value: verbosityDesc },
+        { label: 'Directness', value: directnessDesc },
+        { label: 'Posture',   value: postureDesc },
+      ];
+      if (wizardState.preferences) {
+        rows.push({ label: 'Preference', value: '\u201c' + wizardState.preferences + '\u201d' });
+      }
+
+      rows.forEach(function(row) {
+        var rowEl   = document.createElement('div');
+        rowEl.className = 'review-row';
+        var labelEl = document.createElement('div');
+        labelEl.className = 'review-row-label';
+        labelEl.textContent = row.label;
+        var valueEl = document.createElement('div');
+        valueEl.className = 'review-row-value';
+        valueEl.textContent = row.value; // textContent — safe even with user input
+        rowEl.appendChild(labelEl);
+        rowEl.appendChild(valueEl);
+        card.appendChild(rowEl);
+      });
+    }
+```
+
+- [ ] **Step 8.2: Add `submitWizard()` function**
+
+```javascript
+    function submitWizard() {
+      wizardSaveBtn.disabled = true;
+      wizardSaveBtn.textContent = 'Saving\u2026';
+      wizardError.style.display = 'none';
+
+      // Fetch current identity to preserve behavioral_preferences and constraints.
+      fetch('/api/identity')
+        .then(function(res) { return res.json(); })
+        .then(function(data) {
+          var current = data.identity;
+          var prefs = current.behavioralPreferences ? current.behavioralPreferences.slice() : [];
+          if (wizardState.preferences) { prefs.push(wizardState.preferences); }
+
+          var payload = {
+            identity: {
+              assistant: {
+                name: wizardState.name,
+                title: wizardState.title,
+                emailSignature: wizardState.signature,
+              },
+              tone: {
+                baseline: wizardState.toneBaseline,
+                verbosity: wizardState.verbosity,
+                directness: wizardState.directness,
+              },
+              behavioralPreferences: prefs,
+              decisionStyle: {
+                externalActions: wizardState.posture,
+                // internal_analysis is not surfaced in the wizard — preserve existing value.
+                internalAnalysis: (current.decisionStyle && current.decisionStyle.internalAnalysis)
+                  ? current.decisionStyle.internalAnalysis : 'proactive',
+              },
+              // constraints are immutable via wizard — always preserve.
+              constraints: current.constraints || [],
+            },
+            note: 'Saved via onboarding wizard',
+          };
+
+          return fetch('/api/identity', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+        })
+        .then(function(res) {
+          if (!res.ok) {
+            return res.json().then(function(body) {
+              throw new Error(body.error || 'Save failed');
+            });
+          }
+          return fetch('/api/identity/reload', { method: 'POST' });
+        })
+        .then(function() {
+          hideWizard();
+          if (mainApp && mainApp.style.display === 'none') {
+            mainApp.style.display = 'flex';
+            initCytoscape();
+          }
+          navigate('chat', 'Chat', 'nav-chat');
+          chatSuccessBanner.style.display = 'block';
+          setTimeout(function() { chatSuccessBanner.style.display = 'none'; }, 4000);
+        })
+        .catch(function(err) {
+          wizardError.textContent = err.message || 'Something went wrong — please try again.';
+          wizardError.style.display = 'block';
+          wizardSaveBtn.disabled = false;
+          wizardSaveBtn.textContent = 'Confirm \u0026 save';
+        });
+    }
+```
+
+- [ ] **Step 8.3: Run the full test suite**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git add src/channels/http/routes/kg.ts
+git commit -m "feat: wizard JS — review renderer, submit flow, success banner"
+```
+
+---
+
+## Task 9: Changelog and version bump
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`
+
+- [ ] **Step 9.1: Add to `CHANGELOG.md` under `## [Unreleased]`**
+
+```markdown
+### Added
+- **Onboarding wizard** — multi-step full-screen wizard guides new users through configuring the office identity (assistant name, tone, communication style, decision posture) on first run. Re-enterable from Settings → Setup Wizard. Requires the identity service (spec 13) to be configured.
+- **Settings nav** — new collapsible Settings section in the sidebar with Setup Wizard sub-item.
+- **`configured` flag on `GET /api/identity`** — returns `false` until the wizard or API has saved an identity explicitly; used for first-run detection in the browser without client-side state.
+
+### Changed
+- **Default landing screen** — the app now lands on Chat instead of Knowledge Graph after login.
+- **Session auth refactor** — `assertSecret()` extracted to `src/channels/http/session-auth.ts`; sessions store lifted to `HttpAdapter` so identity routes now accept the `curia_session` cookie in addition to the `x-web-bootstrap-secret` header.
+```
+
+- [ ] **Step 9.2: Bump the version in `package.json`**
+
+Find the current version and increment the minor component (new feature = minor bump):
+
+```json
+"version": "0.9.0"
+```
+
+(Adjust base version to whatever the current value is + 1 minor.)
+
+- [ ] **Step 9.3: Commit**
+
+```bash
+git add CHANGELOG.md package.json
+git commit -m "chore: bump to 0.9.0; changelog for onboarding wizard"
+```
+
+---
+
+## Manual Smoke Test Checklist
+
+Run these checks against a local instance before opening the PR.
+
+**First run:**
+- [ ] Clear cookies → enter access key → wizard appears, main app is hidden
+- [ ] Step 1: blank name field → Next blocked with error message; filled name → proceeds
+- [ ] Step 2: select tone pills up to 3 — 4th is disabled; deselecting re-enables; live preview sentence updates
+- [ ] Step 2: drag verbosity slider — sample sentence changes at each of the 4 bands
+- [ ] Step 2: drag directness slider — sample sentence changes at each of the 4 bands
+- [ ] Step 2: click posture cards — selected card gets border highlight; only one selected at a time
+- [ ] Step 3: textarea optional; Next always proceeds
+- [ ] Step 4: review card shows plain-English summaries (not raw values); freeform preference appears if entered
+- [ ] Confirm & save → button shows "Saving…" → wizard dismisses → Chat view → teal success banner appears and auto-dismisses in 4 seconds
+- [ ] `GET /api/identity` returns `configured: true` after completion
+- [ ] Page refresh → lands on Chat, no wizard
+
+**Re-entry:**
+- [ ] Settings → Setup Wizard → wizard opens with current identity values pre-filled
+- [ ] Completing re-entry → Chat view with success banner
+
+**Navigation:**
+- [ ] Settings section is collapsible (chevron animates)
+- [ ] All existing nav items (Chat, Memory sub-items) work correctly
+- [ ] Default post-login destination is Chat, not Knowledge Graph

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -34,6 +34,7 @@ import { knowledgeGraphRoutes } from './routes/kg.js';
 import { identityRoutes } from './routes/identity.js';
 import type { OfficeIdentityService } from '../../identity/service.js';
 import type { ContactService } from '../../contacts/contact-service.js';
+import { type SessionStore } from './session-auth.js';
 
 export interface HttpAdapterConfig {
   bus: EventBus;
@@ -123,6 +124,17 @@ export class HttpAdapter {
       }
     });
 
+    // Shared session store — used by both KG and identity routes to validate browser sessions.
+    // Sessions are set by POST /auth (KG routes) and verified by both route registrations.
+    const sessions: SessionStore = new Map();
+    const pruneInterval = setInterval(() => {
+      const now = Date.now();
+      for (const [token, expiresAt] of sessions) {
+        if (now > expiresAt) sessions.delete(token);
+      }
+    }, 60_000);
+    pruneInterval.unref();
+
     // Register routes — message routes receive the eventRouter, not raw bus
     await this.app.register(healthRoutes, { pool, logger, agentNames, skillNames });
     await this.app.register(agentRoutes, { agentRegistry });
@@ -138,6 +150,8 @@ export class HttpAdapter {
       await this.app.register(identityRoutes, {
         identityService: this.config.identityService,
         webAppBootstrapSecret,
+        sessions,
+        pool,
       });
     }
 
@@ -160,6 +174,7 @@ export class HttpAdapter {
         bus,
         eventRouter: this.eventRouter,
         contactService: this.config.contactService,
+        sessions,
       });
     }
 

--- a/src/channels/http/routes/identity.ts
+++ b/src/channels/http/routes/identity.ts
@@ -1,72 +1,62 @@
 // identity.ts — HTTP routes for the Office Identity API.
 //
-// All routes require x-web-bootstrap-secret authentication (same as the KG explorer).
-// Routes are only registered when webAppBootstrapSecret is configured.
+// All routes require session cookie or x-web-bootstrap-secret authentication
+// (same as the KG explorer). Routes are only registered when webAppBootstrapSecret
+// is configured.
 //
 // Endpoints:
-//   GET  /api/identity         — return the current active identity config
+//   GET  /api/identity         — return the current active identity config + configured flag
 //   PUT  /api/identity         — save a new version and trigger hot reload
 //   GET  /api/identity/history — return all versions, newest first
 //   POST /api/identity/reload  — force a reload from DB (used post-wizard)
 
-import { timingSafeEqual } from 'node:crypto';
-import type { FastifyInstance, FastifyReply } from 'fastify';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import type { Pool } from 'pg';
 import type { OfficeIdentityService } from '../../../identity/service.js';
 import type { OfficeIdentity } from '../../../identity/types.js';
+import { assertSecret, type SessionStore } from '../session-auth.js';
 
 export interface IdentityRouteOptions {
   identityService: OfficeIdentityService;
   webAppBootstrapSecret: string;
-}
-
-/** Validate the x-web-bootstrap-secret header. Uses timing-safe comparison.
- *
- * We compare buffer byte lengths — not JavaScript string char lengths — before
- * calling timingSafeEqual. timingSafeEqual throws ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH
- * when the two buffers have different byte lengths. A multi-byte UTF-8 header could
- * have the same char count as the configured secret but a different byte count,
- * triggering an unhandled 500 without this guard.
- */
-function validateBootstrapSecret(
-  provided: unknown,
-  configured: string,
-): boolean {
-  if (typeof provided !== 'string') return false;
-  const providedBuf = Buffer.from(provided);
-  const configuredBuf = Buffer.from(configured);
-  if (providedBuf.length !== configuredBuf.length) return false;
-  return timingSafeEqual(providedBuf, configuredBuf);
+  // Shared session store from HttpAdapter — allows browser sessions (cookie auth)
+  // to call identity routes without the raw bootstrap secret being stored in JS.
+  sessions: SessionStore;
+  // Required for the configured flag query on GET /api/identity.
+  pool: Pool;
 }
 
 export async function identityRoutes(
   app: FastifyInstance,
   options: IdentityRouteOptions,
 ): Promise<void> {
-  const { identityService, webAppBootstrapSecret } = options;
+  const { identityService, webAppBootstrapSecret, sessions, pool } = options;
 
-  // Auth helper — validates the bootstrap secret on every request to these routes.
-  function requireBootstrapSecret(
-    headers: Record<string, string | string[] | undefined>,
-    reply: FastifyReply,
-  ): boolean {
-    const provided = headers['x-web-bootstrap-secret'];
-    if (!validateBootstrapSecret(provided, webAppBootstrapSecret)) {
-      void reply.status(401).send({
-        error: 'Unauthorized. Provide a valid x-web-bootstrap-secret header.',
-      });
-      return false;
-    }
-    return true;
+  // Auth helper — validates session cookie or bootstrap secret on every request.
+  function requireAuth(request: FastifyRequest, reply: FastifyReply): boolean {
+    return assertSecret(request, reply, webAppBootstrapSecret, sessions);
   }
 
   // -- GET /api/identity — return current identity config --
 
   app.get('/api/identity', async (request, reply) => {
-    if (!requireBootstrapSecret(request.headers as Record<string, string | string[] | undefined>, reply)) return;
+    if (!requireAuth(request, reply)) return;
 
     try {
       const identity = identityService.get();
-      return reply.send({ identity });
+
+      // Determine whether the identity has ever been explicitly configured via the wizard
+      // or API. A fresh deployment (only file_load versions) returns configured: false,
+      // which triggers the first-run wizard in the browser.
+      const configuredResult = await pool.query<{ configured: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1 FROM office_identity_versions
+           WHERE changed_by IN ('wizard', 'api')
+         ) AS configured`,
+      );
+      const configured = configuredResult.rows[0]?.configured ?? false;
+
+      return reply.send({ identity, configured });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to get identity';
       return reply.status(500).send({ error: message });
@@ -76,7 +66,7 @@ export async function identityRoutes(
   // -- PUT /api/identity — save a new version and trigger hot reload --
 
   app.put('/api/identity', async (request, reply) => {
-    if (!requireBootstrapSecret(request.headers as Record<string, string | string[] | undefined>, reply)) return;
+    if (!requireAuth(request, reply)) return;
 
     const body = request.body as {
       identity?: OfficeIdentity;
@@ -112,7 +102,7 @@ export async function identityRoutes(
   // -- GET /api/identity/history — return all versions, newest first --
 
   app.get('/api/identity/history', async (request, reply) => {
-    if (!requireBootstrapSecret(request.headers as Record<string, string | string[] | undefined>, reply)) return;
+    if (!requireAuth(request, reply)) return;
 
     try {
       const history = await identityService.history();
@@ -128,7 +118,7 @@ export async function identityRoutes(
   // in the in-memory cache before the next coordinator turn.
 
   app.post('/api/identity/reload', async (request, reply) => {
-    if (!requireBootstrapSecret(request.headers as Record<string, string | string[] | undefined>, reply)) return;
+    if (!requireAuth(request, reply)) return;
 
     try {
       await identityService.reload();

--- a/src/channels/http/routes/identity.ts
+++ b/src/channels/http/routes/identity.ts
@@ -58,8 +58,8 @@ export async function identityRoutes(
 
       return reply.send({ identity, configured });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to get identity';
-      return reply.status(500).send({ error: message });
+      request.log.error({ err }, 'GET /api/identity: failed to query configured flag or get identity');
+      return reply.status(500).send({ error: 'Failed to get identity. Check server logs.' });
     }
   });
 
@@ -70,6 +70,7 @@ export async function identityRoutes(
 
     const body = request.body as {
       identity?: OfficeIdentity;
+      changedBy?: string;
       note?: string;
     };
 
@@ -83,10 +84,17 @@ export async function identityRoutes(
     // (explicit confirmation step, separate from tone/persona edits).
 
     try {
-      await identityService.update(body.identity, 'api', body.note);
+      // Accept 'wizard' or 'api' as the source; default to 'api' for direct API callers.
+      const VALID_CHANGED_BY = ['api', 'wizard'] as const;
+      type ChangedBy = typeof VALID_CHANGED_BY[number];
+      const changedBy: ChangedBy = VALID_CHANGED_BY.includes(body.changedBy as ChangedBy)
+        ? (body.changedBy as ChangedBy)
+        : 'api';
+      await identityService.update(body.identity, changedBy, body.note);
       const updated = identityService.get();
       return reply.send({ identity: updated, updated: true });
     } catch (err) {
+      request.log.error({ err }, 'PUT /api/identity: update failed');
       // Validation errors from validateIdentity() are plain Error instances with descriptive
       // messages — return 400 so the wizard UI can surface them to the user.
       // DB / infrastructure errors carry a Postgres error code — return 500.
@@ -108,8 +116,8 @@ export async function identityRoutes(
       const history = await identityService.history();
       return reply.send({ history });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to get identity history';
-      return reply.status(500).send({ error: message });
+      request.log.error({ err }, 'GET /api/identity/history: failed to retrieve history');
+      return reply.status(500).send({ error: 'Failed to get identity history. Check server logs.' });
     }
   });
 

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1244,6 +1244,29 @@ function createUiHtml(): string {
     var cy = null;           // Cytoscape instance (lazy-initialised on first login)
     var memoryOpen = true;   // Memory nav section expanded by default
     var settingsOpen = true; // Settings nav section expanded by default
+
+    // ── Wizard state ───────────────────────────────────────────────────
+    var wizardState = {
+      step: 1,
+      name: '',
+      title: '',
+      signature: '',
+      toneBaseline: ['warm', 'direct'],
+      verbosity: 50,
+      directness: 75,
+      posture: 'conservative',
+      preferences: '',
+    };
+
+    // All valid tone words — mirrors BASELINE_TONE_OPTIONS in src/identity/types.ts.
+    var TONE_OPTIONS = [
+      'warm','friendly','approachable','personable','empathetic','encouraging','gracious','caring',
+      'direct','blunt','candid','frank','matter-of-fact','no-nonsense',
+      'energetic','calm','composed','enthusiastic','steady','measured',
+      'playful','witty','dry','charming','diplomatic','tactful','thoughtful','curious',
+      'confident','assured','polished','authoritative','professional',
+    ];
+
     var activeNavId = 'nav-kg';
     var contacts = [];
     var selectedContactId = null;
@@ -1343,6 +1366,29 @@ function createUiHtml(): string {
     var chatTextarea   = document.getElementById('chat-textarea');
     var chatSendBtn    = document.getElementById('chat-send-btn');
 
+    // Wizard DOM refs
+    var wstep1El         = document.getElementById('wstep-1');
+    var wstep2El         = document.getElementById('wstep-2');
+    var wstep3El         = document.getElementById('wstep-3');
+    var wstep4El         = document.getElementById('wstep-4');
+    var wDots            = [
+      document.getElementById('wdot-1'),
+      document.getElementById('wdot-2'),
+      document.getElementById('wdot-3'),
+      document.getElementById('wdot-4'),
+    ];
+    var wizardStepLabel  = document.getElementById('wizard-step-label');
+    var wNameInput       = document.getElementById('w-name');
+    var wTitleInput      = document.getElementById('w-title');
+    var wSignatureInput  = document.getElementById('w-signature');
+    var wVerbosityInput  = document.getElementById('w-verbosity');
+    var wDirectnessInput = document.getElementById('w-directness');
+    var wPrefsInput      = document.getElementById('w-preferences');
+    var wstep1Error      = document.getElementById('wstep1-error');
+    var wizardError      = document.getElementById('wizard-error');
+    var wizardSaveBtn    = document.getElementById('wizard-save-btn');
+    var chatSuccessBanner = document.getElementById('chat-success-banner');
+
     // Catch template/script divergence early rather than producing cryptic null errors
     if (!authWall || !mainApp || !authForm || !authInput || !authError ||
         !statusEl || !resultsEl || !searchInput || !searchBtn ||
@@ -1361,6 +1407,11 @@ function createUiHtml(): string {
         !jobsForm || !jobsEditorTitle || !jobsDeleteBtn || !jobsSaveBtn || !jobsCancelBtn ||
         !jobAgentIdInput || !jobStatusInput || !jobCronExprInput || !jobRunAtInput ||
         !jobIntentAnchorInput || !jobTaskPayloadInput ||
+        !wstep1El || !wstep2El || !wstep3El || !wstep4El ||
+        wDots.some(function(d) { return !d; }) ||
+        !wizardStepLabel || !wNameInput || !wTitleInput || !wSignatureInput ||
+        !wVerbosityInput || !wDirectnessInput || !wPrefsInput ||
+        !wstep1Error || !wizardError || !wizardSaveBtn || !chatSuccessBanner ||
         !chatMessagesEl || !chatConvListEl || !chatForm || !chatTextarea || !chatSendBtn) {
       throw new Error('Curia KG: required DOM element missing — check template integrity.');
     }
@@ -1593,18 +1644,93 @@ function createUiHtml(): string {
       settingsCaret.classList.toggle('collapsed', !settingsOpen);
     }
 
-    // Wizard show/hide — temporary stubs until Task 6 implements the full wizard.
-    // showMain() and navigate('wizard') call showWizard() before it's fully implemented;
-    // the stub falls back to Chat so the app is never left in a broken state.
+    // ── Wizard step management ─────────────────────────────────────────
+
+    function navigateWizardStep(n) {
+      wstep1El.style.display = n === 1 ? 'flex' : 'none';
+      wstep2El.style.display = n === 2 ? 'flex' : 'none';
+      wstep3El.style.display = n === 3 ? 'flex' : 'none';
+      wstep4El.style.display = n === 4 ? 'flex' : 'none';
+      // Dots for steps before n are filled; current and future are empty.
+      wDots.forEach(function(dot, i) { dot.classList.toggle('done', i < n); });
+      wizardStepLabel.textContent = 'Step ' + n + ' of 4';
+      wizardState.step = n;
+      if (n === 2) {
+        buildTonePills();
+        syncPostureSelection();
+        updateVerbosityPreview();
+        updateDirectnessPreview();
+      }
+      if (n === 4) { renderReview(); }
+    }
+
     function showWizard(identity) {
-      // TODO: implement full wizard overlay — replaced in Task 6
-      mainApp.style.display = 'flex';
-      navigate('chat', 'Chat', 'nav-chat');
-      initCytoscape();
+      wizardState.name      = (identity && identity.assistant && identity.assistant.name)      || '';
+      wizardState.title     = (identity && identity.assistant && identity.assistant.title)     || '';
+      wizardState.signature = (identity && identity.assistant && identity.assistant.emailSignature) || '';
+      wizardState.toneBaseline = (identity && identity.tone && identity.tone.baseline && identity.tone.baseline.length)
+        ? identity.tone.baseline.slice() : ['warm', 'direct'];
+      wizardState.verbosity  = (identity && identity.tone && identity.tone.verbosity  != null) ? identity.tone.verbosity  : 50;
+      wizardState.directness = (identity && identity.tone && identity.tone.directness != null) ? identity.tone.directness : 75;
+      wizardState.posture    = (identity && identity.decisionStyle && identity.decisionStyle.externalActions)
+        ? identity.decisionStyle.externalActions : 'conservative';
+      wizardState.preferences = '';
+
+      wNameInput.value       = wizardState.name;
+      wTitleInput.value      = wizardState.title;
+      wSignatureInput.value  = wizardState.signature;
+      wVerbosityInput.value  = String(wizardState.verbosity);
+      wDirectnessInput.value = String(wizardState.directness);
+      wPrefsInput.value      = '';
+
+      // Reset pill grid so it rebuilds with the new selection state.
+      var grid = document.getElementById('tone-pill-grid');
+      if (grid) grid.replaceChildren();
+
+      document.getElementById('view-wizard').style.display = 'flex';
+      wstep1Error.style.display = 'none';
+      wizardError.style.display = 'none';
+      navigateWizardStep(1);
     }
 
     function hideWizard() {
-      // TODO: implement — replaced in Task 6
+      document.getElementById('view-wizard').style.display = 'none';
+    }
+
+    function validateWizardStep(n) {
+      if (n === 1) {
+        var name = wNameInput.value.trim();
+        if (!name) {
+          wstep1Error.textContent = 'Assistant name is required.';
+          wstep1Error.style.display = 'block';
+          return false;
+        }
+        wstep1Error.style.display = 'none';
+        wizardState.name      = name;
+        wizardState.title     = wTitleInput.value.trim();
+        wizardState.signature = wSignatureInput.value.trim();
+        return true;
+      }
+      if (n === 2) {
+        if (wizardState.toneBaseline.length === 0) return false;
+        wizardState.verbosity  = Number(wVerbosityInput.value);
+        wizardState.directness = Number(wDirectnessInput.value);
+        return true;
+      }
+      if (n === 3) {
+        wizardState.preferences = wPrefsInput.value.trim();
+        return true;
+      }
+      return true;
+    }
+
+    function wizardNext() {
+      if (!validateWizardStep(wizardState.step)) return;
+      if (wizardState.step < 4) navigateWizardStep(wizardState.step + 1);
+    }
+
+    function wizardBack() {
+      if (wizardState.step > 1) navigateWizardStep(wizardState.step - 1);
     }
 
     // ── KG API helpers ─────────────────────────────────────────────────

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1,7 +1,7 @@
 import { randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import type { FastifyInstance } from 'fastify';
 import type { Pool } from 'pg';
 import type { EventBus } from '../../../bus/bus.js';
 import { createInboundMessage } from '../../../bus/events.js';

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1903,8 +1903,8 @@ function createUiHtml(): string {
           return res.json();
         })
         .then(function(data) {
-          var current = data.identity;
-          var prefs = current.behavioralPreferences ? current.behavioralPreferences.slice() : [];
+          var current = (data && data.identity) ? data.identity : {};
+          var prefs = Array.isArray(current.behavioralPreferences) ? current.behavioralPreferences.slice() : [];
           if (wizardState.preferences) { prefs.push(wizardState.preferences); }
 
           var payload = {

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -9,6 +9,7 @@ import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
 import type { ContactStatus } from '../../../contacts/types.js';
 import { MessageRejectedError, type EventRouter } from '../event-router.js';
+import { assertSecret, type SessionStore } from '../session-auth.js';
 
 export interface KnowledgeGraphRouteOptions {
   pool: Pool;
@@ -39,10 +40,6 @@ const WEB_CHANNEL_ID = 'web';
 // short-circuits to the CEO contact for this channel regardless of the sender string.
 const WEB_SENDER_ID = 'ceo-web-user';
 
-// Session token → expiry timestamp (ms). Scoped to the route registration
-// lifetime (process lifetime for production). Single-tenant tool: memory is fine.
-type SessionStore = Map<string, number>;
-
 interface KgNodeRow {
   id: string;
   type: string;
@@ -72,47 +69,6 @@ function normalizeLimit(raw: string | undefined, fallback: number, max: number):
   const parsed = Number.parseInt(raw ?? '', 10);
   if (Number.isNaN(parsed)) return fallback;
   return Math.max(1, Math.min(parsed, max));
-}
-
-function assertSecret(
-  request: FastifyRequest,
-  reply: FastifyReply,
-  configuredSecret: string | undefined,
-  sessions: SessionStore,
-): boolean {
-  if (!configuredSecret) {
-    reply.status(503).send({
-      error: 'Knowledge graph web UI is disabled. Set WEB_APP_BOOTSTRAP_SECRET in .env to enable it.',
-    });
-    return false;
-  }
-
-  // Primary path: browser session cookie set by POST /auth.
-  // @fastify/cookie augments FastifyRequest with .cookies at runtime.
-  const cookies = (request as unknown as { cookies?: Record<string, string | undefined> }).cookies;
-  const sessionToken = cookies?.['curia_session'];
-  if (sessionToken) {
-    const expiresAt = sessions.get(sessionToken);
-    if (expiresAt !== undefined && Date.now() < expiresAt) return true;
-    // Expired or unknown token — fall through to header check below.
-  }
-
-  // Fallback: direct header (programmatic API access via curl / scripts).
-  // Reject non-string values (Fastify coerces duplicate headers to string[]).
-  // Use timing-safe comparison to prevent character-by-character brute force.
-  const provided = request.headers['x-web-bootstrap-secret'];
-  if (
-    typeof provided !== 'string' ||
-    provided.length !== configuredSecret.length ||
-    !timingSafeEqual(Buffer.from(provided), Buffer.from(configuredSecret))
-  ) {
-    reply.status(401).send({
-      error: 'Unauthorized. Authenticate via POST /auth or provide the x-web-bootstrap-secret header.',
-    });
-    return false;
-  }
-
-  return true;
 }
 
 // Design tokens — dark mode, from the Curia design system (theme.md).

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1438,8 +1438,10 @@ function createUiHtml(): string {
             initCytoscape();
           }
         })
-        .catch(function() {
+        .catch(function(err) {
           // Identity service not available or check failed — fall back to main app.
+          // Log so operators can diagnose DB/network issues at login time.
+          console.error('[curia] identity check failed on login:', err);
           mainApp.style.display = 'flex';
           navigate('chat', 'Chat', 'nav-chat');
           initCytoscape();
@@ -1572,12 +1574,9 @@ function createUiHtml(): string {
             return res.json();
           })
           .then(function(data) { showWizard(data.identity); })
-          .catch(function() {
-            showWizard({
-              assistant: { name: '', title: '', emailSignature: '' },
-              tone: { baseline: ['warm', 'direct'], verbosity: 50, directness: 75 },
-              decisionStyle: { externalActions: 'conservative' },
-            });
+          .catch(function(err) {
+            console.error('[curia] failed to load identity for wizard pre-fill:', err);
+            showWizard(null);
           });
         return;
       }
@@ -1665,6 +1664,8 @@ function createUiHtml(): string {
     }
 
     function showWizard(identity) {
+      // Treat null/undefined identity as an empty object — all fields fall back to defaults.
+      if (!identity) identity = {};
       wizardState.name      = (identity && identity.assistant && identity.assistant.name)      || '';
       wizardState.title     = (identity && identity.assistant && identity.assistant.title)     || '';
       wizardState.signature = (identity && identity.assistant && identity.assistant.emailSignature) || '';
@@ -1923,6 +1924,7 @@ function createUiHtml(): string {
               // constraints are immutable via wizard — always preserve.
               constraints: current.constraints || [],
             },
+            changedBy: 'wizard',
             note: 'Saved via onboarding wizard',
           };
 
@@ -1934,13 +1936,20 @@ function createUiHtml(): string {
         })
         .then(function(res) {
           if (!res.ok) {
-            return res.json().then(function(body) {
-              throw new Error(body.error || 'Save failed');
+            return res.text().then(function(text) {
+              var msg = 'Save failed';
+              try { msg = JSON.parse(text).error || msg; } catch (_) {}
+              throw new Error(msg);
             });
           }
           return fetch('/api/identity/reload', { method: 'POST' });
         })
-        .then(function() {
+        .then(function(res) {
+          if (!res.ok) {
+            // Identity was saved to DB, but the in-memory cache was not refreshed.
+            // The error path re-enables the button so the user can retry.
+            throw new Error('Identity saved but in-memory reload failed \u2014 please try again or restart the server.');
+          }
           hideWizard();
           if (mainApp && mainApp.style.display === 'none') {
             mainApp.style.display = 'flex';

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -623,6 +623,35 @@ function createUiHtml(): string {
           </div>
         </div>
 
+        <!-- Settings (expandable section) -->
+        <div>
+          <button class="nav-item" id="settings-toggle" onclick="toggleSettings()">
+            <!-- gear icon -->
+            <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="7.5" cy="7.5" r="2"/>
+              <path d="M7.5 1v1.5M7.5 12.5V14M14 7.5h-1.5M2.5 7.5H1M12.07 2.93l-1.06 1.06M4 11l-1.06 1.06M12.07 12.07l-1.06-1.06M4 4l-1.06-1.06"/>
+            </svg>
+            Settings
+            <svg id="settings-chevron" class="chevron" style="margin-left: auto;" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M3 4.5L6 7.5L9 4.5"/>
+            </svg>
+          </button>
+
+          <div id="settings-submenu" style="display: flex; flex-direction: column; gap: 2px; margin-top: 2px;">
+            <button id="nav-wizard" class="nav-sub-item" onclick="navigate('wizard', 'Setup Wizard', 'nav-wizard')">
+              <!-- wand icon -->
+              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M2 11L8 5"/>
+                <path d="M9.5 1.5l.5.5-.5.5-.5-.5z"/>
+                <path d="M5.5 2.5l.5.5-.5.5-.5-.5z"/>
+                <path d="M10.5 5.5l.5.5-.5.5-.5-.5z"/>
+                <path d="M8 5l3.5-3.5"/>
+              </svg>
+              Setup Wizard
+            </button>
+          </div>
+        </div>
+
       </div>
     </nav>
 
@@ -875,6 +904,7 @@ function createUiHtml(): string {
     // ── State ──────────────────────────────────────────────────────────
     var cy = null;           // Cytoscape instance (lazy-initialised on first login)
     var memoryOpen = true;   // Memory nav section expanded by default
+    var settingsOpen = true; // Settings nav section expanded by default
     var activeNavId = 'nav-kg';
     var contacts = [];
     var selectedContactId = null;
@@ -916,6 +946,8 @@ function createUiHtml(): string {
     var searchBtn     = document.getElementById('search-btn');
     var memoryCaret   = document.getElementById('memory-chevron');
     var memorySubmenu = document.getElementById('memory-submenu');
+    var settingsSubmenu = document.getElementById('settings-submenu');
+    var settingsCaret   = document.getElementById('settings-chevron');
     var contactsStatusEl = document.getElementById('contacts-status');
     var contactsSearchInput = document.getElementById('contacts-search-input');
     var contactsSearchBtn = document.getElementById('contacts-search-btn');
@@ -975,7 +1007,7 @@ function createUiHtml(): string {
     // Catch template/script divergence early rather than producing cryptic null errors
     if (!authWall || !mainApp || !authForm || !authInput || !authError ||
         !statusEl || !resultsEl || !searchInput || !searchBtn ||
-        !memoryCaret || !memorySubmenu ||
+        !memoryCaret || !memorySubmenu || !settingsSubmenu || !settingsCaret ||
         !contactsStatusEl || !contactsSearchInput || !contactsSearchBtn ||
         !contactsNewBtn || !contactsListEl || !contactsForm || !contactsEditorTitle ||
         !contactsDeleteBtn || !contactsSaveBtn || !contactsCancelBtn ||
@@ -1000,9 +1032,28 @@ function createUiHtml(): string {
 
     function showMain() {
       authWall.style.display = 'none';
-      mainApp.style.display  = 'flex';
-      initCytoscape();
-      search(); // auto-load all nodes on entry
+      // Check whether identity has been configured via the wizard. If not, show the
+      // wizard overlay. Main app stays hidden until wizard completes (or identity check fails).
+      fetch('/api/identity')
+        .then(function(res) {
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          return res.json();
+        })
+        .then(function(data) {
+          if (!data.configured) {
+            showWizard(data.identity);
+          } else {
+            mainApp.style.display = 'flex';
+            navigate('chat', 'Chat', 'nav-chat');
+            initCytoscape();
+          }
+        })
+        .catch(function() {
+          // Identity service not available or check failed — fall back to main app.
+          mainApp.style.display = 'flex';
+          navigate('chat', 'Chat', 'nav-chat');
+          initCytoscape();
+        });
     }
 
     function showAuthError(msg) {
@@ -1105,17 +1156,48 @@ function createUiHtml(): string {
 
     // ── Navigation ─────────────────────────────────────────────────────
     function navigate(view, title, navId) {
-      var kgView   = document.getElementById('view-kg');
-      var chatView = document.getElementById('view-chat');
-      var contactsView = document.getElementById('view-contacts');
-      var tasksView = document.getElementById('view-tasks');
+      var kgView            = document.getElementById('view-kg');
+      var chatView          = document.getElementById('view-chat');
+      var contactsView      = document.getElementById('view-contacts');
+      var tasksView         = document.getElementById('view-tasks');
       var scheduledJobsView = document.getElementById('view-scheduled-jobs');
+      var viewWizard        = document.getElementById('view-wizard');
 
-      kgView.style.display   = view === 'kg'           ? 'flex' : 'none';
-      chatView.style.display = view === 'chat'         ? 'flex' : 'none';
-      contactsView.style.display = view === 'contacts' ? 'flex' : 'none';
-      tasksView.style.display = view === 'tasks'       ? 'flex' : 'none';
+      // When navigating to the wizard, fetch the current identity to pre-fill fields,
+      // then delegate to showWizard(). Return early — the wizard has its own overlay.
+      if (view === 'wizard') {
+        // Update active highlight before delegating — same ordering as all other nav paths.
+        if (activeNavId) {
+          var prev = document.getElementById(activeNavId);
+          if (prev) prev.classList.remove('active');
+        }
+        if (navId) {
+          var curr = document.getElementById(navId);
+          if (curr) curr.classList.add('active');
+          activeNavId = navId;
+        }
+        fetch('/api/identity')
+          .then(function(res) {
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            return res.json();
+          })
+          .then(function(data) { showWizard(data.identity); })
+          .catch(function() {
+            showWizard({
+              assistant: { name: '', title: '', emailSignature: '' },
+              tone: { baseline: ['warm', 'direct'], verbosity: 50, directness: 75 },
+              decisionStyle: { externalActions: 'conservative' },
+            });
+          });
+        return;
+      }
+
+      kgView.style.display            = view === 'kg'             ? 'flex' : 'none';
+      chatView.style.display          = view === 'chat'           ? 'flex' : 'none';
+      contactsView.style.display      = view === 'contacts'       ? 'flex' : 'none';
+      tasksView.style.display         = view === 'tasks'          ? 'flex' : 'none';
       scheduledJobsView.style.display = view === 'scheduled-jobs' ? 'flex' : 'none';
+      if (viewWizard) viewWizard.style.display = 'none'; // always hide when navigating elsewhere
       // When returning to the KG view, tell Cytoscape to re-measure the container.
       // The canvas dimensions may be stale if the view was hidden (display:none)
       // since the last render. Defer to requestAnimationFrame so the browser
@@ -1127,6 +1209,9 @@ function createUiHtml(): string {
           cy.resize();
           cy.fit();
         });
+      }
+      if (view === 'kg') {
+        search(); // auto-load all nodes when entering the KG view
       }
       if (view === 'contacts') {
         loadContacts();
@@ -1161,6 +1246,26 @@ function createUiHtml(): string {
       memoryOpen = !memoryOpen;
       memorySubmenu.style.display = memoryOpen ? 'flex' : 'none';
       memoryCaret.classList.toggle('collapsed', !memoryOpen);
+    }
+
+    function toggleSettings() {
+      settingsOpen = !settingsOpen;
+      settingsSubmenu.style.display = settingsOpen ? 'flex' : 'none';
+      settingsCaret.classList.toggle('collapsed', !settingsOpen);
+    }
+
+    // Wizard show/hide — temporary stubs until Task 6 implements the full wizard.
+    // showMain() and navigate('wizard') call showWizard() before it's fully implemented;
+    // the stub falls back to Chat so the app is never left in a broken state.
+    function showWizard(identity) {
+      // TODO: implement full wizard overlay — replaced in Task 6
+      mainApp.style.display = 'flex';
+      navigate('chat', 'Chat', 'nav-chat');
+      initCytoscape();
+    }
+
+    function hideWizard() {
+      // TODO: implement — replaced in Task 6
     }
 
     // ── KG API helpers ─────────────────────────────────────────────────

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1828,6 +1828,136 @@ function createUiHtml(): string {
       selectPosture(wizardState.posture);
     }
 
+    // ── Review & submit ────────────────────────────────────────────────
+
+    function renderReview() {
+      var card = document.getElementById('review-card');
+      // Remove all existing child nodes safely (no innerHTML — user input could contain HTML).
+      while (card.firstChild) card.removeChild(card.firstChild);
+
+      var v = wizardState.verbosity;
+      var verbosityDesc = v <= 25 ? 'Very brief responses — just the essentials.'
+        : v <= 50 ? 'Concise responses by default.'
+        : v <= 75 ? 'Adapts length to the situation.'
+        : 'Thorough by default — full context included.';
+
+      var d = wizardState.directness;
+      var directnessDesc = d <= 25 ? 'Measured — acknowledges uncertainty carefully.'
+        : d <= 50 ? 'Leans direct but hedges where uncertain.'
+        : d <= 75 ? 'Direct — minimal unnecessary hedging.'
+        : 'States positions plainly; no softening.';
+
+      var postureMap = {
+        conservative: 'Verifies before acting on external requests.',
+        balanced:     'Acts when confident; flags when uncertain.',
+        proactive:    'Biases toward action with less checking in.',
+      };
+      var postureDesc = postureMap[wizardState.posture] || '';
+
+      var words = wizardState.toneBaseline;
+      var tonePhrase = words.length === 1 ? words[0]
+        : words.length === 2 ? words[0] + ' and ' + words[1]
+        : words[0] + ', ' + words[1] + ' and ' + words[2];
+
+      var rows = [
+        { label: 'Assistant', value: wizardState.name + (wizardState.title ? ' \u2014 ' + wizardState.title : '') },
+        { label: 'Tone',      value: 'Your tone is ' + tonePhrase + '.' },
+        { label: 'Detail',    value: verbosityDesc },
+        { label: 'Directness', value: directnessDesc },
+        { label: 'Posture',   value: postureDesc },
+      ];
+      if (wizardState.preferences) {
+        rows.push({ label: 'Preference', value: '\u201c' + wizardState.preferences + '\u201d' });
+      }
+
+      rows.forEach(function(row) {
+        var rowEl   = document.createElement('div');
+        rowEl.className = 'review-row';
+        var labelEl = document.createElement('div');
+        labelEl.className = 'review-row-label';
+        labelEl.textContent = row.label;
+        var valueEl = document.createElement('div');
+        valueEl.className = 'review-row-value';
+        valueEl.textContent = row.value; // textContent — safe even with user input
+        rowEl.appendChild(labelEl);
+        rowEl.appendChild(valueEl);
+        card.appendChild(rowEl);
+      });
+    }
+
+    function submitWizard() {
+      wizardSaveBtn.disabled = true;
+      wizardSaveBtn.textContent = 'Saving\u2026';
+      wizardError.style.display = 'none';
+
+      // Fetch current identity to preserve behavioral_preferences and constraints.
+      fetch('/api/identity')
+        .then(function(res) {
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          return res.json();
+        })
+        .then(function(data) {
+          var current = data.identity;
+          var prefs = current.behavioralPreferences ? current.behavioralPreferences.slice() : [];
+          if (wizardState.preferences) { prefs.push(wizardState.preferences); }
+
+          var payload = {
+            identity: {
+              assistant: {
+                name: wizardState.name,
+                title: wizardState.title,
+                emailSignature: wizardState.signature,
+              },
+              tone: {
+                baseline: wizardState.toneBaseline,
+                verbosity: wizardState.verbosity,
+                directness: wizardState.directness,
+              },
+              behavioralPreferences: prefs,
+              decisionStyle: {
+                externalActions: wizardState.posture,
+                // internal_analysis is not surfaced in the wizard — preserve existing value.
+                internalAnalysis: (current.decisionStyle && current.decisionStyle.internalAnalysis)
+                  ? current.decisionStyle.internalAnalysis : 'proactive',
+              },
+              // constraints are immutable via wizard — always preserve.
+              constraints: current.constraints || [],
+            },
+            note: 'Saved via onboarding wizard',
+          };
+
+          return fetch('/api/identity', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+        })
+        .then(function(res) {
+          if (!res.ok) {
+            return res.json().then(function(body) {
+              throw new Error(body.error || 'Save failed');
+            });
+          }
+          return fetch('/api/identity/reload', { method: 'POST' });
+        })
+        .then(function() {
+          hideWizard();
+          if (mainApp && mainApp.style.display === 'none') {
+            mainApp.style.display = 'flex';
+            initCytoscape();
+          }
+          navigate('chat', 'Chat', 'nav-chat');
+          chatSuccessBanner.style.display = 'block';
+          setTimeout(function() { chatSuccessBanner.style.display = 'none'; }, 4000);
+        })
+        .catch(function(err) {
+          wizardError.textContent = err.message || 'Something went wrong — please try again.';
+          wizardError.style.display = 'block';
+          wizardSaveBtn.disabled = false;
+          wizardSaveBtn.textContent = 'Confirm \u0026 save';
+        });
+    }
+
     // ── KG API helpers ─────────────────────────────────────────────────
     function setStatus(msg, isError) {
       statusEl.textContent = msg;

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1431,6 +1431,11 @@ function createUiHtml(): string {
         })
         .then(function(data) {
           if (!data.configured) {
+            // Reveal the main app shell before showing the wizard — #view-wizard is
+            // position:fixed but it's still a DOM child of #main-app, so display:none
+            // on the parent hides it regardless of positioning.
+            mainApp.style.display = 'flex';
+            initCytoscape();
             showWizard(data.identity);
           } else {
             mainApp.style.display = 'flex';
@@ -1951,10 +1956,6 @@ function createUiHtml(): string {
             throw new Error('Identity saved but in-memory reload failed \u2014 please try again or restart the server.');
           }
           hideWizard();
-          if (mainApp && mainApp.style.display === 'none') {
-            mainApp.style.display = 'flex';
-            initCytoscape();
-          }
           navigate('chat', 'Chat', 'nav-chat');
           chatSuccessBanner.style.display = 'block';
           setTimeout(function() { chatSuccessBanner.style.display = 'none'; }, 4000);

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -25,6 +25,9 @@ export interface KnowledgeGraphRouteOptions {
   bus: EventBus;
   eventRouter: EventRouter;
   contactService: ContactService;
+  // Shared session store — created in HttpAdapter, passed to both KG and identity routes
+  // so both can accept the curia_session cookie for authentication.
+  sessions: SessionStore;
 }
 
 // How long the chat POST waits for an agent response before timing out.
@@ -2089,21 +2092,8 @@ export async function knowledgeGraphRoutes(
   app: FastifyInstance,
   options: KnowledgeGraphRouteOptions,
 ): Promise<void> {
-  const { pool, logger, webAppBootstrapSecret, secureCookies, bus, eventRouter, contactService } = options;
-
-  // In-memory session store: token → expiry timestamp (ms).
-  // Single-tenant tool — no DB persistence needed; sessions reset on server restart.
-  const sessions: SessionStore = new Map();
-
-  // Prune expired sessions every minute so the Map doesn't grow unboundedly.
-  const pruneInterval = setInterval(() => {
-    const now = Date.now();
-    for (const [token, expiresAt] of sessions) {
-      if (now > expiresAt) sessions.delete(token);
-    }
-  }, 60_000);
-  // Unref so the interval doesn't prevent process exit during tests.
-  pruneInterval.unref();
+  const { pool, logger, webAppBootstrapSecret, secureCookies, bus, eventRouter, contactService, sessions } = options;
+  // sessions is managed by HttpAdapter — no local Map creation needed here.
 
   app.get('/', async (_request, reply) => {
     reply

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -511,6 +511,233 @@ function createUiHtml(): string {
     .form-field select:focus {
       border-color: var(--teal);
     }
+    /* ── Wizard overlay ─────────────────────────────────────────────── */
+    #view-wizard {
+      position: fixed;
+      inset: 0;
+      z-index: 60;
+      background: var(--bg);
+      display: none;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .wizard-topbar {
+      flex: none;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px 24px;
+      border-bottom: 1px solid var(--border);
+    }
+    .wizard-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 32px 24px 40px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    .wizard-content {
+      width: 100%;
+      max-width: 520px;
+      display: flex;
+      flex-direction: column;
+    }
+    .wizard-heading {
+      font-family: 'Lora', Georgia, serif;
+      font-size: 1.375rem;
+      font-weight: 500;
+      color: var(--fg);
+      margin-bottom: 6px;
+    }
+    .wizard-subheading {
+      font-size: 0.8125rem;
+      color: var(--fg-muted);
+      margin-bottom: 28px;
+    }
+    .wizard-label {
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--fg-muted);
+      margin-bottom: 10px;
+    }
+    .wizard-field { margin-bottom: 20px; }
+    .wizard-field label {
+      display: block;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      color: var(--fg-muted);
+      margin-bottom: 6px;
+    }
+    .wizard-field input {
+      background: var(--muted);
+      border: 1px solid var(--input-border);
+      border-radius: var(--radius-md);
+      color: var(--fg);
+      font-family: inherit;
+      font-size: 0.875rem;
+      padding: 10px 12px;
+      outline: none;
+      width: 100%;
+      transition: border-color 0.12s;
+    }
+    .wizard-field input:focus { border-color: var(--teal); }
+    .wizard-field textarea {
+      background: var(--muted);
+      border: 1px solid var(--input-border);
+      border-radius: var(--radius-md);
+      color: var(--fg);
+      font-family: inherit;
+      font-size: 0.875rem;
+      padding: 10px 12px;
+      outline: none;
+      width: 100%;
+      resize: vertical;
+      min-height: 90px;
+      transition: border-color 0.12s;
+    }
+    .wizard-field textarea:focus { border-color: var(--teal); }
+    .wizard-progress { display: flex; gap: 6px; align-items: center; }
+    .wizard-dot {
+      width: 28px;
+      height: 4px;
+      border-radius: 2px;
+      background: var(--muted);
+      transition: background 0.2s;
+    }
+    .wizard-dot.done { background: var(--primary); }
+    .tone-pill {
+      padding: 6px 14px;
+      border-radius: 99px;
+      border: 1px solid var(--accent);
+      background: none;
+      color: var(--fg-muted);
+      font-family: inherit;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.1s, color 0.1s, border-color 0.1s, opacity 0.1s;
+    }
+    .tone-pill.selected {
+      background: var(--primary);
+      color: var(--primary-fg);
+      border-color: var(--primary);
+    }
+    .tone-pill.disabled { opacity: 0.35; cursor: not-allowed; pointer-events: none; }
+    .wizard-preview {
+      font-size: 0.8125rem;
+      color: var(--teal);
+      min-height: 18px;
+      margin-bottom: 24px;
+    }
+    .wizard-sample {
+      font-size: 0.8125rem;
+      font-style: italic;
+      color: var(--fg-muted);
+      padding: 10px 14px;
+      background: var(--card);
+      border-radius: var(--radius-md);
+      border-left: 2px solid var(--muted);
+      margin-bottom: 24px;
+    }
+    .slider-labels {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.6875rem;
+      color: var(--accent);
+      margin-bottom: 8px;
+    }
+    .posture-grid { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 28px; }
+    .posture-card {
+      flex: 1;
+      min-width: 120px;
+      padding: 12px 14px;
+      border-radius: var(--radius-md);
+      border: 1px solid var(--muted);
+      background: none;
+      color: var(--fg-muted);
+      font-family: inherit;
+      text-align: left;
+      cursor: pointer;
+      transition: border-color 0.12s, background 0.12s;
+    }
+    .posture-card:hover { border-color: var(--accent); }
+    .posture-card.selected {
+      border-color: var(--primary);
+      background: rgba(222,222,222,0.06);
+      color: var(--fg);
+    }
+    .posture-card-title { font-size: 0.8125rem; font-weight: 600; margin-bottom: 3px; }
+    .posture-card-desc  { font-size: 0.75rem; }
+    .review-card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: 20px;
+      margin-bottom: 28px;
+    }
+    .review-row {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 10px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .review-row:last-child { border-bottom: none; }
+    .review-row-label {
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--fg-muted);
+    }
+    .review-row-value { font-size: 0.875rem; color: var(--fg); }
+    .wizard-nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 8px;
+      margin-top: 8px;
+    }
+    .btn-wizard-back {
+      padding: 10px 20px;
+      border-radius: var(--radius-md);
+      border: 1px solid var(--muted);
+      background: none;
+      color: var(--fg-muted);
+      font-family: inherit;
+      font-size: 0.875rem;
+      cursor: pointer;
+      transition: border-color 0.12s, color 0.12s;
+    }
+    .btn-wizard-back:hover { border-color: var(--accent); color: var(--fg); }
+    .btn-wizard-next {
+      padding: 10px 24px;
+      border-radius: var(--radius-md);
+      background: var(--primary);
+      color: var(--primary-fg);
+      font-family: inherit;
+      font-size: 0.875rem;
+      font-weight: 600;
+      border: none;
+      cursor: pointer;
+      transition: opacity 0.12s;
+    }
+    .btn-wizard-next:hover    { opacity: 0.88; }
+    .btn-wizard-next:disabled { opacity: 0.5; cursor: not-allowed; }
+    #chat-success-banner {
+      display: none;
+      background: rgba(71,129,137,0.15);
+      border-bottom: 1px solid rgba(71,129,137,0.35);
+      color: var(--teal);
+      font-size: 0.8125rem;
+      font-weight: 500;
+      padding: 10px 16px;
+      text-align: center;
+      flex: none;
+    }
   </style>
 </head>
 <body>
@@ -885,6 +1112,8 @@ function createUiHtml(): string {
 
         <!-- Right: message thread + input -->
         <div class="chat-thread">
+          <!-- Success banner — shown briefly after wizard completes -->
+          <div id="chat-success-banner">Your assistant is ready.</div>
           <div id="chat-messages" class="chat-messages"></div>
           <div class="chat-input-bar">
             <form id="chat-form" style="display: contents;">
@@ -895,6 +1124,116 @@ function createUiHtml(): string {
         </div>
 
       </div>
+
+      <!-- ============================================================
+           WIZARD OVERLAY — full-screen, z-index 60.
+           Shown on first run (configured: false) or via Settings nav.
+      ============================================================= -->
+      <div id="view-wizard">
+
+        <!-- Top bar: wordmark + progress dots + step counter -->
+        <div class="wizard-topbar">
+          <span style="font-family: 'Lora', Georgia, serif; font-size: 1.125rem; font-weight: 500; letter-spacing: 0.06em; color: var(--fg);">CURIA</span>
+          <div class="wizard-progress">
+            <div class="wizard-dot" id="wdot-1"></div>
+            <div class="wizard-dot" id="wdot-2"></div>
+            <div class="wizard-dot" id="wdot-3"></div>
+            <div class="wizard-dot" id="wdot-4"></div>
+          </div>
+          <span id="wizard-step-label" style="font-size: 0.75rem; color: var(--fg-muted);">Step 1 of 4</span>
+        </div>
+
+        <div class="wizard-body">
+
+          <!-- Step 1 — Name your assistant -->
+          <div id="wstep-1" class="wizard-content" style="display: none;">
+            <div class="wizard-heading">What should your assistant be called?</div>
+            <div class="wizard-subheading">You can change these at any time from Settings.</div>
+            <div class="wizard-field">
+              <label for="w-name">Assistant name</label>
+              <input id="w-name" type="text" placeholder="Alex Curia" />
+            </div>
+            <div class="wizard-field">
+              <label for="w-title">Title</label>
+              <input id="w-title" type="text" placeholder="Executive Assistant to the CEO" />
+            </div>
+            <div class="wizard-field">
+              <label for="w-signature">Email signature <span style="font-weight:400;color:var(--fg-muted);">(optional)</span></label>
+              <textarea id="w-signature" placeholder="Alex Curia&#10;Office of the CEO"></textarea>
+            </div>
+            <div id="wstep1-error" style="display:none;color:var(--destructive);font-size:0.8125rem;margin-bottom:12px;"></div>
+            <div class="wizard-nav">
+              <span></span>
+              <button class="btn-wizard-next" onclick="wizardNext()">Next →</button>
+            </div>
+          </div>
+
+          <!-- Step 2 — Communication style -->
+          <div id="wstep-2" class="wizard-content" style="display: none;">
+            <div class="wizard-heading">How should your assistant communicate?</div>
+            <div class="wizard-subheading">Pick 1–3 words that describe the tone you want.</div>
+            <div class="wizard-label">Tone <span style="font-weight:400;text-transform:none;letter-spacing:0;">(pick up to 3)</span></div>
+            <div id="tone-pill-grid" style="display:flex;flex-wrap:wrap;gap:7px;margin-bottom:10px;"></div>
+            <div id="tone-preview" class="wizard-preview"></div>
+            <div class="wizard-label" style="margin-top:4px;">Detail level</div>
+            <input id="w-verbosity" type="range" min="0" max="100" value="50"
+              style="width:100%;accent-color:var(--primary);margin-bottom:6px;" oninput="updateVerbosityPreview()" />
+            <div class="slider-labels"><span>Brief</span><span>Thorough</span></div>
+            <div id="verbosity-preview" class="wizard-sample"></div>
+            <div class="wizard-label">Directness</div>
+            <input id="w-directness" type="range" min="0" max="100" value="75"
+              style="width:100%;accent-color:var(--primary);margin-bottom:6px;" oninput="updateDirectnessPreview()" />
+            <div class="slider-labels"><span>Measured</span><span>Direct</span></div>
+            <div id="directness-preview" class="wizard-sample"></div>
+            <div class="wizard-label">Decision posture <span style="font-weight:400;text-transform:none;letter-spacing:0;color:var(--accent);">(for external actions)</span></div>
+            <div class="posture-grid">
+              <button class="posture-card" data-posture="conservative" onclick="selectPosture('conservative')">
+                <div class="posture-card-title">Conservative</div>
+                <div class="posture-card-desc">Verify before acting; flag ambiguity</div>
+              </button>
+              <button class="posture-card" data-posture="balanced" onclick="selectPosture('balanced')">
+                <div class="posture-card-title">Balanced</div>
+                <div class="posture-card-desc">Act when confident, flag when uncertain</div>
+              </button>
+              <button class="posture-card" data-posture="proactive" onclick="selectPosture('proactive')">
+                <div class="posture-card-title">Proactive</div>
+                <div class="posture-card-desc">Bias toward action; less checking in</div>
+              </button>
+            </div>
+            <div class="wizard-nav">
+              <button class="btn-wizard-back" onclick="wizardBack()">← Back</button>
+              <button class="btn-wizard-next" onclick="wizardNext()">Next →</button>
+            </div>
+          </div>
+
+          <!-- Step 3 — Anything else? -->
+          <div id="wstep-3" class="wizard-content" style="display: none;">
+            <div class="wizard-heading">Is there anything else we should know?</div>
+            <div class="wizard-subheading">Optional — any specific preferences you'd like your assistant to follow.</div>
+            <div class="wizard-field">
+              <textarea id="w-preferences" style="min-height:140px;"
+                placeholder="E.g., 'Always include agenda items in meeting requests' or 'Flag emails from investors as high priority'"></textarea>
+            </div>
+            <div class="wizard-nav">
+              <button class="btn-wizard-back" onclick="wizardBack()">← Back</button>
+              <button class="btn-wizard-next" onclick="wizardNext()">Review →</button>
+            </div>
+          </div>
+
+          <!-- Step 4 — Review & confirm -->
+          <div id="wstep-4" class="wizard-content" style="display: none;">
+            <div class="wizard-heading">Does everything look right?</div>
+            <div class="wizard-subheading">Go back to change anything, or save to get started.</div>
+            <div class="review-card" id="review-card"></div>
+            <div id="wizard-error" style="display:none;color:var(--destructive);font-size:0.8125rem;margin-bottom:12px;"></div>
+            <div class="wizard-nav">
+              <button class="btn-wizard-back" onclick="wizardBack()">← Back</button>
+              <button id="wizard-save-btn" class="btn-wizard-next" onclick="submitWizard()">Confirm &amp; save</button>
+            </div>
+          </div>
+
+        </div><!-- /.wizard-body -->
+      </div><!-- /#view-wizard -->
 
     </main>
   </div>

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1733,6 +1733,101 @@ function createUiHtml(): string {
       if (wizardState.step > 1) navigateWizardStep(wizardState.step - 1);
     }
 
+    // ── Tone pills ─────────────────────────────────────────────────────
+
+    function buildTonePills() {
+      var grid = document.getElementById('tone-pill-grid');
+      // Rebuild on each entry so the selection syncs with current wizardState.
+      if (grid.children.length > 0) {
+        syncPillSelections();
+        updateTonePreview();
+        return;
+      }
+      TONE_OPTIONS.forEach(function(word) {
+        var btn = document.createElement('button');
+        btn.className = 'tone-pill';
+        btn.textContent = word;
+        btn.dataset.word = word;
+        btn.addEventListener('click', function() { toggleTonePill(btn, word); });
+        grid.appendChild(btn);
+      });
+      syncPillSelections();
+      updateTonePreview();
+    }
+
+    function syncPillSelections() {
+      var grid = document.getElementById('tone-pill-grid');
+      var atMax = wizardState.toneBaseline.length >= 3;
+      Array.from(grid.children).forEach(function(btn) {
+        var word = btn.dataset.word;
+        var isSelected = wizardState.toneBaseline.indexOf(word) !== -1;
+        btn.classList.toggle('selected', isSelected);
+        btn.classList.toggle('disabled', atMax && !isSelected);
+        btn.disabled = atMax && !isSelected;
+      });
+    }
+
+    function toggleTonePill(btn, word) {
+      var idx = wizardState.toneBaseline.indexOf(word);
+      if (idx !== -1) {
+        // Minimum 1: prevent deselecting the last word.
+        if (wizardState.toneBaseline.length <= 1) return;
+        wizardState.toneBaseline.splice(idx, 1);
+      } else {
+        if (wizardState.toneBaseline.length >= 3) return;
+        wizardState.toneBaseline.push(word);
+      }
+      syncPillSelections();
+      updateTonePreview();
+    }
+
+    function updateTonePreview() {
+      var words = wizardState.toneBaseline;
+      var phrase = words.length === 1 ? words[0]
+        : words.length === 2 ? words[0] + ' and ' + words[1]
+        : words[0] + ', ' + words[1] + ' and ' + words[2];
+      var suffix = words.length >= 3 ? ' (Pick up to 3)' : '';
+      document.getElementById('tone-preview').textContent =
+        words.length > 0 ? 'Your tone is ' + phrase + '.' + suffix : '';
+    }
+
+    // ── Slider previews ────────────────────────────────────────────────
+
+    function verbosityBand(v) {
+      if (v <= 25) return '\u201cHere\u2019s the short answer.\u201d';
+      if (v <= 50) return '\u201cHappy to help \u2014 let me know if you\u2019d like more detail.\u201d';
+      if (v <= 75) return '\u201cHere\u2019s what you need to know, plus a bit of context.\u201d';
+      return '\u201cLet me walk you through this thoroughly.\u201d';
+    }
+
+    function directnessBand(v) {
+      if (v <= 25) return '\u201cThere are a few things worth considering here \u2014 it\u2019s hard to say definitively.\u201d';
+      if (v <= 50) return '\u201cI\u2019d lean toward option A, though it depends on your priorities.\u201d';
+      if (v <= 75) return '\u201cThursday works. I\u2019ll send the invite.\u201d';
+      return '\u201cDo it. The risk is low and the upside is clear.\u201d';
+    }
+
+    function updateVerbosityPreview() {
+      document.getElementById('verbosity-preview').textContent = verbosityBand(Number(wVerbosityInput.value));
+    }
+
+    function updateDirectnessPreview() {
+      document.getElementById('directness-preview').textContent = directnessBand(Number(wDirectnessInput.value));
+    }
+
+    // ── Posture picker ─────────────────────────────────────────────────
+
+    function selectPosture(value) {
+      wizardState.posture = value;
+      document.querySelectorAll('.posture-card').forEach(function(card) {
+        card.classList.toggle('selected', card.dataset.posture === value);
+      });
+    }
+
+    function syncPostureSelection() {
+      selectPosture(wizardState.posture);
+    }
+
     // ── KG API helpers ─────────────────────────────────────────────────
     function setStatus(msg, isError) {
       statusEl.textContent = msg;

--- a/src/channels/http/session-auth.ts
+++ b/src/channels/http/session-auth.ts
@@ -47,10 +47,20 @@ export function assertSecret(
   // Fallback: direct header (programmatic access via curl / scripts).
   // Reject non-string values (Fastify coerces duplicate headers to string[]).
   const provided = request.headers['x-web-bootstrap-secret'];
+  if (typeof provided !== 'string') {
+    reply.status(401).send({
+      error: 'Unauthorized. Authenticate via POST /auth or provide the x-web-bootstrap-secret header.',
+    });
+    return false;
+  }
+  // Compare byte lengths (not char lengths) before calling timingSafeEqual — it throws if
+  // the two buffers differ in length. A multi-byte UTF-8 secret can have the same char count
+  // but different byte length, so using Buffer.byteLength rather than String.length is correct.
+  const providedBuf = Buffer.from(provided);
+  const configuredBuf = Buffer.from(configuredSecret);
   if (
-    typeof provided !== 'string' ||
-    provided.length !== configuredSecret.length ||
-    !timingSafeEqual(Buffer.from(provided), Buffer.from(configuredSecret))
+    providedBuf.length !== configuredBuf.length ||
+    !timingSafeEqual(providedBuf, configuredBuf)
   ) {
     reply.status(401).send({
       error: 'Unauthorized. Authenticate via POST /auth or provide the x-web-bootstrap-secret header.',

--- a/src/channels/http/session-auth.ts
+++ b/src/channels/http/session-auth.ts
@@ -1,0 +1,62 @@
+// session-auth.ts — Shared session authentication helper for HTTP routes.
+//
+// Both the KG routes and the identity routes accept authentication via either:
+//   1. A valid `curia_session` HttpOnly cookie (set by POST /auth)
+//   2. A valid `x-web-bootstrap-secret` request header (for programmatic access)
+//
+// The sessions Map is created in HttpAdapter and passed to both route registrations.
+
+import { timingSafeEqual } from 'node:crypto';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+
+// token → expiry timestamp in ms. Lives in HttpAdapter, shared across route registrations.
+export type SessionStore = Map<string, number>;
+
+/**
+ * Verify that the request is authenticated via session cookie or bootstrap secret header.
+ *
+ * Returns true if authenticated. Returns false and sends an error response if not.
+ *
+ * Why timingSafeEqual: prevents character-by-character brute force against the secret.
+ * We compare byte lengths before calling it because timingSafeEqual throws if buffers
+ * differ in length.
+ */
+export function assertSecret(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  configuredSecret: string | undefined,
+  sessions: SessionStore,
+): boolean {
+  if (!configuredSecret) {
+    reply.status(503).send({
+      error: 'Web UI is disabled. Set WEB_APP_BOOTSTRAP_SECRET in .env to enable it.',
+    });
+    return false;
+  }
+
+  // Primary path: browser session cookie set by POST /auth.
+  // @fastify/cookie augments FastifyRequest with .cookies at runtime.
+  const cookies = (request as unknown as { cookies?: Record<string, string | undefined> }).cookies;
+  const sessionToken = cookies?.['curia_session'];
+  if (sessionToken) {
+    const expiresAt = sessions.get(sessionToken);
+    if (expiresAt !== undefined && Date.now() < expiresAt) return true;
+    // Expired or unknown token — fall through to header check below.
+  }
+
+  // Fallback: direct header (programmatic access via curl / scripts).
+  // Reject non-string values (Fastify coerces duplicate headers to string[]).
+  const provided = request.headers['x-web-bootstrap-secret'];
+  if (
+    typeof provided !== 'string' ||
+    provided.length !== configuredSecret.length ||
+    !timingSafeEqual(Buffer.from(provided), Buffer.from(configuredSecret))
+  ) {
+    reply.status(401).send({
+      error: 'Unauthorized. Authenticate via POST /auth or provide the x-web-bootstrap-secret header.',
+    });
+    return false;
+  }
+
+  return true;
+}

--- a/tests/unit/channels/http/identity-routes.test.ts
+++ b/tests/unit/channels/http/identity-routes.test.ts
@@ -1,0 +1,171 @@
+import Fastify from 'fastify';
+import cookie from '@fastify/cookie';
+import type { Pool } from 'pg';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { identityRoutes } from '../../../../src/channels/http/routes/identity.js';
+import type { OfficeIdentityService } from '../../../../src/identity/service.js';
+import type { OfficeIdentity } from '../../../../src/identity/types.js';
+
+const MOCK_IDENTITY: OfficeIdentity = {
+  assistant: { name: 'Alex Curia', title: 'Executive Assistant', emailSignature: 'Alex Curia\nOffice of the CEO' },
+  tone: { baseline: ['warm', 'direct'], verbosity: 50, directness: 75 },
+  behavioralPreferences: ['Be concise'],
+  decisionStyle: { externalActions: 'conservative', internalAnalysis: 'proactive' },
+  constraints: ['Never impersonate the CEO'],
+};
+
+function createMockIdentityService(): OfficeIdentityService {
+  return {
+    get: vi.fn().mockReturnValue(MOCK_IDENTITY),
+    update: vi.fn().mockResolvedValue(undefined),
+    reload: vi.fn().mockResolvedValue(undefined),
+    history: vi.fn().mockResolvedValue([]),
+    compileSystemPromptBlock: vi.fn().mockReturnValue(''),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+  } as unknown as OfficeIdentityService;
+}
+
+const SECRET = 'test-bootstrap-secret';
+
+describe('GET /api/identity — configured flag', () => {
+  const sessions = new Map<string, number>();
+
+  beforeEach(() => sessions.clear());
+
+  it('returns configured: false when only file_load versions exist', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ configured: false }] }),
+    } as unknown as Pool;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(identityRoutes, {
+      identityService: createMockIdentityService(),
+      webAppBootstrapSecret: SECRET,
+      sessions,
+      pool,
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/identity',
+      headers: { 'x-web-bootstrap-secret': SECRET },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.configured).toBe(false);
+    expect(body.identity.assistant.name).toBe('Alex Curia');
+
+    await app.close();
+  });
+
+  it('returns configured: true when a wizard version exists', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ configured: true }] }),
+    } as unknown as Pool;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(identityRoutes, {
+      identityService: createMockIdentityService(),
+      webAppBootstrapSecret: SECRET,
+      sessions,
+      pool,
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/identity',
+      headers: { 'x-web-bootstrap-secret': SECRET },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().configured).toBe(true);
+
+    await app.close();
+  });
+
+  it('accepts a valid session cookie in place of the header', async () => {
+    const token = 'valid-session-token';
+    sessions.set(token, Date.now() + 60_000);
+
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ configured: true }] }),
+    } as unknown as Pool;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(identityRoutes, {
+      identityService: createMockIdentityService(),
+      webAppBootstrapSecret: SECRET,
+      sessions,
+      pool,
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/identity',
+      headers: { cookie: `curia_session=${token}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    await app.close();
+  });
+
+  it('rejects requests with no auth', async () => {
+    const pool = { query: vi.fn() } as unknown as Pool;
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(identityRoutes, {
+      identityService: createMockIdentityService(),
+      webAppBootstrapSecret: SECRET,
+      sessions,
+      pool,
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/identity' });
+
+    expect(res.statusCode).toBe(401);
+
+    await app.close();
+  });
+});
+
+describe('PUT /api/identity — session cookie auth', () => {
+  const sessions = new Map<string, number>();
+
+  beforeEach(() => sessions.clear());
+
+  it('accepts PUT with a valid session cookie', async () => {
+    const token = 'put-session-token';
+    sessions.set(token, Date.now() + 60_000);
+
+    const pool = { query: vi.fn() } as unknown as Pool;
+    const identityService = createMockIdentityService();
+
+    const app = Fastify();
+    await app.register(cookie);
+    await app.register(identityRoutes, {
+      identityService,
+      webAppBootstrapSecret: SECRET,
+      sessions,
+      pool,
+    });
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/identity',
+      headers: { cookie: `curia_session=${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ identity: MOCK_IDENTITY }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(identityService.update).toHaveBeenCalledWith(MOCK_IDENTITY, 'api', undefined);
+
+    await app.close();
+  });
+});

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -31,6 +31,7 @@ describe('knowledgeGraphRoutes', () => {
       logger: createLogger(),
       webAppBootstrapSecret: 'secret-1',
       secureCookies: false,
+      sessions: new Map(),
     });
 
     const response = await app.inject({ method: 'GET', url: '/api/kg/nodes' });
@@ -62,6 +63,7 @@ describe('knowledgeGraphRoutes', () => {
       logger: createLogger(),
       webAppBootstrapSecret: 'secret-1',
       secureCookies: false,
+      sessions: new Map(),
     });
 
     const response = await app.inject({
@@ -85,6 +87,7 @@ describe('knowledgeGraphRoutes', () => {
       logger: createLogger(),
       webAppBootstrapSecret: 'secret-1',
       secureCookies: false,
+      sessions: new Map(),
     });
 
     const response = await app.inject({ method: 'GET', url: '/' });
@@ -101,6 +104,7 @@ describe('knowledgeGraphRoutes', () => {
       logger: createLogger(),
       webAppBootstrapSecret: 'secret-1',
       secureCookies: false,
+      sessions: new Map(),
     });
 
     const response = await app.inject({
@@ -127,6 +131,7 @@ describe('knowledgeGraphRoutes', () => {
       logger: createLogger(),
       webAppBootstrapSecret: undefined,
       secureCookies: false,
+      sessions: new Map(),
     });
 
     const response = await app.inject({ method: 'GET', url: '/api/kg/nodes' });

--- a/tests/unit/channels/http/session-auth.test.ts
+++ b/tests/unit/channels/http/session-auth.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { assertSecret, type SessionStore } from '../../../../src/channels/http/session-auth.js';
+
+// Helper: build a minimal FastifyRequest with optional session cookie and optional secret header.
+function makeRequest(opts: {
+  secretHeader?: string;
+  sessionToken?: string;
+}): FastifyRequest {
+  return {
+    headers: opts.secretHeader ? { 'x-web-bootstrap-secret': opts.secretHeader } : {},
+    cookies: opts.sessionToken ? { curia_session: opts.sessionToken } : undefined,
+  } as unknown as FastifyRequest;
+}
+
+function makeReply(): FastifyReply & { statusCode: number; body: unknown } {
+  const reply = { statusCode: 0, body: undefined as unknown };
+  (reply as unknown as FastifyReply).status = (n: number) => ({
+    send: (b: unknown) => { reply.statusCode = n; reply.body = b; },
+  }) as unknown as FastifyReply;
+  return reply as unknown as FastifyReply & { statusCode: number; body: unknown };
+}
+
+describe('assertSecret', () => {
+  const configuredSecret = 'correct-secret';
+  let sessions: SessionStore;
+
+  beforeEach(() => {
+    sessions = new Map();
+  });
+
+  it('accepts a valid x-web-bootstrap-secret header', () => {
+    const request = makeRequest({ secretHeader: 'correct-secret' });
+    const reply = makeReply();
+    expect(assertSecret(request, reply as unknown as FastifyReply, configuredSecret, sessions)).toBe(true);
+  });
+
+  it('rejects an invalid x-web-bootstrap-secret header', () => {
+    const request = makeRequest({ secretHeader: 'wrong-secret' });
+    const reply = makeReply();
+    expect(assertSecret(request, reply as unknown as FastifyReply, configuredSecret, sessions)).toBe(false);
+    expect(reply.statusCode).toBe(401);
+  });
+
+  it('accepts a valid session cookie', () => {
+    const token = 'valid-token-abc';
+    sessions.set(token, Date.now() + 60_000);
+    const request = makeRequest({ sessionToken: token });
+    const reply = makeReply();
+    expect(assertSecret(request, reply as unknown as FastifyReply, configuredSecret, sessions)).toBe(true);
+  });
+
+  it('rejects an expired session cookie', () => {
+    const token = 'expired-token';
+    sessions.set(token, Date.now() - 1000);
+    const request = makeRequest({ sessionToken: token });
+    const reply = makeReply();
+    expect(assertSecret(request, reply as unknown as FastifyReply, configuredSecret, sessions)).toBe(false);
+    expect(reply.statusCode).toBe(401);
+  });
+
+  it('rejects an unknown session cookie', () => {
+    const request = makeRequest({ sessionToken: 'unknown-token' });
+    const reply = makeReply();
+    expect(assertSecret(request, reply as unknown as FastifyReply, configuredSecret, sessions)).toBe(false);
+    expect(reply.statusCode).toBe(401);
+  });
+
+  it('returns 503 when no configured secret is provided', () => {
+    const request = makeRequest({ secretHeader: 'anything' });
+    const reply = makeReply();
+    expect(assertSecret(request, reply as unknown as FastifyReply, undefined, sessions)).toBe(false);
+    expect(reply.statusCode).toBe(503);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- **Onboarding wizard** — multi-step full-screen overlay (4 steps: assistant name, communication style, freeform preferences, review & confirm) that runs on first login when `configured: false`, and is re-enterable from Settings → Setup Wizard
- **Settings nav** — new collapsible Settings section in the sidebar at the same level as Chat and Memory
- **Session auth refactor** — `assertSecret()` extracted to `src/channels/http/session-auth.ts`; sessions store lifted to `HttpAdapter` so identity routes accept the `curia_session` cookie in addition to the `x-web-bootstrap-secret` header
- **`configured` flag** on `GET /api/identity` — `false` until the wizard or API has explicitly saved; used for first-run detection without client-side state
- **Default landing** — app now lands on Chat instead of Knowledge Graph after login

Closes josephfung/curia#140

## Test Plan

- [x] Clear cookies → enter access key → wizard appears immediately (main app hidden)
- [x] Step 1: blank name → Next blocked with error; fill name → proceeds
- [x] Step 2: tone pills enforce 1–3 selection; sliders update live preview sentences; posture cards highlight on click
- [x] Step 3: textarea optional; Next always proceeds
- [x] Step 4: review card shows plain-English summaries; Confirm & save → "Saving…" → wizard dismisses → Chat → teal banner auto-dismisses in 4s
- [x] `GET /api/identity` returns `configured: true` after completion
- [x] Page refresh after wizard → lands on Chat, no wizard
- [x] Settings → Setup Wizard → wizard opens with current identity values pre-filled
- [x] All existing nav items (Chat, Memory sub-items) still work
- [x] `pnpm test` — 820 tests pass


___

## **CodeAnt-AI Description**
**Add first-run onboarding for office identity and land users in Chat**

### What Changed
- New users now see a full-screen setup wizard before the main app, and can reopen it later from Settings → Setup Wizard
- The wizard guides users through assistant name, tone, communication style, optional preferences, and a final review before saving
- After setup, the app returns to Chat and shows a short success banner
- Identity pages now accept the browser session cookie as well as the access secret, and `GET /api/identity` reports whether setup has already been completed
- The sidebar now includes a collapsible Settings section, and the default post-login landing screen is Chat

### Impact
`✅ Shorter first-time setup`
`✅ Fewer blocked identity edits`
`✅ Faster arrival in Chat after login`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
