### PR TITLE
feat: Signal channel adapter (spec 04, v0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+- **Signal channel** (spec 04): inbound and outbound messaging via signal-cli daemon socket.
+  Includes `SignalRpcClient` (JSON-RPC 2.0 over Unix socket with exponential-backoff reconnect
+  and deduplication), `SignalAdapter` (contact auto-creation, prompt injection sanitization,
+  hold-for-approval unknown sender policy via channel-trust.yaml), and 1:1 read receipts for
+  confirmed senders. `OutboundGateway` extended to support Signal sends alongside email.
+  Enable by setting `SIGNAL_SOCKET_PATH` and `SIGNAL_PHONE_NUMBER` env vars (ADR-013).
+
 ---
 
 ## [0.11.0] — 2026-04-07

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,6 +1,12 @@
 channels:
   cli:
     enabled: true
+  # Signal channel is enabled by setting SIGNAL_SOCKET_PATH + SIGNAL_PHONE_NUMBER env vars.
+  # enabled: false here is the default — the adapter won't start if the env vars are absent.
+  # Trust level and unknown sender policy are in config/channel-trust.yaml (trust: high,
+  # unknown_sender: hold_and_notify) — those don't change regardless of this flag.
+  signal:
+    enabled: false
 
 browser:
   # How long a browser session stays alive after its last action (ms).

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,12 +1,9 @@
 channels:
   cli:
     enabled: true
-  # Signal channel is enabled by setting SIGNAL_SOCKET_PATH + SIGNAL_PHONE_NUMBER env vars.
-  # enabled: false here is the default — the adapter won't start if the env vars are absent.
-  # Trust level and unknown sender policy are in config/channel-trust.yaml (trust: high,
-  # unknown_sender: hold_and_notify) — those don't change regardless of this flag.
-  signal:
-    enabled: false
+  # Signal channel activation is controlled by env vars, not this file.
+  # Set SIGNAL_SOCKET_PATH + SIGNAL_PHONE_NUMBER at runtime to enable the Signal adapter.
+  # Trust level and unknown-sender policy live in config/channel-trust.yaml.
 
 browser:
   # How long a browser session stays alive after its last action (ms).

--- a/docs/adr/013-signal-cli-daemon-mode.md
+++ b/docs/adr/013-signal-cli-daemon-mode.md
@@ -1,0 +1,69 @@
+# ADR-013: signal-cli daemon socket mode for Signal integration
+
+Date: 2026-04-07
+Status: Accepted
+
+## Context
+
+ADR-010 established Signal as the high-trust messaging channel. This ADR covers the lower-level
+question of *how* to integrate with Signal from Node.js, given that Signal offers no official
+bot or developer API.
+
+Three options were evaluated:
+
+**Option A — signal-cli as a managed child process (stdio)**
+spawn signal-cli as a Node.js child process and communicate over stdin/stdout. The Node process
+owns the lifecycle; if Node restarts, signal-cli restarts too.
+
+**Option B — signal-cli in daemon mode, connected via Unix socket**
+signal-cli runs as its own persistent service (e.g., a Docker Compose service). It exposes a
+JSON-RPC socket. Curia connects as a client, reconnecting if the socket drops. The two processes
+have independent lifecycles.
+
+**Option C — Unofficial Node.js Signal libraries**
+Libraries like `@throneless/libsignal` implement the Signal protocol natively in Node.js,
+eliminating the external process dependency.
+
+## Decision
+
+**Option B (signal-cli daemon + Unix socket)** is adopted.
+
+**Rationale for B over A:**
+- signal-cli is a JVM process with its own memory model and connection state. Coupling it to
+  Node's lifecycle means a Node crash drops the Signal session and forces re-registration or
+  session recovery — a non-trivial operation. As a separate service, it stays up across
+  application restarts, configuration reloads, and deployments.
+- In the Docker Compose deployment (ceo-deploy), signal-cli runs as a dedicated service sharing
+  a socket volume with Curia. This is the standard production pattern and cleanly maps to the
+  architecture.
+- Reconnection on the Curia side is cheap: re-open the socket, resume the notification stream.
+  Reconnect on the signal-cli side is expensive: involves Signal protocol handshake.
+
+**Rationale for B over C:**
+- Unofficial Node.js Signal libraries are not production-ready. As of 2026-04, no actively
+  maintained library implements the full Signal protocol (sealed sender, storage service,
+  group messaging v2) without gaps or known security issues.
+- Implementing the Signal protocol from scratch in Node.js would take months and require deep
+  expertise in the Signal Protocol cryptography — not a reasonable investment for a single
+  channel adapter.
+- signal-cli is actively maintained, widely used in self-hosted Signal automation, and has a
+  stable JSON-RPC API with a documented schema.
+
+**Socket type:** Unix socket (same host/container, lowest overhead). TCP socket is supported
+by signal-cli and can be used for unusual Docker networking, but the standard deployment uses
+a shared named volume.
+
+## Consequences
+
+- **Java runtime dependency**: ceo-deploy must include a signal-cli container. This is the only
+  JVM in the stack. Accepted trade-off — the alternative (Option C) would have been much larger
+  scope.
+- **One-time phone number registration**: a real phone number (physical SIM, eSIM, or compatible
+  VoIP number such as Fongo/TextNow) is required. Registration is a one-time CLI operation in
+  the signal-cli container. The registration data must be persisted in a Docker volume.
+- **Socket volume**: the signal-cli socket path must be shared between the signal-cli container
+  and the Curia container via a named volume. This is standard Docker Compose practice.
+- **Reconnect logic in Curia**: the `SignalRpcClient` implements exponential-backoff reconnection
+  so transient socket drops (e.g., signal-cli container restart) are recovered transparently.
+- **VoIP number caveat**: Signal's anti-abuse system occasionally rejects VoIP numbers during
+  registration. If a VoIP number fails, a physical SIM is the reliable fallback.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,7 @@ Each ADR follows the [Nygard format](https://adr.github.io/):
 | [010](010-signal-over-telegram.md) | Signal as high-trust messaging channel, rejecting Telegram | Accepted |
 | [011](011-score-based-autonomy-engine.md) | Score-based autonomy engine over capability-based permissions | Accepted |
 | [012](012-llm-as-judge-evaluation.md) | LLM-as-judge for outbound safety and smoke test evaluation | Accepted |
+| [013](013-signal-cli-daemon-mode.md) | signal-cli daemon socket mode for Signal integration | Accepted |
 
 ## Adding new ADRs
 

--- a/docs/wip/2026-04-07-signal-channel-design.md
+++ b/docs/wip/2026-04-07-signal-channel-design.md
@@ -40,7 +40,7 @@ cross-host or unusual Docker networking, but not needed for the standard deploym
 
 ### Component ownership
 
-```
+```text
 signal-cli (separate service, Java)
   └─ Unix socket /run/signal-cli/socket
        └─ SignalRpcClient (Node.js, owns connection + reconnect)
@@ -108,10 +108,10 @@ JSON-RPC 2.0 client over a Unix/TCP socket. Responsibilities:
 Key interface:
 ```typescript
 class SignalRpcClient extends EventEmitter {
-  async connect(): Promise<void>
-  async disconnect(): Promise<void>
-  async send(params: SignalSendParams): Promise<void>
-  async sendReadReceipt(params: SignalReadReceiptParams): Promise<void>
+  connect(): void                                            // fire-and-forget, starts reconnect loop
+  disconnect(): Promise<void>
+  send(params: SignalSendParams): Promise<void>
+  sendReadReceipt(params: SignalReadReceiptParams): Promise<void>
 }
 ```
 

--- a/docs/wip/2026-04-07-signal-channel-design.md
+++ b/docs/wip/2026-04-07-signal-channel-design.md
@@ -1,0 +1,250 @@
+# Signal Channel — Design Document
+
+Date: 2026-04-07
+Spec: [04-channels.md](../specs/04-channels.md)
+ADR: [ADR-010](../adr/010-signal-over-telegram.md) (Signal vs Telegram), ADR-013 (signal-cli daemon — to be written)
+
+---
+
+## Overview
+
+Adds Signal as a second inbound/outbound message channel. Signal carries `high` trust
+(already declared in `config/channel-trust.yaml`) — phone number identity + E2E encryption
+make it safe to route CEO messages directly without the email channel's SPF/DKIM hedging.
+
+The implementation follows the same structural pattern as the email adapter: a self-contained
+class that publishes `inbound.message` events and subscribes to `outbound.message` to send
+replies. No core bus, dispatcher, or execution layer changes are needed.
+
+---
+
+## Integration Architecture
+
+### signal-cli daemon mode
+
+Signal does not offer an official bot API. signal-cli is the standard open-source bridge:
+a Java CLI tool that implements the Signal protocol and can run as a persistent daemon
+exposing a JSON-RPC socket.
+
+**Why daemon mode over subprocess mode:**
+- signal-cli is a separate JVM process with its own state and memory pressure; coupling
+  it to Node's lifecycle means a Node crash drops the Signal connection and vice versa.
+- In production (Docker Compose), signal-cli runs as its own service, sharing a socket
+  volume with the Curia container. This is the standard pattern and matches the existing
+  `ceo-deploy` architecture.
+- Reconnection on adapter side is cheap (re-open socket); reconnect on signal-cli side
+  would require re-establishing the Signal session.
+
+**Socket type:** Unix socket (same host/container). TCP socket supported as fallback for
+cross-host or unusual Docker networking, but not needed for the standard deployment.
+
+### Component ownership
+
+```
+signal-cli (separate service, Java)
+  └─ Unix socket /run/signal-cli/socket
+       └─ SignalRpcClient (Node.js, owns connection + reconnect)
+            └─ SignalAdapter (ChannelAdapter)
+                 ├─ inbound: envelope → InboundMessage → bus.publish()
+                 ├─ read receipts: direct via SignalRpcClient (bypass gateway — not content)
+                 └─ outbound: bus.subscribe('outbound.message') → OutboundGateway.send()
+                      └─ OutboundGateway (blocked-contact check + content filter + send)
+                           └─ SignalRpcClient.send()
+```
+
+### JSON-RPC framing
+
+signal-cli uses newline-delimited JSON over the socket. Each line is a complete JSON object.
+
+**Inbound notifications** (no `id` field — server-initiated):
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "receive",
+  "params": {
+    "envelope": { ... },
+    "account": "+1xxx"
+  }
+}
+```
+
+**Outbound requests** (with `id` for response correlation):
+```json
+{ "jsonrpc": "2.0", "id": "req-1", "method": "send", "params": { ... } }
+```
+
+**Responses:**
+```json
+{ "jsonrpc": "2.0", "id": "req-1", "result": { ... } }
+{ "jsonrpc": "2.0", "id": "req-1", "error": { "code": -1, "message": "..." } }
+```
+
+---
+
+## New Files
+
+### `src/channels/signal/types.ts`
+
+TypeScript types for the signal-cli JSON-RPC wire format. Key types:
+- `SignalEnvelope` — top-level envelope (source, timestamp, dataMessage | syncMessage | ...)
+- `SignalDataMessage` — text message payload (message, groupInfo, attachments, reaction)
+- `SignalGroupInfo` — groupId + type (DELIVER | UPDATE | QUIT | UNKNOWN)
+- `SignalAttachment` — id, contentType, filename, size
+- `SignalSendParams` — params for `send` RPC call
+- `SignalReadReceiptParams` — params for `sendReceipt` RPC call
+
+### `src/channels/signal/signal-rpc-client.ts`
+
+JSON-RPC 2.0 client over a Unix/TCP socket. Responsibilities:
+- Maintain the socket connection (Node `net.Socket`)
+- Frame/parse newline-delimited JSON
+- Correlate request IDs to Promises for `send()` calls
+- Emit `'message'` events for incoming `receive` notifications
+- Emit `'connected'` / `'disconnected'` events
+- Reconnect with exponential backoff (1s → 2s → 4s → ... → 5min cap)
+- Deduplicate re-delivered messages on reconnect (sliding `Set<string>` keyed on
+  `${sourceNumber}:${timestamp}`, max 1000 entries)
+
+Key interface:
+```typescript
+class SignalRpcClient extends EventEmitter {
+  async connect(): Promise<void>
+  async disconnect(): Promise<void>
+  async send(params: SignalSendParams): Promise<void>
+  async sendReadReceipt(params: SignalReadReceiptParams): Promise<void>
+}
+```
+
+### `src/channels/signal/message-converter.ts`
+
+Converts a `SignalEnvelope` → `InboundMessage`. Key logic:
+- Ignore envelopes with no `dataMessage`, with a `reaction`, or with `viewOnce: true`
+- Ignore `syncMessage` (self-sent from another device)
+- Conversation ID: `signal:+1xxx` for 1:1, `signal:group=<base64Id>` for groups
+- Sender ID: `sourceNumber` (E.164 format)
+- Content: `dataMessage.message` (stripped of any leading/trailing whitespace)
+- Metadata: `{ groupId?, sourceName?, timestamp, attachments? }`
+
+### `src/channels/signal/signal-adapter.ts`
+
+Implements `ChannelAdapter`. Responsibilities:
+- On `start()`: connect RPC client, subscribe to `outbound.message` on bus
+- On `message` event from RPC client:
+  1. Convert envelope → InboundMessage via message-converter
+  2. Resolve sender contact (for auto-create and read-receipt decision)
+  3. Auto-create contact if new (source: `'signal_participant'`, status: `'provisional'`)
+  4. If sender is known (non-provisional, non-blocked) and message is 1:1: send read receipt
+  5. Sanitize content (same `sanitizeOutput()` call as email adapter)
+  6. Publish `inbound.message` to bus
+- On `outbound.message` bus event with `channelId: 'signal'`: call `OutboundGateway.send()`
+- On `stop()`: disconnect RPC client
+
+---
+
+## Modified Files
+
+### `src/skills/outbound-gateway.ts`
+
+`OutboundSendRequest` becomes a discriminated union:
+
+```typescript
+export type OutboundSendRequest =
+  | EmailSendRequest
+  | SignalSendRequest;
+
+interface EmailSendRequest {
+  channel: 'email';
+  to: string;
+  subject: string;
+  body: string;
+  replyToMessageId?: string;
+}
+
+interface SignalSendRequest {
+  channel: 'signal';
+  recipient?: string;   // E.164 phone number for 1:1
+  groupId?: string;     // base64 group ID for group messages
+  message: string;
+}
+```
+
+The gateway gains an optional `signalClient?: SignalRpcClient` dep. `send()` dispatches
+to `dispatchEmail()` or `dispatchSignal()` based on `request.channel`. The blocked-contact
+check and content filter run before both dispatch paths.
+
+For Signal, the blocked-contact check uses `channelIdentifier = request.recipient ?? request.groupId`.
+
+### `src/config.ts`
+
+New fields:
+```typescript
+signalSocketPath: string | undefined;    // e.g. /run/signal-cli/socket
+signalPhoneNumber: string | undefined;   // Nathan's Signal number in E.164
+```
+
+Env vars: `SIGNAL_SOCKET_PATH`, `SIGNAL_PHONE_NUMBER`.
+
+### `config/default.yaml`
+
+```yaml
+channels:
+  signal:
+    enabled: false   # opt-in; no-op if SIGNAL_SOCKET_PATH is not set
+```
+
+### `src/index.ts`
+
+Signal adapter wiring (same pattern as email adapter):
+1. Construct `SignalRpcClient` if `config.signalSocketPath` is set
+2. Construct `SignalAdapter` with `{ bus, logger, rpcClient, outboundGateway, contactService, phoneNumber }`
+3. Start adapter AFTER dispatcher is registered (same ordering rationale as email)
+4. Stop adapter in graceful shutdown handler
+
+---
+
+## ADR-013
+
+Documents the choice of signal-cli daemon socket mode over:
+- **Child process (stdio)** — tighter coupling, fragile lifecycle
+- **Unofficial Node.js Signal libraries** (e.g. `@throneless/libsignal`) — unmaintained, 
+  no production track record, would require reimplementing the Signal protocol
+- **signal-cli HTTP mode** — adds HTTP server overhead for no benefit; socket is simpler
+
+---
+
+## Testing Strategy
+
+| Test file | Type | Approach |
+|---|---|---|
+| `signal-rpc-client.test.ts` | Unit | Mock `net.createConnection` with a fake socket; test framing, correlation, backoff |
+| `message-converter.test.ts` | Unit | Pure function tests over fixture envelopes (1:1, group, attachment, reaction) |
+| `signal-adapter.test.ts` | Unit | Mock RPC client and bus; verify inbound publish, contact auto-create, read receipt logic |
+
+No integration tests requiring a live signal-cli instance — that is deferred until ceo-deploy
+wires the service and a real phone number is registered.
+
+---
+
+## Docker / ceo-deploy Notes (not implemented here)
+
+In `ceo-deploy`, signal-cli runs as a separate Compose service:
+```yaml
+signal-cli:
+  image: bbernhard/signal-cli-rest-api:latest  # or custom signal-cli image
+  volumes:
+    - signal-data:/home/user/.local/share/signal-cli
+    - signal-socket:/run/signal-cli
+```
+
+The Curia service mounts the same `signal-socket` volume and sets:
+```
+SIGNAL_SOCKET_PATH=/run/signal-cli/socket
+SIGNAL_PHONE_NUMBER=+1XXXXXXXXXX
+```
+
+One-time registration (run in the signal-cli container):
+```bash
+signal-cli -a +1XXXXXXXXXX register
+signal-cli -a +1XXXXXXXXXX verify 123456
+signal-cli -a +1XXXXXXXXXX daemon --socket /run/signal-cli/socket
+```

--- a/docs/wip/2026-04-07-signal-channel.md
+++ b/docs/wip/2026-04-07-signal-channel.md
@@ -1,0 +1,501 @@
+# Signal Channel — Implementation Plan
+
+> **Design doc:** [2026-04-07-signal-channel-design.md](2026-04-07-signal-channel-design.md)
+
+**Goal:** Implement the Signal channel adapter (spec 04) — signal-cli daemon socket integration,
+inbound message handling, outbound replies via OutboundGateway, 1:1 read receipts for known
+senders, and contact auto-creation.
+
+**Architecture summary:** `SignalRpcClient` owns the socket + reconnect. `SignalAdapter` owns
+the bus integration. `OutboundGateway` gets a Signal send path alongside the existing email path.
+No core bus/dispatcher/execution layer changes needed.
+
+---
+
+### Task 1: ADR-013 — signal-cli daemon mode
+
+**Files:**
+- Create: `docs/adr/013-signal-cli-daemon-mode.md`
+- Modify: `docs/adr/README.md`
+
+- [ ] **Step 1: Write ADR-013**
+
+Document the decision to use signal-cli in daemon socket mode. Cover:
+- Context: Signal has no official bot API; three integration options evaluated
+- Options rejected: child process stdio (lifecycle coupling), unofficial Node.js Signal
+  libraries (`@throneless/libsignal` — unmaintained, reimplements the protocol),
+  signal-cli HTTP mode (extra server overhead for no benefit)
+- Decision: signal-cli daemon + Unix socket (battle-tested, maintained, production standard)
+- Consequences: Java runtime dependency in ceo-deploy; one-time phone number registration
+  required; socket volume shared between signal-cli container and Curia container
+
+- [ ] **Step 2: Add row to `docs/adr/README.md`**
+
+---
+
+### Task 2: Wire types for signal-cli JSON-RPC
+
+**Files:**
+- Create: `src/channels/signal/types.ts`
+
+- [ ] **Step 1: Write `SignalEnvelope` and related types**
+
+```typescript
+// signal-cli envelope — top-level wrapper for all incoming signal-cli notifications.
+export interface SignalEnvelope {
+  source: string;         // E.164 phone number, e.g. "+14155552671"
+  sourceNumber: string;   // same as source (signal-cli uses both)
+  sourceUuid: string;
+  sourceName: string;
+  sourceDevice: number;
+  timestamp: number;      // Signal-level timestamp (ms) — needed for read receipts
+  dataMessage?: SignalDataMessage;
+  syncMessage?: SignalSyncMessage;
+  // callMessage, typingMessage, receiptMessage — ignored
+}
+
+export interface SignalDataMessage {
+  timestamp: number;
+  message: string | null;  // null for reactions, attachments-only, etc.
+  expiresInSeconds: number;
+  viewOnce: boolean;
+  groupInfo?: SignalGroupInfo;
+  attachments?: SignalAttachment[];
+  reaction?: SignalReaction;
+}
+
+export interface SignalGroupInfo {
+  groupId: string;   // base64-encoded group V2 ID
+  type: 'DELIVER' | 'UPDATE' | 'QUIT' | 'UNKNOWN';
+}
+
+export interface SignalAttachment {
+  contentType: string;
+  filename?: string;
+  id: string;
+  size: number;
+}
+
+export interface SignalReaction {
+  emoji: string;
+  targetAuthor: string;
+  targetTimestamp: number;
+  isRemove: boolean;
+}
+
+// syncMessage — messages sent by Nathan from another device.
+// We don't process these as inbound; they're filtered out in the converter.
+export interface SignalSyncMessage {
+  sentMessage?: { message: string };
+}
+
+// Params for the signal-cli `send` JSON-RPC method
+export interface SignalSendParams {
+  account: string;       // Nathan's phone number
+  recipient?: string[];  // E.164 array for 1:1
+  groupId?: string;      // base64 group ID for group messages
+  message: string;
+}
+
+// Params for the signal-cli `sendReceipt` JSON-RPC method
+export interface SignalReadReceiptParams {
+  account: string;
+  recipient: string;           // sender's E.164 number
+  targetTimestamp: number[];   // array of Signal timestamps to mark read
+  receiptType: 'read' | 'viewed';
+}
+
+// Receive notification payload (the `params` field of a receive notification)
+export interface SignalReceiveParams {
+  envelope: SignalEnvelope;
+  account: string;
+}
+```
+
+---
+
+### Task 3: SignalRpcClient
+
+**Files:**
+- Create: `src/channels/signal/signal-rpc-client.ts`
+- Create: `src/channels/signal/signal-rpc-client.test.ts`
+
+- [ ] **Step 1: Write `SignalRpcClient`**
+
+Key design points:
+- Extends `EventEmitter` — emits `'message'` (with `SignalEnvelope`) and
+  `'connected'` / `'disconnected'`
+- Socket: `net.createConnection({ path: socketPath })` for Unix,
+  `net.createConnection({ host, port })` for TCP
+- Framing: buffer partial reads, split on `\n`, parse each line as JSON
+- Request correlation: `Map<string, { resolve, reject }>` keyed on `id`
+- Request IDs: monotonic counter (`req-1`, `req-2`, ...)
+- Reconnect: exponential backoff starting at 1000ms, doubling, capped at 300_000ms (5 min);
+  use `setTimeout` not `setInterval` so backoff can grow; reset to 1000ms on successful
+  connect
+- `send()` and `sendReadReceipt()`: build JSON-RPC request, write to socket, return Promise
+  that resolves/rejects from the correlation map; reject after 10s timeout
+- On `disconnect` / `error`: reject all pending requests with connection error, schedule reconnect
+- Dedup: `Set<string>` keyed on `${sourceNumber}:${timestamp}`; evict oldest when size > 1000
+  (use an insertion-order array as a queue alongside the set)
+
+```typescript
+export interface SignalRpcClientConfig {
+  socketPath: string;  // Unix socket path (TCP support deferred)
+  accountNumber: string;
+  logger: Logger;
+}
+
+export class SignalRpcClient extends EventEmitter {
+  constructor(config: SignalRpcClientConfig)
+  async connect(): Promise<void>
+  async disconnect(): Promise<void>
+  async send(params: SignalSendParams): Promise<void>
+  async sendReadReceipt(params: SignalReadReceiptParams): Promise<void>
+}
+```
+
+- [ ] **Step 2: Write tests for `SignalRpcClient`**
+
+Use Node's `net.createServer()` to create a real Unix socket server in a temp path.
+Test cases:
+- Parses a valid `receive` notification and emits `'message'`
+- Correlates a `send` request to its response
+- Rejects pending requests on socket close
+- Deduplicates a re-delivered envelope (same `sourceNumber:timestamp`)
+- Evicts oldest dedup entry when Set exceeds 1000
+
+---
+
+### Task 4: Message converter
+
+**Files:**
+- Create: `src/channels/signal/message-converter.ts`
+- Create: `src/channels/signal/message-converter.test.ts`
+
+- [ ] **Step 1: Write `convertSignalEnvelope()`**
+
+```typescript
+export interface ConvertedSignalMessage {
+  conversationId: string;
+  channelId: 'signal';
+  senderId: string;            // E.164 phone number
+  content: string;
+  metadata: {
+    sourceName: string;
+    signalTimestamp: number;   // needed for read receipt
+    groupId?: string;
+    isGroup: boolean;
+    attachments?: SignalAttachment[];
+  };
+}
+
+// Returns null for envelopes that should be ignored (reactions, sync messages,
+// view-once, no text content, group management events)
+export function convertSignalEnvelope(
+  envelope: SignalEnvelope,
+): ConvertedSignalMessage | null
+```
+
+Conversation ID logic:
+```typescript
+const isGroup = !!envelope.dataMessage?.groupInfo;
+const conversationId = isGroup
+  ? `signal:group=${envelope.dataMessage.groupInfo.groupId}`
+  : `signal:${envelope.sourceNumber}`;
+```
+
+Ignore conditions (return `null`):
+- No `dataMessage`
+- Has `syncMessage` (self-sent from another device)
+- `dataMessage.reaction` is set (emoji reaction — ignore per spec)
+- `dataMessage.viewOnce` is true
+- `dataMessage.message` is null or empty after trim
+- `dataMessage.groupInfo?.type !== 'DELIVER'` (group management events like UPDATE, QUIT)
+
+- [ ] **Step 2: Write tests**
+
+Cover: 1:1 message, group message, reaction (null), sync message (null), empty message (null),
+group UPDATE event (null), attachment-only message (null), message with leading/trailing whitespace.
+
+---
+
+### Task 5: SignalAdapter
+
+**Files:**
+- Create: `src/channels/signal/signal-adapter.ts`
+- Create: `src/channels/signal/signal-adapter.test.ts`
+
+- [ ] **Step 1: Write `SignalAdapter`**
+
+```typescript
+export interface SignalAdapterConfig {
+  bus: EventBus;
+  logger: Logger;
+  rpcClient: SignalRpcClient;
+  outboundGateway: OutboundGateway | undefined;
+  contactService: ContactService;
+  phoneNumber: string;  // Nathan's number — used as `account` in all RPC calls
+}
+
+export class SignalAdapter {
+  async start(): Promise<void>
+  async stop(): Promise<void>
+}
+```
+
+`start()` sequence:
+1. Subscribe to `outbound.message` bus event (filter `channelId === 'signal'`)
+2. Register `rpcClient.on('message', handleInbound)`
+3. Call `rpcClient.connect()`
+
+`handleInbound(envelope)` sequence:
+1. `convertSignalEnvelope(envelope)` — return early if null
+2. Try to resolve sender contact via `contactService.resolveByChannelIdentity('signal', senderId)`
+3. If no contact: auto-create with `source: 'signal_participant'`, `status: 'provisional'`,
+   link identity channel='signal', channelIdentifier=senderId
+4. Determine `isKnown`: contact exists AND status is not `'provisional'` AND not `'blocked'`
+5. If `isKnown` AND message is 1:1 (not group): fire read receipt (fire-and-forget, log on error)
+6. Sanitize content with `sanitizeOutput(content, { maxLength: 10_000 })`
+7. Publish `createInboundMessage({ conversationId, channelId: 'signal', senderId, content, metadata })`
+
+`handleOutbound(event)`:
+- Parse `conversationId` to extract recipient or groupId
+- Call `outboundGateway.send({ channel: 'signal', ... })`
+- If no gateway: log warn and return (same degraded-mode pattern as email)
+
+Read receipt:
+```typescript
+await this.config.rpcClient.sendReadReceipt({
+  account: this.config.phoneNumber,
+  recipient: senderId,
+  targetTimestamp: [metadata.signalTimestamp],
+  receiptType: 'read',
+});
+```
+
+- [ ] **Step 2: Write tests**
+
+Mock `SignalRpcClient` (EventEmitter stub) and bus. Test:
+- Inbound 1:1 from known contact → publishes inbound.message, sends read receipt
+- Inbound 1:1 from unknown → publishes inbound.message, no read receipt, auto-creates contact
+- Inbound group message from known contact → publishes inbound.message, no read receipt
+- Reaction envelope → ignored (no publish)
+- Outbound message event (signal channelId) → calls gateway.send()
+- Outbound message event (email channelId) → ignored
+
+---
+
+### Task 6: OutboundGateway — Signal send path
+
+**Files:**
+- Modify: `src/skills/outbound-gateway.ts`
+
+- [ ] **Step 1: Extend `OutboundSendRequest` to a discriminated union**
+
+```typescript
+export type OutboundSendRequest = EmailSendRequest | SignalSendRequest;
+
+export interface EmailSendRequest {
+  channel: 'email';
+  to: string;
+  subject: string;
+  body: string;
+  replyToMessageId?: string;
+}
+
+export interface SignalSendRequest {
+  channel: 'signal';
+  recipient?: string;   // E.164 for 1:1; mutually exclusive with groupId
+  groupId?: string;     // base64 group ID; mutually exclusive with recipient
+  message: string;
+}
+```
+
+- [ ] **Step 2: Add `signalClient?: SignalRpcClient` to `OutboundGatewayConfig`**
+
+- [ ] **Step 3: Add `dispatchSignal()` private method**
+
+```typescript
+private async dispatchSignal(request: SignalSendRequest): Promise<OutboundSendResult>
+```
+
+Logic:
+- If `!this.config.signalClient`: return `{ success: false, blockedReason: 'Signal client not configured' }`
+- Build `SignalSendParams`: `{ account: this.config.signalPhoneNumber, ... }`
+- Call `this.config.signalClient.send(params)`
+- Return `{ success: true }`
+
+- [ ] **Step 4: Update `send()` to dispatch on channel**
+
+Replace the existing unconditional Nylas path with:
+```typescript
+if (request.channel === 'email') {
+  return this.dispatchEmail(request);
+} else {
+  return this.dispatchSignal(request);
+}
+```
+
+The blocked-contact check and content filter already run before this branch — they are
+channel-agnostic.
+
+For Signal's blocked-contact check, the `to` identifier is `request.recipient ?? request.groupId ?? ''`.
+
+- [ ] **Step 5: Add `signalPhoneNumber?: string` to `OutboundGatewayConfig`** (needed for `account` param)
+
+---
+
+### Task 7: Config
+
+**Files:**
+- Modify: `src/config.ts`
+- Modify: `config/default.yaml`
+
+- [ ] **Step 1: Add Signal fields to `Config` interface and `loadConfig()`**
+
+```typescript
+// In Config interface:
+signalSocketPath: string | undefined;
+signalPhoneNumber: string | undefined;
+```
+
+```typescript
+// In loadConfig():
+signalSocketPath: process.env.SIGNAL_SOCKET_PATH || undefined,
+signalPhoneNumber: process.env.SIGNAL_PHONE_NUMBER || undefined,
+```
+
+- [ ] **Step 2: Update `config/default.yaml`**
+
+The `channels.signal` key already exists in `channel-trust.yaml` (trust + policy). Add
+an opt-in `enabled` flag to `default.yaml` for consistency with the CLI channel entry:
+
+```yaml
+channels:
+  cli:
+    enabled: true
+  signal:
+    enabled: false   # enable by setting SIGNAL_SOCKET_PATH + SIGNAL_PHONE_NUMBER
+```
+
+---
+
+### Task 8: Bootstrap wiring
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Construct SignalRpcClient and SignalAdapter**
+
+After the email adapter construction block, add:
+
+```typescript
+// Signal channel — optional; requires SIGNAL_SOCKET_PATH and SIGNAL_PHONE_NUMBER.
+// SignalRpcClient is constructed here; SignalAdapter is started after the dispatcher
+// (same ordering rule as EmailAdapter: no adapter polls before inbound.message has a subscriber).
+let signalAdapter: SignalAdapter | undefined;
+if (config.signalSocketPath && config.signalPhoneNumber) {
+  const signalRpcClient = new SignalRpcClient({
+    socketPath: config.signalSocketPath,
+    accountNumber: config.signalPhoneNumber,
+    logger,
+  });
+  // Inject signalRpcClient and signalPhoneNumber into outboundGateway if it exists.
+  // If outboundGateway is not available (no Nylas), construct a Signal-only gateway.
+  // ...see step 2
+  signalAdapter = new SignalAdapter({
+    bus,
+    logger,
+    rpcClient: signalRpcClient,
+    outboundGateway,   // may be undefined — adapter handles graceful degradation
+    contactService,
+    phoneNumber: config.signalPhoneNumber,
+  });
+} else {
+  logger.warn('SIGNAL_SOCKET_PATH/SIGNAL_PHONE_NUMBER not set — Signal channel disabled');
+}
+```
+
+- [ ] **Step 2: Pass signalRpcClient + signalPhoneNumber to OutboundGateway**
+
+`OutboundGateway` currently requires `nylasClient`. For Signal-only mode (no Nylas),
+`outboundGateway` would be undefined, and the adapter falls back to no outbound.
+
+The cleaner approach: if `signalRpcClient` is available, pass it into `OutboundGateway`
+regardless of Nylas. Update the gateway construction block:
+
+```typescript
+outboundGateway = new OutboundGateway({
+  nylasClient,
+  signalClient: signalRpcClient,    // may be undefined
+  signalPhoneNumber: config.signalPhoneNumber,
+  contactService,
+  contentFilter: outboundFilter,
+  bus,
+  ceoEmail: config.nylasSelfEmail,
+  logger,
+});
+```
+
+Update the gateway initialization guard: currently requires `nylasClient && outboundFilter && ceoEmail`.
+Change to: initialize gateway if `(nylasClient || signalRpcClient) && outboundFilter`.
+`ceoEmail` becomes optional (only needed for email content filter).
+
+- [ ] **Step 3: Start SignalAdapter after dispatcher registration**
+
+After `emailAdapter?.start()`:
+```typescript
+if (signalAdapter) {
+  await signalAdapter.start();
+  logger.info('Signal channel adapter started');
+}
+```
+
+- [ ] **Step 4: Stop SignalAdapter in shutdown handler**
+
+```typescript
+if (signalAdapter) {
+  try {
+    await signalAdapter.stop();
+  } catch (err) {
+    logger.error({ err }, 'Error stopping Signal adapter during shutdown');
+  }
+}
+```
+
+---
+
+### Task 9: CHANGELOG and version bump
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`
+
+- [ ] **Step 1: Add `## [Unreleased]` entry to CHANGELOG.md**
+
+```markdown
+### Added
+- **Signal channel** (spec 04): inbound/outbound messaging via signal-cli daemon socket,
+  1:1 read receipts for known senders, contact auto-creation, unknown sender hold policy.
+```
+
+- [ ] **Step 2: Bump version to `0.10.0`** in `package.json`
+
+New channel = minor bump per versioning table.
+
+---
+
+### Task 10: Run test suite
+
+- [ ] **Step 1: Run full test suite and fix any failures**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-channel test
+```
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-channel run typecheck
+```

--- a/docs/wip/2026-04-07-signal-channel.md
+++ b/docs/wip/2026-04-07-signal-channel.md
@@ -491,11 +491,11 @@ New channel = minor bump per versioning table.
 - [ ] **Step 1: Run full test suite and fix any failures**
 
 ```bash
-npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-channel test
+npm test
 ```
 
 - [ ] **Step 2: Run typecheck**
 
 ```bash
-npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-signal-channel run typecheck
+npm run typecheck
 ```

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/josephfung/Projects/office-of-the-ceo/repos/curia/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/josephfung/Projects/office-of-the-ceo/repos/curia/node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/channels/signal/message-converter.ts
+++ b/src/channels/signal/message-converter.ts
@@ -89,6 +89,12 @@ export function convertSignalEnvelope(
   // 1:1:   signal:<E.164 number>         — the sender's phone number
   // The `group=` prefix prevents collisions between a group ID that happens to
   // look like a phone number and an actual 1:1 conversation.
+  //
+  // Guard: if groupInfo is present but groupId is empty, we cannot form a valid
+  // conversation ID and must skip the message. This should never happen in practice
+  // (signal-cli always sets groupId for group messages), but be defensive.
+  if (groupInfo && !groupInfo.groupId) return null;
+
   const isGroup = !!groupInfo;
   const conversationId = isGroup
     ? `signal:group=${groupInfo.groupId}`

--- a/src/channels/signal/message-converter.ts
+++ b/src/channels/signal/message-converter.ts
@@ -1,0 +1,110 @@
+// src/channels/signal/message-converter.ts
+//
+// Converts a signal-cli SignalEnvelope into a normalized ConvertedSignalMessage
+// that the SignalAdapter can publish to the bus as an inbound.message event.
+//
+// Many envelope types arrive that we don't want to process as messages:
+//   - syncMessage: Nathan sent this from another device — not inbound
+//   - reaction: emoji reaction to a prior message — ignored per spec (MVP)
+//   - viewOnce: self-destructing message — skip (we don't want LLM context on ephemeral content)
+//   - null/empty message: attachment-only or other non-text envelope
+//   - group management events (UPDATE/QUIT): not displayable content
+// All ignored cases return null so the adapter can skip them cleanly.
+
+import type { SignalEnvelope, SignalAttachment } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Output type
+// ---------------------------------------------------------------------------
+
+export interface ConvertedSignalMessage {
+  conversationId: string;
+  channelId: 'signal';
+  /** E.164 sender phone number — used as the bus senderId */
+  senderId: string;
+  content: string;
+  metadata: {
+    /** Sender's Signal display name (may be empty string if not set) */
+    sourceName: string;
+    /**
+     * Signal-level timestamp in milliseconds. This is NOT a wall-clock time —
+     * it's the identifier Signal uses internally. Required for sending read receipts:
+     * the sendReceipt RPC call must supply the exact targetTimestamp from this field.
+     */
+    signalTimestamp: number;
+    /** Set when this was a group message. Needed to route outbound replies to the group. */
+    groupId?: string;
+    /** True when the message arrived in a group chat */
+    isGroup: boolean;
+    attachments?: SignalAttachment[];
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Converter
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a signal-cli envelope to a normalized message shape.
+ *
+ * Returns null for any envelope that should be silently ignored:
+ *   - syncMessage (self-sent from another device)
+ *   - reaction (emoji reaction — no text content)
+ *   - viewOnce (ephemeral content)
+ *   - no dataMessage
+ *   - null or empty message text
+ *   - group management events (type !== 'DELIVER')
+ */
+export function convertSignalEnvelope(
+  envelope: SignalEnvelope,
+): ConvertedSignalMessage | null {
+  // Sync messages are Nathan's outbound activity mirrored back to linked devices.
+  // We never want these to appear as inbound requests to the coordinator.
+  if (envelope.syncMessage) return null;
+
+  // Must have a dataMessage to have any content worth processing.
+  const data = envelope.dataMessage;
+  if (!data) return null;
+
+  // View-once messages are designed to be ephemeral — skip them entirely rather
+  // than storing their content in working memory or the audit log.
+  if (data.viewOnce) return null;
+
+  // Reactions don't carry actionable text content — ignored for MVP per spec.
+  // A future version could acknowledge reactions or use them as signals (e.g.,
+  // thumbs-up = approve pending action), but that's out of scope for the first pass.
+  if (data.reaction) return null;
+
+  // Skip group management events (someone added/left the group, group name changed, etc.)
+  // Only DELIVER means a real message was sent to the group.
+  const groupInfo = data.groupInfo;
+  if (groupInfo && groupInfo.type !== 'DELIVER') return null;
+
+  // Empty or whitespace-only messages have no content worth routing to the LLM.
+  const rawContent = data.message?.trim() ?? '';
+  if (!rawContent) return null;
+
+  // Build conversation ID.
+  // Group: signal:group=<base64GroupId>  — stable across all members
+  // 1:1:   signal:<E.164 number>         — the sender's phone number
+  // The `group=` prefix prevents collisions between a group ID that happens to
+  // look like a phone number and an actual 1:1 conversation.
+  const isGroup = !!groupInfo;
+  const conversationId = isGroup
+    ? `signal:group=${groupInfo.groupId}`
+    : `signal:${envelope.sourceNumber}`;
+
+  return {
+    conversationId,
+    channelId: 'signal',
+    senderId: envelope.sourceNumber,
+    content: rawContent,
+    metadata: {
+      sourceName: envelope.sourceName,
+      signalTimestamp: envelope.timestamp,
+      groupId: groupInfo?.groupId,
+      isGroup,
+      attachments: data.attachments?.length ? data.attachments : undefined,
+    },
+  };
+}

--- a/src/channels/signal/signal-adapter.ts
+++ b/src/channels/signal/signal-adapter.ts
@@ -53,7 +53,16 @@ export class SignalAdapter {
   constructor(config: SignalAdapterConfig) {
     this.config = config;
     this.log = config.logger.child({ component: 'signal-adapter' });
-    this.boundHandleInbound = (envelope) => void this.handleInbound(envelope);
+    // The .catch is required: handleInbound is async and errors inside it (e.g. a
+    // bus.publish rejection) would otherwise become an UnhandledPromiseRejection,
+    // crashing Node in default configuration. We catch here rather than inside
+    // handleInbound because handleInbound already catches expected errors (contact
+    // resolution failures) — this outer catch is the backstop for unexpected throws.
+    this.boundHandleInbound = (envelope) => {
+      void this.handleInbound(envelope).catch((err: unknown) => {
+        this.log.error({ err }, 'Signal adapter: unexpected error in inbound handler');
+      });
+    };
   }
 
   async start(): Promise<void> {
@@ -79,8 +88,12 @@ export class SignalAdapter {
     // missed during the connect window.
     rpcClient.on('message', this.boundHandleInbound);
 
-    await rpcClient.connect();
-    this.log.info({ phoneNumber: this.config.phoneNumber }, 'Signal adapter started');
+    // connect() is synchronous — it starts the connection attempt in the background
+    // and returns immediately. If signal-cli is not yet available (Docker startup race),
+    // the RPC client's exponential backoff will retry until it connects. The 'connected'
+    // event on the RPC client signals when messages will start flowing.
+    rpcClient.connect();
+    this.log.info('Signal adapter started — connecting to signal-cli socket');
   }
 
   async stop(): Promise<void> {
@@ -204,10 +217,13 @@ export class SignalAdapter {
 
     if (!outboundGateway) {
       // Should not happen in normal operation — Signal adapter only starts when
-      // outboundGateway is available (see index.ts wiring). Defensive guard.
+      // outboundGateway is available (see index.ts wiring). If this fires, it
+      // indicates a wiring bug: the adapter was constructed without a gateway.
+      // Logged at error (not warn) because the coordinator's response is silently
+      // lost — the CEO sent a message and got no reply.
       // TODO: once the gateway always has a Signal client when this adapter is
-      // active, upgrade this to log.error — it would indicate a wiring bug.
-      this.log.warn({ conversationId }, 'Signal adapter: outbound gateway not available, cannot send reply');
+      // active, convert this to an explicit assertion.
+      this.log.error({ conversationId }, 'Signal adapter: outbound gateway not available — reply dropped. Check index.ts wiring.');
       return;
     }
 

--- a/src/channels/signal/signal-adapter.ts
+++ b/src/channels/signal/signal-adapter.ts
@@ -1,0 +1,247 @@
+// src/channels/signal/signal-adapter.ts
+//
+// Signal channel adapter — receives inbound messages from the signal-cli RPC
+// client, publishes them to the bus as inbound.message events, auto-creates
+// contacts from new senders, and sends outbound replies when the coordinator
+// responds to a Signal conversation.
+//
+// This adapter mirrors the EmailAdapter pattern. The key differences:
+//   - Transport is a Unix socket (signal-cli daemon) instead of HTTP polling
+//   - Trust level is 'high' — phone number + E2E encryption (see channel-trust.yaml)
+//   - Read receipts are sent back for 1:1 messages from known senders
+//   - Group messages don't get read receipts (group receipt semantics are complex)
+
+import type { EventBus } from '../../bus/bus.js';
+import type { Logger } from '../../logger.js';
+import type { ContactService } from '../../contacts/contact-service.js';
+import type { OutboundGateway } from '../../skills/outbound-gateway.js';
+import type { OutboundMessageEvent } from '../../bus/events.js';
+import type { SignalEnvelope } from './types.js';
+import { SignalRpcClient } from './signal-rpc-client.js';
+import { convertSignalEnvelope } from './message-converter.js';
+import { createInboundMessage } from '../../bus/events.js';
+import { sanitizeOutput } from '../../skills/sanitize.js';
+
+export interface SignalAdapterConfig {
+  bus: EventBus;
+  logger: Logger;
+  rpcClient: SignalRpcClient;
+  /**
+   * The OutboundGateway is optional here because Signal and email can be
+   * configured independently. If the gateway is unavailable (e.g., no Signal
+   * send path wired), outbound replies are logged as warnings rather than
+   * silently dropped — the coordinator's response still completes, but no
+   * message leaves the system.
+   *
+   * TODO: Once OutboundGateway always has a Signal client when the Signal adapter
+   * is active (see index.ts wiring notes), this can be tightened to required.
+   * For now, optional matches the EmailAdapter pattern and keeps bootstrap simpler.
+   */
+  outboundGateway: OutboundGateway | undefined;
+  contactService: ContactService;
+  /** Nathan's E.164 phone number — the Signal account that receives messages */
+  phoneNumber: string;
+}
+
+export class SignalAdapter {
+  private readonly config: SignalAdapterConfig;
+  private readonly log: Logger;
+  // Bound handler so we can remove it in stop() without losing the reference.
+  // Arrow function captures `this` correctly even after .off() removes it.
+  private readonly boundHandleInbound: (envelope: SignalEnvelope) => void;
+
+  constructor(config: SignalAdapterConfig) {
+    this.config = config;
+    this.log = config.logger.child({ component: 'signal-adapter' });
+    this.boundHandleInbound = (envelope) => void this.handleInbound(envelope);
+  }
+
+  async start(): Promise<void> {
+    const { bus, rpcClient } = this.config;
+
+    // Subscribe to outbound messages for the Signal channel.
+    // When the coordinator responds to a Signal-triggered conversation, the
+    // dispatcher creates an outbound.message with channelId 'signal'. The adapter
+    // routes this back to the sender via the OutboundGateway.
+    bus.subscribe('outbound.message', 'channel', async (event) => {
+      const outbound = event as OutboundMessageEvent;
+      if (outbound.payload.channelId !== 'signal') return;
+
+      try {
+        await this.handleOutbound(outbound);
+      } catch (err) {
+        this.log.error({ err, conversationId: outbound.payload.conversationId },
+          'Failed to send Signal response');
+      }
+    });
+
+    // Register inbound message handler before connecting so no messages are
+    // missed during the connect window.
+    rpcClient.on('message', this.boundHandleInbound);
+
+    await rpcClient.connect();
+    this.log.info({ phoneNumber: this.config.phoneNumber }, 'Signal adapter started');
+  }
+
+  async stop(): Promise<void> {
+    this.config.rpcClient.off('message', this.boundHandleInbound);
+    await this.config.rpcClient.disconnect();
+    this.log.info('Signal adapter stopped');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: inbound
+  // ---------------------------------------------------------------------------
+
+  private async handleInbound(envelope: SignalEnvelope): Promise<void> {
+    const converted = convertSignalEnvelope(envelope);
+    if (!converted) {
+      // Reaction, sync, view-once, empty content, group management — silently ignored.
+      // Logged at debug so operators can verify the filter is working without log spam.
+      this.log.debug(
+        { source: envelope.sourceNumber, hasData: !!envelope.dataMessage },
+        'Signal adapter: ignoring non-message envelope',
+      );
+      return;
+    }
+
+    const { conversationId, senderId, content, metadata } = converted;
+
+    // ------------------------------------------------------------------
+    // Step 1: Contact resolution and auto-create
+    // ------------------------------------------------------------------
+    // Try to find an existing contact for this phone number before publishing
+    // so the dispatcher's contact resolver can find the record immediately.
+    let isKnownSender = false;
+    try {
+      const existing = await this.config.contactService.resolveByChannelIdentity('signal', senderId);
+
+      if (existing) {
+        // Known sender: not provisional and not blocked counts as "known"
+        // for read-receipt purposes. The dispatcher enforces hold/block policy.
+        isKnownSender = existing.status !== 'provisional' && existing.status !== 'blocked';
+      } else {
+        // New sender — auto-create a provisional contact.
+        // signal_participant is auto-verified (per contact-service.ts) so the phone
+        // number identity gets verified:true at creation time, matching email_participant.
+        // Display name comes from Signal's profile; phone number is the E.164 fallback.
+        const contact = await this.config.contactService.createContact({
+          displayName: metadata.sourceName || senderId,
+          fallbackDisplayName: senderId,
+          source: 'signal_participant',
+          status: 'provisional',
+        });
+        await this.config.contactService.linkIdentity({
+          contactId: contact.id,
+          channel: 'signal',
+          channelIdentifier: senderId,
+          source: 'signal_participant',
+        });
+        this.log.info({ senderId, sourceName: metadata.sourceName }, 'Auto-created contact from Signal sender');
+      }
+    } catch (err) {
+      // Non-fatal: contact creation is best-effort. The inbound message is still
+      // published — the dispatcher will handle unknown senders per channel policy.
+      // isKnownSender stays false so no read receipt will be sent for this message.
+      this.log.warn({ err, senderId }, 'Failed to resolve/auto-create Signal contact');
+    }
+
+    // ------------------------------------------------------------------
+    // Step 2: Read receipt (1:1 + known sender only)
+    // ------------------------------------------------------------------
+    // We send read receipts only for 1:1 messages from known (non-provisional,
+    // non-blocked) senders. Reasons for each exclusion:
+    //   - Group: receipt semantics broadcast to all group members — deferred to a future version
+    //   - Provisional: CEO hasn't confirmed this contact yet — don't acknowledge unknown senders
+    //   - Blocked: never send receipts back to blocked senders
+    if (isKnownSender && !metadata.isGroup) {
+      // Fire-and-forget: read receipts are best-effort protocol-level acknowledgements.
+      // A failed receipt must never block the inbound publish — the message must reach
+      // the coordinator regardless of whether the receipt lands.
+      this.config.rpcClient.sendReadReceipt({
+        account: this.config.phoneNumber,
+        recipient: senderId,
+        targetTimestamp: [metadata.signalTimestamp],
+        receiptType: 'read',
+      }).catch((err: unknown) => {
+        this.log.warn({ err, senderId }, 'Failed to send Signal read receipt');
+      });
+    }
+
+    // ------------------------------------------------------------------
+    // Step 3: Sanitize and publish
+    // ------------------------------------------------------------------
+    // Sanitize content to mitigate prompt injection from external senders.
+    // Signal messages are shorter than emails but carry the same injection risk —
+    // a malicious sender could craft a message that looks like system instructions.
+    const sanitizedContent = sanitizeOutput(content, {
+      maxLength: 10_000,
+    });
+
+    const event = createInboundMessage({
+      conversationId,
+      channelId: 'signal',
+      senderId,
+      content: sanitizedContent,
+      metadata: metadata as unknown as Record<string, unknown>,
+    });
+
+    await this.config.bus.publish('channel', event);
+
+    this.log.info(
+      { senderId, sourceName: metadata.sourceName, isGroup: metadata.isGroup, conversationId },
+      'Signal message received and published to bus',
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: outbound
+  // ---------------------------------------------------------------------------
+
+  private async handleOutbound(outbound: OutboundMessageEvent): Promise<void> {
+    const { outboundGateway } = this.config;
+    const conversationId = outbound.payload.conversationId;
+
+    if (!outboundGateway) {
+      // Should not happen in normal operation — Signal adapter only starts when
+      // outboundGateway is available (see index.ts wiring). Defensive guard.
+      // TODO: once the gateway always has a Signal client when this adapter is
+      // active, upgrade this to log.error — it would indicate a wiring bug.
+      this.log.warn({ conversationId }, 'Signal adapter: outbound gateway not available, cannot send reply');
+      return;
+    }
+
+    if (!conversationId.startsWith('signal:')) {
+      this.log.warn({ conversationId }, 'Signal adapter: conversation ID not in signal: format');
+      return;
+    }
+
+    const conversationTarget = conversationId.slice('signal:'.length);
+
+    // Determine whether this is a 1:1 or group conversation from the conversation ID format.
+    // Group IDs are prefixed with 'group=' to distinguish them from E.164 phone numbers.
+    let recipient: string | undefined;
+    let groupId: string | undefined;
+
+    if (conversationTarget.startsWith('group=')) {
+      // Strip the 'group=' prefix to get the raw base64 group ID for the RPC call
+      groupId = conversationTarget.slice('group='.length);
+    } else {
+      // 1:1 conversation — the target is the E.164 phone number
+      recipient = conversationTarget;
+    }
+
+    const result = await outboundGateway.send({
+      channel: 'signal',
+      recipient,
+      groupId,
+      message: outbound.payload.content,
+    });
+
+    if (result.success) {
+      this.log.info({ conversationId, recipient, groupId }, 'Signal reply sent via gateway');
+    } else {
+      this.log.warn({ conversationId, reason: result.blockedReason }, 'Signal reply blocked by gateway');
+    }
+  }
+}

--- a/src/channels/signal/signal-rpc-client.ts
+++ b/src/channels/signal/signal-rpc-client.ts
@@ -88,14 +88,25 @@ export class SignalRpcClient extends EventEmitter {
   // ---------------------------------------------------------------------------
 
   /**
-   * Connect to the signal-cli socket and start listening for messages.
-   * Resolves once the connection is established. If the socket is not yet
-   * available, the client will retry automatically — this method resolves on
-   * the first successful connect.
+   * Start the Signal RPC client. Resolves immediately — does NOT wait for the
+   * socket connection to succeed.
+   *
+   * Rationale: In Docker Compose, signal-cli and Curia start concurrently, so
+   * the socket may not be available on the first attempt. Rejecting `connect()`
+   * on the first failure would propagate to `SignalAdapter.start()`, then to
+   * `index.ts`, and crash the process — even though the reconnect loop would
+   * have eventually recovered. Instead, we start the reconnect loop and let it
+   * make the connection in the background. The 'connected' event signals when
+   * the socket is ready; inbound messages flow from that point.
+   *
+   * If you need to know when the first successful connection happens, listen
+   * for the 'connected' event.
    */
-  async connect(): Promise<void> {
+  connect(): void {
     this.stopping = false;
-    return this.attemptConnect();
+    // Start the first attempt but don't await it. If it fails, the 'close' event
+    // handler calls scheduleReconnect(), which will keep retrying with backoff.
+    void this.attemptConnect();
   }
 
   /**
@@ -148,11 +159,15 @@ export class SignalRpcClient extends EventEmitter {
   // ---------------------------------------------------------------------------
 
   private attemptConnect(): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       const socket = new net.Socket();
       this.socket = socket;
+      // Track whether the connect() promise has already settled so the 'error'
+      // handler doesn't try to resolve/reject an already-settled promise.
+      let settled = false;
 
       socket.connect(this.config.socketPath, () => {
+        settled = true;
         this.log.info({ socketPath: this.config.socketPath }, 'Signal RPC client connected');
         // Reset backoff on successful connect so the next disconnect starts fresh.
         this.backoffMs = BACKOFF_INITIAL_MS;
@@ -163,20 +178,32 @@ export class SignalRpcClient extends EventEmitter {
       socket.on('data', (chunk: Buffer) => this.handleData(chunk));
 
       socket.on('close', () => {
-        this.log.warn('Signal RPC socket closed');
+        // Clear the line buffer on disconnect — any partial line buffered from the
+        // previous session is invalid on the new connection and would corrupt the
+        // first message received after reconnect.
+        this.buffer = '';
         this.socket = null;
         // Reject any requests that were waiting for a response — they will never
         // arrive now that the socket is gone.
         this.rejectAllPending(new Error('Signal RPC socket closed unexpectedly'));
         this.emit('disconnected');
+        // Resolve the initial connect() promise if it hasn't settled yet — a
+        // failed first connect still "starts" the client; reconnect takes over.
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
+        if (!this.stopping) {
+          this.log.warn('Signal RPC socket closed — scheduling reconnect');
+        }
         this.scheduleReconnect();
       });
 
       socket.on('error', (err: Error) => {
+        // Log the error. 'close' always fires after 'error' on a net.Socket,
+        // so reconnect scheduling and promise settlement both happen in the
+        // 'close' handler above — no action needed here beyond logging.
         this.log.warn({ err }, 'Signal RPC socket error');
-        // 'close' always fires after 'error', so rejectAllPending + scheduleReconnect
-        // happen there. We only reject the connect() promise here (first-connect failure).
-        reject(err);
       });
     });
   }

--- a/src/channels/signal/signal-rpc-client.ts
+++ b/src/channels/signal/signal-rpc-client.ts
@@ -27,6 +27,7 @@
 
 import { EventEmitter } from 'node:events';
 import * as net from 'node:net';
+import { StringDecoder } from 'node:string_decoder';
 import type { Logger } from '../../logger.js';
 import type {
   SignalSendParams,
@@ -60,6 +61,11 @@ export class SignalRpcClient extends EventEmitter {
 
   private socket: net.Socket | null = null;
   private buffer = '';
+  // StringDecoder handles multibyte characters (e.g. emoji, CJK) that may be
+  // split across TCP/socket chunk boundaries. chunk.toString('utf8') would corrupt
+  // a character whose bytes span two chunks; StringDecoder buffers the incomplete
+  // bytes internally and emits only complete characters.
+  private readonly decoder = new StringDecoder('utf8');
   private requestCounter = 0;
   // Map of pending request IDs → { resolve, reject, timeoutHandle }
   private readonly pending = new Map<
@@ -286,7 +292,7 @@ export class SignalRpcClient extends EventEmitter {
    * signal-cli's newline-delimited JSON means each '\n' marks the end of one message.
    */
   private handleData(chunk: Buffer): void {
-    this.buffer += chunk.toString('utf8');
+    this.buffer += this.decoder.write(chunk);
     const lines = this.buffer.split('\n');
     // The last element is either empty (if chunk ended with '\n') or a partial line.
     // Keep it in the buffer for the next chunk.
@@ -306,14 +312,16 @@ export class SignalRpcClient extends EventEmitter {
       // Guard against valid JSON that isn't an object (e.g. a bare string or number).
       // signal-cli should never send these, but be defensive — 'in' throws on non-objects.
       if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
-        this.log.warn({ line: line.slice(0, 200) }, 'Signal RPC: received unexpected non-object JSON line');
+        // Log the line length only — the raw content may contain message text (PII).
+        this.log.warn({ lineLength: line.length }, 'Signal RPC: received unexpected non-object JSON line');
         return;
       }
       parsed = raw as JsonRpcMessage;
     } catch (err) {
       // Malformed JSON from signal-cli — log and skip. This could indicate a
       // protocol version mismatch or a partial write that wasn't framed correctly.
-      this.log.warn({ err, line: line.slice(0, 200) }, 'Signal RPC: received malformed JSON line');
+      // Log the line length only — the raw content may contain message text (PII).
+      this.log.warn({ err, lineLength: line.length }, 'Signal RPC: received malformed JSON line');
       return;
     }
 

--- a/src/channels/signal/signal-rpc-client.ts
+++ b/src/channels/signal/signal-rpc-client.ts
@@ -1,0 +1,359 @@
+// src/channels/signal/signal-rpc-client.ts
+//
+// JSON-RPC 2.0 client for the signal-cli daemon.
+//
+// signal-cli runs as a separate service and exposes a Unix socket (or TCP port).
+// This client connects to that socket, sends requests, and listens for inbound
+// message notifications.
+//
+// Wire protocol:
+//   - Newline-delimited JSON (one JSON object per line, terminated by '\n')
+//   - Requests:      { jsonrpc: "2.0", id: "req-N", method: "...", params: {...} }
+//   - Responses:     { jsonrpc: "2.0", id: "req-N", result: {...} }
+//                    { jsonrpc: "2.0", id: "req-N", error: {...} }
+//   - Notifications: { jsonrpc: "2.0", method: "receive", params: { envelope: {...} } }
+//                    (no `id` field — server-initiated, no response expected)
+//
+// Reconnect strategy:
+//   Exponential backoff starting at 1s, doubling each attempt, capped at 5 minutes.
+//   Reset to 1s on successful connect.
+//   Pending requests are rejected immediately on disconnect (connection error),
+//   so callers don't hang waiting for a response that will never arrive.
+//
+// Deduplication:
+//   signal-cli may re-deliver the most recent messages after a reconnect in some
+//   versions. We deduplicate by `${sourceNumber}:${timestamp}` using a sliding
+//   window Set (max 1000 entries) so re-delivered envelopes are silently dropped.
+
+import { EventEmitter } from 'node:events';
+import * as net from 'node:net';
+import type { Logger } from '../../logger.js';
+import type {
+  SignalSendParams,
+  SignalReadReceiptParams,
+  JsonRpcRequest,
+  JsonRpcMessage,
+  SignalReceiveParams,
+} from './types.js';
+
+export interface SignalRpcClientConfig {
+  /** Path to the signal-cli Unix socket, e.g. '/run/signal-cli/socket' */
+  socketPath: string;
+  /** Nathan's phone number — sent as the `account` param in all RPC calls */
+  accountNumber: string;
+  logger: Logger;
+}
+
+// Backoff config — tuned for a local socket where the partner service may be
+// briefly unavailable during a container restart or config reload.
+const BACKOFF_INITIAL_MS = 1_000;
+const BACKOFF_MAX_MS = 300_000; // 5 minutes
+const REQUEST_TIMEOUT_MS = 10_000;
+
+// Dedup window — sized to cover all messages that could arrive in a short burst
+// after reconnect. 1000 is generous; Signal conversations are not that bursty.
+const DEDUP_MAX_SIZE = 1_000;
+
+export class SignalRpcClient extends EventEmitter {
+  private readonly config: SignalRpcClientConfig;
+  private readonly log: Logger;
+
+  private socket: net.Socket | null = null;
+  private buffer = '';
+  private requestCounter = 0;
+  // Map of pending request IDs → { resolve, reject, timeoutHandle }
+  private readonly pending = new Map<
+    string,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void; timeout: ReturnType<typeof setTimeout> }
+  >();
+
+  // Deduplication: set of "sourceNumber:timestamp" strings we've already processed.
+  // Insertion-order array serves as an eviction queue so we can drop the oldest entry
+  // when the set grows beyond DEDUP_MAX_SIZE.
+  private readonly dedupSet = new Set<string>();
+  private readonly dedupQueue: string[] = [];
+
+  private backoffMs = BACKOFF_INITIAL_MS;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private stopping = false;
+
+  constructor(config: SignalRpcClientConfig) {
+    super();
+    this.config = config;
+    this.log = config.logger.child({ component: 'signal-rpc-client' });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Connect to the signal-cli socket and start listening for messages.
+   * Resolves once the connection is established. If the socket is not yet
+   * available, the client will retry automatically — this method resolves on
+   * the first successful connect.
+   */
+  async connect(): Promise<void> {
+    this.stopping = false;
+    return this.attemptConnect();
+  }
+
+  /**
+   * Gracefully disconnect and stop reconnecting.
+   * All pending requests are rejected with a "disconnecting" error.
+   */
+  async disconnect(): Promise<void> {
+    this.stopping = true;
+
+    // Cancel any queued reconnect attempt
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    // Reject pending requests so callers don't hang
+    this.rejectAllPending(new Error('Signal RPC client disconnecting'));
+
+    if (this.socket) {
+      this.socket.destroy();
+      this.socket = null;
+    }
+
+    this.log.info('Signal RPC client disconnected');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Outbound RPC calls
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Send a text message via signal-cli.
+   * Resolves when signal-cli acknowledges the send. Rejects on error or timeout.
+   */
+  async send(params: SignalSendParams): Promise<void> {
+    await this.call('send', params as unknown as Record<string, unknown>);
+  }
+
+  /**
+   * Send a read receipt to a specific sender for one or more messages.
+   * Fire-and-forget at the caller level — errors are logged but don't propagate
+   * to the inbound processing pipeline.
+   */
+  async sendReadReceipt(params: SignalReadReceiptParams): Promise<void> {
+    await this.call('sendReceipt', params as unknown as Record<string, unknown>);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: connection management
+  // ---------------------------------------------------------------------------
+
+  private attemptConnect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const socket = new net.Socket();
+      this.socket = socket;
+
+      socket.connect(this.config.socketPath, () => {
+        this.log.info({ socketPath: this.config.socketPath }, 'Signal RPC client connected');
+        // Reset backoff on successful connect so the next disconnect starts fresh.
+        this.backoffMs = BACKOFF_INITIAL_MS;
+        this.emit('connected');
+        resolve();
+      });
+
+      socket.on('data', (chunk: Buffer) => this.handleData(chunk));
+
+      socket.on('close', () => {
+        this.log.warn('Signal RPC socket closed');
+        this.socket = null;
+        // Reject any requests that were waiting for a response — they will never
+        // arrive now that the socket is gone.
+        this.rejectAllPending(new Error('Signal RPC socket closed unexpectedly'));
+        this.emit('disconnected');
+        this.scheduleReconnect();
+      });
+
+      socket.on('error', (err: Error) => {
+        this.log.warn({ err }, 'Signal RPC socket error');
+        // 'close' always fires after 'error', so rejectAllPending + scheduleReconnect
+        // happen there. We only reject the connect() promise here (first-connect failure).
+        reject(err);
+      });
+    });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopping) return;
+
+    const delay = this.backoffMs;
+    // Double for next attempt, capped at max. This means after 5 minutes of
+    // repeated failures the retry cadence stays at 5 minutes (not infinite growth).
+    this.backoffMs = Math.min(this.backoffMs * 2, BACKOFF_MAX_MS);
+
+    this.log.info({ delayMs: delay }, 'Signal RPC client will attempt reconnect');
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      // attemptConnect() resolves on success (we ignore the result here —
+      // events do the work) or rejects on first error (the 'close' handler
+      // will schedule another reconnect).
+      this.attemptConnect().catch((err: unknown) => {
+        // Error already logged in the socket 'error' handler. The 'close' event
+        // that follows will schedule the next reconnect attempt.
+        this.log.debug({ err }, 'Signal RPC reconnect attempt failed — will retry');
+      });
+    }, delay);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: JSON-RPC request/response
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Send a JSON-RPC request and await the response.
+   * Rejects after REQUEST_TIMEOUT_MS if no response arrives.
+   */
+  private call(method: string, params: Record<string, unknown>): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (!this.socket || this.socket.destroyed) {
+        reject(new Error('Signal RPC client is not connected'));
+        return;
+      }
+
+      const id = `req-${++this.requestCounter}`;
+      const request: JsonRpcRequest = { jsonrpc: '2.0', id, method, params };
+
+      // Timeout guard — reject if signal-cli doesn't respond within the window.
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Signal RPC request timed out: ${method} (id=${id})`));
+      }, REQUEST_TIMEOUT_MS);
+
+      this.pending.set(id, { resolve, reject, timeout });
+
+      // Write the request as a single newline-terminated JSON line.
+      const line = JSON.stringify(request) + '\n';
+      this.socket.write(line, (err) => {
+        if (err) {
+          clearTimeout(timeout);
+          this.pending.delete(id);
+          reject(new Error(`Signal RPC write failed: ${err.message}`));
+        }
+      });
+    });
+  }
+
+  private rejectAllPending(error: Error): void {
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+      this.pending.delete(id);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: inbound data parsing
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Accumulate incoming bytes into a line buffer and process complete lines.
+   * signal-cli's newline-delimited JSON means each '\n' marks the end of one message.
+   */
+  private handleData(chunk: Buffer): void {
+    this.buffer += chunk.toString('utf8');
+    const lines = this.buffer.split('\n');
+    // The last element is either empty (if chunk ended with '\n') or a partial line.
+    // Keep it in the buffer for the next chunk.
+    this.buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      this.handleLine(trimmed);
+    }
+  }
+
+  private handleLine(line: string): void {
+    let parsed: JsonRpcMessage;
+    try {
+      const raw = JSON.parse(line);
+      // Guard against valid JSON that isn't an object (e.g. a bare string or number).
+      // signal-cli should never send these, but be defensive — 'in' throws on non-objects.
+      if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+        this.log.warn({ line: line.slice(0, 200) }, 'Signal RPC: received unexpected non-object JSON line');
+        return;
+      }
+      parsed = raw as JsonRpcMessage;
+    } catch (err) {
+      // Malformed JSON from signal-cli — log and skip. This could indicate a
+      // protocol version mismatch or a partial write that wasn't framed correctly.
+      this.log.warn({ err, line: line.slice(0, 200) }, 'Signal RPC: received malformed JSON line');
+      return;
+    }
+
+    // Notifications have no `id` field — they are server-initiated pushes.
+    if (!('id' in parsed)) {
+      this.handleNotification(parsed as { method: string; params: Record<string, unknown> });
+      return;
+    }
+
+    // Response to one of our requests — correlate by id.
+    const id = (parsed as { id: string }).id;
+    const pending = this.pending.get(id);
+    if (!pending) {
+      // Response for an unknown or already-timed-out request — safe to ignore.
+      this.log.debug({ id }, 'Signal RPC: received response for unknown request id');
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pending.delete(id);
+
+    if ('error' in parsed && parsed.error) {
+      const { code, message } = (parsed as { error: { code: number; message: string } }).error;
+      pending.reject(new Error(`Signal RPC error ${code}: ${message}`));
+    } else {
+      pending.resolve((parsed as { result: unknown }).result);
+    }
+  }
+
+  /**
+   * Handle a server-initiated notification (no `id` field).
+   * The only notification we care about is `receive` — inbound messages.
+   */
+  private handleNotification(notification: { method: string; params: Record<string, unknown> }): void {
+    if (notification.method !== 'receive') {
+      // signal-cli may send other notifications in the future (typing indicators, etc.).
+      // Log at debug so we're aware but don't spam at info level.
+      this.log.debug({ method: notification.method }, 'Signal RPC: ignoring non-receive notification');
+      return;
+    }
+
+    const receiveParams = notification.params as unknown as SignalReceiveParams;
+    const envelope = receiveParams?.envelope;
+
+    if (!envelope) {
+      this.log.warn({ params: notification.params }, 'Signal RPC: receive notification missing envelope');
+      return;
+    }
+
+    // Deduplicate using sourceNumber + Signal timestamp.
+    // signal-cli may re-deliver recent messages after a reconnect. Dropping them
+    // here prevents the coordinator from seeing the same message twice.
+    const dedupKey = `${envelope.sourceNumber}:${envelope.timestamp}`;
+    if (this.dedupSet.has(dedupKey)) {
+      this.log.debug({ dedupKey }, 'Signal RPC: dropping duplicate envelope');
+      return;
+    }
+
+    // Add to dedup window; evict oldest entry if we're at capacity.
+    // The queue gives us O(1) eviction without iterating the set.
+    this.dedupSet.add(dedupKey);
+    this.dedupQueue.push(dedupKey);
+    if (this.dedupQueue.length > DEDUP_MAX_SIZE) {
+      const oldest = this.dedupQueue.shift();
+      if (oldest) this.dedupSet.delete(oldest);
+    }
+
+    this.emit('message', envelope);
+  }
+}

--- a/src/channels/signal/signal-rpc-client.ts
+++ b/src/channels/signal/signal-rpc-client.ts
@@ -367,7 +367,8 @@ export class SignalRpcClient extends EventEmitter {
     const envelope = receiveParams?.envelope;
 
     if (!envelope) {
-      this.log.warn({ params: notification.params }, 'Signal RPC: receive notification missing envelope');
+      // Log only structural metadata — params may contain sourceNumber and message text (PII).
+      this.log.warn({ hasParams: !!notification.params }, 'Signal RPC: receive notification missing envelope');
       return;
     }
 

--- a/src/channels/signal/types.ts
+++ b/src/channels/signal/types.ts
@@ -1,0 +1,207 @@
+// src/channels/signal/types.ts
+//
+// TypeScript types for the signal-cli JSON-RPC wire format.
+//
+// signal-cli exposes a JSON-RPC 2.0 interface over a Unix socket (or TCP).
+// These types cover the subset of the wire format that Curia actually uses:
+//   - Inbound: receive notifications (text messages, group messages)
+//   - Outbound: send requests, read receipt requests
+//
+// Ignored envelope types (not modelled here because we drop them):
+//   - callMessage — voice/video call events
+//   - typingMessage — typing indicators
+//   - receiptMessage — delivery/read receipt confirmations from Signal peers
+//
+// signal-cli JSON-RPC docs:
+//   https://github.com/AsamK/signal-cli/wiki/JSON-RPC-service
+
+// ---------------------------------------------------------------------------
+// Inbound — envelope types
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level envelope wrapping every event that signal-cli delivers to us.
+ * Exactly one of {dataMessage, syncMessage} will be set for messages we care
+ * about; the rest will be null or absent.
+ */
+export interface SignalEnvelope {
+  /** Sender's E.164 phone number, e.g. "+14155552671" */
+  source: string;
+  /** Same as source — signal-cli includes both fields */
+  sourceNumber: string;
+  /** Signal's internal UUID for the sender's account */
+  sourceUuid: string;
+  /** Display name from Signal's profile (may be empty string) */
+  sourceName: string;
+  /** Device number (1 = primary device) */
+  sourceDevice: number;
+  /**
+   * Signal-level timestamp in milliseconds. This is NOT a Unix wall-clock time —
+   * it's Signal's own message identifier. Required for read receipts: the Signal
+   * protocol uses targetTimestamp to identify which specific message was read.
+   */
+  timestamp: number;
+  /** Set for regular inbound messages from other Signal users */
+  dataMessage?: SignalDataMessage;
+  /** Set for messages sent from Nathan's own other devices (self-sync) */
+  syncMessage?: SignalSyncMessage;
+}
+
+/**
+ * The payload of a regular inbound message.
+ * `message` is null for reaction-only messages, view-once after viewing, etc.
+ */
+export interface SignalDataMessage {
+  /** Signal-level timestamp (ms) — matches envelope.timestamp for sender-originated messages */
+  timestamp: number;
+  /** Message text content. Null for reactions, attachment-only messages, etc. */
+  message: string | null;
+  /** Expiry timer in seconds (0 = no expiry) */
+  expiresInSeconds: number;
+  /** View-once messages self-destruct after being read — we skip these entirely */
+  viewOnce: boolean;
+  /** Present when the message was sent to a group rather than a direct chat */
+  groupInfo?: SignalGroupInfo;
+  /** File/image attachments. signal-cli saves these to a local directory. */
+  attachments?: SignalAttachment[];
+  /** Present when this is an emoji reaction, not a text message */
+  reaction?: SignalReaction;
+}
+
+/**
+ * Group context attached to messages sent in a Signal group chat.
+ * Only `type: 'DELIVER'` means "this is a real message" — UPDATE, QUIT, and
+ * UNKNOWN are group management events with no displayable content.
+ */
+export interface SignalGroupInfo {
+  /** Base64-encoded group V2 ID — stable identifier for the group conversation */
+  groupId: string;
+  type: 'DELIVER' | 'UPDATE' | 'QUIT' | 'UNKNOWN';
+}
+
+/** Metadata for an inbound attachment. The file itself is saved by signal-cli. */
+export interface SignalAttachment {
+  /** signal-cli internal attachment ID (filename in the attachments directory) */
+  id: string;
+  contentType: string;
+  filename?: string;
+  size: number;
+}
+
+/** An emoji reaction to a previous message. We ignore these per spec (MVP). */
+export interface SignalReaction {
+  emoji: string;
+  /** E.164 number of the message author being reacted to */
+  targetAuthor: string;
+  /** Signal timestamp of the target message */
+  targetTimestamp: number;
+  /** True = removing a previous reaction */
+  isRemove: boolean;
+}
+
+/**
+ * Messages Nathan sends from another Signal device (phone, desktop) are
+ * mirrored back to all linked devices as syncMessage envelopes. We discard
+ * these — they represent Nathan's outbound activity, not inbound requests.
+ */
+export interface SignalSyncMessage {
+  sentMessage?: {
+    message: string;
+    destination?: string;
+    groupInfo?: SignalGroupInfo;
+  };
+}
+
+/**
+ * The `params` field of a `receive` JSON-RPC notification from signal-cli.
+ * This is the top-level payload for every inbound envelope.
+ */
+export interface SignalReceiveParams {
+  envelope: SignalEnvelope;
+  /** Nathan's phone number — the account that received the message */
+  account: string;
+}
+
+// ---------------------------------------------------------------------------
+// Outbound — request param types
+// ---------------------------------------------------------------------------
+
+/**
+ * Params for the signal-cli `send` JSON-RPC method.
+ * Either `recipient` (1:1) or `groupId` (group) must be set, not both.
+ */
+export interface SignalSendParams {
+  /** Nathan's phone number — the sending account */
+  account: string;
+  /** E.164 number array for 1:1 sends. signal-cli takes an array. */
+  recipient?: string[];
+  /** Base64 group ID for group sends */
+  groupId?: string;
+  message: string;
+}
+
+/**
+ * Params for the signal-cli `sendReceipt` JSON-RPC method.
+ * Used to send read receipts back to known senders for 1:1 messages.
+ *
+ * Note: read receipts are 1:1 only — group receipt semantics are more complex
+ * (they broadcast to all group members). Group read receipts are deferred.
+ */
+export interface SignalReadReceiptParams {
+  /** Nathan's phone number — the account sending the receipt */
+  account: string;
+  /** The sender who will receive the read confirmation */
+  recipient: string;
+  /**
+   * Signal timestamps of the messages being acknowledged.
+   * Must match the `timestamp` field from the original envelope exactly —
+   * Signal uses this to identify which specific messages were read.
+   */
+  targetTimestamp: number[];
+  receiptType: 'read' | 'viewed';
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC 2.0 wire types
+// ---------------------------------------------------------------------------
+
+/** A JSON-RPC request that we send to signal-cli */
+export interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: string;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+/** A JSON-RPC success response from signal-cli */
+export interface JsonRpcSuccessResponse {
+  jsonrpc: '2.0';
+  id: string;
+  result: unknown;
+}
+
+/** A JSON-RPC error response from signal-cli */
+export interface JsonRpcErrorResponse {
+  jsonrpc: '2.0';
+  id: string;
+  error: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+/**
+ * A JSON-RPC notification (server-initiated, no `id` field).
+ * signal-cli sends these for inbound messages via the `receive` method.
+ */
+export interface JsonRpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params: Record<string, unknown>;
+}
+
+export type JsonRpcMessage =
+  | JsonRpcSuccessResponse
+  | JsonRpcErrorResponse
+  | JsonRpcNotification;

--- a/src/config.ts
+++ b/src/config.ts
@@ -140,7 +140,9 @@ export function loadConfig(): Config {
     nylasPollingIntervalMs,
     nylasSelfEmail: process.env.NYLAS_SELF_EMAIL ?? '',
     ceoPrimaryEmail: process.env.CEO_PRIMARY_EMAIL?.trim().toLowerCase() || undefined,
-    signalSocketPath: process.env.SIGNAL_SOCKET_PATH || undefined,
-    signalPhoneNumber: process.env.SIGNAL_PHONE_NUMBER || undefined,
+    // .trim() prevents a whitespace-only value (e.g. "  ") from activating the
+    // Signal adapter with a bogus socket path or phone number.
+    signalSocketPath: process.env.SIGNAL_SOCKET_PATH?.trim() || undefined,
+    signalPhoneNumber: process.env.SIGNAL_PHONE_NUMBER?.trim() || undefined,
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,13 @@ export interface Config {
   // Without this, the first inbound email from the CEO creates them as provisional,
   // causing their messages to be held.
   ceoPrimaryEmail: string | undefined;
+  // Signal channel config. Both must be set to enable the Signal adapter.
+  // signalSocketPath: path to the signal-cli daemon Unix socket (e.g. /run/signal-cli/socket).
+  //   In Docker Compose, this is mounted from the signal-cli container's socket volume.
+  // signalPhoneNumber: Nathan's E.164 number (e.g. +12223334444). This is the Signal account
+  //   that was registered via `signal-cli register` + `signal-cli verify`.
+  signalSocketPath: string | undefined;
+  signalPhoneNumber: string | undefined;
 }
 
 /**
@@ -133,5 +140,7 @@ export function loadConfig(): Config {
     nylasPollingIntervalMs,
     nylasSelfEmail: process.env.NYLAS_SELF_EMAIL ?? '',
     ceoPrimaryEmail: process.env.CEO_PRIMARY_EMAIL?.trim().toLowerCase() || undefined,
+    signalSocketPath: process.env.SIGNAL_SOCKET_PATH || undefined,
+    signalPhoneNumber: process.env.SIGNAL_PHONE_NUMBER || undefined,
   };
 }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -75,10 +75,13 @@ interface ContactServiceBackend {
 
 // -- Auto-verification sources --
 // Per spec: ceo_stated, email_participant, crm_import, calendar_attendee are auto-verified.
+// signal_participant is also auto-verified — Signal's phone-number identity is stronger than
+// email (no header spoofing), so we trust the source number at the same level as email_participant.
 // Only self_claimed starts unverified.
 const AUTO_VERIFIED_SOURCES: ReadonlySet<IdentitySource> = new Set([
   'ceo_stated',
   'email_participant',
+  'signal_participant',
   'crm_import',
   'calendar_attendee',
 ]);

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -27,6 +27,7 @@ export interface ChannelIdentity {
 export type IdentitySource =
   | 'ceo_stated'
   | 'email_participant'
+  | 'signal_participant'
   | 'crm_import'
   | 'calendar_attendee'
   | 'self_claimed';

--- a/src/index.ts
+++ b/src/index.ts
@@ -324,6 +324,8 @@ async function main(): Promise<void> {
       logger,
     });
     // SignalAdapter is constructed further below, after OutboundGateway is available.
+    // Note: phone number intentionally omitted from the log — it's PII and would land
+    // in any log aggregation pipeline. The socket path is sufficient for diagnostics.
     logger.info({ socketPath: config.signalSocketPath }, 'Signal RPC client created');
   } else {
     logger.warn('SIGNAL_SOCKET_PATH/SIGNAL_PHONE_NUMBER not set — Signal channel disabled');

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,8 @@ import { createContactDuplicateDetected, createContactMerged } from './bus/event
 import { NylasClient } from './channels/email/nylas-client.js';
 import { NylasCalendarClient } from './channels/calendar/nylas-calendar-client.js';
 import { EmailAdapter } from './channels/email/email-adapter.js';
+import { SignalRpcClient } from './channels/signal/signal-rpc-client.js';
+import { SignalAdapter } from './channels/signal/signal-adapter.js';
 import { loadAuthConfig } from './contacts/config-loader.js';
 import { AuthorizationService } from './contacts/authorization.js';
 import { HeldMessageService } from './contacts/held-messages.js';
@@ -307,6 +309,26 @@ async function main(): Promise<void> {
     logger.warn('NYLAS_API_KEY/NYLAS_GRANT_ID not set — email channel disabled');
   }
 
+  // Signal channel — optional, requires SIGNAL_SOCKET_PATH and SIGNAL_PHONE_NUMBER.
+  // SignalRpcClient is constructed here so it can be passed to OutboundGateway (the gateway
+  // needs it for outbound Signal sends). SignalAdapter is started further below, after the
+  // gateway is constructed and the dispatcher is registered.
+  // Ordering matters: dispatcher must be registered before any adapter starts, so inbound
+  // messages never arrive without a subscriber (same rule as EmailAdapter).
+  let signalRpcClient: SignalRpcClient | undefined;
+  let signalAdapter: SignalAdapter | undefined;
+  if (config.signalSocketPath && config.signalPhoneNumber) {
+    signalRpcClient = new SignalRpcClient({
+      socketPath: config.signalSocketPath,
+      accountNumber: config.signalPhoneNumber,
+      logger,
+    });
+    // SignalAdapter is constructed further below, after OutboundGateway is available.
+    logger.info({ socketPath: config.signalSocketPath }, 'Signal RPC client created');
+  } else {
+    logger.warn('SIGNAL_SOCKET_PATH/SIGNAL_PHONE_NUMBER not set — Signal channel disabled');
+  }
+
   // Calendar client — uses the same Nylas credentials as email.
   // Independent instance, no shared state with the email client.
   let nylasCalendarClient: NylasCalendarClient | undefined;
@@ -435,30 +457,47 @@ async function main(): Promise<void> {
   }
 
   // Outbound gateway — single choke-point for all outbound external communication.
-  // Wraps nylasClient with blocked-contact checks and content filtering before
-  // any message leaves Curia. Only instantiated when nylasClient is available
-  // (i.e., Nylas credentials are configured). Skills receive it via SkillContext.
+  // Runs blocked-contact checks and content filtering before any message leaves Curia.
+  //
+  // Initialization guard:
+  //   Production assumption: Nylas + Signal are always configured together.
+  //   The guard initializes the gateway when either client is available + outboundFilter
+  //   is ready. This keeps the gateway functional for Signal-only setups (e.g., during
+  //   initial deployment before Nylas credentials are added) and for testing scenarios.
+  //
+  //   TODO: If the system ever runs in a Signal-only mode in production (no Nylas), the
+  //   blocked-content CEO notification path will silently degrade (no email to send it on).
+  //   In that mode, log.error is the fallback — see OutboundGateway.send() comments.
+  //   For now we assume Nylas + Signal together, so this path is only for dev flexibility.
   let outboundGateway: OutboundGateway | undefined;
-  if (nylasClient && outboundFilter && config.nylasSelfEmail) {
+  const hasAnyOutboundClient = !!(nylasClient || signalRpcClient);
+  if (hasAnyOutboundClient && outboundFilter) {
     outboundGateway = new OutboundGateway({
       nylasClient,
+      signalClient: signalRpcClient,
+      signalPhoneNumber: config.signalPhoneNumber,
       contactService,
       contentFilter: outboundFilter,
       bus,
-      ceoEmail: config.nylasSelfEmail,
+      // ceoEmail is optional in OutboundGatewayConfig; only needed for email notifications.
+      // When Nylas is configured, this must be set or CEO blocked-content alerts won't send.
+      ceoEmail: config.nylasSelfEmail || undefined,
       logger,
     });
-    logger.info('Outbound gateway initialized');
-  } else if (nylasClient) {
-    // nylasClient is available but outboundFilter or ceoEmail is missing — log a warning.
+    logger.info({
+      hasEmail: !!nylasClient,
+      hasSignal: !!signalRpcClient,
+    }, 'Outbound gateway initialized');
+  } else if (nylasClient && !outboundFilter) {
+    // nylasClient is available but outboundFilter is missing (no coordinator config found).
     // Email skills will be unavailable because they check ctx.outboundGateway before sending.
-    logger.warn('Outbound gateway NOT initialized — missing outboundFilter or nylasSelfEmail. Email send/reply skills will be unavailable.');
+    logger.warn('Outbound gateway NOT initialized — outboundFilter not ready (coordinator config missing?). Outbound send skills will be unavailable.');
   }
 
   // Construct the email adapter (but don't start it yet — it must not poll until
   // the dispatcher is registered, otherwise inbound.message events have no subscriber
   // and are permanently dropped because the adapter advances its high-water mark).
-  if (outboundGateway && config.nylasSelfEmail) {
+  if (outboundGateway && nylasClient && config.nylasSelfEmail) {
     emailAdapter = new EmailAdapter({
       bus,
       logger,
@@ -466,6 +505,19 @@ async function main(): Promise<void> {
       contactService,
       pollingIntervalMs: config.nylasPollingIntervalMs,
       selfEmail: config.nylasSelfEmail,
+    });
+  }
+
+  // Construct the Signal adapter (but don't start it yet — same ordering rule as email:
+  // dispatcher must be registered first so inbound.message always has a subscriber).
+  if (outboundGateway && signalRpcClient && config.signalPhoneNumber) {
+    signalAdapter = new SignalAdapter({
+      bus,
+      logger,
+      rpcClient: signalRpcClient,
+      outboundGateway,
+      contactService,
+      phoneNumber: config.signalPhoneNumber,
     });
   }
 
@@ -641,6 +693,15 @@ async function main(): Promise<void> {
     logger.info('Email channel adapter started');
   }
 
+  // Start the Signal adapter AFTER the dispatcher is registered — same ordering rule as email.
+  // SignalAdapter.start() connects to the signal-cli socket and registers the inbound listener.
+  // If signal-cli is not yet running (e.g., cold start with both containers starting simultaneously),
+  // the RPC client's exponential backoff will retry until the socket is available.
+  if (signalAdapter) {
+    await signalAdapter.start();
+    logger.info('Signal channel adapter started');
+  }
+
   // HTTP API channel — REST + SSE endpoints for external clients.
   // Runs alongside the CLI channel so both can be used simultaneously.
   const httpAdapter = new HttpAdapter({
@@ -674,6 +735,13 @@ async function main(): Promise<void> {
         await emailAdapter.stop();
       } catch (err) {
         logger.error({ err }, 'Error stopping email adapter during shutdown');
+      }
+    }
+    if (signalAdapter) {
+      try {
+        await signalAdapter.stop();
+      } catch (err) {
+        logger.error({ err }, 'Error stopping Signal adapter during shutdown');
       }
     }
     try {

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -404,6 +404,16 @@ export class OutboundGateway {
       return { success: false, blockedReason: 'Signal send requires either recipient or groupId' };
     }
 
+    if (request.recipient && request.groupId) {
+      // Both set is a caller bug — signal-cli would send to both or error unpredictably.
+      // Fail fast with a clear error rather than silently mis-routing.
+      this.log.warn(
+        { channel: 'signal', recipient: request.recipient, groupId: request.groupId },
+        'outbound-gateway: Signal send has both recipient and groupId set — exactly one required',
+      );
+      return { success: false, blockedReason: 'Signal send must specify exactly one of recipient or groupId, not both' };
+    }
+
     try {
       await this.signalClient.send({
         account: this.signalPhoneNumber,

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -2,17 +2,26 @@
 //
 // All sends from Curia to the outside world MUST pass through this gateway.
 // This ensures consistent enforcement of:
-//   1. Blocked contact check (this task)
-//   2. Content filter (Task 2 — placeholder below)
+//   1. Blocked contact check
+//   2. Content filter
 //
 // Design intent: fail-open on infra errors. If the contact DB is unavailable
 // we log a warning and proceed rather than silently blocking legitimate sends.
 // The alternative (fail-closed on DB error) would cause Curia to go silent
 // whenever the DB hiccups, which is worse than a rare false negative on the
 // blocked-contact check.
+//
+// Adding a new channel:
+//   1. Add a new variant to OutboundSendRequest (discriminated union by `channel`)
+//   2. Add the channel client to OutboundGatewayConfig
+//   3. Add a private dispatch<Channel>() method
+//   4. Add a branch in send() to call it
+//   The blocked-contact check and content filter in send() are channel-agnostic and
+//   run for all channels before dispatch.
 
 import { randomUUID } from 'node:crypto';
 import type { NylasClient, NylasMessage, ListMessagesOptions, SendEmailOptions } from '../channels/email/nylas-client.js';
+import type { SignalRpcClient } from '../channels/signal/signal-rpc-client.js';
 import type { ContactService } from '../contacts/contact-service.js';
 import type { OutboundContentFilter } from '../dispatch/outbound-filter.js';
 import type { EventBus } from '../bus/bus.js';
@@ -24,7 +33,7 @@ import { markdownToHtml } from '../channels/email/markdown-to-html.js';
 // Public types
 // ---------------------------------------------------------------------------
 
-export interface OutboundSendRequest {
+export interface EmailSendRequest {
   channel: 'email';
   /** Recipient email address */
   to: string;
@@ -35,6 +44,39 @@ export interface OutboundSendRequest {
   replyToMessageId?: string;
 }
 
+export interface SignalOutboundRequest {
+  channel: 'signal';
+  /**
+   * E.164 phone number for 1:1 sends (e.g. "+14155552671").
+   * Mutually exclusive with groupId — set exactly one.
+   */
+  recipient?: string;
+  /**
+   * Base64-encoded group V2 ID for group sends.
+   * Mutually exclusive with recipient — set exactly one.
+   */
+  groupId?: string;
+  message: string;
+}
+
+/**
+ * Discriminated union of all supported outbound send requests.
+ * Add a new variant here when adding a new channel.
+ *
+ * Note: OutboundSendRequest is a public API surface — adding a new variant is
+ * backwards-compatible, but changing existing field names or types is a breaking
+ * change that must be called out in CHANGELOG.md.
+ */
+export type OutboundSendRequest = EmailSendRequest | SignalOutboundRequest;
+
+// Re-export the old name as an alias so existing callers don't break.
+// Previously OutboundSendRequest was a single interface (email-only). Now it's a
+// discriminated union. Callers that typed a variable as OutboundSendRequest and
+// passed it to send() continue to work unchanged — the union is a superset.
+// This alias exists purely for documentation; the type itself is unchanged in
+// terms of what email callers already do.
+export type { OutboundSendRequest as OutboundEmailSendRequest };
+
 export interface OutboundSendResult {
   success: boolean;
   messageId?: string;
@@ -43,12 +85,45 @@ export interface OutboundSendResult {
 }
 
 export interface OutboundGatewayConfig {
-  nylasClient: NylasClient;
+  /**
+   * Nylas client for email sends. Optional — gateway can be initialized with
+   * only Signal (signalClient) if email is not configured.
+   *
+   * In production (Nylas + Signal mode), this is always set alongside signalClient.
+   * The optional type exists so the gateway can be constructed when only Signal
+   * credentials are provided (e.g., integration tests without Nylas API key).
+   */
+  nylasClient?: NylasClient;
+
+  /**
+   * signal-cli RPC client for Signal sends. Optional — gateway can be initialized
+   * with only email (nylasClient) if Signal is not configured.
+   */
+  signalClient?: SignalRpcClient;
+
+  /**
+   * Nathan's Signal phone number in E.164 format — used as the `account` param in
+   * signal-cli RPC calls. Required when signalClient is provided.
+   */
+  signalPhoneNumber?: string;
+
   contactService: ContactService;
   contentFilter: OutboundContentFilter;
   bus: EventBus;
-  /** CEO's own email — passed to the content filter's allowed-sender list */
-  ceoEmail: string;
+
+  /**
+   * CEO's own email — used as the allowlist entry in the content filter's contact-data-leak
+   * rule and as the To address for blocked-content CEO notifications.
+   *
+   * Required when nylasClient is present (notifications are sent via email).
+   * When email is absent (Signal-only), blocked messages are logged and audited
+   * but no CEO notification is sent. A future version may add a Signal notification path.
+   *
+   * TODO: add a Signal-based blocked-content notification path so the CEO is informed
+   * even without email configured. For now log.error + audit trail is the fallback.
+   */
+  ceoEmail?: string;
+
   logger: Logger;
 }
 
@@ -57,7 +132,9 @@ export interface OutboundGatewayConfig {
 // ---------------------------------------------------------------------------
 
 export class OutboundGateway {
-  private readonly nylasClient: NylasClient;
+  private readonly nylasClient?: NylasClient;
+  private readonly signalClient?: SignalRpcClient;
+  private readonly signalPhoneNumber?: string;
   private readonly contactService: ContactService;
   private readonly contentFilter: OutboundContentFilter;
   private readonly bus: EventBus;
@@ -66,44 +143,54 @@ export class OutboundGateway {
 
   constructor(config: OutboundGatewayConfig) {
     this.nylasClient = config.nylasClient;
+    this.signalClient = config.signalClient;
+    this.signalPhoneNumber = config.signalPhoneNumber;
     this.contactService = config.contactService;
     this.contentFilter = config.contentFilter;
     this.bus = config.bus;
-    this.ceoEmail = config.ceoEmail;
+    this.ceoEmail = config.ceoEmail ?? '';
     this.log = config.logger.child({ component: 'outbound-gateway' });
   }
 
   /**
    * Send an outbound message through the gateway pipeline.
    *
-   * Pipeline steps:
+   * Pipeline steps (channel-agnostic):
    *   1. Contact blocked check
-   *   2. Content filter (Task 2 — placeholder)
-   *   3. Channel dispatch via Nylas
+   *   2. Content filter (fail-closed)
+   *   3. Channel dispatch (email → Nylas, signal → signal-cli RPC)
    */
   async send(request: OutboundSendRequest): Promise<OutboundSendResult> {
+    // Derive a stable recipient identifier for the blocked-contact check and logging.
+    // Email: the To address. Signal: phone number (1:1) or base64 group ID.
+    const recipientId = request.channel === 'email'
+      ? request.to
+      : (request.recipient ?? request.groupId ?? '');
+
+    // The message body field differs between channel types.
+    const messageBody = request.channel === 'email' ? request.body : request.message;
+
     // ------------------------------------------------------------------
     // Step 1: Contact blocked check
     // ------------------------------------------------------------------
     // Resolve the recipient to a known contact. If they are explicitly blocked
-    // by the CEO, reject immediately without touching Nylas or the content filter.
+    // by the CEO, reject immediately without touching the transport layer or filter.
     //
     // Fail-open on DB errors: an infra failure should not silently prevent
     // sending. We warn so the anomaly is visible in logs/alerting.
     try {
-      const contact = await this.contactService.resolveByChannelIdentity(request.channel, request.to);
+      const contact = await this.contactService.resolveByChannelIdentity(request.channel, recipientId);
       if (contact !== null && contact.status === 'blocked') {
         this.log.warn(
-          { channel: request.channel, to: request.to, contactId: contact.contactId },
+          { channel: request.channel, recipientId, contactId: contact.contactId },
           'outbound-gateway: send blocked — recipient is blocked',
         );
         return { success: false, blockedReason: 'Recipient is blocked' };
       }
     } catch (err) {
-      // DB or service error — log at warn and proceed. We don't block outbound
-      // sends on contact-check infrastructure failures.
+      // DB or service error — log at warn and proceed.
       this.log.warn(
-        { err, channel: request.channel, to: request.to },
+        { err, channel: request.channel, recipientId },
         'outbound-gateway: contact resolution failed, proceeding without blocked check',
       );
     }
@@ -111,17 +198,21 @@ export class OutboundGateway {
     // ------------------------------------------------------------------
     // Step 2: Content filter
     // ------------------------------------------------------------------
-    // Fail-closed: if the filter throws for any reason, treat the message
-    // as blocked. A crashing filter is a security anomaly — we'd rather
-    // miss a send than let potentially dangerous content through an
-    // unchecked pipeline.
+    // Fail-closed: if the filter throws for any reason, treat the message as blocked.
+    // A crashing filter is a security anomaly — better to miss a send than let
+    // potentially dangerous content through an unchecked pipeline.
     let filterPassed = false;
     let filterFindings: Array<{ rule: string; detail: string }> = [];
 
     try {
       const filterResult = await this.contentFilter.check({
-        content: request.body,
-        recipientEmail: request.to,
+        content: messageBody,
+        // For Signal sends: passing the phone number/groupId as recipientEmail is intentional.
+        // The contact-data-leak rule scans for *email addresses* in the content — a phone
+        // number passed here will never match an email pattern, so any leaked email address
+        // in the Signal message body is still correctly flagged. The field name is email-centric
+        // but the semantics are "the intended recipient identifier".
+        recipientEmail: recipientId,
         conversationId: '',
         channelId: request.channel,
       });
@@ -130,7 +221,7 @@ export class OutboundGateway {
     } catch (err) {
       // Filter crash — treat as blocked with a synthetic finding
       this.log.warn(
-        { err, channel: request.channel, to: request.to },
+        { err, channel: request.channel, recipientId },
         'outbound-gateway: content filter threw — treating as blocked (fail-closed)',
       );
       filterPassed = false;
@@ -142,7 +233,7 @@ export class OutboundGateway {
       // which may contain sensitive data fragments that triggered the rule).
       const ruleNames = filterFindings.map((f) => f.rule).join('; ');
       this.log.warn(
-        { channel: request.channel, to: request.to, rules: ruleNames },
+        { channel: request.channel, recipientId, rules: ruleNames },
         'outbound-gateway: outbound message blocked by content filter',
       );
 
@@ -152,16 +243,14 @@ export class OutboundGateway {
       const fullReason = filterFindings.map((f) => `${f.rule}: ${f.detail}`).join('; ');
 
       // Publish the blocked event for audit logging and downstream consumers.
-      // Wrapped in try-catch — a bus publish failure must never unblock the message;
-      // the send is already blocked regardless of whether the audit event lands.
       try {
         await this.bus.publish('dispatch',
           createOutboundBlocked({
             blockId,
             conversationId: '',
             channelId: request.channel,
-            content: request.body,
-            recipientId: request.to,
+            content: messageBody,
+            recipientId,
             reason: fullReason,
             findings: filterFindings,
             parentEventId: '',
@@ -174,29 +263,41 @@ export class OutboundGateway {
         );
       }
 
-      // Notify the CEO directly via dispatchEmail (bypassing this.send() to avoid
-      // infinite recursion — the notification itself doesn't need filtering because
-      // it's a hardcoded template with no user-supplied content).
-      // dispatchEmail already catches Nylas errors and returns them, so no try-catch needed.
-      const notifyResult = await this.dispatchEmail({
-        channel: 'email',
-        to: this.ceoEmail,
-        subject: 'Action needed — blocked outbound reply',
-        // Body intentionally contains only the block ID and the intended recipient —
-        // no message content, no rule details, no sensitive data.
-        body: [
-          'An outbound message was blocked by the content filter.',
-          '',
-          `Block ID: ${blockId}`,
-          `Intended recipient: ${request.to}`,
-          '',
-          'Please review the audit log for details.',
-        ].join('\n'),
-      });
-      if (!notifyResult.success) {
+      // Notify the CEO about the blocked message via email.
+      // We always use the email channel for this notification, even when the blocked
+      // message was a Signal send — this avoids a potential Signal → block → Signal
+      // notification loop, and email is the canonical out-of-band channel for system alerts.
+      //
+      // If email is not configured (no nylasClient or no ceoEmail), we log.error and rely
+      // on the audit log. A future Signal notification fallback can be added here.
+      // TODO: add Signal-based blocked-content notification when email is absent.
+      if (this.ceoEmail && this.nylasClient) {
+        // dispatchEmail bypasses this.send() to avoid infinite recursion.
+        // The notification body is a hardcoded template — no user-supplied content.
+        const notifyResult = await this.dispatchEmail({
+          channel: 'email',
+          to: this.ceoEmail,
+          subject: 'Action needed — blocked outbound reply',
+          body: [
+            'An outbound message was blocked by the content filter.',
+            '',
+            `Block ID: ${blockId}`,
+            `Channel: ${request.channel}`,
+            `Intended recipient: ${recipientId}`,
+            '',
+            'Please review the audit log for details.',
+          ].join('\n'),
+        });
+        if (!notifyResult.success) {
+          this.log.error(
+            { blockId, ceoEmail: this.ceoEmail, reason: notifyResult.blockedReason },
+            'Failed to send CEO notification for blocked outbound content',
+          );
+        }
+      } else {
         this.log.error(
-          { blockId, ceoEmail: this.ceoEmail, reason: notifyResult.blockedReason },
-          'Failed to send CEO notification for blocked outbound content',
+          { blockId, channel: request.channel, recipientId },
+          'outbound-gateway: CEO notification skipped — no email client configured. Block recorded in audit log only.',
         );
       }
 
@@ -206,7 +307,11 @@ export class OutboundGateway {
     // ------------------------------------------------------------------
     // Step 3: Channel dispatch
     // ------------------------------------------------------------------
-    return this.dispatchEmail(request);
+    if (request.channel === 'email') {
+      return this.dispatchEmail(request);
+    } else {
+      return this.dispatchSignal(request);
+    }
   }
 
   /**
@@ -214,6 +319,9 @@ export class OutboundGateway {
    * Read-only — no filtering applied.
    */
   async getEmailMessage(messageId: string): Promise<NylasMessage> {
+    if (!this.nylasClient) {
+      throw new Error('outbound-gateway: getEmailMessage called but nylasClient is not configured');
+    }
     return this.nylasClient.getMessage(messageId);
   }
 
@@ -222,6 +330,9 @@ export class OutboundGateway {
    * Read-only — no filtering applied.
    */
   async listEmailMessages(options?: ListMessagesOptions): Promise<NylasMessage[]> {
+    if (!this.nylasClient) {
+      throw new Error('outbound-gateway: listEmailMessages called but nylasClient is not configured');
+    }
     return this.nylasClient.listMessages(options);
   }
 
@@ -230,10 +341,14 @@ export class OutboundGateway {
   // ---------------------------------------------------------------------------
 
   /**
-   * Dispatch a send request to Nylas. Maps our flat request shape into the
-   * SendEmailOptions the NylasClient expects.
+   * Dispatch a send request to Nylas for email delivery.
+   * Maps our flat request shape into the SendEmailOptions the NylasClient expects.
    */
-  private async dispatchEmail(request: OutboundSendRequest): Promise<OutboundSendResult> {
+  private async dispatchEmail(request: EmailSendRequest): Promise<OutboundSendResult> {
+    if (!this.nylasClient) {
+      return { success: false, blockedReason: 'Email client not configured' };
+    }
+
     // markdownToHtml is a pure function (no I/O, no realistic throw path).
     // Called outside the Nylas try-catch so that any future regression in the
     // converter is not silently misattributed as "Nylas send failed" in logs.
@@ -241,7 +356,6 @@ export class OutboundGateway {
 
     try {
       const sendOptions: SendEmailOptions = {
-        // NylasClient expects an array of { email } objects for addressing
         to: [{ email: request.to }],
         cc: request.cc?.map((email) => ({ email })),
         subject: request.subject ?? '',
@@ -252,7 +366,7 @@ export class OutboundGateway {
       const sent = await this.nylasClient.sendMessage(sendOptions);
 
       this.log.info(
-        { messageId: sent.id, channel: request.channel, to: request.to },
+        { messageId: sent.id, channel: 'email', to: request.to },
         'outbound-gateway: message sent successfully',
       );
 
@@ -260,8 +374,56 @@ export class OutboundGateway {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.log.error(
-        { err, channel: request.channel, to: request.to },
+        { err, channel: 'email', to: request.to },
         'outbound-gateway: Nylas send failed',
+      );
+      return { success: false, blockedReason: `Send failed: ${message}` };
+    }
+  }
+
+  /**
+   * Dispatch a send request to signal-cli for Signal delivery.
+   * Calls the signal-cli JSON-RPC `send` method via the RPC client.
+   */
+  private async dispatchSignal(request: SignalOutboundRequest): Promise<OutboundSendResult> {
+    if (!this.signalClient) {
+      return { success: false, blockedReason: 'Signal client not configured' };
+    }
+
+    if (!this.signalPhoneNumber) {
+      // Wiring bug in index.ts — signalClient without signalPhoneNumber should never happen.
+      this.log.error(
+        { channel: 'signal' },
+        'outbound-gateway: signalClient is set but signalPhoneNumber is missing — check index.ts wiring',
+      );
+      return { success: false, blockedReason: 'Signal phone number not configured' };
+    }
+
+    if (!request.recipient && !request.groupId) {
+      this.log.warn({ channel: 'signal' }, 'outbound-gateway: Signal send has neither recipient nor groupId');
+      return { success: false, blockedReason: 'Signal send requires either recipient or groupId' };
+    }
+
+    try {
+      await this.signalClient.send({
+        account: this.signalPhoneNumber,
+        // signal-cli takes recipient as an array; single-element for 1:1 sends
+        recipient: request.recipient ? [request.recipient] : undefined,
+        groupId: request.groupId,
+        message: request.message,
+      });
+
+      this.log.info(
+        { channel: 'signal', recipient: request.recipient, groupId: request.groupId },
+        'outbound-gateway: Signal message sent successfully',
+      );
+
+      return { success: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.log.error(
+        { err, channel: 'signal', recipient: request.recipient, groupId: request.groupId },
+        'outbound-gateway: signal-cli send failed',
       );
       return { success: false, blockedReason: `Send failed: ${message}` };
     }

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -128,6 +128,26 @@ export interface OutboundGatewayConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a redacted form of a recipient identifier safe to write to logs.
+ * Keeps the first 3 and last 3 characters so the log entry is still useful for
+ * debugging (e.g. "joh***com" for an email, "+12***444" for a phone) without
+ * logging the full address.
+ *
+ * Examples:
+ *   "joe@example.com"  → "joe***com"
+ *   "+14155552671"     → "+14***671"
+ *   "abc"              → "***"        (too short — redact fully)
+ */
+function redactId(value: string): string {
+  if (value.length <= 6) return '***';
+  return `${value.slice(0, 3)}***${value.slice(-3)}`;
+}
+
+// ---------------------------------------------------------------------------
 // OutboundGateway
 // ---------------------------------------------------------------------------
 
@@ -182,7 +202,7 @@ export class OutboundGateway {
       const contact = await this.contactService.resolveByChannelIdentity(request.channel, recipientId);
       if (contact !== null && contact.status === 'blocked') {
         this.log.warn(
-          { channel: request.channel, recipientId, contactId: contact.contactId },
+          { channel: request.channel, recipientId: redactId(recipientId), contactId: contact.contactId },
           'outbound-gateway: send blocked — recipient is blocked',
         );
         return { success: false, blockedReason: 'Recipient is blocked' };
@@ -190,7 +210,7 @@ export class OutboundGateway {
     } catch (err) {
       // DB or service error — log at warn and proceed.
       this.log.warn(
-        { err, channel: request.channel, recipientId },
+        { err, channel: request.channel, recipientId: redactId(recipientId) },
         'outbound-gateway: contact resolution failed, proceeding without blocked check',
       );
     }
@@ -221,7 +241,7 @@ export class OutboundGateway {
     } catch (err) {
       // Filter crash — treat as blocked with a synthetic finding
       this.log.warn(
-        { err, channel: request.channel, recipientId },
+        { err, channel: request.channel, recipientId: redactId(recipientId) },
         'outbound-gateway: content filter threw — treating as blocked (fail-closed)',
       );
       filterPassed = false;
@@ -233,7 +253,7 @@ export class OutboundGateway {
       // which may contain sensitive data fragments that triggered the rule).
       const ruleNames = filterFindings.map((f) => f.rule).join('; ');
       this.log.warn(
-        { channel: request.channel, recipientId, rules: ruleNames },
+        { channel: request.channel, recipientId: redactId(recipientId), rules: ruleNames },
         'outbound-gateway: outbound message blocked by content filter',
       );
 
@@ -290,13 +310,13 @@ export class OutboundGateway {
         });
         if (!notifyResult.success) {
           this.log.error(
-            { blockId, ceoEmail: this.ceoEmail, reason: notifyResult.blockedReason },
+            { blockId, ceoEmail: redactId(this.ceoEmail), reason: notifyResult.blockedReason },
             'Failed to send CEO notification for blocked outbound content',
           );
         }
       } else {
         this.log.error(
-          { blockId, channel: request.channel, recipientId },
+          { blockId, channel: request.channel, recipientId: redactId(recipientId) },
           'outbound-gateway: CEO notification skipped — no email client configured. Block recorded in audit log only.',
         );
       }

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -407,8 +407,9 @@ export class OutboundGateway {
     if (request.recipient && request.groupId) {
       // Both set is a caller bug — signal-cli would send to both or error unpredictably.
       // Fail fast with a clear error rather than silently mis-routing.
+      // Don't log the actual values — phone numbers and group IDs are PII.
       this.log.warn(
-        { channel: 'signal', recipient: request.recipient, groupId: request.groupId },
+        { channel: 'signal' },
         'outbound-gateway: Signal send has both recipient and groupId set — exactly one required',
       );
       return { success: false, blockedReason: 'Signal send must specify exactly one of recipient or groupId, not both' };
@@ -423,16 +424,18 @@ export class OutboundGateway {
         message: request.message,
       });
 
+      // Log destination type (1:1 vs group) but not the actual number/ID — PII.
       this.log.info(
-        { channel: 'signal', recipient: request.recipient, groupId: request.groupId },
+        { channel: 'signal', destinationType: request.groupId ? 'group' : '1:1' },
         'outbound-gateway: Signal message sent successfully',
       );
 
       return { success: true };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      // Log destination type only — phone numbers and group IDs are PII.
       this.log.error(
-        { err, channel: 'signal', recipient: request.recipient, groupId: request.groupId },
+        { err, channel: 'signal', destinationType: request.groupId ? 'group' : '1:1' },
         'outbound-gateway: signal-cli send failed',
       );
       return { success: false, blockedReason: `Send failed: ${message}` };

--- a/tests/unit/channels/signal/message-converter.test.ts
+++ b/tests/unit/channels/signal/message-converter.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'vitest';
+import { convertSignalEnvelope } from '../../../../src/channels/signal/message-converter.js';
+import type { SignalEnvelope } from '../../../../src/channels/signal/types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeEnvelope(overrides: Partial<SignalEnvelope> = {}): SignalEnvelope {
+  return {
+    source: '+14155551234',
+    sourceNumber: '+14155551234',
+    sourceUuid: 'uuid-123',
+    sourceName: 'Alice',
+    sourceDevice: 1,
+    timestamp: 1700000000000,
+    dataMessage: {
+      timestamp: 1700000000000,
+      message: 'Hello Nathan',
+      expiresInSeconds: 0,
+      viewOnce: false,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('convertSignalEnvelope', () => {
+  it('converts a 1:1 text message', () => {
+    const result = convertSignalEnvelope(makeEnvelope());
+    expect(result).not.toBeNull();
+    expect(result!.conversationId).toBe('signal:+14155551234');
+    expect(result!.channelId).toBe('signal');
+    expect(result!.senderId).toBe('+14155551234');
+    expect(result!.content).toBe('Hello Nathan');
+    expect(result!.metadata.isGroup).toBe(false);
+    expect(result!.metadata.groupId).toBeUndefined();
+    expect(result!.metadata.signalTimestamp).toBe(1700000000000);
+    expect(result!.metadata.sourceName).toBe('Alice');
+  });
+
+  it('converts a group text message', () => {
+    const result = convertSignalEnvelope(makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: 'Team meeting at 3pm',
+        expiresInSeconds: 0,
+        viewOnce: false,
+        groupInfo: { groupId: 'abc123==', type: 'DELIVER' },
+      },
+    }));
+    expect(result).not.toBeNull();
+    expect(result!.conversationId).toBe('signal:group=abc123==');
+    expect(result!.metadata.isGroup).toBe(true);
+    expect(result!.metadata.groupId).toBe('abc123==');
+  });
+
+  it('trims leading and trailing whitespace from message content', () => {
+    const result = convertSignalEnvelope(makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: '  hello world  ',
+        expiresInSeconds: 0,
+        viewOnce: false,
+      },
+    }));
+    expect(result!.content).toBe('hello world');
+  });
+
+  it('includes attachments in metadata when present', () => {
+    const result = convertSignalEnvelope(makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: 'See attached',
+        expiresInSeconds: 0,
+        viewOnce: false,
+        attachments: [{ id: 'att1', contentType: 'image/png', filename: 'photo.png', size: 12345 }],
+      },
+    }));
+    expect(result!.metadata.attachments).toHaveLength(1);
+    expect(result!.metadata.attachments![0].id).toBe('att1');
+  });
+
+  it('omits attachments from metadata when array is empty', () => {
+    const result = convertSignalEnvelope(makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: 'No attachments',
+        expiresInSeconds: 0,
+        viewOnce: false,
+        attachments: [],
+      },
+    }));
+    expect(result!.metadata.attachments).toBeUndefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Ignored envelope types
+  // ---------------------------------------------------------------------------
+
+  it('returns null for a sync message (self-sent from another device)', () => {
+    const result = convertSignalEnvelope(makeEnvelope({
+      dataMessage: undefined,
+      syncMessage: { sentMessage: { message: 'sent from my phone' } },
+    }));
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a reaction', () => {
+    const result = convertSignalEnvelope(makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: null,
+        expiresInSeconds: 0,
+        viewOnce: false,
+        reaction: {
+          emoji: '👍',
+          targetAuthor: '+14155559999',
+          targetTimestamp: 1699999999999,
+          isRemove: false,
+        },
+      },
+    }));
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a view-once message', () => {
+    const result = convertSignalEnvelope(makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: 'secret',
+        expiresInSeconds: 0,
+        viewOnce: true,
+      },
+    }));
+    expect(result).toBeNull();
+  });
+
+  it('returns null when dataMessage is missing', () => {
+    const result = convertSignalEnvelope(makeEnvelope({ dataMessage: undefined }));
+    expect(result).toBeNull();
+  });
+
+  it('returns null when message text is null', () => {
+    const result = convertSignalEnvelope(makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: null,
+        expiresInSeconds: 0,
+        viewOnce: false,
+      },
+    }));
+    expect(result).toBeNull();
+  });
+
+  it('returns null when message text is empty after trimming', () => {
+    const result = convertSignalEnvelope(makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: '   ',
+        expiresInSeconds: 0,
+        viewOnce: false,
+      },
+    }));
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a group UPDATE event (management, not a message)', () => {
+    const result = convertSignalEnvelope(makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: null,
+        expiresInSeconds: 0,
+        viewOnce: false,
+        groupInfo: { groupId: 'abc123==', type: 'UPDATE' },
+      },
+    }));
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a group QUIT event', () => {
+    const result = convertSignalEnvelope(makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: null,
+        expiresInSeconds: 0,
+        viewOnce: false,
+        groupInfo: { groupId: 'abc123==', type: 'QUIT' },
+      },
+    }));
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a group UNKNOWN event', () => {
+    const result = convertSignalEnvelope(makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: null,
+        expiresInSeconds: 0,
+        viewOnce: false,
+        groupInfo: { groupId: 'abc123==', type: 'UNKNOWN' },
+      },
+    }));
+    expect(result).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Conversation ID format
+  // ---------------------------------------------------------------------------
+
+  it('uses group= prefix for group conversation IDs to prevent collisions with phone numbers', () => {
+    const result = convertSignalEnvelope(makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: 'hi group',
+        expiresInSeconds: 0,
+        viewOnce: false,
+        groupInfo: { groupId: 'groupIdBase64==', type: 'DELIVER' },
+      },
+    }));
+    expect(result!.conversationId).toMatch(/^signal:group=/);
+  });
+
+  it('uses the E.164 number directly for 1:1 conversation IDs', () => {
+    const result = convertSignalEnvelope(makeEnvelope({ sourceNumber: '+14155559999' }));
+    expect(result!.conversationId).toBe('signal:+14155559999');
+  });
+});

--- a/tests/unit/channels/signal/signal-adapter.test.ts
+++ b/tests/unit/channels/signal/signal-adapter.test.ts
@@ -29,7 +29,8 @@ function makeMockRpcClient() {
     simulateMessage: (envelope: SignalEnvelope) => void;
   };
 
-  emitter.connect = vi.fn().mockResolvedValue(undefined);
+  // connect() is synchronous in the real implementation
+  emitter.connect = vi.fn().mockReturnValue(undefined);
   emitter.disconnect = vi.fn().mockResolvedValue(undefined);
   emitter.send = vi.fn().mockResolvedValue(undefined);
   emitter.sendReadReceipt = vi.fn().mockResolvedValue(undefined);

--- a/tests/unit/channels/signal/signal-adapter.test.ts
+++ b/tests/unit/channels/signal/signal-adapter.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { EventBus } from '../../../../src/bus/bus.js';
+import { SignalAdapter } from '../../../../src/channels/signal/signal-adapter.js';
+import type { SignalRpcClient } from '../../../../src/channels/signal/signal-rpc-client.js';
+import type { OutboundGateway } from '../../../../src/skills/outbound-gateway.js';
+import type { ContactService } from '../../../../src/contacts/contact-service.js';
+import type { SignalEnvelope } from '../../../../src/channels/signal/types.js';
+import type { OutboundMessageEvent } from '../../../../src/bus/events.js';
+import { createLogger } from '../../../../src/logger.js';
+import pino from 'pino';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSilentLogger() {
+  return pino({ level: 'silent' });
+}
+
+/** Minimal EventEmitter standing in for SignalRpcClient */
+function makeMockRpcClient() {
+  const emitter = new EventEmitter() as EventEmitter & {
+    connect: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn>;
+    sendReadReceipt: ReturnType<typeof vi.fn>;
+    // Helper to simulate an inbound message from signal-cli
+    simulateMessage: (envelope: SignalEnvelope) => void;
+  };
+
+  emitter.connect = vi.fn().mockResolvedValue(undefined);
+  emitter.disconnect = vi.fn().mockResolvedValue(undefined);
+  emitter.send = vi.fn().mockResolvedValue(undefined);
+  emitter.sendReadReceipt = vi.fn().mockResolvedValue(undefined);
+  emitter.simulateMessage = (envelope) => emitter.emit('message', envelope);
+
+  return emitter as unknown as SignalRpcClient & {
+    connect: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn>;
+    sendReadReceipt: ReturnType<typeof vi.fn>;
+    simulateMessage: (envelope: SignalEnvelope) => void;
+  };
+}
+
+function makeMockGateway() {
+  return {
+    send: vi.fn().mockResolvedValue({ success: true }),
+  } as unknown as OutboundGateway;
+}
+
+function makeMockContactService(resolved: { contactId: string; status: string } | null = null) {
+  return {
+    resolveByChannelIdentity: vi.fn().mockResolvedValue(resolved),
+    createContact: vi.fn().mockResolvedValue({ id: 'new-contact-id' }),
+    linkIdentity: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ContactService;
+}
+
+function makeEnvelope(overrides: Partial<SignalEnvelope> = {}): SignalEnvelope {
+  return {
+    source: '+14155551234',
+    sourceNumber: '+14155551234',
+    sourceUuid: 'uuid-abc',
+    sourceName: 'Alice',
+    sourceDevice: 1,
+    timestamp: 1700000000000,
+    dataMessage: {
+      timestamp: 1700000000000,
+      message: 'Hello Nathan',
+      expiresInSeconds: 0,
+      viewOnce: false,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SignalAdapter', () => {
+  let bus: EventBus;
+  let rpcClient: ReturnType<typeof makeMockRpcClient>;
+  let gateway: ReturnType<typeof makeMockGateway>;
+  let contactService: ReturnType<typeof makeMockContactService>;
+  let adapter: SignalAdapter;
+  const logger = makeSilentLogger();
+  const PHONE = '+15555550000';
+
+  beforeEach(async () => {
+    bus = new EventBus(createLogger('error'));
+    rpcClient = makeMockRpcClient();
+    gateway = makeMockGateway();
+    contactService = makeMockContactService();
+
+    adapter = new SignalAdapter({
+      bus,
+      logger,
+      rpcClient,
+      outboundGateway: gateway,
+      contactService,
+      phoneNumber: PHONE,
+    });
+
+    await adapter.start();
+  });
+
+  afterEach(async () => {
+    await adapter.stop();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Inbound — happy path
+  // ---------------------------------------------------------------------------
+
+  it('publishes an inbound.message event when a 1:1 message arrives', async () => {
+    const published: unknown[] = [];
+    bus.subscribe('inbound.message', 'dispatch', (e) => { published.push(e); });
+
+    rpcClient.simulateMessage(makeEnvelope());
+
+    // Give async processing a tick
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(published).toHaveLength(1);
+    const event = published[0] as { type: string; payload: { channelId: string; senderId: string; content: string } };
+    expect(event.type).toBe('inbound.message');
+    expect(event.payload.channelId).toBe('signal');
+    expect(event.payload.senderId).toBe('+14155551234');
+    expect(event.payload.content).toBe('Hello Nathan');
+  });
+
+  it('sends a read receipt for a 1:1 message from a known (confirmed) sender', async () => {
+    // resolveByChannelIdentity returns confirmed contact
+    const confirmedService = makeMockContactService({ contactId: 'c1', status: 'confirmed' });
+    const confirmedAdapter = new SignalAdapter({
+      bus,
+      logger,
+      rpcClient,
+      outboundGateway: gateway,
+      contactService: confirmedService,
+      phoneNumber: PHONE,
+    });
+    await confirmedAdapter.start();
+
+    rpcClient.simulateMessage(makeEnvelope());
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(rpcClient.sendReadReceipt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: PHONE,
+        recipient: '+14155551234',
+        targetTimestamp: [1700000000000],
+        receiptType: 'read',
+      }),
+    );
+
+    await confirmedAdapter.stop();
+  });
+
+  it('does NOT send a read receipt for a provisional sender', async () => {
+    // resolveByChannelIdentity returns provisional contact
+    const provisionalService = makeMockContactService({ contactId: 'c2', status: 'provisional' });
+    const provisionalAdapter = new SignalAdapter({
+      bus,
+      logger,
+      rpcClient,
+      outboundGateway: gateway,
+      contactService: provisionalService,
+      phoneNumber: PHONE,
+    });
+    await provisionalAdapter.start();
+
+    rpcClient.simulateMessage(makeEnvelope());
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(rpcClient.sendReadReceipt).not.toHaveBeenCalled();
+
+    await provisionalAdapter.stop();
+  });
+
+  it('does NOT send a read receipt for a blocked sender', async () => {
+    const blockedService = makeMockContactService({ contactId: 'c3', status: 'blocked' });
+    const blockedAdapter = new SignalAdapter({
+      bus,
+      logger,
+      rpcClient,
+      outboundGateway: gateway,
+      contactService: blockedService,
+      phoneNumber: PHONE,
+    });
+    await blockedAdapter.start();
+
+    rpcClient.simulateMessage(makeEnvelope());
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(rpcClient.sendReadReceipt).not.toHaveBeenCalled();
+
+    await blockedAdapter.stop();
+  });
+
+  it('does NOT send a read receipt for a group message even from a known sender', async () => {
+    const confirmedService = makeMockContactService({ contactId: 'c4', status: 'confirmed' });
+    const confirmedAdapter = new SignalAdapter({
+      bus,
+      logger,
+      rpcClient,
+      outboundGateway: gateway,
+      contactService: confirmedService,
+      phoneNumber: PHONE,
+    });
+    await confirmedAdapter.start();
+
+    const groupEnvelope = makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: 'Team standup?',
+        expiresInSeconds: 0,
+        viewOnce: false,
+        groupInfo: { groupId: 'grp123==', type: 'DELIVER' },
+      },
+    });
+    rpcClient.simulateMessage(groupEnvelope);
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(rpcClient.sendReadReceipt).not.toHaveBeenCalled();
+
+    await confirmedAdapter.stop();
+  });
+
+  it('auto-creates a contact for an unknown sender', async () => {
+    // null = not found
+    const unknownService = makeMockContactService(null);
+    const unknownAdapter = new SignalAdapter({
+      bus,
+      logger,
+      rpcClient,
+      outboundGateway: gateway,
+      contactService: unknownService,
+      phoneNumber: PHONE,
+    });
+    await unknownAdapter.start();
+
+    rpcClient.simulateMessage(makeEnvelope());
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(unknownService.createContact).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'signal_participant', status: 'provisional' }),
+    );
+    expect(unknownService.linkIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'signal', channelIdentifier: '+14155551234' }),
+    );
+
+    await unknownAdapter.stop();
+  });
+
+  it('ignores reaction envelopes (no publish)', async () => {
+    const published: unknown[] = [];
+    bus.subscribe('inbound.message', 'dispatch', (e) => { published.push(e); });
+
+    rpcClient.simulateMessage(makeEnvelope({
+      dataMessage: {
+        timestamp: 1700000000000,
+        message: null,
+        expiresInSeconds: 0,
+        viewOnce: false,
+        reaction: { emoji: '👍', targetAuthor: '+1', targetTimestamp: 0, isRemove: false },
+      },
+    }));
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(published).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Outbound
+  // ---------------------------------------------------------------------------
+
+  it('routes a 1:1 outbound.message with signal channelId through the gateway', async () => {
+    const outboundEvent: OutboundMessageEvent = {
+      id: 'evt-1',
+      timestamp: new Date(),
+      type: 'outbound.message',
+      sourceLayer: 'dispatch',
+      payload: {
+        conversationId: 'signal:+14155551234',
+        channelId: 'signal',
+        content: 'Hello from Nathan',
+      },
+    };
+
+    await bus.publish('dispatch', outboundEvent);
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(gateway.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'signal',
+        recipient: '+14155551234',
+        message: 'Hello from Nathan',
+      }),
+    );
+  });
+
+  it('routes a group outbound.message through the gateway', async () => {
+    const outboundEvent: OutboundMessageEvent = {
+      id: 'evt-2',
+      timestamp: new Date(),
+      type: 'outbound.message',
+      sourceLayer: 'dispatch',
+      payload: {
+        conversationId: 'signal:group=abc123==',
+        channelId: 'signal',
+        content: 'Group reply',
+      },
+    };
+
+    await bus.publish('dispatch', outboundEvent);
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(gateway.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'signal',
+        groupId: 'abc123==',
+        recipient: undefined,
+        message: 'Group reply',
+      }),
+    );
+  });
+
+  it('ignores outbound.message events for other channels (e.g. email)', async () => {
+    const outboundEvent: OutboundMessageEvent = {
+      id: 'evt-3',
+      timestamp: new Date(),
+      type: 'outbound.message',
+      sourceLayer: 'dispatch',
+      payload: {
+        conversationId: 'email:thread123',
+        channelId: 'email',
+        content: 'Email reply',
+      },
+    };
+
+    await bus.publish('dispatch', outboundEvent);
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(gateway.send).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  it('calls rpcClient.connect() on start and disconnect() on stop', async () => {
+    // adapter was already started in beforeEach
+    expect(rpcClient.connect).toHaveBeenCalledTimes(1);
+
+    await adapter.stop();
+    expect(rpcClient.disconnect).toHaveBeenCalledTimes(1);
+
+    // Re-start for afterEach cleanup
+    await adapter.start();
+  });
+});

--- a/tests/unit/channels/signal/signal-rpc-client.test.ts
+++ b/tests/unit/channels/signal/signal-rpc-client.test.ts
@@ -107,7 +107,12 @@ describe('SignalRpcClient', () => {
       accountNumber: '+15555550000',
       logger: makeLogger(),
     });
-    await client.connect();
+    // connect() is now synchronous — it starts the attempt in the background.
+    // Wait for the 'connected' event to know the socket is actually open.
+    await new Promise<void>((resolve) => {
+      client.once('connected', resolve);
+      client.connect();
+    });
   });
 
   afterEach(async () => {

--- a/tests/unit/channels/signal/signal-rpc-client.test.ts
+++ b/tests/unit/channels/signal/signal-rpc-client.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { SignalRpcClient } from '../../../../src/channels/signal/signal-rpc-client.js';
+import type { SignalEnvelope } from '../../../../src/channels/signal/types.js';
+import pino from 'pino';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeLogger() {
+  return pino({ level: 'silent' });
+}
+
+function tmpSocketPath() {
+  return path.join(os.tmpdir(), `test-signal-${process.pid}-${Date.now()}.sock`);
+}
+
+/**
+ * Creates a simple mock signal-cli server that listens on a Unix socket.
+ * Call pushLine() to send a JSON-RPC message to any connected client.
+ * Call respondToNext() to auto-respond to the next incoming request.
+ */
+function createMockServer(socketPath: string) {
+  const server = net.createServer();
+  let clientSocket: net.Socket | null = null;
+  const requestQueue: Array<{ id: string; method: string; params: unknown }> = [];
+
+  server.on('connection', (socket) => {
+    clientSocket = socket;
+    let buf = '';
+    socket.on('data', (chunk) => {
+      buf += chunk.toString('utf8');
+      const lines = buf.split('\n');
+      buf = lines.pop() ?? '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed) as { id: string; method: string; params: unknown };
+          requestQueue.push(parsed);
+        } catch { /* ignore */ }
+      }
+    });
+  });
+
+  return {
+    server,
+    listen: () => new Promise<void>((resolve) => server.listen(socketPath, resolve)),
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+    push: (obj: unknown) => {
+      if (clientSocket) {
+        clientSocket.write(JSON.stringify(obj) + '\n');
+      }
+    },
+    popRequest: () => requestQueue.shift(),
+    respondSuccess: (id: string, result: unknown = {}) => {
+      if (clientSocket) {
+        clientSocket.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n');
+      }
+    },
+    respondError: (id: string, code: number, message: string) => {
+      if (clientSocket) {
+        clientSocket.write(JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } }) + '\n');
+      }
+    },
+  };
+}
+
+function makeEnvelope(overrides: Partial<SignalEnvelope> = {}): SignalEnvelope {
+  return {
+    source: '+14155551234',
+    sourceNumber: '+14155551234',
+    sourceUuid: 'uuid-abc',
+    sourceName: 'Alice',
+    sourceDevice: 1,
+    timestamp: 1700000000000,
+    dataMessage: {
+      timestamp: 1700000000000,
+      message: 'hello',
+      expiresInSeconds: 0,
+      viewOnce: false,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SignalRpcClient', () => {
+  let socketPath: string;
+  let mock: ReturnType<typeof createMockServer>;
+  let client: SignalRpcClient;
+
+  beforeEach(async () => {
+    socketPath = tmpSocketPath();
+    mock = createMockServer(socketPath);
+    await mock.listen();
+
+    client = new SignalRpcClient({
+      socketPath,
+      accountNumber: '+15555550000',
+      logger: makeLogger(),
+    });
+    await client.connect();
+  });
+
+  afterEach(async () => {
+    await client.disconnect();
+    await mock.close();
+    // Clean up socket file
+    try { fs.unlinkSync(socketPath); } catch { /* ok */ }
+  });
+
+  it('parses a receive notification and emits a message event', async () => {
+    const envelope = makeEnvelope();
+    const received = new Promise<SignalEnvelope>((resolve) => {
+      client.once('message', resolve);
+    });
+
+    mock.push({
+      jsonrpc: '2.0',
+      method: 'receive',
+      params: { envelope, account: '+15555550000' },
+    });
+
+    const emitted = await received;
+    expect(emitted.sourceNumber).toBe('+14155551234');
+    expect(emitted.dataMessage?.message).toBe('hello');
+  });
+
+  it('correlates a send request to its success response', async () => {
+    const sendPromise = client.send({
+      account: '+15555550000',
+      recipient: ['+14155551234'],
+      message: 'hi',
+    });
+
+    // Wait briefly for the request to arrive
+    await new Promise((r) => setTimeout(r, 20));
+    const req = mock.popRequest();
+    expect(req).toBeDefined();
+    expect(req!.method).toBe('send');
+    mock.respondSuccess(req!.id, { timestamp: 1700000000000 });
+
+    await expect(sendPromise).resolves.toBeUndefined();
+  });
+
+  it('rejects a send request when signal-cli returns an error', async () => {
+    const sendPromise = client.send({
+      account: '+15555550000',
+      recipient: ['+14155551234'],
+      message: 'hi',
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    const req = mock.popRequest();
+    expect(req).toBeDefined();
+    mock.respondError(req!.id, -1, 'Rate limit exceeded');
+
+    await expect(sendPromise).rejects.toThrow('Rate limit exceeded');
+  });
+
+  it('deduplicates a re-delivered envelope with the same sourceNumber:timestamp', async () => {
+    const envelope = makeEnvelope({ timestamp: 9999 });
+    const messages: SignalEnvelope[] = [];
+    client.on('message', (e) => messages.push(e));
+
+    // Deliver the same envelope twice
+    const notification = {
+      jsonrpc: '2.0',
+      method: 'receive',
+      params: { envelope, account: '+15555550000' },
+    };
+    mock.push(notification);
+    mock.push(notification);
+
+    await new Promise((r) => setTimeout(r, 50));
+    // Only the first delivery should have been emitted
+    expect(messages).toHaveLength(1);
+  });
+
+  it('treats two envelopes with different timestamps as distinct', async () => {
+    const messages: SignalEnvelope[] = [];
+    client.on('message', (e) => messages.push(e));
+
+    mock.push({ jsonrpc: '2.0', method: 'receive', params: { envelope: makeEnvelope({ timestamp: 1 }), account: '+15555550000' } });
+    mock.push({ jsonrpc: '2.0', method: 'receive', params: { envelope: makeEnvelope({ timestamp: 2 }), account: '+15555550000' } });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(messages).toHaveLength(2);
+  });
+
+  it('ignores non-receive notifications silently', async () => {
+    const messages: SignalEnvelope[] = [];
+    client.on('message', (e) => messages.push(e));
+
+    mock.push({ jsonrpc: '2.0', method: 'typing', params: { action: 'STARTED' } });
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(messages).toHaveLength(0);
+  });
+
+  it('handles malformed JSON lines without crashing', async () => {
+    // Inject a malformed line between two valid notifications
+    const messages: SignalEnvelope[] = [];
+    client.on('message', (e) => messages.push(e));
+
+    // Write raw bytes to simulate a corrupted line followed by a valid notification
+    // We access the internal socket indirectly via the server's client write
+    const good = { jsonrpc: '2.0', method: 'receive', params: { envelope: makeEnvelope({ timestamp: 777 }), account: '+15555550000' } };
+    mock.push('not valid json at all');
+    mock.push(good);
+
+    await new Promise((r) => setTimeout(r, 50));
+    // The good message should still arrive
+    expect(messages).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- **Signal channel** via signal-cli daemon socket — inbound messages, outbound replies, 1:1 read receipts for confirmed senders, contact auto-creation, hold-for-approval unknown sender policy (matches email channel)
- **`SignalRpcClient`** — JSON-RPC 2.0 over Unix socket; newline-delimited framing; request/response correlation; exponential-backoff reconnect (1s → 5min cap); dedup sliding window (1000 entries) to handle re-delivered messages on reconnect; synchronous `connect()` so a Docker startup race between Curia and signal-cli never crashes the process
- **`OutboundGateway`** extended: `OutboundSendRequest` becomes a discriminated union (`EmailSendRequest | SignalOutboundRequest`); `nylasClient` is now optional; `dispatchSignal()` added alongside existing `dispatchEmail()`
- **`IdentitySource`** gains `signal_participant` (auto-verified, same trust as `email_participant`)
- **ADR-013** documents signal-cli daemon socket decision
- Enable by setting `SIGNAL_SOCKET_PATH` + `SIGNAL_PHONE_NUMBER` env vars; disabled by default

## Test plan

- [x] 34 new unit tests across `message-converter`, `signal-rpc-client`, and `signal-adapter` — 858 total passing, typecheck clean
- [ ] Verify Docker Compose startup order: Curia starts cleanly even if signal-cli socket is not yet available
- [ ] Register a Fongo/TextNow number with signal-cli, set env vars, confirm inbound message flows through to coordinator
- [ ] Confirm read receipt arrives on sender's phone for a 1:1 message from a confirmed contact
- [ ] Confirm no read receipt for provisional sender (hold-for-approval policy applies)
- [ ] Confirm outbound reply lands in Signal after coordinator responds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signal messaging channel: inbound/outbound support for 1:1 and group conversations, with contact auto-creation, input sanitization, and optional 1:1 read receipts for confirmed contacts.
  * Outbound gateway extended to send via Signal alongside email.
  * Controlled activation via SIGNAL_SOCKET_PATH and SIGNAL_PHONE_NUMBER environment variables.

* **Documentation**
  * Added ADR documenting the chosen daemon-socket integration approach for Signal.

* **Chores**
  * Package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->