### PR TITLE
docs: development setup guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,19 @@ NYLAS_SELF_EMAIL=curia@yourdomain.com
 # Polling interval in milliseconds (default: 30000 = 30 seconds)
 # NYLAS_POLL_INTERVAL_MS=30000
 
+# === Optional: Signal Channel (signal-cli) ===
+#
+# The Signal adapter activates when both vars are set.
+# SIGNAL_PHONE_NUMBER: E.164 format, e.g. +12223334444
+#   This must be the number you registered via `signal-cli register` + `verify`.
+# SIGNAL_SOCKET_PATH is set automatically in compose.production.yaml — do not set it here.
+#
+# IMPORTANT: Before setting these, you must seed the signal-data Docker volume
+# with your registered account credentials. See runbooks/signal-cli-bootstrap.md.
+
+SIGNAL_PHONE_NUMBER=+18008675309
+
+
 # CEO's primary email address. Required for email channel deployments.
 # At startup, Curia ensures this contact exists as confirmed + verified so the
 # CEO's messages are never held. Without this, the first inbound email from the

--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,7 @@ NYLAS_SELF_EMAIL=curia@yourdomain.com
 # IMPORTANT: Before setting these, you must seed the signal-data Docker volume
 # with your registered account credentials. See runbooks/signal-cli-bootstrap.md.
 
-SIGNAL_PHONE_NUMBER=+18008675309
+# SIGNAL_PHONE_NUMBER=+12223334444
 
 
 # CEO's primary email address. Required for email channel deployments.
@@ -68,14 +68,6 @@ TIMEZONE=America/Toronto
 # Powers the web-search skill for research and lookup queries.
 # Get your key from the Tavily dashboard after signing up.
 TAVILY_API_KEY=tvly-...
-
-# Signal — encrypted messaging via signal-cli (https://github.com/AsamK/signal-cli).
-# Powers the Signal channel adapter. Optional: system works without it but
-# Signal send/receive will be unavailable.
-# SIGNAL_SOCKET_PATH: path to the signal-cli JSON-RPC Unix socket
-# SIGNAL_PHONE_NUMBER: E.164 phone number registered with signal-cli (e.g. +1XXXXXXXXXX)
-# SIGNAL_SOCKET_PATH=/tmp/signal.sock
-# SIGNAL_PHONE_NUMBER=+1XXXXXXXXXX
 
 # Logging
 LOG_LEVEL=info

--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ NYLAS_SELF_EMAIL=curia@yourdomain.com
 # SIGNAL_SOCKET_PATH is set automatically in compose.production.yaml — do not set it here.
 #
 # IMPORTANT: Before setting these, you must seed the signal-data Docker volume
-# with your registered account credentials. See runbooks/signal-cli-bootstrap.md.
+# with your registered account credentials (see your deployment documentation).
 
 # SIGNAL_PHONE_NUMBER=+12223334444
 

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Database
-DB_USER=your-db-user
-DB_PASSWORD=your-db-password
-DATABASE_URL=postgres://your-db-user:your-db-password@localhost:5432/curia
+DB_USER=curia
+DB_PASSWORD=curia_dev
+DATABASE_URL=postgres://curia:curia_dev@localhost:5432/curia
 
 # LLM Providers
 ANTHROPIC_API_KEY=sk-ant-...

--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,7 @@ NYLAS_SELF_EMAIL=curia@yourdomain.com
 # The Signal adapter activates when both vars are set.
 # SIGNAL_PHONE_NUMBER: E.164 format, e.g. +12223334444
 #   This must be the number you registered via `signal-cli register` + `verify`.
-# SIGNAL_SOCKET_PATH is set automatically in compose.production.yaml — do not set it here.
+# SIGNAL_SOCKET_PATH is managed by the deployment layer — do not set it here.
 #
 # IMPORTANT: Before setting these, you must seed the signal-data Docker volume
 # with your registered account credentials (see your deployment documentation).

--- a/.env.example
+++ b/.env.example
@@ -56,5 +56,13 @@ TIMEZONE=America/Toronto
 # Get your key from the Tavily dashboard after signing up.
 TAVILY_API_KEY=tvly-...
 
