### PR TITLE
feat: secrets isolation — ctx.secret() audit trail, pino redaction, manifest coverage test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+- **Secrets isolation audit trail** — Every `ctx.secret()` call now emits a `secret.accessed`
+  bus event (skill name, secret name, agentId, taskEventId — never the secret value), giving a
+  durable write-ahead audit record for all secret access through the execution layer (spec 06,
+  Secrets Isolation). Pino loggers now redact fields named `password`, `token`, `secret`, and
+  `api_key` as a last-resort safety net against accidental leakage into structured logs. A new
+  static analysis Vitest test (`secret-manifest-coverage`) scans every skill handler for
+  `ctx.secret()` calls and fails CI if any accessed secret name is not declared in that skill's
+  `skill.json` manifest, catching both missed declarations and cross-skill secret access attempts.
+
+### Added
+- **`secret.accessed` bus event type** — New event type published by the `execution` layer
+  (added to `src/bus/events.ts` and `src/bus/permissions.ts`). System layer can subscribe for
+  monitoring; audit logger persists it write-ahead like all bus events. Payload carries
+  `skillName`, `secretName`, `agentId`, and `taskEventId` — never the resolved secret value.
+
 ### Added
 - **Bus layer enforcement: `llm.call` and `human.decision` event types** — Added the two new
   event types from spec 10 (audit log hardening) to the bus: `llm.call` (published by the agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
   (added to `src/bus/events.ts` and `src/bus/permissions.ts`). System layer can subscribe for
   monitoring; audit logger persists it write-ahead like all bus events. Payload carries
   `skillName`, `secretName`, `agentId`, and `taskEventId` — never the resolved secret value.
-
-### Added
+- **Bus layer enforcement: `llm.call` and `human.decision` event types** — Added the two new
 - **Bus layer enforcement: `llm.call` and `human.decision` event types** — Added the two new
   event types from spec 10 (audit log hardening) to the bus: `llm.call` (published by the agent
   layer after every LLM API call; carries model provenance, token accounting, timing, and content

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.14.2",
+  "version": "0.14.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.14.2",
+      "version": "0.14.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -258,6 +258,16 @@ interface LlmCallPayload {
   responseHash: string;
 }
 
+// SecretAccessedPayload — emitted by the execution layer whenever a skill calls ctx.secret().
+// Records which skill accessed which secret, from which agent/task — never the secret value.
+// This is the primary audit trail for secrets isolation (spec 06, Secrets Isolation).
+interface SecretAccessedPayload {
+  skillName: string;
+  secretName: string;     // the declared key name — never the resolved value
+  agentId?: string;       // agent that invoked the skill
+  taskEventId?: string;   // causal chain: the agent.task that triggered this invocation
+}
+
 // HumanDecisionPayload — emitted by the dispatch layer when a human approves, denies, or
 // reviews an agent action. Captures the full decision context for compliance and audit.
 // Spec 10 (audit log hardening): required by EU AI Act Article 14, HITL audit standards.
@@ -449,6 +459,15 @@ export interface HumanDecisionEvent extends BaseEvent {
   payload: HumanDecisionPayload;
 }
 
+// SecretAccessedEvent — published by the execution layer for every ctx.secret() call.
+// Goes through the write-ahead audit logger like all bus events, giving a durable
+// record of which skill accessed which secret without the value ever leaving the process.
+export interface SecretAccessedEvent extends BaseEvent {
+  type: 'secret.accessed';
+  sourceLayer: 'execution';
+  payload: SecretAccessedPayload;
+}
+
 interface ConversationCheckpointPayload {
   conversationId: string;
   agentId: string;
@@ -494,7 +513,8 @@ export type BusEvent =
   | ConfigChangeEvent        // System: config object changed (office identity, etc.)
   | ConversationCheckpointEvent // Checkpoint pipeline: Dispatch fires after inactivity window
   | LlmCallEvent             // Spec 10: LLM API call provenance (model, tokens, cost, hashes)
-  | HumanDecisionEvent;      // Spec 10: human-in-the-loop decision record (approve/deny/etc.)
+  | HumanDecisionEvent       // Spec 10: human-in-the-loop decision record (approve/deny/etc.)
+  | SecretAccessedEvent;     // Spec 06: secrets isolation audit trail (name only, never value)
 
 // Convenience alias for use in handler maps / switch statements.
 export type EventType = BusEvent['type'];
@@ -862,6 +882,20 @@ export function createHumanDecision(
     type: 'human.decision',
     sourceLayer: 'dispatch',
     payload: rest,
+    parentEventId,
+  };
+}
+
+export function createSecretAccessed(
+  payload: SecretAccessedPayload,
+  parentEventId?: string,
+): SecretAccessedEvent {
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'secret.accessed',
+    sourceLayer: 'execution',
+    payload,
     parentEventId,
   };
 }

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -15,12 +15,14 @@ import type { Layer, EventType } from './events.js';
 // Spec 10 (audit log hardening): agent layer publishes llm.call for LLM provenance (NIST AI 600-1,
 //          EU AI Act Art. 12); dispatch layer publishes human.decision for HITL records (EU AI Act Art. 14).
 //          system layer gets full access to both for audit logging and monitoring.
