### PR TITLE
docs: add implementation status table to spec 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Added
+- **Spec 11 implementation status table** — added Implementation Status section to `docs/specs/11-entity-context-enrichment.md` documenting what's done and what's outstanding across all three phases.
 - **Conversation checkpoint pipeline** — Dispatch publishes a `conversation.checkpoint` event after 10 minutes of inactivity per conversation–agent pair. A new System Layer `ConversationCheckpointProcessor` subscribes, concatenates new turns since the last watermark, fans out to background memory skills (`extract-relationships`; extensible to future skills), then advances the per-(conversationId, agentId) watermark in the new `conversation_checkpoints` table. Adds migration 017. **Breaking change:** `conversation.checkpoint` added to the bus event type discriminated union.
 
 ### Changed

--- a/docs/specs/11-entity-context-enrichment.md
+++ b/docs/specs/11-entity-context-enrichment.md
@@ -498,3 +498,38 @@ Calendars, email accounts, and CRM connections have fundamentally different sche
 - [ ] `entity-lookup` skill for broad KG entity search (orgs, events, places)
 - [ ] Knowledge skills adoption (travel-preferences, loyalty-programs, etc.)
 - [ ] Email skills adoption (when email connected accounts are added)
+
+---
+
+## Implementation Status
+
+### Phase 1: Foundation
+
+| Item | Status |
+|---|---|
+| Agent self-identity: KG node + contact record, bootstrap seeding | Done |
+| Agent contactId injection into coordinator system prompt | Done |
+| Entity-context assembly module (`src/entity-context/`) | Done |
+| `entity-context` skill (manifest + handler) | Done |
+| `ctx.entityContext` field on `SkillContext` | Done |
+| `entity_enrichment` manifest declaration support in execution layer | Done |
+| TTL cache for entity context payloads | Done |
+| Cache invalidation on contact/KG mutations | Done |
+| Proactive account discovery (`discoveredAccounts` field) | Not done |
+| Unit tests: entity-context assembly, execution layer pre-enrichment, cache | Not done |
+
+### Phase 2: Calendar adoption
+
+| Item | Status |
+|---|---|
+| Calendar skills declare `entity_enrichment` in their manifests | Not done |
+| Remove `calendarId` from LLM-visible tool definitions | Not done |
+| Integration test: end-to-end "What's on Jenna's calendar?" flow | Not done |
+
+### Phase 3: Broader adoption
+
+| Item | Status |
+|---|---|
+| `entity-lookup` skill for broad KG entity search (orgs, events, places) | Not done |
+| Knowledge skills adoption (travel-preferences, loyalty-programs, etc.) | Not done |
+| Email skills adoption (when email connected accounts are added) | Not done |

--- a/docs/specs/11-entity-context-enrichment.md
+++ b/docs/specs/11-entity-context-enrichment.md
@@ -516,7 +516,9 @@ Calendars, email accounts, and CRM connections have fundamentally different sche
 | TTL cache for entity context payloads | Done |
 | Cache invalidation on contact/KG mutations | Done |
 | Proactive account discovery (`discoveredAccounts` field) | Not done |
-| Unit tests: entity-context assembly, execution layer pre-enrichment, cache | Not done |
+| Unit tests: entity-context assembly | Done |
+| Unit tests: execution layer pre-enrichment | Done |
+| Unit tests: cache behavior (hit, miss, invalidation) | Done |
 
 ### Phase 2: Calendar adoption
 


### PR DESCRIPTION
## Summary

- Adds an **Implementation Status** section at the end of `docs/specs/11-entity-context-enrichment.md`, divided by phase, recording what's been built and what's still outstanding
- Fixes an inaccuracy caught in review: unit tests for assembly, execution-enrichment, and cache all exist and are now correctly marked Done
- CHANGELOG entry under `[Unreleased]`

## Test plan

- [ ] Verify the Markdown tables render correctly in GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added implementation status tracking for the entity-context enrichment feature, documenting completed components and outstanding work across three development phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->