### PR TITLE
feat: intent anchor — inject original task intent into system prompt on every burst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ bus event types) are noted explicitly even in the `0.x` range.
   than the agent whose YAML contains the schedule. Defaults to the source agent's name
   for backward compatibility. A startup warning is logged if two agents form a targeting
   cycle. Public API surface: agent YAML schema.
+- **Intent anchor** — `intentAnchor` field on `AgentTaskEvent` payload; the scheduler
+  passes the anchor from `agent_tasks.intent_anchor` through the event, and the runtime
+  injects a `## Original Task Intent` block into `effectiveSystemPrompt` on every burst
+  for persistent tasks. Prevents multi-burst drift (spec 01). Coordinator YAML updated
+  with guidance on when and how to provide `intent_anchor` to `scheduler-create`.
 
 ---
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -162,6 +162,30 @@ system_prompt: |
   ### batch scan without CEO review, and present only `probable` pairs for confirmation.
   ### See docs/superpowers/specs/2026-04-03-autonomy-engine-design.md.
 
+  ## Scheduled Tasks
+  When the CEO asks you to set up a recurring task (e.g. "check X every week",
+  "remind me every Monday"), use scheduler-create with a cron_expr.
+
+  **Always provide intent_anchor for recurring (cron_expr) jobs.** Write one or
+  two sentences describing what the task is meant to accomplish and why — the
+  original mandate. This is the anchor that prevents drift across multiple
+  executions.
+
+  Rules for writing a good intent_anchor:
+  - Describe *intent*, not *implementation*: what should be achieved, not which
+    tools to call
+  - Good: "Run weekly contacts dedup scan and present any probable/certain
+    duplicate pairs to Joseph for review."
+  - Bad: "Call contact-find-duplicates with min_confidence probable then loop
+    through pairs calling contact-merge dry_run: true."
+
+  **Do NOT provide intent_anchor for one-shot (run_at) jobs.** A one-shot job
+  fires once and is done — there is no multi-burst drift risk.
+
+  **The anchor should be stable.** If the CEO fundamentally changes what a
+  recurring task should do, cancel the old job and create a new one with a
+  fresh anchor. Do not treat it as an update to the existing job.
+
   ## Research
   You can search the web and fetch pages to answer questions and do research.
   - For simple lookups ("find a restaurant", "what is X"), one search is enough.

--- a/docs/specs/00-overview.md
+++ b/docs/specs/00-overview.md
@@ -8,7 +8,7 @@
 | # | Document | Scope | Status |
 |---|----------|-------|--------|
 | 00 | This file | Architecture, layers, bus, message flow, design principles | ✅ Implemented |
-| 01 | [Memory System](01-memory-system.md) | Knowledge graph, entity memory, working memory, Bullpen, embeddings | Partial — core and Bullpen implemented; context management, decay engine planned |
+| 01 | [Memory System](01-memory-system.md) | Knowledge graph, entity memory, working memory, Bullpen, embeddings | ✅ Implemented |
 | 02 | [Agent System](02-agent-system.md) | Agent definition, lifecycle, state, execution modes, LLM providers | ✅ Implemented |
 | 03 | [Skills & Execution](03-skills-and-execution.md) | Local skills, MCP, discovery, secrets, permissions | Partial — local skills implemented; MCP discovery planned |
 | 04 | [Channels](04-channels.md) | Adapter interface, CLI, HTTP, Signal, Email channels, message normalization | ✅ Implemented |

--- a/docs/specs/01-memory-system.md
+++ b/docs/specs/01-memory-system.md
@@ -172,5 +172,5 @@ When a persistent task is created, the original task description is stored as an
 | `src/memory/bullpen.ts` — thread management and context formatting | Done |
 | `src/memory/entity-memory.ts` — high-level query layer over knowledge graph | Done |
 | `src/memory/knowledge-graph.ts` — full graph store with traversal and semantic search | Done |
-| Context summarization — rolling window condensing at 20 turns with archival | Not Done |
-| Intent anchor — stored on task creation, injected into system prompt each burst | Not Done |
+| Context summarization — rolling window condensing at 20 turns with archival | Done |
+| Intent anchor — stored on task creation, injected into system prompt each burst | Done |