+// Spec 06 (secrets isolation): execution layer publishes secret.accessed for every ctx.secret() call;
+//          system layer gets full access for audit logging and monitoring.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message']),
   dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint', 'human.decision']),
   agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss', 'llm.call']),
-  execution: new Set(['skill.result']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision']),
+  execution: new Set(['skill.result', 'secret.accessed']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed']),
 };
 
 // agent.discuss subscribe for 'dispatch': used by BullpenDispatcher (wired in index.ts after agent registration).
@@ -29,7 +31,7 @@ const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -12,14 +12,24 @@ import { Writable } from 'node:stream';
 export function createLogger(level: string = 'info'): pino.Logger {
   const isProduction = process.env.NODE_ENV === 'production';
 
+  // Last-resort redaction for common secret field names. The primary defense is the
+  // ctx.secret() interface — secret values should never reach the logger in the first
+  // place. This catches accidental leakage (e.g. logging an object that happens to
+  // contain a 'token' field). Wildcard prefix covers one level of nesting.
+  const redact = {
+    paths: ['password', '*.password', 'token', '*.token', 'secret', '*.secret', 'api_key', '*.api_key'],
+    censor: '[REDACTED]',
+  };
+
   if (isProduction) {
-    return pino({ level });
+    return pino({ level, redact });
   }
 
   // Dev mode: write to curia.log instead of stdout so the CLI stays clean.
   // Use pino-pretty for readable format in the log file.
   return pino({
     level,
+    redact,
     transport: {
       target: 'pino-pretty',
       options: {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,9 +15,14 @@ export function createLogger(level: string = 'info'): pino.Logger {
   // Last-resort redaction for common secret field names. The primary defense is the
   // ctx.secret() interface — secret values should never reach the logger in the first
   // place. This catches accidental leakage (e.g. logging an object that happens to
-  // contain a 'token' field). Wildcard prefix covers one level of nesting.
+  // contain a 'token' field). The ** paths cover deep nesting (pino v8+ feature).
   const redact = {
-    paths: ['password', '*.password', 'token', '*.token', 'secret', '*.secret', 'api_key', '*.api_key'],
+    paths: [
+      'password', '*.password', '**.password',
+      'token', '*.token', '**.token',
+      'secret', '*.secret', '**.secret',
+      'api_key', '*.api_key', '**.api_key',
+    ],
     censor: '[REDACTED]',
   };
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -15,13 +15,18 @@ export function createLogger(level: string = 'info'): pino.Logger {
   // Last-resort redaction for common secret field names. The primary defense is the
   // ctx.secret() interface — secret values should never reach the logger in the first
   // place. This catches accidental leakage (e.g. logging an object that happens to
-  // contain a 'token' field). The ** paths cover deep nesting (pino v8+ feature).
+  // contain a 'token' field).
+  //
+  // Depth note: pino v10 uses @pinojs/redact which supports single-level wildcards
+  // ('*.field') but NOT deep wildcards ('**.field'). The two-level 'a.*.field' paths
+  // cover the most common nesting depth. For deeper nesting the primary defense
+  // (ctx.secret() interface) must hold — redaction is a safety net, not a guarantee.
   const redact = {
     paths: [
-      'password', '*.password', '**.password',
-      'token', '*.token', '**.token',
-      'secret', '*.secret', '**.secret',
-      'api_key', '*.api_key', '**.api_key',
+      'password', '*.password', '*.*.password',
+      'token', '*.token', '*.*.token',
+      'secret', '*.secret', '*.*.secret',
+      'api_key', '*.api_key', '*.*.api_key',
     ],
     censor: '[REDACTED]',
   };

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -21,6 +21,7 @@ import type { SkillResult, SkillContext, CallerContext, AgentPersona } from './t
 import { normalizeTimestamp } from '../time/timestamp.js';
 import type { SkillRegistry } from './registry.js';
 import { sanitizeOutput } from './sanitize.js';
+import { createSecretAccessed } from '../bus/events.js';
 import type { Logger } from '../logger.js';
 import type { EventBus } from '../bus/bus.js';
 import type { AgentRegistry } from '../agents/agent-registry.js';
@@ -222,7 +223,21 @@ export class ExecutionLayer {
         if (!value) {
           throw new Error(`Secret '${name}' is declared but not set in the environment`);
         }
-        // Log at debug level — info is too noisy for every secret access
+        // Audit log — fire-and-forget so ctx.secret() stays synchronous.
+        // Records skill name, secret name, and causal IDs — never the secret value.
+        // Falls back to debug-only logging if the bus is not wired (e.g. test environments).
+        if (this.bus) {
+          this.bus.publish('execution', createSecretAccessed({
+            skillName,
+            secretName: name,
+            agentId: options?.agentId,
+            taskEventId: options?.taskEventId,
+          })).catch((err) => {
+            // Warn but don't fail — a dropped audit event is bad, but it must not
+            // break the skill invocation. The pino debug log below is the fallback record.
+            skillLogger.warn({ err, secretName: name }, 'Failed to publish secret.accessed audit event');
+          });
+        }
         skillLogger.debug({ secretName: name }, 'Secret accessed');
         return value;
       },

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -233,9 +233,13 @@ export class ExecutionLayer {
             agentId: options?.agentId,
             taskEventId: options?.taskEventId,
           })).catch((err) => {
-            // Warn but don't fail — a dropped audit event is bad, but it must not
-            // break the skill invocation. The pino debug log below is the fallback record.
-            skillLogger.warn({ err, secretName: name }, 'Failed to publish secret.accessed audit event');
+            // Error (not warn) — a dropped audit event on a security-critical path must
+            // surface at error level so it reaches SIEM/alerting dashboards. The debug
+            // log below still fires, but it is not a durable audit record.
+            skillLogger.error(
+              { err, secretName: name, skillName, agentId: options?.agentId, taskEventId: options?.taskEventId },
+              'AUDIT FAILURE: secret.accessed event could not be published — secret was returned but access may not be recorded',
+            );
           });
         }
         skillLogger.debug({ secretName: name }, 'Secret accessed');

--- a/tests/unit/skills/execution.test.ts
+++ b/tests/unit/skills/execution.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ExecutionLayer } from '../../../src/skills/execution.js';
 import { SkillRegistry } from '../../../src/skills/registry.js';
+import { EventBus } from '../../../src/bus/bus.js';
+import type { BusEvent } from '../../../src/bus/events.js';
 import type { SkillManifest, SkillHandler, SkillContext } from '../../../src/skills/types.js';
 import pino from 'pino';
 
@@ -401,6 +403,132 @@ describe('ExecutionLayer', () => {
         expect(result.error).not.toContain('ignore all rules');
         expect(result.error).toContain('real error');
       }
+    });
+  });
+
+  describe('secret.accessed audit events', () => {
+    it('publishes a secret.accessed event with secret name but not value', async () => {
+      process.env.AUDIT_TEST_SECRET = 'do-not-log-this-value';
+
+      const publishedEvents: BusEvent[] = [];
+      const bus = new EventBus(logger);
+      // System layer can subscribe to secret.accessed for audit purposes
+      bus.subscribe('secret.accessed', 'system', (event) => { publishedEvents.push(event); });
+
+      const handler: SkillHandler = {
+        execute: async (ctx: SkillContext) => {
+          ctx.secret('audit_test_secret');
+          return { success: true, data: 'ok' };
+        },
+      };
+      const reg = new SkillRegistry();
+      reg.register(makeManifest({ name: 'audited-skill', secrets: ['audit_test_secret'] }), handler);
+      const exec = new ExecutionLayer(reg, logger, { bus });
+
+      await exec.invoke('audited-skill', {});
+
+      // Fire-and-forget — give the event loop a tick to resolve the publish promise
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(publishedEvents).toHaveLength(1);
+      const event = publishedEvents[0];
+      if (event.type === 'secret.accessed') {
+        // Name is present
+        expect(event.payload.secretName).toBe('audit_test_secret');
+        expect(event.payload.skillName).toBe('audited-skill');
+        // Value must never appear in the event payload
+        expect(JSON.stringify(event.payload)).not.toContain('do-not-log-this-value');
+      } else {
+        expect.fail('Expected a secret.accessed event');
+      }
+
+      delete process.env.AUDIT_TEST_SECRET;
+    });
+
+    it('publishes separate secret.accessed events for multiple ctx.secret() calls', async () => {
+      process.env.SECRET_ONE = 'val-one';
+      process.env.SECRET_TWO = 'val-two';
+
+      const publishedEvents: BusEvent[] = [];
+      const bus = new EventBus(logger);
+      bus.subscribe('secret.accessed', 'system', (event) => { publishedEvents.push(event); });
+
+      const handler: SkillHandler = {
+        execute: async (ctx: SkillContext) => {
+          ctx.secret('secret_one');
+          ctx.secret('secret_two');
+          return { success: true, data: 'ok' };
+        },
+      };
+      const reg = new SkillRegistry();
+      reg.register(makeManifest({ name: 'multi-secret-skill', secrets: ['secret_one', 'secret_two'] }), handler);
+      const exec = new ExecutionLayer(reg, logger, { bus });
+
+      await exec.invoke('multi-secret-skill', {});
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(publishedEvents).toHaveLength(2);
+      const names = publishedEvents
+        .filter(e => e.type === 'secret.accessed')
+        .map(e => e.type === 'secret.accessed' ? e.payload.secretName : '');
+      expect(names).toContain('secret_one');
+      expect(names).toContain('secret_two');
+
+      delete process.env.SECRET_ONE;
+      delete process.env.SECRET_TWO;
+    });
+
+    it('does not publish secret.accessed when no bus is wired', async () => {
+      // Ensures the fire-and-forget silently skips when bus is absent (test environments)
+      process.env.NO_BUS_SECRET = 'secret-val';
+
+      const handler: SkillHandler = {
+        execute: async (ctx: SkillContext) => {
+          ctx.secret('no_bus_secret');
+          return { success: true, data: 'ok' };
+        },
+      };
+      const reg = new SkillRegistry();
+      reg.register(makeManifest({ name: 'no-bus-skill', secrets: ['no_bus_secret'] }), handler);
+      // ExecutionLayer without bus — should not throw
+      const exec = new ExecutionLayer(reg, logger);
+
+      const result = await exec.invoke('no-bus-skill', {});
+      expect(result.success).toBe(true);
+
+      delete process.env.NO_BUS_SECRET;
+    });
+
+    it('propagates agentId and taskEventId into secret.accessed payload', async () => {
+      process.env.TRACED_SECRET = 'traced-val';
+
+      const publishedEvents: BusEvent[] = [];
+      const bus = new EventBus(logger);
+      bus.subscribe('secret.accessed', 'system', (event) => { publishedEvents.push(event); });
+
+      const handler: SkillHandler = {
+        execute: async (ctx: SkillContext) => {
+          ctx.secret('traced_secret');
+          return { success: true, data: 'ok' };
+        },
+      };
+      const reg = new SkillRegistry();
+      reg.register(makeManifest({ name: 'traced-skill', secrets: ['traced_secret'] }), handler);
+      const exec = new ExecutionLayer(reg, logger, { bus });
+
+      await exec.invoke('traced-skill', {}, undefined, { agentId: 'agent-123', taskEventId: 'task-456' });
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(publishedEvents).toHaveLength(1);
+      const event = publishedEvents[0];
+      if (event.type === 'secret.accessed') {
+        expect(event.payload.agentId).toBe('agent-123');
+        expect(event.payload.taskEventId).toBe('task-456');
+      } else {
+        expect.fail('Expected a secret.accessed event');
+      }
+
+      delete process.env.TRACED_SECRET;
     });
   });
 

--- a/tests/unit/skills/secret-manifest-coverage.test.ts
+++ b/tests/unit/skills/secret-manifest-coverage.test.ts
@@ -1,0 +1,63 @@
+// secret-manifest-coverage.test.ts — static analysis guard for secrets isolation.
+//
+// Every ctx.secret('name') call in a skill handler must have 'name' declared in
+// that skill's manifest secrets array. This test catches:
+//
+//   1. A developer adds ctx.secret('new_key') but forgets to update skill.json.
+//   2. A malicious handler calls ctx.secret('OTHER_SKILL_API_KEY') — cross-skill
+//      secret access. The runtime allowlist blocks this at execution time, but this
+//      test surfaces it at CI time before it can reach production.
+//
+// The test reads manifests from disk and scans handler source for literal string
+// arguments to ctx.secret(). Dynamic arguments (e.g. ctx.secret(keyVar)) cannot
+// be caught here — those would be a code review concern.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// Resolve skills/ directory relative to this test file (tests/unit/skills/ → ../../../skills/)
+const SKILLS_DIR = path.join(import.meta.dirname, '../../../skills');
+
+describe('secret manifest coverage', () => {
+  it('every ctx.secret() call references a secret declared in that skill\'s manifest', () => {
+    const entries = fs.readdirSync(SKILLS_DIR, { withFileTypes: true });
+    const violations: string[] = [];
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const skillDir = path.join(SKILLS_DIR, entry.name);
+      const manifestPath = path.join(skillDir, 'skill.json');
+
+      // Prefer handler.ts (development source) over handler.js (compiled output)
+      const handlerPath = fs.existsSync(path.join(skillDir, 'handler.ts'))
+        ? path.join(skillDir, 'handler.ts')
+        : path.join(skillDir, 'handler.js');
+
+      if (!fs.existsSync(manifestPath) || !fs.existsSync(handlerPath)) continue;
+
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as { secrets?: string[] };
+      const declaredSecrets = new Set<string>(manifest.secrets ?? []);
+
+      const handlerSource = fs.readFileSync(handlerPath, 'utf-8');
+
+      // Match both single-quoted and double-quoted literal string arguments:
+      //   ctx.secret('tavily_api_key')
+      //   ctx.secret("ANTHROPIC_API_KEY")
+      // Template literals and variable arguments are not checked here — use code review.
+      const pattern = /ctx\.secret\(\s*['"]([^'"]+)['"]\s*\)/g;
+      for (const match of handlerSource.matchAll(pattern)) {
+        const secretName = match[1];
+        if (!declaredSecrets.has(secretName)) {
+          violations.push(
+            `${entry.name}/handler: ctx.secret('${secretName}') is not declared in skill.json secrets array`,
+          );
+        }
+      }
+    }
+
+    // Surface all violations together so a developer can fix them in one pass
+    expect(violations, `\nSecret manifest violations found:\n${violations.map(v => `  - ${v}`).join('\n')}\n`).toHaveLength(0);
+  });
+});

