### PR TITLE
feat: input validation — message size limits, config schema, and manifest validation (issue #196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,22 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **Agent YAML schema now enforced at startup** — previously-ignored unknown keys and missing required fields now cause a descriptive `process.exit(1)`. Any `agents/*.yaml` that was silently tolerated must be fixed before upgrading. This is a change to the agent YAML public API surface (minor bump required per versioning policy).
+- **Skill manifest schema now enforced at startup** — same as above for `skills/*/skill.json`. Invalid manifests (missing `version`, `action_risk`, unknown keys) cause startup failure.
+- **`MessageRejectedPayload.reason`** extended with `'message_too_large'` (bus event type, public API surface) — exhaustive handlers over the `reason` union must add this case. The payload also gains optional `size` and `limit` fields populated when the reason is `message_too_large`.
+- **HTTP 413 for oversized messages** — inbound messages that exceed `channels.max_message_bytes` now receive HTTP 413 (Payload Too Large) instead of 403.
+
 ### Security
 - **Input validation** — startup validator (`src/startup/validator.ts`) validates `config/default.yaml`, all `agents/*.yaml`, and all `skills/*/skill.json` against JSON Schema (Ajv) at boot time. Invalid configs cause a descriptive `process.exit(1)` before any service initializes (spec §06).
-- **Message size limiting** — dispatcher rejects inbound messages exceeding `channels.max_message_bytes` (default 100KB) before routing; rejection is audit-logged as `message.rejected` with causal `parentEventId` (spec §06).
+- **Message size limiting** — dispatcher rejects inbound messages exceeding `channels.max_message_bytes` (default 100KB) before routing; rejection is audit-logged as `message.rejected` with causal `parentEventId` and includes the message byte size and configured limit (spec §06).
 
 ### Added
 - **`schemas/` directory** — JSON Schema files for agent configs, skill manifests, and `config/default.yaml`. Schemas are legible without TypeScript and can be validated with third-party tools.
 - **`channels.max_message_bytes`** in `config/default.yaml` — configures the inbound message size limit (default `102400`).
 
 ### Changed
-- **`MessageRejectedPayload.reason`** extended with `'message_too_large'` — bus event API surface change.
 - **Agent and skill loaders** — manual field checks removed; validation is now handled by the startup validator schema.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Breaking Changes
 
-- **Agent YAML schema now enforced at startup** — previously-ignored unknown keys and missing required fields now cause a descriptive `process.exit(1)`. Any `agents/*.yaml` that was silently tolerated must be fixed before upgrading. This is a change to the agent YAML public API surface (minor bump required per versioning policy).
+- **Agent YAML schema now enforced at startup** — previously-ignored unknown keys and missing required fields now cause a descriptive `process.exit(1)`. Any `agents/*.yaml` that was silently tolerated must be fixed before upgrading.
 - **Skill manifest schema now enforced at startup** — same as above for `skills/*/skill.json`. Invalid manifests (missing `version`, `action_risk`, unknown keys) cause startup failure.
 - **`MessageRejectedPayload.reason`** extended with `'message_too_large'` (bus event type, public API surface) — exhaustive handlers over the `reason` union must add this case. The payload also gains optional `size` and `limit` fields populated when the reason is `message_too_large`.
 - **HTTP 413 for oversized messages** — inbound messages that exceed `channels.max_message_bytes` now receive HTTP 413 (Payload Too Large) instead of 403.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Breaking Changes
 
-- **Agent YAML schema now enforced at startup** — previously-ignored unknown keys and missing required fields now cause a descriptive `process.exit(1)`. Any `agents/*.yaml` that was silently tolerated must be fixed before upgrading.
+- **Agent YAML schema now enforced at startup** — previously ignored unknown keys and missing required fields now cause a descriptive `process.exit(1)`. Any `agents/*.yaml` that was silently tolerated must be fixed before upgrading.
 - **Skill manifest schema now enforced at startup** — same as above for `skills/*/skill.json`. Invalid manifests (missing `version`, `action_risk`, unknown keys) cause startup failure.
 - **`MessageRejectedPayload.reason`** extended with `'message_too_large'` (bus event type, public API surface) — exhaustive handlers over the `reason` union must add this case. The payload also gains optional `size` and `limit` fields populated when the reason is `message_too_large`.
 - **HTTP 413 for oversized messages** — inbound messages that exceed `channels.max_message_bytes` now receive HTTP 413 (Payload Too Large) instead of 403.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+- **Input validation** — startup validator (`src/startup/validator.ts`) validates `config/default.yaml`, all `agents/*.yaml`, and all `skills/*/skill.json` against JSON Schema (Ajv) at boot time. Invalid configs cause a descriptive `process.exit(1)` before any service initializes (spec §06).
+- **Message size limiting** — dispatcher rejects inbound messages exceeding `channels.max_message_bytes` (default 100KB) before routing; rejection is audit-logged as `message.rejected` with causal `parentEventId` (spec §06).
+
+### Added
+- **`schemas/` directory** — JSON Schema files for agent configs, skill manifests, and `config/default.yaml`. Schemas are legible without TypeScript and can be validated with third-party tools.
+- **`channels.max_message_bytes`** in `config/default.yaml` — configures the inbound message size limit (default `102400`).
+
+### Changed
+- **`MessageRejectedPayload.reason`** extended with `'message_too_large'` — bus event API surface change.
+- **Agent and skill loaders** — manual field checks removed; validation is now handled by the startup validator schema.
+
 ### Fixed
 - **Null byte crash in audit logger** — `AuditLogger.log()` now strips U+0000 from all
   string values in event payloads before writing to `audit_log.payload`. Previously, binary

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,7 +1,7 @@
 channels:
   cli:
     enabled: true
-  maxMessageBytes: 102400   # 100KB — inbound messages exceeding this are rejected before routing
+  max_message_bytes: 102400   # 100KB — inbound messages exceeding this are rejected before routing
   # Signal channel activation is controlled by env vars, not this file.
   # Set SIGNAL_SOCKET_PATH + SIGNAL_PHONE_NUMBER at runtime to enable the Signal adapter.
   # Trust level and unknown-sender policy live in config/channel-trust.yaml.

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,6 +1,7 @@
 channels:
   cli:
     enabled: true
+  maxMessageBytes: 102400   # 100KB — inbound messages exceeding this are rejected before routing
   # Signal channel activation is controlled by env vars, not this file.
   # Set SIGNAL_SOCKET_PATH + SIGNAL_PHONE_NUMBER at runtime to enable the Signal adapter.
   # Trust level and unknown-sender policy live in config/channel-trust.yaml.

--- a/docs/specs/06-audit-and-security.md
+++ b/docs/specs/06-audit-and-security.md
@@ -350,7 +350,7 @@ These are non-negotiable for launch.
 | Tool output sanitization active for all skill results | Done |
 | Inbound message sanitization active (injection pattern detection) | Done |
 | Error strings scrubbed before LLM injection | Done (#250) |
-| Agent config validation blocks malformed YAML at startup | Not Done |
+| Agent config validation blocks malformed YAML at startup | Done (#263) |
 | HTTP API channel requires token authentication | Done |
 | Rate limiting active at dispatch layer | Not Done |
 | Intent drift detection pauses tasks (not just logs) | Not Done |

--- a/docs/wip/2026-04-10-input-validation-design.md
+++ b/docs/wip/2026-04-10-input-validation-design.md
@@ -1,0 +1,263 @@
+# Input Validation: Message Size Limits, Config Schema Validation, and Manifest Validation
+
+**Issue:** [#196](https://github.com/josephfung/curia/issues/196)
+**Date:** 2026-04-10
+
+## Overview
+
+Implement input validation at four system boundaries:
+
+1. **Inbound message size limiting** — dispatcher rejects oversized messages before routing
+2. **`config/default.yaml` validation** — JSON Schema check at startup
+3. **Agent YAML config validation** — JSON Schema check at startup
+4. **Skill manifest validation** — JSON Schema check at startup
+
+All four are enforced by a centralized startup validator (`src/startup/validator.ts`) plus a dispatcher-level size check. Invalid config causes a loud startup failure (`process.exit(1)`) rather than silent misbehavior at runtime.
+
+---
+
+## Design Decisions
+
+### Centralized startup validator
+
+All schema-based validation is orchestrated by a single `src/startup/validator.ts` called early in `index.ts` — before the DB connection, before any service is initialized. This is the right place for "fail fast" checks:
+
+- Single call site in the bootstrap sequence
+- Future startup checks (e.g., DB connectivity, LLM provider reachability) can be added here as the system grows
+- Errors surface before any side-effectful initialization
+
+### JSON Schema with Ajv + dedicated schema files
+
+Schema definitions live in `src/schemas/` as `.schema.json` files. Ajv is used for validation with `allErrors: true` so all violations in a file are reported at once.
+
+**Why schema files over inline constants:**
+- Schema files are legible without reading TypeScript
+- Easier to maintain and audit independently
+- Can be validated with third-party JSON Schema tools
+- A natural home for documentation about each field's constraints
+
+### Message size check in the dispatcher (not channel adapters)
+
+The spec mentions "channel layer" rejection, but enforcing the check in each channel adapter would require expanding the channel layer's bus publish permissions (`message.rejected` is currently a dispatch-layer event). Doing it in the dispatcher instead:
+
+- Avoids permission boundary expansion
+- Creates a clean causal chain in the audit log: `inbound.message` (parentEventId) → `message.rejected`
+- Single enforcement point — future channel adapters get the check for free
+- The oversized content briefly enters the bus (in-process memory only), which is acceptable and actually gives forensic value in the audit log
+
+### `config/default.yaml` validation (scope expansion beyond issue #196)
+
+The issue only specifies agent YAML and skill manifest validation, but `config/default.yaml` carries numeric thresholds (trust score weights, policy thresholds) that are currently unvalidated. A misconfigured value (e.g., a string where a number is expected, or a trust threshold above 1.0) fails silently and is difficult to diagnose. Since we're adding Ajv and a schemas directory anyway, the marginal cost of covering `default.yaml` is low and the benefit is high.
+
+---
+
+## New Files
+
+### `src/schemas/agent-config.schema.json`
+
+JSON Schema for `agents/*.yaml` files.
+
+Required fields: `name`, `description`, `model.provider`, `model.model`, `system_prompt`
+
+Optional typed fields: `role`, `persona` (object with optional `display_name`, `tone`, `title`, `email_signature`), `pinned_skills` (array of strings), `allow_discovery` (boolean), `memory.scopes` (array of strings), `schedule` (array of objects), `error_budget` (object with optional numeric fields).
+
+`additionalProperties: false` at the top level and all nested objects — catches YAML key typos that would otherwise be silently ignored.
+
+### `src/schemas/skill-manifest.schema.json`
+
+JSON Schema for `skills/*/skill.json` files.
+
+Required fields: `name` (string), `description` (string), `version` (string), `action_risk` (string enum `none|low|medium|high|critical` OR integer 0–100).
+
+Optional fields: `sensitivity` (enum: `normal|elevated`), `inputs` (object), `outputs` (object), `permissions` (array of strings), `secrets` (array of strings), `timeout` (integer ≥ 1), `infrastructure` (boolean), `entity_enrichment` (object with `param` string and `default` enum `caller|agent`).
+
+Handler path is not a schema field — the loader verifies `handler.ts`/`handler.js` exists on disk, which is the correct approach for a filesystem-derived property.
+
+`additionalProperties: false` throughout.
+
+### `src/schemas/default-config.schema.json`
+
+JSON Schema for `config/default.yaml`. All fields are optional (the file is intentionally partial — defaults are applied in code). When fields are present, types and ranges are enforced.
+
+Key constraints:
+- `channels.maxMessageBytes`: integer, minimum 1
+- `security.trust_score.channel_weight`: number, minimum 0, maximum 1
+- `security.trust_score.contact_weight`: number, minimum 0, maximum 1
+- `security.trust_score.max_risk_penalty`: number, minimum 0, maximum 1
+- `security.trust_score_floor`: number, minimum 0, maximum 1
+- `trust_policy.financial_actions`: number, minimum 0, maximum 1
+- `trust_policy.data_export`: number, minimum 0, maximum 1
+- `trust_policy.scheduling`: number, minimum 0, maximum 1
+- `trust_policy.information_queries`: number, minimum 0, maximum 1
+- `workingMemory.summarization.threshold`: integer, minimum 2
+- `workingMemory.summarization.keepWindow`: integer, minimum 1
+- `skillOutput.maxLength`: integer, minimum 1
+- `browser.sessionTtlMs`: integer, minimum 1
+- `browser.sweepIntervalMs`: integer, minimum 1
+- `dispatch.conversationCheckpointDebounceMs`: integer, minimum 1
+
+`additionalProperties: false` at every nesting level catches typos like `trust-policy` instead of `trust_policy`.
+
+### `src/startup/validator.ts`
+
+```typescript
+export async function runStartupValidation(opts: {
+  configDir: string;
+  agentsDir: string;
+  skillsDir: string;
+  logger: Logger;
+}): Promise<void>
+```
+
+Execution order:
+1. Load and validate `config/default.yaml` against `default-config.schema.json`
+2. Load and validate each `agents/*.yaml` file against `agent-config.schema.json`
+3. Load and validate each `skills/*/skill.json` file against `skill-manifest.schema.json`
+
+On validation failure: throws with a descriptive message that includes the file path and all failing field paths/messages (Ajv `allErrors: true` collects all errors before throwing).
+
+The Ajv instance is created once and schemas are compiled once — not recreated per file. This keeps startup fast even with many agents/skills.
+
+---
+
+## Modified Files
+
+### `config/default.yaml`
+
+Add `maxMessageBytes` to the `channels` section:
+
+```yaml
+channels:
+  cli:
+    enabled: true
+  maxMessageBytes: 102400   # 100KB — inbound messages exceeding this are rejected before routing
+```
+
+### `src/config.ts`
+
+Add `maxMessageBytes` to the `YamlConfig.channels` type:
+
+```typescript
+channels?: {
+  cli?: { enabled?: boolean };
+  maxMessageBytes?: number;
+};
+```
+
+### `src/index.ts`
+
+1. Call `runStartupValidation()` immediately after config and logger are initialized, before DB connection:
+
+```typescript
+await runStartupValidation({
+  configDir,
+  agentsDir: path.resolve(import.meta.dirname, '../agents'),
+  skillsDir: path.resolve(import.meta.dirname, '../skills'),
+  logger,
+});
+```
+
+2. Pass `maxMessageBytes` into `DispatcherConfig`:
+
+```typescript
+maxMessageBytes: yamlConfig.channels?.maxMessageBytes ?? 102_400,
+```
+
+### `src/agents/loader.ts`
+
+Remove the manual field checks (`if (!config.name)`, `if (!config.model?.provider)`, etc.) — these are now enforced by the startup validator's Ajv schema check, which runs before the loaders are called. The loader retains YAML parse error handling and persona interpolation logic, which are not schema concerns.
+
+### `src/skills/loader.ts`
+
+Same: remove the manual `if (!manifest.name || !manifest.description)` check. Ajv now enforces all required fields. The loader retains handler discovery (`handler.ts`/`handler.js`) and dynamic import logic.
+
+### `src/bus/events.ts`
+
+Add `'message_too_large'` to the `reason` union in `MessageRejectedPayload`:
+
+```typescript
+reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender' | 'message_too_large';
+```
+
+This is a change to a public API surface (`bus/events.ts`) and must be called out in the CHANGELOG.
+
+### `src/dispatch/dispatcher.ts`
+
+Add `maxMessageBytes` to `DispatcherConfig`. In the `inbound.message` handler, before contact resolution:
+
+```typescript
+const contentByteSize = Buffer.byteLength(event.payload.content, 'utf-8');
+if (contentByteSize > this.maxMessageBytes) {
+  this.logger.warn(
+    { channelId: event.payload.channelId, senderId: event.payload.senderId,
+      contentByteSize, maxBytes: this.maxMessageBytes },
+    'Inbound message exceeded size limit — rejected',
+  );
+  await this.bus.publish('dispatch', createMessageRejected({
+    conversationId: event.payload.conversationId,
+    channelId: event.payload.channelId,
+    senderId: event.payload.senderId,
+    reason: 'message_too_large',
+    parentEventId: event.id,
+  }));
+  return;
+}
+```
+
+The `message.rejected` event is already in the dispatch layer's publish permissions — no permission changes needed.
+
+---
+
+## Message Size Rejection Behavior
+
+- **All channels:** silent drop — no response sent to the sender
+- **Email specifically:** consistent with the unknown sender policy (`ignore`) — no auto-reply
+- **Audit trail:** the `inbound.message` event is written to audit_log before dispatch (write-ahead), and the `message.rejected` event follows with `parentEventId` pointing to the oversized `inbound.message`. Both records are in the audit log.
+- **Configurable:** `channels.maxMessageBytes` in `config/default.yaml`. Default: `102400` (100KB). The schema enforces this is an integer ≥ 1.
+
+---
+
+## Testing
+
+### Unit tests (new)
+
+**`tests/unit/startup/validator.test.ts`**
+- Valid agent YAML → no error
+- Agent YAML missing `name` → throws with file path and field name
+- Agent YAML missing `description` → throws
+- Agent YAML missing `model.provider` → throws
+- Agent YAML with unknown top-level key → throws (additionalProperties)
+- Valid skill manifest → no error
+- Skill manifest missing `version` → throws
+- Skill manifest missing `action_risk` → throws
+- Skill manifest with invalid `action_risk` value → throws
+- Valid `default.yaml` → no error
+- `default.yaml` with `trust_score_floor: 1.5` → throws (out of range)
+- `default.yaml` with `maxMessageBytes: "big"` → throws (wrong type)
+- `default.yaml` with unknown key → throws (additionalProperties)
+
+**`tests/unit/dispatch/dispatcher.test.ts`** (additions to existing file)
+- Message with content ≤ maxMessageBytes → routes normally
+- Message with content > maxMessageBytes → publishes `message.rejected`, does not publish `agent.task`
+- Rejection event has correct `parentEventId` pointing to the inbound message
+
+### Manual verification at startup
+
+With a deliberately broken `agents/coordinator.yaml` (remove `description` field), startup should exit with a message like:
+
+```
+Fatal: Startup validation failed for agents/coordinator.yaml:
+  - /description: must have required property 'description'
+```
+
+---
+
+## Acceptance Criteria (from issue #196)
+
+- [x] Inbound messages exceeding 100KB are rejected before bus routing; rejection is audit-logged
+- [x] Max message size is configurable in `config/default.yaml` as `channels.maxMessageBytes`
+- [x] Bootstrap orchestrator validates all `agents/*.yaml` files against JSON Schema at startup
+- [x] Bootstrap orchestrator validates all `skills/*/skill.json` manifests against JSON Schema at startup
+- [x] Invalid config or manifest causes process exit with a descriptive error (not a silent failure)
+- [x] Dispatch policy rules (`trust_policy.*`, `security.trust_score.*`) validated at load time
+- [x] Unit tests: oversized message → rejected; invalid agent YAML → startup error; invalid manifest → startup error

--- a/docs/wip/2026-04-10-input-validation-design.md
+++ b/docs/wip/2026-04-10-input-validation-design.md
@@ -80,7 +80,7 @@ Handler path is not a schema field — the loader verifies `handler.ts`/`handler
 JSON Schema for `config/default.yaml`. All fields are optional (the file is intentionally partial — defaults are applied in code). When fields are present, types and ranges are enforced.
 
 Key constraints:
-- `channels.maxMessageBytes`: integer, minimum 1
+- `channels.max_message_bytes`: integer, minimum 1
 - `security.trust_score.channel_weight`: number, minimum 0, maximum 1
 - `security.trust_score.contact_weight`: number, minimum 0, maximum 1
 - `security.trust_score.max_risk_penalty`: number, minimum 0, maximum 1
@@ -124,23 +124,23 @@ The Ajv instance is created once and schemas are compiled once — not recreated
 
 ### `config/default.yaml`
 
-Add `maxMessageBytes` to the `channels` section:
+Add `max_message_bytes` to the `channels` section:
 
 ```yaml
 channels:
   cli:
     enabled: true
-  maxMessageBytes: 102400   # 100KB — inbound messages exceeding this are rejected before routing
+  max_message_bytes: 102400   # 100KB — inbound messages exceeding this are rejected before routing
 ```
 
 ### `src/config.ts`
 
-Add `maxMessageBytes` to the `YamlConfig.channels` type:
+Add `max_message_bytes` to the `YamlConfig.channels` type:
 
 ```typescript
 channels?: {
   cli?: { enabled?: boolean };
-  maxMessageBytes?: number;
+  max_message_bytes?: number;
 };
 ```
 
@@ -157,10 +157,10 @@ await runStartupValidation({
 });
 ```
 
-2. Pass `maxMessageBytes` into `DispatcherConfig`:
+2. Pass `max_message_bytes` into `DispatcherConfig`:
 
 ```typescript
-maxMessageBytes: yamlConfig.channels?.maxMessageBytes ?? 102_400,
+maxMessageBytes: yamlConfig.channels?.max_message_bytes ?? 102_400,
 ```
 
 ### `src/agents/loader.ts`
@@ -213,7 +213,7 @@ The `message.rejected` event is already in the dispatch layer's publish permissi
 - **All channels:** silent drop — no response sent to the sender
 - **Email specifically:** consistent with the unknown sender policy (`ignore`) — no auto-reply
 - **Audit trail:** the `inbound.message` event is written to audit_log before dispatch (write-ahead), and the `message.rejected` event follows with `parentEventId` pointing to the oversized `inbound.message`. Both records are in the audit log.
-- **Configurable:** `channels.maxMessageBytes` in `config/default.yaml`. Default: `102400` (100KB). The schema enforces this is an integer ≥ 1.
+- **Configurable:** `channels.max_message_bytes` in `config/default.yaml`. Default: `102400` (100KB). The schema enforces this is an integer ≥ 1.
 
 ---
 
@@ -233,12 +233,12 @@ The `message.rejected` event is already in the dispatch layer's publish permissi
 - Skill manifest with invalid `action_risk` value → throws
 - Valid `default.yaml` → no error
 - `default.yaml` with `trust_score_floor: 1.5` → throws (out of range)
-- `default.yaml` with `maxMessageBytes: "big"` → throws (wrong type)
+- `default.yaml` with `max_message_bytes: "big"` → throws (wrong type)
 - `default.yaml` with unknown key → throws (additionalProperties)
 
 **`tests/unit/dispatch/dispatcher.test.ts`** (additions to existing file)
-- Message with content ≤ maxMessageBytes → routes normally
-- Message with content > maxMessageBytes → publishes `message.rejected`, does not publish `agent.task`
+- Message with content ≤ `max_message_bytes` → routes normally
+- Message with content > `max_message_bytes` → publishes `message.rejected`, does not publish `agent.task`
 - Rejection event has correct `parentEventId` pointing to the inbound message
 
 ### Manual verification at startup
@@ -255,7 +255,7 @@ Fatal: Startup validation failed for agents/coordinator.yaml:
 ## Acceptance Criteria (from issue #196)
 
 - [x] Inbound messages exceeding 100KB are rejected before bus routing; rejection is audit-logged
-- [x] Max message size is configurable in `config/default.yaml` as `channels.maxMessageBytes`
+- [x] Max message size is configurable in `config/default.yaml` as `channels.max_message_bytes`
 - [x] Bootstrap orchestrator validates all `agents/*.yaml` files against JSON Schema at startup
 - [x] Bootstrap orchestrator validates all `skills/*/skill.json` manifests against JSON Schema at startup
 - [x] Invalid config or manifest causes process exit with a descriptive error (not a silent failure)

--- a/docs/wip/2026-04-10-input-validation-design.md
+++ b/docs/wip/2026-04-10-input-validation-design.md
@@ -28,7 +28,7 @@ All schema-based validation is orchestrated by a single `src/startup/validator.t
 
 ### JSON Schema with Ajv + dedicated schema files
 
-Schema definitions live in `src/schemas/` as `.schema.json` files. Ajv is used for validation with `allErrors: true` so all violations in a file are reported at once.
+Schema definitions live in `schemas/` (project root) as `.schema.json` files. Ajv is used for validation with `allErrors: true` so all violations in a file are reported at once.
 
 **Why schema files over inline constants:**
 - Schema files are legible without reading TypeScript
@@ -245,7 +245,7 @@ The `message.rejected` event is already in the dispatch layer's publish permissi
 
 With a deliberately broken `agents/coordinator.yaml` (remove `description` field), startup should exit with a message like:
 
-```
+```text
 Fatal: Startup validation failed for agents/coordinator.yaml:
   - /description: must have required property 'description'
 ```

--- a/docs/wip/2026-04-10-input-validation.md
+++ b/docs/wip/2026-04-10-input-validation.md
@@ -12,6 +12,8 @@
 
 ---
 
+## Tasks
+
 ### Task 1: Install Ajv
 
 **Files:**

--- a/docs/wip/2026-04-10-input-validation.md
+++ b/docs/wip/2026-04-10-input-validation.md
@@ -1,0 +1,1464 @@
+# Input Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add fail-fast startup validation for agent configs, skill manifests, and `config/default.yaml` using JSON Schema + Ajv, and reject oversized inbound messages in the dispatcher before routing.
+
+**Architecture:** A centralized `src/startup/validator.ts` runs before the DB connection and validates all config files against JSON Schema files in `schemas/` at the project root. The dispatcher gets a `maxMessageBytes` guard that publishes `message.rejected` (already a dispatch-layer event) for oversized content.
+
+**Tech Stack:** Ajv v8 (JSON Schema validation), Vitest (tests), existing `js-yaml` for YAML parsing
+
+**Design doc:** `docs/wip/2026-04-10-input-validation-design.md`
+
+---
+
+### Task 1: Install Ajv
+
+**Files:**
+- Modify: `package.json` (via pnpm)
+- Modify: `pnpm-lock.yaml` (via pnpm)
+
+- [ ] **Step 1: Install the dependency**
+
+```bash
+pnpm add ajv
+```
+
+Expected output: something like `+ ajv 8.x.x` — no errors.
+
+- [ ] **Step 2: Verify it imports correctly**
+
+```bash
+node --input-type=module <<'EOF'
+import Ajv from 'ajv';
+const ajv = new Ajv({ allErrors: true });
+console.log('Ajv version:', ajv.constructor.name);
+EOF
+```
+
+Expected: prints `Ajv version: Ajv2020` or similar — no error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation add package.json pnpm-lock.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation commit -m "chore: add ajv for JSON Schema validation"
+```
+
+---
+
+### Task 2: Extend `MessageRejectedPayload` with `message_too_large`
+
+The dispatcher will publish `message.rejected` for oversized messages. The `reason` union in `src/bus/events.ts` must include the new value.
+
+**Files:**
+- Modify: `src/bus/events.ts`
+
+- [ ] **Step 1: Add `message_too_large` to the reason union**
+
+In `src/bus/events.ts`, find `MessageRejectedPayload` (around line 164) and update `reason`:
+
+```typescript
+// MessageRejectedPayload — emitted by the dispatch layer when a message is rejected
+// due to an unknown_sender: ignore policy, a blocked sender, or an oversized message.
+// The conversationId is included so the HTTP adapter can immediately resolve the pending
+// response with an error rather than hanging until the 120-second timeout.
+interface MessageRejectedPayload {
+  conversationId: string;
+  channelId: string;
+  senderId: string;
+  /** Why the message was rejected — used by the HTTP adapter to select the status code. */
+  reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender' | 'message_too_large';
+}
+```
+
+- [ ] **Step 2: Verify TypeScript is happy**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation run typecheck 2>&1 | head -20
+```
+
+Expected: no errors (or only pre-existing errors unrelated to this change).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation add src/bus/events.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation commit -m "feat: add message_too_large to MessageRejectedPayload reason union"
+```
+
+---
+
+### Task 3: Create the three JSON Schema files
+
+Schemas live in `schemas/` at the project root — sibling of `config/`, `agents/`, `skills/`. This path resolves correctly from both `src/` (tsx dev) and `dist/` (compiled production).
+
+**Files:**
+- Create: `schemas/agent-config.schema.json`
+- Create: `schemas/skill-manifest.schema.json`
+- Create: `schemas/default-config.schema.json`
+
+- [ ] **Step 1: Create `schemas/agent-config.schema.json`**
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "agent-config",
+  "type": "object",
+  "required": ["name", "description", "model", "system_prompt"],
+  "additionalProperties": false,
+  "properties": {
+    "name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "role": { "type": "string" },
+    "persona": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "display_name": { "type": "string" },
+        "tone": { "type": "string" },
+        "title": { "type": "string" },
+        "email_signature": { "type": "string" }
+      }
+    },
+    "model": {
+      "type": "object",
+      "required": ["provider", "model"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": { "type": "string", "minLength": 1 },
+        "model": { "type": "string", "minLength": 1 },
+        "fallback": {
+          "type": "object",
+          "required": ["provider", "model"],
+          "additionalProperties": false,
+          "properties": {
+            "provider": { "type": "string", "minLength": 1 },
+            "model": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "system_prompt": { "type": "string", "minLength": 1 },
+    "pinned_skills": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "allow_discovery": { "type": "boolean" },
+    "memory": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "schedule": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["cron", "task"],
+        "additionalProperties": false,
+        "properties": {
+          "cron": { "type": "string" },
+          "task": { "type": "string" },
+          "agent_id": { "type": "string" },
+          "expectedDurationSeconds": { "type": "number", "minimum": 0 }
+        }
+      }
+    },
+    "error_budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_turns": { "type": "integer", "minimum": 1 },
+        "max_cost_usd": { "type": "number", "minimum": 0 },
+        "max_errors": { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Create `schemas/skill-manifest.schema.json`**
+
+The `action_risk` field accepts either a named label string OR an integer 0–100, modelled with `oneOf`.
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "skill-manifest",
+  "type": "object",
+  "required": ["name", "description", "version", "action_risk"],
+  "additionalProperties": false,
+  "properties": {
+    "name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "version": { "type": "string", "minLength": 1 },
+    "action_risk": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["none", "low", "medium", "high", "critical"]
+        },
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      ]
+    },
+    "sensitivity": {
+      "type": "string",
+      "enum": ["normal", "elevated"]
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "outputs": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "permissions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "secrets": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "timeout": { "type": "integer", "minimum": 1 },
+    "infrastructure": { "type": "boolean" },
+    "entity_enrichment": {
+      "type": "object",
+      "required": ["param", "default"],
+      "additionalProperties": false,
+      "properties": {
+        "param": { "type": "string", "minLength": 1 },
+        "default": { "type": "string", "enum": ["caller", "agent"] }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Create `schemas/default-config.schema.json`**
+
+All fields optional — the file is intentionally partial. Types and ranges are enforced when present. `additionalProperties: false` catches key typos.
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "default-config",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "channels": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cli": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "maxMessageBytes": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "browser": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sessionTtlMs": { "type": "integer", "minimum": 1 },
+        "sweepIntervalMs": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "agents": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coordinator": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "config_path": { "type": "string" }
+          }
+        }
+      }
+    },
+    "dispatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "conversationCheckpointDebounceMs": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "workingMemory": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "summarization": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "threshold": { "type": "integer", "minimum": 2 },
+            "keepWindow": { "type": "integer", "minimum": 1 }
+          }
+        }
+      }
+    },
+    "skillOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "maxLength": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "security": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "extra_injection_patterns": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["regex", "label"],
+            "additionalProperties": false,
+            "properties": {
+              "regex": { "type": "string", "minLength": 1 },
+              "label": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "trust_score": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "channel_weight": { "type": "number", "minimum": 0, "maximum": 1 },
+            "contact_weight": { "type": "number", "minimum": 0, "maximum": 1 },
+            "max_risk_penalty": { "type": "number", "minimum": 0, "maximum": 1 }
+          }
+        },
+        "trust_score_floor": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "trust_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "financial_actions": { "type": "number", "minimum": 0, "maximum": 1 },
+        "data_export": { "type": "number", "minimum": 0, "maximum": 1 },
+        "scheduling": { "type": "number", "minimum": 0, "maximum": 1 },
+        "information_queries": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "pii": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "extra_patterns": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["regex", "replacement"],
+            "additionalProperties": false,
+            "properties": {
+              "regex": { "type": "string", "minLength": 1 },
+              "replacement": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Verify existing config files pass the schemas manually**
+
+Run this quick smoke check to confirm the real `config/default.yaml` and `agents/coordinator.yaml` are valid before adding the validator to startup. If any fail, fix the YAML files first (not the schemas).
+
+```bash
+node --input-type=module <<'EOF'
+import Ajv from 'ajv';
+import { readFileSync } from 'node:fs';
+import yaml from 'js-yaml';
+
+const ajv = new Ajv({ allErrors: true });
+
+const defaultConfigSchema = JSON.parse(readFileSync('schemas/default-config.schema.json', 'utf-8'));
+const agentSchema = JSON.parse(readFileSync('schemas/agent-config.schema.json', 'utf-8'));
+const skillSchema = JSON.parse(readFileSync('schemas/skill-manifest.schema.json', 'utf-8'));
+
+const validateConfig = ajv.compile(defaultConfigSchema);
+const validateAgent = ajv.compile(agentSchema);
+const validateSkill = ajv.compile(skillSchema);
+
+// Test config
+const config = yaml.load(readFileSync('config/default.yaml', 'utf-8'));
+if (!validateConfig(config)) {
+  console.error('config/default.yaml FAILED:', ajv.errorsText(validateConfig.errors));
+} else {
+  console.log('config/default.yaml OK');
+}
+
+// Test coordinator agent
+const agent = yaml.load(readFileSync('agents/coordinator.yaml', 'utf-8'));
+if (!validateAgent(agent)) {
+  console.error('agents/coordinator.yaml FAILED:', ajv.errorsText(validateAgent.errors));
+} else {
+  console.log('agents/coordinator.yaml OK');
+}
+
+// Test one skill
+const skill = JSON.parse(readFileSync('skills/web-search/skill.json', 'utf-8'));
+if (!validateSkill(skill)) {
+  console.error('skills/web-search/skill.json FAILED:', ajv.errorsText(validateSkill.errors));
+} else {
+  console.log('skills/web-search/skill.json OK');
+}
+EOF
+```
+
+Run this from the worktree root: `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation/`
+
+Expected: all three print `OK`. If any fail, update the YAML/JSON to match the schema (the schema defines what's correct; the files are the source of truth for what fields actually exist). Common issues: missing `description` in agent YAML, missing `version` in skill manifest.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation add schemas/
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation commit -m "feat: add JSON Schema files for agent configs, skill manifests, and default config"
+```
+
+---
+
+### Task 4: Write failing tests for the startup validator
+
+Tests use fixture files in `tests/unit/startup/fixtures/` to avoid temp directory management. All fixtures are minimal valid/invalid YAML and JSON that exercise specific schema rules.
+
+**Files:**
+- Create: `tests/unit/startup/fixtures/agents/valid.yaml`
+- Create: `tests/unit/startup/fixtures/agents/missing-description.yaml`
+- Create: `tests/unit/startup/fixtures/agents/missing-model-provider.yaml`
+- Create: `tests/unit/startup/fixtures/agents/unknown-key.yaml`
+- Create: `tests/unit/startup/fixtures/skills/valid-skill/skill.json`
+- Create: `tests/unit/startup/fixtures/skills/missing-version/skill.json`
+- Create: `tests/unit/startup/fixtures/skills/missing-action-risk/skill.json`
+- Create: `tests/unit/startup/fixtures/skills/bad-action-risk/skill.json`
+- Create: `tests/unit/startup/fixtures/config/valid.yaml`
+- Create: `tests/unit/startup/fixtures/config/invalid-trust-floor.yaml`
+- Create: `tests/unit/startup/fixtures/config/wrong-type.yaml`
+- Create: `tests/unit/startup/fixtures/config/unknown-key.yaml`
+- Create: `tests/unit/startup/validator.test.ts`
+
+- [ ] **Step 1: Create the fixture files**
+
+**`tests/unit/startup/fixtures/agents/valid.yaml`:**
+```yaml
+name: test-agent
+description: A valid test agent
+model:
+  provider: anthropic
+  model: claude-sonnet-4-6
+system_prompt: You are a test agent.
+```
+
+**`tests/unit/startup/fixtures/agents/missing-description.yaml`:**
+```yaml
+name: test-agent
+model:
+  provider: anthropic
+  model: claude-sonnet-4-6
+system_prompt: You are a test agent.
+```
+
+**`tests/unit/startup/fixtures/agents/missing-model-provider.yaml`:**
+```yaml
+name: test-agent
+description: Missing model provider
+model:
+  model: claude-sonnet-4-6
+system_prompt: You are a test agent.
+```
+
+**`tests/unit/startup/fixtures/agents/unknown-key.yaml`:**
+```yaml
+name: test-agent
+description: Has a typo key
+model:
+  provider: anthropic
+  model: claude-sonnet-4-6
+system_prompt: You are a test agent.
+typo_key: this should not be here
+```
+
+**`tests/unit/startup/fixtures/skills/valid-skill/skill.json`:**
+```json
+{
+  "name": "valid-skill",
+  "description": "A valid test skill",
+  "version": "1.0.0",
+  "action_risk": "none"
+}
+```
+
+**`tests/unit/startup/fixtures/skills/missing-version/skill.json`:**
+```json
+{
+  "name": "missing-version-skill",
+  "description": "Missing the version field",
+  "action_risk": "none"
+}
+```
+
+**`tests/unit/startup/fixtures/skills/missing-action-risk/skill.json`:**
+```json
+{
+  "name": "missing-action-risk-skill",
+  "description": "Missing the action_risk field",
+  "version": "1.0.0"
+}
+```
+
+**`tests/unit/startup/fixtures/skills/bad-action-risk/skill.json`:**
+```json
+{
+  "name": "bad-action-risk-skill",
+  "description": "Has an invalid action_risk string",
+  "version": "1.0.0",
+  "action_risk": "super-dangerous"
+}
+```
+
+**`tests/unit/startup/fixtures/config/valid.yaml`:**
+```yaml
+security:
+  trust_score_floor: 0.2
+  trust_score:
+    channel_weight: 0.4
+    contact_weight: 0.4
+    max_risk_penalty: 0.2
+trust_policy:
+  financial_actions: 0.8
+  data_export: 0.8
+  scheduling: 0.5
+  information_queries: 0.2
+```
+
+**`tests/unit/startup/fixtures/config/invalid-trust-floor.yaml`:**
+```yaml
+security:
+  trust_score_floor: 1.5
+```
+
+**`tests/unit/startup/fixtures/config/wrong-type.yaml`:**
+```yaml
+channels:
+  maxMessageBytes: "not-a-number"
+```
+
+**`tests/unit/startup/fixtures/config/unknown-key.yaml`:**
+```yaml
+trust-policy:
+  financial_actions: 0.8
+```
+
+- [ ] **Step 2: Write the test file**
+
+Create `tests/unit/startup/validator.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
+import { runStartupValidation } from '../../../src/startup/validator.js';
+import { createLogger } from '../../../src/logger.js';
+
+// Resolve fixture directories relative to this test file.
+const FIXTURES = path.resolve(import.meta.dirname, './fixtures');
+const agentsFixtures = path.join(FIXTURES, 'agents');
+const configFixtures = path.join(FIXTURES, 'config');
+const skillsFixtures = path.join(FIXTURES, 'skills');
+
+// Shared logger that suppresses output during tests
+const logger = createLogger('silent');
+
+// Helper: run validation pointing at specific fixture subdirs
+async function validate(opts: {
+  agentsDir?: string;
+  skillsDir?: string;
+  configFile?: string; // full path to a single config yaml to test
+}): Promise<void> {
+  // We can't easily point the validator at a single config file, so we use
+  // a real empty dir for dirs we don't want to test. A valid-only dir for
+  // config means we pass a dir with one valid file.
+  return runStartupValidation({
+    agentsDir: opts.agentsDir ?? path.join(agentsFixtures, '_empty'),
+    skillsDir: opts.skillsDir ?? path.join(skillsFixtures, '_empty'),
+    configDir: opts.configFile ? path.dirname(opts.configFile) : path.join(configFixtures, '_empty'),
+    configFileName: opts.configFile ? path.basename(opts.configFile) : undefined,
+    logger,
+  });
+}
+
+describe('startup validator — agent configs', () => {
+  it('passes for a valid agent YAML', async () => {
+    await expect(
+      runStartupValidation({
+        agentsDir: path.join(agentsFixtures),
+        skillsDir: path.join(skillsFixtures, '_empty'),
+        configDir: path.join(configFixtures, '_empty'),
+        logger,
+      }),
+    ).resolves.toBeUndefined();
+    // Note: all valid fixtures in agentsFixtures are checked, including valid.yaml.
+    // Invalid fixtures are in subdirs — agent fixtures are flat files, so only
+    // valid.yaml (and others created in Step 1) are in agentsFixtures itself.
+    // We check a specific valid file by using a temp-like approach:
+  });
+
+  it('throws when an agent YAML is missing description', async () => {
+    // Create a temp agents dir with only the invalid file
+    await expect(
+      runStartupValidation({
+        agentsDir: agentsFixtures,
+        skillsDir: path.join(skillsFixtures, '_empty'),
+        configDir: path.join(configFixtures, '_empty'),
+        logger,
+      }),
+    ).rejects.toThrow('description');
+  });
+});
+```
+
+Hmm — the fixture layout won't work well with a flat directory because all agent fixtures are in the same dir and we'd validate all of them. Let me restructure the approach.
+
+**Better approach:** pass the path to a single-file agent directory per test. Rename the fixtures:
+
+- `tests/unit/startup/fixtures/agents/valid/coordinator.yaml` — the valid one
+- `tests/unit/startup/fixtures/agents/missing-description/coordinator.yaml`
+- etc.
+
+Rewrite Step 1 fixture files (delete previous plan for step 1 and use this layout instead), then write the test:
+
+- [ ] **Step 1 (revised): Create fixture files with one-per-directory layout**
+
+**`tests/unit/startup/fixtures/agents/valid/coordinator.yaml`:**
+```yaml
+name: test-agent
+description: A valid test agent
+model:
+  provider: anthropic
+  model: claude-sonnet-4-6
+system_prompt: You are a test agent.
+```
+
+**`tests/unit/startup/fixtures/agents/missing-description/coordinator.yaml`:**
+```yaml
+name: test-agent
+model:
+  provider: anthropic
+  model: claude-sonnet-4-6
+system_prompt: You are a test agent.
+```
+
+**`tests/unit/startup/fixtures/agents/missing-model-provider/coordinator.yaml`:**
+```yaml
+name: test-agent
+description: Missing model provider
+model:
+  model: claude-sonnet-4-6
+system_prompt: You are a test agent.
+```
+
+**`tests/unit/startup/fixtures/agents/unknown-key/coordinator.yaml`:**
+```yaml
+name: test-agent
+description: Has a typo key
+model:
+  provider: anthropic
+  model: claude-sonnet-4-6
+system_prompt: You are a test agent.
+typo_key: this should not be here
+```
+
+Skills fixtures stay as-is (they already use one skill per subdirectory, matching the real layout).
+
+Config fixtures:
+
+**`tests/unit/startup/fixtures/config/valid/default.yaml`:**
+```yaml
+security:
+  trust_score_floor: 0.2
+  trust_score:
+    channel_weight: 0.4
+    contact_weight: 0.4
+    max_risk_penalty: 0.2
+trust_policy:
+  financial_actions: 0.8
+  data_export: 0.8
+  scheduling: 0.5
+  information_queries: 0.2
+```
+
+**`tests/unit/startup/fixtures/config/invalid-trust-floor/default.yaml`:**
+```yaml
+security:
+  trust_score_floor: 1.5
+```
+
+**`tests/unit/startup/fixtures/config/wrong-type/default.yaml`:**
+```yaml
+channels:
+  maxMessageBytes: "not-a-number"
+```
+
+**`tests/unit/startup/fixtures/config/unknown-key/default.yaml`:**
+```yaml
+trust-policy:
+  financial_actions: 0.8
+```
+
+**`tests/unit/startup/fixtures/config/empty/default.yaml`:** *(empty file — valid because all fields are optional)*
+```yaml
+# empty config — all fields are optional
+```
+
+- [ ] **Step 2: Write `tests/unit/startup/validator.test.ts`**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
+import { runStartupValidation } from '../../../src/startup/validator.js';
+import { createLogger } from '../../../src/logger.js';
+
+const F = path.resolve(import.meta.dirname, 'fixtures');
+const logger = createLogger('silent');
+
+// Shorthand: run validation with specific fixture directories, using empty dirs for
+// the components we're not testing in a given test case.
+function runWith(opts: { agents?: string; skills?: string; config?: string }) {
+  return runStartupValidation({
+    agentsDir: opts.agents ?? path.join(F, 'agents/valid'),
+    skillsDir: opts.skills ?? path.join(F, 'skills/valid-skill'),
+    configDir: opts.config ?? path.join(F, 'config/empty'),
+    logger,
+  });
+}
+
+// ── Agent config validation ──────────────────────────────────────────────────
+
+describe('startup validator — agent configs', () => {
+  it('passes for a valid agent YAML', async () => {
+    await expect(runWith({ agents: path.join(F, 'agents/valid') })).resolves.toBeUndefined();
+  });
+
+  it('throws when agent YAML is missing description', async () => {
+    await expect(
+      runWith({ agents: path.join(F, 'agents/missing-description') }),
+    ).rejects.toThrow(/description/);
+  });
+
+  it('throws when agent YAML is missing model.provider', async () => {
+    await expect(
+      runWith({ agents: path.join(F, 'agents/missing-model-provider') }),
+    ).rejects.toThrow(/provider/);
+  });
+
+  it('includes the file path in the error message', async () => {
+    await expect(
+      runWith({ agents: path.join(F, 'agents/missing-description') }),
+    ).rejects.toThrow(/coordinator\.yaml/);
+  });
+
+  it('throws for unknown top-level keys (additionalProperties)', async () => {
+    await expect(
+      runWith({ agents: path.join(F, 'agents/unknown-key') }),
+    ).rejects.toThrow(/typo_key/);
+  });
+});
+
+// ── Skill manifest validation ────────────────────────────────────────────────
+
+describe('startup validator — skill manifests', () => {
+  it('passes for a valid skill manifest', async () => {
+    await expect(runWith({ skills: path.join(F, 'skills/valid-skill') })).resolves.toBeUndefined();
+  });
+
+  it('throws when skill manifest is missing version', async () => {
+    await expect(
+      runWith({ skills: path.join(F, 'skills/missing-version') }),
+    ).rejects.toThrow(/version/);
+  });
+
+  it('throws when skill manifest is missing action_risk', async () => {
+    await expect(
+      runWith({ skills: path.join(F, 'skills/missing-action-risk') }),
+    ).rejects.toThrow(/action_risk/);
+  });
+
+  it('throws for an invalid action_risk string value', async () => {
+    await expect(
+      runWith({ skills: path.join(F, 'skills/bad-action-risk') }),
+    ).rejects.toThrow(/action_risk/);
+  });
+
+  it('passes for action_risk as an integer (e.g. 75)', async () => {
+    // numeric action_risk should be valid per the oneOf schema
+    await expect(runWith({ skills: path.join(F, 'skills/valid-skill') })).resolves.toBeUndefined();
+  });
+});
+
+// ── default-config.yaml validation ──────────────────────────────────────────
+
+describe('startup validator — default config', () => {
+  it('passes for a valid config', async () => {
+    await expect(runWith({ config: path.join(F, 'config/valid') })).resolves.toBeUndefined();
+  });
+
+  it('passes for an empty config (all fields optional)', async () => {
+    await expect(runWith({ config: path.join(F, 'config/empty') })).resolves.toBeUndefined();
+  });
+
+  it('throws when trust_score_floor is out of range (1.5)', async () => {
+    await expect(
+      runWith({ config: path.join(F, 'config/invalid-trust-floor') }),
+    ).rejects.toThrow(/trust_score_floor/);
+  });
+
+  it('throws when maxMessageBytes is the wrong type (string)', async () => {
+    await expect(
+      runWith({ config: path.join(F, 'config/wrong-type') }),
+    ).rejects.toThrow(/maxMessageBytes/);
+  });
+
+  it('throws for unknown top-level keys (e.g. trust-policy typo)', async () => {
+    await expect(
+      runWith({ config: path.join(F, 'config/unknown-key') }),
+    ).rejects.toThrow(/trust-policy/);
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests — confirm they all fail**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation run test tests/unit/startup/validator.test.ts 2>&1 | tail -20
+```
+
+Expected: all tests fail with something like `Cannot find module '../../../src/startup/validator.js'`. This confirms the tests are wired correctly and the module doesn't exist yet.
+
+- [ ] **Step 4: Commit the test file and fixtures**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation add tests/unit/startup/
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation commit -m "test: add failing tests for startup validator"
+```
+
+---
+
+### Task 5: Implement the startup validator
+
+**Files:**
+- Create: `src/startup/validator.ts`
+
+- [ ] **Step 1: Create `src/startup/validator.ts`**
+
+```typescript
+// src/startup/validator.ts
+//
+// Centralized startup validation — runs before any services are initialized.
+// Validates config/default.yaml, all agents/*.yaml, and all skills/*/skill.json
+// against JSON Schema using Ajv. Any failure throws with a descriptive message
+// and causes process.exit(1) in the bootstrap orchestrator.
+//
+// Spec: docs/specs/06-audit-and-security.md — Input Validation
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import Ajv from 'ajv';
+import yaml from 'js-yaml';
+import type { Logger } from '../logger.js';
+
+// Schemas live at the project root in schemas/, sibling of config/ and agents/.
+// Resolving relative to this file: src/startup/ → ../../schemas → schemas/
+// This works from both tsx (src/startup/) and compiled dist (dist/startup/).
+const SCHEMAS_DIR = path.resolve(import.meta.dirname, '../../schemas');
+
+function loadSchema(name: string): object {
+  const schemaPath = path.join(SCHEMAS_DIR, name);
+  return JSON.parse(fs.readFileSync(schemaPath, 'utf-8')) as object;
+}
+
+/**
+ * Run all startup validation checks. Throws with a descriptive error on any
+ * failure — callers should catch, log fatal, and exit.
+ *
+ * Validation order:
+ *   1. config/default.yaml (or configFileName override)
+ *   2. all *.yaml files in agentsDir
+ *   3. all */skill.json files in skillsDir
+ */
+export async function runStartupValidation(opts: {
+  configDir: string;
+  agentsDir: string;
+  skillsDir: string;
+  logger: Logger;
+  /** Override config filename for testing. Defaults to 'default.yaml'. */
+  configFileName?: string;
+}): Promise<void> {
+  const { configDir, agentsDir, skillsDir, logger } = opts;
+  const configFileName = opts.configFileName ?? 'default.yaml';
+
+  // Compile schemas once — Ajv compilation is expensive; reuse across files.
+  const ajv = new Ajv({ allErrors: true });
+  const validateConfig = ajv.compile(loadSchema('default-config.schema.json'));
+  const validateAgent = ajv.compile(loadSchema('agent-config.schema.json'));
+  const validateSkill = ajv.compile(loadSchema('skill-manifest.schema.json'));
+
+  // 1. Validate config/default.yaml (absent file is OK — all fields are optional)
+  const configPath = path.join(configDir, configFileName);
+  if (fs.existsSync(configPath)) {
+    const raw = yaml.load(fs.readFileSync(configPath, 'utf-8'));
+    // null/empty YAML is valid (same as no config)
+    if (raw != null) {
+      if (!validateConfig(raw)) {
+        throw new Error(
+          `Startup validation failed for ${configPath}:\n  - ${ajv.errorsText(validateConfig.errors, { separator: '\n  - ', dataVar: '' })}`,
+        );
+      }
+    }
+  }
+
+  // 2. Validate all agents/*.yaml
+  if (fs.existsSync(agentsDir)) {
+    const agentFiles = fs.readdirSync(agentsDir)
+      .filter(f => f.endsWith('.yaml') || f.endsWith('.yml'));
+
+    for (const file of agentFiles) {
+      const filePath = path.join(agentsDir, file);
+      const raw = yaml.load(fs.readFileSync(filePath, 'utf-8'));
+      if (!validateAgent(raw)) {
+        throw new Error(
+          `Startup validation failed for ${filePath}:\n  - ${ajv.errorsText(validateAgent.errors, { separator: '\n  - ', dataVar: '' })}`,
+        );
+      }
+    }
+  }
+
+  // 3. Validate all skills/*/skill.json
+  if (fs.existsSync(skillsDir)) {
+    const skillEntries = fs.readdirSync(skillsDir, { withFileTypes: true })
+      .filter(e => e.isDirectory());
+
+    for (const entry of skillEntries) {
+      const manifestPath = path.join(skillsDir, entry.name, 'skill.json');
+      if (!fs.existsSync(manifestPath)) continue;
+
+      const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as unknown;
+      if (!validateSkill(raw)) {
+        throw new Error(
+          `Startup validation failed for ${manifestPath}:\n  - ${ajv.errorsText(validateSkill.errors, { separator: '\n  - ', dataVar: '' })}`,
+        );
+      }
+    }
+  }
+
+  logger.info('Startup validation passed');
+}
+```
+
+- [ ] **Step 2: Run the tests — confirm they all pass**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation run test tests/unit/startup/validator.test.ts 2>&1 | tail -30
+```
+
+Expected: all tests pass. If `trust_score_floor` or `typo_key` errors don't surface by field name, check that Ajv's `errorsText` is including `instancePath` — you may need to adjust the error message format in the throw. The error text from Ajv for `additionalProperties` violations includes the property name in `params.additionalProperty`, accessible via `errors[].params.additionalProperty`. If the default `errorsText` doesn't include it, switch to a custom formatter:
+
+```typescript
+// Replace the ajv.errorsText call with this if field names don't appear:
+const details = (ajv.errors ?? [])
+  .map(e => {
+    const extra = e.params && 'additionalProperty' in e.params
+      ? ` (${String(e.params.additionalProperty)})`
+      : '';
+    return `${e.instancePath || '(root)'} ${e.message ?? 'invalid'}${extra}`;
+  })
+  .join('\n  - ');
+throw new Error(`Startup validation failed for ${filePath}:\n  - ${details}`);
+```
+
+Apply this pattern to all three validation blocks if needed. Re-run the tests after adjusting.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation add src/startup/
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation commit -m "feat: implement startup validator with Ajv JSON Schema validation"
+```
+
+---
+
+### Task 6: Wire startup validator into `src/index.ts` and clean up loaders
+
+**Files:**
+- Modify: `src/index.ts`
+- Modify: `src/agents/loader.ts`
+- Modify: `src/skills/loader.ts`
+
+- [ ] **Step 1: Add the import and call to `src/index.ts`**
+
+Add the import near the top of `src/index.ts` with the other imports:
+
+```typescript
+import { runStartupValidation } from './startup/validator.js';
+```
+
+Find the section right after `const logger = createLogger(config.logLevel);` and `logger.info('Curia starting...');` — **before** the `const pool = createPool(...)` call — and insert:
+
+```typescript
+  // 1b. Startup validation — fail fast before any I/O if configs are malformed.
+  // Validates config/default.yaml, agents/*.yaml, and skills/*/skill.json against
+  // JSON Schema. Any failure exits the process before the DB connection is attempted.
+  try {
+    await runStartupValidation({
+      configDir,
+      agentsDir: path.resolve(import.meta.dirname, '../agents'),
+      skillsDir: path.resolve(import.meta.dirname, '../skills'),
+      logger,
+    });
+  } catch (err) {
+    logger.fatal({ err }, 'Startup validation failed — fix the config errors above and restart');
+    process.exit(1);
+  }
+```
+
+- [ ] **Step 2: Remove manual field checks from `src/agents/loader.ts`**
+
+In `src/agents/loader.ts`, find `loadAgentConfig()`. Delete these lines (they are now enforced by the startup validator schema):
+
+```typescript
+  // Validate required fields
+  if (!config.name) {
+    throw new Error(`Agent config at ${filePath} is missing required field: name`);
+  }
+  if (!config.model?.provider || !config.model?.model) {
+    throw new Error(`Agent config '${config.name}' at ${filePath} is missing model.provider or model.model`);
+  }
+  if (!config.system_prompt) {
+    throw new Error(`Agent config '${config.name}' at ${filePath} is missing system_prompt`);
+  }
+```
+
+Leave the YAML parse error handling (`try { config = yaml.load(...) } catch`) and all interpolation logic intact — those are not schema concerns.
+
+- [ ] **Step 3: Remove manual field check from `src/skills/loader.ts`**
+
+In `src/skills/loader.ts`, inside the `try` block in the `for` loop, delete:
+
+```typescript
+      if (!manifest.name || !manifest.description) {
+        throw new Error('Manifest missing required fields: name, description');
+      }
+```
+
+Leave all other logic intact (defaults assignment, handler discovery, dynamic import).
+
+- [ ] **Step 4: Verify TypeScript compiles cleanly**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation run typecheck 2>&1 | head -20
+```
+
+Expected: no new errors.
+
+- [ ] **Step 5: Run the full test suite to confirm nothing broke**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation run test 2>&1 | tail -20
+```
+
+Expected: all tests pass (including the startup validator tests from Task 4 and any existing tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation add src/index.ts src/agents/loader.ts src/skills/loader.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation commit -m "feat: wire startup validator into bootstrap; remove redundant manual checks from loaders"
+```
+
+---
+
+### Task 7: Add `maxMessageBytes` to config
+
+**Files:**
+- Modify: `config/default.yaml`
+- Modify: `src/config.ts`
+
+- [ ] **Step 1: Add `maxMessageBytes` to `config/default.yaml`**
+
+The `channels` section currently has `cli.enabled`. Add `maxMessageBytes` as a sibling of `cli` (not nested inside it):
+
+```yaml
+channels:
+  cli:
+    enabled: true
+  maxMessageBytes: 102400   # 100KB — inbound messages exceeding this are rejected before routing
+```
+
+- [ ] **Step 2: Update `YamlConfig.channels` in `src/config.ts`**
+
+Find the `YamlConfig` interface and update the `channels` property:
+
+```typescript
+  channels?: {
+    cli?: { enabled?: boolean };
+    /** Max inbound message content size in bytes. Default: 102400 (100KB).
+     *  Messages exceeding this are rejected by the dispatcher before routing. */
+    maxMessageBytes?: number;
+  };
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation add config/default.yaml src/config.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation commit -m "feat: add channels.maxMessageBytes config (default 100KB)"
+```
+
+---
+
+### Task 8: Write failing dispatcher size-check tests
+
+**Files:**
+- Modify: `tests/unit/dispatch/dispatcher.test.ts`
+
+- [ ] **Step 1: Add the size-check test suite to the existing dispatcher test file**
+
+Open `tests/unit/dispatch/dispatcher.test.ts` and append this new `describe` block at the end of the file:
+
+```typescript
+describe('Dispatcher message size limit', () => {
+  function makeDispatcher(bus: EventBus, maxMessageBytes: number) {
+    const logger = createLogger('silent');
+    const dispatcher = new Dispatcher({ bus, logger, maxMessageBytes });
+    dispatcher.register();
+    return dispatcher;
+  }
+
+  it('routes normally when content is at the size limit', async () => {
+    const logger = createLogger('silent');
+    const bus = new EventBus(logger);
+
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'ok',
+        usage: { inputTokens: 1, outputTokens: 1 },
+      }),
+    };
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a helpful assistant.',
+      provider: mockProvider,
+      bus,
+      logger,
+    });
+    coordinator.register();
+
+    const outbound: OutboundMessageEvent[] = [];
+    bus.subscribe('outbound.message', 'channel', (e) => outbound.push(e as OutboundMessageEvent));
+
+    // 10 bytes exactly — at limit
+    makeDispatcher(bus, 10);
+
+    const event = createInboundMessage({
+      conversationId: 'conv-size-ok',
+      channelId: 'cli',
+      senderId: 'user',
+      content: '1234567890', // exactly 10 bytes
+    });
+    await bus.publish('channel', event);
+
+    expect(outbound).toHaveLength(1);
+  });
+
+  it('publishes message.rejected when content exceeds the size limit', async () => {
+    const logger = createLogger('silent');
+    const bus = new EventBus(logger);
+
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('message.rejected', 'channel', (e) => rejected.push(e as MessageRejectedEvent));
+
+    makeDispatcher(bus, 5); // 5 byte limit
+
+    const event = createInboundMessage({
+      conversationId: 'conv-size-exceeded',
+      channelId: 'email',
+      senderId: 'spammer@example.com',
+      content: 'This message is definitely longer than 5 bytes',
+    });
+    await bus.publish('channel', event);
+
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.payload.reason).toBe('message_too_large');
+    expect(rejected[0]?.payload.conversationId).toBe('conv-size-exceeded');
+    expect(rejected[0]?.payload.channelId).toBe('email');
+    expect(rejected[0]?.payload.senderId).toBe('spammer@example.com');
+  });
+
+  it('does not publish agent.task when content exceeds the size limit', async () => {
+    const logger = createLogger('silent');
+    const bus = new EventBus(logger);
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+
+    makeDispatcher(bus, 5);
+
+    const event = createInboundMessage({
+      conversationId: 'conv-no-task',
+      channelId: 'email',
+      senderId: 'spammer@example.com',
+      content: 'Way more than 5 bytes here',
+    });
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(0);
+  });
+
+  it('sets parentEventId on the rejection event to the original inbound message id', async () => {
+    const logger = createLogger('silent');
+    const bus = new EventBus(logger);
+
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('message.rejected', 'channel', (e) => rejected.push(e as MessageRejectedEvent));
+
+    makeDispatcher(bus, 1); // absurdly low limit
+
+    const event = createInboundMessage({
+      conversationId: 'conv-causal-chain',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'ab', // 2 bytes > 1 byte limit
+    });
+    await bus.publish('channel', event);
+
+    expect(rejected[0]?.parentEventId).toBe(event.id);
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests — confirm they fail**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation run test tests/unit/dispatch/dispatcher.test.ts 2>&1 | tail -20
+```
+
+Expected: the new `Dispatcher message size limit` tests fail because `DispatcherConfig` doesn't have `maxMessageBytes` yet.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation add tests/unit/dispatch/dispatcher.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation commit -m "test: add failing dispatcher message size limit tests"
+```
+
+---
+
+### Task 9: Implement the dispatcher size check
+
+**Files:**
+- Modify: `src/dispatch/dispatcher.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add `maxMessageBytes` to `DispatcherConfig` and the constructor**
+
+In `src/dispatch/dispatcher.ts`, add `maxMessageBytes` to the `DispatcherConfig` interface:
+
+```typescript
+export interface DispatcherConfig {
+  bus: EventBus;
+  logger: Logger;
+  contactResolver?: ContactResolver;
+  heldMessages?: HeldMessageService;
+  channelPolicies?: Record<string, ChannelPolicyConfig>;
+  injectionScanner?: InboundScanner;
+  pool?: DbPool;
+  conversationCheckpointDebounceMs?: number;
+  trustScorerWeights?: TrustScorerWeights;
+  trustScoreFloor?: number;
+  /** Maximum inbound message content size in bytes. Messages exceeding this are
+   *  rejected before routing. Default: 102400 (100KB). */
+  maxMessageBytes?: number;
+}
+```
+
+Add a private field and set it in the constructor (after `this.trustScoreFloor = ...`):
+
+```typescript
+  private maxMessageBytes: number;
+```
+
+```typescript
+    this.maxMessageBytes = config.maxMessageBytes ?? 102_400;
+```
+
+- [ ] **Step 2: Add the size check to `handleInbound`**
+
+In `handleInbound`, add the size check as the very first thing, before the `this.logger.info(...)` call:
+
+```typescript
+  private async handleInbound(event: InboundMessageEvent): Promise<void> {
+    const { payload } = event;
+
+    // Reject oversized messages before any processing — no routing, no contact
+    // lookup, no LLM cost. The inbound.message event is already in the audit log
+    // (write-ahead); this rejection creates a causal chain via parentEventId.
+    const contentByteSize = Buffer.byteLength(payload.content, 'utf-8');
+    if (contentByteSize > this.maxMessageBytes) {
+      this.logger.warn(
+        { channelId: payload.channelId, senderId: payload.senderId, contentByteSize, maxBytes: this.maxMessageBytes },
+        'Inbound message exceeded size limit — rejected',
+      );
+      await this.bus.publish('dispatch', createMessageRejected({
+        conversationId: payload.conversationId,
+        channelId: payload.channelId,
+        senderId: payload.senderId,
+        reason: 'message_too_large',
+        parentEventId: event.id,
+      }));
+      return;
+    }
+
+    this.logger.info(
+      { channelId: payload.channelId, senderId: payload.senderId },
+      'Dispatching to coordinator',
+    );
+    // ... rest of handleInbound unchanged
+```
+
+Make sure `createMessageRejected` is in the import at the top of the file. It's already imported in the dispatcher (check the import line — add it if missing).
+
+- [ ] **Step 3: Pass `maxMessageBytes` from `index.ts` to the dispatcher**
+
+In `src/index.ts`, find where `new Dispatcher(...)` is called. Add `maxMessageBytes`:
+
+```typescript
+  const dispatcher = new Dispatcher({
+    bus,
+    logger,
+    contactResolver,
+    heldMessages: heldMessageService,
+    channelPolicies,
+    injectionScanner,
+    pool,
+    conversationCheckpointDebounceMs: yamlConfig.dispatch?.conversationCheckpointDebounceMs,
+    trustScorerWeights,
+    trustScoreFloor: yamlConfig.security?.trust_score_floor,
+    maxMessageBytes: yamlConfig.channels?.maxMessageBytes ?? 102_400,
+  });
+```
+
+- [ ] **Step 4: Run the dispatcher tests — confirm all pass**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation run test tests/unit/dispatch/dispatcher.test.ts 2>&1 | tail -20
+```
+
+Expected: all tests pass, including the four new `Dispatcher message size limit` tests.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation run test 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation add src/dispatch/dispatcher.ts src/index.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation commit -m "feat: reject oversized inbound messages in dispatcher (spec §06)"
+```
+
+---
+
+### Task 10: Update CHANGELOG and version
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`
+
+- [ ] **Step 1: Add CHANGELOG entries**
+
+Under `## [Unreleased]` in `CHANGELOG.md`, add:
+
+```markdown
+### Security
+- **Input validation** — startup validator (`src/startup/validator.ts`) validates `config/default.yaml`, all `agents/*.yaml`, and all `skills/*/skill.json` against JSON Schema (Ajv) at boot time. Invalid configs cause a descriptive `process.exit(1)` before any service initializes (spec §06).
+- **Message size limiting** — dispatcher rejects inbound messages exceeding `channels.maxMessageBytes` (default 100KB) before routing; rejection is audit-logged as `message.rejected` with causal `parentEventId` (spec §06).
+
+### Added
+- **`schemas/` directory** — JSON Schema files for agent configs, skill manifests, and `config/default.yaml`. Schemas are legible without TypeScript and can be validated with third-party tools.
+- **`channels.maxMessageBytes`** in `config/default.yaml` — configures the inbound message size limit (default `102400`).
+
+### Changed
+- **`MessageRejectedPayload.reason`** extended with `'message_too_large'` — bus event API surface change.
+- **Agent and skill loaders** — manual field checks removed; validation is now handled by the startup validator schema.
+```
+
+- [ ] **Step 2: Bump the version**
+
+This completes spec §06 input validation (partially shipped) — use a patch bump. In `package.json`, update `"version"`:
+
+```json
+"version": "0.14.1"
+```
+
+(Replace `0.14.1` with current version + patch. Check `package.json` for current version first.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation add CHANGELOG.md package.json
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation commit -m "chore: update changelog and bump version for input validation (issue #196)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Task that implements it |
+|---|---|
+| Inbound messages exceeding 100KB rejected before bus routing | Task 9 |
+| Max size configurable as `channels.maxMessageBytes` | Task 7 |
+| Rejection audit-logged via `message.rejected` with `parentEventId` | Task 9 |
+| Agent YAML validated against JSON Schema at startup | Tasks 3, 5, 6 |
+| Skill manifests validated against JSON Schema at startup | Tasks 3, 5, 6 |
+| Invalid config causes `process.exit(1)` with descriptive error | Task 6 (index.ts wiring) |
+| Dispatch policy rules (`trust_policy.*`, `security.trust_score.*`) validated | Task 3 (default-config schema), Task 5 (validator) |
+| Unit tests: oversized message → rejected | Task 8 |
+| Unit tests: invalid agent YAML → startup error | Tasks 4, 5 |
+| Unit tests: invalid manifest → startup error | Tasks 4, 5 |
+| `message_too_large` in `MessageRejectedPayload.reason` | Task 2 |
+| `config/default.yaml` schema validation (scope addition) | Tasks 3, 5 |
+
+**Placeholder scan:** None found — all code blocks are complete.
+
+**Type consistency check:**
+- `runStartupValidation` signature: defined in Task 5, called in Task 6 ✓
+- `configFileName` optional parameter: used in Task 4 tests for fixture isolation ✓
+- `maxMessageBytes` field: added to `DispatcherConfig` in Task 9, passed from `index.ts` in Task 9, default `102_400` ✓
+- `createMessageRejected` with `channelId`: matches the updated `MessageRejectedPayload` from Task 2 ✓
+- `reason: 'message_too_large'`: defined in Task 2, used in Task 9, asserted in Task 8 tests ✓

--- a/docs/wip/2026-04-10-input-validation.md
+++ b/docs/wip/2026-04-10-input-validation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add fail-fast startup validation for agent configs, skill manifests, and `config/default.yaml` using JSON Schema + Ajv, and reject oversized inbound messages in the dispatcher before routing.
 
-**Architecture:** A centralized `src/startup/validator.ts` runs before the DB connection and validates all config files against JSON Schema files in `schemas/` at the project root. The dispatcher gets a `maxMessageBytes` guard that publishes `message.rejected` (already a dispatch-layer event) for oversized content.
+**Architecture:** A centralized `src/startup/validator.ts` runs before the DB connection and validates all config files against JSON Schema files in `schemas/` at the project root. The dispatcher gets a `max_message_bytes` guard that publishes `message.rejected` (already a dispatch-layer event) for oversized content.
 
 **Tech Stack:** Ajv v8 (JSON Schema validation), Vitest (tests), existing `js-yaml` for YAML parsing
 
@@ -269,7 +269,7 @@ All fields optional — the file is intentionally partial. Types and ranges are 
             "enabled": { "type": "boolean" }
           }
         },
-        "maxMessageBytes": { "type": "integer", "minimum": 1 }
+        "max_message_bytes": { "type": "integer", "minimum": 1 }
       }
     },
     "browser": {
@@ -562,7 +562,7 @@ security:
 **`tests/unit/startup/fixtures/config/wrong-type.yaml`:**
 ```yaml
 channels:
-  maxMessageBytes: "not-a-number"
+  max_message_bytes: "not-a-number"
 ```
 
 **`tests/unit/startup/fixtures/config/unknown-key.yaml`:**
@@ -717,7 +717,7 @@ security:
 **`tests/unit/startup/fixtures/config/wrong-type/default.yaml`:**
 ```yaml
 channels:
-  maxMessageBytes: "not-a-number"
+  max_message_bytes: "not-a-number"
 ```
 
 **`tests/unit/startup/fixtures/config/unknown-key/default.yaml`:**
@@ -833,10 +833,10 @@ describe('startup validator — default config', () => {
     ).rejects.toThrow(/trust_score_floor/);
   });
 
-  it('throws when maxMessageBytes is the wrong type (string)', async () => {
+  it('throws when max_message_bytes is the wrong type (string)', async () => {
     await expect(
       runWith({ config: path.join(F, 'config/wrong-type') }),
-    ).rejects.toThrow(/maxMessageBytes/);
+    ).rejects.toThrow(/max_message_bytes/);
   });
 
   it('throws for unknown top-level keys (e.g. trust-policy typo)', async () => {
@@ -1097,21 +1097,21 @@ git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-valida
 
 ---
 
-### Task 7: Add `maxMessageBytes` to config
+### Task 7: Add `max_message_bytes` to config
 
 **Files:**
 - Modify: `config/default.yaml`
 - Modify: `src/config.ts`
 
-- [ ] **Step 1: Add `maxMessageBytes` to `config/default.yaml`**
+- [ ] **Step 1: Add `max_message_bytes` to `config/default.yaml`**
 
-The `channels` section currently has `cli.enabled`. Add `maxMessageBytes` as a sibling of `cli` (not nested inside it):
+The `channels` section currently has `cli.enabled`. Add `max_message_bytes` as a sibling of `cli` (not nested inside it):
 
 ```yaml
 channels:
   cli:
     enabled: true
-  maxMessageBytes: 102400   # 100KB — inbound messages exceeding this are rejected before routing
+  max_message_bytes: 102400   # 100KB — inbound messages exceeding this are rejected before routing
 ```
 
 - [ ] **Step 2: Update `YamlConfig.channels` in `src/config.ts`**
@@ -1123,7 +1123,7 @@ Find the `YamlConfig` interface and update the `channels` property:
     cli?: { enabled?: boolean };
     /** Max inbound message content size in bytes. Default: 102400 (100KB).
      *  Messages exceeding this are rejected by the dispatcher before routing. */
-    maxMessageBytes?: number;
+    max_message_bytes?: number;
   };
 ```
 
@@ -1131,7 +1131,7 @@ Find the `YamlConfig` interface and update the `channels` property:
 
 ```bash
 git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation add config/default.yaml src/config.ts
-git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation commit -m "feat: add channels.maxMessageBytes config (default 100KB)"
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-validation commit -m "feat: add channels.max_message_bytes config (default 100KB)"
 ```
 
 ---
@@ -1365,7 +1365,7 @@ In `src/index.ts`, find where `new Dispatcher(...)` is called. Add `maxMessageBy
     conversationCheckpointDebounceMs: yamlConfig.dispatch?.conversationCheckpointDebounceMs,
     trustScorerWeights,
     trustScoreFloor: yamlConfig.security?.trust_score_floor,
-    maxMessageBytes: yamlConfig.channels?.maxMessageBytes ?? 102_400,
+    maxMessageBytes: yamlConfig.channels?.max_message_bytes ?? 102_400,
   });
 ```
 
@@ -1407,11 +1407,11 @@ Under `## [Unreleased]` in `CHANGELOG.md`, add:
 ```markdown
 ### Security
 - **Input validation** — startup validator (`src/startup/validator.ts`) validates `config/default.yaml`, all `agents/*.yaml`, and all `skills/*/skill.json` against JSON Schema (Ajv) at boot time. Invalid configs cause a descriptive `process.exit(1)` before any service initializes (spec §06).
-- **Message size limiting** — dispatcher rejects inbound messages exceeding `channels.maxMessageBytes` (default 100KB) before routing; rejection is audit-logged as `message.rejected` with causal `parentEventId` (spec §06).
+- **Message size limiting** — dispatcher rejects inbound messages exceeding `channels.max_message_bytes` (default 100KB) before routing; rejection is audit-logged as `message.rejected` with causal `parentEventId` (spec §06).
 
 ### Added
 - **`schemas/` directory** — JSON Schema files for agent configs, skill manifests, and `config/default.yaml`. Schemas are legible without TypeScript and can be validated with third-party tools.
-- **`channels.maxMessageBytes`** in `config/default.yaml` — configures the inbound message size limit (default `102400`).
+- **`channels.max_message_bytes`** in `config/default.yaml` — configures the inbound message size limit (default `102400`).
 
 ### Changed
 - **`MessageRejectedPayload.reason`** extended with `'message_too_large'` — bus event API surface change.
@@ -1444,7 +1444,7 @@ git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-input-valida
 | Spec requirement | Task that implements it |
 |---|---|
 | Inbound messages exceeding 100KB rejected before bus routing | Task 9 |
-| Max size configurable as `channels.maxMessageBytes` | Task 7 |
+| Max size configurable as `channels.max_message_bytes` | Task 7 |
 | Rejection audit-logged via `message.rejected` with `parentEventId` | Task 9 |
 | Agent YAML validated against JSON Schema at startup | Tasks 3, 5, 6 |
 | Skill manifests validated against JSON Schema at startup | Tasks 3, 5, 6 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.15.3",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.15.3",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",
@@ -15,6 +15,7 @@
         "@fastify/rate-limit": "^10.3.0",
         "@ghostery/adblocker-playwright": "^2.14.1",
         "@openredaction/openredaction": "^1.0.4",
+        "ajv": "^8.18.0",
         "chokidar": "^5.0.0",
         "cron-parser": "^5.5.0",
         "cytoscape": "^3.33.1",
@@ -691,28 +692,6 @@
         "ajv-formats": "^3.0.1",
         "fast-uri": "^3.0.0"
       }
-    },
-    "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/@fastify/cookie": {
       "version": "11.0.2",
@@ -2234,16 +2213,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2266,28 +2244,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -2849,6 +2805,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
@@ -2871,6 +2844,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "11.2.0",
@@ -3018,28 +2998,6 @@
         "json-schema-ref-resolver": "^3.0.0",
         "rfdc": "^1.2.0"
       }
-    },
-    "node_modules/fast-json-stringify/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -3502,10 +3460,9 @@
       }
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.17.0",
+  "version": "0.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.17.0",
+      "version": "0.16.3",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.17.0",
+  "version": "0.16.3",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "curia",
-idation
   "version": "0.16.3",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@fastify/rate-limit": "^10.3.0",
     "@ghostery/adblocker-playwright": "^2.14.1",
     "@openredaction/openredaction": "^1.0.4",
+    "ajv": "^8.18.0",
     "chokidar": "^5.0.0",
     "cron-parser": "^5.5.0",
     "cytoscape": "^3.33.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@openredaction/openredaction':
         specifier: ^1.0.4
         version: 1.0.4
+      ajv:
+        specifier: ^8.18.0
+        version: 8.18.0
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0

--- a/schemas/agent-config.schema.json
+++ b/schemas/agent-config.schema.json
@@ -59,8 +59,8 @@
         "required": ["cron", "task"],
         "additionalProperties": false,
         "properties": {
-          "cron": { "type": "string" },
-          "task": { "type": "string" },
+          "cron": { "type": "string", "minLength": 1 },
+          "task": { "type": "string", "minLength": 1 },
           "agent_id": { "type": "string" },
           "expectedDurationSeconds": { "type": "number", "minimum": 0 }
         }

--- a/schemas/agent-config.schema.json
+++ b/schemas/agent-config.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "agent-config",
+  "type": "object",
+  "required": ["name", "description", "model", "system_prompt"],
+  "additionalProperties": false,
+  "properties": {
+    "name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "role": { "type": "string" },
+    "persona": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "display_name": { "type": "string" },
+        "tone": { "type": "string" },
+        "title": { "type": "string" },
+        "email_signature": { "type": "string" }
+      }
+    },
+    "model": {
+      "type": "object",
+      "required": ["provider", "model"],
+      "additionalProperties": false,
+      "properties": {
+        "provider": { "type": "string", "minLength": 1 },
+        "model": { "type": "string", "minLength": 1 },
+        "fallback": {
+          "type": "object",
+          "required": ["provider", "model"],
+          "additionalProperties": false,
+          "properties": {
+            "provider": { "type": "string", "minLength": 1 },
+            "model": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "system_prompt": { "type": "string", "minLength": 1 },
+    "pinned_skills": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "allow_discovery": { "type": "boolean" },
+    "memory": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "schedule": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["cron", "task"],
+        "additionalProperties": false,
+        "properties": {
+          "cron": { "type": "string" },
+          "task": { "type": "string" },
+          "agent_id": { "type": "string" },
+          "expectedDurationSeconds": { "type": "number", "minimum": 0 }
+        }
+      }
+    },
+    "error_budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_turns": { "type": "integer", "minimum": 1 },
+        "max_cost_usd": { "type": "number", "minimum": 0 },
+        "max_errors": { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
+}

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "default-config",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "channels": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cli": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "maxMessageBytes": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "browser": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sessionTtlMs": { "type": "integer", "minimum": 1 },
+        "sweepIntervalMs": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "agents": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "coordinator": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "config_path": { "type": "string" }
+          }
+        }
+      }
+    },
+    "dispatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "conversationCheckpointDebounceMs": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "workingMemory": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "summarization": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "threshold": { "type": "integer", "minimum": 2 },
+            "keepWindow": { "type": "integer", "minimum": 1 }
+          }
+        }
+      }
+    },
+    "skillOutput": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "maxLength": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "security": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "extra_injection_patterns": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["regex", "label"],
+            "additionalProperties": false,
+            "properties": {
+              "regex": { "type": "string", "minLength": 1 },
+              "label": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "trust_score": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "channel_weight": { "type": "number", "minimum": 0, "maximum": 1 },
+            "contact_weight": { "type": "number", "minimum": 0, "maximum": 1 },
+            "max_risk_penalty": { "type": "number", "minimum": 0, "maximum": 1 }
+          }
+        },
+        "trust_score_floor": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "trust_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "financial_actions": { "type": "number", "minimum": 0, "maximum": 1 },
+        "data_export": { "type": "number", "minimum": 0, "maximum": 1 },
+        "scheduling": { "type": "number", "minimum": 0, "maximum": 1 },
+        "information_queries": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "pii": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "extra_patterns": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["regex", "replacement"],
+            "additionalProperties": false,
+            "properties": {
+              "regex": { "type": "string", "minLength": 1 },
+              "replacement": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -15,7 +15,7 @@
             "enabled": { "type": "boolean" }
           }
         },
-        "maxMessageBytes": { "type": "integer", "minimum": 1 }
+        "max_message_bytes": { "type": "integer", "minimum": 1 }
       }
     },
     "browser": {

--- a/schemas/skill-manifest.schema.json
+++ b/schemas/skill-manifest.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "skill-manifest",
+  "type": "object",
+  "required": ["name", "description", "version", "action_risk"],
+  "additionalProperties": false,
+  "properties": {
+    "name": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "version": { "type": "string", "minLength": 1 },
+    "action_risk": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["none", "low", "medium", "high", "critical"]
+        },
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100
+        }
+      ]
+    },
+    "sensitivity": {
+      "type": "string",
+      "enum": ["normal", "elevated"]
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "outputs": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "permissions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "secrets": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "timeout": { "type": "integer", "minimum": 1 },
+    "infrastructure": { "type": "boolean" },
+    "entity_enrichment": {
+      "type": "object",
+      "required": ["param", "default"],
+      "additionalProperties": false,
+      "properties": {
+        "param": { "type": "string", "minLength": 1 },
+        "default": { "type": "string", "enum": ["caller", "agent"] }
+      }
+    }
+  }
+}

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -69,17 +69,6 @@ export function loadAgentConfig(filePath: string): AgentYamlConfig {
     throw new Error(`Invalid YAML in agent config at ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
   }
 
-  // Validate required fields
-  if (!config.name) {
-    throw new Error(`Agent config at ${filePath} is missing required field: name`);
-  }
-  if (!config.model?.provider || !config.model?.model) {
-    throw new Error(`Agent config '${config.name}' at ${filePath} is missing model.provider or model.model`);
-  }
-  if (!config.system_prompt) {
-    throw new Error(`Agent config '${config.name}' at ${filePath} is missing system_prompt`);
-  }
-
   // Interpolate ${persona.*} placeholders in the system prompt.
   // The persona section is the single source of truth for display name, tone, etc.
   // Keeping them as references in system_prompt avoids duplication and makes

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -170,6 +170,10 @@ interface MessageRejectedPayload {
   /** Why the message was rejected — used by the HTTP adapter to select the status code.
    * 'message_too_large' is set when the message body exceeds the configured size limit. */
   reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender' | 'message_too_large';
+  /** UTF-8 byte size of the rejected message content. Present when reason is 'message_too_large'. */
+  size?: number;
+  /** Configured max_message_bytes limit at the time of rejection. Present when reason is 'message_too_large'. */
+  limit?: number;
 }
 
 // Memory event payloads — used for the knowledge graph audit trail (Phase 6).

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -167,8 +167,9 @@ interface MessageRejectedPayload {
   conversationId: string;
   channelId: string;
   senderId: string;
-  /** Why the message was rejected — used by the HTTP adapter to select the status code. */
-  reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender';
+  /** Why the message was rejected — used by the HTTP adapter to select the status code.
+   * 'message_too_large' is set when the message body exceeds the configured size limit. */
+  reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender' | 'message_too_large';
 }
 
 // Memory event payloads — used for the knowledge graph audit trail (Phase 6).

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -21,9 +21,9 @@ import type { ServerResponse } from 'node:http';
  * matching on the error message.
  */
 export class MessageRejectedError extends Error {
-  readonly reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender';
+  readonly reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender' | 'message_too_large';
 
-  constructor(reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender') {
+  constructor(reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender' | 'message_too_large') {
     super(`Message rejected — sender not authorized (${reason})`);
     this.name = 'MessageRejectedError';
     this.reason = reason;

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -24,7 +24,11 @@ export class MessageRejectedError extends Error {
   readonly reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender' | 'message_too_large';
 
   constructor(reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender' | 'message_too_large') {
-    super(`Message rejected — sender not authorized (${reason})`);
+    super(
+      reason === 'message_too_large'
+        ? 'Message too large — inbound content exceeds the configured size limit'
+        : `Message rejected — sender not authorized (${reason})`,
+    );
     this.name = 'MessageRejectedError';
     this.reason = reason;
   }

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -3570,12 +3570,13 @@ export async function knowledgeGraphRoutes(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logger.error({ err, conversationId }, 'KG chat message handling failed');
-      // instanceof check for rejection — string matching would silently break if the
+      // instanceof + reason check for rejection — string matching would silently break if the
       // error wording changes. Timeout still falls back to substring because the event
       // router doesn't expose a dedicated TimeoutError class.
       const isRejected = err instanceof MessageRejectedError;
+      const isTooLarge = isRejected && err.reason === 'message_too_large';
       const isTimeout = message.includes('timeout') || message.includes('Timeout');
-      const status = isRejected ? 403 : isTimeout ? 504 : 500;
+      const status = isTooLarge ? 413 : isRejected ? 403 : isTimeout ? 504 : 500;
       return reply.status(status).send({ error: message });
     }
   });

--- a/src/channels/http/routes/messages.ts
+++ b/src/channels/http/routes/messages.ts
@@ -94,12 +94,13 @@ export async function messageRoutes(
       const message = err instanceof Error ? err.message : String(err);
       logger.error({ err, conversationId }, 'HTTP message handling failed');
 
-      // Distinguish rejection (403), timeout (504), superseded/internal failures (500).
-      // Use instanceof rather than string matching so a wording change can't
+      // Distinguish oversized (413), other rejections (403), timeout (504), internal (500).
+      // Use instanceof + reason check rather than string matching so wording changes can't
       // silently break the status code.
       const isRejected = err instanceof MessageRejectedError;
+      const isTooLarge = isRejected && err.reason === 'message_too_large';
       const isTimeout = message.includes('timeout') || message.includes('Timeout');
-      const status = isRejected ? 403 : isTimeout ? 504 : 500;
+      const status = isTooLarge ? 413 : isRejected ? 403 : isTimeout ? 504 : 500;
       return reply.status(status).send({ error: message });
     }
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,7 +49,7 @@ export interface YamlConfig {
     cli?: { enabled?: boolean };
     /** Max inbound message content size in bytes. Default: 102400 (100KB).
      *  Messages exceeding this are rejected by the dispatcher before routing. */
-    maxMessageBytes?: number;
+    max_message_bytes?: number;
   };
   browser?: {
     sessionTtlMs?: number;

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,9 @@ export interface Config {
 export interface YamlConfig {
   channels?: {
     cli?: { enabled?: boolean };
+    /** Max inbound message content size in bytes. Default: 102400 (100KB).
+     *  Messages exceeding this are rejected by the dispatcher before routing. */
+    maxMessageBytes?: number;
   };
   browser?: {
     sessionTtlMs?: number;

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -135,6 +135,8 @@ export class Dispatcher {
         channelId: payload.channelId,
         senderId: payload.senderId,
         reason: 'message_too_large',
+        size: contentByteSize,
+        limit: this.maxMessageBytes,
         parentEventId: event.id,
       }));
       return;

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -29,6 +29,9 @@ export interface DispatcherConfig {
   /** Messages scoring below this floor trigger hold_and_notify regardless of per-channel policy
    *  (unless channel is 'ignore'). Default: 0.2 */
   trustScoreFloor?: number;
+  /** Maximum inbound message content size in bytes. Messages exceeding this are
+   *  rejected before routing. Default: 102400 (100KB). */
+  maxMessageBytes?: number;
 }
 
 /**
@@ -63,6 +66,7 @@ export class Dispatcher {
   private checkpointTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private pool: DbPool | undefined;
   private conversationCheckpointDebounceMs: number;
+  private maxMessageBytes: number;
 
   constructor(config: DispatcherConfig) {
     this.bus = config.bus;
@@ -75,6 +79,7 @@ export class Dispatcher {
     this.conversationCheckpointDebounceMs = config.conversationCheckpointDebounceMs ?? 600_000;
     this.trustScorerWeights = config.trustScorerWeights ?? DEFAULT_TRUST_WEIGHTS;
     this.trustScoreFloor = config.trustScoreFloor ?? 0.2;
+    this.maxMessageBytes = config.maxMessageBytes ?? 102_400;
 
     // Warn if the trust floor is active but no held-message service was provided — the floor
     // silently becomes a no-op in that case, which is a security-relevant degradation.
@@ -115,6 +120,26 @@ export class Dispatcher {
 
   private async handleInbound(event: InboundMessageEvent): Promise<void> {
     const { payload } = event;
+
+    // Reject oversized messages before any processing — no routing, no contact
+    // lookup, no LLM cost. The inbound.message event is already in the audit log
+    // (write-ahead); this rejection creates a causal chain via parentEventId.
+    const contentByteSize = Buffer.byteLength(payload.content, 'utf-8');
+    if (contentByteSize > this.maxMessageBytes) {
+      this.logger.warn(
+        { channelId: payload.channelId, senderId: payload.senderId, contentByteSize, maxBytes: this.maxMessageBytes },
+        'Inbound message exceeded size limit — rejected',
+      );
+      await this.bus.publish('dispatch', createMessageRejected({
+        conversationId: payload.conversationId,
+        channelId: payload.channelId,
+        senderId: payload.senderId,
+        reason: 'message_too_large',
+        parentEventId: event.id,
+      }));
+      return;
+    }
+
     this.logger.info(
       { channelId: payload.channelId, senderId: payload.senderId },
       'Dispatching to coordinator',

--- a/src/index.ts
+++ b/src/index.ts
@@ -780,7 +780,7 @@ async function main(): Promise<void> {
     conversationCheckpointDebounceMs: yamlConfig.dispatch?.conversationCheckpointDebounceMs,
     trustScorerWeights,
     trustScoreFloor,
-    maxMessageBytes: yamlConfig.channels?.maxMessageBytes ?? 102_400,
+    maxMessageBytes: yamlConfig.channels?.max_message_bytes ?? 102_400,
   });
   dispatcher.register();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -780,6 +780,7 @@ async function main(): Promise<void> {
     conversationCheckpointDebounceMs: yamlConfig.dispatch?.conversationCheckpointDebounceMs,
     trustScorerWeights,
     trustScoreFloor,
+    maxMessageBytes: yamlConfig.channels?.maxMessageBytes ?? 102_400,
   });
   dispatcher.register();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ import type { ConfigChangeEvent } from './bus/events.js';
 import { BullpenService } from './memory/bullpen.js';
 import { BullpenDispatcher } from './dispatch/bullpen-dispatcher.js';
 import { ConversationCheckpointProcessor } from './checkpoint/processor.js';
+import { runStartupValidation } from './startup/validator.js';
 
 async function main(): Promise<void> {
   // 1. Config & logging — no dependencies, must come first.
@@ -82,6 +83,21 @@ async function main(): Promise<void> {
   const yamlConfig = loadYamlConfig(configDir);
   const logger = createLogger(config.logLevel);
   logger.info('Curia starting...');
+
+  // 1b. Startup validation — fail fast before any I/O if configs are malformed.
+  // Validates config/default.yaml, agents/*.yaml, and skills/*/skill.json against
+  // JSON Schema. Any failure exits the process before the DB connection is attempted.
+  try {
+    await runStartupValidation({
+      configDir,
+      agentsDir: path.resolve(import.meta.dirname, '../agents'),
+      skillsDir: path.resolve(import.meta.dirname, '../skills'),
+      logger,
+    });
+  } catch (err) {
+    logger.fatal({ err }, 'Startup validation failed — fix the config errors above and restart');
+    process.exit(1);
+  }
 
   // 2. Database — needed by audit logger before the bus can accept events.
   // We probe with SELECT 1 to distinguish a misconfigured URL (fast fail)

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -53,10 +53,6 @@ export async function loadSkillsFromDirectory(
       const raw = fs.readFileSync(manifestPath, 'utf-8');
       const manifest = JSON.parse(raw) as SkillManifest;
 
-      if (!manifest.name || !manifest.description) {
-        throw new Error('Manifest missing required fields: name, description');
-      }
-
       // Set defaults for optional fields
       manifest.timeout ??= 30000;
       manifest.sensitivity ??= 'normal';

--- a/src/startup/validator.ts
+++ b/src/startup/validator.ts
@@ -1,0 +1,146 @@
+// src/startup/validator.ts
+//
+// Centralized startup validation — runs before any services are initialized.
+// Validates config/default.yaml, all agents/*.yaml, and all skills/*/skill.json
+// against JSON Schema using Ajv. Any failure throws with a descriptive message
+// and causes process.exit(1) in the bootstrap orchestrator (src/index.ts).
+//
+// Spec: docs/specs/06-audit-and-security.md — Input Validation
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+// Ajv is a CJS module with __esModule:true — nodenext resolution requires the
+// named export form when esModuleInterop is active.
+import { Ajv, type ErrorObject } from 'ajv';
+import yaml from 'js-yaml';
+import type { Logger } from '../logger.js';
+
+// Schemas live at the project root in schemas/, sibling of config/ and agents/.
+// Resolving two levels up from src/startup/ reaches the project root.
+// This works from both tsx (src/startup/) and compiled dist (dist/startup/).
+const SCHEMAS_DIR = path.resolve(import.meta.dirname, '../../schemas');
+
+function loadSchema(name: string): object {
+  const schemaPath = path.join(SCHEMAS_DIR, name);
+  return JSON.parse(fs.readFileSync(schemaPath, 'utf-8')) as object;
+}
+
+/**
+ * Format Ajv errors into a human-readable string that includes field paths and
+ * values. Handles `additionalProperties` violations specially to surface the
+ * offending property name (which lives in `params.additionalProperty`).
+ */
+function formatErrors(errors: ErrorObject[]): string {
+  return errors
+    .map(e => {
+      const fieldPath = e.instancePath || '(root)';
+      // additionalProperties errors put the unknown key in params.additionalProperty —
+      // standard errorsText() omits it, so we add it explicitly here.
+      const extra =
+        e.keyword === 'additionalProperties' && e.params && 'additionalProperty' in e.params
+          ? ` (unknown property: ${String(e.params.additionalProperty)})`
+          : '';
+      return `${fieldPath} ${e.message ?? 'invalid'}${extra}`;
+    })
+    .join('\n  - ');
+}
+
+/**
+ * Run all startup validation checks. Throws with a descriptive error on any
+ * failure — callers should catch, log fatal, and call process.exit(1).
+ *
+ * Validation order:
+ *   1. config/default.yaml (or configFileName override)
+ *   2. all *.yaml and *.yml files in agentsDir
+ *   3. all skill.json files in skillsDir (one per skill subdirectory)
+ */
+export async function runStartupValidation(opts: {
+  configDir: string;
+  agentsDir: string;
+  skillsDir: string;
+  logger: Logger;
+  /** Override config filename for testing. Defaults to 'default.yaml'. */
+  configFileName?: string;
+}): Promise<void> {
+  const { configDir, agentsDir, skillsDir, logger } = opts;
+  const configFileName = opts.configFileName ?? 'default.yaml';
+
+  // Compile schemas once — Ajv compilation is expensive; reuse across files.
+  const ajv = new Ajv({ allErrors: true });
+  const validateConfig = ajv.compile(loadSchema('default-config.schema.json'));
+  const validateAgent = ajv.compile(loadSchema('agent-config.schema.json'));
+  const validateSkill = ajv.compile(loadSchema('skill-manifest.schema.json'));
+
+  // 1. Validate config/default.yaml (absent file is OK — all fields are optional)
+  const configPath = path.join(configDir, configFileName);
+  if (fs.existsSync(configPath)) {
+    const raw = yaml.load(fs.readFileSync(configPath, 'utf-8'));
+    // null/empty YAML is valid (same as no config)
+    if (raw != null) {
+      if (!validateConfig(raw)) {
+        throw new Error(
+          `Startup validation failed for ${configPath}:\n  - ${formatErrors(validateConfig.errors ?? [])}`,
+        );
+      }
+    }
+  }
+
+  // 2. Validate all agents/*.yaml
+  if (fs.existsSync(agentsDir)) {
+    const agentFiles = fs
+      .readdirSync(agentsDir)
+      .filter(f => f.endsWith('.yaml') || f.endsWith('.yml'));
+
+    for (const file of agentFiles) {
+      const filePath = path.join(agentsDir, file);
+      const raw = yaml.load(fs.readFileSync(filePath, 'utf-8'));
+      if (!validateAgent(raw)) {
+        throw new Error(
+          `Startup validation failed for ${filePath}:\n  - ${formatErrors(validateAgent.errors ?? [])}`,
+        );
+      }
+    }
+  }
+
+  // 3. Validate all skills/*/skill.json
+  //
+  // Supports two layouts:
+  //   a) skillsDir is a parent containing multiple skill subdirectories (production):
+  //        skills/web-search/skill.json, skills/email-send/skill.json, ...
+  //   b) skillsDir is a single skill directory directly containing skill.json (tests):
+  //        skills/valid-skill/skill.json — tests pass path.join(F, 'skills/valid-skill')
+  //
+  // In case (b), the directory is checked first for a direct skill.json, then
+  // subdirectories are scanned as in case (a).
+  if (fs.existsSync(skillsDir)) {
+    // Case (b): direct skill.json in skillsDir itself
+    const directManifest = path.join(skillsDir, 'skill.json');
+    if (fs.existsSync(directManifest)) {
+      const raw = JSON.parse(fs.readFileSync(directManifest, 'utf-8')) as unknown;
+      if (!validateSkill(raw)) {
+        throw new Error(
+          `Startup validation failed for ${directManifest}:\n  - ${formatErrors(validateSkill.errors ?? [])}`,
+        );
+      }
+    } else {
+      // Case (a): parent directory — iterate subdirectories
+      const skillEntries = fs
+        .readdirSync(skillsDir, { withFileTypes: true })
+        .filter(e => e.isDirectory());
+
+      for (const entry of skillEntries) {
+        const manifestPath = path.join(skillsDir, entry.name, 'skill.json');
+        if (!fs.existsSync(manifestPath)) continue;
+
+        const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as unknown;
+        if (!validateSkill(raw)) {
+          throw new Error(
+            `Startup validation failed for ${manifestPath}:\n  - ${formatErrors(validateSkill.errors ?? [])}`,
+          );
+        }
+      }
+    }
+  }
+
+  logger.info('Startup validation passed');
+}

--- a/src/startup/validator.ts
+++ b/src/startup/validator.ts
@@ -94,6 +94,9 @@ export async function runStartupValidation(opts: {
     for (const file of agentFiles) {
       const filePath = path.join(agentsDir, file);
       const raw = yaml.load(fs.readFileSync(filePath, 'utf-8'));
+      if (raw == null) {
+        throw new Error(`Startup validation failed: agent config file is empty: ${filePath}`);
+      }
       if (!validateAgent(raw)) {
         throw new Error(
           `Startup validation failed for ${filePath}:\n  - ${formatErrors(validateAgent.errors ?? [])}`,

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -547,3 +547,118 @@ describe('Dispatcher — contact.unknown event payload', () => {
     expect(unknownEvents[0]!.payload.routingDecision).toBe('allow');
   });
 });
+
+describe('Dispatcher message size limit', () => {
+  /**
+   * Creates a Dispatcher with the given maxMessageBytes config and registers it.
+   * The coordinator agent must be set up separately by tests that need a full routing path.
+   */
+  function makeDispatcher(bus: EventBus, maxMessageBytes: number) {
+    const logger = createLogger('error');
+    const dispatcher = new Dispatcher({ bus, logger, maxMessageBytes });
+    dispatcher.register();
+    return dispatcher;
+  }
+
+  it('routes normally when content is at the size limit', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'ok',
+        usage: { inputTokens: 1, outputTokens: 1 },
+      }),
+    };
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a helpful assistant.',
+      provider: mockProvider,
+      bus,
+      logger,
+    });
+    coordinator.register();
+
+    const outbound: OutboundMessageEvent[] = [];
+    bus.subscribe('outbound.message', 'channel', (e) => outbound.push(e as OutboundMessageEvent));
+
+    // 10 bytes exactly — at limit
+    makeDispatcher(bus, 10);
+
+    const event = createInboundMessage({
+      conversationId: 'conv-size-ok',
+      channelId: 'cli',
+      senderId: 'user',
+      content: '1234567890', // exactly 10 bytes
+    });
+    await bus.publish('channel', event);
+
+    expect(outbound).toHaveLength(1);
+  });
+
+  it('publishes message.rejected when content exceeds the size limit', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('message.rejected', 'channel', (e) => rejected.push(e as MessageRejectedEvent));
+
+    makeDispatcher(bus, 5); // 5 byte limit
+
+    const event = createInboundMessage({
+      conversationId: 'conv-size-exceeded',
+      channelId: 'email',
+      senderId: 'spammer@example.com',
+      content: 'This message is definitely longer than 5 bytes',
+    });
+    await bus.publish('channel', event);
+
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.payload.reason).toBe('message_too_large');
+    expect(rejected[0]?.payload.conversationId).toBe('conv-size-exceeded');
+    expect(rejected[0]?.payload.channelId).toBe('email');
+    expect(rejected[0]?.payload.senderId).toBe('spammer@example.com');
+  });
+
+  it('does not publish agent.task when content exceeds the size limit', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+
+    makeDispatcher(bus, 5);
+
+    const event = createInboundMessage({
+      conversationId: 'conv-no-task',
+      channelId: 'email',
+      senderId: 'spammer@example.com',
+      content: 'Way more than 5 bytes here',
+    });
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(0);
+  });
+
+  it('sets parentEventId on the rejection event to the original inbound message id', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('message.rejected', 'channel', (e) => rejected.push(e as MessageRejectedEvent));
+
+    makeDispatcher(bus, 1); // absurdly low limit
+
+    const event = createInboundMessage({
+      conversationId: 'conv-causal-chain',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'ab', // 2 bytes > 1 byte limit
+    });
+    await bus.publish('channel', event);
+
+    expect(rejected[0]?.parentEventId).toBe(event.id);
+  });
+});

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -661,4 +661,32 @@ describe('Dispatcher message size limit', () => {
 
     expect(rejected[0]?.parentEventId).toBe(event.id);
   });
+
+  it('enforces byte length not char length for multibyte UTF-8 content', async () => {
+    // The emoji '😀' is 1 character but 4 UTF-8 bytes.
+    // With a limit of 3, char-length check (content.length === 1) would pass,
+    // but byte-length check (Buffer.byteLength === 4) should reject it.
+    const emoji = '😀';
+    expect(emoji.length).toBe(2); // surrogate pair in JS: 2 code units, not 1
+    expect(Buffer.byteLength(emoji, 'utf-8')).toBe(4); // 4 bytes in UTF-8
+
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('message.rejected', 'channel', (e) => rejected.push(e as MessageRejectedEvent));
+
+    makeDispatcher(bus, 3); // 3-byte limit — passes char-length check but fails byte-length
+
+    const event = createInboundMessage({
+      conversationId: 'conv-multibyte',
+      channelId: 'cli',
+      senderId: 'user',
+      content: emoji,
+    });
+    await bus.publish('channel', event);
+
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.payload.reason).toBe('message_too_large');
+  });
 });

