### PR TITLE
feat: add routingDecision to contact.unknown event, close #192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Spec 10 audit log hardening completion table** — replaced implementation checklist in `docs/specs/10-audit-log-hardening.md` with Done/Not Done table.
 
 ### Changed
+- **Sender trust routing** (spec §06): `contact.unknown` event now includes `routingDecision` field (`allow` | `hold_and_notify` | `ignore`), making the unknown-sender audit trail self-contained. The dispatcher now determines routing policy before publishing the event so the intent is always recorded accurately.
 - **`unknown_sender: reject` renamed to `unknown_sender: ignore`** — behaviour unchanged (silent drop + audit event); new name clarifies no rejection notice is sent to the sender.
 - **`contact.unknown` event** — `channelTrustLevel` is now required (was optional); `messageTrustScore` field added.
 - **`completeJobRun`** — writes `last_run_outcome = 'completed'` or `'failed'` on completion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,8 +86,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Spec 06 security completion table** — replaced implementation checklist in `docs/specs/06-audit-and-security.md` with Done/Not Done table; reconciled against open `audit`-labeled issues.
 - **Spec 10 audit log hardening completion table** — replaced implementation checklist in `docs/specs/10-audit-log-hardening.md` with Done/Not Done table.
 
+### Security
+- **Dispatcher fail-closed on audit publish failure** (spec §06): the `contact.unknown` publish is now wrapped in its own try/catch with an explicit return, so a failing audit hook cannot fall through the outer resolver catch and bypass `hold_and_notify` / `ignore` policy. Closes #192.
+
 ### Changed
-- **Sender trust routing** (spec §06): `contact.unknown` event now includes `routingDecision` field (`allow` | `hold_and_notify` | `ignore`), making the unknown-sender audit trail self-contained. The dispatcher now determines routing policy before publishing the event so the intent is always recorded accurately.
+- **Sender trust routing** (spec §06): `contact.unknown` event now includes `routingDecision` field (`allow` | `hold_and_notify` | `ignore`), making the unknown-sender audit trail self-contained. The dispatcher now determines routing policy before publishing the event so the intent is always recorded accurately. Closes #192.
 - **`unknown_sender: reject` renamed to `unknown_sender: ignore`** — behaviour unchanged (silent drop + audit event); new name clarifies no rejection notice is sent to the sender.
 - **`contact.unknown` event** — `channelTrustLevel` is now required (was optional); `messageTrustScore` field added.
 - **`completeJobRun`** — writes `last_run_outcome = 'completed'` or `'failed'` on completion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ bus event types) are noted explicitly even in the `0.x` range.
   delivery lifecycle record. A startup scan (`scanForUnacknowledged`) logs a warning
   for any rows that were written but never acknowledged, indicating delivery may have
   been incomplete on a prior crash. Closes #202.
+- **Dispatcher fail-closed on audit publish failure** (spec §06): the `contact.unknown` publish is now wrapped in its own try/catch with an explicit return, so a failing audit hook cannot fall through the outer resolver catch and bypass `hold_and_notify` / `ignore` policy. Closes #192.
 
 ### Fixed
 - **Outbound content filter: wrong `ceoEmail` causing false-positive blocks** — The
@@ -85,9 +86,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Intent anchor** — `intentAnchor` on `AgentTaskPayload`; scheduler passes it through; runtime injects `## Original Task Intent` block on every burst to prevent multi-burst drift (spec 01).
 - **Spec 06 security completion table** — replaced implementation checklist in `docs/specs/06-audit-and-security.md` with Done/Not Done table; reconciled against open `audit`-labeled issues.
 - **Spec 10 audit log hardening completion table** — replaced implementation checklist in `docs/specs/10-audit-log-hardening.md` with Done/Not Done table.
-
-### Security
-- **Dispatcher fail-closed on audit publish failure** (spec §06): the `contact.unknown` publish is now wrapped in its own try/catch with an explicit return, so a failing audit hook cannot fall through the outer resolver catch and bypass `hold_and_notify` / `ignore` policy. Closes #192.
 
 ### Changed
 - **Sender trust routing** (spec §06): `contact.unknown` event now includes `routingDecision` field (`allow` | `hold_and_notify` | `ignore`), making the unknown-sender audit trail self-contained. The dispatcher now determines routing policy before publishing the event so the intent is always recorded accurately. Closes #192.

--- a/docs/specs/06-audit-and-security.md
+++ b/docs/specs/06-audit-and-security.md
@@ -360,6 +360,8 @@ These are non-negotiable for launch.
 | All `agent.task` events carry `messageTrustScore` (computed float); `trustLevel` and `contactConfidence` are inputs only, not propagated to bus events | Done |
 | Unknown sender lookup targets `contact_channel_identities (channel, channel_identifier)` | Done |
 | Unknown sender routing configured in `config/channel-trust.yaml` using `allow` / `hold_and_notify` / `ignore` | Done |
