### PR TITLE
chore(spec): update spec 03 implementation status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **Spec 03 implementation status** — corrected and annotated the implementation status table: secrets access (`ctx.secret()`) marked Done, safety gate and skill discovery marked Partial with detail, MCP and skill-registry cross-referenced to tracking issues (#270, #274).
+
 ### Breaking Changes
 
 - **Agent YAML schema now enforced at startup** — previously ignored unknown keys and missing required fields now cause a descriptive `process.exit(1)`. Any `agents/*.yaml` that was silently tolerated must be fixed before upgrading.

--- a/docs/specs/03-skills-and-execution.md
+++ b/docs/specs/03-skills-and-execution.md
@@ -47,7 +47,7 @@ interface SkillHandler {
 
 interface SkillContext {
   input: Record<string, unknown>;     // validated against manifest inputs
-  secret(name: string): Promise<string>;  // scoped secret access
+  secret(name: string): string;  // scoped secret access (synchronous — reads env vars)
   log: Logger;                         // scoped pino child logger
 }
 

--- a/docs/specs/03-skills-and-execution.md
+++ b/docs/specs/03-skills-and-execution.md
@@ -191,13 +191,13 @@ Custom MCP servers will be needed for Google Calendar and expense platforms (Exp
 | Resource boundaries — per-invocation timeout enforcement from manifest | Done |
 | Built-in skill: `web-fetch` | Done |
 | Built-in skill: `scheduler` (create, list, cancel) | Done |
-| MCP skills — MCP client, stdio/SSE transport, `tools/list` discovery | Not Done |
-| Safety gate for first-time elevated skill use — `skill_approvals` table and approval workflow | Not Done |
-| Built-in skill: `skill-registry` (agent-invocable search) | Not Done |
+| MCP skills — MCP client, stdio/SSE transport, `tools/list` discovery | Not Done — tracked in #270 |
+| Safety gate for first-time elevated skill use — `skill_approvals` table and approval workflow | Partial — role-based elevation gate exists in execution layer (caller must have `role: ceo`); per-agent-skill `skill_approvals` table with persist-once-ask-once flow not yet built |
+| Built-in skill: `skill-registry` (agent-invocable search) | Not Done — `SkillRegistry.search()` exists; skill wrapper and runtime wiring pending (#274) |
 | Built-in skill: `memory-query` | Not Done |
 | Built-in skill: `memory-store` | Not Done |
 | Built-in skill: `file-reader` | Not Done |
 | Built-in skill: `file-writer` | Not Done |
-| Skill discovery — `allow_discovery` agent config field wired to registry search | Not Done |
-| Secrets access — `ctx.secret()` accessor backed by env vars, validated against manifest `secrets` array | Not Done |
+| Skill discovery — `allow_discovery` agent config field wired to registry search | Partial — field parsed by agent loader and set in agent YAMLs; not yet wired to runtime tool-list builder (#274) |
+| Secrets access — `ctx.secret()` accessor backed by env vars, validated against manifest `secrets` array | Done |
 | Resource boundaries — max 5 concurrent skill invocations per agent task | Not Done |


### PR DESCRIPTION
## Summary

Corrects the implementation status table in `docs/specs/03-skills-and-execution.md` to reflect what's actually in the codebase:

- **Secrets access** (`ctx.secret()`) — was marked Not Done; fully implemented in `src/skills/execution.ts` (env-var backed, manifest-validated, audit-logged)
- **Safety gate for elevated skills** — was marked Not Done; a role-based elevation gate exists in the execution layer; annotated as Partial with detail on what remains (`skill_approvals` table, per-agent-skill approval flow)
- **Skill discovery** (`allow_discovery`) — was marked Not Done; field is parsed by agent loader and set in agent YAMLs; annotated as Partial (not yet wired to runtime tool-list builder)
- **MCP** and **skill-registry** entries — cross-referenced to tracking issues #270 and #274

No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated specs and changelog to reflect current implementation status: secrets access marked Done; safety gate and skill discovery marked Partial; MCP and skill-registry noted as tracked in follow-up issues. Clarified which capabilities are implemented versus pending wiring and runtime integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->