### PR TITLE
fix: use session-cookie auth for /api/jobs routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+- **Scheduled Jobs page auth** — `/api/jobs` routes now use session-cookie auth (same as KG/identity routes) instead of the global Bearer token hook, so the dashboard can load the page without an `Unauthorized` error.
+
 ### Added
 - **Onboarding wizard** — multi-step full-screen wizard guides new users through configuring the office identity (assistant name, tone, communication style, decision posture) on first run. Re-enterable from Settings → Setup Wizard. Requires the identity service (spec 13) to be configured.
 - **Settings nav** — new collapsible Settings section in the sidebar with Setup Wizard sub-item.

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -111,12 +111,15 @@ export class HttpAdapter {
       // KG web app routes bypass bearer auth — the app shell, static assets, and
       // /auth exchange need no token; /api/kg/* routes enforce their own session/secret.
       // Identity routes bypass bearer auth — they enforce their own bootstrap secret auth.
+      // Job routes bypass bearer auth — the dashboard accesses them via session cookie,
+      // and jobRoutes calls assertSecret on every handler.
       if (
         routeUrl === '/' ||
         routeUrl === '/auth' ||
         routeUrl.startsWith('/assets') ||
         routeUrl.startsWith('/api/kg') ||
-        routeUrl.startsWith('/api/identity')
+        routeUrl.startsWith('/api/identity') ||
+        routeUrl.startsWith('/api/jobs')
       ) return;
 
       if (!validateBearerToken(request.headers.authorization, apiToken)) {
@@ -141,7 +144,14 @@ export class HttpAdapter {
     await this.app.register(messageRoutes, { bus, logger, eventRouter: this.eventRouter });
 
     if (this.config.schedulerService) {
-      await this.app.register(jobRoutes, { schedulerService: this.config.schedulerService });
+      // Job routes use session-cookie auth (same as KG routes) so the dashboard can
+      // access them without a Bearer token. webAppBootstrapSecret may be undefined when
+      // the web UI is disabled; assertSecret will return 503 in that case.
+      await this.app.register(jobRoutes, {
+        schedulerService: this.config.schedulerService,
+        webAppBootstrapSecret,
+        sessions,
+      });
     }
 
     // Identity routes — only registered when the bootstrap secret is configured.

--- a/src/channels/http/routes/jobs.ts
+++ b/src/channels/http/routes/jobs.ts
@@ -4,23 +4,35 @@
 // and cancelling scheduled jobs. All mutations are delegated to
 // SchedulerService so business rules (cron parsing, auto-suspend,
 // event publishing) stay in one place.
+//
+// Auth: these routes bypass the global Bearer token hook and instead
+// use session-cookie / bootstrap-secret auth (same as KG and identity
+// routes). This allows the dashboard web app to call them without a
+// Bearer token — the browser sends the curia_session cookie automatically.
 
 import type { FastifyInstance } from 'fastify';
 import type { SchedulerService } from '../../../scheduler/scheduler-service.js';
+import { assertSecret, type SessionStore } from '../session-auth.js';
 
 export interface JobRouteOptions {
   schedulerService: SchedulerService;
+  // Session auth — same pattern as KG and identity routes.
+  // Required so the dashboard (which authenticates via session cookie, not Bearer token)
+  // can access job endpoints.
+  webAppBootstrapSecret: string | undefined;
+  sessions: SessionStore;
 }
 
 export async function jobRoutes(
   app: FastifyInstance,
   options: JobRouteOptions,
 ): Promise<void> {
-  const { schedulerService } = options;
+  const { schedulerService, webAppBootstrapSecret, sessions } = options;
 
   // -- GET /api/jobs — list jobs with optional filters --
 
   app.get('/api/jobs', async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     try {
       const { status, agent_id } = request.query as { status?: string; agent_id?: string };
       const jobs = await schedulerService.listJobs({
@@ -37,6 +49,7 @@ export async function jobRoutes(
   // -- GET /api/jobs/:id — get a single job --
 
   app.get('/api/jobs/:id', async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     try {
       const { id } = request.params as { id: string };
       const job = await schedulerService.getJob(id);
@@ -53,6 +66,7 @@ export async function jobRoutes(
   // -- POST /api/jobs — create a new job --
 
   app.post('/api/jobs', async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const body = request.body as {
       agent_id?: string;
       cron_expr?: string;
@@ -93,6 +107,7 @@ export async function jobRoutes(
   // -- PATCH /api/jobs/:id — update an existing job --
 
   app.patch('/api/jobs/:id', async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const { id } = request.params as { id: string };
     const body = request.body as {
       status?: string;
@@ -132,6 +147,7 @@ export async function jobRoutes(
   // -- DELETE /api/jobs/:id — cancel (soft-delete) a job --
 
   app.delete('/api/jobs/:id', async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const { id } = request.params as { id: string };
     try {
       await schedulerService.cancelJob(id);

--- a/tests/unit/channels/http/jobs-routes.test.ts
+++ b/tests/unit/channels/http/jobs-routes.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import Fastify from 'fastify';
+import cookie from '@fastify/cookie';
 import { jobRoutes } from '../../../../src/channels/http/routes/jobs.js';
 import type { SchedulerService } from '../../../../src/scheduler/scheduler-service.js';
 import type { JobRow } from '../../../../src/scheduler/scheduler-service.js';
+import type { SessionStore } from '../../../../src/channels/http/session-auth.js';
+
+// Shared bootstrap secret used across all tests.
+const TEST_SECRET = 'test-bootstrap-secret';
+// Auth header included in every inject call so assertSecret passes.
+const AUTH = { 'x-web-bootstrap-secret': TEST_SECRET };
 
 /** Build a mock SchedulerService with vi.fn() stubs for every method the routes call. */
 function mockSchedulerService(): SchedulerService {
@@ -18,10 +25,17 @@ function mockSchedulerService(): SchedulerService {
 
 describe('Job routes', () => {
   const scheduler = mockSchedulerService();
+  const sessions: SessionStore = new Map();
   const app = Fastify();
 
   beforeAll(async () => {
-    await app.register(jobRoutes, { schedulerService: scheduler });
+    // cookie plugin required by assertSecret's session-cookie path
+    await app.register(cookie);
+    await app.register(jobRoutes, {
+      schedulerService: scheduler,
+      webAppBootstrapSecret: TEST_SECRET,
+      sessions,
+    });
     await app.ready();
   });
 
@@ -32,7 +46,7 @@ describe('Job routes', () => {
   // -- GET /api/jobs --
 
   it('GET /api/jobs returns empty list', async () => {
-    const response = await app.inject({ method: 'GET', url: '/api/jobs' });
+    const response = await app.inject({ method: 'GET', url: '/api/jobs', headers: AUTH });
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(response.body);
     expect(body).toEqual({ jobs: [] });
@@ -40,17 +54,22 @@ describe('Job routes', () => {
   });
 
   it('GET /api/jobs passes query filters to service', async () => {
-    await app.inject({ method: 'GET', url: '/api/jobs?status=pending&agent_id=agent-a' });
+    await app.inject({ method: 'GET', url: '/api/jobs?status=pending&agent_id=agent-a', headers: AUTH });
     expect(scheduler.listJobs).toHaveBeenCalledWith({
       status: 'pending',
       agentId: 'agent-a',
     });
   });
 
+  it('GET /api/jobs returns 401 without auth', async () => {
+    const response = await app.inject({ method: 'GET', url: '/api/jobs' });
+    expect(response.statusCode).toBe(401);
+  });
+
   // -- GET /api/jobs/:id --
 
   it('GET /api/jobs/:id returns 404 for unknown job', async () => {
-    const response = await app.inject({ method: 'GET', url: '/api/jobs/unknown-id' });
+    const response = await app.inject({ method: 'GET', url: '/api/jobs/unknown-id', headers: AUTH });
     expect(response.statusCode).toBe(404);
     const body = JSON.parse(response.body);
     expect(body).toEqual({ error: 'Job not found' });
@@ -76,7 +95,7 @@ describe('Job routes', () => {
     };
     vi.mocked(scheduler.getJob).mockResolvedValueOnce(fakeJob);
 
-    const response = await app.inject({ method: 'GET', url: '/api/jobs/job-42' });
+    const response = await app.inject({ method: 'GET', url: '/api/jobs/job-42', headers: AUTH });
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(response.body);
     expect(body.job.id).toBe('job-42');
@@ -88,6 +107,7 @@ describe('Job routes', () => {
     const response = await app.inject({
       method: 'POST',
       url: '/api/jobs',
+      headers: AUTH,
       payload: {
         agent_id: 'agent-a',
         cron_expr: '0 9 * * *',
@@ -110,6 +130,7 @@ describe('Job routes', () => {
     const response = await app.inject({
       method: 'POST',
       url: '/api/jobs',
+      headers: AUTH,
       payload: {
         cron_expr: '0 9 * * *',
         task_payload: { task: 'test' },
@@ -124,6 +145,7 @@ describe('Job routes', () => {
     const response = await app.inject({
       method: 'POST',
       url: '/api/jobs',
+      headers: AUTH,
       payload: {
         agent_id: 'agent-a',
         cron_expr: '0 9 * * *',
@@ -138,6 +160,7 @@ describe('Job routes', () => {
     const response = await app.inject({
       method: 'POST',
       url: '/api/jobs',
+      headers: AUTH,
       payload: {
         agent_id: 'agent-a',
         task_payload: { task: 'test' },
@@ -151,7 +174,7 @@ describe('Job routes', () => {
   // -- DELETE /api/jobs/:id --
 
   it('DELETE /api/jobs/:id cancels a job', async () => {
-    const response = await app.inject({ method: 'DELETE', url: '/api/jobs/job-99' });
+    const response = await app.inject({ method: 'DELETE', url: '/api/jobs/job-99', headers: AUTH });
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(response.body);
     expect(body).toEqual({ cancelled: true, jobId: 'job-99' });
@@ -164,6 +187,7 @@ describe('Job routes', () => {
     const response = await app.inject({
       method: 'PATCH',
       url: '/api/jobs/job-50',
+      headers: AUTH,
       payload: { status: 'pending' },
     });
     expect(response.statusCode).toBe(200);
@@ -176,6 +200,7 @@ describe('Job routes', () => {
     const response = await app.inject({
       method: 'PATCH',
       url: '/api/jobs/job-50',
+      headers: AUTH,
       payload: { cron_expr: '0 12 * * *' },
     });
     expect(response.statusCode).toBe(200);
@@ -192,6 +217,7 @@ describe('Job routes', () => {
     const response = await app.inject({
       method: 'PATCH',
       url: '/api/jobs/job-50',
+      headers: AUTH,
       payload: { status: 'pending' },
     });
     expect(response.statusCode).toBe(400);


### PR DESCRIPTION
## **User description**
## Summary

- `/api/jobs` routes were subject to the global Bearer-token `onRequest` hook, but the dashboard web app authenticates via a session cookie (set by `POST /auth`) — not a Bearer token. This caused an `Unauthorized — provide a valid Bearer token` 401 every time the Scheduled Jobs page loaded.
- Fix: add `/api/jobs` to the Bearer-auth bypass list in `http-adapter.ts`, and call `assertSecret` at the top of each job route handler — the same pattern used by `/api/kg/*` and `/api/identity/*` routes.
- Updated tests to register the cookie plugin, pass the bootstrap secret + sessions to the route registration, include the auth header in all inject calls, and add an explicit 401-without-auth test.

## Test plan

- [ ] All existing tests pass (`pnpm test` — 821 tests, 0 failures)
- [ ] TypeScript compiles cleanly (`pnpm tsc --noEmit`)
- [ ] Manually visit Scheduled Jobs in the dashboard — should load without the Unauthorized error
- [ ] Confirm unauthenticated requests to `/api/jobs` return 401

## Pre-existing issues spotted (not fixed here, scope discipline)

- `jobs.ts` catch blocks don't call `request.log.error` before responding — violates the project's "every catch must log" rule. Worth a follow-up.
- `session-auth.ts` doesn't log when a session cookie is present but expired.


___

## **CodeAnt-AI Description**
**Scheduled Jobs page loads with session login**

### What Changed
- Scheduled Jobs endpoints no longer require a Bearer token from the browser; the dashboard can access them with its session cookie
- Requests to job actions now return 401 when no valid session or bootstrap secret is present
- Existing job behaviors for listing, viewing, creating, updating, and cancelling stay the same once authenticated

### Impact
`✅ Scheduled Jobs page loads without unauthorized errors`
`✅ Fewer login failures in the dashboard`
`✅ Clearer access checks for job actions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
