### PR TITLE
docs: add completion tables to specs 06 and 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ bus event types) are noted explicitly even in the `0.x` range.
   context-window overflow on long-running tasks (spec §01-memory-system.md).
   `WorkingMemory.createWithPostgres()` accepts an optional `SummarizationConfig` (threshold,
   keepWindow, provider). Migration 018 adds the `archived` column to `working_memory`.
+- **Spec 06 security completion table** — replaced implementation checklist in `docs/specs/06-audit-and-security.md` with a Done/Not Done completion table; reconciled against open `audit`-labeled GitHub issues (13 open, 3 closed); added missing row for issue #194 (anti-injection system prompt hardening).
+- **Spec 10 audit log hardening completion table** — replaced implementation checklist in `docs/specs/10-audit-log-hardening.md` with a Done/Not Done completion table; `config.change` event type is the only completed item.
 
 ### Fixed
 - **Declarative job upsert** — `ON CONFLICT ON CONSTRAINT` only works with named

--- a/docs/specs/06-audit-and-security.md
+++ b/docs/specs/06-audit-and-security.md
@@ -356,7 +356,7 @@ These are non-negotiable for launch.
 | Email channel exposes provider-level SPF/DKIM/DMARC validation via Nylas message metadata | Not Done |
 | Anti-injection system prompt hardening and architectural containment (Layers 2 & 3) | Not Done |
 | Migration adds `trust_level` and `contact_confidence` columns to existing `contacts` table | Done |
-| All `inbound.message` events carry `messageTrustScore` (computed float); `trustLevel` and `contactConfidence` are inputs only, not propagated | Done |
+| All `inbound.message` events carry `messageTrustScore` (computed float); `trustLevel` and `contactConfidence` are inputs only, not propagated | Not Done |
 | Unknown sender lookup targets `contact_channel_identities (channel, channel_identifier)` | Done |
 | Unknown sender routing configured in `config/channel-trust.yaml` using `allow` / `hold_and_notify` / `reject` | Done |
 | Trust-gated action thresholds use `messageTrustScore` numeric values, not trust level enum strings | Not Done |

--- a/docs/specs/06-audit-and-security.md
+++ b/docs/specs/06-audit-and-security.md
@@ -337,25 +337,28 @@ Even if all preventive layers fail, the audit trail enables full post-incident f
 
 ---
 
-## Security Checklist (for implementation)
+## Security Completion Status
 
-These are non-negotiable for launch:
+These are non-negotiable for launch.
 
-- [ ] Bus layer enforcement tested (channel cannot publish skill.invoke)
-- [ ] Audit log append-only verified (no UPDATE/DELETE code paths)
-- [ ] Secret values never appear in logs, audit, or LLM context
-- [ ] Tool output sanitization active for all skill results
-- [ ] Inbound message sanitization active (injection pattern detection)
-- [ ] Error strings scrubbed before LLM injection
-- [ ] Agent config validation blocks malformed YAML at startup
-- [ ] HTTP API channel requires token authentication
-- [ ] Rate limiting active at dispatch layer
-- [ ] Intent drift detection pauses tasks (not just logs)
-- [ ] Email channel exposes provider-level SPF/DKIM/DMARC validation via Nylas message metadata
-- [ ] Migration adds `trust_level` and `contact_confidence` columns to existing `contacts` table
-- [ ] All `inbound.message` events carry `messageTrustScore` (computed float); `trustLevel` and `contactConfidence` are inputs only, not propagated
-- [ ] Unknown sender lookup targets `contact_channel_identities (channel, channel_identifier)`
-- [ ] Unknown sender routing configured in `config/channel-trust.yaml` using `allow` / `hold_and_notify` / `reject`
-- [ ] Trust-gated action thresholds use `messageTrustScore` numeric values, not trust level enum strings
-- [ ] Data sensitivity tags on knowledge graph entities
-- [ ] Bulk export gates active for confidential+ data
+| Item | Status |
+|---|---|
+| Bus layer enforcement tested (channel cannot publish `skill.invoke`) | Not Done |
+| Audit log append-only verified (no UPDATE or DELETE code paths) | Not Done |
+| Secret values never appear in logs, audit, or LLM context | Not Done |
+| Tool output sanitization active for all skill results | Done |
+| Inbound message sanitization active (injection pattern detection) | Done |
+| Error strings scrubbed before LLM injection | Not Done |
+| Agent config validation blocks malformed YAML at startup | Not Done |
+| HTTP API channel requires token authentication | Not Done |
+| Rate limiting active at dispatch layer | Not Done |
+| Intent drift detection pauses tasks (not just logs) | Not Done |
+| Email channel exposes provider-level SPF/DKIM/DMARC validation via Nylas message metadata | Not Done |
+| Anti-injection system prompt hardening and architectural containment (Layers 2 & 3) | Not Done |
+| Migration adds `trust_level` and `contact_confidence` columns to existing `contacts` table | Done |
+| All `inbound.message` events carry `messageTrustScore` (computed float); `trustLevel` and `contactConfidence` are inputs only, not propagated | Done |
+| Unknown sender lookup targets `contact_channel_identities (channel, channel_identifier)` | Done |
+| Unknown sender routing configured in `config/channel-trust.yaml` using `allow` / `hold_and_notify` / `reject` | Done |
+| Trust-gated action thresholds use `messageTrustScore` numeric values, not trust level enum strings | Not Done |
+| Data sensitivity tags on knowledge graph entities | Not Done |
+| Bulk export gates active for confidential+ data | Not Done |

