### PR TITLE
fix: sanitize null bytes from audit log payloads (fixes #257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **ADR-014: Capability-tier model routing** — Documents the decision to replace per-agent model declarations with a capability-tier system (`fast | standard | powerful`) mapped by the operator, with optional modality/capability needs flags (`vision`, `large_context`, `reasoning`, `coding`, `audio`, `image_generation`). Implementation tracked in the linked issue.
 
 ### Fixed
+- **Null byte crash in audit logger** — `AuditLogger.log()` now strips U+0000 from all
+  string values in event payloads before writing to `audit_log.payload`. Previously, binary
+  content returned by `web-fetch` could embed null bytes that PostgreSQL rejects with
+  `22P05`, causing the agent task to crash mid-run. Fixes josephfung/curia#257.
 - **contact-data-leak false positives** — The `contact-data-leak` deterministic filter rule
   now uses a single-axis policy based solely on recipient trust level, instead of blocking all
   third-party email addresses unconditionally. A third-party email is blocked only when the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/audit/logger.ts
+++ b/src/audit/logger.ts
@@ -24,7 +24,11 @@ function stripNullBytes(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(stripNullBytes);
   }
-  if (value !== null && typeof value === 'object') {
+  // Only recurse into plain objects. Non-plain objects (Date, Buffer, RegExp, etc.)
+  // must pass through untouched — Object.entries() on a Date returns [] which would
+  // silently replace the Date with {}, corrupting timestamp fields like mergedAt.
+  // JSON.stringify handles non-plain objects correctly on its own (e.g. Date.toISOString()).
+  if (value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, stripNullBytes(v)]),
     );
