### PR TITLE
docs: sync spec index and clean up README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+- **`docs/specs/00-overview.md` spec index** — added Status column, rows 12–16 (Knowledge Graph Web Explorer, Office Identity, Autonomy Engine, Outbound Safety, Smoke Test Framework), and unified Scope notes with README Area column (channels named explicitly, cron/one-shot in scheduler, unknown sender policy in contacts, KG-backed profiles in entity context enrichment).
+
 ### Added
 - **Conversation checkpoint pipeline** — Dispatch publishes a `conversation.checkpoint` event after 10 minutes of inactivity per conversation–agent pair. A new System Layer `ConversationCheckpointProcessor` subscribes, concatenates new turns since the last watermark, fans out to background memory skills (`extract-relationships`; extensible to future skills), then advances the per-(conversationId, agentId) watermark in the new `conversation_checkpoints` table. Adds migration 017. **Breaking change:** `conversation.checkpoint` added to the bus event type discriminated union.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 - **`docs/specs/00-overview.md` spec index** — added Status column, rows 12–16 (Knowledge Graph Web Explorer, Office Identity, Autonomy Engine, Outbound Safety, Smoke Test Framework), and unified Scope notes with README Area column (channels named explicitly, cron/one-shot in scheduler, unknown sender policy in contacts, KG-backed profiles in entity context enrichment).
+- **README.md** — removed Project Status & Documentation table; status is now consolidated in `docs/specs/00-overview.md`.
 
 ### Added
 - **Conversation checkpoint pipeline** — Dispatch publishes a `conversation.checkpoint` event after 10 minutes of inactivity per conversation–agent pair. A new System Layer `ConversationCheckpointProcessor` subscribes, concatenates new turns since the last watermark, fans out to background memory skills (`extract-relationships`; extensible to future skills), then advances the per-(conversationId, agentId) watermark in the new `conversation_checkpoints` table. Adds migration 017. **Breaking change:** `conversation.checkpoint` added to the bus event type discriminated union.

--- a/README.md
+++ b/README.md
@@ -286,32 +286,6 @@ The web app requires `WEB_APP_BOOTSTRAP_SECRET` in `.env` — set this to any lo
 
 ---
 
-## Project Status & Documentation
-
-| Spec | Area | Status |
-|---|---|---|
-| [00](docs/specs/00-overview.md) | Architecture & message bus | ✅ Implemented |
-| [01](docs/specs/01-memory-system.md) | Memory system (working memory + knowledge graph) | Partial — core implemented; Bullpen, context management, decay engine planned |
-| [02](docs/specs/02-agent-system.md) | Agent system (config, delegation, registry) | ✅ Implemented |
-| [03](docs/specs/03-skills-and-execution.md) | Skills & execution layer | Partial — local skills implemented; MCP discovery planned |
-| [04](docs/specs/04-channels.md) | Channels (CLI, HTTP, Signal, Email) | ✅ Implemented |
-| [05](docs/specs/05-error-recovery.md) | Error recovery (budgets, patterns, continuity) | ✅ Implemented |
-| [06](docs/specs/06-audit-and-security.md) | Audit & security | Partial — basic audit logging in place; redaction & hardening planned |
-| [07](docs/specs/07-scheduler.md) | Scheduler (cron, one-shot, persistent tasks) | ✅ Implemented |
-| [08](docs/specs/08-operations.md) | Operations (deployment, health, monitoring) | Planned |
-| [09](docs/specs/09-contacts-and-identity.md) | Contacts & identity (auth, unknown sender policy) | ✅ Implemented |
-| [10](docs/specs/10-audit-log-hardening.md) | Audit log hardening (hash-chain, HITL, provenance) | Planned |
-| [11](docs/specs/11-entity-context-enrichment.md) | Entity context enrichment (KG-backed sender/entity profiles) | Planned — spec drafted |
-| [12](docs/specs/12-knowledge-graph-web-explorer.md) | Knowledge graph web explorer | ✅ Implemented |
-| [13](docs/specs/13-office-identity.md) | Office identity (persona, voice, runtime config) |  ✅ Implemented |
-| [14](docs/specs/14-autonomy-engine.md) | Autonomy engine (global score, CEO controls, per-task prompt injection) | Partial: core implemented; self-monitoring & tuning planned |
-| [15](docs/specs/15-outbound-safety.md) | Outbound safety (content filter, gateway, display name sanitization, caller verification) | Partial — deterministic rules done; LLM-as-judge planned |
-| [16](docs/specs/16-smoke-test-framework.md) | Smoke test framework (chat-based cases, LLM-as-judge, HTML reports) | ✅ Implemented |
-| — | Web dashboard | Partial |
-| — | Additional channels: Voice, Slack, Telegram | Future |
-
----
-
 ## Contributing
 
 Curia is in early development and welcomes contributions — including AI-assisted ones.

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ The web app requires `WEB_APP_BOOTSTRAP_SECRET` in `.env` — set this to any lo
 | [01](docs/specs/01-memory-system.md) | Memory system (working memory + knowledge graph) | Partial — core implemented; Bullpen, context management, decay engine planned |
 | [02](docs/specs/02-agent-system.md) | Agent system (config, delegation, registry) | ✅ Implemented |
 | [03](docs/specs/03-skills-and-execution.md) | Skills & execution layer | Partial — local skills implemented; MCP discovery planned |
