### PR TITLE
feat: scheduler prior run context (fix history poisoning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,13 @@ bus event types) are noted explicitly even in the `0.x` range.
   tests verify 401 on missing/invalid token and 200 on valid token (spec 06, issue #189)
 
 ### Added
+- **Scheduler prior run context** — three new DB columns (`last_run_outcome`, `last_run_summary`, `last_run_context`) on `scheduled_jobs` give agents structured facts about prior runs without replaying raw conversation history (spec 07)
+- **`scheduler-report` skill** — agents call this at the end of a scheduled run to write a summary and optional continuity context for the next run
+- **Migration 019** — `last_run_outcome`, `last_run_summary`, `last_run_context` columns on `scheduled_jobs`
 - **`secret.accessed` bus event type** — New event type published by the `execution` layer
   (added to `src/bus/events.ts` and `src/bus/permissions.ts`). System layer can subscribe for
   monitoring; audit logger persists it write-ahead like all bus events. Payload carries
   `skillName`, `secretName`, `agentId`, and `taskEventId` — never the resolved secret value.
-- **Bus layer enforcement: `llm.call` and `human.decision` event types** — Added the two new
 - **Bus layer enforcement: `llm.call` and `human.decision` event types** — Added the two new
   event types from spec 10 (audit log hardening) to the bus: `llm.call` (published by the agent
   layer after every LLM API call; carries model provenance, token accounting, timing, and content
@@ -50,14 +52,6 @@ bus event types) are noted explicitly even in the `0.x` range.
   keepWindow, provider). Migration 018 adds the `archived` column to `working_memory`.
 - **Spec 06 security completion table** — replaced implementation checklist in `docs/specs/06-audit-and-security.md` with a Done/Not Done completion table; reconciled against open `audit`-labeled GitHub issues (13 open, 3 closed); added missing row for issue #194 (anti-injection system prompt hardening).
 - **Spec 10 audit log hardening completion table** — replaced implementation checklist in `docs/specs/10-audit-log-hardening.md` with a Done/Not Done completion table; `config.change` event type is the only completed item.
-
-### Fixed
-- **Declarative job upsert** — `ON CONFLICT ON CONSTRAINT` only works with named
-  constraints, not named indexes. Switched to column-based conflict syntax matching
-  the `scheduled_jobs_declarative_uq` partial unique index definition, fixing
-  startup failures when declarative schedule entries are present.
-
-### Added
 - **Schedule `agent_id` field** — Declarative schedule entries now support an optional
   `agent_id` field to fire the job at a different agent (e.g. the coordinator) rather
   than the agent whose YAML contains the schedule. Defaults to the source agent's name
@@ -68,6 +62,17 @@ bus event types) are noted explicitly even in the `0.x` range.
   injects a `## Original Task Intent` block into `effectiveSystemPrompt` on every burst
   for persistent tasks. Prevents multi-burst drift (spec 01). Coordinator YAML updated
   with guidance on when and how to provide `intent_anchor` to `scheduler-create`.
+
+### Fixed
+- **Scheduler history poisoning** — scheduled job runs now use a unique per-run `conversationId`, preventing working memory from loading turns from prior runs (root cause of 2026-04-09 production incident where the daily schedule job called `scheduler-create` instead of executing its task)
+- **Declarative job upsert** — `ON CONFLICT ON CONSTRAINT` only works with named
+  constraints, not named indexes. Switched to column-based conflict syntax matching
+  the `scheduled_jobs_declarative_uq` partial unique index definition, fixing
+  startup failures when declarative schedule entries are present.
+
+### Changed
+- **`completeJobRun`** — now writes `last_run_outcome = 'completed'` or `'failed'` on completion
+- **`recoverStuckJob`** — now writes `last_run_outcome = 'timed_out'` on recovery
 
 ---
 

--- a/docs/specs/07-scheduler.md
+++ b/docs/specs/07-scheduler.md
@@ -30,7 +30,12 @@ CREATE TABLE scheduled_jobs (
   consecutive_failures  INTEGER NOT NULL DEFAULT 0,
   created_by    TEXT NOT NULL,
   created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
-  timezone      TEXT NOT NULL DEFAULT 'UTC'
+  timezone      TEXT NOT NULL DEFAULT 'UTC',
+
+  -- Prior run context (see Prior Run Context section below)
+  last_run_outcome  TEXT CHECK (last_run_outcome IN ('completed', 'failed', 'timed_out')),
+  last_run_summary  TEXT,
+  last_run_context  JSONB
 );
 
 CHECK (cron_expr IS NOT NULL OR run_at IS NOT NULL)
@@ -120,6 +125,39 @@ The agent doesn't stay running between bursts. State lives entirely in Postgres.
 
 ---
 
+## Prior Run Context
+
+Scheduled jobs should receive **memory** (stable facts the next run needs), not **history** (the raw turn sequence from a prior execution). Raw history carries execution state — if a prior run died mid-loop, replaying those turns causes the next run to continue the bad loop rather than execute the task fresh.
+
+### No conversation history on scheduled job runs
+
+When the scheduler fires a job, the emitted `agent.task` event carries no conversation history. The agent always starts from zero turns. This is distinct from interactive agent tasks, which do carry conversation context.
+
+### How prior-run context is injected
+
+If the job has prior-run data (`last_run_outcome IS NOT NULL`), the scheduler injects a structured system message as the first content of the new execution — before the task payload, alongside the agent's persona and date/timezone context:
+
+```
+[Prior run context — 2026-04-08 07:30 ET]
+Outcome: completed
+Summary: Sent schedule for 6 events to joseph@josephfung.ca
+Agent context: {"events_sent": 6}
+```
+
+If the job has never run, no prior-run block is injected.
+
+### What gets written and by whom
+
+| Field | Written by | When |
+|---|---|---|
+| `last_run_outcome` | Scheduler | On `completeJobRun()` success/failure; stuck-job recovery writes `timed_out` |
+| `last_run_summary` | Agent (via `scheduler-report` skill) | At the end of a successful run |
+| `last_run_context` | Agent (via `scheduler-report` skill) | At the end of a successful run |
+
+Agents are not required to call `scheduler-report`. Stateless jobs (e.g. a daily email that simply reads the calendar and sends) can skip it — `last_run_context` stays `NULL` and the next run starts with only the outcome/summary from the scheduler.
+
+---
+
 ## Creating Scheduled Jobs
 
 ### From Agent Config (declarative)
@@ -153,6 +191,17 @@ Users can manage jobs directly:
 - `GET /api/jobs` — list all jobs
 - `PATCH /api/jobs/:id` — update (e.g., unsuspend)
 - `DELETE /api/jobs/:id` — cancel
+
+---
+
+## Skills
+
+Four skills available to agents:
+
+- **`scheduler-create`** — create a cron or one-shot job, optionally with a linked persistent task (`intent_anchor`)
+- **`scheduler-list`** — list jobs with optional status/agent_id filters
+- **`scheduler-cancel`** — cancel a job by ID
+- **`scheduler-report`** — write prior-run context at the end of a run. Input: `{ job_id, summary, context? }`. Action risk: `none`. The scheduler writes `last_run_outcome` itself; this skill writes `last_run_summary` and `last_run_context`.
 
 ---
 

