### PR TITLE
feat: multi-account email channel support (closes #272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+- **Multi-account email channel** (spec §03) — `channel_accounts.email` YAML block supports N named Nylas-backed email accounts, each with its own grant ID, `self_email`, and `outbound_policy` (`direct | draft_gate | autonomy_gated`). One `EmailAdapter` instance is constructed per account at startup; inbound events are stamped with the receiving `accountId` and replies are routed back through the same account. Closes #272.
+- **`draft_gate` outbound policy** — when set on an email account, the coordinator's reply is saved as a Nylas draft for human review instead of being sent immediately. The notification → approval → send flow is deferred to issue #278.
+- **`autonomy_gated` outbound policy** — checks the global autonomy score before each send; if the score meets `autonomy_threshold`, sends directly; otherwise falls back to `draft_gate`.
+- **`accountId` on bus events** — optional `accountId` field added to `InboundMessagePayload`, `AgentTaskPayload`, and `OutboundMessagePayload`. Propagated through the dispatch routing table so replies are always sent from the account that received the original message. This is an additive change; existing handlers that do not destructure `accountId` are unaffected.
+- **`createEmailDraft` on `OutboundGateway`** — creates a Nylas draft without sending; runs the blocked-contact check but skips the content filter (drafts stay in the mailbox until explicitly sent by a human).
+- **Backward-compatible single-account fallback** — if `channel_accounts.email` is absent, the email channel falls back to the existing `NYLAS_GRANT_ID` / `NYLAS_SELF_EMAIL` env-var mode; no config changes needed for existing deployments.
+
 ---
 
 ## [0.17.0] — 2026-04-10

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -6,6 +6,45 @@ channels:
   # Set SIGNAL_SOCKET_PATH + SIGNAL_PHONE_NUMBER at runtime to enable the Signal adapter.
   # Trust level and unknown-sender policy live in config/channel-trust.yaml.
 
+# Multi-account email configuration (spec §03-email-channel.md).
+#
+# channel_accounts.email defines one or more named Nylas-backed email accounts.
+# Each account has its own grant ID, self-email address, and outbound policy.
+#
+# Outbound policies:
+#   direct          — send immediately via the OutboundGateway (blocked-contact + content
+#                     filter enforced by the gateway). This is the default for most accounts.
+#   draft_gate      — save the coordinator's reply as a Nylas draft for human review;
+#                     the notification → approval → send flow is deferred (see issue #273).
+#   autonomy_gated  — check the global autonomy score before sending; if the score meets
+#                     `autonomy_threshold`, send directly; otherwise fall back to draft_gate.
+#
+# Credential values may be supplied inline or as env-var references using the
+# `env:VAR_NAME` syntax (recommended for secrets):
+#
+#   nylas_grant_id: "env:NYLAS_GRANT_ID"
+#   self_email:     "env:NYLAS_SELF_EMAIL"
+#
+# Backward compatibility: if this block is absent, the email channel falls back to the
+# single-account env-var mode (NYLAS_API_KEY / NYLAS_GRANT_ID / NYLAS_SELF_EMAIL).
+#
+# Example — two accounts, one direct and one draft-gated:
+#
+# channel_accounts:
+#   email:
+#     - name: curia
+#       nylas_grant_id: "env:NYLAS_GRANT_ID_CURIA"
+#       self_email:     "env:NYLAS_SELF_EMAIL_CURIA"
+#       outbound_policy: direct
+#
+#     - name: joseph
+#       nylas_grant_id: "env:NYLAS_GRANT_ID_JOSEPH"
+#       self_email:     "env:NYLAS_SELF_EMAIL_JOSEPH"
+#       outbound_policy: autonomy_gated
+#       autonomy_threshold: 80   # score out of 100; below this, replies are saved as drafts
+#
+# channel_accounts: {}
+
 browser:
   # How long a browser session stays alive after its last action (ms).
   sessionTtlMs: 600000   # 10 minutes

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -28,16 +28,17 @@ channels:
 # Backward compatibility: if this block is absent, the email channel falls back to the
 # single-account env-var mode (NYLAS_API_KEY / NYLAS_GRANT_ID / NYLAS_SELF_EMAIL).
 #
-# Example — two accounts, one direct and one draft-gated:
+# Example — two accounts, one direct and one autonomy-gated:
+# (Keys are the logical account names; they become the accountId on bus events.)
 #
 # channel_accounts:
 #   email:
-#     - name: curia
+#     curia:
 #       nylas_grant_id: "env:NYLAS_GRANT_ID_CURIA"
 #       self_email:     "env:NYLAS_SELF_EMAIL_CURIA"
 #       outbound_policy: direct
 #
-#     - name: joseph
+#     joseph:
 #       nylas_grant_id: "env:NYLAS_GRANT_ID_JOSEPH"
 #       self_email:     "env:NYLAS_SELF_EMAIL_JOSEPH"
 #       outbound_policy: autonomy_gated

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -15,7 +15,7 @@ channels:
 #   direct          — send immediately via the OutboundGateway (blocked-contact + content
 #                     filter enforced by the gateway). This is the default for most accounts.
 #   draft_gate      — save the coordinator's reply as a Nylas draft for human review;
-#                     the notification → approval → send flow is deferred (see issue #273).
+#                     the notification → approval → send flow is deferred (see issue #278).
 #   autonomy_gated  — check the global autonomy score before sending; if the score meets
 #                     `autonomy_threshold`, send directly; otherwise fall back to draft_gate.
 #

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -173,13 +173,12 @@
       "additionalProperties": false,
       "properties": {
         "email": {
-          "type": "array",
-          "items": {
+          "type": "object",
+          "additionalProperties": {
             "type": "object",
-            "required": ["name", "nylas_grant_id", "self_email", "outbound_policy"],
+            "required": ["nylas_grant_id", "self_email", "outbound_policy"],
             "additionalProperties": false,
             "properties": {
-              "name": { "type": "string", "minLength": 1 },
               "nylas_grant_id": { "type": "string", "minLength": 1 },
               "self_email": { "type": "string", "minLength": 1 },
               "outbound_policy": {

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -159,15 +159,6 @@
         }
       }
     },
-    "intentDrift": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "enabled": { "type": "boolean" },
-        "checkEveryNBursts": { "type": "integer", "minimum": 1 },
-        "minConfidenceToPause": { "type": "string", "enum": ["high", "medium", "low"] }
-      }
-    },
     "channel_accounts": {
       "type": "object",
       "additionalProperties": false,
@@ -185,7 +176,7 @@
                 "type": "string",
                 "enum": ["direct", "draft_gate", "autonomy_gated"]
               },
-              "autonomy_threshold": { "type": "number", "minimum": 0, "maximum": 100 }
+              "autonomy_threshold": { "type": "integer", "minimum": 0, "maximum": 100 }
             }
           }
         }

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -158,6 +158,39 @@
           }
         }
       }