-| [04](docs/specs/04-channels.md) | Channels (CLI, HTTP, Email) | Partial — CLI, HTTP, Email done; Signal planned |
+| [04](docs/specs/04-channels.md) | Channels (CLI, HTTP, Signal, Email) | ✅ Implemented |
 | [05](docs/specs/05-error-recovery.md) | Error recovery (budgets, patterns, continuity) | ✅ Implemented |
 | [06](docs/specs/06-audit-and-security.md) | Audit & security | Partial — basic audit logging in place; redaction & hardening planned |
 | [07](docs/specs/07-scheduler.md) | Scheduler (cron, one-shot, persistent tasks) | ✅ Implemented |

--- a/docs/specs/00-overview.md
+++ b/docs/specs/00-overview.md
@@ -8,7 +8,7 @@
 | # | Document | Scope | Status |
 |---|----------|-------|--------|
 | 00 | This file | Architecture, layers, bus, message flow, design principles | ✅ Implemented |
-| 01 | [Memory System](01-memory-system.md) | Knowledge graph, entity memory, working memory, Bullpen, embeddings | Partial — core implemented; Bullpen, context management, decay engine planned |
+| 01 | [Memory System](01-memory-system.md) | Knowledge graph, entity memory, working memory, Bullpen, embeddings | Partial — core and Bullpen implemented; context management, decay engine planned |
 | 02 | [Agent System](02-agent-system.md) | Agent definition, lifecycle, state, execution modes, LLM providers | ✅ Implemented |
 | 03 | [Skills & Execution](03-skills-and-execution.md) | Local skills, MCP, discovery, secrets, permissions | Partial — local skills implemented; MCP discovery planned |
 | 04 | [Channels](04-channels.md) | Adapter interface, CLI, HTTP, Signal, Email channels, message normalization | ✅ Implemented |

--- a/docs/specs/00-overview.md
+++ b/docs/specs/00-overview.md
@@ -5,20 +5,25 @@
 
 ## Spec Index
 
