### PR TITLE
feat: HTTP API channel token authentication (closes #189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+
+- **HTTP API token authentication** — failed auth attempts are now audit-logged (IP, route, reason); authenticated messages carry `trustLevel: 'medium'` in bus event metadata; integration tests verify 401 on missing/invalid token and 200 on valid token (spec 06, issue #189)
+
 ### Added
 - **Bus layer enforcement: `llm.call` and `human.decision` event types** — Added the two new
   event types from spec 10 (audit log hardening) to the bus: `llm.call` (published by the agent

--- a/docs/specs/06-audit-and-security.md
+++ b/docs/specs/06-audit-and-security.md
@@ -350,7 +350,7 @@ These are non-negotiable for launch.
 | Inbound message sanitization active (injection pattern detection) | Done |
 | Error strings scrubbed before LLM injection | Not Done |
 | Agent config validation blocks malformed YAML at startup | Not Done |
-| HTTP API channel requires token authentication | Not Done |
+| HTTP API channel requires token authentication | Done |
 | Rate limiting active at dispatch layer | Not Done |
 | Intent drift detection pauses tasks (not just logs) | Not Done |
 | Email channel exposes provider-level SPF/DKIM/DMARC validation via Nylas message metadata | Not Done |

--- a/docs/wip/2026-04-09-http-auth-token-design.md
+++ b/docs/wip/2026-04-09-http-auth-token-design.md
@@ -19,7 +19,7 @@ Most of the implementation already exists: `validateBearerToken()` with timing-s
 
 The `onRequest` hook in `http-adapter.ts` returns 401 silently — no log entry. The issue requires auth failures to be audit-logged with source IP, timestamp, and the failure reason (not the token value).
 
-**Implementation:** Add a `logger.warn` call before the 401 reply with `{ ip: request.ip, reason: 'missing_token' | 'invalid_token' }`. Timestamp comes from pino automatically.
+**Implementation:** Add a `logger.warn` call before the 401 reply with `{ ip: request.ip, route: routeUrl, reason: 'missing_token' | 'invalid_token' }`. Timestamp comes from pino automatically.
 
 ### 2. `trustLevel: 'medium'` in message metadata
 
@@ -42,7 +42,7 @@ The test should skip `/api/health` (exempt from auth per existing code) to confi
 
 ## What's NOT changing
 
-- `validateBearerToken()` — already correct, no changes
+- `validateBearerToken()` — one change: added an empty-token guard (`if (!provided) return false`) to explicitly reject `"Bearer "` with no token value
 - Token config — `API_TOKEN` env var already works; `config/default.yaml` doesn't store secrets (it's committed to git), so env var is the correct and only mechanism
 - Auth-disabled path when `API_TOKEN` is unset — stays as-is for local dev
 - No changes to `InboundMessagePayload` type or `createInboundMessage` factory — `metadata` already accepts arbitrary key/value pairs

--- a/docs/wip/2026-04-09-http-auth-token-design.md
+++ b/docs/wip/2026-04-09-http-auth-token-design.md
@@ -1,0 +1,58 @@
+# HTTP API Channel: Token-Based Authentication
+
+**Issue:** josephfung/curia#189
+**Date:** 2026-04-09
+
+---
+
+## Background
+
+The HTTP API channel is how external clients (dashboards, mobile apps, integrations) send messages to Curia. Without authentication, any process that can reach the HTTP port can inject messages into the bus. The security spec assigns `medium` trust to this channel, contingent on tokens being secured.
+
+Most of the implementation already exists: `validateBearerToken()` with timing-safe comparison, the `onRequest` auth hook returning 401, and `API_TOKEN` env var config. Three gaps remain.
+
+---
+
+## What's Missing
+
+### 1. Failed auth logging
+
+The `onRequest` hook in `http-adapter.ts` returns 401 silently — no log entry. The issue requires auth failures to be audit-logged with source IP, timestamp, and the failure reason (not the token value).
+
+**Implementation:** Add a `logger.warn` call before the 401 reply with `{ ip: request.ip, reason: 'missing_token' | 'invalid_token' }`. Timestamp comes from pino automatically.
+
+### 2. `trustLevel: 'medium'` in message metadata
+
+Authenticated HTTP messages carry no trust signal in the bus event. The HTTP channel's structural trust level is `medium` (token-based auth, low spoofing risk when tokens are secured). Future work will compute `messageTrustScore` from `trustLevel` + `contactConfidence` + content risk; for now, the channel tags messages with its structural level.
+
+**Implementation:** In `messages.ts`, pass `metadata: { trustLevel: 'medium' }` when calling `createInboundMessage`. Uses the existing optional `metadata: Record<string, unknown>` field on `InboundMessagePayload` — no schema changes required.
+
+### 3. Integration test for auth middleware
+
+The existing `http-api.test.ts` builds a raw Fastify app with just routes (no auth hook). Auth middleware is only in `HttpAdapter` and is untested end-to-end.
+
+**Implementation:** Add a new `describe` block in `http-api.test.ts` using `HttpAdapter` directly (or a minimal Fastify app that registers the same `onRequest` hook). Test three cases:
+- No `Authorization` header → 401
+- Wrong token → 401
+- Valid `Bearer <token>` → 200 (message accepted)
+
+The test should skip `/api/health` (exempt from auth per existing code) to confirm the exemption still works.
+
+---
+
+## What's NOT changing
+
+- `validateBearerToken()` — already correct, no changes
+- Token config — `API_TOKEN` env var already works; `config/default.yaml` doesn't store secrets (it's committed to git), so env var is the correct and only mechanism
+- Auth-disabled path when `API_TOKEN` is unset — stays as-is for local dev
+- No changes to `InboundMessagePayload` type or `createInboundMessage` factory — `metadata` already accepts arbitrary key/value pairs
+
+---
+
+## Files Affected
+
+| File | Change |
+|---|---|
+| `src/channels/http/http-adapter.ts` | Add `logger.warn` on auth failure |
+| `src/channels/http/routes/messages.ts` | Pass `metadata: { trustLevel: 'medium' }` |
+| `tests/integration/http-api.test.ts` | Add auth test suite |

--- a/docs/wip/2026-04-09-http-auth-token.md
+++ b/docs/wip/2026-04-09-http-auth-token.md
@@ -288,15 +288,15 @@ You also need to add `validateBearerToken` to the imports at the top of the test
 import { validateBearerToken } from '../../src/channels/http/auth.js';
 ```
 
-- [ ] **Step 2: Run the new tests to verify they fail (not yet — they should pass since impl is done)**
+- [ ] **Step 2: Run the new tests and verify they pass**
 
-Actually: since Tasks 1 and 2 are already committed before this task, the tests should pass on first run. Run them to confirm:
+Tasks 1 and 2 are already committed before this task, so the tests should pass on first run:
 
 ```bash
 npm --prefix $WORKTREE run test -- tests/integration/http-api.test.ts 2>&1 | tail -20
 ```
 
-Expected: all 10 tests pass (5 existing + 5 new).
+Expected: all 11 tests pass (5 existing + 6 new).
 
 - [ ] **Step 3: Commit**
 

--- a/docs/wip/2026-04-09-http-auth-token.md
+++ b/docs/wip/2026-04-09-http-auth-token.md
@@ -348,3 +348,33 @@ npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-a
 ```
 
 Expected: exits 0.
+
+---
+
+## Task 6: Mark spec checklist item as done
+
+**Files:**
+- Modify: `docs/specs/06-audit-and-security.md`
+
+The security checklist in the spec tracks implementation status. Mark the HTTP auth item as complete.
+
+- [ ] **Step 1: Check the item**
+
+Open `docs/specs/06-audit-and-security.md`. Find line 351:
+
+```markdown
+- [ ] HTTP API channel requires token authentication
+```
+
+Change it to:
+
+```markdown
+- [x] HTTP API channel requires token authentication
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token add docs/specs/06-audit-and-security.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token commit -m "docs: mark HTTP API token auth complete in spec 06 checklist"
+```

--- a/docs/wip/2026-04-09-http-auth-token.md
+++ b/docs/wip/2026-04-09-http-auth-token.md
@@ -1,0 +1,350 @@
+# HTTP API Token Authentication Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the three remaining acceptance criteria for issue #189 — failed-auth logging, `trustLevel: 'medium'` on message metadata, and an integration test for the auth middleware.
+
+**Architecture:** Auth enforcement already lives in the `onRequest` hook in `HttpAdapter`. The two production changes are surgical additions to existing files: one `logger.warn` call in the hook, and one metadata field in the route handler. The integration test needs a Fastify app that includes the auth hook (the existing test suite skips it).
+
+**Tech Stack:** TypeScript/ESM, Fastify, Vitest, pino
+
+**Worktree:** `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token`
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `src/channels/http/http-adapter.ts` | Add `logger.warn` in auth hook when token is missing or invalid |
+| `src/channels/http/routes/messages.ts` | Add `metadata: { trustLevel: 'medium' }` to `createInboundMessage` call |
+| `tests/integration/http-api.test.ts` | Add new `describe` block testing auth middleware end-to-end |
+
+---
+
+## Task 1: Log failed auth attempts
+
+**Files:**
+- Modify: `src/channels/http/http-adapter.ts:125-127`
+
+The auth hook currently returns 401 silently. We need a `logger.warn` before the reply so failed attempts are structured-logged with source IP and failure reason. The `logger` variable is already in scope (captured at the top of `start()`).
+
+- [ ] **Step 1: Add the warn log in the auth hook**
+
+Open `src/channels/http/http-adapter.ts`. Find the auth check at line 125:
+
+```typescript
+      if (!validateBearerToken(request.headers.authorization, apiToken)) {
+        return reply.status(401).send({ error: 'Unauthorized — provide a valid Bearer token' });
+      }
+```
+
+Replace it with:
+
+```typescript
+      if (!validateBearerToken(request.headers.authorization, apiToken)) {
+        // Audit-log the failure: IP, route, and whether a token was even provided.
+        // Never log the token value — only that it was present and wrong vs absent.
+        const reason = request.headers.authorization ? 'invalid_token' : 'missing_token';
+        logger.warn({ ip: request.ip, route: routeUrl, reason }, 'HTTP auth failed');
+        return reply.status(401).send({ error: 'Unauthorized — provide a valid Bearer token' });
+      }
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token run build 2>&1 | tail -10
+```
+
+Expected: exits 0, no type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token add src/channels/http/http-adapter.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token commit -m "feat: log failed HTTP auth attempts (issue #189)"
+```
+
+---
+
+## Task 2: Tag authenticated messages with `trustLevel: 'medium'`
+
+**Files:**
+- Modify: `src/channels/http/routes/messages.ts:56-61`
+
+The HTTP channel's structural trust level is `medium` (token auth, low spoofing risk). Downstream consumers (dispatch, agents) use this to compute trust scores. The `metadata` field on `InboundMessagePayload` is `Record<string, unknown>` — no type changes needed.
+
+- [ ] **Step 1: Add `metadata` to the `createInboundMessage` call**
+
+Open `src/channels/http/routes/messages.ts`. Find the `createInboundMessage` call at line 56:
+
+```typescript
+    const inboundEvent = createInboundMessage({
+      conversationId,
+      channelId: 'http',
+      senderId,
+      content: body.content,
+    });
+```
+
+Replace it with:
+
+```typescript
+    const inboundEvent = createInboundMessage({
+      conversationId,
+      channelId: 'http',
+      senderId,
+      content: body.content,
+      // Tag with structural channel trust level. Future work will compute
+      // messageTrustScore from trustLevel + contactConfidence + content risk.
+      metadata: { trustLevel: 'medium' },
+    });
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token run build 2>&1 | tail -10
+```
+
+Expected: exits 0, no type errors.
+
+- [ ] **Step 3: Run the existing integration tests to confirm nothing broke**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token run test -- tests/integration/http-api.test.ts 2>&1 | tail -15
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token add src/channels/http/routes/messages.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token commit -m "feat: tag HTTP messages with trustLevel medium (issue #189)"
+```
+
+---
+
+## Task 3: Integration test for auth middleware
+
+**Files:**
+- Modify: `tests/integration/http-api.test.ts` (add new `describe` block at the end)
+
+The existing test suites build raw Fastify apps with just routes — no auth hook. This new suite builds a minimal Fastify app with the same `onRequest` hook logic as `HttpAdapter` to test it end-to-end without needing to spin up the full adapter.
+
+Strategy: replicate the auth hook in the test's Fastify app, identical to what `HttpAdapter.start()` does, so we test the actual hook logic rather than a mock.
+
+- [ ] **Step 1: Write the failing test suite**
+
+Append the following `describe` block to `tests/integration/http-api.test.ts`:
+
+```typescript
+// Issue #189: HTTP API channel must require token-based authentication.
+// This suite exercises the auth middleware (onRequest hook) end-to-end.
+// It builds a minimal Fastify app with the same hook as HttpAdapter
+// to test auth independently from the message flow.
+describe('HTTP API — bearer token authentication', () => {
+  const TEST_TOKEN = 'test-secret-token-abc123';
+
+  // Build a minimal Fastify app with the same onRequest hook as HttpAdapter.
+  // We test auth in isolation here — message routing is covered by other suites.
+  async function buildApp(token: string | undefined) {
+    const app = Fastify();
+    const bus = new EventBus(logger);
+    const eventRouter = new EventRouter(logger);
+    const mockPool = {
+      query: async () => ({ rows: [{ '?column?': 1 }] }),
+    } as unknown as Pool;
+
+    eventRouter.setupSubscriptions(bus);
+
+    // Register a minimal agent so POST /api/messages can return a response.
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: async () => ({
+        type: 'text' as const,
+        content: 'auth test response',
+        usage: { inputTokens: 1, outputTokens: 1 },
+      }),
+    };
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a test agent.',
+      provider: mockProvider,
+      bus,
+      logger,
+    });
+    coordinator.register();
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    // Auth hook — same logic as HttpAdapter.start()
+    app.addHook('onRequest', async (request, reply) => {
+      const routeUrl = request.routeOptions.url ?? '';
+      if (routeUrl === '/api/health') return;
+      if (!validateBearerToken(request.headers.authorization, token)) {
+        const reason = request.headers.authorization ? 'invalid_token' : 'missing_token';
+        logger.warn({ ip: request.ip, route: routeUrl, reason }, 'HTTP auth failed');
+        return reply.status(401).send({ error: 'Unauthorized — provide a valid Bearer token' });
+      }
+    });
+
+    app.register(messageRoutes, { bus, logger, eventRouter });
+    app.register(healthRoutes, { pool: mockPool, logger, agentNames: ['coordinator'], skillNames: [] });
+
+    await app.ready();
+    return app;
+  }
+
+  it('rejects POST /api/messages with no Authorization header (401)', async () => {
+    const app = await buildApp(TEST_TOKEN);
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/messages',
+      payload: { content: 'hello' },
+      // No headers — no Authorization
+    });
+    await app.close();
+    expect(response.statusCode).toBe(401);
+    const body = JSON.parse(response.body);
+    expect(body.error).toContain('Unauthorized');
+  });
+
+  it('rejects POST /api/messages with a wrong token (401)', async () => {
+    const app = await buildApp(TEST_TOKEN);
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/messages',
+      payload: { content: 'hello' },
+      headers: { authorization: 'Bearer wrong-token' },
+    });
+    await app.close();
+    expect(response.statusCode).toBe(401);
+    const body = JSON.parse(response.body);
+    expect(body.error).toContain('Unauthorized');
+  });
+
+  it('accepts POST /api/messages with a valid token (200)', async () => {
+    const app = await buildApp(TEST_TOKEN);
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/messages',
+      payload: { content: 'hello', conversation_id: 'auth-test-conv-1' },
+      headers: { authorization: `Bearer ${TEST_TOKEN}` },
+    });
+    await app.close();
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.conversation_id).toBe('auth-test-conv-1');
+  });
+
+  it('allows GET /api/health with no token (health is auth-exempt)', async () => {
+    const app = await buildApp(TEST_TOKEN);
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/health',
+      // No Authorization header
+    });
+    await app.close();
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('accepts POST /api/messages when no token is configured (auth disabled)', async () => {
+    const app = await buildApp(undefined); // auth disabled
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/messages',
+      payload: { content: 'hello', conversation_id: 'auth-disabled-conv-1' },
+      // No Authorization header
+    });
+    await app.close();
+    expect(response.statusCode).toBe(200);
+  });
+});
+```
+
+You also need to add `validateBearerToken` to the imports at the top of the test file. The existing import block starts at line 1 — add one line:
+
+```typescript
+import { validateBearerToken } from '../../src/channels/http/auth.js';
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail (not yet — they should pass since impl is done)**
+
+Actually: since Tasks 1 and 2 are already committed before this task, the tests should pass on first run. Run them to confirm:
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token run test -- tests/integration/http-api.test.ts 2>&1 | tail -20
+```
+
+Expected: all 10 tests pass (5 existing + 5 new).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token add tests/integration/http-api.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token commit -m "test: integration tests for HTTP bearer token auth (issue #189)"
+```
+
+---
+
+## Task 4: Update CHANGELOG and version
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`
+
+This is completing a partially-shipped spec (HTTP auth was stubbed, now it's complete) — patch bump per versioning policy.
+
+- [ ] **Step 1: Check current version**
+
+```bash
+grep '"version"' /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token/package.json
+```
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Open `CHANGELOG.md`. Under `## [Unreleased]`, add to the `Security` section (create it if absent):
+
+```markdown
+### Security
+
+- **HTTP API token authentication** — failed auth attempts are now audit-logged (IP, route, reason); authenticated messages carry `trustLevel: 'medium'` in bus event metadata; integration tests verify 401 on missing/invalid token and 200 on valid token (spec 06, issue #189)
+```
+
+- [ ] **Step 3: Bump patch version in package.json**
+
+If current version is `0.14.4`, change to `0.14.5`. Edit `package.json`:
+
+```json
+"version": "0.14.5",
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token add CHANGELOG.md package.json
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token commit -m "chore: bump to 0.14.5, changelog for HTTP auth (issue #189)"
+```
+
+---
+
+## Task 5: Full test run before PR
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token run test 2>&1 | tail -20
+```
+
+Expected: all tests pass, no failures.
+
+- [ ] **Step 2: Confirm build is clean**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token run build 2>&1 | tail -10
+```
+
+Expected: exits 0.

--- a/docs/wip/2026-04-09-http-auth-token.md
+++ b/docs/wip/2026-04-09-http-auth-token.md
@@ -8,7 +8,9 @@
 
 **Tech Stack:** TypeScript/ESM, Fastify, Vitest, pino
 
-**Worktree:** `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token`
+**Worktree:** `<repo-root>/worktrees/curia-http-auth-token`
+
+> Commands below use `$WORKTREE` as a placeholder for the full worktree path (e.g. `export WORKTREE=/path/to/worktrees/curia-http-auth-token`).
 
 ---
 
@@ -54,7 +56,7 @@ Replace it with:
 - [ ] **Step 2: Verify TypeScript compiles**
 
 ```bash
-npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token run build 2>&1 | tail -10
+npm --prefix $WORKTREE run build 2>&1 | tail -10
 ```
 
 Expected: exits 0, no type errors.
@@ -62,8 +64,8 @@ Expected: exits 0, no type errors.
 - [ ] **Step 3: Commit**
 
 ```bash
-git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token add src/channels/http/http-adapter.ts
-git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token commit -m "feat: log failed HTTP auth attempts (issue #189)"
+git -C $WORKTREE add src/channels/http/http-adapter.ts
+git -C $WORKTREE commit -m "feat: log failed HTTP auth attempts (issue #189)"
 ```
 
 ---
@@ -105,7 +107,7 @@ Replace it with:
 - [ ] **Step 2: Verify TypeScript compiles**
 
 ```bash
-npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token run build 2>&1 | tail -10
+npm --prefix $WORKTREE run build 2>&1 | tail -10
 ```
 
 Expected: exits 0, no type errors.
@@ -113,7 +115,7 @@ Expected: exits 0, no type errors.
 - [ ] **Step 3: Run the existing integration tests to confirm nothing broke**
 
 ```bash
-npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token run test -- tests/integration/http-api.test.ts 2>&1 | tail -15
+npm --prefix $WORKTREE run test -- tests/integration/http-api.test.ts 2>&1 | tail -15
 ```
 
 Expected: 5 tests pass.
@@ -121,8 +123,8 @@ Expected: 5 tests pass.
 - [ ] **Step 4: Commit**
 
 ```bash
-git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token add src/channels/http/routes/messages.ts
-git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token commit -m "feat: tag HTTP messages with trustLevel medium (issue #189)"
+git -C $WORKTREE add src/channels/http/routes/messages.ts
+git -C $WORKTREE commit -m "feat: tag HTTP messages with trustLevel medium (issue #189)"
 ```
 
 ---
@@ -200,67 +202,82 @@ describe('HTTP API — bearer token authentication', () => {
 
   it('rejects POST /api/messages with no Authorization header (401)', async () => {
     const app = await buildApp(TEST_TOKEN);
-    const response = await app.inject({
-      method: 'POST',
-      url: '/api/messages',
-      payload: { content: 'hello' },
-      // No headers — no Authorization
-    });
-    await app.close();
-    expect(response.statusCode).toBe(401);
-    const body = JSON.parse(response.body);
-    expect(body.error).toContain('Unauthorized');
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/messages',
+        payload: { content: 'hello' },
+        // No headers — no Authorization
+      });
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('Unauthorized');
+    } finally {
+      await app.close();
+    }
   });
 
   it('rejects POST /api/messages with a wrong token (401)', async () => {
     const app = await buildApp(TEST_TOKEN);
-    const response = await app.inject({
-      method: 'POST',
-      url: '/api/messages',
-      payload: { content: 'hello' },
-      headers: { authorization: 'Bearer wrong-token' },
-    });
-    await app.close();
-    expect(response.statusCode).toBe(401);
-    const body = JSON.parse(response.body);
-    expect(body.error).toContain('Unauthorized');
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/messages',
+        payload: { content: 'hello' },
+        headers: { authorization: 'Bearer wrong-token' },
+      });
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('Unauthorized');
+    } finally {
+      await app.close();
+    }
   });
 
   it('accepts POST /api/messages with a valid token (200)', async () => {
     const app = await buildApp(TEST_TOKEN);
-    const response = await app.inject({
-      method: 'POST',
-      url: '/api/messages',
-      payload: { content: 'hello', conversation_id: 'auth-test-conv-1' },
-      headers: { authorization: `Bearer ${TEST_TOKEN}` },
-    });
-    await app.close();
-    expect(response.statusCode).toBe(200);
-    const body = JSON.parse(response.body);
-    expect(body.conversation_id).toBe('auth-test-conv-1');
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/messages',
+        payload: { content: 'hello', conversation_id: 'auth-test-conv-1' },
+        headers: { authorization: `Bearer ${TEST_TOKEN}` },
+      });
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.conversation_id).toBe('auth-test-conv-1');
+    } finally {
+      await app.close();
+    }
   });
 
   it('allows GET /api/health with no token (health is auth-exempt)', async () => {
     const app = await buildApp(TEST_TOKEN);
-    const response = await app.inject({
-      method: 'GET',
-      url: '/api/health',
-      // No Authorization header
-    });
-    await app.close();
-    expect(response.statusCode).toBe(200);
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/health',
+        // No Authorization header
+      });
+      expect(response.statusCode).toBe(200);
+    } finally {
+      await app.close();
+    }
   });
 
   it('accepts POST /api/messages when no token is configured (auth disabled)', async () => {
     const app = await buildApp(undefined); // auth disabled
-    const response = await app.inject({
-      method: 'POST',
-      url: '/api/messages',
-      payload: { content: 'hello', conversation_id: 'auth-disabled-conv-1' },
-      // No Authorization header
-    });
-    await app.close();
-    expect(response.statusCode).toBe(200);
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/messages',
+        payload: { content: 'hello', conversation_id: 'auth-disabled-conv-1' },
+        // No Authorization header
+      });
+      expect(response.statusCode).toBe(200);
+    } finally {
+      await app.close();
+    }
   });
 });
 ```
@@ -276,7 +293,7 @@ import { validateBearerToken } from '../../src/channels/http/auth.js';
 Actually: since Tasks 1 and 2 are already committed before this task, the tests should pass on first run. Run them to confirm:
 
 ```bash
-npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token run test -- tests/integration/http-api.test.ts 2>&1 | tail -20
+npm --prefix $WORKTREE run test -- tests/integration/http-api.test.ts 2>&1 | tail -20
 ```
 
 Expected: all 10 tests pass (5 existing + 5 new).
@@ -284,8 +301,8 @@ Expected: all 10 tests pass (5 existing + 5 new).
 - [ ] **Step 3: Commit**
 
 ```bash
-git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token add tests/integration/http-api.test.ts
-git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token commit -m "test: integration tests for HTTP bearer token auth (issue #189)"
+git -C $WORKTREE add tests/integration/http-api.test.ts
+git -C $WORKTREE commit -m "test: integration tests for HTTP bearer token auth (issue #189)"
 ```
 
 ---
@@ -301,7 +318,7 @@ This is completing a partially-shipped spec (HTTP auth was stubbed, now it's com
 - [ ] **Step 1: Check current version**
 
 ```bash
-grep '"version"' /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token/package.json
+grep '"version"' $WORKTREE/package.json
 ```
 
 - [ ] **Step 2: Update CHANGELOG.md**
@@ -325,8 +342,8 @@ If current version is `0.14.4`, change to `0.14.5`. Edit `package.json`:
 - [ ] **Step 4: Commit**
 
 ```bash