+    },
+    "intentDrift": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "checkEveryNBursts": { "type": "integer", "minimum": 1 },
+        "minConfidenceToPause": { "type": "string", "enum": ["high", "medium", "low"] }
+      }
+    },
+    "channel_accounts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "email": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "nylas_grant_id", "self_email", "outbound_policy"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "nylas_grant_id": { "type": "string", "minLength": 1 },
+              "self_email": { "type": "string", "minLength": 1 },
+              "outbound_policy": {
+                "type": "string",
+                "enum": ["direct", "draft_gate", "autonomy_gated"]
+              },
+              "autonomy_threshold": { "type": "number", "minimum": 0, "maximum": 100 }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -22,6 +22,11 @@ export type Layer = 'channel' | 'dispatch' | 'agent' | 'execution' | 'system';
 interface InboundMessagePayload {
   conversationId: string;
   channelId: string;
+  /** Which named account received this message (e.g. "curia", "joseph").
+   *  Set by the channel adapter; used by the dispatcher to route replies back
+   *  to the same account. Absent for channels without multi-account support
+   *  (Signal, CLI). */
+  accountId?: string;
   senderId: string;
   content: string;
   metadata?: Record<string, unknown>;
@@ -31,6 +36,9 @@ interface AgentTaskPayload {
   agentId: string;
   conversationId: string;
   channelId: string;
+  /** Propagated from the originating inbound.message — identifies which email account
+   *  to reply from. Absent for Signal, CLI, and other single-account channels. */
+  accountId?: string;
   senderId: string;
   content: string;
   metadata?: Record<string, unknown>;
@@ -59,6 +67,10 @@ interface AgentResponsePayload {
 interface OutboundMessagePayload {
   conversationId: string;
   channelId: string;
+  /** Which named account should send this reply. Propagated from the inbound routing
+   *  table so the email adapter uses the same account that received the original message.
+   *  Absent for Signal, CLI, and other single-account channels. */
+  accountId?: string;
   content: string;
 }
 

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -323,9 +323,11 @@ export class EmailAdapter {
       if (!autonomyService || autonomyThreshold === undefined) {
         logger.error(
           { ...logCtx, accountId: this.config.accountId },
-          'autonomy_gated policy requires autonomyService and autonomyThreshold — falling back to draft_gate',
+          'autonomy_gated policy requires autonomyService and autonomyThreshold — degrading to draft_gate for this reply',
         );
-        // Fall through to draft_gate rather than silently sending or silently dropping
+        // Explicit fall-through to draft_gate below (operator sees error log above).
+        // Degrading to draft rather than silently sending or dropping is the safest
+        // choice: the reply is preserved for human review despite the misconfiguration.
       } else {
         const score = await autonomyService.getScore();
         if (score >= autonomyThreshold) {
@@ -356,10 +358,18 @@ export class EmailAdapter {
         { ...logCtx, accountId: this.config.accountId, draftId: draftResult.draftId },
         'Email reply saved as draft pending human approval (TODO(#273): wire up notification+approval)',
       );
-    } else {
+    } else if (draftResult.blockedReason === 'Recipient is blocked') {
+      // Intentional block — not an infrastructure failure
       logger.warn(
         { ...logCtx, accountId: this.config.accountId, reason: draftResult.blockedReason },
-        'Email draft creation failed or was blocked',
+        'Email draft blocked — recipient is on the blocked list',
+      );
+    } else {
+      // Infrastructure failure (Nylas error, contact resolution failure, client not configured).
+      // The reply is permanently lost — log at error so operators can investigate.
+      logger.error(
+        { ...logCtx, accountId: this.config.accountId, reason: draftResult.blockedReason },
+        'Email draft creation failed — reply permanently lost',
       );
     }
   }

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -300,7 +300,7 @@ export class EmailAdapter {
    *                   configured threshold, send directly; otherwise draft-gate
    */
   private async dispatchByPolicy(
-    sendRequest: Parameters<OutboundGateway['send']>[0],
+    sendRequest: EmailSendRequest,
     logCtx: Record<string, unknown>,
   ): Promise<void> {
     const { outboundGateway, logger, outboundPolicy, autonomyThreshold, autonomyService } = this.config;
@@ -329,24 +329,35 @@ export class EmailAdapter {
         // Degrading to draft rather than silently sending or dropping is the safest
         // choice: the reply is preserved for human review despite the misconfiguration.
       } else {
-        const score = await autonomyService.getScore();
-        if (score >= autonomyThreshold) {
-          const result = await outboundGateway.send(sendRequest);
-          if (result.success) {
-            logger.info(
-              { ...logCtx, accountId: this.config.accountId, autonomyScore: score, threshold: autonomyThreshold },
-              'Email reply sent autonomously (autonomy threshold met)',
-            );
-          } else {
-            logger.warn({ ...logCtx, accountId: this.config.accountId, reason: result.blockedReason }, 'Email reply blocked by gateway');
+        const autonomyCfg = await autonomyService.getConfig();
+        if (autonomyCfg === null) {
+          // Autonomy not yet configured (pre-migration environment) — preserve for
+          // human review rather than sending autonomously or dropping the reply.
+          logger.warn(
+            { ...logCtx, accountId: this.config.accountId },
+            'Autonomy config not found (pre-migration?) — degrading to draft_gate for this reply',
+          );
+          // Fall through to draft_gate below
+        } else {
+          const score = autonomyCfg.score;
+          if (score >= autonomyThreshold) {
+            const result = await outboundGateway.send(sendRequest);
+            if (result.success) {
+              logger.info(
+                { ...logCtx, accountId: this.config.accountId, autonomyScore: score, threshold: autonomyThreshold },
+                'Email reply sent autonomously (autonomy threshold met)',
+              );
+            } else {
+              logger.warn({ ...logCtx, accountId: this.config.accountId, reason: result.blockedReason }, 'Email reply blocked by gateway');
+            }
+            return;
           }
-          return;
+          logger.info(
+            { ...logCtx, accountId: this.config.accountId, autonomyScore: score, threshold: autonomyThreshold },
+            'Autonomy score below threshold — saving reply as draft',
+          );
+          // Score too low: fall through to draft_gate behaviour
         }
-        logger.info(
-          { ...logCtx, accountId: this.config.accountId, autonomyScore: score, threshold: autonomyThreshold },
-          'Autonomy score below threshold — saving reply as draft',
-        );
-        // Score too low: fall through to draft_gate behaviour
       }
     }
 

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -3,22 +3,46 @@
 // Email channel adapter — polls Nylas for new inbound emails, publishes them
 // to the bus as inbound.message events, auto-creates contacts from participants,
 // and sends outbound replies when the coordinator responds to an email thread.
+//
+// Multi-account: one EmailAdapter instance is constructed per configured email account.
+// Each instance owns a single Nylas grant and applies its own outbound policy.
 
 import type { EventBus } from '../../bus/bus.js';
 import type { Logger } from '../../logger.js';
-import type { OutboundGateway } from '../../skills/outbound-gateway.js';
+import type { OutboundGateway, EmailSendRequest } from '../../skills/outbound-gateway.js';
 import type { ContactService } from '../../contacts/contact-service.js';
+import type { AutonomyService } from '../../autonomy/autonomy-service.js';
+import type { OutboundPolicy } from '../../config.js';
 import { convertNylasMessage } from './message-converter.js';
 import { createInboundMessage, type OutboundMessageEvent } from '../../bus/events.js';
 import { sanitizeOutput } from '../../skills/sanitize.js';
 
 export interface EmailAdapterConfig {
+  /**
+   * Logical name for this email account (e.g. "curia", "joseph").
+   * Stamped onto every inbound.message event as accountId so the dispatcher
+   * can route replies back through the same account.
+   */
+  accountId: string;
+  /**
+   * How outbound replies from this account are handled.
+   *
+   * - direct:          send immediately via OutboundGateway (current behavior)
+   * - draft_gate:      save as a Nylas draft; human approves before sending
+   *                    TODO(#273): wire up notification → approval → send flow
+   * - autonomy_gated:  send only when autonomy score >= autonomyThreshold
+   */
+  outboundPolicy: OutboundPolicy;
+  /** Required when outboundPolicy is 'autonomy_gated'. Minimum score (0–100) to send. */
+  autonomyThreshold?: number;
+  /** Required when outboundPolicy is 'autonomy_gated'. Queried before each send. */
+  autonomyService?: AutonomyService;
   bus: EventBus;
   logger: Logger;
   outboundGateway: OutboundGateway;
   contactService: ContactService;
   pollingIntervalMs: number;
-  /** Curia's own email address — used to filter out self-sent messages */
+  /** This account's own email address — used to filter out self-sent messages */
   selfEmail: string;
 }
 
@@ -35,13 +59,20 @@ export class EmailAdapter {
   async start(): Promise<void> {
     const { bus, logger, pollingIntervalMs } = this.config;
 
-    // Subscribe to outbound messages for the email channel.
+    // Subscribe to outbound messages for this specific email account.
     // When the coordinator responds to an email-triggered conversation, the dispatcher
-    // creates an outbound.message with channelId 'email'. The adapter sends this as
-    // a reply to the original email thread via Nylas.
+    // creates an outbound.message with channelId 'email' and the accountId that received
+    // the original message. Each adapter instance filters to its own accountId so replies
+    // are always sent from the same account that received the inbound message.
     bus.subscribe('outbound.message', 'channel', async (event) => {
       const outbound = event as OutboundMessageEvent;
       if (outbound.payload.channelId !== 'email') return;
+      // Only handle events addressed to this account.
+      // When accountId is absent (legacy events from before multi-account support),
+      // default to 'curia' so the primary account claims the event — consistent with
+      // the backward-compat fallback in resolveChannelAccounts().
+      const targetAccountId = outbound.payload.accountId ?? 'curia';
+      if (targetAccountId !== this.config.accountId) return;
 
       try {
         await this.sendOutboundReply(outbound);
@@ -88,7 +119,7 @@ export class EmailAdapter {
         // and compute senderVerified (SPF/DKIM/DMARC). Without this flag, Nylas
         // omits headers from the response entirely and senderVerified will be false.
         fields: 'include_headers',
-      });
+      }, this.config.accountId);
     } catch (err) {
       this.config.logger.error({ err }, 'Email polling failed — will retry');
       this.processing = false;
@@ -132,6 +163,7 @@ export class EmailAdapter {
           const event = createInboundMessage({
             conversationId: converted.conversationId,
             channelId: converted.channelId,
+            accountId: this.config.accountId,
             senderId: converted.senderId,
             content: sanitizedContent,
             metadata: converted.metadata as unknown as Record<string, unknown>,
@@ -167,9 +199,14 @@ export class EmailAdapter {
   }
 
   /**
-   * Send the coordinator's response as an email reply in the original thread.
+   * Send (or draft) the coordinator's response as an email reply in the original thread.
    * The conversationId encodes the thread (email:{threadId}), so we look up the
    * most recent inbound message in that thread and reply to it.
+   *
+   * The actual send behaviour is controlled by this account's outboundPolicy:
+   *   - direct:         send immediately via OutboundGateway
+   *   - draft_gate:     save as Nylas draft for human approval (TODO(#273): full flow)
+   *   - autonomy_gated: check autonomy score before sending; hold as draft if below threshold
    */
   private async sendOutboundReply(outbound: OutboundMessageEvent): Promise<void> {
     const { outboundGateway, logger } = this.config;
@@ -190,7 +227,7 @@ export class EmailAdapter {
       // latest. If Curia was the last sender (a prior turn in the conversation),
       // messages[0].from is Curia's own address — we must NOT reply to ourselves.
       // In that case, look at messages[0].to to find the human recipient.
-      const messages = await outboundGateway.listEmailMessages({ limit: 1, threadId });
+      const messages = await outboundGateway.listEmailMessages({ limit: 1, threadId }, this.config.accountId);
       const threadMessage = messages[0];
       if (!threadMessage) {
         logger.warn({ threadId }, 'Cannot find message to reply to in thread');
@@ -237,23 +274,93 @@ export class EmailAdapter {
       // "Re: Re: Re: ..." chains when replying to already-replied threads.
       const baseSubject = threadMessage.subject.replace(/^Re:\s*/i, '');
 
-      // Route through the gateway so the blocked-contact check and content filter
-      // run on every outbound reply, not just those originating from skills.
-      const result = await outboundGateway.send({
-        channel: 'email',
+      const sendRequest = {
+        channel: 'email' as const,
+        accountId: this.config.accountId,
         to: recipientEmail,
         subject: `Re: ${baseSubject}`,
         body: outbound.payload.content,
         replyToMessageId: threadMessage.id,
-      });
+      };
 
-      if (result.success) {
-        logger.info({ to: recipientEmail, threadId, latestIsOurs }, 'Email reply sent via gateway');
-      } else {
-        logger.warn({ to: recipientEmail, threadId, latestIsOurs, reason: result.blockedReason }, 'Email reply blocked by gateway');
-      }
+      await this.dispatchByPolicy(sendRequest, { threadId, latestIsOurs, to: recipientEmail });
     } catch (err) {
       logger.error({ err, threadId }, 'Failed to send email reply');
+    }
+  }
+
+  /**
+   * Apply this account's outbound policy before dispatching a reply.
+   *
+   * - direct:         send immediately through the gateway (blocked-contact +
+   *                   content filter run inside gateway.send)
+   * - draft_gate:     save as a Nylas draft for human review; the notification +
+   *                   approval + send flow is deferred (TODO(#273))
+   * - autonomy_gated: check the current global autonomy score; if it meets the
+   *                   configured threshold, send directly; otherwise draft-gate
+   */
+  private async dispatchByPolicy(
+    sendRequest: Parameters<OutboundGateway['send']>[0],
+    logCtx: Record<string, unknown>,
+  ): Promise<void> {
+    const { outboundGateway, logger, outboundPolicy, autonomyThreshold, autonomyService } = this.config;
+
+    if (outboundPolicy === 'direct') {
+      // Standard path — gateway enforces blocked-contact check + content filter
+      const result = await outboundGateway.send(sendRequest);
+      if (result.success) {
+        logger.info({ ...logCtx, accountId: this.config.accountId }, 'Email reply sent via gateway');
+      } else {
+        logger.warn({ ...logCtx, accountId: this.config.accountId, reason: result.blockedReason }, 'Email reply blocked by gateway');
+      }
+      return;
+    }
+
+    if (outboundPolicy === 'autonomy_gated') {
+      // Check the global autonomy score before committing to a send.
+      // autonomyThreshold and autonomyService are guaranteed to be set when
+      // outboundPolicy is 'autonomy_gated' — validated at startup via config.ts.
+      if (!autonomyService || autonomyThreshold === undefined) {
+        logger.error(
+          { ...logCtx, accountId: this.config.accountId },
+          'autonomy_gated policy requires autonomyService and autonomyThreshold — falling back to draft_gate',
+        );
+        // Fall through to draft_gate rather than silently sending or silently dropping
+      } else {
+        const score = await autonomyService.getScore();
+        if (score >= autonomyThreshold) {
+          const result = await outboundGateway.send(sendRequest);
+          if (result.success) {
+            logger.info(
+              { ...logCtx, accountId: this.config.accountId, autonomyScore: score, threshold: autonomyThreshold },
+              'Email reply sent autonomously (autonomy threshold met)',
+            );
+          } else {
+            logger.warn({ ...logCtx, accountId: this.config.accountId, reason: result.blockedReason }, 'Email reply blocked by gateway');
+          }
+          return;
+        }
+        logger.info(
+          { ...logCtx, accountId: this.config.accountId, autonomyScore: score, threshold: autonomyThreshold },
+          'Autonomy score below threshold — saving reply as draft',
+        );
+        // Score too low: fall through to draft_gate behaviour
+      }
+    }
+
+    // draft_gate (and autonomy_gated fallback): save as draft for human approval.
+    // TODO(#273): after draft creation, notify the CEO and wire up the approval flow.
+    const draftResult = await outboundGateway.createEmailDraft(sendRequest);
+    if (draftResult.success) {
+      logger.info(
+        { ...logCtx, accountId: this.config.accountId, draftId: draftResult.draftId },
+        'Email reply saved as draft pending human approval (TODO(#273): wire up notification+approval)',
+      );
+    } else {
+      logger.warn(
+        { ...logCtx, accountId: this.config.accountId, reason: draftResult.blockedReason },
+        'Email draft creation failed or was blocked',
+      );
     }
   }
 

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -29,7 +29,7 @@ export interface EmailAdapterConfig {
    *
    * - direct:          send immediately via OutboundGateway (current behavior)
    * - draft_gate:      save as a Nylas draft; human approves before sending
-   *                    TODO(#273): wire up notification → approval → send flow
+   *                    TODO(#278): wire up notification → approval → send flow
    * - autonomy_gated:  send only when autonomy score >= autonomyThreshold
    */
   outboundPolicy: OutboundPolicy;
@@ -205,7 +205,7 @@ export class EmailAdapter {
    *
    * The actual send behaviour is controlled by this account's outboundPolicy:
    *   - direct:         send immediately via OutboundGateway
-   *   - draft_gate:     save as Nylas draft for human approval (TODO(#273): full flow)
+   *   - draft_gate:     save as Nylas draft for human approval (TODO(#278): full flow)
    *   - autonomy_gated: check autonomy score before sending; hold as draft if below threshold
    */
   private async sendOutboundReply(outbound: OutboundMessageEvent): Promise<void> {
@@ -295,7 +295,7 @@ export class EmailAdapter {
    * - direct:         send immediately through the gateway (blocked-contact +
    *                   content filter run inside gateway.send)
    * - draft_gate:     save as a Nylas draft for human review; the notification +
-   *                   approval + send flow is deferred (TODO(#273))
+   *                   approval + send flow is deferred (TODO(#278))
    * - autonomy_gated: check the current global autonomy score; if it meets the
    *                   configured threshold, send directly; otherwise draft-gate
    */
@@ -351,12 +351,12 @@ export class EmailAdapter {
     }
 
     // draft_gate (and autonomy_gated fallback): save as draft for human approval.
-    // TODO(#273): after draft creation, notify the CEO and wire up the approval flow.
+    // TODO(#278): after draft creation, notify the CEO and wire up the approval flow.
     const draftResult = await outboundGateway.createEmailDraft(sendRequest);
     if (draftResult.success) {
       logger.info(
         { ...logCtx, accountId: this.config.accountId, draftId: draftResult.draftId },
-        'Email reply saved as draft pending human approval (TODO(#273): wire up notification+approval)',
+        'Email reply saved as draft pending human approval (TODO(#278): wire up notification+approval)',
       );
     } else if (draftResult.blockedReason === 'Recipient is blocked') {
       // Intentional block — not an infrastructure failure

--- a/src/channels/email/nylas-client.ts
+++ b/src/channels/email/nylas-client.ts
@@ -18,6 +18,8 @@ import type {
   NylasListResponse,
   SendMessageRequest,
   MessageFields,
+  Draft as NylasDraft,
+  CreateDraftRequest,
 } from 'nylas';
 import type { Logger } from '../../logger.js';
 
@@ -42,6 +44,12 @@ interface NylasLike {
       identifier: string;
       requestBody: SendMessageRequest;
     }): Promise<NylasResponse<NylasSdkMessage>>;
+  };
+  drafts: {
+    create(params: {
+      identifier: string;
+      requestBody: CreateDraftRequest;
+    }): Promise<NylasResponse<NylasDraft>>;
   };
 }
 
@@ -205,6 +213,45 @@ export class NylasClient {
       this.log.error(
         { err, grantId: this.grantId, to: options.to, subject: options.subject, isReply: !!options.replyToMessageId },
         'Nylas sendMessage failed',
+      );
+      throw err;
+    }
+  }
+
+  /**
+   * Save an email as a draft (without sending). Used by the 'draft_gate' outbound
+   * policy to hold replies for human review before they leave Curia's mailbox.
+   *
+   * Draft and Message share the same BaseMessage shape in the Nylas SDK, so the
+   * response can be normalised with the same helper as a sent message.
+   *
+   * TODO(#273): wire up the CEO notification → approval → send flow that turns
+   * a draft created here into an actually-sent reply.
+   */
+  async createDraft(options: SendEmailOptions): Promise<NylasMessage> {
+    this.log.debug(
+      { to: options.to, subject: options.subject, isReply: !!options.replyToMessageId },
+      'creating draft',
+    );
+
+    try {
+      const response = await this.nylas.drafts.create({
+        identifier: this.grantId,
+        requestBody: {
+          to: options.to,
+          cc: options.cc,
+          subject: options.subject,
+          body: options.body,
+          replyToMessageId: options.replyToMessageId,
+        },
+      });
+      // Draft and NylasSdkMessage (Message) both extend BaseMessage — the fields we
+      // normalise (id, threadId, subject, from, to, cc, body, etc.) are present on both.
+      return this.normalizeMessage(response.data as unknown as NylasSdkMessage);
+    } catch (err) {
+      this.log.error(
+        { err, grantId: this.grantId, to: options.to, subject: options.subject, isReply: !!options.replyToMessageId },
+        'Nylas createDraft failed',
       );
       throw err;
     }

--- a/src/channels/email/nylas-client.ts
+++ b/src/channels/email/nylas-client.ts
@@ -225,7 +225,7 @@ export class NylasClient {
    * Draft and Message share the same BaseMessage shape in the Nylas SDK, so the
    * response can be normalised with the same helper as a sent message.
    *
-   * TODO(#273): wire up the CEO notification → approval → send flow that turns
+   * TODO(#278): wire up the CEO notification → approval → send flow that turns
    * a draft created here into an actually-sent reply.
    */
   async createDraft(options: SendEmailOptions): Promise<NylasMessage> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -284,7 +284,7 @@ export function loadYamlConfig(configDir: string): YamlConfig {
     // Validate channel_accounts if present
     const channelAccounts = config.channel_accounts?.email;
     if (channelAccounts !== undefined) {
-      if (typeof channelAccounts !== 'object' || Array.isArray(channelAccounts)) {
+      if (channelAccounts === null || typeof channelAccounts !== 'object' || Array.isArray(channelAccounts)) {
         throw new Error('channel_accounts.email must be a YAML mapping');
       }
       const validPolicies: OutboundPolicy[] = ['direct', 'draft_gate', 'autonomy_gated'];

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,48 @@ import yaml from 'js-yaml';
 import { readFileSync } from 'node:fs';
 import * as path from 'node:path';
 
+// ---------------------------------------------------------------------------
+// Multi-account email config types
+// ---------------------------------------------------------------------------
+
+/**
+ * Outbound send policy for a named email account.
+ *
+ * - direct:          send immediately (default for Curia's own account)
+ * - draft_gate:      create a Nylas draft; human must approve before the reply goes out
+ *                    TODO(#273): wire up the notification → approval → send flow
+ * - autonomy_gated:  send autonomously only when the global autonomy score meets or
+ *                    exceeds the account's autonomy_threshold value
+ */
+export type OutboundPolicy = 'direct' | 'draft_gate' | 'autonomy_gated';
+
+/**
+ * Raw per-account email entry as read from config/default.yaml.
+ * Values may be literal strings or "env:VAR_NAME" env-var references.
+ */
+export interface RawEmailAccountConfig {
+  nylas_grant_id: string;
+  self_email: string;
+  outbound_policy: OutboundPolicy;
+  /** Required when outbound_policy is 'autonomy_gated'. Integer 0–100. */
+  autonomy_threshold?: number;
+}
+
+/**
+ * Fully resolved per-account email config with env-var references expanded
+ * to their actual values. This is the shape passed to NylasClient and EmailAdapter.
+ */
+export interface ResolvedEmailAccount {
+  /** Logical name for this account as declared in the YAML (e.g. "curia", "joseph"). */
+  name: string;
+  nylasGrantId: string;
+  selfEmail: string;
+  outboundPolicy: OutboundPolicy;
+  /** Minimum autonomy score (0–100) required for autonomous sends. Only set when
+   *  outboundPolicy is 'autonomy_gated'. */
+  autonomyThreshold?: number;
+}
+
 export interface Config {
   databaseUrl: string;
   anthropicApiKey: string | undefined;
@@ -50,6 +92,32 @@ export interface YamlConfig {
     /** Max inbound message content size in bytes. Default: 102400 (100KB).
      *  Messages exceeding this are rejected by the dispatcher before routing. */
     max_message_bytes?: number;
+  };
+  /**
+   * Multi-account channel config (spec 03 - #3).
+   *
+   * Defines N named accounts per channel type, each with its own credentials
+   * and outbound_policy. When this block is absent, the system falls back to the
+   * legacy single-account env-var config (NYLAS_GRANT_ID + NYLAS_SELF_EMAIL).
+   *
+   * Values may be literal strings or "env:VAR_NAME" references resolved at startup.
+   * The Nylas API key (NYLAS_API_KEY) is shared across all email accounts —
+   * it is the application key, not per-account.
+   *
+   * Example:
+   *   channel_accounts:
+   *     email:
+   *       curia:
+   *         nylas_grant_id: env:NYLAS_GRANT_ID
+   *         self_email: env:NYLAS_SELF_EMAIL
+   *         outbound_policy: direct
+   *       joseph:
+   *         nylas_grant_id: env:JOSEPH_NYLAS_GRANT_ID
+   *         self_email: env:JOSEPH_EMAIL
+   *         outbound_policy: draft_gate
+   */
+  channel_accounts?: {
+    email?: Record<string, RawEmailAccountConfig>;
   };
   browser?: {
     sessionTtlMs?: number;
@@ -213,6 +281,48 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       }
     }
 
+    // Validate channel_accounts if present
+    const channelAccounts = config.channel_accounts?.email;
+    if (channelAccounts !== undefined) {
+      if (typeof channelAccounts !== 'object' || Array.isArray(channelAccounts)) {
+        throw new Error('channel_accounts.email must be a YAML mapping');
+      }
+      const validPolicies: OutboundPolicy[] = ['direct', 'draft_gate', 'autonomy_gated'];
+      for (const [accountName, rawAccount] of Object.entries(channelAccounts)) {
+        if (typeof rawAccount !== 'object' || rawAccount === null || Array.isArray(rawAccount)) {
+          throw new Error(`channel_accounts.email.${accountName} must be a YAML mapping`);
+        }
+        if (typeof rawAccount.nylas_grant_id !== 'string' || !rawAccount.nylas_grant_id) {
+          throw new Error(`channel_accounts.email.${accountName}.nylas_grant_id must be a non-empty string`);
+        }
+        if (typeof rawAccount.self_email !== 'string' || !rawAccount.self_email) {
+          throw new Error(`channel_accounts.email.${accountName}.self_email must be a non-empty string`);
+        }
+        if (!validPolicies.includes(rawAccount.outbound_policy)) {
+          throw new Error(
+            `channel_accounts.email.${accountName}.outbound_policy must be one of: ${validPolicies.join(', ')}, got: "${rawAccount.outbound_policy}"`,
+          );
+        }
+        if (rawAccount.outbound_policy === 'autonomy_gated') {
+          if (rawAccount.autonomy_threshold === undefined) {
+            throw new Error(
+              `channel_accounts.email.${accountName}: outbound_policy 'autonomy_gated' requires autonomy_threshold`,
+            );
+          }
+          if (!Number.isInteger(rawAccount.autonomy_threshold) || rawAccount.autonomy_threshold < 0 || rawAccount.autonomy_threshold > 100) {
+            throw new Error(
+              `channel_accounts.email.${accountName}.autonomy_threshold must be an integer 0–100, got: ${rawAccount.autonomy_threshold}`,
+            );
+          }
+        }
+        if (rawAccount.autonomy_threshold !== undefined && rawAccount.outbound_policy !== 'autonomy_gated') {
+          throw new Error(
+            `channel_accounts.email.${accountName}: autonomy_threshold is only valid when outbound_policy is 'autonomy_gated'`,
+          );
+        }
+      }
+    }
+
     const drift = config.intentDrift;
     if (drift !== undefined) {
       // Reject non-object roots (e.g. `intentDrift: false`, `intentDrift: "off"`, `intentDrift: []`).
@@ -256,6 +366,84 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       `Failed to load config/default.yaml: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Multi-account resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an "env:VAR_NAME" reference to its actual env-var value, or pass
+ * through a literal string unchanged.
+ *
+ * Throws at startup if a referenced env var is not set — a missing credential
+ * should fail loudly rather than produce a silent no-op.
+ */
+function resolveEnvValue(value: string, context: string): string {
+  if (value.startsWith('env:')) {
+    const varName = value.slice(4);
+    const resolved = process.env[varName];
+    if (!resolved) {
+      throw new Error(`${context}: env var "${varName}" is not set`);
+    }
+    return resolved;
+  }
+  return value;
+}
+
+/**
+ * Resolve the final list of email accounts to bootstrap, merging YAML multi-account
+ * config with the legacy env-var single-account fallback.
+ *
+ * Resolution order:
+ *   1. If channel_accounts.email is present in YAML → use it (multi-account mode)
+ *   2. Otherwise → fall back to NYLAS_GRANT_ID + NYLAS_SELF_EMAIL env vars with
+ *      a synthetic "curia" account (single-account backward-compat mode)
+ *
+ * Returns an empty array when neither source provides credentials — in that case
+ * the email channel is simply disabled at startup, matching existing behaviour.
+ *
+ * The Nylas API key (NYLAS_API_KEY) is always read from env and shared across all
+ * accounts; it lives in Config, not per-account config.
+ */
+export function resolveChannelAccounts(yamlConfig: YamlConfig, config: Config): ResolvedEmailAccount[] {
+  const emailAccounts = yamlConfig.channel_accounts?.email;
+
+  // Multi-account mode: YAML block is present and has at least one account
+  if (emailAccounts && Object.keys(emailAccounts).length > 0) {
+    return Object.entries(emailAccounts).map(([name, raw]) => {
+      const nylasGrantId = resolveEnvValue(
+        raw.nylas_grant_id,
+        `channel_accounts.email.${name}.nylas_grant_id`,
+      );
+      const selfEmail = resolveEnvValue(
+        raw.self_email,
+        `channel_accounts.email.${name}.self_email`,
+      );
+      return {
+        name,
+        nylasGrantId,
+        selfEmail,
+        outboundPolicy: raw.outbound_policy,
+        autonomyThreshold: raw.autonomy_threshold,
+      };
+    });
+  }
+
+  // Backward-compat mode: fall back to the legacy single-account env vars.
+  // This path is taken when channel_accounts.email is absent or empty, ensuring
+  // existing single-account deployments require no config changes.
+  if (config.nylasGrantId && config.nylasSelfEmail) {
+    return [{
+      name: 'curia',
+      nylasGrantId: config.nylasGrantId,
+      selfEmail: config.nylasSelfEmail,
+      outboundPolicy: 'direct',
+    }];
+  }
+
+  // No credentials available — email channel will be disabled
+  return [];
 }
 
 export function loadConfig(): Config {

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ import * as path from 'node:path';
  *
  * - direct:          send immediately (default for Curia's own account)
  * - draft_gate:      create a Nylas draft; human must approve before the reply goes out
- *                    TODO(#273): wire up the notification → approval → send flow
+ *                    TODO(#278): wire up the notification → approval → send flow
  * - autonomy_gated:  send autonomously only when the global autonomy score meets or
  *                    exceeds the account's autonomy_threshold value
  */

--- a/src/config.ts
+++ b/src/config.ts
@@ -409,8 +409,11 @@ function resolveEnvValue(value: string, context: string): string {
 export function resolveChannelAccounts(yamlConfig: YamlConfig, config: Config): ResolvedEmailAccount[] {
   const emailAccounts = yamlConfig.channel_accounts?.email;
 
-  // Multi-account mode: YAML block is present and has at least one account
-  if (emailAccounts && Object.keys(emailAccounts).length > 0) {
+  // Multi-account mode: YAML block is present (even if empty).
+  // An explicit empty mapping ({ }) means "no configured email accounts" — do NOT
+  // fall through to the legacy env-var path, so operators can intentionally
+  // disable email in YAML without the legacy account silently reappearing.
+  if (emailAccounts !== undefined) {
     return Object.entries(emailAccounts).map(([name, raw]) => {
       const nylasGrantId = resolveEnvValue(
         raw.nylas_grant_id,
@@ -431,8 +434,8 @@ export function resolveChannelAccounts(yamlConfig: YamlConfig, config: Config): 
   }
 
   // Backward-compat mode: fall back to the legacy single-account env vars.
-  // This path is taken when channel_accounts.email is absent or empty, ensuring
-  // existing single-account deployments require no config changes.
+  // This path is only taken when channel_accounts.email is absent entirely,
+  // ensuring existing single-account deployments require no config changes.
   if (config.nylasGrantId && config.nylasSelfEmail) {
     return [{
       name: 'curia',

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -66,7 +66,7 @@ export class Dispatcher {
    * We key on the task event ID (not the inbound message ID) because the agent
    * runtime sets parentEventId on its response to the task event that triggered it.
    */
-  private taskRouting = new Map<string, { channelId: string; conversationId: string; senderId: string }>();
+  private taskRouting = new Map<string, { channelId: string; conversationId: string; senderId: string; accountId?: string }>();
   /** Key: `${conversationId}:${agentId}` — reset on every agent.response */
   private checkpointTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private pool: DbPool | undefined;
@@ -569,6 +569,7 @@ export class Dispatcher {
       agentId: 'coordinator',
       conversationId: payload.conversationId,
       channelId: payload.channelId,
+      accountId: payload.accountId,
       senderId: payload.senderId,
       content: taskContent,
       senderContext,
@@ -585,10 +586,13 @@ export class Dispatcher {
 
     // Store routing info keyed by the task event ID so we can look it up
     // when the agent publishes its response (agent sets parentEventId = task.id).
+    // accountId is stored so the outbound.message is routed to the same email account
+    // that received the original inbound message.
     this.taskRouting.set(taskEvent.id, {
       channelId: payload.channelId,
       conversationId: payload.conversationId,
       senderId: payload.senderId,
+      accountId: payload.accountId,
     });
 
     await this.bus.publish('dispatch', taskEvent);
@@ -629,6 +633,7 @@ export class Dispatcher {
     const outbound = createOutboundMessage({
       conversationId: routing.conversationId,
       channelId: routing.channelId,
+      accountId: routing.accountId,
       content: event.payload.content,
       parentEventId: event.id,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@
 
 import * as path from 'node:path';
 import { runner } from 'node-pg-migrate';
-import { loadConfig, loadYamlConfig } from './config.js';
+import { loadConfig, loadYamlConfig, resolveChannelAccounts } from './config.js';
 import { createLogger } from './logger.js';
 import { HttpAdapter } from './channels/http/http-adapter.js';
 import { createPool } from './db/connection.js';
@@ -361,20 +361,40 @@ async function main(): Promise<void> {
   const heldMessages = HeldMessageService.createWithPostgres(pool, logger);
   logger.info('Held message service initialized');
 
-  // Email channel — optional, requires NYLAS_API_KEY, NYLAS_GRANT_ID, and NYLAS_SELF_EMAIL.
-  // NylasClient is constructed here (needed by OutboundGateway), but EmailAdapter is
-  // started later after the gateway is fully wired (adapter needs the gateway, not raw client).
-  let nylasClient: NylasClient | undefined;
-  let emailAdapter: EmailAdapter | undefined;
-  if (config.nylasApiKey && config.nylasGrantId) {
-    nylasClient = new NylasClient(config.nylasApiKey, config.nylasGrantId, logger);
-    if (!config.nylasSelfEmail) {
-      logger.warn('NYLAS_SELF_EMAIL not set — email adapter disabled (required to filter self-sent messages)');
+  // Email channel — optional. Supports N named accounts via channel_accounts.email in
+  // config/default.yaml, or falls back to the legacy NYLAS_GRANT_ID + NYLAS_SELF_EMAIL
+  // env vars for single-account backward compatibility.
+  //
+  // One NylasClient is constructed per account (needed by OutboundGateway's client map).
+  // EmailAdapters are constructed further below, after OutboundGateway is ready,
+  // and started after the dispatcher is registered to avoid dropping inbound messages.
+  const resolvedEmailAccounts = resolveChannelAccounts(yamlConfig, config);
+  const nylasClientMap = new Map<string, NylasClient>();
+
+  if (!config.nylasApiKey) {
+    if (resolvedEmailAccounts.length > 0) {
+      logger.warn('NYLAS_API_KEY not set — email channel disabled despite accounts being configured');
+    } else {
+      logger.warn('NYLAS_API_KEY/NYLAS_GRANT_ID not set — email channel disabled');
     }
-    // EmailAdapter is started further below, after OutboundGateway is constructed.
+  } else if (resolvedEmailAccounts.length === 0) {
+    logger.warn('No email accounts resolved — email channel disabled. Set NYLAS_GRANT_ID + NYLAS_SELF_EMAIL, or configure channel_accounts.email in config/default.yaml');
   } else {
-    logger.warn('NYLAS_API_KEY/NYLAS_GRANT_ID not set — email channel disabled');
+    for (const account of resolvedEmailAccounts) {
+      nylasClientMap.set(account.name, new NylasClient(config.nylasApiKey, account.nylasGrantId, logger));
+    }
+    logger.info(
+      { accounts: [...nylasClientMap.keys()] },
+      `Email channel: ${nylasClientMap.size} account(s) configured`,
+    );
   }
+
+  // Keep a reference to the first client for backward-compat code paths that
+  // still use a single-client assumption (e.g. NylasCalendarClient setup below).
+  const primaryNylasClient = nylasClientMap.values().next().value as NylasClient | undefined;
+
+  // EmailAdapters are built later (post-gateway) and stored here.
+  const emailAdapters: EmailAdapter[] = [];
 
   // Signal channel — optional, requires SIGNAL_SOCKET_PATH and SIGNAL_PHONE_NUMBER.
   // SignalRpcClient is constructed here so it can be passed to OutboundGateway (the gateway
@@ -398,11 +418,13 @@ async function main(): Promise<void> {
     logger.warn('SIGNAL_SOCKET_PATH/SIGNAL_PHONE_NUMBER not set — Signal channel disabled');
   }
 
-  // Calendar client — uses the same Nylas credentials as email.
-  // Independent instance, no shared state with the email client.
+  // Calendar client — uses the primary email account's Nylas credentials.
+  // For multi-account deployments the calendar is always associated with the first
+  // (primary) account; a future spec can extend this to per-account calendars.
   let nylasCalendarClient: NylasCalendarClient | undefined;
-  if (config.nylasApiKey && config.nylasGrantId) {
-    nylasCalendarClient = new NylasCalendarClient(config.nylasApiKey, config.nylasGrantId, logger);
+  if (config.nylasApiKey && primaryNylasClient && resolvedEmailAccounts.length > 0) {
+    const primaryAccount = resolvedEmailAccounts[0]!;
+    nylasCalendarClient = new NylasCalendarClient(config.nylasApiKey, primaryAccount.nylasGrantId, logger);
     logger.info('Nylas calendar client initialized');
   }
 
@@ -564,10 +586,10 @@ async function main(): Promise<void> {
   //   In that mode, log.error is the fallback — see OutboundGateway.send() comments.
   //   For now we assume Nylas + Signal together, so this path is only for dev flexibility.
   let outboundGateway: OutboundGateway | undefined;
-  const hasAnyOutboundClient = !!(nylasClient || signalRpcClient);
+  const hasAnyOutboundClient = nylasClientMap.size > 0 || !!signalRpcClient;
   if (hasAnyOutboundClient && outboundFilter) {
     outboundGateway = new OutboundGateway({
-      nylasClient,
+      nylasClients: nylasClientMap.size > 0 ? nylasClientMap : undefined,
       signalClient: signalRpcClient,
       signalPhoneNumber: config.signalPhoneNumber,
       contactService,
@@ -581,27 +603,47 @@ async function main(): Promise<void> {
       logger,
     });
     logger.info({
-      hasEmail: !!nylasClient,
+      emailAccounts: [...nylasClientMap.keys()],
       hasSignal: !!signalRpcClient,
     }, 'Outbound gateway initialized');
-  } else if (nylasClient && !outboundFilter) {
-    // nylasClient is available but outboundFilter is missing (no coordinator config found).
+  } else if (nylasClientMap.size > 0 && !outboundFilter) {
+    // Nylas clients are available but outboundFilter is missing (no coordinator config found).
     // Email skills will be unavailable because they check ctx.outboundGateway before sending.
     logger.warn('Outbound gateway NOT initialized — outboundFilter not ready (coordinator config missing?). Outbound send skills will be unavailable.');
   }
 
-  // Construct the email adapter (but don't start it yet — it must not poll until
-  // the dispatcher is registered, otherwise inbound.message events have no subscriber
-  // and are permanently dropped because the adapter advances its high-water mark).
-  if (outboundGateway && nylasClient && config.nylasSelfEmail) {
-    emailAdapter = new EmailAdapter({
-      bus,
-      logger,
-      outboundGateway,
-      contactService,
-      pollingIntervalMs: config.nylasPollingIntervalMs,
-      selfEmail: config.nylasSelfEmail,
-    });
+  // Construct one EmailAdapter per resolved account (but don't start any yet —
+  // adapters must not poll until the dispatcher is registered, otherwise inbound.message
+  // events have no subscriber and are permanently dropped because each adapter advances
+  // its own high-water mark on poll).
+  if (outboundGateway) {
+    for (const account of resolvedEmailAccounts) {
+      if (!nylasClientMap.has(account.name)) continue; // skip accounts with no client (NYLAS_API_KEY missing)
+
+      if (account.outboundPolicy === 'autonomy_gated' && !account.autonomyThreshold) {
+        // This should be caught by config validation, but guard defensively at runtime too.
+        logger.warn(
+          { accountId: account.name },
+          'Email account has outbound_policy=autonomy_gated but no autonomy_threshold — skipping adapter',
+        );
+        continue;
+      }
+
+      emailAdapters.push(new EmailAdapter({
+        accountId: account.name,
+        outboundPolicy: account.outboundPolicy,
+        autonomyThreshold: account.autonomyThreshold,
+        // autonomyService is only injected when the policy actually needs it, to avoid
+        // passing a live service reference to adapters that will never call it.
+        autonomyService: account.outboundPolicy === 'autonomy_gated' ? autonomyService : undefined,
+        bus,
+        logger,
+        outboundGateway,
+        contactService,
+        pollingIntervalMs: config.nylasPollingIntervalMs,
+        selfEmail: account.selfEmail,
+      }));
+    }
   }
 
   // Construct the Signal adapter (but don't start it yet — same ordering rule as email:
@@ -875,13 +917,15 @@ async function main(): Promise<void> {
   const bullpenDispatcher = new BullpenDispatcher(bus, logger, bullpenService);
   bullpenDispatcher.register();
 
-  // Start the email adapter AFTER the dispatcher is registered so inbound.message
+  // Start all email adapters AFTER the dispatcher is registered so inbound.message
   // events always have a subscriber. Starting before registration would drop emails
-  // arriving during the startup window (the adapter advances its high-water mark
+  // arriving during the startup window (each adapter advances its own high-water mark
   // on poll, so dropped messages are never retried).
-  if (emailAdapter) {
-    await emailAdapter.start();
-    logger.info('Email channel adapter started');
+  for (const adapter of emailAdapters) {
+    await adapter.start();
+  }
+  if (emailAdapters.length > 0) {
+    logger.info({ count: emailAdapters.length }, 'Email channel adapter(s) started');
   }
 
   // Start the Signal adapter AFTER the dispatcher is registered — same ordering rule as email.
@@ -921,9 +965,9 @@ async function main(): Promise<void> {
   // Graceful shutdown — stop accepting new input first, then close connections.
   const shutdown = async () => {
     logger.info('Shutting down...');
-    if (emailAdapter) {
+    for (const adapter of emailAdapters) {
       try {
-        await emailAdapter.stop();
+        await adapter.stop();
       } catch (err) {
         logger.error({ err }, 'Error stopping email adapter during shutdown');
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -620,7 +620,7 @@ async function main(): Promise<void> {
     for (const account of resolvedEmailAccounts) {
       if (!nylasClientMap.has(account.name)) continue; // skip accounts with no client (NYLAS_API_KEY missing)
 
-      if (account.outboundPolicy === 'autonomy_gated' && !account.autonomyThreshold) {
+      if (account.outboundPolicy === 'autonomy_gated' && account.autonomyThreshold === undefined) {
         // This should be caught by config validation, but guard defensively at runtime too.
         logger.warn(
           { accountId: account.name },

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -409,7 +409,7 @@ export class OutboundGateway {
    * mailbox until explicitly sent). The reply goes through the full pipeline when the
    * draft is eventually approved and sent.
    *
-   * TODO(#273): after draft creation, notify the CEO and wire up the approval flow.
+   * TODO(#278): after draft creation, notify the CEO and wire up the approval flow.
    */
   async createEmailDraft(request: EmailSendRequest): Promise<OutboundDraftResult> {
     const recipientId = request.to;

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -355,9 +355,6 @@ export class OutboundGateway {
           'outbound-gateway: CEO notification skipped — no email client configured. Block recorded in audit log only.',
         );
       }
-
-
-
       return { success: false, blockedReason: 'Content blocked by filter' };
     }
 

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -36,6 +36,10 @@ import { markdownToHtml } from '../channels/email/markdown-to-html.js';
 
 export interface EmailSendRequest {
   channel: 'email';
+  /** Which named account should send this message (e.g. "curia", "joseph").
+   *  Used by the gateway to select the right NylasClient from its map.
+   *  Defaults to the first configured account when absent. */
+  accountId?: string;
   /** Recipient email address */
   to: string;
   subject?: string;
@@ -85,16 +89,27 @@ export interface OutboundSendResult {
   blockedReason?: string;
 }
 
+/** Result from createEmailDraft() — extends send result with the Nylas draft ID. */
+export interface OutboundDraftResult extends OutboundSendResult {
+  /** Nylas draft ID when success is true. */
+  draftId?: string;
+}
+
 export interface OutboundGatewayConfig {
   /**
-   * Nylas client for email sends. Optional — gateway can be initialized with
-   * only Signal (signalClient) if email is not configured.
+   * Map of accountId → NylasClient, one entry per configured email account.
+   * The gateway uses this map to route email sends and draft creations to the
+   * correct Nylas grant. The first entry in the map is treated as the primary
+   * account and is used for system notifications (e.g. blocked-content alerts).
    *
-   * In production (Nylas + Signal mode), this is always set alongside signalClient.
-   * The optional type exists so the gateway can be constructed when only Signal
-   * credentials are provided (e.g., integration tests without Nylas API key).
+   * Optional — gateway can be initialised with only Signal (signalClient) if
+   * email is not configured.
+   *
+   * TODO: If non-Nylas email backends are added in future, replace this map with
+   * an AccountManager abstraction that can hold heterogeneous client types and
+   * abstract over the underlying send/draft/list APIs per account.
    */
-  nylasClient?: NylasClient;
+  nylasClients?: Map<string, NylasClient>;
 
   /**
    * signal-cli RPC client for Signal sends. Optional — gateway can be initialized
@@ -153,7 +168,13 @@ function redactId(value: string): string {
 // ---------------------------------------------------------------------------
 
 export class OutboundGateway {
-  private readonly nylasClient?: NylasClient;
+  /** All configured email accounts: accountId → NylasClient. */
+  private readonly nylasClients: Map<string, NylasClient>;
+  /**
+   * The primary NylasClient — first entry in nylasClients, used for system
+   * notifications (blocked-content CEO alerts) when no accountId is specified.
+   */
+  private readonly primaryNylasClient: NylasClient | undefined;
   private readonly signalClient?: SignalRpcClient;
   private readonly signalPhoneNumber?: string;
   private readonly contactService: ContactService;
@@ -163,7 +184,8 @@ export class OutboundGateway {
   private readonly log: Logger;
 
   constructor(config: OutboundGatewayConfig) {
-    this.nylasClient = config.nylasClient;
+    this.nylasClients = config.nylasClients ?? new Map();
+    this.primaryNylasClient = this.nylasClients.values().next().value;
     this.signalClient = config.signalClient;
     this.signalPhoneNumber = config.signalPhoneNumber;
     this.contactService = config.contactService;
@@ -299,10 +321,11 @@ export class OutboundGateway {
       // message was a Signal send — this avoids a potential Signal → block → Signal
       // notification loop, and email is the canonical out-of-band channel for system alerts.
       //
-      // If email is not configured (no nylasClient or no ceoEmail), we log.error and rely
+      // Uses the primary email account (first in nylasClients map) for notifications.
+      // If email is not configured (no accounts or no ceoEmail), we log.error and rely
       // on the audit log. A future Signal notification fallback can be added here.
       // TODO: add Signal-based blocked-content notification when email is absent.
-      if (this.ceoEmail && this.nylasClient) {
+      if (this.ceoEmail && this.primaryNylasClient) {
         // dispatchEmail bypasses this.send() to avoid infinite recursion.
         // The notification body is a hardcoded template — no user-supplied content.
         // dispatchEmail skips the content filter entirely, so triggerSource is irrelevant.
@@ -333,6 +356,8 @@ export class OutboundGateway {
         );
       }
 
+
+
       return { success: false, blockedReason: 'Content blocked by filter' };
     }
 
@@ -348,24 +373,67 @@ export class OutboundGateway {
 
   /**
    * Fetch a single email message by its Nylas message ID.
-   * Read-only — no filtering applied.
+   * Read-only — no security filtering applied.
+   *
+   * @param messageId  Nylas message ID
+   * @param accountId  Which account to query. Defaults to the primary account.
    */
-  async getEmailMessage(messageId: string): Promise<NylasMessage> {
-    if (!this.nylasClient) {
-      throw new Error('outbound-gateway: getEmailMessage called but nylasClient is not configured');
+  async getEmailMessage(messageId: string, accountId?: string): Promise<NylasMessage> {
+    const client = this.getNylasClient(accountId);
+    if (!client) {
+      throw new Error('outbound-gateway: getEmailMessage called but no nylasClient is configured');
     }
-    return this.nylasClient.getMessage(messageId);
+    return client.getMessage(messageId);
   }
 
   /**
    * List email messages, optionally filtered by the provided options.
-   * Read-only — no filtering applied.
+   * Read-only — no security filtering applied.
+   *
+   * @param options    Nylas list-messages query params
+   * @param accountId  Which account to query. Defaults to the primary account.
    */
-  async listEmailMessages(options?: ListMessagesOptions): Promise<NylasMessage[]> {
-    if (!this.nylasClient) {
-      throw new Error('outbound-gateway: listEmailMessages called but nylasClient is not configured');
+  async listEmailMessages(options?: ListMessagesOptions, accountId?: string): Promise<NylasMessage[]> {
+    const client = this.getNylasClient(accountId);
+    if (!client) {
+      throw new Error('outbound-gateway: listEmailMessages called but no nylasClient is configured');
     }
-    return this.nylasClient.listMessages(options);
+    return client.listMessages(options);
+  }
+
+  /**
+   * Create a Nylas draft without sending it — used by the draft_gate outbound policy.
+   *
+   * Runs the same blocked-contact check as send() but skips the content filter
+   * (the filter is designed for messages leaving Curia's control; drafts stay in the
+   * mailbox until explicitly sent). The reply goes through the full pipeline when the
+   * draft is eventually approved and sent.
+   *
+   * TODO(#273): after draft creation, notify the CEO and wire up the approval flow.
+   */
+  async createEmailDraft(request: EmailSendRequest): Promise<OutboundDraftResult> {
+    const recipientId = request.to;
+
+    // ------------------------------------------------------------------
+    // Blocked contact check
+    // ------------------------------------------------------------------
+    try {
+      const contact = await this.contactService.resolveByChannelIdentity('email', recipientId);
+      if (contact !== null && contact.status === 'blocked') {
+        this.log.warn(
+          { channel: 'email', recipientId: redactId(recipientId), contactId: contact.contactId },
+          'outbound-gateway: draft blocked — recipient is blocked',
+        );
+        return { success: false, blockedReason: 'Recipient is blocked' };
+      }
+    } catch (err) {
+      this.log.warn(
+        { err, channel: 'email', recipientId: redactId(recipientId) },
+        'outbound-gateway: contact resolution failed for draft, proceeding without blocked check',
+      );
+    }
+
+    return this.dispatchEmailDraft(request);
   }
 
   /**
@@ -405,11 +473,70 @@ export class OutboundGateway {
   // ---------------------------------------------------------------------------
 
   /**
+   * Return the NylasClient for the given accountId, or the primary client if
+   * accountId is absent. Returns undefined when no clients are configured.
+   */
+  private getNylasClient(accountId?: string): NylasClient | undefined {
+    if (this.nylasClients.size === 0) return undefined;
+    if (accountId) {
+      const client = this.nylasClients.get(accountId);
+      if (!client) {
+        this.log.warn(
+          { accountId },
+          'outbound-gateway: no NylasClient found for accountId — falling back to primary account',
+        );
+      }
+      return client ?? this.primaryNylasClient;
+    }
+    return this.primaryNylasClient;
+  }
+
+  /**
+   * Create a Nylas draft without sending.
+   * Called from createEmailDraft() after the blocked-contact check passes.
+   */
+  private async dispatchEmailDraft(request: EmailSendRequest): Promise<OutboundDraftResult> {
+    const nylasClient = this.getNylasClient(request.accountId);
+    if (!nylasClient) {
+      return { success: false, blockedReason: 'Email client not configured' };
+    }
+
+    const htmlBody = markdownToHtml(request.body);
+
+    try {
+      const sendOptions: SendEmailOptions = {
+        to: [{ email: request.to }],
+        cc: request.cc?.map((email) => ({ email })),
+        subject: request.subject ?? '',
+        body: htmlBody,
+        replyToMessageId: request.replyToMessageId,
+      };
+
+      const draft = await nylasClient.createDraft(sendOptions);
+
+      this.log.info(
+        { draftId: draft.id, channel: 'email', to: request.to, accountId: request.accountId },
+        'outbound-gateway: draft created successfully',
+      );
+
+      return { success: true, draftId: draft.id };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.log.error(
+        { err, channel: 'email', to: request.to, accountId: request.accountId },
+        'outbound-gateway: Nylas createDraft failed',
+      );
+      return { success: false, blockedReason: `Draft creation failed: ${message}` };
+    }
+  }
+
+  /**
    * Dispatch a send request to Nylas for email delivery.
    * Maps our flat request shape into the SendEmailOptions the NylasClient expects.
    */
   private async dispatchEmail(request: EmailSendRequest): Promise<OutboundSendResult> {
-    if (!this.nylasClient) {
+    const nylasClient = this.getNylasClient(request.accountId);
+    if (!nylasClient) {
       return { success: false, blockedReason: 'Email client not configured' };
     }
 
@@ -427,10 +554,10 @@ export class OutboundGateway {
         replyToMessageId: request.replyToMessageId,
       };
 
-      const sent = await this.nylasClient.sendMessage(sendOptions);
+      const sent = await nylasClient.sendMessage(sendOptions);
 
       this.log.info(
-        { messageId: sent.id, channel: 'email', to: request.to },
+        { messageId: sent.id, channel: 'email', to: request.to, accountId: request.accountId },
         'outbound-gateway: message sent successfully',
       );
 

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -427,10 +427,14 @@ export class OutboundGateway {
         return { success: false, blockedReason: 'Recipient is blocked' };
       }
     } catch (err) {
-      this.log.warn(
+      // For drafts, fail-closed on contact-resolution errors: a draft created for a
+      // blocked contact could be sent by a human later, bypassing the block entirely.
+      // Better to drop the draft and surface the error than to silently bypass the check.
+      this.log.error(
         { err, channel: 'email', recipientId: redactId(recipientId) },
-        'outbound-gateway: contact resolution failed for draft, proceeding without blocked check',
+        'outbound-gateway: contact resolution failed — aborting draft to avoid bypassing block check',
       );
+      return { success: false, blockedReason: 'Contact resolution failed; draft not created' };
     }
 
     return this.dispatchEmailDraft(request);
@@ -481,12 +485,16 @@ export class OutboundGateway {
     if (accountId) {
       const client = this.nylasClients.get(accountId);
       if (!client) {
-        this.log.warn(
-          { accountId },
-          'outbound-gateway: no NylasClient found for accountId — falling back to primary account',
+        // Do NOT fall back to the primary account — sending from the wrong account
+        // (wrong From address, wrong mailbox) is a correctness failure, not a graceful
+        // degradation. The caller will receive undefined and return { success: false }.
+        this.log.error(
+          { accountId, availableAccounts: [...this.nylasClients.keys()] },
+          'outbound-gateway: no NylasClient found for accountId — cannot route send; reply dropped',
         );
+        return undefined;
       }
-      return client ?? this.primaryNylasClient;
+      return client;
     }
     return this.primaryNylasClient;
   }

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -61,6 +61,8 @@ function createMocks() {
 
 function makeAdapter(mocks: ReturnType<typeof createMocks>) {
   return new EmailAdapter({
+    accountId: 'curia',
+    outboundPolicy: 'direct',
     bus: mocks.bus,
     logger: mocks.logger,
     outboundGateway: mocks.outboundGateway,

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -61,7 +61,7 @@ describe('OutboundGateway', () => {
     });
 
     const gateway = new OutboundGateway({
-      nylasClient: mocks.nylasClient,
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
       contactService: mocks.contactService,
       contentFilter: mocks.contentFilter,
       bus: mocks.bus,
@@ -90,7 +90,7 @@ describe('OutboundGateway', () => {
     });
 
     const gateway = new OutboundGateway({
-      nylasClient: mocks.nylasClient,
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
       contactService: mocks.contactService,
       contentFilter: mocks.contentFilter,
       bus: mocks.bus,
@@ -110,7 +110,7 @@ describe('OutboundGateway', () => {
     (mocks.contactService.resolveByChannelIdentity as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
     const gateway = new OutboundGateway({
-      nylasClient: mocks.nylasClient,
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
       contactService: mocks.contactService,
       contentFilter: mocks.contentFilter,
       bus: mocks.bus,
@@ -133,7 +133,7 @@ describe('OutboundGateway', () => {
     );
 
     const gateway = new OutboundGateway({
-      nylasClient: mocks.nylasClient,
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
       contactService: mocks.contactService,
       contentFilter: mocks.contentFilter,
       bus: mocks.bus,
@@ -159,7 +159,7 @@ describe('OutboundGateway', () => {
       });
 
       const gateway = new OutboundGateway({
-        nylasClient: mocks.nylasClient,
+        nylasClients: new Map([['curia', mocks.nylasClient]]),
         contactService: mocks.contactService,
         contentFilter: mocks.contentFilter,
         bus: mocks.bus,
@@ -185,7 +185,7 @@ describe('OutboundGateway', () => {
       });
 
       const gateway = new OutboundGateway({
-        nylasClient: mocks.nylasClient,
+        nylasClients: new Map([['curia', mocks.nylasClient]]),
         contactService: mocks.contactService,
         contentFilter: mocks.contentFilter,
         bus: mocks.bus,
@@ -216,7 +216,7 @@ describe('OutboundGateway', () => {
       });
 
       const gateway = new OutboundGateway({
-        nylasClient: mocks.nylasClient,
+        nylasClients: new Map([['curia', mocks.nylasClient]]),
         contactService: mocks.contactService,
         contentFilter: mocks.contentFilter,
         bus: mocks.bus,
@@ -245,7 +245,7 @@ describe('OutboundGateway', () => {
       });
 
       const gateway = new OutboundGateway({
-        nylasClient: mocks.nylasClient,
+        nylasClients: new Map([['curia', mocks.nylasClient]]),
         contactService: mocks.contactService,
         contentFilter: mocks.contentFilter,
         bus: mocks.bus,
@@ -273,7 +273,7 @@ describe('OutboundGateway', () => {
       );
 
       const gateway = new OutboundGateway({
-        nylasClient: mocks.nylasClient,
+        nylasClients: new Map([['curia', mocks.nylasClient]]),
         contactService: mocks.contactService,
         contentFilter: mocks.contentFilter,
         bus: mocks.bus,
@@ -299,7 +299,7 @@ describe('OutboundGateway', () => {
       });
 
       const gateway = new OutboundGateway({
-        nylasClient: mocks.nylasClient,
+        nylasClients: new Map([['curia', mocks.nylasClient]]),
         contactService: mocks.contactService,
         contentFilter: mocks.contentFilter,
         bus: mocks.bus,
@@ -339,7 +339,7 @@ describe('OutboundGateway', () => {
       });
 
       const gateway = new OutboundGateway({
-        nylasClient: mocks.nylasClient,
+        nylasClients: new Map([['curia', mocks.nylasClient]]),
         contactService: mocks.contactService,
         contentFilter: mocks.contentFilter,
         bus: mocks.bus,


### PR DESCRIPTION
## Summary

Implements [#272](https://github.com/josephfung/curia/issues/272): multi-account email channel support.

- **`channel_accounts.email` YAML config** — N named Nylas-backed email accounts, each with its own grant ID, `self_email`, and `outbound_policy` (`direct | draft_gate | autonomy_gated`). Keys are logical account names that become the `accountId` stamped on bus events.
- **One `EmailAdapter` per account** — each adapter owns a single Nylas grant and applies its own outbound policy independently.
- **`accountId` propagation** — added as optional field to `InboundMessagePayload`, `AgentTaskPayload`, and `OutboundMessagePayload` so replies are always routed back through the account that received the original message.
- **`draft_gate` policy** — saves the coordinator's reply as a Nylas draft for human review; full notification → approval → send flow tracked in #278.
- **`autonomy_gated` policy** — checks the global autonomy score before each send; falls back to `draft_gate` when below threshold.
- **`OutboundGateway.createEmailDraft()`** — new method; runs blocked-contact check (fail-closed on resolution errors), skips content filter (drafts never leave the mailbox until manually sent).
- **Backward compatible** — when `channel_accounts.email` is absent, falls back to single-account env-var mode (`NYLAS_GRANT_ID` / `NYLAS_SELF_EMAIL`). No config changes needed for existing deployments.
- **Schema fixes** — `intentDrift` and `channel_accounts` added to `schemas/default-config.schema.json`; fixes pre-existing schema validation failure on the project's own `config/default.yaml`.

## Test plan

- [x] All 1250 existing unit tests pass
- [x] `tests/unit/skills/outbound-gateway.test.ts` updated for `nylasClients` Map config
- [x] `tests/unit/channels/email/email-adapter.test.ts` updated for `accountId` + `outboundPolicy` fields
- [x] Startup validator test passes (`config/default.yaml` now validates cleanly)
- [ ] Manual smoke test: configure two accounts in `channel_accounts.email` and verify each receives inbound email and replies from the correct mailbox
- [ ] Manual smoke test: set `outbound_policy: draft_gate` and verify a Nylas draft is created (not sent)
- [ ] Manual smoke test: set `outbound_policy: autonomy_gated` with a threshold above current score and verify draft is created instead of sending

## Notes

- `TODO(#278)` marks the deferred notification → approval → send flow for `draft_gate`
- The `accountId ?? 'curia'` fallback in `EmailAdapter` is intentional: legacy events without `accountId` only arise in single-account backward-compat mode, where the account is always synthesised with name `'curia'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-account email support with per-account outbound policies: direct, draft_gate (creates drafts), and autonomy_gated (sends when autonomy score meets threshold).
  * Inbound/outbound messages carry accountId so replies are routed via the same receiving account.
  * Outbound API: createEmailDraft to save Nylas drafts without sending.

* **Configuration**
  * Schema and commented config docs for per-account credentials, outbound_policy, and optional autonomy_threshold; legacy single-account env fallback preserved.

* **Documentation**
  * CHANGELOG updated.

* **Tests**
  * Fixtures/tests updated for multi-account flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->