+| `contact.unknown` event includes `routingDecision` field so audit trail is self-contained without downstream correlation | Done (#254) |
+| Unknown sender → `hold_and_notify` path covered by integration test (in-memory `HeldMessageService`, verifies score, event payload, and store write) | Done (#254) |
 | Trust score floor: messages below `security.trust_score_floor` (default 0.2) trigger `hold_and_notify` regardless of per-channel policy | Done |
 | Trust-gated action thresholds use `messageTrustScore` numeric values, enforced via Coordinator system prompt | Done |
 | Data sensitivity tags on knowledge graph entities | Not Done |

--- a/docs/wip/2026-04-09-sender-trust-routing-design.md
+++ b/docs/wip/2026-04-09-sender-trust-routing-design.md
@@ -1,0 +1,86 @@
+# Sender Trust & Routing — Completion Design
+
+**Issue:** josephfung/curia#192  
+**Date:** 2026-04-09  
+**Branch:** feat/sender-trust
+
+## Context
+
+Most of issue #192 is already implemented: migration 020 (trust columns), `trust-scorer.ts`, the full dispatcher trust pipeline, unknown-sender routing, trust floor, configurable weights, and coordinator system prompt thresholds. Two acceptance criteria remain open:
+
+1. **`routingDecision` on `contact.unknown` event** — the AC requires the event to include the routing decision alongside sender, channel, and score. The event is currently published before policy is evaluated, so it lacks this field.
+2. **Test coverage** — the AC requires an integration test for the unknown-sender → `hold_and_notify` path with a correct `messageTrustScore`. We will address this with both a unit-level payload assertion and an integration scenario in the existing vertical-slice suite.
+
+---
+
+## Change 1: `routingDecision` on `contact.unknown`
+
+### Event schema (`src/bus/events.ts`)
+
+Add `routingDecision: UnknownSenderPolicy` to `ContactUnknownPayload`:
+
+```typescript
+interface ContactUnknownPayload {
+  channel: string;
+  senderId: string;
+  channelTrustLevel: 'low' | 'medium' | 'high';
+  messageTrustScore: number;
+  routingDecision: 'allow' | 'hold_and_notify' | 'ignore';
+}
+```
+
+`UnknownSenderPolicy` is already defined in `src/contacts/types.ts`; we reuse it here rather than duplicating the union.
+
+### Dispatcher restructure (`src/dispatch/dispatcher.ts`)
+
+In the unknown-sender branch, the current order is:
+1. Publish `contact.unknown` (without routing decision)
+2. Read policy
+3. Execute routing
+
+We reorder to:
+1. Read policy (pure lookup, no side effects)
+2. Determine `routingDecision`: `'hold_and_notify'` if policy is `hold_and_notify` and `heldMessages` is available; `'ignore'` if policy is `ignore`; otherwise `'allow'`
+3. Publish `contact.unknown` with all four fields
+4. Execute routing (unchanged logic)
+
+No behavior change — only the publish call moves after the policy lookup.
+
+---
+
+## Change 2: Unit test — `contact.unknown` payload
+
+In `tests/unit/dispatch/dispatcher.test.ts`, add three cases to the existing `Dispatcher — messageTrustScore` describe block. Each test uses `makeResolverWithNoContact()`, captures the `contact.unknown` event off the bus, and asserts the full payload:
+
+| Test | Channel policy | Expected `routingDecision` | Expected `messageTrustScore` |
+|---|---|---|---|
+| hold_and_notify channel | email / hold_and_notify | `'hold_and_notify'` | ≈ 0.12 (low channel, 0.0 confidence) |
+| ignore channel | http / ignore | `'ignore'` | ≈ 0.12 |
+| allow channel | cli / allow | `'allow'` | ≈ 0.4 (high channel, 0.0 confidence) |
+
+These tests require no DB and run in < 5 ms each.
+
+---
+
+## Change 3: Integration scenario — `vertical-slice.test.ts`
+
+Add one scenario to the existing integration suite. Setup reuses the test DB and the real `HeldMessageService`. The dispatcher is wired with:
+- Real `HeldMessageService` (backed by the `held_messages` table)
+- A mock `ContactResolver` returning an unknown sender (no real DB contact lookup needed — the resolver interface is thin and the test is about dispatcher + DB, not resolver logic)
+- Channel policies: `{ email: { trust: 'low', unknownSender: 'hold_and_notify' } }`
+
+**Scenario:** email arrives from `stranger@example.com` (no contact record).
+
+**Assertions:**
+1. No `agent.task` event published
+2. `message.held` event published with `senderId: 'stranger@example.com'`, `channel: 'email'`
+3. `contact.unknown` event has `routingDecision: 'hold_and_notify'` and `messageTrustScore` ≈ 0.12
+4. `SELECT COUNT(*) FROM held_messages WHERE sender_id = 'stranger@example.com'` returns 1
+
+---
+
+## What is NOT in scope
+
+- `last_seen_at` write-back: the migration adds the column; updating it on each inbound message is explicitly deferred via a TODO in `contact-service.ts` and has no AC checkbox in this issue.
+- `contact_confidence` accumulation: future scoring infrastructure.
+- Any other open items in the spec 06 completion table (rate limiting, SPF/DKIM, etc.) — those are separate issues.

--- a/docs/wip/2026-04-09-sender-trust-routing.md
+++ b/docs/wip/2026-04-09-sender-trust-routing.md
@@ -1,0 +1,508 @@
+# Sender Trust Routing Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `routingDecision` to the `contact.unknown` event payload and add both unit and integration test coverage for the unknown-sender → hold_and_notify path.
+
+**Architecture:** Three isolated changes in dependency order: event schema first, then dispatcher restructure to populate the new field, then tests. No new files — all changes are additions to existing files.
+
+**Tech Stack:** TypeScript (ESM), Vitest, Node.js 22+
+
+**Worktree:** `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust`
+**Branch:** `feat/sender-trust`
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `src/bus/events.ts` | Add `routingDecision` field to `ContactUnknownPayload` |
+| `src/dispatch/dispatcher.ts` | Import `UnknownSenderPolicy`; determine routing decision before publishing `contact.unknown` |
+| `tests/unit/dispatch/dispatcher.test.ts` | Add 3 unit tests verifying `contact.unknown` payload for each routing policy |
+| `tests/integration/vertical-slice.test.ts` | Add end-to-end scenario for unknown sender → hold_and_notify |
+
+---
+
+## Task 1: Add `routingDecision` to `ContactUnknownPayload`
+
+**Files:**
+- Modify: `src/bus/events.ts:127-134`
+
+- [ ] **Step 1: Update the payload interface**
+
+Open `src/bus/events.ts`. Find `ContactUnknownPayload` (around line 127). Replace it with:
+
+```typescript
+interface ContactUnknownPayload {
+  channel: string;
+  senderId: string;
+  /** Channel trust level — required for trust score audit trail. */
+  channelTrustLevel: 'low' | 'medium' | 'high';
+  /** Computed message trust score for this unknown sender's message. */
+  messageTrustScore: number;
+  /** Routing decision applied to this unknown sender — mirrors the configured per-channel policy. */
+  routingDecision: 'allow' | 'hold_and_notify' | 'ignore';
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust run build 2>&1
+```
+
+Expected: compile error — `createContactUnknown` call sites in `dispatcher.ts` are missing the new required field. This confirms the type is enforced. Proceed to Task 2.
+
+---
+
+## Task 2: Populate `routingDecision` in the dispatcher
+
+**Files:**
+- Modify: `src/dispatch/dispatcher.ts:7` (import line)
+- Modify: `src/dispatch/dispatcher.ts:239-316` (unknown-sender branch)
+
+- [ ] **Step 1: Add `UnknownSenderPolicy` to the type import**
+
+Find line 7 in `src/dispatch/dispatcher.ts`:
+
+```typescript
+import type { InboundSenderContext, ChannelPolicyConfig, TrustLevel } from '../contacts/types.js';
+```
+
+Replace with:
+
+```typescript
+import type { InboundSenderContext, ChannelPolicyConfig, TrustLevel, UnknownSenderPolicy } from '../contacts/types.js';
+```
+
+- [ ] **Step 2: Restructure the unknown-sender branch**
+
+Find the `} else {` block that begins with the comment `// Unknown sender — publish audit event and check channel policy.` (around line 235). Replace the entire block up to (but not including) the outer `} catch (err) {`) with:
+
+```typescript
+        } else {
+          // Unknown sender — determine routing decision first so the audit event is self-contained.
+          // Compute a preliminary trust score (injection risk not yet available — the unknown-sender
+          // branch returns early before the scanner runs).
+          const prelimChannelTrust = (this.channelPolicies?.[payload.channelId]?.trust ?? 'low') as TrustLevel;
+          const prelimScore = computeTrustScore({
+            channelTrustLevel: prelimChannelTrust,
+            contactConfidence: 0.0,  // unknown sender has no confidence
+            injectionRiskScore: 0,
+            trustLevel: null,
+            weights: this.trustScorerWeights,
+          });
+
+          const policy = this.channelPolicies?.[payload.channelId];
+
+          // Routing decision reflects the configured policy intent. When hold_and_notify is
+          // configured but heldMessages is not wired, the decision still says 'hold_and_notify'
+          // so the audit trail is accurate — execution may degrade but the intent is recorded.
+          const routingDecision: UnknownSenderPolicy =
+            policy?.unknownSender === 'hold_and_notify' ? 'hold_and_notify'
+            : policy?.unknownSender === 'ignore' ? 'ignore'
+            : 'allow';
+
+          await this.bus.publish('dispatch', createContactUnknown({
+            channel: senderContext.channel,
+            senderId: senderContext.senderId,
+            channelTrustLevel: prelimChannelTrust,
+            messageTrustScore: prelimScore,
+            routingDecision,
+            parentEventId: event.id,
+          }));
+
+          if (policy?.unknownSender === 'hold_and_notify' && this.heldMessages) {
+            try {
+              // Hold the message instead of routing to coordinator
+              const subject = (payload.metadata as Record<string, unknown> | undefined)?.subject as string | null ?? null;
+              const heldId = await this.heldMessages.hold({
+                channel: payload.channelId,
+                senderId: payload.senderId,
+                conversationId: payload.conversationId,
+                content: payload.content,
+                subject,
+                metadata: payload.metadata ?? {},
+              });
+
+              // Publish held event so CLI can notify and audit can log
+              await this.bus.publish('dispatch', createMessageHeld({
+                heldMessageId: heldId,
+                channel: payload.channelId,
+                senderId: payload.senderId,
+                subject,
+                parentEventId: event.id,
+              }));
+
+              this.logger.info(
+                { heldMessageId: heldId, channel: payload.channelId, senderId: payload.senderId },
+                'Message held from unknown sender',
+              );
+            } catch (holdErr) {
+              // Fail closed: if we can't hold the message, drop it rather than
+              // routing an unknown sender's message to the coordinator.
+              // This is a security boundary — prefer message loss over policy bypass.
+              this.logger.error(
+                { err: holdErr, channel: payload.channelId, senderId: payload.senderId },
+                'Failed to hold unknown sender message — dropping (fail-closed)',
+              );
+            }
+            return; // Always return — whether hold succeeded or failed
+          }
+
+          if (policy?.unknownSender === 'ignore') {
+            this.logger.info(
+              { channel: payload.channelId, senderId: payload.senderId },
+              'Rejected message from unknown sender',
+            );
+            try {
+              await this.bus.publish('dispatch', createMessageRejected({
+                conversationId: payload.conversationId,
+                channelId: payload.channelId,
+                senderId: payload.senderId,
+                reason: 'unknown_sender',
+                parentEventId: event.id,
+              }));
+            } catch (publishErr) {
+              this.logger.error(
+                { err: publishErr, channel: payload.channelId, senderId: payload.senderId },
+                'Failed to publish unknown-sender rejection event — dropping (fail-closed)',
+              );
+            }
+            return;
+          }
+
+          // 'allow' policy or no policy configured — fall through to normal routing
+        }
+```
+
+- [ ] **Step 3: Verify TypeScript compiles cleanly**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust run build 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Run existing dispatcher tests**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust run test -- tests/unit/dispatch/dispatcher.test.ts 2>&1
+```
+
+Expected: all existing tests pass (the new field is additive — existing call sites in tests that build events via the bus don't assert on `contact.unknown` payload shape yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust add src/bus/events.ts src/dispatch/dispatcher.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust commit -m "feat: add routingDecision to contact.unknown event payload"
+```
+
+---
+
+## Task 3: Unit tests — `contact.unknown` payload verification
+
+**Files:**
+- Modify: `tests/unit/dispatch/dispatcher.test.ts`
+
+- [ ] **Step 1: Add the import for `ContactUnknownEvent`**
+
+Find the existing import at the top of `tests/unit/dispatch/dispatcher.test.ts`:
+
+```typescript
+import { createInboundMessage, createAgentError, type OutboundMessageEvent, type MessageRejectedEvent, type AgentTaskEvent, type MessageHeldEvent } from '../../../src/bus/events.js';
+```
+
+Add `type ContactUnknownEvent` to it:
+
+```typescript
+import { createInboundMessage, createAgentError, type OutboundMessageEvent, type MessageRejectedEvent, type AgentTaskEvent, type MessageHeldEvent, type ContactUnknownEvent } from '../../../src/bus/events.js';
+```
+
+- [ ] **Step 2: Add the three payload tests**
+
+Append a new `describe` block after the closing `});` of `describe('Dispatcher — messageTrustScore', ...)`:
+
+```typescript
+describe('Dispatcher — contact.unknown event payload', () => {
+  it('contact.unknown includes routingDecision: hold_and_notify for email channel', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const heldMessages = makeInMemoryHeldMessages();
+    const resolver = makeResolverWithNoContact();
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: resolver,
+      heldMessages,
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify' } },
+    });
+    dispatcher.register();
+
+    const unknownEvents: ContactUnknownEvent[] = [];
+    bus.subscribe('contact.unknown', 'system', (e) => { unknownEvents.push(e as ContactUnknownEvent); });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-cu-hold',
+      channelId: 'email',
+      senderId: 'stranger@example.com',
+      content: 'Hello',
+    }));
+
+    expect(unknownEvents).toHaveLength(1);
+    expect(unknownEvents[0]!.payload.channel).toBe('email');
+    expect(unknownEvents[0]!.payload.senderId).toBe('stranger@example.com');
+    expect(unknownEvents[0]!.payload.channelTrustLevel).toBe('low');
+    // email low=0.3*0.4=0.12, unknown=0.0 → 0.12
+    expect(unknownEvents[0]!.payload.messageTrustScore).toBeCloseTo(0.12);
+    expect(unknownEvents[0]!.payload.routingDecision).toBe('hold_and_notify');
+  });
+
+  it('contact.unknown includes routingDecision: ignore for http channel', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const resolver = makeResolverWithNoContact();
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: resolver,
+      channelPolicies: { http: { trust: 'medium', unknownSender: 'ignore' } },
+    });
+    dispatcher.register();
+
+    const unknownEvents: ContactUnknownEvent[] = [];
+    bus.subscribe('contact.unknown', 'system', (e) => { unknownEvents.push(e as ContactUnknownEvent); });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-cu-ignore',
+      channelId: 'http',
+      senderId: 'api-caller',
+      content: 'Hello',
+    }));
+
+    expect(unknownEvents).toHaveLength(1);
+    expect(unknownEvents[0]!.payload.channelTrustLevel).toBe('medium');
+    // http medium=0.6*0.4=0.24, unknown=0.0 → 0.24
+    expect(unknownEvents[0]!.payload.messageTrustScore).toBeCloseTo(0.24);
+    expect(unknownEvents[0]!.payload.routingDecision).toBe('ignore');
+  });
+
+  it('contact.unknown includes routingDecision: allow for high-trust allow channel', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const resolver = makeResolverWithNoContact();
+    // Use a mock provider so the agent.task that flows through doesn't error
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'OK',
+        usage: { inputTokens: 1, outputTokens: 1 },
+      }),
+    };
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a helpful assistant.',
+      provider: mockProvider,
+      bus,
+      logger,
+    });
+    coordinator.register();
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: resolver,
+      channelPolicies: { signal: { trust: 'high', unknownSender: 'allow' } },
+    });
+    dispatcher.register();
+
+    const unknownEvents: ContactUnknownEvent[] = [];
+    bus.subscribe('contact.unknown', 'system', (e) => { unknownEvents.push(e as ContactUnknownEvent); });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-cu-allow',
+      channelId: 'signal',
+      senderId: '+15550001234',
+      content: 'Hello',
+    }));
+
+    expect(unknownEvents).toHaveLength(1);
+    expect(unknownEvents[0]!.payload.channelTrustLevel).toBe('high');
+    // signal high=1.0*0.4=0.40, unknown=0.0 → 0.40
+    expect(unknownEvents[0]!.payload.messageTrustScore).toBeCloseTo(0.40);
+    expect(unknownEvents[0]!.payload.routingDecision).toBe('allow');
+  });
+});
+```
+
+- [ ] **Step 3: Run the new tests**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust run test -- tests/unit/dispatch/dispatcher.test.ts 2>&1
+```
+
+Expected: all tests pass including the three new ones.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust add tests/unit/dispatch/dispatcher.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust commit -m "test: verify contact.unknown routingDecision payload for all three policies"
+```
+
+---
+
+## Task 4: Integration scenario — unknown sender → hold_and_notify
+
+**Files:**
+- Modify: `tests/integration/vertical-slice.test.ts`
+
+- [ ] **Step 1: Add imports**
+
+Find the existing import block at the top of `tests/integration/vertical-slice.test.ts`:
+
+```typescript
+import { createInboundMessage, type OutboundMessageEvent } from '../../src/bus/events.js';
+import type { LLMProvider } from '../../src/agents/llm/provider.js';
+```
+
+Replace with:
+
+```typescript
+import { createInboundMessage, type OutboundMessageEvent, type ContactUnknownEvent, type MessageHeldEvent, type AgentTaskEvent } from '../../src/bus/events.js';
+import type { LLMProvider } from '../../src/agents/llm/provider.js';
+import type { ContactResolver } from '../../src/contacts/contact-resolver.js';
+import type { InboundSenderContext } from '../../src/contacts/types.js';
+import { HeldMessageService } from '../../src/contacts/held-messages.js';
+```
+
+- [ ] **Step 2: Add the integration scenario**
+
+Append a new `describe` block after the closing `});` of the existing describe block:
+
+```typescript
+describe('Vertical Slice: Unknown sender email → hold_and_notify', () => {
+  it('holds the message, fires contact.unknown with correct routingDecision and score, suppresses agent.task', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    // In-memory held messages — same interface as the real Postgres backend.
+    const heldMessages = HeldMessageService.createInMemory();
+
+    // Mock resolver: always returns unknown sender.
+    // We test the dispatcher + HeldMessageService interaction here, not contact resolution.
+    const mockResolver: ContactResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: false,
+        channel: 'email',
+        senderId: 'stranger@example.com',
+      } satisfies InboundSenderContext),
+    } as unknown as ContactResolver;
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: mockResolver,
+      heldMessages,
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify' } },
+    });
+    dispatcher.register();
+
+    // Capture events
+    const unknownEvents: ContactUnknownEvent[] = [];
+    const heldEvents: MessageHeldEvent[] = [];
+    const taskEvents: AgentTaskEvent[] = [];
+
+    bus.subscribe('contact.unknown', 'system', (e) => { unknownEvents.push(e as ContactUnknownEvent); });
+    bus.subscribe('message.held', 'channel', (e) => { heldEvents.push(e as MessageHeldEvent); });
+    bus.subscribe('agent.task', 'agent', (e) => { taskEvents.push(e as AgentTaskEvent); });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'email:stranger:1',
+      channelId: 'email',
+      senderId: 'stranger@example.com',
+      content: 'Hey, can we talk?',
+    }));
+
+    // Message must NOT reach the coordinator
+    expect(taskEvents).toHaveLength(0);
+
+    // contact.unknown event must carry the correct audit fields
+    expect(unknownEvents).toHaveLength(1);
+    expect(unknownEvents[0]!.payload.channel).toBe('email');
+    expect(unknownEvents[0]!.payload.senderId).toBe('stranger@example.com');
+    expect(unknownEvents[0]!.payload.channelTrustLevel).toBe('low');
+    // email low channel (0.3 * 0.4 = 0.12) + unknown sender (0.0 * 0.4 = 0.0) = 0.12
+    expect(unknownEvents[0]!.payload.messageTrustScore).toBeCloseTo(0.12);
+    expect(unknownEvents[0]!.payload.routingDecision).toBe('hold_and_notify');
+
+    // message.held event must fire with correct identifiers
+    expect(heldEvents).toHaveLength(1);
+    expect(heldEvents[0]!.payload.channel).toBe('email');
+    expect(heldEvents[0]!.payload.senderId).toBe('stranger@example.com');
+
+    // The message must be retrievable from the held messages store
+    const pending = await heldMessages.listPending('email');
+    expect(pending).toHaveLength(1);
+    expect(pending[0]!.senderId).toBe('stranger@example.com');
+    expect(pending[0]!.content).toBe('Hey, can we talk?');
+  });
+});
+```
+
+- [ ] **Step 3: Run the new scenario**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust run test -- tests/integration/vertical-slice.test.ts 2>&1
+```
+
+Expected: both scenarios pass — the existing CLI slice and the new unknown-sender hold scenario.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust run test 2>&1
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust add tests/integration/vertical-slice.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust commit -m "test: add vertical-slice scenario for unknown sender hold_and_notify path"
+```
+
+---
+
+## Task 5: Update CHANGELOG and close the loop
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add changelog entry under `## [Unreleased]`**
+
+```markdown
+### Added
+- **Sender trust routing** (spec §06): `contact.unknown` event now includes `routingDecision` field (`allow` | `hold_and_notify` | `ignore`), making the unknown-sender audit trail self-contained without requiring correlation with downstream events.
+
+### Changed
+- **Dispatcher**: unknown-sender branch now determines routing policy before publishing `contact.unknown`, ensuring the event accurately reflects the configured intent even when the `heldMessages` service is not wired.
+```
+
+- [ ] **Step 2: Check current version and bump**
+
+```bash
+cat /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust/package.json | grep '"version"'
+```
+
+This is completing a partially-shipped spec feature → patch bump. Update `package.json` version field: e.g., `0.14.0` → `0.14.1`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust add CHANGELOG.md package.json
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-sender-trust commit -m "chore: bump to 0.14.1, update changelog for sender trust routing completion"
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.15.1",
+  "version": "0.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.15.1",
+      "version": "0.15.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -131,6 +131,8 @@ interface ContactUnknownPayload {
   channelTrustLevel: 'low' | 'medium' | 'high';
   /** Computed message trust score for this unknown sender's message. */
   messageTrustScore: number;
+  /** Routing decision applied to this unknown sender — mirrors the configured per-channel policy. */
+  routingDecision: 'allow' | 'hold_and_notify' | 'ignore';
 }
 
 // contact.duplicate_detected — published when a newly-created contact scores above

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -4,7 +4,7 @@ import { createAgentTask, createOutboundMessage, createContactResolved, createCo
 import type { Logger } from '../logger.js';
 import type { ContactResolver } from '../contacts/contact-resolver.js';
 import type { HeldMessageService } from '../contacts/held-messages.js';
-import type { InboundSenderContext, ChannelPolicyConfig, TrustLevel } from '../contacts/types.js';
+import type { InboundSenderContext, ChannelPolicyConfig, TrustLevel, UnknownSenderPolicy } from '../contacts/types.js';
 import type { InboundScanner } from './inbound-scanner.js';
 import type { DbPool } from '../db/connection.js';
 import { computeTrustScore, DEFAULT_TRUST_WEIGHTS } from './trust-scorer.js';
@@ -233,10 +233,9 @@ export class Dispatcher {
             }
           }
         } else {
-          // Unknown sender — publish audit event and check channel policy.
-          // Compute a preliminary trust score for the audit event (injection risk not yet
-          // available at this point — the unknown-sender branch returns early before the
-          // scanner runs).
+          // Unknown sender — determine routing decision first so the audit event is self-contained.
+          // Compute a preliminary trust score (injection risk not yet available — the unknown-sender
+          // branch returns early before the scanner runs).
           const prelimChannelTrust = (this.channelPolicies?.[payload.channelId]?.trust ?? 'low') as TrustLevel;
           const prelimScore = computeTrustScore({
             channelTrustLevel: prelimChannelTrust,
@@ -245,15 +244,25 @@ export class Dispatcher {
             trustLevel: null,
             weights: this.trustScorerWeights,
           });
+
+          const policy = this.channelPolicies?.[payload.channelId];
+
+          // Routing decision reflects the configured policy intent. When hold_and_notify is
+          // configured but heldMessages is not wired, the decision still says 'hold_and_notify'
+          // so the audit trail is accurate — execution may degrade but the intent is recorded.
+          const routingDecision: UnknownSenderPolicy =
+            policy?.unknownSender === 'hold_and_notify' ? 'hold_and_notify'
+            : policy?.unknownSender === 'ignore' ? 'ignore'
+            : 'allow';
+
           await this.bus.publish('dispatch', createContactUnknown({
             channel: senderContext.channel,
             senderId: senderContext.senderId,
             channelTrustLevel: prelimChannelTrust,
             messageTrustScore: prelimScore,
+            routingDecision,
             parentEventId: event.id,
           }));
-
-          const policy = this.channelPolicies?.[payload.channelId];
 
           if (policy?.unknownSender === 'hold_and_notify' && this.heldMessages) {
             try {

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -255,14 +255,25 @@ export class Dispatcher {
             : policy?.unknownSender === 'ignore' ? 'ignore'
             : 'allow';
 
-          await this.bus.publish('dispatch', createContactUnknown({
-            channel: senderContext.channel,
-            senderId: senderContext.senderId,
-            channelTrustLevel: prelimChannelTrust,
-            messageTrustScore: prelimScore,
-            routingDecision,
-            parentEventId: event.id,
-          }));
+          // Wrapped in its own try/catch so a publish failure (e.g. audit hook throws)
+          // cannot escape to the outer resolver catch and fall through to normal routing —
+          // which would bypass the hold/ignore policy. Fail-closed: drop the message.
+          try {
+            await this.bus.publish('dispatch', createContactUnknown({
+              channel: senderContext.channel,
+              senderId: senderContext.senderId,
+              channelTrustLevel: prelimChannelTrust,
+              messageTrustScore: prelimScore,
+              routingDecision,
+              parentEventId: event.id,
+            }));
+          } catch (publishErr) {
+            this.logger.error(
+              { err: publishErr, channel: payload.channelId, senderId: payload.senderId },
+              'Failed to publish contact.unknown event — dropping message (fail-closed)',
+            );
+            return;
+          }
 
           if (policy?.unknownSender === 'hold_and_notify' && this.heldMessages) {
             try {

--- a/tests/integration/vertical-slice.test.ts
+++ b/tests/integration/vertical-slice.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, vi } from 'vitest';
 import { EventBus } from '../../src/bus/bus.js';
 import { Dispatcher } from '../../src/dispatch/dispatcher.js';
 import { AgentRuntime } from '../../src/agents/runtime.js';
-import { createInboundMessage, type OutboundMessageEvent } from '../../src/bus/events.js';
+import { createInboundMessage, type OutboundMessageEvent, type ContactUnknownEvent, type MessageHeldEvent, type AgentTaskEvent } from '../../src/bus/events.js';
 import type { LLMProvider } from '../../src/agents/llm/provider.js';
 import { createLogger } from '../../src/logger.js';
+import type { ContactResolver } from '../../src/contacts/contact-resolver.js';
+import { HeldMessageService } from '../../src/contacts/held-messages.js';
 
 describe('Vertical Slice: CLI → Dispatch → Coordinator → Response', () => {
   it('routes an inbound message through the full pipeline', async () => {
@@ -110,5 +112,74 @@ describe('Vertical Slice: CLI → Dispatch → Coordinator → Response', () => 
         { role: 'user', content: 'Good morning!' },
       ],
     });
+  });
+});
+
+describe('Vertical Slice: Unknown sender email → hold_and_notify', () => {
+  it('holds the message, fires contact.unknown with correct routingDecision and score, suppresses agent.task', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    // In-memory held messages — same interface as the real Postgres backend.
+    const heldMessages = HeldMessageService.createInMemory();
+
+    // Mock resolver: always returns unknown sender.
+    // We test the dispatcher + HeldMessageService interaction here, not contact resolution.
+    // ContactResolver is a class, not an interface — cast via unknown to satisfy TypeScript.
+    const mockResolver: ContactResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: false,
+        channel: 'email',
+        senderId: 'stranger@example.com',
+      }),
+    } as unknown as ContactResolver;
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: mockResolver,
+      heldMessages,
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify' } },
+    });
+    dispatcher.register();
+
+    // Capture events
+    const unknownEvents: ContactUnknownEvent[] = [];
+    const heldEvents: MessageHeldEvent[] = [];
+    const taskEvents: AgentTaskEvent[] = [];
+
+    bus.subscribe('contact.unknown', 'system', (e) => { unknownEvents.push(e as ContactUnknownEvent); });
+    bus.subscribe('message.held', 'channel', (e) => { heldEvents.push(e as MessageHeldEvent); });
+    bus.subscribe('agent.task', 'agent', (e) => { taskEvents.push(e as AgentTaskEvent); });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'email:stranger:1',
+      channelId: 'email',
+      senderId: 'stranger@example.com',
+      content: 'Hey, can we talk?',
+    }));
+
+    // Message must NOT reach the coordinator
+    expect(taskEvents).toHaveLength(0);
+
+    // contact.unknown event must carry the correct audit fields
+    expect(unknownEvents).toHaveLength(1);
+    expect(unknownEvents[0]!.payload.channel).toBe('email');
+    expect(unknownEvents[0]!.payload.senderId).toBe('stranger@example.com');
+    expect(unknownEvents[0]!.payload.channelTrustLevel).toBe('low');
+    // email low channel (0.3 * 0.4 = 0.12) + unknown sender (0.0 * 0.4 = 0.0) = 0.12
+    expect(unknownEvents[0]!.payload.messageTrustScore).toBeCloseTo(0.12);
+    expect(unknownEvents[0]!.payload.routingDecision).toBe('hold_and_notify');
+
+    // message.held event must fire with correct identifiers
+    expect(heldEvents).toHaveLength(1);
+    expect(heldEvents[0]!.payload.channel).toBe('email');
+    expect(heldEvents[0]!.payload.senderId).toBe('stranger@example.com');
+
+    // The message must be retrievable from the held messages store
+    const pending = await heldMessages.listPending('email');
+    expect(pending).toHaveLength(1);
+    expect(pending[0]!.senderId).toBe('stranger@example.com');
+    expect(pending[0]!.content).toBe('Hey, can we talk?');
   });
 });

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
 import { EventBus } from '../../../src/bus/bus.js';
 import { AgentRuntime } from '../../../src/agents/runtime.js';
