### PR TITLE
chore: kg_nodes deduplication and uniqueness constraint (closes #157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **KG node deduplication** — one-time migration deduplicates existing `kg_nodes` rows with matching `(lower(label), type)`, re-pointing edges and contacts to canonical nodes before removing duplicates.
+
+### Added
+- **`kg_nodes` uniqueness constraint** — `idx_kg_nodes_unique` on `(lower(label), type) WHERE type != 'fact'` prevents future duplicate entity nodes.
+- **`KnowledgeGraphStore.upsertNode()`** — idempotent node creation; raises confidence on conflict, never creates duplicates. Returns `{ node, created }`.
+- **`EntityMemory.createEntity()`** — now returns `{ entity, created }` instead of `KgNode`. Delegates to `upsertNode` for race-safe creation. **Breaking change** for callers (all internal call sites updated).
+- **`EntityMemory.updateNode()`** — new public method. Label changes that collide with an existing node of the same type automatically merge the nodes. Returns `{ node, merged }` — callers must use the returned `node.id`, which may differ from the input id when `merged: true`.
+- **`mergeEntities` Phase 2** — re-points secondary entity edges to primary and deletes the secondary node (was previously deferred with a TODO).
+
+---
+
 ## [0.12.1] — 2026-04-07
 
 ### Added

--- a/docs/wip/2026-04-08-kg-node-uniqueness-design.md
+++ b/docs/wip/2026-04-08-kg-node-uniqueness-design.md
@@ -99,18 +99,41 @@ The `KnowledgeGraphBackend` interface gains a corresponding `upsertNode` method.
 
 ### 3. `EntityMemory` changes
 
-#### 3a. Expose `updateNode()` publicly
+#### 3a. Expose `updateNode()` publicly — with merge-on-collision
 
-`EntityMemory` gains a public `updateNode()` pass-through to `store.updateNode()`. It is
-currently called only internally (in `mergeEntities` and `storeFact`), but `contact-service`
-needs to call it after a `createEntity` conflict.
+`EntityMemory` gains a public `updateNode()` method. It is not a simple pass-through —
+when `updates.label` is present it must guard against the case where the new label
+collides with an existing node of the same type (e.g. renaming "Joe" → "Joseph Fung"
+when a "Joseph Fung" node already exists).
 
+Updating a label to match an existing node is a signal that the two nodes represent the
+same entity. The correct response is to merge them, not to throw a constraint violation.
+
+**Algorithm when `updates.label` is provided:**
+
+1. Fetch the current node (needed to know its `type` for the collision check).
+2. Query for an existing node with `lower(label) = lower(updates.label)` and the same
+   `type`, excluding `fact` and excluding `id` itself.
+3. If a collision exists → call `mergeEntities(existingId, id)` (existing node is the
+   canonical; the node being renamed is the secondary). Return
+   `{ node: canonical, merged: true }`.
+4. If no collision → call `store.updateNode(id, updates)` as normal. Return
+   `{ node: updated, merged: false }`.
+
+**Return type:**
 ```ts
 async updateNode(
   id: string,
   updates: { label?: string; properties?: Record<string, unknown> }
-): Promise<KgNode>
+): Promise<{ node: KgNode; merged: boolean }>
 ```
+
+`merged: true` signals that `node.id` in the result is **different** from the `id` the
+caller passed in. Any code holding a reference to the old ID should update it.
+
+**Internal callers are unaffected.** `mergeEntities()` and `storeFact()` call
+`store.updateNode()` directly (bypassing `EntityMemory.updateNode()`) and only pass
+`properties`, never `label` — the merge-on-collision logic is never triggered for them.
 
 #### 3b. `createEntity()` returns `{ entity, created }`
 
@@ -143,12 +166,18 @@ const { entity, created } = await this.entityMemory.createEntity({
   source: options.source,
 });
 if (!created && options.role) {
-  await this.entityMemory.updateNode(entity.id, {
+  const { node } = await this.entityMemory.updateNode(entity.id, {
     properties: { ...entity.properties, role: options.role },
   });
+  kgNodeId = node.id;
+} else {
+  kgNodeId = entity.id;
 }
-kgNodeId = entity.id;
 ```
+
+Note: `updateNode` now returns `{ node, merged }`. Even for a properties-only update
+(no label change), we destructure `node` to get the canonical ID — though `merged` will
+always be `false` here since no label is being changed.
 
 Other call sites (`extract-relationships`, `knowledge-meeting-links`, `template-base`)
 pass `{}` or constant category properties into race-guarded find-first patterns; no
@@ -185,6 +214,12 @@ After the existing Phase 1 logic (property merge + fact migration), add:
   already had the same relationship) are not duplicated
 - `createEntity` returns `created: true` on first call, `created: false` on second call
   with the same `(label, type)`
+- `updateNode` with a label change to a non-conflicting label updates normally,
+  returns `{ node: updated, merged: false }`
+- `updateNode` with a label change that collides with an existing node of the same type
+  merges the two nodes, returns `{ node: canonical, merged: true }` where `node.id` is
+  the canonical node's ID (not the original ID passed in)
+- `updateNode` with only a properties change (no label) never triggers merge logic
 
 Tests use the in-memory backend (no Postgres required). The migration SQL is tested by
 the existing integration test harness that runs migrations against a real Postgres
@@ -195,7 +230,7 @@ instance.
 | File | Change |
 |---|---|
 | `src/memory/knowledge-graph.ts` | Add `upsertNode` to backend interface, `PostgresBackend`, `InMemoryBackend`, and `KnowledgeGraphStore` |
-| `src/memory/entity-memory.ts` | Expose `updateNode()` publicly; change `createEntity()` return type; complete `mergeEntities()` Phase 2 |
+| `src/memory/entity-memory.ts` | Add public `updateNode()` with merge-on-collision; change `createEntity()` return type; complete `mergeEntities()` Phase 2 |
 | `src/contacts/contact-service.ts` | Destructure `{ entity, created }` from `createEntity()`; call `updateNode()` if `!created && options.role` |
 | `skills/extract-relationships/handler.ts` | Destructure `{ entity }` from `createEntity()` — no other change |
 | `skills/knowledge-meeting-links/handler.ts` | Destructure `{ entity }` from `createEntity()` — no other change |

--- a/docs/wip/2026-04-08-kg-node-uniqueness-design.md
+++ b/docs/wip/2026-04-08-kg-node-uniqueness-design.md
@@ -1,0 +1,208 @@
+# Design: KG Node Deduplication and Uniqueness Constraint
+
+**Issue:** josephfung/curia#157
+**Date:** 2026-04-08
+**Status:** Draft
+
+## Background
+
+`kg_nodes` has no uniqueness constraint on `(label, type)`. Concurrent relationship
+extractions can race and create duplicate nodes for the same entity — e.g. two `person`
+nodes both labeled "Joseph Fung". The `query-relationships` skill degrades gracefully when
+duplicates exist (returns `ambiguous: true`), but the underlying data is messy and will
+confuse future queries.
+
+Migration 014 solved the same problem for `kg_edges` by adding a bidirectional unique
+index and updating the write path to use `INSERT ... ON CONFLICT DO UPDATE`. This design
+applies the same approach to `kg_nodes`.
+
+## Scope
+
+Three pieces of work, in dependency order:
+
+1. **One-time dedup migration** — clean up existing duplicates in the database
+2. **Unique constraint** — prevent future duplicates at the DB level
+3. **`upsertNode` + updated write path** — make node creation race-safe at the app level
+
+`fact` nodes are excluded from the uniqueness constraint throughout — facts are
+intentionally many-per-entity and have no meaningful label uniqueness.
+
+## Design
+
+### 1. Migration `016_kg_node_uniqueness.sql`
+
+#### Dedup pass
+
+For each `(lower(label), type)` group with more than one node where `type != 'fact'`:
+
+- **Pick a canonical node**: highest `confidence`, ties broken by oldest `created_at`
+  (the node that has been around longest is the most "established").
+- **Re-point `kg_edges`**: `UPDATE kg_edges SET source_node_id = canonical WHERE
+  source_node_id = duplicate`, and same for `target_node_id`. Before updating, delete
+  any edge that would create a conflict with the bidirectional unique index already on
+  `kg_edges` (i.e. canonical already has an equivalent edge in either direction).
+- **Re-point `contacts.kg_node_id`**: `UPDATE contacts SET kg_node_id = canonical WHERE
+  kg_node_id = duplicate`. If the canonical node already has a contact pointing to it,
+  the update would violate the partial unique index on `contacts(kg_node_id)`. In that
+  case, NULL out the duplicate's contact FK instead — the two contact rows represent the
+  same person and should be merged separately via the contact-merge flow.
+- **Delete duplicate nodes**: `DELETE FROM kg_nodes WHERE id = duplicate`. The `ON DELETE
+  CASCADE` on `kg_edges` cleans up any edges that were not re-pointed (e.g. edges that
+  were left behind because re-pointing would have created a conflict).
+
+The dedup pass runs entirely in SQL within the migration, with no application-layer
+involvement.
+
+#### Unique constraint
+
+```sql
+CREATE UNIQUE INDEX idx_kg_nodes_unique
+  ON kg_nodes (lower(label), type)
+  WHERE type != 'fact';
+```
+
+This allows:
+- "Apple" as an `organization` and "Apple" as a `concept` — different `(label, type)` pairs
+- Any number of `fact` nodes with any label — excluded by the partial predicate
+
+### 2. `KnowledgeGraphStore.upsertNode()`
+
+New method, analogous to `upsertEdge()`.
+
+**Signature:**
+```ts
+async upsertNode(
+  options: CreateNodeOptions & { confidence: number }
+): Promise<{ node: KgNode; created: boolean }>
+```
+
+**Postgres implementation:**
+```sql
+INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at)
+VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $9)
+ON CONFLICT (lower(label), type) WHERE type != 'fact'
+DO UPDATE SET
+  confidence = GREATEST(kg_nodes.confidence, EXCLUDED.confidence),
+  last_confirmed_at = EXCLUDED.last_confirmed_at
+RETURNING *, (created_at = $9) AS is_new
+```
+
+On conflict: raises confidence (never lowers), refreshes `last_confirmed_at`. Properties,
+label, and embedding of the existing node are left untouched — the caller manages those
+explicitly via `updateNode()`.
+
+**InMemory implementation:** scan nodes for matching `(lower(label), type)` where
+`type != 'fact'`; if found, update `confidence` and `lastConfirmedAt` and return
+`{ node: updated, created: false }`; otherwise insert and return `{ node, created: true }`.
+
+The `KnowledgeGraphBackend` interface gains a corresponding `upsertNode` method.
+
+### 3. `EntityMemory` changes
+
+#### 3a. Expose `updateNode()` publicly
+
+`EntityMemory` gains a public `updateNode()` pass-through to `store.updateNode()`. It is
+currently called only internally (in `mergeEntities` and `storeFact`), but `contact-service`
+needs to call it after a `createEntity` conflict.
+
+```ts
+async updateNode(
+  id: string,
+  updates: { label?: string; properties?: Record<string, unknown> }
+): Promise<KgNode>
+```
+
+#### 3b. `createEntity()` returns `{ entity, created }`
+
+The return type changes from `KgNode` to `{ entity: KgNode; created: boolean }`.
+Internally, `createEntity()` delegates to `store.upsertNode()` instead of
+`store.createNode()`.
+
+This is a breaking change to the method signature. All call sites update from:
+```ts
+const entity = await entityMemory.createEntity({ ... });
+```
+to:
+```ts
+const { entity } = await entityMemory.createEntity({ ... });
+// or
+const { entity, created } = await entityMemory.createEntity({ ... });
+```
+
+#### 3c. `contact-service.ts` — apply `role` on conflict
+
+`contact-service.ts` is the only `createEntity` call site that passes non-empty properties
+(`{ role: options.role }`). On conflict, the existing node may not have `role` set. The
+updated call site:
+
+```ts
+const { entity, created } = await this.entityMemory.createEntity({
+  type: 'person',
+  label: safeName,
+  properties: options.role ? { role: options.role } : {},
+  source: options.source,
+});
+if (!created && options.role) {
+  await this.entityMemory.updateNode(entity.id, {
+    properties: { ...entity.properties, role: options.role },
+  });
+}
+kgNodeId = entity.id;
+```
+
+Other call sites (`extract-relationships`, `knowledge-meeting-links`, `template-base`)
+pass `{}` or constant category properties into race-guarded find-first patterns; no
+`updateNode()` follow-up is needed at those sites.
+
+#### 3d. Complete `mergeEntities()` Phase 2
+
+The existing `mergeEntities()` merges scalar properties and facts but leaves a `@TODO`
+comment for Phase 2: re-pointing edges and deleting the secondary node. This work
+completes Phase 2.
+
+After the existing Phase 1 logic (property merge + fact migration), add:
+
+1. **Re-point edges**: fetch all edges for the secondary node via
+   `store.getEdgesForNode(secondaryId)`. For each edge, determine the "other" endpoint
+   and call `store.upsertEdge()` with `primaryId` as the new endpoint. `upsertEdge`
+   handles the bidirectional uniqueness constraint atomically — if primary already has an
+   equivalent edge, it just raises confidence rather than creating a duplicate.
+
+2. **Delete secondary node**: call `store.deleteNode(secondaryId)`. The `ON DELETE
+   CASCADE` on `kg_edges` cleans up any secondary edges that were not transferred (e.g.
+   self-loops or edges that resolved to a no-op upsert on primary).
+
+3. Remove the `@TODO Phase 2` comment.
+
+### 4. Tests
+
+- `upsertNode` creates a new node when none exists
+- `upsertNode` on conflict returns the existing node with updated confidence and
+  `last_confirmed_at`, leaves properties untouched, returns `created: false`
+- `upsertNode` never lowers confidence (concurrent re-assertion with lower confidence)
+- `mergeEntities` Phase 2: secondary's edges are transferred to primary; secondary node
+  is deleted; primary's edge count reflects the merged set; duplicate edges (where primary
+  already had the same relationship) are not duplicated
+- `createEntity` returns `created: true` on first call, `created: false` on second call
+  with the same `(label, type)`
+
+Tests use the in-memory backend (no Postgres required). The migration SQL is tested by
+the existing integration test harness that runs migrations against a real Postgres
+instance.
+
+## Call-site impact summary
+
+| File | Change |
+|---|---|
+| `src/memory/knowledge-graph.ts` | Add `upsertNode` to backend interface, `PostgresBackend`, `InMemoryBackend`, and `KnowledgeGraphStore` |
+| `src/memory/entity-memory.ts` | Expose `updateNode()` publicly; change `createEntity()` return type; complete `mergeEntities()` Phase 2 |
+| `src/contacts/contact-service.ts` | Destructure `{ entity, created }` from `createEntity()`; call `updateNode()` if `!created && options.role` |
+| `skills/extract-relationships/handler.ts` | Destructure `{ entity }` from `createEntity()` — no other change |
+| `skills/knowledge-meeting-links/handler.ts` | Destructure `{ entity }` from `createEntity()` — no other change |
+| `skills/_shared/template-base.ts` | Destructure `entity` from `createEntity()` — no other change |
+| `src/db/migrations/016_kg_node_uniqueness.sql` | New file |
+
+## Versioning
+
+Patch bump (`0.x.Y`): this is a data-hygiene fix with infrastructure additions, no new
+user-facing capability.

--- a/docs/wip/2026-04-08-kg-node-uniqueness-design.md
+++ b/docs/wip/2026-04-08-kg-node-uniqueness-design.md
@@ -241,3 +241,14 @@ instance.
 
 Patch bump (`0.x.Y`): this is a data-hygiene fix with infrastructure additions, no new
 user-facing capability.
+
+The `createEntity()` return type change (from `KgNode` to `{ entity: KgNode; created: boolean }`)
+is an internal breaking change. A patch bump is correct here because `EntityMemory` is not a
+listed public API surface per the project's versioning policy. Public surfaces are: `skill.json`
+schema, `SkillHandler`/`SkillContext`/`SkillResult` interfaces, agent YAML schema, bus event
+type definitions, and channel adapter interface. `EntityMemory` is an internal platform service;
+all callers live in the same repository and were updated atomically in this PR.
+
+Note: even though this does not trigger a minor bump, the `createEntity()` signature change IS
+called out explicitly in CHANGELOG.md as a breaking change so the impact is visible to reviewers
+and future readers of the history.

--- a/docs/wip/2026-04-08-kg-node-uniqueness.md
+++ b/docs/wip/2026-04-08-kg-node-uniqueness.md
@@ -1,0 +1,1129 @@
+# KG Node Deduplication and Uniqueness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deduplicate existing `kg_nodes` rows, enforce a `(lower(label), type)` unique constraint, and make all node-creation and node-update paths race-safe via upsert and merge-on-collision logic.
+
+**Architecture:** Three layers of change: (1) a one-time SQL migration that cleans up existing duplicates and adds the unique index; (2) a new `upsertNode` method on `KnowledgeGraphStore` that uses `INSERT ... ON CONFLICT DO UPDATE`; (3) `EntityMemory` updates — a public `updateNode` that detects label collisions and merges nodes, a changed `createEntity` return type, and completing `mergeEntities` Phase 2 (edge re-pointing + secondary deletion).
+
+**Tech Stack:** TypeScript/ESM, Vitest, PostgreSQL 16+/pgvector, node-postgres
+
+**Worktree:** `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness`
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|---|---|---|
+| `src/memory/knowledge-graph.ts` | Modify | Add `upsertNode` to backend interface, `PostgresBackend`, `InMemoryBackend`, and `KnowledgeGraphStore` |
+| `src/memory/knowledge-graph.upsert.test.ts` | Modify | Add `upsertNode` tests alongside existing `upsertEdge` tests |
+| `src/memory/entity-memory.ts` | Modify | Complete `mergeEntities` Phase 2; add public `updateNode` with merge-on-collision; change `createEntity` return type |
+| `src/memory/entity-memory.upsert.test.ts` | Create | Tests for `mergeEntities` Phase 2, `updateNode`, and `createEntity` new return type |
+| `src/memory/entity-memory.edges.test.ts` | Modify | Update all `createEntity` call sites to destructure `{ entity }` |
+| `src/contacts/contact-service.ts` | Modify | Destructure `{ entity, created }` from `createEntity`; apply `role` on conflict |
+| `skills/extract-relationships/handler.ts` | Modify | Destructure `{ entity }` from `createEntity` in two places |
+| `skills/knowledge-meeting-links/handler.ts` | Modify | Destructure `{ entity }` from `createEntity` |
+| `skills/_shared/template-base.ts` | Modify | Destructure `{ entity }` from `createEntity` |
+| `skills/query-relationships/handler.test.ts` | Modify | Update `createEntity` calls; fix ambiguous-duplicate test to use `store.createNode` directly |
+| `skills/delete-relationship/handler.test.ts` | Modify | Update `createEntity` calls to destructure |
+| `src/db/migrations/016_kg_node_uniqueness.sql` | Create | One-time dedup pass + unique index |
+| `CHANGELOG.md` | Modify | Add entry under `[Unreleased]` |
+| `package.json` | Modify | Patch version bump to `0.12.2` |
+
+---
+
+## Task 1: `upsertNode` in KnowledgeGraphStore
+
+**Files:**
+- Modify: `src/memory/knowledge-graph.upsert.test.ts`
+- Modify: `src/memory/knowledge-graph.ts`
+
+- [ ] **Step 1: Write failing tests for `upsertNode`**
+
+Append to `src/memory/knowledge-graph.upsert.test.ts` (after the existing `upsertEdge` describe block):
+
+```ts
+describe('KnowledgeGraphStore.upsertNode', () => {
+  it('creates a new node and returns created:true', async () => {
+    const store = makeStore();
+
+    const { node, created } = await store.upsertNode({
+      type: 'person',
+      label: 'Alice',
+      properties: {},
+      confidence: 0.8,
+      source: 'test',
+    });
+
+    expect(created).toBe(true);
+    expect(node.label).toBe('Alice');
+    expect(node.temporal.confidence).toBe(0.8);
+  });
+
+  it('returns existing node with created:false on same (label, type)', async () => {
+    const store = makeStore();
+
+    const { node: first } = await store.upsertNode({ type: 'person', label: 'Alice', properties: {}, confidence: 0.8, source: 'test' });
+    const { node: second, created } = await store.upsertNode({ type: 'person', label: 'ALICE', properties: { extra: true }, confidence: 0.9, source: 'test' });
+
+    expect(created).toBe(false);
+    expect(second.id).toBe(first.id);
+    // Confidence raised
+    expect(second.temporal.confidence).toBe(0.9);
+    // Properties NOT overwritten on conflict
+    expect(second.properties).not.toHaveProperty('extra');
+  });
+
+  it('never lowers confidence on re-assertion', async () => {
+    const store = makeStore();
+
+    await store.upsertNode({ type: 'person', label: 'Alice', properties: {}, confidence: 0.9, source: 'test' });
+    const { node } = await store.upsertNode({ type: 'person', label: 'Alice', properties: {}, confidence: 0.5, source: 'test' });
+
+    expect(node.temporal.confidence).toBe(0.9);
+  });
+
+  it('allows same label under different types', async () => {
+    const store = makeStore();
+
+    const { created: c1 } = await store.upsertNode({ type: 'person', label: 'Apple', properties: {}, confidence: 0.8, source: 'test' });
+    const { created: c2 } = await store.upsertNode({ type: 'organization', label: 'Apple', properties: {}, confidence: 0.8, source: 'test' });
+
+    expect(c1).toBe(true);
+    expect(c2).toBe(true);
+  });
+
+  it('always creates fact nodes regardless of label collision', async () => {
+    const store = makeStore();
+
+    const { created: c1 } = await store.upsertNode({ type: 'fact', label: 'CEO', properties: {}, confidence: 0.8, source: 'test' });
+    const { created: c2 } = await store.upsertNode({ type: 'fact', label: 'CEO', properties: {}, confidence: 0.8, source: 'test' });
+
+    expect(c1).toBe(true);
+    expect(c2).toBe(true); // fact nodes are always new inserts, not upserts
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness run test -- --reporter=verbose src/memory/knowledge-graph.upsert.test.ts
+```
+
+Expected: FAIL — `upsertNode is not a function`
+
+- [ ] **Step 3: Add `upsertNode` to the backend interface**
+
+In `src/memory/knowledge-graph.ts`, add to the `KnowledgeGraphBackend` interface (after `upsertEdge`):
+
+```ts
+upsertNode(node: KgNode): Promise<{ node: KgNode; created: boolean }>;
+```
+
+- [ ] **Step 4: Implement `upsertNode` in `InMemoryBackend`**
+
+Add after `createNode` in `InMemoryBackend`:
+
+```ts
+async upsertNode(node: KgNode): Promise<{ node: KgNode; created: boolean }> {
+  // fact nodes are never deduplicated — always insert as new
+  if (node.type === 'fact') {
+    this.nodes.set(node.id, node);
+    return { node, created: true };
+  }
+
+  const lowerLabel = node.label.toLowerCase();
+  let existing: KgNode | undefined;
+  for (const n of this.nodes.values()) {
+    if (n.type !== 'fact' && n.label.toLowerCase() === lowerLabel && n.type === node.type) {
+      existing = n;
+      break;
+    }
+  }
+
+  if (existing) {
+    const updated: KgNode = {
+      ...existing,
+      temporal: {
+        ...existing.temporal,
+        confidence: Math.max(existing.temporal.confidence, node.temporal.confidence),
+        lastConfirmedAt: node.temporal.lastConfirmedAt,
+      },
+    };
+    this.nodes.set(existing.id, updated);
+    return { node: updated, created: false };
+  }
+
+  this.nodes.set(node.id, node);
+  return { node, created: true };
+}
+```
+
+- [ ] **Step 5: Implement `upsertNode` in `PostgresBackend`**
+
+Add after `createNode` in `PostgresBackend`:
+
+```ts
+async upsertNode(node: KgNode): Promise<{ node: KgNode; created: boolean }> {
+  this.logger.debug({ type: node.type, label: node.label }, 'kg: upserting node');
+  const embeddingStr = node.embedding ? `[${node.embedding.join(',')}]` : null;
+  const result = await this.pool.query<PgNodeRow & { is_new: boolean }>(
+    `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at)
+     VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $9)
+     ON CONFLICT (lower(label), type) WHERE type != 'fact'
+     DO UPDATE SET
+       confidence = GREATEST(kg_nodes.confidence, EXCLUDED.confidence),
+       last_confirmed_at = EXCLUDED.last_confirmed_at
+     RETURNING *, (created_at = $9) AS is_new`,
+    [
+      node.id,
+      node.type,
+      node.label,
+      JSON.stringify(node.properties),
+      embeddingStr,
+      node.temporal.confidence,
+      node.temporal.decayClass,
+      node.temporal.source,
+      node.temporal.createdAt,
+    ],
+  );
+  const row = result.rows[0];
+  if (!row) {
+    this.logger.error(
+      { type: node.type, label: node.label },
+      'kg: upsertNode — RETURNING produced no row; possible trigger or RLS suppression',
+    );
+    throw new Error('upsertNode: database returned no row after INSERT ... ON CONFLICT');
+  }
+  return { node: pgRowToNode(row), created: row.is_new };
+}
+```
+
+- [ ] **Step 6: Add `upsertNode` public method to `KnowledgeGraphStore`**
+
+Add after `createNode` in `KnowledgeGraphStore`:
+
+```ts
+/**
+ * Idempotent node creation for non-fact entity nodes.
+ *
+ * Creates a new node if none with the same (lower(label), type) exists.
+ * If one exists, raises its confidence (never lowers) and refreshes
+ * lastConfirmedAt. Properties, label, and embedding of the existing node
+ * are left untouched — use updateNode() to change those explicitly.
+ *
+ * fact nodes always create a new node regardless of label collision.
+ *
+ * Returns the persisted node and whether it was newly created.
+ */
+async upsertNode(options: CreateNodeOptions & { confidence: number }): Promise<{ node: KgNode; created: boolean }> {
+  const now = new Date();
+  const embedding = options.embedding ?? await this.embeddingService.embed(options.label);
+
+  const node: KgNode = {
+    id: createNodeId(),
+    type: options.type,
+    label: options.label,
+    properties: { ...options.properties },
+    embedding,
+    temporal: {
+      createdAt: now,
+      lastConfirmedAt: now,
+      confidence: options.confidence,
+      decayClass: options.decayClass ?? 'slow_decay',
+      source: options.source,
+    },
+  };
+
+  return this.backend.upsertNode(node);
+}
+```
+
+- [ ] **Step 7: Run tests to confirm they pass**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness run test -- --reporter=verbose src/memory/knowledge-graph.upsert.test.ts
+```
+
+Expected: All `upsertNode` tests PASS. All existing `upsertEdge` tests still PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness add src/memory/knowledge-graph.ts src/memory/knowledge-graph.upsert.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness commit -m "feat: add KnowledgeGraphStore.upsertNode() with idempotent conflict handling"
+```
+
+---
+
+## Task 2: `mergeEntities` Phase 2 — edge re-pointing and secondary deletion
+
+**Files:**
+- Create: `src/memory/entity-memory.upsert.test.ts`
+- Modify: `src/memory/entity-memory.ts`
+
+- [ ] **Step 1: Create the test file with failing Phase 2 tests**
+
+Create `src/memory/entity-memory.upsert.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { KnowledgeGraphStore } from './knowledge-graph.js';
+import { EmbeddingService } from './embedding.js';
+import { EntityMemory } from './entity-memory.js';
+import { MemoryValidator } from './validation.js';
+
+function makeEntityMemory() {
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  return new EntityMemory(store, validator, embeddingService);
+}
+
+describe('EntityMemory.mergeEntities Phase 2', () => {
+  it('re-points secondary edges to primary after merge', async () => {
+    const mem = makeEntityMemory();
+    const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const secondary = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+    const org = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+
+    // secondary has a relationship with org
+    await mem.upsertEdge(secondary.entity.id, org.entity.id, 'member_of', {}, 'test', 0.8);
+
+    await mem.mergeEntities(primary.entity.id, secondary.entity.id);
+
+    // secondary node is gone
+    expect(await mem.getEntity(secondary.entity.id)).toBeUndefined();
+
+    // primary now has the edge to org
+    const edges = await mem.findEdges(primary.entity.id);
+    expect(edges.some(e => e.node.id === org.entity.id && e.edge.type === 'member_of')).toBe(true);
+  });
+
+  it('does not duplicate edges that primary already has', async () => {
+    const mem = makeEntityMemory();
+    const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const secondary = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+    const org = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+
+    // both nodes already have the same relationship with org
+    await mem.upsertEdge(primary.entity.id, org.entity.id, 'member_of', {}, 'test', 0.7);
+    await mem.upsertEdge(secondary.entity.id, org.entity.id, 'member_of', {}, 'test', 0.9);
+
+    await mem.mergeEntities(primary.entity.id, secondary.entity.id);
+
+    const edges = await mem.findEdges(primary.entity.id);
+    const memberOfEdges = edges.filter(e => e.edge.type === 'member_of' && e.node.id === org.entity.id);
+    // exactly one edge, not two
+    expect(memberOfEdges).toHaveLength(1);
+    // confidence raised to the higher value
+    expect(memberOfEdges[0]!.edge.temporal.confidence).toBe(0.9);
+  });
+
+  it('deletes the secondary node after merge', async () => {
+    const mem = makeEntityMemory();
+    const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const secondary = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+
+    await mem.mergeEntities(primary.entity.id, secondary.entity.id);
+
+    expect(await mem.getEntity(secondary.entity.id)).toBeUndefined();
+  });
+
+  it('cleans up secondary fact nodes after merge (no orphans)', async () => {
+    const mem = makeEntityMemory();
+    const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const secondary = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+
+    await mem.storeFact({
+      entityNodeId: secondary.entity.id,
+      label: 'title: CEO',
+      properties: {},
+      confidence: 0.8,
+      source: 'test',
+    });
+
+    // get the secondary fact node ID before merge
+    const preMergeFacts = await mem.getFacts(secondary.entity.id);
+    expect(preMergeFacts).toHaveLength(1);
+    const secondaryFactId = preMergeFacts[0]!.id;
+
+    await mem.mergeEntities(primary.entity.id, secondary.entity.id);
+
+    // secondary fact node itself is deleted (not orphaned)
+    expect(await mem.getEntity(secondaryFactId)).toBeUndefined();
+
+    // primary has the fact (re-stored in Phase 1)
+    const primaryFacts = await mem.getFacts(primary.entity.id);
+    expect(primaryFacts.some(f => f.label === 'title: CEO')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness run test -- --reporter=verbose src/memory/entity-memory.upsert.test.ts
+```
+
+Expected: FAIL — `secondary.entity is undefined` (because `createEntity` still returns `KgNode` not `{ entity, created }`)
+
+> Note: tests reference `primary.entity.id` and `secondary.entity.id` because Task 4 will change `createEntity` return type. For now the tests will fail because of the type mismatch — that's expected. We'll fix `createEntity` in Task 4.
+
+**Temporarily rewrite these tests to call `createEntity` with the current return type** so Phase 2 tests can be validated independently. Replace `.entity.id` with `.id` in just this file for now:
+
+```ts
+// Temporary: current createEntity returns KgNode directly
+const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+const secondary = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+const org = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+// use primary.id, secondary.id, org.id
+```
+
+Then run tests — expected: FAIL because mergeEntities doesn't delete secondary yet.
+
+- [ ] **Step 3: Implement Phase 2 in `mergeEntities`**
+
+In `src/memory/entity-memory.ts`, replace the `@TODO Phase 2` block at the end of `mergeEntities` (lines 349–354) with:
+
+```ts
+    // Phase 2: Re-point secondary's entity relationship edges to primary.
+    // We iterate all edges on secondary and upsert equivalent edges on primary.
+    // upsertEdge handles the bidirectional uniqueness constraint atomically —
+    // if primary already has the same edge, confidence is raised rather than
+    // creating a duplicate. Edges to fact nodes are skipped — facts were
+    // already re-stored on primary in Phase 1 via storeFact().
+    const secondaryEdges = await this.store.getEdgesForNode(secondaryId);
+    const secondaryFactNodeIds: string[] = [];
+
+    for (const edge of secondaryEdges) {
+      const isOutbound = edge.sourceNodeId === secondaryId;
+      const otherId = isOutbound ? edge.targetNodeId : edge.sourceNodeId;
+
+      // Self-loop guard (should not exist, but be defensive)
+      if (otherId === secondaryId) continue;
+
+      const otherNode = await this.store.getNode(otherId);
+      if (!otherNode) continue;
+
+      if (otherNode.type === FACT_TYPE) {
+        // Collect secondary fact node IDs for cleanup after edge transfer.
+        // These were re-stored on primary in Phase 1; deleting them here
+        // prevents orphaned fact nodes after the secondary entity is removed.
+        secondaryFactNodeIds.push(otherId);
+        continue;
+      }
+
+      // Transfer the relationship edge to primary
+      await this.store.upsertEdge({
+        sourceNodeId: isOutbound ? primaryId : otherId,
+        targetNodeId: isOutbound ? otherId : primaryId,
+        type: edge.type,
+        properties: edge.properties,
+        confidence: edge.temporal.confidence,
+        decayClass: edge.temporal.decayClass,
+        source: edge.temporal.source,
+      });
+    }
+
+    // Delete secondary's fact nodes (already re-created on primary in Phase 1).
+    // Must happen before deleteNode so cascade doesn't beat us to it.
+    for (const factNodeId of secondaryFactNodeIds) {
+      await this.store.deleteNode(factNodeId);
+    }
+
+    // Delete the secondary entity node. ON DELETE CASCADE on kg_edges removes
+    // any remaining edges (e.g. self-loops or edges not transferred above).
+    await this.store.deleteNode(secondaryId);
+```
+
+- [ ] **Step 4: Run tests to confirm Phase 2 tests pass**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness run test -- --reporter=verbose src/memory/entity-memory.upsert.test.ts
+```
+
+Expected: All Phase 2 tests PASS.
+
+- [ ] **Step 5: Run full test suite to confirm no regressions**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness run test
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness add src/memory/entity-memory.ts src/memory/entity-memory.upsert.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness commit -m "feat: complete mergeEntities Phase 2 — edge re-pointing and secondary node deletion"
+```
+
+---
+
+## Task 3: `EntityMemory.updateNode()` — public method with merge-on-collision
+
+**Files:**
+- Modify: `src/memory/entity-memory.upsert.test.ts`
+- Modify: `src/memory/entity-memory.ts`
+
+- [ ] **Step 1: Add failing `updateNode` tests to `entity-memory.upsert.test.ts`**
+
+Append a new describe block to `src/memory/entity-memory.upsert.test.ts`:
+
+```ts
+describe('EntityMemory.updateNode', () => {
+  it('updates properties without merge when no label change', async () => {
+    const mem = makeEntityMemory();
+    const node = await mem.createEntity({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+
+    const { node: updated, merged } = await mem.updateNode(node.id, { properties: { role: 'CEO' } });
+
+    expect(merged).toBe(false);
+    expect(updated.id).toBe(node.id);
+    expect(updated.properties).toEqual({ role: 'CEO' });
+  });
+
+  it('updates label without merge when no collision', async () => {
+    const mem = makeEntityMemory();
+    const node = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+
+    const { node: updated, merged } = await mem.updateNode(node.id, { label: 'Joseph' });
+
+    expect(merged).toBe(false);
+    expect(updated.id).toBe(node.id);
+    expect(updated.label).toBe('Joseph');
+  });
+
+  it('merges nodes when label update collides with an existing node of the same type', async () => {
+    const mem = makeEntityMemory();
+    const canonical = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const toRename = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+
+    const { node: result, merged } = await mem.updateNode(toRename.id, { label: 'Joseph Fung' });
+
+    expect(merged).toBe(true);
+    // Returned node is the canonical, not the renamed node
+    expect(result.id).toBe(canonical.id);
+    // The renamed node no longer exists
+    expect(await mem.getEntity(toRename.id)).toBeUndefined();
+  });
+
+  it('does NOT merge when same label but different type', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'organization', label: 'Apple', properties: {}, source: 'test' });
+    const concept = await mem.createEntity({ type: 'concept', label: 'Fruit', properties: {}, source: 'test' });
+
+    // Renaming concept to 'Apple' — no collision because types differ
+    const { merged } = await mem.updateNode(concept.id, { label: 'Apple' });
+
+    expect(merged).toBe(false);
+  });
+
+  it('transfers edges to canonical on merge-on-collision', async () => {
+    const mem = makeEntityMemory();
+    const canonical = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const toRename = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+    const org = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+
+    await mem.upsertEdge(toRename.id, org.id, 'member_of', {}, 'test', 0.8);
+
+    await mem.updateNode(toRename.id, { label: 'Joseph Fung' });
+
+    const edges = await mem.findEdges(canonical.id);
+    expect(edges.some(e => e.node.id === org.id && e.edge.type === 'member_of')).toBe(true);
+  });
+});
+```
+
+Note: these tests reference `.id` directly on the `createEntity` result. They will need updating once Task 4 changes the return type. For now, use the current return type (`KgNode`).
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness run test -- --reporter=verbose src/memory/entity-memory.upsert.test.ts
+```
+
+Expected: FAIL — `mem.updateNode is not a function`
+
+- [ ] **Step 3: Add `updateNode` to `EntityMemory`**
+
+In `src/memory/entity-memory.ts`, add after `getEntity`:
+
+```ts
+  /**
+   * Update a node's label and/or properties.
+   *
+   * ╔══════════════════════════════════════════════════════════════════════╗
+   * ║  IMPORTANT — READ BEFORE CALLING THIS METHOD                        ║
+   * ║                                                                      ║
+   * ║  When `updates.label` is provided, this method checks whether the   ║
+   * ║  new label collides with an existing node of the same type.         ║
+   * ║  If a collision is found, the two nodes are MERGED — the existing   ║
+   * ║  node becomes canonical and the node you passed in is DELETED.      ║
+   * ║                                                                      ║
+   * ║  When merged === true:                                               ║
+   * ║    • node.id in the result is DIFFERENT from the id you passed in   ║
+   * ║    • The original id no longer exists in the knowledge graph        ║
+   * ║    • You MUST update any local reference to the old id              ║
+   * ║    • Surface this to the agent — it needs to know the canonical id  ║
+   * ║                                                                      ║
+   * ║  Example:                                                            ║
+   * ║    const { node, merged } = await entityMemory.updateNode(          ║
+   * ║      joeId, { label: 'Joseph Fung' }                                ║
+   * ║    );                                                                ║
+   * ║    if (merged) {                                                     ║
+   * ║      // joeId is gone. node.id is the canonical Joseph Fung node.   ║
+   * ║      // Log, surface to the agent, update your local reference.     ║
+   * ║    }                                                                 ║
+   * ╚══════════════════════════════════════════════════════════════════════╝
+   */
+  async updateNode(
+    id: string,
+    updates: { label?: string; properties?: Record<string, unknown> },
+  ): Promise<{ node: KgNode; merged: boolean }> {
+    if (!updates.label) {
+      // Properties-only update — no collision possible, simple pass-through
+      const node = await this.store.updateNode(id, updates);
+      return { node, merged: false };
+    }
+
+    // Label change: check for a collision with an existing node of the same type
+    const current = await this.store.getNode(id);
+    if (!current) throw new Error(`Node not found: ${id}`);
+
+    if (current.type !== FACT_TYPE) {
+      const candidates = await this.store.findNodesByLabel(updates.label);
+      const collision = candidates.find(n => n.type === current.type && n.id !== id);
+
+      if (collision) {
+        // Merge: the existing node is canonical; the node being renamed is secondary.
+        // mergeEntities handles property merge, fact migration, edge re-pointing,
+        // and deletion of the secondary node.
+        await this.mergeEntities(collision.id, id);
+        // Re-fetch canonical to get post-merge state (properties may have been updated)
+        const canonical = await this.store.getNode(collision.id);
+        if (!canonical) throw new Error(`Canonical node not found after merge: ${collision.id}`);
+        return { node: canonical, merged: true };
+      }
+    }
+
+    // No collision — proceed with normal label update
+    const node = await this.store.updateNode(id, updates);
+    return { node, merged: false };
+  }
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness run test -- --reporter=verbose src/memory/entity-memory.upsert.test.ts
+```
+
+Expected: All `updateNode` tests PASS. All `mergeEntities` tests still PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness run test
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness add src/memory/entity-memory.ts src/memory/entity-memory.upsert.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness commit -m "feat: add EntityMemory.updateNode() with merge-on-collision for label changes"
+```
+
+---
+
+## Task 4: `createEntity` return type change + call-site updates
+
+This task changes `createEntity` from returning `KgNode` to `{ entity: KgNode; created: boolean }`. It will break several TypeScript call sites — fix them all in one commit.
+
+**Files:**
+- Modify: `src/memory/entity-memory.ts`
+- Modify: `src/memory/entity-memory.upsert.test.ts`
+- Modify: `src/memory/entity-memory.edges.test.ts`
+- Modify: `src/contacts/contact-service.ts`
+- Modify: `skills/extract-relationships/handler.ts`
+- Modify: `skills/knowledge-meeting-links/handler.ts`
+- Modify: `skills/_shared/template-base.ts`
+- Modify: `skills/query-relationships/handler.test.ts`
+- Modify: `skills/delete-relationship/handler.test.ts`
+
+- [ ] **Step 1: Add failing `createEntity` return-type tests to `entity-memory.upsert.test.ts`**
+
+Append a new describe block to `src/memory/entity-memory.upsert.test.ts`:
+
+```ts
+describe('EntityMemory.createEntity', () => {
+  it('returns { entity, created: true } on first call', async () => {
+    const mem = makeEntityMemory();
+
+    const result = await mem.createEntity({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+
+    expect(result.created).toBe(true);
+    expect(result.entity.label).toBe('Alice');
+    expect(result.entity.type).toBe('person');
+  });
+
+  it('returns { entity, created: false } on second call with same (label, type)', async () => {
+    const mem = makeEntityMemory();
+
+    const first = await mem.createEntity({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const second = await mem.createEntity({ type: 'person', label: 'ALICE', properties: {}, source: 'test' });
+
+    expect(second.created).toBe(false);
+    expect(second.entity.id).toBe(first.entity.id);
+  });
+
+  it('returns created: true for same label under different types', async () => {
+    const mem = makeEntityMemory();
+
+    const r1 = await mem.createEntity({ type: 'person', label: 'Apple', properties: {}, source: 'test' });
+    const r2 = await mem.createEntity({ type: 'organization', label: 'Apple', properties: {}, source: 'test' });
+
+    expect(r1.created).toBe(true);
+    expect(r2.created).toBe(true);
+    expect(r1.entity.id).not.toBe(r2.entity.id);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness run test -- --reporter=verbose src/memory/entity-memory.upsert.test.ts
+```
+
+Expected: FAIL — `result.created is undefined` (returns `KgNode` not `{ entity, created }`)
+
+- [ ] **Step 3: Change `createEntity` in `entity-memory.ts`**
+
+Replace the existing `createEntity` method body:
+
+```ts
+  async createEntity(options: CreateEntityOptions): Promise<{ entity: KgNode; created: boolean }> {
+    const { node, created } = await this.store.upsertNode({
+      type: options.type,
+      label: options.label,
+      properties: options.properties,
+      source: options.source,
+      confidence: options.confidence ?? 0.7,
+    });
+    return { entity: node, created };
+  }
+```
+
+- [ ] **Step 4: Fix `entity-memory.upsert.test.ts` — update Phase 2 and updateNode tests**
+
+In `src/memory/entity-memory.upsert.test.ts`, update all `createEntity` calls in the Phase 2 and `updateNode` describe blocks to destructure `entity`:
+
+```ts
+// Before:
+const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', ... });
+await mem.upsertEdge(primary.id, ...);
+
+// After:
+const { entity: primary } = await mem.createEntity({ type: 'person', label: 'Joseph Fung', ... });
+await mem.upsertEdge(primary.id, ...);
+```
+
+Apply this pattern to every `createEntity` call in the file except the new `createEntity` describe block (which already uses the new return type).
+
+- [ ] **Step 5: Fix `entity-memory.edges.test.ts`**
+
+In `src/memory/entity-memory.edges.test.ts`, update all `createEntity` calls:
+
+```ts
+// Before:
+const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', ... });
+await mem.upsertEdge(joseph.id, xiaopu.id, ...);
+
+// After:
+const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph', ... });
+await mem.upsertEdge(joseph.id, xiaopu.id, ...);
+```
+
+Apply to every `createEntity` call in the file.
+
+- [ ] **Step 6: Fix `skills/query-relationships/handler.test.ts`**
+
+Two changes needed:
+
+**a)** Update all `createEntity` calls that use the return value:
+
+```ts
+// Before:
+const joseph = await mem.createEntity({ type: 'person', label: 'Joseph Fung', ... });
+await mem.upsertEdge(joseph.id, xiaopu.id, ...);
+
+// After:
+const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph Fung', ... });
+await mem.upsertEdge(joseph.id, xiaopu.id, ...);
+```
+
+**b)** The "ambiguous" test (line 73–87) creates two nodes with the same label to trigger `ambiguous: true`. After the return type change, the second `createEntity` call returns `created: false` and the same node — only one node exists. The test must be rewritten to insert a duplicate directly via `store.createNode()`, bypassing the upsert:
+
+```ts
+it('returns ambiguous:true with candidates when multiple nodes match', async () => {
+  // createEntity uses upsertNode which prevents duplicates.
+  // To test the ambiguous code path (pre-migration data or direct DB insert),
+  // we insert a second node directly via the store, bypassing dedup logic.
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  const mem = new EntityMemory(store, validator, embeddingService);
+
+  // Create first node via normal path
+  await mem.createEntity({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
+  // Insert second node directly to bypass upsert (simulates pre-migration duplicate)
+  await store.createNode({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
+
+  const handler = new QueryRelationshipsHandler();
+  const ctx = makeCtx(mem, { entity: 'John Smith' });
+  const result = await handler.execute(ctx);
+
+  expect(result.success).toBe(true);
+  const data = (result as { success: true; data: { ambiguous: boolean; candidates: unknown[] } }).data;
+  expect(data.ambiguous).toBe(true);
+  expect(data.candidates).toHaveLength(2);
+});
+```
+
+This requires importing `KnowledgeGraphStore`, `EmbeddingService`, `MemoryValidator`, and `EntityMemory` at the top of the test file. Check what's already imported and add what's missing.
+
+- [ ] **Step 7: Fix `skills/delete-relationship/handler.test.ts`**
+
+Update all `createEntity` calls to destructure `{ entity }`:
+
+```ts
+// Before:
+const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', ... });
+
+// After:
+const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph', ... });
+```
+
+- [ ] **Step 8: Fix `skills/extract-relationships/handler.ts`**
+
+The two `createEntity` calls are the fallback in a nullish-coalescing chain. Change:
+
+```ts
+// Before (lines ~183 and ~196):
+const subjectNode =
+  subjectMatches.find(n => n.type === subjectType) ??
+  subjectMatches[0] ??
+  await ctx.entityMemory.createEntity({
+    type: subjectType,
+    label: triple.subject,
+    properties: {},
+    source,
+    confidence: 0.6,
+  });
+
+// After:
+const subjectMatch = subjectMatches.find(n => n.type === subjectType) ?? subjectMatches[0];
+const subjectNode = subjectMatch ?? (await ctx.entityMemory.createEntity({
+  type: subjectType,
+  label: triple.subject,
+  properties: {},
+  source,
+  confidence: 0.6,
+})).entity;
+```
+
+Apply the same pattern for the `objectNode` resolution (~line 196).
+
+- [ ] **Step 9: Fix `skills/knowledge-meeting-links/handler.ts`**
+
+In `findOrCreateAnchor`, the method returns the `createEntity` result directly and the caller uses `.id`:
+
+```ts
+// Before:
+private async findOrCreateAnchor(ctx: SkillContext) {
+  const existing = await ctx.entityMemory!.findEntities(ANCHOR_LABEL);
+  if (existing.length > 0) {
+    return existing[0]!;
+  }
+
+  return ctx.entityMemory!.createEntity({
+    type: 'concept',
+    label: ANCHOR_LABEL,
+    properties: { category: 'meeting-knowledge' },
+    source: 'skill:knowledge-meeting-links',
+  });
+}
+
+// After:
+private async findOrCreateAnchor(ctx: SkillContext) {
+  const existing = await ctx.entityMemory!.findEntities(ANCHOR_LABEL);
+  if (existing.length > 0) {
+    return existing[0]!;
+  }
+
+  const { entity } = await ctx.entityMemory!.createEntity({
+    type: 'concept',
+    label: ANCHOR_LABEL,
+    properties: { category: 'meeting-knowledge' },
+    source: 'skill:knowledge-meeting-links',
+  });
+  return entity;
+}
+```
+
+- [ ] **Step 10: Fix `skills/_shared/template-base.ts`**
+
+```ts
+// Before:
+const anchor = await ctx.entityMemory!.createEntity({
+  type: 'concept',
+  label: templateLabel,
+  properties: { category: 'email-policy' },
+  source: skillSource,
+});
+return anchor.id;
+
+// After:
+const { entity: anchor } = await ctx.entityMemory!.createEntity({
+  type: 'concept',
+  label: templateLabel,
+  properties: { category: 'email-policy' },
+  source: skillSource,
+});
+return anchor.id;
+```
+
+- [ ] **Step 11: Fix `src/contacts/contact-service.ts`**
+
+```ts
+// Before (lines ~163–173):
+let kgNodeId: string | null = options.kgNodeId ?? null;
+if (!kgNodeId && this.entityMemory) {
+  const entity = await this.entityMemory.createEntity({
+    type: 'person',
+    label: safeName,
+    properties: options.role ? { role: options.role } : {},
+    source: options.source,
+  });
+  kgNodeId = entity.id;
+}
+
+// After:
+let kgNodeId: string | null = options.kgNodeId ?? null;
+if (!kgNodeId && this.entityMemory) {
+  const { entity, created } = await this.entityMemory.createEntity({
+    type: 'person',
+    label: safeName,
+    properties: options.role ? { role: options.role } : {},
+    source: options.source,
+  });
+  if (!created && options.role) {
+    // A KG node already existed for this label. Apply the role property if
+    // it isn't already set — the existing node may have been created without
+    // one (e.g. by extract-relationships which always passes empty properties).
+    const { node } = await this.entityMemory.updateNode(entity.id, {
+      properties: { ...entity.properties, role: options.role },
+    });
+    kgNodeId = node.id;
+  } else {
+    kgNodeId = entity.id;
+  }
+}
+```
+
+- [ ] **Step 12: Run full test suite**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness run test
+```
+
+Expected: All tests PASS. No TypeScript errors.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness add \
+  src/memory/entity-memory.ts \
+  src/memory/entity-memory.upsert.test.ts \
+  src/memory/entity-memory.edges.test.ts \
+  src/contacts/contact-service.ts \
+  skills/extract-relationships/handler.ts \
+  skills/knowledge-meeting-links/handler.ts \
+  skills/_shared/template-base.ts \
+  skills/query-relationships/handler.test.ts \
+  skills/delete-relationship/handler.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness commit -m "feat: change createEntity() to return { entity, created } and update all call sites"
+```
+
+---
+
+## Task 5: Migration `016_kg_node_uniqueness.sql`
+
+**Files:**
+- Create: `src/db/migrations/016_kg_node_uniqueness.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+Create `src/db/migrations/016_kg_node_uniqueness.sql`:
+
+```sql
+-- Up Migration
+
+-- Step 1: Build a map of (duplicate_id → canonical_id) for all non-fact node groups
+-- with more than one member. Canonical = highest confidence, ties by oldest created_at.
+CREATE TEMP TABLE _kg_node_canonical AS
+SELECT
+  dup.id   AS duplicate_id,
+  canon.id AS canonical_id
+FROM kg_nodes dup
+JOIN (
+  -- One canonical node per (lower(label), type) group
+  SELECT DISTINCT ON (lower(label), type)
+    id,
+    lower(label) AS lower_label,
+    type
+  FROM kg_nodes
+  WHERE type != 'fact'
+  ORDER BY lower(label), type, confidence DESC, created_at ASC
+) canon
+  ON  lower(dup.label) = canon.lower_label
+  AND dup.type         = canon.type
+  AND dup.id          != canon.id
+WHERE dup.type != 'fact';
+
+-- Step 2: Delete edges that would conflict with the bidirectional unique index
+-- after re-pointing. An edge conflicts if the canonical already has an edge of
+-- the same type connecting the same two node IDs in either direction.
+DELETE FROM kg_edges e
+USING _kg_node_canonical m
+WHERE (e.source_node_id = m.duplicate_id OR e.target_node_id = m.duplicate_id)
+  AND EXISTS (
+    SELECT 1 FROM kg_edges existing
+    WHERE existing.id != e.id
+      AND existing.type = e.type
+      AND LEAST(existing.source_node_id::text, existing.target_node_id::text) =
+            LEAST(
+              CASE WHEN e.source_node_id = m.duplicate_id THEN m.canonical_id ELSE e.source_node_id END,
+              CASE WHEN e.target_node_id = m.duplicate_id THEN m.canonical_id ELSE e.target_node_id END
+            )::text
+      AND GREATEST(existing.source_node_id::text, existing.target_node_id::text) =
+            GREATEST(
+              CASE WHEN e.source_node_id = m.duplicate_id THEN m.canonical_id ELSE e.source_node_id END,
+              CASE WHEN e.target_node_id = m.duplicate_id THEN m.canonical_id ELSE e.target_node_id END
+            )::text
+  );
+
+-- Step 3: Re-point remaining edges to the canonical node
+UPDATE kg_edges
+SET source_node_id = m.canonical_id
+FROM _kg_node_canonical m
+WHERE source_node_id = m.duplicate_id;
+
+UPDATE kg_edges
+SET target_node_id = m.canonical_id
+FROM _kg_node_canonical m
+WHERE target_node_id = m.duplicate_id;
+
+-- Step 4: Re-point contacts.kg_node_id to canonical.
+-- If the canonical node already has a contact, NULL out the duplicate's FK
+-- to avoid violating the partial unique index on contacts(kg_node_id).
+-- The nulled-out contact row should be merged via the contact-merge flow.
+UPDATE contacts
+SET kg_node_id = CASE
+  WHEN NOT EXISTS (
+    SELECT 1 FROM contacts c2
+    WHERE c2.kg_node_id = m.canonical_id
+      AND c2.id != contacts.id
+  ) THEN m.canonical_id
+  ELSE NULL
+END
+FROM _kg_node_canonical m
+WHERE contacts.kg_node_id = m.duplicate_id;
+
+-- Step 5: Delete duplicate nodes (ON DELETE CASCADE removes remaining edges)
+DELETE FROM kg_nodes
+WHERE id IN (SELECT duplicate_id FROM _kg_node_canonical);
+
+DROP TABLE _kg_node_canonical;
+
+-- Step 6: Enforce uniqueness going forward.
+-- Excludes fact nodes — facts are intentionally many-per-entity.
+-- Allows same label under different types (e.g. "Apple" org vs "Apple" concept).
+CREATE UNIQUE INDEX idx_kg_nodes_unique
+  ON kg_nodes (lower(label), type)
+  WHERE type != 'fact';
+
+-- Down Migration
+DROP INDEX IF EXISTS idx_kg_nodes_unique;
+-- Note: the dedup data changes are not reversible.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness add src/db/migrations/016_kg_node_uniqueness.sql
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness commit -m "chore: migration 016 — dedup kg_nodes and add uniqueness constraint on (lower(label), type)"
+```
+
+---
+
+## Task 6: Changelog and version bump
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`
+
+- [ ] **Step 1: Add changelog entry**
+
+In `CHANGELOG.md`, add under `## [Unreleased]`:
+
+```markdown
+### Fixed
+- **KG node deduplication** — one-time migration deduplicates existing `kg_nodes` rows with matching `(lower(label), type)`, re-pointing edges and contacts to canonical nodes before removing duplicates.
+
+### Added
+- **`kg_nodes` uniqueness constraint** — `idx_kg_nodes_unique` on `(lower(label), type) WHERE type != 'fact'` prevents future duplicate entity nodes.
+- **`KnowledgeGraphStore.upsertNode()`** — idempotent node creation; raises confidence on conflict, never creates duplicates. Returns `{ node, created }`.
+- **`EntityMemory.createEntity()`** — now returns `{ entity, created }` instead of `KgNode`. Delegates to `upsertNode` for race-safe creation. **Breaking change** for callers (all internal call sites updated).
+- **`EntityMemory.updateNode()`** — new public method. Label changes that collide with an existing node of the same type automatically merge the nodes. Returns `{ node, merged }` — callers must use the returned `node.id`, which may differ from the input id when `merged: true`.
+- **`mergeEntities` Phase 2** — re-points secondary entity edges to primary and deletes the secondary node (was previously deferred with a TODO).
+```
+
+- [ ] **Step 2: Bump version in `package.json`**
+
+Change `"version": "0.12.1"` to `"version": "0.12.2"`.
+
+- [ ] **Step 3: Run full test suite one final time**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness run test
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness add CHANGELOG.md package.json
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-kg-node-uniqueness commit -m "chore: bump version to 0.12.2 and update changelog for kg-node-uniqueness"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] `upsertNode` in both backends with `created` flag — Task 1
+- [x] `mergeEntities` Phase 2: edge re-pointing, secondary fact node cleanup, secondary deletion — Task 2
+- [x] `updateNode` public method with merge-on-collision, strong directive comment — Task 3
+- [x] `createEntity` return type change + all call sites updated — Task 4
+- [x] `contact-service` applies `role` on `!created` — Task 4, Step 11
+- [x] `query-relationships` ambiguous test fixed for new upsert semantics — Task 4, Step 6b
+- [x] Migration: dedup, edge conflict resolution, contacts re-pointing, delete, unique index — Task 5
+- [x] Changelog + version bump — Task 6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/_shared/template-base.ts
+++ b/skills/_shared/template-base.ts
@@ -248,7 +248,7 @@ async function findOrCreateAnchor(
   const existing = await ctx.entityMemory!.findEntities(templateLabel);
   if (existing.length > 0) return existing[0]!.id;
 
-  const anchor = await ctx.entityMemory!.createEntity({
+  const { entity: anchor } = await ctx.entityMemory!.createEntity({
     type: 'concept',
     label: templateLabel,
     properties: { category: 'email-policy' },

--- a/skills/delete-relationship/handler.test.ts
+++ b/skills/delete-relationship/handler.test.ts
@@ -9,10 +9,16 @@ import { DeleteRelationshipHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 
 function makeEntityMemory() {
+  return makeEntityMemoryWithStore().mem;
+}
+
+// Returns both mem and store for tests that need to bypass upsert
+// (e.g. to simulate pre-migration duplicate data by inserting directly)
+function makeEntityMemoryWithStore() {
   const embeddingService = EmbeddingService.createForTesting();
   const store = KnowledgeGraphStore.createInMemory(embeddingService);
   const validator = new MemoryValidator(store, embeddingService);
-  return new EntityMemory(store, validator, embeddingService, createSilentLogger());
+  return { mem: new EntityMemory(store, validator, embeddingService, createSilentLogger()), store };
 }
 
 function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {
@@ -38,8 +44,8 @@ describe('DeleteRelationshipHandler', () => {
 
   it('returns deleted:false (idempotent) when edge does not exist', async () => {
     const mem = makeEntityMemory();
-    await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
-    await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' }); // return value not needed
+    await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' }); // return value not needed
 
     const handler = new DeleteRelationshipHandler();
     const ctx = makeCtx(mem, { subject: 'Joseph', predicate: 'spouse', object: 'Xiaopu' });
@@ -50,8 +56,8 @@ describe('DeleteRelationshipHandler', () => {
 
   it('deletes the edge and returns deleted:true with edge_id', async () => {
     const mem = makeEntityMemory();
-    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
-    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const { entity: xiaopu } = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
     const { edge } = await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
 
     const handler = new DeleteRelationshipHandler();
@@ -70,8 +76,8 @@ describe('DeleteRelationshipHandler', () => {
 
   it('finds the edge regardless of which direction it was stored', async () => {
     const mem = makeEntityMemory();
-    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
-    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const { entity: xiaopu } = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
     // Stored with xiaopu as source
     await mem.upsertEdge(xiaopu.id, joseph.id, 'spouse', {}, 'test', 0.9);
 
@@ -85,9 +91,11 @@ describe('DeleteRelationshipHandler', () => {
   });
 
   it('returns ambiguous:true when subject matches multiple nodes', async () => {
-    const mem = makeEntityMemory();
+    // createEntity uses upsertNode which prevents duplicates.
+    // Insert a second node directly to simulate pre-migration duplicate data.
+    const { mem, store } = makeEntityMemoryWithStore();
     await mem.createEntity({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
-    await mem.createEntity({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
+    await store.createNode({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
     await mem.createEntity({ type: 'person', label: 'Jane', properties: {}, source: 'test' });
 
     const handler = new DeleteRelationshipHandler();
@@ -102,10 +110,12 @@ describe('DeleteRelationshipHandler', () => {
   });
 
   it('returns ambiguous:true when object matches multiple nodes', async () => {
-    const mem = makeEntityMemory();
+    // createEntity uses upsertNode which prevents duplicates.
+    // Insert a second node directly to simulate pre-migration duplicate data.
+    const { mem, store } = makeEntityMemoryWithStore();
     await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
     await mem.createEntity({ type: 'person', label: 'Jane Smith', properties: {}, source: 'test' });
-    await mem.createEntity({ type: 'person', label: 'Jane Smith', properties: {}, source: 'test' });
+    await store.createNode({ type: 'person', label: 'Jane Smith', properties: {}, source: 'test' });
 
     const handler = new DeleteRelationshipHandler();
     const ctx = makeCtx(mem, { subject: 'Joseph', predicate: 'manages', object: 'Jane Smith' });

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -177,29 +177,25 @@ ${text}`,
         // Falling back to the first match handles cases where a node was previously
         // created under a different type; creating a new node is the last resort.
         const subjectMatches = await ctx.entityMemory.findEntities(triple.subject);
-        const subjectNode =
-          subjectMatches.find(n => n.type === subjectType) ??
-          subjectMatches[0] ??
-          await ctx.entityMemory.createEntity({
-            type: subjectType,
-            label: triple.subject,
-            properties: {},
-            source,
-            confidence: 0.6,
-          });
+        const subjectMatch = subjectMatches.find(n => n.type === subjectType) ?? subjectMatches[0];
+        const subjectNode = subjectMatch ?? (await ctx.entityMemory.createEntity({
+          type: subjectType,
+          label: triple.subject,
+          properties: {},
+          source,
+          confidence: 0.6,
+        })).entity;
 
         // Resolve object — same pattern
         const objectMatches = await ctx.entityMemory.findEntities(triple.object);
-        const objectNode =
-          objectMatches.find(n => n.type === objectType) ??
-          objectMatches[0] ??
-          await ctx.entityMemory.createEntity({
-            type: objectType,
-            label: triple.object,
-            properties: {},
-            source,
-            confidence: 0.6,
-          });
+        const objectMatch = objectMatches.find(n => n.type === objectType) ?? objectMatches[0];
+        const objectNode = objectMatch ?? (await ctx.entityMemory.createEntity({
+          type: objectType,
+          label: triple.object,
+          properties: {},
+          source,
+          confidence: 0.6,
+        })).entity;
 
         // Skip self-loops — subject and object resolved to the same node.
         // The extraction prompt asks for two distinct entities but the LLM can still

--- a/skills/knowledge-company-overview/handler.ts
+++ b/skills/knowledge-company-overview/handler.ts
@@ -102,11 +102,12 @@ export class KnowledgeCompanyOverviewHandler implements SkillHandler {
       return existing[0]!;
     }
 
-    return ctx.entityMemory!.createEntity({
+    const { entity } = await ctx.entityMemory!.createEntity({
       type: 'organization',
       label: ANCHOR_LABEL,
       properties: { category: 'company-knowledge' },
       source: 'skill:knowledge-company-overview',
     });
+    return entity;
   }
 }

--- a/skills/knowledge-loyalty-programs/handler.ts
+++ b/skills/knowledge-loyalty-programs/handler.ts
@@ -119,11 +119,12 @@ export class KnowledgeLoyaltyProgramsHandler implements SkillHandler {
       return existing[0]!;
     }
 
-    return ctx.entityMemory!.createEntity({
+    const { entity } = await ctx.entityMemory!.createEntity({
       type: 'concept',
       label: ANCHOR_LABEL,
       properties: { category: 'loyalty-knowledge' },
       source: 'skill:knowledge-loyalty-programs',
     });
+    return entity;
   }
 }

--- a/skills/knowledge-meeting-links/handler.ts
+++ b/skills/knowledge-meeting-links/handler.ts
@@ -123,11 +123,12 @@ export class KnowledgeMeetingLinksHandler implements SkillHandler {
       return existing[0]!;
     }
 
-    return ctx.entityMemory!.createEntity({
+    const { entity } = await ctx.entityMemory!.createEntity({
       type: 'concept',
       label: ANCHOR_LABEL,
       properties: { category: 'meeting-knowledge' },
       source: 'skill:knowledge-meeting-links',
     });
+    return entity;
   }
 }

--- a/skills/knowledge-travel-preferences/handler.ts
+++ b/skills/knowledge-travel-preferences/handler.ts
@@ -100,11 +100,12 @@ export class KnowledgeTravelPreferencesHandler implements SkillHandler {
       return existing[0]!;
     }
 
-    return ctx.entityMemory!.createEntity({
+    const { entity } = await ctx.entityMemory!.createEntity({
       type: 'concept',
       label: ANCHOR_LABEL,
       properties: { category: 'travel-knowledge' },
       source: 'skill:knowledge-travel-preferences',
     });
+    return entity;
   }
 }

--- a/skills/query-relationships/handler.test.ts
+++ b/skills/query-relationships/handler.test.ts
@@ -8,11 +8,17 @@ import { createSilentLogger } from '../../src/logger.js';
 import { QueryRelationshipsHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 
-function makeEntityMemory() {
+// makeEntityMemoryWithStore returns both for tests that need direct store access
+// (e.g. to simulate pre-migration duplicates by bypassing upsert logic)
+function makeEntityMemoryWithStore() {
   const embeddingService = EmbeddingService.createForTesting();
   const store = KnowledgeGraphStore.createInMemory(embeddingService);
   const validator = new MemoryValidator(store, embeddingService);
-  return new EntityMemory(store, validator, embeddingService, createSilentLogger());
+  return { mem: new EntityMemory(store, validator, embeddingService, createSilentLogger()), store };
+}
+
+function makeEntityMemory() {
+  return makeEntityMemoryWithStore().mem;
 }
 
 function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {
@@ -37,9 +43,9 @@ describe('QueryRelationshipsHandler', () => {
 
   it('returns all relationships for a known entity', async () => {
     const mem = makeEntityMemory();
-    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
-    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu Fung', properties: {}, source: 'test' });
-    const acme = await mem.createEntity({ type: 'organization', label: 'Acme Corp', properties: {}, source: 'test' });
+    const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const { entity: xiaopu } = await mem.createEntity({ type: 'person', label: 'Xiaopu Fung', properties: {}, source: 'test' });
+    const { entity: acme } = await mem.createEntity({ type: 'organization', label: 'Acme Corp', properties: {}, source: 'test' });
     await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
     await mem.upsertEdge(joseph.id, acme.id, 'member_of', {}, 'test', 0.8);
 
@@ -55,9 +61,9 @@ describe('QueryRelationshipsHandler', () => {
 
   it('filters by edge_type when provided', async () => {
     const mem = makeEntityMemory();
-    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
-    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu Fung', properties: {}, source: 'test' });
-    const acme = await mem.createEntity({ type: 'organization', label: 'Acme Corp', properties: {}, source: 'test' });
+    const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const { entity: xiaopu } = await mem.createEntity({ type: 'person', label: 'Xiaopu Fung', properties: {}, source: 'test' });
+    const { entity: acme } = await mem.createEntity({ type: 'organization', label: 'Acme Corp', properties: {}, source: 'test' });
     await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
     await mem.upsertEdge(joseph.id, acme.id, 'member_of', {}, 'test', 0.8);
 
@@ -72,10 +78,14 @@ describe('QueryRelationshipsHandler', () => {
   });
 
   it('returns ambiguous:true with candidates when multiple nodes match', async () => {
-    const mem = makeEntityMemory();
-    // Two nodes with the same label
+    // createEntity uses upsertNode which prevents duplicates.
+    // Insert a second node directly via the store to simulate pre-migration duplicate data.
+    const { mem, store } = makeEntityMemoryWithStore();
+
+    // Create first node via normal path
     await mem.createEntity({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
-    await mem.createEntity({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
+    // Insert second node directly to bypass upsert (simulates pre-migration duplicate)
+    await store.createNode({ type: 'person', label: 'John Smith', properties: {}, source: 'test' });
 
     const handler = new QueryRelationshipsHandler();
     const ctx = makeCtx(mem, { entity: 'John Smith' });
@@ -89,7 +99,7 @@ describe('QueryRelationshipsHandler', () => {
 
   it('returns error for an unknown edge_type', async () => {
     const mem = makeEntityMemory();
-    await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' }); // return value not needed
 
     const handler = new QueryRelationshipsHandler();
     const ctx = makeCtx(mem, { entity: 'Joseph Fung', edge_type: 'not_a_real_type' });
@@ -101,8 +111,8 @@ describe('QueryRelationshipsHandler', () => {
 
   it('labels outbound and inbound direction correctly', async () => {
     const mem = makeEntityMemory();
-    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
-    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu Fung', properties: {}, source: 'test' });
+    const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const { entity: xiaopu } = await mem.createEntity({ type: 'person', label: 'Xiaopu Fung', properties: {}, source: 'test' });
     // Edge is stored outbound from joseph to xiaopu
     await mem.upsertEdge(joseph.id, xiaopu.id, 'manages', {}, 'test', 0.8);
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -163,13 +163,23 @@ export class ContactService {
     // Auto-create a KG person node if we have entityMemory and no explicit kgNodeId
     let kgNodeId: string | null = options.kgNodeId ?? null;
     if (!kgNodeId && this.entityMemory) {
-      const entity = await this.entityMemory.createEntity({
+      const { entity, created } = await this.entityMemory.createEntity({
         type: 'person',
         label: safeName,
         properties: options.role ? { role: options.role } : {},
         source: options.source,
       });
-      kgNodeId = entity.id;
+      if (!created && options.role) {
+        // A KG node already existed for this label. Apply the role property if
+        // it isn't already set — the existing node may have been created without
+        // one (e.g. by extract-relationships which always passes empty properties).
+        const { node } = await this.entityMemory.updateNode(entity.id, {
+          properties: { ...entity.properties, role: options.role },
+        });
+        kgNodeId = node.id;
+      } else {
+        kgNodeId = entity.id;
+      }
     }
 
     const contact: Contact = {

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -196,11 +196,26 @@ export class ContactService {
     try {
       await this.backend.createContact(contact);
     } catch (err) {
-      // TODO: The KG node auto-created above is now orphaned — it exists in the knowledge
-      // graph with no corresponding contact row. Clean up once EntityMemory exposes a
-      // delete method. For now the orphan is harmless (person node with no contact link).
-      this.logger?.error({ err, contactId: contact.id }, 'Contact creation failed');
-      throw err;
+      const pgCode = (err as { code?: string }).code;
+      const constraint = (err as { constraint?: string }).constraint;
+      // idx_contacts_kg_node_unique (partial unique index on kg_node_id) fires when
+      // upsertNode returned an existing kg_node that is already claimed by another
+      // contact — e.g. two people both named "Alice Smith". Retry without a KG link;
+      // the two contacts can be merged later via the contact-merge flow.
+      if (pgCode === '23505' && constraint === 'idx_contacts_kg_node_unique') {
+        this.logger?.warn(
+          { contactId: contact.id, kgNodeId: contact.kgNodeId },
+          'KG node already claimed by another contact — creating contact without KG link',
+        );
+        contact.kgNodeId = null;
+        await this.backend.createContact(contact);
+      } else {
+        // TODO: The KG node auto-created above is now orphaned — it exists in the knowledge
+        // graph with no corresponding contact row. Clean up once EntityMemory exposes a
+        // delete method. For now the orphan is harmless (person node with no contact link).
+        this.logger?.error({ err, contactId: contact.id }, 'Contact creation failed');
+        throw err;
+      }
     }
 
     // Fire-and-forget dedup check. Runs asynchronously — never blocks the create.
@@ -1128,6 +1143,18 @@ class InMemoryContactBackend implements ContactServiceBackend {
   private calendars = new Map<string, ContactCalendar>();
 
   async createContact(contact: Contact): Promise<void> {
+    // Enforce the partial unique index idx_contacts_kg_node_unique to match Postgres.
+    if (contact.kgNodeId !== null) {
+      for (const existing of this.contacts.values()) {
+        if (existing.kgNodeId === contact.kgNodeId) {
+          const err = Object.assign(new Error('duplicate key value violates unique constraint "idx_contacts_kg_node_unique"'), {
+            code: '23505',
+            constraint: 'idx_contacts_kg_node_unique',
+          });
+          throw err;
+        }
+      }
+    }
     this.contacts.set(contact.id, contact);
   }
 

--- a/src/db/migrations/016_kg_node_uniqueness.sql
+++ b/src/db/migrations/016_kg_node_uniqueness.sql
@@ -15,7 +15,7 @@ JOIN (
     type
   FROM kg_nodes
   WHERE type != 'fact'
-  ORDER BY lower(label), type, confidence DESC, created_at ASC
+  ORDER BY lower(label), type, confidence DESC, created_at ASC, id ASC
 ) canon
   ON  lower(dup.label) = canon.lower_label
   AND dup.type         = canon.type
@@ -56,20 +56,27 @@ FROM _kg_node_canonical m
 WHERE target_node_id = m.duplicate_id;
 
 -- Step 4: Re-point contacts.kg_node_id to canonical.
--- If the canonical node already has a contact, NULL out the duplicate's FK
--- to avoid violating the partial unique index on contacts(kg_node_id).
--- The nulled-out contact row should be merged via the contact-merge flow.
+-- Use ROW_NUMBER() to deterministically pick one contact per canonical_id.
+-- That contact gets re-pointed; all other contacts for the same canonical
+-- are NULLed to avoid violating idx_contacts_kg_node_unique.
+WITH ranked AS (
+  SELECT
+    c.id           AS contact_id,
+    m.canonical_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY m.canonical_id
+      ORDER BY c.id
+    ) AS rn
+  FROM contacts c
+  JOIN _kg_node_canonical m ON c.kg_node_id = m.duplicate_id
+)
 UPDATE contacts
 SET kg_node_id = CASE
-  WHEN NOT EXISTS (
-    SELECT 1 FROM contacts c2
-    WHERE c2.kg_node_id = m.canonical_id
-      AND c2.id != contacts.id
-  ) THEN m.canonical_id
+  WHEN r.rn = 1 THEN r.canonical_id
   ELSE NULL
 END
-FROM _kg_node_canonical m
-WHERE contacts.kg_node_id = m.duplicate_id;
+FROM ranked r
+WHERE contacts.id = r.contact_id;
 
 -- Step 5: Delete duplicate nodes (ON DELETE CASCADE removes remaining edges)
 DELETE FROM kg_nodes

--- a/src/db/migrations/016_kg_node_uniqueness.sql
+++ b/src/db/migrations/016_kg_node_uniqueness.sql
@@ -1,0 +1,89 @@
+-- Up Migration
+
+-- Step 1: Build a map of (duplicate_id → canonical_id) for all non-fact node groups
+-- with more than one member. Canonical = highest confidence, ties by oldest created_at.
+CREATE TEMP TABLE _kg_node_canonical AS
+SELECT
+  dup.id   AS duplicate_id,
+  canon.id AS canonical_id
+FROM kg_nodes dup
+JOIN (
+  -- One canonical node per (lower(label), type) group
+  SELECT DISTINCT ON (lower(label), type)
+    id,
+    lower(label) AS lower_label,
+    type
+  FROM kg_nodes
+  WHERE type != 'fact'
+  ORDER BY lower(label), type, confidence DESC, created_at ASC
+) canon
+  ON  lower(dup.label) = canon.lower_label
+  AND dup.type         = canon.type
+  AND dup.id          != canon.id
+WHERE dup.type != 'fact';
+
+-- Step 2: Delete edges that would conflict with the bidirectional unique index
+-- after re-pointing. An edge conflicts if the canonical already has an edge of
+-- the same type connecting the same two node IDs in either direction.
+DELETE FROM kg_edges e
+USING _kg_node_canonical m
+WHERE (e.source_node_id = m.duplicate_id OR e.target_node_id = m.duplicate_id)
+  AND EXISTS (
+    SELECT 1 FROM kg_edges existing
+    WHERE existing.id != e.id
+      AND existing.type = e.type
+      AND LEAST(existing.source_node_id::text, existing.target_node_id::text) =
+            LEAST(
+              CASE WHEN e.source_node_id = m.duplicate_id THEN m.canonical_id ELSE e.source_node_id END,
+              CASE WHEN e.target_node_id = m.duplicate_id THEN m.canonical_id ELSE e.target_node_id END
+            )::text
+      AND GREATEST(existing.source_node_id::text, existing.target_node_id::text) =
+            GREATEST(
+              CASE WHEN e.source_node_id = m.duplicate_id THEN m.canonical_id ELSE e.source_node_id END,
+              CASE WHEN e.target_node_id = m.duplicate_id THEN m.canonical_id ELSE e.target_node_id END
+            )::text
+  );
+
+-- Step 3: Re-point remaining edges to the canonical node
+UPDATE kg_edges
+SET source_node_id = m.canonical_id
+FROM _kg_node_canonical m
+WHERE source_node_id = m.duplicate_id;
+
+UPDATE kg_edges
+SET target_node_id = m.canonical_id
+FROM _kg_node_canonical m
+WHERE target_node_id = m.duplicate_id;
+
+-- Step 4: Re-point contacts.kg_node_id to canonical.
+-- If the canonical node already has a contact, NULL out the duplicate's FK
+-- to avoid violating the partial unique index on contacts(kg_node_id).
+-- The nulled-out contact row should be merged via the contact-merge flow.
+UPDATE contacts
+SET kg_node_id = CASE
+  WHEN NOT EXISTS (
+    SELECT 1 FROM contacts c2
+    WHERE c2.kg_node_id = m.canonical_id
+      AND c2.id != contacts.id
+  ) THEN m.canonical_id
+  ELSE NULL
+END
+FROM _kg_node_canonical m
+WHERE contacts.kg_node_id = m.duplicate_id;
+
+-- Step 5: Delete duplicate nodes (ON DELETE CASCADE removes remaining edges)
+DELETE FROM kg_nodes
+WHERE id IN (SELECT duplicate_id FROM _kg_node_canonical);
+
+DROP TABLE _kg_node_canonical;
+
+-- Step 6: Enforce uniqueness going forward.
+-- Excludes fact nodes — facts are intentionally many-per-entity.
+-- Allows same label under different types (e.g. "Apple" org vs "Apple" concept).
+CREATE UNIQUE INDEX idx_kg_nodes_unique
+  ON kg_nodes (lower(label), type)
+  WHERE type != 'fact';
+
+-- Down Migration
+DROP INDEX IF EXISTS idx_kg_nodes_unique;
+-- Note: the dedup data changes are not reversible.

--- a/src/memory/entity-memory.edges.test.ts
+++ b/src/memory/entity-memory.edges.test.ts
@@ -15,9 +15,9 @@ function makeEntityMemory() {
 describe('EntityMemory.findEdges', () => {
   it('returns all edges for a node in both directions', async () => {
     const mem = makeEntityMemory();
-    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
-    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
-    const acme = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+    const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const { entity: xiaopu } = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const { entity: acme } = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
     await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
     await mem.upsertEdge(acme.id, joseph.id, 'member_of', {}, 'test', 0.8); // inbound to joseph
 
@@ -27,9 +27,9 @@ describe('EntityMemory.findEdges', () => {
 
   it('filters by edge type', async () => {
     const mem = makeEntityMemory();
-    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
-    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
-    const acme = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+    const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const { entity: xiaopu } = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const { entity: acme } = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
     await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
     await mem.upsertEdge(joseph.id, acme.id, 'member_of', {}, 'test', 0.8);
 
@@ -41,8 +41,8 @@ describe('EntityMemory.findEdges', () => {
 
   it('labels direction correctly', async () => {
     const mem = makeEntityMemory();
-    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
-    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const { entity: xiaopu } = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
     await mem.upsertEdge(joseph.id, xiaopu.id, 'manages', {}, 'test', 0.8);
 
     const fromJoseph = await mem.findEdges(joseph.id);
@@ -54,10 +54,10 @@ describe('EntityMemory.findEdges', () => {
 
   it('filters out fact-type nodes', async () => {
     const mem = makeEntityMemory();
-    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
     // Store a fact — this creates a 'fact' node linked via 'relates_to' edge
     await mem.storeFact({ entityNodeId: joseph.id, label: 'Lives in Toronto', source: 'test' });
-    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const { entity: xiaopu } = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
     await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
 
     const results = await mem.findEdges(joseph.id);
@@ -68,9 +68,9 @@ describe('EntityMemory.findEdges', () => {
 
   it('filters by direction:inbound', async () => {
     const mem = makeEntityMemory();
-    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
-    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
-    const acme = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+    const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const { entity: xiaopu } = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const { entity: acme } = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
     // joseph manages xiaopu (outbound from joseph)
     await mem.upsertEdge(joseph.id, xiaopu.id, 'manages', {}, 'test', 0.8);
     // acme advises joseph (inbound to joseph)
@@ -86,8 +86,8 @@ describe('EntityMemory.findEdges', () => {
 describe('EntityMemory.deleteEdge', () => {
   it('removes the edge so it no longer appears in findEdges', async () => {
     const mem = makeEntityMemory();
-    const joseph = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
-    const xiaopu = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
+    const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Joseph', properties: {}, source: 'test' });
+    const { entity: xiaopu } = await mem.createEntity({ type: 'person', label: 'Xiaopu', properties: {}, source: 'test' });
     const { edge } = await mem.upsertEdge(joseph.id, xiaopu.id, 'spouse', {}, 'test', 0.9);
 
     await mem.deleteEdge(edge.id);

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -159,9 +159,41 @@ export class EntityMemory {
       }
     }
 
-    // No collision — proceed with normal label update
-    const node = await this.store.updateNode(id, updates);
-    return { node, merged: false };
+    // No collision — proceed with normal label update.
+    // Wrap in try/catch to handle a TOCTOU race: another process may have inserted
+    // a conflicting node between the findNodesByLabel check above and the UPDATE here.
+    // Postgres error 23505 (unique_violation) indicates exactly this scenario.
+    try {
+      const node = await this.store.updateNode(id, updates);
+      return { node, merged: false };
+    } catch (err) {
+      const pgCode = (err as { code?: string }).code;
+      const errMessage = (err as { message?: string }).message ?? '';
+      const isUniqueViolation = pgCode === '23505' || errMessage.toLowerCase().includes('unique');
+
+      if (!isUniqueViolation) throw err;
+
+      // Race lost: re-do collision lookup now that the conflicting row exists.
+      // Re-fetch current to ensure we have the latest type (the node may have been
+      // modified by the concurrent process between our initial getNode and now).
+      const raced = await this.store.getNode(id);
+      if (!raced) throw new Error(`Node not found after unique-violation race: ${id}`);
+
+      const racedCandidates = await this.store.findNodesByLabel(updates.label!);
+      const racedCollision = racedCandidates.find(n => n.type === raced.type && n.id !== id);
+
+      if (!racedCollision) {
+        // The conflicting node was deleted before we re-queried — retry the update.
+        const node = await this.store.updateNode(id, updates);
+        return { node, merged: false };
+      }
+
+      // Collision confirmed post-race: merge as normal.
+      await this.mergeEntities(racedCollision.id, id);
+      const canonical = await this.store.getNode(racedCollision.id);
+      if (!canonical) throw new Error(`Canonical node not found after race-condition merge: ${racedCollision.id}`);
+      return { node: canonical, merged: true };
+    }
   }
 
   /**
@@ -451,6 +483,8 @@ export class EntityMemory {
 
       // Self-loop guard (should not exist, but be defensive)
       if (otherId === secondaryId) continue;
+      // Skip edges pointing to primary — would become self-loops after merge
+      if (otherId === primaryId) continue;
 
       const otherNode = await this.store.getNode(otherId);
       if (!otherNode) continue;

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -314,10 +314,8 @@ export class EntityMemory {
    * - Facts (child fact nodes): secondary's facts are re-stored on primary
    *   via storeFact() to preserve deduplication logic.
    *
-   * Phase 1 scope: scalar properties + facts. Edge re-pointing and secondary
-   * node deletion are deferred to Phase 2.
-   * @TODO Phase 2: re-point relationship edges from secondary to primary,
-   * then delete secondary node.
+   * Phase 1: scalar properties + facts. Phase 2: relationship edge re-pointing
+   * and secondary node deletion (implemented below).
    */
   async mergeEntities(primaryId: string, secondaryId: string): Promise<void> {
     const primaryNode = await this.store.getNode(primaryId);
@@ -370,11 +368,54 @@ export class EntityMemory {
       });
     }
 
-    // @TODO Phase 2: re-point relationship edges from secondaryId to primaryId,
-    // then delete the secondary node. Until then, the secondary node remains in the
-    // KG as a dangling node — its contact row has been deleted, but it is still
-    // reachable via queryEntity(secondaryId) and semantic search. Any code that
-    // resolves a kg_node_id back to a contact will find no contact for this node.
+    // Phase 2: Re-point secondary's entity relationship edges to primary.
+    // We iterate all edges on secondary and upsert equivalent edges on primary.
+    // upsertEdge handles the bidirectional uniqueness constraint atomically —
+    // if primary already has the same edge, confidence is raised rather than
+    // creating a duplicate. Edges to fact nodes are skipped — facts were
+    // already re-stored on primary in Phase 1 via storeFact().
+    const secondaryEdges = await this.store.getEdgesForNode(secondaryId);
+    const secondaryFactNodeIds: string[] = [];
+
+    for (const edge of secondaryEdges) {
+      const isOutbound = edge.sourceNodeId === secondaryId;
+      const otherId = isOutbound ? edge.targetNodeId : edge.sourceNodeId;
+
+      // Self-loop guard (should not exist, but be defensive)
+      if (otherId === secondaryId) continue;
+
+      const otherNode = await this.store.getNode(otherId);
+      if (!otherNode) continue;
+
+      if (otherNode.type === FACT_TYPE) {
+        // Collect secondary fact node IDs for cleanup after edge transfer.
+        // These were re-stored on primary in Phase 1; deleting them here
+        // prevents orphaned fact nodes after the secondary entity is removed.
+        secondaryFactNodeIds.push(otherId);
+        continue;
+      }
+
+      // Transfer the relationship edge to primary
+      await this.store.upsertEdge({
+        sourceNodeId: isOutbound ? primaryId : otherId,
+        targetNodeId: isOutbound ? otherId : primaryId,
+        type: edge.type,
+        properties: edge.properties,
+        confidence: edge.temporal.confidence,
+        decayClass: edge.temporal.decayClass,
+        source: edge.temporal.source,
+      });
+    }
+
+    // Delete secondary's fact nodes (already re-created on primary in Phase 1).
+    // Must happen before deleteNode so cascade doesn't beat us to it.
+    for (const factNodeId of secondaryFactNodeIds) {
+      await this.store.deleteNode(factNodeId);
+    }
+
+    // Delete the secondary entity node. ON DELETE CASCADE on kg_edges removes
+    // any remaining edges (e.g. self-loops or edges not transferred above).
+    await this.store.deleteNode(secondaryId);
   }
 
   /**

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -97,6 +97,68 @@ export class EntityMemory {
   }
 
   /**
+   * Update a node's label and/or properties.
+   *
+   * ╔══════════════════════════════════════════════════════════════════════╗
+   * ║  IMPORTANT — READ BEFORE CALLING THIS METHOD                        ║
+   * ║                                                                      ║
+   * ║  When `updates.label` is provided, this method checks whether the   ║
+   * ║  new label collides with an existing node of the same type.         ║
+   * ║  If a collision is found, the two nodes are MERGED — the existing   ║
+   * ║  node becomes canonical and the node you passed in is DELETED.      ║
+   * ║                                                                      ║
+   * ║  When merged === true:                                               ║
+   * ║    • node.id in the result is DIFFERENT from the id you passed in   ║
+   * ║    • The original id no longer exists in the knowledge graph        ║
+   * ║    • You MUST update any local reference to the old id              ║
+   * ║    • Surface this to the agent — it needs to know the canonical id  ║
+   * ║                                                                      ║
+   * ║  Example:                                                            ║
+   * ║    const { node, merged } = await entityMemory.updateNode(          ║
+   * ║      joeId, { label: 'Joseph Fung' }                                ║
+   * ║    );                                                                ║
+   * ║    if (merged) {                                                     ║
+   * ║      // joeId is gone. node.id is the canonical Joseph Fung node.   ║
+   * ║      // Log, surface to the agent, update your local reference.     ║
+   * ║    }                                                                 ║
+   * ╚══════════════════════════════════════════════════════════════════════╝
+   */
+  async updateNode(
+    id: string,
+    updates: { label?: string; properties?: Record<string, unknown> },
+  ): Promise<{ node: KgNode; merged: boolean }> {
+    if (!updates.label) {
+      // Properties-only update — no collision possible, simple pass-through
+      const node = await this.store.updateNode(id, updates);
+      return { node, merged: false };
+    }
+
+    // Label change: check for a collision with an existing node of the same type
+    const current = await this.store.getNode(id);
+    if (!current) throw new Error(`Node not found: ${id}`);
+
+    if (current.type !== FACT_TYPE) {
+      const candidates = await this.store.findNodesByLabel(updates.label);
+      const collision = candidates.find(n => n.type === current.type && n.id !== id);
+
+      if (collision) {
+        // Merge: the existing node is canonical; the node being renamed is secondary.
+        // mergeEntities handles property merge, fact migration, edge re-pointing,
+        // and deletion of the secondary node.
+        await this.mergeEntities(collision.id, id);
+        // Re-fetch canonical to get post-merge state (properties may have been updated)
+        const canonical = await this.store.getNode(collision.id);
+        if (!canonical) throw new Error(`Canonical node not found after merge: ${collision.id}`);
+        return { node: canonical, merged: true };
+      }
+    }
+
+    // No collision — proceed with normal label update
+    const node = await this.store.updateNode(id, updates);
+    return { node, merged: false };
+  }
+
+  /**
    * Find entity nodes by label (case-insensitive, exact match).
    * Delegates to store.findNodesByLabel which uses ILIKE in Postgres
    * and a toLowerCase comparison in the in-memory backend.

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -79,16 +79,22 @@ export class EntityMemory {
   /**
    * Create a non-fact entity node (person, org, project, etc.).
    * Facts about the entity are stored separately via storeFact().
+   *
+   * Uses upsertNode internally so that calling createEntity twice with the
+   * same (label, type) pair returns the existing node rather than creating
+   * a duplicate. The `created` flag lets callers distinguish first-insert
+   * from re-assertion, which is useful for applying defaults (e.g. roles in
+   * ContactService) without overwriting data set by a later, richer call.
    */
-  async createEntity(options: CreateEntityOptions): Promise<KgNode> {
-    return this.store.createNode({
+  async createEntity(options: CreateEntityOptions): Promise<{ entity: KgNode; created: boolean }> {
+    const { node, created } = await this.store.upsertNode({
       type: options.type,
       label: options.label,
       properties: options.properties,
       source: options.source,
-      // Thread through the optional confidence override
-      confidence: options.confidence,
+      confidence: options.confidence ?? 0.7,
     });
+    return { entity: node, created };
   }
 
   /** Retrieve an entity node by ID. Returns undefined if not found. */

--- a/src/memory/entity-memory.upsert.test.ts
+++ b/src/memory/entity-memory.upsert.test.ts
@@ -3,12 +3,13 @@ import { KnowledgeGraphStore } from './knowledge-graph.js';
 import { EmbeddingService } from './embedding.js';
 import { EntityMemory } from './entity-memory.js';
 import { MemoryValidator } from './validation.js';
+import { createSilentLogger } from '../logger.js';
 
 function makeEntityMemory() {
   const embeddingService = EmbeddingService.createForTesting();
   const store = KnowledgeGraphStore.createInMemory(embeddingService);
   const validator = new MemoryValidator(store, embeddingService);
-  return { mem: new EntityMemory(store, validator, embeddingService), store };
+  return { mem: new EntityMemory(store, validator, embeddingService, createSilentLogger()), store };
 }
 
 describe('EntityMemory.mergeEntities Phase 2', () => {

--- a/src/memory/entity-memory.upsert.test.ts
+++ b/src/memory/entity-memory.upsert.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { KnowledgeGraphStore } from './knowledge-graph.js';
+import { EmbeddingService } from './embedding.js';
+import { EntityMemory } from './entity-memory.js';
+import { MemoryValidator } from './validation.js';
+
+function makeEntityMemory() {
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  return { mem: new EntityMemory(store, validator, embeddingService), store };
+}
+
+describe('EntityMemory.mergeEntities Phase 2', () => {
+  it('re-points secondary edges to primary after merge', async () => {
+    const { mem } = makeEntityMemory();
+    const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const secondary = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+    const org = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+
+    // secondary has a relationship with org
+    await mem.upsertEdge(secondary.id, org.id, 'member_of', {}, 'test', 0.8);
+
+    await mem.mergeEntities(primary.id, secondary.id);
+
+    // secondary node is gone
+    expect(await mem.getEntity(secondary.id)).toBeUndefined();
+
+    // primary now has the edge to org
+    const edges = await mem.findEdges(primary.id);
+    expect(edges.some(e => e.node.id === org.id && e.edge.type === 'member_of')).toBe(true);
+  });
+
+  it('does not duplicate edges that primary already has', async () => {
+    const { mem } = makeEntityMemory();
+    const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const secondary = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+    const org = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+
+    // both nodes already have the same relationship with org
+    await mem.upsertEdge(primary.id, org.id, 'member_of', {}, 'test', 0.7);
+    await mem.upsertEdge(secondary.id, org.id, 'member_of', {}, 'test', 0.9);
+
+    await mem.mergeEntities(primary.id, secondary.id);
+
+    const edges = await mem.findEdges(primary.id);
+    const memberOfEdges = edges.filter(e => e.edge.type === 'member_of' && e.node.id === org.id);
+    // exactly one edge, not two
+    expect(memberOfEdges).toHaveLength(1);
+    // confidence raised to the higher value
+    expect(memberOfEdges[0]!.edge.temporal.confidence).toBe(0.9);
+  });
+
+  it('deletes the secondary node after merge', async () => {
+    const { mem } = makeEntityMemory();
+    const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const secondary = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+
+    await mem.mergeEntities(primary.id, secondary.id);
+
+    expect(await mem.getEntity(secondary.id)).toBeUndefined();
+  });
+
+  it('cleans up secondary fact nodes after merge (no orphans)', async () => {
+    const { mem } = makeEntityMemory();
+    const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const secondary = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+
+    await mem.storeFact({
+      entityNodeId: secondary.id,
+      label: 'title: CEO',
+      properties: {},
+      confidence: 0.8,
+      source: 'test',
+    });
+
+    // get the secondary fact node ID before merge
+    const preMergeFacts = await mem.getFacts(secondary.id);
+    expect(preMergeFacts).toHaveLength(1);
+    const secondaryFactId = preMergeFacts[0]!.id;
+
+    await mem.mergeEntities(primary.id, secondary.id);
+
+    // secondary fact node itself is deleted (not orphaned)
+    expect(await mem.getEntity(secondaryFactId)).toBeUndefined();
+
+    // primary has the fact (re-stored in Phase 1)
+    const primaryFacts = await mem.getFacts(primary.id);
+    expect(primaryFacts.some(f => f.label === 'title: CEO')).toBe(true);
+  });
+});

--- a/src/memory/entity-memory.upsert.test.ts
+++ b/src/memory/entity-memory.upsert.test.ts
@@ -89,3 +89,66 @@ describe('EntityMemory.mergeEntities Phase 2', () => {
     expect(primaryFacts.some(f => f.label === 'title: CEO')).toBe(true);
   });
 });
+
+describe('EntityMemory.updateNode', () => {
+  it('updates properties without merge when no label change', async () => {
+    const { mem } = makeEntityMemory();
+    const node = await mem.createEntity({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+
+    const { node: updated, merged } = await mem.updateNode(node.id, { properties: { role: 'CEO' } });
+
+    expect(merged).toBe(false);
+    expect(updated.id).toBe(node.id);
+    expect(updated.properties).toEqual({ role: 'CEO' });
+  });
+
+  it('updates label without merge when no collision', async () => {
+    const { mem } = makeEntityMemory();
+    const node = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+
+    const { node: updated, merged } = await mem.updateNode(node.id, { label: 'Joseph' });
+
+    expect(merged).toBe(false);
+    expect(updated.id).toBe(node.id);
+    expect(updated.label).toBe('Joseph');
+  });
+
+  it('merges nodes when label update collides with an existing node of the same type', async () => {
+    const { mem } = makeEntityMemory();
+    const canonical = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const toRename = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+
+    const { node: result, merged } = await mem.updateNode(toRename.id, { label: 'Joseph Fung' });
+
+    expect(merged).toBe(true);
+    // Returned node is the canonical, not the renamed node
+    expect(result.id).toBe(canonical.id);
+    // The renamed node no longer exists
+    expect(await mem.getEntity(toRename.id)).toBeUndefined();
+  });
+
+  it('does NOT merge when same label but different type', async () => {
+    const { mem } = makeEntityMemory();
+    await mem.createEntity({ type: 'organization', label: 'Apple', properties: {}, source: 'test' });
+    const concept = await mem.createEntity({ type: 'concept', label: 'Fruit', properties: {}, source: 'test' });
+
+    // Renaming concept to 'Apple' — no collision because types differ
+    const { merged } = await mem.updateNode(concept.id, { label: 'Apple' });
+
+    expect(merged).toBe(false);
+  });
+
+  it('transfers edges to canonical on merge-on-collision', async () => {
+    const { mem } = makeEntityMemory();
+    const canonical = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const toRename = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+    const org = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+
+    await mem.upsertEdge(toRename.id, org.id, 'member_of', {}, 'test', 0.8);
+
+    await mem.updateNode(toRename.id, { label: 'Joseph Fung' });
+
+    const edges = await mem.findEdges(canonical.id);
+    expect(edges.some(e => e.node.id === org.id && e.edge.type === 'member_of')).toBe(true);
+  });
+});

--- a/src/memory/entity-memory.upsert.test.ts
+++ b/src/memory/entity-memory.upsert.test.ts
@@ -14,9 +14,9 @@ function makeEntityMemory() {
 describe('EntityMemory.mergeEntities Phase 2', () => {
   it('re-points secondary edges to primary after merge', async () => {
     const { mem } = makeEntityMemory();
-    const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
-    const secondary = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
-    const org = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+    const { entity: primary } = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const { entity: secondary } = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+    const { entity: org } = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
 
     // secondary has a relationship with org
     await mem.upsertEdge(secondary.id, org.id, 'member_of', {}, 'test', 0.8);
@@ -33,9 +33,9 @@ describe('EntityMemory.mergeEntities Phase 2', () => {
 
   it('does not duplicate edges that primary already has', async () => {
     const { mem } = makeEntityMemory();
-    const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
-    const secondary = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
-    const org = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+    const { entity: primary } = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const { entity: secondary } = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+    const { entity: org } = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
 
     // both nodes already have the same relationship with org
     await mem.upsertEdge(primary.id, org.id, 'member_of', {}, 'test', 0.7);
@@ -53,8 +53,8 @@ describe('EntityMemory.mergeEntities Phase 2', () => {
 
   it('deletes the secondary node after merge', async () => {
     const { mem } = makeEntityMemory();
-    const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
-    const secondary = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+    const { entity: primary } = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const { entity: secondary } = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
 
     await mem.mergeEntities(primary.id, secondary.id);
 
@@ -63,8 +63,8 @@ describe('EntityMemory.mergeEntities Phase 2', () => {
 
   it('cleans up secondary fact nodes after merge (no orphans)', async () => {
     const { mem } = makeEntityMemory();
-    const primary = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
-    const secondary = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+    const { entity: primary } = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const { entity: secondary } = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
 
     await mem.storeFact({
       entityNodeId: secondary.id,
@@ -93,7 +93,7 @@ describe('EntityMemory.mergeEntities Phase 2', () => {
 describe('EntityMemory.updateNode', () => {
   it('updates properties without merge when no label change', async () => {
     const { mem } = makeEntityMemory();
-    const node = await mem.createEntity({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const { entity: node } = await mem.createEntity({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
 
     const { node: updated, merged } = await mem.updateNode(node.id, { properties: { role: 'CEO' } });
 
@@ -104,7 +104,7 @@ describe('EntityMemory.updateNode', () => {
 
   it('updates label without merge when no collision', async () => {
     const { mem } = makeEntityMemory();
-    const node = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+    const { entity: node } = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
 
     const { node: updated, merged } = await mem.updateNode(node.id, { label: 'Joseph' });
 
@@ -115,8 +115,8 @@ describe('EntityMemory.updateNode', () => {
 
   it('merges nodes when label update collides with an existing node of the same type', async () => {
     const { mem } = makeEntityMemory();
-    const canonical = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
-    const toRename = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+    const { entity: canonical } = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const { entity: toRename } = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
 
     const { node: result, merged } = await mem.updateNode(toRename.id, { label: 'Joseph Fung' });
 
@@ -130,7 +130,7 @@ describe('EntityMemory.updateNode', () => {
   it('does NOT merge when same label but different type', async () => {
     const { mem } = makeEntityMemory();
     await mem.createEntity({ type: 'organization', label: 'Apple', properties: {}, source: 'test' });
-    const concept = await mem.createEntity({ type: 'concept', label: 'Fruit', properties: {}, source: 'test' });
+    const { entity: concept } = await mem.createEntity({ type: 'concept', label: 'Fruit', properties: {}, source: 'test' });
 
     // Renaming concept to 'Apple' — no collision because types differ
     const { merged } = await mem.updateNode(concept.id, { label: 'Apple' });
@@ -140,9 +140,9 @@ describe('EntityMemory.updateNode', () => {
 
   it('transfers edges to canonical on merge-on-collision', async () => {
     const { mem } = makeEntityMemory();
-    const canonical = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
-    const toRename = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
-    const org = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
+    const { entity: canonical } = await mem.createEntity({ type: 'person', label: 'Joseph Fung', properties: {}, source: 'test' });
+    const { entity: toRename } = await mem.createEntity({ type: 'person', label: 'Joe', properties: {}, source: 'test' });
+    const { entity: org } = await mem.createEntity({ type: 'organization', label: 'Acme', properties: {}, source: 'test' });
 
     await mem.upsertEdge(toRename.id, org.id, 'member_of', {}, 'test', 0.8);
 
@@ -150,5 +150,38 @@ describe('EntityMemory.updateNode', () => {
 
     const edges = await mem.findEdges(canonical.id);
     expect(edges.some(e => e.node.id === org.id && e.edge.type === 'member_of')).toBe(true);
+  });
+});
+
+describe('EntityMemory.createEntity', () => {
+  it('returns { entity, created: true } on first call', async () => {
+    const { mem } = makeEntityMemory();
+
+    const result = await mem.createEntity({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+
+    expect(result.created).toBe(true);
+    expect(result.entity.label).toBe('Alice');
+    expect(result.entity.type).toBe('person');
+  });
+
+  it('returns { entity, created: false } on second call with same (label, type)', async () => {
+    const { mem } = makeEntityMemory();
+
+    const first = await mem.createEntity({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const second = await mem.createEntity({ type: 'person', label: 'ALICE', properties: {}, source: 'test' });
+
+    expect(second.created).toBe(false);
+    expect(second.entity.id).toBe(first.entity.id);
+  });
+
+  it('returns created: true for same label under different types', async () => {
+    const { mem } = makeEntityMemory();
+
+    const r1 = await mem.createEntity({ type: 'person', label: 'Apple', properties: {}, source: 'test' });
+    const r2 = await mem.createEntity({ type: 'organization', label: 'Apple', properties: {}, source: 'test' });
+
+    expect(r1.created).toBe(true);
+    expect(r2.created).toBe(true);
+    expect(r1.entity.id).not.toBe(r2.entity.id);
   });
 });

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -57,6 +57,9 @@ interface KnowledgeGraphBackend {
   // Atomic upsert: creates if no matching (src, tgt, type) pair exists in either
   // direction; otherwise raises confidence and refreshes lastConfirmedAt.
   upsertEdge(edge: KgEdge): Promise<{ edge: KgEdge; created: boolean }>;
+  // Idempotent node creation: matches on lower(label) + type for non-fact nodes.
+  // fact nodes always insert as new regardless of label collision.
+  upsertNode(node: KgNode): Promise<{ node: KgNode; created: boolean }>;
   traverse(startNodeId: string, maxDepth: number): Promise<TraversalResult>;
   semanticSearch(queryEmbedding: number[], limit: number): Promise<SearchResult[]>;
 }
@@ -126,6 +129,40 @@ export class KnowledgeGraphStore {
 
     await this.backend.createNode(node);
     return node;
+  }
+
+  /**
+   * Idempotent node creation for non-fact entity nodes.
+   *
+   * Creates a new node if none with the same (lower(label), type) exists.
+   * If one exists, raises its confidence (never lowers) and refreshes
+   * lastConfirmedAt. Properties, label, and embedding of the existing node
+   * are left untouched — use updateNode() to change those explicitly.
+   *
+   * fact nodes always create a new node regardless of label collision.
+   *
+   * Returns the persisted node and whether it was newly created.
+   */
+  async upsertNode(options: CreateNodeOptions & { confidence: number }): Promise<{ node: KgNode; created: boolean }> {
+    const now = new Date();
+    const embedding = options.embedding ?? await this.embeddingService.embed(options.label);
+
+    const node: KgNode = {
+      id: createNodeId(),
+      type: options.type,
+      label: options.label,
+      properties: { ...options.properties },
+      embedding,
+      temporal: {
+        createdAt: now,
+        lastConfirmedAt: now,
+        confidence: options.confidence,
+        decayClass: options.decayClass ?? 'slow_decay',
+        source: options.source,
+      },
+    };
+
+    return this.backend.upsertNode(node);
   }
 
   /** Retrieve a node by ID, or undefined if not found */
@@ -298,6 +335,40 @@ class PostgresBackend implements KnowledgeGraphBackend {
         node.temporal.lastConfirmedAt,
       ],
     );
+  }
+
+  async upsertNode(node: KgNode): Promise<{ node: KgNode; created: boolean }> {
+    this.logger.debug({ type: node.type, label: node.label }, 'kg: upserting node');
+    const embeddingStr = node.embedding ? `[${node.embedding.join(',')}]` : null;
+    const result = await this.pool.query<PgNodeRow & { is_new: boolean }>(
+      `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at)
+       VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $9)
+       ON CONFLICT (lower(label), type) WHERE type != 'fact'
+       DO UPDATE SET
+         confidence = GREATEST(kg_nodes.confidence, EXCLUDED.confidence),
+         last_confirmed_at = EXCLUDED.last_confirmed_at
+       RETURNING *, (created_at = $9) AS is_new`,
+      [
+        node.id,
+        node.type,
+        node.label,
+        JSON.stringify(node.properties),
+        embeddingStr,
+        node.temporal.confidence,
+        node.temporal.decayClass,
+        node.temporal.source,
+        node.temporal.createdAt,
+      ],
+    );
+    const row = result.rows[0];
+    if (!row) {
+      this.logger.error(
+        { type: node.type, label: node.label },
+        'kg: upsertNode — RETURNING produced no row; possible trigger or RLS suppression',
+      );
+      throw new Error('upsertNode: database returned no row after INSERT ... ON CONFLICT');
+    }
+    return { node: pgRowToNode(row), created: row.is_new };
   }
 
   async getNode(id: string): Promise<KgNode | undefined> {
@@ -591,6 +662,39 @@ class InMemoryBackend implements KnowledgeGraphBackend {
 
   async createNode(node: KgNode): Promise<void> {
     this.nodes.set(node.id, node);
+  }
+
+  async upsertNode(node: KgNode): Promise<{ node: KgNode; created: boolean }> {
+    // fact nodes are never deduplicated — always insert as new
+    if (node.type === 'fact') {
+      this.nodes.set(node.id, node);
+      return { node, created: true };
+    }
+
+    const lowerLabel = node.label.toLowerCase();
+    let existing: KgNode | undefined;
+    for (const n of this.nodes.values()) {
+      if (n.type !== 'fact' && n.label.toLowerCase() === lowerLabel && n.type === node.type) {
+        existing = n;
+        break;
+      }
+    }
+
+    if (existing) {
+      const updated: KgNode = {
+        ...existing,
+        temporal: {
+          ...existing.temporal,
+          confidence: Math.max(existing.temporal.confidence, node.temporal.confidence),
+          lastConfirmedAt: node.temporal.lastConfirmedAt,
+        },
+      };
+      this.nodes.set(existing.id, updated);
+      return { node: updated, created: false };
+    }
+
+    this.nodes.set(node.id, node);
+    return { node, created: true };
   }
 
   async getNode(id: string): Promise<KgNode | undefined> {

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -347,7 +347,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
        DO UPDATE SET
          confidence = GREATEST(kg_nodes.confidence, EXCLUDED.confidence),
          last_confirmed_at = EXCLUDED.last_confirmed_at
-       RETURNING *, (created_at = $9) AS is_new`,
+       RETURNING *, (xmax = 0) AS is_new`,
       [
         node.id,
         node.type,
@@ -458,8 +458,8 @@ class PostgresBackend implements KnowledgeGraphBackend {
   async upsertEdge(edge: KgEdge): Promise<{ edge: KgEdge; created: boolean }> {
     this.logger.debug({ sourceNodeId: edge.sourceNodeId, targetNodeId: edge.targetNodeId, type: edge.type }, 'kg: upserting edge');
     // ON CONFLICT uses the full expression from idx_kg_edges_unique.
-    // RETURNING (created_at = $9) detects new inserts: for a new row, created_at equals
-    // the value we passed in ($9 = now); for an update, created_at stays as the original.
+    // xmax = 0 reliably detects new inserts: Postgres sets xmax to 0 on INSERT and
+    // to the updating transaction XID on UPDATE, making it the canonical new-row check.
     const result = await this.pool.query<PgEdgeRow & { is_new: boolean }>(
       `INSERT INTO kg_edges
          (id, source_node_id, target_node_id, type, properties, confidence, decay_class, source, created_at, last_confirmed_at)
@@ -471,7 +471,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
        ) DO UPDATE SET
          confidence = GREATEST(kg_edges.confidence, EXCLUDED.confidence),
          last_confirmed_at = EXCLUDED.last_confirmed_at
-       RETURNING *, (created_at = $9) AS is_new`,
+       RETURNING *, (xmax = 0) AS is_new`,
       [
         edge.id,
         edge.sourceNodeId,

--- a/src/memory/knowledge-graph.upsert.test.ts
+++ b/src/memory/knowledge-graph.upsert.test.ts
@@ -64,3 +64,64 @@ describe('KnowledgeGraphStore.upsertEdge', () => {
     expect(edge.temporal.confidence).toBe(0.9); // not lowered
   });
 });
+
+describe('KnowledgeGraphStore.upsertNode', () => {
+  it('creates a new node and returns created:true', async () => {
+    const store = makeStore();
+
+    const { node, created } = await store.upsertNode({
+      type: 'person',
+      label: 'Alice',
+      properties: {},
+      confidence: 0.8,
+      source: 'test',
+    });
+
+    expect(created).toBe(true);
+    expect(node.label).toBe('Alice');
+    expect(node.temporal.confidence).toBe(0.8);
+  });
+
+  it('returns existing node with created:false on same (label, type)', async () => {
+    const store = makeStore();
+
+    const { node: first } = await store.upsertNode({ type: 'person', label: 'Alice', properties: {}, confidence: 0.8, source: 'test' });
+    const { node: second, created } = await store.upsertNode({ type: 'person', label: 'ALICE', properties: { extra: true }, confidence: 0.9, source: 'test' });
+
+    expect(created).toBe(false);
+    expect(second.id).toBe(first.id);
+    // Confidence raised
+    expect(second.temporal.confidence).toBe(0.9);
+    // Properties NOT overwritten on conflict
+    expect(second.properties).not.toHaveProperty('extra');
+  });
+
+  it('never lowers confidence on re-assertion', async () => {
+    const store = makeStore();
+
+    await store.upsertNode({ type: 'person', label: 'Alice', properties: {}, confidence: 0.9, source: 'test' });
+    const { node } = await store.upsertNode({ type: 'person', label: 'Alice', properties: {}, confidence: 0.5, source: 'test' });
+
+    expect(node.temporal.confidence).toBe(0.9);
+  });
+
+  it('allows same label under different types', async () => {
+    const store = makeStore();
+
+    const { created: c1 } = await store.upsertNode({ type: 'person', label: 'Apple', properties: {}, confidence: 0.8, source: 'test' });
+    const { created: c2 } = await store.upsertNode({ type: 'organization', label: 'Apple', properties: {}, confidence: 0.8, source: 'test' });
+
+    expect(c1).toBe(true);
+    expect(c2).toBe(true);
+  });
+
+  it('always creates fact nodes regardless of label collision', async () => {
+    const store = makeStore();
+
+    const { created: c1 } = await store.upsertNode({ type: 'fact', label: 'CEO', properties: {}, confidence: 0.8, source: 'test' });
+    const { created: c2 } = await store.upsertNode({ type: 'fact', label: 'CEO', properties: {}, confidence: 0.8, source: 'test' });
+
+    expect(c1).toBe(true);
+    expect(c2).toBe(true); // fact nodes are always new inserts, not upserts
+  });
+});

--- a/tests/integration/contacts.test.ts
+++ b/tests/integration/contacts.test.ts
@@ -58,12 +58,14 @@ describeIf('Contacts Integration', () => {
 
   it('creates a contact with auto-linked KG node', async () => {
     const contact = await contactService.createContact({
-      displayName: 'Integration Test Person',
+      // Unique name: avoids collision with knowledge-graph.test.ts which also creates
+      // "Integration Test Person" — upsertNode would share the node, breaking cleanup.
+      displayName: 'Contacts-Only Test Person',
       role: 'Advisor',
       source: 'integration-test',
     });
     expect(contact.id).toBeDefined();
-    expect(contact.displayName).toBe('Integration Test Person');
+    expect(contact.displayName).toBe('Contacts-Only Test Person');
     expect(contact.role).toBe('Advisor');
     // entityMemory is wired in, so a KG person node should be auto-created
     expect(contact.kgNodeId).toBeDefined();

--- a/tests/integration/extract-relationships.test.ts
+++ b/tests/integration/extract-relationships.test.ts
@@ -63,11 +63,20 @@ describeIf('extract-relationships integration', () => {
 
     // Clean any stale rows from previous runs that crashed before teardown.
     // Without this, leftover 'integration-test' rows cause flaky toHaveLength(1) failures.
+    // Delete contacts first: contacts may reference kg_nodes (due to upsertNode dedup), and
+    // FK constraints require contacts to be removed before their referenced nodes can be deleted.
+    await pool.query("DELETE FROM contact_auth_overrides WHERE contact_id IN (SELECT c.id FROM contacts c JOIN kg_nodes n ON c.kg_node_id = n.id WHERE n.source = 'integration-test')");
+    await pool.query("DELETE FROM contact_channel_identities WHERE contact_id IN (SELECT c.id FROM contacts c JOIN kg_nodes n ON c.kg_node_id = n.id WHERE n.source = 'integration-test')");
+    await pool.query("DELETE FROM contacts WHERE kg_node_id IN (SELECT id FROM kg_nodes WHERE source = 'integration-test')");
     await pool.query("DELETE FROM kg_edges WHERE source = 'integration-test'");
     await pool.query("DELETE FROM kg_nodes WHERE source = 'integration-test'");
   });
 
   afterAll(async () => {
+    // Same FK-safe order as beforeAll cleanup.
+    await pool.query("DELETE FROM contact_auth_overrides WHERE contact_id IN (SELECT c.id FROM contacts c JOIN kg_nodes n ON c.kg_node_id = n.id WHERE n.source = 'integration-test')");
+    await pool.query("DELETE FROM contact_channel_identities WHERE contact_id IN (SELECT c.id FROM contacts c JOIN kg_nodes n ON c.kg_node_id = n.id WHERE n.source = 'integration-test')");
+    await pool.query("DELETE FROM contacts WHERE kg_node_id IN (SELECT id FROM kg_nodes WHERE source = 'integration-test')");
     await pool.query("DELETE FROM kg_edges WHERE source = 'integration-test'");
     await pool.query("DELETE FROM kg_nodes WHERE source = 'integration-test'");
     await pool.end();

--- a/tests/integration/knowledge-graph.test.ts
+++ b/tests/integration/knowledge-graph.test.ts
@@ -30,7 +30,12 @@ describeIf('Knowledge Graph Integration', () => {
   });
 
   afterAll(async () => {
-    // Clean up test data
+    // Clean up test data in FK-safe order.
+    // Contacts (from the contacts integration test running concurrently) may reference
+    // kg_nodes, so we must clear contacts first to avoid a FK violation on DELETE FROM kg_nodes.
+    await pool.query('DELETE FROM contact_auth_overrides');
+    await pool.query('DELETE FROM contact_channel_identities');
+    await pool.query('DELETE FROM contacts');
     await pool.query('DELETE FROM kg_edges');
     await pool.query('DELETE FROM kg_nodes');
     await pool.end();

--- a/tests/integration/knowledge-graph.test.ts
+++ b/tests/integration/knowledge-graph.test.ts
@@ -75,7 +75,7 @@ describeIf('Knowledge Graph Integration', () => {
   });
 
   it('stores and retrieves entity facts via EntityMemory', async () => {
-    const entity = await entityMemory.createEntity({
+    const { entity } = await entityMemory.createEntity({
       type: 'person',
       label: 'Integration Person',
       properties: {},

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -73,7 +73,7 @@ describe('ContactService', () => {
     });
 
     it('links to existing KG node when kgNodeId provided', async () => {
-      const entity = await entityMemory.createEntity({
+      const { entity } = await entityMemory.createEntity({
         type: 'person',
         label: 'Existing Person',
         properties: {},
@@ -544,22 +544,23 @@ describe('ContactService', () => {
 
 describe('EntityMemory.mergeEntities', () => {
   let entityMemory: EntityMemory;
+  let store: KnowledgeGraphStore;
 
   beforeEach(() => {
     const embeddingService = EmbeddingService.createForTesting();
-    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    store = KnowledgeGraphStore.createInMemory(embeddingService);
     const validator = new MemoryValidator(store, embeddingService);
     entityMemory = new EntityMemory(store, validator, embeddingService, createSilentLogger());
   });
 
   it('merges scalar properties onto primary node (most-recent-wins)', async () => {
-    const primary = await entityMemory.createEntity({
+    const { entity: primary } = await entityMemory.createEntity({
       type: 'person',
       label: 'Jenna Torres',
       properties: { title: 'CFO', city: 'Toronto' },
       source: 'test',
     });
-    const secondary = await entityMemory.createEntity({
+    const { entity: secondary } = await entityMemory.createEntity({
       type: 'person',
       label: 'J. Torres',
       properties: { title: 'Chief Financial Officer', city: 'New York' },
@@ -575,13 +576,13 @@ describe('EntityMemory.mergeEntities', () => {
   });
 
   it('secondary properties override primary when secondary was updated more recently', async () => {
-    const primary = await entityMemory.createEntity({
+    const { entity: primary } = await entityMemory.createEntity({
       type: 'person',
       label: 'Old Primary',
       properties: { city: 'Toronto', title: 'CFO' },
       source: 'test',
     });
-    const secondary = await entityMemory.createEntity({
+    const { entity: secondary } = await entityMemory.createEntity({
       type: 'person',
       label: 'New Secondary',
       properties: { city: 'New York', title: 'Chief Financial Officer' },
@@ -607,13 +608,15 @@ describe('EntityMemory.mergeEntities', () => {
   });
 
   it('does not affect the primary node when secondary has no properties', async () => {
-    const primary = await entityMemory.createEntity({
+    const { entity: primary } = await entityMemory.createEntity({
       type: 'person',
       label: 'Alice',
       properties: { city: 'Vancouver' },
       source: 'test',
     });
-    const secondary = await entityMemory.createEntity({
+    // Insert secondary directly via store to bypass upsert dedup
+    // (simulates pre-migration duplicate with same label but empty properties)
+    const secondary = await store.createNode({
       type: 'person',
       label: 'Alice',
       properties: {},

--- a/tests/unit/memory/entity-memory.test.ts
+++ b/tests/unit/memory/entity-memory.test.ts
@@ -18,7 +18,7 @@ describe('EntityMemory', () => {
 
   describe('entity management', () => {
     it('creates a new entity and retrieves it', async () => {
-      const entity = await entityMemory.createEntity({
+      const { entity } = await entityMemory.createEntity({
         type: 'person',
         label: 'Joseph Fung',
         properties: { title: 'CEO' },
@@ -53,7 +53,7 @@ describe('EntityMemory', () => {
     });
 
     it('stores entity properties on the node', async () => {
-      const entity = await entityMemory.createEntity({
+      const { entity } = await entityMemory.createEntity({
         type: 'organization',
         label: 'Curia',
         properties: { founded: 2023, industry: 'AI' },
@@ -66,7 +66,7 @@ describe('EntityMemory', () => {
 
   describe('fact management', () => {
     it('stores a fact about an entity', async () => {
-      const entity = await entityMemory.createEntity({
+      const { entity } = await entityMemory.createEntity({
         type: 'person',
         label: 'Joseph',
         properties: {},
@@ -82,7 +82,7 @@ describe('EntityMemory', () => {
     });
 
     it('returns nodeId when a fact is stored', async () => {
-      const entity = await entityMemory.createEntity({
+      const { entity } = await entityMemory.createEntity({
         type: 'person',
         label: 'Joseph',
         properties: {},
@@ -98,7 +98,7 @@ describe('EntityMemory', () => {
     });
 
     it('retrieves all facts about an entity', async () => {
-      const entity = await entityMemory.createEntity({
+      const { entity } = await entityMemory.createEntity({
         type: 'person',
         label: 'Joseph',
         properties: {},
@@ -119,13 +119,13 @@ describe('EntityMemory', () => {
     });
 
     it('getFacts returns only fact-type nodes, not entity nodes', async () => {
-      const personA = await entityMemory.createEntity({
+      const { entity: personA } = await entityMemory.createEntity({
         type: 'person',
         label: 'Alice',
         properties: {},
         source: 'test',
       });
-      const personB = await entityMemory.createEntity({
+      const { entity: personB } = await entityMemory.createEntity({
         type: 'person',
         label: 'Bob',
         properties: {},
@@ -147,7 +147,7 @@ describe('EntityMemory', () => {
     });
 
     it('deduplicates identical facts (returns stored:true with existing nodeId)', async () => {
-      const entity = await entityMemory.createEntity({
+      const { entity } = await entityMemory.createEntity({
         type: 'person',
         label: 'Joseph',
         properties: {},
@@ -174,7 +174,7 @@ describe('EntityMemory', () => {
     });
 
     it('returns stored:false with conflict reason on contradiction', async () => {
-      const entity = await entityMemory.createEntity({
+      const { entity } = await entityMemory.createEntity({
         type: 'person',
         label: 'Joseph',
         properties: {},
@@ -210,13 +210,13 @@ describe('EntityMemory', () => {
 
   describe('link', () => {
     it('creates a directed edge between two entities', async () => {
-      const person = await entityMemory.createEntity({
+      const { entity: person } = await entityMemory.createEntity({
         type: 'person',
         label: 'Alice',
         properties: {},
         source: 'test',
       });
-      const project = await entityMemory.createEntity({
+      const { entity: project } = await entityMemory.createEntity({
         type: 'project',
         label: 'Curia',
         properties: {},
@@ -232,7 +232,7 @@ describe('EntityMemory', () => {
 
   describe('semantic search', () => {
     it('searches across all knowledge', async () => {
-      const entity = await entityMemory.createEntity({
+      const { entity } = await entityMemory.createEntity({
         type: 'project',
         label: 'Curia AI Platform',
         properties: {},
@@ -269,7 +269,7 @@ describe('EntityMemory', () => {
       const validator = new MemoryValidator(localStore, embeddingService);
       const em = new EntityMemory(localStore, validator, embeddingService, createSilentLogger());
 
-      const entity = await em.createEntity({
+      const { entity } = await em.createEntity({
         type: 'person',
         label: 'Test Subject',
         properties: {},
@@ -305,13 +305,13 @@ describe('EntityMemory', () => {
 
   describe('query - what do I know about X?', () => {
     it('returns entity with connected facts and relationships', async () => {
-      const person = await entityMemory.createEntity({
+      const { entity: person } = await entityMemory.createEntity({
         type: 'person',
         label: 'Alice',
         properties: {},
         source: 'test',
       });
-      const project = await entityMemory.createEntity({
+      const { entity: project } = await entityMemory.createEntity({
         type: 'project',
         label: 'Curia',
         properties: {},
@@ -330,7 +330,7 @@ describe('EntityMemory', () => {
     });
 
     it('returns the queried entity node', async () => {
-      const entity = await entityMemory.createEntity({
+      const { entity } = await entityMemory.createEntity({
         type: 'organization',
         label: 'Anthropic',
         properties: { sector: 'AI safety' },
@@ -342,7 +342,7 @@ describe('EntityMemory', () => {
     });
 
     it('returns empty facts and relationships when entity is isolated', async () => {
-      const entity = await entityMemory.createEntity({
+      const { entity } = await entityMemory.createEntity({
         type: 'concept',
         label: 'Isolated Node',
         properties: {},
@@ -355,13 +355,13 @@ describe('EntityMemory', () => {
     });
 
     it('relationships include the edge and the connected node', async () => {
-      const a = await entityMemory.createEntity({
+      const { entity: a } = await entityMemory.createEntity({
         type: 'person',
         label: 'Bob',
         properties: {},
         source: 'test',
       });
-      const b = await entityMemory.createEntity({
+      const { entity: b } = await entityMemory.createEntity({
         type: 'project',
         label: 'ProjectX',
         properties: {},
@@ -383,8 +383,8 @@ describe('EntityMemory', () => {
 
   describe('upsertEdge', () => {
     it('creates a new edge when none exists', async () => {
-      const a = await entityMemory.createEntity({ type: 'person', label: 'Upsert-A', properties: {}, source: 'test' });
-      const b = await entityMemory.createEntity({ type: 'person', label: 'Upsert-B', properties: {}, source: 'test' });
+      const { entity: a } = await entityMemory.createEntity({ type: 'person', label: 'Upsert-A', properties: {}, source: 'test' });
+      const { entity: b } = await entityMemory.createEntity({ type: 'person', label: 'Upsert-B', properties: {}, source: 'test' });
 
       const result = await entityMemory.upsertEdge(a.id, b.id, 'spouse', {}, 'test', 0.8);
 
@@ -394,8 +394,8 @@ describe('EntityMemory', () => {
     });
 
     it('confirms an existing edge when called again with same direction', async () => {
-      const a = await entityMemory.createEntity({ type: 'person', label: 'Upsert-C', properties: {}, source: 'test' });
-      const b = await entityMemory.createEntity({ type: 'person', label: 'Upsert-D', properties: {}, source: 'test' });
+      const { entity: a } = await entityMemory.createEntity({ type: 'person', label: 'Upsert-C', properties: {}, source: 'test' });
+      const { entity: b } = await entityMemory.createEntity({ type: 'person', label: 'Upsert-D', properties: {}, source: 'test' });
       await entityMemory.upsertEdge(a.id, b.id, 'manages', {}, 'test', 0.7);
 
       const result = await entityMemory.upsertEdge(a.id, b.id, 'manages', {}, 'test', 0.7);
@@ -407,8 +407,8 @@ describe('EntityMemory', () => {
     });
 
     it('confirms an existing edge when called with reversed direction (bidirectional check)', async () => {
-      const a = await entityMemory.createEntity({ type: 'person', label: 'Upsert-E', properties: {}, source: 'test' });
-      const b = await entityMemory.createEntity({ type: 'person', label: 'Upsert-F', properties: {}, source: 'test' });
+      const { entity: a } = await entityMemory.createEntity({ type: 'person', label: 'Upsert-E', properties: {}, source: 'test' });
+      const { entity: b } = await entityMemory.createEntity({ type: 'person', label: 'Upsert-F', properties: {}, source: 'test' });
       await entityMemory.upsertEdge(a.id, b.id, 'spouse', {}, 'test', 0.8);
 
       // Call with reversed order — should confirm the existing edge, not create a duplicate
@@ -420,8 +420,8 @@ describe('EntityMemory', () => {
     });
 
     it('raises confidence when re-assertion has higher confidence', async () => {
-      const a = await entityMemory.createEntity({ type: 'person', label: 'Upsert-G', properties: {}, source: 'test' });
-      const b = await entityMemory.createEntity({ type: 'person', label: 'Upsert-H', properties: {}, source: 'test' });
+      const { entity: a } = await entityMemory.createEntity({ type: 'person', label: 'Upsert-G', properties: {}, source: 'test' });
+      const { entity: b } = await entityMemory.createEntity({ type: 'person', label: 'Upsert-H', properties: {}, source: 'test' });
       await entityMemory.upsertEdge(a.id, b.id, 'reports_to', {}, 'test', 0.6);
 
       const result = await entityMemory.upsertEdge(a.id, b.id, 'reports_to', {}, 'test', 0.9);
@@ -431,8 +431,8 @@ describe('EntityMemory', () => {
     });
 
     it('does not lower confidence when re-assertion has lower confidence', async () => {
-      const a = await entityMemory.createEntity({ type: 'person', label: 'Upsert-I', properties: {}, source: 'test' });
-      const b = await entityMemory.createEntity({ type: 'person', label: 'Upsert-J', properties: {}, source: 'test' });
+      const { entity: a } = await entityMemory.createEntity({ type: 'person', label: 'Upsert-I', properties: {}, source: 'test' });
+      const { entity: b } = await entityMemory.createEntity({ type: 'person', label: 'Upsert-J', properties: {}, source: 'test' });
       await entityMemory.upsertEdge(a.id, b.id, 'sibling', {}, 'test', 0.9);
 
       const result = await entityMemory.upsertEdge(a.id, b.id, 'sibling', {}, 'test', 0.3);
@@ -443,8 +443,8 @@ describe('EntityMemory', () => {
     });
 
     it('refreshes lastConfirmedAt on re-assertion', async () => {
-      const a = await entityMemory.createEntity({ type: 'person', label: 'Upsert-K', properties: {}, source: 'test' });
-      const b = await entityMemory.createEntity({ type: 'person', label: 'Upsert-L', properties: {}, source: 'test' });
+      const { entity: a } = await entityMemory.createEntity({ type: 'person', label: 'Upsert-K', properties: {}, source: 'test' });
+      const { entity: b } = await entityMemory.createEntity({ type: 'person', label: 'Upsert-L', properties: {}, source: 'test' });
       const first = await entityMemory.upsertEdge(a.id, b.id, 'advises', {}, 'test', 0.7);
       const firstConfirmedAt = first.edge.temporal.lastConfirmedAt;
 

--- a/tests/unit/skills/context-for-email.test.ts
+++ b/tests/unit/skills/context-for-email.test.ts
@@ -42,7 +42,8 @@ function makeEntityMemory() {
       const entity = { id, label: opts.label, properties: opts.properties };
       entities.set(id, entity);
       facts.set(id, []);
-      return entity;
+      // Return the new { entity, created } shape matching the updated createEntity API
+      return { entity, created: true };
     }),
     storeFact: vi.fn(async (opts: { entityNodeId: string; label: string; properties: Record<string, unknown>; confidence: number; decayClass: string; source: string }) => {
       const entityFacts = facts.get(opts.entityNodeId) ?? [];
@@ -142,7 +143,7 @@ describe('ContextForEmailHandler', () => {
     it('includes meeting link when found in KG', async () => {
       const em = makeEntityMemory();
       // Set up a meeting-links anchor with Alice's Zoom link
-      const anchor = await em.createEntity({
+      const { entity: anchor } = await em.createEntity({
         type: 'concept', label: 'meeting-links',
         properties: {}, source: 'test',
       });

--- a/tests/unit/skills/knowledge-company-overview.test.ts
+++ b/tests/unit/skills/knowledge-company-overview.test.ts
@@ -39,7 +39,8 @@ function makeEntityMemory() {
       const entity = { id, label: opts.label, properties: opts.properties };
       entities.set(id, entity);
       facts.set(id, []);
-      return entity;
+      // Return the new { entity, created } shape matching the updated createEntity API
+      return { entity, created: true };
     }),
     storeFact: vi.fn(async (opts: { entityNodeId: string; label: string; properties: Record<string, unknown>; confidence: number; decayClass: string; source: string }) => {
       const entityFacts = facts.get(opts.entityNodeId) ?? [];
@@ -196,7 +197,7 @@ describe('KnowledgeCompanyOverviewHandler', () => {
       em.storeFact.mockRejectedValueOnce(new Error('DB connection lost'));
 
       // First need to create anchor
-      em.createEntity.mockResolvedValueOnce({ id: 'e-1', label: 'company-overview', properties: {} });
+      em.createEntity.mockResolvedValueOnce({ entity: { id: 'e-1', label: 'company-overview', properties: {} }, created: true });
 
       const result = await handler.execute(makeCtx(
         { action: 'store', field: 'legal_name', value: 'Acme' },

--- a/tests/unit/skills/template-meeting-request.test.ts
+++ b/tests/unit/skills/template-meeting-request.test.ts
@@ -39,11 +39,17 @@ function makeEntityMemory() {
       return matches;
     }),
     createEntity: vi.fn(async (opts: { type: string; label: string; properties: Record<string, unknown>; source: string }) => {
+      // Check if an entity with this label already exists (mimics upsert behaviour)
+      for (const e of entities.values()) {
+        if (e.label.toLowerCase() === opts.label.toLowerCase()) {
+          return { entity: e, created: false };
+        }
+      }
       const id = `entity-${nextId++}`;
       const entity = { id, label: opts.label, properties: opts.properties };
       entities.set(id, entity);
       facts.set(id, []);
-      return entity;
+      return { entity, created: true };
     }),
     storeFact: vi.fn(async (opts: { entityNodeId: string; label: string; properties: Record<string, unknown>; confidence: number; decayClass: string; source: string }) => {
       const entityFacts = facts.get(opts.entityNodeId) ?? [];
@@ -126,7 +132,7 @@ describe('TemplateMeetingRequestHandler', () => {
 
     it('returns custom policy from KG when available', async () => {
       const em = makeEntityMemory();
-      const anchor = await em.createEntity({
+      const { entity: anchor } = await em.createEntity({
         type: 'concept', label: 'template:meeting-request',
         properties: { category: 'email-policy' }, source: 'test',
       });
@@ -158,7 +164,7 @@ describe('TemplateMeetingRequestHandler', () => {
 
     it('handles plain-text custom policy (non-JSON)', async () => {
       const em = makeEntityMemory();
-      const anchor = await em.createEntity({
+      const { entity: anchor } = await em.createEntity({
         type: 'concept', label: 'template:meeting-request',
         properties: {}, source: 'test',
       });

--- a/tests/unit/skills/template-meeting-request.test.ts
+++ b/tests/unit/skills/template-meeting-request.test.ts
@@ -26,27 +26,29 @@ function makeCtx(
 
 /** Stub EntityMemory with in-memory storage. */
 function makeEntityMemory() {
-  const entities = new Map<string, { id: string; label: string; properties: Record<string, unknown> }>();
+  const entities = new Map<string, { id: string; type: string; label: string; properties: Record<string, unknown> }>();
   const facts = new Map<string, Array<{ id: string; label: string; properties: Record<string, unknown>; temporal: { lastConfirmedAt: Date; confidence: number; decayClass: string; source: string; createdAt: Date } }>>();
   let nextId = 1;
 
   return {
     findEntities: vi.fn(async (label: string) => {
-      const matches: Array<{ id: string; label: string; properties: Record<string, unknown> }> = [];
+      const matches: Array<{ id: string; type: string; label: string; properties: Record<string, unknown> }> = [];
       for (const e of entities.values()) {
         if (e.label.toLowerCase() === label.toLowerCase()) matches.push(e);
       }
       return matches;
     }),
     createEntity: vi.fn(async (opts: { type: string; label: string; properties: Record<string, unknown>; source: string }) => {
-      // Check if an entity with this label already exists (mimics upsert behaviour)
+      // Check if an entity with this (label, type) pair already exists (mimics upsert
+      // behaviour). The real upsertNode deduplicates on lower(label) + type — checking
+      // label alone would wrongly deduplicate nodes with the same label but different types.
       for (const e of entities.values()) {
-        if (e.label.toLowerCase() === opts.label.toLowerCase()) {
+        if (e.label.toLowerCase() === opts.label.toLowerCase() && e.type === opts.type) {
           return { entity: e, created: false };
         }
       }
       const id = `entity-${nextId++}`;
-      const entity = { id, label: opts.label, properties: opts.properties };
+      const entity = { id, type: opts.type, label: opts.label, properties: opts.properties };
       entities.set(id, entity);
       facts.set(id, []);
       return { entity, created: true };


### PR DESCRIPTION
## Summary

- **Migration 016** — one-time dedup pass that identifies duplicate `kg_nodes` rows by `(lower(label), type)`, re-points `kg_edges` and `contacts.kg_node_id` to canonical nodes, then deletes duplicates. Adds `idx_kg_nodes_unique` on `(lower(label), type) WHERE type != 'fact'` to prevent future duplicates.
- **`KnowledgeGraphStore.upsertNode()`** — new idempotent method mirroring `upsertEdge`. Uses `INSERT ... ON CONFLICT DO UPDATE` on Postgres; case-insensitive scan in the in-memory backend. Raises confidence on conflict (never lowers), leaves properties/label/embedding untouched.
- **`EntityMemory.createEntity()`** — now delegates to `upsertNode` and returns `{ entity, created }`. Breaking change; all internal call sites updated.
- **`EntityMemory.updateNode()`** — new public method. Label changes that collide with an existing node of the same type trigger `mergeEntities` automatically instead of throwing a constraint violation. Returns `{ node, merged }` with a strong JSDoc warning when `merged: true` (node.id in the result differs from the input id).
- **`mergeEntities` Phase 2** — completes the deferred TODO: re-points secondary entity edges to primary via `upsertEdge`, deletes secondary fact nodes, deletes the secondary entity node.

## Test plan

- [ ] All 1009 unit tests pass (`npm test`)
- [ ] `upsertNode` returns `created: false` on second call with same label (case-insensitive)
- [ ] `updateNode` with `label: 'Joseph Fung'` when that node already exists merges and returns `merged: true`
- [ ] Migration 016 runs cleanly against a fresh Postgres instance (integration test harness)
- [ ] After migration, verify `idx_kg_nodes_unique` exists and prevents duplicate inserts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Idempotent entity upsert/creation that returns the created entity plus a creation flag; public node-update API that can merge on label/type collisions. Contact creation now applies roles when reusing existing entities.

* **Bug Fixes**
  * One-time deduplication migration and enforcement of case-insensitive label+type uniqueness for non-fact nodes.
  * Completed merge flow to re-point relationships and remove merged nodes.

* **Documentation**
  * Added design and changelog entries describing uniqueness and migration behavior.

* **Tests**
  * Added and updated tests for upsert, merge, update and related call-site changes.

* **Chores**
  * Version bumped to 0.12.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->