### PR TITLE
fix: remove extract-relationships from coordinator tool loop (v0.12.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Fixed
+- **Coordinator confabulation bug** — removed `extract-relationships` from the coordinator's LLM tool loop. The per-message tool call caused empty-text turns that triggered the empty-response recovery mechanism, which confabulated "I already provided my response" in Signal group chats and the web UI. Relationship extraction moves to the conversation checkpoint pipeline (forthcoming).
+
+### Fixed
 - **KG node deduplication** — one-time migration deduplicates existing `kg_nodes` rows with matching `(lower(label), type)`, re-pointing edges and contacts to canonical nodes before removing duplicates.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 - **Coordinator confabulation bug** — removed `extract-relationships` from the coordinator's LLM tool loop. The per-message tool call caused empty-text turns that triggered the empty-response recovery mechanism, which confabulated "I already provided my response" in Signal group chats and the web UI. Relationship extraction moves to the conversation checkpoint pipeline (forthcoming).
-
-### Fixed
 - **KG node deduplication** — one-time migration deduplicates existing `kg_nodes` rows with matching `(lower(label), type)`, re-pointing edges and contacts to canonical nodes before removing duplicates.
 
 ### Added

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -41,18 +41,6 @@ system_prompt: |
   When an email arrives from someone not yet in contacts, the system auto-creates
   a contact. You can enrich it with contact-set-role if you learn their role.
 
-  ## Relationship Extraction
-  After every message, call `extract-relationships` with the full message text
-  and your current task source string. You do not need to decide whether the
-  message contains relationships — the skill handles that internally and exits
-  immediately if there is nothing to extract. Always call it; never skip it.
-
-  IMPORTANT: `extract-relationships` is a silent background housekeeping task.
-  It must never replace your text response to the user. Always write your reply
-  to the user first, then call `extract-relationships` as a follow-up step.
-  If you have nothing else to say, write a brief acknowledgement before calling it.
-  The user must always receive a non-empty text response from you.
-
   ## Relationship Management
   Use `query-relationships` to look up stored relationships for any entity by name.
   Use `delete-relationship` when the user explicitly says a relationship is wrong,
@@ -258,7 +246,6 @@ pinned_skills:
   - knowledge-travel-preferences
   - knowledge-loyalty-programs
   - context-for-email
-  - extract-relationships
   - calendar-list-calendars
   - calendar-register
   - calendar-list-events

--- a/docs/wip/2026-04-08-conversation-checkpoint-design.md
+++ b/docs/wip/2026-04-08-conversation-checkpoint-design.md
@@ -135,9 +135,11 @@ private scheduleCheckpoint(conversationId: string, agentId: string, channelId: s
 
   const debounceMs = this.config.dispatch?.conversationCheckpointDebounceMs ?? 600_000; // 10 min default
 
-  const timer = setTimeout(async () => {
+  const timer = setTimeout(() => {
     this.checkpointTimers.delete(key);
-    await this.fireCheckpoint(conversationId, agentId, channelId);
+    void this.fireCheckpoint(conversationId, agentId, channelId).catch(err =>
+      this.logger.error({ err, conversationId, agentId }, 'Checkpoint timer callback failed'),
+    );
   }, debounceMs);
 
   this.checkpointTimers.set(key, timer);

--- a/docs/wip/2026-04-08-conversation-checkpoint-design.md
+++ b/docs/wip/2026-04-08-conversation-checkpoint-design.md
@@ -1,0 +1,281 @@
+# Design: Conversation Checkpoint Pipeline
+
+**Date:** 2026-04-08
+**Status:** Draft
+
+---
+
+## Background
+
+Two production bugs were traced to a single root cause: `extract-relationships` is wired as an LLM tool call inside the coordinator's turn loop. Because the skill is declared as a background housekeeping task that must always run, the coordinator calls it with no text preamble — returning an empty content string. The agent runtime's empty-response recovery mechanism then fires, appending a nudge prompt to a message array that still contains the tool_use/tool_result blocks. The recovery LLM call sees its own prior tool call and confabulates "I already provided my response," delivering that text to the user instead of a real reply.
+
+Beyond the bug, the per-message invocation pattern is the wrong granularity for relationship and entity extraction. Individual messages are often fragments of thought. Extraction across a full conversational exchange yields richer, more accurate triples. Running the classifier gate on every message also wastes tokens on the majority of turns (scheduling, lookups, email drafts) that contain no relationship signal.
+
+`extract-entities` (issue #151) will need exactly the same invocation pattern. Encoding each new extraction skill as a coordinator tool call repeats the same fragile design.
+
+---
+
+## Goals
+
+1. Fix the Signal and web chat confabulation bugs by removing `extract-relationships` from the LLM tool loop entirely.
+2. Establish a **conversation checkpoint pipeline** — a System Layer mechanism that fires when a conversation goes quiet, fetches new turns since the last checkpoint, and fans out to all registered checkpoint skills.
+3. Support incremental processing via a per-conversation **watermark**, so re-opening a quiet conversation triggers extraction on only the new turns.
+4. Make adding future checkpoint skills (e.g. `extract-entities`, `extract-facts`) a self-contained change — no modifications to Dispatch or the runtime required.
+
+---
+
+## Out of Scope
+
+- Working memory expiry / TTL cleanup (noted as future work — `expires_at` column exists but is unpopulated)
+- The `extract-entities` skill implementation (covered by issue #151; this spec wires the pipeline it will plug into)
+- The `extract-facts` skill
+- Tuning the debounce window
+- Per-channel or per-agent checkpoint configuration
+
+---
+
+## Architecture
+
+```
+[Dispatch Layer]
+  agent.response received
+      │
+      ▼
+  reset debounce timer (conversationId + agentId)
+      │
+      │  (N minutes of inactivity)
+      ▼
+  publish conversation.checkpoint
+      │
+[System Layer]
+      ▼
+  ConversationCheckpointProcessor
+      │
+      ├─ fetch turns from working_memory WHERE created_at > last_checkpoint_at
+      │
+      ├─ fire-and-forget: extract-relationships(transcript, source)
+      ├─ fire-and-forget: extract-entities(transcript, source)        ← future
+      └─ fire-and-forget: extract-facts(transcript, source)           ← future
+      │
+      ▼
+  upsert conversation_checkpoints (advance watermark)
+```
+
+The checkpoint processor is a **System Layer** subscriber — it has full bus access and is trusted infrastructure, following the same pattern as the audit logger and scheduler.
+
+---
+
+## Section 1 — Coordinator Change
+
+Remove the "Relationship Extraction" block from `agents/coordinator.yaml`. `extract-relationships` is no longer a tool the LLM calls. The skill manifest (`skill.json`) and handler are unchanged.
+
+This is the minimal fix for the production bugs. Everything else in this spec builds on top of it.
+
+---
+
+## Section 2 — New Bus Event: `conversation.checkpoint`
+
+Add to `src/bus/events.ts`:
+
+```typescript
+// Fired by Dispatch when a conversation has been quiet for the checkpoint
+// debounce window. The payload includes the turns since the last watermark
+// so the processor does not need to re-query working memory.
+export interface ConversationCheckpointPayload {
+  conversationId: string;
+  agentId: string;
+  channelId: string;
+  // ISO timestamp — only turns created after this point are included in `turns`.
+  // Empty string on the first checkpoint (no prior watermark).
+  since: string;
+  // Ordered chronologically (oldest first). Contains only turns since `since`.
+  turns: Array<{ role: 'user' | 'assistant'; content: string }>;
+}
+```
+
+Add `'conversation.checkpoint'` to the `BusEvent` discriminated union and the `createConversationCheckpoint` factory, following the same pattern as existing event factories.
+
+**Permissions:** `dispatch` layer may publish `conversation.checkpoint`. System Layer subscribers may consume it. Add to `src/bus/permissions.ts`.
+
+---
+
+## Section 3 — New Database Table: `conversation_checkpoints`
+
+```sql
+-- Migration: 016_create_conversation_checkpoints.sql
+
+CREATE TABLE conversation_checkpoints (
+  conversation_id   TEXT        NOT NULL,
+  agent_id          TEXT        NOT NULL,
+  last_checkpoint_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (conversation_id, agent_id)
+);
+```
+
+The primary key enforces one watermark row per (conversation, agent) pair. Upsert advances it; there is no delete path.
+
+---
+
+## Section 4 — Dispatch: Debounce Timer
+
+In `src/dispatch/dispatcher.ts`, maintain an in-memory debounce timer map:
+
+```typescript
+// Key: `${conversationId}:${agentId}`
+private checkpointTimers = new Map<string, ReturnType<typeof setTimeout>>();
+```
+
+In the `agent.response` handler (after routing the outbound message), reset the debounce:
+
+```typescript
+private scheduleCheckpoint(conversationId: string, agentId: string, channelId: string): void {
+  const key = `${conversationId}:${agentId}`;
+  const existing = this.checkpointTimers.get(key);
+  if (existing) clearTimeout(existing);
+
+  const debounceMs = this.config.dispatch?.conversationCheckpointDebounceMs ?? 600_000; // 10 min default
+
+  const timer = setTimeout(async () => {
+    this.checkpointTimers.delete(key);
+    await this.fireCheckpoint(conversationId, agentId, channelId);
+  }, debounceMs);
+
+  this.checkpointTimers.set(key, timer);
+}
+```
+
+`fireCheckpoint` queries `conversation_checkpoints` for the last watermark, reads turns from `working_memory` since that watermark, and publishes `conversation.checkpoint`. If working memory returns no turns (e.g. a timer that fired after the conversation was already fully processed), it publishes nothing.
+
+**On shutdown:** In the `close()` method, iterate `checkpointTimers` and `clearTimeout` each — prevents dangling timers in tests and clean process exit.
+
+---
+
+## Section 5 — System Layer: ConversationCheckpointProcessor
+
+New file: `src/checkpoint/processor.ts`
+
+```typescript
+export class ConversationCheckpointProcessor {
+  constructor(
+    private bus: Bus,
+    private skillRunner: SkillRunner,
+    private pool: DbPool,
+    private logger: Logger,
+  ) {}
+
+  register(): void {
+    this.bus.subscribe('conversation.checkpoint', 'system', async (event) => {
+      await this.handleCheckpoint(event);
+    });
+  }
+
+  private async handleCheckpoint(event: BusEvent & { type: 'conversation.checkpoint' }): Promise<void> {
+    const { conversationId, agentId, channelId, turns } = event.payload;
+
+    if (turns.length === 0) return;
+
+    // Concatenate turns into a single transcript string for skills that take `text`.
+    const transcript = turns
+      .map(t => `${t.role === 'user' ? 'User' : 'Curia'}: ${t.content}`)
+      .join('\n\n');
+
+    const source = `system:checkpoint/conversation:${conversationId}/agent:${agentId}/channel:${channelId}`;
+
+    // Fire all checkpoint skills concurrently, fire-and-forget.
+    // Errors are logged but do not block watermark advancement.
+    const skills: Array<{ name: string; input: Record<string, string> }> = [
+      { name: 'extract-relationships', input: { text: transcript, source } },
+      // extract-entities goes here when built (issue #151)
+    ];
+
+    await Promise.allSettled(
+      skills.map(skill =>
+        this.skillRunner.run(skill.name, skill.input)
+          .catch(err => this.logger.error({ err, skill: skill.name, conversationId }, 'checkpoint skill failed')),
+      ),
+    );
+
+    // Advance watermark — upsert so first checkpoint creates the row.
+    await this.pool.query(
+      `INSERT INTO conversation_checkpoints (conversation_id, agent_id, last_checkpoint_at)
+       VALUES ($1, $2, now())
+       ON CONFLICT (conversation_id, agent_id)
+       DO UPDATE SET last_checkpoint_at = now()`,
+      [conversationId, agentId],
+    );
+  }
+}
+```
+
+Register in `src/index.ts` alongside the audit logger and scheduler, passing it the bus, skill runner, pool, and logger.
+
+**Why `Promise.allSettled` and not `Promise.all`:** A failure in one checkpoint skill (e.g. network error in extract-relationships) must not prevent the watermark from advancing. Silently swallowing skill errors is intentional here — the logger call ensures observability.
+
+---
+
+## Section 6 — Config
+
+Add to `config/default.yaml` under `dispatch:`:
+
+```yaml
+dispatch:
+  conversationCheckpointDebounceMs: 600000   # 10 minutes
+```
+
+Typed in the config schema (`src/config.ts`) as `number | undefined` with a documented default.
+
+---
+
+## Section 7 — Testing
+
+### Unit: Dispatcher debounce (`tests/unit/dispatch/dispatcher-checkpoint.test.ts`)
+
+Use fake timers (Vitest's `vi.useFakeTimers()`).
+
+| Test | Assertion |
+|---|---|
+| Timer fires after debounce window | `fireCheckpoint` called once |
+| Incoming message resets the timer | Only one `fireCheckpoint` call after the second debounce elapses |
+| Shutdown clears all timers | No `fireCheckpoint` calls after `close()` |
+| No turns since watermark | `conversation.checkpoint` not published |
+
+### Unit: ConversationCheckpointProcessor (`tests/unit/checkpoint/processor.test.ts`)
+
+Use an in-memory skill runner stub and in-memory working memory.
+
+| Test | Assertion |
+|---|---|
+| Both skills called with concatenated transcript | Skill runner receives correct `text` and `source` |
+| Skill failure does not block watermark | Watermark advanced even when skill throws |
+| Watermark upserted after first checkpoint | Row created in `conversation_checkpoints` |
+| Watermark upserted after subsequent checkpoint | Row updated, not duplicated |
+| Empty turns list | No skills called, no watermark update |
+
+### Integration: Full round-trip (`tests/integration/checkpoint.test.ts`)
+
+Real Postgres (Docker), real skill runner.
+
+1. Insert two working_memory turns for a test conversationId
+2. Publish `conversation.checkpoint` event directly (bypass debounce)
+3. Assert `extract-relationships` ran: check `kg_edges` table for expected edge
+4. Assert `conversation_checkpoints` row exists with `last_checkpoint_at` > test start
+5. Insert two more turns, publish another checkpoint
+6. Assert only the two new turns were passed to the skill (watermark respected)
+
+---
+
+## Section 8 — Migration Sequence
+
+1. Deploy coordinator.yaml without the `extract-relationships` tool instruction (bug fix — no schema changes required)
+2. Run migration `016_create_conversation_checkpoints.sql`
+3. Deploy updated dispatcher + checkpoint processor
+
+Step 1 can ship independently as a fast hotfix for the production bugs.
+
+---
+
+## Open Questions
+
+- **Debounce window:** 10 minutes is a reasonable default for async extraction but may feel long if the KG is used for context in the same session. Accept for now; revisit when entity context enrichment is in production and latency matters.
+- **Bullpen conversations:** Bullpen threads use `conversationId = threadId`. The same checkpoint pipeline applies — inter-agent discussions may contain relationship signal worth extracting. No special case needed.
+- **Multi-agent:** Each `(conversationId, agentId)` pair gets its own timer and watermark. If the coordinator and a sub-agent both respond in the same conversation, each fires its own checkpoint. This is correct — their working memory histories are independent.

--- a/docs/wip/2026-04-08-conversation-checkpoint.md
+++ b/docs/wip/2026-04-08-conversation-checkpoint.md
@@ -150,7 +150,8 @@ export function createConversationCheckpoint(
 ): ConversationCheckpointEvent {
   return {
     id: crypto.randomUUID(),
-    timestamp: new Date().toISOString(),
+    timestamp: new Date(),
+    sourceLayer: 'dispatch',
     type: 'conversation.checkpoint',
     payload,
   };
@@ -549,14 +550,12 @@ async function fireAgentResponse(
     taskEventId,
     conversationId,
     agentId,
-    channelId,
     content = 'ok',
-  }: { taskEventId: string; conversationId: string; agentId: string; channelId: string; content?: string },
+  }: { taskEventId: string; conversationId: string; agentId: string; content?: string },
 ) {
   const event = createAgentResponse({
     agentId,
     conversationId,
-    channelId,
     content,
     parentEventId: taskEventId,
   });
@@ -579,7 +578,6 @@ describe('Dispatcher checkpoint debounce', () => {
       taskEventId: 'task-1',
       conversationId: 'email:thread-abc',
       agentId: 'coordinator',
-      channelId: 'email',
     });
 
     // No checkpoint yet
@@ -601,7 +599,6 @@ describe('Dispatcher checkpoint debounce', () => {
       taskEventId: 'task-1',
       conversationId: 'email:thread-abc',
       agentId: 'coordinator',
-      channelId: 'email',
     });
 
     await vi.advanceTimersByTimeAsync(300); // not yet elapsed
@@ -611,7 +608,6 @@ describe('Dispatcher checkpoint debounce', () => {
       taskEventId: 'task-2',
       conversationId: 'email:thread-abc',
       agentId: 'coordinator',
-      channelId: 'email',
     });
 
     await vi.advanceTimersByTimeAsync(300); // 300ms after reset — still not elapsed
@@ -629,7 +625,6 @@ describe('Dispatcher checkpoint debounce', () => {
       taskEventId: 'task-1',
       conversationId: 'email:thread-abc',
       agentId: 'coordinator',
-      channelId: 'email',
     });
 
     dispatcher.close();

--- a/docs/wip/2026-04-08-conversation-checkpoint.md
+++ b/docs/wip/2026-04-08-conversation-checkpoint.md
@@ -1,0 +1,1038 @@
+# Conversation Checkpoint Pipeline — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a conversation checkpoint pipeline that fires after conversational inactivity, fetches new turns since the last watermark, and fans out to background memory skills (`extract-relationships` and future skills).
+
+**Architecture:** Dispatch maintains an in-memory debounce timer per `(conversationId, agentId)`, reset on every `agent.response`. After inactivity, Dispatch queries working memory for new turns, publishes a `conversation.checkpoint` bus event, then cleans up the timer. A new `ConversationCheckpointProcessor` in the System Layer subscribes to that event, runs registered skills concurrently via `ExecutionLayer`, and advances a per-conversation watermark in a new `conversation_checkpoints` Postgres table.
+
+**Tech Stack:** TypeScript/ESM, Node 22, PostgreSQL 16, Vitest, node-pg-migrate, pino
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/db/migrations/017_create_conversation_checkpoints.sql` | Create | Watermark table |
+| `src/bus/events.ts` | Modify | Add `conversation.checkpoint` event type + factory |
+| `src/bus/permissions.ts` | Modify | Allow dispatch to publish, system to subscribe |
+| `src/checkpoint/processor.ts` | Create | System Layer subscriber — runs skills, advances watermark |
+| `src/dispatch/dispatcher.ts` | Modify | Add debounce timer map + `scheduleCheckpoint` + `fireCheckpoint` |
+| `src/config.ts` | Modify | Add `dispatch.conversationCheckpointDebounceMs` config field |
+| `config/default.yaml` | Modify | Set default debounce value |
+| `src/index.ts` | Modify | Instantiate + register `ConversationCheckpointProcessor` |
+| `tests/unit/checkpoint/processor.test.ts` | Create | Unit tests for processor |
+| `tests/unit/dispatch/dispatcher-checkpoint.test.ts` | Create | Unit tests for debounce timer |
+| `tests/integration/checkpoint.test.ts` | Create | Full round-trip integration test |
+
+---
+
+### Task 1: Database migration — conversation_checkpoints table
+
+**Files:**
+- Create: `src/db/migrations/017_create_conversation_checkpoints.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+```sql
+-- Up Migration
+-- Watermark table for the conversation checkpoint pipeline.
+-- One row per (conversation_id, agent_id) pair — upserted after each checkpoint run.
+-- The primary key enforces at-most-one watermark per pair; there is no delete path.
+
+CREATE TABLE conversation_checkpoints (
+  conversation_id    TEXT        NOT NULL,
+  agent_id           TEXT        NOT NULL,
+  last_checkpoint_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (conversation_id, agent_id)
+);
+
+-- Down Migration
+DROP TABLE IF EXISTS conversation_checkpoints;
+```
+
+- [ ] **Step 2: Run the migration against the dev database**
+
+```bash
+npm --prefix /path/to/worktree run migrate
+```
+
+Expected: migration applies cleanly, `conversation_checkpoints` table visible in psql.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add src/db/migrations/017_create_conversation_checkpoints.sql
+git -C /path/to/worktree commit -m "feat: add conversation_checkpoints watermark table (migration 017)"
+```
+
+---
+
+### Task 2: Bus event — `conversation.checkpoint`
+
+**Files:**
+- Modify: `src/bus/events.ts`
+- Modify: `src/bus/permissions.ts`
+
+- [ ] **Step 1: Write a failing test for the event factory**
+
+In `src/bus/events.ts` there are factory functions like `createAgentTask`, `createOutboundMessage`, etc. Add a test in `tests/unit/bus/events.test.ts` (or the closest existing events test file — check `tests/unit/bus/`):
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { createConversationCheckpoint } from '../../../src/bus/events.js';
+
+describe('createConversationCheckpoint', () => {
+  it('creates a well-formed conversation.checkpoint event', () => {
+    const event = createConversationCheckpoint({
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+      since: '2026-04-08T10:00:00Z',
+      turns: [
+        { role: 'user', content: 'Xiaopu is my wife' },
+        { role: 'assistant', content: 'Got it, I will remember that.' },
+      ],
+    });
+
+    expect(event.type).toBe('conversation.checkpoint');
+    expect(event.payload.conversationId).toBe('email:thread-abc');
+    expect(event.payload.turns).toHaveLength(2);
+    expect(event.id).toBeTruthy();
+    expect(event.timestamp).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```bash
+npm --prefix /path/to/worktree test tests/unit/bus/events.test.ts
+```
+
+Expected: FAIL — `createConversationCheckpoint is not a function` (or similar import error).
+
+- [ ] **Step 3: Add the payload interface and event type to events.ts**
+
+Locate the existing payload interfaces (search for `AgentTaskPayload`). Add after the last payload interface:
+
+```typescript
+export interface ConversationCheckpointPayload {
+  conversationId: string;
+  agentId: string;
+  channelId: string;
+  /** ISO timestamp — turns created after this point are included. Empty string on first checkpoint. */
+  since: string;
+  /** Ordered chronologically (oldest first). Contains only turns since `since`. */
+  turns: Array<{ role: 'user' | 'assistant'; content: string }>;
+}
+```
+
+Add to the `BusEvent` discriminated union (find where `type: 'agent.discuss'` is declared and add after it):
+
+```typescript
+export interface ConversationCheckpointEvent extends BaseEvent {
+  type: 'conversation.checkpoint';
+  payload: ConversationCheckpointPayload;
+}
+```
+
+Add `ConversationCheckpointEvent` to the `BusEvent` union type.
+
+Add `'conversation.checkpoint'` to the `EventType` union (find the existing string union of all event type strings).
+
+Add the factory function (find `createAgentTask` for the pattern):
+
+```typescript
+export function createConversationCheckpoint(
+  payload: ConversationCheckpointPayload,
+): ConversationCheckpointEvent {
+  return {
+    id: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    type: 'conversation.checkpoint',
+    payload,
+  };
+}
+```
+
+- [ ] **Step 4: Run to confirm test passes**
+
+```bash
+npm --prefix /path/to/worktree test tests/unit/bus/events.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Update permissions.ts**
+
+In `src/bus/permissions.ts`, add `'conversation.checkpoint'` to:
+- `publishAllowlist.dispatch` — Dispatch publishes this event
+- `subscribeAllowlist.system` — System Layer processor subscribes to it
+
+Find the existing string sets and append:
+
+```typescript
+// publishAllowlist (dispatch entry):
+'conversation.checkpoint'
+
+// subscribeAllowlist (system entry):
+'conversation.checkpoint'
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /path/to/worktree add src/bus/events.ts src/bus/permissions.ts tests/unit/bus/events.test.ts
+git -C /path/to/worktree commit -m "feat: add conversation.checkpoint bus event type and factory"
+```
+
+---
+
+### Task 3: Config — debounce window
+
+**Files:**
+- Modify: `src/config.ts`
+- Modify: `config/default.yaml`
+
+- [ ] **Step 1: Add config field**
+
+In `src/config.ts`, find the `dispatch` config section type (or the top-level config type). Add:
+
+```typescript
+dispatch?: {
+  /** Milliseconds of inactivity before a conversation.checkpoint event is published.
+   *  Defaults to 600000 (10 minutes). */
+  conversationCheckpointDebounceMs?: number;
+};
+```
+
+If `dispatch` already exists in the type, add only the new field.
+
+- [ ] **Step 2: Add default value to config/default.yaml**
+
+```yaml
+dispatch:
+  conversationCheckpointDebounceMs: 600000   # 10 minutes
+```
+
+If `dispatch:` already exists in the file, add only the new key under it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add src/config.ts config/default.yaml
+git -C /path/to/worktree commit -m "feat: add dispatch.conversationCheckpointDebounceMs config field"
+```
+
+---
+
+### Task 4: ConversationCheckpointProcessor
+
+**Files:**
+- Create: `src/checkpoint/processor.ts`
+- Create: `tests/unit/checkpoint/processor.test.ts`
+
+- [ ] **Step 1: Write failing unit tests**
+
+Create `tests/unit/checkpoint/processor.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConversationCheckpointProcessor } from '../../../src/checkpoint/processor.js';
+import type { EventBus } from '../../../src/bus/bus.js';
+import type { ExecutionLayer } from '../../../src/skills/execution.js';
+import type { DbPool } from '../../../src/db/connection.js';
+import type { Logger } from '../../../src/logger.js';
+import { createConversationCheckpoint } from '../../../src/bus/events.js';
+
+function makeStubs() {
+  const subscribeHandlers = new Map<string, (event: unknown) => Promise<void>>();
+  const bus = {
+    subscribe: vi.fn((eventType: string, _layer: string, handler: (e: unknown) => Promise<void>) => {
+      subscribeHandlers.set(eventType, handler);
+    }),
+  } as unknown as EventBus;
+
+  const executionLayer = {
+    invoke: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  } as unknown as ExecutionLayer;
+
+  const queryMock = vi.fn().mockResolvedValue({ rows: [] });
+  const pool = { query: queryMock } as unknown as DbPool;
+
+  const logger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+  } as unknown as Logger;
+
+  return { bus, executionLayer, pool, logger, subscribeHandlers, queryMock };
+}
+
+async function fireCheckpoint(
+  subscribeHandlers: Map<string, (event: unknown) => Promise<void>>,
+  payload: {
+    conversationId: string;
+    agentId: string;
+    channelId: string;
+    since: string;
+    turns: Array<{ role: 'user' | 'assistant'; content: string }>;
+  },
+) {
+  const event = createConversationCheckpoint(payload);
+  const handler = subscribeHandlers.get('conversation.checkpoint');
+  if (!handler) throw new Error('No handler registered for conversation.checkpoint');
+  await handler(event);
+}
+
+describe('ConversationCheckpointProcessor', () => {
+  let stubs: ReturnType<typeof makeStubs>;
+
+  beforeEach(() => {
+    stubs = makeStubs();
+  });
+
+  it('registers a conversation.checkpoint subscriber on register()', () => {
+    const processor = new ConversationCheckpointProcessor(
+      stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+    );
+    processor.register();
+    expect(stubs.bus.subscribe).toHaveBeenCalledWith(
+      'conversation.checkpoint', 'system', expect.any(Function),
+    );
+  });
+
+  it('calls extract-relationships with concatenated transcript', async () => {
+    const processor = new ConversationCheckpointProcessor(
+      stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+    );
+    processor.register();
+
+    await fireCheckpoint(stubs.subscribeHandlers, {
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+      since: '',
+      turns: [
+        { role: 'user', content: 'Xiaopu is my wife' },
+        { role: 'assistant', content: 'Got it.' },
+      ],
+    });
+
+    expect(stubs.executionLayer.invoke).toHaveBeenCalledWith(
+      'extract-relationships',
+      expect.objectContaining({
+        text: 'User: Xiaopu is my wife\n\nCuria: Got it.',
+        source: expect.stringContaining('email:thread-abc'),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('advances the watermark after skills run', async () => {
+    const processor = new ConversationCheckpointProcessor(
+      stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+    );
+    processor.register();
+
+    await fireCheckpoint(stubs.subscribeHandlers, {
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+      since: '',
+      turns: [{ role: 'user', content: 'test' }],
+    });
+
+    expect(stubs.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO conversation_checkpoints'),
+      ['email:thread-abc', 'coordinator'],
+    );
+  });
+
+  it('advances the watermark even when a skill fails', async () => {
+    stubs.executionLayer.invoke = vi.fn().mockRejectedValue(new Error('API timeout'));
+    const processor = new ConversationCheckpointProcessor(
+      stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+    );
+    processor.register();
+
+    await fireCheckpoint(stubs.subscribeHandlers, {
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+      since: '',
+      turns: [{ role: 'user', content: 'test' }],
+    });
+
+    // Watermark upsert still called despite skill failure
+    expect(stubs.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO conversation_checkpoints'),
+      expect.any(Array),
+    );
+  });
+
+  it('does nothing when turns list is empty', async () => {
+    const processor = new ConversationCheckpointProcessor(
+      stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+    );
+    processor.register();
+
+    await fireCheckpoint(stubs.subscribeHandlers, {
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+      since: '',
+      turns: [],
+    });
+
+    expect(stubs.executionLayer.invoke).not.toHaveBeenCalled();
+    expect(stubs.queryMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm tests fail**
+
+```bash
+npm --prefix /path/to/worktree test tests/unit/checkpoint/processor.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement ConversationCheckpointProcessor**
+
+Create `src/checkpoint/processor.ts`:
+
+```typescript
+import type { EventBus } from '../bus/bus.js';
+import type { ExecutionLayer } from '../skills/execution.js';
+import type { DbPool } from '../db/connection.js';
+import type { Logger } from '../logger.js';
+import type { ConversationCheckpointEvent } from '../bus/events.js';
+
+// Skills invoked at every checkpoint, in addition to any future skills.
+// Add new checkpoint skills here — no changes to Dispatch or the runtime required.
+const CHECKPOINT_SKILLS: Array<{ name: string }> = [
+  { name: 'extract-relationships' },
+  // { name: 'extract-entities' },  // add when issue #151 is built
+];
+
+export class ConversationCheckpointProcessor {
+  constructor(
+    private bus: EventBus,
+    private executionLayer: ExecutionLayer,
+    private pool: DbPool,
+    private logger: Logger,
+  ) {}
+
+  register(): void {
+    this.bus.subscribe('conversation.checkpoint', 'system', async (event) => {
+      await this.handleCheckpoint(event as ConversationCheckpointEvent);
+    });
+  }
+
+  private async handleCheckpoint(event: ConversationCheckpointEvent): Promise<void> {
+    const { conversationId, agentId, channelId, turns } = event.payload;
+
+    if (turns.length === 0) return;
+
+    const transcript = turns
+      .map(t => `${t.role === 'user' ? 'User' : 'Curia'}: ${t.content}`)
+      .join('\n\n');
+
+    const source = `system:checkpoint/conversation:${conversationId}/agent:${agentId}/channel:${channelId}`;
+
+    // Caller context for ExecutionLayer — system-layer invocations are trusted
+    // and have no human sender. Use a minimal CallerContext.
+    const callerContext = {
+      layer: 'system' as const,
+      agentId,
+      conversationId,
+    };
+
+    // Run all checkpoint skills concurrently. A failure in one must not block the
+    // others or prevent the watermark from advancing — hence Promise.allSettled.
+    await Promise.allSettled(
+      CHECKPOINT_SKILLS.map(skill =>
+        this.executionLayer.invoke(skill.name, { text: transcript, source }, callerContext)
+          .catch(err =>
+            this.logger.error(
+              { err, skill: skill.name, conversationId },
+              'checkpoint skill failed — watermark will still advance',
+            ),
+          ),
+      ),
+    );
+
+    // Advance the watermark. Upsert so first checkpoint creates the row.
+    await this.pool.query(
+      `INSERT INTO conversation_checkpoints (conversation_id, agent_id, last_checkpoint_at)
+       VALUES ($1, $2, now())
+       ON CONFLICT (conversation_id, agent_id)
+       DO UPDATE SET last_checkpoint_at = now()`,
+      [conversationId, agentId],
+    );
+
+    this.logger.info({ conversationId, agentId, turnCount: turns.length }, 'Conversation checkpoint complete');
+  }
+}
+```
+
+- [ ] **Step 4: Run to confirm tests pass**
+
+```bash
+npm --prefix /path/to/worktree test tests/unit/checkpoint/processor.test.ts
+```
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /path/to/worktree add src/checkpoint/processor.ts tests/unit/checkpoint/processor.test.ts
+git -C /path/to/worktree commit -m "feat: add ConversationCheckpointProcessor (System Layer)"
+```
+
+---
+
+### Task 5: Dispatcher debounce
+
+**Files:**
+- Modify: `src/dispatch/dispatcher.ts`
+- Create: `tests/unit/dispatch/dispatcher-checkpoint.test.ts`
+
+- [ ] **Step 1: Write failing tests for the debounce**
+
+Create `tests/unit/dispatch/dispatcher-checkpoint.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
+import type { EventBus } from '../../../src/bus/bus.js';
+import type { DbPool } from '../../../src/db/connection.js';
+import type { Logger } from '../../../src/logger.js';
+import { createAgentResponse } from '../../../src/bus/events.js';
+
+function makeStubs(debounceMs = 500) {
+  const publishedEvents: unknown[] = [];
+  const subscribeHandlers = new Map<string, (event: unknown) => Promise<void>>();
+
+  const bus = {
+    subscribe: vi.fn((eventType: string, _layer: string, handler: (e: unknown) => Promise<void>) => {
+      subscribeHandlers.set(eventType, handler);
+    }),
+    publish: vi.fn(async (_layer: string, event: unknown) => {
+      publishedEvents.push(event);
+    }),
+  } as unknown as EventBus;
+
+  const queryMock = vi.fn().mockResolvedValue({ rows: [] });
+  const pool = { query: queryMock } as unknown as DbPool;
+
+  const logger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+  } as unknown as Logger;
+
+  const dispatcher = new Dispatcher({
+    bus,
+    logger,
+    pool,
+    conversationCheckpointDebounceMs: debounceMs,
+  });
+
+  return { dispatcher, bus, pool, logger, publishedEvents, subscribeHandlers, queryMock };
+}
+
+async function fireAgentResponse(
+  subscribeHandlers: Map<string, (event: unknown) => Promise<void>>,
+  {
+    taskEventId,
+    conversationId,
+    agentId,
+    channelId,
+    content = 'ok',
+  }: { taskEventId: string; conversationId: string; agentId: string; channelId: string; content?: string },
+) {
+  const event = createAgentResponse({
+    agentId,
+    conversationId,
+    channelId,
+    content,
+    parentEventId: taskEventId,
+  });
+  const handler = subscribeHandlers.get('agent.response');
+  if (!handler) throw new Error('No agent.response handler registered');
+  await handler(event);
+}
+
+describe('Dispatcher checkpoint debounce', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('publishes conversation.checkpoint after debounce window elapses', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(500);
+    dispatcher.register();
+
+    // Seed routing so agent.response is handled
+    // (pre-seed taskRouting via the internal map — reach in via the response handler)
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-1',
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+    });
+
+    // No checkpoint yet
+    expect(publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint')).toHaveLength(0);
+
+    // Advance time past debounce
+    await vi.advanceTimersByTimeAsync(600);
+
+    const checkpoints = publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint');
+    expect(checkpoints).toHaveLength(1);
+    expect((checkpoints[0] as any).payload.conversationId).toBe('email:thread-abc');
+  });
+
+  it('resets the timer on a second agent.response before debounce elapses', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(500);
+    dispatcher.register();
+
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-1',
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+    });
+
+    await vi.advanceTimersByTimeAsync(300); // not yet elapsed
+
+    // Second response — resets timer
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-2',
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+    });
+
+    await vi.advanceTimersByTimeAsync(300); // 300ms after reset — still not elapsed
+    expect(publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint')).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(300); // now past debounce from second response
+    expect(publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint')).toHaveLength(1);
+  });
+
+  it('clears all timers on close() — no checkpoint fires after shutdown', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(500);
+    dispatcher.register();
+
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-1',
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+    });
+
+    dispatcher.close();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint')).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm tests fail**
+
+```bash
+npm --prefix /path/to/worktree test tests/unit/dispatch/dispatcher-checkpoint.test.ts
+```
+
+Expected: FAIL — `pool` not in `DispatcherConfig`, `close()` not defined, debounce not implemented.
+
+- [ ] **Step 3: Add pool and debounce config to DispatcherConfig**
+
+In `src/dispatch/dispatcher.ts`, update the `DispatcherConfig` interface:
+
+```typescript
+export interface DispatcherConfig {
+  bus: EventBus;
+  logger: Logger;
+  contactResolver?: ContactResolver;
+  heldMessages?: HeldMessageService;
+  channelPolicies?: Record<string, ChannelPolicyConfig>;
+  injectionScanner?: InboundScanner;
+  /** Postgres pool — used to query working_memory for checkpoint turns. */
+  pool: DbPool;
+  /** Milliseconds of inactivity before conversation.checkpoint fires. Default: 600000. */
+  conversationCheckpointDebounceMs?: number;
+}
+```
+
+- [ ] **Step 4: Add the debounce timer map and close() to the Dispatcher class**
+
+In the `Dispatcher` class, add properties after `private taskRouting`:
+
+```typescript
+/** Key: `${conversationId}:${agentId}` — reset on every agent.response */
+private checkpointTimers = new Map<string, ReturnType<typeof setTimeout>>();
+private pool: DbPool;
+private conversationCheckpointDebounceMs: number;
+```
+
+Update the constructor body to assign them:
+
+```typescript
+this.pool = config.pool;
+this.conversationCheckpointDebounceMs = config.conversationCheckpointDebounceMs ?? 600_000;
+```
+
+Add a `close()` method at the end of the class:
+
+```typescript
+/** Clear all pending checkpoint timers. Call during graceful shutdown. */
+close(): void {
+  for (const timer of this.checkpointTimers.values()) {
+    clearTimeout(timer);
+  }
+  this.checkpointTimers.clear();
+}
+```
+
+- [ ] **Step 5: Implement scheduleCheckpoint and fireCheckpoint**
+
+Add these two private methods to the `Dispatcher` class:
+
+```typescript
+private scheduleCheckpoint(conversationId: string, agentId: string, channelId: string): void {
+  const key = `${conversationId}:${agentId}`;
+  const existing = this.checkpointTimers.get(key);
+  if (existing) clearTimeout(existing);
+
+  const timer = setTimeout(() => {
+    this.checkpointTimers.delete(key);
+    // Fire-and-forget — errors are logged inside fireCheckpoint
+    void this.fireCheckpoint(conversationId, agentId, channelId);
+  }, this.conversationCheckpointDebounceMs);
+
+  this.checkpointTimers.set(key, timer);
+}
+
+private async fireCheckpoint(conversationId: string, agentId: string, channelId: string): Promise<void> {
+  try {
+    // Look up the last watermark for this conversation+agent pair
+    const watermarkResult = await this.pool.query<{ last_checkpoint_at: string }>(
+      `SELECT last_checkpoint_at FROM conversation_checkpoints
+       WHERE conversation_id = $1 AND agent_id = $2`,
+      [conversationId, agentId],
+    );
+    const since = watermarkResult.rows[0]?.last_checkpoint_at ?? '';
+
+    // Fetch turns from working memory since the watermark
+    const turnsResult = await this.pool.query<{ role: string; content: string }>(
+      `SELECT role, content FROM working_memory
+       WHERE conversation_id = $1 AND agent_id = $2
+         AND role IN ('user', 'assistant')
+         ${since ? 'AND created_at > $3' : ''}
+       ORDER BY created_at ASC`,
+      since ? [conversationId, agentId, since] : [conversationId, agentId],
+    );
+
+    if (turnsResult.rows.length === 0) {
+      // Nothing new since last checkpoint — skip publishing
+      return;
+    }
+
+    const turns = turnsResult.rows.map(row => ({
+      role: row.role as 'user' | 'assistant',
+      content: row.content,
+    }));
+
+    const event = createConversationCheckpoint({
+      conversationId,
+      agentId,
+      channelId,
+      since,
+      turns,
+    });
+
+    await this.bus.publish('dispatch', event);
+    this.logger.info({ conversationId, agentId, turnCount: turns.length }, 'Conversation checkpoint published');
+  } catch (err) {
+    this.logger.error({ err, conversationId, agentId }, 'Failed to fire conversation checkpoint');
+  }
+}
+```
+
+Also add the import for `createConversationCheckpoint` at the top of `dispatcher.ts`:
+
+```typescript
+import { createConversationCheckpoint } from '../bus/events.js';
+```
+
+And add the `DbPool` import:
+
+```typescript
+import type { DbPool } from '../db/connection.js';
+```
+
+- [ ] **Step 6: Call scheduleCheckpoint from handleAgentResponse**
+
+In the existing `handleAgentResponse` method, after `await this.bus.publish('dispatch', outbound)`, add:
+
+```typescript
+// Schedule a checkpoint for this conversation — resets the debounce timer if
+// already running, so only fires after a full window of inactivity.
+this.scheduleCheckpoint(routing.conversationId, event.payload.agentId, routing.channelId);
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+npm --prefix /path/to/worktree test tests/unit/dispatch/dispatcher-checkpoint.test.ts
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C /path/to/worktree add src/dispatch/dispatcher.ts tests/unit/dispatch/dispatcher-checkpoint.test.ts
+git -C /path/to/worktree commit -m "feat: add conversation checkpoint debounce to Dispatcher"
+```
+
+---
+
+### Task 6: Wire ConversationCheckpointProcessor into index.ts
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add import**
+
+Near the other System Layer imports (audit logger, scheduler), add:
+
+```typescript
+import { ConversationCheckpointProcessor } from './checkpoint/processor.js';
+```
+
+- [ ] **Step 2: Instantiate and register**
+
+Find where `auditLogger` and `scheduler` are registered. After them, add:
+
+```typescript
+// Conversation checkpoint processor — System Layer subscriber that runs
+// background memory skills (extract-relationships, etc.) at end of conversation.
+const checkpointProcessor = new ConversationCheckpointProcessor(bus, executionLayer, pool, logger);
+checkpointProcessor.register();
+```
+
+- [ ] **Step 3: Pass pool to Dispatcher**
+
+The `Dispatcher` constructor now requires `pool`. Find the `new Dispatcher({...})` call and add:
+
+```typescript
+pool,
+```
+
+- [ ] **Step 4: Call dispatcher.close() in shutdown**
+
+Find the graceful shutdown block (where `pool.end()` is called). Add before it:
+
+```typescript
+dispatcher.close();
+```
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+npm --prefix /path/to/worktree test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /path/to/worktree add src/index.ts
+git -C /path/to/worktree commit -m "feat: register ConversationCheckpointProcessor in bootstrap"
+```
+
+---
+
+### Task 7: Integration test — full round-trip
+
+**Files:**
+- Create: `tests/integration/checkpoint.test.ts`
+
+This test requires Docker Postgres. Check existing integration tests (e.g. `tests/integration/extract-relationships.test.ts`) for the setup/teardown pattern — connection string, migration runner, and cleanup.
+
+- [ ] **Step 1: Write the integration test**
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createPool } from '../../src/db/connection.js';
+import { WorkingMemory } from '../../src/memory/working-memory.js';
+import { ConversationCheckpointProcessor } from '../../src/checkpoint/processor.js';
+import { createConversationCheckpoint } from '../../src/bus/events.js';
+// Import ExecutionLayer, SkillRegistry, EntityMemory — follow pattern from existing integration tests
+
+// Use the same test DB URL pattern as existing integration tests
+const TEST_DB_URL = process.env.TEST_DATABASE_URL ?? 'postgresql://postgres:postgres@localhost:5432/curia_test';
+
+describe('ConversationCheckpointProcessor — integration', () => {
+  let pool: ReturnType<typeof createPool>;
+  let memory: WorkingMemory;
+  const conversationId = `test:checkpoint-${Date.now()}`;
+  const agentId = 'coordinator';
+
+  beforeAll(async () => {
+    pool = createPool(TEST_DB_URL, { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} } as any);
+    memory = WorkingMemory.createWithPostgres(pool, { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} } as any);
+    // Insert test turns
+    await memory.addTurn(conversationId, agentId, { role: 'user', content: 'Xiaopu Fung is my wife' });
+    await memory.addTurn(conversationId, agentId, { role: 'assistant', content: 'Got it, I will remember that.' });
+  });
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM conversation_checkpoints WHERE conversation_id = $1', [conversationId]);
+    await pool.query('DELETE FROM working_memory WHERE conversation_id = $1', [conversationId]);
+    await pool.query('DELETE FROM kg_edges WHERE source = $1', [`system:checkpoint/conversation:${conversationId}/agent:${agentId}/channel:test`]);
+    await pool.end();
+  });
+
+  it('runs extract-relationships and persists a watermark', async () => {
+    // Build a minimal ExecutionLayer with real skill registry — follow existing integration test patterns
+    // ... (see tests/integration/extract-relationships.test.ts for exact setup)
+
+    const bus = { subscribe: vi.fn(), publish: vi.fn() } as any;
+    const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } as any;
+
+    const processor = new ConversationCheckpointProcessor(bus, executionLayer, pool, logger);
+    processor.register();
+
+    // Fire checkpoint directly (bypasses debounce)
+    const event = createConversationCheckpoint({
+      conversationId,
+      agentId,
+      channelId: 'test',
+      since: '',
+      turns: [
+        { role: 'user', content: 'Xiaopu Fung is my wife' },
+        { role: 'assistant', content: 'Got it, I will remember that.' },
+      ],
+    });
+
+    const handler = (bus.subscribe as any).mock.calls[0][2];
+    await handler(event);
+
+    // Watermark created
+    const watermark = await pool.query(
+      'SELECT last_checkpoint_at FROM conversation_checkpoints WHERE conversation_id = $1 AND agent_id = $2',
+      [conversationId, agentId],
+    );
+    expect(watermark.rows).toHaveLength(1);
+    expect(new Date(watermark.rows[0].last_checkpoint_at).getTime()).toBeGreaterThan(Date.now() - 5000);
+
+    // Relationship persisted — a spouse edge should exist between Xiaopu and Joseph
+    const edges = await pool.query(
+      `SELECT e.type FROM kg_edges e
+       JOIN kg_nodes n1 ON e.source_node_id = n1.id
+       JOIN kg_nodes n2 ON e.target_node_id = n2.id
+       WHERE n1.label ILIKE '%xiaopu%' OR n2.label ILIKE '%xiaopu%'`,
+    );
+    expect(edges.rows.length).toBeGreaterThan(0);
+    expect(edges.rows.some((r: any) => r.type === 'spouse')).toBe(true);
+  });
+
+  it('respects the watermark on second checkpoint — does not reprocess old turns', async () => {
+    // Add new turns after the first checkpoint
+    await memory.addTurn(conversationId, agentId, { role: 'user', content: 'Ada Chen is the lead on Project Orion' });
+    await memory.addTurn(conversationId, agentId, { role: 'assistant', content: 'Noted.' });
+
+    // Get current watermark
+    const before = await pool.query(
+      'SELECT last_checkpoint_at FROM conversation_checkpoints WHERE conversation_id = $1 AND agent_id = $2',
+      [conversationId, agentId],
+    );
+    const since = before.rows[0].last_checkpoint_at;
+
+    const invokedTexts: string[] = [];
+    const spyLayer = {
+      invoke: vi.fn(async (_name: string, input: Record<string, string>) => {
+        invokedTexts.push(input.text);
+        return { success: true, data: {} };
+      }),
+    } as any;
+
+    const bus = { subscribe: vi.fn(), publish: vi.fn() } as any;
+    const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } as any;
+    const processor = new ConversationCheckpointProcessor(bus, spyLayer, pool, logger);
+    processor.register();
+
+    const event = createConversationCheckpoint({
+      conversationId,
+      agentId,
+      channelId: 'test',
+      since,
+      turns: [
+        { role: 'user', content: 'Ada Chen is the lead on Project Orion' },
+        { role: 'assistant', content: 'Noted.' },
+      ],
+    });
+
+    const handler = (bus.subscribe as any).mock.calls[0][2];
+    await handler(event);
+
+    // Only the two new turns in the transcript — not the original spouse turns
+    expect(invokedTexts[0]).toContain('Ada Chen');
+    expect(invokedTexts[0]).not.toContain('Xiaopu');
+  });
+});
+```
+
+- [ ] **Step 2: Run the integration test**
+
+```bash
+npm --prefix /path/to/worktree test tests/integration/checkpoint.test.ts
+```
+
+Expected: both tests PASS (requires Docker Postgres with migrations applied).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add tests/integration/checkpoint.test.ts
+git -C /path/to/worktree commit -m "test: add conversation checkpoint integration tests"
+```
+
+---
+
+### Task 8: CHANGELOG and version bump
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`
+
+This is a new minor-level feature (new system component, new bus event type, new DB table).
+
+- [ ] **Step 1: Add entry under `## [Unreleased]`**
+
+```markdown
+### Added
+- **Conversation checkpoint pipeline** — Dispatch publishes a `conversation.checkpoint` event after 10 minutes of inactivity per conversation. A new System Layer `ConversationCheckpointProcessor` subscribes, concatenates new turns since the last watermark, fans out to background memory skills (`extract-relationships`; extensible to future skills), then advances a per-conversation watermark in the new `conversation_checkpoints` table. Adds migration 017.
+
+### Changed
+- **`extract-relationships` removed from coordinator tool loop** — extraction now runs via the checkpoint pipeline rather than as an LLM tool call. Fixes Signal and web chat confabulation bugs (see hotfix PR).
+```
+
+- [ ] **Step 2: Bump minor version in package.json**
+
+```json
+"version": "0.19.0"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add CHANGELOG.md package.json
+git -C /path/to/worktree commit -m "chore: release 0.19.0 — conversation checkpoint pipeline"
+```

--- a/docs/wip/2026-04-08-coordinator-hotfix.md
+++ b/docs/wip/2026-04-08-coordinator-hotfix.md
@@ -149,10 +149,9 @@ This is a bug fix, so a patch bump applies.
 
 - [ ] **Step 2: Bump patch version in package.json**
 
-Find the current version (e.g. `"version": "0.18.0"`) and increment the patch digit:
-```json
-"version": "0.18.1"
-```
+Find the `"version"` field in `package.json` and increment the patch component
+(`x.y.Z` → `x.y.(Z+1)`). Patch bumps apply to bug fixes, small improvements,
+and doc-only changes — see the versioning table in `CLAUDE.md`.
 
 - [ ] **Step 3: Commit**
 

--- a/docs/wip/2026-04-08-coordinator-hotfix.md
+++ b/docs/wip/2026-04-08-coordinator-hotfix.md
@@ -1,0 +1,162 @@
+# Coordinator Relationship Extraction Hotfix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove `extract-relationships` from the coordinator's LLM tool loop to fix the Signal and web chat confabulation bugs.
+
+**Architecture:** The coordinator's system prompt currently instructs the LLM to call `extract-relationships` as a background housekeeping tool after every message. This causes the LLM to return an empty text turn (tool call only), triggering the runtime's recovery mechanism, which confabulates "I already provided my response." Removing it from the tool list and system prompt eliminates the trigger entirely. Relationship extraction will be wired through the conversation checkpoint pipeline in a follow-up PR.
+
+**Tech Stack:** YAML (coordinator config), TypeScript (runtime.ts recovery comment), Vitest (existing tests)
+
+---
+
+### Task 1: Remove `extract-relationships` from coordinator.yaml
+
+**Files:**
+- Modify: `agents/coordinator.yaml` (lines 44–54 system prompt block, line 261 pinned_skills list)
+
+The coordinator.yaml has two places referencing `extract-relationships`:
+1. A "Relationship Extraction" system prompt block (lines 44–54) that instructs the LLM to call the skill
+2. A `pinned_skills` list entry (line 261) that makes the skill available as a tool
+
+Both must be removed together — leaving one without the other would either confuse the LLM (prompt references a tool it can't call) or waste a tool slot silently.
+
+- [ ] **Step 1: Open the file and locate the two sections**
+
+Read `agents/coordinator.yaml`. Confirm:
+- Lines ~44–54: the `## Relationship Extraction` block ends with "The user must always receive a non-empty text response from you."
+- Line ~261: `- extract-relationships` in the `pinned_skills` list
+
+- [ ] **Step 2: Remove the Relationship Extraction system prompt block**
+
+Delete this entire block from `agents/coordinator.yaml`:
+
+```yaml
+  ## Relationship Extraction
+  After every message, call `extract-relationships` with the full message text
+  and your current task source string. You do not need to decide whether the
+  message contains relationships — the skill handles that internally and exits
+  immediately if there is nothing to extract. Always call it; never skip it.
+
+  IMPORTANT: `extract-relationships` is a silent background housekeeping task.
+  It must never replace your text response to the user. Always write your reply
+  to the user first, then call `extract-relationships` as a follow-up step.
+  If you have nothing else to say, write a brief acknowledgement before calling it.
+  The user must always receive a non-empty text response from you.
+```
+
+Leave the `## Relationship Management` block (query-relationships, delete-relationship) intact — that is user-facing functionality, not background housekeeping.
+
+- [ ] **Step 3: Remove `extract-relationships` from pinned_skills**
+
+In the `pinned_skills` list, delete the line:
+```yaml
+  - extract-relationships
+```
+
+- [ ] **Step 4: Verify no other coordinator references remain**
+
+```bash
+grep -n "extract-relationships" agents/coordinator.yaml
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /path/to/worktree add agents/coordinator.yaml
+git -C /path/to/worktree commit -m "fix: remove extract-relationships from coordinator tool loop
+
+Caused the LLM to return an empty-text tool-call turn, triggering the
+empty-response recovery mechanism, which confabulated 'I already provided
+my response' to the user. Extraction will move to the conversation
+checkpoint pipeline (feat/conversation-checkpoint)."
+```
+
+---
+
+### Task 2: Update the recovery mechanism comment in runtime.ts
+
+**Files:**
+- Modify: `src/agents/runtime.ts` (lines ~448–455, the warning comment block)
+
+The recovery mechanism itself is still valid for other tools that legitimately produce empty turns. But its comment currently names `extract-relationships` as the canonical example — that example is now incorrect and will confuse future readers.
+
+- [ ] **Step 1: Update the inline comment**
+
+Find this block in `src/agents/runtime.ts` (around line 448):
+
+```typescript
+      if (response.content.trim() === '') {
+        // The LLM returned end_turn with no text — this happens when the model considers
+        // its tool calls (e.g. extract-relationships) to be the full response and produces
+        // an empty content array. Attempt one recovery: append the empty turn + a nudge,
+        // then call the LLM again without tools to force it to write the text reply.
+```
+
+Replace with:
+
+```typescript
+      if (response.content.trim() === '') {
+        // The LLM returned end_turn with no text — this happens when the model considers
+        // its tool calls to be the full response and produces an empty content array.
+        // Attempt one recovery: append the empty turn + a nudge, then call the LLM again
+        // without tools to force it to write the text reply.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /path/to/worktree add src/agents/runtime.ts
+git -C /path/to/worktree commit -m "chore: update recovery comment — extract-relationships no longer a coordinator tool"
+```
+
+---
+
+### Task 3: Run the test suite
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run all tests**
+
+```bash
+npm --prefix /path/to/worktree test
+```
+
+Expected: all tests pass. The coordinator's pinned_skills change reduces the tool list but no test asserts on that specific list, so no test changes are needed.
+
+- [ ] **Step 2: If any test fails**
+
+Check whether the failure references `extract-relationships` in a coordinator context. If so, update the test to remove that assertion — it was testing the (now-removed) broken behaviour.
+
+---
+
+### Task 4: Update CHANGELOG and bump version
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`
+
+This is a bug fix, so a patch bump applies.
+
+- [ ] **Step 1: Add CHANGELOG entry under `## [Unreleased]`**
+
+```markdown
+### Fixed
+- **Coordinator confabulation bug** — removed `extract-relationships` from the coordinator's LLM tool loop. The per-message tool call caused empty-text turns that triggered the empty-response recovery mechanism, which confabulated "I already provided my response" in Signal group chats and the web UI. Relationship extraction moves to the conversation checkpoint pipeline.
+```
+
+- [ ] **Step 2: Bump patch version in package.json**
+
+Find the current version (e.g. `"version": "0.18.0"`) and increment the patch digit:
+```json
+"version": "0.18.1"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add CHANGELOG.md package.json
+git -C /path/to/worktree commit -m "chore: release 0.18.1 — fix coordinator confabulation bug"
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -446,9 +446,9 @@ export class AgentRuntime {
       );
       if (response.content.trim() === '') {
         // The LLM returned end_turn with no text — this happens when the model considers
-        // its tool calls (e.g. extract-relationships) to be the full response and produces
-        // an empty content array. Attempt one recovery: append the empty turn + a nudge,
-        // then call the LLM again without tools to force it to write the text reply.
+        // its tool calls to be the full response and produces an empty content array.
+        // Attempt one recovery: append the empty turn + a nudge, then call the LLM again
+        // without tools to force it to write the text reply.
         logger.warn(
           { agentId, conversationId, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens },
           'LLM returned empty text after tool use — attempting recovery prompt',


### PR DESCRIPTION
## Summary

- Removes `extract-relationships` from the coordinator's `pinned_skills` list and system prompt, fixing two production confabulation bugs observed in Signal group chat and the web UI
- Updates a comment in `runtime.ts` that cited `extract-relationships` as a specific example of the empty-response recovery trigger
- Includes design spec and implementation plans for the follow-up conversation checkpoint pipeline (the permanent home for relationship extraction)

## Root cause

The coordinator's system prompt instructed the LLM to call `extract-relationships` as a background task after every message. This caused the LLM to return a tool-call turn with no text preamble. The runtime's empty-response recovery mechanism then fired — appending a nudge prompt to a message array that still contained the `tool_use`/`tool_result` blocks. The recovery LLM call read the conversation history, saw its own prior tool call, and confabulated "I already provided my response to the user" as its reply, delivering that text to the user.

## What's included

**Hotfix (ships now):**
- `agents/coordinator.yaml` — removed "Relationship Extraction" prompt block and `extract-relationships` from `pinned_skills`
- `src/agents/runtime.ts` — comment cleanup

**Design docs (for reviewers / follow-up PR):**
- `docs/wip/2026-04-08-conversation-checkpoint-design.md` — architecture spec for the conversation checkpoint pipeline
- `docs/wip/2026-04-08-coordinator-hotfix.md` — implementation plan for this PR
- `docs/wip/2026-04-08-conversation-checkpoint.md` — implementation plan for the follow-up pipeline PR

## Test plan

- [ ] All 1009 unit tests pass (`npm test`)
- [ ] Deploy to production and send a test message in Signal — confirm Curia responds directly without confabulating
- [ ] Verify `extract-relationships` is no longer visible in coordinator tool calls in logs
- [ ] Note: relationship extraction is temporarily disabled until the checkpoint pipeline PR lands; existing KG edges are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed per-message relationship extraction to prevent empty response recovery cycles that caused confabulated replies in Signal group chats and the web UI.

* **New Features**
  * Introduced conversation checkpoint pipeline for deferred relationship extraction after conversation inactivity, replacing per-message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->