### PR TITLE
fix: return calendar event timestamps as ISO strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 - **Scheduled Jobs page auth** — `/api/jobs` routes now use session-cookie auth (same as KG/identity routes) instead of the global Bearer token hook, so the dashboard can load the page without an `Unauthorized` error.
+- **`calendar-list-events` timestamp display** — timed event `startTime`/`endTime` are now returned as UTC ISO 8601 strings instead of raw Unix seconds. LLMs can't reliably convert Unix epoch integers to wall-clock times (wrong times were displayed to the user); ISO strings are unambiguous and correctly interpreted using the timezone already in the system prompt.
 
 ### Added
 - **Onboarding wizard** — multi-step full-screen wizard guides new users through configuring the office identity (assistant name, tone, communication style, decision posture) on first run. Re-enterable from Settings → Setup Wizard. Requires the identity service (spec 13) to be configured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 - **Scheduled Jobs page auth** — `/api/jobs` routes now use session-cookie auth (same as KG/identity routes) instead of the global Bearer token hook, so the dashboard can load the page without an `Unauthorized` error.
-- **`calendar-list-events` timestamp display** — timed event `startTime`/`endTime` are now returned as UTC ISO 8601 strings instead of raw Unix seconds. LLMs can't reliably convert Unix epoch integers to wall-clock times (wrong times were displayed to the user); ISO strings are unambiguous and correctly interpreted using the timezone already in the system prompt.
+- **Calendar skill timestamp display** — all calendar skills (`calendar-list-events`, `calendar-create-event`, `calendar-update-event`, `calendar-check-conflicts`, `calendar-find-free-time`) now return event and slot timestamps as UTC ISO 8601 strings instead of raw Unix seconds. LLMs can't reliably convert Unix epoch integers to wall-clock times (wrong times were displayed to the user); ISO strings are unambiguous and correctly interpreted using the timezone already in the system prompt.
 
 ### Added
 - **Onboarding wizard** — multi-step full-screen wizard guides new users through configuring the office identity (assistant name, tone, communication style, decision posture) on first run. Re-enterable from Settings → Setup Wizard. Requires the identity service (spec 13) to be configured.

--- a/skills/calendar-check-conflicts/handler.ts
+++ b/skills/calendar-check-conflicts/handler.ts
@@ -37,8 +37,8 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
       const conflicts: Array<{
         calendarId: string;
         contactName: string | null;
-        startTime: number;
-        endTime: number;
+        startTime: string;
+        endTime: string;
         status: string;
       }> = [];
 
