### PR TITLE
feat: data sensitivity classification on KG nodes (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ bus event types) are noted explicitly even in the `0.x` range.
   spec §06 security checklist. Closes #198.
 
 ### Added
+- **Data sensitivity tags on KG nodes** — every KG node now carries a `sensitivity` field (`public | internal | confidential | restricted`). `EntityMemory.createEntity()` and `storeFact()` auto-classify content via `SensitivityClassifier` using keyword rules loaded from `config/default.yaml` (`sensitivity_rules`). Explicit caller overrides always win. Sensitivity is threaded through `memory.store` audit events, enabling downstream gating (e.g. bulk export). Closes #200.
 - **Intent drift detection** — after each burst of a persistent scheduled task, an LLM judge compares the current `task_payload` against the original `intent_anchor`. Tasks that drift with sufficient confidence are paused, and a follow-up `agent.task` is dispatched to the coordinator to notify the CEO (spec §06-audit-and-security.md). Configured via `intentDrift:` block in `config/default.yaml`.
 - **`schemas/` directory** — JSON Schema files for agent configs, skill manifests, and `config/default.yaml`. Schemas are legible without TypeScript and can be validated with third-party tools.
 - **`channels.max_message_bytes`** in `config/default.yaml` — configures the inbound message size limit (default `102400`).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.16.0-blueviolet" alt="Version: 0.16.0" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.16.4-blueviolet" alt="Version: 0.16.4" /></a>
   <img src="https://img.shields.io/badge/status-pre--alpha-orange" alt="Status: Pre-Alpha" />
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License: MIT" />
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node >= 22" />

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -275,6 +275,13 @@ system_prompt: |
     honest answer ("I'm an AI assistant with access to your contacts, email, and a
     research team") without naming specific systems or tools.
 
+  ## Data Protection
+  Never bulk-export sensitive data without explicit confirmation.
+  If asked to share confidential information with a new or unrecognised
+  destination, verify through a high-trust channel first.
+  When in doubt about the scope of a data request, ask for clarification
+  rather than exporting everything that matches.
+
   ## Guidelines
   - For casual messages, respond naturally and warmly
   - Handle tasks within your capability directly

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -165,3 +165,126 @@ intentDrift:
   enabled: true
   checkEveryNBursts: 1
   minConfidenceToPause: high
+
+# Sensitivity classification rules for KG nodes (issue #200).
+# Rules are evaluated in descending sensitivity order — 'restricted' rules are
+# checked before 'confidential', so the most protective rule always wins.
+# Add patterns in lowercase; matching is case-insensitive substring search across
+# the node label and all string property values.
+sensitivity_rules:
+  # Credentials — blocked from bulk export entirely
+  - category: credentials
+    sensitivity: restricted
+    patterns:
+      - password
+      - api key
+      - api_key
+      - secret key
+      - private key
+      - access token
+      - credential
+      - ssh key
+      - client secret
+
+  # Board-level materials — blocked from bulk export
+  - category: board
+    sensitivity: restricted
+    patterns:
+      - board meeting
+      - board decision
+      - board of directors
+      - shareholder
+      - equity grant
+      - executive compensation
+      - option grant
+      - cap table
+
+  # Litigation — blocked from bulk export
+  - category: litigation
+    sensitivity: restricted
+    patterns:
+      - lawsuit
+      - litigation
+      - legal hold
+      - court order
+      - subpoena
+      - deposition
+      - opposing counsel
+      - legal dispute
+
+  # Corporate strategy — blocked from bulk export
+  - category: strategy
+    sensitivity: restricted
+    patterns:
+      - acquisition
+      - divestiture
+      - investment banker
+      - ipo
+      - merger
+      - strategic review
+      - takeover
+      - going public
+
+  # Financial data — requires approval to export
+  - category: financial
+    sensitivity: confidential
+    patterns:
+      - salary
+      - compensation
+      - budget
+      - revenue
+      - invoice
+      - payment
+      - profit
+      - loss
+      - financial statement
+      - bank account
+      - payroll
+      - expense report
+      - annual report
+
+  # Contracts and legal agreements — requires approval to export
+  - category: contract
+    sensitivity: confidential
+    patterns:
+      - contract
+      - nda
+      - non-disclosure
+      - statement of work
+      - sow
+      - master service agreement
+      - msa
+      - agreement signed
+      - binding agreement
+
+  # HR matters — requires approval to export
+  - category: hr
+    sensitivity: confidential
+    patterns:
+      - performance review
+      - performance improvement plan
+      - pip
+      - termination
+      - resignation
+      - headcount
+      - layoff
+      - reduction in force
+      - rif
+      - compensation band
+      - hiring plan
+      - offer letter
+
+  # Personal identifiers — requires approval to export
+  - category: personal
+    sensitivity: confidential
+    patterns:
+      - sin number
+      - social insurance
+      - ssn
+      - social security
+      - passport number
+      - date of birth
+      - health condition
+      - medical record
+      - home address
+      - personal phone

--- a/docs/specs/06-audit-and-security.md
+++ b/docs/specs/06-audit-and-security.md
@@ -364,5 +364,5 @@ These are non-negotiable for launch.
 | Unknown sender → `hold_and_notify` path covered by integration test (in-memory `HeldMessageService`, verifies score, event payload, and store write) | Done (#254) |
 | Trust score floor: messages below `security.trust_score_floor` (default 0.2) trigger `hold_and_notify` regardless of per-channel policy | Done |
 | Trust-gated action thresholds use `messageTrustScore` numeric values, enforced via Coordinator system prompt | Done |
-| Data sensitivity tags on knowledge graph entities | Not Done |
+| Data sensitivity tags on knowledge graph entities | Done (#200) |
 | Bulk export gates active for confidential+ data | Not Done |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -125,6 +125,7 @@
     },
     "sensitivity_rules": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "required": ["category", "sensitivity", "patterns"],

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -114,6 +114,32 @@
         "information_queries": { "type": "number", "minimum": 0, "maximum": 1 }
       }
     },
