### PR TITLE
fix: remove useless try/catch in contact-service createContact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 - **Scheduled Jobs page auth** — `/api/jobs` routes now use session-cookie auth (same as KG/identity routes) instead of the global Bearer token hook, so the dashboard can load the page without an `Unauthorized` error.
 - **Calendar skill timestamp display** — all calendar skills (`calendar-list-events`, `calendar-create-event`, `calendar-update-event`, `calendar-check-conflicts`, `calendar-find-free-time`) now return event and slot timestamps as UTC ISO 8601 strings instead of raw Unix seconds. LLMs can't reliably convert Unix epoch integers to wall-clock times (wrong times were displayed to the user); ISO strings are unambiguous and correctly interpreted using the timezone already in the system prompt.
+- **contact-service useless catch** — removed no-op try/catch in `createContact` that caught and immediately rethrew without adding any logic; preserved the KG orphan TODO as a comment at the call site (issue #49).
 
 ### Added
 - **Onboarding wizard** — multi-step full-screen wizard guides new users through configuring the office identity (assistant name, tone, communication style, decision posture) on first run. Re-enterable from Settings → Setup Wizard. Requires the identity service (spec 13) to be configured.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -180,17 +180,12 @@ export class ContactService {
       updatedAt: now,
     };
 
-    try {
-      await this.backend.createContact(contact);
-    } catch (err) {
-      // If the DB insert fails after we auto-created a KG node, that node is now
-      // orphaned — it exists in the knowledge graph with no corresponding contact row.
-      // TODO: Clean up the orphaned KG node once EntityMemory exposes a delete method.
-      // For now, the orphan will remain. It won't cause functional issues (it's just a
-      // person node with no contact link), but should be cleaned up when entity deletion
-      // is added. Tracked by: https://github.com/curia-ai/curia/issues/TBD
-      throw err;
-    }
+    // TODO: If this throws after we auto-created a KG node above, that node is now
+    // orphaned — it exists in the knowledge graph with no corresponding contact row.
+    // Clean up the orphaned KG node once EntityMemory exposes a delete method.
+    // For now it won't cause functional issues (just a person node with no contact link),
+    // but should be cleaned up when entity deletion is added.
+    await this.backend.createContact(contact);
 
     // Fire-and-forget dedup check. Runs asynchronously — never blocks the create.
     // A failure here is logged and swallowed; it must not fail the contact creation.

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -180,12 +180,15 @@ export class ContactService {
       updatedAt: now,
     };
 
-    // TODO: If this throws after we auto-created a KG node above, that node is now
-    // orphaned — it exists in the knowledge graph with no corresponding contact row.
-    // Clean up the orphaned KG node once EntityMemory exposes a delete method.
-    // For now it won't cause functional issues (just a person node with no contact link),
-    // but should be cleaned up when entity deletion is added.
-    await this.backend.createContact(contact);
+    try {
+      await this.backend.createContact(contact);
+    } catch (err) {
+      // TODO: The KG node auto-created above is now orphaned — it exists in the knowledge
+      // graph with no corresponding contact row. Clean up once EntityMemory exposes a
+      // delete method. For now the orphan is harmless (person node with no contact link).
+      this.logger?.error({ err, contactId: contact.id }, 'Contact creation failed');
+      throw err;
+    }
 
     // Fire-and-forget dedup check. Runs asynchronously — never blocks the create.
     // A failure here is logged and swallowed; it must not fail the contact creation.


### PR DESCRIPTION
## **User description**
## Summary

- Removes the no-op try/catch in `ContactService.createContact` that caught `err` and immediately rethrew it without adding any logic
- Moves the KG orphan TODO comment to the `await` call site where it documents the concern without masking the lint signal
- Bumps version to 0.9.1 (patch)

Closes #49.

## Test plan

- [ ] Existing unit/integration tests for ContactService pass unchanged — behavior is identical
- [ ] Lint passes without `no-useless-catch` warning on this file


___

## **CodeAnt-AI Description**
**Remove a no-op contact creation catch and update the release notes**

### What Changed
- Contact creation now runs without an empty error-catching wrapper, so failures surface the same way without extra handling
- The note about a possible orphaned knowledge-graph node stays with the contact creation call where it explains the edge case
- The release version and changelog were updated for the patch release

### Impact
`✅ Cleaner contact creation errors`
`✅ No change in successful contact creation`
`✅ Up-to-date patch release notes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
