### PR TITLE
feat: add agent_id to declarative schedule block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+- **Schedule `agent_id` field** — Declarative schedule entries now support an optional
+  `agent_id` field to fire the job at a different agent (e.g. the coordinator) rather
+  than the agent whose YAML contains the schedule. Defaults to the source agent's name
+  for backward compatibility. A startup warning is logged if two agents form a targeting
+  cycle. Public API surface: agent YAML schema.
+
 ---
 
 ## [0.14.0] — 2026-04-08

--- a/docs/dev/adding-an-agent.md
+++ b/docs/dev/adding-an-agent.md
@@ -165,6 +165,16 @@ Current built-in skills include (see `skills/` for the full list):
 | **Templates** | `template-meeting-request`, `template-reschedule`, `template-cancel`, `template-doc-request` |
 | **Knowledge** | `knowledge-company-overview`, `knowledge-meeting-links`, `knowledge-travel-preferences`, `knowledge-loyalty-programs` |
 
+#### Specialists don't own outbound comms
+
+Do not pin `email-send`, `email-reply`, or `signal-send` on specialist agents. The
+coordinator owns all outbound communication — it applies persona, tone, and
+audience-awareness logic that specialists are not equipped to replicate. Return
+structured findings from your specialist; let the coordinator decide how to present them.
+
+If your specialist runs on a schedule and needs to send output, use `agent_id: coordinator`
+in the schedule block (see the schedule section below).
+
 ### `allow_discovery` (optional, default: `false`)
 
 When `true`, the agent can call the skill registry at runtime to find and request skills not in its `pinned_skills` list. The runtime handles the approval gate:
