### PR TITLE
fix: replace curia_dev with obviously-dummy DB credential placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Database
-DB_USER=curia
-DB_PASSWORD=curia_dev
-DATABASE_URL=postgres://curia:curia_dev@localhost:5432/curia
+DB_USER=your-db-user
+DB_PASSWORD=your-db-password
+DATABASE_URL=postgres://your-db-user:your-db-password@localhost:5432/curia
 
 # LLM Providers
 ANTHROPIC_API_KEY=sk-ant-...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Security
-- **`.env.example` credential placeholders** — replaced `curia_dev` database credentials with obviously-dummy `your-db-user` / `your-db-password` placeholders to avoid false-positive secrets scanner alerts.
+- **Dummy credential placeholders** — replaced `curia_dev` in `.env.example` and `docker-compose.yml` defaults with obviously-dummy `your-db-user` / `your-db-password` values to eliminate false-positive secrets scanner alerts (closes #50).
 
 ### Fixed
 - **Scheduled Jobs page auth** — `/api/jobs` routes now use session-cookie auth (same as KG/identity routes) instead of the global Bearer token hook, so the dashboard can load the page without an `Unauthorized` error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+- **`.env.example` credential placeholders** — replaced `curia_dev` database credentials with obviously-dummy `your-db-user` / `your-db-password` placeholders to avoid false-positive secrets scanner alerts.
+
 ### Fixed
 - **Scheduled Jobs page auth** — `/api/jobs` routes now use session-cookie auth (same as KG/identity routes) instead of the global Bearer token hook, so the dashboard can load the page without an `Unauthorized` error.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       - ./docker/postgres-init-pgaudit.sql:/docker-entrypoint-initdb.d/10-pgaudit.sql:ro
     environment:
       POSTGRES_DB: curia
-      POSTGRES_USER: ${DB_USER:-curia}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-curia_dev}
+      POSTGRES_USER: ${DB_USER:-your-db-user}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-your-db-password}
     # Load pgAudit and configure session-level auditing via command args.
     # All pgAudit settings are here (not in the init script) so there's one
     # place to look. The init script only handles CREATE EXTENSION and role setup.


### PR DESCRIPTION
## **User description**
## Summary

- Replaces `curia_dev` in `.env.example` and `docker-compose.yml` defaults with `your-db-user` / `your-db-password` — unambiguously non-real placeholders consistent with the rest of `.env.example` (`your-secret-token-here`, `replace-with-a-long-random-secret`, etc.)
- **No behaviour change** — these are example/default values only; no production code is affected

Closes #50

## Test plan

- [ ] Confirm `curia_dev` no longer appears in `.env.example` or `docker-compose.yml`
- [ ] Verify `docker compose up` still works end-to-end (with `DB_USER`/`DB_PASSWORD` set in `.env`)
- [ ] Confirm secrets scanner (CodeAnt) no longer flags line 4 of `.env.example` on next scan


___

## **CodeAnt-AI Description**
**Replace real-looking database placeholders with dummy values**

### What Changed
- Example database credentials in the setup files now use obvious placeholder values instead of `curia_dev`
- The default database login shown in local Docker setup now matches those dummy placeholders
- The changelog now records this security-related cleanup

### Impact
`✅ Fewer secrets scanner alerts`
`✅ Safer-looking local setup examples`
`✅ Clearer sample configuration`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
