### PR TITLE
feat(memory): context summarization for working memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+- **Context summarization** — When active conversation history in working memory exceeds a
+  configurable threshold (default: 20 turns), the oldest turns are condensed into a synthetic
+  summary turn via an LLM call and the originals are archived (`archived = true`) in Postgres.
+  Active context assembly loads the summary instead of archived originals, preventing silent
+  context-window overflow on long-running tasks (spec §01-memory-system.md).
+  `WorkingMemory.createWithPostgres()` accepts an optional `SummarizationConfig` (threshold,
+  keepWindow, provider). Migration 018 adds the `archived` column to `working_memory`.
+
 ### Fixed
 - **Declarative job upsert** — `ON CONFLICT ON CONSTRAINT` only works with named
   constraints, not named indexes. Switched to column-based conflict syntax matching

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,8 @@ Bump `package.json` version in the same PR as the changelog entry. If the versio
 | Change type | Bump | Examples |
 |---|---|---|
 | New skill, agent, or channel | **minor** (`0.X.0`) | Adding `web-search`, adding Signal channel |
-| Completed spec / major feature | **minor** (`0.X.0`) | Autonomy engine shipped, entity context enrichment |
+| New spec shipped for the first time (brand-new capability) | **minor** (`0.X.0`) | Autonomy engine shipped, entity context enrichment |
+| Completing a partially-shipped spec or feature | **patch** (`0.x.Y`) | Context summarization completing §01-memory-system.md |
 | Bug fix, small improvement, doc-only | **patch** (`0.x.Y`) | Fixing a skill error path, updating a guide |
 | Breaking change to public API surface | **minor** + note in changelog | Renaming a `SkillContext` field, changing `skill.json` schema |
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -20,6 +20,21 @@ dispatch:
   # event fires and background memory extraction (extract-relationships, etc.) runs.
   conversationCheckpointDebounceMs: 600000   # 10 minutes
 
+workingMemory:
+  # Rolling context summarization (spec §01-memory-system.md).
+  # When the active turn count for a conversation exceeds `threshold`, the oldest
+  # (count - keepWindow) turns are condensed into a synthetic summary turn via an
+  # LLM call and archived. Active context assembly sees the summary instead of the
+  # archived originals, preventing silent context-window overflow on long tasks.
+  #
+  # Summarization is best-effort — a failed LLM call is logged at error level and
+  # skipped; the turn is still written and the next add() will retry automatically.
+  #
+  # Constraints: keepWindow must be less than threshold, both must be >= 1.
+  summarization:
+    threshold: 20   # turns that trigger a summarization pass
+    keepWindow: 10  # most-recent turns to retain as active after summarization
+
 skillOutput:
   # Maximum character length of a sanitized skill result before truncation.
   # Skills that return more than this (search results, page crawls, long calendar

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -30,7 +30,7 @@ workingMemory:
   # Summarization is best-effort — a failed LLM call is logged at error level and
   # skipped; the turn is still written and the next add() will retry automatically.
   #
-  # Constraints: keepWindow must be less than threshold, both must be >= 1.
+  # Constraints: threshold must be >= 2, keepWindow must be >= 1, keepWindow < threshold.
   summarization:
     threshold: 20   # turns that trigger a summarization pass
     keepWindow: 10  # most-recent turns to retain as active after summarization

