### PR TITLE
fix: use column-based ON CONFLICT syntax for declarative job upsert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+- **Declarative job upsert** — `ON CONFLICT ON CONSTRAINT` only works with named
+  constraints, not named indexes. Switched to column-based conflict syntax matching
+  the `scheduled_jobs_declarative_uq` partial unique index definition, fixing
+  startup failures when declarative schedule entries are present.
+
 ### Added
 - **Schedule `agent_id` field** — Declarative schedule entries now support an optional
   `agent_id` field to fire the job at a different agent (e.g. the coordinator) rather

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -365,7 +365,10 @@ export class SchedulerService {
 
   /**
    * Upsert a declarative job (system-created, idempotent on restart).
-   * Uses ON CONFLICT on the unique index for (agent_id, cron_expr, task_payload) WHERE created_by = 'system'.
+   * Uses ON CONFLICT with the column list matching the partial unique index
+   * scheduled_jobs_declarative_uq (agent_id, cron_expr, task_payload::text WHERE created_by = 'system').
+   * Note: ON CONFLICT ON CONSTRAINT only works with named CONSTRAINTS, not named indexes —
+   * so we use the column-based syntax here to match the CREATE UNIQUE INDEX definition.
    */
   async upsertDeclarativeJob(
     agentId: string,
@@ -391,7 +394,7 @@ export class SchedulerService {
     const sql = `
       INSERT INTO scheduled_jobs (agent_id, cron_expr, task_payload, status, next_run_at, created_by, timezone${hasExpectedDuration ? ', expected_duration_seconds' : ''})
       VALUES ($1, $2, $3, $4, $5, $6, $7${hasExpectedDuration ? ', $8' : ''})
-      ON CONFLICT ON CONSTRAINT scheduled_jobs_declarative_uq
+      ON CONFLICT (agent_id, cron_expr, (task_payload::text)) WHERE created_by = 'system'
       DO UPDATE SET next_run_at = $5,
                     timezone = $7${hasExpectedDuration ? ',\n                    expected_duration_seconds = $8' : ''}
       RETURNING id

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -526,8 +526,9 @@ describe('SchedulerService', () => {
 
       expect(id).toBe('job-decl');
       const [sql] = pool.query.mock.calls[0] as [string];
-      expect(sql).toContain('ON CONFLICT');
-      expect(sql).toContain('scheduled_jobs_declarative_uq');
+      // Column-based conflict syntax — matches the partial unique index definition.
+      // ON CONFLICT ON CONSTRAINT only works with named CONSTRAINTs, not named indexes.
+      expect(sql).toContain('ON CONFLICT (agent_id, cron_expr, (task_payload::text)) WHERE created_by = \'system\'');
     });
 
     it('writes expectedDurationSeconds when provided', async () => {


### PR DESCRIPTION
## Summary

- `ON CONFLICT ON CONSTRAINT` requires a named **constraint** (created via `ADD CONSTRAINT`), but `scheduled_jobs_declarative_uq` was created with `CREATE UNIQUE INDEX` — which only creates a named index. PostgreSQL error `42704` at startup blocked all declarative schedule entries from registering.
- Switched to column-based conflict syntax: `ON CONFLICT (agent_id, cron_expr, (task_payload::text)) WHERE created_by = 'system'`, which exactly matches the index definition in migration 008.
- Updated the corresponding test assertion to verify the new syntax.
- Bumps to 0.14.2.

## Test plan

- [ ] All 1034 unit tests pass (`vitest run`)
- [ ] After deploy: `docker logs curia-curia-1 2>&1 | grep -E "writing-scout|Declarative job upserted"` shows two upserted jobs targeting `coordinator` with crons `30 8 * * 2` and `30 8 * * 5`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved startup failures that occurred when declarative scheduler entries were configured.

* **Chores**
  * Updated version to 0.14.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->