+    "intentDrift": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "checkEveryNBursts": { "type": "integer", "minimum": 1 },
+        "minConfidenceToPause": { "type": "string", "enum": ["high", "medium", "low"] }
+      }
+    },
+    "sensitivity_rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["category", "sensitivity", "patterns"],
+        "additionalProperties": false,
+        "properties": {
+          "category": { "type": "string", "minLength": 1 },
+          "sensitivity": { "type": "string", "enum": ["public", "internal", "confidential", "restricted"] },
+          "patterns": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
     "pii": {
       "type": "object",
       "additionalProperties": false,

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -485,9 +485,13 @@ export class AgentRuntime {
         await bus.publish('agent', invokeEvent);
 
         const startTime = Date.now();
+        // Thread task context so the execution layer can emit memory.store audit events
+        // for any KG writes that happen inside this skill invocation (#200).
         const result = await executionLayer.invoke(toolCall.name, skillInput, caller, {
           taskEventId: taskEvent.id,
           agentId,
+          conversationId,
+          parentEventId: invokeEvent.id,
         });
         const durationMs = Date.now() - startTime;
 

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import type { ErrorType } from '../errors/types.js';
 import type { DedupConfidence } from '../contacts/types.js';
+import type { Sensitivity } from '../memory/types.js';
 
 // -- Base event shape --
 // Every event on the bus shares these fields; parentEventId forms the causal chain.
@@ -192,6 +193,8 @@ interface MemoryStorePayload {
   nodeType: string;
   label: string;
   source: string;
+  /** Sensitivity level assigned to the node at creation time (#200). */
+  sensitivity: Sensitivity;
 }
 
 interface MemoryQueryPayload {

--- a/src/db/migrations/014_add_kg_node_sensitivity.sql
+++ b/src/db/migrations/014_add_kg_node_sensitivity.sql
@@ -1,0 +1,24 @@
+-- Up Migration
+
+-- Add sensitivity classification to KG nodes per issue #200.
+-- This is the foundational piece for bulk export controls (#201).
+--
+-- Default is 'internal' — the least permissive safe default that still allows
+-- normal operations. Callers that don't specify a sensitivity level get 'internal',
+-- not 'public', so unclassified data is protected by default.
+--
+-- Valid values: 'public' | 'internal' | 'confidential' | 'restricted'
+-- Enforced both at the DB level (CHECK constraint) and the application layer
+-- (Sensitivity type in src/memory/types.ts) so that direct SQL writes and
+-- future code paths cannot persist an invalid value that would confuse export gates.
+
+ALTER TABLE kg_nodes ADD COLUMN sensitivity TEXT NOT NULL DEFAULT 'internal'
+  CHECK (sensitivity IN ('public', 'internal', 'confidential', 'restricted'));
+
+-- Index for export gate queries: "give me all nodes above sensitivity X"
+CREATE INDEX idx_kg_nodes_sensitivity ON kg_nodes (sensitivity);
+
+-- Down Migration
+
+DROP INDEX IF EXISTS idx_kg_nodes_sensitivity;
+ALTER TABLE kg_nodes DROP COLUMN IF EXISTS sensitivity;

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,25 +207,27 @@ async function main(): Promise<void> {
   // If not configured, agents still work — they just don't have KG access.
   let entityMemory: EntityMemory | undefined;
   if (config.openaiApiKey) {
-    const embeddingService = EmbeddingService.createWithOpenAI(config.openaiApiKey, logger);
-    const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
-    const validator = new MemoryValidator(kgStore, embeddingService);
-
     // Sensitivity classifier — loads rules from config/default.yaml at startup (#200).
-    // Used by EntityMemory to auto-classify KG nodes based on content. Rules are
-    // loaded once here so YAML parsing doesn't happen on every node creation.
-    // Scoped inside the openai block so deployments without KG don't fail on a
-    // missing or misconfigured config file.
-    let sensitivityClassifier: SensitivityClassifier | undefined;
+    // Resolved from __dirname so the path is stable regardless of which directory the
+    // process was launched from (systemd, Docker, worktree, test harness, etc.).
+    // Fail fast with a structured log if the file is missing or malformed — the service
+    // cannot safely protect sensitive data without classification rules.
+    let sensitivityClassifier: SensitivityClassifier;
+    const sensitivityConfigPath = path.resolve(import.meta.dirname, '../config/default.yaml');
     try {
-      const sensitivityConfigPath = path.resolve(import.meta.dirname, '../config/default.yaml');
       sensitivityClassifier = SensitivityClassifier.fromYaml(sensitivityConfigPath);
-      logger.info('Sensitivity classifier loaded');
+      logger.info({ configPath: sensitivityConfigPath }, 'Sensitivity classifier loaded');
     } catch (err) {
-      logger.fatal({ err, configPath: 'config/default.yaml' }, 'Failed to load sensitivity classifier — check config/default.yaml syntax and sensitivity_rules section');
+      logger.fatal(
+        { err, configPath: sensitivityConfigPath },
+        'Failed to load sensitivity classifier — check that config/default.yaml exists and contains a valid sensitivity_rules array',
+      );
       process.exit(1);
     }
 
+    const embeddingService = EmbeddingService.createWithOpenAI(config.openaiApiKey, logger);
+    const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
+    const validator = new MemoryValidator(kgStore, embeddingService);
     entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger, sensitivityClassifier);
     logger.info('Entity memory initialized with knowledge graph');
   } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ import { bootstrapCeoContact } from './contacts/ceo-bootstrap.js';
 import { AutonomyService } from './autonomy/autonomy-service.js';
 import { BrowserService } from './browser/browser-service.js';
 import { OfficeIdentityService } from './identity/service.js';
+import { SensitivityClassifier } from './memory/sensitivity.js';
 import type { AgentPersona } from './skills/types.js';
 import type { ConfigChangeEvent } from './bus/events.js';
 import { BullpenService } from './memory/bullpen.js';
@@ -209,7 +210,23 @@ async function main(): Promise<void> {
     const embeddingService = EmbeddingService.createWithOpenAI(config.openaiApiKey, logger);
     const kgStore = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, logger);
     const validator = new MemoryValidator(kgStore, embeddingService);
-    entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger);
+
+    // Sensitivity classifier — loads rules from config/default.yaml at startup (#200).
+    // Used by EntityMemory to auto-classify KG nodes based on content. Rules are
+    // loaded once here so YAML parsing doesn't happen on every node creation.
+    // Scoped inside the openai block so deployments without KG don't fail on a
+    // missing or misconfigured config file.
+    let sensitivityClassifier: SensitivityClassifier | undefined;
+    try {
+      const sensitivityConfigPath = path.resolve(import.meta.dirname, '../config/default.yaml');
+      sensitivityClassifier = SensitivityClassifier.fromYaml(sensitivityConfigPath);
+      logger.info('Sensitivity classifier loaded');
+    } catch (err) {
+      logger.fatal({ err, configPath: 'config/default.yaml' }, 'Failed to load sensitivity classifier — check config/default.yaml syntax and sensitivity_rules section');
+      process.exit(1);
+    }
+
+    entityMemory = new EntityMemory(kgStore, validator, embeddingService, logger, sensitivityClassifier);
     logger.info('Entity memory initialized with knowledge graph');
   } else {
     logger.warn('OPENAI_API_KEY not set — entity memory disabled (knowledge graph unavailable)');

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -6,6 +6,7 @@ import type { KnowledgeGraphStore } from './knowledge-graph.js';
 import type { EmbeddingService } from './embedding.js';
 import type { MemoryValidator } from './validation.js';
 import type { Logger } from '../logger.js';
+import { maxSensitivity } from './sensitivity.js';
 import type { SensitivityClassifier } from './sensitivity.js';
 import type {
   KgNode,
@@ -312,28 +313,35 @@ export class EntityMemory {
 
       case 'update': {
         // Near-duplicate detected — merge properties into the existing node.
-        // Sensitivity is not updated on merge; the original classification stands.
         await this.store.updateNode(result.existingNodeId, {
           properties: result.mergedProperties,
         });
         this.validator.recordWrite(options.source);
 
-        // Read the existing node's sensitivity for the audit event.
+        // Read the existing node after the merge to get the current state.
         // A successful updateNode followed by a missing getNode is unexpected — flag it
         // via sensitivityFallback so the caller (execution layer observer) can log a
-        // warning. We still emit the audit event rather than dropping it, but the
-        // sensitivity is re-classified from the incoming options and may differ from
-        // the node's original classification.
+        // warning. We still emit the audit event rather than dropping it.
         const existingNode = await this.store.getNode(result.existingNodeId);
         const sensitivityFallback = existingNode === undefined;
-        const sensitivity: Sensitivity = existingNode?.sensitivity
-          ?? options.sensitivity
+        const existingSensitivity: Sensitivity = existingNode?.sensitivity ?? 'internal';
+
+        // Ratchet: merged content can only increase sensitivity, never decrease.
+        // A near-duplicate that adds PII or financial data must be persisted at the
+        // higher level — keeping the original classification would silently under-protect.
+        const incomingSensitivity: Sensitivity = options.sensitivity
           ?? this.sensitivityClassifier?.classify(
             options.label,
-            options.properties ?? {},
+            result.mergedProperties ?? options.properties ?? {},
             options.sensitivityCategory,
           )
           ?? 'internal';
+        const sensitivity = maxSensitivity(existingSensitivity, incomingSensitivity);
+
+        if (!sensitivityFallback && sensitivity !== existingSensitivity) {
+          await this.store.updateNode(result.existingNodeId, { sensitivity });
+        }
+
         return { stored: true, nodeId: result.existingNodeId, sensitivity, sensitivityFallback };
       }
 

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -319,15 +319,11 @@ export class EntityMemory {
         this.validator.recordWrite(options.source);
 
         // Read the existing node's sensitivity for the audit event.
-        // If the node is unexpectedly missing (race condition or transient DB error),
-        // fall back to re-classifying from the incoming options rather than returning
-        // undefined — a missing sensitivity would silently suppress the audit event.
-        // Read the existing node's sensitivity for the audit event.
         // A successful updateNode followed by a missing getNode is unexpected — flag it
-        // via sensitivityFallback so the caller (execution layer observer) can log a warning.
-        // We still emit the audit event rather than dropping it, but the sensitivity is
-        // re-classified from the incoming options and may differ from the node's original
-        // classification.
+        // via sensitivityFallback so the caller (execution layer observer) can log a
+        // warning. We still emit the audit event rather than dropping it, but the
+        // sensitivity is re-classified from the incoming options and may differ from
+        // the node's original classification.
         const existingNode = await this.store.getNode(result.existingNodeId);
         const sensitivityFallback = existingNode === undefined;
         const sensitivity: Sensitivity = existingNode?.sensitivity

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -6,11 +6,13 @@ import type { KnowledgeGraphStore } from './knowledge-graph.js';
 import type { EmbeddingService } from './embedding.js';
 import type { MemoryValidator } from './validation.js';
 import type { Logger } from '../logger.js';
+import type { SensitivityClassifier } from './sensitivity.js';
 import type {
   KgNode,
   KgEdge,
   NodeType,
   EdgeType,
+  Sensitivity,
   StoreFactOptions,
   SearchResult,
 } from './types.js';
@@ -33,12 +35,24 @@ export interface CreateEntityOptions {
   // Pass a lower value (e.g. 0.6) when creating nodes from LLM extraction
   // output, where the entity may be a first-time mention with no prior context.
   confidence?: number;
+  // Explicit sensitivity override. When omitted, EntityMemory auto-classifies
+  // the content using SensitivityClassifier and defaults to 'internal'.
+  sensitivity?: Sensitivity;
+  // Optional category hint for the classifier (e.g. 'financial').
+  sensitivityCategory?: string;
 }
 
 export interface StoreFactResult {
   stored: boolean;
   /** The ID of the persisted (or existing) fact node, if stored is true. */
   nodeId?: string;
+  /** The sensitivity level that was assigned to the node (for audit event emission). */
+  sensitivity?: Sensitivity;
+  /** True when the sensitivity was re-classified from incoming content because the stored
+   *  node could not be read back after an update (race condition / transient DB error).
+   *  The emitted audit event sensitivity may differ from what is stored on the node.
+   *  The caller should log a warning when this is true. */
+  sensitivityFallback?: boolean;
   /** Human-readable reason for a conflict or rate-limit rejection. */
   conflict?: string;
 }
@@ -64,6 +78,9 @@ const FACT_TYPE: NodeType = 'fact';
  * Design: EntityMemory owns no storage — it delegates to store and validator.
  * This keeps it thin and testable. The store handles persistence and embeddings;
  * the validator handles rate limiting, deduplication, and contradiction detection.
+ *
+ * The optional SensitivityClassifier (issue #200) auto-assigns sensitivity to nodes
+ * when the caller does not specify one. Without a classifier, nodes default to 'internal'.
  */
 export class EntityMemory {
   constructor(
@@ -74,6 +91,7 @@ export class EntityMemory {
     // store (createNode embeds labels; semanticSearch embeds query strings internally).
     _embeddingService: EmbeddingService,
     private logger: Logger,
+    private sensitivityClassifier?: SensitivityClassifier,
   ) {}
 
   /**
@@ -85,14 +103,22 @@ export class EntityMemory {
    * a duplicate. The `created` flag lets callers distinguish first-insert
    * from re-assertion, which is useful for applying defaults (e.g. roles in
    * ContactService) without overwriting data set by a later, richer call.
+   *
+   * Sensitivity is auto-classified from the label + properties unless explicitly
+   * provided by the caller.
    */
   async createEntity(options: CreateEntityOptions): Promise<{ entity: KgNode; created: boolean }> {
+    const sensitivity: Sensitivity = options.sensitivity
+      ?? this.sensitivityClassifier?.classify(options.label, options.properties, options.sensitivityCategory)
+      ?? 'internal';
+
     const { node, created } = await this.store.upsertNode({
       type: options.type,
       label: options.label,
       properties: options.properties,
       source: options.source,
       confidence: options.confidence ?? 0.7,
+      sensitivity,
     });
     return { entity: node, created };
   }
@@ -210,9 +236,12 @@ export class EntityMemory {
    * rate limiting → deduplication → (optionally) contradiction detection.
    *
    * Returns:
-   * - { stored: true, nodeId } on create (new fact node + edge persisted)
-   * - { stored: true, nodeId } on update (duplicate merged into existing node)
+   * - { stored: true, nodeId, sensitivity } on create (new fact node + edge persisted)
+   * - { stored: true, nodeId, sensitivity } on update (duplicate merged into existing node)
    * - { stored: false, conflict } on rate-limit rejection or contradiction
+   *
+   * The sensitivity field in the result is what was actually assigned to the node —
+   * the execution layer uses this to populate memory.store audit events.
    *
    * Note: storeFact calls validator.validate(), which handles rate limiting and
    * deduplication but NOT contradiction detection. Contradiction detection
@@ -224,6 +253,17 @@ export class EntityMemory {
 
     switch (result.action) {
       case 'create': {
+        // Resolve sensitivity: caller override → classifier → default 'internal'.
+        // The classifier runs on the fact label and any provided properties so that
+        // content like "Q3 salary plan: $2.4M" is tagged 'confidential' automatically.
+        const sensitivity: Sensitivity = options.sensitivity
+          ?? this.sensitivityClassifier?.classify(
+            options.label,
+            options.properties ?? {},
+            options.sensitivityCategory,
+          )
+          ?? 'internal';
+
         // Persist the fact node, then link it to the entity with a 'relates_to' edge
         // so getFacts() can discover it. store.createNode() returns the persisted node
         // with its assigned ID, so we use that directly for the edge.
@@ -237,6 +277,7 @@ export class EntityMemory {
           // Pass the pre-computed embedding from the validator's dedup check
           // to avoid a redundant OpenAI API call.
           embedding: result.validated.embedding,
+          sensitivity,
         });
 
         // If edge creation fails, the node we just created becomes an orphan
@@ -266,16 +307,38 @@ export class EntityMemory {
         }
 
         this.validator.recordWrite(options.source);
-        return { stored: true, nodeId: persistedNode.id };
+        return { stored: true, nodeId: persistedNode.id, sensitivity };
       }
 
       case 'update': {
         // Near-duplicate detected — merge properties into the existing node.
+        // Sensitivity is not updated on merge; the original classification stands.
         await this.store.updateNode(result.existingNodeId, {
           properties: result.mergedProperties,
         });
         this.validator.recordWrite(options.source);
-        return { stored: true, nodeId: result.existingNodeId };
+
+        // Read the existing node's sensitivity for the audit event.
+        // If the node is unexpectedly missing (race condition or transient DB error),
+        // fall back to re-classifying from the incoming options rather than returning
+        // undefined — a missing sensitivity would silently suppress the audit event.
+        // Read the existing node's sensitivity for the audit event.
+        // A successful updateNode followed by a missing getNode is unexpected — flag it
+        // via sensitivityFallback so the caller (execution layer observer) can log a warning.
+        // We still emit the audit event rather than dropping it, but the sensitivity is
+        // re-classified from the incoming options and may differ from the node's original
+        // classification.
+        const existingNode = await this.store.getNode(result.existingNodeId);
+        const sensitivityFallback = existingNode === undefined;
+        const sensitivity: Sensitivity = existingNode?.sensitivity
+          ?? options.sensitivity
+          ?? this.sensitivityClassifier?.classify(
+            options.label,
+            options.properties ?? {},
+            options.sensitivityCategory,
+          )
+          ?? 'internal';
+        return { stored: true, nodeId: result.existingNodeId, sensitivity, sensitivityFallback };
       }
 
       case 'conflict':
@@ -457,7 +520,7 @@ export class EntityMemory {
     const secondaryFacts = await this.getFacts(secondaryId);
     for (const factNode of secondaryFacts) {
       // Fact content lives in the node label; extra attributes may be in properties.
-      // We propagate the original source so provenance is preserved.
+      // We propagate the original source and sensitivity so provenance is preserved.
       await this.storeFact({
         entityNodeId: primaryId,
         label: factNode.label,
@@ -465,6 +528,9 @@ export class EntityMemory {
         confidence: factNode.temporal.confidence,
         decayClass: factNode.temporal.decayClass,
         source: factNode.temporal.source,
+        // Carry the original sensitivity — don't re-classify on merge since the node's
+        // content hasn't changed.
+        sensitivity: factNode.sensitivity,
       });
     }
 

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -183,7 +183,7 @@ export class KnowledgeGraphStore {
    */
   async updateNode(
     id: string,
-    updates: { label?: string; properties?: Record<string, unknown> },
+    updates: { label?: string; properties?: Record<string, unknown>; sensitivity?: Sensitivity },
   ): Promise<KgNode> {
     const existing = await this.backend.getNode(id);
     if (!existing) {
@@ -196,6 +196,7 @@ export class KnowledgeGraphStore {
       ...existing,
       label: updates.label ?? existing.label,
       properties: updates.properties ?? existing.properties,
+      sensitivity: updates.sensitivity ?? existing.sensitivity,
       // Re-embed if the label changed, otherwise keep existing embedding
       embedding: labelChanged
         ? await this.embeddingService.embed(updates.label!)

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -6,6 +6,7 @@ import type {
   NodeType,
   EdgeType,
   DecayClass,
+  Sensitivity,
   SearchResult,
   TraversalResult,
 } from './types.js';
@@ -25,6 +26,10 @@ export interface CreateNodeOptions {
    *  Used by EntityMemory.storeFact() to avoid double-embedding — the validator
    *  already embedded the label during dedup checks. */
   embedding?: number[];
+  /** Sensitivity classification assigned at creation (#200). EntityMemory resolves
+   *  this via SensitivityClassifier before calling createNode, so this should always
+   *  be set. Defaults to 'internal' if somehow omitted. */
+  sensitivity?: Sensitivity;
 }
 
 export interface CreateEdgeOptions {
@@ -125,6 +130,7 @@ export class KnowledgeGraphStore {
         decayClass: options.decayClass ?? 'slow_decay',
         source: options.source,
       },
+      sensitivity: options.sensitivity ?? 'internal',
     };
 
     await this.backend.createNode(node);
@@ -317,11 +323,11 @@ class PostgresBackend implements KnowledgeGraphBackend {
   constructor(private pool: DbPool, private logger: Logger) {}
 
   async createNode(node: KgNode): Promise<void> {
-    this.logger.debug({ nodeId: node.id, type: node.type }, 'kg: creating node');
+    this.logger.debug({ nodeId: node.id, type: node.type, sensitivity: node.sensitivity }, 'kg: creating node');
     const embeddingStr = node.embedding ? `[${node.embedding.join(',')}]` : null;
     await this.pool.query(
-      `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at)
-       VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $10)`,
+      `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity)
+       VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $10, $11)`,
       [
         node.id,
         node.type,
@@ -333,6 +339,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
         node.temporal.source,
         node.temporal.createdAt,
         node.temporal.lastConfirmedAt,
+        node.sensitivity,
       ],
     );
   }
@@ -341,8 +348,8 @@ class PostgresBackend implements KnowledgeGraphBackend {
     this.logger.debug({ type: node.type, label: node.label }, 'kg: upserting node');
     const embeddingStr = node.embedding ? `[${node.embedding.join(',')}]` : null;
     const result = await this.pool.query<PgNodeRow & { is_new: boolean }>(
-      `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at)
-       VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $9)
+      `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity)
+       VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $9, $10)
        ON CONFLICT (lower(label), type) WHERE type != 'fact'
        DO UPDATE SET
          confidence = GREATEST(kg_nodes.confidence, EXCLUDED.confidence),
@@ -358,6 +365,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
         node.temporal.decayClass,
         node.temporal.source,
         node.temporal.createdAt,
+        node.sensitivity,
       ],
     );
     const row = result.rows[0];
@@ -583,6 +591,7 @@ interface PgNodeRow {
   source: string;
   created_at: Date;
   last_confirmed_at: Date;
+  sensitivity: string;
 }
 
 interface PgEdgeRow {
@@ -612,6 +621,7 @@ function pgRowToNode(row: PgNodeRow): KgNode {
       decayClass: row.decay_class as DecayClass,
       source: row.source,
     },
+    sensitivity: (row.sensitivity as Sensitivity) ?? 'internal',
   };
 }
 

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -166,6 +166,7 @@ export class KnowledgeGraphStore {
         decayClass: options.decayClass ?? 'slow_decay',
         source: options.source,
       },
+      sensitivity: options.sensitivity ?? 'internal',
     };
 
     return this.backend.upsertNode(node);

--- a/src/memory/sensitivity.ts
+++ b/src/memory/sensitivity.ts
@@ -1,0 +1,163 @@
+// sensitivity.ts — content-based sensitivity classification for KG nodes.
+//
+// The SensitivityClassifier inspects a node's label and properties at creation
+// time and assigns a Sensitivity level. Rules are loaded from config/default.yaml
+// at startup so they can be tuned without code changes.
+//
+// Classification is keyword-based: the label and all string property values are
+// concatenated into a single lowercase search string and checked against each
+// rule's pattern list. The most restrictive matching rule wins.
+//
+// When no rule matches, the default is 'internal' — callers that don't specify
+// sensitivity get a conservative default that still allows normal operations.
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import yaml from 'js-yaml';
+import type { Sensitivity } from './types.js';
+import { SENSITIVITY_LEVELS } from './types.js';
+
+// -- Rule shape (mirrors config/default.yaml structure) --
+
+export interface SensitivityRule {
+  /** Human-readable category name, e.g. 'financial', 'hr'. Used for logging only. */
+  category: string;
+  /** Sensitivity level to assign when any pattern matches. */
+  sensitivity: Sensitivity;
+  /** Lowercase keywords to search for in the combined label + property text. */
+  patterns: string[];
+}
+
+// Precedence order: higher index = higher sensitivity (restricted wins over confidential, etc.)
+const SENSITIVITY_ORDER: Record<Sensitivity, number> = {
+  public: 0,
+  internal: 1,
+  confidential: 2,
+  restricted: 3,
+};
+
+/**
+ * Classifies KG node content into a Sensitivity level.
+ *
+ * Instantiate once at startup via SensitivityClassifier.fromYaml() or
+ * SensitivityClassifier.fromRules() (for tests). The instance is stateless
+ * and safe to share across concurrent requests.
+ */
+export class SensitivityClassifier {
+  // Rules sorted highest-sensitivity-first so we can return on first match
+  // when two rules would match the same text.
+  private readonly rules: SensitivityRule[];
+
+  private constructor(rules: SensitivityRule[]) {
+    // Sort descending by sensitivity level so more restrictive rules win.
+    this.rules = [...rules].sort(
+      (a, b) => SENSITIVITY_ORDER[b.sensitivity] - SENSITIVITY_ORDER[a.sensitivity],
+    );
+  }
+
+  /**
+   * Classify a node's content. Returns the highest-sensitivity matching rule,
+   * or 'internal' if no rule matches.
+   *
+   * @param label     The KG node label (fact text, entity name, etc.)
+   * @param properties The node's structured properties
+   * @param overrideCategory Optional category hint from the caller (e.g. 'financial').
+   *                         Checked against rule.category for an exact match before
+   *                         running keyword analysis, allowing skills to opt in to
+   *                         category-based classification without embedding all keywords.
+   */
+  classify(
+    label: string,
+    properties: Record<string, unknown>,
+    overrideCategory?: string,
+  ): Sensitivity {
+    // Build a single searchable text blob from the label and all string property values.
+    // Properties like { value: 'Q3 salary plan' } contribute their text to the search.
+    const searchText = buildSearchText(label, properties);
+
+    for (const rule of this.rules) {
+      // Category hint: exact match against rule.category (e.g. a skill that knows it's
+      // storing financial data can pass category:'financial' to skip keyword scanning).
+      if (overrideCategory && rule.category === overrideCategory) {
+        return rule.sensitivity;
+      }
+
+      if (rule.patterns.some((p) => searchText.includes(p))) {
+        return rule.sensitivity;
+      }
+    }
+
+    return 'internal';
+  }
+
+  /**
+   * Load rules from a YAML config file.
+   *
+   * Expects the YAML to contain a top-level `sensitivity_rules` array where each
+   * entry has `category`, `sensitivity`, and `patterns` fields.
+   *
+   * Validates that all sensitivity values are known levels and throws if any are
+   * unrecognised — misconfigured rules would silently under-protect data otherwise.
+   *
+   * @param configPath Absolute path to the YAML file (e.g. resolve('config/default.yaml'))
+   */
+  static fromYaml(configPath: string): SensitivityClassifier {
+    const raw = readFileSync(configPath, 'utf-8');
+    const parsed = yaml.load(raw) as Record<string, unknown>;
+
+    const rulesRaw = parsed['sensitivity_rules'];
+    if (!Array.isArray(rulesRaw)) {
+      throw new Error(`SensitivityClassifier: 'sensitivity_rules' missing or not an array in ${configPath}`);
+    }
+
+    const rules: SensitivityRule[] = rulesRaw.map((entry: unknown, i: number) => {
+      const e = entry as Record<string, unknown>;
+      const category = String(e['category'] ?? '');
+      const sensitivity = e['sensitivity'] as string;
+      const patterns = e['patterns'];
+
+      if (!category) throw new Error(`sensitivity_rules[${i}]: missing 'category'`);
+      if (!(SENSITIVITY_LEVELS as readonly string[]).includes(sensitivity)) {
+        throw new Error(`sensitivity_rules[${i}]: unknown sensitivity '${sensitivity}'`);
+      }
+      if (!Array.isArray(patterns) || patterns.length === 0) {
+        throw new Error(`sensitivity_rules[${i}]: 'patterns' must be a non-empty array`);
+      }
+
+      return {
+        category,
+        sensitivity: sensitivity as Sensitivity,
+        // Normalise to lowercase at load time so classify() never needs to lowercase patterns.
+        patterns: patterns.map((p: unknown) => String(p).toLowerCase()),
+      };
+    });
+
+    return new SensitivityClassifier(rules);
+  }
+
+  /** Construct directly from a rules array. Useful in tests. */
+  static fromRules(rules: SensitivityRule[]): SensitivityClassifier {
+    return new SensitivityClassifier(rules);
+  }
+}
+
+// -- Internal helpers --
+
+/**
+ * Flatten a node's label and all string-typed property values into a single
+ * lowercase string for keyword matching.
+ *
+ * Only string values are included — numeric IDs, booleans, and nested objects
+ * are not part of the human-readable content and shouldn't trigger keyword rules.
+ */
+function buildSearchText(label: string, properties: Record<string, unknown>): string {
+  const parts: string[] = [label];
+
+  for (const val of Object.values(properties)) {
+    if (typeof val === 'string') {
+      parts.push(val);
+    }
+  }
+
+  return parts.join(' ').toLowerCase();
+}

--- a/src/memory/sensitivity.ts
+++ b/src/memory/sensitivity.ts
@@ -36,6 +36,14 @@ const SENSITIVITY_ORDER: Record<Sensitivity, number> = {
 };
 
 /**
+ * Return whichever sensitivity level is more restrictive.
+ * Used when merging nodes to ensure content can only ratchet sensitivity upward.
+ */
+export function maxSensitivity(a: Sensitivity, b: Sensitivity): Sensitivity {
+  return SENSITIVITY_ORDER[a] >= SENSITIVITY_ORDER[b] ? a : b;
+}
+
+/**
  * Classifies KG node content into a Sensitivity level.
  *
  * Instantiate once at startup via SensitivityClassifier.fromYaml() or
@@ -102,9 +110,12 @@ export class SensitivityClassifier {
    */
   static fromYaml(configPath: string): SensitivityClassifier {
     const raw = readFileSync(configPath, 'utf-8');
-    const parsed = yaml.load(raw) as Record<string, unknown>;
+    const parsed = yaml.load(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`SensitivityClassifier: invalid YAML root in ${configPath}`);
+    }
 
-    const rulesRaw = parsed['sensitivity_rules'];
+    const rulesRaw = (parsed as Record<string, unknown>)['sensitivity_rules'];
     if (!Array.isArray(rulesRaw)) {
       throw new Error(`SensitivityClassifier: 'sensitivity_rules' missing or not an array in ${configPath}`);
     }
@@ -123,11 +134,18 @@ export class SensitivityClassifier {
         throw new Error(`sensitivity_rules[${i}]: 'patterns' must be a non-empty array`);
       }
 
+      // Normalise to lowercase and trim at load time so classify() never needs to.
+      // Reject blank entries: searchText.includes('') is always true, which would
+      // make the rule match unconditionally and override all other classifications.
+      const normalizedPatterns = patterns.map((p: unknown) => String(p).trim().toLowerCase());
+      if (normalizedPatterns.some((p) => p.length === 0)) {
+        throw new Error(`sensitivity_rules[${i}]: patterns must not contain empty values`);
+      }
+
       return {
         category,
         sensitivity: sensitivity as Sensitivity,
-        // Normalise to lowercase at load time so classify() never needs to lowercase patterns.
-        patterns: patterns.map((p: unknown) => String(p).toLowerCase()),
+        patterns: normalizedPatterns,
       };
     });
 

--- a/src/memory/sensitivity.ts
+++ b/src/memory/sensitivity.ts
@@ -12,7 +12,6 @@
 // sensitivity get a conservative default that still allows normal operations.
 
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import yaml from 'js-yaml';
 import type { Sensitivity } from './types.js';
 import { SENSITIVITY_LEVELS } from './types.js';

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from 'node:crypto';
 
+// -- Sensitivity levels from spec (06-audit-and-security.md) --
+// Four levels in ascending order of restriction. Used by export gates (#201)
+// to decide whether bulk export requires approval or is blocked outright.
+export const SENSITIVITY_LEVELS = ['public', 'internal', 'confidential', 'restricted'] as const;
+export type Sensitivity = (typeof SENSITIVITY_LEVELS)[number];
+
 // -- Node types from spec (01-memory-system.md line 61) --
 export const NODE_TYPES = [
   'person',
@@ -62,6 +68,9 @@ export interface KgNode {
   properties: Record<string, unknown>;
   embedding?: number[]; // VECTOR(1536) — undefined until embedded
   temporal: TemporalMetadata;
+  // Sensitivity classification assigned at creation time (#200).
+  // Immutable after creation — changing sensitivity requires a manual data migration.
+  sensitivity: Sensitivity;
 }
 
 // -- Knowledge Graph Edge --
@@ -82,6 +91,12 @@ export interface StoreFactOptions {
   confidence?: number; // defaults to 0.7
   decayClass?: DecayClass; // defaults to 'slow_decay'
   source: string; // provenance: "agent:coordinator/task:abc123/channel:cli"
+  // Explicit sensitivity override. When omitted, EntityMemory auto-classifies
+  // the content using SensitivityClassifier and defaults to 'internal'.
+  sensitivity?: Sensitivity;
+  // Optional category hint passed to the classifier (e.g. 'financial').
+  // Allows skills that know the category of their data to skip keyword scanning.
+  sensitivityCategory?: string;
 }
 
 // -- Validated data for a new fact node, produced by MemoryValidator --

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -29,7 +29,9 @@ import type { ContactService } from '../contacts/contact-service.js';
 import type { OutboundGateway } from './outbound-gateway.js';
 import type { HeldMessageService } from '../contacts/held-messages.js';
 import type { SchedulerService } from '../scheduler/scheduler-service.js';
-import type { EntityMemory } from '../memory/entity-memory.js';
+import type { EntityMemory, CreateEntityOptions, StoreFactResult } from '../memory/entity-memory.js';
+import type { StoreFactOptions } from '../memory/types.js';
+import { createMemoryStore } from '../bus/events.js';
 import type { NylasCalendarClient } from '../channels/calendar/nylas-calendar-client.js';
 import type { EntityContextAssembler } from '../entity-context/assembler.js';
 import type { AutonomyService } from '../autonomy/autonomy-service.js';
@@ -148,7 +150,7 @@ export class ExecutionLayer {
     skillName: string,
     input: Record<string, unknown>,
     caller?: CallerContext,
-    options?: { taskEventId?: string; agentId?: string },
+    options?: { taskEventId?: string; agentId?: string; conversationId?: string; parentEventId?: string },
   ): Promise<SkillResult> {
     const skill = this.registry.get(skillName);
 
@@ -288,9 +290,13 @@ export class ExecutionLayer {
       if (this.schedulerService) {
         ctx.schedulerService = this.schedulerService;
       }
-      // entityMemory is optional — only skills that read/write the knowledge graph need it
+      // entityMemory is optional — only skills that read/write the knowledge graph need it.
+      // When memory audit context and bus are both available, wrap entityMemory in an observer
+      // that emits memory.store audit events after each node creation (Phase 6 / issue #200).
       if (this.entityMemory) {
-        ctx.entityMemory = this.entityMemory;
+        ctx.entityMemory = options?.conversationId && options?.parentEventId && this.bus
+          ? buildEntityMemoryObserver(this.entityMemory, this.bus, options, skillLogger)
+          : this.entityMemory;
       }
       // nylasCalendarClient is optional — only calendar skills need it
       if (this.nylasCalendarClient) {
@@ -447,4 +453,76 @@ export class ExecutionLayer {
       clearTimeout(timer!);
     }
   }
+}
+
+/**
+ * Wrap an EntityMemory instance with an observer that emits memory.store audit
+ * events after each successful node creation (issue #200 / Phase 6).
+ *
+ * Uses prototype delegation: the returned object inherits all EntityMemory methods
+ * from the original instance and only overrides storeFact and createEntity.
+ *
+ * Audit event emission is best-effort — a bus failure logs a warning but does not
+ * fail the skill invocation. The skill's own result is always returned intact.
+ */
+function buildEntityMemoryObserver(
+  entityMemory: EntityMemory,
+  bus: EventBus,
+  invokeOptions: { agentId?: string; conversationId?: string; parentEventId?: string; taskEventId?: string },
+  logger: Logger,
+): EntityMemory {
+  // Object.create(instance) produces an object whose [[Prototype]] is the EntityMemory
+  // instance, so all non-overridden methods are inherited and run with correct 'this'
+  // binding (they find store, validator, etc. on the prototype).
+  const observer = Object.create(entityMemory) as EntityMemory;
+
+  observer.storeFact = async (options: StoreFactOptions): Promise<StoreFactResult> => {
+    const result = await entityMemory.storeFact(options);
+    if (result.stored && result.nodeId && result.sensitivity) {
+      if (result.sensitivityFallback) {
+        logger.warn(
+          { nodeId: result.nodeId },
+          'storeFact: sensitivity fallback used — node could not be read back after update; audit event sensitivity may differ from stored value',
+        );
+      }
+      try {
+        await bus.publish('agent', createMemoryStore({
+          agentId: invokeOptions.agentId,
+          conversationId: invokeOptions.conversationId,
+          nodeId: result.nodeId,
+          nodeType: 'fact',
+          label: options.label,
+          source: options.source,
+          sensitivity: result.sensitivity,
+          parentEventId: invokeOptions.parentEventId,
+        }));
+      } catch (err) {
+        // Audit event failure must not fail the skill — log and continue.
+        logger.warn({ err, nodeId: result.nodeId }, 'memory.store audit event failed to emit');
+      }
+    }
+    return result;
+  };
+
+  observer.createEntity = async (options: CreateEntityOptions) => {
+    const result = await entityMemory.createEntity(options);
+    const { entity } = result;
+    try {
+      await bus.publish('agent', createMemoryStore({
+        agentId: invokeOptions.agentId,
+        conversationId: invokeOptions.conversationId,
+        nodeId: entity.id,
+        nodeType: entity.type,
+        label: entity.label,
+        source: entity.temporal.source,
+        sensitivity: entity.sensitivity,
+        parentEventId: invokeOptions.parentEventId,
+      }));
+    } catch (err) {
+      logger.warn({ err, nodeId: entity.id }, 'memory.store audit event failed to emit');
+    }
+    return result;
+  };
+
+  return observer;
 }

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -471,6 +471,11 @@ function buildEntityMemoryObserver(
   invokeOptions: { agentId?: string; conversationId?: string; parentEventId?: string; taskEventId?: string },
   logger: Logger,
 ): EntityMemory {
+  // Callers must ensure parentEventId is truthy before calling this function (see line 297).
+  // Capturing it here narrows the type from string | undefined to string so TypeScript
+  // can verify that createMemoryStore (which requires parentEventId: string) is satisfied.
+  const parentEventId = invokeOptions.parentEventId as string;
+
   // Object.create(instance) produces an object whose [[Prototype]] is the EntityMemory
   // instance, so all non-overridden methods are inherited and run with correct 'this'
   // binding (they find store, validator, etc. on the prototype).
@@ -497,7 +502,7 @@ function buildEntityMemoryObserver(
           label: options.label,
           source: options.source,
           sensitivity: result.sensitivity,
-          parentEventId: invokeOptions.parentEventId,
+          parentEventId,
         }));
       } catch (err) {
         // Audit event failure must not fail the skill — log and continue.

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -479,10 +479,13 @@ function buildEntityMemoryObserver(
   observer.storeFact = async (options: StoreFactOptions): Promise<StoreFactResult> => {
     const result = await entityMemory.storeFact(options);
     if (result.stored && result.nodeId && result.sensitivity) {
+      // sensitivityFallback means the stored node was unreadable after the update —
+      // the audit event sensitivity is re-classified from incoming content and may
+      // not match what is on the stored node. Log so operators can investigate.
       if (result.sensitivityFallback) {
         logger.warn(
-          { nodeId: result.nodeId },
-          'storeFact: sensitivity fallback used — node could not be read back after update; audit event sensitivity may differ from stored value',
+          { nodeId: result.nodeId, fallbackSensitivity: result.sensitivity },
+          'memory.store: sensitivity in audit event may be inaccurate — stored node was unreadable after update (race/transient error)',
         );
       }
       try {

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -471,9 +471,12 @@ function buildEntityMemoryObserver(
   invokeOptions: { agentId?: string; conversationId?: string; parentEventId?: string; taskEventId?: string },
   logger: Logger,
 ): EntityMemory {
-  // Callers must ensure parentEventId is truthy before calling this function (see line 297).
-  // Capturing it here narrows the type from string | undefined to string so TypeScript
-  // can verify that createMemoryStore (which requires parentEventId: string) is satisfied.
+  // All three fields are required strings in MemoryStorePayload. The call site (line 297)
+  // guards on conversationId and parentEventId being truthy before entering here, and
+  // agentId is always set from the agent config. Capture as locals so TypeScript can
+  // verify the createMemoryStore call sites rather than seeing string | undefined.
+  const agentId = invokeOptions.agentId as string;
+  const conversationId = invokeOptions.conversationId as string;
   const parentEventId = invokeOptions.parentEventId as string;
 
   // Object.create(instance) produces an object whose [[Prototype]] is the EntityMemory
@@ -495,8 +498,8 @@ function buildEntityMemoryObserver(
       }
       try {
         await bus.publish('agent', createMemoryStore({
-          agentId: invokeOptions.agentId,
-          conversationId: invokeOptions.conversationId,
+          agentId,
+          conversationId,
           nodeId: result.nodeId,
           nodeType: 'fact',
           label: options.label,
@@ -517,14 +520,14 @@ function buildEntityMemoryObserver(
     const { entity } = result;
     try {
       await bus.publish('agent', createMemoryStore({
-        agentId: invokeOptions.agentId,
-        conversationId: invokeOptions.conversationId,
+        agentId,
+        conversationId,
         nodeId: entity.id,
         nodeType: entity.type,
         label: entity.label,
         source: entity.temporal.source,
         sensitivity: entity.sensitivity,
-        parentEventId: invokeOptions.parentEventId,
+        parentEventId,
       }));
     } catch (err) {
       logger.warn({ err, nodeId: entity.id }, 'memory.store audit event failed to emit');

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -291,11 +291,16 @@ export class ExecutionLayer {
         ctx.schedulerService = this.schedulerService;
       }
       // entityMemory is optional — only skills that read/write the knowledge graph need it.
-      // When memory audit context and bus are both available, wrap entityMemory in an observer
-      // that emits memory.store audit events after each node creation (Phase 6 / issue #200).
+      // When all three audit context fields and bus are available, wrap entityMemory in an
+      // observer that emits memory.store audit events after each node creation (#200).
+      // All three fields are required by createMemoryStore — guard all three together so the
+      // narrowed type flows into buildEntityMemoryObserver without unsafe casts.
       if (this.entityMemory) {
-        ctx.entityMemory = options?.conversationId && options?.parentEventId && this.bus
-          ? buildEntityMemoryObserver(this.entityMemory, this.bus, options, skillLogger)
+        const memAudit = options?.agentId && options?.conversationId && options?.parentEventId
+          ? { agentId: options.agentId, conversationId: options.conversationId, parentEventId: options.parentEventId, taskEventId: options.taskEventId }
+          : undefined;
+        ctx.entityMemory = memAudit && this.bus
+          ? buildEntityMemoryObserver(this.entityMemory, this.bus, memAudit, skillLogger)
           : this.entityMemory;
       }
       // nylasCalendarClient is optional — only calendar skills need it
@@ -468,16 +473,13 @@ export class ExecutionLayer {
 function buildEntityMemoryObserver(
   entityMemory: EntityMemory,
   bus: EventBus,
-  invokeOptions: { agentId?: string; conversationId?: string; parentEventId?: string; taskEventId?: string },
+  // All three audit fields are required by createMemoryStore. The call site guards
+  // all three before invoking this function, so requiring them here eliminates
+  // the unsafe `as string` casts that were needed when the type was optional.
+  invokeOptions: { agentId: string; conversationId: string; parentEventId: string; taskEventId?: string },
   logger: Logger,
 ): EntityMemory {
-  // All three fields are required strings in MemoryStorePayload. The call site (line 297)
-  // guards on conversationId and parentEventId being truthy before entering here, and
-  // agentId is always set from the agent config. Capture as locals so TypeScript can
-  // verify the createMemoryStore call sites rather than seeing string | undefined.
-  const agentId = invokeOptions.agentId as string;
-  const conversationId = invokeOptions.conversationId as string;
-  const parentEventId = invokeOptions.parentEventId as string;
+  const { agentId, conversationId, parentEventId } = invokeOptions;
 
   // Object.create(instance) produces an object whose [[Prototype]] is the EntityMemory
   // instance, so all non-overridden methods are inherited and run with correct 'this'
@@ -517,7 +519,11 @@ function buildEntityMemoryObserver(
 
   observer.createEntity = async (options: CreateEntityOptions) => {
     const result = await entityMemory.createEntity(options);
-    const { entity } = result;
+    const { entity, created } = result;
+    // Only emit for new nodes. On upsert (created === false), entity.temporal.source
+    // is the original creation provenance — emitting it here would point the audit
+    // log at the wrong task/channel. Callers can rely on the original creation event.
+    if (!created) return result;
     try {
       await bus.publish('agent', createMemoryStore({
         agentId,
@@ -525,7 +531,7 @@ function buildEntityMemoryObserver(
         nodeId: entity.id,
         nodeType: entity.type,
         label: entity.label,
-        source: entity.temporal.source,
+        source: options.source,
         sensitivity: entity.sensitivity,
         parentEventId,
       }));

--- a/src/startup/validator.ts
+++ b/src/startup/validator.ts
@@ -9,9 +9,10 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-// Ajv is a CJS module with __esModule:true — nodenext resolution requires the
-// named export form when esModuleInterop is active.
-import { Ajv, type ErrorObject } from 'ajv';
+// Ajv v6 is a plain CJS module: `module.exports = Ajv`. Under ESM (nodenext),
+// the constructor is the default export — the named destructured form
+// `import { Ajv }` returns undefined and causes "Ajv is not a constructor".
+import Ajv from 'ajv';
 import yaml from 'js-yaml';
 import type { Logger } from '../logger.js';
 
@@ -30,10 +31,10 @@ function loadSchema(name: string): object {
  * values. Handles `additionalProperties` violations specially to surface the
  * offending property name (which lives in `params.additionalProperty`).
  */
-function formatErrors(errors: ErrorObject[]): string {
+function formatErrors(errors: Ajv.ErrorObject[]): string {
   return errors
     .map(e => {
-      const fieldPath = e.instancePath || '(root)';
+      const fieldPath = e.dataPath || '(root)';  // Ajv v6 uses dataPath; v8+ renamed it instancePath
       // additionalProperties errors put the unknown key in params.additionalProperty —
       // standard errorsText() omits it, so we add it explicitly here.
       const extra =

--- a/src/startup/validator.ts
+++ b/src/startup/validator.ts
@@ -9,10 +9,10 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-// Ajv v6 is a plain CJS module: `module.exports = Ajv`. Under ESM (nodenext),
-// the constructor is the default export — the named destructured form
-// `import { Ajv }` returns undefined and causes "Ajv is not a constructor".
-import Ajv from 'ajv';
+// Ajv v8 is a CJS module with __esModule:true and named exports (exports.Ajv = class).
+// Under ESM (nodenext), the named import `{ Ajv }` is the constructor; the default
+// import gives a non-constructable value in TypeScript 6 strict mode.
+import { Ajv, type ErrorObject } from 'ajv';
 import yaml from 'js-yaml';
 import type { Logger } from '../logger.js';
 
@@ -31,10 +31,10 @@ function loadSchema(name: string): object {
  * values. Handles `additionalProperties` violations specially to surface the
  * offending property name (which lives in `params.additionalProperty`).
  */
-function formatErrors(errors: Ajv.ErrorObject[]): string {
+function formatErrors(errors: ErrorObject[]): string {
   return errors
     .map(e => {
-      const fieldPath = e.dataPath || '(root)';  // Ajv v6 uses dataPath; v8+ renamed it instancePath
+      const fieldPath = e.instancePath || '(root)';
       // additionalProperties errors put the unknown key in params.additionalProperty —
       // standard errorsText() omits it, so we add it explicitly here.
       const extra =

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -452,12 +452,13 @@ describe('AgentRuntime tool-use loop', () => {
     await bus.publish('dispatch', task);
 
     // caller is undefined because the task payload has no senderContext;
-    // agentId and taskEventId are threaded through for infrastructure skills
+    // agentId, taskEventId, conversationId, and parentEventId are threaded through
+    // for infrastructure skills and memory.store audit events (#200)
     expect(mockExecution.invoke).toHaveBeenCalledWith(
       'web-fetch',
       { url: 'https://example.com' },
       undefined,
-      expect.objectContaining({ agentId: 'coordinator', taskEventId: expect.any(String) }),
+      expect.objectContaining({ agentId: 'coordinator', taskEventId: expect.any(String), conversationId: 'conv-1' }),
     );
     expect(responseContent).toContain('Call count: 2');
   });

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -458,7 +458,12 @@ describe('AgentRuntime tool-use loop', () => {
       'web-fetch',
       { url: 'https://example.com' },
       undefined,
-      expect.objectContaining({ agentId: 'coordinator', taskEventId: expect.any(String), conversationId: 'conv-1' }),
+      expect.objectContaining({
+        agentId: 'coordinator',
+        taskEventId: expect.any(String),
+        conversationId: 'conv-1',
+        parentEventId: expect.any(String),
+      }),
     );
     expect(responseContent).toContain('Call count: 2');
   });

--- a/tests/unit/memory/sensitivity.test.ts
+++ b/tests/unit/memory/sensitivity.test.ts
@@ -69,11 +69,23 @@ function makeClassifier(): SensitivityClassifier {
   return SensitivityClassifier.fromRules(TEST_RULES);
 }
 
+// Minimal no-op logger — EntityMemory now requires a Logger as the 4th arg.
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  fatal: () => {},
+  trace: () => {},
+  child: () => noopLogger,
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
 function makeEntityMemory(classifier?: SensitivityClassifier): EntityMemory {
   const embeddingService = EmbeddingService.createForTesting();
   const store = KnowledgeGraphStore.createInMemory(embeddingService);
   const validator = new MemoryValidator(store, embeddingService);
-  return new EntityMemory(store, validator, embeddingService, classifier);
+  return new EntityMemory(store, validator, embeddingService, noopLogger, classifier);
 }
 
 // -- SensitivityClassifier unit tests --
@@ -215,7 +227,7 @@ describe('EntityMemory sensitivity integration', () => {
     });
 
     it('AC: new entity without explicit sensitivity defaults to internal', async () => {
-      const node = await em.createEntity({
+      const { entity: node } = await em.createEntity({
         type: 'concept',
         label: 'Q3 planning notes',
         properties: {},
@@ -225,7 +237,7 @@ describe('EntityMemory sensitivity integration', () => {
     });
 
     it('AC: new fact without explicit sensitivity defaults to internal', async () => {
-      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const { entity } = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
       const result = await em.storeFact({
         entityNodeId: entity.id,
         label: 'some meeting note',
@@ -244,7 +256,7 @@ describe('EntityMemory sensitivity integration', () => {
     });
 
     it('AC: new node without explicit sensitivity → defaults to internal (non-sensitive content)', async () => {
-      const node = await em.createEntity({
+      const { entity: node } = await em.createEntity({
         type: 'concept',
         label: 'Q3 planning notes',
         properties: {},
@@ -254,7 +266,7 @@ describe('EntityMemory sensitivity integration', () => {
     });
 
     it('AC: financial fact auto-tagged as confidential', async () => {
-      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const { entity } = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
       const result = await em.storeFact({
         entityNodeId: entity.id,
         label: 'Q4 salary budget approved',
@@ -265,7 +277,7 @@ describe('EntityMemory sensitivity integration', () => {
     });
 
     it('restricted content auto-tagged as restricted', async () => {
-      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const { entity } = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
       const result = await em.storeFact({
         entityNodeId: entity.id,
         label: 'Board meeting agenda for November',
@@ -276,7 +288,7 @@ describe('EntityMemory sensitivity integration', () => {
     });
 
     it('property values trigger classification', async () => {
-      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const { entity } = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
       const result = await em.storeFact({
         entityNodeId: entity.id,
         label: 'Employee record',
@@ -288,7 +300,7 @@ describe('EntityMemory sensitivity integration', () => {
     });
 
     it('explicit override wins over classifier (public beats confidential content)', async () => {
-      const node = await em.createEntity({
+      const { entity: node } = await em.createEntity({
         type: 'concept',
         label: 'Annual budget summary',   // would normally be confidential
         properties: {},
@@ -299,7 +311,7 @@ describe('EntityMemory sensitivity integration', () => {
     });
 
     it('explicit override wins over classifier on storeFact', async () => {
-      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const { entity } = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
       const result = await em.storeFact({
         entityNodeId: entity.id,
         label: 'Password reset policy',   // would be restricted
@@ -311,7 +323,7 @@ describe('EntityMemory sensitivity integration', () => {
     });
 
     it('category hint forces classification without keyword match', async () => {
-      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const { entity } = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
       const result = await em.storeFact({
         entityNodeId: entity.id,
         label: 'Q4 planning session',     // no financial keywords
@@ -323,7 +335,7 @@ describe('EntityMemory sensitivity integration', () => {
     });
 
     it('sensitivity is preserved on the node returned by createEntity', async () => {
-      const node = await em.createEntity({
+      const { entity: node } = await em.createEntity({
         type: 'decision',
         label: 'litigation hold initiated',
         properties: {},
@@ -333,7 +345,7 @@ describe('EntityMemory sensitivity integration', () => {
     });
 
     it('storeFact result includes sensitivity for audit event emission', async () => {
-      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const { entity } = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
       const result = await em.storeFact({
         entityNodeId: entity.id,
         label: 'NDA signed with partner',

--- a/tests/unit/memory/sensitivity.test.ts
+++ b/tests/unit/memory/sensitivity.test.ts
@@ -1,0 +1,346 @@
+// sensitivity.test.ts — unit tests for SensitivityClassifier and auto-classification
+// in EntityMemory.
+//
+// Covers:
+//  1. SensitivityClassifier.fromRules() — direct rule construction and classification
+//  2. Content-based keyword matching (various categories)
+//  3. Most-restrictive-wins when multiple rules match
+//  4. Default 'internal' when no rule matches
+//  5. Category hint bypass (skip keyword scan)
+//  6. EntityMemory integration — sensitivity threaded through createEntity/storeFact
+//  7. AC: new node without explicit sensitivity → defaults to 'internal'
+//  8. AC: financial node → 'confidential'
+//  9. Explicit override wins over classifier
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SensitivityClassifier } from '../../../src/memory/sensitivity.js';
+import { EntityMemory } from '../../../src/memory/entity-memory.js';
+import { KnowledgeGraphStore } from '../../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../../src/memory/embedding.js';
+import { MemoryValidator } from '../../../src/memory/validation.js';
+import type { SensitivityRule } from '../../../src/memory/sensitivity.js';
+
+// -- Fixture rules (mirrors a subset of config/default.yaml) --
+
+const TEST_RULES: SensitivityRule[] = [
+  {
+    category: 'credentials',
+    sensitivity: 'restricted',
+    patterns: ['password', 'api key', 'secret key'],
+  },
+  {
+    category: 'board',
+    sensitivity: 'restricted',
+    patterns: ['board meeting', 'shareholder'],
+  },
+  {
+    category: 'litigation',
+    sensitivity: 'restricted',
+    patterns: ['lawsuit', 'litigation'],
+  },
+  {
+    category: 'strategy',
+    sensitivity: 'restricted',
+    patterns: ['acquisition', 'ipo', 'investment banker'],
+  },
+  {
+    category: 'financial',
+    sensitivity: 'confidential',
+    patterns: ['salary', 'budget', 'revenue', 'invoice'],
+  },
+  {
+    category: 'hr',
+    sensitivity: 'confidential',
+    patterns: ['performance review', 'termination', 'layoff'],
+  },
+  {
+    category: 'personal',
+    sensitivity: 'confidential',
+    patterns: ['sin number', 'passport number', 'date of birth'],
+  },
+  {
+    category: 'contract',
+    sensitivity: 'confidential',
+    patterns: ['nda', 'non-disclosure'],
+  },
+];
+
+function makeClassifier(): SensitivityClassifier {
+  return SensitivityClassifier.fromRules(TEST_RULES);
+}
+
+function makeEntityMemory(classifier?: SensitivityClassifier): EntityMemory {
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  return new EntityMemory(store, validator, embeddingService, classifier);
+}
+
+// -- SensitivityClassifier unit tests --
+
+describe('SensitivityClassifier', () => {
+  let classifier: SensitivityClassifier;
+
+  beforeEach(() => {
+    classifier = makeClassifier();
+  });
+
+  describe('default when no rule matches', () => {
+    it('returns internal for ordinary text with no sensitive keywords', () => {
+      expect(classifier.classify('Meeting notes from Q3 planning', {})).toBe('internal');
+    });
+
+    it('returns internal for an empty label with empty properties', () => {
+      expect(classifier.classify('', {})).toBe('internal');
+    });
+  });
+
+  describe('confidential rules', () => {
+    it('matches salary in label → confidential', () => {
+      expect(classifier.classify('salary for Q4', {})).toBe('confidential');
+    });
+
+    it('matches salary in property value → confidential', () => {
+      expect(classifier.classify('Q4 compensation note', { detail: 'revised salary budget' })).toBe('confidential');
+    });
+
+    it('matches budget keyword → confidential', () => {
+      expect(classifier.classify('Annual budget review notes', {})).toBe('confidential');
+    });
+
+    it('matches invoice in label → confidential', () => {
+      expect(classifier.classify('Invoice #1042 for services', {})).toBe('confidential');
+    });
+
+    it('matches performance review in label → confidential (hr)', () => {
+      expect(classifier.classify('performance review for Alice', {})).toBe('confidential');
+    });
+
+    it('matches termination keyword → confidential (hr)', () => {
+      expect(classifier.classify('Termination letter sent', {})).toBe('confidential');
+    });
+
+    it('matches sin number in value → confidential (personal)', () => {
+      expect(classifier.classify('Employee record', { id_info: 'SIN number 123456789' })).toBe('confidential');
+    });
+
+    it('matches NDA keyword → confidential (contract)', () => {
+      expect(classifier.classify('NDA signed with Vendor X', {})).toBe('confidential');
+    });
+  });
+
+  describe('restricted rules', () => {
+    it('matches password in label → restricted', () => {
+      expect(classifier.classify('Admin password reset', {})).toBe('restricted');
+    });
+
+    it('matches api key in property value → restricted', () => {
+      expect(classifier.classify('Integration config', { notes: 'store the api key here' })).toBe('restricted');
+    });
+
+    it('matches board meeting → restricted', () => {
+      expect(classifier.classify('Board meeting agenda', {})).toBe('restricted');
+    });
+
+    it('matches lawsuit → restricted', () => {
+      expect(classifier.classify('Ongoing lawsuit with supplier', {})).toBe('restricted');
+    });
+
+    it('matches litigation → restricted', () => {
+      expect(classifier.classify('Litigation status update', {})).toBe('restricted');
+    });
+
+    it('matches acquisition → restricted (strategy)', () => {
+      expect(classifier.classify('Acquisition target analysis', {})).toBe('restricted');
+    });
+
+    it('matches ipo → restricted (strategy)', () => {
+      expect(classifier.classify('IPO roadshow planning', {})).toBe('restricted');
+    });
+
+    it('matches investment banker → restricted (strategy)', () => {
+      expect(classifier.classify('Meeting with investment banker', {})).toBe('restricted');
+    });
+  });
+
+  describe('most-restrictive wins when multiple rules match', () => {
+    it('restricted beats confidential when both match', () => {
+      // "salary" (confidential/financial) + "board meeting" (restricted/board) in same text
+      const result = classifier.classify('Board meeting: salary discussion', {});
+      expect(result).toBe('restricted');
+    });
+
+    it('restricted beats confidential when match is in property', () => {
+      const result = classifier.classify('Q4 revenue report', { context: 'board meeting materials' });
+      expect(result).toBe('restricted');
+    });
+  });
+
+  describe('category hint bypass', () => {
+    it('returns the category sensitivity without scanning keywords when category matches', () => {
+      // Label has no financial keywords, but category hint forces 'confidential'
+      const result = classifier.classify('Q4 planning notes', {}, 'financial');
+      expect(result).toBe('confidential');
+    });
+
+    it('category hint for restricted category returns restricted regardless of content', () => {
+      const result = classifier.classify('generic label', {}, 'board');
+      expect(result).toBe('restricted');
+    });
+
+    it('unknown category hint falls through to keyword scan', () => {
+      // 'unknown-category' doesn't match any rule.category, so falls through to keywords
+      const result = classifier.classify('salary update', {}, 'unknown-category');
+      expect(result).toBe('confidential'); // matched by financial keyword
+    });
+  });
+
+  describe('fromRules validation', () => {
+    it('sorts rules so restricted is checked before confidential', () => {
+      // Both salary (confidential) and password (restricted) match — restricted must win
+      const c = SensitivityClassifier.fromRules(TEST_RULES);
+      expect(c.classify('salary password', {})).toBe('restricted');
+    });
+  });
+});
+
+// -- EntityMemory integration tests --
+
+describe('EntityMemory sensitivity integration', () => {
+  describe('without a classifier', () => {
+    let em: EntityMemory;
+
+    beforeEach(() => {
+      em = makeEntityMemory(); // no classifier
+    });
+
+    it('AC: new entity without explicit sensitivity defaults to internal', async () => {
+      const node = await em.createEntity({
+        type: 'concept',
+        label: 'Q3 planning notes',
+        properties: {},
+        source: 'test',
+      });
+      expect(node.sensitivity).toBe('internal');
+    });
+
+    it('AC: new fact without explicit sensitivity defaults to internal', async () => {
+      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const result = await em.storeFact({
+        entityNodeId: entity.id,
+        label: 'some meeting note',
+        source: 'test',
+      });
+      expect(result.stored).toBe(true);
+      expect(result.sensitivity).toBe('internal');
+    });
+  });
+
+  describe('with a classifier', () => {
+    let em: EntityMemory;
+
+    beforeEach(() => {
+      em = makeEntityMemory(makeClassifier());
+    });
+
+    it('AC: new node without explicit sensitivity → defaults to internal (non-sensitive content)', async () => {
+      const node = await em.createEntity({
+        type: 'concept',
+        label: 'Q3 planning notes',
+        properties: {},
+        source: 'test',
+      });
+      expect(node.sensitivity).toBe('internal');
+    });
+
+    it('AC: financial fact auto-tagged as confidential', async () => {
+      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const result = await em.storeFact({
+        entityNodeId: entity.id,
+        label: 'Q4 salary budget approved',
+        source: 'test',
+      });
+      expect(result.stored).toBe(true);
+      expect(result.sensitivity).toBe('confidential');
+    });
+
+    it('restricted content auto-tagged as restricted', async () => {
+      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const result = await em.storeFact({
+        entityNodeId: entity.id,
+        label: 'Board meeting agenda for November',
+        source: 'test',
+      });
+      expect(result.stored).toBe(true);
+      expect(result.sensitivity).toBe('restricted');
+    });
+
+    it('property values trigger classification', async () => {
+      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const result = await em.storeFact({
+        entityNodeId: entity.id,
+        label: 'Employee record',
+        properties: { detail: 'sin number on file' },
+        source: 'test',
+      });
+      expect(result.stored).toBe(true);
+      expect(result.sensitivity).toBe('confidential');
+    });
+
+    it('explicit override wins over classifier (public beats confidential content)', async () => {
+      const node = await em.createEntity({
+        type: 'concept',
+        label: 'Annual budget summary',   // would normally be confidential
+        properties: {},
+        source: 'test',
+        sensitivity: 'public',            // explicit override
+      });
+      expect(node.sensitivity).toBe('public');
+    });
+
+    it('explicit override wins over classifier on storeFact', async () => {
+      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const result = await em.storeFact({
+        entityNodeId: entity.id,
+        label: 'Password reset policy',   // would be restricted
+        source: 'test',
+        sensitivity: 'internal',          // explicit override
+      });
+      expect(result.stored).toBe(true);
+      expect(result.sensitivity).toBe('internal');
+    });
+
+    it('category hint forces classification without keyword match', async () => {
+      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const result = await em.storeFact({
+        entityNodeId: entity.id,
+        label: 'Q4 planning session',     // no financial keywords
+        source: 'test',
+        sensitivityCategory: 'financial', // hint forces confidential
+      });
+      expect(result.stored).toBe(true);
+      expect(result.sensitivity).toBe('confidential');
+    });
+
+    it('sensitivity is preserved on the node returned by createEntity', async () => {
+      const node = await em.createEntity({
+        type: 'decision',
+        label: 'litigation hold initiated',
+        properties: {},
+        source: 'test',
+      });
+      expect(node.sensitivity).toBe('restricted');
+    });
+
+    it('storeFact result includes sensitivity for audit event emission', async () => {
+      const entity = await em.createEntity({ type: 'concept', label: 'anchor', properties: {}, source: 'test' });
+      const result = await em.storeFact({
+        entityNodeId: entity.id,
+        label: 'NDA signed with partner',
+        source: 'test',
+      });
+      // result.sensitivity is used by the ExecutionLayer to populate the memory.store event
+      expect(result.sensitivity).toBe('confidential');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a four-level `sensitivity` tag (`public` / `internal` / `confidential` / `restricted`) to every KG node, persisted as a `NOT NULL` column with a DB-level `CHECK` constraint
- Introduces `SensitivityClassifier` with content-based keyword rules loaded from `config/default.yaml` at startup — eight categories: credentials, board, litigation, strategy, financial, contract, hr, personal
- Classification is content-based (label + property values), not skill-based — a SIN number is tagged confidential regardless of which skill stored it
- `EntityMemory.createEntity()` and `storeFact()` auto-classify when no explicit sensitivity is provided; callers can override or pass a category hint
- Finishes the Phase 6 memory audit trail: `memory.store` events now include `sensitivity` and are actually emitted via an `EntityMemoryObserver` in the `ExecutionLayer` (previously scaffolded but never wired)
- Coordinator system prompt gains exfiltration-aware data protection directives

## Acceptance criteria

- [x] KG node storage includes a `sensitivity` column (default: `internal`)
- [x] Memory engine accepts and stores `sensitivity` on node creation
- [x] Financial data auto-tagged as `confidential` based on configurable rules
- [x] `memory.store` audit event includes the sensitivity level of the stored node
- [x] Coordinator system prompt includes the exfiltration-aware directives
- [x] Unit tests: new node without sensitivity → defaults to `internal`; finance node → `confidential`

## Test plan

- [x] 35 new tests in `tests/unit/memory/sensitivity.test.ts` covering classifier rules, most-restrictive-wins, category hint bypass, explicit overrides, EntityMemory integration, and both ACs
- [x] Full test suite: 818 passed, 0 failed
- [ ] Deploy to staging and verify `kg_nodes.sensitivity` column appears after migration
- [ ] Confirm `memory.store` events appear in `audit_log` with the sensitivity field populated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data sensitivity tagging for knowledge-graph nodes (public, internal, confidential, restricted) with keyword-based auto-classification, category hints, and explicit overrides.
  * Memory/audit events now include sensitivity and conversation/parent-event linkage to support controlled sharing and export controls.
  * Database now persists node sensitivity.

* **Tests**
  * Added unit tests for classifier rules, priority, hints, overrides, and memory integration.

* **Documentation**
  * Security checklist updated to mark data sensitivity tagging complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->