--- a/docs/dev/configuration.md
+++ b/docs/dev/configuration.md
@@ -1,0 +1,148 @@
+# Configuration Reference
+
+Curia is configured through two complementary mechanisms:
+
+- **`.env`** — secrets and environment-specific values (API keys, database URL, port). Never committed to version control.
+- **`config/default.yaml`** — tuning knobs and feature flags that are safe to commit. Defaults are set here; `.env` overrides nothing in this file — the two are independent.
+
+Changes to `default.yaml` take effect on restart. Changes to `.env` also require a restart.
+
+---
+
+## `config/default.yaml` — full reference
+
+### `channels`
+
+Controls which channel adapters activate at startup.
+
+```yaml
+channels:
+  cli:
+    enabled: true   # Set to false to disable the terminal CLI entirely
+```
+
+Signal and email are **not** controlled here — they activate based on environment variables (`SIGNAL_PHONE_NUMBER`, `NYLAS_API_KEY`, etc.). See [setup.md](setup.md) for details.
+
+---
+
+### `browser`
+
+Controls the lifetime of browser sessions used by skills like `browser-navigate`.
+
+```yaml
+browser:
+  sessionTtlMs: 600000    # How long a session stays alive after its last action (ms). Default: 10 minutes.
+  sweepIntervalMs: 120000 # How often the session cleanup sweep runs (ms). Default: 2 minutes.
+```
+
+Raise `sessionTtlMs` if skills that open browser sessions are timing out mid-task. Lower it to free resources faster on memory-constrained deployments.
+
+---
+
+### `agents`
+
+Points to agent YAML config files. Currently only the coordinator is configurable here.
+
+```yaml
+agents:
+  coordinator:
+    config_path: agents/coordinator.yaml
+```
+
+You generally don't need to change this unless you're testing a different coordinator config in place.
+
+---
+
+### `dispatch`
+
+Controls the conversation checkpoint pipeline — the debounced background process that runs relationship extraction and other memory tasks after conversations go quiet.
+
+```yaml
+dispatch:
+  conversationCheckpointDebounceMs: 600000  # Default: 10 minutes
+```
+
+Lower this to run memory extraction sooner after conversations end. Raise it on slow or cost-sensitive deployments to batch more activity before triggering extraction.
+
+---
+
+### `workingMemory`
+
+Controls rolling context summarization (spec §01-memory-system.md). Agents that run long conversations will eventually exceed their LLM's context window. Summarization prevents this by condensing old turns into a compact narrative and archiving the originals.
+
+```yaml
+workingMemory:
+  summarization:
+    threshold: 20   # Active turns that trigger a summarization pass. Default: 20.
+    keepWindow: 10  # Most-recent turns to retain as active after summarization. Default: 10.
+```
+
+**How it works:** After each turn is written to working memory, if the active (non-archived) turn count exceeds `threshold`, the oldest `count - keepWindow` turns are sent to the LLM to condense into a summary. The originals are marked `archived = true` in Postgres (retained for audit) and replaced in active context by a synthetic system turn containing the summary. Subsequent LLM calls see: summary turn → most recent `keepWindow` turns → new user message.
+
+**Tuning guidance:**
+- `threshold` should be well below your model's practical context limit. At 20 turns, a typical conversation is 2,000–6,000 tokens of history — comfortable headroom even with large system prompts and tool outputs.
+- `keepWindow` controls recency. 10 turns gives the agent immediate conversational context. Lower values reduce context pressure; higher values preserve more recent detail at the cost of a longer active window.
+- `keepWindow` must always be less than `threshold` — Curia validates this at startup and exits with an error if violated.
+
+**Disabling:** Remove the `workingMemory` block entirely (or omit `summarization`). Summarization is opt-in by presence of the config block.
+
+---
+
+### `skillOutput`
+
+Controls truncation of skill results before they're included in LLM context.
+
+```yaml
+skillOutput:
+  maxLength: 200000  # Default: 200,000 characters (~50k tokens at 4 chars/token)
+```
+
+Skills that return large payloads (web search results, long calendar lists, crawled pages) are clipped to this length with a truncation note appended. Raise the limit if skills are cutting off important results. Lower it on installations with tight context budgets or many concurrent agents.
+
+---
+
+### `security`
+
+Extra prompt injection detection patterns applied to every inbound message, in addition to the built-in defaults.
+
+```yaml
+security:
+  extra_injection_patterns:
+    - regex: "forget everything above"
+      label: "forget everything above"
+    - regex: "new\\s+persona"
+      label: "new persona"
+```
+
+Each entry needs:
+- `regex` — a JavaScript regex string (case-insensitive matching is applied automatically)
+- `label` — a human-readable name that appears in the audit log when the pattern fires
+
+Built-in defaults already cover the most common injection attempts (`ignore previous instructions`, `you are now`, `act as`, etc.). Add entries here for patterns specific to your deployment or user base.
+
+> **⚠️ ReDoS warning:** Avoid patterns with unbounded nested quantifiers like `(a+)+` or `(.+)+`. These can cause catastrophic backtracking on adversarial input and freeze the Node.js event loop. Prefer simple bounded patterns. These patterns run on every inbound message in the main process.
+
+Changes take effect on restart.
+
+---
+
+## Environment variables (`.env`)
+
+Environment variables control secrets and deployment-specific values that must not be committed. A full list with descriptions lives in `.env.example` at the repo root. Key variables:
+
+| Variable | Required | Description |
+|---|---|---|
+| `DATABASE_URL` | Yes | Postgres connection string |
+| `ANTHROPIC_API_KEY` | Yes | Powers all agents |
+| `API_TOKEN` | Yes | Authenticates HTTP API requests |
+| `WEB_APP_BOOTSTRAP_SECRET` | Yes | Web app login secret |
+| `TIMEZONE` | Yes | IANA timezone (e.g. `America/Toronto`) |
+| `CEO_PRIMARY_EMAIL` | Recommended | Prevents first CEO email from being held |
+| `OPENAI_API_KEY` | Tier 2 | Enables entity memory and semantic search |
+| `NYLAS_API_KEY` | Tier 2 | Email channel |
+| `NYLAS_GRANT_ID` | Tier 2 | Email grant (connected account) |
+| `NYLAS_SELF_EMAIL` | Tier 2 | Address Curia reads and sends from |
+| `SIGNAL_PHONE_NUMBER` | Tier 3 | Enables Signal channel |
+| `TAVILY_API_KEY` | Tier 3 | Enables `web-search` skill |
+
+See [setup.md](setup.md) for a step-by-step walkthrough of setting these up.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.15.0",
+  "version": "0.14.3",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,24 +114,27 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       );
     }
 
