### PR TITLE
docs: add implementation status tables to specs 01, 03, 08

### DIFF
--- a/docs/specs/01-memory-system.md
+++ b/docs/specs/01-memory-system.md
@@ -155,3 +155,22 @@ When conversation history in working memory exceeds a configurable threshold (de
 *Lesson from Zora's ASI gaps: agents drift from their original task during extended operations.*
 
 When a persistent task is created, the original task description is stored as an **intent anchor** in the task record. On each burst execution, the intent anchor is included in the system prompt as a grounding reference. The agent can evolve its approach, but the anchor prevents wholesale drift from the original goal.
+
+---
+
+## Implementation Status
+
+| Item | Status |
+|---|---|
+| `working_memory` table and migration | Done |
+| `bullpen_threads` and `bullpen_messages` tables and migration | Done |
+| `kg_nodes` and `kg_edges` tables and migration | Done |
+| Embedding layer — pgvector HNSW index + OpenAI `text-embedding-3-small` generation | Done |
+| Memory validation gates — deduplication (cosine similarity), contradiction detection, rate limiting | Done |
+| Context management — priority-ordered context budget assembly | Done |
+| `src/memory/working-memory.ts` — Postgres + in-memory backends | Done |
+| `src/memory/bullpen.ts` — thread management and context formatting | Done |
+| `src/memory/entity-memory.ts` — high-level query layer over knowledge graph | Done |
+| `src/memory/knowledge-graph.ts` — full graph store with traversal and semantic search | Done |
+| Context summarization — rolling window condensing at 20 turns with archival | Not Done |
+| Intent anchor — stored on task creation, injected into system prompt each burst | Not Done |

--- a/docs/specs/03-skills-and-execution.md
+++ b/docs/specs/03-skills-and-execution.md
@@ -178,3 +178,26 @@ These are not bundled but documented as recommended integrations:
 | **Fetch** | Web fetching with robots.txt compliance | [modelcontextprotocol/servers/fetch](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) |
 
 Custom MCP servers will be needed for Google Calendar and expense platforms (Expensify, QuickBooks). These can be built as local skills initially and promoted to MCP servers when the protocol stabilizes for those APIs.
+
+---
+
+## Implementation Status
+
+| Item | Status |
+|---|---|
+| Local skill directory structure — `skill.json` manifest + `handler.ts` loading | Done |
+| Execution layer — resolve, validate permissions, validate secrets, execute, sanitize, publish `skill.result` | Done |
+| Output sanitization — tag stripping, secret redaction, truncation, error wrapping | Done |
+| Resource boundaries — per-invocation timeout enforcement from manifest | Done |
+| Built-in skill: `web-fetch` | Done |
+| Built-in skill: `scheduler` (create, list, cancel) | Done |
+| MCP skills — MCP client, stdio/SSE transport, `tools/list` discovery | Not Done |
+| Safety gate for first-time elevated skill use — `skill_approvals` table and approval workflow | Not Done |
+| Built-in skill: `skill-registry` (agent-invocable search) | Not Done |
+| Built-in skill: `memory-query` | Not Done |
+| Built-in skill: `memory-store` | Not Done |
+| Built-in skill: `file-reader` | Not Done |
+| Built-in skill: `file-writer` | Not Done |
+| Skill discovery — `allow_discovery` agent config field wired to registry search | Not Done |
+| Secrets access — `ctx.secret()` accessor backed by env vars, validated against manifest `secrets` array | Not Done |
+| Resource boundaries — max 5 concurrent skill invocations per agent task | Not Done |

--- a/docs/specs/08-operations.md
+++ b/docs/specs/08-operations.md
@@ -291,3 +291,21 @@ curia/
 - `src/index.ts` — Bootstrap orchestrator. Initializes all services in dependency order: DB → migrations → bus → audit → memory → scheduler → execution → agents → channels → dispatch. This is the single place where everything is wired together.
 - `src/bus/events.ts` — The event type registry. All event types as a TypeScript discriminated union. This file is the source of truth for what flows through the system.
 - `src/bus/permissions.ts` — The layer-to-event authorization map. Defines the hard security boundary.
+
+---
+
+## Implementation Status
+
+| Item | Status |
+|---|---|
+| Layered YAML config — `default.yaml` / `local.yaml` / `production.yaml` with env var interpolation | Done |
+| `docker-compose.yml` — postgres (pgvector) + curia services with healthchecks | Done |
+| `Dockerfile` — multi-stage build, Node 22, tsx at runtime | Done |
+| `GET /health` endpoint — database, agents, skills, uptime | Done |
+| Structured logging via pino — correct log levels, no `console.log` | Done |
+| No-`console.log` lint rule (ESLint `no-console: error`) | Done |
+| Graceful shutdown — SIGTERM/SIGINT handler with ordered cleanup sequence | Done |
+| DB migrations via `node-pg-migrate` — auto-run on startup | Done |
+| Project directory structure — matches spec layout | Done |
+| Config validation against JSON Schema at startup | Not Done |
+| `curia setup` CLI — guided onboarding wizard for credentials and channel setup | Not Done |


### PR DESCRIPTION
## Summary

- Audited the codebase against specs 01, 03, and 08
- Added an **Implementation Status** table at the end of each spec document listing every specced item as Done or Not Done

## What's tracked

**Spec 01 (Memory System):** 12 items — 10 done, 2 not done (context summarization, intent anchor injection)

**Spec 03 (Skills & Execution):** 16 items — 6 done, 10 not done (MCP client, skill-registry/memory-query/memory-store/file-reader/file-writer built-ins, safety gate, ctx.secret(), concurrency cap, allow_discovery)

**Spec 08 (Operations):** 11 items — 9 done, 2 not done (JSON Schema config validation, curia setup CLI)

No code changes — docs only.