--- a/docs/wip/2026-04-09-scheduler-prior-run-context-design.md
+++ b/docs/wip/2026-04-09-scheduler-prior-run-context-design.md
@@ -1,0 +1,180 @@
+# Scheduler: Prior Run Context
+
+**Date:** 2026-04-09  
+**Status:** Draft  
+**Related spec:** [07-scheduler.md](../../specs/07-scheduler.md)  
+**Motivated by:** Production incident where the daily schedule summary job failed because stale conversation history from a prior run caused the agent to attempt `scheduler-create` instead of executing the task.
+
+---
+
+## Problem
+
+When the scheduler fires a job, it currently passes raw conversation history from prior runs into the new agent execution context. This means the agent doesn't start fresh — it starts mid-loop, continuing whatever reasoning chain was in progress during the last run.
+
+This is wrong for two reasons:
+
+1. **Raw history carries execution state, not just knowledge.** A prior run that died while attempting a self-registration loop will cause the next run to continue that loop, not execute the scheduled task.
+2. **The agent has no way to distinguish "history from a prior run" from "current context."** It reads the turns as if it is already mid-task.
+
+The correct mental model: scheduled jobs should receive **memory** (stable facts the next run genuinely needs), not **history** (the raw turn sequence from a previous execution).
+
+This is complementary to intent anchoring. Intent anchoring prevents drift *within* a run. Prior run context prevents corrupt starting conditions *across* runs. Without both, an agent can know what it's supposed to do but still go wrong because it started from a bad state.
+
+---
+
+## Design
+
+### New columns on `scheduled_jobs`
+
+Three new columns, added via a single migration:
+
+```sql
+ALTER TABLE scheduled_jobs
+  ADD COLUMN last_run_outcome     TEXT,
+  ADD COLUMN last_run_summary     TEXT,
+  ADD COLUMN last_run_context     JSONB;
+```
+
+**`last_run_outcome`** — enum-like text: `completed`, `failed`, `timed_out`. Written by the scheduler on job completion (success or failure) and by the stuck-job recovery sweep (writes `timed_out`). Queryable — the scheduler can filter or alert on outcome patterns. `NULL` means the job has never completed a run.
+
+**`last_run_summary`** — free-text written by the *agent* at the end of its run. A human-readable one-sentence description of what it did: "Sent schedule for 6 events to joseph@josephfung.ca" or "No events found for today — nothing sent." This is what a human would want to see in an audit log or job status display.
+
+**`last_run_context`** — JSONB blob written by the *agent* and read only by the *agent*. Opaque to the scheduler. Used for job-specific continuity state: cursors, watermarks, last-processed IDs, preferences learned from prior runs. The scheduler does not interpret this field — it just passes it through. The field is **overwritten** each run; it does not accumulate.
+
+### The rule: columns vs. JSON
+
+> If the scheduler needs to act on it → column.  
+> If only the agent needs to read it → JSON blob.
+
+`last_run_outcome` is a column because the scheduler may eventually alert, suppress, or vary retry behaviour based on it. `last_run_summary` is a column because it is surfaced in the health endpoint and API responses. `last_run_context` is JSONB because each job type needs different fields and the scheduler never queries inside it.
+
+---
+
+## How agents write prior-run context
+
+Agents emit structured completion metadata via a new `scheduler-report` skill.
+
+```typescript
+// skill input
+interface SchedulerReportInput {
+  job_id: string;
+  summary: string;                      // one sentence, human-readable
+  context?: Record<string, unknown>;    // opaque — only the agent reads this next run
+}
+```
+
+The skill writes `last_run_summary` and `last_run_context` on the `scheduled_jobs` row. `last_run_outcome` is always written by the scheduler itself — the agent doesn't set it.
+
+Agents are not required to call this skill. If they don't:
+- `last_run_summary` stays `NULL` — the job ran but left no summary
+- `last_run_context` stays `NULL` — the next run starts with no agent-level context (fine for stateless jobs like the daily schedule email)
+
+---
+
+## How context is injected at the start of the next run
+
+When the scheduler fires a job and the job has prior-run data, it injects a structured system message as the **first content** of the new execution context — before the task payload, before any conversation history.
+
+```
+[Prior run context — 2026-04-08 07:30 ET]
+Outcome: completed
+Summary: Sent schedule for 6 events to joseph@josephfung.ca
+Agent context: {"events_sent": 6}
+```
+
+If the job has never run (`last_run_outcome IS NULL`), no prior-run block is injected — the agent starts completely fresh.
+
+This is **not** conversation history. It is injected as a system-level context block, the same way the agent's persona, date/timezone, and autonomy score are injected. The agent reads it as stable facts about the world ("here's what happened last time"), not as a continuation of a prior conversation.
+
+For persistent multi-burst tasks (using `agent_tasks`), the agent receives all of:
+1. Prior-run context block (from `scheduled_jobs`)
+2. Intent anchor (from `agent_tasks.intent_anchor`)
+3. Current progress (from `agent_tasks.progress`)
+4. Task payload
+
+---
+
+## Stopping raw history replay
+
+The root cause of the production incident was `historyLength: 6` being passed into a fresh job run. The scheduler must stop passing raw conversation history when constructing the `agent.task` event for a scheduled job.
+
+**Scheduled job executions always start with zero conversation history.** No prior turns are replayed. The only prior-run data the agent receives is the structured prior-run context block described above.
+
+This is a targeted change to how `agent.task` events are constructed inside the scheduler loop — not a change to how interactive agent tasks work.
+
+---
+
+## Data model changes summary
+
+### Migration (new file: `0XX_scheduler_prior_run_context.sql`)
+
+```sql
+ALTER TABLE scheduled_jobs
+  ADD COLUMN last_run_outcome     TEXT
+    CHECK (last_run_outcome IN ('completed', 'failed', 'timed_out')),
+  ADD COLUMN last_run_summary     TEXT,
+  ADD COLUMN last_run_context     JSONB;
+```
+
+No backfill needed. All three columns default to `NULL` for existing rows.
+
+### Updates to `SchedulerService.completeJobRun()`
+
+- Success path writes `last_run_outcome = 'completed'`
+- Failure path writes `last_run_outcome = 'failed'`
+
+### Updates to stuck-job recovery (`recoverStuckJobs()`)
+
+- Recovered jobs write `last_run_outcome = 'timed_out'` (alongside existing `last_error` write)
+
+### New `scheduler-report` skill
+
+- **Input:** `{ job_id, summary, context? }`
+- **Action risk:** `none` (writes internal state only, no external effect)
+- Validates that `job_id` belongs to a job associated with the calling agent
+- Writes `last_run_summary` and `last_run_context` on the row
+- Returns `{ success: true }`
+
+---
+
+## Spec updates required
+
+`docs/specs/07-scheduler.md` needs:
+1. New columns added to the Job Model schema block
+2. A new section "Prior Run Context" describing the injection mechanism and the no-history-replay rule
+3. The `scheduler-report` skill listed in the Skills section
+4. Note that scheduled jobs fire with no conversation history
+
+---
+
+## Testing
+
+**Unit: `completeJobRun()`**
+- Success path writes `last_run_outcome = 'completed'`
+- Failure path writes `last_run_outcome = 'failed'`
+- Neither path touches `last_run_summary` or `last_run_context` (agent-only fields)
+
+**Unit: `recoverStuckJobs()`**
+- Recovered jobs write `last_run_outcome = 'timed_out'`
+
+**Unit: `scheduler-report` skill**
+- Writes `last_run_summary` and `last_run_context` on the correct row
+- Rejects a `job_id` that doesn't belong to the calling agent
+- `context` field is optional — omitting it does not clear existing context
+
+**Unit: scheduler loop — context injection**
+- Job with `last_run_outcome = NULL`: no prior-run block in emitted `agent.task`
+- Job with prior-run data: structured prior-run context block injected as first system message
+- Emitted `agent.task` always has empty conversation history for scheduled jobs
+
+**Integration: end-to-end**
+- Fire job → agent calls `scheduler-report` → verify columns written
+- Fire same job again → verify prior-run context block appears in agent's first turn
+- Verify no raw conversation history is present in the injected context
+
+---
+
+## Out of scope
+
+- UI display of `last_run_summary` in the web app — tracked in josephfung/curia#241
+- Expiry of `last_run_context` — the field is overwritten each run, not accumulated; if an agent writes an excessively large blob that becomes a concern, a size check in the skill handler is the right fix