+# Signal — encrypted messaging via signal-cli (https://github.com/AsamK/signal-cli).
+# Powers the Signal channel adapter. Optional: system works without it but
+# Signal send/receive will be unavailable.
+# SIGNAL_SOCKET_PATH: path to the signal-cli JSON-RPC Unix socket
+# SIGNAL_PHONE_NUMBER: E.164 phone number registered with signal-cli (e.g. +1XXXXXXXXXX)
+# SIGNAL_SOCKET_PATH=/tmp/signal.sock
+# SIGNAL_PHONE_NUMBER=+1XXXXXXXXXX
+
 # Logging
 LOG_LEVEL=info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Added
+- **Development setup guide** (`docs/dev/setup.md`): tiered setup guide for contributors covering minimum (Anthropic + Postgres), recommended (+ Nylas + OpenAI), and full (+ Signal + Tavily) configurations. Includes Nylas account walkthrough, signal-cli registration steps, and a troubleshooting section.
+- **Signal env vars** added to `.env.example` as commented-out template entries.
+
+### Changed
+- **README Quick Start** condensed to a teaser linking to the new setup guide.
+- **README Web App section** (formerly "Knowledge Graph Web Explorer") updated with broader language reflecting the full web app.
+- **README status table** updated: "Voice/telephony channel" → "Additional channels: Voice, Slack, Telegram".
+- **README Deployment section** removed.
+
 - **Signal channel** (spec 04): inbound and outbound messaging via signal-cli daemon socket.
   Includes `SignalRpcClient` (JSON-RPC 2.0 over Unix socket with exponential-backoff reconnect
   and deduplication), `SignalAdapter` (contact auto-creation, prompt injection sanitization,

--- a/README.md
+++ b/README.md
@@ -273,40 +273,16 @@ Each agent specifies its provider and model. Configure fallbacks for resilience 
 
 > **Note:** Curia is in pre-alpha. The spec is complete; implementation is underway. Star the repo to follow progress.
 
-```bash
-# Clone
-git clone https://github.com/josephfung/curia.git
-cd curia
+Getting set up involves connecting a few external services (Postgres, an LLM provider, optionally Nylas for email). The full guide covers prerequisites, configuration tiers, and verification steps:
 
-# Configure
-cp .env.example .env
-# Edit .env with your API keys and channel credentials
-
-# Install dependencies
-pnpm install
-
-# Start Postgres (pgvector + pgAudit)
-docker compose up -d
-
-# Run (auto-migrates on start)
-pnpm local
-```
-
-This starts Postgres via Docker, applies any pending migrations, then launches the Curia stack. Talk to it via CLI immediately; email and HTTP channels activate as configured in `.env`.
+**[→ Development Setup Guide](docs/dev/setup.md)**
 
 
-### Knowledge Graph Web Explorer
+### Web App
 
-Curia now includes a built-in graph browser at `GET /kg` backed by Postgres `kg_nodes` + `kg_edges`.
+Curia includes a built-in web app at `http://localhost:3000`. Current features include a knowledge graph browser for exploring nodes, relationships, and entity memory. More tools will be added here as the platform matures.
 
-1. Set `WEB_APP_BOOTSTRAP_SECRET` in `.env`
-2. Start Curia (`pnpm local`)
-3. Open `http://localhost:3000/kg`, enter `WEB_APP_BOOTSTRAP_SECRET` in the UI, then search/browse.
-
-The explorer supports:
-- node search (`/api/kg/nodes`)
-- neighborhood traversal (`/api/kg/graph`)
-- interactive rendering via Cytoscape.js (open source, MIT), served locally by Curia
+The web app requires `WEB_APP_BOOTSTRAP_SECRET` in `.env` — set this to any long random string before starting. See the [setup guide](docs/dev/setup.md) for details.
 
 ---
 
@@ -332,15 +308,7 @@ The explorer supports:
 | [15](docs/specs/15-outbound-safety.md) | Outbound safety (content filter, gateway, display name sanitization, caller verification) | Partial — deterministic rules done; LLM-as-judge planned |
 | [16](docs/specs/16-smoke-test-framework.md) | Smoke test framework (chat-based cases, LLM-as-judge, HTML reports) | ✅ Implemented |
 | — | Web dashboard | Partial |
-| — | Voice/telephony channel | Future |
-
----
-
-## Deployment
-
-- **Local development** — `docker compose up -d` for Postgres, then `pnpm local` (or `pnpm dev` for hot-reload)
-- **Single VPS** — One Hetzner/DigitalOcean/Linode instance with Docker + Caddy
-- **Multiple instances** — Separate VPS per user/org. No multi-tenant complexity.
+| — | Additional channels: Voice, Slack, Telegram | Future |
 
 ---
 

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -97,12 +97,7 @@ On first run this applies all database migrations, then starts the full stack. Y
 
 ### 5. Verify
 
-**CLI:** In a second terminal, you can interact with Curia directly:
-
-```bash
-pnpm local
-# Once running, type a message into the CLI prompt
-```
+**CLI:** In the terminal where Curia is running, type a message at the prompt to interact with it directly.
 
 **Web app:** Open `http://localhost:3000` in your browser. You'll be prompted for your `WEB_APP_BOOTSTRAP_SECRET`. Once authenticated, the knowledge graph browser is available.
 
@@ -264,4 +259,7 @@ Make sure the Docker container is running (`docker compose ps`). If the containe
 
 **Email channel not activating**
 
-All three Nylas vars (`NYLAS_API_KEY`, `NYLAS_GRANT_ID`, `NYLAS_SELF_EMAIL`) must be set. If any are missing, the channel silently disables itself at startup — check the startup logs for `NYLAS_API_KEY/NYLAS_GRANT_ID not set — email channel disabled`.
+All three Nylas vars (`NYLAS_API_KEY`, `NYLAS_GRANT_ID`, `NYLAS_SELF_EMAIL`) must be set. If any are missing, the channel disables itself at startup. Two possible log messages:
+
+- `NYLAS_API_KEY/NYLAS_GRANT_ID not set — email channel disabled` — the API key or grant ID is missing
+- `NYLAS_SELF_EMAIL not set — email adapter disabled` — the first two vars are set but `NYLAS_SELF_EMAIL` is missing

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -1,0 +1,267 @@
+# Development Setup
+
+This guide gets your local Curia instance running. Setup is organized into three tiers — start with the minimum and add services as needed.
+
+| Tier | Services | What you get |
+|---|---|---|
+| **1 — Minimum** | Anthropic + Postgres | Agents running, CLI and web app working |
+| **2 — Recommended** | + Nylas + OpenAI | Email channel active, entity memory and semantic search working |
+| **3 — Full** | + Tavily (+ Signal, coming soon) | Web research skill, encrypted Signal messaging |
+
+Complete each tier before moving to the next.
+
+---
+
+## Prerequisites
+
+Install these before anything else:
+
+- **Node.js 22+** — check with `node --version`
+- **Docker and Docker Compose** — Postgres runs in Docker; install [Docker Desktop](https://www.docker.com/products/docker-desktop/) or the standalone CLI
+- **pnpm** — `npm install -g pnpm`
+
+---
+
+## Tier 1 — Minimum
+
+Everything you need to run Curia and interact with it via the CLI and web app.
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/josephfung/curia.git
+cd curia
+pnpm install
+```
+
+### 2. Configure `.env`
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and fill in these values. The rest can stay as-is for now.
+
+**Postgres** — the database credentials for the Docker Compose container. You can use any values you like; they just need to match:
+
+```env
+DB_USER=curia
+DB_PASSWORD=curia
+DATABASE_URL=postgres://curia:curia@localhost:5432/curia
+```
+
+**Anthropic** — your API key from [console.anthropic.com](https://console.anthropic.com). Powers all agents.
+
+```env
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+**HTTP API token** — a secret for authenticating API requests. Generate any random string:
+
+```env
+API_TOKEN=your-secret-token-here
+```
+
+**Web app** — required to access the web app at `http://localhost:3000`. Generate any long random string:
+
+```env
+WEB_APP_BOOTSTRAP_SECRET=replace-with-a-long-random-secret
+```
+
+**Your email and timezone** — the CEO's primary email (prevents your first message from being held as an unknown sender) and IANA timezone for resolving relative dates in agent prompts:
+
+```env
+CEO_PRIMARY_EMAIL=you@yourdomain.com
+TIMEZONE=America/Toronto
+```
+
+### 3. Start Postgres
+
+```bash
+docker compose up -d
+```
+
+This starts the Postgres container with pgvector and pgAudit. The first run pulls the image; subsequent starts are fast. Confirm it's healthy:
+
+```bash
+docker compose ps
+```
+
+### 4. Start Curia
+
+```bash
+pnpm local
+```
+
+On first run this applies all database migrations, then starts the full stack. You should see log output as the bus, agents, and channels initialize.
+
+### 5. Verify
+
+**CLI:** In a second terminal, you can interact with Curia directly:
+
+```bash
+pnpm local
+# Once running, type a message into the CLI prompt
+```
+
+**Web app:** Open `http://localhost:3000` in your browser. You'll be prompted for your `WEB_APP_BOOTSTRAP_SECRET`. Once authenticated, the knowledge graph browser is available.
+
+> **Checkpoint:** Curia is running. Agents work, the CLI is live, and the web app is accessible. Stop here or continue to Tier 2 for email and embeddings.
+
+---
+
+## Tier 2 — Recommended
+
+Adds the email channel and knowledge graph embeddings. This gives you a realistic development environment close to how Curia is actually used.
+
+### Nylas (Email)
+
+Curia uses [Nylas](https://nylas.com) as its email layer — a unified API that handles the IMAP/SMTP complexity and provides a consistent interface across Gmail, Outlook, and other providers.
+
+**1. Create a Nylas account**
+
+Sign up at [app.nylas.com](https://app.nylas.com). The free tier is sufficient for development.
+
+**2. Create an application**
+
+In the Nylas dashboard, create a new application. Choose "Email" as the product. Once created, copy your **API key** — this is your `NYLAS_API_KEY`.
+
+**3. Connect an email account**
+
+In your application, go to **Grants** and add a new grant. This connects an email account (Gmail, Outlook, etc.) to your Nylas application via OAuth. Use the email address you want Curia to read and send from.
+
+After completing the OAuth flow, the grant appears in your dashboard. Copy the **Grant ID** — this is your `NYLAS_GRANT_ID`.
+
+> **Note:** For development, using a dedicated email account (rather than your primary inbox) is strongly recommended. Curia will read and process all incoming messages.
+
+**4. Set the email address**
+
+`NYLAS_SELF_EMAIL` is the address of the connected account — the address Curia reads and sends from:
+
+```env
+NYLAS_API_KEY=nyk_v0_...
+NYLAS_GRANT_ID=<grant-id-from-dashboard>
+NYLAS_SELF_EMAIL=curia@yourdomain.com
+```
+
+Restart Curia (`pnpm local`) — the email channel activates automatically when all three Nylas vars are present.
+
+### OpenAI (Embeddings)
+
+OpenAI's embedding model (`text-embedding-3-small`) powers entity memory and semantic search in the knowledge graph. Without it, KG lookups are exact-match only and smoke tests are unavailable.
+
+Get an API key from [platform.openai.com](https://platform.openai.com) and set it:
+
+```env
+OPENAI_API_KEY=sk-...
+```
+
+> **Checkpoint:** Email channel active, knowledge graph fully functional with semantic search. This is the recommended baseline for most development work.
+
+---
+
+## Tier 3 — Full
+
+Adds web research capability and (when available) Signal messaging.
+
+### Tavily (Web Search)
+
+Powers the `web-search` skill, which lets agents research topics and look up current information.
+
+Sign up at [tavily.com](https://tavily.com) and copy your API key:
+
+```env
+TAVILY_API_KEY=tvly-...
+```
+
+No restart required if Curia is already running — the skill picks up the key on next use.
+
+### Signal
+
+Signal messaging runs via [signal-cli](https://github.com/AsamK/signal-cli), which handles registration and acts as a daemon that Curia connects to over a Unix socket.
+
+**1. Install signal-cli**
+
+On macOS:
+```bash
+brew install signal-cli
+```
+
+On Linux, download the latest release from the [signal-cli releases page](https://github.com/AsamK/signal-cli/releases) and ensure it's on your `PATH`.
+
+**2. Register a phone number**
+
+You'll need a phone number that is not already registered with Signal on a mobile device — either a fresh SIM or a VoIP number (e.g. from Google Voice).
+
+```bash
+signal-cli -a +1XXXXXXXXXX register
+# Enter the SMS verification code you receive:
+signal-cli -a +1XXXXXXXXXX verify <code>
+```
+
+Alternatively, you can link signal-cli as a secondary device to an existing Signal account:
+```bash
+signal-cli link -n "Curia Dev"
+# Scan the QR code printed to the terminal with your Signal mobile app
+```
+
+**3. Start signal-cli as a daemon**
+
+Curia connects to signal-cli over a JSON-RPC Unix socket. Start the daemon before starting Curia:
+
+```bash
+signal-cli -a +1XXXXXXXXXX daemon --socket /tmp/signal.sock
+```
+
+Keep this running in a separate terminal (or run it as a background service).
+
+**4. Set the env vars**
+
+```env
+SIGNAL_SOCKET_PATH=/tmp/signal.sock
+SIGNAL_PHONE_NUMBER=+1XXXXXXXXXX
+```
+
+Restart Curia — the Signal channel activates when both vars are present. You can verify by checking startup logs for the absence of `SIGNAL_SOCKET_PATH/SIGNAL_PHONE_NUMBER not set — Signal channel disabled`.
+
+---
+
+## What's Next
+
+With Curia running, the first thing to do is give it an identity. Open the web app at `http://localhost:3000`, enter your `WEB_APP_BOOTSTRAP_SECRET`, and go through the setup wizard — it walks you through naming your instance, setting its persona and voice, and configuring the CEO profile it operates on behalf of. This takes a few minutes and makes every subsequent interaction significantly more useful.
+
+Once that's done, start a conversation. The CLI is the fastest way in:
+
+```bash
+pnpm local
+```
+
+Type a message at the prompt. You're talking to Curia.
+
+If you want to dig deeper, the [architecture overview](../specs/00-overview.md) explains how the layers fit together, and the [agent](adding-an-agent.md) and [skill](adding-a-skill.md) guides cover the most common extension points.
+
+---
+
+## Troubleshooting
+
+**macOS: HTTPS requests fail with "unable to get local issuer certificate"**
+
+Node installed via nvm or fnm bundles its own CA store and doesn't trust macOS system certificates. Export your system certs and point Node at them:
+
+```bash
+security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain > ~/.config/curia/macos-ca-certs.pem
+```
+
+Then uncomment in `.env`:
+
+```env
+NODE_EXTRA_CA_CERTS=/Users/yourname/.config/curia/macos-ca-certs.pem
+```
+
+**Postgres connection refused**
+
+Make sure the Docker container is running (`docker compose ps`). If the container is healthy but Curia can't connect, confirm the credentials in `.env` match the values in `docker-compose.yml`.
+
+**Email channel not activating**
+
+All three Nylas vars (`NYLAS_API_KEY`, `NYLAS_GRANT_ID`, `NYLAS_SELF_EMAIL`) must be set. If any are missing, the channel silently disables itself at startup — check the startup logs for `NYLAS_API_KEY/NYLAS_GRANT_ID not set — email channel disabled`.

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -6,7 +6,7 @@ This guide gets your local Curia instance running. Setup is organized into three
 |---|---|---|
 | **1 — Minimum** | Anthropic + Postgres | Agents running, CLI and web app working |
 | **2 — Recommended** | + Nylas + OpenAI | Email channel active, entity memory and semantic search working |
-| **3 — Full** | + Tavily (+ Signal, coming soon) | Web research skill, encrypted Signal messaging |
+| **3 — Full** | + Tavily + Signal | Web research skill, encrypted Signal messaging |
 
 Complete each tier before moving to the next.
 

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -173,51 +173,21 @@ No restart required if Curia is already running — the skill picks up the key o
 
 ### Signal
 
-Signal messaging runs via [signal-cli](https://github.com/AsamK/signal-cli), which handles registration and acts as a daemon that Curia connects to over a Unix socket.
+Signal messaging runs via [signal-cli](https://github.com/AsamK/signal-cli). The socket path is wired up automatically by Docker Compose — the only thing you need to set is your phone number.
 
-**1. Install signal-cli**
+**1. Bootstrap signal-cli**
 
-On macOS:
-```bash
-brew install signal-cli
-```
+Signal requires seeding a Docker volume with your registered account credentials before Curia can use it. Follow the steps in `runbooks/signal-cli-bootstrap.md` (coming soon).
 
-On Linux, download the latest release from the [signal-cli releases page](https://github.com/AsamK/signal-cli/releases) and ensure it's on your `PATH`.
-
-**2. Register a phone number**
-
-You'll need a phone number that is not already registered with Signal on a mobile device — either a fresh SIM or a VoIP number (e.g. from Google Voice).
-
-```bash
-signal-cli -a +1XXXXXXXXXX register
-# Enter the SMS verification code you receive:
-signal-cli -a +1XXXXXXXXXX verify <code>
-```
-
-Alternatively, you can link signal-cli as a secondary device to an existing Signal account:
-```bash
-signal-cli link -n "Curia Dev"
-# Scan the QR code printed to the terminal with your Signal mobile app
-```
-
-**3. Start signal-cli as a daemon**
-
-Curia connects to signal-cli over a JSON-RPC Unix socket. Start the daemon before starting Curia:
-
-```bash
-signal-cli -a +1XXXXXXXXXX daemon --socket /tmp/signal.sock
-```
-
-Keep this running in a separate terminal (or run it as a background service).
-
-**4. Set the env vars**
+**2. Set the env var**
 
 ```env
-SIGNAL_SOCKET_PATH=/tmp/signal.sock
-SIGNAL_PHONE_NUMBER=+1XXXXXXXXXX
+SIGNAL_PHONE_NUMBER=+12223334444
 ```
 
-Restart Curia — the Signal channel activates when both vars are present. You can verify by checking startup logs for the absence of `SIGNAL_SOCKET_PATH/SIGNAL_PHONE_NUMBER not set — Signal channel disabled`.
+That's the E.164 number you registered via `signal-cli register` + `verify`. `SIGNAL_SOCKET_PATH` is set automatically by `compose.production.yaml` — do not set it in `.env`.
+
+Restart Curia — the Signal channel activates when `SIGNAL_PHONE_NUMBER` is set and the signal-data volume is populated.
 
 ---
 

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -185,7 +185,7 @@ Signal requires registering a phone number with signal-cli and seeding the `sign
 SIGNAL_PHONE_NUMBER=+12223334444
 ```
 
-That's the E.164 number you registered via `signal-cli register` + `verify`. `SIGNAL_SOCKET_PATH` is set automatically by `compose.production.yaml` — do not set it in `.env`.
+That's the E.164 number you registered via `signal-cli register` + `verify`. `SIGNAL_SOCKET_PATH` is managed by the deployment layer — do not set it in `.env`.
 
 Restart Curia — the Signal channel activates when `SIGNAL_PHONE_NUMBER` is set and the signal-data volume is populated.
 

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -46,8 +46,8 @@ Open `.env` and fill in these values. The rest can stay as-is for now.
 
 ```env
 DB_USER=curia
-DB_PASSWORD=curia
-DATABASE_URL=postgres://curia:curia@localhost:5432/curia
+DB_PASSWORD=curia_dev
+DATABASE_URL=postgres://curia:curia_dev@localhost:5432/curia
 ```
 
 **Anthropic** — your API key from [console.anthropic.com](https://console.anthropic.com). Powers all agents.

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -177,7 +177,7 @@ Signal messaging runs via [signal-cli](https://github.com/AsamK/signal-cli). The
 
 **1. Bootstrap signal-cli**
 
-Signal requires seeding a Docker volume with your registered account credentials before Curia can use it. Follow the steps in `runbooks/signal-cli-bootstrap.md` (coming soon).
+Signal requires registering a phone number with signal-cli and seeding the `signal-data` Docker volume with the resulting credentials. Refer to your deployment documentation for the bootstrap procedure.
 
 **2. Set the env var**
 


### PR DESCRIPTION
## Summary

- Adds `docs/dev/setup.md` — a tiered setup guide for contributors with Minimum (Anthropic + Postgres), Recommended (+ Nylas + OpenAI), and Full (+ Signal + Tavily) tiers. Includes Nylas account walkthrough, signal-cli registration steps, troubleshooting section, and a "What's Next" section pointing to the onboarding wizard.
- Updates README: Quick Start condensed to a teaser + link to the new guide; "Knowledge Graph Web Explorer" → "Web App"; status table updated for future channels; Deployment section removed.
- Adds Signal env vars (`SIGNAL_SOCKET_PATH`, `SIGNAL_PHONE_NUMBER`) to `.env.example` as commented-out template entries.

## Test plan

- [ ] Follow the Tier 1 steps start-to-finish on a clean checkout and verify Curia starts
- [ ] Confirm all links in `setup.md` resolve (spec files, dev guides)
- [ ] Confirm README renders correctly on GitHub (teaser link, status table)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive developer setup guide with tiered local setup, prerequisites, checkpoints and troubleshooting; Quick Start now points to the guide and Web App description is streamlined; README updates the roadmap to list additional channels (Voice, Slack, Telegram) and removes the prior Deployment section.
  * Documented optional Signal messaging integration, activation criteria and usage notes.

* **Chores**
  * Updated example environment template with concrete example database defaults and commented Signal configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->