### PR TITLE
fix: wire expected_duration_seconds through to delegate skill timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Fixed
+- **Delegate skill timeout now wired to `expected_duration_seconds`** — the delegate skill
+  previously used a hardcoded 90-second timeout regardless of job type, causing long-running
+  scheduled specialists (e.g. writing-scout doing many web-fetch calls) to time out and retry
+  unnecessarily. `expected_duration_seconds` from the scheduler job is now forwarded through the
+  `agent.task` event payload; the runtime injects it as `timeout_ms` on every `delegate` call so
+  the specialist gets appropriate headroom without any coordinator.yaml changes. The 90-second
+  default is preserved for interactive tasks that carry no scheduler hint. The delegate skill
+  outer execution timeout has been raised to 660 s to accommodate jobs up to 600 s. Closes #258.
+- **`CreateJobParams` now accepts `expectedDurationSeconds`** — dynamic job creation (HTTP API,
+  skills) previously could not set `expected_duration_seconds`; the field was only reachable via
+  declarative YAML. `CreateJobParams` now exposes the field with the same validation rules as the
+  YAML path (positive finite integer; non-integer/zero/negative values rejected with a clear
+  error). Part of #258.
 - **Null byte crash in audit logger** — `AuditLogger.log()` now strips U+0000 from all
   string values in event payloads before writing to `audit_log.payload`. Previously, binary
   content returned by `web-fetch` could embed null bytes that PostgreSQL rejects with

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -35,14 +35,22 @@ export class DelegateHandler implements SkillHandler {
     }
 
     // Use caller-supplied timeout if it's a valid positive finite integer; fall back to default.
-    // Invalid values are silently ignored so a bad LLM-supplied timeout never breaks the call.
-    const specialistTimeoutMs =
+    // Invalid values fall back silently so a bad LLM-supplied value never breaks the call.
+    // When the runtime injects timeout_ms from expectedDurationSeconds (scheduled tasks), the
+    // value should always be valid — a warn here helps distinguish LLM garbage from a runtime bug.
+    const isValidTimeout =
       typeof timeout_ms === 'number' &&
       Number.isInteger(timeout_ms) &&
       timeout_ms > 0 &&
