### PR TITLE
feat: conversation checkpoint pipeline (v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Added
-- **Conversation checkpoint pipeline** — Dispatch publishes a `conversation.checkpoint` event after 10 minutes of inactivity per conversation. A new System Layer `ConversationCheckpointProcessor` subscribes, concatenates new turns since the last watermark, fans out to background memory skills (`extract-relationships`; extensible to future skills), then advances a per-conversation watermark in the new `conversation_checkpoints` table. Adds migration 017. **Breaking change:** `conversation.checkpoint` added to the bus event type discriminated union.
+- **Conversation checkpoint pipeline** — Dispatch publishes a `conversation.checkpoint` event after 10 minutes of inactivity per conversation–agent pair. A new System Layer `ConversationCheckpointProcessor` subscribes, concatenates new turns since the last watermark, fans out to background memory skills (`extract-relationships`; extensible to future skills), then advances the per-(conversationId, agentId) watermark in the new `conversation_checkpoints` table. Adds migration 017. **Breaking change:** `conversation.checkpoint` added to the bus event type discriminated union.
 
 ### Changed
-- **`extract-relationships` moved to checkpoint pipeline** — extraction now runs once per conversation (after 10 min of inactivity) rather than as an LLM tool call on every message. Fixes the coordinator confabulation bugs (see PR #221).
+- **`extract-relationships` moved to checkpoint pipeline** — extraction now runs once per conversation–agent pair (after 10 min of inactivity) rather than as an LLM tool call on every message. Fixes the coordinator confabulation bugs (see PR #221).
 
 ### Fixed
 - **Coordinator confabulation bug** — removed `extract-relationships` from the coordinator's LLM tool loop. The per-message tool call caused empty-text turns that triggered the empty-response recovery mechanism, which confabulated "I already provided my response" in Signal group chats and the web UI. Relationship extraction moves to the conversation checkpoint pipeline (forthcoming).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+- **Conversation checkpoint pipeline** — Dispatch publishes a `conversation.checkpoint` event after 10 minutes of inactivity per conversation. A new System Layer `ConversationCheckpointProcessor` subscribes, concatenates new turns since the last watermark, fans out to background memory skills (`extract-relationships`; extensible to future skills), then advances a per-conversation watermark in the new `conversation_checkpoints` table. Adds migration 017. **Breaking change:** `conversation.checkpoint` added to the bus event type discriminated union.
+
+### Changed
+- **`extract-relationships` moved to checkpoint pipeline** — extraction now runs once per conversation (after 10 min of inactivity) rather than as an LLM tool call on every message. Fixes the coordinator confabulation bugs (see PR #221).
+
 ### Fixed
 - **Coordinator confabulation bug** — removed `extract-relationships` from the coordinator's LLM tool loop. The per-message tool call caused empty-text turns that triggered the empty-response recovery mechanism, which confabulated "I already provided my response" in Signal group chats and the web UI. Relationship extraction moves to the conversation checkpoint pipeline (forthcoming).
 - **KG node deduplication** — one-time migration deduplicates existing `kg_nodes` rows with matching `(lower(label), type)`, re-pointing edges and contacts to canonical nodes before removing duplicates.

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -15,6 +15,11 @@ agents:
   coordinator:
     config_path: agents/coordinator.yaml
 
+dispatch:
+  # Milliseconds of inactivity after the last agent response before a conversation.checkpoint
+  # event fires and background memory extraction (extract-relationships, etc.) runs.
+  conversationCheckpointDebounceMs: 600000   # 10 minutes
+
 skillOutput:
   # Maximum character length of a sanitized skill result before truncation.
   # Skills that return more than this (search results, page crawls, long calendar

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -378,6 +378,22 @@ export interface ConfigChangeEvent extends BaseEvent {
   payload: ConfigChangePayload;
 }
 
+export interface ConversationCheckpointPayload {
+  conversationId: string;
+  agentId: string;
+  channelId: string;
+  /** ISO timestamp — turns created after this point are included. Empty string on first checkpoint. */
+  since: string;
+  /** Ordered chronologically (oldest first). Contains only turns since `since`. */
+  turns: Array<{ role: 'user' | 'assistant'; content: string }>;
+}
+
+export interface ConversationCheckpointEvent extends BaseEvent {
+  type: 'conversation.checkpoint';
+  sourceLayer: 'dispatch';
+  payload: ConversationCheckpointPayload;
+}
+
 export type BusEvent =
   | InboundMessageEvent
   | AgentTaskEvent
@@ -400,7 +416,8 @@ export type BusEvent =
   | ScheduleFiredEvent     // Scheduler: job fired
   | ScheduleSuspendedEvent   // Scheduler: job auto-suspended
   | ScheduleRecoveredEvent   // Scheduler: stuck job auto-recovered
-  | ConfigChangeEvent;       // System: config object changed (office identity, etc.)
+  | ConfigChangeEvent        // System: config object changed (office identity, etc.)
+  | ConversationCheckpointEvent; // Checkpoint pipeline: Dispatch fires after inactivity window
 
 // Convenience alias for use in handler maps / switch statements.
 export type EventType = BusEvent['type'];
@@ -727,5 +744,17 @@ export function createConfigChange(
     sourceLayer: 'system',
     payload: rest,
     parentEventId,
+  };
+}
+
+export function createConversationCheckpoint(
+  payload: ConversationCheckpointPayload,
+): ConversationCheckpointEvent {
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    sourceLayer: 'dispatch',
+    type: 'conversation.checkpoint',
+    payload,
   };
 }

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -378,7 +378,7 @@ export interface ConfigChangeEvent extends BaseEvent {
   payload: ConfigChangePayload;
 }
 
-export interface ConversationCheckpointPayload {
+interface ConversationCheckpointPayload {
   conversationId: string;
   agentId: string;
   channelId: string;

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -384,6 +384,10 @@ interface ConversationCheckpointPayload {
   channelId: string;
   /** ISO timestamp — turns created after this point are included. Empty string on first checkpoint. */
   since: string;
+  /** ISO timestamp of the newest turn in this batch. Used as the new watermark value
+   *  in conversation_checkpoints.last_checkpoint_at; avoids advancing the watermark past
+   *  turns that arrived between the DB read and the upsert. */
+  through: string;
   /** Ordered chronologically (oldest first). Contains only turns since `since`. */
   turns: Array<{ role: 'user' | 'assistant'; content: string }>;
 }

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -17,7 +17,7 @@ const publishAllowlist: Record<Layer, Set<EventType>> = {
   dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint']),
   agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss']),
   execution: new Set(['skill.result']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint']),
 };
 
 // agent.discuss subscribe for 'dispatch': used by BullpenDispatcher (wired in index.ts after agent registration).

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -10,9 +10,11 @@ import type { Layer, EventType } from './events.js';
 // Contact Merge: dispatch layer publishes contact.duplicate_detected and contact.merged — these
 //                fire as background side-effects of createContact() when DedupService is wired.
 // Bullpen: agent layer publishes agent.discuss; dispatch and system layers subscribe.
+// Checkpoint pipeline: dispatch layer publishes conversation.checkpoint after inactivity;
+//                      system layer's ConversationCheckpointProcessor subscribes to run skills.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message']),
-  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged']),
+  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint']),
   agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss']),
   execution: new Set(['skill.result']),
   system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss']),
@@ -24,7 +26,7 @@ const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/checkpoint/processor.ts
+++ b/src/checkpoint/processor.ts
@@ -1,0 +1,75 @@
+import type { EventBus } from '../bus/bus.js';
+import type { ExecutionLayer } from '../skills/execution.js';
+import type { DbPool } from '../db/connection.js';
+import type { Logger } from '../logger.js';
+import type { ConversationCheckpointEvent } from '../bus/events.js';
+
+// Skills invoked at every checkpoint, in addition to any future skills.
+// Add new checkpoint skills here — no changes to Dispatch or the runtime required.
+const CHECKPOINT_SKILLS: Array<{ name: string }> = [
+  { name: 'extract-relationships' },
+  // { name: 'extract-entities' },  // add when issue #151 is built
+];
+
+export class ConversationCheckpointProcessor {
+  constructor(
+    private bus: EventBus,
+    private executionLayer: ExecutionLayer,
+    private pool: DbPool,
+    private logger: Logger,
+  ) {}
+
+  register(): void {
+    this.bus.subscribe('conversation.checkpoint', 'system', async (event) => {
+      await this.handleCheckpoint(event as ConversationCheckpointEvent);
+    });
+  }
+
+  private async handleCheckpoint(event: ConversationCheckpointEvent): Promise<void> {
+    const { conversationId, agentId, channelId, turns } = event.payload;
+
+    if (turns.length === 0) return;
+
+    const transcript = turns
+      .map(t => `${t.role === 'user' ? 'User' : 'Curia'}: ${t.content}`)
+      .join('\n\n');
+
+    const source = `system:checkpoint/conversation:${conversationId}/agent:${agentId}/channel:${channelId}`;
+
+    // CallerContext for system-layer invocations — no human contact involved.
+    // Use 'system' as a sentinel contactId; channel carries the originating channel.
+    const callerContext = {
+      contactId: 'system',
+      role: null,
+      channel: channelId,
+    };
+
+    // Run all checkpoint skills concurrently. A failure in one must not block the
+    // others or prevent the watermark from advancing — hence Promise.allSettled.
+    await Promise.allSettled(
+      CHECKPOINT_SKILLS.map(skill =>
+        this.executionLayer.invoke(skill.name, { text: transcript, source }, callerContext)
+          .catch(err =>
+            this.logger.error(
+              { err, skill: skill.name, conversationId },
+              'checkpoint skill failed — watermark will still advance',
+            ),
+          ),
+      ),
+    );
+
+    // Advance the watermark. Upsert so first checkpoint creates the row.
+    await this.pool.query(
+      `INSERT INTO conversation_checkpoints (conversation_id, agent_id, last_checkpoint_at)
+       VALUES ($1, $2, now())
+       ON CONFLICT (conversation_id, agent_id)
+       DO UPDATE SET last_checkpoint_at = now()`,
+      [conversationId, agentId],
+    );
+
+    this.logger.info(
+      { conversationId, agentId, turnCount: turns.length },
+      'Conversation checkpoint complete',
+    );
+  }
+}

--- a/src/checkpoint/processor.ts
+++ b/src/checkpoint/processor.ts
@@ -3,6 +3,7 @@ import type { ExecutionLayer } from '../skills/execution.js';
 import type { DbPool } from '../db/connection.js';
 import type { Logger } from '../logger.js';
 import type { ConversationCheckpointEvent } from '../bus/events.js';
+import type { SkillResult } from '../skills/types.js';
 
 // Skills invoked at every checkpoint, in addition to any future skills.
 // Add new checkpoint skills here — no changes to Dispatch or the runtime required.
@@ -46,19 +47,38 @@ export class ConversationCheckpointProcessor {
 
     // Run all checkpoint skills concurrently. A failure in one must not block the
     // others or prevent the watermark from advancing — hence Promise.allSettled.
-    await Promise.allSettled(
+    // Check both rejected promises (thrown errors) and resolved { success: false }
+    // results — ExecutionLayer never throws, so the latter is the normal failure path.
+    const results = await Promise.allSettled(
       CHECKPOINT_SKILLS.map(skill =>
-        this.executionLayer.invoke(skill.name, { text: transcript, source }, callerContext)
-          .catch(err =>
-            this.logger.error(
-              { err, skill: skill.name, conversationId },
-              'checkpoint skill failed — watermark will still advance',
-            ),
-          ),
+        this.executionLayer.invoke(skill.name, { text: transcript, source }, callerContext),
       ),
     );
 
-    // Advance the watermark. Upsert so first checkpoint creates the row.
+    results.forEach((result, index) => {
+      const skillName = CHECKPOINT_SKILLS[index]!.name;
+      if (result.status === 'rejected') {
+        this.logger.error(
+          { err: result.reason as Error, skill: skillName, conversationId },
+          'checkpoint skill threw unexpectedly — watermark will still advance',
+        );
+        return;
+      }
+      const skillResult = result.value as SkillResult;
+      if (!skillResult.success) {
+        this.logger.error(
+          { skill: skillName, conversationId, error: skillResult.error },
+          'checkpoint skill returned failure — watermark will still advance',
+        );
+      }
+    });
+
+    // Advance the watermark to the batch's upper-bound timestamp (not now()).
+    // Using now() would advance the watermark past any turns that arrived between
+    // the Dispatcher's DB read and this upsert, causing those turns to be silently
+    // skipped on the next checkpoint. `through` is set by Dispatcher to the
+    // created_at of the newest turn in the batch, so the boundary is exact.
+    // Upsert so the first checkpoint creates the row.
     // Wrapped in its own try/catch so that a transient DB error is logged with
     // full context (conversationId/agentId) rather than surfacing to the bus's
     // generic catch-all which would lose those fields. Consequence of failure:
@@ -66,10 +86,10 @@ export class ConversationCheckpointProcessor {
     try {
       await this.pool.query(
         `INSERT INTO conversation_checkpoints (conversation_id, agent_id, last_checkpoint_at)
-         VALUES ($1, $2, now())
+         VALUES ($1, $2, $3)
          ON CONFLICT (conversation_id, agent_id)
-         DO UPDATE SET last_checkpoint_at = now()`,
-        [conversationId, agentId],
+         DO UPDATE SET last_checkpoint_at = EXCLUDED.last_checkpoint_at`,
+        [conversationId, agentId, event.payload.through],
       );
     } catch (err) {
       this.logger.error(

--- a/src/checkpoint/processor.ts
+++ b/src/checkpoint/processor.ts
@@ -59,13 +59,25 @@ export class ConversationCheckpointProcessor {
     );
 
     // Advance the watermark. Upsert so first checkpoint creates the row.
-    await this.pool.query(
-      `INSERT INTO conversation_checkpoints (conversation_id, agent_id, last_checkpoint_at)
-       VALUES ($1, $2, now())
-       ON CONFLICT (conversation_id, agent_id)
-       DO UPDATE SET last_checkpoint_at = now()`,
-      [conversationId, agentId],
-    );
+    // Wrapped in its own try/catch so that a transient DB error is logged with
+    // full context (conversationId/agentId) rather than surfacing to the bus's
+    // generic catch-all which would lose those fields. Consequence of failure:
+    // the same turns will be re-processed on the next checkpoint (idempotent).
+    try {
+      await this.pool.query(
+        `INSERT INTO conversation_checkpoints (conversation_id, agent_id, last_checkpoint_at)
+         VALUES ($1, $2, now())
+         ON CONFLICT (conversation_id, agent_id)
+         DO UPDATE SET last_checkpoint_at = now()`,
+        [conversationId, agentId],
+      );
+    } catch (err) {
+      this.logger.error(
+        { err, conversationId, agentId },
+        'Failed to advance checkpoint watermark — skills ran but watermark not saved; turns will re-process on next checkpoint',
+      );
+      return;
+    }
 
     this.logger.info(
       { conversationId, agentId, turnCount: turns.length },

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,11 @@ export interface YamlConfig {
     /** Max character length for skill results before truncation. Default: 200_000. */
     maxLength?: number;
   };
+  dispatch?: {
+    /** Milliseconds of inactivity before a conversation.checkpoint event is published.
+     *  Defaults to 600000 (10 minutes). */
+    conversationCheckpointDebounceMs?: number;
+  };
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,6 +99,13 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       throw new Error(`skillOutput.maxLength must be a positive integer, got: ${maxLength}`);
     }
 
+    const checkpointDebounceMs = config.dispatch?.conversationCheckpointDebounceMs;
+    if (checkpointDebounceMs !== undefined && (!Number.isInteger(checkpointDebounceMs) || checkpointDebounceMs <= 0)) {
+      throw new Error(
+        `dispatch.conversationCheckpointDebounceMs must be a positive integer, got: ${checkpointDebounceMs}`,
+      );
+    }
+
     return config;
   } catch (err) {
     // File absent in test/CI environments — silently return empty config.

--- a/src/db/migrations/017_create_conversation_checkpoints.sql
+++ b/src/db/migrations/017_create_conversation_checkpoints.sql
@@ -1,0 +1,14 @@
+-- Up Migration
+-- Watermark table for the conversation checkpoint pipeline.
+-- One row per (conversation_id, agent_id) pair — upserted after each checkpoint run.
+-- The primary key enforces at-most-one watermark per pair; there is no delete path.
+
+CREATE TABLE conversation_checkpoints (
+  conversation_id    TEXT        NOT NULL,
+  agent_id           TEXT        NOT NULL,
+  last_checkpoint_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (conversation_id, agent_id)
+);
+
+-- Down Migration
+DROP TABLE IF EXISTS conversation_checkpoints;

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -1,11 +1,12 @@
 import type { EventBus } from '../bus/bus.js';
 import type { InboundMessageEvent, AgentResponseEvent, AgentErrorEvent } from '../bus/events.js';
-import { createAgentTask, createOutboundMessage, createContactResolved, createContactUnknown, createMessageHeld, createMessageRejected } from '../bus/events.js';
+import { createAgentTask, createOutboundMessage, createContactResolved, createContactUnknown, createMessageHeld, createMessageRejected, createConversationCheckpoint } from '../bus/events.js';
 import type { Logger } from '../logger.js';
 import type { ContactResolver } from '../contacts/contact-resolver.js';
 import type { HeldMessageService } from '../contacts/held-messages.js';
 import type { InboundSenderContext, ChannelPolicyConfig } from '../contacts/types.js';
 import type { InboundScanner } from './inbound-scanner.js';
+import type { DbPool } from '../db/connection.js';
 
 export interface DispatcherConfig {
   bus: EventBus;
@@ -16,6 +17,11 @@ export interface DispatcherConfig {
   /** Layer 1 prompt injection scanner. When provided, every inbound message is
    *  scanned before reaching the Coordinator — tags stripped, risk_score attached. */
   injectionScanner?: InboundScanner;
+  /** Postgres pool — used to query working_memory for checkpoint turns.
+   *  When omitted, checkpoint scheduling is disabled (e.g. in unit tests). */
+  pool?: DbPool;
+  /** Milliseconds of inactivity before conversation.checkpoint fires. Default: 600000. */
+  conversationCheckpointDebounceMs?: number;
 }
 
 /**
@@ -44,6 +50,10 @@ export class Dispatcher {
    * runtime sets parentEventId on its response to the task event that triggered it.
    */
   private taskRouting = new Map<string, { channelId: string; conversationId: string; senderId: string }>();
+  /** Key: `${conversationId}:${agentId}` — reset on every agent.response */
+  private checkpointTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private pool: DbPool | undefined;
+  private conversationCheckpointDebounceMs: number;
 
   constructor(config: DispatcherConfig) {
     this.bus = config.bus;
@@ -52,6 +62,16 @@ export class Dispatcher {
     this.heldMessages = config.heldMessages;
     this.channelPolicies = config.channelPolicies;
     this.injectionScanner = config.injectionScanner;
+    this.pool = config.pool;
+    this.conversationCheckpointDebounceMs = config.conversationCheckpointDebounceMs ?? 600_000;
+  }
+
+  /** Clear all pending checkpoint timers. Call during graceful shutdown. */
+  close(): void {
+    for (const timer of this.checkpointTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.checkpointTimers.clear();
   }
 
   register(): void {
@@ -381,5 +401,74 @@ export class Dispatcher {
       parentEventId: event.id,
     });
     await this.bus.publish('dispatch', outbound);
+
+    // Schedule a checkpoint for this conversation — resets the debounce timer if
+    // already running, so only fires after a full window of inactivity.
+    this.scheduleCheckpoint(routing.conversationId, event.payload.agentId, routing.channelId);
+  }
+
+  private scheduleCheckpoint(conversationId: string, agentId: string, channelId: string): void {
+    // Checkpoint requires pool to query working_memory — if not configured, skip.
+    if (!this.pool) return;
+
+    const key = `${conversationId}:${agentId}`;
+    const existing = this.checkpointTimers.get(key);
+    if (existing) clearTimeout(existing);
+
+    const timer = setTimeout(() => {
+      this.checkpointTimers.delete(key);
+      // Fire-and-forget — errors are logged inside fireCheckpoint
+      void this.fireCheckpoint(conversationId, agentId, channelId);
+    }, this.conversationCheckpointDebounceMs);
+
+    this.checkpointTimers.set(key, timer);
+  }
+
+  private async fireCheckpoint(conversationId: string, agentId: string, channelId: string): Promise<void> {
+    try {
+      // Look up the last watermark for this conversation+agent pair
+      const watermarkResult = await this.pool!.query<{ last_checkpoint_at: string }>(
+        `SELECT last_checkpoint_at FROM conversation_checkpoints
+         WHERE conversation_id = $1 AND agent_id = $2`,
+        [conversationId, agentId],
+      );
+      const since = watermarkResult.rows[0]?.last_checkpoint_at ?? '';
+
+      // Fetch turns from working memory since the watermark
+      const turnsResult = await this.pool!.query<{ role: string; content: string }>(
+        `SELECT role, content FROM working_memory
+         WHERE conversation_id = $1 AND agent_id = $2
+           AND role IN ('user', 'assistant')
+           ${since ? 'AND created_at > $3' : ''}
+         ORDER BY created_at ASC`,
+        since ? [conversationId, agentId, since] : [conversationId, agentId],
+      );
+
+      if (turnsResult.rows.length === 0) {
+        // Nothing new since last checkpoint — skip publishing
+        return;
+      }
+
+      const turns = turnsResult.rows.map(row => ({
+        role: row.role as 'user' | 'assistant',
+        content: row.content,
+      }));
+
+      const event = createConversationCheckpoint({
+        conversationId,
+        agentId,
+        channelId,
+        since,
+        turns,
+      });
+
+      await this.bus.publish('dispatch', event);
+      this.logger.info(
+        { conversationId, agentId, turnCount: turns.length },
+        'Conversation checkpoint published',
+      );
+    } catch (err) {
+      this.logger.error({ err, conversationId, agentId }, 'Failed to fire conversation checkpoint');
+    }
   }
 }

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -434,19 +434,22 @@ export class Dispatcher {
       );
       const since = watermarkResult.rows[0]?.last_checkpoint_at ?? '';
 
-      // Fetch turns from working memory since the watermark.
+      // Fetch turns from working memory since the watermark. Also select created_at so
+      // we can carry the newest turn's timestamp as `through` in the event payload — the
+      // processor uses that exact value as the new watermark, avoiding the window between
+      // the batch read and the upsert where new turns could otherwise be silently skipped.
       // Two explicit query strings rather than a conditional template fragment — avoids
       // the risk of a parameter slot ($3) drifting out of sync with the array when edited.
       const turnsQuery = since
-        ? `SELECT role, content FROM working_memory
+        ? `SELECT role, content, created_at FROM working_memory
            WHERE conversation_id = $1 AND agent_id = $2
              AND role IN ('user', 'assistant') AND created_at > $3
            ORDER BY created_at ASC`
-        : `SELECT role, content FROM working_memory
+        : `SELECT role, content, created_at FROM working_memory
            WHERE conversation_id = $1 AND agent_id = $2
              AND role IN ('user', 'assistant')
            ORDER BY created_at ASC`;
-      const turnsResult = await this.pool!.query<{ role: string; content: string }>(
+      const turnsResult = await this.pool!.query<{ role: string; content: string; created_at: string }>(
         turnsQuery,
         since ? [conversationId, agentId, since] : [conversationId, agentId],
       );
@@ -461,11 +464,15 @@ export class Dispatcher {
         content: row.content,
       }));
 
+      // Use the last row's created_at as the batch upper bound (rows ordered ASC).
+      const through = turnsResult.rows[turnsResult.rows.length - 1]!.created_at;
+
       const event = createConversationCheckpoint({
         conversationId,
         agentId,
         channelId,
         since,
+        through,
         turns,
       });
 

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -434,13 +434,20 @@ export class Dispatcher {
       );
       const since = watermarkResult.rows[0]?.last_checkpoint_at ?? '';
 
-      // Fetch turns from working memory since the watermark
+      // Fetch turns from working memory since the watermark.
+      // Two explicit query strings rather than a conditional template fragment — avoids
+      // the risk of a parameter slot ($3) drifting out of sync with the array when edited.
+      const turnsQuery = since
+        ? `SELECT role, content FROM working_memory
+           WHERE conversation_id = $1 AND agent_id = $2
+             AND role IN ('user', 'assistant') AND created_at > $3
+           ORDER BY created_at ASC`
+        : `SELECT role, content FROM working_memory
+           WHERE conversation_id = $1 AND agent_id = $2
+             AND role IN ('user', 'assistant')
+           ORDER BY created_at ASC`;
       const turnsResult = await this.pool!.query<{ role: string; content: string }>(
-        `SELECT role, content FROM working_memory
-         WHERE conversation_id = $1 AND agent_id = $2
-           AND role IN ('user', 'assistant')
-           ${since ? 'AND created_at > $3' : ''}
-         ORDER BY created_at ASC`,
+        turnsQuery,
         since ? [conversationId, agentId, since] : [conversationId, agentId],
       );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -779,7 +779,11 @@ async function main(): Promise<void> {
     }
     // Clear pending checkpoint timers before closing the pool — prevents in-flight
     // fireCheckpoint calls from querying a closed pool during shutdown.
-    dispatcher.close();
+    try {
+      dispatcher.close();
+    } catch (err) {
+      logger.error({ err }, 'Error clearing checkpoint timers during shutdown');
+    }
     try {
       await pool.end();
     } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ import type { AgentPersona } from './skills/types.js';
 import type { ConfigChangeEvent } from './bus/events.js';
 import { BullpenService } from './memory/bullpen.js';
 import { BullpenDispatcher } from './dispatch/bullpen-dispatcher.js';
+import { ConversationCheckpointProcessor } from './checkpoint/processor.js';
 
 async function main(): Promise<void> {
   // 1. Config & logging — no dependencies, must come first.
@@ -680,8 +681,15 @@ async function main(): Promise<void> {
     heldMessages,
     channelPolicies: authConfig?.channelPolicies,
     injectionScanner,
+    pool,
+    conversationCheckpointDebounceMs: yamlConfig.dispatch?.conversationCheckpointDebounceMs,
   });
   dispatcher.register();
+
+  // Conversation checkpoint processor — System Layer subscriber that runs background
+  // memory skills (extract-relationships, etc.) at end of each conversation.
+  const checkpointProcessor = new ConversationCheckpointProcessor(bus, executionLayer, pool, logger);
+  checkpointProcessor.register();
 
   // BullpenDispatcher — routes agent.discuss → agent.task for inter-agent Bullpen discussions.
   const bullpenDispatcher = new BullpenDispatcher(bus, logger, bullpenService);
@@ -769,6 +777,9 @@ async function main(): Promise<void> {
         logger.error({ err }, 'Error stopping browser service during shutdown');
       }
     }
+    // Clear pending checkpoint timers before closing the pool — prevents in-flight
+    // fireCheckpoint calls from querying a closed pool during shutdown.
+    dispatcher.close();
     try {
       await pool.end();
     } catch (err) {

--- a/tests/integration/checkpoint.test.ts
+++ b/tests/integration/checkpoint.test.ts
@@ -3,8 +3,7 @@
 // Uses real Postgres (DATABASE_URL must be set) and a mock ExecutionLayer
 // so no real LLM API calls are made. Tests that:
 // 1. The processor creates a watermark row after the first checkpoint
-// 2. The processor advances the watermark on subsequent checkpoints
-// 3. The watermark is respected — only turns after `since` are passed to skills
+// 2. The watermark is respected — only turns after `since` are passed to skills
 
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import pg from 'pg';
@@ -14,6 +13,7 @@ import { createConversationCheckpoint } from '../../src/bus/events.js';
 import type { ExecutionLayer } from '../../src/skills/execution.js';
 import type { EventBus } from '../../src/bus/bus.js';
 import type { Logger } from '../../src/logger.js';
+import type { DbPool } from '../../src/db/connection.js';
 
 const { Pool } = pg;
 
@@ -31,123 +31,180 @@ function makeBusAndLogger() {
 
 describeIf('ConversationCheckpointProcessor — integration', () => {
   let pool: pg.Pool;
-  let memory: WorkingMemory;
 
-  // Unique conversation ID per test run to avoid cross-run interference
-  const conversationId = `test:checkpoint-${Date.now()}`;
   const agentId = 'coordinator';
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: DATABASE_URL });
-    memory = WorkingMemory.createWithPostgres(pool as any, {
-      info: () => {}, error: () => {}, warn: () => {}, debug: () => {},
-    } as any);
-
-    // Insert two initial turns
-    await memory.addTurn(conversationId, agentId, { role: 'user', content: 'Xiaopu Fung is my wife' });
-    await memory.addTurn(conversationId, agentId, { role: 'assistant', content: 'Got it, I will remember that.' });
   });
 
   afterAll(async () => {
-    await pool.query('DELETE FROM conversation_checkpoints WHERE conversation_id = $1', [conversationId]);
-    await pool.query('DELETE FROM working_memory WHERE conversation_id = $1', [conversationId]);
     await pool.end();
   });
 
   it('creates a watermark and calls the skill with the full transcript', async () => {
-    const invokedArgs: Array<{ name: string; input: Record<string, unknown> }> = [];
-    const executionLayer = {
-      invoke: vi.fn(async (name: string, input: Record<string, unknown>) => {
-        invokedArgs.push({ name, input });
-        return { success: true, data: {} };
-      }),
-    } as unknown as ExecutionLayer;
+    // Each test gets its own conversationId so tests are fully independent
+    const conversationId = `test:checkpoint-first-${Date.now()}`;
+    const { logger } = makeBusAndLogger();
+    const memory = WorkingMemory.createWithPostgres(pool as unknown as DbPool, logger);
 
-    const { bus, logger } = makeBusAndLogger();
-    const processor = new ConversationCheckpointProcessor(bus, executionLayer, pool as any, logger);
-    processor.register();
+    await memory.addTurn(conversationId, agentId, { role: 'user', content: 'Xiaopu Fung is my wife' });
+    await memory.addTurn(conversationId, agentId, { role: 'assistant', content: 'Got it, I will remember that.' });
 
-    // Fire checkpoint directly (bypass debounce)
-    const event = createConversationCheckpoint({
-      conversationId,
-      agentId,
-      channelId: 'test',
-      since: '',
-      turns: [
-        { role: 'user', content: 'Xiaopu Fung is my wife' },
-        { role: 'assistant', content: 'Got it, I will remember that.' },
-      ],
-    });
+    try {
+      const invokedArgs: Array<{ name: string; input: Record<string, unknown> }> = [];
+      const executionLayer = {
+        invoke: vi.fn(async (name: string, input: Record<string, unknown>) => {
+          invokedArgs.push({ name, input });
+          return { success: true, data: {} };
+        }),
+      } as unknown as ExecutionLayer;
 
-    // Retrieve the registered handler and call it directly
-    const handler = (bus.subscribe as ReturnType<typeof vi.fn>).mock.calls[0][2] as (e: unknown) => Promise<void>;
-    await handler(event);
+      const { bus, logger: processorLogger } = makeBusAndLogger();
+      const processor = new ConversationCheckpointProcessor(
+        bus, executionLayer, pool as unknown as DbPool, processorLogger,
+      );
+      processor.register();
 
-    // Skill was invoked with concatenated transcript
-    expect(invokedArgs).toHaveLength(1);
-    expect(invokedArgs[0]!.name).toBe('extract-relationships');
-    expect(invokedArgs[0]!.input['text']).toContain('Xiaopu Fung');
-    expect(invokedArgs[0]!.input['source']).toContain(conversationId);
+      // Determine `through`: the newest turn's created_at
+      const turnsResult = await pool.query<{ created_at: string }>(
+        `SELECT created_at FROM working_memory
+         WHERE conversation_id = $1 AND agent_id = $2
+           AND role IN ('user', 'assistant')
+         ORDER BY created_at DESC LIMIT 1`,
+        [conversationId, agentId],
+      );
+      const through = turnsResult.rows[0]!.created_at;
 
-    // Watermark was created
-    const watermark = await pool.query(
-      'SELECT last_checkpoint_at FROM conversation_checkpoints WHERE conversation_id = $1 AND agent_id = $2',
-      [conversationId, agentId],
-    );
-    expect(watermark.rows).toHaveLength(1);
-    expect(new Date(watermark.rows[0].last_checkpoint_at).getTime()).toBeGreaterThan(Date.now() - 10_000);
+      const event = createConversationCheckpoint({
+        conversationId,
+        agentId,
+        channelId: 'test',
+        since: '',
+        through,
+        turns: [
+          { role: 'user', content: 'Xiaopu Fung is my wife' },
+          { role: 'assistant', content: 'Got it, I will remember that.' },
+        ],
+      });
+
+      // Retrieve the registered handler and call it directly
+      const handler = (bus.subscribe as ReturnType<typeof vi.fn>).mock.calls[0][2] as (e: unknown) => Promise<void>;
+      await handler(event);
+
+      // Skill was invoked with concatenated transcript
+      expect(invokedArgs).toHaveLength(1);
+      expect(invokedArgs[0]!.name).toBe('extract-relationships');
+      expect(invokedArgs[0]!.input['text']).toContain('Xiaopu Fung');
+      expect(invokedArgs[0]!.input['source']).toContain(conversationId);
+
+      // Watermark was created at the batch's upper bound
+      const watermark = await pool.query(
+        'SELECT last_checkpoint_at FROM conversation_checkpoints WHERE conversation_id = $1 AND agent_id = $2',
+        [conversationId, agentId],
+      );
+      expect(watermark.rows).toHaveLength(1);
+      expect(new Date(watermark.rows[0].last_checkpoint_at).getTime())
+        .toBeGreaterThan(Date.now() - 10_000);
+    } finally {
+      await pool.query('DELETE FROM conversation_checkpoints WHERE conversation_id = $1', [conversationId]);
+      await pool.query('DELETE FROM working_memory WHERE conversation_id = $1', [conversationId]);
+    }
   });
 
   it('respects the watermark — second checkpoint only passes new turns to skills', async () => {
-    // Insert two new turns after the first checkpoint
-    await memory.addTurn(conversationId, agentId, { role: 'user', content: 'Ada Chen leads Project Orion' });
-    await memory.addTurn(conversationId, agentId, { role: 'assistant', content: 'Noted.' });
+    // Self-contained: seeds its own turns, fires an initial checkpoint, then a second one
+    const conversationId = `test:checkpoint-second-${Date.now()}`;
+    const { logger } = makeBusAndLogger();
+    const memory = WorkingMemory.createWithPostgres(pool as unknown as DbPool, logger);
 
-    // Get current watermark (set by the first test)
-    const before = await pool.query(
-      'SELECT last_checkpoint_at FROM conversation_checkpoints WHERE conversation_id = $1 AND agent_id = $2',
-      [conversationId, agentId],
-    );
-    const since: string = before.rows[0].last_checkpoint_at;
+    await memory.addTurn(conversationId, agentId, { role: 'user', content: 'Xiaopu Fung is my wife' });
+    await memory.addTurn(conversationId, agentId, { role: 'assistant', content: 'Got it, I will remember that.' });
 
-    const invokedTexts: string[] = [];
-    const executionLayer = {
-      invoke: vi.fn(async (_name: string, input: Record<string, unknown>) => {
-        invokedTexts.push(input['text'] as string);
-        return { success: true, data: {} };
-      }),
-    } as unknown as ExecutionLayer;
+    try {
+      // --- First checkpoint: establish the watermark ---
+      const firstTurnsResult = await pool.query<{ created_at: string }>(
+        `SELECT created_at FROM working_memory
+         WHERE conversation_id = $1 AND agent_id = $2
+           AND role IN ('user', 'assistant')
+         ORDER BY created_at DESC LIMIT 1`,
+        [conversationId, agentId],
+      );
+      const firstThrough = firstTurnsResult.rows[0]!.created_at;
 
-    const { bus, logger } = makeBusAndLogger();
-    const processor = new ConversationCheckpointProcessor(bus, executionLayer, pool as any, logger);
-    processor.register();
+      const { bus: bus1, logger: logger1 } = makeBusAndLogger();
+      const proc1 = new ConversationCheckpointProcessor(
+        bus1, { invoke: vi.fn().mockResolvedValue({ success: true, data: {} }) } as unknown as ExecutionLayer,
+        pool as unknown as DbPool, logger1,
+      );
+      proc1.register();
+      const handler1 = (bus1.subscribe as ReturnType<typeof vi.fn>).mock.calls[0][2] as (e: unknown) => Promise<void>;
+      await handler1(createConversationCheckpoint({
+        conversationId, agentId, channelId: 'test', since: '', through: firstThrough,
+        turns: [
+          { role: 'user', content: 'Xiaopu Fung is my wife' },
+          { role: 'assistant', content: 'Got it, I will remember that.' },
+        ],
+      }));
 
-    // Fire second checkpoint with only the new turns
-    const event = createConversationCheckpoint({
-      conversationId,
-      agentId,
-      channelId: 'test',
-      since,
-      turns: [
-        { role: 'user', content: 'Ada Chen leads Project Orion' },
-        { role: 'assistant', content: 'Noted.' },
-      ],
-    });
+      // Read back the watermark just set
+      const wmRow = await pool.query(
+        'SELECT last_checkpoint_at FROM conversation_checkpoints WHERE conversation_id = $1 AND agent_id = $2',
+        [conversationId, agentId],
+      );
+      const since: string = wmRow.rows[0].last_checkpoint_at;
 
-    const handler = (bus.subscribe as ReturnType<typeof vi.fn>).mock.calls[0][2] as (e: unknown) => Promise<void>;
-    await handler(event);
+      // --- Add new turns after the watermark ---
+      await memory.addTurn(conversationId, agentId, { role: 'user', content: 'Ada Chen leads Project Orion' });
+      await memory.addTurn(conversationId, agentId, { role: 'assistant', content: 'Noted.' });
 
-    // Only the two new turns in the transcript — not the original wife turns
-    expect(invokedTexts).toHaveLength(1);
-    expect(invokedTexts[0]).toContain('Ada Chen');
-    expect(invokedTexts[0]).not.toContain('Xiaopu');
+      const secondTurnsResult = await pool.query<{ created_at: string }>(
+        `SELECT created_at FROM working_memory
+         WHERE conversation_id = $1 AND agent_id = $2
+           AND role IN ('user', 'assistant') AND created_at > $3
+         ORDER BY created_at DESC LIMIT 1`,
+        [conversationId, agentId, since],
+      );
+      const secondThrough = secondTurnsResult.rows[0]!.created_at;
 
-    // Watermark was advanced
-    const after = await pool.query(
-      'SELECT last_checkpoint_at FROM conversation_checkpoints WHERE conversation_id = $1 AND agent_id = $2',
-      [conversationId, agentId],
-    );
-    expect(new Date(after.rows[0].last_checkpoint_at).getTime())
-      .toBeGreaterThan(new Date(since).getTime());
+      // --- Second checkpoint: only new turns ---
+      const invokedTexts: string[] = [];
+      const executionLayer2 = {
+        invoke: vi.fn(async (_name: string, input: Record<string, unknown>) => {
+          invokedTexts.push(input['text'] as string);
+          return { success: true, data: {} };
+        }),
+      } as unknown as ExecutionLayer;
+
+      const { bus: bus2, logger: logger2 } = makeBusAndLogger();
+      const proc2 = new ConversationCheckpointProcessor(
+        bus2, executionLayer2, pool as unknown as DbPool, logger2,
+      );
+      proc2.register();
+      const handler2 = (bus2.subscribe as ReturnType<typeof vi.fn>).mock.calls[0][2] as (e: unknown) => Promise<void>;
+      await handler2(createConversationCheckpoint({
+        conversationId, agentId, channelId: 'test', since, through: secondThrough,
+        turns: [
+          { role: 'user', content: 'Ada Chen leads Project Orion' },
+          { role: 'assistant', content: 'Noted.' },
+        ],
+      }));
+
+      // Only the two new turns in the transcript — not the original wife turns
+      expect(invokedTexts).toHaveLength(1);
+      expect(invokedTexts[0]).toContain('Ada Chen');
+      expect(invokedTexts[0]).not.toContain('Xiaopu');
+
+      // Watermark was advanced past the first checkpoint
+      const after = await pool.query(
+        'SELECT last_checkpoint_at FROM conversation_checkpoints WHERE conversation_id = $1 AND agent_id = $2',
+        [conversationId, agentId],
+      );
+      expect(new Date(after.rows[0].last_checkpoint_at).getTime())
+        .toBeGreaterThanOrEqual(new Date(since).getTime());
+    } finally {
+      await pool.query('DELETE FROM conversation_checkpoints WHERE conversation_id = $1', [conversationId]);
+      await pool.query('DELETE FROM working_memory WHERE conversation_id = $1', [conversationId]);
+    }
   });
 });

--- a/tests/integration/checkpoint.test.ts
+++ b/tests/integration/checkpoint.test.ts
@@ -1,0 +1,153 @@
+// Integration test: ConversationCheckpointProcessor full round-trip.
+//
+// Uses real Postgres (DATABASE_URL must be set) and a mock ExecutionLayer
+// so no real LLM API calls are made. Tests that:
+// 1. The processor creates a watermark row after the first checkpoint
+// 2. The processor advances the watermark on subsequent checkpoints
+// 3. The watermark is respected — only turns after `since` are passed to skills
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import { WorkingMemory } from '../../src/memory/working-memory.js';
+import { ConversationCheckpointProcessor } from '../../src/checkpoint/processor.js';
+import { createConversationCheckpoint } from '../../src/bus/events.js';
+import type { ExecutionLayer } from '../../src/skills/execution.js';
+import type { EventBus } from '../../src/bus/bus.js';
+import type { Logger } from '../../src/logger.js';
+
+const { Pool } = pg;
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+function makeBusAndLogger() {
+  const bus = { subscribe: vi.fn(), publish: vi.fn() } as unknown as EventBus;
+  const logger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  } as unknown as Logger;
+  return { bus, logger };
+}
+
+describeIf('ConversationCheckpointProcessor — integration', () => {
+  let pool: pg.Pool;
+  let memory: WorkingMemory;
+
+  // Unique conversation ID per test run to avoid cross-run interference
+  const conversationId = `test:checkpoint-${Date.now()}`;
+  const agentId = 'coordinator';
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    memory = WorkingMemory.createWithPostgres(pool as any, {
+      info: () => {}, error: () => {}, warn: () => {}, debug: () => {},
+    } as any);
+
+    // Insert two initial turns
+    await memory.addTurn(conversationId, agentId, { role: 'user', content: 'Xiaopu Fung is my wife' });
+    await memory.addTurn(conversationId, agentId, { role: 'assistant', content: 'Got it, I will remember that.' });
+  });
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM conversation_checkpoints WHERE conversation_id = $1', [conversationId]);
+    await pool.query('DELETE FROM working_memory WHERE conversation_id = $1', [conversationId]);
+    await pool.end();
+  });
+
+  it('creates a watermark and calls the skill with the full transcript', async () => {
+    const invokedArgs: Array<{ name: string; input: Record<string, unknown> }> = [];
+    const executionLayer = {
+      invoke: vi.fn(async (name: string, input: Record<string, unknown>) => {
+        invokedArgs.push({ name, input });
+        return { success: true, data: {} };
+      }),
+    } as unknown as ExecutionLayer;
+
+    const { bus, logger } = makeBusAndLogger();
+    const processor = new ConversationCheckpointProcessor(bus, executionLayer, pool as any, logger);
+    processor.register();
+
+    // Fire checkpoint directly (bypass debounce)
+    const event = createConversationCheckpoint({
+      conversationId,
+      agentId,
+      channelId: 'test',
+      since: '',
+      turns: [
+        { role: 'user', content: 'Xiaopu Fung is my wife' },
+        { role: 'assistant', content: 'Got it, I will remember that.' },
+      ],
+    });
+
+    // Retrieve the registered handler and call it directly
+    const handler = (bus.subscribe as ReturnType<typeof vi.fn>).mock.calls[0][2] as (e: unknown) => Promise<void>;
+    await handler(event);
+
+    // Skill was invoked with concatenated transcript
+    expect(invokedArgs).toHaveLength(1);
+    expect(invokedArgs[0]!.name).toBe('extract-relationships');
+    expect(invokedArgs[0]!.input['text']).toContain('Xiaopu Fung');
+    expect(invokedArgs[0]!.input['source']).toContain(conversationId);
+
+    // Watermark was created
+    const watermark = await pool.query(
+      'SELECT last_checkpoint_at FROM conversation_checkpoints WHERE conversation_id = $1 AND agent_id = $2',
+      [conversationId, agentId],
+    );
+    expect(watermark.rows).toHaveLength(1);
+    expect(new Date(watermark.rows[0].last_checkpoint_at).getTime()).toBeGreaterThan(Date.now() - 10_000);
+  });
+
+  it('respects the watermark — second checkpoint only passes new turns to skills', async () => {
+    // Insert two new turns after the first checkpoint
+    await memory.addTurn(conversationId, agentId, { role: 'user', content: 'Ada Chen leads Project Orion' });
+    await memory.addTurn(conversationId, agentId, { role: 'assistant', content: 'Noted.' });
+
+    // Get current watermark (set by the first test)
+    const before = await pool.query(
+      'SELECT last_checkpoint_at FROM conversation_checkpoints WHERE conversation_id = $1 AND agent_id = $2',
+      [conversationId, agentId],
+    );
+    const since: string = before.rows[0].last_checkpoint_at;
+
+    const invokedTexts: string[] = [];
+    const executionLayer = {
+      invoke: vi.fn(async (_name: string, input: Record<string, unknown>) => {
+        invokedTexts.push(input['text'] as string);
+        return { success: true, data: {} };
+      }),
+    } as unknown as ExecutionLayer;
+
+    const { bus, logger } = makeBusAndLogger();
+    const processor = new ConversationCheckpointProcessor(bus, executionLayer, pool as any, logger);
+    processor.register();
+
+    // Fire second checkpoint with only the new turns
+    const event = createConversationCheckpoint({
+      conversationId,
+      agentId,
+      channelId: 'test',
+      since,
+      turns: [
+        { role: 'user', content: 'Ada Chen leads Project Orion' },
+        { role: 'assistant', content: 'Noted.' },
+      ],
+    });
+
+    const handler = (bus.subscribe as ReturnType<typeof vi.fn>).mock.calls[0][2] as (e: unknown) => Promise<void>;
+    await handler(event);
+
+    // Only the two new turns in the transcript — not the original wife turns
+    expect(invokedTexts).toHaveLength(1);
+    expect(invokedTexts[0]).toContain('Ada Chen');
+    expect(invokedTexts[0]).not.toContain('Xiaopu');
+
+    // Watermark was advanced
+    const after = await pool.query(
+      'SELECT last_checkpoint_at FROM conversation_checkpoints WHERE conversation_id = $1 AND agent_id = $2',
+      [conversationId, agentId],
+    );
+    expect(new Date(after.rows[0].last_checkpoint_at).getTime())
+      .toBeGreaterThan(new Date(since).getTime());
+  });
+});

--- a/tests/unit/bus/events.test.ts
+++ b/tests/unit/bus/events.test.ts
@@ -6,6 +6,7 @@ import {
   createOutboundMessage,
   createSkillInvoke,
   createSkillResult,
+  createConversationCheckpoint,
   type BusEvent,
 } from '../../../src/bus/events.js';
 
@@ -93,6 +94,26 @@ describe('Event Types', () => {
     expect(event.type).toBe('skill.result');
     expect(event.sourceLayer).toBe('execution');
     expect(event.payload.durationMs).toBe(250);
+  });
+
+  it('creates a conversation.checkpoint event', () => {
+    const event = createConversationCheckpoint({
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+      since: '2026-04-08T10:00:00Z',
+      turns: [
+        { role: 'user', content: 'Xiaopu is my wife' },
+        { role: 'assistant', content: 'Got it, I will remember that.' },
+      ],
+    });
+
+    expect(event.type).toBe('conversation.checkpoint');
+    expect(event.sourceLayer).toBe('dispatch');
+    expect(event.payload.conversationId).toBe('email:thread-abc');
+    expect(event.payload.turns).toHaveLength(2);
+    expect(event.id).toBeTruthy();
+    expect(event.timestamp).toBeInstanceOf(Date);
   });
 
   it('type narrows via discriminated union', () => {

--- a/tests/unit/checkpoint/processor.test.ts
+++ b/tests/unit/checkpoint/processor.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConversationCheckpointProcessor } from '../../../src/checkpoint/processor.js';
+import type { EventBus } from '../../../src/bus/bus.js';
+import type { ExecutionLayer } from '../../../src/skills/execution.js';
+import type { DbPool } from '../../../src/db/connection.js';
+import type { Logger } from '../../../src/logger.js';
+import { createConversationCheckpoint } from '../../../src/bus/events.js';
+
+function makeStubs() {
+  const subscribeHandlers = new Map<string, (event: unknown) => Promise<void>>();
+  const bus = {
+    subscribe: vi.fn((eventType: string, _layer: string, handler: (e: unknown) => Promise<void>) => {
+      subscribeHandlers.set(eventType, handler);
+    }),
+  } as unknown as EventBus;
+
+  const executionLayer = {
+    invoke: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  } as unknown as ExecutionLayer;
+
+  const queryMock = vi.fn().mockResolvedValue({ rows: [] });
+  const pool = { query: queryMock } as unknown as DbPool;
+
+  const logger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  } as unknown as Logger;
+
+  return { bus, executionLayer, pool, logger, subscribeHandlers, queryMock };
+}
+
+async function fireCheckpoint(
+  subscribeHandlers: Map<string, (event: unknown) => Promise<void>>,
+  payload: {
+    conversationId: string;
+    agentId: string;
+    channelId: string;
+    since: string;
+    turns: Array<{ role: 'user' | 'assistant'; content: string }>;
+  },
+) {
+  const event = createConversationCheckpoint(payload);
+  const handler = subscribeHandlers.get('conversation.checkpoint');
+  if (!handler) throw new Error('No handler registered for conversation.checkpoint');
+  await handler(event);
+}
+
+describe('ConversationCheckpointProcessor', () => {
+  let stubs: ReturnType<typeof makeStubs>;
+
+  beforeEach(() => {
+    stubs = makeStubs();
+  });
+
+  it('registers a conversation.checkpoint subscriber on register()', () => {
+    const processor = new ConversationCheckpointProcessor(
+      stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+    );
+    processor.register();
+    expect(stubs.bus.subscribe).toHaveBeenCalledWith(
+      'conversation.checkpoint', 'system', expect.any(Function),
+    );
+  });
+
+  it('calls extract-relationships with concatenated transcript', async () => {
+    const processor = new ConversationCheckpointProcessor(
+      stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+    );
+    processor.register();
+
+    await fireCheckpoint(stubs.subscribeHandlers, {
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+      since: '',
+      turns: [
+        { role: 'user', content: 'Xiaopu is my wife' },
+        { role: 'assistant', content: 'Got it.' },
+      ],
+    });
+
+    expect(stubs.executionLayer.invoke).toHaveBeenCalledWith(
+      'extract-relationships',
+      expect.objectContaining({
+        text: 'User: Xiaopu is my wife\n\nCuria: Got it.',
+        source: expect.stringContaining('email:thread-abc'),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('advances the watermark after skills run', async () => {
+    const processor = new ConversationCheckpointProcessor(
+      stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+    );
+    processor.register();
+
+    await fireCheckpoint(stubs.subscribeHandlers, {
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+      since: '',
+      turns: [{ role: 'user', content: 'test' }],
+    });
+
+    expect(stubs.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO conversation_checkpoints'),
+      ['email:thread-abc', 'coordinator'],
+    );
+  });
+
+  it('advances the watermark even when a skill fails', async () => {
+    stubs.executionLayer.invoke = vi.fn().mockRejectedValue(new Error('API timeout'));
+    const processor = new ConversationCheckpointProcessor(
+      stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+    );
+    processor.register();
+
+    await fireCheckpoint(stubs.subscribeHandlers, {
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+      since: '',
+      turns: [{ role: 'user', content: 'test' }],
+    });
+
+    // Watermark upsert still called despite skill failure
+    expect(stubs.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO conversation_checkpoints'),
+      expect.any(Array),
+    );
+  });
+
+  it('does nothing when turns list is empty', async () => {
+    const processor = new ConversationCheckpointProcessor(
+      stubs.bus, stubs.executionLayer, stubs.pool, stubs.logger,
+    );
+    processor.register();
+
+    await fireCheckpoint(stubs.subscribeHandlers, {
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+      channelId: 'email',
+      since: '',
+      turns: [],
+    });
+
+    expect(stubs.executionLayer.invoke).not.toHaveBeenCalled();
+    expect(stubs.queryMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/checkpoint/processor.test.ts
+++ b/tests/unit/checkpoint/processor.test.ts
@@ -36,10 +36,14 @@ async function fireCheckpoint(
     agentId: string;
     channelId: string;
     since: string;
+    through?: string;
     turns: Array<{ role: 'user' | 'assistant'; content: string }>;
   },
 ) {
-  const event = createConversationCheckpoint(payload);
+  const event = createConversationCheckpoint({
+    ...payload,
+    through: payload.through ?? '2026-01-01T00:00:00Z',
+  });
   const handler = subscribeHandlers.get('conversation.checkpoint');
   if (!handler) throw new Error('No handler registered for conversation.checkpoint');
   await handler(event);
@@ -105,7 +109,7 @@ describe('ConversationCheckpointProcessor', () => {
 
     expect(stubs.queryMock).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO conversation_checkpoints'),
-      ['email:thread-abc', 'coordinator'],
+      ['email:thread-abc', 'coordinator', '2026-01-01T00:00:00Z'],
     );
   });
 

--- a/tests/unit/dispatch/dispatcher-checkpoint.test.ts
+++ b/tests/unit/dispatch/dispatcher-checkpoint.test.ts
@@ -3,30 +3,34 @@ import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
 import type { EventBus } from '../../../src/bus/bus.js';
 import type { DbPool } from '../../../src/db/connection.js';
 import type { Logger } from '../../../src/logger.js';
-import { createAgentResponse } from '../../../src/bus/events.js';
+import { createAgentResponse, type BusEvent, type ConversationCheckpointEvent } from '../../../src/bus/events.js';
+
+function isCheckpointEvent(e: BusEvent): e is ConversationCheckpointEvent {
+  return e.type === 'conversation.checkpoint';
+}
 
 function makeStubs(debounceMs = 500) {
-  const publishedEvents: unknown[] = [];
-  const subscribeHandlers = new Map<string, (event: unknown) => Promise<void>>();
+  const publishedEvents: BusEvent[] = [];
+  const subscribeHandlers = new Map<string, (event: BusEvent) => Promise<void>>();
 
   const bus = {
-    subscribe: vi.fn((eventType: string, _layer: string, handler: (e: unknown) => Promise<void>) => {
+    subscribe: vi.fn((eventType: string, _layer: string, handler: (e: BusEvent) => Promise<void>) => {
       subscribeHandlers.set(eventType, handler);
     }),
-    publish: vi.fn(async (_layer: string, event: unknown) => {
+    publish: vi.fn(async (_layer: string, event: BusEvent) => {
       publishedEvents.push(event);
     }),
   } as unknown as EventBus;
 
   // Two-call sequence for every fireCheckpoint invocation:
   //   call 1 — conversation_checkpoints watermark query → no prior watermark
-  //   call 2 — working_memory turns query → one turn to process
+  //   call 2 — working_memory turns query → one turn to process (includes created_at for `through`)
   const queryMock = vi.fn()
     .mockResolvedValueOnce({ rows: [] })
-    .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'hello' }] })
+    .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'hello', created_at: '2026-01-01T00:00:00Z' }] })
     // Subsequent invocations (reset/debounce tests) also need pairs
     .mockResolvedValueOnce({ rows: [] })
-    .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'hello again' }] });
+    .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'hello again', created_at: '2026-01-01T00:01:00Z' }] });
 
   const pool = { query: queryMock } as unknown as DbPool;
 
@@ -51,7 +55,7 @@ function seedRouting(dispatcher: Dispatcher, taskEventId: string, channelId: str
 }
 
 async function fireAgentResponse(
-  subscribeHandlers: Map<string, (event: unknown) => Promise<void>>,
+  subscribeHandlers: Map<string, (event: BusEvent) => Promise<void>>,
   {
     taskEventId,
     conversationId,
@@ -88,14 +92,14 @@ describe('Dispatcher checkpoint debounce', () => {
     });
 
     // No checkpoint yet — debounce hasn't elapsed
-    expect(publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint')).toHaveLength(0);
+    expect(publishedEvents.filter(isCheckpointEvent)).toHaveLength(0);
 
     // Advance time past debounce
     await vi.advanceTimersByTimeAsync(600);
 
-    const checkpoints = publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint');
+    const checkpoints = publishedEvents.filter(isCheckpointEvent);
     expect(checkpoints).toHaveLength(1);
-    expect((checkpoints[0] as any).payload.conversationId).toBe('email:thread-abc');
+    expect(checkpoints[0]!.payload.conversationId).toBe('email:thread-abc');
   });
 
   it('resets the timer on a second agent.response before debounce elapses', async () => {
@@ -120,10 +124,10 @@ describe('Dispatcher checkpoint debounce', () => {
     });
 
     await vi.advanceTimersByTimeAsync(300); // 300ms after reset — still not elapsed
-    expect(publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint')).toHaveLength(0);
+    expect(publishedEvents.filter(isCheckpointEvent)).toHaveLength(0);
 
     await vi.advanceTimersByTimeAsync(300); // now past debounce from second response
-    expect(publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint')).toHaveLength(1);
+    expect(publishedEvents.filter(isCheckpointEvent)).toHaveLength(1);
   });
 
   it('clears all timers on close() — no checkpoint fires after shutdown', async () => {
@@ -140,6 +144,6 @@ describe('Dispatcher checkpoint debounce', () => {
     dispatcher.close();
 
     await vi.advanceTimersByTimeAsync(1000);
-    expect(publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint')).toHaveLength(0);
+    expect(publishedEvents.filter(isCheckpointEvent)).toHaveLength(0);
   });
 });

--- a/tests/unit/dispatch/dispatcher-checkpoint.test.ts
+++ b/tests/unit/dispatch/dispatcher-checkpoint.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
+import type { EventBus } from '../../../src/bus/bus.js';
+import type { DbPool } from '../../../src/db/connection.js';
+import type { Logger } from '../../../src/logger.js';
+import { createAgentResponse } from '../../../src/bus/events.js';
+
+function makeStubs(debounceMs = 500) {
+  const publishedEvents: unknown[] = [];
+  const subscribeHandlers = new Map<string, (event: unknown) => Promise<void>>();
+
+  const bus = {
+    subscribe: vi.fn((eventType: string, _layer: string, handler: (e: unknown) => Promise<void>) => {
+      subscribeHandlers.set(eventType, handler);
+    }),
+    publish: vi.fn(async (_layer: string, event: unknown) => {
+      publishedEvents.push(event);
+    }),
+  } as unknown as EventBus;
+
+  // Two-call sequence for every fireCheckpoint invocation:
+  //   call 1 — conversation_checkpoints watermark query → no prior watermark
+  //   call 2 — working_memory turns query → one turn to process
+  const queryMock = vi.fn()
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'hello' }] })
+    // Subsequent invocations (reset/debounce tests) also need pairs
+    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'hello again' }] });
+
+  const pool = { query: queryMock } as unknown as DbPool;
+
+  const logger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+  } as unknown as Logger;
+
+  const dispatcher = new Dispatcher({
+    bus,
+    logger,
+    pool,
+    conversationCheckpointDebounceMs: debounceMs,
+  });
+
+  return { dispatcher, bus, pool, logger, publishedEvents, subscribeHandlers, queryMock };
+}
+
+/** Seeds the Dispatcher's private taskRouting map so handleAgentResponse finds the route. */
+function seedRouting(dispatcher: Dispatcher, taskEventId: string, channelId: string, conversationId: string) {
+  (dispatcher as unknown as { taskRouting: Map<string, { channelId: string; conversationId: string; senderId: string }> })
+    .taskRouting.set(taskEventId, { channelId, conversationId, senderId: 'user-1' });
+}
+
+async function fireAgentResponse(
+  subscribeHandlers: Map<string, (event: unknown) => Promise<void>>,
+  {
+    taskEventId,
+    conversationId,
+    agentId,
+    content = 'ok',
+  }: { taskEventId: string; conversationId: string; agentId: string; content?: string },
+) {
+  const event = createAgentResponse({
+    agentId,
+    conversationId,
+    content,
+    parentEventId: taskEventId,
+  });
+  const handler = subscribeHandlers.get('agent.response');
+  if (!handler) throw new Error('No agent.response handler registered');
+  await handler(event);
+}
+
+describe('Dispatcher checkpoint debounce', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('publishes conversation.checkpoint after debounce window elapses', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(500);
+    dispatcher.register();
+
+    // Pre-seed routing so handleAgentResponse doesn't drop the event
+    seedRouting(dispatcher, 'task-1', 'email', 'email:thread-abc');
+
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-1',
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+    });
+
+    // No checkpoint yet — debounce hasn't elapsed
+    expect(publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint')).toHaveLength(0);
+
+    // Advance time past debounce
+    await vi.advanceTimersByTimeAsync(600);
+
+    const checkpoints = publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint');
+    expect(checkpoints).toHaveLength(1);
+    expect((checkpoints[0] as any).payload.conversationId).toBe('email:thread-abc');
+  });
+
+  it('resets the timer on a second agent.response before debounce elapses', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(500);
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-1', 'email', 'email:thread-abc');
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-1',
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+    });
+
+    await vi.advanceTimersByTimeAsync(300); // not yet elapsed
+
+    // Second response — resets timer (re-seed routing since first response consumed it)
+    seedRouting(dispatcher, 'task-2', 'email', 'email:thread-abc');
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-2',
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+    });
+
+    await vi.advanceTimersByTimeAsync(300); // 300ms after reset — still not elapsed
+    expect(publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint')).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(300); // now past debounce from second response
+    expect(publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint')).toHaveLength(1);
+  });
+
+  it('clears all timers on close() — no checkpoint fires after shutdown', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs(500);
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-1', 'email', 'email:thread-abc');
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-1',
+      conversationId: 'email:thread-abc',
+      agentId: 'coordinator',
+    });
+
+    dispatcher.close();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(publishedEvents.filter((e: any) => e.type === 'conversation.checkpoint')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **New `conversation.checkpoint` bus event** — Dispatch publishes this after 10 minutes of inactivity per `(conversationId, agentId)` pair. The debounce timer resets on every `agent.response` and is cleared on graceful shutdown.
- **New `ConversationCheckpointProcessor` (System Layer)** — subscribes to `conversation.checkpoint`, concatenates turns since the last watermark into a transcript, fans out to checkpoint skills (`extract-relationships`; extensible list in `processor.ts`), then advances the watermark via upsert. Skill failures are logged and do not block watermark advancement.
- **New `conversation_checkpoints` table (migration 017)** — one row per `(conversation_id, agent_id)`, advanced after each checkpoint. Prevents re-processing already-seen turns.

This completes the permanent fix for the confabulation bugs addressed in #221 — `extract-relationships` no longer runs as an LLM tool call, and instead runs once per conversation after a quiet period.

## Test Plan

- [x] Unit tests: `ConversationCheckpointProcessor` (5 tests — empty turns, skill failure, watermark advance, watermark advance on failure, subscriber registration)
- [x] Unit tests: Dispatcher debounce (3 tests — timer fires after window, timer resets on second response, `close()` cancels timers)
- [x] Integration tests: real Postgres — watermark creation, watermark respected on second checkpoint (`tests/integration/checkpoint.test.ts`)
- [x] Full test suite: 101 files, 1018 tests passing

## Migration Sequence

1. Deploy this branch (coordinator no longer has `extract-relationships` as a tool — already in production via #221)
2. Run migration `017_create_conversation_checkpoints.sql`
3. Restart — Dispatcher and ConversationCheckpointProcessor come up together

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation checkpoint pipeline: dispatch publishes checkpoint events after 10 minutes of inactivity to aggregate recent turns and trigger background memory processing.
  * New configuration to customise checkpoint debounce timing (default 10 minutes).

* **Changed Behavior**
  * Relationship extraction and other memory skills now run as background tasks at checkpoints instead of being invoked on every message.

* **Tests**
  * Added unit and integration tests covering checkpoint scheduling, event creation and processor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->