-git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token add CHANGELOG.md package.json
-git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token commit -m "chore: bump to 0.14.5, changelog for HTTP auth (issue #189)"
+git -C $WORKTREE add CHANGELOG.md package.json
+git -C $WORKTREE commit -m "chore: bump to 0.14.5, changelog for HTTP auth (issue #189)"
 ```
 
 ---
@@ -336,7 +353,7 @@ git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-to
 - [ ] **Step 1: Run the full test suite**
 
 ```bash
-npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token run test 2>&1 | tail -20
+npm --prefix $WORKTREE run test 2>&1 | tail -20
 ```
 
 Expected: all tests pass, no failures.
@@ -344,7 +361,7 @@ Expected: all tests pass, no failures.
 - [ ] **Step 2: Confirm build is clean**
 
 ```bash
-npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token run build 2>&1 | tail -10
+npm --prefix $WORKTREE run build 2>&1 | tail -10
 ```
 
 Expected: exits 0.
@@ -375,6 +392,6 @@ Change it to:
 - [ ] **Step 2: Commit**
 
 ```bash
-git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token add docs/specs/06-audit-and-security.md
-git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-http-auth-token commit -m "docs: mark HTTP API token auth complete in spec 06 checklist"
+git -C $WORKTREE add docs/specs/06-audit-and-security.md
+git -C $WORKTREE commit -m "docs: mark HTTP API token auth complete in spec 06 checklist"
 ```

--- a/src/channels/http/auth.ts
+++ b/src/channels/http/auth.ts
@@ -25,6 +25,9 @@ export function validateBearerToken(
   if (!authHeader || !authHeader.startsWith('Bearer ')) return false;
 
   const provided = authHeader.slice('Bearer '.length);
+  // Reject empty token immediately — "Bearer " with no value is always invalid
+  // and avoids a misleading length-match if configuredToken were ever empty.
+  if (!provided) return false;
 
   // Timing-safe comparison to prevent timing attacks
   if (provided.length !== configuredToken.length) return false;

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -123,6 +123,10 @@ export class HttpAdapter {
       ) return;
 
       if (!validateBearerToken(request.headers.authorization, apiToken)) {
+        // Audit-log the failure: IP, route, and whether a token was even provided.
+        // Never log the token value — only that it was present and wrong vs absent.
+        const reason = request.headers.authorization ? 'invalid_token' : 'missing_token';
+        logger.warn({ ip: request.ip, route: routeUrl, reason }, 'HTTP auth failed');
         return reply.status(401).send({ error: 'Unauthorized — provide a valid Bearer token' });
       }
     });

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -3551,6 +3551,9 @@ export async function knowledgeGraphRoutes(
         channelId: WEB_CHANNEL_ID,
         senderId: WEB_SENDER_ID,
         content: body.message,
+        // Tag with structural channel trust level — session-cookie auth earns medium trust,
+        // same as bearer token auth on the API channel. Required for messageTrustScore computation.
+        metadata: { trustLevel: 'medium' },
       }));
     } catch (publishErr) {
       // Publish failed synchronously — cancel our pending waiter (still ours, nothing

--- a/src/channels/http/routes/messages.ts
+++ b/src/channels/http/routes/messages.ts
@@ -58,6 +58,9 @@ export async function messageRoutes(
       channelId: 'http',
       senderId,
       content: body.content,
+      // Tag with structural channel trust level. Future work will compute
+      // messageTrustScore from trustLevel + contactConfidence + content risk.
+      metadata: { trustLevel: 'medium' },
     });
 
     // Publish failure: bus.publish() threw synchronously. Cancel our pending entry

--- a/tests/integration/http-api.test.ts
+++ b/tests/integration/http-api.test.ts
@@ -8,6 +8,7 @@ import { messageRoutes } from '../../src/channels/http/routes/messages.js';
 import { healthRoutes } from '../../src/channels/http/routes/health.js';
 import { agentRoutes } from '../../src/channels/http/routes/agents.js';
 import { Dispatcher } from '../../src/dispatch/dispatcher.js';
+import { validateBearerToken } from '../../src/channels/http/auth.js';
 import type { LLMProvider } from '../../src/agents/llm/provider.js';
 import type { ContactResolver } from '../../src/contacts/contact-resolver.js';
 import type { InboundSenderContext } from '../../src/contacts/types.js';
@@ -176,5 +177,153 @@ describe('HTTP API — unknown_sender: reject policy', () => {
     expect(response.statusCode).toBe(403);
     const body = JSON.parse(response.body);
     expect(body.error).toContain('sender not authorized');
+  });
+});
+
+// Issue #189: HTTP API channel must require token-based authentication.
+// This suite exercises the auth middleware (onRequest hook) end-to-end.
+// It builds a minimal Fastify app with the same hook as HttpAdapter
+// to test auth independently from the message flow.
+describe('HTTP API — bearer token authentication', () => {
+  const TEST_TOKEN = 'test-secret-token-abc123';
+
+  // Build a minimal Fastify app with the same onRequest hook as HttpAdapter.
+  // We test auth in isolation here — message routing is covered by other suites.
+  async function buildApp(token: string | undefined) {
+    const app = Fastify();
+    const bus = new EventBus(logger);
+    const eventRouter = new EventRouter(logger);
+    const mockPool = {
+      query: async () => ({ rows: [{ '?column?': 1 }] }),
+    } as unknown as Pool;
+
+    eventRouter.setupSubscriptions(bus);
+
+    // Register a minimal agent so POST /api/messages can return a response.
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: async () => ({
+        type: 'text' as const,
+        content: 'auth test response',
+        usage: { inputTokens: 1, outputTokens: 1 },
+      }),
+    };
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a test agent.',
+      provider: mockProvider,
+      bus,
+      logger,
+    });
+    coordinator.register();
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    // Auth hook — same logic as HttpAdapter.start()
+    app.addHook('onRequest', async (request, reply) => {
+      const routeUrl = request.routeOptions.url ?? '';
+      if (routeUrl === '/api/health') return;
+      // Mirror the full HttpAdapter exemption list — these routes use their own auth mechanisms.
+      // None are registered in this test app, but the hook must match production exactly.
+      if (
+        routeUrl === '/' ||
+        routeUrl === '/auth' ||
+        routeUrl.startsWith('/assets') ||
+        routeUrl.startsWith('/api/kg') ||
+        routeUrl.startsWith('/api/identity') ||
+        routeUrl.startsWith('/api/jobs')
+      ) return;
+      if (!validateBearerToken(request.headers.authorization, token)) {
+        const reason = request.headers.authorization ? 'invalid_token' : 'missing_token';
+        logger.warn({ ip: request.ip, route: routeUrl, reason }, 'HTTP auth failed');
+        return reply.status(401).send({ error: 'Unauthorized — provide a valid Bearer token' });
+      }
+    });
+
+    app.register(messageRoutes, { bus, logger, eventRouter });
+    app.register(healthRoutes, { pool: mockPool, logger, agentNames: ['coordinator'], skillNames: [] });
+
+    await app.ready();
+    return app;
+  }
+
+  it('rejects POST /api/messages with no Authorization header (401)', async () => {
+    const app = await buildApp(TEST_TOKEN);
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/messages',
+        payload: { content: 'hello' },
+        // No headers — no Authorization
+      });
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('Unauthorized');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects POST /api/messages with a wrong token (401)', async () => {
+    const app = await buildApp(TEST_TOKEN);
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/messages',
+        payload: { content: 'hello' },
+        headers: { authorization: 'Bearer wrong-token' },
+      });
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('Unauthorized');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('accepts POST /api/messages with a valid token (200)', async () => {
+    const app = await buildApp(TEST_TOKEN);
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/messages',
+        payload: { content: 'hello', conversation_id: 'auth-test-conv-1' },
+        headers: { authorization: `Bearer ${TEST_TOKEN}` },
+      });
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.conversation_id).toBe('auth-test-conv-1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('allows GET /api/health with no token (health is auth-exempt)', async () => {
+    const app = await buildApp(TEST_TOKEN);
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/health',
+        // No Authorization header
+      });
+      expect(response.statusCode).toBe(200);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('accepts POST /api/messages when no token is configured (auth disabled)', async () => {
+    const app = await buildApp(undefined); // auth disabled
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/messages',
+        payload: { content: 'hello', conversation_id: 'auth-disabled-conv-1' },
+        // No Authorization header
+      });
+      expect(response.statusCode).toBe(200);
+    } finally {
+      await app.close();
+    }
   });
 });

--- a/tests/integration/http-api.test.ts
+++ b/tests/integration/http-api.test.ts
@@ -281,6 +281,23 @@ describe('HTTP API — bearer token authentication', () => {
     }
   });
 
+  it('rejects POST /api/messages with empty bearer value (401)', async () => {
+    const app = await buildApp(TEST_TOKEN);
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/messages',
+        payload: { content: 'hello' },
+        headers: { authorization: 'Bearer ' }, // Empty token value — "Bearer " with no value
+      });
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.error).toContain('Unauthorized');
+    } finally {
+      await app.close();
+    }
+  });
+
   it('accepts POST /api/messages with a valid token (200)', async () => {
     const app = await buildApp(TEST_TOKEN);
     try {

--- a/tests/unit/channels/http/auth.test.ts
+++ b/tests/unit/channels/http/auth.test.ts
@@ -29,4 +29,8 @@ describe('validateBearerToken', () => {
   it('returns true for any header when no API token is configured', () => {
     expect(validateBearerToken('Bearer anything', undefined)).toBe(true);
   });
+
+  it('returns false for "Bearer " with no token value', () => {
+    expect(validateBearerToken('Bearer ', 'my-secret-token')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- **Failed auth logging** — `logger.warn` with `{ ip, route, reason }` fires before every 401 reply; token value is never logged; `reason` distinguishes `missing_token` from `invalid_token`
- **Trust metadata (API + web)** — all authenticated HTTP messages now carry `metadata: { trustLevel: 'medium' }` in the bus event: bearer-token path (`/api/messages`) and session-cookie path (`/api/kg/chat/messages`). Consistent across all HTTP channel event sources — required foundation for `messageTrustScore` computation
- **Integration tests** — 5 new tests covering: no token → 401, wrong token → 401, valid token → 200, `/api/health` exempt from auth, auth-disabled path; auth hook in tests mirrors production exactly
- **Empty token fix** — `validateBearerToken` now rejects `Bearer ` (header present, value empty) explicitly before the timing-safe comparison

## Test Plan

- [ ] `npm test` — 1050 tests pass
- [ ] `POST /api/messages` with no `Authorization` → 401
- [ ] `POST /api/messages` with wrong token → 401
- [ ] `POST /api/messages` with valid `Bearer <API_TOKEN>` → 200
- [ ] `GET /api/health` with no token → 200 (exempt)
- [ ] `API_TOKEN` unset → all requests accepted (local dev mode unchanged)

## Notes

- Pre-existing build failure (`baseUrl` deprecation in tsconfig, TS 6.0) is unrelated to this PR — present on `main` before this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP API token auth now audit-logs failed attempts (records source IP, route and failure reason)
  * Authenticated inbound messages include a medium trust-level metadata field

* **Bug Fixes**
  * Improved handling of malformed/empty Bearer token edge cases during validation

* **Tests**
  * New integration tests covering 401/200 token scenarios and health-route exemption
  * Added unit test for empty Bearer token case
<!-- end of auto-generated comment: release notes by coderabbit.ai -->