--- a/tests/unit/startup/fixtures/agents/missing-description/coordinator.yaml
+++ b/tests/unit/startup/fixtures/agents/missing-description/coordinator.yaml
@@ -1,0 +1,5 @@
+name: test-agent
+model:
+  provider: anthropic
+  model: claude-sonnet-4-6
+system_prompt: You are a test agent.

--- a/tests/unit/startup/fixtures/agents/missing-model-provider/coordinator.yaml
+++ b/tests/unit/startup/fixtures/agents/missing-model-provider/coordinator.yaml
@@ -1,0 +1,5 @@
+name: test-agent
+description: Missing model provider
+model:
+  model: claude-sonnet-4-6
+system_prompt: You are a test agent.

--- a/tests/unit/startup/fixtures/agents/unknown-key/coordinator.yaml
+++ b/tests/unit/startup/fixtures/agents/unknown-key/coordinator.yaml
@@ -1,0 +1,7 @@
+name: test-agent
+description: Has a typo key
+model:
+  provider: anthropic
+  model: claude-sonnet-4-6
+system_prompt: You are a test agent.
+typo_key: this should not be here

--- a/tests/unit/startup/fixtures/agents/valid/coordinator.yaml
+++ b/tests/unit/startup/fixtures/agents/valid/coordinator.yaml
@@ -1,0 +1,6 @@
+name: test-agent
+description: A valid test agent
+model:
+  provider: anthropic
+  model: claude-sonnet-4-6
+system_prompt: You are a test agent.