-| # | Document | Scope |
-|---|----------|-------|
-| 00 | This file | Architecture, layers, bus, message flow, design principles |
-| 01 | [Memory System](01-memory-system.md) | Knowledge graph, entity memory, working memory, Bullpen, embeddings |
-| 02 | [Agent System](02-agent-system.md) | Agent definition, lifecycle, state, execution modes, LLM providers |
-| 03 | [Skills & Execution](03-skills-and-execution.md) | Local skills, MCP, discovery, secrets, permissions |
-| 04 | [Channels](04-channels.md) | Adapter interface, launch channels, message normalization |
-| 05 | [Error Recovery](05-error-recovery.md) | Error budgets, state continuity, pattern detection, failure model |
-| 06 | [Audit & Security](06-audit-and-security.md) | Audit log, redaction, tool sanitization, intent drift, security |
-| 07 | [Scheduler](07-scheduler.md) | Job model, persistent tasks, burst execution |
-| 08 | [Operations](08-operations.md) | Config, deployment, health checks, logging, project structure |
-| 09 | [Contacts & Identity](09-contacts-and-identity.md) | Contact resolution, identity verification, authorization, channel identity linking |
-| 10 | [Audit Log Hardening](10-audit-log-hardening.md) | Structured audit fields, LLM provenance, tamper evidence, source attribution, HITL records |
-| 11 | [Entity Context Enrichment](11-entity-context-enrichment.md) | Entity model, context assembly, agent self-identity, skill convention for entity-scoped operations |
+| # | Document | Scope | Status |
+|---|----------|-------|--------|
+| 00 | This file | Architecture, layers, bus, message flow, design principles | ✅ Implemented |
+| 01 | [Memory System](01-memory-system.md) | Knowledge graph, entity memory, working memory, Bullpen, embeddings | Partial — core implemented; Bullpen, context management, decay engine planned |
+| 02 | [Agent System](02-agent-system.md) | Agent definition, lifecycle, state, execution modes, LLM providers | ✅ Implemented |
+| 03 | [Skills & Execution](03-skills-and-execution.md) | Local skills, MCP, discovery, secrets, permissions | Partial — local skills implemented; MCP discovery planned |
+| 04 | [Channels](04-channels.md) | Adapter interface, CLI, HTTP, Email channels, message normalization | Partial — CLI, HTTP, Email done; Signal planned |
+| 05 | [Error Recovery](05-error-recovery.md) | Error budgets, state continuity, pattern detection, failure model | ✅ Implemented |
+| 06 | [Audit & Security](06-audit-and-security.md) | Audit log, redaction, tool sanitization, intent drift, security | Partial — basic audit logging in place; redaction & hardening planned |
+| 07 | [Scheduler](07-scheduler.md) | Job model, cron, one-shot, persistent tasks, burst execution | ✅ Implemented |
+| 08 | [Operations](08-operations.md) | Config, deployment, health checks, logging, project structure | Planned |
+| 09 | [Contacts & Identity](09-contacts-and-identity.md) | Contact resolution, identity verification, unknown sender policy, authorization, channel identity linking | ✅ Implemented |
+| 10 | [Audit Log Hardening](10-audit-log-hardening.md) | Structured audit fields, LLM provenance, tamper evidence, source attribution, HITL records | Planned |
+| 11 | [Entity Context Enrichment](11-entity-context-enrichment.md) | Entity model, KG-backed sender/entity profiles, context assembly, agent self-identity, skill convention for entity-scoped operations | Planned — spec drafted |
+| 12 | [Knowledge Graph Web Explorer](12-knowledge-graph-web-explorer.md) | Knowledge graph browser, relationship visualization, entity memory viewer | ✅ Implemented |
+| 13 | [Office Identity](13-office-identity.md) | Persona config, voice settings, runtime identity injection | ✅ Implemented |
+| 14 | [Autonomy Engine](14-autonomy-engine.md) | Global score, autonomy bands, skill action_risk, per-task prompt injection, CEO controls | Partial — core implemented; self-monitoring & tuning planned |
+| 15 | [Outbound Safety](15-outbound-safety.md) | Content filter, display name sanitization, caller verification, LLM-as-judge gateway | Partial — deterministic rules done; LLM-as-judge planned |
+| 16 | [Smoke Test Framework](16-smoke-test-framework.md) | Chat-based test cases, LLM-as-judge evaluation, HTML reports | ✅ Implemented |
 
 ---
 

