### PR TITLE
feat: rate limiting at the dispatch layer (closes #198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+- **Rate limiting at the dispatch layer** — the dispatch layer now enforces two independent
+  in-memory fixed-window rate limits: a global limit (default 100 msg/min across all senders)
+  checked before any policy-gate processing to stop aggregate DoS floods early, and a per-sender
+  limit (default 15 msg/min) checked after policy gates so blocked/held senders don't consume
+  quota for legitimate senders. Excess messages are dropped silently; violations are audit-logged
+  as `message.rejected` events with reason `global_rate_limited` or `sender_rate_limited` and
+  logged at `warn` level. Both limits and the window duration are configurable in
+  `config/default.yaml` under `dispatch.rate_limit`. Completes the rate-limiting item in the
+  spec §06 security checklist. Closes #198.
+
 ### Fixed
 - **Delegate skill timeout now wired to `expected_duration_seconds`** — the delegate skill
   previously used a hardcoded 90-second timeout regardless of job type, causing long-running

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -20,6 +20,25 @@ dispatch:
   # event fires and background memory extraction (extract-relationships, etc.) runs.
   conversationCheckpointDebounceMs: 600000   # 10 minutes
 
+  # In-memory rate limiting for the dispatch layer (spec §06-audit-and-security.md).
+  # Protects against message flooding from malfunctioning channels, abusive senders,
+  # or compromised integrations. Two independent limits are enforced:
+  #
+  #   global     — total messages per window across all senders; enforced before any
+  #                policy-gate processing (guards against aggregate DoS flooding).
+  #   per-sender — messages per sender per window; enforced after policy gates
+  #                (blocked/held senders are already dropped before this check).
+  #
+  # Excess messages are dropped silently — no response is sent to the sender.
+  # Violations are audit-logged as message.rejected events with reason
+  # 'global_rate_limited' or 'sender_rate_limited', and logged at warn level.
+  #
+  # Changes take effect on restart.
+  rate_limit:
+    window_ms: 60000        # 1-minute fixed window
+    max_per_sender: 15      # messages per sender per window (15 allows for an active chat burst)
+    max_global: 100         # total messages per window across all senders
+
 workingMemory:
   # Rolling context summarization (spec §01-memory-system.md).
   # When the active turn count for a conversation exceeds `threshold`, the oldest

--- a/docs/specs/06-audit-and-security.md
+++ b/docs/specs/06-audit-and-security.md
@@ -352,7 +352,7 @@ These are non-negotiable for launch.
 | Error strings scrubbed before LLM injection | Done (#250) |
 | Agent config validation blocks malformed YAML at startup | Not Done |
 | HTTP API channel requires token authentication | Done |
-| Rate limiting active at dispatch layer | Not Done |
+| Rate limiting active at dispatch layer | Done (#198) |
 | Intent drift detection pauses tasks (not just logs) | Not Done |
 | Email channel exposes provider-level SPF/DKIM/DMARC validation via Nylas message metadata | Done (#195) |
 | Anti-injection system prompt hardening and architectural containment (Layers 2 & 3) | Done (#194) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -173,7 +173,7 @@ interface MessageRejectedPayload {
   channelId: string;
   senderId: string;
   /** Why the message was rejected — used by the HTTP adapter to select the status code. */
-  reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender';
+  reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender' | 'global_rate_limited' | 'sender_rate_limited';
 }
 
 // Memory event payloads — used for the knowledge graph audit trail (Phase 6).

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -15,15 +15,18 @@ import type { Logger } from '../../logger.js';
 import type { ServerResponse } from 'node:http';
 
 /**
- * Thrown by the event router when the dispatcher rejects a message via the
- * `unknown_sender: ignore` policy. Typed separately from Error so the route
- * handler can detect the rejection case and return 403 without brittle string
- * matching on the error message.
+ * Thrown by the event router when the dispatcher rejects a message. Typed
+ * separately from Error so the route handler can detect the rejection case and
+ * return 403 without brittle string matching on the error message.
+ *
+ * reason values:
+ *   unknown_sender / provisional_sender / blocked_sender — policy-gate rejections
+ *   global_rate_limited / sender_rate_limited — rate limit rejections (spec §06)
  */
 export class MessageRejectedError extends Error {
-  readonly reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender';
+  readonly reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender' | 'global_rate_limited' | 'sender_rate_limited';
 
-  constructor(reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender') {
+  constructor(reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender' | 'global_rate_limited' | 'sender_rate_limited') {
     super(`Message rejected — sender not authorized (${reason})`);
     this.name = 'MessageRejectedError';
     this.reason = reason;

--- a/src/channels/http/event-router.ts
+++ b/src/channels/http/event-router.ts
@@ -17,24 +17,30 @@ import type { ServerResponse } from 'node:http';
 /**
  * Thrown by the event router when the dispatcher rejects a message. Typed
  * separately from Error so the route handler can detect the rejection case and
- * return 403/413 without brittle string matching on the error message.
+ * return 403/413/429 without brittle string matching on the error message.
  *
  * reason values:
- *   unknown_sender / provisional_sender / blocked_sender — policy-gate rejections
- *   message_too_large — inbound content exceeded the configured size limit (spec §06)
- *   global_rate_limited / sender_rate_limited — rate limit rejections (spec §06)
+ *   unknown_sender / provisional_sender / blocked_sender — policy-gate rejections (403)
+ *   message_too_large — inbound content exceeded the configured size limit (413, spec §06)
+ *   global_rate_limited / sender_rate_limited — rate limit rejections (429, spec §06)
  */
 export class MessageRejectedError extends Error {
   readonly reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender' | 'message_too_large' | 'global_rate_limited' | 'sender_rate_limited';
+  /** HTTP status code for this rejection — use this instead of hardcoding per reason. */
+  readonly statusCode: 403 | 429;
 
   constructor(reason: 'unknown_sender' | 'provisional_sender' | 'blocked_sender' | 'message_too_large' | 'global_rate_limited' | 'sender_rate_limited') {
+    const isRateLimited = reason === 'global_rate_limited' || reason === 'sender_rate_limited';
     super(
       reason === 'message_too_large'
         ? 'Message too large — inbound content exceeds the configured size limit'
-        : `Message rejected — sender not authorized (${reason})`,
+        : isRateLimited
+          ? `Message rejected — rate limit exceeded (${reason})`
+          : `Message rejected — sender not authorized (${reason})`,
     );
     this.name = 'MessageRejectedError';
     this.reason = reason;
+    this.statusCode = isRateLimited ? 429 : 403;
   }
 }
 

--- a/src/channels/http/routes/messages.ts
+++ b/src/channels/http/routes/messages.ts
@@ -94,13 +94,13 @@ export async function messageRoutes(
       const message = err instanceof Error ? err.message : String(err);
       logger.error({ err, conversationId }, 'HTTP message handling failed');
 
-      // Distinguish oversized (413), other rejections (403), timeout (504), internal (500).
-      // Use instanceof + reason check rather than string matching so wording changes can't
-      // silently break the status code.
+      // Distinguish oversized (413), rate-limited (429), other rejections (403),
+      // timeout (504), and internal errors (500). Use instanceof + err.statusCode
+      // rather than string matching so wording changes can't silently break status codes.
       const isRejected = err instanceof MessageRejectedError;
       const isTooLarge = isRejected && err.reason === 'message_too_large';
       const isTimeout = message.includes('timeout') || message.includes('Timeout');
-      const status = isTooLarge ? 413 : isRejected ? 403 : isTimeout ? 504 : 500;
+      const status = isTooLarge ? 413 : isRejected ? err.statusCode : isTimeout ? 504 : 500;
       return reply.status(status).send({ error: message });
     }
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,14 @@ export interface YamlConfig {
     /** Milliseconds of inactivity before a conversation.checkpoint event is published.
      *  Defaults to 600000 (10 minutes). */
     conversationCheckpointDebounceMs?: number;
+    rate_limit?: {
+      /** Duration of each rate-limit window in milliseconds. Default: 60000 (1 minute). */
+      window_ms?: number;
+      /** Maximum messages allowed per sender per window. Default: 15. */
+      max_per_sender?: number;
+      /** Maximum total messages allowed per window across all senders. Default: 100. */
+      max_global?: number;
+    };
   };
   security?: {
     extra_injection_patterns?: Array<{ regex: string; label: string }>;
@@ -144,6 +152,31 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       throw new Error(
         `dispatch.conversationCheckpointDebounceMs must be a positive integer, got: ${checkpointDebounceMs}`,
       );
+    }
+
+    const rateLimit = config.dispatch?.rate_limit;
+    if (rateLimit !== undefined) {
+      const { window_ms, max_per_sender, max_global } = rateLimit;
+      if (window_ms !== undefined && (!Number.isInteger(window_ms) || window_ms <= 0)) {
+        throw new Error(`dispatch.rate_limit.window_ms must be a positive integer, got: ${window_ms}`);
+      }
+      if (max_per_sender !== undefined && (!Number.isInteger(max_per_sender) || max_per_sender <= 0)) {
+        throw new Error(`dispatch.rate_limit.max_per_sender must be a positive integer, got: ${max_per_sender}`);
+      }
+      if (max_global !== undefined && (!Number.isInteger(max_global) || max_global <= 0)) {
+        throw new Error(`dispatch.rate_limit.max_global must be a positive integer, got: ${max_global}`);
+      }
+      // Cross-validate: global must be at least as large as per-sender, otherwise no single
+      // sender can ever reach their per-sender quota — the global becomes the effective ceiling
+      // for everyone, making per-sender meaningless. This is almost certainly a misconfiguration.
+      // Uses effective values (same defaults as index.ts) so a partial config is also caught.
+      const effectiveMaxPerSender = max_per_sender ?? 15;
+      const effectiveMaxGlobal = max_global ?? 100;
+      if (effectiveMaxGlobal < effectiveMaxPerSender) {
+        throw new Error(
+          `dispatch.rate_limit.max_global (${effectiveMaxGlobal}) must be >= max_per_sender (${effectiveMaxPerSender})`,
+        );
+      }
     }
 
     if (config.workingMemory?.summarization !== undefined) {

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -6,6 +6,7 @@ import type { ContactResolver } from '../contacts/contact-resolver.js';
 import type { HeldMessageService } from '../contacts/held-messages.js';
 import type { InboundSenderContext, ChannelPolicyConfig, TrustLevel, UnknownSenderPolicy } from '../contacts/types.js';
 import type { InboundScanner } from './inbound-scanner.js';
+import type { RateLimiter } from './rate-limiter.js';
 import type { DbPool } from '../db/connection.js';
 import { computeTrustScore, DEFAULT_TRUST_WEIGHTS } from './trust-scorer.js';
 import type { TrustScorerWeights } from './trust-scorer.js';
@@ -29,6 +30,9 @@ export interface DispatcherConfig {
   /** Messages scoring below this floor trigger hold_and_notify regardless of per-channel policy
    *  (unless channel is 'ignore'). Default: 0.2 */
   trustScoreFloor?: number;
+  /** In-memory rate limiter. When provided, enforces global and per-sender message rate limits.
+   *  When omitted, rate limiting is disabled (e.g. in unit tests that don't exercise it). */
+  rateLimiter?: RateLimiter;
 }
 
 /**
@@ -48,6 +52,7 @@ export class Dispatcher {
   private heldMessages?: HeldMessageService;
   private channelPolicies?: Record<string, ChannelPolicyConfig>;
   private injectionScanner?: InboundScanner;
+  private rateLimiter?: RateLimiter;
   private trustScorerWeights: TrustScorerWeights;
   private trustScoreFloor: number;
   /**
@@ -71,6 +76,7 @@ export class Dispatcher {
     this.heldMessages = config.heldMessages;
     this.channelPolicies = config.channelPolicies;
     this.injectionScanner = config.injectionScanner;
+    this.rateLimiter = config.rateLimiter;
     this.pool = config.pool;
     this.conversationCheckpointDebounceMs = config.conversationCheckpointDebounceMs ?? 600_000;
     this.trustScorerWeights = config.trustScorerWeights ?? DEFAULT_TRUST_WEIGHTS;
@@ -119,6 +125,31 @@ export class Dispatcher {
       { channelId: payload.channelId, senderId: payload.senderId },
       'Dispatching to coordinator',
     );
+
+    // Global rate limit — checked before any policy-gate processing so that aggregate
+    // flooding (e.g. a DoS attack across many senders) is stopped as early as possible.
+    // Intentionally fail-open: if publish throws, we log and still drop the message.
+    if (this.rateLimiter && !this.rateLimiter.checkGlobal()) {
+      this.logger.warn(
+        { channelId: payload.channelId, senderId: payload.senderId },
+        'Global rate limit exceeded — dropping message',
+      );
+      try {
+        await this.bus.publish('dispatch', createMessageRejected({
+          conversationId: payload.conversationId,
+          channelId: payload.channelId,
+          senderId: payload.senderId,
+          reason: 'global_rate_limited',
+          parentEventId: event.id,
+        }));
+      } catch (publishErr) {
+        this.logger.error(
+          { err: publishErr, channelId: payload.channelId, senderId: payload.senderId },
+          'Failed to publish global-rate-limit rejection event — dropping (fail-closed)',
+        );
+      }
+      return;
+    }
 
     // Resolve sender if contact resolver is available.
     // Wrapped in try/catch so DB errors degrade gracefully (no sender context)
@@ -345,6 +376,38 @@ export class Dispatcher {
           'Contact resolution failed — proceeding without sender context',
         );
       }
+    }
+
+    // Per-sender rate limit — checked after policy gates so blocked/held senders
+    // (already dropped above) don't consume quota for legitimate senders.
+    // Uses the raw senderId from the inbound payload — no stable contactId needed
+    // because unknown senders are more likely to flood from a single address, and
+    // the global limit covers multi-address abuse.
+    //
+    // Note: the global counter above was already incremented for this message. If the
+    // per-sender check drops it here, the global quota is still consumed. This is
+    // intentional: global tracks message arrivals at the dispatch layer (a DoS signal),
+    // not messages that survive both checks and reach the coordinator.
+    if (this.rateLimiter && !this.rateLimiter.checkSender(payload.senderId)) {
+      this.logger.warn(
+        { channelId: payload.channelId, senderId: payload.senderId },
+        'Per-sender rate limit exceeded — dropping message',
+      );
+      try {
+        await this.bus.publish('dispatch', createMessageRejected({
+          conversationId: payload.conversationId,
+          channelId: payload.channelId,
+          senderId: payload.senderId,
+          reason: 'sender_rate_limited',
+          parentEventId: event.id,
+        }));
+      } catch (publishErr) {
+        this.logger.error(
+          { err: publishErr, channelId: payload.channelId, senderId: payload.senderId },
+          'Failed to publish sender-rate-limit rejection event — dropping (fail-closed)',
+        );
+      }
+      return;
     }
 
     // Layer 1 prompt injection scan — runs after policy gates so blocked/held

--- a/src/dispatch/rate-limiter.ts
+++ b/src/dispatch/rate-limiter.ts
@@ -1,0 +1,98 @@
+// rate-limiter.ts — In-memory fixed-window rate limiter for the dispatch layer.
+//
+// Enforces two independent limits:
+//   1. Global — total messages per window across all senders.
+//   2. Per-sender — messages per sender per window.
+//
+// Both use a fixed-window counter: the window resets once `windowMs` elapses
+// since the first message in that window. This is intentionally simple — Curia
+// runs as a single process on a single VPS, so in-memory state is sufficient.
+// A sliding-window or Redis-backed approach can be layered on if multi-process
+// deployment becomes a requirement.
+//
+// Spec: docs/specs/06-audit-and-security.md — Security Checklist → Rate limiting
+
+export interface RateLimiterConfig {
+  /** Duration of each rate-limit window in milliseconds. Default: 60000 (1 minute). */
+  windowMs: number;
+  /** Maximum messages allowed per sender per window. Default: 15. */
+  maxPerSender: number;
+  /** Maximum total messages allowed per window across all senders. Default: 100. */
+  maxGlobal: number;
+}
+
+interface WindowEntry {
+  count: number;
+  windowStart: number;   // ms timestamp of the first message in this window
+}
+
+export class RateLimiter {
+  private readonly windowMs: number;
+  private readonly maxPerSender: number;
+  private readonly maxGlobal: number;
+
+  /** Per-sender counters — keyed by senderId. */
+  private readonly senderWindows = new Map<string, WindowEntry>();
+
+  /** Single global counter — tracks aggregate message rate across all senders. */
+  private globalWindow: WindowEntry = { count: 0, windowStart: 0 };
+
+  constructor(config: RateLimiterConfig) {
+    this.windowMs = config.windowMs;
+    this.maxPerSender = config.maxPerSender;
+    this.maxGlobal = config.maxGlobal;
+  }
+
+  /**
+   * Check the global rate limit and increment the counter if allowed.
+   *
+   * Returns true if the message is within the global limit (caller should proceed).
+   * Returns false if the global limit is exceeded (caller should drop the message).
+   *
+   * The counter is NOT incremented on false — a rejected message does not consume quota.
+   */
+  checkGlobal(): boolean {
+    return this.check(this.globalWindow, this.maxGlobal);
+  }
+
+  /**
+   * Check the per-sender rate limit for the given senderId and increment if allowed.
+   *
+   * Returns true if the sender is within their limit (caller should proceed).
+   * Returns false if the sender's limit is exceeded (caller should drop the message).
+   *
+   * The counter is NOT incremented on false — a rejected message does not consume quota.
+   */
+  checkSender(senderId: string): boolean {
+    let entry = this.senderWindows.get(senderId);
+    if (!entry) {
+      entry = { count: 0, windowStart: 0 };
+      this.senderWindows.set(senderId, entry);
+    }
+    return this.check(entry, this.maxPerSender);
+  }
+
+  /**
+   * Core fixed-window check+increment logic, shared by both global and per-sender checks.
+   *
+   * Mutates `entry` in place — both methods above hold references to the same object
+   * stored in the Map (or the global field), so no re-assignment is needed.
+   */
+  private check(entry: WindowEntry, limit: number): boolean {
+    const now = Date.now();
+
+    // Reset the window if the current window period has elapsed.
+    if (now - entry.windowStart >= this.windowMs) {
+      entry.count = 0;
+      entry.windowStart = now;
+    }
+
+    if (entry.count >= limit) {
+      // Limit exceeded — do not increment, return false.
+      return false;
+    }
+
+    entry.count++;
+    return true;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ import { DEFAULT_ERROR_BUDGET } from './errors/types.js';
 import { OutboundContentFilter } from './dispatch/outbound-filter.js';
 import { OutboundGateway } from './skills/outbound-gateway.js';
 import { InboundScanner } from './dispatch/inbound-scanner.js';
+import { RateLimiter } from './dispatch/rate-limiter.js';
 import { loadExtraInjectionPatterns, type ExtraInjectionPattern } from './dispatch/security-config-loader.js';
 import { parseExtraPiiPatterns, getMissingBuiltInPatterns, getBuiltInPatternCount } from './pii/scrubber.js';
 import { setErrorPiiPatterns } from './errors/classify.js';
@@ -748,6 +749,23 @@ async function main(): Promise<void> {
 
   const trustScoreFloor = yamlConfig.security?.trust_score_floor ?? 0.2;
 
+  // Rate limiter — enforces global and per-sender message rate limits at the dispatch layer.
+  // Constructed from config/default.yaml dispatch.rate_limit section; falls back to safe defaults
+  // if the section is absent (same pattern as other optional dispatch config).
+  const rateLimitConfig = yamlConfig.dispatch?.rate_limit;
+  const rateLimiterWindowMs = rateLimitConfig?.window_ms ?? 60_000;
+  const rateLimiterMaxPerSender = rateLimitConfig?.max_per_sender ?? 15;
+  const rateLimiterMaxGlobal = rateLimitConfig?.max_global ?? 100;
+  const rateLimiter = new RateLimiter({
+    windowMs: rateLimiterWindowMs,
+    maxPerSender: rateLimiterMaxPerSender,
+    maxGlobal: rateLimiterMaxGlobal,
+  });
+  logger.info(
+    { windowMs: rateLimiterWindowMs, maxPerSender: rateLimiterMaxPerSender, maxGlobal: rateLimiterMaxGlobal },
+    'Dispatch rate limiter initialized',
+  );
+
   // 7. Dispatcher — subscribes to inbound.message + agent.response.
   // Registered after the coordinator so agent.task already has a handler
   // when the dispatcher fans the first inbound message out.
@@ -760,6 +778,7 @@ async function main(): Promise<void> {
     heldMessages,
     channelPolicies: authConfig?.channelPolicies,
     injectionScanner,
+    rateLimiter,
     pool,
     conversationCheckpointDebounceMs: yamlConfig.dispatch?.conversationCheckpointDebounceMs,
     trustScorerWeights,

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -547,3 +547,199 @@ describe('Dispatcher — contact.unknown event payload', () => {
     expect(unknownEvents[0]!.payload.routingDecision).toBe('allow');
   });
 });
+
+describe('Dispatcher — rate limiting', () => {
+  it('drops messages once per-sender limit is exceeded and publishes message.rejected (sender_rate_limited)', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    // Limit each sender to 2 messages per window; global is generous so it doesn't interfere.
+    const { RateLimiter } = await import('../../../src/dispatch/rate-limiter.js');
+    const rateLimiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 2, maxGlobal: 1000 });
+
+    const dispatcher = new Dispatcher({ bus, logger, rateLimiter });
+    dispatcher.register();
+
+    const tasks: AgentTaskEvent[] = [];
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => { tasks.push(e as AgentTaskEvent); });
+    bus.subscribe('message.rejected', 'channel', (e) => { rejected.push(e as MessageRejectedEvent); });
+
+    const send = (n: number) => bus.publish('channel', createInboundMessage({
+      conversationId: `conv-rl-sender-${n}`,
+      channelId: 'cli',
+      senderId: 'alice',
+      content: `Message ${n}`,
+    }));
+
+    // First two messages are within limit
+    await send(1);
+    await send(2);
+    // Third message exceeds the per-sender limit of 2
+    await send(3);
+
+    // Only 2 tasks dispatched to coordinator; 3rd was dropped
+    expect(tasks).toHaveLength(2);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]!.payload.reason).toBe('sender_rate_limited');
+    expect(rejected[0]!.payload.channelId).toBe('cli');
+  });
+
+  it('a different sender is not blocked by another sender hitting their limit', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const { RateLimiter } = await import('../../../src/dispatch/rate-limiter.js');
+    const rateLimiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 1, maxGlobal: 1000 });
+
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'OK',
+        usage: { inputTokens: 1, outputTokens: 1 },
+      }),
+    };
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a helpful assistant.',
+      provider: mockProvider,
+      bus,
+      logger,
+    });
+    coordinator.register();
+
+    const dispatcher = new Dispatcher({ bus, logger, rateLimiter });
+    dispatcher.register();
+
+    const tasks: AgentTaskEvent[] = [];
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => { tasks.push(e as AgentTaskEvent); });
+    bus.subscribe('message.rejected', 'channel', (e) => { rejected.push(e as MessageRejectedEvent); });
+
+    // alice sends 2 messages — only 1 allowed per window
+    await bus.publish('channel', createInboundMessage({ conversationId: 'c1', channelId: 'cli', senderId: 'alice', content: 'Hi' }));
+    await bus.publish('channel', createInboundMessage({ conversationId: 'c2', channelId: 'cli', senderId: 'alice', content: 'Hi again' }));
+
+    // bob sends 1 message — his window is independent of alice's
+    await bus.publish('channel', createInboundMessage({ conversationId: 'c3', channelId: 'cli', senderId: 'bob', content: 'Hello' }));
+
+    // 1 from alice + 1 from bob reach the coordinator; alice's second is dropped
+    expect(tasks).toHaveLength(2);
+    expect(tasks.map(t => t.payload.senderId)).toEqual(expect.arrayContaining(['alice', 'bob']));
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]!.payload.reason).toBe('sender_rate_limited');
+  });
+
+  it('drops messages from all senders once global limit is exceeded and publishes message.rejected (global_rate_limited)', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    // Global limit of 2, sender limit generous so it doesn't interfere.
+    const { RateLimiter } = await import('../../../src/dispatch/rate-limiter.js');
+    const rateLimiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 1000, maxGlobal: 2 });
+
+    const dispatcher = new Dispatcher({ bus, logger, rateLimiter });
+    dispatcher.register();
+
+    const tasks: AgentTaskEvent[] = [];
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => { tasks.push(e as AgentTaskEvent); });
+    bus.subscribe('message.rejected', 'channel', (e) => { rejected.push(e as MessageRejectedEvent); });
+
+    // Three different senders — global fills after 2
+    const senders = ['alice', 'bob', 'carol'];
+    for (const sender of senders) {
+      await bus.publish('channel', createInboundMessage({
+        conversationId: `conv-global-${sender}`,
+        channelId: 'cli',
+        senderId: sender,
+        content: 'Hello',
+      }));
+    }
+
+    // Only 2 tasks dispatched; carol's message was dropped by the global limit
+    expect(tasks).toHaveLength(2);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]!.payload.reason).toBe('global_rate_limited');
+  });
+
+  it('global rate limit fires before contact resolution — second message from any sender is dropped', async () => {
+    // Verifies the global check runs at the very start of handleInbound, before contact
+    // resolution or policy gates. No contact resolver is wired here — the test isolates
+    // the global counter behaviour from all other dispatch logic.
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const { RateLimiter } = await import('../../../src/dispatch/rate-limiter.js');
+    // Global limit of 1 — second message (from any sender) hits the global limit
+    const rateLimiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 1000, maxGlobal: 1 });
+
+    const dispatcher = new Dispatcher({ bus, logger, rateLimiter });
+    dispatcher.register();
+
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('message.rejected', 'channel', (e) => { rejected.push(e as MessageRejectedEvent); });
+
+    // First message — allowed by global limit
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-global-first',
+      channelId: 'cli',
+      senderId: 'alice',
+      content: 'First',
+    }));
+
+    // Second message from a different sender — global is exhausted
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-global-second',
+      channelId: 'cli',
+      senderId: 'bob',
+      content: 'Second',
+    }));
+
+    // The second rejection is due to global rate limit, not any other policy
+    const globalRejected = rejected.filter(r => r.payload.reason === 'global_rate_limited');
+    expect(globalRejected).toHaveLength(1);
+  });
+
+  it('per-sender limit fires after policy gates — does not block blocked senders twice', async () => {
+    // Blocked senders are already dropped at the policy gate and never reach the
+    // per-sender rate limiter. This test verifies that a blocked sender's drop
+    // produces a blocked_sender rejection, not a sender_rate_limited one.
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const { RateLimiter } = await import('../../../src/dispatch/rate-limiter.js');
+    // Per-sender limit of 1 — if the blocked sender were to reach the rate limiter,
+    // their second message would produce a sender_rate_limited rejection instead.
+    const rateLimiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 1, maxGlobal: 1000 });
+
+    const mockResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        resolved: true,
+        contactId: 'blocked-id',
+        displayName: 'Bad Actor',
+        role: null,
+        status: 'blocked',
+        verified: false,
+        kgNodeId: null,
+        knowledgeSummary: '',
+        authorization: null,
+      } satisfies InboundSenderContext),
+    } as unknown as ContactResolver;
+
+    const dispatcher = new Dispatcher({ bus, logger, contactResolver: mockResolver, rateLimiter });
+    dispatcher.register();
+
+    const rejected: MessageRejectedEvent[] = [];
+    bus.subscribe('message.rejected', 'channel', (e) => { rejected.push(e as MessageRejectedEvent); });
+
+    // Send two messages from the blocked sender
+    await bus.publish('channel', createInboundMessage({ conversationId: 'c1', channelId: 'cli', senderId: 'bad-actor', content: 'Hi' }));
+    await bus.publish('channel', createInboundMessage({ conversationId: 'c2', channelId: 'cli', senderId: 'bad-actor', content: 'Hi again' }));
+
+    // Both rejections must come from the blocked-sender gate, not the rate limiter
+    expect(rejected).toHaveLength(2);
+    expect(rejected.every(r => r.payload.reason === 'blocked_sender')).toBe(true);
+  });
+});

