### PR TITLE
feat: enforce audit_log append-only at DB level and add delivery acknowledgement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+- **Audit log append-only enforcement** (spec 06) — Added a PostgreSQL trigger
+  (`021_audit_log_append_only`) that raises an exception on any UPDATE or DELETE to
+  `audit_log`, with the single permitted exception of flipping `acknowledged` from
+  false to true. Code-level grep confirms no other UPDATE/DELETE paths exist.
+  `EventBus` now accepts an `onDelivered` hook that fires after all subscribers have
+  been attempted; `AuditLogger` uses it to set `acknowledged = true`, completing the
+  delivery lifecycle record. A startup scan (`scanForUnacknowledged`) logs a warning
+  for any rows that were written but never acknowledged, indicating delivery may have
+  been incomplete on a prior crash. Closes #202.
+
 ### Fixed
 - **Outbound content filter: wrong `ceoEmail` causing false-positive blocks** — The
   `OutboundContentFilter` and `OutboundGateway` were initialized with `nylasSelfEmail`

--- a/docs/specs/06-audit-and-security.md
+++ b/docs/specs/06-audit-and-security.md
@@ -345,7 +345,7 @@ These are non-negotiable for launch.
 | Item | Status |
 |---|---|
 | Bus layer enforcement tested (channel cannot publish `skill.invoke`) | Done (#187) |
-| Audit log append-only verified (no UPDATE or DELETE code paths) | Not Done |
+| Audit log append-only verified (no UPDATE or DELETE code paths) and DB-level trigger enforcement | Done (#248) |
 | Secret values never appear in logs, audit, or LLM context | Not Done |
 | Tool output sanitization active for all skill results | Done |
 | Inbound message sanitization active (injection pattern detection) | Done |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/audit/logger.ts
+++ b/src/audit/logger.ts
@@ -116,43 +116,60 @@ export class AuditLogger {
    * This scan is diagnostic only.
    */
   async scanForUnacknowledged(): Promise<void> {
-    type ScanRow = { id: string; event_type: string; timestamp: Date };
-    let rows: ScanRow[];
-    try {
-      const result = await this.pool.query<ScanRow>(
-        `SELECT id, event_type, timestamp FROM audit_log WHERE acknowledged = false ORDER BY timestamp ASC`,
-      );
-      rows = result.rows;
-    } catch (err) {
-      // Log at error — by the time this scan runs, the DB connection and schema are
-      // already confirmed healthy (the migration runner would have exited the process
-      // on any DB error). A failure here indicates a permissions problem, schema
-      // mismatch, or query bug — not a transient connection blip. Startup continues
-      // regardless (the scan is diagnostic only), but the error is surfaced at the
-      // correct severity.
-      this.logger.error({ err }, 'Audit log startup scan failed — could not query unacknowledged rows');
-      return;
-    }
-
-    if (rows.length === 0) {
-      this.logger.debug('Audit log startup scan: no unacknowledged events');
-      return;
-    }
-
     // Cap the number of events included in the log entry to avoid overflowing
     // log aggregator per-entry size limits (typically 64KB–256KB). The total
     // count is always logged so operators know whether rows were omitted.
     const LOG_LIMIT = 50;
-    const shown = rows.slice(0, LOG_LIMIT);
+
+    // Query the total count first — avoids materialising potentially millions
+    // of rows into application memory (e.g. after a crash loop). Only if
+    // unacknowledged rows exist do we fetch the first LOG_LIMIT details.
+    //
+    // Log at error — by the time this scan runs, the DB connection and schema
+    // are already confirmed healthy (the migration runner would have exited on
+    // any DB error). A failure here indicates a permissions problem, schema
+    // mismatch, or query bug — not a transient connection blip. Startup
+    // continues regardless (the scan is diagnostic only), but the error is
+    // surfaced at the correct severity.
+    let count: number;
+    try {
+      const countResult = await this.pool.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM audit_log WHERE acknowledged = false`,
+      );
+      count = parseInt(countResult.rows[0].count, 10);
+    } catch (err) {
+      this.logger.error({ err }, 'Audit log startup scan failed — could not query unacknowledged rows');
+      return;
+    }
+
+    if (count === 0) {
+      this.logger.debug('Audit log startup scan: no unacknowledged events');
+      return;
+    }
+
+    // Fetch only the first LOG_LIMIT rows for the log entry — the total count
+    // already tells operators the full scale of the problem.
+    type ScanRow = { id: string; event_type: string; timestamp: Date };
+    let shown: ScanRow[];
+    try {
+      const result = await this.pool.query<ScanRow>(
+        `SELECT id, event_type, timestamp FROM audit_log WHERE acknowledged = false ORDER BY timestamp ASC LIMIT $1`,
+        [LOG_LIMIT],
+      );
+      shown = result.rows;
+    } catch (err) {
+      this.logger.error({ err }, 'Audit log startup scan failed — could not fetch unacknowledged row details');
+      return;
+    }
 
     // Log at warn level — unacknowledged rows mean delivery may have been
     // incomplete on the previous run. This is not an error (crash recovery
     // is expected), but it warrants operator attention.
     this.logger.warn(
       {
-        count: rows.length,
+        count,
         shown: shown.length,
-        truncated: rows.length > LOG_LIMIT,
+        truncated: count > LOG_LIMIT,
         events: shown.map(r => ({ id: r.id, eventType: r.event_type, timestamp: r.timestamp })),
       },
       'Audit log startup scan: unacknowledged events detected — delivery may have been incomplete on previous run',

--- a/src/audit/logger.ts
+++ b/src/audit/logger.ts
@@ -7,7 +7,9 @@ import type { Logger } from '../logger.js';
  * BEFORE the event is delivered to other subscribers. This ensures audit
  * completeness even if the process crashes mid-delivery.
  *
- * The audit log is append-only — no UPDATE or DELETE operations.
+ * The audit log is append-only — no UPDATE or DELETE operations, with the
+ * single exception of flipping `acknowledged` from false to true after
+ * delivery has been attempted for all subscribers.
  */
 export class AuditLogger {
   constructor(
@@ -66,5 +68,76 @@ export class AuditLogger {
       this.logger.error({ err, eventId: event.id, eventType: event.type }, 'Audit log write failed');
       throw err;
     }
+  }
+
+  /**
+   * Mark an audit_log row as acknowledged after delivery has been attempted.
+   * This is the ONLY permitted UPDATE on audit_log — enforced by a database
+   * trigger (migration 021) that rejects all other mutations.
+   *
+   * Called as the onDelivered hook in EventBus after all subscribers have been
+   * attempted. Delivery is "attempted", not "succeeded" — per-subscriber errors
+   * are swallowed by the bus and don't prevent acknowledgement.
+   *
+   * Errors are logged and re-thrown. A failed acknowledgement write is not
+   * catastrophic — the row remains unacknowledged and surfaces in the startup
+   * scan — but it should not be silently swallowed.
+   */
+  async markAcknowledged(eventId: string): Promise<void> {
+    try {
+      await this.pool.query(
+        // The WHERE clause guards against double-acknowledgement. The DB trigger
+        // also rejects acknowledged = true → true flips, but the WHERE makes
+        // the intent explicit in the application layer.
+        `UPDATE audit_log SET acknowledged = true WHERE id = $1 AND acknowledged = false`,
+        [eventId],
+      );
+    } catch (err) {
+      this.logger.error({ err, eventId }, 'Failed to mark audit log row as acknowledged');
+      throw err;
+    }
+  }
+
+  /**
+   * Scan for audit_log rows that were written but never acknowledged.
+   * Called once at startup, after migrations run and before serving requests.
+   *
+   * Unacknowledged rows indicate the process crashed between writing the
+   * write-ahead record and completing subscriber delivery. They are flagged
+   * here so operators can identify which events may not have been delivered.
+   *
+   * Replay of unacknowledged events is a separate feature (not yet implemented).
+   * This scan is diagnostic only.
+   */
+  async scanForUnacknowledged(): Promise<void> {
+    type ScanRow = { id: string; event_type: string; timestamp: Date };
+    let rows: ScanRow[];
+    try {
+      const result = await this.pool.query<ScanRow>(
+        `SELECT id, event_type, timestamp FROM audit_log WHERE acknowledged = false ORDER BY timestamp ASC`,
+      );
+      rows = result.rows;
+    } catch (err) {
+      // Diagnostic scan failure — log and continue. Startup must not be blocked by a
+      // transient DB error here; the scan is observability-only, not a hard requirement.
+      this.logger.warn({ err }, 'Audit log startup scan failed — could not query unacknowledged rows');
+      return;
+    }
+
+    if (rows.length === 0) {
+      this.logger.debug('Audit log startup scan: no unacknowledged events');
+      return;
+    }
+
+    // Log at warn level — unacknowledged rows mean delivery may have been
+    // incomplete on the previous run. This is not an error (crash recovery
+    // is expected), but it warrants operator attention.
+    this.logger.warn(
+      {
+        count: rows.length,
+        events: rows.map(r => ({ id: r.id, eventType: r.event_type, timestamp: r.timestamp })),
+      },
+      'Audit log startup scan: unacknowledged events detected — delivery may have been incomplete on previous run',
+    );
   }
 }

--- a/src/audit/logger.ts
+++ b/src/audit/logger.ts
@@ -136,7 +136,10 @@ export class AuditLogger {
       const countResult = await this.pool.query<{ count: string }>(
         `SELECT COUNT(*) AS count FROM audit_log WHERE acknowledged = false`,
       );
-      count = parseInt(countResult.rows[0].count, 10);
+      // COUNT(*) always returns exactly one row, but TypeScript's pg typings
+      // type rows as T[] (no tuple inference), so rows[0] is technically T|undefined.
+      // The `?? '0'` fallback satisfies the type checker without altering behaviour.
+      count = parseInt(countResult.rows[0]?.count ?? '0', 10);
     } catch (err) {
       this.logger.error({ err }, 'Audit log startup scan failed — could not query unacknowledged rows');
       return;

--- a/src/audit/logger.ts
+++ b/src/audit/logger.ts
@@ -85,13 +85,19 @@ export class AuditLogger {
    */
   async markAcknowledged(eventId: string): Promise<void> {
     try {
-      await this.pool.query(
+      const result = await this.pool.query(
         // The WHERE clause guards against double-acknowledgement. The DB trigger
         // also rejects acknowledged = true → true flips, but the WHERE makes
         // the intent explicit in the application layer.
         `UPDATE audit_log SET acknowledged = true WHERE id = $1 AND acknowledged = false`,
         [eventId],
       );
+      if ((result.rowCount ?? 0) === 0) {
+        // 0 rows updated — either the row is already acknowledged (acceptable) or
+        // the eventId was never inserted (would indicate the write-ahead INSERT
+        // silently failed, leaving a gap in the audit trail).
+        this.logger.warn({ eventId }, 'markAcknowledged matched 0 rows — row may already be acknowledged or eventId not found in audit_log');
+      }
     } catch (err) {
       this.logger.error({ err, eventId }, 'Failed to mark audit log row as acknowledged');
       throw err;
@@ -118,9 +124,13 @@ export class AuditLogger {
       );
       rows = result.rows;
     } catch (err) {
-      // Diagnostic scan failure — log and continue. Startup must not be blocked by a
-      // transient DB error here; the scan is observability-only, not a hard requirement.
-      this.logger.warn({ err }, 'Audit log startup scan failed — could not query unacknowledged rows');
+      // Log at error — by the time this scan runs, the DB connection and schema are
+      // already confirmed healthy (the migration runner would have exited the process
+      // on any DB error). A failure here indicates a permissions problem, schema
+      // mismatch, or query bug — not a transient connection blip. Startup continues
+      // regardless (the scan is diagnostic only), but the error is surfaced at the
+      // correct severity.
+      this.logger.error({ err }, 'Audit log startup scan failed — could not query unacknowledged rows');
       return;
     }
 
@@ -129,13 +139,21 @@ export class AuditLogger {
       return;
     }
 
+    // Cap the number of events included in the log entry to avoid overflowing
+    // log aggregator per-entry size limits (typically 64KB–256KB). The total
+    // count is always logged so operators know whether rows were omitted.
+    const LOG_LIMIT = 50;
+    const shown = rows.slice(0, LOG_LIMIT);
+
     // Log at warn level — unacknowledged rows mean delivery may have been
     // incomplete on the previous run. This is not an error (crash recovery
     // is expected), but it warrants operator attention.
     this.logger.warn(
       {
         count: rows.length,
-        events: rows.map(r => ({ id: r.id, eventType: r.event_type, timestamp: r.timestamp })),
+        shown: shown.length,
+        truncated: rows.length > LOG_LIMIT,
+        events: shown.map(r => ({ id: r.id, eventType: r.event_type, timestamp: r.timestamp })),
       },
       'Audit log startup scan: unacknowledged events detected — delivery may have been incomplete on previous run',
     );

--- a/src/bus/bus.ts
+++ b/src/bus/bus.ts
@@ -9,15 +9,22 @@ type EventHandler = (event: BusEvent) => void | Promise<void>;
 // throws or the process crashes mid-delivery, the event is already persisted.
 type OnEventHook = (event: BusEvent) => void | Promise<void>;
 
+// The onDelivered hook runs after all subscribers have been attempted (regardless
+// of per-subscriber errors). The audit logger uses it to flip acknowledged = true,
+// signalling that delivery was attempted for all registered handlers.
+type OnDeliveredHook = (eventId: string) => void | Promise<void>;
+
 export class EventBus {
   // Keyed by EventType so dispatch is O(1) lookup rather than scanning all subscribers.
   private subscribers = new Map<EventType, EventHandler[]>();
   private logger: Logger;
   private onEvent?: OnEventHook;
+  private onDelivered?: OnDeliveredHook;
 
-  constructor(logger: Logger, onEvent?: OnEventHook) {
+  constructor(logger: Logger, onEvent?: OnEventHook, onDelivered?: OnDeliveredHook) {
     this.logger = logger;
     this.onEvent = onEvent;
+    this.onDelivered = onDelivered;
   }
 
   subscribe(eventType: EventType, layer: Layer, handler: EventHandler): void {
@@ -72,6 +79,23 @@ export class EventBus {
         this.logger.error(
           { err, eventType: event.type, eventId: event.id },
           'Subscriber error',
+        );
+      }
+    }
+
+    // Delivery confirmation hook — runs after all handlers have been attempted.
+    // "Delivery attempted" (not "all succeeded") is the guarantee: per-subscriber
+    // errors are swallowed above, but the event was dispatched to every registered
+    // handler. The audit logger uses this to flip acknowledged = true.
+    // Errors here are logged but not re-thrown — a failed acknowledgement write
+    // should not roll back a completed delivery.
+    if (this.onDelivered) {
+      try {
+        await this.onDelivered(event.id);
+      } catch (err) {
+        this.logger.error(
+          { err, eventType: event.type, eventId: event.id },
+          'Delivery acknowledgement failed',
         );
       }
     }

--- a/src/db/migrations/021_audit_log_append_only.sql
+++ b/src/db/migrations/021_audit_log_append_only.sql
@@ -1,5 +1,10 @@
 -- Up Migration
 --
+-- Down Migration (rollback):
+--   DROP TRIGGER IF EXISTS audit_log_immutable_trigger ON audit_log;
+--   DROP FUNCTION IF EXISTS audit_log_immutable();
+--
+--
 -- Enforce audit_log append-only at the database level.
 --
 -- The audit log is immutable by design: no UPDATE or DELETE is ever permitted

--- a/src/db/migrations/021_audit_log_append_only.sql
+++ b/src/db/migrations/021_audit_log_append_only.sql
@@ -1,0 +1,42 @@
+-- Up Migration
+--
+-- Enforce audit_log append-only at the database level.
+--
+-- The audit log is immutable by design: no UPDATE or DELETE is ever permitted
+-- on a persisted row, with exactly one exception — the delivery acknowledgement
+-- path is allowed to flip `acknowledged` from false to true once per row.
+--
+-- This trigger runs BEFORE any UPDATE or DELETE so the operation is rejected
+-- before it reaches storage. Using a RAISE EXCEPTION (rather than a silent
+-- DO INSTEAD NOTHING rule) makes accidental mutations visible immediately
+-- rather than silently disappearing.
+
+CREATE OR REPLACE FUNCTION audit_log_immutable()
+RETURNS trigger AS $$
+BEGIN
+  -- The only permitted mutation: marking a row as acknowledged (false → true).
+  -- All other columns must remain identical to prevent any partial update from
+  -- sneaking through by bundling with the acknowledged flip.
+  IF TG_OP = 'UPDATE'
+    AND OLD.acknowledged = false
+    AND NEW.acknowledged = true
+    AND OLD.id                = NEW.id
+    AND OLD.timestamp         = NEW.timestamp
+    AND OLD.event_type        = NEW.event_type
+    AND OLD.source_layer      = NEW.source_layer
+    AND OLD.source_id         = NEW.source_id
+    AND OLD.payload           = NEW.payload
+    AND (OLD.conversation_id  IS NOT DISTINCT FROM NEW.conversation_id)
+    AND (OLD.task_id          IS NOT DISTINCT FROM NEW.task_id)
+    AND (OLD.parent_event_id  IS NOT DISTINCT FROM NEW.parent_event_id)
+  THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'audit_log is append-only: % operations are not permitted (only acknowledged false→true is allowed)', TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER audit_log_immutable_trigger
+  BEFORE UPDATE OR DELETE ON audit_log
+  FOR EACH ROW EXECUTE FUNCTION audit_log_immutable();

--- a/src/db/migrations/021_audit_log_append_only.sql
+++ b/src/db/migrations/021_audit_log_append_only.sql
@@ -1,9 +1,7 @@
 -- Up Migration
 --
--- Down Migration (rollback):
---   DROP TRIGGER IF EXISTS audit_log_immutable_trigger ON audit_log;
---   DROP FUNCTION IF EXISTS audit_log_immutable();
---
+-- To rollback: DROP TRIGGER IF EXISTS audit_log_immutable_trigger ON audit_log;
+--              DROP FUNCTION IF EXISTS audit_log_immutable();
 --
 -- Enforce audit_log append-only at the database level.
 --

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,10 +127,22 @@ async function main(): Promise<void> {
   // delivering to any subscriber, so this must exist when the bus is constructed.
   const auditLogger = new AuditLogger(pool, logger);
 
+  // 3b. Startup scan — flag any events that were written but never acknowledged.
+  // These indicate the process crashed between write-ahead and delivery on a
+  // previous run. Logged at warn level for operator visibility; replay is a
+  // separate future feature.
+  await auditLogger.scanForUnacknowledged();
+
   // 4. Message bus — the write-ahead hook ensures every event is durably
   // recorded before it reaches any subscriber. Losing a message is worse
   // than slowing down delivery, hence the synchronous-before-fanout design.
-  const bus = new EventBus(logger, (event) => auditLogger.log(event));
+  // The onDelivered hook flips acknowledged = true after all handlers have
+  // been attempted, completing the delivery lifecycle record.
+  const bus = new EventBus(
+    logger,
+    (event) => auditLogger.log(event),
+    (eventId) => auditLogger.markAcknowledged(eventId),
+  );
 
   // 4b. Office identity — System-layer service that owns the instance persona.
   // Must be initialized after migrations (schema) and bus (emits config.change events),

--- a/tests/integration/audit-log.test.ts
+++ b/tests/integration/audit-log.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import pg from 'pg';
 import { AuditLogger } from '../../src/audit/logger.js';
 import { EventBus } from '../../src/bus/bus.js';
@@ -22,6 +22,25 @@ describeIf('audit_log append-only enforcement', () => {
 
     // Sanity check: migrations have run and the table exists.
     await pool.query('SELECT 1 FROM audit_log LIMIT 0');
+
+    // Fast-fail if migration 021 (append-only trigger) hasn't been applied.
+    // Without the trigger the "rejects" assertions below would fail with
+    // misleading "expected to throw but didn't" errors instead of surfacing
+    // the real problem: a missing migration.
+    const triggerResult = await pool.query<{ exists: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1
+         FROM   pg_trigger  t
+         JOIN   pg_class    c ON c.oid = t.tgrelid
+         WHERE  c.relname = 'audit_log'
+         AND    t.tgname  = 'audit_log_immutable_trigger'
+       ) AS exists`,
+    );
+    if (!triggerResult.rows[0].exists) {
+      throw new Error(
+        'audit_log_immutable_trigger not found — run migration 021 before running integration tests',
+      );
+    }
   });
 
   afterAll(async () => {
@@ -166,20 +185,45 @@ describeIf('audit_log append-only enforcement', () => {
 
   // ---- AuditLogger.scanForUnacknowledged ----
 
-  it('scanForUnacknowledged returns without error when all rows are acknowledged', async () => {
+  it('scanForUnacknowledged resolves without throwing when called', async () => {
     // Insert a row and immediately acknowledge it.
     const id = await insertTestRow();
     await auditLogger.markAcknowledged(id);
 
-    // Should resolve without throwing. (Silent logger swallows output.)
-    await expect(auditLogger.scanForUnacknowledged()).resolves.toBeUndefined();
+    // The append-only table means prior tests left unacknowledged rows — we
+    // cannot guarantee the "no unacked rows" branch. What we CAN assert: the
+    // function always resolves regardless of DB state, and no spurious debug
+    // call is emitted for the row this test inserted (it's already acked).
+    //
+    // Use a spy logger to confirm no unexpected error-level calls occur.
+    const spyLogger = createSilentLogger();
+    const errorSpy = vi.spyOn(spyLogger, 'error');
+    const scanLogger = new AuditLogger(pool, spyLogger);
+
+    await expect(scanLogger.scanForUnacknowledged()).resolves.toBeUndefined();
+
+    // The scan query itself must not fail — any error would surface here.
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 
-  it('scanForUnacknowledged resolves without error even when unacknowledged rows exist', async () => {
-    // Insert a row and leave it unacknowledged.
+  it('scanForUnacknowledged logs a warn with pending count when unacknowledged rows exist', async () => {
+    // Insert a row and leave it unacknowledged so the scan definitely finds it.
     await insertTestRow();
 
+    const spyLogger = createSilentLogger();
+    const warnSpy = vi.spyOn(spyLogger, 'warn');
+    const scanLogger = new AuditLogger(pool, spyLogger);
+
     // The scan logs a warning but does NOT throw — it's diagnostic only.
-    await expect(auditLogger.scanForUnacknowledged()).resolves.toBeUndefined();
+    await expect(scanLogger.scanForUnacknowledged()).resolves.toBeUndefined();
+
+    // Assert the observable logging contract: at least one warn call with a
+    // numeric count field > 0.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ count: expect.any(Number) }),
+      expect.any(String),
+    );
+    const [payload] = warnSpy.mock.calls[0];
+    expect((payload as { count: number }).count).toBeGreaterThan(0);
   });
 });

--- a/tests/integration/audit-log.test.ts
+++ b/tests/integration/audit-log.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import { AuditLogger } from '../../src/audit/logger.js';
+import { EventBus } from '../../src/bus/bus.js';
+import { createInboundMessage } from '../../src/bus/events.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+
+// Skip if DATABASE_URL is not set (CI may not have Postgres).
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('audit_log append-only enforcement', () => {
+  let pool: pg.Pool;
+  let auditLogger: AuditLogger;
+  const logger = createSilentLogger();
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    auditLogger = new AuditLogger(pool, logger);
+
+    // Sanity check: migrations have run and the table exists.
+    await pool.query('SELECT 1 FROM audit_log LIMIT 0');
+  });
+
+  afterAll(async () => {
+    // audit_log is append-only — rows cannot be deleted, even in tests.
+    // The trigger we're verifying here blocks DELETE, so teardown is just closing the pool.
+    // Test rows (source_layer = 'test-audit-enforcement') accumulate in the dev DB but are
+    // harmless; they will not appear in production.
+    await pool.end();
+  });
+
+  // Helper: insert a raw row with a known source_layer sentinel so cleanup is precise.
+  async function insertTestRow(): Promise<string> {
+    const result = await pool.query<{ id: string }>(
+      `INSERT INTO audit_log (event_type, source_layer, source_id, payload)
+       VALUES ('inbound.message', 'test-audit-enforcement', 'test-source', '{}')
+       RETURNING id`,
+    );
+    return result.rows[0].id;
+  }
+
+  // ---- Trigger: DELETE is rejected ----
+
+  it('rejects DELETE on audit_log', async () => {
+    const id = await insertTestRow();
+
+    await expect(
+      pool.query('DELETE FROM audit_log WHERE id = $1', [id]),
+    ).rejects.toThrow(/append-only/);
+  });
+
+  // ---- Trigger: arbitrary UPDATE is rejected ----
+
+  it('rejects UPDATE of any immutable column', async () => {
+    const id = await insertTestRow();
+
+    await expect(
+      pool.query(`UPDATE audit_log SET event_type = $2 WHERE id = $1`, [id, 'tampered']),
+    ).rejects.toThrow(/append-only/);
+  });
+
+  it('rejects UPDATE that changes payload', async () => {
+    const id = await insertTestRow();
+
+    await expect(
+      pool.query(`UPDATE audit_log SET payload = $2 WHERE id = $1`, [id, '{"tampered":true}']),
+    ).rejects.toThrow(/append-only/);
+  });
+
+  it('rejects UPDATE that flips acknowledged true → true (already acknowledged)', async () => {
+    const id = await insertTestRow();
+    // First, legitimately acknowledge the row.
+    await pool.query(`UPDATE audit_log SET acknowledged = true WHERE id = $1 AND acknowledged = false`, [id]);
+
+    // Attempting to set it to true again should be rejected because
+    // OLD.acknowledged = true (not false), so the trigger's exception branch fires.
+    await expect(
+      pool.query(`UPDATE audit_log SET acknowledged = true WHERE id = $1`, [id]),
+    ).rejects.toThrow(/append-only/);
+  });
+
+  // ---- Trigger: acknowledged false → true is the one permitted UPDATE ----
+
+  it('allows UPDATE that flips acknowledged from false to true', async () => {
+    const id = await insertTestRow();
+
+    // Must not throw.
+    await expect(
+      pool.query(
+        `UPDATE audit_log SET acknowledged = true WHERE id = $1 AND acknowledged = false`,
+        [id],
+      ),
+    ).resolves.toBeDefined();
+
+    const result = await pool.query<{ acknowledged: boolean }>(
+      `SELECT acknowledged FROM audit_log WHERE id = $1`,
+      [id],
+    );
+    expect(result.rows[0].acknowledged).toBe(true);
+  });
+
+  // ---- AuditLogger.markAcknowledged ----
+
+  it('markAcknowledged flips the row to acknowledged = true', async () => {
+    const id = await insertTestRow();
+    await auditLogger.markAcknowledged(id);
+
+    const result = await pool.query<{ acknowledged: boolean }>(
+      `SELECT acknowledged FROM audit_log WHERE id = $1`,
+      [id],
+    );
+    expect(result.rows[0].acknowledged).toBe(true);
+  });
+
+  it('markAcknowledged is idempotent (no error on already-acknowledged row)', async () => {
+    const id = await insertTestRow();
+    // Pre-acknowledge using parameterized query (WHERE guards double-flip in app layer).
+    await pool.query(
+      `UPDATE audit_log SET acknowledged = true WHERE id = $1 AND acknowledged = false`,
+      [id],
+    );
+
+    // The WHERE id = $1 AND acknowledged = false matches 0 rows — no UPDATE issued,
+    // so the trigger never fires. markAcknowledged should silently succeed.
+    await expect(auditLogger.markAcknowledged(id)).resolves.toBeUndefined();
+  });
+
+  // ---- EventBus + AuditLogger end-to-end: INSERT succeeds, acknowledged flips ----
+
+  it('publishes an event: audit row is inserted then acknowledged', async () => {
+    const bus = new EventBus(
+      logger,
+      (event) => auditLogger.log(event),
+      (eventId) => auditLogger.markAcknowledged(eventId),
+    );
+
+    const event = createInboundMessage({
+      conversationId: 'conv-test',
+      channelId: 'test-channel',
+      senderId: 'test-sender',
+      content: 'hello audit',
+    });
+
+    await bus.publish('channel', event);
+
+    const result = await pool.query<{ acknowledged: boolean; source_layer: string }>(
+      `SELECT acknowledged, source_layer FROM audit_log WHERE id = $1`,
+      [event.id],
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].acknowledged).toBe(true);
+    expect(result.rows[0].source_layer).toBe('channel');
+
+    // Clean up this row (different source_layer sentinel, so clean up individually).
+    // The trigger blocks DELETE — use the test workaround: UPDATE is the only path,
+    // but we actually want to remove it. We must bypass via a direct pool query
+    // that the trigger allows... but it doesn't. Instead, leave it and rely on
+    // a future cleanup migration, OR mark it acknowledged and leave it.
+    // Acceptable: the row is already acknowledged = true, it won't appear in scans.
+    // NOTE: leaving this row is intentional — audit rows are immutable by design.
+  });
+
+  // ---- AuditLogger.scanForUnacknowledged ----
+
+  it('scanForUnacknowledged returns without error when all rows are acknowledged', async () => {
+    // Insert a row and immediately acknowledge it.
+    const id = await insertTestRow();
+    await auditLogger.markAcknowledged(id);
+
+    // Should resolve without throwing. (Silent logger swallows output.)
+    await expect(auditLogger.scanForUnacknowledged()).resolves.toBeUndefined();
+  });
+
+  it('scanForUnacknowledged resolves without error even when unacknowledged rows exist', async () => {
+    // Insert a row and leave it unacknowledged.
+    await insertTestRow();
+
+    // The scan logs a warning but does NOT throw — it's diagnostic only.
+    await expect(auditLogger.scanForUnacknowledged()).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/bus/bus.test.ts
+++ b/tests/unit/bus/bus.test.ts
@@ -81,12 +81,18 @@ describe('EventBus', () => {
     expect(onEvent).toHaveBeenCalledWith(event);
   });
 
-  it('calls onDelivered hook after all subscribers have been attempted', async () => {
+  it('calls onDelivered hook strictly after all subscribers have been attempted', async () => {
     // The onDelivered hook is used by the audit logger to flip acknowledged = true
     // after all handlers have been dispatched (regardless of per-subscriber errors).
-    const onDelivered = vi.fn();
+    // Verify ordering by tracking invocation sequence across two subscribers.
+    const callOrder: string[] = [];
+    const subscriber1 = vi.fn(() => { callOrder.push('subscriber1'); });
+    const subscriber2 = vi.fn(() => { callOrder.push('subscriber2'); });
+    const onDelivered = vi.fn(() => { callOrder.push('onDelivered'); });
+
     bus = new EventBus(createLogger('error'), undefined, onDelivered);
-    bus.subscribe('inbound.message', 'dispatch', vi.fn());
+    bus.subscribe('inbound.message', 'dispatch', subscriber1);
+    bus.subscribe('inbound.message', 'dispatch', subscriber2);
 
     const event = createInboundMessage({
       conversationId: 'conv-1',
@@ -96,15 +102,28 @@ describe('EventBus', () => {
     });
     await bus.publish('channel', event);
 
+    expect(subscriber1).toHaveBeenCalledWith(event);
+    expect(subscriber2).toHaveBeenCalledWith(event);
     expect(onDelivered).toHaveBeenCalledWith(event.id);
+    // onDelivered must come last — both subscribers were attempted first.
+    expect(callOrder).toEqual(['subscriber1', 'subscriber2', 'onDelivered']);
   });
 
   it('calls onDelivered even when a subscriber throws', async () => {
     // A failing subscriber must not prevent acknowledgement — the event was
-    // dispatched and the audit record should reflect that.
-    const onDelivered = vi.fn();
+    // dispatched and the audit record should reflect that. Verify ordering:
+    // both subscribers are attempted before onDelivered fires.
+    const callOrder: string[] = [];
+    const failingSubscriber = vi.fn(() => {
+      callOrder.push('failingSubscriber');
+      throw new Error('subscriber failure');
+    });
+    const successSubscriber = vi.fn(() => { callOrder.push('successSubscriber'); });
+    const onDelivered = vi.fn(() => { callOrder.push('onDelivered'); });
+
     bus = new EventBus(createLogger('error'), undefined, onDelivered);
-    bus.subscribe('inbound.message', 'dispatch', () => { throw new Error('subscriber failure'); });
+    bus.subscribe('inbound.message', 'dispatch', failingSubscriber);
+    bus.subscribe('inbound.message', 'dispatch', successSubscriber);
 
     const event = createInboundMessage({
       conversationId: 'conv-1',
@@ -115,6 +134,8 @@ describe('EventBus', () => {
     await bus.publish('channel', event);
 
     expect(onDelivered).toHaveBeenCalledWith(event.id);
+    // onDelivered must fire after both subscribers — even the failing one.
+    expect(callOrder).toEqual(['failingSubscriber', 'successSubscriber', 'onDelivered']);
   });
 
   it('resolves publish() even when onDelivered throws', async () => {

--- a/tests/unit/bus/bus.test.ts
+++ b/tests/unit/bus/bus.test.ts
@@ -116,4 +116,23 @@ describe('EventBus', () => {
 
     expect(onDelivered).toHaveBeenCalledWith(event.id);
   });
+
+  it('resolves publish() even when onDelivered throws', async () => {
+    // A failed acknowledgement write must not roll back a completed delivery.
+    // The publisher's view of the event (published successfully) must remain
+    // stable regardless of whether the post-delivery audit flip succeeded.
+    const failingOnDelivered = vi.fn().mockRejectedValue(new Error('ack write failed'));
+    bus = new EventBus(createLogger('error'), undefined, failingOnDelivered);
+    bus.subscribe('inbound.message', 'dispatch', vi.fn());
+
+    const event = createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Hello',
+    });
+
+    // Must resolve — not reject — even though onDelivered threw.
+    await expect(bus.publish('channel', event)).resolves.toBeUndefined();
+  });
 });

--- a/tests/unit/bus/bus.test.ts
+++ b/tests/unit/bus/bus.test.ts
@@ -80,4 +80,40 @@ describe('EventBus', () => {
 
     expect(onEvent).toHaveBeenCalledWith(event);
   });
+
+  it('calls onDelivered hook after all subscribers have been attempted', async () => {
+    // The onDelivered hook is used by the audit logger to flip acknowledged = true
+    // after all handlers have been dispatched (regardless of per-subscriber errors).
+    const onDelivered = vi.fn();
+    bus = new EventBus(createLogger('error'), undefined, onDelivered);
+    bus.subscribe('inbound.message', 'dispatch', vi.fn());
+
+    const event = createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Hello',
+    });
+    await bus.publish('channel', event);
+
+    expect(onDelivered).toHaveBeenCalledWith(event.id);
+  });
+
+  it('calls onDelivered even when a subscriber throws', async () => {
+    // A failing subscriber must not prevent acknowledgement — the event was
+    // dispatched and the audit record should reflect that.
+    const onDelivered = vi.fn();
+    bus = new EventBus(createLogger('error'), undefined, onDelivered);
+    bus.subscribe('inbound.message', 'dispatch', () => { throw new Error('subscriber failure'); });
+
+    const event = createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Hello',
+    });
+    await bus.publish('channel', event);
+
+    expect(onDelivered).toHaveBeenCalledWith(event.id);
+  });
 });


### PR DESCRIPTION
## Summary

- **Migration 021** adds a PostgreSQL trigger (`audit_log_immutable_trigger`) that raises an exception on any `UPDATE` or `DELETE` to `audit_log`, with the single permitted exception of flipping `acknowledged` from `false` to `true` after delivery
- **`EventBus`** gains an `onDelivered` hook that fires after all subscribers have been attempted (regardless of per-subscriber errors)
- **`AuditLogger`** gains `markAcknowledged()` (called by `onDelivered` to flip the flag) and `scanForUnacknowledged()` (called once at startup to warn on rows that were never delivered)
- **Code-level grep** confirmed zero existing `UPDATE audit_log` or `DELETE FROM audit_log` paths — enforcement was convention-only before this PR

Closes #202. Replay of unacknowledged events on startup tracked in #247.

## What changed

| File | Change |
|---|---|
| `src/db/migrations/021_audit_log_append_only.sql` | New — trigger + function |
| `src/bus/bus.ts` | Added `onDelivered` hook (third constructor param) |
| `src/audit/logger.ts` | Added `markAcknowledged()`, `scanForUnacknowledged()` |
| `src/index.ts` | Wires `onDelivered` hook; calls startup scan after migrations |
| `tests/unit/bus/bus.test.ts` | 3 new tests for `onDelivered` behavior |
| `tests/integration/audit-log.test.ts` | New — 10 integration tests against real Postgres |

## Test plan

- [x] `npm test tests/unit/bus/bus.test.ts` — 8 tests pass
- [x] `DATABASE_URL=... npm test tests/integration/audit-log.test.ts` — 10 tests pass against real Postgres
- [x] Trigger blocks `DELETE` (raises exception)
- [x] Trigger blocks arbitrary `UPDATE` (raises exception)
- [x] Trigger allows `acknowledged false → true` flip
- [x] Trigger blocks `acknowledged true → true` double-flip
- [x] `markAcknowledged` is idempotent (0 rows updated = silent, with warn log)
- [x] `publish()` resolves even when `onDelivered` throws (delivery not rolled back)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Audit log is now enforced append-only at the database level, blocking unauthorized updates/deletes while allowing acknowledgement flips.

* **New Features**
  * Events are automatically acknowledged after delivery attempts complete.
  * Startup scan warns about previously unacknowledged events from prior runs.

* **Tests**
  * Added integration and unit tests covering append-only enforcement and delivery-acknowledgement behaviour.

* **Documentation**
  * Security checklist updated to reflect DB-level append-only enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->