--- a/tests/unit/startup/fixtures/config/empty/default.yaml
+++ b/tests/unit/startup/fixtures/config/empty/default.yaml
@@ -1,0 +1,1 @@
+# empty config — all fields are optional

--- a/tests/unit/startup/fixtures/config/invalid-trust-floor/default.yaml
+++ b/tests/unit/startup/fixtures/config/invalid-trust-floor/default.yaml
@@ -1,0 +1,2 @@
+security:
+  trust_score_floor: 1.5

--- a/tests/unit/startup/fixtures/config/unknown-key/default.yaml
+++ b/tests/unit/startup/fixtures/config/unknown-key/default.yaml
@@ -1,0 +1,2 @@
+trust-policy:
+  financial_actions: 0.8

--- a/tests/unit/startup/fixtures/config/valid/default.yaml
+++ b/tests/unit/startup/fixtures/config/valid/default.yaml
@@ -1,0 +1,11 @@
+security:
+  trust_score_floor: 0.2
+  trust_score:
+    channel_weight: 0.4
+    contact_weight: 0.4
+    max_risk_penalty: 0.2
+trust_policy:
+  financial_actions: 0.8
+  data_export: 0.8
+  scheduling: 0.5
+  information_queries: 0.2

--- a/tests/unit/startup/fixtures/config/wrong-type/default.yaml
+++ b/tests/unit/startup/fixtures/config/wrong-type/default.yaml
@@ -1,0 +1,2 @@
+channels:
+  maxMessageBytes: "not-a-number"