--- a/docs/wip/2026-04-09-scheduler-prior-run-context.md
+++ b/docs/wip/2026-04-09-scheduler-prior-run-context.md
@@ -1,0 +1,893 @@
+# Scheduler Prior Run Context Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the production incident where scheduled jobs replay stale conversation history across runs, and add structured prior-run context so agents can start each run with the right information.
+
+**Architecture:** Two interlinked fixes. (1) Change the `conversationId` in `fireJob()` to be unique per run so working memory never loads turns from a prior run. (2) Add three new DB columns (`last_run_outcome`, `last_run_summary`, `last_run_context`) so prior-run facts can be distilled and re-injected cleanly. A new `scheduler-report` skill lets agents write their summary and context at the end of each run.
+
+**Tech Stack:** PostgreSQL (node-postgres), TypeScript/ESM, Vitest, existing `SchedulerService` + `Scheduler` pattern
+
+**Worktree:** `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context`
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|---|---|---|
+| Create | `src/db/migrations/019_scheduler_prior_run_context.sql` | 3 new columns on `scheduled_jobs` |
+| Modify | `src/scheduler/scheduler-service.ts` | `DbJobRow`, `JobRow`, `mapJobRow`, `completeJobRun`, `recoverStuckJob` |
+| Modify | `src/scheduler/scheduler.ts` | `fireJob` — unique per-run conversationId + prior-run context injection |
+| Create | `skills/scheduler-report/skill.json` | New skill manifest |
+| Create | `skills/scheduler-report/handler.ts` | New skill handler |
+| Modify | `tests/unit/scheduler/scheduler-service.test.ts` | Tests for new `last_run_outcome` writes |
+| Modify | `tests/unit/scheduler/scheduler.test.ts` | Tests for prior-run injection + unique conversationId |
+| Create | `tests/unit/skills/scheduler-report.test.ts` | Full skill handler test suite |
+
+---
+
+## Task 1: Migration
+
+**Files:**
+- Create: `src/db/migrations/019_scheduler_prior_run_context.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+```sql
+-- 019_scheduler_prior_run_context.sql
+--
+-- Adds three columns to support structured prior-run context for scheduled jobs.
+-- last_run_outcome: written by the scheduler on completion/timeout (queryable).
+-- last_run_summary: agent-written human-readable summary of what the job did.
+-- last_run_context: agent-written opaque JSONB for job-specific continuity state.
+--
+-- All three default to NULL — no backfill needed. The no-history-replay fix
+-- (unique per-run conversationId) is a code-only change; no schema change required.
+
+ALTER TABLE scheduled_jobs
+  ADD COLUMN last_run_outcome TEXT
+    CHECK (last_run_outcome IN ('completed', 'failed', 'timed_out')),
+  ADD COLUMN last_run_summary TEXT,
+  ADD COLUMN last_run_context JSONB;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  add src/db/migrations/019_scheduler_prior_run_context.sql
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  commit -m "chore: add migration 019 — scheduler prior run context columns"
+```
+
+---
+
+## Task 2: Types — `DbJobRow`, `JobRow`, `mapJobRow`
+
+**Files:**
+- Modify: `src/scheduler/scheduler-service.ts`
+
+- [ ] **Step 1: Add new fields to `DbJobRow` (internal snake_case)**
+
+In `scheduler-service.ts`, find the `DbJobRow` interface (around line 58). Add three fields after `expected_duration_seconds`:
+
+```typescript
+  last_run_outcome: string | null;   // 'completed' | 'failed' | 'timed_out' | null
+  last_run_summary: string | null;   // agent-written summary; null until first scheduler-report call
+  last_run_context: Record<string, unknown> | null; // opaque agent context; null until first scheduler-report call
+```
+
+- [ ] **Step 2: Add new fields to `JobRow` (public camelCase)**
+
+Find the `JobRow` interface (around line 28). Add after `expectedDurationSeconds`:
+
+```typescript
+  lastRunOutcome: string | null;
+  lastRunSummary: string | null;
+  lastRunContext: Record<string, unknown> | null;
+```
+
+- [ ] **Step 3: Update `mapJobRow` to include new fields**
+
+Find the `mapJobRow` function at the bottom of the file. Add after `expectedDurationSeconds`:
+
+```typescript
+    lastRunOutcome: row.last_run_outcome,
+    lastRunSummary: row.last_run_summary,
+    lastRunContext: row.last_run_context,
+```
+
+- [ ] **Step 4: Run the tests to verify no regressions**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  test -- tests/unit/scheduler/scheduler-service.test.ts
+```
+
+Expected: all existing tests pass (the new fields are nullable and existing test data doesn't include them).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  add src/scheduler/scheduler-service.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  commit -m "feat: add lastRunOutcome/Summary/Context fields to JobRow types"
+```
+
+---
+
+## Task 3: `completeJobRun()` — write `last_run_outcome`
+
+**Files:**
+- Modify: `src/scheduler/scheduler-service.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/unit/scheduler/scheduler-service.test.ts`, find the `completeJobRun` describe block and add:
+
+```typescript
+it('writes last_run_outcome = completed on success (recurring)', async () => {
+  const jobId = 'job-complete-success';
+  // First query: fetchSql — returns a recurring job
+  pool.query.mockResolvedValueOnce({
+    rows: [{ id: jobId, cron_expr: '0 9 * * *', status: 'running', consecutive_failures: 0, timezone: 'UTC' }],
+  });
+  // Second query: updateSql
+  pool.query.mockResolvedValueOnce({ rows: [] });
+
+  await svc.completeJobRun(jobId, true);
+
+  const updateCall = pool.query.mock.calls[1];
+  const sql: string = updateCall[0];
+  const params: unknown[] = updateCall[1];
+  expect(sql).toContain('last_run_outcome');
+  expect(params).toContain('completed');
+});
+
+it('writes last_run_outcome = completed on success (one-shot)', async () => {
+  const jobId = 'job-complete-oneshot';
+  pool.query.mockResolvedValueOnce({
+    rows: [{ id: jobId, cron_expr: null, status: 'running', consecutive_failures: 0, timezone: 'UTC' }],
+  });
+  pool.query.mockResolvedValueOnce({ rows: [] });
+
+  await svc.completeJobRun(jobId, true);
+
+  const updateCall = pool.query.mock.calls[1];
+  const sql: string = updateCall[0];
+  const params: unknown[] = updateCall[1];
+  expect(sql).toContain('last_run_outcome');
+  expect(params).toContain('completed');
+});
+
+it('writes last_run_outcome = failed on failure', async () => {
+  const jobId = 'job-complete-fail';
+  pool.query.mockResolvedValueOnce({
+    rows: [{ id: jobId, cron_expr: '0 9 * * *', status: 'running', consecutive_failures: 0, timezone: 'UTC' }],
+  });
+  pool.query.mockResolvedValueOnce({ rows: [] });
+
+  await svc.completeJobRun(jobId, false, 'something went wrong');
+
+  const updateCall = pool.query.mock.calls[1];
+  const sql: string = updateCall[0];
+  const params: unknown[] = updateCall[1];
+  expect(sql).toContain('last_run_outcome');
+  expect(params).toContain('failed');
+});
+
+it('does not overwrite last_run_summary or last_run_context in completeJobRun', async () => {
+  const jobId = 'job-no-overwrite';
+  pool.query.mockResolvedValueOnce({
+    rows: [{ id: jobId, cron_expr: null, status: 'running', consecutive_failures: 0, timezone: 'UTC' }],
+  });
+  pool.query.mockResolvedValueOnce({ rows: [] });
+
+  await svc.completeJobRun(jobId, true);
+
+  const updateCall = pool.query.mock.calls[1];
+  const sql: string = updateCall[0];
+  expect(sql).not.toContain('last_run_summary');
+  expect(sql).not.toContain('last_run_context');
+});
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  test -- tests/unit/scheduler/scheduler-service.test.ts
+```
+
+Expected: the 4 new tests FAIL.
+
+- [ ] **Step 3: Update `completeJobRun` success path (recurring)**
+
+In the recurring job success branch (around line 445), change the SQL to include `last_run_outcome`:
+
+```typescript
+const updateSql = `
+  UPDATE scheduled_jobs
+     SET last_run_at = now(),
+         next_run_at = $1,
+         consecutive_failures = 0,
+         last_error = NULL,
+         run_started_at = NULL,
+         status = $2,
+         last_run_outcome = $4
+   WHERE id = $3
+`;
+await this.pool.query(updateSql, [nextRunAt, 'pending', jobId, 'completed']);
+```
+
+- [ ] **Step 4: Update `completeJobRun` success path (one-shot)**
+
+In the one-shot success branch, change:
+
+```typescript
+const updateSql = `
+  UPDATE scheduled_jobs
+     SET last_run_at = now(),
+         status = $1,
+         consecutive_failures = 0,
+         last_error = NULL,
+         run_started_at = NULL,
+         last_run_outcome = $3
+   WHERE id = $2
+`;
+await this.pool.query(updateSql, ['completed', jobId, 'completed']);
+```
+
+- [ ] **Step 5: Update `completeJobRun` failure path**
+
+In the failure branch (around line 482), change:
+
+```typescript
+const updateSql = `
+  UPDATE scheduled_jobs
+     SET last_run_at = now(),
+         consecutive_failures = $1,
+         last_error = $2,
+         run_started_at = NULL,
+         status = $3,
+         last_run_outcome = $5
+   WHERE id = $4
+`;
+await this.pool.query(updateSql, [newFailures, error ?? null, newStatus, jobId, 'failed']);
+```
+
+- [ ] **Step 6: Run tests — should pass now**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  test -- tests/unit/scheduler/scheduler-service.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  add src/scheduler/scheduler-service.ts tests/unit/scheduler/scheduler-service.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  commit -m "feat: write last_run_outcome in completeJobRun"
+```
+
+---
+
+## Task 4: `recoverStuckJob()` — write `last_run_outcome = 'timed_out'`
+
+**Files:**
+- Modify: `src/scheduler/scheduler-service.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/unit/scheduler/scheduler-service.test.ts`, find the `recoverStuckJob` describe block and add:
+
+```typescript
+it('writes last_run_outcome = timed_out on recovery', async () => {
+  const jobId = 'job-stuck';
+  pool.query
+    .mockResolvedValueOnce({
+      rows: [{ id: jobId, cron_expr: null, run_at: null, consecutive_failures: 0, timezone: 'UTC' }],
+    })
+    .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+  await svc.recoverStuckJob(jobId, 600);
+
+  const updateCall = pool.query.mock.calls[1];
+  const sql: string = updateCall[0];
+  const params: unknown[] = updateCall[1];
+  expect(sql).toContain('last_run_outcome');
+  expect(params).toContain('timed_out');
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  test -- tests/unit/scheduler/scheduler-service.test.ts
+```
+
+Expected: new test FAILS.
+
+- [ ] **Step 3: Update `recoverStuckJob` SQL**
+
+In `recoverStuckJob` (around line 545), change the UPDATE to include `last_run_outcome`:
+
+```typescript
+const result = await this.pool.query(
+  `UPDATE scheduled_jobs
+      SET status = $1,
+          consecutive_failures = $2,
+          last_error = $3,
+          run_started_at = NULL,
+          next_run_at = $4,
+          last_run_outcome = $6
+    WHERE id = $5
+      AND status = 'running'`,
+  [newStatus, newFailures, lastError, nextRunAt, jobId, 'timed_out'],
+);
+```
+
+- [ ] **Step 4: Run tests — should pass**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  test -- tests/unit/scheduler/scheduler-service.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  add src/scheduler/scheduler-service.ts tests/unit/scheduler/scheduler-service.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  commit -m "feat: write last_run_outcome = timed_out in recoverStuckJob"
+```
+
+---
+
+## Task 5: `fireJob()` — unique per-run conversationId + prior-run context injection
+
+**Files:**
+- Modify: `src/scheduler/scheduler.ts`
+
+The root cause of the production incident: `fireJob()` always uses `conversationId: \`scheduler:${job.id}\``. Working memory loads history keyed on that ID, so stale turns from prior runs are replayed into the new run.
+
+Fix: use `scheduler:<job-id>:<taskEventId>`. Each run gets a unique conversation ID, so working memory returns no history.
+
+Additionally: when the job has `lastRunOutcome` set, prepend a prior-run context block to the `content` so the agent has structured facts about the last run without raw history.
+
+**Note:** `JobRow` needs `lastRunOutcome`, `lastRunSummary`, `lastRunContext` available in `fireJob()`. The `pollDueJobs` query already does `SELECT sj.*` so new columns are included automatically — but the `JobRow` mapping in `pollDueJobs` (around line 152) must be updated to include the new fields.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/unit/scheduler/scheduler.test.ts`, find the `fireJob` / `pollDueJobs` tests and add:
+
+```typescript
+it('uses a unique conversationId per run (not job ID)', async () => {
+  const jobId = 'job-unique-conv';
+  const firedEvent = { id: 'fired-evt-1' };
+  const taskEvent = { id: 'task-evt-1' };
+
+  pool.query
+    .mockResolvedValueOnce({
+      rows: [{
+        id: jobId, agent_id: 'coordinator', cron_expr: '0 9 * * *',
+        run_at: null, task_payload: { task: 'do work' }, status: 'pending',
+        last_run_at: null, next_run_at: new Date(), last_error: null,
+        consecutive_failures: 0, created_by: 'system', created_at: new Date(),
+        timezone: 'UTC', agent_task_id: null, intent_anchor: null, progress: null,
+        run_started_at: null, expected_duration_seconds: null,
+        last_run_outcome: null, last_run_summary: null, last_run_context: null,
+      }],
+    })
+    .mockResolvedValueOnce({ rowCount: 1 }); // claim update
+
+  bus.publish.mockResolvedValue(undefined);
+  bus.publish.mockImplementation((_layer: unknown, event: { id: string; type: string }) => {
+    if (event.type === 'schedule.fired') Object.assign(firedEvent, event);
+    if (event.type === 'agent.task') Object.assign(taskEvent, event);
+    return Promise.resolve();
+  });
+
+  await scheduler.pollDueJobs();
+
+  // The conversationId must NOT be just `scheduler:<jobId>`
+  const taskPayload = (taskEvent as { payload?: { conversationId?: string } }).payload;
+  expect(taskPayload?.conversationId).not.toBe(`scheduler:${jobId}`);
+  expect(taskPayload?.conversationId).toMatch(new RegExp(`^scheduler:${jobId}:`));
+});
+
+it('injects prior-run context block when last_run_outcome is set', async () => {
+  const jobId = 'job-prior-run';
+  const taskEvent = { payload: { content: '' } };
+
+  pool.query
+    .mockResolvedValueOnce({
+      rows: [{
+        id: jobId, agent_id: 'coordinator', cron_expr: '0 9 * * *',
+        run_at: null, task_payload: { task: 'do work' }, status: 'pending',
+        last_run_at: new Date('2026-04-08T11:30:00Z'), next_run_at: new Date(),
+        last_error: null, consecutive_failures: 0, created_by: 'system',
+        created_at: new Date(), timezone: 'America/Toronto',
+        agent_task_id: null, intent_anchor: null, progress: null,
+        run_started_at: null, expected_duration_seconds: null,
+        last_run_outcome: 'completed',
+        last_run_summary: 'Sent schedule for 6 events to joseph@josephfung.ca',
+        last_run_context: { events_sent: 6 },
+      }],
+    })
+    .mockResolvedValueOnce({ rowCount: 1 });
+
+  bus.publish.mockImplementation((_layer: unknown, event: { type: string; payload?: unknown }) => {
+    if (event.type === 'agent.task') Object.assign(taskEvent, event);
+    return Promise.resolve();
+  });
+
+  await scheduler.pollDueJobs();
+
+  const content: string = (taskEvent as { payload: { content: string } }).payload.content;
+  expect(content).toContain('[Prior run context');
+  expect(content).toContain('completed');
+  expect(content).toContain('Sent schedule for 6 events');
+  expect(content).toContain('"events_sent": 6');
+});
+
+it('does not inject prior-run block when last_run_outcome is null (first run)', async () => {
+  const jobId = 'job-first-run';
+  const taskEvent = { payload: { content: '' } };
+
+  pool.query
+    .mockResolvedValueOnce({
+      rows: [{
+        id: jobId, agent_id: 'coordinator', cron_expr: '0 9 * * *',
+        run_at: null, task_payload: { task: 'do work' }, status: 'pending',
+        last_run_at: null, next_run_at: new Date(), last_error: null,
+        consecutive_failures: 0, created_by: 'system', created_at: new Date(),
+        timezone: 'UTC', agent_task_id: null, intent_anchor: null, progress: null,
+        run_started_at: null, expected_duration_seconds: null,
+        last_run_outcome: null, last_run_summary: null, last_run_context: null,
+      }],
+    })
+    .mockResolvedValueOnce({ rowCount: 1 });
+
+  bus.publish.mockImplementation((_layer: unknown, event: { type: string; payload?: unknown }) => {
+    if (event.type === 'agent.task') Object.assign(taskEvent, event);
+    return Promise.resolve();
+  });
+
+  await scheduler.pollDueJobs();
+
+  const content: string = (taskEvent as { payload: { content: string } }).payload.content;
+  expect(content).not.toContain('[Prior run context');
+});
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  test -- tests/unit/scheduler/scheduler.test.ts
+```
+
+Expected: the 3 new tests FAIL.
+
+- [ ] **Step 3: Update `pollDueJobs` row mapping to include new fields**
+
+In `pollDueJobs` (around line 152), add new fields to the `JobRow` mapping:
+
+```typescript
+const job: JobRow = {
+  // ... existing fields ...
+  runStartedAt: row.run_started_at ?? null,
+  expectedDurationSeconds: row.expected_duration_seconds ?? null,
+  // New prior-run context fields
+  lastRunOutcome: row.last_run_outcome ?? null,
+  lastRunSummary: row.last_run_summary ?? null,
+  lastRunContext: row.last_run_context ?? null,
+};
+```
+
+- [ ] **Step 4: Update `fireJob()` — unique conversationId**
+
+In `fireJob()`, find the `createAgentTask` call (around line 237). Change the `conversationId` to include the task event ID for uniqueness:
+
+```typescript
+// Build the task event first so we can use its ID in the conversationId.
+// Using a per-run conversationId (not just job ID) prevents working memory from
+// loading turns from prior runs — each run starts with zero history.
+const taskEvent = createAgentTask({
+  agentId: job.agentId,
+  // Include a unique suffix so working memory never loads history from a prior run.
+  // Format: scheduler:<jobId>:<taskEventId>
+  conversationId: `scheduler:${job.id}:${/* taskEvent.id not available yet — use randomUUID */}`,
+  // ...
+});
+```
+
+Wait — `createAgentTask` generates the event ID internally, so we can't reference it before calling the function. Use `randomUUID()` for the run suffix instead:
+
+```typescript
+import { randomUUID } from 'crypto';
+
+// In fireJob():
+
+// Unique per-run conversationId prevents working memory from replaying
+// turns from prior runs. Format: scheduler:<jobId>:<runId>
+const runId = randomUUID();
+const conversationId = `scheduler:${job.id}:${runId}`;
+```
+
+Then use `conversationId` in the `createAgentTask` call.
+
+- [ ] **Step 5: Update `fireJob()` — prior-run context injection**
+
+Add a helper to build the prior-run block, then prepend it to `content`:
+
+```typescript
+/**
+ * Build a structured prior-run context block from the job's last-run fields.
+ * Returns null if the job has never run (lastRunOutcome is null).
+ * Injected as a prefix to the task content so the agent sees it before the task.
+ */
+function buildPriorRunBlock(job: JobRow): string | null {
+  if (!job.lastRunOutcome) return null;
+
+  const lastRunAt = job.lastRunAt
+    ? new Date(job.lastRunAt).toLocaleString('en-CA', { timeZone: job.timezone, dateStyle: 'short', timeStyle: 'short' })
+    : 'unknown';
+
+  const lines = [
+    `[Prior run context — ${lastRunAt}]`,
+    `Outcome: ${job.lastRunOutcome}`,
+  ];
+
+  if (job.lastRunSummary) {
+    lines.push(`Summary: ${job.lastRunSummary}`);
+  }
+
+  if (job.lastRunContext) {
+    lines.push(`Agent context: ${JSON.stringify(job.lastRunContext, null, 2)}`);
+  }
+
+  return lines.join('\n');
+}
+```
+
+Then in `fireJob()`, prepend the block to `content`:
+
+```typescript
+// Inject prior-run context block before task content if the job has run before.
+// This gives the agent stable facts about the last run without replaying raw history.
+const priorRunBlock = buildPriorRunBlock(job);
+if (priorRunBlock) {
+  content = priorRunBlock + '\n\n---\n\n' + content;
+}
+```
+
+- [ ] **Step 6: Run tests — should pass**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  test -- tests/unit/scheduler/scheduler.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  add src/scheduler/scheduler.ts tests/unit/scheduler/scheduler.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  commit -m "feat: unique per-run conversationId and prior-run context injection in fireJob"
+```
+
+---
+
+## Task 6: New `scheduler-report` skill
+
+**Files:**
+- Create: `skills/scheduler-report/skill.json`
+- Create: `skills/scheduler-report/handler.ts`
+- Create: `tests/unit/skills/scheduler-report.test.ts`
+
+This skill lets agents write `last_run_summary` and `last_run_context` on the job row at the end of a run. The scheduler always writes `last_run_outcome` itself; this skill handles the agent-owned fields.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/skills/scheduler-report.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { SchedulerReportHandler } from '../../../skills/scheduler-report/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(
+  input: Record<string, unknown>,
+  overrides?: Partial<SkillContext>,
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    ...overrides,
+  };
+}
+
+describe('SchedulerReportHandler', () => {
+  const handler = new SchedulerReportHandler();
+
+  it('returns failure when schedulerService is not available', async () => {
+    const result = await handler.execute(makeCtx({ job_id: 'job-1', summary: 'done' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('schedulerService');
+  });
+
+  it('returns failure when job_id is missing', async () => {
+    const schedulerService = { reportJobRun: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      { summary: 'done' },
+      { schedulerService: schedulerService as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('job_id');
+  });
+
+  it('returns failure when summary is missing', async () => {
+    const schedulerService = { reportJobRun: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-1' },
+      { schedulerService: schedulerService as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('summary');
+  });
+
+  it('calls reportJobRun with summary and no context when context is omitted', async () => {
+    const schedulerService = { reportJobRun: vi.fn().mockResolvedValue(undefined) };
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-1', summary: 'Sent 6 events' },
+      { schedulerService: schedulerService as never },
+    ));
+    expect(result.success).toBe(true);
+    expect(schedulerService.reportJobRun).toHaveBeenCalledWith('job-1', 'Sent 6 events', undefined);
+  });
+
+  it('calls reportJobRun with summary and context', async () => {
+    const schedulerService = { reportJobRun: vi.fn().mockResolvedValue(undefined) };
+    const ctx = { events_sent: 6 };
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-1', summary: 'Sent 6 events', context: ctx },
+      { schedulerService: schedulerService as never },
+    ));
+    expect(result.success).toBe(true);
+    expect(schedulerService.reportJobRun).toHaveBeenCalledWith('job-1', 'Sent 6 events', ctx);
+  });
+
+  it('returns failure when reportJobRun throws', async () => {
+    const schedulerService = {
+      reportJobRun: vi.fn().mockRejectedValue(new Error('job not found')),
+    };
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-1', summary: 'Sent 6 events' },
+      { schedulerService: schedulerService as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('job not found');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failures (file doesn't exist yet)**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  test -- tests/unit/skills/scheduler-report.test.ts
+```
+
+Expected: import errors / test failures.
+
+- [ ] **Step 3: Create `skills/scheduler-report/skill.json`**
+
+```json
+{
+  "name": "scheduler-report",
+  "description": "Write a summary and optional context for the current scheduled job run. Call this at the end of a successful scheduled task to record what was done and carry forward any state the next run needs.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "infrastructure": true,
+  "inputs": {
+    "job_id": "string",
+    "summary": "string (one sentence describing what was done this run)",
+    "context": "object? (optional — job-specific state for the next run, e.g. cursors, counts)"
+  },
+  "outputs": { "success": "boolean" },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000
+}
+```
+
+- [ ] **Step 4: Create `skills/scheduler-report/handler.ts`**
+
+```typescript
+// handler.ts — scheduler-report skill implementation.
+//
+// Writes last_run_summary and last_run_context on the scheduled_jobs row at the
+// end of a run. The scheduler writes last_run_outcome itself; this skill handles
+// the agent-owned fields so agents can carry forward job-specific continuity state.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class SchedulerReportHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.schedulerService) {
+      return {
+        success: false,
+        error: 'scheduler-report requires schedulerService in context. Is infrastructure: true set in the manifest?',
+      };
+    }
+
+    const { job_id, summary, context } = ctx.input as {
+      job_id?: string;
+      summary?: string;
+      context?: Record<string, unknown>;
+    };
+
+    if (!job_id || typeof job_id !== 'string') {
+      return { success: false, error: 'Missing required input: job_id (string)' };
+    }
+    if (!summary || typeof summary !== 'string') {
+      return { success: false, error: 'Missing required input: summary (string)' };
+    }
+
+    try {
+      await ctx.schedulerService.reportJobRun(job_id, summary, context);
+      ctx.log.info({ jobId: job_id }, 'scheduler-report written');
+      return { success: true, data: { success: true } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'scheduler-report failed');
+      return { success: false, error: message };
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Add `reportJobRun` to `SchedulerService`**
+
+In `src/scheduler/scheduler-service.ts`, add this method after `completeJobRun`:
+
+```typescript
+/**
+ * Write agent-owned prior-run context fields on the job row.
+ * Called by the scheduler-report skill at the end of a successful run.
+ * last_run_outcome is written by the scheduler itself — this only touches
+ * the agent-controlled fields (summary and opaque context blob).
+ */
+async reportJobRun(
+  jobId: string,
+  summary: string,
+  context?: Record<string, unknown>,
+): Promise<void> {
+  if (context !== undefined) {
+    await this.pool.query(
+      `UPDATE scheduled_jobs
+          SET last_run_summary = $1,
+              last_run_context = $2
+        WHERE id = $3`,
+      [summary, JSON.stringify(context), jobId],
+    );
+  } else {
+    await this.pool.query(
+      `UPDATE scheduled_jobs
+          SET last_run_summary = $1
+        WHERE id = $2`,
+      [summary, jobId],
+    );
+  }
+  this.logger.info({ jobId }, 'scheduler-report written');
+}
+```
+
+- [ ] **Step 6: Run tests — should pass**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  test -- tests/unit/skills/scheduler-report.test.ts
+```
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  add skills/scheduler-report/ src/scheduler/scheduler-service.ts tests/unit/skills/scheduler-report.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  commit -m "feat: add scheduler-report skill and reportJobRun service method"
+```
+
+---
+
+## Task 7: Full test run + CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context test
+```
+
+Expected: all tests PASS with no failures.
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Added
+- **Scheduler prior run context** — three new DB columns (`last_run_outcome`, `last_run_summary`, `last_run_context`) on `scheduled_jobs` give agents structured facts about prior runs without replaying raw conversation history (spec 07)
+- **`scheduler-report` skill** — agents call this at the end of a scheduled run to write a summary and optional continuity context for the next run
+- **Migration 019** — `last_run_outcome`, `last_run_summary`, `last_run_context` columns on `scheduled_jobs`
+
+### Fixed
+- **Scheduler history poisoning** — scheduled job runs now use a unique per-run `conversationId`, preventing working memory from loading turns from prior runs (root cause of 2026-04-09 production incident where the daily schedule job called `scheduler-create` instead of executing its task)
+
+### Changed
+- **`completeJobRun`** — now writes `last_run_outcome = 'completed'` or `'failed'` on completion
+- **`recoverStuckJob`** — now writes `last_run_outcome = 'timed_out'` on recovery
+```
+
+- [ ] **Step 3: Bump version in `package.json`**
+
+This is infrastructure adding new DB columns, a new skill, and a spec fix — patch bump per CLAUDE.md versioning table (completing a partially-shipped spec feature).
+
+Read `package.json` to find current version, increment the patch digit by 1.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  add CHANGELOG.md package.json
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-scheduler-prior-run-context \
+  commit -m "chore: changelog and version bump for scheduler prior run context"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Design requirement | Covered by |
+|---|---|
+| `last_run_outcome` column, written by scheduler | Task 1 (migration), Task 3 (completeJobRun), Task 4 (recoverStuckJob) |
+| `last_run_summary` column, written by agent | Task 1 (migration), Task 6 (reportJobRun + skill) |
+| `last_run_context` column, written by agent | Task 1 (migration), Task 6 (reportJobRun + skill) |
+| No conversation history on scheduled runs | Task 5 (unique conversationId) |
+| Prior-run block injected when `last_run_outcome` set | Task 5 (buildPriorRunBlock) |
+| No prior-run block on first run | Task 5 (null check) |
+| `scheduler-report` skill with `action_risk: none` | Task 6 |
+| `context` optional — omitting does not clear existing context | Task 6 (two-branch SQL in `reportJobRun`) |
+| Spec 07 updated | Already done in design phase |
+| UI issue filed | josephfung/curia#241 (already done) |
+
+**Placeholder scan:** No TBD, TODO, or "similar to" references. All SQL and code is explicit.
+
+**Type consistency:** `reportJobRun` is called from the handler with `(job_id, summary, context?)` and defined in `SchedulerService` with the same signature. `JobRow.lastRunOutcome/Summary/Context` match `DbJobRow.last_run_outcome/summary/context` via `mapJobRow`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.14.6",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.14.6",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.14.6",
+  "version": "0.15.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/scheduler-report/handler.ts
+++ b/skills/scheduler-report/handler.ts
@@ -1,0 +1,36 @@
+// handler.ts — scheduler-report skill implementation.
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class SchedulerReportHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.schedulerService) {
+      return {
+        success: false,
+        error: 'scheduler-report requires schedulerService in context. Is infrastructure: true set in the manifest?',
+      };
+    }
+
+    const { job_id, summary, context } = ctx.input as {
+      job_id?: string;
+      summary?: string;
+      context?: Record<string, unknown>;
+    };
+
+    if (!job_id || typeof job_id !== 'string') {
+      return { success: false, error: 'Missing required input: job_id (string)' };
+    }
+    if (!summary || typeof summary !== 'string') {
+      return { success: false, error: 'Missing required input: summary (string)' };
+    }
+
+    try {
+      await ctx.schedulerService.reportJobRun(job_id, summary, context);
+      ctx.log.info({ jobId: job_id }, 'scheduler-report written');
+      return { success: true, data: { success: true } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err }, 'scheduler-report failed');
+      return { success: false, error: message };
+    }
+  }
+}

--- a/skills/scheduler-report/skill.json
+++ b/skills/scheduler-report/skill.json
@@ -1,0 +1,17 @@
+{
+  "name": "scheduler-report",
+  "description": "Report the outcome of a scheduled job run. Writes a summary and optional structured context to the job's run record so the CEO and agents can review what happened on the last execution.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "action_risk": "low",
+  "infrastructure": true,
+  "inputs": {
+    "job_id": "string",
+    "summary": "string",
+    "context": "object?"
+  },
+  "outputs": { "success": "boolean" },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}

--- a/skills/scheduler-report/skill.json
+++ b/skills/scheduler-report/skill.json
@@ -3,7 +3,7 @@
   "description": "Report the outcome of a scheduled job run. Writes a summary and optional structured context to the job's run record so the CEO and agents can review what happened on the last execution.",
   "version": "1.0.0",
   "sensitivity": "elevated",
-  "action_risk": "low",
+  "action_risk": "none",
   "infrastructure": true,
   "inputs": {
     "job_id": "string",

--- a/src/db/migrations/019_scheduler_prior_run_context.sql
+++ b/src/db/migrations/019_scheduler_prior_run_context.sql
@@ -1,0 +1,15 @@
+-- 019_scheduler_prior_run_context.sql
+--
+-- Adds three columns to support structured prior-run context for scheduled jobs.
+-- last_run_outcome: written by the scheduler on completion/timeout (queryable).
+-- last_run_summary: agent-written human-readable summary of what the job did.
+-- last_run_context: agent-written opaque JSONB for job-specific continuity state.
+--
+-- All three default to NULL — no backfill needed. The no-history-replay fix
+-- (unique per-run conversationId) is a code-only change; no schema change required.
+
+ALTER TABLE scheduled_jobs
+  ADD COLUMN last_run_outcome TEXT
+    CHECK (last_run_outcome IN ('completed', 'failed', 'timed_out')),
+  ADD COLUMN last_run_summary TEXT,
+  ADD COLUMN last_run_context JSONB;

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -46,7 +46,7 @@ export interface JobRow {
   progress: Record<string, unknown> | null;
   runStartedAt: string | null;
   expectedDurationSeconds: number | null;
-  lastRunOutcome: string | null;
+  lastRunOutcome: 'completed' | 'failed' | 'timed_out' | null;
   lastRunSummary: string | null;
   lastRunContext: Record<string, unknown> | null;
 }
@@ -77,7 +77,7 @@ interface DbJobRow {
   progress: Record<string, unknown> | null;
   run_started_at: string | null;          // set when job enters 'running'; cleared on completion
   expected_duration_seconds: number | null; // per-job timeout hint; NULL → system default (600s)
-  last_run_outcome: string | null;   // 'completed' | 'failed' | 'timed_out' | null
+  last_run_outcome: 'completed' | 'failed' | 'timed_out' | null;
   last_run_summary: string | null;   // agent-written summary; null until first scheduler-report call
   last_run_context: Record<string, unknown> | null; // opaque agent context; null until first scheduler-report call
 }
@@ -593,8 +593,10 @@ export class SchedulerService {
     summary: string,
     context?: Record<string, unknown>,
   ): Promise<void> {
+    let result: { rowCount: number | null };
+
     if (context !== undefined) {
-      await this.pool.query(
+      result = await this.pool.query(
         `UPDATE scheduled_jobs
             SET last_run_summary = $1,
                 last_run_context = $2
@@ -602,13 +604,18 @@ export class SchedulerService {
         [summary, JSON.stringify(context), jobId],
       );
     } else {
-      await this.pool.query(
+      result = await this.pool.query(
         `UPDATE scheduled_jobs
             SET last_run_summary = $1
           WHERE id = $2`,
         [summary, jobId],
       );
     }
+
+    if (!result.rowCount) {
+      throw new Error(`reportJobRun: no job found with id "${jobId}" — report not written`);
+    }
+
     this.logger.info({ jobId }, 'scheduler-report written');
   }
 }

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -593,19 +593,23 @@ export class SchedulerService {
     summary: string,
     context?: Record<string, unknown>,
   ): Promise<void> {
-    const { rowCount } = await this.pool.query(
-      `UPDATE scheduled_jobs
-          SET last_run_summary = $1,
-              last_run_context = $2
-        WHERE id = $3`,
-      [summary, context !== undefined ? JSON.stringify(context) : null, jobId],
-    );
-
-    if (rowCount === 0) {
-      throw new Error(`reportJobRun: job not found: ${jobId}`);
+    if (context !== undefined) {
+      await this.pool.query(
+        `UPDATE scheduled_jobs
+            SET last_run_summary = $1,
+                last_run_context = $2
+          WHERE id = $3`,
+        [summary, JSON.stringify(context), jobId],
+      );
+    } else {
+      await this.pool.query(
+        `UPDATE scheduled_jobs
+            SET last_run_summary = $1
+          WHERE id = $2`,
+        [summary, jobId],
+      );
     }
-
-    this.logger.info({ jobId }, 'Job run report written');
+    this.logger.info({ jobId }, 'scheduler-report written');
   }
 }
 

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -46,6 +46,9 @@ export interface JobRow {
   progress: Record<string, unknown> | null;
   runStartedAt: string | null;
   expectedDurationSeconds: number | null;
+  lastRunOutcome: string | null;
+  lastRunSummary: string | null;
+  lastRunContext: Record<string, unknown> | null;
 }
 
 export interface ListJobsFilters {
@@ -74,6 +77,9 @@ interface DbJobRow {
   progress: Record<string, unknown> | null;
   run_started_at: string | null;          // set when job enters 'running'; cleared on completion
   expected_duration_seconds: number | null; // per-job timeout hint; NULL → system default (600s)
+  last_run_outcome: string | null;   // 'completed' | 'failed' | 'timed_out' | null
+  last_run_summary: string | null;   // agent-written summary; null until first scheduler-report call
+  last_run_context: Record<string, unknown> | null; // opaque agent context; null until first scheduler-report call
 }
 
 // Threshold for auto-suspending jobs after consecutive failures.
@@ -593,5 +599,8 @@ function mapJobRow(row: DbJobRow): JobRow {
     progress: row.progress,
     runStartedAt: row.run_started_at,
     expectedDurationSeconds: row.expected_duration_seconds,
+    lastRunOutcome: row.last_run_outcome,
+    lastRunSummary: row.last_run_summary,
+    lastRunContext: row.last_run_context,
   };
 }

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -458,10 +458,11 @@ export class SchedulerService {
                  consecutive_failures = 0,
                  last_error = NULL,
                  run_started_at = NULL,
-                 status = $2
+                 status = $2,
+                 last_run_outcome = $4
            WHERE id = $3
         `;
-        await this.pool.query(updateSql, [nextRunAt, 'pending', jobId]);
+        await this.pool.query(updateSql, [nextRunAt, 'pending', jobId, 'completed']);
       } else {
         // One-shot job: mark as completed.
         const updateSql = `
@@ -470,10 +471,11 @@ export class SchedulerService {
                  status = $1,
                  consecutive_failures = 0,
                  last_error = NULL,
-                 run_started_at = NULL
+                 run_started_at = NULL,
+                 last_run_outcome = $3
            WHERE id = $2
         `;
-        await this.pool.query(updateSql, ['completed', jobId]);
+        await this.pool.query(updateSql, ['completed', jobId, 'completed']);
       }
 
       this.logger.info({ jobId }, 'Job run completed successfully');
@@ -491,10 +493,11 @@ export class SchedulerService {
              consecutive_failures = $1,
              last_error = $2,
              run_started_at = NULL,
-             status = $3
+             status = $3,
+             last_run_outcome = $5
        WHERE id = $4
     `;
-    await this.pool.query(updateSql, [newFailures, error ?? null, newStatus, jobId]);
+    await this.pool.query(updateSql, [newFailures, error ?? null, newStatus, jobId, 'failed']);
 
     if (shouldSuspend) {
       this.logger.warn({ jobId, consecutiveFailures: newFailures }, 'Job auto-suspended after consecutive failures');

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -578,6 +578,35 @@ export class SchedulerService {
 
     return { noOp: false, suspended: shouldSuspend, consecutiveFailures: newFailures };
   }
+
+  /**
+   * Write an agent-authored summary and optional structured context to the job's
+   * last-run record. Called by the scheduler-report skill at the end of each job
+   * execution so operators and agents can inspect what happened without trawling logs.
+   *
+   * @param jobId    The job to update.
+   * @param summary  Human-readable description of what the run accomplished.
+   * @param context  Optional opaque structured data (e.g. counts, entity IDs, errors).
+   */
+  async reportJobRun(
+    jobId: string,
+    summary: string,
+    context?: Record<string, unknown>,
+  ): Promise<void> {
+    const { rowCount } = await this.pool.query(
+      `UPDATE scheduled_jobs
+          SET last_run_summary = $1,
+              last_run_context = $2
+        WHERE id = $3`,
+      [summary, context !== undefined ? JSON.stringify(context) : null, jobId],
+    );
+
+    if (rowCount === 0) {
+      throw new Error(`reportJobRun: job not found: ${jobId}`);
+    }
+
+    this.logger.info({ jobId }, 'Job run report written');
+  }
 }
 
 // -- Row mapping --

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -557,10 +557,11 @@ export class SchedulerService {
               consecutive_failures = $2,
               last_error = $3,
               run_started_at = NULL,
-              next_run_at = $4
+              next_run_at = $4,
+              last_run_outcome = $6
         WHERE id = $5
           AND status = 'running'`,
-      [newStatus, newFailures, lastError, nextRunAt, jobId],
+      [newStatus, newFailures, lastError, nextRunAt, jobId, 'timed_out'],
     );
 
     if (result.rowCount === 0) {

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { Pool } from 'pg';
 import type { EventBus } from '../bus/bus.js';
 import type { Logger } from '../logger.js';
@@ -26,6 +27,32 @@ const DEFAULT_EXPECTED_DURATION_SECONDS = 600; // 10 minutes
 //   2m expected → 15m timeout;  30m expected → 90m timeout.
 const RECOVERY_TIMEOUT_MULTIPLIER = 7.5;
 const RECOVERY_TIMEOUT_CAP_SECONDS = 3600;
+
+/**
+ * Build a structured text block summarising the previous run's outcome.
+ * Injected into the agent.task content so the agent can avoid repeating work
+ * or adjust its approach based on what happened last time.
+ *
+ * Returns an empty string when there is no prior-run data (first run ever).
+ */
+function buildPriorRunBlock(job: JobRow): string {
+  if (!job.lastRunOutcome) return '';
+
+  const parts: string[] = [
+    `[Prior run context — last ran ${job.lastRunAt ?? 'unknown'}]`,
+    `outcome: ${job.lastRunOutcome}`,
+  ];
+
+  if (job.lastRunSummary) {
+    parts.push(`summary: ${job.lastRunSummary}`);
+  }
+
+  if (job.lastRunContext) {
+    parts.push(`context: ${JSON.stringify(job.lastRunContext, null, 2)}`);
+  }
+
+  return parts.join('\n');
+}
 
 /**
  * Compute the recovery timeout for a job given its expected duration.
@@ -168,6 +195,9 @@ export class Scheduler {
           progress: row.progress ?? null,
           runStartedAt: row.run_started_at ?? null,
           expectedDurationSeconds: row.expected_duration_seconds ?? null,
+          lastRunOutcome: row.last_run_outcome ?? null,
+          lastRunSummary: row.last_run_summary ?? null,
+          lastRunContext: row.last_run_context ?? null,
         };
         try {
           await this.fireJob(job);
@@ -225,6 +255,13 @@ export class Scheduler {
       });
     }
 
+    // Prepend prior-run context so the agent knows what happened last time
+    // and can avoid repeating work or adjust its approach accordingly.
+    const priorRunBlock = buildPriorRunBlock(job);
+    if (priorRunBlock) {
+      content = `${priorRunBlock}\n\n${content}`;
+    }
+
     // Publish schedule.fired for audit trail.
     const firedEvent = createScheduleFired({
       jobId: job.id,
@@ -233,10 +270,15 @@ export class Scheduler {
     });
     await this.bus.publish('system', firedEvent);
 
+    // Use a unique per-run conversationId so that each scheduler invocation gets
+    // its own conversation thread. Re-using just the job ID would let unrelated
+    // runs bleed into the same conversation history.
+    const runId = randomUUID();
+
     // Publish agent.task so the coordinator picks up the work.
     const taskEvent = createAgentTask({
       agentId: job.agentId,
-      conversationId: `scheduler:${job.id}`,
+      conversationId: `scheduler:${job.id}:${runId}`,
       channelId: 'scheduler',
       senderId: 'scheduler',
       content,

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -40,15 +40,15 @@ function buildPriorRunBlock(job: JobRow): string {
 
   const parts: string[] = [
     `[Prior run context — last ran ${job.lastRunAt ?? 'unknown'}]`,
-    `outcome: ${job.lastRunOutcome}`,
+    `Outcome: ${job.lastRunOutcome}`,
   ];
 
   if (job.lastRunSummary) {
-    parts.push(`summary: ${job.lastRunSummary}`);
+    parts.push(`Summary: ${job.lastRunSummary}`);
   }
 
   if (job.lastRunContext) {
-    parts.push(`context: ${JSON.stringify(job.lastRunContext, null, 2)}`);
+    parts.push(`Agent context: ${JSON.stringify(job.lastRunContext, null, 2)}`);
   }
 
   return parts.join('\n');

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -38,8 +38,14 @@ const RECOVERY_TIMEOUT_CAP_SECONDS = 3600;
 function buildPriorRunBlock(job: JobRow): string {
   if (!job.lastRunOutcome) return '';
 
+  const lastRanStr = job.lastRunAt
+    ? new Date(job.lastRunAt).toLocaleString('en-CA', { timeZone: job.timezone, dateStyle: 'short', timeStyle: 'short' })
+    : job.lastRunOutcome === 'timed_out'
+      ? 'no completion recorded (timed out)'
+      : 'no completion recorded';
+
   const parts: string[] = [
-    `[Prior run context — last ran ${job.lastRunAt ?? 'unknown'}]`,
+    `[Prior run context — ${lastRanStr}]`,
     `Outcome: ${job.lastRunOutcome}`,
   ];
 

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -576,6 +576,23 @@ describe('SchedulerService', () => {
       pool.query.mockResolvedValueOnce({ rows: [] });
       await expect(svc.recoverStuckJob('missing-job', 600)).rejects.toThrow('Job not found');
     });
+
+    it('writes last_run_outcome = timed_out on recovery', async () => {
+      const jobId = 'job-stuck';
+      pool.query
+        .mockResolvedValueOnce({
+          rows: [{ id: jobId, cron_expr: null, run_at: null, consecutive_failures: 0, timezone: 'UTC' }],
+        })
+        .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+      await svc.recoverStuckJob(jobId, 600);
+
+      const updateCall = pool.query.mock.calls[1];
+      const sql: string = updateCall[0];
+      const params: unknown[] = updateCall[1];
+      expect(sql).toContain('last_run_outcome');
+      expect(params).toContain('timed_out');
+    });
   });
 
   // -- upsertDeclarativeJob --

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -387,6 +387,71 @@ describe('SchedulerService', () => {
       const [updateSql] = pool.query.mock.calls[1] as [string, unknown[]];
       expect(updateSql).toContain('run_started_at = NULL');
     });
+
+    it('writes last_run_outcome = completed on success (recurring)', async () => {
+      const jobId = 'job-complete-success';
+      // First query: fetchSql — returns a recurring job
+      pool.query.mockResolvedValueOnce({
+        rows: [{ id: jobId, cron_expr: '0 9 * * *', status: 'running', consecutive_failures: 0, timezone: 'UTC' }],
+      });
+      // Second query: updateSql
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      await svc.completeJobRun(jobId, true);
+
+      const updateCall = pool.query.mock.calls[1];
+      const sql: string = updateCall[0];
+      const params: unknown[] = updateCall[1];
+      expect(sql).toContain('last_run_outcome');
+      expect(params).toContain('completed');
+    });
+
+    it('writes last_run_outcome = completed on success (one-shot)', async () => {
+      const jobId = 'job-complete-oneshot';
+      pool.query.mockResolvedValueOnce({
+        rows: [{ id: jobId, cron_expr: null, status: 'running', consecutive_failures: 0, timezone: 'UTC' }],
+      });
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      await svc.completeJobRun(jobId, true);
+
+      const updateCall = pool.query.mock.calls[1];
+      const sql: string = updateCall[0];
+      const params: unknown[] = updateCall[1];
+      expect(sql).toContain('last_run_outcome');
+      expect(params).toContain('completed');
+    });
+
+    it('writes last_run_outcome = failed on failure', async () => {
+      const jobId = 'job-complete-fail';
+      pool.query.mockResolvedValueOnce({
+        rows: [{ id: jobId, cron_expr: '0 9 * * *', status: 'running', consecutive_failures: 0, timezone: 'UTC' }],
+      });
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      await svc.completeJobRun(jobId, false, 'something went wrong');
+
+      const updateCall = pool.query.mock.calls[1];
+      const sql: string = updateCall[0];
+      const params: unknown[] = updateCall[1];
+      expect(sql).toContain('last_run_outcome');
+      expect(params).toContain('failed');
+    });
+
+    it('does not overwrite last_run_summary or last_run_context in completeJobRun', async () => {
+      const jobId = 'job-no-overwrite';
+      pool.query.mockResolvedValueOnce({
+        rows: [{ id: jobId, cron_expr: null, status: 'running', consecutive_failures: 0, timezone: 'UTC' }],
+      });
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      await svc.completeJobRun(jobId, true);
+
+      const updateCall = pool.query.mock.calls[1];
+      const sql: string = updateCall[0];
+      expect(sql).not.toContain('last_run_summary');
+      expect(sql).not.toContain('last_run_context');
+    });
   });
 
   // -- recoverStuckJob --

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -205,7 +205,8 @@ describe('Scheduler', () => {
       expect(event2.type).toBe('agent.task');
       expect(event2.payload.channelId).toBe('scheduler');
       expect(event2.payload.senderId).toBe('scheduler');
-      expect(event2.payload.conversationId).toBe('scheduler:job-1');
+      // conversationId format is scheduler:<jobId>:<runUUID> — unique per run
+      expect(event2.payload.conversationId).toMatch(/^scheduler:job-1:[0-9a-f-]{36}$/);
     });
 
     it('passes intentAnchor in event payload for persistent tasks', async () => {
@@ -272,6 +273,104 @@ describe('Scheduler', () => {
       expect(claimSql).toContain('run_started_at');
       expect(claimSql).toContain('now()');
       expect(claimParams).toContain('job-1');
+    });
+
+    it('uses a unique conversationId per run (not job ID)', async () => {
+      const jobId = 'job-unique-conv';
+      const firedEvent = { id: 'fired-evt-1' };
+      const taskEvent = { id: 'task-evt-1' };
+
+      pool.query
+        .mockResolvedValueOnce({
+          rows: [{
+            id: jobId, agent_id: 'coordinator', cron_expr: '0 9 * * *',
+            run_at: null, task_payload: { task: 'do work' }, status: 'pending',
+            last_run_at: null, next_run_at: new Date(), last_error: null,
+            consecutive_failures: 0, created_by: 'system', created_at: new Date(),
+            timezone: 'UTC', agent_task_id: null, intent_anchor: null, progress: null,
+            run_started_at: null, expected_duration_seconds: null,
+            last_run_outcome: null, last_run_summary: null, last_run_context: null,
+          }],
+        })
+        .mockResolvedValueOnce({ rowCount: 1 }); // claim update
+
+      bus.publish.mockResolvedValue(undefined);
+      bus.publish.mockImplementation((_layer: unknown, event: { id: string; type: string }) => {
+        if (event.type === 'schedule.fired') Object.assign(firedEvent, event);
+        if (event.type === 'agent.task') Object.assign(taskEvent, event);
+        return Promise.resolve();
+      });
+
+      await scheduler.pollDueJobs();
+
+      // The conversationId must NOT be just `scheduler:<jobId>`
+      const taskPayload = (taskEvent as { payload?: { conversationId?: string } }).payload;
+      expect(taskPayload?.conversationId).not.toBe(`scheduler:${jobId}`);
+      expect(taskPayload?.conversationId).toMatch(new RegExp(`^scheduler:${jobId}:`));
+    });
+
+    it('injects prior-run context block when last_run_outcome is set', async () => {
+      const jobId = 'job-prior-run';
+      const taskEvent = { payload: { content: '' } };
+
+      pool.query
+        .mockResolvedValueOnce({
+          rows: [{
+            id: jobId, agent_id: 'coordinator', cron_expr: '0 9 * * *',
+            run_at: null, task_payload: { task: 'do work' }, status: 'pending',
+            last_run_at: new Date('2026-04-08T11:30:00Z'), next_run_at: new Date(),
+            last_error: null, consecutive_failures: 0, created_by: 'system',
+            created_at: new Date(), timezone: 'America/Toronto',
+            agent_task_id: null, intent_anchor: null, progress: null,
+            run_started_at: null, expected_duration_seconds: null,
+            last_run_outcome: 'completed',
+            last_run_summary: 'Sent schedule for 6 events to joseph@josephfung.ca',
+            last_run_context: { events_sent: 6 },
+          }],
+        })
+        .mockResolvedValueOnce({ rowCount: 1 });
+
+      bus.publish.mockImplementation((_layer: unknown, event: { type: string; payload?: unknown }) => {
+        if (event.type === 'agent.task') Object.assign(taskEvent, event);
+        return Promise.resolve();
+      });
+
+      await scheduler.pollDueJobs();
+
+      const content: string = (taskEvent as { payload: { content: string } }).payload.content;
+      expect(content).toContain('[Prior run context');
+      expect(content).toContain('completed');
+      expect(content).toContain('Sent schedule for 6 events');
+      expect(content).toContain('"events_sent": 6');
+    });
+
+    it('does not inject prior-run block when last_run_outcome is null (first run)', async () => {
+      const jobId = 'job-first-run';
+      const taskEvent = { payload: { content: '' } };
+
+      pool.query
+        .mockResolvedValueOnce({
+          rows: [{
+            id: jobId, agent_id: 'coordinator', cron_expr: '0 9 * * *',
+            run_at: null, task_payload: { task: 'do work' }, status: 'pending',
+            last_run_at: null, next_run_at: new Date(), last_error: null,
+            consecutive_failures: 0, created_by: 'system', created_at: new Date(),
+            timezone: 'UTC', agent_task_id: null, intent_anchor: null, progress: null,
+            run_started_at: null, expected_duration_seconds: null,
+            last_run_outcome: null, last_run_summary: null, last_run_context: null,
+          }],
+        })
+        .mockResolvedValueOnce({ rowCount: 1 });
+
+      bus.publish.mockImplementation((_layer: unknown, event: { type: string; payload?: unknown }) => {
+        if (event.type === 'agent.task') Object.assign(taskEvent, event);
+        return Promise.resolve();
+      });
+
+      await scheduler.pollDueJobs();
+
+      const content: string = (taskEvent as { payload: { content: string } }).payload.content;
+      expect(content).not.toContain('[Prior run context');
     });
   });
 

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -324,7 +324,7 @@ describe('Scheduler', () => {
             agent_task_id: null, intent_anchor: null, progress: null,
             run_started_at: null, expected_duration_seconds: null,
             last_run_outcome: 'completed',
-            last_run_summary: 'Sent schedule for 6 events to joseph@josephfung.ca',
+            last_run_summary: 'Sent schedule',
             last_run_context: { events_sent: 6 },
           }],
         })
@@ -339,8 +339,9 @@ describe('Scheduler', () => {
 
       const content: string = (taskEvent as { payload: { content: string } }).payload.content;
       expect(content).toContain('[Prior run context');
-      expect(content).toContain('completed');
-      expect(content).toContain('Sent schedule for 6 events');
+      expect(content).toContain('Outcome: completed');
+      expect(content).toContain('Summary: Sent schedule');
+      expect(content).toContain('Agent context:');
       expect(content).toContain('"events_sent": 6');
     });
 

--- a/tests/unit/skills/scheduler-report.test.ts
+++ b/tests/unit/skills/scheduler-report.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SchedulerReportHandler } from '../../../skills/scheduler-report/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(
+  input: Record<string, unknown>,
+  overrides?: Partial<SkillContext>,
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    ...overrides,
+  };
+}
+
+describe('SchedulerReportHandler', () => {
+  const handler = new SchedulerReportHandler();
+
+  it('returns failure when schedulerService is not available', async () => {
+    const result = await handler.execute(makeCtx({ job_id: 'job-1', summary: 'done' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('schedulerService');
+  });
+
+  it('returns failure when job_id is missing', async () => {
+    const schedulerService = { reportJobRun: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      { summary: 'done' },
+      { schedulerService: schedulerService as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('job_id');
+  });
+
+  it('returns failure when summary is missing', async () => {
+    const schedulerService = { reportJobRun: vi.fn() };
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-1' },
+      { schedulerService: schedulerService as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('summary');
+  });
+
+  it('calls reportJobRun with summary and no context when context is omitted', async () => {
+    const schedulerService = { reportJobRun: vi.fn().mockResolvedValue(undefined) };
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-1', summary: 'Sent 6 events' },
+      { schedulerService: schedulerService as never },
+    ));
+    expect(result.success).toBe(true);
+    expect(schedulerService.reportJobRun).toHaveBeenCalledWith('job-1', 'Sent 6 events', undefined);
+  });
+
+  it('calls reportJobRun with summary and context', async () => {
+    const schedulerService = { reportJobRun: vi.fn().mockResolvedValue(undefined) };
+    const ctx = { events_sent: 6 };
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-1', summary: 'Sent 6 events', context: ctx },
+      { schedulerService: schedulerService as never },
+    ));
+    expect(result.success).toBe(true);
+    expect(schedulerService.reportJobRun).toHaveBeenCalledWith('job-1', 'Sent 6 events', ctx);
+  });
+
+  it('returns failure when reportJobRun throws', async () => {
+    const schedulerService = {
+      reportJobRun: vi.fn().mockRejectedValue(new Error('job not found')),
+    };
+    const result = await handler.execute(makeCtx(
+      { job_id: 'job-1', summary: 'Sent 6 events' },
+      { schedulerService: schedulerService as never },
+    ));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('job not found');
+  });
+});


### PR DESCRIPTION
## Summary

- **Fixes history poisoning** — scheduled job runs now use a unique per-run \`conversationId\` (\`scheduler:<jobId>:<runId>\`), preventing working memory from loading conversation turns from prior runs into fresh executions. Root cause of the 2026-04-09 production incident.
- **Adds prior-run context injection** — when a job has run before, a structured \`[Prior run context]\` block is injected as a prefix to the task content, giving the agent stable facts about the last run without replaying raw history.
- **New \`scheduler-report\` skill** — agents call this at the end of a successful run to write \`last_run_summary\` and \`last_run_context\`; the scheduler writes \`last_run_outcome\` itself.
- **Migration 019** — adds \`last_run_outcome\`, \`last_run_summary\`, \`last_run_context\` columns to \`scheduled_jobs\`.

## Test Plan
- [ ] Run full test suite: \`npm test\` — 1079 tests pass
- [ ] Verify migration applies cleanly against a dev DB
- [ ] Fire a scheduled job manually, confirm prior-run context block appears in the agent's next run
- [ ] Call \`scheduler-report\` skill, confirm columns written; call again without context, confirm \`last_run_context\` is preserved
- [ ] Confirm a bad \`job_id\` passed to \`scheduler-report\` returns \`{ success: false }\` with a clear error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New scheduler-report skill to let agents persist run summaries and optional context between runs.
  * DB migration adds prior-run fields so runs can record outcome, summary and context.

* **Bug Fixes**
  * Prevented history poisoning by using unique per-run identifiers, isolating each run’s working memory.

* **Changed**
  * Scheduler now records run outcomes (completed/failed/timed_out) and injects prior-run context into task payloads.

* **Documentation**
  * Updated scheduler specs and design notes; added changelog entry and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->