--- a/tests/unit/dispatch/rate-limiter.test.ts
+++ b/tests/unit/dispatch/rate-limiter.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RateLimiter } from '../../../src/dispatch/rate-limiter.js';
+
+describe('RateLimiter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // -- Global rate limit --
+
+  describe('checkGlobal()', () => {
+    it('allows messages up to the global limit', () => {
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 15, maxGlobal: 3 });
+
+      expect(limiter.checkGlobal()).toBe(true);
+      expect(limiter.checkGlobal()).toBe(true);
+      expect(limiter.checkGlobal()).toBe(true);
+    });
+
+    it('blocks messages once global limit is reached', () => {
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 15, maxGlobal: 2 });
+
+      expect(limiter.checkGlobal()).toBe(true);
+      expect(limiter.checkGlobal()).toBe(true);
+      // 3rd message exceeds limit of 2
+      expect(limiter.checkGlobal()).toBe(false);
+      expect(limiter.checkGlobal()).toBe(false);
+    });
+
+    it('does not increment the counter when the limit is exceeded', () => {
+      // With a limit of 1, the second and third calls should both return false —
+      // rejected messages must not consume quota (otherwise 1 bad message would
+      // permanently block all future messages until the window resets).
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 15, maxGlobal: 1 });
+
+      expect(limiter.checkGlobal()).toBe(true);   // count: 1 (at limit)
+      expect(limiter.checkGlobal()).toBe(false);  // rejected, count remains 1
+      expect(limiter.checkGlobal()).toBe(false);  // still rejected
+    });
+
+    it('resets the window after windowMs elapses', async () => {
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 15, maxGlobal: 2 });
+
+      expect(limiter.checkGlobal()).toBe(true);
+      expect(limiter.checkGlobal()).toBe(true);
+      expect(limiter.checkGlobal()).toBe(false); // blocked
+
+      // Advance time past the window boundary
+      await vi.advanceTimersByTimeAsync(60_001);
+
+      // Window has reset — new messages are allowed again
+      expect(limiter.checkGlobal()).toBe(true);
+      expect(limiter.checkGlobal()).toBe(true);
+      expect(limiter.checkGlobal()).toBe(false); // blocked again in new window
+    });
+  });
+
+  // -- Per-sender rate limit --
+
+  describe('checkSender()', () => {
+    it('allows messages up to the per-sender limit', () => {
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 3, maxGlobal: 100 });
+
+      expect(limiter.checkSender('alice')).toBe(true);
+      expect(limiter.checkSender('alice')).toBe(true);
+      expect(limiter.checkSender('alice')).toBe(true);
+    });
+
+    it('blocks messages once per-sender limit is reached', () => {
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 2, maxGlobal: 100 });
+
+      expect(limiter.checkSender('alice')).toBe(true);
+      expect(limiter.checkSender('alice')).toBe(true);
+      expect(limiter.checkSender('alice')).toBe(false); // 3rd exceeds limit of 2
+    });
+
+    it('tracks senders independently', () => {
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 1, maxGlobal: 100 });
+
+      // alice uses her one message
+      expect(limiter.checkSender('alice')).toBe(true);
+      expect(limiter.checkSender('alice')).toBe(false); // blocked
+
+      // bob has his own independent window — not affected by alice
+      expect(limiter.checkSender('bob')).toBe(true);
+      expect(limiter.checkSender('bob')).toBe(false); // blocked
+    });
+
+    it('does not increment the counter when the sender limit is exceeded', () => {
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 1, maxGlobal: 100 });
+
+      expect(limiter.checkSender('alice')).toBe(true);
+      expect(limiter.checkSender('alice')).toBe(false);
+      expect(limiter.checkSender('alice')).toBe(false); // still false, not incrementing
+    });
+
+    it('resets per-sender window after windowMs elapses', async () => {
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 1, maxGlobal: 100 });
+
+      expect(limiter.checkSender('alice')).toBe(true);
+      expect(limiter.checkSender('alice')).toBe(false); // blocked
+
+      await vi.advanceTimersByTimeAsync(60_001);
+
+      // Window reset — alice is allowed again
+      expect(limiter.checkSender('alice')).toBe(true);
+      expect(limiter.checkSender('alice')).toBe(false); // blocked again
+    });
+  });
+
+  // -- Global and per-sender limits are independent --
+
+  describe('global and per-sender limits are independent', () => {
+    it('global limit can be hit while individual senders are below their limit', () => {
+      // Global limit 2, sender limit 5
+      // Two different senders send one message each — global fills up,
+      // but neither sender has hit their personal limit.
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 5, maxGlobal: 2 });
+
+      expect(limiter.checkGlobal()).toBe(true);   // 1/2 global
+      expect(limiter.checkSender('alice')).toBe(true);  // 1/5 alice
+
+      expect(limiter.checkGlobal()).toBe(true);   // 2/2 global (at limit)
+      expect(limiter.checkSender('bob')).toBe(true);    // 1/5 bob
+
+      // Global is now exhausted — but per-sender checks are independent
+      expect(limiter.checkGlobal()).toBe(false);
+      // alice and bob can still pass their per-sender check (checked separately by dispatcher)
+      expect(limiter.checkSender('alice')).toBe(true);
+    });
+
+    it('sender limit can be hit while global still has capacity', () => {
+      const limiter = new RateLimiter({ windowMs: 60_000, maxPerSender: 1, maxGlobal: 100 });
+
+      expect(limiter.checkGlobal()).toBe(true);  // global: 1/100
+      expect(limiter.checkSender('alice')).toBe(true);  // alice: 1/1
+
+      expect(limiter.checkGlobal()).toBe(true);  // global: 2/100
+      expect(limiter.checkSender('alice')).toBe(false); // alice: blocked
+
+      // bob is a different sender and is unaffected
+      expect(limiter.checkSender('bob')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **New `RateLimiter` class** (`src/dispatch/rate-limiter.ts`) — in-memory fixed-window counter following the `InboundScanner` pattern. Two independent checks: `checkGlobal()` and `checkSender(senderId)`.
- **Global limit (default 100/min)** — fires at the very start of `handleInbound()`, before contact resolution and policy gates, to catch aggregate DoS floods as early as possible.
- **Per-sender limit (default 15/min)** — fires after policy gates so blocked/held senders (already dropped) don't consume quota for legitimate senders.
- Excess messages are dropped silently; violations are audit-logged as `message.rejected` with reason `global_rate_limited` or `sender_rate_limited`, and logged at `warn` level via pino.
- All three parameters (`window_ms`, `max_per_sender`, `max_global`) are configurable in `config/default.yaml` under `dispatch.rate_limit`, with startup validation (positive integers; `max_global >= max_per_sender`).

## Files changed

| File | Change |
|------|--------|
| `src/dispatch/rate-limiter.ts` | New — `RateLimiter` class |
| `src/dispatch/dispatcher.ts` | Global check at top of `handleInbound()`; per-sender check after policy gates |
| `src/bus/events.ts` | Added `'global_rate_limited' \| 'sender_rate_limited'` to `MessageRejectedPayload.reason` |
| `src/config.ts` | Added `rate_limit` sub-object to `YamlConfig.dispatch`; validation in `loadYamlConfig` |
| `config/default.yaml` | Added `dispatch.rate_limit` section with documented defaults |
| `src/index.ts` | Constructs `RateLimiter` from config; passes to `Dispatcher` |
| `tests/unit/dispatch/rate-limiter.test.ts` | New — 11 unit tests for `RateLimiter` in isolation |
| `tests/unit/dispatch/dispatcher.test.ts` | 5 new dispatcher integration tests for rate limiting |

## Dependency note

This PR adds `'global_rate_limited' | 'sender_rate_limited'` to the `MessageRejectedPayload.reason` union — a public bus event type. PR #263 (input validation) is touching the same `config/default.yaml` structure. This PR does not conflict with #263 but should be reviewed in that context. The YAML schema update contemplated in #263 should include the new `dispatch.rate_limit` keys once that PR lands.

## Test plan

- [x] `tests/unit/dispatch/rate-limiter.test.ts` — 11 tests: allows up to limit, blocks at limit, no counter increment on rejection, window reset, independent per-sender tracking, global/sender independence
- [x] `tests/unit/dispatch/dispatcher.test.ts` — 5 new tests: per-sender drop + audit event; independent sender windows; global drop + audit event; global fires before contact resolution; per-sender does not double-drop blocked senders
- [x] Full test suite: 1204 passed, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dispatch-layer rate limiting with configurable global and per-sender limits to prevent message flooding.
  * Rate-limited requests return HTTP 429 status code; excess messages are silently dropped and logged.
  * Configuration available via dispatch settings with customizable window duration and thresholds.

* **Documentation**
  * Updated security specifications and changelog documenting rate-limiting behaviour and rejection reasons.

* **Tests**
  * Added comprehensive test coverage for rate-limiting functionality and rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->