### PR TITLE
feat: Bullpen — Tier 2 inter-agent discussion (closes #25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **contact-service useless catch** — removed no-op try/catch in `createContact` that caught and immediately rethrew without adding any logic; preserved the KG orphan TODO as a comment at the call site (issue #49).
 
 ### Added
+- **Bullpen (Tier 2 inter-agent discussion)** — shared threaded workspace where agents can open, reply to, and close discussion threads. Flows through the bus as `agent.discuss` events. BullpenDispatcher routes discuss events to `agent.task` for all thread participants. Pending threads injected into agent context before every LLM call. Visible to dashboards via SSE stream. Implements spec 01 (lines 24–44). Closes #25.
 - **Onboarding wizard** — multi-step full-screen wizard guides new users through configuring the office identity (assistant name, tone, communication style, decision posture) on first run. Re-enterable from Settings → Setup Wizard. Requires the identity service (spec 13) to be configured.
 - **Settings nav** — new collapsible Settings section in the sidebar with Setup Wizard sub-item.
 - **`configured` flag on `GET /api/identity`** — returns `false` until the wizard or API has saved an identity explicitly; used for first-run detection in the browser without client-side state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ---
 
-## [Unreleased]
+## [0.11.0] — 2026-04-07
 
 ### Security
 - **Inbound message sanitization: prompt injection detection (Layer 1)** — `Dispatcher.handleInbound()` now scans messages that pass the blocked/held/rejected sender policy gates before routing them to the Coordinator's LLM. Instruction-mimicking XML/HTML tags (`<system>`, `<instructions>`, `<prompt>`, `<context>`, `<assistant>`, `<user>`) are stripped from message content; instruction-like phrases ("ignore previous instructions", "act as", "you are now", etc.) are detected via configurable regex. Flagged messages are tagged with a `risk_score` (0–1) in the `agent.task` event metadata — not blocked — and are automatically captured in the audit log. Extra patterns can be added to `config/default.yaml` under `security.extra_injection_patterns` without code changes (spec §06, closes #190).
@@ -20,26 +20,22 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Elevated-skill gate: remove CLI channel bypass** — the `caller.channel !== 'cli'` branch in `src/skills/execution.ts` was redundant (the contact resolver already maps CLI callers to `role: 'ceo'`) and created latent attack surface: any future code path that published an `inbound.message` event with `channelId: 'cli'` and a non-CEO sender would have passed the gate. Gate now relies solely on `caller.role`.
 
 ### Added
-- **Scheduler stuck-job recovery** — startup sweep and 5-minute watchdog detect jobs stuck in `running` state beyond their timeout threshold and reset them to `pending`. Adds `run_started_at` (set on job claim, cleared on completion) and `expected_duration_seconds` (per-job timeout hint, sourced from YAML or job creation) columns to `scheduled_jobs`. Timeout formula: `min(expected × 7.5, expected + 60m)`. Recovery increments `consecutive_failures`; third consecutive recovery suspends the job. Emits `schedule.recovered` audit event per recovered job. Resolves silent failure mode observed 2026-04-07.
-
-### Changed
-- **Agent YAML `schedule` entries** — optional `expectedDurationSeconds` field added to the schedule entry type in `AgentYamlConfig`; used to set a per-job stuck-job recovery timeout.
-
-### Fixed
-- **Scheduled Jobs page auth** — `/api/jobs` routes now use session-cookie auth (same as KG/identity routes) instead of the global Bearer token hook, so the dashboard can load the page without an `Unauthorized` error.
-- **Calendar skill timestamp display** — all calendar skills (`calendar-list-events`, `calendar-create-event`, `calendar-update-event`, `calendar-check-conflicts`, `calendar-find-free-time`) now return event and slot timestamps as UTC ISO 8601 strings instead of raw Unix seconds. LLMs can't reliably convert Unix epoch integers to wall-clock times (wrong times were displayed to the user); ISO strings are unambiguous and correctly interpreted using the timezone already in the system prompt.
-- **contact-service useless catch** — removed no-op try/catch in `createContact` that caught and immediately rethrew without adding any logic; preserved the KG orphan TODO as a comment at the call site (issue #49).
-
-### Added
 - **Bullpen (Tier 2 inter-agent discussion)** — shared threaded workspace where agents can open, reply to, and close discussion threads. Flows through the bus as `agent.discuss` events. BullpenDispatcher routes discuss events to `agent.task` for all thread participants. Pending threads injected into agent context before every LLM call. Visible to dashboards via SSE stream. Implements spec 01 (lines 24–44). Closes #25.
+- **Scheduler stuck-job recovery** — startup sweep and 5-minute watchdog detect jobs stuck in `running` state beyond their timeout threshold and reset them to `pending`. Adds `run_started_at` (set on job claim, cleared on completion) and `expected_duration_seconds` (per-job timeout hint, sourced from YAML or job creation) columns to `scheduled_jobs`. Timeout formula: `min(expected × 7.5, expected + 60m)`. Recovery increments `consecutive_failures`; third consecutive recovery suspends the job. Emits `schedule.recovered` audit event per recovered job. Resolves silent failure mode observed 2026-04-07.
 - **Onboarding wizard** — multi-step full-screen wizard guides new users through configuring the office identity (assistant name, tone, communication style, decision posture) on first run. Re-enterable from Settings → Setup Wizard. Requires the identity service (spec 13) to be configured.
 - **Settings nav** — new collapsible Settings section in the sidebar with Setup Wizard sub-item.
 - **`configured` flag on `GET /api/identity`** — returns `false` until the wizard or API has saved an identity explicitly; used for first-run detection in the browser without client-side state.
 
 ### Changed
+- **Agent YAML `schedule` entries** — optional `expectedDurationSeconds` field added to the schedule entry type in `AgentYamlConfig`; used to set a per-job stuck-job recovery timeout.
 - **`ValidationResult` 'create' variant** — replaced `{ node: KgNode }` with `{ validated: ValidatedFactData }`, a narrower type that only carries label, properties, temporal metadata, and embedding. Removes the wasted `createNodeId()` call in the validator and makes the ownership boundary explicit: the validator validates, the store mints the ID and persists. (Closes #30)
 - **Default landing screen** — the app now lands on Chat instead of Knowledge Graph after login.
 - **Session auth refactor** — `assertSecret()` extracted to `src/channels/http/session-auth.ts`; sessions store lifted to `HttpAdapter` so identity routes now accept the `curia_session` cookie in addition to the `x-web-bootstrap-secret` header.
+
+### Fixed
+- **Scheduled Jobs page auth** — `/api/jobs` routes now use session-cookie auth (same as KG/identity routes) instead of the global Bearer token hook, so the dashboard can load the page without an `Unauthorized` error.
+- **Calendar skill timestamp display** — all calendar skills (`calendar-list-events`, `calendar-create-event`, `calendar-update-event`, `calendar-check-conflicts`, `calendar-find-free-time`) now return event and slot timestamps as UTC ISO 8601 strings instead of raw Unix seconds. LLMs can't reliably convert Unix epoch integers to wall-clock times (wrong times were displayed to the user); ISO strings are unambiguous and correctly interpreted using the timezone already in the system prompt.
+- **contact-service useless catch** — removed no-op try/catch in `createContact` that caught and immediately rethrew without adding any logic; preserved the KG orphan TODO as a comment at the call site (issue #49).
 
 ---
 
@@ -189,7 +185,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Bootstrap orchestrator** — `src/index.ts` wires all layers in dependency order
 - Architecture specs 00–08, contributor docs (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
 
-[Unreleased]: https://github.com/josephfung/curia/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/josephfung/curia/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/josephfung/curia/compare/v0.10.1...v0.11.0
 [0.8.0]: https://github.com/josephfung/curia/compare/v0.7.2...v0.8.0
 [0.7.0]: https://github.com/josephfung/curia/compare/v0.6.1...v0.7.2
 [0.6.0]: https://github.com/josephfung/curia/compare/v0.5.0...v0.6.1

--- a/docs/wip/2026-04-06-bullpen-design.md
+++ b/docs/wip/2026-04-06-bullpen-design.md
@@ -1,0 +1,422 @@
+# Bullpen Design — Inter-Agent Discussion (Tier 2 Memory)
+
+**Issue:** [josephfung/curia#25](https://github.com/josephfung/curia/issues/25)
+**Spec reference:** `docs/specs/01-memory-system.md` lines 24–44
+**Date:** 2026-04-06
+
+---
+
+## Overview
+
+The Bullpen is a shared, threaded workspace for inter-agent discussion. Agents can open threads, post to them, and reply to each other. The CEO/user can observe discussions via the SSE stream. User participation (intervene, start threads) is explicitly **out of scope** for this phase.
+
+The Bullpen sits between ephemeral working memory (Tier 1) and the knowledge graph (Tier 4). It is the coordination layer where agents work through problems together before producing results visible to the user.
+
+---
+
+## Architecture
+
+```
+agent calls bullpen skill
+  → skill writes to DB (BullpenService)
+  → skill publishes agent.discuss event (bus, agent layer)
+      → BullpenDispatcher subscribes
+          → creates agent.task for all thread participants
+            (mentioned agents: reply expected; non-mentioned: FYI)
+          → each addressed agent processes task, may call bullpen skill to reply
+          → cycle continues until thread is closed or message cap hit
+      → EventRouter streams agent.discuss to SSE clients (observability)
+
+On any agent.task (channel-originated or bullpen-originated):
+  → AgentRuntime queries BullpenService for pending threads
+  → injects compact thread context before LLM call
+```
+
+---
+
+## Data Model
+
+### Migration: `015_create_bullpen.sql`
+
+```sql
+CREATE TABLE bullpen_threads (
+  id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  topic             TEXT        NOT NULL,
+  creator_agent_id  TEXT        NOT NULL,
+  participants      TEXT[]      NOT NULL,    -- all agent IDs in the thread
+  status            TEXT        NOT NULL DEFAULT 'open',  -- 'open' | 'closed'
+  message_count     INT         NOT NULL DEFAULT 0,       -- enforced cap: 100
+  last_message_at   TIMESTAMPTZ,                          -- avoids subquery; updated on every post
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE bullpen_messages (
+  id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  thread_id           UUID        NOT NULL REFERENCES bullpen_threads(id),
+  sender_type         TEXT        NOT NULL DEFAULT 'agent',  -- 'agent' only; 'user' reserved
+  sender_id           TEXT        NOT NULL,                  -- agent ID
+  content             JSONB       NOT NULL,
+  mentioned_agent_ids TEXT[]      NOT NULL DEFAULT '{}',     -- empty = broadcast, no reply expected
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Fast lookups for context injection (pending threads per agent)
+CREATE INDEX ON bullpen_threads USING GIN (participants);
+CREATE INDEX ON bullpen_messages (thread_id, created_at);
+```
+
+**Notes:**
+- `last_message_at` is maintained by `BullpenService.postMessage` in the same UPDATE that increments `message_count`, avoiding an expensive subquery in the pending-thread lookup.
+- `mentioned_agent_ids` drives task creation in BullpenDispatcher. An empty array means the message is a broadcast — no agent tasks are triggered.
+- `sender_type` is stored as a column (not inferred) to make the audit trail self-describing and to support future user participation without schema changes.
+
+---
+
+## Bus Event: `agent.discuss`
+
+Added to `src/bus/events.ts`:
+
+```typescript
+interface AgentDiscussPayload {
+  threadId: string;
+  messageId: string;           // DB row ID — for audit traceability
+  topic: string;               // denormalized for SSE display without a DB hit
+  senderAgentId: string;
+  participants: string[];      // all thread participants
+  mentionedAgentIds: string[]; // who gets tasks triggered (may be empty)
+  content: string;
+}
+
+export interface AgentDiscussEvent extends BaseEvent {
+  type: 'agent.discuss';
+  sourceLayer: 'agent';
+  payload: AgentDiscussPayload;
+}
+```
+
+Factory follows the required-`parentEventId` pattern (every discuss event traces back to the agent task that triggered it):
+
+```typescript
+export function createAgentDiscuss(
+  payload: AgentDiscussPayload & { parentEventId: string },
+): AgentDiscussEvent { ... }
+```
+
+`agent.discuss` is added to the `BusEvent` union and to `src/bus/permissions.ts`:
+
+| Layer      | Permission  |
+|------------|-------------|
+| `agent`    | publish     |
+| `dispatch` | subscribe   |
+| `system`   | subscribe   |
+
+---
+
+## BullpenService (`src/memory/bullpen.ts`)
+
+Owns all DB reads and writes for the Bullpen. Injected into the skill, the runtime, and the BullpenDispatcher.
+
+### Types
+
+```typescript
+export interface BullpenMessage {
+  id: string;
+  threadId: string;
+  senderType: 'agent';
+  senderId: string;
+  content: unknown;
+  mentionedAgentIds: string[];
+  createdAt: Date;
+}
+
+export interface BullpenThread {
+  id: string;
+  topic: string;
+  creatorAgentId: string;
+  participants: string[];
+  status: 'open' | 'closed';
+  messageCount: number;
+  lastMessageAt: Date | null;
+  createdAt: Date;
+}
+
+export interface PendingThreadContext {
+  threadId: string;
+  topic: string;
+  totalMessages: number;      // agent knows if it's seeing partial history
+  recentMessages: Array<{
+    senderAgentId: string;
+    content: unknown;
+    mentionedAgentIds: string[];
+    createdAt: Date;
+  }>;
+}
+```
+
+### Methods
+
+```typescript
+openThread(
+  topic: string,
+  creatorAgentId: string,
+  participants: string[],
+  initialContent: string,
+  mentionedAgentIds: string[],
+): Promise<{ thread: BullpenThread; message: BullpenMessage }>
+```
+Inserts both the thread and the first message in a transaction. Sets `last_message_at` and `message_count = 1`.
+
+```typescript
+postMessage(
+  threadId: string,
+  senderAgentId: string,
+  content: string,
+  mentionedAgentIds: string[],
+): Promise<BullpenMessage>
+```
+Rejects (throws) if `status = 'closed'` or `message_count >= 100`. Updates `message_count` and `last_message_at` atomically with the INSERT using a CTE.
+
+```typescript
+closeThread(threadId: string, requestingAgentId: string): Promise<void>
+```
+Sets `status = 'closed'`. Enforces that `requestingAgentId` is either the `creator_agent_id` or `'coordinator'`; throws an error otherwise.
+
+```typescript
+getThread(threadId: string): Promise<{ thread: BullpenThread; messages: BullpenMessage[] } | null>
+```
+Returns the full thread + all messages ordered by `created_at ASC`. Returns `null` if not found.
+
+```typescript
+getPendingThreadsForAgent(agentId: string, windowMinutes: number): Promise<PendingThreadContext[]>
+```
+Pending = `status = 'open'` AND `last_message_at` within `windowMinutes` AND the most recent message's `sender_id != agentId` (something unresponded to). Returns max 5 threads, ordered by `last_message_at DESC`. Each thread includes at most 5 most-recent messages. Uses the GIN index on `participants` for the participant filter.
+
+---
+
+## Bullpen Skill (`skills/bullpen/`)
+
+### `skill.json`
+
+```json
+{
+  "name": "bullpen",
+  "description": "Open, reply to, read, or close inter-agent Bullpen discussion threads. Use 'post' to start a new thread, 'reply' to add a message, 'get_thread' to read full history, and 'close' to end a thread.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "infrastructure": true,
+  "inputs": {
+    "action":               "string: 'post' | 'reply' | 'get_thread' | 'close'",
+    "topic":                "string: thread topic — required for 'post'",
+    "participants":         "string[]: agent IDs to include in the thread — required for 'post'",
+    "mentioned_agent_ids":  "string[]: agent IDs to notify (@ mention) — optional for 'post', optional for 'reply'",
+    "content":              "string: message content — required for 'post' and 'reply'",
+    "thread_id":            "string: thread ID — required for 'reply', 'get_thread', 'close'"
+  },
+  "outputs": {
+    "thread_id":  "string: the thread ID",
+    "message_id": "string: the persisted message ID (post/reply)",
+    "thread":     "object: full thread + messages (get_thread)",
+    "status":     "string: 'closed' (close)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000
+}
+```
+
+`infrastructure: true` is required because the handler publishes `agent.discuss` to the bus. `action_risk: 'low'` — internal state write, no external communication.
+
+### `handler.ts` — action dispatch
+
+**`post`**: calls `bullpenService.openThread(topic, agentId, participants, content, mentionedAgentIds ?? participants)`. `mentionedAgentIds` defaults to all participants when omitted (you usually want responses when opening a thread). Publishes `agent.discuss` with `parentEventId = ctx.taskEventId`.
+
+**`reply`**: calls `bullpenService.postMessage(threadId, agentId, content, mentionedAgentIds ?? [])`. Fetches the thread to get `participants` for the event payload. Publishes `agent.discuss`.
+
+**`get_thread`**: calls `bullpenService.getThread(threadId)`. Returns the full thread object. Does not publish a bus event.
+
+**`close`**: calls `bullpenService.closeThread(threadId, agentId)`. BullpenService enforces creator/coordinator only; the handler surfaces the error as `{ success: false, error: ... }` if rejected. Does not publish a bus event.
+
+### SkillContext additions
+
+Two fields added to `SkillContext` in `src/skills/types.ts`:
+
+```typescript
+/** The calling agent's string ID (e.g. 'coordinator'). Populated by execution layer. */
+agentId?: string;
+/** The ID of the agent.task event that triggered this skill call. Used for parentEventId on bus events. */
+taskEventId?: string;
+/** Bullpen service — available to infrastructure skills. */
+bullpenService?: import('../memory/bullpen.js').BullpenService;
+```
+
+The execution layer already has `agentId` and `taskEventId` at invocation time — they just need to be threaded into `SkillContext`.
+
+---
+
+## BullpenDispatcher (`src/dispatch/bullpen-dispatcher.ts`)
+
+Handles the `agent.discuss` → `agent.task` routing loop. Wired at startup alongside the main `Dispatcher`.
+
+```typescript
+export class BullpenDispatcher {
+  constructor(private bus: EventBus, private logger: Logger) {}
+
+  register(): void {
+    this.bus.subscribe('agent.discuss', 'dispatch', async (event) => {
+      await this.handleDiscuss(event as AgentDiscussEvent);
+    });
+    this.logger.info('BullpenDispatcher registered');
+  }
+}
+```
+
+### Routing logic
+
+For every `agent.discuss` event, create one `agent.task` per thread participant **excluding the sender** (no agent gets notified about its own message):
+
+```typescript
+const otherParticipants = event.payload.participants.filter(
+  (id) => id !== event.payload.senderAgentId,
+);
+for (const agentId of otherParticipants) {
+  const isMentioned = event.payload.mentionedAgentIds.includes(agentId);
+  const task = createAgentTask({
+    agentId,
+    conversationId: event.payload.threadId,  // thread IS the conversation; preserves working memory
+    channelId: 'bullpen',                     // virtual channel identifier
+    senderId: event.payload.senderAgentId,
+    content: isMentioned
+      ? `You've been mentioned in Bullpen thread "${event.payload.topic}" (thread_id: ${event.payload.threadId}). Review the injected thread context and reply using the bullpen skill.`
+      : `FYI: New activity in Bullpen thread "${event.payload.topic}" (thread_id: ${event.payload.threadId}). No response required, but reply if you have something to add.`,
+    metadata: {
+      taskOrigin: 'bullpen',
+      threadId: event.payload.threadId,
+      mentioned: isMentioned,
+    },
+    parentEventId: event.id,
+  });
+  await this.bus.publish('dispatch', task);
+}
+```
+
+**Message cap check:** Before creating any tasks, BullpenDispatcher reads the thread's `message_count`. If `>= 100`, it logs a warning and skips task creation for all participants. The thread remains open for reading but goes quiet.
+
+**No `agent.response` subscription.** The agent's output returns to the Bullpen entirely via the `bullpen` skill (DB write + new `agent.discuss`). The `agent.response` produced at task completion has no corresponding routing entry in the main Dispatcher's `taskRouting` map — the main Dispatcher's "no routing info" log for these is downgraded from `warn` to `debug` with a comment noting it is expected for multi-dispatcher setups.
+
+**`conversationId = threadId`** means each agent's working memory is scoped to the thread. The agent accumulates context across multiple activations in the same discussion.
+
+---
+
+## Runtime Context Injection (`src/agents/runtime.ts`)
+
+### AgentConfig additions
+
+```typescript
+/** Optional Bullpen service for pending thread context injection. */
+bullpenService?: BullpenService;
+/** How far back to look for active threads (minutes). Default: 60. */
+bullpenWindowMinutes?: number;
+```
+
+### Injection in `processTask`
+
+After loading conversation history, before the first LLM call:
+
+```typescript
+if (this.config.bullpenService) {
+  const pending = await this.config.bullpenService.getPendingThreadsForAgent(
+    agentId,
+    this.config.bullpenWindowMinutes ?? 60,
+  );
+  if (pending.length > 0) {
+    // Inserted at position 1: after system prompt, before conversation history.
+    // Matches spec context budget priority: working memory > Bullpen > KG.
+    messages.splice(1, 0, {
+      role: 'system',
+      content: formatBullpenContext(pending),
+    });
+  }
+}
+```
+
+### `formatBullpenContext` output
+
+```
+[Bullpen — 2 active threads]
+
+Thread "Q2 venue planning" (thread_id: abc-123, 8 total messages — showing last 5):
+  coordinator [10:23]: "Can you check availability for Thursday?"
+  calendar-agent [10:24]: "Thursday is clear, Friday has a conflict."
+  coordinator [10:25]: "@research-agent can you find alternatives?"
+  research-agent [10:27]: "Found two venues with Thursday availability."
+  calendar-agent [10:28]: "Confirmed the first option works."
+  → Call bullpen get_thread for full history.
+
+Thread "Vendor research" (thread_id: def-456, 3 total messages):
+  research-agent [09:15]: "@coordinator Found 3 relevant vendors."
+```
+
+The `totalMessages` count signals when the agent is seeing partial history, so it knows to call `get_thread` if it needs more context.
+
+This injection runs for **all** agent tasks — both channel-originated and Bullpen-originated. For Bullpen-triggered tasks, the thread that triggered the task appears in the injected context alongside the task's `content` field, giving the agent full situational awareness.
+
+---
+
+## SSE Observability
+
+One new subscription added to `EventRouter.setupSubscriptions` in `src/channels/http/event-router.ts`, using `'system'` layer (same pattern as `skill.invoke` / `skill.result`):
+
+```typescript
+bus.subscribe('agent.discuss', 'system', (event: BusEvent) => {
+  if (event.type !== 'agent.discuss') return;
+  const sseData = JSON.stringify({
+    type: 'agent.discuss',
+    thread_id: event.payload.threadId,
+    topic: event.payload.topic,
+    sender_agent_id: event.payload.senderAgentId,
+    mentioned_agent_ids: event.payload.mentionedAgentIds,
+    participants: event.payload.participants,
+    timestamp: event.timestamp,
+  });
+  // System-wide broadcast — not filtered by conversationId
+  this.broadcastToSseClients(sseData);
+});
+```
+
+Dashboard clients see inter-agent discussions in real-time on the same `/api/messages/stream` endpoint they already use for `skill.invoke` and `skill.result`.
+
+---
+
+## Amplification Controls
+
+The design avoids exponential message runaway through two mechanisms:
+
+**1. Explicit mention targeting.** The `mentioned_agent_ids` field controls who gets a reply-expected task. A broadcast reply (empty mentions) creates FYI tasks for all participants but does not create reply pressure. Agents are guided by their system prompts to mention specifically who needs to respond.
+
+**2. Hard message cap.** Threads are capped at 100 messages. Once the cap is hit, BullpenDispatcher stops creating new tasks for that thread and logs a warning. The thread stays readable but goes quiet naturally.
+
+---
+
+## Bootstrapping
+
+In `src/index.ts`, alongside the existing Dispatcher:
+
+```typescript
+const bullpenService = new BullpenService(pool);
+const bullpenDispatcher = new BullpenDispatcher(bus, logger);
+bullpenDispatcher.register();
+```
+
+`bullpenService` is injected into:
+- Each `AgentRuntime` config (`bullpenService`, `bullpenWindowMinutes`)
+- The execution layer's `SkillContext` (for infrastructure skills)
+
+---
+
+## Out of Scope
+
+- **User participation** — CEO observing, intervening in, or starting Bullpen threads. Deferred to a future phase.
+- **Entity extraction from Bullpen messages** — agents may call `extract-relationships` explicitly if they discover something worth storing, but there is no automatic extraction pipeline for Bullpen content.
+- **Thread summarization** — long threads are capped at 100 messages; no summarization of closed threads in this phase.
+- **Rate-limiting FYI tasks** — if task churn from non-mentioned FYI tasks becomes a concern in production, a per-agent/per-thread rate limiter can be added. Deferred.

--- a/docs/wip/2026-04-06-bullpen-design.md
+++ b/docs/wip/2026-04-06-bullpen-design.md
@@ -16,7 +16,7 @@ The Bullpen sits between ephemeral working memory (Tier 1) and the knowledge gra
 
 ## Architecture
 
-```
+```text
 agent calls bullpen skill
   → skill writes to DB (BullpenService)
   → skill publishes agent.discuss event (bus, agent layer)
@@ -67,7 +67,7 @@ CREATE INDEX ON bullpen_messages (thread_id, created_at);
 
 **Notes:**
 - `last_message_at` is maintained by `BullpenService.postMessage` in the same UPDATE that increments `message_count`, avoiding an expensive subquery in the pending-thread lookup.
-- `mentioned_agent_ids` drives task creation in BullpenDispatcher. An empty array means the message is a broadcast — no agent tasks are triggered.
+- `mentioned_agent_ids` controls FYI vs. reply-expected semantics in `BullpenDispatcher`. The dispatcher fans out `agent.task` events to **all non-sender participants** regardless of this field. Agents listed in `mentioned_agent_ids` receive a task marked with reply-expected intent; all other participants receive an FYI-only task. An empty array is a broadcast: every non-sender participant gets an FYI task, but no specific reply is expected from any of them.
 - `sender_type` is stored as a column (not inferred) to make the audit trail self-describing and to support future user participation without schema changes.
 
 ---
@@ -342,7 +342,7 @@ if (this.config.bullpenService) {
 
 ### `formatBullpenContext` output
 
-```
+```text
 [Bullpen — 2 active threads]
 
 Thread "Q2 venue planning" (thread_id: abc-123, 8 total messages — showing last 5):

--- a/docs/wip/2026-04-07-bullpen.md
+++ b/docs/wip/2026-04-07-bullpen.md
@@ -1,0 +1,1828 @@
+# Bullpen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the Bullpen — a shared threaded workspace for inter-agent discussion backed by Postgres, flowing through the event bus, with a `bullpen` skill for agent participation and a `BullpenDispatcher` for fan-out routing.
+
+**Architecture:** BullpenService owns all DB reads/writes; the `bullpen` infrastructure skill publishes `agent.discuss` events; BullpenDispatcher subscribes and creates `agent.task` events for all thread participants; AgentRuntime injects pending thread context before every LLM call; EventRouter streams `agent.discuss` to SSE clients.
+
+**Tech Stack:** TypeScript ESM, Postgres, Vitest, node-pg-migrate (plain SQL migrations), Fastify (SSE), pino logging.
+
+**Design spec:** `docs/wip/2026-04-06-bullpen-design.md`
+**Issue:** [josephfung/curia#25](https://github.com/josephfung/curia/issues/25)
+**Working directory:** This plan must be executed in the `worktrees/curia-bullpen` worktree on branch `feat/bullpen`.
+
+---
+
+## File Map
+
+### New files
+| File | Purpose |
+|------|---------|
+| `src/db/migrations/015_create_bullpen.sql` | Creates `bullpen_threads` and `bullpen_messages` tables |
+| `src/memory/bullpen.ts` | `BullpenService` + types + `formatBullpenContext` |
+| `tests/unit/memory/bullpen.test.ts` | Unit tests for BullpenService (in-memory backend) |
+| `tests/integration/bullpen.test.ts` | Integration tests for BullpenService (real Postgres) |
+| `src/dispatch/bullpen-dispatcher.ts` | `BullpenDispatcher` — routes `agent.discuss` → `agent.task` |
+| `tests/unit/dispatch/bullpen-dispatcher.test.ts` | Unit tests for BullpenDispatcher |
+| `skills/bullpen/skill.json` | Bullpen skill manifest |
+| `skills/bullpen/handler.ts` | Bullpen skill handler |
+| `skills/bullpen/handler.test.ts` | Bullpen skill handler unit tests |
+
+### Modified files
+| File | What changes |
+|------|-------------|
+| `src/bus/events.ts` | Add `AgentDiscussPayload`, `AgentDiscussEvent`, `createAgentDiscuss`; add to `BusEvent` union |
+| `src/bus/permissions.ts` | Add `agent.discuss` to publish/subscribe allowlists |
+| `src/skills/types.ts` | Add `agentId?`, `taskEventId?`, `bullpenService?` to `SkillContext` |
+| `src/skills/execution.ts` | Accept `options?: { taskEventId?: string; agentId?: string }` in `invoke`; thread into context |
+| `src/agents/runtime.ts` | Add `bullpenService?` / `bullpenWindowMinutes?` to `AgentConfig`; inject pending threads; pass `taskEventId`/`agentId` to `executionLayer.invoke` |
+| `src/channels/http/event-router.ts` | Subscribe to `agent.discuss` for SSE broadcast |
+| `src/dispatch/dispatcher.ts` | Downgrade "no routing info" `warn` → `debug` for Bullpen tasks |
+| `src/index.ts` | Instantiate `BullpenService` + `BullpenDispatcher`; wire into `ExecutionLayer` and each `AgentRuntime` |
+
+---
+
+## Task 1: Database Migration
+
+**Files:**
+- Create: `src/db/migrations/015_create_bullpen.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Up Migration
+
+CREATE TABLE bullpen_threads (
+  id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  topic             TEXT        NOT NULL,
+  creator_agent_id  TEXT        NOT NULL,
+  participants      TEXT[]      NOT NULL,
+  status            TEXT        NOT NULL DEFAULT 'open',
+  message_count     INT         NOT NULL DEFAULT 0,
+  last_message_at   TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE bullpen_messages (
+  id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  thread_id           UUID        NOT NULL REFERENCES bullpen_threads(id),
+  sender_type         TEXT        NOT NULL DEFAULT 'agent',
+  sender_id           TEXT        NOT NULL,
+  content             JSONB       NOT NULL,
+  mentioned_agent_ids TEXT[]      NOT NULL DEFAULT '{}',
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Fast participant lookups for context injection
+CREATE INDEX ON bullpen_threads USING GIN (participants);
+-- Fast message retrieval per thread
+CREATE INDEX ON bullpen_messages (thread_id, created_at);
+
+-- Down Migration
+
+DROP TABLE IF EXISTS bullpen_messages;
+DROP TABLE IF EXISTS bullpen_threads;
+```
+
+- [ ] **Step 2: Run the migration**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm run migrate
+```
+
+Expected: `015_create_bullpen` applied, no errors.
+
+- [ ] **Step 3: Verify the tables exist**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+node --env-file=.env -e "
+import pg from 'pg';
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+const res = await pool.query(\"SELECT table_name FROM information_schema.tables WHERE table_name IN ('bullpen_threads','bullpen_messages') ORDER BY table_name\");
+console.log(res.rows);
+await pool.end();
+" --input-type=module
+```
+
+Expected: `[ { table_name: 'bullpen_messages' }, { table_name: 'bullpen_threads' } ]`
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+git add src/db/migrations/015_create_bullpen.sql
+git commit -m "feat: add bullpen_threads and bullpen_messages migration"
+```
+
+---
+
+## Task 2: Bus Event — `agent.discuss`
+
+**Files:**
+- Modify: `src/bus/events.ts`
+- Modify: `src/bus/permissions.ts`
+
+- [ ] **Step 1: Add payload interface, event interface, and factory to `src/bus/events.ts`**
+
+Add the payload interface after the `ConfigChangePayload` block (around line 204):
+
+```typescript
+// AgentDiscussPayload — emitted by the agent layer when a Bullpen message is posted.
+// `participants` is the full thread membership; `mentionedAgentIds` is the subset
+// that BullpenDispatcher will create tasks for (may be empty for broadcast messages).
+interface AgentDiscussPayload {
+  threadId: string;
+  messageId: string;           // DB row ID — for audit traceability
+  topic: string;               // denormalized for SSE display without a DB hit
+  senderAgentId: string;
+  participants: string[];      // all thread participants
+  mentionedAgentIds: string[]; // subset that get reply-expected tasks (empty = broadcast)
+  content: string;
+}
+```
+
+Add the event interface after `ConfigChangeEvent` (around line 339):
+
+```typescript
+export interface AgentDiscussEvent extends BaseEvent {
+  type: 'agent.discuss';
+  sourceLayer: 'agent';
+  payload: AgentDiscussPayload;
+}
+```
+
+Add `AgentDiscussEvent` to the `BusEvent` union after `ConfigChangeEvent`:
+
+```typescript
+  | AgentDiscussEvent;          // Bullpen: inter-agent discussion message
+```
+
+Add the factory function at the bottom of the factories section:
+
+```typescript
+export function createAgentDiscuss(
+  // parentEventId is required — every discuss event must trace back to the agent.task that triggered it.
+  payload: AgentDiscussPayload & { parentEventId: string },
+): AgentDiscussEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'agent.discuss',
+    sourceLayer: 'agent',
+    payload: rest,
+    parentEventId,
+  };
+}
+```
+
+- [ ] **Step 2: Update `src/bus/permissions.ts`**
+
+In `publishAllowlist`, add `'agent.discuss'` to the `agent` set:
+
+```typescript
+  agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss']),
+```
+
+In `subscribeAllowlist`, add `'agent.discuss'` to both `dispatch` and `system` sets:
+
+```typescript
+  dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss']),
+```
+
+```typescript
+  system: new Set([/* ...existing... */, 'agent.discuss']),
+```
+
+Also add `'agent.discuss'` to the `system` publish allowlist (system layer gets full access):
+
+```typescript
+  system: new Set([/* ...existing... */, 'agent.discuss']),
+```
+
+- [ ] **Step 3: Run the test suite to verify no regressions**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/bus/events.ts src/bus/permissions.ts
+git commit -m "feat: add agent.discuss bus event and permissions"
+```
+
+---
+
+## Task 3: BullpenService
+
+**Files:**
+- Create: `src/memory/bullpen.ts`
+
+- [ ] **Step 1: Write the failing unit tests first**
+
+Create `tests/unit/memory/bullpen.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { BullpenService } from '../../../src/memory/bullpen.js';
+
+describe('BullpenService (in-memory)', () => {
+  let service: BullpenService;
+
+  beforeEach(() => {
+    service = BullpenService.createInMemory();
+  });
+
+  it('opens a thread and returns thread + first message', async () => {
+    const { thread, message } = await service.openThread(
+      'Q2 planning',
+      'coordinator',
+      ['coordinator', 'calendar-agent'],
+      'Can you check availability?',
+      ['calendar-agent'],
+    );
+    expect(thread.id).toBeTruthy();
+    expect(thread.topic).toBe('Q2 planning');
+    expect(thread.creatorAgentId).toBe('coordinator');
+    expect(thread.participants).toEqual(['coordinator', 'calendar-agent']);
+    expect(thread.status).toBe('open');
+    expect(thread.messageCount).toBe(1);
+    expect(thread.lastMessageAt).toBeTruthy();
+    expect(message.senderId).toBe('coordinator');
+    expect(message.mentionedAgentIds).toEqual(['calendar-agent']);
+  });
+
+  it('posts a message and increments message_count', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator', 'agent-b'], 'Hello', []);
+    await service.postMessage(thread.id, 'agent-b', 'Reply', []);
+    const result = await service.getThread(thread.id);
+    expect(result?.thread.messageCount).toBe(2);
+    expect(result?.messages).toHaveLength(2);
+  });
+
+  it('returns null for unknown thread', async () => {
+    const result = await service.getThread('00000000-0000-0000-0000-000000000000');
+    expect(result).toBeNull();
+  });
+
+  it('throws when posting to a closed thread', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator'], 'Hi', []);
+    await service.closeThread(thread.id, 'coordinator');
+    await expect(service.postMessage(thread.id, 'coordinator', 'Late reply', [])).rejects.toThrow('closed');
+  });
+
+  it('throws when posting to a capped thread (100 messages)', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator'], 'Start', []);
+    // Post 99 more to reach the cap (thread starts at 1)
+    for (let i = 0; i < 99; i++) {
+      await service.postMessage(thread.id, 'coordinator', `Message ${i}`, []);
+    }
+    await expect(service.postMessage(thread.id, 'coordinator', 'Over cap', [])).rejects.toThrow('message cap');
+  });
+
+  it('enforces close permission: only creator or coordinator may close', async () => {
+    const { thread } = await service.openThread('Test', 'agent-b', ['agent-b', 'agent-c'], 'Hi', []);
+    await expect(service.closeThread(thread.id, 'agent-c')).rejects.toThrow('not authorized');
+  });
+
+  it('allows coordinator to close any thread', async () => {
+    const { thread } = await service.openThread('Test', 'agent-b', ['agent-b'], 'Hi', []);
+    await expect(service.closeThread(thread.id, 'coordinator')).resolves.not.toThrow();
+    const result = await service.getThread(thread.id);
+    expect(result?.thread.status).toBe('closed');
+  });
+
+  it('getPendingThreadsForAgent returns only threads where latest sender is not the agent', async () => {
+    const { thread } = await service.openThread(
+      'Pending test',
+      'coordinator',
+      ['coordinator', 'agent-b'],
+      'What do you think?',
+      ['agent-b'],
+    );
+    // coordinator posted last — agent-b has a pending thread
+    const pending = await service.getPendingThreadsForAgent('agent-b', 60);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.threadId).toBe(thread.id);
+    expect(pending[0]?.topic).toBe('Pending test');
+  });
+
+  it('getPendingThreadsForAgent excludes threads where agent posted last', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator', 'agent-b'], 'Hi', []);
+    await service.postMessage(thread.id, 'agent-b', 'Replied', []);
+    const pending = await service.getPendingThreadsForAgent('agent-b', 60);
+    expect(pending).toHaveLength(0);
+  });
+
+  it('getPendingThreadsForAgent excludes closed threads', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator', 'agent-b'], 'Hi', []);
+    await service.closeThread(thread.id, 'coordinator');
+    const pending = await service.getPendingThreadsForAgent('agent-b', 60);
+    expect(pending).toHaveLength(0);
+  });
+
+  it('getPendingThreadsForAgent includes up to 5 recent messages per thread', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator', 'agent-b'], 'Msg 1', []);
+    for (let i = 2; i <= 8; i++) {
+      await service.postMessage(thread.id, 'coordinator', `Msg ${i}`, []);
+    }
+    const pending = await service.getPendingThreadsForAgent('agent-b', 60);
+    expect(pending[0]?.totalMessages).toBe(8);
+    expect(pending[0]?.recentMessages).toHaveLength(5);
+    // Should be the last 5 messages
+    expect(pending[0]?.recentMessages[4]?.content).toBe('Msg 8');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test tests/unit/memory/bullpen.test.ts
+```
+
+Expected: FAIL — `BullpenService` not found.
+
+- [ ] **Step 3: Implement `src/memory/bullpen.ts`**
+
+```typescript
+import { randomUUID } from 'node:crypto';
+import type { Pool } from 'pg';
+import type { Logger } from '../logger.js';
+
+// -- Public types --
+
+export interface BullpenThread {
+  id: string;
+  topic: string;
+  creatorAgentId: string;
+  participants: string[];
+  status: 'open' | 'closed';
+  messageCount: number;
+  lastMessageAt: Date | null;
+  createdAt: Date;
+}
+
+export interface BullpenMessage {
+  id: string;
+  threadId: string;
+  senderType: 'agent';
+  senderId: string;
+  content: string;
+  mentionedAgentIds: string[];
+  createdAt: Date;
+}
+
+export interface PendingThreadContext {
+  threadId: string;
+  topic: string;
+  totalMessages: number;
+  recentMessages: Array<{
+    senderAgentId: string;
+    content: string;
+    mentionedAgentIds: string[];
+    createdAt: Date;
+  }>;
+}
+
+// -- Backend interface --
+
+interface BullpenBackend {
+  openThread(
+    thread: BullpenThread,
+    message: BullpenMessage,
+  ): Promise<void>;
+
+  postMessage(
+    threadId: string,
+    message: BullpenMessage,
+  ): Promise<void>;
+
+  closeThread(threadId: string): Promise<void>;
+
+  getThread(threadId: string): Promise<{ thread: BullpenThread; messages: BullpenMessage[] } | null>;
+
+  getPendingThreadsForAgent(
+    agentId: string,
+    windowMs: number,
+  ): Promise<PendingThreadContext[]>;
+}
+
+// -- In-memory backend (for unit tests) --
+
+class InMemoryBullpenBackend implements BullpenBackend {
+  private threads = new Map<string, BullpenThread>();
+  private messages = new Map<string, BullpenMessage[]>();
+
+  async openThread(thread: BullpenThread, message: BullpenMessage): Promise<void> {
+    this.threads.set(thread.id, { ...thread });
+    this.messages.set(thread.id, [{ ...message }]);
+  }
+
+  async postMessage(threadId: string, message: BullpenMessage): Promise<void> {
+    const thread = this.threads.get(threadId);
+    if (!thread) throw new Error(`Thread ${threadId} not found`);
+    thread.messageCount++;
+    thread.lastMessageAt = message.createdAt;
+    const msgs = this.messages.get(threadId) ?? [];
+    msgs.push({ ...message });
+    this.messages.set(threadId, msgs);
+  }
+
+  async closeThread(threadId: string): Promise<void> {
+    const thread = this.threads.get(threadId);
+    if (thread) thread.status = 'closed';
+  }
+
+  async getThread(threadId: string): Promise<{ thread: BullpenThread; messages: BullpenMessage[] } | null> {
+    const thread = this.threads.get(threadId);
+    if (!thread) return null;
+    return { thread: { ...thread }, messages: [...(this.messages.get(threadId) ?? [])] };
+  }
+
+  async getPendingThreadsForAgent(agentId: string, windowMs: number): Promise<PendingThreadContext[]> {
+    const cutoff = new Date(Date.now() - windowMs);
+    const result: PendingThreadContext[] = [];
+
+    for (const [threadId, thread] of this.threads) {
+      if (thread.status !== 'open') continue;
+      if (!thread.participants.includes(agentId)) continue;
+      if (!thread.lastMessageAt || thread.lastMessageAt < cutoff) continue;
+
+      const msgs = this.messages.get(threadId) ?? [];
+      if (msgs.length === 0) continue;
+
+      const lastMsg = msgs[msgs.length - 1]!;
+      if (lastMsg.senderId === agentId) continue;
+
+      const recentMessages = msgs.slice(-5).map(m => ({
+        senderAgentId: m.senderId,
+        content: m.content,
+        mentionedAgentIds: m.mentionedAgentIds,
+        createdAt: m.createdAt,
+      }));
+
+      result.push({ threadId, topic: thread.topic, totalMessages: thread.messageCount, recentMessages });
+    }
+
+    // Sort by lastMessageAt descending, return max 5
+    return result
+      .sort((a, b) => {
+        const ta = this.threads.get(a.threadId)?.lastMessageAt?.getTime() ?? 0;
+        const tb = this.threads.get(b.threadId)?.lastMessageAt?.getTime() ?? 0;
+        return tb - ta;
+      })
+      .slice(0, 5);
+  }
+}
+
+// -- Postgres backend --
+
+class PostgresBullpenBackend implements BullpenBackend {
+  constructor(private pool: Pool, private logger: Logger) {}
+
+  async openThread(thread: BullpenThread, message: BullpenMessage): Promise<void> {
+    // Use a transaction so both rows land atomically or neither does
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `INSERT INTO bullpen_threads (id, topic, creator_agent_id, participants, status, message_count, last_message_at, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [thread.id, thread.topic, thread.creatorAgentId, thread.participants, thread.status, thread.messageCount, thread.lastMessageAt, thread.createdAt],
+      );
+      await client.query(
+        `INSERT INTO bullpen_messages (id, thread_id, sender_type, sender_id, content, mentioned_agent_ids, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [message.id, message.threadId, message.senderType, message.senderId, JSON.stringify(message.content), message.mentionedAgentIds, message.createdAt],
+      );
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async postMessage(threadId: string, message: BullpenMessage): Promise<void> {
+    // Atomically insert the message and update the thread counter in a single CTE
+    await this.pool.query(
+      `WITH ins AS (
+         INSERT INTO bullpen_messages (id, thread_id, sender_type, sender_id, content, mentioned_agent_ids, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+       )
+       UPDATE bullpen_threads
+       SET message_count = message_count + 1,
+           last_message_at = $7
+       WHERE id = $2`,
+      [message.id, threadId, message.senderType, message.senderId, JSON.stringify(message.content), message.mentionedAgentIds, message.createdAt],
+    );
+  }
+
+  async closeThread(threadId: string): Promise<void> {
+    await this.pool.query(
+      `UPDATE bullpen_threads SET status = 'closed' WHERE id = $1`,
+      [threadId],
+    );
+  }
+
+  async getThread(threadId: string): Promise<{ thread: BullpenThread; messages: BullpenMessage[] } | null> {
+    const threadRes = await this.pool.query<{
+      id: string; topic: string; creator_agent_id: string; participants: string[];
+      status: string; message_count: number; last_message_at: Date | null; created_at: Date;
+    }>(
+      `SELECT id, topic, creator_agent_id, participants, status, message_count, last_message_at, created_at
+       FROM bullpen_threads WHERE id = $1`,
+      [threadId],
+    );
+    if (threadRes.rows.length === 0) return null;
+    const row = threadRes.rows[0]!;
+    const thread: BullpenThread = {
+      id: row.id, topic: row.topic, creatorAgentId: row.creator_agent_id,
+      participants: row.participants, status: row.status as 'open' | 'closed',
+      messageCount: row.message_count, lastMessageAt: row.last_message_at, createdAt: row.created_at,
+    };
+
+    const msgRes = await this.pool.query<{
+      id: string; thread_id: string; sender_type: string; sender_id: string;
+      content: unknown; mentioned_agent_ids: string[]; created_at: Date;
+    }>(
+      `SELECT id, thread_id, sender_type, sender_id, content, mentioned_agent_ids, created_at
+       FROM bullpen_messages WHERE thread_id = $1 ORDER BY created_at ASC`,
+      [threadId],
+    );
+    const messages: BullpenMessage[] = msgRes.rows.map(m => ({
+      id: m.id, threadId: m.thread_id, senderType: 'agent' as const,
+      senderId: m.sender_id, content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+      mentionedAgentIds: m.mentioned_agent_ids, createdAt: m.created_at,
+    }));
+
+    return { thread, messages };
+  }
+
+  async getPendingThreadsForAgent(agentId: string, windowMs: number): Promise<PendingThreadContext[]> {
+    const windowSeconds = windowMs / 1000;
+    // Find open threads where this agent is a participant and the last message
+    // was NOT from this agent, within the time window.
+    const threadsRes = await this.pool.query<{
+      id: string; topic: string; message_count: number; last_message_at: Date;
+    }>(
+      `SELECT t.id, t.topic, t.message_count, t.last_message_at
+       FROM bullpen_threads t
+       WHERE t.status = 'open'
+         AND $1 = ANY(t.participants)
+         AND t.last_message_at > NOW() - ($2 || ' seconds')::INTERVAL
+         AND (
+           SELECT sender_id FROM bullpen_messages
+           WHERE thread_id = t.id ORDER BY created_at DESC LIMIT 1
+         ) != $1
+       ORDER BY t.last_message_at DESC
+       LIMIT 5`,
+      [agentId, windowSeconds],
+    );
+
+    const results: PendingThreadContext[] = [];
+    for (const row of threadsRes.rows) {
+      const msgsRes = await this.pool.query<{
+        sender_id: string; content: unknown; mentioned_agent_ids: string[]; created_at: Date;
+      }>(
+        `SELECT sender_id, content, mentioned_agent_ids, created_at
+         FROM bullpen_messages WHERE thread_id = $1
+         ORDER BY created_at DESC LIMIT 5`,
+        [row.id],
+      );
+      // Rows are newest-first; reverse for chronological display
+      const recentMessages = msgsRes.rows.reverse().map(m => ({
+        senderAgentId: m.sender_id,
+        content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+        mentionedAgentIds: m.mentioned_agent_ids,
+        createdAt: m.created_at,
+      }));
+      results.push({ threadId: row.id, topic: row.topic, totalMessages: row.message_count, recentMessages });
+    }
+    return results;
+  }
+}
+
+// -- BullpenService --
+
+export class BullpenService {
+  private backend: BullpenBackend;
+
+  private constructor(backend: BullpenBackend) {
+    this.backend = backend;
+  }
+
+  static createWithPostgres(pool: Pool, logger: Logger): BullpenService {
+    return new BullpenService(new PostgresBullpenBackend(pool, logger));
+  }
+
+  static createInMemory(): BullpenService {
+    return new BullpenService(new InMemoryBullpenBackend());
+  }
+
+  async openThread(
+    topic: string,
+    creatorAgentId: string,
+    participants: string[],
+    initialContent: string,
+    mentionedAgentIds: string[],
+  ): Promise<{ thread: BullpenThread; message: BullpenMessage }> {
+    const now = new Date();
+    const thread: BullpenThread = {
+      id: randomUUID(), topic, creatorAgentId, participants,
+      status: 'open', messageCount: 1, lastMessageAt: now, createdAt: now,
+    };
+    const message: BullpenMessage = {
+      id: randomUUID(), threadId: thread.id, senderType: 'agent',
+      senderId: creatorAgentId, content: initialContent,
+      mentionedAgentIds, createdAt: now,
+    };
+    await this.backend.openThread(thread, message);
+    return { thread, message };
+  }
+
+  async postMessage(
+    threadId: string,
+    senderAgentId: string,
+    content: string,
+    mentionedAgentIds: string[],
+  ): Promise<BullpenMessage> {
+    const existing = await this.backend.getThread(threadId);
+    if (!existing) throw new Error(`Thread ${threadId} not found`);
+    if (existing.thread.status === 'closed') {
+      throw new Error(`Cannot post to closed thread ${threadId}`);
+    }
+    if (existing.thread.messageCount >= 100) {
+      throw new Error(`Thread ${threadId} has reached the message cap (100)`);
+    }
+    const message: BullpenMessage = {
+      id: randomUUID(), threadId, senderType: 'agent',
+      senderId: senderAgentId, content, mentionedAgentIds,
+      createdAt: new Date(),
+    };
+    await this.backend.postMessage(threadId, message);
+    return message;
+  }
+
+  async closeThread(threadId: string, requestingAgentId: string): Promise<void> {
+    const existing = await this.backend.getThread(threadId);
+    if (!existing) throw new Error(`Thread ${threadId} not found`);
+    if (requestingAgentId !== existing.thread.creatorAgentId && requestingAgentId !== 'coordinator') {
+      throw new Error(
+        `Agent '${requestingAgentId}' is not authorized to close thread ${threadId} — only the creator or coordinator may close threads`,
+      );
+    }
+    await this.backend.closeThread(threadId);
+  }
+
+  async getThread(threadId: string): Promise<{ thread: BullpenThread; messages: BullpenMessage[] } | null> {
+    return this.backend.getThread(threadId);
+  }
+
+  async getPendingThreadsForAgent(agentId: string, windowMinutes: number): Promise<PendingThreadContext[]> {
+    return this.backend.getPendingThreadsForAgent(agentId, windowMinutes * 60 * 1000);
+  }
+}
+
+// -- Context formatter --
+
+/**
+ * Formats pending Bullpen threads as a compact system-message block for LLM context injection.
+ * Shows up to 5 threads × 5 recent messages each.
+ */
+export function formatBullpenContext(pending: PendingThreadContext[]): string {
+  if (pending.length === 0) return '';
+  const lines: string[] = [`[Bullpen — ${pending.length} active thread${pending.length === 1 ? '' : 's'}]`];
+  for (const thread of pending) {
+    const showing = thread.recentMessages.length < thread.totalMessages
+      ? ` — showing last ${thread.recentMessages.length}`
+      : '';
+    lines.push('');
+    lines.push(`Thread "${thread.topic}" (thread_id: ${thread.threadId}, ${thread.totalMessages} total messages${showing}):`);
+    for (const msg of thread.recentMessages) {
+      const ts = msg.createdAt.toTimeString().slice(0, 5);
+      const mentions = msg.mentionedAgentIds.length > 0
+        ? msg.mentionedAgentIds.map(id => `@${id}`).join(' ') + ' '
+        : '';
+      lines.push(`  ${msg.senderAgentId} [${ts}]: "${mentions}${msg.content}"`);
+    }
+    if (thread.recentMessages.length < thread.totalMessages) {
+      lines.push(`  → Call bullpen get_thread for full history.`);
+    }
+  }
+  return lines.join('\n');
+}
+```
+
+- [ ] **Step 4: Run the unit tests**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test tests/unit/memory/bullpen.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/memory/bullpen.ts tests/unit/memory/bullpen.test.ts
+git commit -m "feat: add BullpenService with in-memory and Postgres backends"
+```
+
+---
+
+## Task 4: BullpenService Integration Tests
+
+**Files:**
+- Create: `tests/integration/bullpen.test.ts`
+
+- [ ] **Step 1: Write the integration tests**
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import { BullpenService } from '../../src/memory/bullpen.js';
+import { createLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('BullpenService integration (Postgres)', () => {
+  let pool: pg.Pool;
+  let service: BullpenService;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    await pool.query('SELECT 1 FROM bullpen_threads LIMIT 0');
+    const logger = createLogger('error');
+    service = BullpenService.createWithPostgres(pool, logger);
+  });
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM bullpen_messages');
+    await pool.query('DELETE FROM bullpen_threads');
+    await pool.end();
+  });
+
+  it('opens a thread and persists to Postgres', async () => {
+    const { thread, message } = await service.openThread(
+      'Integration test thread',
+      'coordinator',
+      ['coordinator', 'agent-b'],
+      'Hello agent-b',
+      ['agent-b'],
+    );
+    const fetched = await service.getThread(thread.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.thread.topic).toBe('Integration test thread');
+    expect(fetched!.messages).toHaveLength(1);
+    expect(fetched!.messages[0]!.id).toBe(message.id);
+  });
+
+  it('postMessage increments message_count and updates last_message_at', async () => {
+    const { thread } = await service.openThread('Count test', 'coordinator', ['coordinator', 'agent-b'], 'Msg 1', []);
+    const before = await service.getThread(thread.id);
+    await service.postMessage(thread.id, 'agent-b', 'Msg 2', []);
+    const after = await service.getThread(thread.id);
+    expect(after!.thread.messageCount).toBe(before!.thread.messageCount + 1);
+    expect(after!.thread.lastMessageAt!.getTime()).toBeGreaterThanOrEqual(before!.thread.lastMessageAt!.getTime());
+  });
+
+  it('getPendingThreadsForAgent respects time window', async () => {
+    const { thread } = await service.openThread('Old thread', 'coordinator', ['coordinator', 'agent-b'], 'Old', []);
+    // Force last_message_at to be 2 hours ago
+    await pool.query(
+      `UPDATE bullpen_threads SET last_message_at = NOW() - INTERVAL '2 hours' WHERE id = $1`,
+      [thread.id],
+    );
+    // 60-minute window should exclude this thread
+    const pending = await service.getPendingThreadsForAgent('agent-b', 60);
+    expect(pending.find(p => p.threadId === thread.id)).toBeUndefined();
+  });
+
+  it('closeThread prevents further posts', async () => {
+    const { thread } = await service.openThread('Close test', 'coordinator', ['coordinator'], 'Hi', []);
+    await service.closeThread(thread.id, 'coordinator');
+    await expect(service.postMessage(thread.id, 'coordinator', 'After close', [])).rejects.toThrow('closed');
+  });
+});
+```
+
+- [ ] **Step 2: Run the integration tests**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test tests/integration/bullpen.test.ts
+```
+
+Expected: all tests pass (skipped if `DATABASE_URL` is not set).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/bullpen.test.ts
+git commit -m "test: add BullpenService integration tests"
+```
+
+---
+
+## Task 5: Bullpen Skill
+
+**Files:**
+- Create: `skills/bullpen/skill.json`
+- Create: `skills/bullpen/handler.ts`
+- Create: `skills/bullpen/handler.test.ts`
+
+- [ ] **Step 1: Write the failing handler tests**
+
+Create `skills/bullpen/handler.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BullpenHandler } from './handler.js';
+import { BullpenService } from '../../src/memory/bullpen.js';
+import { createLogger } from '../../src/logger.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  const bullpenService = BullpenService.createInMemory();
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: createLogger('error'),
+    agentId: 'coordinator',
+    taskEventId: 'task-123',
+    bullpenService,
+    // bus is needed to publish agent.discuss — use a spy
+    bus: {
+      publish: vi.fn().mockResolvedValue(undefined),
+      subscribe: vi.fn(),
+    } as unknown as SkillContext['bus'],
+    agentRegistry: { list: vi.fn().mockReturnValue([]) } as unknown as SkillContext['agentRegistry'],
+    ...overrides,
+  } as unknown as SkillContext;
+}
+
+describe('BullpenHandler', () => {
+  let handler: BullpenHandler;
+
+  beforeEach(() => {
+    handler = new BullpenHandler();
+  });
+
+  it('post: opens a thread and publishes agent.discuss', async () => {
+    const ctx = makeCtx({
+      action: 'post',
+      topic: 'Q2 budget',
+      participants: ['coordinator', 'research-agent'],
+      content: 'Can you look into Q2 costs?',
+      mentioned_agent_ids: ['research-agent'],
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(typeof data.thread_id).toBe('string');
+    expect(typeof data.message_id).toBe('string');
+    expect(ctx.bus!.publish).toHaveBeenCalledOnce();
+    const publishCall = (ctx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(publishCall[0]).toBe('agent');
+    expect(publishCall[1].type).toBe('agent.discuss');
+  });
+
+  it('post: defaults mentionedAgentIds to all participants when omitted', async () => {
+    const ctx = makeCtx({
+      action: 'post',
+      topic: 'Broadcast',
+      participants: ['coordinator', 'agent-b', 'agent-c'],
+      content: 'Heads up',
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const publishCall = (ctx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(publishCall[1].payload.mentionedAgentIds).toEqual(['coordinator', 'agent-b', 'agent-c']);
+  });
+
+  it('reply: posts a message to an existing thread', async () => {
+    // First open a thread
+    const openCtx = makeCtx({
+      action: 'post',
+      topic: 'Reply test',
+      participants: ['coordinator', 'agent-b'],
+      content: 'Start',
+      mentioned_agent_ids: ['agent-b'],
+    });
+    const openResult = await handler.execute(openCtx);
+    const threadId = ((openResult as { success: true; data: Record<string, unknown> }).data).thread_id as string;
+
+    // Now reply
+    const replyCtx = makeCtx({
+      action: 'reply',
+      thread_id: threadId,
+      content: 'Here is my reply',
+      mentioned_agent_ids: ['coordinator'],
+    }, { bullpenService: openCtx.bullpenService, bus: openCtx.bus, agentId: 'agent-b' });
+    const replyResult = await handler.execute(replyCtx);
+    expect(replyResult.success).toBe(true);
+    // bus.publish called twice total (open + reply)
+    expect((openCtx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+  });
+
+  it('get_thread: returns full thread without publishing', async () => {
+    const ctx = makeCtx({
+      action: 'post',
+      topic: 'Get test',
+      participants: ['coordinator'],
+      content: 'Only message',
+    });
+    const openResult = await handler.execute(ctx);
+    const threadId = ((openResult as { success: true; data: Record<string, unknown> }).data).thread_id as string;
+
+    const getCtx = makeCtx({ action: 'get_thread', thread_id: threadId }, { bullpenService: ctx.bullpenService, bus: ctx.bus });
+    const result = await handler.execute(getCtx);
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.thread).toBeDefined();
+    expect((data.thread as { topic: string }).topic).toBe('Get test');
+    // No additional publish after the open
+    expect((ctx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+  });
+
+  it('close: closes the thread without publishing', async () => {
+    const ctx = makeCtx({
+      action: 'post',
+      topic: 'Close test',
+      participants: ['coordinator'],
+      content: 'Will close',
+    });
+    const openResult = await handler.execute(ctx);
+    const threadId = ((openResult as { success: true; data: Record<string, unknown> }).data).thread_id as string;
+
+    const closeCtx = makeCtx({ action: 'close', thread_id: threadId }, { bullpenService: ctx.bullpenService, bus: ctx.bus });
+    const closeResult = await handler.execute(closeCtx);
+    expect(closeResult.success).toBe(true);
+    const data = (closeResult as { success: true; data: Record<string, unknown> }).data;
+    expect((data as { status: string }).status).toBe('closed');
+  });
+
+  it('close: returns error when unauthorized agent tries to close', async () => {
+    const ctx = makeCtx({
+      action: 'post',
+      topic: 'Auth test',
+      participants: ['agent-b', 'agent-c'],
+      content: 'Start',
+    }, { agentId: 'agent-b' });
+    const openResult = await handler.execute(ctx);
+    const threadId = ((openResult as { success: true; data: Record<string, unknown> }).data).thread_id as string;
+
+    // agent-c tries to close — not authorized
+    const closeCtx = makeCtx(
+      { action: 'close', thread_id: threadId },
+      { bullpenService: ctx.bullpenService, bus: ctx.bus, agentId: 'agent-c' },
+    );
+    const closeResult = await handler.execute(closeCtx);
+    expect(closeResult.success).toBe(false);
+    expect((closeResult as { success: false; error: string }).error).toMatch(/not authorized/);
+  });
+
+  it('returns error for missing required fields', async () => {
+    const ctx = makeCtx({ action: 'post' }); // missing topic, participants, content
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error for unknown action', async () => {
+    const ctx = makeCtx({ action: 'fly' });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/unknown action/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test skills/bullpen/handler.test.ts
+```
+
+Expected: FAIL — handler not found.
+
+- [ ] **Step 3: Create `skills/bullpen/skill.json`**
+
+```json
+{
+  "name": "bullpen",
+  "description": "Open, reply to, read, or close inter-agent Bullpen discussion threads. Use 'post' to start a new thread addressed to other agents, 'reply' to add a message to an existing thread, 'get_thread' to read the full message history, and 'close' to end a thread when the discussion is complete.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "infrastructure": true,
+  "inputs": {
+    "action": "string: 'post' | 'reply' | 'get_thread' | 'close'",
+    "topic": "string: thread topic — required for 'post'",
+    "participants": "string[]: agent IDs to include in the thread — required for 'post'",
+    "mentioned_agent_ids": "string[]: agent IDs to @ mention (optional for 'post' and 'reply'; defaults to all participants for 'post')",
+    "content": "string: message content — required for 'post' and 'reply'",
+    "thread_id": "string: thread ID — required for 'reply', 'get_thread', 'close'"
+  },
+  "outputs": {
+    "thread_id": "string: the thread ID",
+    "message_id": "string: the persisted message ID (post/reply)",
+    "thread": "object: full thread + messages (get_thread)",
+    "status": "string: 'closed' (close)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000
+}
+```
+
+- [ ] **Step 4: Create `skills/bullpen/handler.ts`**
+
+```typescript
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { createAgentDiscuss } from '../../src/bus/events.js';
+
+export class BullpenHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { input } = ctx;
+    const action = input['action'];
+
+    if (!ctx.bullpenService) {
+      return { success: false, error: 'BullpenService not available in context' };
+    }
+    if (!ctx.bus) {
+      return { success: false, error: 'Bus not available in context (infrastructure skill requires bus)' };
+    }
+    if (!ctx.agentId) {
+      return { success: false, error: 'agentId not available in context' };
+    }
+    if (!ctx.taskEventId) {
+      return { success: false, error: 'taskEventId not available in context' };
+    }
+
+    try {
+      switch (action) {
+        case 'post': {
+          const topic = input['topic'];
+          const participants = input['participants'];
+          const content = input['content'];
+          if (typeof topic !== 'string' || !topic) return { success: false, error: "Missing required field: 'topic'" };
+          if (!Array.isArray(participants) || participants.length === 0) return { success: false, error: "Missing required field: 'participants' (non-empty string array)" };
+          if (typeof content !== 'string' || !content) return { success: false, error: "Missing required field: 'content'" };
+
+          const rawMentioned = input['mentioned_agent_ids'];
+          // Default: mention all participants when not specified (caller typically wants replies when opening a thread)
+          const mentionedAgentIds: string[] = Array.isArray(rawMentioned) ? rawMentioned as string[] : participants as string[];
+
+          const { thread, message } = await ctx.bullpenService.openThread(
+            topic, ctx.agentId, participants as string[], content, mentionedAgentIds,
+          );
+
+          await ctx.bus.publish('agent', createAgentDiscuss({
+            threadId: thread.id,
+            messageId: message.id,
+            topic: thread.topic,
+            senderAgentId: ctx.agentId,
+            participants: thread.participants,
+            mentionedAgentIds,
+            content,
+            parentEventId: ctx.taskEventId,
+          }));
+
+          return { success: true, data: { thread_id: thread.id, message_id: message.id } };
+        }
+
+        case 'reply': {
+          const threadId = input['thread_id'];
+          const content = input['content'];
+          if (typeof threadId !== 'string' || !threadId) return { success: false, error: "Missing required field: 'thread_id'" };
+          if (typeof content !== 'string' || !content) return { success: false, error: "Missing required field: 'content'" };
+
+          const rawMentioned = input['mentioned_agent_ids'];
+          // Default: empty (broadcast reply — no specific response expected)
+          const mentionedAgentIds: string[] = Array.isArray(rawMentioned) ? rawMentioned as string[] : [];
+
+          const message = await ctx.bullpenService.postMessage(threadId, ctx.agentId, content, mentionedAgentIds);
+
+          // Fetch thread for participants list needed in the event payload
+          const existing = await ctx.bullpenService.getThread(threadId);
+          if (!existing) return { success: false, error: `Thread ${threadId} not found after posting` };
+
+          await ctx.bus.publish('agent', createAgentDiscuss({
+            threadId,
+            messageId: message.id,
+            topic: existing.thread.topic,
+            senderAgentId: ctx.agentId,
+            participants: existing.thread.participants,
+            mentionedAgentIds,
+            content,
+            parentEventId: ctx.taskEventId,
+          }));
+
+          return { success: true, data: { thread_id: threadId, message_id: message.id } };
+        }
+
+        case 'get_thread': {
+          const threadId = input['thread_id'];
+          if (typeof threadId !== 'string' || !threadId) return { success: false, error: "Missing required field: 'thread_id'" };
+
+          const result = await ctx.bullpenService.getThread(threadId);
+          if (!result) return { success: false, error: `Thread ${threadId} not found` };
+
+          return { success: true, data: { thread_id: threadId, thread: result } };
+        }
+
+        case 'close': {
+          const threadId = input['thread_id'];
+          if (typeof threadId !== 'string' || !threadId) return { success: false, error: "Missing required field: 'thread_id'" };
+
+          await ctx.bullpenService.closeThread(threadId, ctx.agentId);
+          return { success: true, data: { thread_id: threadId, status: 'closed' } };
+        }
+
+        default:
+          return { success: false, error: `Unknown action: '${String(action)}'. Valid actions: post, reply, get_thread, close` };
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, action, agentId: ctx.agentId }, 'Bullpen skill error');
+      return { success: false, error: message };
+    }
+  }
+}
+
+export default new BullpenHandler();
+```
+
+- [ ] **Step 5: Run the handler tests**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test skills/bullpen/handler.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add skills/bullpen/skill.json skills/bullpen/handler.ts skills/bullpen/handler.test.ts
+git commit -m "feat: add bullpen skill (post, reply, get_thread, close)"
+```
+
+---
+
+## Task 6: SkillContext + ExecutionLayer Threading
+
+**Files:**
+- Modify: `src/skills/types.ts`
+- Modify: `src/skills/execution.ts`
+- Modify: `src/agents/runtime.ts`
+
+- [ ] **Step 1: Add fields to `SkillContext` in `src/skills/types.ts`**
+
+Add after the `autonomyService?` field (around line 157):
+
+```typescript
+  /** The calling agent's string ID (e.g. 'coordinator'). Populated by the execution layer.
+   *  Required by infrastructure skills that publish bus events on behalf of the agent. */
+  agentId?: string;
+  /** The ID of the agent.task event that triggered this skill call.
+   *  Used as parentEventId on bus events published by infrastructure skills. */
+  taskEventId?: string;
+  /** Bullpen service — available to infrastructure skills for inter-agent discussion. */
+  bullpenService?: import('../memory/bullpen.js').BullpenService;
+```
+
+- [ ] **Step 2: Update `ExecutionLayer.invoke` in `src/skills/execution.ts`**
+
+Change the signature of `invoke` to accept a 4th `options` parameter. Find:
+
+```typescript
+  async invoke(
+    skillName: string,
+    input: Record<string, unknown>,
+    caller?: CallerContext,
+  ): Promise<SkillResult> {
+```
+
+Replace with:
+
+```typescript
+  async invoke(
+    skillName: string,
+    input: Record<string, unknown>,
+    caller?: CallerContext,
+    options?: { taskEventId?: string; agentId?: string },
+  ): Promise<SkillResult> {
+```
+
+Then in the same method, after `ctx.agentPersona = this.agentPersona` (around line 199), add `agentId` and `taskEventId` to the context:
+
+```typescript
+      agentPersona: this.agentPersona,
+      caller,
+      agentContactId: this.agentContactId,
+      contactService: this.contactService,
+      // Thread agentId and taskEventId into context for infrastructure skills that publish events
+      agentId: options?.agentId,
+      taskEventId: options?.taskEventId,
+```
+
+In the `infrastructure` block (around line 221, where `ctx.bus` and `ctx.agentRegistry` are set), also add `bullpenService` injection. After the existing infrastructure service injections (after `ctx.entityMemory`), add:
+
+```typescript
+      // bullpenService is optional — only the bullpen skill needs it
+      if (this.bullpenService) {
+        ctx.bullpenService = this.bullpenService;
+      }
+```
+
+Add `bullpenService` to the `ExecutionLayer` constructor options and private fields. After the `browserService` field:
+
+```typescript
+  private bullpenService?: import('../memory/bullpen.js').BullpenService;
+```
+
+In the constructor options interface (after `browserService?`):
+
+```typescript
+    bullpenService?: import('../memory/bullpen.js').BullpenService;
+```
+
+In the constructor body (after `this.browserService = options?.browserService`):
+
+```typescript
+    this.bullpenService = options?.bullpenService;
+```
+
+- [ ] **Step 3: Update the runtime's call to `executionLayer.invoke` in `src/agents/runtime.ts`**
+
+Find the line (around line 334):
+
+```typescript
+        const result = await executionLayer.invoke(toolCall.name, toolCall.input, caller);
+```
+
+Replace with:
+
+```typescript
+        const result = await executionLayer.invoke(toolCall.name, toolCall.input, caller, {
+          taskEventId: taskEvent.id,
+          agentId,
+        });
+```
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/skills/types.ts src/skills/execution.ts src/agents/runtime.ts
+git commit -m "feat: thread agentId, taskEventId, and bullpenService into SkillContext"
+```
+
+---
+
+## Task 7: BullpenDispatcher
+
+**Files:**
+- Create: `src/dispatch/bullpen-dispatcher.ts`
+- Create: `tests/unit/dispatch/bullpen-dispatcher.test.ts`
+- Modify: `src/dispatch/dispatcher.ts`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `tests/unit/dispatch/bullpen-dispatcher.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BullpenDispatcher } from '../../../src/dispatch/bullpen-dispatcher.js';
+import { BullpenService } from '../../../src/memory/bullpen.js';
+import { createLogger } from '../../../src/logger.js';
+import { createAgentDiscuss } from '../../../src/bus/events.js';
+import type { EventBus } from '../../../src/bus/bus.js';
+
+function makeBus() {
+  const handlers = new Map<string, ((event: unknown) => void)[]>();
+  return {
+    subscribe: vi.fn((type: string, _layer: string, handler: (event: unknown) => void) => {
+      const list = handlers.get(type) ?? [];
+      list.push(handler);
+      handlers.set(type, list);
+    }),
+    publish: vi.fn(async (_layer: string, event: unknown) => {
+      // Simulate bus delivery so tests can inspect published events
+    }),
+    _trigger: async (type: string, event: unknown) => {
+      for (const h of handlers.get(type) ?? []) await h(event);
+    },
+  };
+}
+
+describe('BullpenDispatcher', () => {
+  let bus: ReturnType<typeof makeBus>;
+  let bullpenService: BullpenService;
+  let dispatcher: BullpenDispatcher;
+
+  beforeEach(() => {
+    bus = makeBus();
+    bullpenService = BullpenService.createInMemory();
+    dispatcher = new BullpenDispatcher(bus as unknown as EventBus, createLogger('error'), bullpenService);
+    dispatcher.register();
+  });
+
+  it('registers a subscriber for agent.discuss', () => {
+    expect(bus.subscribe).toHaveBeenCalledWith('agent.discuss', 'dispatch', expect.any(Function));
+  });
+
+  it('creates agent.task for all participants except sender', async () => {
+    const { thread } = await bullpenService.openThread(
+      'Test thread', 'coordinator', ['coordinator', 'agent-b', 'agent-c'], 'Hello', ['agent-b'],
+    );
+    const event = createAgentDiscuss({
+      threadId: thread.id,
+      messageId: 'msg-1',
+      topic: 'Test thread',
+      senderAgentId: 'coordinator',
+      participants: ['coordinator', 'agent-b', 'agent-c'],
+      mentionedAgentIds: ['agent-b'],
+      content: 'Hello',
+      parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    // Should create 2 tasks: agent-b (mentioned) and agent-c (FYI), NOT coordinator
+    const publishedTasks = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([_layer, e]) => (e as { type: string }).type === 'agent.task');
+    expect(publishedTasks).toHaveLength(2);
+    const agentIds = publishedTasks.map(([_layer, e]) => (e as { payload: { agentId: string } }).payload.agentId);
+    expect(agentIds).toContain('agent-b');
+    expect(agentIds).toContain('agent-c');
+    expect(agentIds).not.toContain('coordinator');
+  });
+
+  it('sets channelId to "bullpen" and metadata.taskOrigin to "bullpen"', async () => {
+    const { thread } = await bullpenService.openThread(
+      'Meta test', 'coordinator', ['coordinator', 'agent-b'], 'Hi', ['agent-b'],
+    );
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-1', topic: 'Meta test',
+      senderAgentId: 'coordinator', participants: ['coordinator', 'agent-b'],
+      mentionedAgentIds: ['agent-b'], content: 'Hi', parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    const task = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .find(([_l, e]) => (e as { type: string }).type === 'agent.task')?.[1] as { payload: { channelId: string; metadata: Record<string, unknown> } };
+    expect(task?.payload.channelId).toBe('bullpen');
+    expect(task?.payload.metadata?.taskOrigin).toBe('bullpen');
+  });
+
+  it('marks mentioned agents with mentioned: true in metadata', async () => {
+    const { thread } = await bullpenService.openThread(
+      'Mention test', 'coordinator', ['coordinator', 'agent-b', 'agent-c'], 'Hi', ['agent-b'],
+    );
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-1', topic: 'Mention test',
+      senderAgentId: 'coordinator', participants: ['coordinator', 'agent-b', 'agent-c'],
+      mentionedAgentIds: ['agent-b'], content: 'Hi', parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    const tasks = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([_l, e]) => (e as { type: string }).type === 'agent.task')
+      .map(([_l, e]) => e as { payload: { agentId: string; metadata: Record<string, unknown> } });
+    const bTask = tasks.find(t => t.payload.agentId === 'agent-b');
+    const cTask = tasks.find(t => t.payload.agentId === 'agent-c');
+    expect(bTask?.payload.metadata?.mentioned).toBe(true);
+    expect(cTask?.payload.metadata?.mentioned).toBe(false);
+  });
+
+  it('skips task creation when thread message_count >= 100', async () => {
+    const { thread } = await bullpenService.openThread(
+      'Cap test', 'coordinator', ['coordinator', 'agent-b'], 'Start', [],
+    );
+    // Manually inflate the count to simulate a capped thread
+    // Use the InMemory backend — need to post 99 more messages
+    for (let i = 0; i < 99; i++) {
+      await bullpenService.postMessage(thread.id, 'coordinator', `Msg ${i}`, []);
+    }
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-cap', topic: 'Cap test',
+      senderAgentId: 'coordinator', participants: ['coordinator', 'agent-b'],
+      mentionedAgentIds: ['agent-b'], content: 'Over cap', parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    // No tasks should be created (thread is at 100)
+    const tasks = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([_l, e]) => (e as { type: string }).type === 'agent.task');
+    expect(tasks).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test tests/unit/dispatch/bullpen-dispatcher.test.ts
+```
+
+Expected: FAIL — `BullpenDispatcher` not found.
+
+- [ ] **Step 3: Implement `src/dispatch/bullpen-dispatcher.ts`**
+
+```typescript
+import type { EventBus } from '../bus/bus.js';
+import type { AgentDiscussEvent } from '../bus/events.js';
+import { createAgentTask } from '../bus/events.js';
+import type { Logger } from '../logger.js';
+import type { BullpenService } from '../memory/bullpen.js';
+
+export class BullpenDispatcher {
+  constructor(
+    private bus: EventBus,
+    private logger: Logger,
+    private bullpenService: BullpenService,
+  ) {}
+
+  register(): void {
+    this.bus.subscribe('agent.discuss', 'dispatch', async (event) => {
+      await this.handleDiscuss(event as AgentDiscussEvent);
+    });
+    this.logger.info('BullpenDispatcher registered');
+  }
+
+  private async handleDiscuss(event: AgentDiscussEvent): Promise<void> {
+    const { threadId, topic, senderAgentId, participants, mentionedAgentIds } = event.payload;
+
+    // Cap check: defense-in-depth — the skill already enforces this, but check
+    // here too so a future code path cannot accidentally bypass the skill.
+    try {
+      const thread = await this.bullpenService.getThread(threadId);
+      if (!thread) {
+        this.logger.warn({ threadId }, 'BullpenDispatcher: thread not found for agent.discuss event — skipping');
+        return;
+      }
+      if (thread.thread.messageCount >= 100) {
+        this.logger.warn(
+          { threadId, messageCount: thread.thread.messageCount },
+          'BullpenDispatcher: thread has hit message cap (100) — skipping task creation',
+        );
+        return;
+      }
+    } catch (err) {
+      this.logger.error({ err, threadId }, 'BullpenDispatcher: failed to check thread cap — skipping');
+      return;
+    }
+
+    // Create one agent.task per participant, excluding the sender.
+    // Mentioned agents get a reply-expected prompt; others get an FYI.
+    const otherParticipants = participants.filter((id) => id !== senderAgentId);
+
+    for (const agentId of otherParticipants) {
+      const isMentioned = mentionedAgentIds.includes(agentId);
+      const content = isMentioned
+        ? `You've been mentioned in Bullpen thread "${topic}" (thread_id: ${threadId}) by ${senderAgentId}. Review the injected thread context and reply using the bullpen skill.`
+        : `FYI: New activity in Bullpen thread "${topic}" (thread_id: ${threadId}) from ${senderAgentId}. No response required, but reply if you have something to add.`;
+
+      try {
+        const task = createAgentTask({
+          agentId,
+          // threadId as conversationId scopes working memory to this thread,
+          // so agents accumulate context across multiple activations in the same discussion.
+          conversationId: threadId,
+          channelId: 'bullpen',
+          senderId: senderAgentId,
+          content,
+          metadata: {
+            taskOrigin: 'bullpen',
+            threadId,
+            mentioned: isMentioned,
+          },
+          parentEventId: event.id,
+        });
+        await this.bus.publish('dispatch', task);
+        this.logger.debug(
+          { agentId, threadId, mentioned: isMentioned },
+          'BullpenDispatcher: created agent.task for participant',
+        );
+      } catch (err) {
+        this.logger.error(
+          { err, agentId, threadId },
+          'BullpenDispatcher: failed to publish agent.task for participant',
+        );
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Downgrade the "no routing info" log in `src/dispatch/dispatcher.ts`**
+
+Find the `handleAgentResponse` method (around line 303). Locate the warning:
+
+```typescript
+      this.logger.warn(
+        { parentEventId: event.parentEventId },
+        'No routing info for agent response — cannot deliver',
+      );
+```
+
+Replace with:
+
+```typescript
+      // Bullpen-originated tasks (channelId: 'bullpen') produce agent.response events
+      // that have no routing entry here — the agent's output goes back to the thread
+      // via the bullpen skill, not through the channel layer. This is expected.
+      this.logger.debug(
+        { parentEventId: event.parentEventId },
+        'No routing info for agent response — expected for bullpen tasks, ignored',
+      );
+```
+
+- [ ] **Step 5: Run the dispatcher unit tests**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test tests/unit/dispatch/bullpen-dispatcher.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/dispatch/bullpen-dispatcher.ts tests/unit/dispatch/bullpen-dispatcher.test.ts src/dispatch/dispatcher.ts
+git commit -m "feat: add BullpenDispatcher and downgrade routing warn for bullpen tasks"
+```
+
+---
+
+## Task 8: Runtime Context Injection
+
+**Files:**
+- Modify: `src/agents/runtime.ts`
+
+- [ ] **Step 1: Add `bullpenService` and `bullpenWindowMinutes` to `AgentConfig`**
+
+In `src/agents/runtime.ts`, add to the `AgentConfig` interface after the `officeIdentityService?` field:
+
+```typescript
+  /** Optional Bullpen service for pending thread context injection.
+   *  When provided, pending threads are injected as a system message before every LLM call. */
+  bullpenService?: import('../memory/bullpen.js').BullpenService;
+  /** How far back to look for active threads, in minutes. Default: 60. */
+  bullpenWindowMinutes?: number;
+```
+
+- [ ] **Step 2: Inject pending threads in `processTask`**
+
+Add the import at the top of `src/agents/runtime.ts`:
+
+```typescript
+import { formatBullpenContext } from '../memory/bullpen.js';
+```
+
+In `processTask`, after the block that inserts sender context (around line 256, after the `messages.splice(1, 0, { role: 'system', content: senderInfo })` block), add:
+
+```typescript
+    // Inject pending Bullpen threads as a system message so the agent is aware
+    // of active inter-agent discussions. Inserted after sender context (if any),
+    // before conversation history — matching spec context budget priority order.
+    if (this.config.bullpenService) {
+      try {
+        const pendingThreads = await this.config.bullpenService.getPendingThreadsForAgent(
+          agentId,
+          this.config.bullpenWindowMinutes ?? 60,
+        );
+        if (pendingThreads.length > 0) {
+          const bullpenBlock = formatBullpenContext(pendingThreads);
+          // Insert at position 1 (after main system prompt) so it precedes
+          // conversation history but doesn't displace the system prompt itself.
+          messages.splice(1, 0, { role: 'system', content: bullpenBlock });
+        }
+      } catch (err) {
+        // A Bullpen lookup failure must not abort the task. Log and continue —
+        // the agent will proceed without thread context rather than failing entirely.
+        logger.error({ err, agentId }, 'Failed to load Bullpen pending threads — proceeding without thread context');
+      }
+    }
+```
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/agents/runtime.ts
+git commit -m "feat: inject pending Bullpen threads into agent task context"
+```
+
+---
+
+## Task 9: SSE Observability
+
+**Files:**
+- Modify: `src/channels/http/event-router.ts`
+
+- [ ] **Step 1: Add the `agent.discuss` subscription**
+
+In `src/channels/http/event-router.ts`, at the end of `setupSubscriptions`, after the `message.rejected` subscription block (around line 179), add:
+
+```typescript
+    // agent.discuss — broadcast Bullpen activity to all SSE clients for dashboard observability.
+    // Uses 'system' layer (same privilege as skill.invoke/skill.result) so the HTTP channel
+    // can observe agent-layer events without publishing them.
+    bus.subscribe('agent.discuss', 'system', (event: BusEvent) => {
+      if (event.type !== 'agent.discuss') return;
+      const sseData = JSON.stringify({
+        type: 'agent.discuss',
+        thread_id: event.payload.threadId,
+        topic: event.payload.topic,
+        sender_agent_id: event.payload.senderAgentId,
+        mentioned_agent_ids: event.payload.mentionedAgentIds,
+        participants: event.payload.participants,
+        timestamp: event.timestamp,
+      });
+      // System-wide broadcast — not filtered by conversationId
+      this.broadcastToSseClients(sseData);
+    });
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/channels/http/event-router.ts
+git commit -m "feat: stream agent.discuss events to SSE clients"
+```
+
+---
+
+## Task 10: Bootstrap Wiring
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Import BullpenService and BullpenDispatcher**
+
+Add imports near the other memory/dispatch imports at the top of `src/index.ts`:
+
+```typescript
+import { BullpenService } from './memory/bullpen.js';
+import { BullpenDispatcher } from './dispatch/bullpen-dispatcher.js';
+```
+
+- [ ] **Step 2: Instantiate BullpenService after the DB connection is confirmed**
+
+After the `EntityMemory` initialization block (around line 162), add:
+
+```typescript
+  // Bullpen service — Tier 2 inter-agent discussion. Always initialized (no
+  // external API key required — just Postgres, which is already confirmed).
+  const bullpenService = BullpenService.createWithPostgres(pool, logger);
+  logger.info('Bullpen service initialized');
+```
+
+- [ ] **Step 3: Thread `bullpenService` into ExecutionLayer**
+
+Find the `ExecutionLayer` constructor call (around line 468). Add `bullpenService` to the options object:
+
+```typescript
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, {
+    bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService,
+    entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler,
+    agentContactId: agentIdentityContactId, autonomyService, browserService,
+    timezone: config.timezone,
+    bullpenService,          // ← add this
+  });
+```
+
+- [ ] **Step 4: Thread `bullpenService` into each `AgentRuntime`**
+
+Find the `new AgentRuntime({...})` constructor call (around line 519). Add after the `errorBudget` field:
+
+```typescript
+      // All agents get Bullpen context injection — pending threads appear in task context
+      // so agents are aware of inter-agent discussions they should participate in.
+      bullpenService,
+      bullpenWindowMinutes: 60,
+```
+
+- [ ] **Step 5: Register the BullpenDispatcher**
+
+After `dispatcher.register()` (around line 582), add:
+
+```typescript
+  // BullpenDispatcher — routes agent.discuss → agent.task for inter-agent Bullpen discussions.
+  // Registered after the main Dispatcher (same ordering principle: subscribers exist before events flow).
+  const bullpenDispatcher = new BullpenDispatcher(bus, logger, bullpenService);
+  bullpenDispatcher.register();
+```
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Smoke test (optional — requires a running instance)**
+
+```bash
+cd /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-bullpen
+npm run smoke
+```
+
+Expected: smoke test passes, no startup errors in logs.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: wire BullpenService and BullpenDispatcher into bootstrap"
+```
+
+---
+
+## Task 11: CHANGELOG + Version
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`
+
+- [ ] **Step 1: Update `CHANGELOG.md`**
+
+Under `## [Unreleased]`, add an `Added` section (or append to it if it already exists):
+
+```markdown
+### Added
+- **Bullpen (Tier 2 inter-agent discussion)** — shared threaded workspace where agents can open, reply to, and close discussion threads. Flows through the bus as `agent.discuss` events. BullpenDispatcher routes discuss events to `agent.task` for all thread participants. Pending threads injected into agent context before every LLM call. Visible to dashboards via SSE stream. Implements spec 01 (lines 24–44). Closes #25.
+```
+
+- [ ] **Step 2: Bump version in `package.json`**
+
+This is a new feature — bump the minor version. Change `"version": "0.0.1"` to `"version": "0.1.0"` in `package.json`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md package.json
+git commit -m "chore: bump version and update changelog for Bullpen (closes #25)"
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/bullpen/handler.test.ts
+++ b/skills/bullpen/handler.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BullpenHandler } from './handler.js';
+import { BullpenService } from '../../src/memory/bullpen.js';
+import { createLogger } from '../../src/logger.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  const bullpenService = BullpenService.createInMemory();
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: createLogger('error'),
+    agentId: 'coordinator',
+    taskEventId: 'task-123',
+    bullpenService,
+    // bus is needed to publish agent.discuss — use a spy
+    bus: {
+      publish: vi.fn().mockResolvedValue(undefined),
+      subscribe: vi.fn(),
+    } as unknown as SkillContext['bus'],
+    agentRegistry: { list: vi.fn().mockReturnValue([]) } as unknown as SkillContext['agentRegistry'],
+    ...overrides,
+  } as unknown as SkillContext;
+}
+
+describe('BullpenHandler', () => {
+  let handler: BullpenHandler;
+
+  beforeEach(() => {
+    handler = new BullpenHandler();
+  });
+
+  it('post: opens a thread and publishes agent.discuss', async () => {
+    const ctx = makeCtx({
+      action: 'post',
+      topic: 'Q2 budget',
+      participants: ['coordinator', 'research-agent'],
+      content: 'Can you look into Q2 costs?',
+      mentioned_agent_ids: ['research-agent'],
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(typeof data.thread_id).toBe('string');
+    expect(typeof data.message_id).toBe('string');
+    expect(ctx.bus!.publish).toHaveBeenCalledOnce();
+    const publishCall = (ctx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(publishCall[0]).toBe('agent');
+    expect(publishCall[1].type).toBe('agent.discuss');
+  });
+
+  it('post: defaults mentionedAgentIds to all participants when omitted', async () => {
+    const ctx = makeCtx({
+      action: 'post',
+      topic: 'Broadcast',
+      participants: ['coordinator', 'agent-b', 'agent-c'],
+      content: 'Heads up',
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const publishCall = (ctx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(publishCall[1].payload.mentionedAgentIds).toEqual(['coordinator', 'agent-b', 'agent-c']);
+  });
+
+  it('reply: posts a message to an existing thread', async () => {
+    // First open a thread
+    const openCtx = makeCtx({
+      action: 'post',
+      topic: 'Reply test',
+      participants: ['coordinator', 'agent-b'],
+      content: 'Start',
+      mentioned_agent_ids: ['agent-b'],
+    });
+    const openResult = await handler.execute(openCtx);
+    const threadId = ((openResult as { success: true; data: Record<string, unknown> }).data).thread_id as string;
+
+    // Now reply
+    const replyCtx = makeCtx({
+      action: 'reply',
+      thread_id: threadId,
+      content: 'Here is my reply',
+      mentioned_agent_ids: ['coordinator'],
+    }, { bullpenService: openCtx.bullpenService, bus: openCtx.bus, agentId: 'agent-b' });
+    const replyResult = await handler.execute(replyCtx);
+    expect(replyResult.success).toBe(true);
+    // bus.publish called twice total (open + reply)
+    expect((openCtx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+  });
+
+  it('get_thread: returns full thread without publishing', async () => {
+    const ctx = makeCtx({
+      action: 'post',
+      topic: 'Get test',
+      participants: ['coordinator'],
+      content: 'Only message',
+    });
+    const openResult = await handler.execute(ctx);
+    const threadId = ((openResult as { success: true; data: Record<string, unknown> }).data).thread_id as string;
+
+    const getCtx = makeCtx({ action: 'get_thread', thread_id: threadId }, { bullpenService: ctx.bullpenService, bus: ctx.bus });
+    const result = await handler.execute(getCtx);
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.thread).toBeDefined();
+    expect((data.thread as { topic: string }).topic).toBe('Get test');
+    // No additional publish after the open
+    expect((ctx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+  });
+
+  it('close: closes the thread without publishing', async () => {
+    const ctx = makeCtx({
+      action: 'post',
+      topic: 'Close test',
+      participants: ['coordinator'],
+      content: 'Will close',
+    });
+    const openResult = await handler.execute(ctx);
+    const threadId = ((openResult as { success: true; data: Record<string, unknown> }).data).thread_id as string;
+
+    const closeCtx = makeCtx({ action: 'close', thread_id: threadId }, { bullpenService: ctx.bullpenService, bus: ctx.bus });
+    const closeResult = await handler.execute(closeCtx);
+    expect(closeResult.success).toBe(true);
+    const data = (closeResult as { success: true; data: Record<string, unknown> }).data;
+    expect((data as { status: string }).status).toBe('closed');
+  });
+
+  it('close: returns error when unauthorized agent tries to close', async () => {
+    const ctx = makeCtx({
+      action: 'post',
+      topic: 'Auth test',
+      participants: ['agent-b', 'agent-c'],
+      content: 'Start',
+    }, { agentId: 'agent-b' });
+    const openResult = await handler.execute(ctx);
+    const threadId = ((openResult as { success: true; data: Record<string, unknown> }).data).thread_id as string;
+
+    // agent-c tries to close — not authorized
+    const closeCtx = makeCtx(
+      { action: 'close', thread_id: threadId },
+      { bullpenService: ctx.bullpenService, bus: ctx.bus, agentId: 'agent-c' },
+    );
+    const closeResult = await handler.execute(closeCtx);
+    expect(closeResult.success).toBe(false);
+    expect((closeResult as { success: false; error: string }).error).toMatch(/not authorized/);
+  });
+
+  it('returns error for missing required fields', async () => {
+    const ctx = makeCtx({ action: 'post' }); // missing topic, participants, content
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error for unknown action', async () => {
+    const ctx = makeCtx({ action: 'fly' });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/unknown action/i);
+  });
+});

--- a/skills/bullpen/handler.ts
+++ b/skills/bullpen/handler.ts
@@ -1,0 +1,158 @@
+// handler.ts — bullpen skill implementation.
+//
+// This is an infrastructure skill that allows agents to open, reply to, read,
+// and close inter-agent Bullpen discussion threads. It persists thread state
+// via BullpenService and publishes agent.discuss events so the BullpenDispatcher
+// can route reply tasks to mentioned agents.
+//
+// Actions:
+//   post       — open a new thread with an initial message
+//   reply      — post a follow-up message to an existing thread
+//   get_thread — read the full message history for a thread
+//   close      — close a thread (creator or coordinator only)
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { createAgentDiscuss } from '../../src/bus/events.js';
+
+export class BullpenHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { input } = ctx;
+    const action = input['action'];
+
+    // Guard: infrastructure context must be present
+    if (!ctx.bullpenService) {
+      return { success: false, error: 'BullpenService not available in context' };
+    }
+    if (!ctx.bus) {
+      return { success: false, error: 'Bus not available in context (infrastructure skill requires bus)' };
+    }
+    if (!ctx.agentId) {
+      return { success: false, error: 'agentId not available in context' };
+    }
+    if (!ctx.taskEventId) {
+      return { success: false, error: 'taskEventId not available in context' };
+    }
+
+    try {
+      switch (action) {
+        case 'post': {
+          const topic = input['topic'];
+          const participants = input['participants'];
+          const content = input['content'];
+
+          if (typeof topic !== 'string' || !topic) {
+            return { success: false, error: "Missing required field: 'topic'" };
+          }
+          if (!Array.isArray(participants) || participants.length === 0 || !participants.every(p => typeof p === 'string')) {
+            return { success: false, error: "Missing required field: 'participants' (non-empty string array)" };
+          }
+          if (typeof content !== 'string' || !content) {
+            return { success: false, error: "Missing required field: 'content'" };
+          }
+
+          const rawMentioned = input['mentioned_agent_ids'];
+          // Default: mention all participants when not specified (caller typically wants replies when opening a thread)
+          const mentionedAgentIds: string[] = Array.isArray(rawMentioned) && rawMentioned.every(m => typeof m === 'string')
+            ? rawMentioned as string[]
+            : participants as string[];
+
+          const { thread, message } = await ctx.bullpenService.openThread(
+            topic, ctx.agentId, participants as string[], content, mentionedAgentIds,
+          );
+
+          await ctx.bus.publish('agent', createAgentDiscuss({
+            threadId: thread.id,
+            messageId: message.id,
+            topic: thread.topic,
+            senderAgentId: ctx.agentId,
+            participants: thread.participants,
+            mentionedAgentIds,
+            content,
+            parentEventId: ctx.taskEventId,
+          }));
+
+          return { success: true, data: { thread_id: thread.id, message_id: message.id } };
+        }
+
+        case 'reply': {
+          const threadId = input['thread_id'];
+          const content = input['content'];
+
+          if (typeof threadId !== 'string' || !threadId) {
+            return { success: false, error: "Missing required field: 'thread_id'" };
+          }
+          if (typeof content !== 'string' || !content) {
+            return { success: false, error: "Missing required field: 'content'" };
+          }
+
+          const rawMentioned = input['mentioned_agent_ids'];
+          // Default: empty (broadcast reply — no specific response expected)
+          const mentionedAgentIds: string[] = Array.isArray(rawMentioned) && rawMentioned.every(m => typeof m === 'string')
+            ? rawMentioned as string[]
+            : [];
+
+          // Fetch thread before posting to get participants for the event payload.
+          // postMessage will also validate the thread exists, but we need participants here.
+          const existing = await ctx.bullpenService.getThread(threadId);
+          if (!existing) return { success: false, error: `Thread ${threadId} not found` };
+
+          const message = await ctx.bullpenService.postMessage(threadId, ctx.agentId, content, mentionedAgentIds);
+
+          await ctx.bus.publish('agent', createAgentDiscuss({
+            threadId,
+            messageId: message.id,
+            topic: existing.thread.topic,
+            senderAgentId: ctx.agentId,
+            participants: existing.thread.participants,
+            mentionedAgentIds,
+            content,
+            parentEventId: ctx.taskEventId,
+          }));
+
+          return { success: true, data: { thread_id: threadId, message_id: message.id } };
+        }
+
+        case 'get_thread': {
+          const threadId = input['thread_id'];
+
+          if (typeof threadId !== 'string' || !threadId) {
+            return { success: false, error: "Missing required field: 'thread_id'" };
+          }
+
+          const result = await ctx.bullpenService.getThread(threadId);
+          if (!result) {
+            return { success: false, error: `Thread ${threadId} not found` };
+          }
+
+          // Return the BullpenThread under 'thread' and messages array separately.
+          // Together they represent the "full thread + messages" output.
+          return { success: true, data: { thread_id: threadId, thread: result.thread, messages: result.messages } };
+        }
+
+        case 'close': {
+          const threadId = input['thread_id'];
+
+          if (typeof threadId !== 'string' || !threadId) {
+            return { success: false, error: "Missing required field: 'thread_id'" };
+          }
+
+          // closeThread throws if the requesting agent is not the creator or coordinator
+          await ctx.bullpenService.closeThread(threadId, ctx.agentId);
+          return { success: true, data: { thread_id: threadId, status: 'closed' } };
+        }
+
+        default:
+          return {
+            success: false,
+            error: `Unknown action: '${String(action)}'. Valid actions: post, reply, get_thread, close`,
+          };
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, action, agentId: ctx.agentId }, 'Bullpen skill error');
+      return { success: false, error: message };
+    }
+  }
+}
+
+export default new BullpenHandler();

--- a/skills/bullpen/handler.ts
+++ b/skills/bullpen/handler.ts
@@ -60,16 +60,25 @@ export class BullpenHandler implements SkillHandler {
             topic, ctx.agentId, participants as string[], content, mentionedAgentIds,
           );
 
-          await ctx.bus.publish('agent', createAgentDiscuss({
-            threadId: thread.id,
-            messageId: message.id,
-            topic: thread.topic,
-            senderAgentId: ctx.agentId,
-            participants: thread.participants,
-            mentionedAgentIds,
-            content,
-            parentEventId: ctx.taskEventId,
-          }));
+          // Publish is best-effort — thread is already persisted. If publish fails,
+          // agents will still see the thread via pending-thread context injection.
+          try {
+            await ctx.bus.publish('agent', createAgentDiscuss({
+              threadId: thread.id,
+              messageId: message.id,
+              topic: thread.topic,
+              senderAgentId: ctx.agentId,
+              participants: thread.participants,
+              mentionedAgentIds,
+              content,
+              parentEventId: ctx.taskEventId,
+            }));
+          } catch (publishErr) {
+            ctx.log.error(
+              { err: publishErr, threadId: thread.id },
+              'Bullpen: thread created but discuss event publish failed — agents will see it on next poll',
+            );
+          }
 
           return { success: true, data: { thread_id: thread.id, message_id: message.id } };
         }
@@ -98,16 +107,25 @@ export class BullpenHandler implements SkillHandler {
 
           const message = await ctx.bullpenService.postMessage(threadId, ctx.agentId, content, mentionedAgentIds);
 
-          await ctx.bus.publish('agent', createAgentDiscuss({
-            threadId,
-            messageId: message.id,
-            topic: existing.thread.topic,
-            senderAgentId: ctx.agentId,
-            participants: existing.thread.participants,
-            mentionedAgentIds,
-            content,
-            parentEventId: ctx.taskEventId,
-          }));
+          // Publish is best-effort — reply is already persisted. If publish fails,
+          // agents will still see the message via pending-thread context injection.
+          try {
+            await ctx.bus.publish('agent', createAgentDiscuss({
+              threadId,
+              messageId: message.id,
+              topic: existing.thread.topic,
+              senderAgentId: ctx.agentId,
+              participants: existing.thread.participants,
+              mentionedAgentIds,
+              content,
+              parentEventId: ctx.taskEventId,
+            }));
+          } catch (publishErr) {
+            ctx.log.error(
+              { err: publishErr, threadId },
+              'Bullpen: reply posted but discuss event publish failed — agents will see it on next poll',
+            );
+          }
 
           return { success: true, data: { thread_id: threadId, message_id: message.id } };
         }

--- a/skills/bullpen/handler.ts
+++ b/skills/bullpen/handler.ts
@@ -50,14 +50,21 @@ export class BullpenHandler implements SkillHandler {
             return { success: false, error: "Missing required field: 'content'" };
           }
 
+          // Trim and reject blank/whitespace-only participant IDs
+          const cleanParticipants = (participants as string[]).map(p => p.trim()).filter(p => p.length > 0);
+          if (cleanParticipants.length === 0) {
+            return { success: false, error: "Field 'participants' must contain at least one non-empty agent ID" };
+          }
+
           const rawMentioned = input['mentioned_agent_ids'];
-          // Default: mention all participants when not specified (caller typically wants replies when opening a thread)
+          // Trim/filter mentions, then constrain to thread participants to prevent out-of-thread fan-out.
+          // Default: mention all participants when not specified (caller wants replies when opening a thread).
           const mentionedAgentIds: string[] = Array.isArray(rawMentioned) && rawMentioned.every(m => typeof m === 'string')
-            ? rawMentioned as string[]
-            : participants as string[];
+            ? (rawMentioned as string[]).map(m => m.trim()).filter(m => m.length > 0 && cleanParticipants.includes(m))
+            : cleanParticipants;
 
           const { thread, message } = await ctx.bullpenService.openThread(
-            topic, ctx.agentId, participants as string[], content, mentionedAgentIds,
+            topic, ctx.agentId, cleanParticipants, content, mentionedAgentIds,
           );
 
           // Publish is best-effort — thread is already persisted. If publish fails,
@@ -94,16 +101,18 @@ export class BullpenHandler implements SkillHandler {
             return { success: false, error: "Missing required field: 'content'" };
           }
 
-          const rawMentioned = input['mentioned_agent_ids'];
-          // Default: empty (broadcast reply — no specific response expected)
-          const mentionedAgentIds: string[] = Array.isArray(rawMentioned) && rawMentioned.every(m => typeof m === 'string')
-            ? rawMentioned as string[]
-            : [];
-
-          // Fetch thread before posting to get participants for the event payload.
-          // postMessage will also validate the thread exists, but we need participants here.
+          // Fetch thread before posting to get participants for the event payload and to
+          // constrain mentions to actual thread members. postMessage validates the thread too,
+          // but we need participants here for mention filtering.
           const existing = await ctx.bullpenService.getThread(threadId);
           if (!existing) return { success: false, error: `Thread ${threadId} not found` };
+
+          const rawMentioned = input['mentioned_agent_ids'];
+          // Trim/filter mentions, then constrain to actual thread participants to prevent out-of-thread fan-out.
+          // Default: empty (broadcast reply — no specific response expected).
+          const mentionedAgentIds: string[] = Array.isArray(rawMentioned) && rawMentioned.every(m => typeof m === 'string')
+            ? (rawMentioned as string[]).map(m => m.trim()).filter(m => m.length > 0 && existing.thread.participants.includes(m))
+            : [];
 
           const message = await ctx.bullpenService.postMessage(threadId, ctx.agentId, content, mentionedAgentIds);
 

--- a/skills/bullpen/skill.json
+++ b/skills/bullpen/skill.json
@@ -1,0 +1,25 @@
+{
+  "name": "bullpen",
+  "description": "Open, reply to, read, or close inter-agent Bullpen discussion threads. Use 'post' to start a new thread addressed to other agents, 'reply' to add a message to an existing thread, 'get_thread' to read the full message history, and 'close' to end a thread when the discussion is complete.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "infrastructure": true,
+  "inputs": {
+    "action": "string: 'post' | 'reply' | 'get_thread' | 'close'",
+    "topic": "string: thread topic — required for 'post'",
+    "participants": "string[]: agent IDs to include in the thread — required for 'post'",
+    "mentioned_agent_ids": "string[]: agent IDs to @ mention (optional for 'post' and 'reply'; defaults to all participants for 'post')",
+    "content": "string: message content — required for 'post' and 'reply'",
+    "thread_id": "string: thread ID — required for 'reply', 'get_thread', 'close'"
+  },
+  "outputs": {
+    "thread_id": "string: the thread ID",
+    "message_id": "string: the persisted message ID (post/reply)",
+    "thread": "object: full thread + messages (get_thread)",
+    "status": "string: 'closed' (close)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000
+}

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -13,6 +13,7 @@ import { DEFAULT_ERROR_BUDGET, type AgentError, type ErrorBudget } from '../erro
 import { AutonomyService } from '../autonomy/autonomy-service.js';
 import { formatTimeContextBlock } from '../time/time-context.js';
 import type { OfficeIdentityService } from '../identity/service.js';
+import { formatBullpenContext } from '../memory/bullpen.js';
 
 export interface AgentConfig {
   agentId: string;
@@ -49,6 +50,11 @@ export interface AgentConfig {
     maxTurns: number;
     maxConsecutiveErrors: number;
   };
+  /** Optional Bullpen service for pending thread context injection.
+   *  When provided, pending threads are injected as a system message before every LLM call. */
+  bullpenService?: import('../memory/bullpen.js').BullpenService;
+  /** How far back to look for active threads, in minutes. Default: 60. */
+  bullpenWindowMinutes?: number;
 }
 
 // LLM retry backoff schedule (milliseconds). Three attempts with exponential backoff.
@@ -254,6 +260,28 @@ export class AgentRuntime {
 
       // Insert after system prompt (index 0) but before history
       messages.splice(1, 0, { role: 'system', content: senderInfo });
+    }
+
+    // Inject pending Bullpen threads as a system message so the agent is aware
+    // of active inter-agent discussions. Inserted after sender context (if any),
+    // before conversation history — matching spec context budget priority order.
+    if (this.config.bullpenService) {
+      try {
+        const pendingThreads = await this.config.bullpenService.getPendingThreadsForAgent(
+          agentId,
+          this.config.bullpenWindowMinutes ?? 60,
+        );
+        if (pendingThreads.length > 0) {
+          const bullpenBlock = formatBullpenContext(pendingThreads);
+          // Insert at position 1 (after main system prompt) so it precedes
+          // conversation history but doesn't displace the system prompt itself.
+          messages.splice(1, 0, { role: 'system', content: bullpenBlock });
+        }
+      } catch (err) {
+        // A Bullpen lookup failure must not abort the task. Log and continue —
+        // the agent will proceed without thread context rather than failing entirely.
+        logger.error({ err, agentId }, 'Failed to load Bullpen pending threads — proceeding without thread context');
+      }
     }
 
     logger.info({ agentId, conversationId, historyLength: history.length }, 'Agent processing task');

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -13,7 +13,7 @@ import { DEFAULT_ERROR_BUDGET, type AgentError, type ErrorBudget } from '../erro
 import { AutonomyService } from '../autonomy/autonomy-service.js';
 import { formatTimeContextBlock } from '../time/time-context.js';
 import type { OfficeIdentityService } from '../identity/service.js';
-import { formatBullpenContext } from '../memory/bullpen.js';
+import { formatBullpenContext, type BullpenService } from '../memory/bullpen.js';
 
 export interface AgentConfig {
   agentId: string;
@@ -52,7 +52,7 @@ export interface AgentConfig {
   };
   /** Optional Bullpen service for pending thread context injection.
    *  When provided, pending threads are injected as a system message before every LLM call. */
-  bullpenService?: import('../memory/bullpen.js').BullpenService;
+  bullpenService?: BullpenService;
   /** How far back to look for active threads, in minutes. Default: 60. */
   bullpenWindowMinutes?: number;
 }
@@ -210,6 +210,10 @@ export class AgentRuntime {
       { role: 'user', content },
     ];
 
+    // Track insertion position for Bullpen context — it must follow sender context (if any)
+    // so the agent reads: system prompt → who is talking → what's pending in Bullpen → history.
+    let bullpenInsertAt = 1;
+
     // Inject resolved sender context as a system message so the coordinator
     // knows who it's talking to. Inserted after the system prompt but before
     // history, so it's visible but doesn't pollute working memory.
@@ -260,6 +264,8 @@ export class AgentRuntime {
 
       // Insert after system prompt (index 0) but before history
       messages.splice(1, 0, { role: 'system', content: senderInfo });
+      // Bullpen block must come after sender context, so advance its insertion index
+      bullpenInsertAt = 2;
     }
 
     // Inject pending Bullpen threads as a system message so the agent is aware
@@ -273,9 +279,9 @@ export class AgentRuntime {
         );
         if (pendingThreads.length > 0) {
           const bullpenBlock = formatBullpenContext(pendingThreads);
-          // Insert at position 1 (after main system prompt) so it precedes
-          // conversation history but doesn't displace the system prompt itself.
-          messages.splice(1, 0, { role: 'system', content: bullpenBlock });
+          // Insert after sender context (if present) but before conversation history.
+          // bullpenInsertAt is 2 when sender context was injected, 1 otherwise.
+          messages.splice(bullpenInsertAt, 0, { role: 'system', content: bullpenBlock });
         }
       } catch (err) {
         // A Bullpen lookup failure must not abort the task. Log and continue —

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -331,7 +331,10 @@ export class AgentRuntime {
         await bus.publish('agent', invokeEvent);
 
         const startTime = Date.now();
-        const result = await executionLayer.invoke(toolCall.name, toolCall.input, caller);
+        const result = await executionLayer.invoke(toolCall.name, toolCall.input, caller, {
+          taskEventId: taskEvent.id,
+          agentId,
+        });
         const durationMs = Date.now() - startTime;
 
         // Publish skill.result for audit trail

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -90,6 +90,19 @@ interface AgentErrorPayload {
   context: Record<string, unknown>;
 }
 
+// AgentDiscussPayload — emitted by the agent layer when a Bullpen message is posted.
+// `participants` is the full thread membership; `mentionedAgentIds` is the subset
+// that BullpenDispatcher will create tasks for (may be empty for broadcast messages).
+interface AgentDiscussPayload {
+  threadId: string;
+  messageId: string;           // DB row ID — for audit traceability
+  topic: string;               // denormalized for SSE display without a DB hit
+  senderAgentId: string;
+  participants: string[];      // all thread participants
+  mentionedAgentIds: string[]; // subset that get reply-expected tasks (empty = broadcast)
+  content: string;
+}
+
 // Contact event payloads — emitted by the dispatch layer during contact resolution (Contacts Phase A).
 
 interface ContactResolvedPayload {
@@ -216,18 +229,6 @@ interface ConfigChangePayload {
   diff_summary: string;         // human-readable summary of what changed
 }
 
-// AgentDiscussPayload — emitted by the agent layer when a Bullpen message is posted.
-// `participants` is the full thread membership; `mentionedAgentIds` is the subset
-// that BullpenDispatcher will create tasks for (may be empty for broadcast messages).
-interface AgentDiscussPayload {
-  threadId: string;
-  messageId: string;           // DB row ID — for audit traceability
-  topic: string;               // denormalized for SSE display without a DB hit
-  senderAgentId: string;
-  participants: string[];      // all thread participants
-  mentionedAgentIds: string[]; // subset that get reply-expected tasks (empty = broadcast)
-  content: string;
-}
 
 // -- Discriminated union --
 // The `type` field is the discriminant; `sourceLayer` records which layer emitted the event.
@@ -286,6 +287,12 @@ export interface AgentErrorEvent extends BaseEvent {
   payload: AgentErrorPayload;
 }
 
+export interface AgentDiscussEvent extends BaseEvent {
+  type: 'agent.discuss';
+  sourceLayer: 'agent';
+  payload: AgentDiscussPayload;
+}
+
 // Contact events — emitted by the dispatch layer during the contact resolution step.
 // contact.resolved fires when a sender maps to a known contact; contact.unknown fires when no match is found.
 
@@ -325,11 +332,6 @@ export interface MessageRejectedEvent extends BaseEvent {
   payload: MessageRejectedPayload;
 }
 
-export interface AgentDiscussEvent extends BaseEvent {
-  type: 'agent.discuss';
-  sourceLayer: 'agent';
-  payload: AgentDiscussPayload;
-}
 
 // Memory events — emitted by the agent layer whenever the knowledge graph is written to or queried.
 // These form the audit trail for memory operations (Phase 6).
@@ -384,6 +386,7 @@ export type BusEvent =
   | SkillInvokeEvent
   | SkillResultEvent
   | AgentErrorEvent          // Error recovery: structured error events for audit and user notification
+  | AgentDiscussEvent        // Bullpen: inter-agent discussion message
   | MemoryStoreEvent      // Phase 6: knowledge graph write audit
   | MemoryQueryEvent      // Phase 6: knowledge graph read audit
   | ContactResolvedEvent  // Contacts Phase A: sender matched to a known contact
@@ -397,8 +400,7 @@ export type BusEvent =
   | ScheduleFiredEvent     // Scheduler: job fired
   | ScheduleSuspendedEvent   // Scheduler: job auto-suspended
   | ScheduleRecoveredEvent   // Scheduler: stuck job auto-recovered
-  | ConfigChangeEvent        // System: config object changed (office identity, etc.)
-  | AgentDiscussEvent;       // Bullpen: inter-agent discussion message
+  | ConfigChangeEvent;       // System: config object changed (office identity, etc.)
 
 // Convenience alias for use in handler maps / switch statements.
 export type EventType = BusEvent['type'];
@@ -519,6 +521,21 @@ export function createAgentError(
     id: randomUUID(),
     timestamp: new Date(),
     type: 'agent.error',
+    sourceLayer: 'agent',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createAgentDiscuss(
+  // parentEventId is required — every discuss event must trace back to the agent.task that triggered it.
+  payload: AgentDiscussPayload & { parentEventId: string },
+): AgentDiscussEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'agent.discuss',
     sourceLayer: 'agent',
     payload: rest,
     parentEventId,
@@ -708,21 +725,6 @@ export function createConfigChange(
     timestamp: new Date(),
     type: 'config.change',
     sourceLayer: 'system',
-    payload: rest,
-    parentEventId,
-  };
-}
-
-export function createAgentDiscuss(
-  // parentEventId is required — every discuss event must trace back to the agent.task that triggered it.
-  payload: AgentDiscussPayload & { parentEventId: string },
-): AgentDiscussEvent {
-  const { parentEventId, ...rest } = payload;
-  return {
-    id: randomUUID(),
-    timestamp: new Date(),
-    type: 'agent.discuss',
-    sourceLayer: 'agent',
     payload: rest,
     parentEventId,
   };

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -216,6 +216,19 @@ interface ConfigChangePayload {
   diff_summary: string;         // human-readable summary of what changed
 }
 
+// AgentDiscussPayload — emitted by the agent layer when a Bullpen message is posted.
+// `participants` is the full thread membership; `mentionedAgentIds` is the subset
+// that BullpenDispatcher will create tasks for (may be empty for broadcast messages).
+interface AgentDiscussPayload {
+  threadId: string;
+  messageId: string;           // DB row ID — for audit traceability
+  topic: string;               // denormalized for SSE display without a DB hit
+  senderAgentId: string;
+  participants: string[];      // all thread participants
+  mentionedAgentIds: string[]; // subset that get reply-expected tasks (empty = broadcast)
+  content: string;
+}
+
 // -- Discriminated union --
 // The `type` field is the discriminant; `sourceLayer` records which layer emitted the event.
 
@@ -312,6 +325,12 @@ export interface MessageRejectedEvent extends BaseEvent {
   payload: MessageRejectedPayload;
 }
 
+export interface AgentDiscussEvent extends BaseEvent {
+  type: 'agent.discuss';
+  sourceLayer: 'agent';
+  payload: AgentDiscussPayload;
+}
+
 // Memory events — emitted by the agent layer whenever the knowledge graph is written to or queried.
 // These form the audit trail for memory operations (Phase 6).
 
@@ -378,7 +397,8 @@ export type BusEvent =
   | ScheduleFiredEvent     // Scheduler: job fired
   | ScheduleSuspendedEvent   // Scheduler: job auto-suspended
   | ScheduleRecoveredEvent   // Scheduler: stuck job auto-recovered
-  | ConfigChangeEvent;      // System: config object changed (office identity, etc.)
+  | ConfigChangeEvent        // System: config object changed (office identity, etc.)
+  | AgentDiscussEvent;       // Bullpen: inter-agent discussion message
 
 // Convenience alias for use in handler maps / switch statements.
 export type EventType = BusEvent['type'];
@@ -688,6 +708,21 @@ export function createConfigChange(
     timestamp: new Date(),
     type: 'config.change',
     sourceLayer: 'system',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createAgentDiscuss(
+  // parentEventId is required — every discuss event must trace back to the agent.task that triggered it.
+  payload: AgentDiscussPayload & { parentEventId: string },
+): AgentDiscussEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'agent.discuss',
+    sourceLayer: 'agent',
     payload: rest,
     parentEventId,
   };

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -9,20 +9,22 @@ import type { Layer, EventType } from './events.js';
 //                 system layer gets full access for audit logging and monitoring.
 // Contact Merge: dispatch layer publishes contact.duplicate_detected and contact.merged — these
 //                fire as background side-effects of createContact() when DedupService is wired.
+// Bullpen: agent layer publishes agent.discuss; dispatch and system layers subscribe.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message']),
   dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged']),
-  agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query']),
+  agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss']),
   execution: new Set(['skill.result']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'config.change', 'contact.duplicate_detected', 'contact.merged']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss']),
 };
 
+// agent.discuss subscribe for 'dispatch': used by BullpenDispatcher (wired in index.ts after agent registration).
 const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['outbound.message', 'outbound.blocked', 'message.held', 'message.rejected']),
-  dispatch: new Set(['inbound.message', 'agent.response', 'agent.error']),
+  dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'config.change', 'contact.duplicate_detected', 'contact.merged']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -252,12 +252,12 @@ export class EventRouter {
       if (!shouldSend) continue;
       try {
         client.res.write(`data: ${sseData}\n\n`);
-      } catch {
+      } catch (err) {
         // Client connection is dead — remove it. The 'close' event handler
         // will also fire eventually, but cleaning up here prevents repeated
         // failed writes for subsequent events in this tick.
         this.sseClients.delete(client);
-        this.logger.debug({ conversationId: client.conversationId }, 'Removed dead SSE client');
+        this.logger.debug({ err, conversationId: client.conversationId }, 'Removed dead SSE client');
       }
     }
   }

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -178,6 +178,25 @@ export class EventRouter {
       this.broadcastToSseClients(sseData, convId);
     });
 
+    // agent.discuss — broadcast Bullpen activity to all SSE clients for dashboard observability.
+    // Uses 'system' layer (same privilege as skill.invoke/skill.result) so the HTTP channel
+    // can observe agent-layer events without publishing them.
+    bus.subscribe('agent.discuss', 'system', (event: BusEvent) => {
+      if (event.type !== 'agent.discuss') return;
+      const sseData = JSON.stringify({
+        type: 'agent.discuss',
+        thread_id: event.payload.threadId,
+        topic: event.payload.topic,
+        sender_agent_id: event.payload.senderAgentId,
+        mentioned_agent_ids: event.payload.mentionedAgentIds,
+        participants: event.payload.participants,
+        timestamp: event.timestamp,
+      });
+      // System-wide broadcast — not filtered by conversationId
+      this.broadcastToSseClients(sseData);
+    });
+
+
     this.logger.info('HTTP event router subscriptions registered');
   }
 

--- a/src/db/migrations/015_create_bullpen.sql
+++ b/src/db/migrations/015_create_bullpen.sql
@@ -6,14 +6,14 @@ CREATE TABLE bullpen_threads (
   creator_agent_id  TEXT        NOT NULL,
   participants      TEXT[]      NOT NULL,
   status            TEXT        NOT NULL DEFAULT 'open',
-  message_count     INT         NOT NULL DEFAULT 0,
+  message_count     INT         NOT NULL DEFAULT 0,       -- maintained atomically by BullpenService (CTE update + INSERT)
   last_message_at   TIMESTAMPTZ,
   created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE TABLE bullpen_messages (
   id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-  thread_id           UUID        NOT NULL REFERENCES bullpen_threads(id),
+  thread_id           UUID        NOT NULL REFERENCES bullpen_threads(id) ON DELETE CASCADE,
   sender_type         TEXT        NOT NULL DEFAULT 'agent',
   sender_id           TEXT        NOT NULL,
   content             JSONB       NOT NULL,
@@ -22,9 +22,9 @@ CREATE TABLE bullpen_messages (
 );
 
 -- Fast participant lookups for context injection
-CREATE INDEX ON bullpen_threads USING GIN (participants);
+CREATE INDEX idx_bullpen_threads_participants ON bullpen_threads USING GIN (participants);
 -- Fast message retrieval per thread
-CREATE INDEX ON bullpen_messages (thread_id, created_at);
+CREATE INDEX idx_bullpen_messages_thread_created ON bullpen_messages (thread_id, created_at);
 
 -- Down Migration
 

--- a/src/db/migrations/015_create_bullpen.sql
+++ b/src/db/migrations/015_create_bullpen.sql
@@ -1,0 +1,32 @@
+-- Up Migration
+
+CREATE TABLE bullpen_threads (
+  id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  topic             TEXT        NOT NULL,
+  creator_agent_id  TEXT        NOT NULL,
+  participants      TEXT[]      NOT NULL,
+  status            TEXT        NOT NULL DEFAULT 'open',
+  message_count     INT         NOT NULL DEFAULT 0,
+  last_message_at   TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE bullpen_messages (
+  id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  thread_id           UUID        NOT NULL REFERENCES bullpen_threads(id),
+  sender_type         TEXT        NOT NULL DEFAULT 'agent',
+  sender_id           TEXT        NOT NULL,
+  content             JSONB       NOT NULL,
+  mentioned_agent_ids TEXT[]      NOT NULL DEFAULT '{}',
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Fast participant lookups for context injection
+CREATE INDEX ON bullpen_threads USING GIN (participants);
+-- Fast message retrieval per thread
+CREATE INDEX ON bullpen_messages (thread_id, created_at);
+
+-- Down Migration
+
+DROP TABLE IF EXISTS bullpen_messages;
+DROP TABLE IF EXISTS bullpen_threads;

--- a/src/dispatch/bullpen-dispatcher.ts
+++ b/src/dispatch/bullpen-dispatcher.ts
@@ -19,27 +19,39 @@ export class BullpenDispatcher {
   }
 
   private async handleDiscuss(event: AgentDiscussEvent): Promise<void> {
-    const { threadId, topic, senderAgentId, participants, mentionedAgentIds } = event.payload;
+    const { threadId, senderAgentId, mentionedAgentIds } = event.payload;
 
-    // Cap check: defense-in-depth — the skill already enforces this, but check
-    // here too so a future code path cannot accidentally bypass the skill.
+    // Load the thread from DB to get authoritative participant list and topic.
+    // This also serves as cap + existence check, and prevents forged event.payload
+    // values (e.g. a rogue agent inflating participants or spoofing topic).
+    let threadRecord: Awaited<ReturnType<BullpenService['getThread']>>;
     try {
-      const thread = await this.bullpenService.getThread(threadId);
-      if (!thread) {
-        this.logger.warn({ threadId }, 'BullpenDispatcher: thread not found for agent.discuss event — skipping');
-        return;
-      }
-      if (thread.thread.messageCount >= 100) {
-        this.logger.warn(
-          { threadId, messageCount: thread.thread.messageCount },
-          'BullpenDispatcher: thread has hit message cap (100) — skipping task creation',
-        );
-        return;
-      }
+      threadRecord = await this.bullpenService.getThread(threadId);
     } catch (err) {
-      this.logger.error({ err, threadId }, 'BullpenDispatcher: failed to check thread cap — skipping');
+      this.logger.error({ err, threadId }, 'BullpenDispatcher: failed to load thread — skipping');
       return;
     }
+
+    if (!threadRecord) {
+      this.logger.warn({ threadId }, 'BullpenDispatcher: thread not found for agent.discuss event — skipping');
+      return;
+    }
+
+    // Validate that the event sender is actually a thread participant.
+    if (!threadRecord.thread.participants.includes(senderAgentId)) {
+      this.logger.warn({ threadId, senderAgentId }, 'BullpenDispatcher: senderAgentId not in thread participants — skipping');
+      return;
+    }
+
+    if (threadRecord.thread.messageCount >= 100) {
+      this.logger.warn(
+        { threadId, messageCount: threadRecord.thread.messageCount },
+        'BullpenDispatcher: thread has hit message cap (100) — skipping task creation',
+      );
+      return;
+    }
+
+    const { topic, participants } = threadRecord.thread;
 
     // Create one agent.task per participant, excluding the sender.
     // Mentioned agents get a reply-expected prompt; others get an FYI.

--- a/src/dispatch/bullpen-dispatcher.ts
+++ b/src/dispatch/bullpen-dispatcher.ts
@@ -45,6 +45,7 @@ export class BullpenDispatcher {
     // Mentioned agents get a reply-expected prompt; others get an FYI.
     const otherParticipants = participants.filter((id) => id !== senderAgentId);
 
+    let dispatched = 0;
     for (const agentId of otherParticipants) {
       const isMentioned = mentionedAgentIds.includes(agentId);
       const content = isMentioned
@@ -68,6 +69,7 @@ export class BullpenDispatcher {
           parentEventId: event.id,
         });
         await this.bus.publish('dispatch', task);
+        dispatched++;
         this.logger.debug(
           { agentId, threadId, mentioned: isMentioned },
           'BullpenDispatcher: created agent.task for participant',
@@ -78,6 +80,14 @@ export class BullpenDispatcher {
           'BullpenDispatcher: failed to publish agent.task for participant',
         );
       }
+    }
+
+    // If every dispatch failed, log an aggregated error — the thread will go unanswered.
+    if (dispatched === 0 && otherParticipants.length > 0) {
+      this.logger.error(
+        { threadId, expected: otherParticipants.length },
+        'BullpenDispatcher: all participant task dispatches failed — thread will receive no replies',
+      );
     }
   }
 }

--- a/src/dispatch/bullpen-dispatcher.ts
+++ b/src/dispatch/bullpen-dispatcher.ts
@@ -1,0 +1,83 @@
+import type { EventBus } from '../bus/bus.js';
+import type { AgentDiscussEvent } from '../bus/events.js';
+import { createAgentTask } from '../bus/events.js';
+import type { Logger } from '../logger.js';
+import type { BullpenService } from '../memory/bullpen.js';
+
+export class BullpenDispatcher {
+  constructor(
+    private bus: EventBus,
+    private logger: Logger,
+    private bullpenService: BullpenService,
+  ) {}
+
+  register(): void {
+    this.bus.subscribe('agent.discuss', 'dispatch', async (event) => {
+      await this.handleDiscuss(event as AgentDiscussEvent);
+    });
+    this.logger.info('BullpenDispatcher registered');
+  }
+
+  private async handleDiscuss(event: AgentDiscussEvent): Promise<void> {
+    const { threadId, topic, senderAgentId, participants, mentionedAgentIds } = event.payload;
+
+    // Cap check: defense-in-depth — the skill already enforces this, but check
+    // here too so a future code path cannot accidentally bypass the skill.
+    try {
+      const thread = await this.bullpenService.getThread(threadId);
+      if (!thread) {
+        this.logger.warn({ threadId }, 'BullpenDispatcher: thread not found for agent.discuss event — skipping');
+        return;
+      }
+      if (thread.thread.messageCount >= 100) {
+        this.logger.warn(
+          { threadId, messageCount: thread.thread.messageCount },
+          'BullpenDispatcher: thread has hit message cap (100) — skipping task creation',
+        );
+        return;
+      }
+    } catch (err) {
+      this.logger.error({ err, threadId }, 'BullpenDispatcher: failed to check thread cap — skipping');
+      return;
+    }
+
+    // Create one agent.task per participant, excluding the sender.
+    // Mentioned agents get a reply-expected prompt; others get an FYI.
+    const otherParticipants = participants.filter((id) => id !== senderAgentId);
+
+    for (const agentId of otherParticipants) {
+      const isMentioned = mentionedAgentIds.includes(agentId);
+      const content = isMentioned
+        ? `You've been mentioned in Bullpen thread "${topic}" (thread_id: ${threadId}) by ${senderAgentId}. Review the injected thread context and reply using the bullpen skill.`
+        : `FYI: New activity in Bullpen thread "${topic}" (thread_id: ${threadId}) from ${senderAgentId}. No response required, but reply if you have something to add.`;
+
+      try {
+        const task = createAgentTask({
+          agentId,
+          // threadId as conversationId scopes working memory to this thread,
+          // so agents accumulate context across multiple activations in the same discussion.
+          conversationId: threadId,
+          channelId: 'bullpen',
+          senderId: senderAgentId,
+          content,
+          metadata: {
+            taskOrigin: 'bullpen',
+            threadId,
+            mentioned: isMentioned,
+          },
+          parentEventId: event.id,
+        });
+        await this.bus.publish('dispatch', task);
+        this.logger.debug(
+          { agentId, threadId, mentioned: isMentioned },
+          'BullpenDispatcher: created agent.task for participant',
+        );
+      } catch (err) {
+        this.logger.error(
+          { err, agentId, threadId },
+          'BullpenDispatcher: failed to publish agent.task for participant',
+        );
+      }
+    }
+  }
+}

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -359,9 +359,12 @@ export class Dispatcher {
       : undefined;
 
     if (!routing) {
-      this.logger.warn(
+      // Expected for bullpen tasks: BullpenDispatcher publishes agent.task events with
+      // channelId "bullpen", which have no routing entry here. Downgraded to debug to
+      // avoid noisy warn logs in normal operation.
+      this.logger.debug(
         { parentEventId: event.parentEventId },
-        'No routing info for agent response — cannot deliver',
+        'No routing info for agent response — expected for bullpen tasks, skipping outbound delivery',
       );
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,8 @@ import { BrowserService } from './browser/browser-service.js';
 import { OfficeIdentityService } from './identity/service.js';
 import type { AgentPersona } from './skills/types.js';
 import type { ConfigChangeEvent } from './bus/events.js';
+import { BullpenService } from './memory/bullpen.js';
+import { BullpenDispatcher } from './dispatch/bullpen-dispatcher.js';
 
 async function main(): Promise<void> {
   // 1. Config & logging — no dependencies, must come first.
@@ -164,6 +166,11 @@ async function main(): Promise<void> {
   } else {
     logger.warn('OPENAI_API_KEY not set — entity memory disabled (knowledge graph unavailable)');
   }
+
+  // Bullpen service — Tier 2 inter-agent discussion. Always initialized (no
+  // external API key required — just Postgres, which is already confirmed above).
+  const bullpenService = BullpenService.createWithPostgres(pool, logger);
+  logger.info('Bullpen service initialized');
 
   // Contact system — provides identity resolution and contact management.
   // Always initialized (contacts work even without entity memory / KG).
@@ -472,7 +479,7 @@ async function main(): Promise<void> {
   // infrastructure skills. outboundGateway gives email skills their send path.
   // entityContextAssembler enables entity_enrichment pre-enrichment and the
   // entity-context skill. agentContactId enables entity_enrichment default='agent'.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, browserService, timezone: config.timezone, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, browserService, bullpenService, timezone: config.timezone, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete
@@ -554,6 +561,8 @@ async function main(): Promise<void> {
         maxTurns: agentConfig.error_budget.max_turns ?? DEFAULT_ERROR_BUDGET.maxTurns,
         maxConsecutiveErrors: agentConfig.error_budget.max_errors ?? DEFAULT_ERROR_BUDGET.maxConsecutiveErrors,
       } : undefined,
+      bullpenService,
+      bullpenWindowMinutes: 60,
     });
     agent.register();
 
@@ -618,6 +627,10 @@ async function main(): Promise<void> {
     injectionScanner,
   });
   dispatcher.register();
+
+  // BullpenDispatcher — routes agent.discuss → agent.task for inter-agent Bullpen discussions.
+  const bullpenDispatcher = new BullpenDispatcher(bus, logger, bullpenService);
+  bullpenDispatcher.register();
 
   // Start the email adapter AFTER the dispatcher is registered so inbound.message
   // events always have a subscriber. Starting before registration would drop emails

--- a/src/memory/bullpen.ts
+++ b/src/memory/bullpen.ts
@@ -221,7 +221,7 @@ class PostgresBullpenBackend implements BullpenBackend {
        FROM bullpen_threads t
        WHERE t.status = 'open'
          AND $1 = ANY(t.participants)
-         AND t.last_message_at > NOW() - ($2 || ' seconds')::INTERVAL
+         AND t.last_message_at > NOW() - ($2::numeric * INTERVAL '1 second')
          AND (
            SELECT sender_id FROM bullpen_messages
            WHERE thread_id = t.id ORDER BY created_at DESC LIMIT 1
@@ -305,6 +305,12 @@ export class BullpenService {
     if (existing.thread.messageCount >= 100) {
       throw new Error(`Thread ${threadId} has reached the message cap (100)`);
     }
+    // NOTE: The cap check above is not atomically enforced at the DB level — it is
+    // checked in application code between getThread() and postMessage(). Under concurrent
+    // load, two agents replying simultaneously could both pass this check and push
+    // message_count slightly past 100. This is accepted: the cap is a soft amplification
+    // control, not a hard data integrity constraint. BullpenDispatcher re-checks the cap
+    // before creating new tasks, so any overshoot self-limits quickly.
     const message: BullpenMessage = {
       id: randomUUID(), threadId, senderType: 'agent',
       senderId: senderAgentId, content, mentionedAgentIds,

--- a/src/memory/bullpen.ts
+++ b/src/memory/bullpen.ts
@@ -135,6 +135,7 @@ class PostgresBullpenBackend implements BullpenBackend {
       );
       await client.query('COMMIT');
     } catch (err) {
+      this.logger.error({ err, threadId: thread.id }, 'Bullpen openThread transaction failed');
       await client.query('ROLLBACK');
       throw err;
     } finally {
@@ -168,6 +169,7 @@ class PostgresBullpenBackend implements BullpenBackend {
       }
       await client.query('COMMIT');
     } catch (err) {
+      this.logger.error({ err, threadId }, 'Bullpen postMessage transaction failed');
       await client.query('ROLLBACK');
       throw err;
     } finally {

--- a/src/memory/bullpen.ts
+++ b/src/memory/bullpen.ts
@@ -1,0 +1,364 @@
+import { randomUUID } from 'node:crypto';
+import type { Pool } from 'pg';
+import type { Logger } from '../logger.js';
+
+// -- Public types --
+
+export interface BullpenThread {
+  id: string;
+  topic: string;
+  creatorAgentId: string;
+  participants: string[];
+  status: 'open' | 'closed';
+  messageCount: number;
+  lastMessageAt: Date | null;
+  createdAt: Date;
+}
+
+export interface BullpenMessage {
+  id: string;
+  threadId: string;
+  senderType: 'agent';
+  senderId: string;
+  content: string;
+  mentionedAgentIds: string[];
+  createdAt: Date;
+}
+
+export interface PendingThreadContext {
+  threadId: string;
+  topic: string;
+  totalMessages: number;
+  recentMessages: Array<{
+    senderAgentId: string;
+    content: string;
+    mentionedAgentIds: string[];
+    createdAt: Date;
+  }>;
+}
+
+// -- Backend interface --
+
+interface BullpenBackend {
+  openThread(thread: BullpenThread, message: BullpenMessage): Promise<void>;
+  postMessage(threadId: string, message: BullpenMessage): Promise<void>;
+  closeThread(threadId: string): Promise<void>;
+  getThread(threadId: string): Promise<{ thread: BullpenThread; messages: BullpenMessage[] } | null>;
+  getPendingThreadsForAgent(agentId: string, windowMs: number): Promise<PendingThreadContext[]>;
+}
+
+// -- In-memory backend (for unit tests) --
+
+class InMemoryBullpenBackend implements BullpenBackend {
+  private threads = new Map<string, BullpenThread>();
+  private messages = new Map<string, BullpenMessage[]>();
+
+  async openThread(thread: BullpenThread, message: BullpenMessage): Promise<void> {
+    this.threads.set(thread.id, { ...thread });
+    this.messages.set(thread.id, [{ ...message }]);
+  }
+
+  async postMessage(threadId: string, message: BullpenMessage): Promise<void> {
+    const thread = this.threads.get(threadId);
+    if (!thread) throw new Error(`Thread ${threadId} not found`);
+    thread.messageCount++;
+    thread.lastMessageAt = message.createdAt;
+    const msgs = this.messages.get(threadId) ?? [];
+    msgs.push({ ...message });
+    this.messages.set(threadId, msgs);
+  }
+
+  async closeThread(threadId: string): Promise<void> {
+    const thread = this.threads.get(threadId);
+    if (thread) thread.status = 'closed';
+  }
+
+  async getThread(threadId: string): Promise<{ thread: BullpenThread; messages: BullpenMessage[] } | null> {
+    const thread = this.threads.get(threadId);
+    if (!thread) return null;
+    return { thread: { ...thread }, messages: [...(this.messages.get(threadId) ?? [])] };
+  }
+
+  async getPendingThreadsForAgent(agentId: string, windowMs: number): Promise<PendingThreadContext[]> {
+    const cutoff = new Date(Date.now() - windowMs);
+    const result: PendingThreadContext[] = [];
+
+    for (const [threadId, thread] of this.threads) {
+      if (thread.status !== 'open') continue;
+      if (!thread.participants.includes(agentId)) continue;
+      if (!thread.lastMessageAt || thread.lastMessageAt < cutoff) continue;
+
+      const msgs = this.messages.get(threadId) ?? [];
+      if (msgs.length === 0) continue;
+
+      const lastMsg = msgs[msgs.length - 1]!;
+      if (lastMsg.senderId === agentId) continue;
+
+      const recentMessages = msgs.slice(-5).map(m => ({
+        senderAgentId: m.senderId,
+        content: m.content,
+        mentionedAgentIds: m.mentionedAgentIds,
+        createdAt: m.createdAt,
+      }));
+
+      result.push({ threadId, topic: thread.topic, totalMessages: thread.messageCount, recentMessages });
+    }
+
+    return result
+      .sort((a, b) => {
+        const ta = this.threads.get(a.threadId)?.lastMessageAt?.getTime() ?? 0;
+        const tb = this.threads.get(b.threadId)?.lastMessageAt?.getTime() ?? 0;
+        return tb - ta;
+      })
+      .slice(0, 5);
+  }
+}
+
+// -- Postgres backend --
+
+class PostgresBullpenBackend implements BullpenBackend {
+  constructor(private pool: Pool, private logger: Logger) {}
+
+  async openThread(thread: BullpenThread, message: BullpenMessage): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `INSERT INTO bullpen_threads (id, topic, creator_agent_id, participants, status, message_count, last_message_at, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [thread.id, thread.topic, thread.creatorAgentId, thread.participants, thread.status, thread.messageCount, thread.lastMessageAt, thread.createdAt],
+      );
+      await client.query(
+        `INSERT INTO bullpen_messages (id, thread_id, sender_type, sender_id, content, mentioned_agent_ids, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [message.id, message.threadId, message.senderType, message.senderId, JSON.stringify(message.content), message.mentionedAgentIds, message.createdAt],
+      );
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async postMessage(threadId: string, message: BullpenMessage): Promise<void> {
+    // Two separate statements wrapped in a transaction for atomicity.
+    // (A CTE that does INSERT + UPDATE requires the INSERT to be in the CTE's WITH clause,
+    // which Postgres supports, but requires careful parameter numbering.)
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `INSERT INTO bullpen_messages (id, thread_id, sender_type, sender_id, content, mentioned_agent_ids, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [message.id, threadId, message.senderType, message.senderId, JSON.stringify(message.content), message.mentionedAgentIds, message.createdAt],
+      );
+      await client.query(
+        `UPDATE bullpen_threads
+         SET message_count = message_count + 1,
+             last_message_at = $1
+         WHERE id = $2`,
+        [message.createdAt, threadId],
+      );
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async closeThread(threadId: string): Promise<void> {
+    await this.pool.query(
+      `UPDATE bullpen_threads SET status = 'closed' WHERE id = $1`,
+      [threadId],
+    );
+  }
+
+  async getThread(threadId: string): Promise<{ thread: BullpenThread; messages: BullpenMessage[] } | null> {
+    const threadRes = await this.pool.query<{
+      id: string; topic: string; creator_agent_id: string; participants: string[];
+      status: string; message_count: number; last_message_at: Date | null; created_at: Date;
+    }>(
+      `SELECT id, topic, creator_agent_id, participants, status, message_count, last_message_at, created_at
+       FROM bullpen_threads WHERE id = $1`,
+      [threadId],
+    );
+    if (threadRes.rows.length === 0) return null;
+    const row = threadRes.rows[0]!;
+    const thread: BullpenThread = {
+      id: row.id, topic: row.topic, creatorAgentId: row.creator_agent_id,
+      participants: row.participants, status: row.status as 'open' | 'closed',
+      messageCount: row.message_count, lastMessageAt: row.last_message_at, createdAt: row.created_at,
+    };
+
+    const msgRes = await this.pool.query<{
+      id: string; thread_id: string; sender_type: string; sender_id: string;
+      content: unknown; mentioned_agent_ids: string[]; created_at: Date;
+    }>(
+      `SELECT id, thread_id, sender_type, sender_id, content, mentioned_agent_ids, created_at
+       FROM bullpen_messages WHERE thread_id = $1 ORDER BY created_at ASC`,
+      [threadId],
+    );
+    const messages: BullpenMessage[] = msgRes.rows.map(m => ({
+      id: m.id, threadId: m.thread_id, senderType: 'agent' as const,
+      senderId: m.sender_id,
+      content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+      mentionedAgentIds: m.mentioned_agent_ids, createdAt: m.created_at,
+    }));
+
+    return { thread, messages };
+  }
+
+  async getPendingThreadsForAgent(agentId: string, windowMs: number): Promise<PendingThreadContext[]> {
+    const windowSeconds = windowMs / 1000;
+    const threadsRes = await this.pool.query<{
+      id: string; topic: string; message_count: number; last_message_at: Date;
+    }>(
+      `SELECT t.id, t.topic, t.message_count, t.last_message_at
+       FROM bullpen_threads t
+       WHERE t.status = 'open'
+         AND $1 = ANY(t.participants)
+         AND t.last_message_at > NOW() - ($2 || ' seconds')::INTERVAL
+         AND (
+           SELECT sender_id FROM bullpen_messages
+           WHERE thread_id = t.id ORDER BY created_at DESC LIMIT 1
+         ) != $1
+       ORDER BY t.last_message_at DESC
+       LIMIT 5`,
+      [agentId, windowSeconds],
+    );
+
+    const results: PendingThreadContext[] = [];
+    for (const row of threadsRes.rows) {
+      const msgsRes = await this.pool.query<{
+        sender_id: string; content: unknown; mentioned_agent_ids: string[]; created_at: Date;
+      }>(
+        `SELECT sender_id, content, mentioned_agent_ids, created_at
+         FROM bullpen_messages WHERE thread_id = $1
+         ORDER BY created_at DESC LIMIT 5`,
+        [row.id],
+      );
+      const recentMessages = msgsRes.rows.reverse().map(m => ({
+        senderAgentId: m.sender_id,
+        content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+        mentionedAgentIds: m.mentioned_agent_ids,
+        createdAt: m.created_at,
+      }));
+      results.push({ threadId: row.id, topic: row.topic, totalMessages: row.message_count, recentMessages });
+    }
+    return results;
+  }
+}
+
+// -- BullpenService --
+
+export class BullpenService {
+  private backend: BullpenBackend;
+
+  private constructor(backend: BullpenBackend) {
+    this.backend = backend;
+  }
+
+  static createWithPostgres(pool: Pool, logger: Logger): BullpenService {
+    return new BullpenService(new PostgresBullpenBackend(pool, logger));
+  }
+
+  static createInMemory(): BullpenService {
+    return new BullpenService(new InMemoryBullpenBackend());
+  }
+
+  async openThread(
+    topic: string,
+    creatorAgentId: string,
+    participants: string[],
+    initialContent: string,
+    mentionedAgentIds: string[],
+  ): Promise<{ thread: BullpenThread; message: BullpenMessage }> {
+    const now = new Date();
+    const thread: BullpenThread = {
+      id: randomUUID(), topic, creatorAgentId, participants,
+      status: 'open', messageCount: 1, lastMessageAt: now, createdAt: now,
+    };
+    const message: BullpenMessage = {
+      id: randomUUID(), threadId: thread.id, senderType: 'agent',
+      senderId: creatorAgentId, content: initialContent,
+      mentionedAgentIds, createdAt: now,
+    };
+    await this.backend.openThread(thread, message);
+    return { thread, message };
+  }
+
+  async postMessage(
+    threadId: string,
+    senderAgentId: string,
+    content: string,
+    mentionedAgentIds: string[],
+  ): Promise<BullpenMessage> {
+    const existing = await this.backend.getThread(threadId);
+    if (!existing) throw new Error(`Thread ${threadId} not found`);
+    if (existing.thread.status === 'closed') {
+      throw new Error(`Cannot post to closed thread ${threadId}`);
+    }
+    if (existing.thread.messageCount >= 100) {
+      throw new Error(`Thread ${threadId} has reached the message cap (100)`);
+    }
+    const message: BullpenMessage = {
+      id: randomUUID(), threadId, senderType: 'agent',
+      senderId: senderAgentId, content, mentionedAgentIds,
+      createdAt: new Date(),
+    };
+    await this.backend.postMessage(threadId, message);
+    return message;
+  }
+
+  async closeThread(threadId: string, requestingAgentId: string): Promise<void> {
+    const existing = await this.backend.getThread(threadId);
+    if (!existing) throw new Error(`Thread ${threadId} not found`);
+    if (requestingAgentId !== existing.thread.creatorAgentId && requestingAgentId !== 'coordinator') {
+      throw new Error(
+        `Agent '${requestingAgentId}' is not authorized to close thread ${threadId} — only the creator or coordinator may close threads`,
+      );
+    }
+    await this.backend.closeThread(threadId);
+  }
+
+  async getThread(threadId: string): Promise<{ thread: BullpenThread; messages: BullpenMessage[] } | null> {
+    return this.backend.getThread(threadId);
+  }
+
+  async getPendingThreadsForAgent(agentId: string, windowMinutes: number): Promise<PendingThreadContext[]> {
+    return this.backend.getPendingThreadsForAgent(agentId, windowMinutes * 60 * 1000);
+  }
+}
+
+// -- Context formatter --
+
+/**
+ * Formats pending Bullpen threads as a compact system-message block for LLM context injection.
+ * Shows up to 5 threads × 5 recent messages each.
+ */
+export function formatBullpenContext(pending: PendingThreadContext[]): string {
+  if (pending.length === 0) return '';
+  const lines: string[] = [`[Bullpen — ${pending.length} active thread${pending.length === 1 ? '' : 's'}]`];
+  for (const thread of pending) {
+    const showing = thread.recentMessages.length < thread.totalMessages
+      ? ` — showing last ${thread.recentMessages.length}`
+      : '';
+    lines.push('');
+    lines.push(`Thread "${thread.topic}" (thread_id: ${thread.threadId}, ${thread.totalMessages} total messages${showing}):`);
+    for (const msg of thread.recentMessages) {
+      const ts = msg.createdAt.toTimeString().slice(0, 5);
+      const mentions = msg.mentionedAgentIds.length > 0
+        ? msg.mentionedAgentIds.map(id => `@${id}`).join(' ') + ' '
+        : '';
+      lines.push(`  ${msg.senderAgentId} [${ts}]: "${mentions}${msg.content}"`);
+    }
+    if (thread.recentMessages.length < thread.totalMessages) {
+      lines.push(`  → Call bullpen get_thread for full history.`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/src/memory/bullpen.ts
+++ b/src/memory/bullpen.ts
@@ -143,9 +143,9 @@ class PostgresBullpenBackend implements BullpenBackend {
   }
 
   async postMessage(threadId: string, message: BullpenMessage): Promise<void> {
-    // Two separate statements wrapped in a transaction for atomicity.
-    // (A CTE that does INSERT + UPDATE requires the INSERT to be in the CTE's WITH clause,
-    // which Postgres supports, but requires careful parameter numbering.)
+    // Atomically insert the message and conditionally increment message_count.
+    // The UPDATE uses WHERE status='open' AND message_count<100 so that concurrent
+    // close or cap-reaching posts are rejected at the DB level, not just app level.
     const client = await this.pool.connect();
     try {
       await client.query('BEGIN');
@@ -154,13 +154,18 @@ class PostgresBullpenBackend implements BullpenBackend {
          VALUES ($1, $2, $3, $4, $5, $6, $7)`,
         [message.id, threadId, message.senderType, message.senderId, JSON.stringify(message.content), message.mentionedAgentIds, message.createdAt],
       );
-      await client.query(
+      const updateRes = await client.query<{ message_count: number }>(
         `UPDATE bullpen_threads
          SET message_count = message_count + 1,
              last_message_at = $1
-         WHERE id = $2`,
+         WHERE id = $2 AND status = 'open' AND message_count < 100
+         RETURNING message_count`,
         [message.createdAt, threadId],
       );
+      if (updateRes.rows.length === 0) {
+        // Thread is closed or at cap — roll back the message insert.
+        throw new Error(`Thread ${threadId} is closed or has reached the message cap`);
+      }
       await client.query('COMMIT');
     } catch (err) {
       await client.query('ROLLBACK');
@@ -220,7 +225,7 @@ class PostgresBullpenBackend implements BullpenBackend {
       `SELECT t.id, t.topic, t.message_count, t.last_message_at
        FROM bullpen_threads t
        WHERE t.status = 'open'
-         AND $1 = ANY(t.participants)
+         AND t.participants @> ARRAY[$1]::text[]
          AND t.last_message_at > NOW() - ($2::numeric * INTERVAL '1 second')
          AND (
            SELECT sender_id FROM bullpen_messages
@@ -277,9 +282,11 @@ export class BullpenService {
     initialContent: string,
     mentionedAgentIds: string[],
   ): Promise<{ thread: BullpenThread; message: BullpenMessage }> {
+    // Normalize: always include the creator, deduplicate, preserve order.
+    const normalizedParticipants = [...new Set([creatorAgentId, ...participants])];
     const now = new Date();
     const thread: BullpenThread = {
-      id: randomUUID(), topic, creatorAgentId, participants,
+      id: randomUUID(), topic, creatorAgentId, participants: normalizedParticipants,
       status: 'open', messageCount: 1, lastMessageAt: now, createdAt: now,
     };
     const message: BullpenMessage = {
@@ -305,12 +312,12 @@ export class BullpenService {
     if (existing.thread.messageCount >= 100) {
       throw new Error(`Thread ${threadId} has reached the message cap (100)`);
     }
-    // NOTE: The cap check above is not atomically enforced at the DB level — it is
-    // checked in application code between getThread() and postMessage(). Under concurrent
-    // load, two agents replying simultaneously could both pass this check and push
-    // message_count slightly past 100. This is accepted: the cap is a soft amplification
-    // control, not a hard data integrity constraint. BullpenDispatcher re-checks the cap
-    // before creating new tasks, so any overshoot self-limits quickly.
+    if (!existing.thread.participants.includes(senderAgentId)) {
+      throw new Error(`Agent '${senderAgentId}' is not a participant of thread ${threadId}`);
+    }
+    // NOTE: The above checks run before the DB write; under concurrent load the
+    // Postgres backend re-validates status and cap atomically in the UPDATE WHERE
+    // clause, so a race can only overshoot by rejecting — not by persisting extra messages.
     const message: BullpenMessage = {
       id: randomUUID(), threadId, senderType: 'agent',
       senderId: senderAgentId, content, mentionedAgentIds,

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -54,6 +54,7 @@ export class ExecutionLayer {
   private entityContextAssembler?: EntityContextAssembler;
   private autonomyService?: AutonomyService;
   private browserService?: BrowserService;
+  private bullpenService?: import('../memory/bullpen.js').BullpenService;
   /** The agent's own contactId — injected into ctx.agentContactId for entity_enrichment default='agent' */
   private agentContactId?: string;
   /** IANA timezone name used for normalizing offset-less timestamp inputs from the LLM. */
@@ -74,6 +75,7 @@ export class ExecutionLayer {
     entityContextAssembler?: EntityContextAssembler;
     autonomyService?: AutonomyService;
     browserService?: BrowserService;
+    bullpenService?: import('../memory/bullpen.js').BullpenService;
     agentContactId?: string;
     timezone?: string;
     skillOutputMaxLength?: number;
@@ -92,6 +94,7 @@ export class ExecutionLayer {
     this.entityContextAssembler = options?.entityContextAssembler;
     this.autonomyService = options?.autonomyService;
     this.browserService = options?.browserService;
+    this.bullpenService = options?.bullpenService;
     this.agentContactId = options?.agentContactId;
     this.timezone = options?.timezone ?? 'UTC';
     this.skillOutputMaxLength = options?.skillOutputMaxLength ?? DEFAULT_SKILL_OUTPUT_MAX_LENGTH;
@@ -144,6 +147,7 @@ export class ExecutionLayer {
     skillName: string,
     input: Record<string, unknown>,
     caller?: CallerContext,
+    options?: { taskEventId?: string; agentId?: string },
   ): Promise<SkillResult> {
     const skill = this.registry.get(skillName);
 
@@ -229,6 +233,10 @@ export class ExecutionLayer {
       // contactService is available to all skills — read-only contact lookups
       // (calendars, display names, etc.) are not a privilege escalation.
       contactService: this.contactService,
+      // Thread agentId and taskEventId into context unconditionally — infrastructure
+      // skills (bullpen) need these for event publishing; harmless for others.
+      agentId: options?.agentId,
+      taskEventId: options?.taskEventId,
     };
 
     // Infrastructure skills get bus and agent registry access.
@@ -268,6 +276,10 @@ export class ExecutionLayer {
       // nylasCalendarClient is optional — only calendar skills need it
       if (this.nylasCalendarClient) {
         ctx.nylasCalendarClient = this.nylasCalendarClient;
+      }
+      // bullpenService is optional — only the bullpen skill needs it
+      if (this.bullpenService) {
+        ctx.bullpenService = this.bullpenService;
       }
     }
 

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -137,6 +137,12 @@ export interface SkillContext {
    *  Provides CRUD operations on calendar events and free/busy queries
    *  via the Nylas unified API (provider-agnostic). */
   nylasCalendarClient?: import('../channels/calendar/nylas-calendar-client.js').NylasCalendarClient;
+  /** Bullpen service — available to infrastructure skills for inter-agent discussion threads */
+  bullpenService?: import('../memory/bullpen.js').BullpenService;
+  /** ID of the agent invoking this skill — injected by the execution layer */
+  agentId?: string;
+  /** ID of the originating agent.task event — for causal chain tracing in event payloads */
+  taskEventId?: string;
   /** Caller identity — populated from the task event's sender context.
    *  Guaranteed to be defined for elevated skills (execution layer rejects without it).
    *  Available but optional for normal skills. */

--- a/tests/integration/bullpen.test.ts
+++ b/tests/integration/bullpen.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import pg from 'pg';
+import { BullpenService } from '../../src/memory/bullpen.js';
+import { createLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('BullpenService integration (Postgres)', () => {
+  let pool: pg.Pool;
+  let service: BullpenService;
+  // Per-run ID ensures concurrent test runs don't clobber each other's rows
+  let runId: string;
+
+  beforeAll(async () => {
+    runId = randomUUID();
+    pool = new Pool({ connectionString: DATABASE_URL });
+    await pool.query('SELECT 1 FROM bullpen_threads LIMIT 0');
+    const logger = createLogger('error');
+    service = BullpenService.createWithPostgres(pool, logger);
+  });
+
+  afterAll(async () => {
+    // Delete only rows created by this run, scoped by the runId topic prefix.
+    // ON DELETE CASCADE handles bullpen_messages automatically.
+    await pool.query(
+      `DELETE FROM bullpen_threads WHERE topic LIKE $1`,
+      [`${runId}%`],
+    );
+    await pool.end();
+  });
+
+  it('opens a thread and persists to Postgres', async () => {
+    const { thread, message } = await service.openThread(
+      `${runId} — Integration test thread`,
+      'coordinator',
+      ['coordinator', 'agent-b'],
+      'Hello agent-b',
+      ['agent-b'],
+    );
+    const fetched = await service.getThread(thread.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.thread.topic).toBe(`${runId} — Integration test thread`);
+    expect(fetched!.messages).toHaveLength(1);
+    expect(fetched!.messages[0]!.id).toBe(message.id);
+  });
+
+  it('postMessage increments message_count and updates last_message_at', async () => {
+    const { thread } = await service.openThread(`${runId} — Count test`, 'coordinator', ['coordinator', 'agent-b'], 'Msg 1', []);
+    const before = await service.getThread(thread.id);
+    await service.postMessage(thread.id, 'agent-b', 'Msg 2', []);
+    const after = await service.getThread(thread.id);
+    expect(after!.thread.messageCount).toBe(before!.thread.messageCount + 1);
+    expect(after!.thread.lastMessageAt!.getTime()).toBeGreaterThanOrEqual(before!.thread.lastMessageAt!.getTime());
+  });
+
+  it('getPendingThreadsForAgent respects time window', async () => {
+    const { thread } = await service.openThread(`${runId} — Old thread`, 'coordinator', ['coordinator', 'agent-b'], 'Old', []);
+    // Force last_message_at to be 2 hours ago
+    await pool.query(
+      `UPDATE bullpen_threads SET last_message_at = NOW() - INTERVAL '2 hours' WHERE id = $1`,
+      [thread.id],
+    );
+    // 60-minute window should exclude this thread
+    const pending = await service.getPendingThreadsForAgent('agent-b', 60);
+    expect(pending.find(p => p.threadId === thread.id)).toBeUndefined();
+  });
+
+  it('closeThread prevents further posts', async () => {
+    const { thread } = await service.openThread(`${runId} — Close test`, 'coordinator', ['coordinator'], 'Hi', []);
+    await service.closeThread(thread.id, 'coordinator');
+    // Verify the DB write actually persisted the closed status
+    const closed = await service.getThread(thread.id);
+    expect(closed!.thread.status).toBe('closed');
+    // Also verify the application-layer guard blocks further posts
+    await expect(service.postMessage(thread.id, 'coordinator', 'After close', [])).rejects.toThrow('closed');
+  });
+});

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -389,8 +389,14 @@ describe('AgentRuntime tool-use loop', () => {
     });
     await bus.publish('dispatch', task);
 
-    // caller is undefined because the task payload has no senderContext
-    expect(mockExecution.invoke).toHaveBeenCalledWith('web-fetch', { url: 'https://example.com' }, undefined);
+    // caller is undefined because the task payload has no senderContext;
+    // agentId and taskEventId are threaded through for infrastructure skills
+    expect(mockExecution.invoke).toHaveBeenCalledWith(
+      'web-fetch',
+      { url: 'https://example.com' },
+      undefined,
+      expect.objectContaining({ agentId: 'coordinator', taskEventId: expect.any(String) }),
+    );
     expect(responseContent).toContain('Call count: 2');
   });
 

--- a/tests/unit/bus/agent-discuss-event.test.ts
+++ b/tests/unit/bus/agent-discuss-event.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { createAgentDiscuss } from '../../../src/bus/events.js';
+import { canPublish, canSubscribe } from '../../../src/bus/permissions.js';
+
+describe('agent.discuss event', () => {
+  const basePayload = {
+    threadId: 'thread-1',
+    messageId: 'msg-1',
+    topic: 'Test topic',
+    senderAgentId: 'coordinator',
+    participants: ['coordinator', 'agent-b'],
+    mentionedAgentIds: ['agent-b'],
+    content: 'Hello agent-b',
+    parentEventId: 'task-1',
+  };
+
+  it('createAgentDiscuss returns correct event shape', () => {
+    const event = createAgentDiscuss(basePayload);
+    expect(event.type).toBe('agent.discuss');
+    expect(event.sourceLayer).toBe('agent');
+    expect(event.parentEventId).toBe('task-1');
+    expect(event.payload.threadId).toBe('thread-1');
+    expect(event.payload.senderAgentId).toBe('coordinator');
+    expect(event.payload.participants).toEqual(['coordinator', 'agent-b']);
+    expect(event.payload.mentionedAgentIds).toEqual(['agent-b']);
+    expect(event.id).toBeTruthy();
+    expect(event.timestamp).toBeInstanceOf(Date);
+  });
+
+  it('parentEventId is NOT in the payload', () => {
+    const event = createAgentDiscuss(basePayload);
+    expect((event.payload as Record<string, unknown>)['parentEventId']).toBeUndefined();
+  });
+
+  it('agent layer can publish agent.discuss', () => {
+    expect(canPublish('agent', 'agent.discuss')).toBe(true);
+  });
+
+  it('dispatch layer cannot publish agent.discuss', () => {
+    expect(canPublish('dispatch', 'agent.discuss')).toBe(false);
+  });
+
+  it('channel layer cannot publish agent.discuss', () => {
+    expect(canPublish('channel', 'agent.discuss')).toBe(false);
+  });
+
+  it('dispatch layer can subscribe to agent.discuss', () => {
+    expect(canSubscribe('dispatch', 'agent.discuss')).toBe(true);
+  });
+
+  it('system layer can subscribe to agent.discuss', () => {
+    expect(canSubscribe('system', 'agent.discuss')).toBe(true);
+  });
+
+  it('agent layer cannot subscribe to agent.discuss', () => {
+    expect(canSubscribe('agent', 'agent.discuss')).toBe(false);
+  });
+
+  it('channel layer cannot subscribe to agent.discuss', () => {
+    expect(canSubscribe('channel', 'agent.discuss')).toBe(false);
+  });
+});

--- a/tests/unit/dispatch/bullpen-dispatcher.test.ts
+++ b/tests/unit/dispatch/bullpen-dispatcher.test.ts
@@ -13,7 +13,7 @@ function makeBus() {
       list.push(handler);
       handlers.set(type, list);
     }),
-    publish: vi.fn(async (_layer: string, event: unknown) => {
+    publish: vi.fn(async (_layer: string, _event: unknown) => {
       // Simulate bus delivery so tests can inspect published events
     }),
     _trigger: async (type: string, event: unknown) => {

--- a/tests/unit/dispatch/bullpen-dispatcher.test.ts
+++ b/tests/unit/dispatch/bullpen-dispatcher.test.ts
@@ -77,6 +77,7 @@ describe('BullpenDispatcher', () => {
       .find(([_l, e]) => (e as { type: string }).type === 'agent.task')?.[1] as { payload: { channelId: string; metadata: Record<string, unknown> } };
     expect(task?.payload.channelId).toBe('bullpen');
     expect(task?.payload.metadata?.taskOrigin).toBe('bullpen');
+    expect(task?.payload.metadata?.threadId).toBe(thread.id);
   });
 
   it('marks mentioned agents with mentioned: true in metadata', async () => {

--- a/tests/unit/dispatch/bullpen-dispatcher.test.ts
+++ b/tests/unit/dispatch/bullpen-dispatcher.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BullpenDispatcher } from '../../../src/dispatch/bullpen-dispatcher.js';
+import { BullpenService } from '../../../src/memory/bullpen.js';
+import { createLogger } from '../../../src/logger.js';
+import { createAgentDiscuss } from '../../../src/bus/events.js';
+import type { EventBus } from '../../../src/bus/bus.js';
+
+function makeBus() {
+  const handlers = new Map<string, ((event: unknown) => void)[]>();
+  return {
+    subscribe: vi.fn((type: string, _layer: string, handler: (event: unknown) => void) => {
+      const list = handlers.get(type) ?? [];
+      list.push(handler);
+      handlers.set(type, list);
+    }),
+    publish: vi.fn(async (_layer: string, event: unknown) => {
+      // Simulate bus delivery so tests can inspect published events
+    }),
+    _trigger: async (type: string, event: unknown) => {
+      for (const h of handlers.get(type) ?? []) await h(event);
+    },
+  };
+}
+
+describe('BullpenDispatcher', () => {
+  let bus: ReturnType<typeof makeBus>;
+  let bullpenService: BullpenService;
+  let dispatcher: BullpenDispatcher;
+
+  beforeEach(() => {
+    bus = makeBus();
+    bullpenService = BullpenService.createInMemory();
+    dispatcher = new BullpenDispatcher(bus as unknown as EventBus, createLogger('error'), bullpenService);
+    dispatcher.register();
+  });
+
+  it('registers a subscriber for agent.discuss', () => {
+    expect(bus.subscribe).toHaveBeenCalledWith('agent.discuss', 'dispatch', expect.any(Function));
+  });
+
+  it('creates agent.task for all participants except sender', async () => {
+    const { thread } = await bullpenService.openThread(
+      'Test thread', 'coordinator', ['coordinator', 'agent-b', 'agent-c'], 'Hello', ['agent-b'],
+    );
+    const event = createAgentDiscuss({
+      threadId: thread.id,
+      messageId: 'msg-1',
+      topic: 'Test thread',
+      senderAgentId: 'coordinator',
+      participants: ['coordinator', 'agent-b', 'agent-c'],
+      mentionedAgentIds: ['agent-b'],
+      content: 'Hello',
+      parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    // Should create 2 tasks: agent-b (mentioned) and agent-c (FYI), NOT coordinator
+    const publishedTasks = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([_layer, e]) => (e as { type: string }).type === 'agent.task');
+    expect(publishedTasks).toHaveLength(2);
+    const agentIds = publishedTasks.map(([_layer, e]) => (e as { payload: { agentId: string } }).payload.agentId);
+    expect(agentIds).toContain('agent-b');
+    expect(agentIds).toContain('agent-c');
+    expect(agentIds).not.toContain('coordinator');
+  });
+
+  it('sets channelId to "bullpen" and metadata.taskOrigin to "bullpen"', async () => {
+    const { thread } = await bullpenService.openThread(
+      'Meta test', 'coordinator', ['coordinator', 'agent-b'], 'Hi', ['agent-b'],
+    );
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-1', topic: 'Meta test',
+      senderAgentId: 'coordinator', participants: ['coordinator', 'agent-b'],
+      mentionedAgentIds: ['agent-b'], content: 'Hi', parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    const task = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .find(([_l, e]) => (e as { type: string }).type === 'agent.task')?.[1] as { payload: { channelId: string; metadata: Record<string, unknown> } };
+    expect(task?.payload.channelId).toBe('bullpen');
+    expect(task?.payload.metadata?.taskOrigin).toBe('bullpen');
+  });
+
+  it('marks mentioned agents with mentioned: true in metadata', async () => {
+    const { thread } = await bullpenService.openThread(
+      'Mention test', 'coordinator', ['coordinator', 'agent-b', 'agent-c'], 'Hi', ['agent-b'],
+    );
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-1', topic: 'Mention test',
+      senderAgentId: 'coordinator', participants: ['coordinator', 'agent-b', 'agent-c'],
+      mentionedAgentIds: ['agent-b'], content: 'Hi', parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    const tasks = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([_l, e]) => (e as { type: string }).type === 'agent.task')
+      .map(([_l, e]) => e as { payload: { agentId: string; metadata: Record<string, unknown> } });
+    const bTask = tasks.find(t => t.payload.agentId === 'agent-b');
+    const cTask = tasks.find(t => t.payload.agentId === 'agent-c');
+    expect(bTask?.payload.metadata?.mentioned).toBe(true);
+    expect(cTask?.payload.metadata?.mentioned).toBe(false);
+  });
+
+  it('skips task creation when thread message_count >= 100', async () => {
+    const { thread } = await bullpenService.openThread(
+      'Cap test', 'coordinator', ['coordinator', 'agent-b'], 'Start', [],
+    );
+    // Post 99 more to reach the cap (thread starts at 1)
+    for (let i = 0; i < 99; i++) {
+      await bullpenService.postMessage(thread.id, 'coordinator', `Msg ${i}`, []);
+    }
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-cap', topic: 'Cap test',
+      senderAgentId: 'coordinator', participants: ['coordinator', 'agent-b'],
+      mentionedAgentIds: ['agent-b'], content: 'Over cap', parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    // No tasks should be created (thread is at 100)
+    const tasks = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([_l, e]) => (e as { type: string }).type === 'agent.task');
+    expect(tasks).toHaveLength(0);
+  });
+});

--- a/tests/unit/memory/bullpen.test.ts
+++ b/tests/unit/memory/bullpen.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { BullpenService } from '../../../src/memory/bullpen.js';
+
+describe('BullpenService (in-memory)', () => {
+  let service: BullpenService;
+
+  beforeEach(() => {
+    service = BullpenService.createInMemory();
+  });
+
+  it('opens a thread and returns thread + first message', async () => {
+    const { thread, message } = await service.openThread(
+      'Q2 planning',
+      'coordinator',
+      ['coordinator', 'calendar-agent'],
+      'Can you check availability?',
+      ['calendar-agent'],
+    );
+    expect(thread.id).toBeTruthy();
+    expect(thread.topic).toBe('Q2 planning');
+    expect(thread.creatorAgentId).toBe('coordinator');
+    expect(thread.participants).toEqual(['coordinator', 'calendar-agent']);
+    expect(thread.status).toBe('open');
+    expect(thread.messageCount).toBe(1);
+    expect(thread.lastMessageAt).toBeTruthy();
+    expect(message.senderId).toBe('coordinator');
+    expect(message.mentionedAgentIds).toEqual(['calendar-agent']);
+  });
+
+  it('posts a message and increments message_count', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator', 'agent-b'], 'Hello', []);
+    await service.postMessage(thread.id, 'agent-b', 'Reply', []);
+    const result = await service.getThread(thread.id);
+    expect(result?.thread.messageCount).toBe(2);
+    expect(result?.messages).toHaveLength(2);
+  });
+
+  it('returns null for unknown thread', async () => {
+    const result = await service.getThread('00000000-0000-0000-0000-000000000000');
+    expect(result).toBeNull();
+  });
+
+  it('throws when posting to a closed thread', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator'], 'Hi', []);
+    await service.closeThread(thread.id, 'coordinator');
+    await expect(service.postMessage(thread.id, 'coordinator', 'Late reply', [])).rejects.toThrow('closed');
+  });
+
+  it('throws when posting to a capped thread (100 messages)', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator'], 'Start', []);
+    // Post 99 more to reach the cap (thread starts at 1)
+    for (let i = 0; i < 99; i++) {
+      await service.postMessage(thread.id, 'coordinator', `Message ${i}`, []);
+    }
+    await expect(service.postMessage(thread.id, 'coordinator', 'Over cap', [])).rejects.toThrow('message cap');
+  });
+
+  it('enforces close permission: only creator or coordinator may close', async () => {
+    const { thread } = await service.openThread('Test', 'agent-b', ['agent-b', 'agent-c'], 'Hi', []);
+    await expect(service.closeThread(thread.id, 'agent-c')).rejects.toThrow('not authorized');
+  });
+
+  it('allows coordinator to close any thread', async () => {
+    const { thread } = await service.openThread('Test', 'agent-b', ['agent-b'], 'Hi', []);
+    await expect(service.closeThread(thread.id, 'coordinator')).resolves.not.toThrow();
+    const result = await service.getThread(thread.id);
+    expect(result?.thread.status).toBe('closed');
+  });
+
+  it('getPendingThreadsForAgent returns only threads where latest sender is not the agent', async () => {
+    const { thread } = await service.openThread(
+      'Pending test',
+      'coordinator',
+      ['coordinator', 'agent-b'],
+      'What do you think?',
+      ['agent-b'],
+    );
+    // coordinator posted last — agent-b has a pending thread
+    const pending = await service.getPendingThreadsForAgent('agent-b', 60);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.threadId).toBe(thread.id);
+    expect(pending[0]?.topic).toBe('Pending test');
+  });
+
+  it('getPendingThreadsForAgent excludes threads where agent posted last', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator', 'agent-b'], 'Hi', []);
+    await service.postMessage(thread.id, 'agent-b', 'Replied', []);
+    const pending = await service.getPendingThreadsForAgent('agent-b', 60);
+    expect(pending).toHaveLength(0);
+  });
+
+  it('getPendingThreadsForAgent excludes closed threads', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator', 'agent-b'], 'Hi', []);
+    await service.closeThread(thread.id, 'coordinator');
+    const pending = await service.getPendingThreadsForAgent('agent-b', 60);
+    expect(pending).toHaveLength(0);
+  });
+
+  it('getPendingThreadsForAgent includes up to 5 recent messages per thread', async () => {
+    const { thread } = await service.openThread('Test', 'coordinator', ['coordinator', 'agent-b'], 'Msg 1', []);
+    for (let i = 2; i <= 8; i++) {
+      await service.postMessage(thread.id, 'coordinator', `Msg ${i}`, []);
+    }
+    const pending = await service.getPendingThreadsForAgent('agent-b', 60);
+    expect(pending[0]?.totalMessages).toBe(8);
+    expect(pending[0]?.recentMessages).toHaveLength(5);
+    // Should be the last 5 messages
+    expect(pending[0]?.recentMessages[4]?.content).toBe('Msg 8');
+  });
+});


### PR DESCRIPTION
## Summary

- **Bullpen** — shared threaded workspace for inter-agent discussion, backed by Postgres and flowing through the event bus
- Agents open threads, post replies, and close discussions using the new `bullpen` infrastructure skill (4 actions: `post`, `reply`, `get_thread`, `close`)
- `BullpenDispatcher` routes `agent.discuss` events to `agent.task` for all thread participants; mentioned agents get a reply-expected task, others get an FYI task
- Pending threads are injected into every agent's LLM context before each task, so agents are always aware of active discussions
- `agent.discuss` events are streamed to SSE clients for dashboard observability
- Hard cap of 100 messages per thread; `mentionedAgentIds` controls reply pressure to prevent runaway amplification
- Implements spec 01 (lines 24–44). Closes #25.

## What's included

- `src/db/migrations/015_create_bullpen.sql` — `bullpen_threads` + `bullpen_messages` tables with GIN index on participants
- `src/memory/bullpen.ts` — `BullpenService` with in-memory (tests) and Postgres backends, `formatBullpenContext` for LLM injection
- `src/dispatch/bullpen-dispatcher.ts` — `BullpenDispatcher` routing `agent.discuss` → `agent.task`
- `skills/bullpen/` — skill manifest + handler (post, reply, get_thread, close)
- `src/bus/events.ts` — `AgentDiscussEvent` + `createAgentDiscuss` factory
- `src/skills/execution.ts` + `src/skills/types.ts` — `agentId`, `taskEventId`, `bullpenService` threaded through `SkillContext`
- `src/agents/runtime.ts` — pending thread context injection before LLM calls
- `src/channels/http/event-router.ts` — SSE broadcast for `agent.discuss`
- `src/index.ts` — bootstrap wiring for `BullpenService` and `BullpenDispatcher`
- Full test coverage: 11 unit tests (BullpenService), 5 unit tests (BullpenDispatcher), 8 unit tests (skill handler), 4 integration tests, 9 bus event tests

## Test plan

- [ ] All 423 unit tests pass (`npm test`)
- [ ] Integration tests pass against a real Postgres instance (`DATABASE_URL` set)
- [ ] Server starts without errors; logs show "Bullpen service initialized" and "BullpenDispatcher registered"
- [ ] An agent calling the `bullpen` skill with `action: 'post'` creates a thread and emits `agent.discuss` on the SSE stream
- [ ] Agents listed as participants receive `agent.task` events via `BullpenDispatcher`
- [ ] Pending threads appear in agent context on the next task invocation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bullpen: shared threaded agent discussions — open, reply, close threads; mention participants; pending threads injected into agent context; real-time discussion stream for dashboards; targeted reply vs FYI notifications.

* **Bug Fixes**
  * Fixed session-cookie auth for job API and calendar timestamps formatted in UTC ISO 8601; removed a redundant contact-creation try/catch.

* **Documentation**
  * Changelog updated to v0.11.0 (dated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->