### PR TITLE
feat: PII scrubbing for LLM-facing error strings and pino log output (spec 06, #197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+- **PII scrubbing for LLM-facing error strings** — Error messages that enter the LLM's
+  context window (via `classifyError` / `classifySkillError`) are now scrubbed of email
+  addresses, US/CA/UK phone numbers, credit card numbers, and keyword-prefixed SSNs before
+  reaching the model. The audit log retains the full unredacted error for debugging. Patterns
+  are sourced from `@openredaction/openredaction` and applied synchronously via a thin
+  extraction layer (`src/pii/scrubber.ts`). Operator-configurable extra patterns via
+  `pii.extra_patterns` in `config/default.yaml` (spec 06, issue #197).
+- **Pino logger PII redaction** — Added `senderId`, `email`, `from`, and `phoneNumber` to
+  pino's structured-field redact list (at 0/1/2 nesting levels) as a last-resort safety net
+  against sender identifiers appearing in stdout log output (spec 06, issue #197).
+
 ### Fixed
 - **Outbound content filter: wrong `ceoEmail` causing false-positive blocks** — The
   `OutboundContentFilter` and `OutboundGateway` were initialized with `nylasSelfEmail`

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -85,6 +85,38 @@ security:
   # unless the channel is configured as 'ignore'.
   trust_score_floor: 0.2
 
+pii:
+  # Extra PII patterns to scrub from LLM-facing error strings, beyond the built-in
+  # defaults (spec §06-audit-and-security.md — PII Handling).
+  #
+  # Built-in defaults (sourced from @openredaction/openredaction):
+  #   - Email addresses       → [EMAIL]
+  #   - US-format phone numbers (also matches CA)   → [PHONE]
+  #   - UK phone numbers      → [PHONE]
+  #   - Credit card numbers   → [CREDIT_CARD]
+  #   - US SSNs (keyword-prefixed, e.g. "SSN: 123-45-6789") → [SSN]
+  #
+  # Add custom patterns here for any PII types specific to your deployment
+  # (employee IDs, account numbers, national IDs, etc.).
+  #
+  # Each entry must have:
+  #   regex       — a valid JavaScript regex string (gi flags applied automatically)
+  #   replacement — the placeholder to substitute, e.g. "[EMPLOYEE_ID]"
+  #
+  # Example:
+  #   extra_patterns:
+  #     - regex: "EMP-\\d{6}"
+  #       replacement: "[EMPLOYEE_ID]"
+  #     - regex: "\\b\\d{3}[-\\s]?\\d{3}[-\\s]?\\d{3}\\b"
+  #       replacement: "[CA_SIN]"
+  #
+  # Changes take effect on restart — no code changes required.
+  #
+  # ⚠️  ReDoS warning: avoid patterns with unbounded nested quantifiers such as
+  # (a+)+ or (.+)+ — these can cause catastrophic backtracking on adversarial input.
+  # These patterns run on every LLM-facing error message.
+  extra_patterns: []
+
 # Trust-gated action thresholds (spec §06-audit-and-security.md).
 # The Coordinator checks messageTrustScore against these thresholds before
 # taking actions on behalf of a sender. Enforced via the Coordinator's system prompt.

--- a/docs/specs/06-audit-and-security.md
+++ b/docs/specs/06-audit-and-security.md
@@ -94,9 +94,9 @@ For persistent tasks:
 
 ### PII Handling
 
-- Error strings surfaced to the LLM are scrubbed of PII patterns (email addresses, phone numbers) using configurable regex
+- Error strings surfaced to the LLM are scrubbed of PII patterns (email addresses, phone numbers, credit cards, SSNs) via `src/pii/scrubber.ts`, which extracts regexes from `@openredaction/openredaction` at startup. Operators can add extra patterns via `pii.extra_patterns` in `config/default.yaml`.
 - The audit log retains the full error (PII included) for debugging — the redaction is only for LLM-facing context
-- No PII is logged to stdout/pino — only to the audit log
+- No PII is logged to stdout/pino — field-level redaction via pino's `redact` config covers known PII field names (`senderId`, `email`, `senderEmail`, `phoneNumber`) as a last-resort safety net
 
 ---
 
@@ -349,7 +349,7 @@ These are non-negotiable for launch.
 | Secret values never appear in logs, audit, or LLM context | Not Done |
 | Tool output sanitization active for all skill results | Done |
 | Inbound message sanitization active (injection pattern detection) | Done |
-| Error strings scrubbed before LLM injection | Not Done |
+| Error strings scrubbed before LLM injection | Done (#250) |
 | Agent config validation blocks malformed YAML at startup | Not Done |
 | HTTP API channel requires token authentication | Done |
 | Rate limiting active at dispatch layer | Not Done |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",
@@ -14,6 +14,7 @@
         "@fastify/cors": "^11.2.0",
         "@fastify/rate-limit": "^10.3.0",
         "@ghostery/adblocker-playwright": "^2.14.1",
+        "@openredaction/openredaction": "^1.0.4",
         "chokidar": "^5.0.0",
         "cron-parser": "^5.5.0",
         "cytoscape": "^3.33.1",
@@ -1043,6 +1044,43 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@openredaction/openredaction": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@openredaction/openredaction/-/openredaction-1.0.4.tgz",
+      "integrity": "sha512-BOd4nEiz+uhV0YY7P7gBmJIiHKBO7w9e5P5iaLErJ3Ay8IdYHYIORmmTh1xVpwbWYNLtGbGHfn3OFs1aX8QThg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "bin": {
+        "openredaction": "dist/index.cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0",
+        "mammoth": "^1.6.0",
+        "pdf-parse": "^1.1.1",
+        "react": "^18.0.0 || ^19.0.0",
+        "tesseract.js": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        },
+        "mammoth": {
+          "optional": true
+        },
+        "pdf-parse": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "tesseract.js": {
+          "optional": true
+        }
       }
     },
     "node_modules/@oxc-project/types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {
@@ -27,6 +27,7 @@
     "@fastify/cors": "^11.2.0",
     "@fastify/rate-limit": "^10.3.0",
     "@ghostery/adblocker-playwright": "^2.14.1",
+    "@openredaction/openredaction": "^1.0.4",
     "chokidar": "^5.0.0",
     "cron-parser": "^5.5.0",
     "cytoscape": "^3.33.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@ghostery/adblocker-playwright':
         specifier: ^2.14.1
         version: 2.14.1(playwright@1.59.1)
+      '@openredaction/openredaction':
+        specifier: ^1.0.4
+        version: 1.0.4
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -409,6 +412,29 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@openredaction/openredaction@1.0.4':
+    resolution: {integrity: sha512-BOd4nEiz+uhV0YY7P7gBmJIiHKBO7w9e5P5iaLErJ3Ay8IdYHYIORmmTh1xVpwbWYNLtGbGHfn3OFs1aX8QThg==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    hasBin: true
+    peerDependencies:
+      express: ^4.18.0 || ^5.0.0
+      mammoth: ^1.6.0
+      pdf-parse: ^1.1.1
+      react: ^18.0.0 || ^19.0.0
+      tesseract.js: ^5.0.0
+    peerDependenciesMeta:
+      express:
+        optional: true
+      mammoth:
+        optional: true
+      pdf-parse:
+        optional: true
+      react:
+        optional: true
+      tesseract.js:
+        optional: true
+
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
 
@@ -468,36 +494,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
     resolution: {integrity: sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
     resolution: {integrity: sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
     resolution: {integrity: sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==}
@@ -559,66 +591,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -1259,24 +1304,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2156,6 +2205,8 @@ snapshots:
       '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@openredaction/openredaction@1.0.4': {}
 
   '@oxc-project/types@0.122.0': {}
 

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -135,14 +135,14 @@ export class EmailAdapter {
           await this.config.bus.publish('channel', event);
 
           this.config.logger.info(
-            { from: fromEmail, subject: msg.subject, threadId: msg.threadId },
+            { senderEmail: fromEmail, subject: msg.subject, threadId: msg.threadId },
             'Email received and published to bus',
           );
         } catch (err) {
           // Log and skip — the high-water mark was already advanced above,
           // so this message will not be retried on the next poll cycle.
           this.config.logger.error(
-            { err, messageId: msg.id, threadId: msg.threadId, from: fromEmail },
+            { err, messageId: msg.id, threadId: msg.threadId, senderEmail: fromEmail },
             'Failed to process inbound email — skipping message',
           );
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,6 +91,19 @@ export interface YamlConfig {
     scheduling?: number;
     information_queries?: number;
   };
+  pii?: {
+    /**
+     * Extra PII patterns to scrub from LLM-facing error strings, beyond the
+     * built-in defaults (email, phone, credit card, SSN).
+     *
+     * Each entry must have:
+     *   regex       — a valid JavaScript regex string (gi flags applied automatically)
+     *   replacement — the placeholder to substitute, e.g. "[EMPLOYEE_ID]"
+     *
+     * Changes take effect on restart.
+     */
+    extra_patterns?: Array<{ regex: string; replacement: string }>;
+  };
 }
 
 /**

--- a/src/errors/classify.ts
+++ b/src/errors/classify.ts
@@ -10,6 +10,21 @@
 import type { AgentError, ErrorType } from './types.js';
 import { isRetryable } from './types.js';
 import { sanitizeOutput } from '../skills/sanitize.js';
+import { scrubPii, type PiiPattern } from '../pii/scrubber.js';
+
+// Extra PII patterns loaded from config/default.yaml at startup.
+// Injected via setErrorPiiPatterns() in index.ts after config is parsed.
+// Using module-level state avoids threading extra parameters through every
+// classifyError / classifySkillError call in the codebase.
+let _extraPiiPatterns: PiiPattern[] = [];
+
+/**
+ * Configure additional PII patterns for LLM-facing error messages.
+ * Call once at startup after loading pii.extra_patterns from default.yaml.
+ */
+export function setErrorPiiPatterns(patterns: PiiPattern[]): void {
+  _extraPiiPatterns = patterns;
+}
 
 // HTTP status code → ErrorType mapping.
 // Checked first (most reliable signal).
@@ -58,10 +73,17 @@ function extractMessage(err: unknown): string {
 
 /**
  * Sanitize an error message for safe inclusion in LLM context.
- * Reuses the existing sanitizeOutput() from skills/sanitize.ts for consistency.
+ *
+ * Two-pass pipeline:
+ * 1. scrubPii() — remove email addresses, phone numbers, credit card numbers,
+ *    and other PII before the message reaches the LLM's context window.
+ *    The audit log retains the original unredacted error separately.
+ * 2. sanitizeOutput() — strip XML injection tags, redact API key patterns,
+ *    and truncate to the 400-char limit.
  */
 function sanitizeMessage(message: string): string {
-  return sanitizeOutput(message, { maxLength: MAX_MESSAGE_LENGTH });
+  const piiScrubbed = scrubPii(message, _extraPiiPatterns);
+  return sanitizeOutput(piiScrubbed, { maxLength: MAX_MESSAGE_LENGTH });
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -672,9 +672,6 @@ async function main(): Promise<void> {
 
   // PII scrubbing for LLM-facing error strings — loads extra patterns from
   // config/default.yaml pii.extra_patterns and injects them into classify.ts.
-  // Non-fatal on loader error: warn and fall back to built-in defaults.
-  // PII scrubbing for LLM-facing error strings — loads extra patterns from
-  // config/default.yaml pii.extra_patterns and injects them into classify.ts.
   // An invalid extra pattern is treated as fatal: the operator's intent was to
   // protect a specific PII type and silently ignoring their config would mean
   // that data flows unredacted to the LLM without any warning.
@@ -685,7 +682,7 @@ async function main(): Promise<void> {
     // invalid regex or missing fields, which is treated as a startup-blocking misconfiguration.
     const extraPiiPatterns = parseExtraPiiPatterns(
       piiPatternEntries,
-      configDir + '/default.yaml',
+      path.join(configDir, 'default.yaml'),
     );
     setErrorPiiPatterns(extraPiiPatterns);
     extraPiiPatternCount = extraPiiPatterns.length;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,8 @@ import { OutboundContentFilter } from './dispatch/outbound-filter.js';
 import { OutboundGateway } from './skills/outbound-gateway.js';
 import { InboundScanner } from './dispatch/inbound-scanner.js';
 import { loadExtraInjectionPatterns, type ExtraInjectionPattern } from './dispatch/security-config-loader.js';
+import { parseExtraPiiPatterns, getMissingBuiltInPatterns, getBuiltInPatternCount } from './pii/scrubber.js';
+import { setErrorPiiPatterns } from './errors/classify.js';
 import type { TrustScorerWeights } from './dispatch/trust-scorer.js';
 import { SchedulerService } from './scheduler/scheduler-service.js';
 import { Scheduler } from './scheduler/scheduler.js';
@@ -667,6 +669,44 @@ async function main(): Promise<void> {
   }
   scheduler.start();
   logger.info('Scheduler started');
+
+  // PII scrubbing for LLM-facing error strings — loads extra patterns from
+  // config/default.yaml pii.extra_patterns and injects them into classify.ts.
+  // Non-fatal on loader error: warn and fall back to built-in defaults.
+  // PII scrubbing for LLM-facing error strings — loads extra patterns from
+  // config/default.yaml pii.extra_patterns and injects them into classify.ts.
+  // An invalid extra pattern is treated as fatal: the operator's intent was to
+  // protect a specific PII type and silently ignoring their config would mean
+  // that data flows unredacted to the LLM without any warning.
+  const piiPatternEntries = yamlConfig.pii?.extra_patterns ?? [];
+  let extraPiiPatternCount = 0;
+  if (piiPatternEntries.length > 0) {
+    // Errors here are intentionally not caught — parseExtraPiiPatterns throws on
+    // invalid regex or missing fields, which is treated as a startup-blocking misconfiguration.
+    const extraPiiPatterns = parseExtraPiiPatterns(
+      piiPatternEntries,
+      configDir + '/default.yaml',
+    );
+    setErrorPiiPatterns(extraPiiPatterns);
+    extraPiiPatternCount = extraPiiPatterns.length;
+  }
+
+  // Log the scrubber status after the logger is available (patterns are loaded at module
+  // init time, before pino exists, so any load-time failures are deferred to here).
+  const missingBuiltInPatterns = getMissingBuiltInPatterns();
+  if (missingBuiltInPatterns.length > 0) {
+    // Library version drift — one or more built-in PII pattern types were not found
+    // in @openredaction/openredaction. These PII types will NOT be scrubbed from
+    // LLM-facing error messages. Log at error so alerting catches this.
+    logger.error(
+      { missingPatterns: missingBuiltInPatterns },
+      'PII scrubber: built-in pattern types missing from @openredaction/openredaction — check library version',
+    );
+  }
+  logger.info(
+    { builtInPatterns: getBuiltInPatternCount(), extraPatterns: extraPiiPatternCount },
+    'PII scrubber active',
+  );
 
   // Layer 1 inbound injection scanner — loads extra patterns from config/default.yaml
   // and constructs the scanner. Non-fatal on loader error: a broken custom pattern

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -12,21 +12,38 @@ import { Writable } from 'node:stream';
 export function createLogger(level: string = 'info'): pino.Logger {
   const isProduction = process.env.NODE_ENV === 'production';
 
-  // Last-resort redaction for common secret field names. The primary defense is the
-  // ctx.secret() interface — secret values should never reach the logger in the first
-  // place. This catches accidental leakage (e.g. logging an object that happens to
-  // contain a 'token' field).
+  // Last-resort redaction for common secret and PII field names.
+  //
+  // Primary defenses:
+  //   - ctx.secret() interface prevents secret values from reaching the logger
+  //   - Logging call sites should use contact IDs / conversation IDs, not raw PII values
+  //   - scrubPii() in src/pii/scrubber.ts strips PII from error strings before LLM context
+  //
+  // This redact config is a safety net for structured log fields — it catches
+  // accidental leakage when an object with a known PII field name is logged
+  // (e.g. `logger.info({ senderId, channelId }, '...')`).
   //
   // Depth note: pino v10 uses @pinojs/redact which supports single-level wildcards
   // ('*.field') but NOT deep wildcards ('**.field'). The two-level 'a.*.field' paths
-  // cover the most common nesting depth. For deeper nesting the primary defense
-  // (ctx.secret() interface) must hold — redaction is a safety net, not a guarantee.
+  // cover the most common nesting depth. For deeper nesting the primary call-site
+  // discipline must hold — this is a safety net, not a guarantee.
   const redact = {
     paths: [
+      // Secrets
       'password', '*.password', '*.*.password',
       'token', '*.token', '*.*.token',
       'secret', '*.secret', '*.*.secret',
       'api_key', '*.api_key', '*.*.api_key',
+      // PII — sender identifiers (email addresses, phone numbers).
+      // 'senderId' covers raw email/phone logged by the dispatcher and channel adapters.
+      // 'email' covers participant email fields logged by the email adapter.
+      // 'senderEmail' covers renamed log fields in the email adapter (more specific than
+      //   'from', which also appears in non-PII contexts like date ranges).
+      // 'phoneNumber' covers E.164 phone numbers logged as a named field.
+      'senderId', '*.senderId', '*.*.senderId',
+      'email', '*.email', '*.*.email',
+      'senderEmail', '*.senderEmail', '*.*.senderEmail',
+      'phoneNumber', '*.phoneNumber', '*.*.phoneNumber',
     ],
     censor: '[REDACTED]',
   };

--- a/src/pii/scrubber.test.ts
+++ b/src/pii/scrubber.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import { scrubPii, parseExtraPiiPatterns } from './scrubber.js';
+
+describe('scrubPii — built-in patterns', () => {
+  // ── Email ──────────────────────────────────────────────────────────────────
+
+  it('scrubs a plain email address', () => {
+    expect(scrubPii('Contact resolution failed for user@example.com')).not.toContain('user@example.com');
+    expect(scrubPii('Contact resolution failed for user@example.com')).toContain('[EMAIL]');
+  });
+
+  it('scrubs email with subdomains and plus-addressing', () => {
+    const result = scrubPii('Failed to send to john.doe+tag@mail.company.co.uk');
+    expect(result).not.toContain('john.doe');
+    expect(result).toContain('[EMAIL]');
+  });
+
+  it('scrubs multiple emails in one string', () => {
+    const result = scrubPii('from alice@example.com to bob@other.org');
+    expect(result).not.toContain('alice@example.com');
+    expect(result).not.toContain('bob@other.org');
+    expect(result.match(/\[EMAIL\]/g)?.length).toBe(2);
+  });
+
+  // ── Phone numbers ─────────────────────────────────────────────────────────
+
+  it('scrubs a US phone in +1-NXX format', () => {
+    expect(scrubPii('Phone lookup error for +1-555-867-5309')).toContain('[PHONE]');
+  });
+
+  it('scrubs a US phone in (NXX) NXX-XXXX format', () => {
+    expect(scrubPii('Failed for (416) 555-1234')).toContain('[PHONE]');
+  });
+
+  it('scrubs a 10-digit US phone without formatting', () => {
+    expect(scrubPii('Nylas error for sender at 5558675309')).toContain('[PHONE]');
+  });
+
+  // ── Credit card ───────────────────────────────────────────────────────────
+
+  it('scrubs a credit card with spaces', () => {
+    expect(scrubPii('Payment failed for card 4111 1111 1111 1111')).toContain('[CREDIT_CARD]');
+  });
+
+  it('scrubs a credit card without spaces', () => {
+    expect(scrubPii('Payment failed for card 4111111111111111')).toContain('[CREDIT_CARD]');
+  });
+
+  it('scrubs a credit card with dashes', () => {
+    expect(scrubPii('Card: 4111-1111-1111-1111')).toContain('[CREDIT_CARD]');
+  });
+
+  // ── SSN (keyword-prefixed only) ───────────────────────────────────────────
+
+  it('scrubs SSN when preceded by "SSN:" keyword', () => {
+    expect(scrubPii('SSN: 123-45-6789 is invalid')).toContain('[SSN]');
+  });
+
+  it('does NOT scrub bare 9-digit sequences without SSN keyword', () => {
+    // Bare numbers (e.g. port numbers, order IDs) should not be scrubbed
+    const result = scrubPii('order ref 123456789 processed');
+    expect(result).toBe('order ref 123456789 processed');
+  });
+
+  // ── UUID protection ───────────────────────────────────────────────────────
+  // UUIDs appear constantly in Curia logs (conversationId, contactId, taskId).
+  // They must never be scrubbed as false-positive PII matches.
+
+  it('does NOT scrub standard v4 UUIDs', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(scrubPii(`taskId: ${uuid}`)).toContain(uuid);
+  });
+
+  it('does NOT scrub UUIDs with zero-heavy segments that look like credit cards', () => {
+    const uuid = '00000000-0000-0000-0000-000000000001';
+    expect(scrubPii(`taskId: ${uuid}`)).toContain(uuid);
+  });
+
+  it('does NOT scrub UUIDs with hex digit groups that look like phone numbers', () => {
+    const uuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    expect(scrubPii(`convId: ${uuid}`)).toContain(uuid);
+  });
+
+  it('scrubs PII in a string that also contains a UUID', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    const result = scrubPii(`taskId: ${uuid} failed for user@example.com`);
+    expect(result).toContain(uuid);          // UUID preserved
+    expect(result).toContain('[EMAIL]');     // email scrubbed
+    expect(result).not.toContain('user@example.com');
+  });
+
+  // ── No-false-positive cases ───────────────────────────────────────────────
+
+  it('does not alter plain log strings without PII', () => {
+    const inputs = [
+      'Dispatching to coordinator',
+      'Skill timeout after 5000ms',
+      'rate limited: 429 retry after 30s',
+      'Error: ECONNREFUSED 127.0.0.1:5432',
+      'Trust score: 0.85 for conversationId conv:xyz',
+      'version 0.15.1 started',
+    ];
+    for (const input of inputs) {
+      expect(scrubPii(input)).toBe(input);
+    }
+  });
+
+  it('does not scrub ISO timestamps', () => {
+    const ts = '2024-01-15T10:30:00.000Z';
+    expect(scrubPii(`Failed to process message ${ts}`)).toContain(ts);
+  });
+
+  // ── Audit log contract ────────────────────────────────────────────────────
+  // scrubPii is called on the LLM-facing copy only; the raw error is retained
+  // in the audit log. This test verifies the scrubber doesn't mutate inputs.
+
+  it('does not mutate the input string', () => {
+    const original = 'error for user@example.com';
+    const copy = original;
+    scrubPii(original);
+    expect(original).toBe(copy);
+  });
+});
+
+describe('scrubPii — extra patterns', () => {
+  it('applies operator-supplied extra patterns', () => {
+    const extras = parseExtraPiiPatterns(
+      [{ regex: 'EMP-\\d{6}', replacement: '[EMPLOYEE_ID]' }],
+      'test',
+    );
+    const result = scrubPii('failed for employee EMP-123456 at step 3', extras);
+    expect(result).not.toContain('EMP-123456');
+    expect(result).toContain('[EMPLOYEE_ID]');
+  });
+
+  it('extra patterns are applied case-insensitively', () => {
+    const extras = parseExtraPiiPatterns(
+      [{ regex: 'passport-[a-z0-9]+', replacement: '[PASSPORT]' }],
+      'test',
+    );
+    expect(scrubPii('doc PASSPORT-AB1234 failed', extras)).toContain('[PASSPORT]');
+  });
+
+  it('built-in patterns still apply when extras are provided', () => {
+    const extras = parseExtraPiiPatterns(
+      [{ regex: 'EMP-\\d{6}', replacement: '[EMPLOYEE_ID]' }],
+      'test',
+    );
+    const result = scrubPii('EMP-999999 emailed user@example.com', extras);
+    expect(result).toContain('[EMPLOYEE_ID]');
+    expect(result).toContain('[EMAIL]');
+  });
+});
+
+describe('parseExtraPiiPatterns — validation', () => {
+  it('throws on missing regex field', () => {
+    expect(() =>
+      parseExtraPiiPatterns([{ regex: '', replacement: '[X]' }], 'test.yaml'),
+    ).toThrow(/missing a valid 'regex'/);
+  });
+
+  it('throws on missing replacement field', () => {
+    expect(() =>
+      parseExtraPiiPatterns([{ regex: 'foo', replacement: '' }], 'test.yaml'),
+    ).toThrow(/missing a valid 'replacement'/);
+  });
+
+  it('throws on invalid regex syntax', () => {
+    expect(() =>
+      parseExtraPiiPatterns([{ regex: '(unclosed', replacement: '[X]' }], 'test.yaml'),
+    ).toThrow(/invalid regex/);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parseExtraPiiPatterns([], 'test.yaml')).toEqual([]);
+  });
+});
+
+describe('classify.ts integration — PII scrubbing in error messages', () => {
+  // These tests verify the full path: classify an error that contains PII
+  // and confirm the LLM-facing message is scrubbed.
+
+  it('scrubs email from classifyError message', async () => {
+    // Dynamic import so setErrorPiiPatterns state is isolated from unit tests above
+    const { classifyError } = await import('../errors/classify.js');
+    const err = new Error('failed to contact user@example.com: timeout');
+    const result = classifyError(err, 'nylas');
+    expect(result.message).not.toContain('user@example.com');
+    expect(result.message).toContain('[EMAIL]');
+  });
+
+  it('scrubs phone from classifySkillError message', async () => {
+    const { classifySkillError } = await import('../errors/classify.js');
+    const result = classifySkillError('signal-send', 'recipient +1-555-867-5309 not found');
+    expect(result.message).not.toContain('+1-555-867-5309');
+    expect(result.message).toContain('[PHONE]');
+  });
+
+  it('scrubs credit card from classifySkillError message', async () => {
+    const { classifySkillError } = await import('../errors/classify.js');
+    const result = classifySkillError('payment', 'card 4111 1111 1111 1111 declined');
+    expect(result.message).not.toContain('4111 1111 1111 1111');
+    expect(result.message).toContain('[CREDIT_CARD]');
+  });
+});

--- a/src/pii/scrubber.ts
+++ b/src/pii/scrubber.ts
@@ -1,0 +1,190 @@
+// pii/scrubber.ts — synchronous PII scrubber for error strings and log output.
+//
+// Uses regex patterns extracted from @openredaction/openredaction at module-load
+// time. Keeping the scrubber synchronous is a deliberate choice — it plugs into
+// sanitizeOutput() and sanitizeMessage(), which are both sync. Making those async
+// would cascade through the entire error normalization path.
+//
+// The library is used as a pattern source, not as a runtime dependency on hot paths.
+// Regexes are compiled once at startup; scrub() itself is a plain string loop.
+//
+// UUID protection: several PII patterns (especially CREDIT_CARD and PHONE_US) can
+// false-positive on UUID segments (e.g. "0000-0000-0000-0001" looks like a card
+// number). We protect UUIDs before scrubbing and restore them after.
+
+import { allPatterns as _allPatterns } from '@openredaction/openredaction';
+
+/** A compiled PII pattern ready for synchronous scrubbing. */
+export interface PiiPattern {
+  /** Human-readable name used in logs and config (e.g. "email", "phone_us"). */
+  name: string;
+  /** The compiled regex — must have the global flag. */
+  regex: RegExp;
+  /** Replacement string, e.g. "[EMAIL]". */
+  replacement: string;
+}
+
+// Standard RFC 4122 UUID pattern. UUIDs are extremely common in Curia log
+// output (conversation IDs, task IDs, contact IDs) and must be shielded from
+// PII pattern matching — some patterns (credit card, phone) false-positive on
+// UUID hex digit segments.
+const UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+
+/**
+ * Extract a pattern from the openredaction allPatterns list by type name.
+ * Returns null if the type is not found (library version drift).
+ */
+function extractPattern(typeName: string): RegExp | null {
+  // allPatterns is typed as unknown[] in some library versions; cast carefully.
+  const patterns = _allPatterns as Array<{ type: string; regex: unknown }>;
+  const entry = patterns.find((p) => p.type === typeName);
+  if (!entry || !(entry.regex instanceof RegExp)) return null;
+  // Clone with explicit global flag — the library's regexes use global already,
+  // but we clone to avoid shared lastIndex state across concurrent calls.
+  return new RegExp(entry.regex.source, entry.regex.flags.includes('g') ? entry.regex.flags : entry.regex.flags + 'g');
+}
+
+/**
+ * Built-in PII patterns sourced from @openredaction/openredaction.
+ *
+ * Deliberately narrow: only include patterns with low false-positive risk
+ * in the context of structured application logs and error messages.
+ *
+ * Intentionally excluded:
+ *   - PHONE_INTERNATIONAL: too broad, matches many numeric IDs
+ *   - CANADIAN_SIN: `\d{3}[-\s]?\d{3}[-\s]?\d{3}` matches too many 9-digit
+ *     sequences in application data (order IDs, reference numbers, etc.)
+ *   - ADDRESS_*: high false-positive rate in log strings
+ *   - NAME: extremely high false-positive rate
+ *
+ * All built-in patterns are applied with UUID protection (see scrubPii).
+ */
+function buildBuiltInPatterns(): PiiPattern[] {
+  const entries: Array<{ typeName: string; replacement: string }> = [
+    { typeName: 'EMAIL',       replacement: '[EMAIL]'       },
+    { typeName: 'PHONE_US',    replacement: '[PHONE]'       },
+    { typeName: 'PHONE_UK',    replacement: '[PHONE]'       },
+    { typeName: 'PHONE_UK_MOBILE', replacement: '[PHONE]'   },
+    { typeName: 'CREDIT_CARD', replacement: '[CREDIT_CARD]' },
+    // SSN: the library's pattern requires an "SSN" / "social security" keyword
+    // prefix, making it safe from false positives on bare digit sequences.
+    { typeName: 'SSN',         replacement: '[SSN]'         },
+  ];
+
+  const result: PiiPattern[] = [];
+  for (const { typeName, replacement } of entries) {
+    const regex = extractPattern(typeName);
+    if (regex) {
+      result.push({ name: typeName.toLowerCase(), regex, replacement });
+    } else {
+      // Library version drift — pattern not found. Record in missingPatternTypes
+      // so index.ts can log the failure via pino after the logger is initialized.
+      // We never call console.warn here — the project's lint rule prohibits it and
+      // this module is loaded before pino exists.
+      missingPatternTypes.push(typeName);
+    }
+  }
+  return result;
+}
+
+// Names of built-in patterns that failed to load from @openredaction/openredaction.
+// Populated during module init; read by index.ts via getMissingBuiltInPatterns().
+const missingPatternTypes: string[] = [];
+
+/**
+ * Returns the names of any built-in PII patterns that failed to load due to
+ * library version drift. Empty array means all patterns loaded successfully.
+ * Called by index.ts to log failures via pino after the logger is available.
+ */
+export function getMissingBuiltInPatterns(): string[] {
+  return missingPatternTypes;
+}
+
+/** Number of built-in patterns that loaded successfully. Used for startup logging. */
+export function getBuiltInPatternCount(): number {
+  return BUILT_IN_PATTERNS.length;
+}
+
+// Compiled once at module load — avoids per-call regex compilation.
+const BUILT_IN_PATTERNS: PiiPattern[] = buildBuiltInPatterns();
+
+/**
+ * Scrub PII from a string using the built-in patterns plus any caller-supplied
+ * extra patterns (from config/default.yaml).
+ *
+ * UUID protection: standard RFC 4122 UUIDs are replaced with stable tokens
+ * before scrubbing and restored after, preventing false-positive matches on
+ * UUID hex segments.
+ *
+ * This function is intentionally synchronous — it is called on every error
+ * message that enters LLM context and must not introduce async overhead.
+ *
+ * @param text          The string to scrub.
+ * @param extraPatterns Additional patterns from operator config (loaded once
+ *                      at startup and passed through the call chain).
+ */
+export function scrubPii(text: string, extraPatterns: PiiPattern[] = []): string {
+  // 1. Shield UUIDs from PII pattern matching.
+  //    Tokens use a format that cannot be confused with real UUIDs or PII.
+  const uuids: string[] = [];
+  let shielded = text.replace(UUID_RE, (match) => {
+    uuids.push(match);
+    return `\x00UUID${uuids.length - 1}\x00`;
+  });
+
+  // 2. Apply all patterns (built-in first, then extras).
+  const allPatterns = [...BUILT_IN_PATTERNS, ...extraPatterns];
+  for (const { regex, replacement } of allPatterns) {
+    // Reset lastIndex — global regexes retain state across calls if reused.
+    regex.lastIndex = 0;
+    shielded = shielded.replace(regex, replacement);
+  }
+
+  // 3. Restore shielded UUIDs.
+  // Return the raw token on index miss rather than '' — erasing content silently
+  // would be harder to notice than an ugly token in the LLM's context.
+  // An index miss is only possible if the input contained a deliberate
+  // \x00UUID<n>\x00 byte sequence before scrubbing, which is pathological.
+  return shielded.replace(/\x00UUID(\d+)\x00/g, (match, i) => uuids[parseInt(i, 10)] ?? match);
+}
+
+/**
+ * Parse operator-supplied PII patterns from config/default.yaml.
+ *
+ * Each entry specifies a raw regex string and a replacement label.
+ * Called once at startup; the resulting PiiPattern[] is passed into scrubPii()
+ * at each call site.
+ *
+ * Throws on invalid regex so startup fails loudly rather than silently
+ * running with broken PII config.
+ */
+export function parseExtraPiiPatterns(
+  entries: Array<{ regex: string; replacement: string }>,
+  configPath: string,
+): PiiPattern[] {
+  return entries.map((entry, i) => {
+    if (typeof entry.regex !== 'string' || !entry.regex) {
+      throw new Error(`pii.extra_patterns[${i}] is missing a valid 'regex' string in ${configPath}`);
+    }
+    if (typeof entry.replacement !== 'string' || !entry.replacement) {
+      throw new Error(`pii.extra_patterns[${i}] is missing a valid 'replacement' string in ${configPath}`);
+    }
+
+    let compiled: RegExp;
+    try {
+      // Always global + case-insensitive, matching built-in pattern behavior.
+      compiled = new RegExp(entry.regex, 'gi');
+    } catch (regexErr) {
+      throw new Error(
+        `pii.extra_patterns[${i}] has invalid regex '${entry.regex}' in ${configPath}`,
+        { cause: regexErr },
+      );
+    }
+
+    return {
+      name: `extra_${i}`,
+      regex: compiled,
+      replacement: entry.replacement,
+    };
+  });
+}


### PR DESCRIPTION
## Summary

- **`src/pii/scrubber.ts`** — New synchronous PII scrubber backed by regex patterns extracted from `@openredaction/openredaction` at module load. Covers email, US/UK phone, credit card, and SSN (keyword-prefixed). UUID protection prevents false-positive matches on conversation/task IDs.
- **`src/errors/classify.ts`** — `sanitizeMessage()` now calls `scrubPii()` before `sanitizeOutput()`, stripping PII before errors reach the LLM context window. Audit log retains full unredacted errors (write-ahead by design).
- **`src/logger.ts`** — Adds `senderId`, `email`, `senderEmail`, `phoneNumber` to pino's redact paths as a last-resort safety net for structured log fields.
- **`src/channels/email/email-adapter.ts`** — Renames `from` log field to `senderEmail` (more specific, avoids overly-broad redaction of generic `from` fields).
- **Config** — `pii.extra_patterns` in `YamlConfig` and `config/default.yaml` for operator-configurable patterns without code changes. Invalid patterns are fatal at startup.
- **28 unit tests** covering built-in patterns, UUID protection, false-positive resistance, extra patterns, validation, and `classify.ts` integration.

Separate issue filed for the context-aware outbound channel PII policy (passport OK to travel API, credit card blocked from email): #249

## Test plan

- [ ] `npm run test` passes (1143 tests, 0 failures)
- [ ] `npm run typecheck` passes
- [ ] Error message containing `user@example.com` → LLM sees `[EMAIL]`, audit log retains original
- [ ] Error message containing `+1-555-867-5309` → LLM sees `[PHONE]`
- [ ] UUID `550e8400-e29b-41d4-a716-446655440000` in log → not redacted
- [ ] Startup log shows `PII scrubber active` with built-in pattern count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic scrubbing of sensitive personal information from AI-facing error messages, with operator-configurable extra redaction patterns.

* **Security**
  * Extended structured logging redaction to include common sender/contact fields as a safety net.
  * Startup now reports scrubber readiness and missing built-in pattern types.

* **Documentation**
  * Security docs updated to describe PII scrubbing and logging behavior.

* **Tests**
  * Added comprehensive tests for PII scrubbing and pattern parsing.

* **Chores**
  * Bumped package version and added a PII redaction runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->