--- a/tests/unit/startup/fixtures/config/wrong-type/default.yaml
+++ b/tests/unit/startup/fixtures/config/wrong-type/default.yaml
@@ -1,2 +1,2 @@
 channels:
-  maxMessageBytes: "not-a-number"
+  max_message_bytes: "not-a-number"

--- a/tests/unit/startup/fixtures/skills/bad-action-risk-numeric/skill.json
+++ b/tests/unit/startup/fixtures/skills/bad-action-risk-numeric/skill.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-skill",
+  "description": "A test skill",
+  "version": "1.0.0",
+  "action_risk": 150
+}

--- a/tests/unit/startup/fixtures/skills/bad-action-risk/skill.json
+++ b/tests/unit/startup/fixtures/skills/bad-action-risk/skill.json
@@ -1,0 +1,6 @@
+{
+  "name": "bad-action-risk-skill",
+  "description": "Has an invalid action_risk string",
+  "version": "1.0.0",
+  "action_risk": "super-dangerous"
+}

--- a/tests/unit/startup/fixtures/skills/missing-action-risk/skill.json
+++ b/tests/unit/startup/fixtures/skills/missing-action-risk/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "missing-action-risk-skill",
+  "description": "Missing the action_risk field",
+  "version": "1.0.0"
+}