-    const summarizationThreshold = config.workingMemory?.summarization?.threshold;
-    if (summarizationThreshold !== undefined && (!Number.isInteger(summarizationThreshold) || summarizationThreshold < 2)) {
-      throw new Error(`workingMemory.summarization.threshold must be an integer >= 2, got: ${summarizationThreshold}`);
-    }
+    if (config.workingMemory?.summarization !== undefined) {
+      const summarizationThreshold = config.workingMemory.summarization.threshold;
+      if (summarizationThreshold !== undefined && (!Number.isInteger(summarizationThreshold) || summarizationThreshold < 2)) {
+        throw new Error(`workingMemory.summarization.threshold must be an integer >= 2, got: ${summarizationThreshold}`);
+      }
 
-    const summarizationKeepWindow = config.workingMemory?.summarization?.keepWindow;
-    if (summarizationKeepWindow !== undefined && (!Number.isInteger(summarizationKeepWindow) || summarizationKeepWindow < 1)) {
-      throw new Error(`workingMemory.summarization.keepWindow must be a positive integer, got: ${summarizationKeepWindow}`);
-    }
+      const summarizationKeepWindow = config.workingMemory.summarization.keepWindow;
+      if (summarizationKeepWindow !== undefined && (!Number.isInteger(summarizationKeepWindow) || summarizationKeepWindow < 1)) {
+        throw new Error(`workingMemory.summarization.keepWindow must be a positive integer, got: ${summarizationKeepWindow}`);
+      }
 
-    if (
-      summarizationThreshold !== undefined &&
-      summarizationKeepWindow !== undefined &&
-      summarizationKeepWindow >= summarizationThreshold
-    ) {
-      throw new Error(
-        `workingMemory.summarization.keepWindow (${summarizationKeepWindow}) must be less than threshold (${summarizationThreshold})`,
-      );
+      // Cross-validate using effective values (same defaults as index.ts bootstrap) so a
+      // config like { keepWindow: 25 } (no explicit threshold) is caught here rather than
+      // silently passing validation and failing at runtime.
+      const effectiveThreshold = summarizationThreshold ?? 20;
+      const effectiveKeepWindow = summarizationKeepWindow ?? 10;
+      if (effectiveKeepWindow >= effectiveThreshold) {
+        throw new Error(
+          `workingMemory.summarization.keepWindow (${effectiveKeepWindow}) must be less than threshold (${effectiveThreshold})`,
+        );
+      }
     }
 
     return config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,6 +55,14 @@ export interface YamlConfig {
   agents?: {
     coordinator?: { config_path?: string };
   };
+  workingMemory?: {
+    summarization?: {
+      /** Active turn count that triggers a summarization pass. Default: 20. Must be >= 2. */
+      threshold?: number;
+      /** Most-recent turns to retain as active after summarization. Default: 10. Must be < threshold. */
+      keepWindow?: number;
+    };
+  };
   skillOutput?: {
     /** Max character length for skill results before truncation. Default: 200_000. */
     maxLength?: number;
@@ -103,6 +111,26 @@ export function loadYamlConfig(configDir: string): YamlConfig {
     if (checkpointDebounceMs !== undefined && (!Number.isInteger(checkpointDebounceMs) || checkpointDebounceMs <= 0)) {
       throw new Error(
         `dispatch.conversationCheckpointDebounceMs must be a positive integer, got: ${checkpointDebounceMs}`,
+      );
+    }
+
+    const summarizationThreshold = config.workingMemory?.summarization?.threshold;
+    if (summarizationThreshold !== undefined && (!Number.isInteger(summarizationThreshold) || summarizationThreshold < 2)) {
+      throw new Error(`workingMemory.summarization.threshold must be an integer >= 2, got: ${summarizationThreshold}`);
+    }
+
+    const summarizationKeepWindow = config.workingMemory?.summarization?.keepWindow;
+    if (summarizationKeepWindow !== undefined && (!Number.isInteger(summarizationKeepWindow) || summarizationKeepWindow < 1)) {
+      throw new Error(`workingMemory.summarization.keepWindow must be a positive integer, got: ${summarizationKeepWindow}`);
+    }
+
+    if (
+      summarizationThreshold !== undefined &&
+      summarizationKeepWindow !== undefined &&
+      summarizationKeepWindow >= summarizationThreshold
+    ) {
+      throw new Error(
+        `workingMemory.summarization.keepWindow (${summarizationKeepWindow}) must be less than threshold (${summarizationThreshold})`,
       );
     }
 

--- a/src/db/migrations/018_add_working_memory_archived.sql
+++ b/src/db/migrations/018_add_working_memory_archived.sql
@@ -1,0 +1,14 @@
+-- Up Migration
+-- Add archived column to working_memory for context summarization (spec §01-memory-system.md).
+-- Archived rows remain in Postgres for audit purposes but are excluded from active context loading.
+
+ALTER TABLE working_memory ADD COLUMN archived BOOLEAN NOT NULL DEFAULT false;
+
+-- Partial index covering only active (non-archived) rows — the hot query path.
+-- Replaces the full-table idx_wm_conversation for the primary SELECT in get().
+CREATE INDEX idx_wm_active ON working_memory (conversation_id, agent_id, created_at)
+  WHERE archived = false;
+
+-- Down Migration
+DROP INDEX IF EXISTS idx_wm_active;
+ALTER TABLE working_memory DROP COLUMN IF EXISTS archived;

--- a/src/db/migrations/018_add_working_memory_archived.sql
+++ b/src/db/migrations/018_add_working_memory_archived.sql
@@ -4,8 +4,9 @@
 
 ALTER TABLE working_memory ADD COLUMN archived BOOLEAN NOT NULL DEFAULT false;
 
--- Partial index covering only active (non-archived) rows — the hot query path.
--- Replaces the full-table idx_wm_conversation for the primary SELECT in get().
+-- Partial index covering only active (non-archived) rows — the hot query path for get().
+-- Coexists with idx_wm_conversation (added in migration 002); the planner will prefer
+-- idx_wm_active for queries that filter archived = false.
 CREATE INDEX idx_wm_active ON working_memory (conversation_id, agent_id, created_at)
   WHERE archived = false;
 

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -440,14 +440,17 @@ export class Dispatcher {
       // the batch read and the upsert where new turns could otherwise be silently skipped.
       // Two explicit query strings rather than a conditional template fragment — avoids
       // the risk of a parameter slot ($3) drifting out of sync with the array when edited.
+      // Exclude archived rows — they were summarized and their content is preserved
+      // in the synthetic summary turn. Including them would feed stale/duplicate
+      // turns to the relationship-extraction processor.
       const turnsQuery = since
         ? `SELECT role, content, created_at FROM working_memory
            WHERE conversation_id = $1 AND agent_id = $2
-             AND role IN ('user', 'assistant') AND created_at > $3
+             AND role IN ('user', 'assistant') AND archived = false AND created_at > $3
            ORDER BY created_at ASC`
         : `SELECT role, content, created_at FROM working_memory
            WHERE conversation_id = $1 AND agent_id = $2
-             AND role IN ('user', 'assistant')
+             AND role IN ('user', 'assistant') AND archived = false
            ORDER BY created_at ASC`;
       const turnsResult = await this.pool!.query<{ role: string; content: string; created_at: string }>(
         turnsQuery,

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,18 @@ async function main(): Promise<void> {
 
   // Working memory — created after the pool is confirmed healthy so we know
   // the working_memory table is reachable before the first message arrives.
-  const memory = WorkingMemory.createWithPostgres(pool, logger);
+  // Summarization config is read from default.yaml (workingMemory.summarization).
+  // llmProvider is already initialized above (step 5) so we can pass it directly.
+  // If the config block is absent, summarization is disabled (no-op backend).
+  const summarizationCfg = yamlConfig.workingMemory?.summarization;
+  const memory = WorkingMemory.createWithPostgres(pool, logger, summarizationCfg
+    ? {
+        threshold: summarizationCfg.threshold ?? 20,
+        keepWindow: summarizationCfg.keepWindow ?? 10,
+        provider: llmProvider,
+      }
+    : undefined,
+  );
 
   // Entity memory — optional, requires OPENAI_API_KEY for embeddings.
   // If not configured, agents still work — they just don't have KG access.

--- a/src/memory/working-memory.ts
+++ b/src/memory/working-memory.ts
@@ -1,9 +1,24 @@
 import type { DbPool } from '../db/connection.js';
 import type { Logger } from '../logger.js';
+import type { LLMProvider } from '../agents/llm/provider.js';
 
 export interface ConversationTurn {
   role: 'user' | 'assistant' | 'system';
   content: string;
+}
+
+/**
+ * Configuration for rolling context summarization.
+ * When the active turn count exceeds `threshold`, the oldest (count - keepWindow) turns
+ * are condensed into a single synthetic system turn and marked archived in the DB.
+ */
+export interface SummarizationConfig {
+  /** Number of active turns that triggers a summarization pass. Default: 20. */
+  threshold: number;
+  /** Number of most-recent turns to retain as active after summarization. Default: 10. */
+  keepWindow: number;
+  /** LLM provider used for the condensation call — same provider the agent uses. */
+  provider: LLMProvider;
 }
 
 interface StorageBackend {
@@ -17,6 +32,11 @@ interface StorageBackend {
  *
  * Uses a backend interface so unit tests can use in-memory storage
  * while production uses Postgres.
+ *
+ * When a `SummarizationConfig` is provided, the Postgres backend automatically
+ * summarizes old turns once the active count exceeds `threshold`. Summarized turns
+ * are marked `archived = true` in the DB (retained for audit) and replaced in active
+ * context by a condensed synthetic system turn. See spec §01-memory-system.md.
  */
 export class WorkingMemory {
   private backend: StorageBackend;
@@ -26,8 +46,12 @@ export class WorkingMemory {
   }
 
   /** Create a Postgres-backed instance for production use */
-  static createWithPostgres(pool: DbPool, logger: Logger): WorkingMemory {
-    return new WorkingMemory(new PostgresBackend(pool, logger));
+  static createWithPostgres(
+    pool: DbPool,
+    logger: Logger,
+    summarization?: SummarizationConfig,
+  ): WorkingMemory {
+    return new WorkingMemory(new PostgresBackend(pool, logger, summarization));
   }
 
   /** Create an in-memory instance for testing */
@@ -56,9 +80,16 @@ export class WorkingMemory {
  * Postgres-backed storage. Conversation turns are rows in the working_memory table.
  * History is returned in chronological order (oldest first) so the LLM sees
  * the conversation in natural reading order.
+ *
+ * When summarization is configured, `add()` triggers a summarization check after
+ * every write. Archived rows stay in the DB but are excluded from `get()` results.
  */
 class PostgresBackend implements StorageBackend {
-  constructor(private pool: DbPool, private logger: Logger) {}
+  constructor(
+    private pool: DbPool,
+    private logger: Logger,
+    private summarization?: SummarizationConfig,
+  ) {}
 
   async add(conversationId: string, agentId: string, turn: ConversationTurn): Promise<void> {
     this.logger.debug({ conversationId, agentId, role: turn.role }, 'working_memory: adding turn');
@@ -67,19 +98,37 @@ class PostgresBackend implements StorageBackend {
        VALUES ($1, $2, $3, $4)`,
       [conversationId, agentId, turn.role, turn.content],
     );
+
+    // After writing, check whether we've crossed the summarization threshold.
+    // Summarization is best-effort — a failure must not abort the agent turn since
+    // the turn has already been persisted. Catch here (not inside maybeSummarize)
+    // so errors propagate cleanly out of the private method and the non-fatal
+    // decision is explicit and visible at the call site.
+    if (this.summarization) {
+      try {
+        await this.maybeSummarize(conversationId, agentId, this.summarization);
+      } catch (err) {
+        this.logger.error(
+          { err, conversationId, agentId },
+          'working_memory: summarization failed — turn written, context window will grow until next successful pass',
+        );
+      }
+    }
   }
 
   async get(conversationId: string, agentId: string, maxTurns?: number): Promise<ConversationTurn[]> {
     const limit = maxTurns ?? 50;
 
-    // Subquery gets the most recent N rows (newest first by created_at),
-    // then outer query reverses to chronological order for LLM context.
-    // This ensures we always get the LAST N turns, not the first N.
+    // Subquery gets the most recent N active (non-archived) rows (newest first),
+    // then the outer query reverses to chronological order for LLM context.
+    // Archived rows are excluded — they're represented by the synthetic summary turn.
     const result = await this.pool.query<{ role: string; content: string }>(
       `SELECT role, content FROM (
          SELECT role, content, created_at
          FROM working_memory
-         WHERE conversation_id = $1 AND agent_id = $2
+         WHERE conversation_id = $1
+           AND agent_id = $2
+           AND archived = false
          ORDER BY created_at DESC
          LIMIT $3
        ) sub ORDER BY created_at ASC`,
@@ -91,11 +140,191 @@ class PostgresBackend implements StorageBackend {
       content: row.content,
     }));
   }
+
+  /**
+   * Check whether the active turn count has crossed the summarization threshold.
+   * If so, archive the oldest (count - keepWindow) turns and replace them with
+   * a condensed synthetic system turn at the head of the kept window.
+   *
+   * Failures are logged but do NOT propagate — a failed summarization is preferable
+   * to aborting the agent turn. The next add() will retry automatically.
+   */
+  private async maybeSummarize(
+    conversationId: string,
+    agentId: string,
+    config: SummarizationConfig,
+  ): Promise<void> {
+    const { threshold, keepWindow, provider } = config;
+
+    // Count active (non-archived) turns for this conversation+agent
+    const countResult = await this.pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count
+       FROM working_memory
+       WHERE conversation_id = $1
+         AND agent_id = $2
+         AND archived = false`,
+      [conversationId, agentId],
+    );
+
+    // COUNT(*) always returns exactly one row — if it doesn't, something is structurally wrong.
+    const countRow = countResult.rows[0];
+    if (!countRow) {
+      throw new Error('working_memory: COUNT(*) returned no rows — unexpected database driver behavior');
+    }
+    const activeCount = parseInt(countRow.count, 10);
+    if (isNaN(activeCount)) {
+      throw new Error(`working_memory: COUNT(*) returned non-numeric value: ${countRow.count}`);
+    }
+
+    if (activeCount <= threshold) {
+      return; // Below threshold — nothing to do
+    }
+
+    const toArchiveCount = activeCount - keepWindow;
+    if (toArchiveCount <= 0) {
+      return;
+    }
+
+    this.logger.info(
+      { conversationId, agentId, activeCount, toArchiveCount, keepWindow },
+      'working_memory: threshold exceeded, summarizing oldest turns',
+    );
+
+    // Fetch the oldest toArchiveCount active rows in chronological order.
+    // Existing synthetic summary turns (role = 'system') are included so the new
+    // summary absorbs prior summaries rather than leaving orphaned ones behind.
+    const turnsResult = await this.pool.query<{ id: string; role: string; content: string; created_at: Date }>(
+      `SELECT id, role, content, created_at
+       FROM working_memory
+       WHERE conversation_id = $1
+         AND agent_id = $2
+         AND archived = false
+       ORDER BY created_at ASC
+       LIMIT $3`,
+      [conversationId, agentId, toArchiveCount],
+    );
+
+    const turnsToArchive = turnsResult.rows;
+    if (turnsToArchive.length === 0) {
+      return;
+    }
+
+    // Build the summarization prompt from the turns being archived.
+    // Prior summaries (system role) are labelled distinctly so the LLM carries them forward.
+    const transcript = turnsToArchive
+      .map((t) => {
+        const label = t.role === 'system' ? 'PRIOR SUMMARY' : t.role.toUpperCase();
+        return `[${label}]: ${t.content}`;
+      })
+      .join('\n\n');
+
+    const summaryPrompt = [
+      'You are a precise summarizer. Condense the following conversation excerpt into a concise narrative.',
+      'Preserve: key decisions made, entities discussed (people, projects, companies), and any commitments or action items.',
+      'Omit: small talk, repeated questions, verbatim tool outputs.',
+      'Output only the summary — no preamble, no meta-commentary.',
+      '',
+      transcript,
+    ].join('\n');
+
+    const response = await provider.chat({
+      messages: [{ role: 'user', content: summaryPrompt }],
+    });
+
+    if (response.type === 'error') {
+      // Propagates to add()'s catch — full AgentError struct preserved in the log there.
+      throw Object.assign(
+        new Error(`working_memory: summarization LLM call failed — ${response.error.message}`),
+        { agentError: response.error },
+      );
+    }
+    if (response.type !== 'text' || !response.content.trim()) {
+      throw new Error(
+        `working_memory: summarization LLM call returned unexpected non-text response type "${response.type}"`,
+      );
+    }
+    const summaryContent = response.content.trim();
+
+    // The synthetic summary is inserted 1ms before the oldest *kept* turn so that
+    // chronological ordering places it at the head of the active window.
+    const oldestKeptResult = await this.pool.query<{ created_at: Date }>(
+      `SELECT created_at
+       FROM working_memory
+       WHERE conversation_id = $1
+         AND agent_id = $2
+         AND archived = false
+         AND id != ALL($3::uuid[])
+       ORDER BY created_at ASC
+       LIMIT 1`,
+      [conversationId, agentId, turnsToArchive.map((t) => t.id)],
+    );
+
+    // If toArchiveCount < activeCount, there must always be at least one kept row.
+    // No kept row means a concurrent write changed the count between our COUNT query
+    // and this SELECT — abort to avoid inserting a misanchored summary.
+    if (!oldestKeptResult.rows[0]) {
+      throw new Error(
+        'working_memory: kept-row invariant violated (possible concurrent write) — aborting summarization',
+      );
+    }
+    const summaryTimestamp = new Date(oldestKeptResult.rows[0].created_at.getTime() - 1);
+
+    // Atomic transaction: archive old turns + insert synthetic summary.
+    // If either step fails the whole operation rolls back — no partial state.
+    const archiveIds = turnsToArchive.map((t) => t.id);
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      await client.query(
+        `UPDATE working_memory
+         SET archived = true
+         WHERE id = ANY($1::uuid[])`,
+        [archiveIds],
+      );
+
+      await client.query(
+        `INSERT INTO working_memory (conversation_id, agent_id, role, content, created_at)
+         VALUES ($1, $2, 'system', $3, $4)`,
+        [conversationId, agentId, `[Conversation summary]\n${summaryContent}`, summaryTimestamp],
+      );
+
+      await client.query('COMMIT');
+      this.logger.info(
+        { conversationId, agentId, archivedCount: archiveIds.length },
+        'working_memory: summarization complete',
+      );
+    } catch (err) {
+      // Guard the ROLLBACK itself — if the connection was dropped it may throw.
+      // We still want to log and propagate the original error, not replace it.
+      try {
+        await client.query('ROLLBACK');
+      } catch (rollbackErr) {
+        this.logger.error(
+          { err: rollbackErr, conversationId, agentId },
+          'working_memory: ROLLBACK failed after transaction error — connection may be in bad state',
+        );
+      }
+      // Propagate to add()'s catch so the non-fatal policy is applied at the call site.
+      throw err;
+    } finally {
+      // Guard release() so it cannot replace the original error with its own exception.
+      try {
+        client.release();
+      } catch (releaseErr) {
+        this.logger.error(
+          { err: releaseErr, conversationId, agentId },
+          'working_memory: pg client release failed — connection may leak from pool',
+        );
+      }
+    }
+  }
 }
 
 /**
  * In-memory storage for testing. No database required.
  * Maintains insertion order so chronological retrieval works naturally.
+ * Does not implement summarization — use integration tests for end-to-end coverage.
  */
 class InMemoryBackend implements StorageBackend {
   private store = new Map<string, ConversationTurn[]>();

--- a/tests/unit/memory/working-memory-summarization.test.ts
+++ b/tests/unit/memory/working-memory-summarization.test.ts
@@ -13,7 +13,7 @@
  *   - get() loads the summary instead of archived originals
  *   - Failed LLM call: skips summarization without aborting the agent turn
  */
-import { describe, it, expect, vi, beforeEach, type MockedFunction } from 'vitest';
+import { describe, it, expect, vi, type MockedFunction } from 'vitest';
 import { WorkingMemory, type SummarizationConfig } from '../../../src/memory/working-memory.js';
 import type { LLMProvider } from '../../../src/agents/llm/provider.js';
 import type { DbPool } from '../../../src/db/connection.js';
@@ -72,9 +72,7 @@ describe('WorkingMemory — context summarization', () => {
   const CONV = 'conv-summarize';
   const AGENT = 'coordinator';
 
-  // Fixed UUIDs for archived turns (16 oldest) and kept turns (10 newest)
   const makeId = (i: number) => `00000000-0000-0000-0000-${String(i).padStart(12, '0')}`;
-  const allTurnIds = Array.from({ length: 26 }, (_, i) => makeId(i));
 
   /**
    * Build a pool that simulates:

--- a/tests/unit/memory/working-memory-summarization.test.ts
+++ b/tests/unit/memory/working-memory-summarization.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Unit tests for WorkingMemory context summarization.
+ *
+ * We test the PostgresBackend indirectly via the WorkingMemory.createWithPostgres()
+ * factory, using a carefully controlled mock pool. This avoids a real DB while still
+ * exercising the summarization logic paths.
+ *
+ * Acceptance criteria from issue #232:
+ *   - Threshold triggers summarization
+ *   - LLM condenses the oldest turns into a summary preserving decisions/entities/commitments
+ *   - Summarized originals are marked archived = true
+ *   - Condensed summary inserted as synthetic system turn at head of kept window
+ *   - get() loads the summary instead of archived originals
+ *   - Failed LLM call: skips summarization without aborting the agent turn
+ */
+import { describe, it, expect, vi, beforeEach, type MockedFunction } from 'vitest';
+import { WorkingMemory, type SummarizationConfig } from '../../../src/memory/working-memory.js';
+import type { LLMProvider } from '../../../src/agents/llm/provider.js';
+import type { DbPool } from '../../../src/db/connection.js';
+
+// ---------------------------------------------------------------------------
+// Minimal mock pool builder
+// ---------------------------------------------------------------------------
+
+type QueryResult<T> = { rows: T[] };
+
+/**
+ * Builds a mock pg.Pool that routes `pool.query()` calls to the supplied handler,
+ * and provides a mock client for transaction use via `pool.connect()`.
+ */
+function buildMockPool(
+  queryHandler: (sql: string, params?: unknown[]) => QueryResult<unknown>,
+): DbPool {
+  // Mock client used inside transactions (BEGIN/COMMIT/ROLLBACK + DML)
+  const mockClient = {
+    query: vi.fn().mockImplementation((sql: string, params?: unknown[]) =>
+      Promise.resolve(queryHandler(sql, params)),
+    ),
+    release: vi.fn(),
+  };
+
+  const pool = {
+    query: vi.fn().mockImplementation((sql: string, params?: unknown[]) =>
+      Promise.resolve(queryHandler(sql, params)),
+    ),
+    connect: vi.fn().mockResolvedValue(mockClient),
+  } as unknown as DbPool;
+
+  return pool;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: mock LLMProvider
+// ---------------------------------------------------------------------------
+
+function buildMockProvider(summaryText = 'SUMMARY: key decisions made.'): LLMProvider {
+  return {
+    id: 'mock',
+    chat: vi.fn().mockResolvedValue({
+      type: 'text' as const,
+      content: summaryText,
+      usage: { inputTokens: 10, outputTokens: 5 },
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WorkingMemory — context summarization', () => {
+  const CONV = 'conv-summarize';
+  const AGENT = 'coordinator';
+
+  // Fixed UUIDs for archived turns (16 oldest) and kept turns (10 newest)
+  const makeId = (i: number) => `00000000-0000-0000-0000-${String(i).padStart(12, '0')}`;
+  const allTurnIds = Array.from({ length: 26 }, (_, i) => makeId(i));
+
+  /**
+   * Build a pool that simulates:
+   *  - INSERT of a new turn (no-op returns)
+   *  - COUNT query returning activeCount
+   *  - SELECT of oldest toArchiveCount turns (returns mock rows)
+   *  - SELECT oldest kept turn created_at
+   *  - Transaction: UPDATE archived=true, INSERT summary
+   */
+  function buildPool(activeCount: number, toArchiveCount: number): { pool: DbPool; mockProvider: LLMProvider } {
+    const now = new Date('2026-01-01T12:00:00Z');
+    const archivedRows = Array.from({ length: toArchiveCount }, (_, i) => ({
+      id: makeId(i),
+      role: 'user',
+      content: `Turn ${i}`,
+      created_at: new Date(now.getTime() + i * 1000),
+    }));
+    const oldestKeptAt = new Date(now.getTime() + toArchiveCount * 1000);
+
+    const mockProvider = buildMockProvider();
+
+    const queryHandler = (sql: string, _params?: unknown[]): QueryResult<unknown> => {
+      const normalized = sql.replace(/\s+/g, ' ').trim();
+
+      if (normalized.startsWith('INSERT INTO working_memory')) {
+        return { rows: [] };
+      }
+      if (normalized.startsWith('SELECT COUNT(*)')) {
+        return { rows: [{ count: String(activeCount) }] };
+      }
+      if (normalized.startsWith('SELECT id, role, content, created_at')) {
+        return { rows: archivedRows };
+      }
+      if (normalized.startsWith('SELECT created_at')) {
+        return { rows: [{ created_at: oldestKeptAt }] };
+      }
+      // Transaction queries (BEGIN, COMMIT, UPDATE, INSERT summary)
+      return { rows: [] };
+    };
+
+    return { pool: buildMockPool(queryHandler), mockProvider };
+  }
+
+  it('does not call LLM when active count is at or below threshold', async () => {
+    const mockProvider = buildMockProvider();
+    let insertCount = 0;
+    let countQueried = false;
+
+    const queryHandler = (sql: string): QueryResult<unknown> => {
+      const normalized = sql.replace(/\s+/g, ' ').trim();
+      if (normalized.startsWith('INSERT INTO working_memory')) {
+        insertCount++;
+        return { rows: [] };
+      }
+      if (normalized.startsWith('SELECT COUNT(*)')) {
+        countQueried = true;
+        // Return exactly at threshold — should NOT trigger summarization
+        return { rows: [{ count: '20' }] };
+      }
+      return { rows: [] };
+    };
+
+    const pool = buildMockPool(queryHandler);
+    const config: SummarizationConfig = { threshold: 20, keepWindow: 10, provider: mockProvider };
+    const memory = WorkingMemory.createWithPostgres(pool, { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never, config);
+
+    await memory.addTurn(CONV, AGENT, { role: 'user', content: 'Hello' });
+
+    expect(insertCount).toBe(1);
+    expect(countQueried).toBe(true);
+    expect(mockProvider.chat).not.toHaveBeenCalled();
+  });
+
+  it('calls LLM when active count exceeds threshold', async () => {
+    const { pool, mockProvider } = buildPool(21, 11); // 21 active, keep 10, archive 11
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never;
+    const config: SummarizationConfig = { threshold: 20, keepWindow: 10, provider: mockProvider };
+
+    const memory = WorkingMemory.createWithPostgres(pool, logger, config);
+    await memory.addTurn(CONV, AGENT, { role: 'user', content: 'Trigger turn' });
+
+    expect(mockProvider.chat).toHaveBeenCalledOnce();
+    // Verify the prompt includes the transcript of archived turns
+    const callArg = (mockProvider.chat as MockedFunction<LLMProvider['chat']>).mock.calls[0]![0];
+    const promptContent = callArg.messages[0]!.content as string;
+    expect(promptContent).toContain('Turn 0');
+    expect(promptContent).toContain('Condense');
+  });
+
+  it('archives old turns and inserts synthetic summary in a transaction', async () => {
+    const toArchiveCount = 11;
+    const { pool, mockProvider } = buildPool(21, toArchiveCount);
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never;
+    const config: SummarizationConfig = { threshold: 20, keepWindow: 10, provider: mockProvider };
+
+    const memory = WorkingMemory.createWithPostgres(pool, logger, config);
+    await memory.addTurn(CONV, AGENT, { role: 'user', content: 'Trigger turn' });
+
+    // Retrieve the mock client used for the transaction
+    const client = await (pool as unknown as { connect(): Promise<{ query: MockedFunction<() => unknown>; release: () => void }> }).connect();
+
+    // BEGIN and COMMIT must have been called
+    const clientCalls = (client.query as MockedFunction<() => unknown>).mock.calls.map((c) => (c[0] as string).trim());
+    expect(clientCalls).toContain('BEGIN');
+    expect(clientCalls).toContain('COMMIT');
+
+    // UPDATE archived = true must reference the archived IDs
+    const updateCall = clientCalls.find((sql) => sql.startsWith('UPDATE working_memory'));
+    expect(updateCall).toBeDefined();
+
+    // INSERT of synthetic summary must be present
+    const insertCall = clientCalls.find((sql) => sql.startsWith('INSERT INTO working_memory'));
+    expect(insertCall).toBeDefined();
+
+    // Verify the summary content is the LLM's response
+    const insertParams = (client.query as MockedFunction<() => unknown>).mock.calls.find(
+      (c) => (c[0] as string).startsWith('INSERT INTO working_memory'),
+    );
+    // Third parameter ($3) is the summary content
+    expect((insertParams![1] as string[])[2]).toContain('[Conversation summary]');
+    expect((insertParams![1] as string[])[2]).toContain('SUMMARY: key decisions made.');
+  });
+
+  it('get() excludes archived rows (queries with archived = false)', async () => {
+    const activeRows = [
+      { role: 'system', content: '[Conversation summary]\nSome prior context.' },
+      { role: 'user', content: 'Recent message' },
+    ];
+    let getQuery = '';
+    const queryHandler = (sql: string): QueryResult<unknown> => {
+      const normalized = sql.replace(/\s+/g, ' ').trim();
+      if (normalized.startsWith('SELECT role, content')) {
+        getQuery = normalized;
+        return { rows: activeRows };
+      }
+      return { rows: [] };
+    };
+
+    const pool = buildMockPool(queryHandler);
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never;
+    const memory = WorkingMemory.createWithPostgres(pool, logger);
+
+    const history = await memory.getHistory(CONV, AGENT);
+
+    // get() must filter by archived = false
+    expect(getQuery).toContain('archived = false');
+    expect(history).toHaveLength(2);
+    expect(history[0]?.role).toBe('system');
+    expect(history[0]?.content).toContain('[Conversation summary]');
+    expect(history[1]?.content).toBe('Recent message');
+  });
+
+  it('skips summarization without throwing when LLM returns an error response', async () => {
+    const errorProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'error' as const,
+        error: { type: 'PROVIDER_ERROR', source: 'mock', message: 'oops', retryable: false, timestamp: new Date() },
+      }),
+    };
+
+    let insertCount = 0;
+    const queryHandler = (sql: string): QueryResult<unknown> => {
+      const normalized = sql.replace(/\s+/g, ' ').trim();
+      if (normalized.startsWith('INSERT INTO working_memory')) {
+        insertCount++;
+        return { rows: [] };
+      }
+      if (normalized.startsWith('SELECT COUNT(*)')) {
+        return { rows: [{ count: '21' }] };
+      }
+      if (normalized.startsWith('SELECT id, role')) {
+        return { rows: [{ id: makeId(0), role: 'user', content: 'Old', created_at: new Date() }] };
+      }
+      if (normalized.startsWith('SELECT created_at')) {
+        return { rows: [{ created_at: new Date() }] };
+      }
+      return { rows: [] };
+    };
+
+    const pool = buildMockPool(queryHandler);
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never;
+    const config: SummarizationConfig = { threshold: 20, keepWindow: 10, provider: errorProvider };
+
+    const memory = WorkingMemory.createWithPostgres(pool, logger, config);
+
+    // Should NOT throw — failed summarization is non-fatal
+    await expect(memory.addTurn(CONV, AGENT, { role: 'user', content: 'Message' })).resolves.toBeUndefined();
+    expect(insertCount).toBe(1); // The turn was still written
+    expect((logger as unknown as { error: MockedFunction<() => void> }).error).toHaveBeenCalledOnce();
+  });
+
+  it('skips summarization without throwing when LLM call throws', async () => {
+    const throwingProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockRejectedValue(new Error('Network timeout')),
+    };
+
+    const queryHandler = (sql: string): QueryResult<unknown> => {
+      const normalized = sql.replace(/\s+/g, ' ').trim();
+      if (normalized.startsWith('INSERT INTO working_memory')) return { rows: [] };
+      if (normalized.startsWith('SELECT COUNT(*)')) return { rows: [{ count: '21' }] };
+      if (normalized.startsWith('SELECT id, role')) {
+        return { rows: [{ id: makeId(0), role: 'user', content: 'Old', created_at: new Date() }] };
+      }
+      if (normalized.startsWith('SELECT created_at')) return { rows: [{ created_at: new Date() }] };
+      return { rows: [] };
+    };
+
+    const pool = buildMockPool(queryHandler);
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never;
+    const config: SummarizationConfig = { threshold: 20, keepWindow: 10, provider: throwingProvider };
+
+    const memory = WorkingMemory.createWithPostgres(pool, logger, config);
+    await expect(memory.addTurn(CONV, AGENT, { role: 'user', content: 'Message' })).resolves.toBeUndefined();
+    expect((logger as unknown as { error: MockedFunction<() => void> }).error).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

Implements rolling context summarization for working memory (spec §01-memory-system.md, issue #232).

- **Migration 018** adds `archived BOOLEAN NOT NULL DEFAULT false` to `working_memory` with a partial index on active rows (`WHERE archived = false`)
- **`WorkingMemory.createWithPostgres()`** accepts an optional `SummarizationConfig` (`threshold`, `keepWindow`, `provider`) — existing callers unaffected
- When active turn count exceeds `threshold` (default: 20), the oldest `count - keepWindow` turns are condensed via LLM call into a synthetic `system` turn; originals are marked `archived = true` in a single atomic transaction
- `get()` filters `archived = false` — context assembly receives the summary turn instead of archived originals
- Summarization is best-effort: failures are caught at the `add()` call site, logged at `error`, and do not abort the agent turn

## Test plan

- [ ] All existing unit tests pass (103 files, 1040 tests)
- [ ] 6 new unit tests in `tests/unit/memory/working-memory-summarization.test.ts`:
  - No-op below threshold
  - LLM called above threshold with correct transcript in prompt
  - Transaction structure: BEGIN/COMMIT, UPDATE archived=true, INSERT synthetic summary
  - `get()` filters by `archived = false` and returns summary turn
  - Graceful skip when LLM returns error response (non-fatal, logger.error called)
  - Graceful skip when LLM call throws (non-fatal, logger.error called)
- [ ] Run migration 018 against dev database and verify `archived` column and index created
- [ ] Wire `SummarizationConfig` in `src/index.ts` bootstrap and verify summarization fires on a >20-turn conversation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic rolling context summarization when working memory exceeds a configurable threshold (default 20); older turns are condensed and archived, retaining a recent window (default 10).
  * Database schema updated to track archived working-memory turns to support summarization.

* **Bug Fixes**
  * Archived turns are excluded from active-history retrievals and checkpoint assembly to avoid reprocessing summarized content.
  * Summarization failures are non-fatal and logged; original turns remain written.

* **Documentation**
  * Added comprehensive configuration reference for tuning and environment variables.

* **Tests**
  * Added unit tests validating summarization, archiving, and failure handling.

* **Chores**
  * Version bumped to 0.14.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->