--- a/tests/unit/skills/secret-manifest-coverage.test.ts
+++ b/tests/unit/skills/secret-manifest-coverage.test.ts
@@ -38,22 +38,37 @@ describe('secret manifest coverage', () => {
       if (!fs.existsSync(manifestPath) || !fs.existsSync(handlerPath)) continue;
 
       const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as { secrets?: string[] };
-      const declaredSecrets = new Set<string>(manifest.secrets ?? []);
+      // Normalize to lowercase for matching — the runtime resolves secrets via
+      // name.toUpperCase() against process.env, so 'ANTHROPIC_API_KEY' and
+      // 'anthropic_api_key' are the same secret at runtime. The test must match
+      // that semantics so it does not produce false positives or false negatives.
+      const declaredSecrets = new Set<string>((manifest.secrets ?? []).map(s => s.toLowerCase()));
 
       const handlerSource = fs.readFileSync(handlerPath, 'utf-8');
 
-      // Match both single-quoted and double-quoted literal string arguments:
-      //   ctx.secret('tavily_api_key')
-      //   ctx.secret("ANTHROPIC_API_KEY")
-      // Template literals and variable arguments are not checked here — use code review.
-      const pattern = /ctx\.secret\(\s*['"]([^'"]+)['"]\s*\)/g;
-      for (const match of handlerSource.matchAll(pattern)) {
-        const secretName = match[1];
+      // Check literal string arguments: ctx.secret('name') and ctx.secret("name").
+      // Case-insensitive comparison matches the runtime's toUpperCase() normalization.
+      const literalPattern = /ctx\.secret\(\s*['"]([^'"]+)['"]\s*\)/g;
+      for (const match of handlerSource.matchAll(literalPattern)) {
+        const secretName = match[1].toLowerCase();
         if (!declaredSecrets.has(secretName)) {
           violations.push(
-            `${entry.name}/handler: ctx.secret('${secretName}') is not declared in skill.json secrets array`,
+            `${entry.name}/handler: ctx.secret('${match[1]}') is not declared in skill.json secrets array`,
           );
         }
+      }
+
+      // Detect dynamic ctx.secret() calls (template literals, variable arguments) that
+      // cannot be statically verified. Emit a visible warning to stderr so CI output
+      // never silently implies full coverage when dynamic patterns are present.
+      const dynamicPattern = /ctx\.secret\(\s*(?!['"])[^)]+\)/g;
+      const dynamicMatches = [...handlerSource.matchAll(dynamicPattern)];
+      if (dynamicMatches.length > 0) {
+        process.stderr.write(
+          `[secret-manifest-coverage] WARNING: ${entry.name}/handler has ${dynamicMatches.length} ` +
+          `dynamic ctx.secret() call(s) that cannot be statically verified — manual review required:\n` +
+          dynamicMatches.map(m => `  ${m[0].trim()}`).join('\n') + '\n',
+        );
       }
     }
 


### PR DESCRIPTION
Closes #188

## Summary

- **`secret.accessed` bus event** — every `ctx.secret()` call now fires a `secret.accessed` bus event (skill name, secret name, agentId, taskEventId — never the value), flowing through the write-ahead audit logger for a durable record of all secret access
- **Pino redaction** — `createLogger()` now configures redact paths for `password`, `token`, `secret`, `api_key` at top level, one level deep (`*.field`), and two levels deep (`*.*.field`) as a last-resort safety net against accidental leakage into structured logs
- **Manifest coverage static analysis test** — new `secret-manifest-coverage.test.ts` scans every skill handler for `ctx.secret()` calls and fails CI if any accessed secret name is not declared in that skill's `skill.json`, catching both missed declarations and cross-skill secret access attempts at CI time

## Test plan

- [ ] All existing tests pass (`npm test` — 1070 tests)
- [ ] New `secret.accessed` audit event tests pass (4 cases: value not in payload, multiple calls, no-bus fallback, causal ID propagation)
- [ ] New `secret-manifest-coverage` static analysis test passes against all 40+ skills
- [ ] `ctx.secret()` with undeclared name still throws (existing test)
- [ ] Fire-and-forget audit failure logs at `error` level with full context (skillName, agentId, taskEventId)

## Files changed

- `src/bus/events.ts` — `SecretAccessedPayload`, `SecretAccessedEvent`, `createSecretAccessed` factory, union addition
- `src/bus/permissions.ts` — `secret.accessed` added to execution publish allowlist and system full access
- `src/skills/execution.ts` — fire-and-forget `bus.publish` in `ctx.secret()` closure
- `src/logger.ts` — pino `redact` config (top, `*`, `*.*` nesting)
- `tests/unit/skills/execution.test.ts` — 4 new audit event tests
- `tests/unit/skills/secret-manifest-coverage.test.ts` — new static analysis test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Secret access auditing: execution-layer audit events record secret access using identifiers only (secret values are never logged).
  * Logging hardening: automatic redaction of sensitive structured fields (password, token, secret, api_key).

* **Added**
  * New system/exec event type for secret accesses to support audit persistence.

* **Quality Assurance**
  * CI static check ensures literal secret uses are declared in each skill manifest; dynamic uses warn for review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->