### PR TITLE
fix: narrow ValidatedFactData.temporal to provenance (closes #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **README** — removed redundant Project Status table; status consolidated in spec index.
 
 ### Fixed
+- **`ValidatedFactData.temporal` misleading type** — replaced `temporal: TemporalMetadata` (which included `createdAt`/`lastConfirmedAt`) with a narrower `provenance: { confidence, decayClass, source }`. The store always stamps its own timestamps on INSERT; the old type falsely implied the caller-set timestamps would survive to the persisted node. Closes #183.
 - **Coordinator confabulation** — removing `extract-relationships` from the coordinator's LLM tool loop eliminated empty-text turns that triggered confabulated "I already provided my response" replies in Signal group chats and the web UI.
 - **KG node deduplication** — one-time migration deduplicates existing `kg_nodes` rows with matching `(lower(label), type)`, re-pointing edges and contacts to canonical nodes before removing duplicates.
 

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -231,9 +231,9 @@ export class EntityMemory {
           type: FACT_TYPE,
           label: result.validated.label,
           properties: result.validated.properties,
-          confidence: result.validated.temporal.confidence,
-          decayClass: result.validated.temporal.decayClass,
-          source: result.validated.temporal.source,
+          confidence: result.validated.provenance.confidence,
+          decayClass: result.validated.provenance.decayClass,
+          source: result.validated.provenance.source,
           // Pass the pre-computed embedding from the validator's dedup check
           // to avoid a redundant OpenAI API call.
           embedding: result.validated.embedding,

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -85,14 +85,20 @@ export interface StoreFactOptions {
 }
 
 // -- Validated data for a new fact node, produced by MemoryValidator --
-// Intentionally excludes `id` and `type`: the store owns ID generation and persistence.
-// The validator's job is to validate inputs and compute the embedding; the store's job
-// is to mint a UUID and write the row. Keeping these responsibilities separate prevents
-// callers from accidentally relying on a pre-computed ID that is never persisted.
+// Intentionally excludes `id`, `type`, `createdAt`, and `lastConfirmedAt`:
+//   - The store owns ID generation and persistence.
+//   - The store always stamps its own timestamps on INSERT — caller-supplied
+//     timestamps would be silently ignored, so they are not part of this type.
+//     (see KnowledgeGraphStore.createNode())
+// Only the provenance fields the store actually honours are included here.
 export interface ValidatedFactData {
   label: string;
   properties: Record<string, unknown>;
-  temporal: TemporalMetadata;
+  provenance: {
+    confidence: number;
+    decayClass: DecayClass;
+    source: string;
+  };
   // Pre-computed embedding from the dedup scan — passed through so the store
   // can skip a redundant embed() call when persisting the new node.
   embedding: number[];

--- a/src/memory/validation.ts
+++ b/src/memory/validation.ts
@@ -121,16 +121,15 @@ export class MemoryValidator {
     //    The caller owns ID generation and the store write so that it can coordinate
     //    with edge creation atomically. We only provide what we've computed here:
     //    the validated inputs plus the embedding from the dedup scan above.
-    const now = new Date();
+    //    Timestamps are intentionally omitted — the store always stamps its own
+    //    createdAt/lastConfirmedAt on INSERT; any value we set here would be ignored.
     return {
       action: 'create',
       validated: {
         label: options.label,
         properties: options.properties ?? {},
         embedding: newEmbedding,
-        temporal: {
-          createdAt: now,
-          lastConfirmedAt: now,
+        provenance: {
           confidence: options.confidence ?? 0.7,
           decayClass: options.decayClass ?? 'slow_decay',
           // Full provenance chain: "agent:<name>/task:<id>/channel:<name>"

--- a/tests/unit/memory/validation.test.ts
+++ b/tests/unit/memory/validation.test.ts
@@ -326,7 +326,7 @@ describe('MemoryValidator', () => {
 
       expect(result.action).toBe('create');
       if (result.action === 'create') {
-        expect(result.validated.temporal.source).toBe('agent:coordinator/task:abc123/channel:cli');
+        expect(result.validated.provenance.source).toBe('agent:coordinator/task:abc123/channel:cli');
       }
     });
 
@@ -348,8 +348,8 @@ describe('MemoryValidator', () => {
 
       expect(result.action).toBe('create');
       if (result.action === 'create') {
-        expect(result.validated.temporal.confidence).toBe(0.95);
-        expect(result.validated.temporal.decayClass).toBe('permanent');
+        expect(result.validated.provenance.confidence).toBe(0.95);
+        expect(result.validated.provenance.decayClass).toBe('permanent');
       }
     });
 
@@ -369,8 +369,8 @@ describe('MemoryValidator', () => {
 
       expect(result.action).toBe('create');
       if (result.action === 'create') {
-        expect(result.validated.temporal.confidence).toBe(0.7);
-        expect(result.validated.temporal.decayClass).toBe('slow_decay');
+        expect(result.validated.provenance.confidence).toBe(0.7);
+        expect(result.validated.provenance.decayClass).toBe('slow_decay');
       }
     });
   });


### PR DESCRIPTION
## Summary

- Replaces `temporal: TemporalMetadata` in `ValidatedFactData` with a narrower `provenance: { confidence, decayClass, source }` field
- Removes the misleading `createdAt`/`lastConfirmedAt` from the validator's output — the store always stamps its own timestamps on INSERT, so the caller-set values were silently discarded anyway
- Updates the single consumer (`entity-memory.ts`) and the validation tests to use `.provenance.*`

## Test plan

- [ ] `npm run typecheck` — passes clean
- [ ] `npm run test -- --run tests/unit/memory/validation.test.ts tests/unit/memory/entity-memory.test.ts` — 39 tests, all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Fixed fact metadata validation to use provenance information (confidence, decay class, source) instead of temporal metadata. The system now exclusively manages timestamps on fact insertion, eliminating support for caller-supplied timestamp values. This ensures accurate and consistent timestamp tracking throughout the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->