### PR TITLE
fix: thread logger into EntityMemory and log silent-skip paths

### DIFF
--- a/skills/delete-relationship/handler.test.ts
+++ b/skills/delete-relationship/handler.test.ts
@@ -4,6 +4,7 @@ import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
 import { EmbeddingService } from '../../src/memory/embedding.js';
 import { EntityMemory } from '../../src/memory/entity-memory.js';
 import { MemoryValidator } from '../../src/memory/validation.js';
+import { createSilentLogger } from '../../src/logger.js';
 import { DeleteRelationshipHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 
@@ -11,7 +12,7 @@ function makeEntityMemory() {
   const embeddingService = EmbeddingService.createForTesting();
   const store = KnowledgeGraphStore.createInMemory(embeddingService);
   const validator = new MemoryValidator(store, embeddingService);
-  return new EntityMemory(store, validator, embeddingService);
+  return new EntityMemory(store, validator, embeddingService, createSilentLogger());
 }
 
 function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {

--- a/skills/extract-relationships/handler.test.ts
+++ b/skills/extract-relationships/handler.test.ts
@@ -9,6 +9,7 @@ import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
 import { EmbeddingService } from '../../src/memory/embedding.js';
 import { EntityMemory } from '../../src/memory/entity-memory.js';
 import { MemoryValidator } from '../../src/memory/validation.js';
+import { createSilentLogger } from '../../src/logger.js';
 import { ExtractRelationshipsHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 
@@ -18,7 +19,7 @@ function makeEntityMemory(): EntityMemory {
   const embeddingService = EmbeddingService.createForTesting();
   const store = KnowledgeGraphStore.createInMemory(embeddingService);
   const validator = new MemoryValidator(store, embeddingService);
-  return new EntityMemory(store, validator, embeddingService);
+  return new EntityMemory(store, validator, embeddingService, createSilentLogger());
 }
 
 function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {

--- a/skills/query-relationships/handler.test.ts
+++ b/skills/query-relationships/handler.test.ts
@@ -4,6 +4,7 @@ import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
 import { EmbeddingService } from '../../src/memory/embedding.js';
 import { EntityMemory } from '../../src/memory/entity-memory.js';
 import { MemoryValidator } from '../../src/memory/validation.js';
+import { createSilentLogger } from '../../src/logger.js';
 import { QueryRelationshipsHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 
@@ -11,7 +12,7 @@ function makeEntityMemory() {
   const embeddingService = EmbeddingService.createForTesting();
   const store = KnowledgeGraphStore.createInMemory(embeddingService);
   const validator = new MemoryValidator(store, embeddingService);
-  return new EntityMemory(store, validator, embeddingService);
+  return new EntityMemory(store, validator, embeddingService, createSilentLogger());
 }
 
 function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,7 @@ async function main(): Promise<void> {
     const embeddingService = EmbeddingService.createWithOpenAI(config.openaiApiKey, logger);
     const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
     const validator = new MemoryValidator(kgStore, embeddingService);
-    entityMemory = new EntityMemory(kgStore, validator, embeddingService);
+    entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
     logger.info('Entity memory initialized with knowledge graph');
   } else {
     logger.warn('OPENAI_API_KEY not set — entity memory disabled (knowledge graph unavailable)');

--- a/src/memory/entity-memory.edges.test.ts
+++ b/src/memory/entity-memory.edges.test.ts
@@ -3,12 +3,13 @@ import { KnowledgeGraphStore } from './knowledge-graph.js';
 import { EmbeddingService } from './embedding.js';
 import { EntityMemory } from './entity-memory.js';
 import { MemoryValidator } from './validation.js';
+import { createSilentLogger } from '../logger.js';
 
 function makeEntityMemory() {
   const embeddingService = EmbeddingService.createForTesting();
   const store = KnowledgeGraphStore.createInMemory(embeddingService);
   const validator = new MemoryValidator(store, embeddingService);
-  return new EntityMemory(store, validator, embeddingService);
+  return new EntityMemory(store, validator, embeddingService, createSilentLogger());
 }
 
 describe('EntityMemory.findEdges', () => {

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -155,8 +155,10 @@ export class EntityMemory {
           try {
             await this.store.deleteNode(persistedNode.id);
           } catch (cleanupErr) {
+            // Include both errors so the log entry is self-contained — an operator can see
+            // why the edge failed and why cleanup failed without correlating with caller logs.
             this.logger.error(
-              { nodeId: persistedNode.id, err: cleanupErr },
+              { nodeId: persistedNode.id, edgeCreationErr: err, cleanupErr },
               'storeFact: edge creation failed and orphan cleanup also failed — fact node is now dangling',
             );
           }
@@ -203,7 +205,16 @@ export class EntityMemory {
         : edge.sourceNodeId;
 
       const node = await this.store.getNode(otherId);
-      if (node && node.type === FACT_TYPE) {
+      if (!node) {
+        // Dangling edge — referenced node no longer exists (referential integrity violation).
+        // @TODO: emit a bus event for the audit logger once bus access is available here.
+        this.logger.error(
+          { edgeId: edge.id, nodeId: otherId, entityNodeId },
+          'getFacts: dangling edge detected — referenced node does not exist',
+        );
+        continue;
+      }
+      if (node.type === FACT_TYPE) {
         facts.push(node);
       }
     }
@@ -247,6 +258,10 @@ export class EntityMemory {
         // integrity violation (cascade delete failure or missing migration). Skip the edge so
         // the caller still gets a result, but log so this surfaces in monitoring.
         // @TODO: emit a bus event for the audit logger once bus access is available here.
+        this.logger.error(
+          { edgeId: edge.id, nodeId: otherId, entityNodeId: nodeId },
+          'findEdges: dangling edge detected — referenced node does not exist',
+        );
         continue;
       }
 
@@ -442,7 +457,15 @@ export class EntityMemory {
         : edge.sourceNodeId;
 
       const node = await this.store.getNode(otherId);
-      if (!node) continue;
+      if (!node) {
+        // Dangling edge — referenced node no longer exists (referential integrity violation).
+        // @TODO: emit a bus event for the audit logger once bus access is available here.
+        this.logger.error(
+          { edgeId: edge.id, nodeId: otherId, entityNodeId },
+          'query: dangling edge detected — referenced node does not exist',
+        );
+        continue;
+      }
 
       if (node.type === FACT_TYPE) {
         // Fact nodes belong in the facts bucket

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -5,6 +5,7 @@ import type { KnowledgeGraphStore } from './knowledge-graph.js';
 // so EntityMemory holds no direct reference. Kept in the API for forward-compatibility.
 import type { EmbeddingService } from './embedding.js';
 import type { MemoryValidator } from './validation.js';
+import type { Logger } from '../logger.js';
 import type {
   KgNode,
   KgEdge,
@@ -72,6 +73,7 @@ export class EntityMemory {
     // that wire the dependency graph. All embedding work is currently delegated to the
     // store (createNode embeds labels; semanticSearch embeds query strings internally).
     _embeddingService: EmbeddingService,
+    private logger: Logger,
   ) {}
 
   /**
@@ -148,8 +150,16 @@ export class EntityMemory {
             source: options.source,
           });
         } catch (err) {
-          // Attempt to clean up the orphan node; ignore errors (best effort)
-          try { await this.store.deleteNode(persistedNode.id); } catch { /* best effort */ }
+          // Attempt to clean up the orphan node. If cleanup also fails, log at error level
+          // so the dangling node can be found and removed manually.
+          try {
+            await this.store.deleteNode(persistedNode.id);
+          } catch (cleanupErr) {
+            this.logger.error(
+              { nodeId: persistedNode.id, err: cleanupErr },
+              'storeFact: edge creation failed and orphan cleanup also failed — fact node is now dangling',
+            );
+          }
           throw err;
         }
 
@@ -237,7 +247,6 @@ export class EntityMemory {
         // integrity violation (cascade delete failure or missing migration). Skip the edge so
         // the caller still gets a result, but log so this surfaces in monitoring.
         // @TODO: emit a bus event for the audit logger once bus access is available here.
-        // @TODO: EntityMemory has no logger; thread one in if this pattern recurs (see also storeFact).
         continue;
       }
 

--- a/tests/integration/contacts.test.ts
+++ b/tests/integration/contacts.test.ts
@@ -12,7 +12,7 @@ import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
 import { EmbeddingService } from '../../src/memory/embedding.js';
 import { EntityMemory } from '../../src/memory/entity-memory.js';
 import { MemoryValidator } from '../../src/memory/validation.js';
-import { createLogger } from '../../src/logger.js';
+import { createLogger, createSilentLogger } from '../../src/logger.js';
 import type { Logger } from '../../src/logger.js';
 import { DedupService } from '../../src/contacts/dedup-service.js';
 
@@ -36,7 +36,7 @@ describeIf('Contacts Integration', () => {
     const embeddingService = EmbeddingService.createForTesting();
     const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
     const validator = new MemoryValidator(kgStore, embeddingService);
-    entityMemory = new EntityMemory(kgStore, validator, embeddingService);
+    entityMemory = new EntityMemory(kgStore, validator, embeddingService, createSilentLogger());
     contactService = ContactService.createWithPostgres(pool, entityMemory, logger);
     resolver = new ContactResolver(contactService, entityMemory, undefined, logger);
 

--- a/tests/integration/extract-relationships.test.ts
+++ b/tests/integration/extract-relationships.test.ts
@@ -14,6 +14,7 @@ import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
 import { EmbeddingService } from '../../src/memory/embedding.js';
 import { EntityMemory } from '../../src/memory/entity-memory.js';
 import { MemoryValidator } from '../../src/memory/validation.js';
+import { createSilentLogger } from '../../src/logger.js';
 import { EntityContextAssembler } from '../../src/entity-context/assembler.js';
 import { ExtractRelationshipsHandler } from '../../skills/extract-relationships/handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
@@ -55,7 +56,7 @@ describeIf('extract-relationships integration', () => {
     const embeddingService = EmbeddingService.createForTesting();
     const store = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
     const validator = new MemoryValidator(store, embeddingService);
-    entityMemory = new EntityMemory(store, validator, embeddingService);
+    entityMemory = new EntityMemory(store, validator, embeddingService, createSilentLogger());
     assembler = new EntityContextAssembler(pool, logger);
 
     await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');

--- a/tests/integration/knowledge-graph.test.ts
+++ b/tests/integration/knowledge-graph.test.ts
@@ -4,7 +4,7 @@ import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
 import { EmbeddingService } from '../../src/memory/embedding.js';
 import { EntityMemory } from '../../src/memory/entity-memory.js';
 import { MemoryValidator } from '../../src/memory/validation.js';
-import { createLogger } from '../../src/logger.js';
+import { createLogger, createSilentLogger } from '../../src/logger.js';
 
 const { Pool } = pg;
 
@@ -23,7 +23,7 @@ describeIf('Knowledge Graph Integration', () => {
     const embeddingService = EmbeddingService.createForTesting();
     store = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
     const validator = new MemoryValidator(store, embeddingService);
-    entityMemory = new EntityMemory(store, validator, embeddingService);
+    entityMemory = new EntityMemory(store, validator, embeddingService, createSilentLogger());
 
     // Verify pgvector extension and tables exist
     await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -73,7 +73,7 @@ export async function createHarness(): Promise<CuriaHarness> {
     const embeddingService = EmbeddingService.createWithOpenAI(config.openaiApiKey, logger);
     const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
     const validator = new MemoryValidator(kgStore, embeddingService);
-    entityMemory = new EntityMemory(kgStore, validator, embeddingService);
+    entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
   }
 
   // Contact system — provides identity resolution and contact management.

--- a/tests/unit/contacts/contact-calendar-service.test.ts
+++ b/tests/unit/contacts/contact-calendar-service.test.ts
@@ -5,6 +5,7 @@ import { KnowledgeGraphStore } from '../../../src/memory/knowledge-graph.js';
 import { EmbeddingService } from '../../../src/memory/embedding.js';
 import { EntityMemory } from '../../../src/memory/entity-memory.js';
 import { MemoryValidator } from '../../../src/memory/validation.js';
+import { createSilentLogger } from '../../../src/logger.js';
 import type { Contact } from '../../../src/contacts/types.js';
 
 describe('ContactService — calendar methods', () => {
@@ -15,7 +16,7 @@ describe('ContactService — calendar methods', () => {
     const embeddingService = EmbeddingService.createForTesting();
     const store = KnowledgeGraphStore.createInMemory(embeddingService);
     const validator = new MemoryValidator(store, embeddingService);
-    const entityMemory = new EntityMemory(store, validator, embeddingService);
+    const entityMemory = new EntityMemory(store, validator, embeddingService, createSilentLogger());
     service = ContactService.createInMemory(entityMemory);
 
     ceoContact = await service.createContact({

--- a/tests/unit/contacts/contact-resolver.test.ts
+++ b/tests/unit/contacts/contact-resolver.test.ts
@@ -6,7 +6,7 @@ import { KnowledgeGraphStore } from '../../../src/memory/knowledge-graph.js';
 import { EmbeddingService } from '../../../src/memory/embedding.js';
 import { EntityMemory } from '../../../src/memory/entity-memory.js';
 import { MemoryValidator } from '../../../src/memory/validation.js';
-import { createLogger } from '../../../src/logger.js';
+import { createLogger, createSilentLogger } from '../../../src/logger.js';
 
 describe('ContactResolver', () => {
   let resolver: ContactResolver;
@@ -17,7 +17,7 @@ describe('ContactResolver', () => {
     const embeddingService = EmbeddingService.createForTesting();
     const store = KnowledgeGraphStore.createInMemory(embeddingService);
     const validator = new MemoryValidator(store, embeddingService);
-    entityMemory = new EntityMemory(store, validator, embeddingService);
+    entityMemory = new EntityMemory(store, validator, embeddingService, createSilentLogger());
     contactService = ContactService.createInMemory(entityMemory);
     resolver = new ContactResolver(contactService, entityMemory, undefined, createLogger('error'));
   });

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -7,6 +7,7 @@ import { KnowledgeGraphStore } from '../../../src/memory/knowledge-graph.js';
 import { EmbeddingService } from '../../../src/memory/embedding.js';
 import { EntityMemory } from '../../../src/memory/entity-memory.js';
 import { MemoryValidator } from '../../../src/memory/validation.js';
+import { createSilentLogger } from '../../../src/logger.js';
 
 describe('ContactService', () => {
   let service: ContactService;
@@ -16,7 +17,7 @@ describe('ContactService', () => {
     const embeddingService = EmbeddingService.createForTesting();
     const store = KnowledgeGraphStore.createInMemory(embeddingService);
     const validator = new MemoryValidator(store, embeddingService);
-    entityMemory = new EntityMemory(store, validator, embeddingService);
+    entityMemory = new EntityMemory(store, validator, embeddingService, createSilentLogger());
     service = ContactService.createInMemory(entityMemory);
   });
 
@@ -548,7 +549,7 @@ describe('EntityMemory.mergeEntities', () => {
     const embeddingService = EmbeddingService.createForTesting();
     const store = KnowledgeGraphStore.createInMemory(embeddingService);
     const validator = new MemoryValidator(store, embeddingService);
-    entityMemory = new EntityMemory(store, validator, embeddingService);
+    entityMemory = new EntityMemory(store, validator, embeddingService, createSilentLogger());
   });
 
   it('merges scalar properties onto primary node (most-recent-wins)', async () => {

--- a/tests/unit/memory/entity-memory.test.ts
+++ b/tests/unit/memory/entity-memory.test.ts
@@ -3,6 +3,7 @@ import { EntityMemory } from '../../../src/memory/entity-memory.js';
 import { KnowledgeGraphStore } from '../../../src/memory/knowledge-graph.js';
 import { EmbeddingService } from '../../../src/memory/embedding.js';
 import { MemoryValidator } from '../../../src/memory/validation.js';
+import { createSilentLogger } from '../../../src/logger.js';
 
 describe('EntityMemory', () => {
   let entityMemory: EntityMemory;
@@ -12,7 +13,7 @@ describe('EntityMemory', () => {
     const embeddingService = EmbeddingService.createForTesting();
     store = KnowledgeGraphStore.createInMemory(embeddingService);
     const validator = new MemoryValidator(store, embeddingService);
-    entityMemory = new EntityMemory(store, validator, embeddingService);
+    entityMemory = new EntityMemory(store, validator, embeddingService, createSilentLogger());
   });
 
   describe('entity management', () => {
@@ -192,7 +193,7 @@ describe('EntityMemory', () => {
       // validate() not validateContradiction(). This test verifies the rejected path.
       // Hit the rate limit to force a rejection.
       const validator = new MemoryValidator(store, EmbeddingService.createForTesting());
-      const em = new EntityMemory(store, validator, EmbeddingService.createForTesting());
+      const em = new EntityMemory(store, validator, EmbeddingService.createForTesting(), createSilentLogger());
       // Pre-fill rate limit counter
       for (let i = 0; i < 50; i++) {
         validator.recordWrite('agent:test/task:rate-limit-test');
@@ -266,7 +267,7 @@ describe('EntityMemory', () => {
       const embeddingService = EmbeddingService.createForTesting();
       const localStore = KnowledgeGraphStore.createInMemory(embeddingService);
       const validator = new MemoryValidator(localStore, embeddingService);
-      const em = new EntityMemory(localStore, validator, embeddingService);
+      const em = new EntityMemory(localStore, validator, embeddingService, createSilentLogger());
 
       const entity = await em.createEntity({
         type: 'person',


### PR DESCRIPTION
## Summary

Fixes #182.

- Adds `logger: Logger` as the final constructor parameter of `EntityMemory` (consistent with the rest of the codebase)
- Replaces the empty `catch { /* best effort */ }` in `storeFact`'s orphan cleanup with a `logger.error` that includes the orphaned node ID, the original edge-creation error, and the cleanup error — making the dangling node findable and the log entry self-contained
- Applies the same treatment to the three other silent-skip sites that were already present: `getFacts`, `findEdges`, and `query` all had `if (!node) continue` paths with no logging; each now emits a `logger.error` with `edgeId`, `nodeId`, and `entityNodeId`
- Updates all call sites (production, smoke harness, 12 test files) to pass a real or silent logger

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test` — 992 tests pass, 22 skipped (pre-existing)
- [x] All 14 `new EntityMemory(...)` call sites in `.ts` files updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Improved error diagnostics and observability for data integrity issues. Dangling references and failed cleanup operations are now logged with contextual details, enabling better monitoring and faster issue resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->