### PR TITLE
fix: add dispatch.rate_limit to default-config schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Agent and skill loaders** — manual field checks removed; validation is now handled by the startup validator schema.
 
 ### Fixed
+- **`dispatch.rate_limit` missing from `default-config.schema.json`** — the rate-limit config block added in this release was not declared in the schema, causing startup validation to reject the config with `additionalProperties` on every deploy. Schema now allows `window_ms`, `max_per_sender`, and `max_global` under `dispatch.rate_limit`.
 - **Delegate skill timeout now wired to `expected_duration_seconds`** — the delegate skill
   previously used a hardcoded 90-second timeout regardless of job type, causing long-running
   scheduled specialists (e.g. writing-scout doing many web-fetch calls) to time out and retry

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -43,7 +43,16 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "conversationCheckpointDebounceMs": { "type": "integer", "minimum": 1 }
+        "conversationCheckpointDebounceMs": { "type": "integer", "minimum": 1 },
+        "rate_limit": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "window_ms": { "type": "integer", "minimum": 1 },
+            "max_per_sender": { "type": "integer", "minimum": 1 },
+            "max_global": { "type": "integer", "minimum": 1 }
+          }
+        }
       }
     },
     "workingMemory": {


### PR DESCRIPTION
## Summary

- PR #265 added `dispatch.rate_limit` to `config/default.yaml` but never added it to `schemas/default-config.schema.json`.
- With startup validation now enforced (also part of that same PR), the schema's `additionalProperties: false` on the `dispatch` block rejects the config on every deploy, making the container immediately unhealthy.

## Test plan

- [ ] Merge and deploy — container should pass its healthcheck
- [ ] Confirm `docker logs curia` shows no validation errors at startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rate limiting configuration is now properly recognized and configurable in the default settings.
  * Delegate skill timeout handling has been improved to respect task duration hints with a 90-second default and extended execution timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->