-import { createInboundMessage, createAgentError, type OutboundMessageEvent, type MessageRejectedEvent, type AgentTaskEvent, type MessageHeldEvent } from '../../../src/bus/events.js';
+import { createInboundMessage, createAgentError, type OutboundMessageEvent, type MessageRejectedEvent, type AgentTaskEvent, type MessageHeldEvent, type ContactUnknownEvent } from '../../../src/bus/events.js';
 import type { LLMProvider } from '../../../src/agents/llm/provider.js';
 import type { ContactResolver } from '../../../src/contacts/contact-resolver.js';
 import type { InboundSenderContext, ContactStatus, TrustLevel } from '../../../src/contacts/types.js';
@@ -435,5 +435,115 @@ describe('Dispatcher — messageTrustScore', () => {
     // email low=0.3*0.4=0.12, below floor of 0.2 → should be held even though channel is 'allow'
     expect(held).toHaveLength(1);
     expect(tasks).toHaveLength(0);
+  });
+});
+
+describe('Dispatcher — contact.unknown event payload', () => {
+  it('contact.unknown includes routingDecision: hold_and_notify for email channel', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const heldMessages = makeInMemoryHeldMessages();
+    const resolver = makeResolverWithNoContact();
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: resolver,
+      heldMessages,
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify' } },
+    });
+    dispatcher.register();
+
+    const unknownEvents: ContactUnknownEvent[] = [];
+    bus.subscribe('contact.unknown', 'system', (e) => { unknownEvents.push(e as ContactUnknownEvent); });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-cu-hold',
+      channelId: 'email',
+      senderId: 'stranger@example.com',
+      content: 'Hello',
+    }));
+
+    expect(unknownEvents).toHaveLength(1);
+    expect(unknownEvents[0]!.payload.channel).toBe('email');
+    expect(unknownEvents[0]!.payload.senderId).toBe('stranger@example.com');
+    expect(unknownEvents[0]!.payload.channelTrustLevel).toBe('low');
+    // email low=0.3*0.4=0.12, unknown=0.0 → 0.12
+    expect(unknownEvents[0]!.payload.messageTrustScore).toBeCloseTo(0.12);
+    expect(unknownEvents[0]!.payload.routingDecision).toBe('hold_and_notify');
+  });
+
+  it('contact.unknown includes routingDecision: ignore for http channel', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const resolver = makeResolverWithNoContact();
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: resolver,
+      channelPolicies: { http: { trust: 'medium', unknownSender: 'ignore' } },
+    });
+    dispatcher.register();
+
+    const unknownEvents: ContactUnknownEvent[] = [];
+    bus.subscribe('contact.unknown', 'system', (e) => { unknownEvents.push(e as ContactUnknownEvent); });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-cu-ignore',
+      channelId: 'http',
+      senderId: 'api-caller',
+      content: 'Hello',
+    }));
+
+    expect(unknownEvents).toHaveLength(1);
+    expect(unknownEvents[0]!.payload.channelTrustLevel).toBe('medium');
+    // http medium=0.6*0.4=0.24, unknown=0.0 → 0.24
+    expect(unknownEvents[0]!.payload.messageTrustScore).toBeCloseTo(0.24);
+    expect(unknownEvents[0]!.payload.routingDecision).toBe('ignore');
+  });
+
+  it('contact.unknown includes routingDecision: allow for high-trust allow channel', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const resolver = makeResolverWithNoContact();
+    // Use a mock provider so the agent.task that flows through does not error
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'OK',
+        usage: { inputTokens: 1, outputTokens: 1 },
+      }),
+    };
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a helpful assistant.',
+      provider: mockProvider,
+      bus,
+      logger,
+    });
+    coordinator.register();
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: resolver,
+      channelPolicies: { signal: { trust: 'high', unknownSender: 'allow' } },
+    });
+    dispatcher.register();
+
+    const unknownEvents: ContactUnknownEvent[] = [];
+    bus.subscribe('contact.unknown', 'system', (e) => { unknownEvents.push(e as ContactUnknownEvent); });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-cu-allow',
+      channelId: 'signal',
+      senderId: '+15550001234',
+      content: 'Hello',
+    }));
+
+    expect(unknownEvents).toHaveLength(1);
+    expect(unknownEvents[0]!.payload.channelTrustLevel).toBe('high');
+    // signal high=1.0*0.4=0.40, unknown=0.0 → 0.40
+    expect(unknownEvents[0]!.payload.messageTrustScore).toBeCloseTo(0.40);
+    expect(unknownEvents[0]!.payload.routingDecision).toBe('allow');
   });
 });


