### PR TITLE
fix: correct ceoEmail in outbound filter and repair self-routing in email replies (#244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+- **Outbound content filter: wrong `ceoEmail` causing false-positive blocks** — The
+  `OutboundContentFilter` and `OutboundGateway` were initialized with `nylasSelfEmail`
+  (Curia's own Gmail address) instead of `ceoPrimaryEmail` (Joseph's address). This had
+  two consequences: (1) the contact-data-leak rule treated Joseph's email as a
+  third-party address and blocked legitimate outbound content; (2) blocked-content
+  notifications were delivered to Curia's own inbox rather than to Joseph. Fixed by
+  using `CEO_PRIMARY_EMAIL` (env var) for both `OutboundContentFilter.ceoEmail` and
+  `OutboundGateway.ceoEmail` in `src/index.ts` (issue #244).
+- **Email reply routing: self-addressed replies when Curia was the last sender** — In
+  multi-turn email threads, `sendOutboundReply` fetched the most recent thread message
+  from Nylas and used its `from` address as the reply-to. Since Nylas returns messages
+  newest-first, if Curia had sent the prior turn the `from` address was Curia's own
+  address, routing the reply to itself. Fixed by checking whether the latest message is
+  from `selfEmail`; if so, the recipient is taken from the first non-self address in
+  the message's `to` field instead (issue #244).
+
 ---
 
 ## [0.15.0] — 2026-04-09

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -200,6 +200,17 @@ export class EmailAdapter {
         return;
       }
 
+      // Guard: if the resolved recipient is still our own address (e.g. a self-addressed
+      // thread or malformed to[] list), bail out rather than looping a reply to our own
+      // inbox. This would produce a misleading "sent" log with no human ever receiving it.
+      if (recipientEmail.toLowerCase() === this.config.selfEmail.toLowerCase()) {
+        logger.error(
+          { threadId, messageId: threadMessage.id, latestIsOurs },
+          'Cannot reply — resolved recipient is selfEmail; thread may be self-addressed or to[] is malformed',
+        );
+        return;
+      }
+
       // Strip any existing "Re:" prefix before prepending our own to avoid
       // "Re: Re: Re: ..." chains when replying to already-replied threads.
       const baseSubject = threadMessage.subject.replace(/^Re:\s*/i, '');
@@ -215,9 +226,9 @@ export class EmailAdapter {
       });
 
       if (result.success) {
-        logger.info({ to: recipientEmail, threadId }, 'Email reply sent via gateway');
+        logger.info({ to: recipientEmail, threadId, latestIsOurs }, 'Email reply sent via gateway');
       } else {
-        logger.warn({ to: recipientEmail, threadId, reason: result.blockedReason }, 'Email reply blocked by gateway');
+        logger.warn({ to: recipientEmail, threadId, latestIsOurs, reason: result.blockedReason }, 'Email reply blocked by gateway');
       }
     } catch (err) {
       logger.error({ err, threadId }, 'Failed to send email reply');

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -168,9 +168,14 @@ export class EmailAdapter {
     const threadId = conversationId.slice('email:'.length);
 
     try {
-      // Find the original message in this thread so we can reply to it.
-      // Pass threadId directly to Nylas so the API filters server-side —
-      // much cheaper than fetching 50 messages and scanning locally.
+      // Fetch the most recent message in this thread. We use it for two things:
+      //   1. The message ID — passed as replyToMessageId so Nylas threads the reply
+      //   2. The human's email address to send the reply to
+      //
+      // Nylas returns messages in most-recent-first order, so messages[0] is the
+      // latest. If Curia was the last sender (a prior turn in the conversation),
+      // messages[0].from is Curia's own address — we must NOT reply to ourselves.
+      // In that case, look at messages[0].to to find the human recipient.
       const messages = await outboundGateway.listEmailMessages({ limit: 1, threadId });
       const threadMessage = messages[0];
       if (!threadMessage) {
@@ -178,9 +183,20 @@ export class EmailAdapter {
         return;
       }
 
-      const fromEmail = threadMessage.from[0]?.email;
-      if (!fromEmail) {
-        logger.warn({ threadId, messageId: threadMessage.id }, 'Cannot reply — original message has no from address');
+      const latestFromEmail = threadMessage.from[0]?.email;
+
+      // If the latest message was sent BY us, the human's address is in 'to'.
+      // Comparing case-insensitively guards against inconsistent casing from mail servers.
+      const latestIsOurs = latestFromEmail?.toLowerCase() === this.config.selfEmail.toLowerCase();
+      const recipientEmail = latestIsOurs
+        ? threadMessage.to[0]?.email
+        : latestFromEmail;
+
+      if (!recipientEmail) {
+        logger.warn(
+          { threadId, messageId: threadMessage.id, latestIsOurs },
+          'Cannot reply — could not resolve human recipient from thread',
+        );
         return;
       }
 
@@ -192,16 +208,16 @@ export class EmailAdapter {
       // run on every outbound reply, not just those originating from skills.
       const result = await outboundGateway.send({
         channel: 'email',
-        to: fromEmail,
+        to: recipientEmail,
         subject: `Re: ${baseSubject}`,
         body: outbound.payload.content,
         replyToMessageId: threadMessage.id,
       });
 
       if (result.success) {
-        logger.info({ to: fromEmail, threadId }, 'Email reply sent via gateway');
+        logger.info({ to: recipientEmail, threadId }, 'Email reply sent via gateway');
       } else {
-        logger.warn({ to: fromEmail, threadId, reason: result.blockedReason }, 'Email reply blocked by gateway');
+        logger.warn({ to: recipientEmail, threadId, reason: result.blockedReason }, 'Email reply blocked by gateway');
       }
     } catch (err) {
       logger.error({ err, threadId }, 'Failed to send email reply');

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -188,8 +188,16 @@ export class EmailAdapter {
       // If the latest message was sent BY us, the human's address is in 'to'.
       // Comparing case-insensitively guards against inconsistent casing from mail servers.
       const latestIsOurs = latestFromEmail?.toLowerCase() === this.config.selfEmail.toLowerCase();
+
+      // When the latest message is ours, find the first non-self address in 'to'.
+      // to[] can contain multiple recipients (e.g. a thread with a CC'd third party);
+      // picking the first non-self address is best-effort for 1:1 conversations.
+      // TODO: proper group-email support would need to track the original sender from
+      // the inbound message rather than inferring the recipient from the thread.
       const recipientEmail = latestIsOurs
-        ? threadMessage.to[0]?.email
+        ? threadMessage.to.find(
+            (r) => r.email.toLowerCase() !== this.config.selfEmail.toLowerCase(),
+          )?.email
         : latestFromEmail;
 
       if (!recipientEmail) {

--- a/src/channels/email/nylas-client.ts
+++ b/src/channels/email/nylas-client.ts
@@ -108,6 +108,10 @@ export class NylasClient {
 
   /**
    * List recent messages, optionally filtered by time / read-state / count.
+   *
+   * Results are ordered newest-first (most-recent-first) per the Nylas API
+   * default. Callers that rely on messages[0] being the latest message in a
+   * thread (e.g. email-adapter's sendOutboundReply) depend on this guarantee.
    */
   async listMessages(options?: ListMessagesOptions): Promise<NylasMessage[]> {
     const queryParams: ListMessagesQueryParams = {};

--- a/src/dispatch/outbound-filter.ts
+++ b/src/dispatch/outbound-filter.ts
@@ -281,9 +281,12 @@ export class OutboundContentFilter {
    */
   private checkContactDataLeak(content: string, recipientEmail: string): FilterFinding[] {
     const findings: FilterFinding[] = [];
+    // Only add ceoEmail if it is actually configured — an empty string (missing
+    // CEO_PRIMARY_EMAIL env var) would be a no-op entry that never matches but
+    // obscures the fact that the config is incomplete.
     const allowedEmails = new Set([
       recipientEmail.toLowerCase(),
-      this.config.ceoEmail.toLowerCase(),
+      ...(this.config.ceoEmail ? [this.config.ceoEmail.toLowerCase()] : []),
     ]);
 
     // Reset regex before use (global regex maintains lastIndex state between calls)

--- a/src/index.ts
+++ b/src/index.ts
@@ -457,9 +457,14 @@ async function main(): Promise<void> {
   let outboundFilter: OutboundContentFilter | undefined;
   if (coordinatorConfig) {
     const systemPromptMarkers = extractIdentityMarkers(officeIdentity);
-    const ceoEmail = config.nylasSelfEmail ?? '';
+    // CEO_PRIMARY_EMAIL is Joseph's email — used to allow his address in outbound
+    // content without triggering the contact-data-leak rule. Must NOT be Curia's
+    // own Nylas address (nylasSelfEmail): using Curia's address here was a bug
+    // that (a) treated Joseph's email as a third-party leak and (b) routed
+    // blocked-content notifications to Curia's inbox instead of Joseph's.
+    const ceoEmail = config.ceoPrimaryEmail ?? '';
     if (!ceoEmail) {
-      logger.warn('Outbound content filter initialized without CEO email — contact-data-leak rule may produce false positives');
+      logger.warn('Outbound content filter initialized without CEO email (CEO_PRIMARY_EMAIL not set) — contact-data-leak rule may produce false positives');
     }
     if (systemPromptMarkers.length === 0) {
       logger.warn('No system prompt markers extracted — system-prompt-fragment rule will not detect prompt leakage. Check that office identity has a name and title configured.');
@@ -496,7 +501,9 @@ async function main(): Promise<void> {
       bus,
       // ceoEmail is optional in OutboundGatewayConfig; only needed for email notifications.
       // When Nylas is configured, this must be set or CEO blocked-content alerts won't send.
-      ceoEmail: config.nylasSelfEmail || undefined,
+      // Must be the CEO's primary email (Joseph's), NOT Curia's own Nylas address —
+      // notifications addressed to Curia's inbox were never visible to Joseph.
+      ceoEmail: config.ceoPrimaryEmail || undefined,
       logger,
     });
     logger.info({

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -180,6 +180,20 @@ describe('EmailAdapter — sendOutboundReply', () => {
     expect(mocks.outboundGateway.send).not.toHaveBeenCalled();
   });
 
+  it('skips send when the resolved recipient from to[] is still selfEmail', async () => {
+    // Edge case: a self-addressed thread where both from and to are Curia.
+    // Must bail out rather than delivering the reply to our own inbox.
+    const selfAddressedMessage = makeMockMessage({
+      from: [{ email: SELF_EMAIL }],
+      to: [{ email: SELF_EMAIL }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([selfAddressedMessage]);
+
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    expect(mocks.outboundGateway.send).not.toHaveBeenCalled();
+  });
+
   it('ignores outbound events for non-email channels', async () => {
     const event = createOutboundMessage({
       conversationId: 'signal:convo-1',

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -1,0 +1,211 @@
+// Tests for EmailAdapter — focused on the outbound reply routing fix (issue #244).
+//
+// The bug: sendOutboundReply() fetches the most-recent thread message from Nylas
+// (which returns newest-first). If Curia was the last sender, from[0].email is
+// Curia's own address — the reply would be self-addressed and blocked by the content
+// filter or silently delivered to Curia's inbox. The fix: detect when the latest
+// message is ours and look at to[0].email instead.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EmailAdapter } from '../../../../src/channels/email/email-adapter.js';
+import { createLogger } from '../../../../src/logger.js';
+import type { OutboundGateway } from '../../../../src/skills/outbound-gateway.js';
+import type { ContactService } from '../../../../src/contacts/contact-service.js';
+import type { EventBus } from '../../../../src/bus/bus.js';
+import type { NylasMessage } from '../../../../src/channels/email/nylas-client.js';
+import type { BusEvent } from '../../../../src/bus/events.js';
+import { createOutboundMessage } from '../../../../src/bus/events.js';
+
+const SELF_EMAIL = 'curia@example.com';
+const CEO_EMAIL = 'ceo@example.com';
+
+function makeMockMessage(overrides: Partial<NylasMessage> = {}): NylasMessage {
+  return {
+    id: 'msg-1',
+    threadId: 'thread-abc',
+    subject: 'Hello',
+    from: [{ email: CEO_EMAIL, name: 'CEO' }],
+    to: [{ email: SELF_EMAIL, name: 'Curia' }],
+    cc: [],
+    bcc: [],
+    body: '<p>Hi</p>',
+    snippet: 'Hi',
+    date: 1700000000,
+    unread: true,
+    folders: ['INBOX'],
+    ...overrides,
+  };
+}
+
+function createMocks() {
+  const logger = createLogger('error');
+
+  const bus = {
+    subscribe: vi.fn(),
+    publish: vi.fn().mockResolvedValue(undefined),
+  } as unknown as EventBus;
+
+  const contactService = {
+    resolveByChannelIdentity: vi.fn().mockResolvedValue(null),
+    createContact: vi.fn(),
+    linkIdentity: vi.fn(),
+  } as unknown as ContactService;
+
+  const outboundGateway = {
+    send: vi.fn().mockResolvedValue({ success: true, messageId: 'sent-1' }),
+    listEmailMessages: vi.fn().mockResolvedValue([]),
+  } as unknown as OutboundGateway;
+
+  return { logger, bus, contactService, outboundGateway };
+}
+
+function makeAdapter(mocks: ReturnType<typeof createMocks>) {
+  return new EmailAdapter({
+    bus: mocks.bus,
+    logger: mocks.logger,
+    outboundGateway: mocks.outboundGateway,
+    contactService: mocks.contactService,
+    pollingIntervalMs: 999999, // never fires in tests
+    selfEmail: SELF_EMAIL,
+  });
+}
+
+// Trigger the outbound.message handler directly by capturing the subscriber
+// registered during start() and calling it with a synthetic event.
+function captureOutboundHandler(mocks: ReturnType<typeof createMocks>): (event: BusEvent) => Promise<void> {
+  // start() calls bus.subscribe('outbound.message', ...). Capture that callback.
+  let handler: ((event: BusEvent) => Promise<void>) | undefined;
+  (mocks.bus.subscribe as ReturnType<typeof vi.fn>).mockImplementation(
+    (eventType: string, _layer: string, cb: (event: BusEvent) => Promise<void>) => {
+      if (eventType === 'outbound.message') {
+        handler = cb;
+      }
+    },
+  );
+  return (...args) => {
+    if (!handler) throw new Error('outbound.message handler not registered — did you call adapter.start()?');
+    return handler(...args);
+  };
+}
+
+function makeOutboundEvent(conversationId: string) {
+  return createOutboundMessage({
+    conversationId,
+    channelId: 'email',
+    content: 'Here is my reply.',
+    parentEventId: 'task-1',
+  });
+}
+
+describe('EmailAdapter — sendOutboundReply', () => {
+  let mocks: ReturnType<typeof createMocks>;
+  let adapter: EmailAdapter;
+  let triggerOutbound: (event: BusEvent) => Promise<void>;
+
+  beforeEach(() => {
+    mocks = createMocks();
+    triggerOutbound = captureOutboundHandler(mocks);
+    adapter = makeAdapter(mocks);
+    // start() registers the bus subscriber without starting the poll timer
+    // (pollingIntervalMs is huge, and we don't await the initial poll)
+    void adapter.start();
+  });
+
+  it('sends reply to from address when the latest thread message is from the human', async () => {
+    // Latest message is from the human — normal first-reply scenario
+    const humanMessage = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      to: [{ email: SELF_EMAIL }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([humanMessage]);
+
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    expect(mocks.outboundGateway.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: CEO_EMAIL }),
+    );
+  });
+
+  it('sends reply to the to address when the latest thread message is from Curia (self)', async () => {
+    // Latest message is FROM Curia (we sent the last reply) — the human's address
+    // is in the to field, not the from field.
+    const curiaMessage = makeMockMessage({
+      from: [{ email: SELF_EMAIL }],
+      to: [{ email: CEO_EMAIL }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([curiaMessage]);
+
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    // Must NOT send to ourselves — must send to the human
+    expect(mocks.outboundGateway.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: CEO_EMAIL }),
+    );
+    const callArg = (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArg.to).not.toBe(SELF_EMAIL);
+  });
+
+  it('self-address detection is case-insensitive', async () => {
+    // Mail servers can return addresses in different casing
+    const curiaMessage = makeMockMessage({
+      from: [{ email: SELF_EMAIL.toUpperCase() }],
+      to: [{ email: CEO_EMAIL }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([curiaMessage]);
+
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    expect(mocks.outboundGateway.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: CEO_EMAIL }),
+    );
+  });
+
+  it('skips send and logs a warning when no thread messages are found', async () => {
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    expect(mocks.outboundGateway.send).not.toHaveBeenCalled();
+  });
+
+  it('skips send when latest message is ours and to field is empty', async () => {
+    const curiaMessageNoTo = makeMockMessage({
+      from: [{ email: SELF_EMAIL }],
+      to: [],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([curiaMessageNoTo]);
+
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    expect(mocks.outboundGateway.send).not.toHaveBeenCalled();
+  });
+
+  it('ignores outbound events for non-email channels', async () => {
+    const event = createOutboundMessage({
+      conversationId: 'signal:convo-1',
+      channelId: 'signal',
+      content: 'hello',
+      parentEventId: 'task-1',
+    });
+
+    await triggerOutbound(event);
+
+    // The send path must not be reached for non-email channels.
+    // (listEmailMessages may be called by the background poll — that's fine.)
+    expect(mocks.outboundGateway.send).not.toHaveBeenCalled();
+  });
+
+  it('passes the most recent message id as replyToMessageId for correct threading', async () => {
+    const latestMessage = makeMockMessage({
+      id: 'msg-latest',
+      from: [{ email: CEO_EMAIL }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([latestMessage]);
+
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    expect(mocks.outboundGateway.send).toHaveBeenCalledWith(
+      expect.objectContaining({ replyToMessageId: 'msg-latest' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Wrong `ceoEmail` in content filter and gateway** (`src/index.ts`): `OutboundContentFilter` and `OutboundGateway` were both wired with `nylasSelfEmail` (Curia's Gmail address) instead of `ceoPrimaryEmail` (Joseph's address). This caused two failures: (1) the `contact-data-leak` rule treated Joseph's email as a third-party address, producing false-positive blocks; (2) blocked-content notifications were delivered to Curia's own inbox rather than Joseph's, making them invisible.
- **Self-routing in multi-turn email threads** (`src/channels/email/email-adapter.ts`): `sendOutboundReply()` fetched the most-recent thread message (Nylas returns newest-first) and used its `from` address as the reply recipient. If Curia had sent the prior turn, `from[0].email` was Curia's own address — the reply was self-addressed. Fixed by detecting when the latest message is ours and using `to[0].email` instead, with a guard to bail if the resolved address is still `selfEmail`.
- **Empty `ceoEmail` allowlist entry** (`src/dispatch/outbound-filter.ts`): empty string was added to the `contact-data-leak` allowlist when `CEO_PRIMARY_EMAIL` is unset — now only added when truthy.

Closes #244.

## Test plan

- [ ] New `tests/unit/channels/email/email-adapter.test.ts`: normal reply path, self-routing guard, case-insensitive self-detection, empty `to[]`, self-addressed thread guard, non-email channel skip, `replyToMessageId` threading
- [ ] Existing `outbound-filter.test.ts` unchanged and passing
- [ ] All 1073 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed email reply routing in multi-turn conversations to correctly identify the human recipient and avoid self-addressed replies.
  * Resolved outbound content-filter behavior to prevent false-positive blocks and misdirected blocked-content notifications.

* **Tests**
  * Added unit tests validating reply-routing logic and edge cases (no messages, self-addressed, case-insensitive checks).

* **Documentation**
  * Clarified message-ordering behaviour in the email client docs.

* **Chores**
  * Bumped package version and updated changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->