@@ -196,6 +206,30 @@ schedule:
 ```
 
 Uses standard UNIX cron syntax (5 fields). Times are in UTC unless a timezone is specified at the job level via the `scheduler-create` skill.
+
+#### Targeting the coordinator from a schedule
+
+If your specialist runs on a schedule and its output should be communicated to the CEO,
+declare `agent_id: coordinator` in the schedule entry. The coordinator receives the
+task, delegates to your specialist for the actual work, and handles sending in its own
+voice with its persona guardrails intact.
+
+```yaml
+# writing-scout.yaml — schedule fires at coordinator, not writing-scout
+schedule:
+  - cron: "30 8 * * 2"
+    agent_id: coordinator
+    task: >
+      The writing scout has run on schedule. Delegate to @writing-scout to research
+      and score 2 high-signal essay ideas for the CEO. Email findings to the CEO.
+```
+
+The `agent_id` field defaults to the agent's own name when omitted — existing schedules
+are unaffected.
+
+> **Warning:** If two agents declare schedules that target each other, Curia will log a
+> warning at startup. This creates an infinite task loop at runtime — fix it before
+> deploying.
 
 ### `error_budget` (optional)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -39,6 +39,7 @@ export interface AgentYamlConfig {
   schedule?: Array<{
     cron: string;
     task: string;
+    agent_id?: string;             // target agent for this job (defaults to config.name if omitted)
     /** Expected wall-clock duration in seconds. Drives stuck-job recovery timeout. */
     expectedDurationSeconds?: number;
   }>;

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -339,13 +339,14 @@ export class Scheduler {
           continue;
         }
 
-        edges.push({ source: config.name, target: targetAgentId });
-
         try {
           const jobId = await this.schedulerService.upsertDeclarativeJob(
             targetAgentId,
             schedule,
           );
+          // Only record the edge after a successful upsert — a failed upsert means
+          // the job doesn't exist in the DB, so it shouldn't influence cycle detection.
+          edges.push({ source: config.name, target: targetAgentId });
           this.logger.info(
             { agentId: targetAgentId, sourceAgent: config.name, cron: schedule.cron, task: schedule.task, jobId },
             'Declarative job upserted',

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -315,27 +315,51 @@ export class Scheduler {
    * so they're always present in the DB on startup.
    */
   async loadDeclarativeJobs(agentConfigs: AgentYamlConfig[]): Promise<void> {
+    // Collect all (source → target) schedule edges for cycle detection after upserts.
+    const edges: Array<{ source: string; target: string }> = [];
+
     for (const config of agentConfigs) {
       if (!config.schedule || config.schedule.length === 0) {
         continue;
       }
 
       for (const schedule of config.schedule) {
+        // agent_id lets a specialist declare its schedule fires at a different agent
+        // (e.g. coordinator). Defaults to the agent's own name if omitted.
+        const targetAgentId = schedule.agent_id ?? config.name;
+        edges.push({ source: config.name, target: targetAgentId });
+
         try {
           const jobId = await this.schedulerService.upsertDeclarativeJob(
-            config.name,
+            targetAgentId,
             schedule,
           );
           this.logger.info(
-            { agentId: config.name, cron: schedule.cron, task: schedule.task, jobId },
+            { agentId: targetAgentId, sourceAgent: config.name, cron: schedule.cron, task: schedule.task, jobId },
             'Declarative job upserted',
           );
         } catch (err) {
           this.logger.error(
-            { err, agentId: config.name, schedule },
+            { err, agentId: targetAgentId, sourceAgent: config.name, schedule },
             'Failed to upsert declarative job',
           );
         }
+      }
+    }
+
+    // Detect two-agent targeting cycles and warn loudly. A cycle means agent A's schedule
+    // targets agent B, and agent B's schedule targets agent A — this will cause infinite
+    // task loops at runtime. Self-targeting (source === target) is intentional and fine.
+    for (const edge of edges) {
+      if (edge.source === edge.target) continue; // self-targeting is fine
+      const hasCycle = edges.some(
+        e => e.source === edge.target && e.target === edge.source,
+      );
+      if (hasCycle) {
+        this.logger.warn(
+          { agentA: edge.source, agentB: edge.target },
+          'Declarative schedule cycle detected — agents target each other; this will cause infinite task loops',
+        );
       }
     }
   }

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -355,7 +355,9 @@ export class Scheduler {
       const hasCycle = edges.some(
         e => e.source === edge.target && e.target === edge.source,
       );
-      if (hasCycle) {
+      // Deduplicate: only warn once per pair by requiring lexicographic ordering.
+      // Without this, a mutual cycle A→B and B→A produces two nearly identical warnings.
+      if (hasCycle && edge.source < edge.target) {
         this.logger.warn(
           { agentA: edge.source, agentB: edge.target },
           'Declarative schedule cycle detected — agents target each other; this will cause infinite task loops',

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -315,6 +315,7 @@ export class Scheduler {
    * so they're always present in the DB on startup.
    */
   async loadDeclarativeJobs(agentConfigs: AgentYamlConfig[]): Promise<void> {
+    const knownAgents = new Set(agentConfigs.map(config => config.name));
     // Collect all (source → target) schedule edges for cycle detection after upserts.
     const edges: Array<{ source: string; target: string }> = [];
 
@@ -327,6 +328,17 @@ export class Scheduler {
         // agent_id lets a specialist declare its schedule fires at a different agent
         // (e.g. coordinator). Defaults to the agent's own name if omitted.
         const targetAgentId = schedule.agent_id ?? config.name;
+
+        // Reject unknown targets early — a typo in agent_id would silently write a
+        // job that targets nobody. Fail loudly at startup instead.
+        if (!knownAgents.has(targetAgentId)) {
+          this.logger.error(
+            { sourceAgent: config.name, targetAgentId, cron: schedule.cron, task: schedule.task },
+            'Skipping declarative job — target agent_id is not a known agent',
+          );
+          continue;
+        }
+
         edges.push({ source: config.name, target: targetAgentId });
 
         try {
@@ -350,14 +362,18 @@ export class Scheduler {
     // Detect two-agent targeting cycles and warn loudly. A cycle means agent A's schedule
     // targets agent B, and agent B's schedule targets agent A — this will cause infinite
     // task loops at runtime. Self-targeting (source === target) is intentional and fine.
+    //
+    // Use a Set keyed on the canonical (sorted) pair to warn exactly once per pair,
+    // even if one agent has multiple schedules targeting the other.
+    const warnedPairs = new Set<string>();
     for (const edge of edges) {
       if (edge.source === edge.target) continue; // self-targeting is fine
       const hasCycle = edges.some(
         e => e.source === edge.target && e.target === edge.source,
       );
-      // Deduplicate: only warn once per pair by requiring lexicographic ordering.
-      // Without this, a mutual cycle A→B and B→A produces two nearly identical warnings.
-      if (hasCycle && edge.source < edge.target) {
+      const pairKey = [edge.source, edge.target].sort().join('::');
+      if (hasCycle && !warnedPairs.has(pairKey)) {
+        warnedPairs.add(pairKey);
         this.logger.warn(
           { agentA: edge.source, agentB: edge.target },
           'Declarative schedule cycle detected — agents target each other; this will cause infinite task loops',

--- a/tests/unit/agents/loader.test.ts
+++ b/tests/unit/agents/loader.test.ts
@@ -58,4 +58,50 @@ error_budget:
 
     fs.rmSync(tempDir, { recursive: true });
   });
+
+  it('parses schedule entry with agent_id field', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-test-'));
+    const yamlContent = `
+name: writing-scout
+model:
+  provider: anthropic
+  model: claude-sonnet-4-20250514
+system_prompt: "Scout agent"
+schedule:
+  - cron: "30 8 * * 2"
+    agent_id: coordinator
+    task: "Run the writing scout"
+`;
+    const filePath = path.join(tempDir, 'writing-scout.yaml');
+    fs.writeFileSync(filePath, yamlContent);
+
+    const config = loadAgentConfig(filePath);
+    expect(config.schedule).toHaveLength(1);
+    expect(config.schedule![0].agent_id).toBe('coordinator');
+    expect(config.schedule![0].cron).toBe('30 8 * * 2');
+    expect(config.schedule![0].task).toBe('Run the writing scout');
+
+    fs.rmSync(tempDir, { recursive: true });
+  });
+
+  it('schedule entry without agent_id has agent_id undefined', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-test-'));
+    const yamlContent = `
+name: test-sched
+model:
+  provider: anthropic
+  model: claude-sonnet-4-20250514
+system_prompt: "Test"
+schedule:
+  - cron: "0 9 * * 1"
+    task: "weekly task"
+`;
+    const filePath = path.join(tempDir, 'test-sched.yaml');
+    fs.writeFileSync(filePath, yamlContent);
+
+    const config = loadAgentConfig(filePath);
+    expect(config.schedule![0].agent_id).toBeUndefined();
+
+    fs.rmSync(tempDir, { recursive: true });
+  });
 });

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -475,6 +475,8 @@ describe('Scheduler', () => {
 
       await scheduler.loadDeclarativeJobs(configs);
 
+      // Exactly one warning per cycle pair (deduped by lexicographic ordering)
+      expect(logger.warn).toHaveBeenCalledTimes(1);
       expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({ agentA: 'agent-a', agentB: 'agent-b' }),
         expect.stringContaining('cycle'),

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -422,6 +422,12 @@ describe('Scheduler', () => {
             { cron: '30 8 * * 2', task: 'Run the writing scout', agent_id: 'coordinator' },
           ],
         },
+        // coordinator must be in the config list so the unknown-agent guard allows the target
+        {
+          name: 'coordinator',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Coord.',
+        },
       ];
 
       await scheduler.loadDeclarativeJobs(configs);
@@ -498,6 +504,28 @@ describe('Scheduler', () => {
       await scheduler.loadDeclarativeJobs(configs);
 
       expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('skips and logs error when agent_id targets an unknown agent', async () => {
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'my-agent',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Agent.',
+          schedule: [
+            { cron: '0 9 * * 1', task: 'weekly task', agent_id: 'nonexistent-agent' },
+          ],
+        },
+      ];
+
+      await scheduler.loadDeclarativeJobs(configs);
+
+      // Should not attempt to upsert — unknown target is rejected before the try block
+      expect(schedulerService.upsertDeclarativeJob).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceAgent: 'my-agent', targetAgentId: 'nonexistent-agent' }),
+        expect.stringContaining('not a known agent'),
+      );
     });
 
     it('logs and continues on upsert failure', async () => {

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -410,6 +410,94 @@ describe('Scheduler', () => {
       expect(schedulerService.upsertDeclarativeJob).not.toHaveBeenCalled();
     });
 
+    it('uses agent_id from schedule entry when present', async () => {
+      schedulerService.upsertDeclarativeJob.mockResolvedValue('job-decl-1');
+
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'writing-scout',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Scout.',
+          schedule: [
+            { cron: '30 8 * * 2', task: 'Run the writing scout', agent_id: 'coordinator' },
+          ],
+        },
+      ];
+
+      await scheduler.loadDeclarativeJobs(configs);
+
+      // Should be called with 'coordinator', not 'writing-scout'
+      expect(schedulerService.upsertDeclarativeJob).toHaveBeenCalledWith(
+        'coordinator',
+        { cron: '30 8 * * 2', task: 'Run the writing scout', agent_id: 'coordinator' },
+      );
+    });
+
+    it('defaults to config.name when agent_id is omitted', async () => {
+      schedulerService.upsertDeclarativeJob.mockResolvedValue('job-decl-2');
+
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'my-agent',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Agent.',
+          schedule: [
+            { cron: '0 9 * * 1', task: 'weekly task' },
+          ],
+        },
+      ];
+
+      await scheduler.loadDeclarativeJobs(configs);
+
+      expect(schedulerService.upsertDeclarativeJob).toHaveBeenCalledWith(
+        'my-agent',
+        { cron: '0 9 * * 1', task: 'weekly task' },
+      );
+    });
+
+    it('warns when two agents form a targeting cycle', async () => {
+      schedulerService.upsertDeclarativeJob.mockResolvedValue('job-1');
+
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'agent-a',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'A.',
+          schedule: [{ cron: '0 9 * * 1', task: 'task', agent_id: 'agent-b' }],
+        },
+        {
+          name: 'agent-b',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'B.',
+          schedule: [{ cron: '0 9 * * 1', task: 'task', agent_id: 'agent-a' }],
+        },
+      ];
+
+      await scheduler.loadDeclarativeJobs(configs);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ agentA: 'agent-a', agentB: 'agent-b' }),
+        expect.stringContaining('cycle'),
+      );
+    });
+
+    it('does not warn when agent targets itself (self-targeting is fine)', async () => {
+      schedulerService.upsertDeclarativeJob.mockResolvedValue('job-1');
+
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'coordinator',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Coord.',
+          schedule: [{ cron: '0 9 * * 1', task: 'task', agent_id: 'coordinator' }],
+        },
+      ];
+
+      await scheduler.loadDeclarativeJobs(configs);
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
     it('logs and continues on upsert failure', async () => {
       schedulerService.upsertDeclarativeJob
         .mockRejectedValueOnce(new Error('db error'))


### PR DESCRIPTION
## Summary
- Adds optional \`agent_id\` field to the \`schedule:\` block in agent YAML
- Allows a specialist to declare its scheduled jobs should fire at the coordinator (or any other agent) rather than itself
- Adds cycle-detection warning at startup if two agents target each other (deduplicated — one warning per pair)
- Documents the coordinator-targeting and comms-ownership patterns in \`docs/dev/adding-an-agent.md\`

## Prerequisites
None — this is the platform fix that writing-scout depends on.

## Test plan
- [ ] All existing scheduler and loader unit tests pass
- [ ] New tests cover: agent_id routing, default fallback, cycle warning (exactly once), self-targeting no-warn
- [ ] Full test suite green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled jobs can include an optional agent_id to target execution under a different agent (defaults to the source agent).

* **Behaviour**
  * Startup now warns if two agents mutually target each other to help avoid infinite scheduling cycles.
  * Schedules targeting unknown agents are skipped and logged as errors.

* **Documentation**
  * Updated scheduling and specialist-agent guidance to describe agent targeting and coordinator handling.

* **Tests**
  * Added unit tests for parsing, targeting, cycle detection and unknown-target handling.

* **Chores**
  * Package version bumped to 0.14.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->