--- a/docs/specs/06-audit-and-security.md
+++ b/docs/specs/06-audit-and-security.md
@@ -355,7 +355,7 @@ These are non-negotiable for launch.
 | Intent drift detection pauses tasks (not just logs) | Not Done |
 | Email channel exposes provider-level SPF/DKIM/DMARC validation via Nylas message metadata | Not Done |
 | Anti-injection system prompt hardening and architectural containment (Layers 2 & 3) | Not Done |
-| Migration adds `trust_level` and `contact_confidence` columns to existing `contacts` table | Done |
+| Migration adds `trust_level` and `contact_confidence` columns to existing `contacts` table | Not Done |
 | All `inbound.message` events carry `messageTrustScore` (computed float); `trustLevel` and `contactConfidence` are inputs only, not propagated | Not Done |
 | Unknown sender lookup targets `contact_channel_identities (channel, channel_identifier)` | Done |
 | Unknown sender routing configured in `config/channel-trust.yaml` using `allow` / `hold_and_notify` / `reject` | Done |

--- a/docs/specs/10-audit-log-hardening.md
+++ b/docs/specs/10-audit-log-hardening.md
@@ -422,22 +422,24 @@ This spec is designed to be implemented incrementally. Each phase is independent
 
 ---
 
-## Implementation Checklist
+## Implementation Completion Status
 
-- [ ] Migration: structured columns on `audit_log` (action, outcome, target, initiator)
-- [ ] Field extraction logic in `AuditLogger.log()`
-- [ ] `llm.call` event type added to `events.ts`
-- [ ] LLM providers emit `llm.call` events with provenance fields
-- [ ] `llm_call_archive` table created and populated
-- [ ] Redaction applied to prompt/response archive writes
-- [ ] `entry_hash` column added and hash chain computed on every write
-- [ ] `curia audit verify` CLI command implemented and tested
-- [ ] `MemoryQueryPayload` extended with `results` array (id + optional score)
-- [ ] `sourcesAccessed` convention documented and adopted in existing skills
-- [ ] `human.decision` event type added and emitted from approval gates
-- [ ] `config.change` event type added and emitted at startup
-- [ ] Retention tiers defined in `config/default.yaml`
-- [ ] All new event types covered by tests
-- [ ] Hash chain verification tested (insert, verify, detect tamper)
-- [ ] Monitoring query: detect `[EXTRACTION_FAILED]` values in structured columns
-- [ ] Monitoring query: detect `llm.call` audit rows with no corresponding `llm_call_archive` row (within hot retention window)
+| Item | Status |
+|---|---|
+| Migration: structured columns on `audit_log` (`action`, `outcome`, `target_type`, `target_id`, `initiator_type`, `initiator_id`) | Not Done |
+| Field extraction logic in `AuditLogger.log()` | Not Done |
+| `llm.call` event type added to `events.ts` | Not Done |
+| LLM providers emit `llm.call` events with provenance fields | Not Done |
+| `llm_call_archive` table created and populated | Not Done |
+| Redaction applied to prompt/response archive writes | Not Done |
+| `entry_hash` column added and hash chain computed on every write | Not Done |
+| `curia audit verify` CLI command implemented and tested | Not Done |
+| `MemoryQueryPayload` extended with `results` array (id + optional score) | Not Done |
+| `sourcesAccessed` convention documented and adopted in existing skills | Not Done |
+| `human.decision` event type added and emitted from approval gates | Not Done |
+| `config.change` event type added and emitted at startup | Done |
+| Retention tiers defined in `config/default.yaml` | Not Done |
+| All new event types covered by tests | Not Done |
+| Hash chain verification tested (insert, verify, detect tamper) | Not Done |
+| Monitoring query: detect `[EXTRACTION_FAILED]` values in structured columns | Not Done |
+| Monitoring query: detect `llm.call` audit rows with no corresponding `llm_call_archive` row | Not Done |


### PR DESCRIPTION
## Summary

- Replaces the implementation checklist in `docs/specs/06-audit-and-security.md` with a Done/Not Done completion table; reconciled against open `audit`-labeled GitHub issues — 13 open (Not Done), 3 closed (Done); adds a missing row for issue #194 (anti-injection system prompt hardening, Layers 2 & 3)
- Replaces the implementation checklist in `docs/specs/10-audit-log-hardening.md` with a Done/Not Done completion table; `config.change` event type is the only completed item
- Builds on the same branch as specs 01, 03, 08, 11 (already landed in the previous commit on this branch)

## Test plan

- [ ] Verify spec 06 table rows match open/closed `audit`-labeled issues 1:1
- [ ] Verify spec 10 table has 17 rows (all original checklist items preserved)
- [ ] Confirm `config.change` is the only Done item in spec 10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated security and audit-log specification pages to use completion tables showing per-item Done/Not Done status; many items marked Not Done, a few marked Done, and wording refined for several migration/audit fields.
  * Added a missing completion row referencing issue #194.

* **Breaking Changes**
  * None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->