--- a/docs/specs/00-overview.md
+++ b/docs/specs/00-overview.md
@@ -18,7 +18,7 @@
 | 08 | [Operations](08-operations.md) | Config, deployment, health checks, logging, project structure | Planned |
 | 09 | [Contacts & Identity](09-contacts-and-identity.md) | Contact resolution, identity verification, unknown sender policy, authorization, channel identity linking | ✅ Implemented |
 | 10 | [Audit Log Hardening](10-audit-log-hardening.md) | Structured audit fields, LLM provenance, tamper evidence, source attribution, HITL records | Planned |
-| 11 | [Entity Context Enrichment](11-entity-context-enrichment.md) | Entity model, KG-backed sender/entity profiles, context assembly, agent self-identity, skill convention for entity-scoped operations | Planned — spec drafted |
+| 11 | [Entity Context Enrichment](11-entity-context-enrichment.md) | Entity model, KG-backed sender/entity profiles, context assembly, agent self-identity, skill convention for entity-scoped operations | Partial - Phase 1 done, Phase 2 and 3 pending  |
 | 12 | [Knowledge Graph Web Explorer](12-knowledge-graph-web-explorer.md) | Knowledge graph browser, relationship visualization, entity memory viewer | ✅ Implemented |
 | 13 | [Office Identity](13-office-identity.md) | Persona config, voice settings, runtime identity injection | ✅ Implemented |
 | 14 | [Autonomy Engine](14-autonomy-engine.md) | Global score, autonomy bands, skill action_risk, per-task prompt injection, CEO controls | Partial — core implemented; self-monitoring & tuning planned |

--- a/docs/specs/00-overview.md
+++ b/docs/specs/00-overview.md
@@ -11,7 +11,7 @@
 | 01 | [Memory System](01-memory-system.md) | Knowledge graph, entity memory, working memory, Bullpen, embeddings | Partial — core implemented; Bullpen, context management, decay engine planned |
 | 02 | [Agent System](02-agent-system.md) | Agent definition, lifecycle, state, execution modes, LLM providers | ✅ Implemented |
 | 03 | [Skills & Execution](03-skills-and-execution.md) | Local skills, MCP, discovery, secrets, permissions | Partial — local skills implemented; MCP discovery planned |
-| 04 | [Channels](04-channels.md) | Adapter interface, CLI, HTTP, Email channels, message normalization | Partial — CLI, HTTP, Email done; Signal planned |
+| 04 | [Channels](04-channels.md) | Adapter interface, CLI, HTTP, Signal, Email channels, message normalization | ✅ Implemented |
 | 05 | [Error Recovery](05-error-recovery.md) | Error budgets, state continuity, pattern detection, failure model | ✅ Implemented |
 | 06 | [Audit & Security](06-audit-and-security.md) | Audit log, redaction, tool sanitization, intent drift, security | Partial — basic audit logging in place; redaction & hardening planned |
 | 07 | [Scheduler](07-scheduler.md) | Job model, cron, one-shot, persistent tasks, burst execution | ✅ Implemented |


### PR DESCRIPTION
## Summary

- **`docs/specs/00-overview.md`** — added Status column, rows 12–16 (Knowledge Graph Web Explorer, Office Identity, Autonomy Engine, Outbound Safety, Smoke Test Framework), and unified Scope notes with the former README table (channels named explicitly, cron/one-shot in scheduler, unknown sender policy in contacts, KG-backed profiles in entity context enrichment)
- **`README.md`** — removed the Project Status & Documentation table; status is now consolidated in the spec index and reachable from the existing "Full Spec" link
- **`CHANGELOG.md`** — entries for both changes above

## Test plan

- [ ] Verify `docs/specs/00-overview.md` table renders correctly on GitHub
- [ ] Verify README no longer has the status table and the "Full Spec" link still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganised project documentation for clearer navigation and consolidated status tracking.
  * Added implementation status for all specs (Implemented, Partial, Planned).
  * Introduced five new specifications: Knowledge Graph Web Explorer, Office Identity, Autonomy Engine, Outbound Safety, Smoke Test Framework.
  * Clarified scopes: channels, scheduling options, identity/unknown-sender handling, knowledge-graph-backed profiles and memory/context plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->