--- a/docs/wip/2026-04-09-intent-anchor-design.md
+++ b/docs/wip/2026-04-09-intent-anchor-design.md
@@ -1,0 +1,155 @@
+# Intent Anchor — Design
+
+**Date:** 2026-04-09
+**Issue:** josephfung/curia#233
+**Status:** Approved
+
+## Problem
+
+Agents drift from their original goal during extended multi-burst operations. This was observed in Zora's ASI gaps: an agent may evolve its approach over multiple scheduler bursts to the point where it has lost track of *why* it was originally invoked.
+
+Additionally, `agent_tasks` records (which carry the `intent_anchor`) are only created when the coordinator explicitly passes `intent_anchor` to `scheduler-create`. The coordinator currently has no guidance on when or how to do this, so in practice no `agent_tasks` records are created for dynamically-scheduled jobs.
+
+## Solution
+
+Two complementary changes:
+
+1. **Runtime injection** — when a scheduler burst fires for a persistent task (one with a linked `agent_tasks` record), the intent anchor is appended to `effectiveSystemPrompt` so it carries the same authority as a behavioral instruction. The agent can evolve its approach, but cannot wholesale abandon its original mandate.
+
+2. **Coordinator guidance** — explicit rules in `agents/coordinator.yaml` telling the coordinator when to provide `intent_anchor` to `scheduler-create`, what to put in it, and when not to use it.
+
+## What Already Exists
+
+- `agent_tasks` table with `intent_anchor TEXT NOT NULL` column (migration 008)
+- `scheduler-service.ts` creates an `agent_tasks` record when `intentAnchor` is passed to `createJob()`
+- `scheduler.ts` reads `intent_anchor` via a `LEFT JOIN agent_tasks` when polling due jobs
+- `scheduler-create` skill accepts `intent_anchor` as an optional input and forwards it to `createJob()`
+- Tests cover the existing content-bundle injection path
+
+## What This Design Changes
+
+### 1. `src/bus/events.ts` — Add `intentAnchor` to event payload
+
+Add `intentAnchor?: string` to `AgentTaskPayload`. This is the channel that carries the anchor from the scheduler into the runtime.
+
+```ts
+interface AgentTaskPayload {
+  agentId: string;
+  conversationId: string;
+  channelId: string;
+  senderId: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  senderContext?: ...;
+  intentAnchor?: string;  // ← new: present only for persistent tasks
+}
+```
+
+### 2. `src/scheduler/scheduler.ts` — Pass anchor in payload, clean up content
+
+In `fireJob()`, move `intent_anchor` from the content JSON bundle into the event payload. The content for persistent tasks becomes `{progress, task_payload}` only — intent belongs in the system prompt, not the conversation.
+
+Before:
+```ts
+if (job.agentTaskId && job.intentAnchor) {
+  content = JSON.stringify({
+    intent_anchor: job.intentAnchor,  // ← remove this
+    progress: job.progress ?? {},
+    task_payload: job.taskPayload,
+  });
+}
+```
+
+After:
+```ts
+if (job.agentTaskId) {
+  content = JSON.stringify({
+    progress: job.progress ?? {},
+    task_payload: job.taskPayload,
+  });
+}
+```
+
+And pass `intentAnchor` in the `createAgentTask()` call:
+```ts
+const taskEvent = createAgentTask({
+  agentId: job.agentId,
+  conversationId: `scheduler:${job.id}`,
+  channelId: 'scheduler',
+  senderId: 'scheduler',
+  content,
+  intentAnchor: job.intentAnchor ?? undefined,  // ← new
+  parentEventId: firedEvent.id,
+});
+```
+
+### 3. `src/agents/runtime.ts` — Inject anchor into system prompt
+
+Following the same pattern as the autonomy block and time context block, append the anchor to `effectiveSystemPrompt` before the LLM call. Inject only when `intentAnchor` is present.
+
+```ts
+if (taskEvent.payload.intentAnchor) {
+  effectiveSystemPrompt += '\n\n## Original Task Intent\n' + taskEvent.payload.intentAnchor;
+}
+```
+
+The anchor is injected **before** the context budget assembly (history, entity memory, bullpen) — it is non-negotiable, like the system prompt itself. It is injected **after** the autonomy block and time block so those remain closest to the base persona.
+
+No error handling needed here beyond what's implicit — `intentAnchor` is a plain string with no external calls, so there's nothing to fail.
+
+### 4. `agents/coordinator.yaml` — Guidance on intent anchors
+
+Add a new section to the coordinator's scheduling guidance:
+
+**Always provide `intent_anchor` when using `scheduler-create` for a recurring (`cron_expr`) job.**
+
+- Write one or two sentences describing what the task is supposed to accomplish and why — the original mandate
+- Describe *intent*, not *implementation*: what should be achieved, not which tools to call
+- Good: `"Run weekly contacts dedup scan and present any probable/certain duplicate pairs to Joseph for review."`
+- Bad: `"Call contact-find-duplicates with min_confidence probable then loop through pairs calling contact-merge dry_run: true."`
+
+**Do not provide `intent_anchor` for one-shot (`run_at`) jobs** — a one-shot job fires once and is done; there is no multi-burst drift risk.
+
+**The anchor should be stable.** If the CEO fundamentally changes what a recurring task should do, cancel the old job and create a new one with a fresh anchor. Do not treat it as an update to the existing job.
+
+**Declarative jobs (defined in agent YAML files) do not need `intent_anchor`.** Their task description is canonically defined in the YAML and cannot drift — the scheduler fires exactly what the YAML says on every restart.
+
+## What This Does NOT Change
+
+- The `agent_tasks` DB schema — `intent_anchor` column already exists and is correct
+- `scheduler-service.ts` — already creates `agent_tasks` records when `intentAnchor` is provided
+- `scheduler-create` skill manifest/handler — already accepts and forwards `intent_anchor`
+- Declarative job upsert path — `upsertDeclarativeJob()` never creates `agent_tasks`, and that remains correct by design
+- The Anthropic provider — anchor injection uses `effectiveSystemPrompt` string concatenation, which is provider-neutral
+
+## Injection Order in `effectiveSystemPrompt`
+
+```
+[base system prompt]
+[office identity block — substituted via placeholder]
+
+[autonomy block — appended if autonomy service configured]
+
+[time context block — appended if timezone configured]
+
+[intent anchor block — appended if intentAnchor present]  ← new
+```
+
+The anchor is appended last so it sits closest to the conversation, making it maximally salient to the model.
+
+## Tests
+
+New unit tests required:
+
+| Test | Location |
+|---|---|
+| Anchor stored in `agent_tasks` at job creation | `tests/unit/scheduler/scheduler-service.test.ts` (already exists, verify coverage) |
+| Anchor passed in event payload when `agentTaskId` is set | `tests/unit/scheduler/scheduler.test.ts` |
+| Anchor NOT in content bundle | `tests/unit/scheduler/scheduler.test.ts` |
+| Anchor injected into system prompt at burst start | `tests/unit/agents/runtime.test.ts` |
+| One-shot tasks (no `intentAnchor`) do not get anchor injected | `tests/unit/agents/runtime.test.ts` |
+| Declarative jobs (no `agentTaskId`) do not pass anchor in payload | `tests/unit/scheduler/scheduler.test.ts` |
+
+## Versioning
+
+Patch bump (`0.x.Y`) — this completes infrastructure that was already partially in place. No new user-facing capability; the `scheduler-create` skill interface is unchanged (adding coordinator guidance to use an existing optional field is not a schema change).

