### PR TITLE
fix: remove CLI channel bypass from elevated-skill gate (closes #120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 - **Dummy credential placeholders** — replaced `curia_dev` in `.env.example` and `docker-compose.yml` defaults with obviously-dummy `your-db-user` / `your-db-password` values to eliminate false-positive secrets scanner alerts (closes #50).
+- **Elevated-skill gate: remove CLI channel bypass** — the `caller.channel !== 'cli'` branch in `src/skills/execution.ts` was redundant (the contact resolver already maps CLI callers to `role: 'ceo'`) and created latent attack surface: any future code path that published an `inbound.message` event with `channelId: 'cli'` and a non-CEO sender would have passed the gate. Gate now relies solely on `caller.role`.
 
 ### Fixed
 - **Scheduled Jobs page auth** — `/api/jobs` routes now use session-cookie auth (same as KG/identity routes) instead of the global Bearer token hook, so the dashboard can load the page without an `Unauthorized` error.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -158,7 +158,7 @@ export class ExecutionLayer {
 
     // Elevated-skill gate: enforce caller verification before building context.
     // Fail-closed — if caller context is missing, elevated skills are blocked.
-    // CLI channel bypasses role check (trusted local operator; role may be null at startup).
+    // Role is authoritative — contact-resolver.ts already maps CLI callers to role: 'ceo'.
     if (manifest.sensitivity === 'elevated') {
       if (!caller) {
         this.logger.warn({ skillName }, 'Elevated skill blocked: no caller context (fail-closed)');
@@ -167,7 +167,7 @@ export class ExecutionLayer {
           error: `Skill '${skillName}' requires elevated privileges — no caller context provided (fail-closed)`,
         };
       }
-      if (caller.role !== 'ceo' && caller.channel !== 'cli') {
+      if (caller.role !== 'ceo') {
         this.logger.warn({ skillName, role: caller.role, channel: caller.channel }, 'Elevated skill blocked: unauthorized caller');
         return {
           success: false,

--- a/tests/unit/skills/execution.test.ts
+++ b/tests/unit/skills/execution.test.ts
@@ -145,40 +145,7 @@ describe('ExecutionLayer', () => {
       expect(result.success).toBe(true);
     });
 
-    it('allows elevated skill when caller channel is cli even with no role', async () => {
-      const handler: SkillHandler = {
-        execute: async () => ({ success: true, data: 'ok' }),
-      };
-      registry.register(makeManifest({ name: 'elevated-skill', sensitivity: 'elevated' }), handler);
-
-      // Use role: null to isolate the CLI channel bypass — if this passed with
-      // role: 'ceo', it would hit the role check first and never exercise the channel path.
-      const result = await execution.invoke('elevated-skill', {}, {
-        contactId: 'primary-user',
-        role: null,
-        channel: 'cli',
-      });
-      expect(result.success).toBe(true);
-    });
-
-    it('allows elevated skill for any caller on cli channel (trusted local operator)', async () => {
-      const handler: SkillHandler = {
-        execute: async () => ({ success: true, data: 'ok' }),
-      };
-      registry.register(makeManifest({ name: 'elevated-skill', sensitivity: 'elevated' }), handler);
-
-      // CLI channel bypasses role check unconditionally — any caller on CLI is
-      // the local operator. This is safe because channelId is set by the channel
-      // adapter, not by user input. The bus permissions layer prevents spoofing.
-      const result = await execution.invoke('elevated-skill', {}, {
-        contactId: 'contact-not-primary',
-        role: 'advisor',
-        channel: 'cli',
-      });
-      expect(result.success).toBe(true);
-    });
-
-    it('rejects elevated skill when caller is not ceo and not cli', async () => {
+    it('rejects elevated skill when caller is not ceo', async () => {
       const handler: SkillHandler = {
         execute: async () => ({ success: true, data: 'should not reach' }),
       };
@@ -194,6 +161,26 @@ describe('ExecutionLayer', () => {
         expect(result.error).toContain('elevated privileges');
         expect(result.error).toContain('cfo');
         expect(result.error).toContain('email');
+      }
+    });
+
+    it('rejects elevated skill when caller has cli channel but non-ceo role (no channel bypass)', async () => {
+      const handler: SkillHandler = {
+        execute: async () => ({ success: true, data: 'should not reach' }),
+      };
+      registry.register(makeManifest({ name: 'elevated-skill', sensitivity: 'elevated' }), handler);
+
+      // Ensures a spoofed channelId: 'cli' with a non-CEO role cannot bypass the gate.
+      // contact-resolver.ts already maps real CLI sessions to role: 'ceo', so this
+      // combination should never arrive legitimately.
+      const result = await execution.invoke('elevated-skill', {}, {
+        contactId: 'contact-spoofed',
+        role: 'advisor',
+        channel: 'cli',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain('elevated privileges');
       }
     });
 


### PR DESCRIPTION
## **User description**
## Summary

- Removes the redundant `caller.channel !== 'cli'` branch from the elevated-skill gate in `src/skills/execution.ts`
- Gate now relies solely on `caller.role !== 'ceo'`, which is the authoritative check
- Updates tests: removes two tests that exercised the removed bypass, renames one, adds a new test verifying a spoofed `channelId: 'cli'` with a non-CEO role is correctly blocked

## Why the bypass was redundant and dangerous

`contact-resolver.ts` already maps any CLI session to `role: 'ceo'` before the caller context reaches the execution layer — including the bootstrap fallback when no CEO contact exists in the DB yet. A legitimate CLI caller passes the role check without needing the channel bypass.

The bypass created latent attack surface: any future code path that published an `inbound.message` event with `channelId: 'cli'` and a non-CEO sender (a debug HTTP endpoint, a test harness, a compromised channel adapter) would have silently passed the elevated-skill gate and gained access to `set-autonomy`, `email-send`, and any other elevated skill.

## Trust chain after this change

```
Real CLI session  → ContactResolver (role: 'ceo') → gate passes
Spoofed cli channelId + non-ceo role → gate blocks, warn logged
No caller context → gate blocks, fail-closed
```

Closes #120


___

## **CodeAnt-AI Description**
**Block elevated skills from any caller that is not marked as CEO**

### What Changed
- Elevated skills now require a CEO role in every case; a CLI channel no longer grants access by itself
- Calls with no caller context still fail closed
- Tests now reject non-CEO callers even when the channel is set to CLI, and keep covering approved CEO access
- Changelog and release version were updated for this fix

### Impact
`✅ Fewer unauthorized elevated-skill calls`
`✅ Safer CLI access checks`
`✅ Clearer rejection of spoofed caller data`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