@@ -56,11 +56,12 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
         for (const slot of result.timeSlots) {
           // Check overlap: busy slot overlaps the proposed range
           if (slot.startTime < proposedEndTs && slot.endTime > proposedStartTs) {
+            // Format timestamps as UTC ISO strings — LLMs can't reliably convert raw Unix seconds.
             conflicts.push({
               calendarId: result.email,
               contactName,
-              startTime: slot.startTime,
-              endTime: slot.endTime,
+              startTime: new Date(slot.startTime * 1000).toISOString(),
+              endTime: new Date(slot.endTime * 1000).toISOString(),
               status: slot.status,
             });
           }

--- a/skills/calendar-create-event/handler.ts
+++ b/skills/calendar-create-event/handler.ts
@@ -68,7 +68,19 @@ export class CalendarCreateEventHandler implements SkillHandler {
 
       const event = await ctx.nylasCalendarClient.createEvent(calendarId, eventData);
       ctx.log.info({ calendarId, eventId: event.id }, 'Created calendar event');
-      return { success: true, data: { event } };
+      // Format timestamps as UTC ISO strings — LLMs can't reliably convert raw Unix seconds.
+      return {
+        success: true,
+        data: {
+          event: {
+            ...event,
+            startTime: event.startTime !== null && Number.isFinite(event.startTime) && event.startTime > 0
+              ? new Date(event.startTime * 1000).toISOString() : null,
+            endTime: event.endTime !== null && Number.isFinite(event.endTime) && event.endTime > 0
+              ? new Date(event.endTime * 1000).toISOString() : null,
+          },
+        },
+      };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       ctx.log.error({ err, calendarId }, 'Failed to create event');

--- a/skills/calendar-find-free-time/handler.ts
+++ b/skills/calendar-find-free-time/handler.ts
@@ -81,8 +81,14 @@ export class CalendarFindFreeTimeHandler implements SkillHandler {
         ? freeWindows.filter((w) => w.end - w.start >= minSeconds)
         : freeWindows;
 
-      ctx.log.info({ calendarCount: calendarIds.length, freeWindowCount: filtered.length }, 'Found free time');
-      return { success: true, data: { freeWindows: filtered } };
+      // Format timestamps as UTC ISO strings — LLMs can't reliably convert raw Unix seconds.
+      const freeWindowsIso = filtered.map((w) => ({
+        start: new Date(w.start * 1000).toISOString(),
+        end: new Date(w.end * 1000).toISOString(),
+      }));
+
+      ctx.log.info({ calendarCount: calendarIds.length, freeWindowCount: freeWindowsIso.length }, 'Found free time');
+      return { success: true, data: { freeWindows: freeWindowsIso } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       ctx.log.error({ err }, 'Failed to find free time');

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -88,8 +88,14 @@ export class CalendarListEventsHandler implements SkillHandler {
       let events = successfulEvents.flat();
 
       // Sort merged events by start time so the agenda reads chronologically.
-      // startTime is Unix seconds (null for all-day events, which sort first at 0).
-      events.sort((a, b) => (a.startTime ?? 0) - (b.startTime ?? 0));
+      // Timed events use startTime (Unix seconds). All-day events have startTime=null and
+      // startDate='YYYY-MM-DD'; parse startDate to a comparable Unix seconds value so they
+      // interleave correctly with timed events. Events with no date at all sort last.
+      events.sort((a, b) => {
+        const aTs = a.startTime ?? (a.startDate ? Date.parse(`${a.startDate}T00:00:00Z`) / 1000 : Number.POSITIVE_INFINITY);
+        const bTs = b.startTime ?? (b.startDate ? Date.parse(`${b.startDate}T00:00:00Z`) / 1000 : Number.POSITIVE_INFINITY);
+        return aTs - bTs;
+      });
 
       // Client-side filtering: query matches title or description (case-insensitive)
       if (query && typeof query === 'string') {

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -12,6 +12,7 @@
 // the skill fetches all events in range and filters locally.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { NylasCalendarEvent } from '../../src/channels/calendar/nylas-calendar-client.js';
 
 export class CalendarListEventsHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -66,7 +67,7 @@ export class CalendarListEventsHandler implements SkillHandler {
       );
 
       const failedCalendarIds: string[] = [];
-      const successfulEvents: Array<typeof settled[0] extends PromiseFulfilledResult<infer T> ? T : never> = [];
+      const successfulEvents: NylasCalendarEvent[][] = [];
       for (let i = 0; i < settled.length; i++) {
         const result = settled[i];
         if (result.status === 'fulfilled') {
@@ -86,8 +87,9 @@ export class CalendarListEventsHandler implements SkillHandler {
 
       let events = successfulEvents.flat();
 
-      // Sort merged events by start time so the agenda reads chronologically
-      events.sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
+      // Sort merged events by start time so the agenda reads chronologically.
+      // startTime is Unix seconds (null for all-day events, which sort first at 0).
+      events.sort((a, b) => (a.startTime ?? 0) - (b.startTime ?? 0));
 
       // Client-side filtering: query matches title or description (case-insensitive)
       if (query && typeof query === 'string') {
@@ -112,8 +114,20 @@ export class CalendarListEventsHandler implements SkillHandler {
         events = events.slice(0, maxResults);
       }
 
-      ctx.log.info({ calendarIds, count: events.length, failedCalendarIds }, 'Listed events');
-      const data: Record<string, unknown> = { events, count: events.length };
+      // Format events for LLM consumption.
+      // Nylas returns timed event timestamps as Unix seconds. LLMs can't reliably
+      // do Unix epoch arithmetic (they produce wrong wall-clock times), so we
+      // convert to UTC ISO 8601 strings here. The LLM already knows the user's
+      // timezone from the system prompt's time context block and can display ISO
+      // strings correctly.
+      const formattedEvents = events.map((evt) => ({
+        ...evt,
+        startTime: evt.startTime !== null ? new Date(evt.startTime * 1000).toISOString() : null,
+        endTime: evt.endTime !== null ? new Date(evt.endTime * 1000).toISOString() : null,
+      }));
+
+      ctx.log.info({ calendarIds, count: formattedEvents.length, failedCalendarIds }, 'Listed events');
+      const data: Record<string, unknown> = { events: formattedEvents, count: formattedEvents.length };
       // Surface partial failures so the LLM can inform the user
       if (failedCalendarIds.length > 0) {
         data.warnings = [`Failed to fetch events from ${failedCalendarIds.length} calendar(s): ${failedCalendarIds.join(', ')}`];

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -120,10 +120,22 @@ export class CalendarListEventsHandler implements SkillHandler {
       // convert to UTC ISO 8601 strings here. The LLM already knows the user's
       // timezone from the system prompt's time context block and can display ISO
       // strings correctly.
+      //
+      // Guard non-finite and non-positive values: Unix 0 is never a real calendar
+      // event time, and passing "1970-01-01T00:00:00Z" to the LLM would be silently
+      // wrong. Log and null-out rather than propagate corrupted data.
+      const toIso = (unix: number | null, field: string, eventId: string): string | null => {
+        if (unix === null) return null;
+        if (!Number.isFinite(unix) || unix <= 0) {
+          ctx.log.warn({ eventId, field, value: unix }, `calendar-list-events: suspicious ${field} value — omitting`);
+          return null;
+        }
+        return new Date(unix * 1000).toISOString();
+      };
       const formattedEvents = events.map((evt) => ({
         ...evt,
-        startTime: evt.startTime !== null ? new Date(evt.startTime * 1000).toISOString() : null,
-        endTime: evt.endTime !== null ? new Date(evt.endTime * 1000).toISOString() : null,
+        startTime: toIso(evt.startTime, 'startTime', evt.id),
+        endTime: toIso(evt.endTime, 'endTime', evt.id),
       }));
 
       ctx.log.info({ calendarIds, count: formattedEvents.length, failedCalendarIds }, 'Listed events');

--- a/skills/calendar-update-event/handler.ts
+++ b/skills/calendar-update-event/handler.ts
@@ -64,7 +64,19 @@ export class CalendarUpdateEventHandler implements SkillHandler {
 
       const event = await ctx.nylasCalendarClient.updateEvent(calendarId, eventId, changes);
       ctx.log.info({ calendarId, eventId }, 'Updated calendar event');
-      return { success: true, data: { event } };
+      // Format timestamps as UTC ISO strings — LLMs can't reliably convert raw Unix seconds.
+      return {
+        success: true,
+        data: {
+          event: {
+            ...event,
+            startTime: event.startTime !== null && Number.isFinite(event.startTime) && event.startTime > 0
+              ? new Date(event.startTime * 1000).toISOString() : null,
+            endTime: event.endTime !== null && Number.isFinite(event.endTime) && event.endTime > 0
+              ? new Date(event.endTime * 1000).toISOString() : null,
+          },
+        },
+      };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       ctx.log.error({ err, calendarId, eventId }, 'Failed to update event');

--- a/tests/unit/skills/calendar-check-conflicts.test.ts
+++ b/tests/unit/skills/calendar-check-conflicts.test.ts
@@ -66,10 +66,13 @@ describe('CalendarCheckConflictsHandler', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { conflicts: Array<{ calendarId: string; contactName: string | null }>; clear: boolean };
+      const data = result.data as { conflicts: Array<{ calendarId: string; contactName: string | null; startTime: string; endTime: string }>; clear: boolean };
       expect(data.clear).toBe(false);
       expect(data.conflicts).toHaveLength(1);
       expect(data.conflicts[0].contactName).toBe('Joseph Fung');
+      // Timestamps must be ISO strings, not raw Unix seconds (1000s → 16:40, 2000s → 33:20)
+      expect(data.conflicts[0].startTime).toBe('1970-01-01T00:16:40.000Z');
+      expect(data.conflicts[0].endTime).toBe('1970-01-01T00:33:20.000Z');
     }
   });
 

--- a/tests/unit/skills/calendar-create-event.test.ts
+++ b/tests/unit/skills/calendar-create-event.test.ts
@@ -43,19 +43,22 @@ describe('CalendarCreateEventHandler', () => {
   });
 
   it('creates event successfully when calendar is unregistered (null from resolveCalendar)', async () => {
-    const createdEvent = { id: 'evt-new', title: 'Team Meeting', description: '', location: '', startTime: 1000, endTime: 2000, startDate: null, endDate: null, participants: [], conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true };
+    const createdEvent = { id: 'evt-new', title: 'Team Meeting', description: '', location: '', startTime: 1775466000, endTime: 1775469600, startDate: null, endDate: null, participants: [], conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true };
     const nylasCalendarClient = { createEvent: vi.fn().mockResolvedValue(createdEvent) };
     const contactService = {
       resolveCalendar: vi.fn().mockResolvedValue(null), // unregistered calendar — proceeds without read-only check
     };
     const result = await handler.execute(makeCtx(
-      { calendarId: 'cal-1', title: 'Team Meeting', start: '2026-04-01T09:00:00Z', end: '2026-04-01T10:00:00Z' },
+      { calendarId: 'cal-1', title: 'Team Meeting', start: '2026-04-06T09:00:00Z', end: '2026-04-06T10:00:00Z' },
       { nylasCalendarClient: nylasCalendarClient as never, contactService: contactService as never },
     ));
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { event: { id: string } };
+      const data = result.data as { event: { id: string; startTime: string; endTime: string } };
       expect(data.event.id).toBe('evt-new');
+      // Timestamps must be ISO strings, not raw Unix seconds
+      expect(data.event.startTime).toBe('2026-04-06T09:00:00.000Z');
+      expect(data.event.endTime).toBe('2026-04-06T10:00:00.000Z');
     }
   });
 

--- a/tests/unit/skills/calendar-find-free-time.test.ts
+++ b/tests/unit/skills/calendar-find-free-time.test.ts
@@ -55,12 +55,13 @@ describe('CalendarFindFreeTimeHandler', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { freeWindows: Array<{ start: number; end: number }> };
-      // Range 0-1000, busy 200-400 and 700-900 → free windows: 0-200, 400-700, 900-1000
+      const data = result.data as { freeWindows: Array<{ start: string; end: string }> };
+      // Range 0-1000 seconds (epoch), busy 200-400 and 700-900 → free windows: 0-200, 400-700, 900-1000
+      // Returned as UTC ISO strings
       expect(data.freeWindows).toEqual([
-        { start: 0, end: 200 },
-        { start: 400, end: 700 },
-        { start: 900, end: 1000 },
+        { start: '1970-01-01T00:00:00.000Z', end: '1970-01-01T00:03:20.000Z' },
+        { start: '1970-01-01T00:06:40.000Z', end: '1970-01-01T00:11:40.000Z' },
+        { start: '1970-01-01T00:15:00.000Z', end: '1970-01-01T00:16:40.000Z' },
       ]);
     }
   });
@@ -84,8 +85,10 @@ describe('CalendarFindFreeTimeHandler', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { freeWindows: Array<{ start: number; end: number }> };
-      expect(data.freeWindows).toEqual([{ start: 200, end: 1000 }]);
+      const data = result.data as { freeWindows: Array<{ start: string; end: string }> };
+      expect(data.freeWindows).toEqual([
+        { start: '1970-01-01T00:03:20.000Z', end: '1970-01-01T00:16:40.000Z' },
+      ]);
     }
   });
 });

--- a/tests/unit/skills/calendar-list-events.test.ts
+++ b/tests/unit/skills/calendar-list-events.test.ts
@@ -147,11 +147,12 @@ describe('CalendarListEventsHandler', () => {
   });
 
   it('merges and sorts events from multiple calendars chronologically', async () => {
+    // startTime is Unix seconds (as returned by Nylas SDK) — smaller = earlier
     const workEvents = [
-      { ...mockEvents[1], id: 'work-1', startTime: '2026-04-01T14:00:00Z' },
+      { ...mockEvents[1], id: 'work-1', startTime: 5000 },
     ];
     const personalEvents = [
-      { ...mockEvents[0], id: 'personal-1', startTime: '2026-04-01T09:00:00Z' },
+      { ...mockEvents[0], id: 'personal-1', startTime: 1000 },
     ];
     const nylasCalendarClient = {
       listEvents: vi.fn()
@@ -178,9 +179,77 @@ describe('CalendarListEventsHandler', () => {
     if (result.success) {
       const data = result.data as { events: Array<{ id: string }> };
       expect(data.events).toHaveLength(2);
-      // personal-1 (09:00) should sort before work-1 (14:00)
+      // personal-1 (startTime: 1000) should sort before work-1 (startTime: 5000)
       expect(data.events[0].id).toBe('personal-1');
       expect(data.events[1].id).toBe('work-1');
+    }
+  });
+
+  it('formats timed event timestamps as UTC ISO strings for LLM consumption', async () => {
+    // 1775489400 Unix seconds = 2026-04-06T15:30:00.000Z (11:30 AM EDT)
+    const timedEvent = {
+      id: 'evt-timed',
+      title: 'Catchup',
+      description: '',
+      participants: [],
+      startTime: 1775489400,
+      endTime: 1775491200,
+      startDate: null,
+      endDate: null,
+      location: '',
+      conferencing: null,
+      status: 'confirmed',
+      calendarId: 'cal-1',
+      busy: true,
+    };
+    const nylasCalendarClient = {
+      listEvents: vi.fn().mockResolvedValue([timedEvent]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', timeMin: '2026-04-06T00:00:00Z', timeMax: '2026-04-07T00:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: Array<{ startTime: string; endTime: string }> };
+      expect(data.events[0].startTime).toBe('2026-04-06T15:30:00.000Z');
+      expect(data.events[0].endTime).toBe('2026-04-06T16:00:00.000Z');
+    }
+  });
+
+  it('leaves startTime/endTime null for all-day events', async () => {
+    const allDayEvent = {
+      id: 'evt-allday',
+      title: 'Birthday',
+      description: '',
+      participants: [],
+      startTime: null,
+      endTime: null,
+      startDate: '2026-04-06',
+      endDate: '2026-04-06',
+      location: '',
+      conferencing: null,
+      status: 'confirmed',
+      calendarId: 'cal-1',
+      busy: false,
+    };
+    const nylasCalendarClient = {
+      listEvents: vi.fn().mockResolvedValue([allDayEvent]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', timeMin: '2026-04-06T00:00:00Z', timeMax: '2026-04-07T00:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: Array<{ startTime: null; endTime: null; startDate: string }> };
+      expect(data.events[0].startTime).toBeNull();
+      expect(data.events[0].endTime).toBeNull();
+      expect(data.events[0].startDate).toBe('2026-04-06');
     }
   });
 

--- a/tests/unit/skills/calendar-list-events.test.ts
+++ b/tests/unit/skills/calendar-list-events.test.ts
@@ -253,6 +253,42 @@ describe('CalendarListEventsHandler', () => {
     }
   });
 
+  it('nulls out and warns on suspicious startTime values (0, negative, non-finite)', async () => {
+    // Unix 0 is never a real calendar time — a Nylas bug returning 0 would silently
+    // produce "1970-01-01T00:00:00Z" without this guard.
+    const suspectEvent = {
+      id: 'evt-suspect',
+      title: 'Corrupted event',
+      description: '',
+      participants: [],
+      startTime: 0,
+      endTime: -1,
+      startDate: null,
+      endDate: null,
+      location: '',
+      conferencing: null,
+      status: 'confirmed',
+      calendarId: 'cal-1',
+      busy: true,
+    };
+    const nylasCalendarClient = {
+      listEvents: vi.fn().mockResolvedValue([suspectEvent]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', timeMin: '2026-04-06T00:00:00Z', timeMax: '2026-04-07T00:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: Array<{ startTime: null; endTime: null }> };
+      // Should be nulled out, not passed as a 1970 date
+      expect(data.events[0].startTime).toBeNull();
+      expect(data.events[0].endTime).toBeNull();
+    }
+  });
+
   it('returns failure when no calendars are registered for caller', async () => {
     const nylasCalendarClient = { listEvents: vi.fn() };
     const contactService = {

--- a/tests/unit/skills/calendar-list-events.test.ts
+++ b/tests/unit/skills/calendar-list-events.test.ts
@@ -185,6 +185,39 @@ describe('CalendarListEventsHandler', () => {
     }
   });
 
+  it('sorts all-day events by startDate, not as epoch 0', async () => {
+    // Regression: before the fix, startTime=null fell back to 0, placing all-day events
+    // before every timed event regardless of their actual date.
+    const allDayLaterInWeek = {
+      id: 'allday-later', title: 'Conference Day', description: '', participants: [],
+      startTime: null, endTime: null, startDate: '2026-04-08', endDate: '2026-04-08',
+      location: '', conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: false,
+    };
+    const timedEarlierInWeek = {
+      id: 'timed-earlier', title: 'Morning Call', description: '', participants: [],
+      startTime: 1775466000, endTime: 1775469600, // 2026-04-06T09:00Z – 10:00Z
+      startDate: null, endDate: null,
+      location: '', conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true,
+    };
+    const nylasCalendarClient = {
+      // Return in "wrong" order (all-day first) so the sort must fix it
+      listEvents: vi.fn().mockResolvedValue([allDayLaterInWeek, timedEarlierInWeek]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', timeMin: '2026-04-06T00:00:00Z', timeMax: '2026-04-09T00:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: Array<{ id: string }> };
+      // timed-earlier (2026-04-06) must come before allday-later (2026-04-08)
+      expect(data.events[0].id).toBe('timed-earlier');
+      expect(data.events[1].id).toBe('allday-later');
+    }
+  });
+
   it('formats timed event timestamps as UTC ISO strings for LLM consumption', async () => {
     // 1775489400 Unix seconds = 2026-04-06T15:30:00.000Z (11:30 AM EDT)
     const timedEvent = {

--- a/tests/unit/skills/calendar-update-event.test.ts
+++ b/tests/unit/skills/calendar-update-event.test.ts
@@ -43,7 +43,7 @@ describe('CalendarUpdateEventHandler', () => {
   });
 
   it('updates event successfully', async () => {
-    const updatedEvent = { id: 'evt-1', title: 'Updated', description: '', location: '', startTime: 1000, endTime: 2000, startDate: null, endDate: null, participants: [], conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true };
+    const updatedEvent = { id: 'evt-1', title: 'Updated', description: '', location: '', startTime: 1775466000, endTime: 1775469600, startDate: null, endDate: null, participants: [], conferencing: null, status: 'confirmed', calendarId: 'cal-1', busy: true };
     const nylasCalendarClient = { updateEvent: vi.fn().mockResolvedValue(updatedEvent) };
     const contactService = { resolveCalendar: vi.fn().mockResolvedValue(null) };
     const result = await handler.execute(makeCtx(
@@ -52,8 +52,11 @@ describe('CalendarUpdateEventHandler', () => {
     ));
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { event: { id: string } };
+      const data = result.data as { event: { id: string; startTime: string; endTime: string } };
       expect(data.event.id).toBe('evt-1');
+      // Timestamps must be ISO strings, not raw Unix seconds
+      expect(data.event.startTime).toBe('2026-04-06T09:00:00.000Z');
+      expect(data.event.endTime).toBe('2026-04-06T10:00:00.000Z');
     }
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause**: `calendar-list-events` was returning Nylas `startTime`/`endTime` as raw Unix seconds (e.g. `1775489400`). LLMs cannot reliably convert Unix epoch integers to wall-clock times — the coordinator was computing wrong times (showing 1:30 PM EDT when the correct answer was 11:30 AM EDT for that timestamp).
- **Fix**: convert `startTime`/`endTime` to UTC ISO 8601 strings in the skill handler before returning. The LLM already knows the user's timezone from the system prompt's time context block and converts ISO strings correctly.
- Also fixed the sort comparator (was calling `new Date(seconds)` treating Unix seconds as milliseconds — same relative order but semantically wrong) and the broken `successfulEvents` type annotation.

## Test plan

- [ ] All 16 unit tests pass (`vitest run tests/unit/skills/calendar-list-events.test.ts`)
- [ ] New test: `1775489400` → `"2026-04-06T15:30:00.000Z"` (11:30 AM EDT) — the exact timestamp from the reported bug
- [ ] New test: all-day events keep `startTime`/`endTime` as `null` (date-only fields unchanged)
- [ ] Existing sort test updated: mock now uses Unix seconds (matching actual Nylas SDK output) instead of ISO strings


___

## **CodeAnt-AI Description**
**Return calendar event times in a format that shows correctly**

### What Changed
- Timed calendar events now return `startTime` and `endTime` as UTC ISO strings instead of raw Unix seconds, so local event times display correctly.
- Event results are now sorted by their actual start time before being shown.
- All-day events still keep `startTime` and `endTime` as null.

### Impact
`✅ Correct meeting times`
`✅ Fewer wrong calendar displays`
`✅ Clearer all-day event handling`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