--- a/tests/unit/startup/fixtures/skills/missing-version/skill.json
+++ b/tests/unit/startup/fixtures/skills/missing-version/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "missing-version-skill",
+  "description": "Missing the version field",
+  "action_risk": "none"
+}

--- a/tests/unit/startup/fixtures/skills/valid-skill-numeric/skill.json
+++ b/tests/unit/startup/fixtures/skills/valid-skill-numeric/skill.json
@@ -1,0 +1,6 @@
+{
+  "name": "valid-skill-numeric",
+  "description": "A test skill with a numeric action_risk value",
+  "version": "1.0.0",
+  "action_risk": 75
+}

--- a/tests/unit/startup/fixtures/skills/valid-skill/skill.json
+++ b/tests/unit/startup/fixtures/skills/valid-skill/skill.json
@@ -1,0 +1,6 @@
+{
+  "name": "valid-skill",
+  "description": "A valid test skill",
+  "version": "1.0.0",
+  "action_risk": "none"
+}

--- a/tests/unit/startup/validator.test.ts
+++ b/tests/unit/startup/validator.test.ts
@@ -48,6 +48,12 @@ describe('startup validator — agent configs', () => {
       runWith({ agents: path.join(F, 'agents/unknown-key') }),
     ).rejects.toThrow(/typo_key/);
   });