### PR DESCRIPTION
## Summary

- **`contact.unknown` event** now includes `routingDecision: 'allow' | 'hold_and_notify' | 'ignore'`, making the unknown-sender audit trail self-contained (no need to correlate downstream events to determine what the dispatcher decided).
- **Dispatcher restructure**: policy lookup and routing decision are now computed *before* publishing `contact.unknown`, so the event accurately reflects intent even when `heldMessages` is not wired.
- **Fail-closed hardening**: wrapped the `contact.unknown` publish in its own try/catch so a publish failure (e.g. audit hook throws) cannot fall through to normal routing and bypass hold/ignore policy. This was a pre-existing gap, fixed in the same PR.

## Test plan

- [ ] Unit: 3 new tests in `tests/unit/dispatch/dispatcher.test.ts` — one per routing policy (`allow`, `hold_and_notify`, `ignore`), asserting full `contact.unknown` payload shape
- [ ] Integration: new scenario in `tests/integration/vertical-slice.test.ts` — unknown sender email → `hold_and_notify`, asserts `agent.task` suppressed, `message.held` fires, message retrievable from held store
- [ ] Full suite: 1153 passed, 36 skipped, 0 failed

Closes #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routing decisions for unknown senders are now recorded (allow, hold_and_notify, ignore)
  * Message trust scores are included in emitted system events

* **Changed**
  * Unknown-sender policy naming standardized (reject → ignore) with unchanged behavior
  * Dispatcher records intended routingDecision in audit events; job run outcomes now persist as completed/failed

* **Documentation**
  * Added design and spec docs for sender-trust routing

* **Tests**
  * Added unit and integration coverage for unknown-sender workflows and payloads
<!-- end of auto-generated comment: release notes by coderabbit.ai -->