--- a/docs/wip/2026-04-09-intent-anchor.md
+++ b/docs/wip/2026-04-09-intent-anchor.md
@@ -1,0 +1,428 @@
+# Intent Anchor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the existing `intent_anchor` DB column through to the agent runtime so it is injected into `effectiveSystemPrompt` on every scheduler burst, preventing multi-burst task drift.
+
+**Architecture:** `AgentTaskPayload` gains an optional `intentAnchor` field; the scheduler passes the anchor through the event rather than the content bundle; the runtime appends a `## Original Task Intent` block to `effectiveSystemPrompt` when the field is present. Coordinator YAML gets explicit guidance on when to supply it.
+
+**Tech Stack:** TypeScript/ESM, Vitest, Postgres (no new dependencies)
+
+---
+
+### Task 1: Add `intentAnchor` to `AgentTaskPayload`
+
+**Files:**
+- Modify: `src/bus/events.ts:29-38`
+
+This is the type change that unblocks everything downstream. No unit test needed — TypeScript will catch misuse at compile time, and the downstream tests in Tasks 2 and 3 exercise the real behaviour.
+
+- [ ] **Step 1: Add the field to the interface**
+
+In `src/bus/events.ts`, update `AgentTaskPayload` (lines 29–38):
+
+```ts
+interface AgentTaskPayload {
+  agentId: string;
+  conversationId: string;
+  channelId: string;
+  senderId: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  /** Resolved sender context from the contact resolver. Undefined if contacts not configured. */
+  senderContext?: import('../contacts/types.js').InboundSenderContext;
+  /** Original task intent for persistent scheduler tasks. Undefined for one-shot and direct tasks.
+   *  Injected into effectiveSystemPrompt by the runtime to prevent multi-burst drift. */
+  intentAnchor?: string;
+}
+```
+
+No change to `createAgentTask()` — it destructures `parentEventId` and spreads the rest, so `intentAnchor` flows through automatically.
+
+- [ ] **Step 2: Build to confirm no type errors**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor run build
+```
+
+Expected: clean build, zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor add src/bus/events.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor commit -m "feat: add intentAnchor to AgentTaskPayload"
+```
+
+---
+
+### Task 2: Update scheduler to pass anchor in payload, not content
+
+**Files:**
+- Modify: `src/scheduler/scheduler.ts` (the `fireJob` method, ~lines 214–223 and 234–242)
+- Test: `tests/unit/scheduler/scheduler.test.ts`
+
+The existing test at line 211–230 asserts `content.intent_anchor === 'weekly-report'`. After this task that assertion must be updated: anchor goes in the payload, not the content.
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `tests/unit/scheduler/scheduler.test.ts`. Find the `describe('pollDueJobs')` block.
+
+**Replace** the existing `'injects persistent task context when agent_task is linked'` test (lines 211–230) with these three tests:
+
+```ts
+it('passes intentAnchor in event payload for persistent tasks', async () => {
+  const row = fakeDbRow({
+    agent_task_id: 'task-aaa',
+    intent_anchor: 'weekly-report',
+    progress: { step: 3 },
+  });
+  pool.query.mockResolvedValueOnce({ rows: [row] });
+  pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] }); // claim
+
+  await scheduler.pollDueJobs();
+
+  const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { intentAnchor?: string } }];
+  expect(taskEvent.payload.intentAnchor).toBe('weekly-report');
+});
+
+it('does NOT include intent_anchor in content bundle for persistent tasks', async () => {
+  const row = fakeDbRow({
+    agent_task_id: 'task-aaa',
+    intent_anchor: 'weekly-report',
+    progress: { step: 3 },
+  });
+  pool.query.mockResolvedValueOnce({ rows: [row] });
+  pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+  await scheduler.pollDueJobs();
+
+  const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { content: string } }];
+  const content = JSON.parse(taskEvent.payload.content);
+  expect(content.intent_anchor).toBeUndefined();
+  expect(content.progress).toEqual({ step: 3 });
+  expect(content.task_payload).toEqual({ skill: 'morning-brief' });
+});
+
+it('does not pass intentAnchor for jobs without a linked agent_task', async () => {
+  const row = fakeDbRow(); // no agent_task_id
+  pool.query.mockResolvedValueOnce({ rows: [row] });
+  pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+  await scheduler.pollDueJobs();
+
+  const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { intentAnchor?: string } }];
+  expect(taskEvent.payload.intentAnchor).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor test -- tests/unit/scheduler/scheduler.test.ts
+```
+
+Expected: the three new tests fail. Existing tests continue to pass.
+
+- [ ] **Step 3: Update `fireJob()` in `src/scheduler/scheduler.ts`**
+
+Find the content-building block (around lines 214–223):
+
+```ts
+// Build the agent.task content, injecting persistent task context if available.
+let content = JSON.stringify(job.taskPayload);
+if (job.agentTaskId && job.intentAnchor) {
+  const context = {
+    intent_anchor: job.intentAnchor,
+    progress: job.progress ?? {},
+    task_payload: job.taskPayload,
+  };
+  content = JSON.stringify(context);
+}
+```
+
+Replace with:
+
+```ts
+// Build the agent.task content. For persistent tasks, include progress and
+// the original task payload so the agent has execution context. Intent anchor
+// is passed in the event payload (not content) so the runtime can inject it
+// into the system prompt as a non-negotiable behavioral instruction.
+let content = JSON.stringify(job.taskPayload);
+if (job.agentTaskId) {
+  content = JSON.stringify({
+    progress: job.progress ?? {},
+    task_payload: job.taskPayload,
+  });
+}
+```
+
+Then find the `createAgentTask()` call (around lines 234–242):
+
+```ts
+const taskEvent = createAgentTask({
+  agentId: job.agentId,
+  conversationId: `scheduler:${job.id}`,
+  channelId: 'scheduler',
+  senderId: 'scheduler',
+  content,
+  parentEventId: firedEvent.id,
+});
+```
+
+Replace with:
+
+```ts
+const taskEvent = createAgentTask({
+  agentId: job.agentId,
+  conversationId: `scheduler:${job.id}`,
+  channelId: 'scheduler',
+  senderId: 'scheduler',
+  content,
+  // Pass the anchor in the payload so the runtime injects it into the system
+  // prompt. null (no linked agent_task) becomes undefined (field omitted).
+  intentAnchor: job.intentAnchor ?? undefined,
+  parentEventId: firedEvent.id,
+});
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor test -- tests/unit/scheduler/scheduler.test.ts
+```
+
+Expected: all tests in the file pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor add src/scheduler/scheduler.ts tests/unit/scheduler/scheduler.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor commit -m "feat: pass intentAnchor in event payload instead of content bundle"
+```
+
+---
+
+### Task 3: Inject intent anchor into `effectiveSystemPrompt` in the runtime
+
+**Files:**
+- Modify: `src/agents/runtime.ts` (~line 189, after the time context block)
+- Test: `tests/unit/agents/runtime.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `tests/unit/agents/runtime.test.ts`. Add these two tests inside the existing `describe('AgentRuntime')` block, after the existing tests:
+
+```ts
+it('appends intent anchor to system prompt when intentAnchor is present', async () => {
+  const provider = createMockProvider('Done.');
+  const runtime = new AgentRuntime({
+    agentId: 'coordinator',
+    systemPrompt: 'You are helpful.',
+    provider,
+    bus,
+    logger: createLogger('error'),
+  });
+  runtime.register();
+
+  const task = createAgentTask({
+    agentId: 'coordinator',
+    conversationId: 'conv-1',
+    channelId: 'scheduler',
+    senderId: 'scheduler',
+    content: JSON.stringify({ progress: {}, task_payload: { task: 'dedup scan' } }),
+    intentAnchor: 'Run weekly contacts dedup scan and present duplicates to Joseph.',
+    parentEventId: 'parent-1',
+  });
+  await bus.publish('dispatch', task);
+
+  expect(provider.chat).toHaveBeenCalledWith(
+    expect.objectContaining({
+      messages: expect.arrayContaining([
+        expect.objectContaining({
+          role: 'system',
+          content: expect.stringContaining(
+            '## Original Task Intent\nRun weekly contacts dedup scan and present duplicates to Joseph.',
+          ),
+        }),
+      ]),
+    }),
+  );
+});
+
+it('does not append intent anchor when intentAnchor is absent', async () => {
+  const provider = createMockProvider('Hello back!');
+  const runtime = new AgentRuntime({
+    agentId: 'coordinator',
+    systemPrompt: 'You are helpful.',
+    provider,
+    bus,
+    logger: createLogger('error'),
+  });
+  runtime.register();
+
+  const task = createAgentTask({
+    agentId: 'coordinator',
+    conversationId: 'conv-1',
+    channelId: 'cli',
+    senderId: 'user',
+    content: 'Hello',
+    parentEventId: 'parent-1',
+  });
+  await bus.publish('dispatch', task);
+
+  const chatCall = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0][0] as { messages: Array<{ role: string; content: string }> };
+  const systemMsg = chatCall.messages.find(m => m.role === 'system');
+  expect(systemMsg?.content).not.toContain('## Original Task Intent');
+});
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor test -- tests/unit/agents/runtime.test.ts
+```
+
+Expected: the two new tests fail. All existing tests continue to pass.
+
+- [ ] **Step 3: Add anchor injection to `processTask()` in `src/agents/runtime.ts`**
+
+Find the time context block (ending around line 189):
+
+```ts
+    const timezone = this.config.timezone?.trim();
+    if (timezone) {
+      try {
+        effectiveSystemPrompt += '\n\n' + formatTimeContextBlock(timezone, new Date());
+      } catch (err) {
+        logger.error({ err, agentId, timezone }, 'formatTimeContextBlock failed — time context not injected; check TIMEZONE config');
+      }
+    }
+```
+
+Add the intent anchor block immediately after it:
+
+```ts
+    const timezone = this.config.timezone?.trim();
+    if (timezone) {
+      try {
+        effectiveSystemPrompt += '\n\n' + formatTimeContextBlock(timezone, new Date());
+      } catch (err) {
+        logger.error({ err, agentId, timezone }, 'formatTimeContextBlock failed — time context not injected; check TIMEZONE config');
+      }
+    }
+
+    // Append intent anchor — present only for persistent scheduler tasks that have a
+    // linked agent_task record. Injected last so it sits closest to the conversation,
+    // making it maximally salient. It is non-negotiable: the agent may evolve its
+    // approach across bursts, but cannot abandon the original mandate.
+    if (taskEvent.payload.intentAnchor) {
+      effectiveSystemPrompt += '\n\n## Original Task Intent\n' + taskEvent.payload.intentAnchor;
+    }
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor test -- tests/unit/agents/runtime.test.ts
+```
+
+Expected: all tests in the file pass.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor add src/agents/runtime.ts tests/unit/agents/runtime.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor commit -m "feat: inject intent anchor into effectiveSystemPrompt at burst start"
+```
+
+---
+
+### Task 4: Add coordinator guidance on intent anchors
+
+**Files:**
+- Modify: `agents/coordinator.yaml`
+
+No tests — this is behavioral guidance in a YAML config.
+
+- [ ] **Step 1: Add the scheduling section**
+
+In `agents/coordinator.yaml`, find the `## Research` section heading (around line 165). Insert a new `## Scheduled Tasks` section immediately before it:
+
+```yaml
+  ## Scheduled Tasks
+  When the CEO asks you to set up a recurring task (e.g. "check X every week",
+  "remind me every Monday"), use scheduler-create with a cron_expr.
+
+  **Always provide intent_anchor for recurring (cron_expr) jobs.** Write one or
+  two sentences describing what the task is meant to accomplish and why — the
+  original mandate. This is the anchor that prevents drift across multiple
+  executions.
+
+  Rules for writing a good intent_anchor:
+  - Describe *intent*, not *implementation*: what should be achieved, not which
+    tools to call
+  - Good: "Run weekly contacts dedup scan and present any probable/certain
+    duplicate pairs to Joseph for review."
+  - Bad: "Call contact-find-duplicates with min_confidence probable then loop
+    through pairs calling contact-merge dry_run: true."
+
+  **Do NOT provide intent_anchor for one-shot (run_at) jobs.** A one-shot job
+  fires once and is done — there is no multi-burst drift risk.
+
+  **The anchor should be stable.** If the CEO fundamentally changes what a
+  recurring task should do, cancel the old job and create a new one with a
+  fresh anchor. Do not treat it as an update to the existing job.
+
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor add agents/coordinator.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor commit -m "feat: add coordinator guidance for intent_anchor on recurring jobs"
+```
+
+---
+
+### Task 5: Changelog and version bump
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`
+
+- [ ] **Step 1: Update CHANGELOG.md**
+
+Under `## [Unreleased]`, add an `### Added` section (or append to it if one already exists):
+
+```markdown
+### Added
+- **Intent anchor** — `intentAnchor` field on `AgentTaskEvent` payload; the scheduler
+  passes the anchor from `agent_tasks.intent_anchor` through the event, and the runtime
+  injects a `## Original Task Intent` block into `effectiveSystemPrompt` on every burst
+  for persistent tasks. Prevents multi-burst drift (spec 01). Coordinator YAML updated
+  with guidance on when and how to provide `intent_anchor` to `scheduler-create`.
+```
+
+Note: `AgentTaskEvent` payload is a public API surface — this additive change must be
+called out. The bump is still patch because the field is optional and the change is
+backward-compatible.
+
+- [ ] **Step 2: Bump version in `package.json`**
+
+Change `"version": "0.14.2"` → `"version": "0.14.3"`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor add CHANGELOG.md package.json
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-intent-anchor commit -m "chore: bump to 0.14.3, changelog for intent anchor"
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.9.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.9.1",
+      "version": "0.14.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/scheduler-create/handler.ts
+++ b/skills/scheduler-create/handler.ts
@@ -34,7 +34,7 @@ export class SchedulerCreateHandler implements SkillHandler {
     }
     // Reject blank intent_anchor — a blank string would be stored in the DB and then silently
     // skipped by the runtime's truthiness guard, giving the illusion of drift prevention with none.
-    if (intent_anchor !== undefined && intent_anchor.trim() === '') {
+    if (intent_anchor !== undefined && typeof intent_anchor === 'string' && intent_anchor.trim() === '') {
       return { success: false, error: 'intent_anchor must not be blank — provide a meaningful description or omit the field' };
     }
 

--- a/skills/scheduler-create/handler.ts
+++ b/skills/scheduler-create/handler.ts
@@ -32,6 +32,11 @@ export class SchedulerCreateHandler implements SkillHandler {
     if (!cron_expr && !run_at) {
       return { success: false, error: 'At least one of cron_expr or run_at must be provided' };
     }
+    // Reject blank intent_anchor — a blank string would be stored in the DB and then silently
+    // skipped by the runtime's truthiness guard, giving the illusion of drift prevention with none.
+    if (intent_anchor !== undefined && intent_anchor.trim() === '') {
+      return { success: false, error: 'intent_anchor must not be blank — provide a meaningful description or omit the field' };
+    }
 
     const agentId = agent_id ?? 'coordinator';
 

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -188,6 +188,14 @@ export class AgentRuntime {
       }
     }
 
+    // Append intent anchor — present only for persistent scheduler tasks that have a
+    // linked agent_task record. Injected last so it sits closest to the conversation,
+    // making it maximally salient. It is non-negotiable: the agent may evolve its
+    // approach across bursts, but cannot abandon the original mandate.
+    if (taskEvent.payload.intentAnchor) {
+      effectiveSystemPrompt += '\n\n## Original Task Intent\n' + taskEvent.payload.intentAnchor;
+    }
+
     // Initialize the error budget for this task.
     // Config values override defaults; budget tracks runtime counters.
     const budgetConfig = this.config.errorBudget;

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -35,6 +35,9 @@ interface AgentTaskPayload {
   metadata?: Record<string, unknown>;
   /** Resolved sender context from the contact resolver. Undefined if contacts not configured. */
   senderContext?: import('../contacts/types.js').InboundSenderContext;
+  /** Original task intent for persistent scheduler tasks. Undefined for one-shot and direct tasks.
+   *  Injected into effectiveSystemPrompt by the runtime to prevent multi-burst drift. */
+  intentAnchor?: string;
 }
 
 interface AgentResponsePayload {

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -589,7 +589,7 @@ function mapJobRow(row: DbJobRow): JobRow {
     createdAt: row.created_at,
     timezone: row.timezone,
     agentTaskId: row.agent_task_id,
-    intentAnchor: row.intent_anchor,
+    intentAnchor: row.intent_anchor ?? null,
     progress: row.progress,
     runStartedAt: row.run_started_at,
     expectedDurationSeconds: row.expected_duration_seconds,

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -195,8 +195,10 @@ export class Scheduler {
   /**
    * Fire a single job: set status to running, publish schedule.fired + agent.task.
    *
-   * For persistent tasks (linked agent_task), injects intent_anchor and progress
-   * into the agent.task content so the agent has context about the ongoing task.
+   * For persistent tasks (linked agent_task), includes progress and task_payload
+   * in content for agent context. The intent anchor is passed separately in the
+   * event payload so the runtime can inject it into the system prompt as a
+   * non-negotiable behavioral instruction.
    */
   private async fireJob(job: JobRow): Promise<void> {
     // Atomically claim the job by setting status to 'running' only if it's still
@@ -211,15 +213,16 @@ export class Scheduler {
       return;
     }
 
-    // Build the agent.task content, injecting persistent task context if available.
+    // Build the agent.task content. For persistent tasks, include progress and
+    // the original task payload so the agent has execution context. Intent anchor
+    // is passed in the event payload (not content) so the runtime can inject it
+    // into the system prompt as a non-negotiable behavioral instruction.
     let content = JSON.stringify(job.taskPayload);
-    if (job.agentTaskId && job.intentAnchor) {
-      const context = {
-        intent_anchor: job.intentAnchor,
+    if (job.agentTaskId) {
+      content = JSON.stringify({
         progress: job.progress ?? {},
         task_payload: job.taskPayload,
-      };
-      content = JSON.stringify(context);
+      });
     }
 
     // Publish schedule.fired for audit trail.
@@ -237,6 +240,9 @@ export class Scheduler {
       channelId: 'scheduler',
       senderId: 'scheduler',
       content,
+      // Pass the anchor in the payload so the runtime injects it into the system
+      // prompt. null (no linked agent_task) becomes undefined (field omitted).
+      intentAnchor: job.intentAnchor ?? undefined,
       parentEventId: firedEvent.id,
     });
     await this.bus.publish('system', taskEvent);

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -325,6 +325,68 @@ describe('AgentRuntime', () => {
     const systemMsg = callArgs?.messages?.[0];
     expect(systemMsg?.content).toBe('Base prompt.');
   });
+
+  it('appends intent anchor to system prompt when intentAnchor is present', async () => {
+    const provider = createMockProvider('Done.');
+    const runtime = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are helpful.',
+      provider,
+      bus,
+      logger: createLogger('error'),
+    });
+    runtime.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-1',
+      channelId: 'scheduler',
+      senderId: 'scheduler',
+      content: JSON.stringify({ progress: {}, task_payload: { task: 'dedup scan' } }),
+      intentAnchor: 'Run weekly contacts dedup scan and present duplicates to Joseph.',
+      parentEventId: 'parent-1',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(provider.chat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: 'system',
+            content: expect.stringContaining(
+              '## Original Task Intent\nRun weekly contacts dedup scan and present duplicates to Joseph.',
+            ),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('does not append intent anchor when intentAnchor is absent', async () => {
+    const provider = createMockProvider('Hello back!');
+    const runtime = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are helpful.',
+      provider,
+      bus,
+      logger: createLogger('error'),
+    });
+    runtime.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-1',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Hello',
+      parentEventId: 'parent-1',
+    });
+    await bus.publish('dispatch', task);
+
+    const chatCall = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0][0] as { messages: Array<{ role: string; content: string }> };
+    const systemMsg = chatCall.messages.find(m => m.role === 'system');
+    expect(systemMsg?.content).not.toContain('## Original Task Intent');
+  });
 });
 
 // Helper: mock LLM that returns tool_use on first call, text on second

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -208,25 +208,48 @@ describe('Scheduler', () => {
       expect(event2.payload.conversationId).toBe('scheduler:job-1');
     });
 
-    it('injects persistent task context when agent_task is linked', async () => {
+    it('passes intentAnchor in event payload for persistent tasks', async () => {
       const row = fakeDbRow({
         agent_task_id: 'task-aaa',
         intent_anchor: 'weekly-report',
         progress: { step: 3 },
       });
-      // SELECT due jobs
       pool.query.mockResolvedValueOnce({ rows: [row] });
-      // UPDATE status to running
-      pool.query.mockResolvedValueOnce({ rows: [] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] }); // claim
 
       await scheduler.pollDueJobs();
 
-      // The agent.task event content should include intent_anchor + progress
+      const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { intentAnchor?: string } }];
+      expect(taskEvent.payload.intentAnchor).toBe('weekly-report');
+    });
+
+    it('does NOT include intent_anchor in content bundle for persistent tasks', async () => {
+      const row = fakeDbRow({
+        agent_task_id: 'task-aaa',
+        intent_anchor: 'weekly-report',
+        progress: { step: 3 },
+      });
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+      await scheduler.pollDueJobs();
+
       const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { content: string } }];
       const content = JSON.parse(taskEvent.payload.content);
-      expect(content.intent_anchor).toBe('weekly-report');
+      expect(content.intent_anchor).toBeUndefined();
       expect(content.progress).toEqual({ step: 3 });
       expect(content.task_payload).toEqual({ skill: 'morning-brief' });
+    });
+
+    it('does not pass intentAnchor for jobs without a linked agent_task', async () => {
+      const row = fakeDbRow(); // no agent_task_id
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+      await scheduler.pollDueJobs();
+
+      const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { intentAnchor?: string } }];
+      expect(taskEvent.payload.intentAnchor).toBeUndefined();
     });
 
     it('logs and swallows errors during polling', async () => {


### PR DESCRIPTION
## Summary

Closes #233.

- **`intentAnchor` field on `AgentTaskPayload`** — optional `string` field carries the original task intent from the scheduler event through to the runtime (public API surface; additive, backward-compatible)
- **Scheduler cleanup** — `fireJob()` moves `intent_anchor` out of the JSON content bundle into the event payload; persistent task content is now `{ progress, task_payload }` only
- **Runtime injection** — `processTask()` appends `## Original Task Intent` block to `effectiveSystemPrompt` when `intentAnchor` is present; injected last, after autonomy and time context blocks, for maximum salience
- **Coordinator guidance** — `agents/coordinator.yaml` gains a `## Scheduled Tasks` section with explicit rules on when/how to provide `intent_anchor` to `scheduler-create` (always for `cron_expr`, never for `run_at`)

## Test Plan

- [x] `tests/unit/scheduler/scheduler.test.ts` — 3 new tests: anchor in payload, anchor absent from content, no anchor for non-persistent jobs
- [x] `tests/unit/agents/runtime.test.ts` — 2 new tests: anchor injected into system prompt when present, absent when not provided
- [x] Full suite: 1038 passed, 0 failed

## Notes

Two low-severity observations from pre-PR review (not blocking):
- Empty string `intentAnchor` silently no-ops in the runtime (no upstream validation rejects blank strings); consider adding skill-level validation in a follow-up
- `mapRowToJob()` in `scheduler-service.ts` lacks explicit `?? null` coalescing unlike the inline mapping in `pollDueJobs()`; consistency nit, not a bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intent Anchor added for persistent scheduled tasks to preserve the original task intent across bursts; runtime now includes an "Original Task Intent" block when present.

* **Documentation**
  * Coordinator guidance and a design doc added detailing when/how to supply intent anchors for recurring jobs.

* **Tests**
  * Unit tests added/updated to verify intent-anchor propagation and prompt injection behaviour.

* **Bug Fixes**
  * Validation rejects empty intent anchors.

* **Chores**
  * Version bumped to 0.14.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->