+
+  it('throws when agent YAML is empty', async () => {
+    await expect(
+      runWith({ agents: path.join(F, 'agents/empty') }),
+    ).rejects.toThrow(/empty/);
+  });
 });
 
 // ── Skill manifest validation ────────────────────────────────────────────────
@@ -74,6 +80,12 @@ describe('startup validator — skill manifests', () => {
       runWith({ skills: path.join(F, 'skills/bad-action-risk') }),
     ).rejects.toThrow(/action_risk/);
   });
+
+  it('throws for an out-of-range numeric action_risk (150)', async () => {
+    await expect(
+      runWith({ skills: path.join(F, 'skills/bad-action-risk-numeric') }),
+    ).rejects.toThrow(/action_risk/);
+  });
 });
 
 // ── default-config.yaml validation ──────────────────────────────────────────
@@ -93,10 +105,10 @@ describe('startup validator — default config', () => {
     ).rejects.toThrow(/trust_score_floor/);
   });
 
-  it('throws when maxMessageBytes is the wrong type (string)', async () => {
+  it('throws when max_message_bytes is the wrong type (string)', async () => {
     await expect(
       runWith({ config: path.join(F, 'config/wrong-type') }),
-    ).rejects.toThrow(/maxMessageBytes/);
+    ).rejects.toThrow(/max_message_bytes/);
   });
 
   it('throws for unknown top-level keys (e.g. trust-policy typo)', async () => {

--- a/tests/unit/startup/validator.test.ts
+++ b/tests/unit/startup/validator.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
+import { runStartupValidation } from '../../../src/startup/validator.js';
+// createSilentLogger is purpose-built for tests: writes to /dev/null, level 'silent'
+import { createSilentLogger } from '../../../src/logger.js';
+
+const F = path.resolve(import.meta.dirname, 'fixtures');
+const logger = createSilentLogger();
+
+// Shorthand: run validation with specific fixture directories.
+// For components not under test, point at a valid fixture to avoid false positives.
+function runWith(opts: { agents?: string; skills?: string; config?: string }) {
+  return runStartupValidation({
+    agentsDir: opts.agents ?? path.join(F, 'agents/valid'),
+    skillsDir: opts.skills ?? path.join(F, 'skills/valid-skill'),
+    configDir: opts.config ?? path.join(F, 'config/empty'),
+    logger,
+  });
+}
+
+// ── Agent config validation ──────────────────────────────────────────────────
+
+describe('startup validator — agent configs', () => {
+  it('passes for a valid agent YAML', async () => {
+    await expect(runWith({ agents: path.join(F, 'agents/valid') })).resolves.toBeUndefined();
+  });
+
+  it('throws when agent YAML is missing description', async () => {
+    await expect(
+      runWith({ agents: path.join(F, 'agents/missing-description') }),
+    ).rejects.toThrow(/description/);
+  });
+
+  it('throws when agent YAML is missing model.provider', async () => {
+    await expect(
+      runWith({ agents: path.join(F, 'agents/missing-model-provider') }),
+    ).rejects.toThrow(/provider/);
+  });
+
+  it('includes the file path in the error message', async () => {
+    await expect(
+      runWith({ agents: path.join(F, 'agents/missing-description') }),
+    ).rejects.toThrow(/coordinator\.yaml/);
+  });
+
+  it('throws for unknown top-level keys (additionalProperties)', async () => {
+    await expect(
+      runWith({ agents: path.join(F, 'agents/unknown-key') }),
+    ).rejects.toThrow(/typo_key/);
+  });
+});
+
+// ── Skill manifest validation ────────────────────────────────────────────────
+
+describe('startup validator — skill manifests', () => {
+  it('passes for a valid skill manifest', async () => {
+    await expect(runWith({ skills: path.join(F, 'skills/valid-skill') })).resolves.toBeUndefined();
+  });
+
+  it('throws when skill manifest is missing version', async () => {
+    await expect(
+      runWith({ skills: path.join(F, 'skills/missing-version') }),
+    ).rejects.toThrow(/version/);
+  });
+
+  it('throws when skill manifest is missing action_risk', async () => {
+    await expect(
+      runWith({ skills: path.join(F, 'skills/missing-action-risk') }),
+    ).rejects.toThrow(/action_risk/);
+  });
+
+  it('throws for an invalid action_risk string value', async () => {
+    await expect(
+      runWith({ skills: path.join(F, 'skills/bad-action-risk') }),
+    ).rejects.toThrow(/action_risk/);
+  });
+});
+
+// ── default-config.yaml validation ──────────────────────────────────────────
+
+describe('startup validator — default config', () => {
+  it('passes for a valid config', async () => {
+    await expect(runWith({ config: path.join(F, 'config/valid') })).resolves.toBeUndefined();
+  });
+
+  it('passes for an empty config (all fields optional)', async () => {
+    await expect(runWith({ config: path.join(F, 'config/empty') })).resolves.toBeUndefined();
+  });
+
+  it('throws when trust_score_floor is out of range (1.5)', async () => {
+    await expect(
+      runWith({ config: path.join(F, 'config/invalid-trust-floor') }),
+    ).rejects.toThrow(/trust_score_floor/);
+  });
+
+  it('throws when maxMessageBytes is the wrong type (string)', async () => {
+    await expect(
+      runWith({ config: path.join(F, 'config/wrong-type') }),
+    ).rejects.toThrow(/maxMessageBytes/);
+  });
+
+  it('throws for unknown top-level keys (e.g. trust-policy typo)', async () => {
+    await expect(
+      runWith({ config: path.join(F, 'config/unknown-key') }),
+    ).rejects.toThrow(/trust-policy/);
+  });
+});

--- a/tests/unit/startup/validator.test.ts
+++ b/tests/unit/startup/validator.test.ts
@@ -86,6 +86,12 @@ describe('startup validator — skill manifests', () => {
       runWith({ skills: path.join(F, 'skills/bad-action-risk-numeric') }),
     ).rejects.toThrow(/action_risk/);
   });
+
+  it('passes for a valid numeric action_risk (75)', async () => {
+    await expect(
+      runWith({ skills: path.join(F, 'skills/valid-skill-numeric') }),
+    ).resolves.toBeUndefined();
+  });
 });
 
 // ── default-config.yaml validation ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Startup validator** (`src/startup/validator.ts`) — validates `config/default.yaml`, all `agents/*.yaml`, and all `skills/*/skill.json` against JSON Schema (Ajv) at boot time before any DB connection; invalid configs exit with a descriptive error
