### PR TITLE
chore: validate real config/agents/skills against schemas in unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 - **`schemas/` directory** — JSON Schema files for agent configs, skill manifests, and `config/default.yaml`. Schemas are legible without TypeScript and can be validated with third-party tools.
 - **`channels.max_message_bytes`** in `config/default.yaml` — configures the inbound message size limit (default `102400`).
+- **Real-config validator tests** — `tests/unit/startup/validator.test.ts` now validates the actual `config/default.yaml`, `agents/*.yaml`, and `skills/*/skill.json` against their schemas. Catches schema/config drift in CI before it reaches prod.
 
 ### Changed
 - **Agent and skill loaders** — manual field checks removed; validation is now handled by the startup validator schema.

--- a/tests/unit/startup/validator.test.ts
+++ b/tests/unit/startup/validator.test.ts
@@ -123,3 +123,48 @@ describe('startup validator — default config', () => {
     ).rejects.toThrow(/trust-policy/);
   });
 });
+
+// ── Real project files ───────────────────────────────────────────────────────
+//
+// Validates the actual config/default.yaml, agents/*.yaml, and skills/*/skill.json
+// against the schemas. This catches schema/config drift before it reaches prod —
+// the incident that prompted this test: dispatch.rate_limit was added to default.yaml
+// but not to the schema, causing every deploy to fail on startup validation.
+
+const ROOT = path.resolve(import.meta.dirname, '../../..');
+
+describe('startup validator — real project files', () => {
+  it('config/default.yaml passes schema validation', async () => {
+    await expect(
+      runStartupValidation({
+        configDir: path.join(ROOT, 'config'),
+        // Point agents/skills at valid fixtures so only the config is under test.
+        agentsDir: path.join(F, 'agents/valid'),
+        skillsDir: path.join(F, 'skills/valid-skill'),
+        logger,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('all agents/*.yaml pass schema validation', async () => {
+    await expect(
+      runStartupValidation({
+        agentsDir: path.join(ROOT, 'agents'),
+        configDir: path.join(F, 'config/empty'),
+        skillsDir: path.join(F, 'skills/valid-skill'),
+        logger,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('all skills/*/skill.json pass schema validation', async () => {
+    await expect(
+      runStartupValidation({
+        skillsDir: path.join(ROOT, 'skills'),
+        configDir: path.join(F, 'config/empty'),
+        agentsDir: path.join(F, 'agents/valid'),
+        logger,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 3 tests to `tests/unit/startup/validator.test.ts` that run the startup validator against the actual `config/default.yaml`, `agents/*.yaml`, and `skills/*/skill.json` instead of synthetic fixtures.
- Prevents a repeat of the `dispatch.rate_limit` incident, where a config field was added without updating the schema — caught only at container startup in prod, not in CI.

## Test plan

- [ ] All 20 tests pass (`vitest run tests/unit/startup/validator.test.ts`)
- [ ] Future: adding a field to `config/default.yaml` without updating the schema should now fail this test in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced validation testing to verify configuration and skill schema integrity, enabling early detection of configuration inconsistencies before production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->