### PR TITLE
chore: tighten ValidationResult 'create' type to ValidatedFactData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`configured` flag on `GET /api/identity`** — returns `false` until the wizard or API has saved an identity explicitly; used for first-run detection in the browser without client-side state.
 
 ### Changed
+- **`ValidationResult` 'create' variant** — replaced `{ node: KgNode }` with `{ validated: ValidatedFactData }`, a narrower type that only carries label, properties, temporal metadata, and embedding. Removes the wasted `createNodeId()` call in the validator and makes the ownership boundary explicit: the validator validates, the store mints the ID and persists. (Closes #30)
 - **Default landing screen** — the app now lands on Chat instead of Knowledge Graph after login.
 - **Session auth refactor** — `assertSecret()` extracted to `src/channels/http/session-auth.ts`; sessions store lifted to `HttpAdapter` so identity routes now accept the `curia_session` cookie in addition to the `x-web-bootstrap-secret` header.
 

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -127,14 +127,14 @@ export class EntityMemory {
         // with its assigned ID, so we use that directly for the edge.
         const persistedNode = await this.store.createNode({
           type: FACT_TYPE,
-          label: result.node.label,
-          properties: result.node.properties,
-          confidence: result.node.temporal.confidence,
-          decayClass: result.node.temporal.decayClass,
-          source: result.node.temporal.source,
+          label: result.validated.label,
+          properties: result.validated.properties,
+          confidence: result.validated.temporal.confidence,
+          decayClass: result.validated.temporal.decayClass,
+          source: result.validated.temporal.source,
           // Pass the pre-computed embedding from the validator's dedup check
           // to avoid a redundant OpenAI API call.
-          embedding: result.node.embedding,
+          embedding: result.validated.embedding,
         });
 
         // If edge creation fails, the node we just created becomes an orphan

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -84,9 +84,23 @@ export interface StoreFactOptions {
   source: string; // provenance: "agent:coordinator/task:abc123/channel:cli"
 }
 
+// -- Validated data for a new fact node, produced by MemoryValidator --
+// Intentionally excludes `id` and `type`: the store owns ID generation and persistence.
+// The validator's job is to validate inputs and compute the embedding; the store's job
+// is to mint a UUID and write the row. Keeping these responsibilities separate prevents
+// callers from accidentally relying on a pre-computed ID that is never persisted.
+export interface ValidatedFactData {
+  label: string;
+  properties: Record<string, unknown>;
+  temporal: TemporalMetadata;
+  // Pre-computed embedding from the dedup scan — passed through so the store
+  // can skip a redundant embed() call when persisting the new node.
+  embedding: number[];
+}
+
 // -- Validation result --
 export type ValidationResult =
-  | { action: 'create'; node: KgNode }
+  | { action: 'create'; validated: ValidatedFactData }
   | { action: 'update'; existingNodeId: string; mergedProperties: Record<string, unknown> }
   | { action: 'conflict'; existingNodeId: string; reason: string }
   | { action: 'rejected'; reason: string };

--- a/src/memory/validation.ts
+++ b/src/memory/validation.ts
@@ -2,8 +2,7 @@ import type { KnowledgeGraphStore } from './knowledge-graph.js';
 // Value import (not `import type`) because we call the static method
 // EmbeddingService.cosineSimilarity() at runtime.
 import { EmbeddingService } from './embedding.js';
-import type { StoreFactOptions, ValidationResult, KgNode } from './types.js';
-import { createNodeId } from './types.js';
+import type { StoreFactOptions, ValidationResult } from './types.js';
 
 // Spec line 116: cosine similarity threshold for deduplication
 const DEDUP_SIMILARITY_THRESHOLD = 0.92;
@@ -62,7 +61,7 @@ export class MemoryValidator {
    * Returns a ValidationResult discriminated union:
    * - 'rejected' if the rate limit is exceeded or the entity node does not exist
    * - 'update' if a near-duplicate fact already exists (caller should merge)
-   * - 'create' with a fully-constructed KgNode ready to persist
+   * - 'create' with validated fact data (label, properties, temporal, embedding) ready to persist
    */
   async validate(options: StoreFactOptions): Promise<ValidationResult> {
     // 1. Rate limiting — checked against the source string which encodes agent+task identity
@@ -118,27 +117,27 @@ export class MemoryValidator {
       }
     }
 
-    // 5. No duplicate found — construct a new fact node with full provenance.
-    //    The node is NOT persisted here; the caller owns the store write so that
-    //    it can coordinate with edge creation atomically.
+    // 5. No duplicate found — return validated fact data for the caller to persist.
+    //    The caller owns ID generation and the store write so that it can coordinate
+    //    with edge creation atomically. We only provide what we've computed here:
+    //    the validated inputs plus the embedding from the dedup scan above.
     const now = new Date();
-    const node: KgNode = {
-      id: createNodeId(),
-      type: 'fact',
-      label: options.label,
-      properties: options.properties ?? {},
-      embedding: newEmbedding,
-      temporal: {
-        createdAt: now,
-        lastConfirmedAt: now,
-        confidence: options.confidence ?? 0.7,
-        decayClass: options.decayClass ?? 'slow_decay',
-        // Full provenance chain: "agent:<name>/task:<id>/channel:<name>"
-        source: options.source,
+    return {
+      action: 'create',
+      validated: {
+        label: options.label,
+        properties: options.properties ?? {},
+        embedding: newEmbedding,
+        temporal: {
+          createdAt: now,
+          lastConfirmedAt: now,
+          confidence: options.confidence ?? 0.7,
+          decayClass: options.decayClass ?? 'slow_decay',
+          // Full provenance chain: "agent:<name>/task:<id>/channel:<name>"
+          source: options.source,
+        },
       },
     };
-
-    return { action: 'create', node };
   }
 
   /**

--- a/tests/unit/memory/validation.test.ts
+++ b/tests/unit/memory/validation.test.ts
@@ -326,7 +326,7 @@ describe('MemoryValidator', () => {
 
       expect(result.action).toBe('create');
       if (result.action === 'create') {
-        expect(result.node.temporal.source).toBe('agent:coordinator/task:abc123/channel:cli');
+        expect(result.validated.temporal.source).toBe('agent:coordinator/task:abc123/channel:cli');
       }
     });
 
@@ -348,8 +348,8 @@ describe('MemoryValidator', () => {
 
       expect(result.action).toBe('create');
       if (result.action === 'create') {
-        expect(result.node.temporal.confidence).toBe(0.95);
-        expect(result.node.temporal.decayClass).toBe('permanent');
+        expect(result.validated.temporal.confidence).toBe(0.95);
+        expect(result.validated.temporal.decayClass).toBe('permanent');
       }
     });
 
@@ -369,8 +369,8 @@ describe('MemoryValidator', () => {
 
       expect(result.action).toBe('create');
       if (result.action === 'create') {
-        expect(result.node.temporal.confidence).toBe(0.7);
-        expect(result.node.temporal.decayClass).toBe('slow_decay');
+        expect(result.validated.temporal.confidence).toBe(0.7);
+        expect(result.validated.temporal.decayClass).toBe('slow_decay');
       }
     });
   });


### PR DESCRIPTION
## **User description**
## Summary

- Replaces `{ action: 'create'; node: KgNode }` with `{ action: 'create'; validated: ValidatedFactData }` in the `ValidationResult` discriminated union
- `ValidatedFactData` carries only the fields the validator actually computes: `label`, `properties`, `temporal`, and `embedding`
- Removes the wasted `createNodeId()` call in `MemoryValidator.validate()` — the ID was never persisted; `store.createNode()` always mints its own UUID
- All consumers (`entity-memory.ts`) and tests updated to use `result.validated.*`

Closes #30

## Why

The previous type allowed callers to accidentally rely on `result.node.id`, which was a transient UUID that was never written to the database. The new type makes the ownership boundary explicit at the type level: the validator validates and computes the embedding; the store owns ID generation and persistence.

## Notes from review

Two pre-existing issues spotted in adjacent code (out of scope for this PR, flagged for follow-up):

- **Empty catch on orphan cleanup** (`entity-memory.ts:150-153`): if `createEdge` fails and the cleanup `deleteNode` also fails, the failure is swallowed silently, violating the no-empty-catch rule in CLAUDE.md. A future PR should thread a logger into `EntityMemory` and log this.
- **`temporal.createdAt`/`lastConfirmedAt` in `ValidatedFactData` are not used by the store** — `createNode` always stamps its own `new Date()`. These fields are included in `TemporalMetadata` (which `ValidatedFactData.temporal` uses), but the store ignores them. Low-impact, but worth noting.

## Test plan

- [x] All 67 unit tests pass (`npx vitest run tests/unit/memory/`)
- [x] `tsc --noEmit` reports zero errors


___

## **CodeAnt-AI Description**
**Return validated fact data when creating a new memory fact**

### What Changed
- New fact creation now passes only the validated fields needed to save the fact, instead of a prebuilt node object
- The validator no longer generates an unused node ID before saving
- Tests and release notes were updated to match the new create result shape

### Impact
`✅ Fewer mismatches between validation and storage`
`✅ Less wasted work during fact creation`
`✅ Clearer ownership of saved fact IDs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