@@ -74,6 +78,19 @@ export class AuditLogger {
     const conversationId =
       typeof payload.conversationId === 'string' ? payload.conversationId : null;
 
+    // Sanitize before the DB write in a separate try/catch so a sanitization
+    // failure is logged with its own distinct message — not conflated with a
+    // DB connectivity or schema error from the INSERT below.
+    // TODO: JSON.stringify can also throw on circular references (pre-existing,
+    // not introduced here). If that becomes a live issue, wrap it separately too.
+    let serializedPayload: string;
+    try {
+      serializedPayload = JSON.stringify(stripNullBytes(event.payload));
+    } catch (err) {
+      this.logger.error({ err, eventId: event.id, eventType: event.type }, 'Audit log payload sanitization failed — event not written');
+      throw err;
+    }
+
     try {
       await this.pool.query(
         // All columns are explicitly listed so schema additions don't silently
@@ -87,7 +104,7 @@ export class AuditLogger {
           event.type,
           event.sourceLayer,
           sourceId,
-          JSON.stringify(stripNullBytes(event.payload)),
+          serializedPayload,
           conversationId,
           event.parentEventId ?? null,
         ],

--- a/src/audit/logger.ts
+++ b/src/audit/logger.ts
@@ -3,6 +3,36 @@ import type { BusEvent } from '../bus/events.js';
 import type { Logger } from '../logger.js';
 
 /**
+ * Recursively strip null bytes (U+0000) from all string values in an object.
+ *
+ * PostgreSQL cannot store U+0000 in text or JSONB columns — it rejects the
+ * write with error 22P05 ("unsupported Unicode escape sequence"). Skill
+ * payloads (especially web-fetch results) can carry null bytes when the
+ * fetched URL returns binary or mixed-encoding content. Stripping them here,
+ * at the single write-path into audit_log, is the correct choke point: it
+ * covers all event types regardless of which skill produced the payload.
+ *
+ * Null bytes are replaced with '' (empty string) rather than a placeholder
+ * like '<0x00>' to keep payloads clean for downstream consumers. The loss of
+ * the byte is acceptable — audit payloads are diagnostic records, not
+ * faithful binary stores.
+ */
+function stripNullBytes(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.replace(/\u0000/g, '');
+  }
+  if (Array.isArray(value)) {
+    return value.map(stripNullBytes);
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, stripNullBytes(v)]),
+    );
+  }
+  return value;
+}
+
+/**
  * Write-ahead audit logger. Persists every bus event to the audit_log table
  * BEFORE the event is delivered to other subscribers. This ensures audit
  * completeness even if the process crashes mid-delivery.
@@ -57,7 +87,7 @@ export class AuditLogger {
           event.type,
           event.sourceLayer,
           sourceId,
-          JSON.stringify(event.payload),
+          JSON.stringify(stripNullBytes(event.payload)),
           conversationId,
           event.parentEventId ?? null,
         ],

--- a/tests/unit/audit/logger.test.ts
+++ b/tests/unit/audit/logger.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuditLogger } from '../../../src/audit/logger.js';
+import { createSilentLogger } from '../../../src/logger.js';
+import { createInboundMessage } from '../../../src/bus/events.js';
+import type { DbPool } from '../../../src/db/connection.js';
+
+// Minimal mock pool that captures what gets written to the DB.
+function makeMockPool() {
+  const written: unknown[] = [];
+  const pool = {
+    query: vi.fn(async (_sql: string, params?: unknown[]) => {
+      if (params) written.push(...params);
+      return { rows: [], rowCount: 1 };
+    }),
+    written,
+  };
+  return pool;
+}
+
+describe('AuditLogger.log — null byte sanitization', () => {
+  let pool: ReturnType<typeof makeMockPool>;
+  let logger: AuditLogger;
+
+  beforeEach(() => {
+    pool = makeMockPool();
+    logger = new AuditLogger(pool as unknown as DbPool, createSilentLogger());
+  });
+
+  it('strips null bytes from a string field in the payload', async () => {
+    const event = createInboundMessage({
+      conversationId: 'conv-1',
+      channelId: 'test',
+      senderId: 'sender',
+      // Simulate a web-fetch result that contains null bytes embedded in content
+      content: 'before\u0000after',
+    });
+
+    await logger.log(event);
+
+    // The $6 parameter is the JSON.stringify'd payload written to audit_log.payload
+    const serialized = pool.written.find(
+      (p) => typeof p === 'string' && p.includes('before') && p.includes('after'),
+    ) as string;
+
+    expect(serialized).toBeDefined();
+    expect(serialized).toContain('beforeafter');
+    expect(serialized).not.toContain('\u0000');
+  });
+
+  it('strips null bytes nested inside objects and arrays', async () => {
+    const event = createInboundMessage({
+      conversationId: 'conv-2',
+      channelId: 'test',
+      senderId: 'sender',
+      content: 'clean',
+    });
+
+    // Manually inject a deeply nested null byte into the payload to simulate
+    // binary web-fetch content surfacing in a nested skill result structure
+    (event.payload as Record<string, unknown>)['nested'] = {
+      arr: ['a\u0000b', { deep: 'x\u0000y' }],
+    };
+
+    await logger.log(event);
+
+    const payloadParam = pool.written.find(
+      (p) => typeof p === 'string' && (p as string).includes('nested'),
+    ) as string;
+
+    expect(payloadParam).toBeDefined();
+    expect(payloadParam).not.toContain('\u0000');
+    expect(payloadParam).toContain('ab');
+    expect(payloadParam).toContain('xy');
+  });
+
+  it('passes through payloads with no null bytes unchanged', async () => {
+    const event = createInboundMessage({
+      conversationId: 'conv-3',
+      channelId: 'test',
+      senderId: 'sender',
+      content: 'clean content',
+    });
+
+    await logger.log(event);
+
+    const payloadParam = pool.written.find(
+      (p) => typeof p === 'string' && (p as string).includes('clean content'),
+    ) as string;
+
+    expect(payloadParam).toBeDefined();
+    expect(JSON.parse(payloadParam)).toMatchObject({ content: 'clean content' });
+  });
+
+  it('does not throw on null, numeric, or boolean values in the payload', async () => {
+    const event = createInboundMessage({
+      conversationId: 'conv-4',
+      channelId: 'test',
+      senderId: 'sender',
+      content: 'check',
+    });
+
+    (event.payload as Record<string, unknown>)['meta'] = {
+      count: 42,
+      flag: true,
+      nothing: null,
+    };
+
+    await expect(logger.log(event)).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/audit/logger.test.ts
+++ b/tests/unit/audit/logger.test.ts
@@ -107,4 +107,30 @@ describe('AuditLogger.log — null byte sanitization', () => {
 
     await expect(logger.log(event)).resolves.toBeUndefined();
   });
+
+  it('passes Date values through without mangling them to {}', async () => {
+    // Date fields exist on live payload types (e.g. ContactMergedPayload.mergedAt,
+    // HumanDecisionPayload.presentedAt/decidedAt). Object.entries(new Date()) returns []
+    // which would cause Object.fromEntries to produce {} — silently destroying the value.
+    const event = createInboundMessage({
+      conversationId: 'conv-5',
+      channelId: 'test',
+      senderId: 'sender',
+      content: 'check',
+    });
+
+    const ts = new Date('2026-04-10T08:30:00.000Z');
+    (event.payload as Record<string, unknown>)['mergedAt'] = ts;
+
+    await logger.log(event);
+
+    const payloadParam = pool.written.find(
+      (p) => typeof p === 'string' && (p as string).includes('mergedAt'),
+    ) as string;
+
+    expect(payloadParam).toBeDefined();
+    const parsed = JSON.parse(payloadParam);
+    // Must serialize as ISO string, not {}
+    expect(parsed.mergedAt).toBe('2026-04-10T08:30:00.000Z');
+  });
 });


### PR DESCRIPTION
## Summary

- **Null byte sanitization in `AuditLogger`** — `stripNullBytes()` recursively removes U+0000 from all string values in event payloads before the DB write. Prevents `22P05` crashes when `web-fetch` returns binary content with embedded null bytes.
- **Date passthrough guard** — sanitizer uses `Object.getPrototypeOf(value) === Object.prototype` to skip non-plain objects, preventing silent corruption of `Date` fields (e.g. `ContactMergedPayload.mergedAt`, `HumanDecisionPayload.presentedAt/decidedAt`).
- **Split error path** — sanitization runs in its own `try/catch` before the DB `INSERT`, with a distinct `'payload sanitization failed'` log message rather than being swallowed by `'Audit log write failed'`.

Fixes #257. Observed cause: writing-scout Friday run (2026-04-10) fetched a URL returning binary content; null bytes in the `skill.result` payload crashed the audit log write and killed the agent task.

## Test plan

- [x] `npm test` — 1154 unit tests pass
- [x] New unit tests in `tests/unit/audit/logger.test.ts` cover: null byte stripping in strings, nested objects/arrays, clean passthrough, primitive values (null/number/bool), and `Date` field passthrough without mangling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audit logs now strip null (U+0000) characters from event payloads before storage, preventing DB errors.
  * Contact-data-leak filter now blocks third‑party emails only for untrusted recipients; related API input changes documented.

* **Tests**
  * Added unit tests covering null-byte removal across nested structures, arrays, dates and mixed types.

* **Documentation**
  * Changelog updated describing the fixes and API changes.

* **Chores**
  * Package version bumped to 0.16.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->