-      Number.isFinite(timeout_ms)
-        ? timeout_ms
-        : DEFAULT_SPECIALIST_TIMEOUT_MS;
+      Number.isFinite(timeout_ms);
+    const specialistTimeoutMs = isValidTimeout ? (timeout_ms as number) : DEFAULT_SPECIALIST_TIMEOUT_MS;
+
+    if (timeout_ms !== undefined && !isValidTimeout) {
+      ctx.log.warn(
+        { targetAgent: agent, providedTimeoutMs: timeout_ms },
+        'timeout_ms was provided but is not a valid positive integer — using default timeout',
+      );
+    }
 
     // Infrastructure skills need bus and agent registry
     if (!ctx.bus || !ctx.agentRegistry) {

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -12,15 +12,18 @@ import { randomUUID } from 'node:crypto';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { createAgentTask, type AgentResponseEvent } from '../../src/bus/events.js';
 
-// How long to wait for the specialist to respond before timing out.
-const SPECIALIST_TIMEOUT_MS = 90000;
+// Default wait for the specialist to respond — appropriate for interactive tasks.
+// Long-running scheduled tasks should pass timeout_ms explicitly (injected by the runtime
+// from the originating agent.task event's expectedDurationSeconds).
+const DEFAULT_SPECIALIST_TIMEOUT_MS = 90000;
 
 export class DelegateHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const { agent, task, conversation_id } = ctx.input as {
+    const { agent, task, conversation_id, timeout_ms } = ctx.input as {
       agent?: string;
       task?: string;
       conversation_id?: string;
+      timeout_ms?: unknown;
     };
 
     // Validate required inputs
@@ -30,6 +33,16 @@ export class DelegateHandler implements SkillHandler {
     if (!task || typeof task !== 'string') {
       return { success: false, error: 'Missing required input: task (string)' };
     }
+
+    // Use caller-supplied timeout if it's a valid positive finite integer; fall back to default.
+    // Invalid values are silently ignored so a bad LLM-supplied timeout never breaks the call.
+    const specialistTimeoutMs =
+      typeof timeout_ms === 'number' &&
+      Number.isInteger(timeout_ms) &&
+      timeout_ms > 0 &&
+      Number.isFinite(timeout_ms)
+        ? timeout_ms
+        : DEFAULT_SPECIALIST_TIMEOUT_MS;
 
     // Infrastructure skills need bus and agent registry
     if (!ctx.bus || !ctx.agentRegistry) {
@@ -58,7 +71,10 @@ export class DelegateHandler implements SkillHandler {
 
     const conversationId = conversation_id ?? `delegate-${randomUUID()}`;
 
-    ctx.log.info({ targetAgent: agent, task: task.slice(0, 100) }, 'Delegating task to specialist');
+    ctx.log.info(
+      { targetAgent: agent, task: task.slice(0, 100), timeoutMs: specialistTimeoutMs },
+      'Delegating task to specialist',
+    );
 
     // Publish an agent.task event for the specialist.
     // parentEventId uses a delegate-prefixed UUID. Ideally this would trace back
@@ -87,9 +103,9 @@ export class DelegateHandler implements SkillHandler {
       timeoutHandle = setTimeout(() => {
         if (!settled) {
           settled = true;
-          reject(new Error(`Specialist '${agent}' did not respond within ${SPECIALIST_TIMEOUT_MS}ms`));
+          reject(new Error(`Specialist '${agent}' did not respond within ${specialistTimeoutMs}ms`));
         }
-      }, SPECIALIST_TIMEOUT_MS);
+      }, specialistTimeoutMs);
 
       ctx.bus!.subscribe('agent.response', 'system', async (event) => {
         if (settled) return; // Skip processing after settlement — prevents double-resolve

--- a/skills/delegate/skill.json
+++ b/skills/delegate/skill.json
@@ -8,7 +8,8 @@
   "inputs": {
     "agent": "string",
     "task": "string",
-    "conversation_id": "string?"
+    "conversation_id": "string?",
+    "timeout_ms": "number?"
   },
   "outputs": {
     "response": "string",
@@ -16,5 +17,5 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 120000
+  "timeout": 660000
 }

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -445,17 +445,6 @@ export class AgentRuntime {
       for (const toolCall of response.toolCalls) {
         logger.info({ agentId, skill: toolCall.name, callId: toolCall.id }, 'Invoking skill');
 
-        // Publish skill.invoke for audit trail
-        const invokeEvent = createSkillInvoke({
-          agentId,
-          conversationId,
-          skillName: toolCall.name,
-          input: toolCall.input,
-          taskEventId: taskEvent.id,
-          parentEventId: taskEvent.id,
-        });
-        await bus.publish('agent', invokeEvent);
-
         // For delegate calls from scheduled tasks: inject timeout_ms from the task event's
         // expectedDurationSeconds so the specialist gets an appropriate wait window.
         // Only injected when: (a) the skill is 'delegate', (b) the task carries a duration
@@ -468,12 +457,32 @@ export class AgentRuntime {
         ) {
           const inputRecord = skillInput as Record<string, unknown>;
           if (!('timeout_ms' in inputRecord) || inputRecord['timeout_ms'] === undefined) {
-            skillInput = {
-              ...inputRecord,
-              timeout_ms: taskEvent.payload.expectedDurationSeconds * 1000,
-            };
+            const timeoutMs = taskEvent.payload.expectedDurationSeconds * 1000;
+            // Guard against non-integer results from floating-point expectedDurationSeconds
+            // stored via out-of-band DB writes — the delegate handler would silently fall back,
+            // but we log here so the root cause is visible in audit logs.
+            if (Number.isInteger(timeoutMs) && timeoutMs > 0) {
+              skillInput = { ...inputRecord, timeout_ms: timeoutMs };
+            } else {
+              logger.warn(
+                { agentId, taskEventId: taskEvent.id, expectedDurationSeconds: taskEvent.payload.expectedDurationSeconds, computedTimeoutMs: timeoutMs },
+                'Computed timeout_ms from expectedDurationSeconds is not a valid positive integer — skipping injection; delegate will use default timeout',
+              );
+            }
           }
         }
+
+        // Publish skill.invoke for audit trail — after injection so the recorded input
+        // reflects the actual values passed to the skill (including injected timeout_ms).
+        const invokeEvent = createSkillInvoke({
+          agentId,
+          conversationId,
+          skillName: toolCall.name,
+          input: skillInput,
+          taskEventId: taskEvent.id,
+          parentEventId: taskEvent.id,
+        });
+        await bus.publish('agent', invokeEvent);
 
         const startTime = Date.now();
         const result = await executionLayer.invoke(toolCall.name, skillInput, caller, {

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -456,8 +456,27 @@ export class AgentRuntime {
         });
         await bus.publish('agent', invokeEvent);
 
+        // For delegate calls from scheduled tasks: inject timeout_ms from the task event's
+        // expectedDurationSeconds so the specialist gets an appropriate wait window.
+        // Only injected when: (a) the skill is 'delegate', (b) the task carries a duration
+        // hint from the scheduler, and (c) the LLM hasn't already supplied a timeout_ms.
+        // This is transparent to the LLM — it doesn't need to know about scheduling internals.
+        let skillInput = toolCall.input;
+        if (
+          toolCall.name === 'delegate' &&
+          taskEvent.payload.expectedDurationSeconds !== undefined
+        ) {
+          const inputRecord = skillInput as Record<string, unknown>;
+          if (!('timeout_ms' in inputRecord) || inputRecord['timeout_ms'] === undefined) {
+            skillInput = {
+              ...inputRecord,
+              timeout_ms: taskEvent.payload.expectedDurationSeconds * 1000,
+            };
+          }
+        }
+
         const startTime = Date.now();
-        const result = await executionLayer.invoke(toolCall.name, toolCall.input, caller, {
+        const result = await executionLayer.invoke(toolCall.name, skillInput, caller, {
           taskEventId: taskEvent.id,
           agentId,
         });

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -42,6 +42,11 @@ interface AgentTaskPayload {
    *  Combines channel trust, contact confidence, and content risk signal.
    *  Not present on tasks created without a contact resolver (e.g. bullpen tasks). */
   messageTrustScore?: number;
+  /** Expected duration hint from the scheduler, in seconds. Set when the originating
+   *  scheduled_job has an explicit expected_duration_seconds value. The runtime uses this
+   *  to automatically widen the delegate skill timeout for long-running scheduled tasks.
+   *  Absent for interactive tasks (direct messages, bullpen, etc.). */
+  expectedDurationSeconds?: number;
 }
 
 interface AgentResponsePayload {

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -17,6 +17,10 @@ export interface CreateJobParams {
   errorBudget?: Record<string, unknown>;
   /** IANA timezone for cron wall-clock interpretation. Defaults to the service's timezone. */
   timezone?: string;
+  /** Expected duration of the job in seconds. Used to widen the delegate skill timeout for
+   *  long-running jobs and to compute the watchdog recovery threshold. Must be a positive
+   *  finite integer; non-integer, zero, negative, and non-finite values are rejected. */
+  expectedDurationSeconds?: number;
 }
 
 export interface CreateJobResult {
@@ -163,16 +167,27 @@ export class SchedulerService {
       this.validateCronFrequency(cronExpr, jobTimezone);
     }
 
+    // Validate expectedDurationSeconds: must be a positive finite integer.
+    // Reject invalid values explicitly so callers get a clear error rather than
+    // silently falling back to the 10-minute watchdog default.
+    const rawDuration = params.expectedDurationSeconds;
+    if (rawDuration !== undefined) {
+      if (!Number.isInteger(rawDuration) || rawDuration <= 0 || !Number.isFinite(rawDuration)) {
+        throw new Error(`expectedDurationSeconds must be a positive finite integer, got: ${rawDuration}`);
+      }
+    }
+    const hasExpectedDuration = rawDuration !== undefined;
+
     // Calculate next_run_at: for cron jobs use the parser (respecting per-job timezone),
     // for one-shot jobs use runAt directly (already UTC from timestamp normalization).
     const nextRunAt = cronExpr ? this.nextRunFromCron(cronExpr, jobTimezone) : runAt!;
 
     const insertSql = `
-      INSERT INTO scheduled_jobs (agent_id, cron_expr, run_at, task_payload, status, next_run_at, created_by, timezone)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      INSERT INTO scheduled_jobs (agent_id, cron_expr, run_at, task_payload, status, next_run_at, created_by, timezone${hasExpectedDuration ? ', expected_duration_seconds' : ''})
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8${hasExpectedDuration ? ', $9' : ''})
       RETURNING id
     `;
-    const insertParams = [
+    const insertParams: unknown[] = [
       agentId,
       cronExpr ?? null,
       runAt ?? null,
@@ -182,6 +197,9 @@ export class SchedulerService {
       createdBy,
       jobTimezone,
     ];
+    if (hasExpectedDuration) {
+      insertParams.push(rawDuration);
+    }
 
     const { rows } = await this.pool.query(insertSql, insertParams);
     const jobId = (rows[0] as { id: string }).id;

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -419,17 +419,24 @@ export class SchedulerService {
       );
     }
 
-    const hasExpectedDuration = validDuration;
+    // NULL when absent or invalid — always written to DO UPDATE so that removing
+    // expectedDurationSeconds from the YAML clears the stale DB value on the next restart,
+    // rather than leaving a now-wrong watchdog threshold silently in place.
+    const durationToWrite = validDuration ? rawDuration : null;
 
     // Include timezone so completeJobRun() re-advances next_run_at in the same zone.
     // Without this, the DB column would default to 'UTC' while next_run_at was computed
     // using this.timezone — causing every post-completion firing to be offset by the UTC delta.
+    // expected_duration_seconds is always included (as $8) so the DO UPDATE can clear it to NULL
+    // when the field is removed from the YAML — the conditional-column pattern would leave a
+    // stale value in place.
     const sql = `
-      INSERT INTO scheduled_jobs (agent_id, cron_expr, task_payload, status, next_run_at, created_by, timezone${hasExpectedDuration ? ', expected_duration_seconds' : ''})
-      VALUES ($1, $2, $3, $4, $5, $6, $7${hasExpectedDuration ? ', $8' : ''})
+      INSERT INTO scheduled_jobs (agent_id, cron_expr, task_payload, status, next_run_at, created_by, timezone, expected_duration_seconds)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
       ON CONFLICT (agent_id, cron_expr, (task_payload::text)) WHERE created_by = 'system'
       DO UPDATE SET next_run_at = $5,
-                    timezone = $7${hasExpectedDuration ? ',\n                    expected_duration_seconds = $8' : ''}
+                    timezone = $7,
+                    expected_duration_seconds = $8
       RETURNING id
     `;
     const params: unknown[] = [
@@ -440,10 +447,8 @@ export class SchedulerService {
       nextRunAt,
       'system',
       this.timezone,
+      durationToWrite,
     ];
-    if (hasExpectedDuration) {
-      params.push(rawDuration);
-    }
 
     const { rows } = await this.pool.query(sql, params);
     return (rows[0] as { id: string }).id;

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -402,14 +402,23 @@ export class SchedulerService {
     const nextRunAt = this.nextRunFromCron(schedule.cron);
 
     // Validate expectedDurationSeconds: must be a finite positive integer.
-    // Invalid values (0, negative, NaN, Infinity, non-integer) are silently treated
-    // as absent so the system default applies rather than breaking recovery.
+    // Invalid values fall back to absent (NULL in DB) so the watchdog default applies.
+    // Unlike createJob() which throws, startup must not abort for a misconfigured hint —
+    // but we warn loudly so operators can identify and fix the YAML config.
     const rawDuration = schedule.expectedDurationSeconds;
     const validDuration =
       rawDuration !== undefined &&
       Number.isInteger(rawDuration) &&
       rawDuration > 0 &&
       Number.isFinite(rawDuration);
+
+    if (rawDuration !== undefined && !validDuration) {
+      this.logger.warn(
+        { agentId, cron: schedule.cron, expectedDurationSeconds: rawDuration },
+        'upsertDeclarativeJob: expectedDurationSeconds is invalid (must be a positive finite integer) — falling back to system default watchdog threshold; check the agent YAML config',
+      );
+    }
+
     const hasExpectedDuration = validDuration;
 
     // Include timezone so completeJobRun() re-advances next_run_at in the same zone.

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -291,6 +291,9 @@ export class Scheduler {
       // Pass the anchor in the payload so the runtime injects it into the system
       // prompt. null (no linked agent_task) becomes undefined (field omitted).
       intentAnchor: job.intentAnchor ?? undefined,
+      // Pass the duration hint so the runtime can widen the delegate timeout for
+      // long-running scheduled tasks. null (no explicit duration) becomes undefined.
+      expectedDurationSeconds: job.expectedDurationSeconds ?? undefined,
       parentEventId: firedEvent.id,
     });
     await this.bus.publish('system', taskEvent);

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -677,20 +677,23 @@ describe('SchedulerService', () => {
       expect(params).toContain(60);
     });
 
-    it('omits expected_duration_seconds when not provided (preserves existing DB value)', async () => {
+    it('writes NULL for expected_duration_seconds when not provided, clearing any stale DB value', async () => {
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-decl-2' }] });
 
       await svc.upsertDeclarativeJob('coordinator', {
         cron: '0 9 * * 1',
         task: 'Weekly standup',
-        // no expectedDurationSeconds
+        // no expectedDurationSeconds — should write NULL, not omit the column
       });
 
-      const [sql] = pool.query.mock.calls[0] as [string];
-      expect(sql).not.toContain('expected_duration_seconds');
+      const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
+      // Column is always present so DO UPDATE can clear a stale value
+      expect(sql).toContain('expected_duration_seconds');
+      // NULL (not a number) is written
+      expect(params[params.length - 1]).toBeNull();
     });
 
-    it('ignores invalid expectedDurationSeconds values (0, negative, NaN, non-integer)', async () => {
+    it('writes NULL for invalid expectedDurationSeconds values (0, negative, NaN, non-integer)', async () => {
       const invalids = [0, -1, NaN, Infinity, 1.5, -0.5];
 
       for (const invalid of invalids) {
@@ -702,8 +705,10 @@ describe('SchedulerService', () => {
           expectedDurationSeconds: invalid,
         });
 
-        const [sql] = pool.query.mock.calls[pool.query.mock.calls.length - 1] as [string];
-        expect(sql).not.toContain('expected_duration_seconds');
+        const [sql, params] = pool.query.mock.calls[pool.query.mock.calls.length - 1] as [string, unknown[]];
+        // Column is always included — invalid value falls back to NULL
+        expect(sql).toContain('expected_duration_seconds');
+        expect(params[params.length - 1]).toBeNull();
       }
     });
   });

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -136,6 +136,56 @@ describe('SchedulerService', () => {
         /cronExpr or runAt/,
       );
     });
+
+    it('persists expectedDurationSeconds when provided', async () => {
+      const jobId = 'job-duration';
+      pool.query.mockResolvedValueOnce({ rows: [{ id: jobId }] });
+
+      const params: CreateJobParams = {
+        agentId: 'agent-1',
+        cronExpr: '0 9 * * *',
+        taskPayload: { task: 'brief' },
+        createdBy: 'user',
+        expectedDurationSeconds: 300,
+      };
+      const result = await svc.createJob(params);
+      expect(result.jobId).toBe(jobId);
+
+      // The INSERT SQL must include expected_duration_seconds and $9
+      const [insertSql, insertParams] = pool.query.mock.calls[0] as [string, unknown[]];
+      expect(insertSql).toContain('expected_duration_seconds');
+      expect(insertParams).toContain(300);
+    });
+
+    it('omits expected_duration_seconds from INSERT when not provided', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-noduration' }] });
+
+      const params: CreateJobParams = {
+        agentId: 'agent-1',
+        cronExpr: '0 9 * * *',
+        taskPayload: { task: 'brief' },
+        createdBy: 'user',
+      };
+      await svc.createJob(params);
+
+      const [insertSql] = pool.query.mock.calls[0] as [string];
+      expect(insertSql).not.toContain('expected_duration_seconds');
+    });
+
+    it('rejects invalid expectedDurationSeconds values', async () => {
+      const base: Omit<CreateJobParams, 'expectedDurationSeconds'> = {
+        agentId: 'agent-1',
+        cronExpr: '0 9 * * *',
+        taskPayload: {},
+        createdBy: 'user',
+      };
+
+      for (const bad of [0, -1, 1.5, NaN, Infinity]) {
+        await expect(
+          svc.createJob({ ...base, expectedDurationSeconds: bad }),
+        ).rejects.toThrow(/expectedDurationSeconds/);
+      }
+    });
   });
 
   // -- cancelJob --

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -253,6 +253,28 @@ describe('Scheduler', () => {
       expect(taskEvent.payload.intentAnchor).toBeUndefined();
     });
 
+    it('forwards expectedDurationSeconds in agent.task payload when set on the job', async () => {
+      const row = fakeDbRow({ expected_duration_seconds: 300 });
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+      await scheduler.pollDueJobs();
+
+      const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { expectedDurationSeconds?: number } }];
+      expect(taskEvent.payload.expectedDurationSeconds).toBe(300);
+    });
+
+    it('omits expectedDurationSeconds from agent.task payload when null on the job', async () => {
+      const row = fakeDbRow({ expected_duration_seconds: null });
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+      await scheduler.pollDueJobs();
+
+      const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { expectedDurationSeconds?: number } }];
+      expect(taskEvent.payload.expectedDurationSeconds).toBeUndefined();
+    });
+
     it('logs and swallows errors during polling', async () => {
       pool.query.mockRejectedValueOnce(new Error('db down'));
 

--- a/tests/unit/skills/delegate.test.ts
+++ b/tests/unit/skills/delegate.test.ts
@@ -71,6 +71,62 @@ describe('DelegateHandler', () => {
     }
   });
 
+  it('uses timeout_ms when provided as a valid positive integer', async () => {
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main' });
+    agentRegistry.register('research-analyst', { role: 'specialist', description: 'Research' });
+    const bus = new EventBus(logger);
+
+    bus.subscribe('agent.task', 'agent', async (event) => {
+      if (event.type === 'agent.task' && event.payload.agentId === 'research-analyst') {
+        const { createAgentResponse } = await import('../../../src/bus/events.js');
+        const response = createAgentResponse({
+          agentId: 'research-analyst',
+          conversationId: event.payload.conversationId,
+          content: 'Done',
+          parentEventId: event.id,
+        });
+        await bus.publish('agent', response);
+      }
+    });
+
+    // Should succeed with an explicit timeout_ms of 5 minutes (300000ms)
+    const result = await handler.execute(makeCtx(
+      { agent: 'research-analyst', task: 'Long task', timeout_ms: 300000 },
+      { bus, agentRegistry },
+    ));
+    expect(result.success).toBe(true);
+  });
+
+  it('falls back to default timeout when timeout_ms is invalid', async () => {
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main' });
+    agentRegistry.register('research-analyst', { role: 'specialist', description: 'Research' });
+    const bus = new EventBus(logger);
+
+    bus.subscribe('agent.task', 'agent', async (event) => {
+      if (event.type === 'agent.task' && event.payload.agentId === 'research-analyst') {
+        const { createAgentResponse } = await import('../../../src/bus/events.js');
+        const response = createAgentResponse({
+          agentId: 'research-analyst',
+          conversationId: event.payload.conversationId,
+          content: 'Done',
+          parentEventId: event.id,
+        });
+        await bus.publish('agent', response);
+      }
+    });
+
+    // Invalid values (0, negative, non-integer) should fall back to default and still succeed
+    for (const badTimeout of [0, -1, 1.5, NaN, Infinity, 'not-a-number', null]) {
+      const result = await handler.execute(makeCtx(
+        { agent: 'research-analyst', task: 'Task', timeout_ms: badTimeout },
+        { bus, agentRegistry },
+      ));
+      expect(result.success).toBe(true);
+    }
+  });
+
   it('delegates to specialist and returns its response', async () => {
     const agentRegistry = new AgentRegistry();
     agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main' });


### PR DESCRIPTION
## Summary

Closes #258.

The delegate skill had a hardcoded 90-second timeout that was appropriate for interactive tasks but caused long-running scheduled specialists (e.g. writing-scout doing 9+ web-fetch calls) to time out on their first attempt. The full pipeline `expected_duration_seconds → agent.task → coordinator → delegate timeout` was never connected despite the DB column existing since #209.

This PR connects all four pieces:

- **`AgentTaskPayload`** — new optional `expectedDurationSeconds` field carries the scheduler hint from the DB into the event
- **`Scheduler.fireJob()`** — forwards `job.expectedDurationSeconds` into the `agent.task` event payload
- **`AgentRuntime` tool-use loop** — when invoking `delegate` and the task carries `expectedDurationSeconds`, injects `timeout_ms = expectedDurationSeconds * 1000` transparently (LLM/coordinator.yaml unchanged); validates the computed value and warns if it is not a valid positive integer
- **`DelegateHandler`** — accepts optional `timeout_ms` input; uses it when valid, falls back to the 90s default for interactive tasks; warns when a provided value is rejected so LLM garbage and runtime injection failures are distinguishable
- **`delegate/skill.json`** — adds `timeout_ms?: number` input; raises outer execution-layer timeout from 120s to 660s to accommodate jobs up to 600s
- **`CreateJobParams`** — exposes `expectedDurationSeconds` for dynamic job creation (HTTP API, skills); invalid values throw with a clear error

Also: `upsertDeclarativeJob` now warns when an invalid `expectedDurationSeconds` is dropped from YAML (previously silent); the `skill.invoke` audit event is published after injection so the recorded input captures the actual `timeout_ms` passed.

## Test plan

- [ ] All 100 unit tests pass (`npm test`)
- [ ] TypeScript type-check passes (`npm run typecheck`)
- [ ] Delegate tests: `timeout_ms` accepted when valid, warn + 90s fallback when invalid
- [ ] Scheduler tests: `expectedDurationSeconds` forwarded in `agent.task` payload; absent when null
- [ ] Scheduler-service tests: `createJob` persists, omits, and rejects `expectedDurationSeconds` correctly
- [ ] Once a YAML job has `expectedDurationSeconds` set, the specialist will receive `timeout_ms` matching that value on every delegation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes (v0.16.2)

* **New Features**
  * The job creation API now accepts an `expectedDurationSeconds` parameter, allowing jobs to specify their expected duration.
  * Delegate skill timeouts are now dynamically configured based on scheduler-provided duration hints, improving timeout accuracy for long-running scheduled tasks.

* **Chores**
  * Version updated to 0.16.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->