- **Message size limiting** — dispatcher rejects inbound messages exceeding `channels.max_message_bytes` (default 100KB) before routing; rejection audit-logged as `message.rejected` with causal `parentEventId`
- **JSON Schema files** (`schemas/`) — three schema files with `additionalProperties: false` throughout; catches key typos in YAML configs at startup

## Changes

- `src/startup/validator.ts` — new centralized startup validator using Ajv
- `schemas/agent-config.schema.json`, `schemas/skill-manifest.schema.json`, `schemas/default-config.schema.json` — new schema files
- `src/dispatch/dispatcher.ts` — `maxMessageBytes` guard in `handleInbound`
- `src/bus/events.ts` — `MessageRejectedPayload.reason` extended with `'message_too_large'` (public API surface change)
- `src/agents/loader.ts`, `src/skills/loader.ts` — redundant manual field checks removed (now handled by schema)
- `config/default.yaml`, `src/config.ts` — `channels.max_message_bytes` config field added
- `src/index.ts` — startup validator wired before DB pool; `max_message_bytes` passed to Dispatcher

## Test Plan

- [ ] 14 new unit tests in `tests/unit/startup/validator.test.ts` — all validation cases (valid, missing fields, wrong types, unknown keys)
- [ ] 4 new unit tests in `tests/unit/dispatch/dispatcher.test.ts` — at-limit routing, over-limit rejection, no task dispatch, causal `parentEventId`
- [ ] Full suite: 1199 tests pass, 0 failures
- [ ] Manual: remove `description` from an agent YAML and verify startup exits with a clear error naming the field and file path

Closes #196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup JSON Schema validation for config, agents and skill manifests; invalid files fail fast and stop startup.
  * Dispatcher enforces configurable inbound message byte-size limit and emits a rejection event with reason, size/limit and causal linkage.

* **Bug Fixes**
  * Oversized inbound messages now return HTTP 413 (Payload Too Large) instead of 403.

* **Documentation**
  * Added design and implementation docs describing input-validation behavior and schemas.

* **Tests**
  * Unit tests covering startup validation and dispatcher size-limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->