### PR TITLE
feat: wire taylorwilsdon/google_workspace_mcp as stdio MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,5 +81,18 @@ TAVILY_API_KEY=tvly-...
 #
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 
+# === Google Workspace MCP (community server — active) ===
+#
+# OAuth 2.0 credentials for taylorwilsdon/google_workspace_mcp.
+# Create a Desktop App OAuth client in Google Cloud Console, then add Curia's
+# Gmail as a test user on the consent screen.
+# See docs/dev/google-drive.md for the full setup runbook.
+#
+# On first startup after these are set, the MCP server prints an OAuth URL.
+# Open it in a browser logged in as Curia's Gmail, complete the flow, and tokens
+# are cached at ~/.workspace-mcp/cli-tokens/ for all subsequent runs.
+# GOOGLE_OAUTH_CLIENT_ID=<your-client-id>.apps.googleusercontent.com
+# GOOGLE_OAUTH_CLIENT_SECRET=GOCSPX-...
+
 # Logging
 LOG_LEVEL=info

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,12 @@ RUN pnpm exec tsup src/index.ts --format esm --no-dts
 FROM node:22-slim
 
 # curl is needed for the HEALTHCHECK command
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends curl python3 && rm -rf /var/lib/apt/lists/*
+
+# Install uv (Python package manager) so uvx workspace-mcp can be spawned as
+# an MCP stdio subprocess by Curia's mcp-loader.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,12 @@ RUN pnpm exec tsup src/index.ts --format esm --no-dts
 FROM node:22-slim
 
 # curl is needed for the HEALTHCHECK command
-RUN apt-get update && apt-get install -y --no-install-recommends curl python3 && rm -rf /var/lib/apt/lists/*
+# Copy uv/uvx binaries from the official signed image (Astral's recommended
+# Docker pattern — no curl|sh, cryptographically signed, version-pinned).
+# uvx is needed to spawn workspace-mcp as an MCP stdio subprocess.
+COPY --from=ghcr.io/astral-sh/uv:0.6.3 /uv /uvx /usr/local/bin/
 
-# Install uv (Python package manager) so uvx workspace-mcp can be spawned as
-# an MCP stdio subprocess by Curia's mcp-loader.
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/config/skills.yaml
+++ b/config/skills.yaml
@@ -49,10 +49,11 @@ servers:
   #   3. Set GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET in .env
   #   4. Run the OAuth flow once locally to cache tokens (~/.workspace-mcp/cli-tokens/)
   #
-  # env: {} is intentional — it triggers the mcp-client.ts branch that passes
-  # { ...process.env, ...{} } to the child, so the Google OAuth credentials from
-  # Curia's .env are available to the subprocess. Without this block, the MCP SDK
-  # uses getDefaultEnvironment() which omits application-defined env vars.
+  # Empty-string env values are resolved from process.env at runtime by
+  # mcp-client.ts's buildChildEnv() — only these two keys are passed to the
+  # subprocess (plus a safe base set: PATH, HOME, USER, etc.). This enforces
+  # least-privilege: DB_PASSWORD, ANTHROPIC_API_KEY, etc. never reach the
+  # third-party process.
   - name: google-workspace
     transport: stdio
     command: uvx
@@ -60,7 +61,9 @@ servers:
       - workspace-mcp
       - --tool-tier
       - extended
-    env: {}
+    env:
+      GOOGLE_OAUTH_CLIENT_ID: ""
+      GOOGLE_OAUTH_CLIENT_SECRET: ""
     action_risk: low
     sensitivity: normal
     timeout_ms: 60000

--- a/config/skills.yaml
+++ b/config/skills.yaml
@@ -37,4 +37,30 @@
 # See docs/dev/google-drive.md for setup instructions and the path forward
 # for Google Drive / Workspace once Google ships their hosted MCP server.
 
-servers: []
+servers:
+  # Community Google Workspace MCP server (taylorwilsdon/google_workspace_mcp).
+  # Covers Drive, Sheets, Docs, Gmail, Calendar, and more via OAuth 2.0 as Curia's
+  # Gmail user. The "extended" tier exposes the full productivity surface without
+  # the long tail of rarely-needed tools — upgrade to "complete" if needed later.
+  #
+  # Prerequisites (one-time human setup — see docs/dev/google-drive.md):
+  #   1. Create a Google Cloud Project, enable Drive/Sheets/Docs/Gmail/Calendar APIs
+  #   2. Create an OAuth 2.0 Desktop App credential
+  #   3. Set GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET in .env
+  #   4. Run the OAuth flow once locally to cache tokens (~/.workspace-mcp/cli-tokens/)
+  #
+  # env: {} is intentional — it triggers the mcp-client.ts branch that passes
+  # { ...process.env, ...{} } to the child, so the Google OAuth credentials from
+  # Curia's .env are available to the subprocess. Without this block, the MCP SDK
+  # uses getDefaultEnvironment() which omits application-defined env vars.
+  - name: google-workspace
+    transport: stdio
+    command: uvx
+    args:
+      - workspace-mcp
+      - --tool-tier
+      - extended
+    env: {}
+    action_risk: low
+    sensitivity: normal
+    timeout_ms: 60000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,13 @@ services:
       timeout: 5s
       start_period: 15s
       retries: 3
+    volumes:
+      # Persist OAuth token cache for the google-workspace MCP server.
+      # Tokens are written here on first OAuth login and auto-refreshed thereafter.
+      # Without this volume, re-authentication is required on every container restart.
+      # See docs/dev/google-drive.md for first-time OAuth setup.
+      - google_workspace_tokens:/root/.workspace-mcp
 
 volumes:
   pgdata:
+  google_workspace_tokens:

--- a/docs/dev/google-drive.md
+++ b/docs/dev/google-drive.md
@@ -89,7 +89,7 @@ ssh <vps-host> "cp -r /tmp/workspace-mcp-tokens /var/lib/docker/volumes/curia_go
 
 After copying, restart Curia and check the logs for:
 
-```
+```text
 INFO  MCP server tools registered  {"server":"google-workspace","registered":N,"total":N}
 ```
 
@@ -120,7 +120,7 @@ repeat Step 5 to re-authenticate and copy fresh tokens to the VPS.
 ### Verification
 
 1. **Startup log**: after Curia boots, look for:
-   ```
+   ```text
    INFO  MCP server tools registered  {"server":"google-workspace","registered":N}
    ```
    A non-zero `registered` count means the server connected and tools are available.

--- a/docs/dev/google-drive.md
+++ b/docs/dev/google-drive.md
@@ -78,13 +78,13 @@ Then copy the token cache to the VPS:
 
 ```bash
 # Replace <vps-host> with your server (e.g. ceo-office)
-scp -r ~/.workspace-mcp/cli-tokens <vps-host>:/tmp/workspace-mcp-tokens
+scp -r ~/.workspace-mcp/cli-tokens <vps-host>:/tmp/cli-tokens
 
-# On the VPS: copy into the Docker volume
-# First find the volume mount path:
+# On the VPS: copy into the Docker volume at the path the server expects.
+# The volume is mounted at /root/.workspace-mcp; the server reads tokens from
+# /root/.workspace-mcp/cli-tokens/, so files must land at _data/cli-tokens/.
 ssh <vps-host> docker volume inspect curia_google_workspace_tokens
-# Then copy:
-ssh <vps-host> "cp -r /tmp/workspace-mcp-tokens /var/lib/docker/volumes/curia_google_workspace_tokens/_data/"
+ssh <vps-host> "cp -r /tmp/cli-tokens /var/lib/docker/volumes/curia_google_workspace_tokens/_data/"
 ```
 
 After copying, restart Curia and check the logs for:
@@ -139,8 +139,9 @@ repeat Step 5 to re-authenticate and copy fresh tokens to the VPS.
 
 **`ERROR Failed to connect to MCP server`**
 
-`uvx` is not on the PATH inside the container. Check that `uv` was installed in the
-Dockerfile and `PATH="/root/.local/bin:$PATH"` is set. Rebuild the image if needed.
+`uvx` is not on the PATH inside the container. The Dockerfile installs `uv`/`uvx` into
+`/usr/local/bin/` via `COPY --from=ghcr.io/astral-sh/uv`. Verify with
+`docker exec curia which uvx` — if missing, rebuild the image.
 
 **`INFO MCP server tools registered {"registered":0}`**
 
@@ -168,12 +169,11 @@ security settings, then repeat Step 5.
 ## Production Dockerfile (`curia-deploy`)
 
 The production image uses `curia-deploy/deploy/compose/Dockerfile.curia` (not the
-`curia/Dockerfile`). That file also needs `uv` installed. Add the same two lines
-after the `apt-get install` block:
+`curia/Dockerfile`). That file also needs `uv`/`uvx`. Use the same signed,
+version-pinned copy pattern as `curia/Dockerfile`:
 
 ```dockerfile
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
+COPY --from=ghcr.io/astral-sh/uv:0.6.3 /uv /uvx /usr/local/bin/
 ```
 
 Also add the token volume to `compose.production.yaml` under the `curia` service:

--- a/docs/dev/google-drive.md
+++ b/docs/dev/google-drive.md
@@ -1,161 +1,225 @@
 # Google Drive Setup
 
-This guide documents the path to Google Drive integration via MCP and explains
-what to do today versus what to do once Google ships their hosted Workspace MCP server.
+This guide covers Google Drive / Workspace integration via the community MCP server
+(`taylorwilsdon/google_workspace_mcp`) and what changes when Google ships their
+official hosted Workspace MCP server.
 
 ---
 
-## Current status (April 2026)
+## Current approach (April 2026): community stdio server
 
-Google Drive is **not yet available** as an official Google-hosted MCP server.
-Google announced Workspace MCP support (Drive, Docs, Sheets, Calendar, Gmail) in
-late 2025 but has not shipped it as of April 2026. Track availability at:
+Google's hosted Workspace MCP server is not yet available. In the meantime, Curia
+uses [`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp)
+as a local stdio subprocess — the MCP loader spawns it via `uvx workspace-mcp` and
+communicates over stdin/stdout.
 
-> https://docs.cloud.google.com/mcp/supported-products
+This gives Curia full access to Drive, Sheets, Docs, Gmail, Calendar, and more using
+OAuth 2.0 as Curia's own Gmail user.
 
-The previously referenced npm package (`@modelcontextprotocol/server-gdrive`) is
-deprecated and marked "no longer supported" — do not use it.
+### One-time setup
 
----
+#### Step 1 — Google Cloud Project
 
-## What's already wired
+1. Go to [console.cloud.google.com](https://console.cloud.google.com) and create a new project (e.g. `curia-workspace`).
+2. Enable these APIs (APIs & Services → Library):
+   - Google Drive API
+   - Google Sheets API
+   - Google Docs API
+   - Gmail API
+   - Google Calendar API
 
-The Curia MCP infrastructure is fully ready for Google Drive the moment Google ships it:
+#### Step 2 — OAuth consent screen
 
-- `config/skills.yaml` uses `transport: sse` which now routes through
-  `StreamableHTTPClientTransport` — the same transport Google's hosted MCP servers use
-- The `headers:` field in `skills.yaml` allows passing `Authorization: Bearer <token>`
-  to any authenticated hosted MCP endpoint
-- The coordinator's `allow_discovery: true` means Drive tools will be discoverable once
-  registered, and you can pin specific tool names in `pinned_skills` for consistent access
+1. Go to APIs & Services → OAuth consent screen.
+2. Choose **External** (works with any Gmail account, including Curia's).
+3. Fill in the app name and contact email.
+4. Add scopes: Drive, Sheets, Docs, Gmail, Calendar.
+5. Under **Test users**, add Curia's Gmail address.
 
-No code changes will be needed. Setup is purely a configuration step.
+> The app can stay in "Testing" mode. If you want non-expiring tokens without having
+> to re-add test users, publish the app (Publish App button). Publishing does not make
+> the app publicly listed — it just removes the 7-day test-token expiry.
 
----
+#### Step 3 — Create OAuth credentials
 
-## When Google ships the Workspace MCP server
+1. APIs & Services → Credentials → Create Credentials → **OAuth client ID**.
+2. Application type: **Desktop app**.
+3. Name it (e.g. `curia-mcp-client`).
+4. Download the credentials JSON — you won't need the file, just the Client ID and Secret.
 
-### Step 1 — Confirm the endpoint URL
+#### Step 4 — Set env vars
 
-Check `https://docs.cloud.google.com/mcp/supported-products` for the official endpoint.
-It will likely follow the pattern `https://workspaceapis.googleapis.com/mcp` or similar.
-
-### Step 2 — Provision a service account and generate a bearer token
-
-Google's hosted MCP servers authenticate via OAuth 2.0 bearer tokens. For unattended
-server use, generate tokens from a service account:
-
-**2a. Create a service account**
-
-1. Go to [console.cloud.google.com](https://console.cloud.google.com) → **IAM & Admin → Service Accounts**.
-2. Click **Create Service Account**. Name it (e.g. `curia-drive`) and click **Create and continue**.
-3. Grant it the minimum Drive scope needed (e.g. `roles/drive.file` to operate only on
-   files created by the service account, or `roles/drive.readonly` for read-only access).
-4. Click **Done**.
-
-**2b. Create and download a key**
-
-1. Click the service account → **Keys** tab → **Add key → Create new key → JSON**.
-2. Move the downloaded file somewhere secure outside the repo
-   (e.g. `~/.config/curia/gdrive-service-account.json`).
-3. Add to `.env`:
+Add to `.env` (VPS and local):
 
 ```env
-GOOGLE_APPLICATION_CREDENTIALS=/path/to/gdrive-service-account.json
+GOOGLE_OAUTH_CLIENT_ID=<your-client-id>.apps.googleusercontent.com
+GOOGLE_OAUTH_CLIENT_SECRET=GOCSPX-...
 ```
 
-**2c. Token injection (tracked as follow-up work)**
+#### Step 5 — Run the first OAuth flow (requires a browser)
 
-`config/skills.yaml` headers are literal strings — no env-var interpolation is performed.
-Bearer tokens expire (typically after 1 hour), so a static value in `skills.yaml` isn't
-suitable for production use.
+The MCP server prints an auth URL on its first run. You must open it in a browser
+signed in as Curia's Gmail.
 
-> **TODO:** Env-var interpolation for `skills.yaml` header values (analogous to
-> `env:VAR_NAME` in `config/default.yaml`) should be added when the Workspace MCP server
-> ships. File a ticket at that point so token generation and injection can be wired up
-> alongside the Drive config. Until then, a `skills.yaml.template` + `envsubst` wrapper
-> at startup is the recommended pattern for any deployment that needs this today.
+**Option A (recommended): auth locally, copy tokens to VPS**
 
-### Step 3 — Update `config/skills.yaml`
+```bash
+# Install uv locally if not already present
+curl -LsSf https://astral.sh/uv/install.sh | sh
 
-Uncomment and fill in the template (already present in the file):
+# Run the MCP server — it will print an OAuth URL
+GOOGLE_OAUTH_CLIENT_ID=<...> GOOGLE_OAUTH_CLIENT_SECRET=<...> uvx workspace-mcp
 
-```yaml
-servers:
-  - name: google-workspace
-    transport: sse
-    url: https://workspaceapis.googleapis.com/mcp   # confirm at launch
-    action_risk: low
-    headers:
-      Authorization: "Bearer <your-token>"          # inject at startup; see above
+# In the browser: open the printed URL, log in as Curia's Gmail, and approve access.
+# Tokens are saved to ~/.workspace-mcp/cli-tokens/.
 ```
 
-### Step 4 — Pin tools in `agents/coordinator.yaml`
+Then copy the token cache to the VPS:
 
-After startup, check the logs for lines like:
+```bash
+# Replace <vps-host> with your server (e.g. ceo-office)
+scp -r ~/.workspace-mcp/cli-tokens <vps-host>:/tmp/workspace-mcp-tokens
+
+# On the VPS: copy into the Docker volume
+# First find the volume mount path:
+ssh <vps-host> docker volume inspect curia_google_workspace_tokens
+# Then copy:
+ssh <vps-host> "cp -r /tmp/workspace-mcp-tokens /var/lib/docker/volumes/curia_google_workspace_tokens/_data/"
+```
+
+After copying, restart Curia and check the logs for:
 
 ```
-INFO  MCP tool registered  {"server":"google-workspace","tool":"drive.files.list"}
 INFO  MCP server tools registered  {"server":"google-workspace","registered":N,"total":N}
 ```
 
-Add the tool names you want the coordinator to use by default to `pinned_skills` in
-`agents/coordinator.yaml`:
+**Option B: auth directly on the VPS** (requires X11 forwarding or port tunneling)
 
-```yaml
-pinned_skills:
-  # ... existing skills ...
-  - drive.files.list
-  - drive.files.get
-  - drive.files.create
-```
+Not recommended for initial setup — Option A is simpler.
 
-Restart Curia after any `coordinator.yaml` change.
+#### Step 6 — Share Drive content with Curia
 
-### Step 5 — Share the target Drive folder
+There's nothing to configure in code. Just use the normal Google Drive UI:
 
-Create or designate a root folder in Drive for Curia's use. Share it with the service
-account's email address (found on the service account detail page, looks like
-`curia-drive@your-project.iam.gserviceaccount.com`) with **Editor** access.
+1. Open the Google Sheet or Drive folder you want Curia to access.
+2. Share it with Curia's Gmail address, granting **Editor** access.
 
-The service account can only access content explicitly shared with it — there's no need
-for code-level path restrictions.
-
-### Step 6 — Smoke test
-
-Ask Curia to list or search Drive files:
-
-> "Search Drive for our expense tracker and summarize the last few entries."
-
-Check the startup logs if tools don't respond — a connection failure produces:
-
-```
-ERROR  Failed to connect to MCP server — tools from this server will be unavailable until restart
-```
+Curia will be able to read and write anything shared with that Gmail.
 
 ---
 
-## Troubleshooting
+### Token refresh and rotation
+
+OAuth tokens auto-refresh in the background — no manual action needed for day-to-day use.
+
+If tokens are ever revoked (e.g. you revoke app access in Google account security settings),
+repeat Step 5 to re-authenticate and copy fresh tokens to the VPS.
+
+---
+
+### Verification
+
+1. **Startup log**: after Curia boots, look for:
+   ```
+   INFO  MCP server tools registered  {"server":"google-workspace","registered":N}
+   ```
+   A non-zero `registered` count means the server connected and tools are available.
+
+2. **Tool discovery**: ask Curia: *"What Google Workspace tools do you have available?"*
+   It should list Drive, Sheets, Docs, Gmail, and Calendar tools.
+
+3. **End-to-end read**: share a test Google Sheet with Curia's Gmail, then ask:
+   *"Read the test sheet and summarize what's in it."*
+
+4. **End-to-end write**: ask Curia to add a row to the test sheet. Verify in Google Sheets.
+
+---
+
+### Troubleshooting
 
 **`ERROR Failed to connect to MCP server`**
 
-Connection to the Google endpoint failed. Check:
-- The URL in `skills.yaml` is correct and the endpoint is live
-- The bearer token is valid and not expired (tokens typically last 1 hour)
+`uvx` is not on the PATH inside the container. Check that `uv` was installed in the
+Dockerfile and `PATH="/root/.local/bin:$PATH"` is set. Rebuild the image if needed.
 
-**Drive calls fail with 401 Unauthorized**
+**`INFO MCP server tools registered {"registered":0}`**
 
-The token is missing, expired, or has insufficient scope. Regenerate via
-`gcloud auth application-default print-access-token` and restart.
+The server connected but advertised no tools. This usually means the OAuth flow has
+not been completed — the token cache at `/root/.workspace-mcp/cli-tokens/` is empty
+or missing. Repeat Step 5.
+
+**Tools disappear after container restart**
+
+The `google_workspace_tokens` Docker volume is not being persisted. Confirm the volume
+is declared in `docker-compose.yml` and mounted at `/root/.workspace-mcp`.
 
 **Drive calls fail with 403 Forbidden**
 
-The service account doesn't have access to the target file or folder. Confirm the
-service account email has been shared on the folder with at least Viewer (read) or
-Editor (write) access.
+The file or folder hasn't been shared with Curia's Gmail. Open Drive and share it
+with Editor access.
 
-**Tools not appearing in coordinator**
+**Drive calls fail with 401 Unauthorized**
 
-Tool names in `pinned_skills` must exactly match what the server advertises via
-`tools/list`. Check startup logs for the registered names and update `coordinator.yaml`
-to match, then restart.
+OAuth token is invalid or expired. Revoke and re-grant access via Google account
+security settings, then repeat Step 5.
+
+---
+
+## Production Dockerfile (`curia-deploy`)
+
+The production image uses `curia-deploy/deploy/compose/Dockerfile.curia` (not the
+`curia/Dockerfile`). That file also needs `uv` installed. Add the same two lines
+after the `apt-get install` block:
+
+```dockerfile
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+```
+
+Also add the token volume to `compose.production.yaml` under the `curia` service:
+
+```yaml
+services:
+  curia:
+    volumes:
+      - google_workspace_tokens:/root/.workspace-mcp
+      # ... existing volumes ...
+
+volumes:
+  google_workspace_tokens:
+  # ... existing volumes ...
+```
+
+> **TODO:** These `curia-deploy` changes are tracked as a follow-up. The community
+> server will not start in production until they are applied.
+
+---
+
+## Future: Google-hosted Workspace MCP server
+
+Google announced a hosted Workspace MCP server (Drive, Docs, Sheets, Calendar, Gmail)
+in late 2025. Track availability at:
+
+> https://docs.cloud.google.com/mcp/supported-products
+
+When it ships, the migration path is:
+
+1. Confirm the endpoint URL (likely `https://workspaceapis.googleapis.com/mcp`).
+2. Generate a bearer token (OAuth 2.0 via service account or user delegation).
+3. In `config/skills.yaml`, replace the current `stdio` entry with:
+   ```yaml
+   - name: google-workspace
+     transport: sse
+     url: https://workspaceapis.googleapis.com/mcp
+     action_risk: low
+     headers:
+       Authorization: "Bearer <token>"
+   ```
+4. Remove the `uv` install from the Dockerfile (no longer needed).
+5. Remove the `google_workspace_tokens` Docker volume (auth moves to the hosted side).
+
+> **Note on token injection**: `skills.yaml` headers are literal strings — no
+> env-var interpolation. Bearer tokens expire (~1 hour), so a static value isn't
+> suitable for production. A `skills.yaml.template` + `envsubst` at startup is the
+> recommended interim pattern. File a ticket when the hosted server ships to wire up
+> token generation and injection alongside the config change.

--- a/src/skills/mcp-client.ts
+++ b/src/skills/mcp-client.ts
@@ -53,6 +53,35 @@ export interface McpSession {
 }
 
 /**
+ * Build a minimal child process environment for a stdio MCP server.
+ *
+ * Starts from the same safe base that the MCP SDK's getDefaultEnvironment()
+ * uses (HOME, LOGNAME, PATH, SHELL, TERM, USER) so spawned tools can locate
+ * binaries and their own config dirs. Then resolves each key declared in
+ * configEnv: an empty string means "inherit the value from process.env at
+ * runtime"; a non-empty string is used as a literal override.
+ *
+ * This enforces least-privilege — the full host environment (DB_PASSWORD,
+ * ANTHROPIC_API_KEY, etc.) is never passed to the third-party subprocess.
+ * Only keys explicitly declared in config/skills.yaml under env: reach it.
+ */
+function buildChildEnv(configEnv: Record<string, string>): Record<string, string> {
+  // Minimal base matching the MCP SDK's getDefaultEnvironment() key set.
+  const env: Record<string, string> = {};
+  for (const key of ['HOME', 'LOGNAME', 'PATH', 'SHELL', 'TERM', 'USER']) {
+    if (process.env[key] !== undefined) env[key] = process.env[key]!;
+  }
+
+  // Resolve declared keys: empty value = inherit from process.env.
+  for (const [key, value] of Object.entries(configEnv)) {
+    const resolved = value !== '' ? value : process.env[key];
+    if (resolved !== undefined) env[key] = resolved;
+  }
+
+  return env;
+}
+
+/**
  * Connect to a stdio MCP server.
  * Spawns the configured process and performs the MCP initialization handshake.
  * Throws on connection failure — callers decide whether to warn-and-continue
@@ -70,11 +99,13 @@ export async function connectStdio(
   const transport = new StdioClientTransport({
     command: config.command,
     args: config.args,
-    // Merge caller-supplied env vars on top of the defaults the SDK inherits.
-    // If no extra env is declared, the SDK's getDefaultEnvironment() applies.
-    env: config.env
-      ? { ...process.env as Record<string, string>, ...config.env }
-      : undefined,
+    // Build a minimal child env rather than spreading all of process.env.
+    // Passing the full host environment to a third-party subprocess violates
+    // least-privilege — DB_PASSWORD, API_TOKEN, etc. have no business there.
+    // buildChildEnv() starts from a safe base (PATH, HOME, USER, etc.) and
+    // resolves only the keys declared in config.env.
+    // If no env block is declared, the SDK's getDefaultEnvironment() applies.
+    env: config.env ? buildChildEnv(config.env) : undefined,
     // Pipe stderr so the spawned server's error output goes through our logger
     // rather than leaking to the parent process's stderr untagged.
     stderr: 'pipe',

--- a/src/skills/mcp-client.ts
+++ b/src/skills/mcp-client.ts
@@ -85,7 +85,19 @@ export async function connectStdio(
     { capabilities: {} },
   );
 
-  await client.connect(transport);
+  try {
+    await client.connect(transport);
+  } catch (err) {
+    // Surface ENOENT as an actionable message — the generic "Failed to connect"
+    // log from mcp-loader gives no clue that the command simply isn't on PATH.
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(
+        `stdio MCP server '${config.name}': command '${config.command}' not found on PATH. ` +
+        `Ensure the tool is installed and accessible from the process environment.`,
+      );
+    }
+    throw err;
+  }
 
   logger.info(
     { server: config.name, serverInfo: client.getServerVersion() },

--- a/src/skills/mcp-loader.ts
+++ b/src/skills/mcp-loader.ts
@@ -210,7 +210,11 @@ export async function loadMcpServers(
 
     const tools = toolList.tools ?? [];
     if (tools.length === 0) {
-      logger.warn({ server: serverEntry.name }, 'MCP server advertises no tools — nothing to register');
+      // Zero tools most commonly means the OAuth flow hasn't been completed yet.
+      // The server starts and handshakes successfully but won't expose tools until
+      // the user authenticates. Check docs/dev/google-drive.md Step 5 if this is
+      // the google-workspace server. Token cache: ~/.workspace-mcp/cli-tokens/
+      logger.warn({ server: serverEntry.name }, 'MCP server advertises no tools — nothing to register. If this is the google-workspace server, the OAuth flow may not have been completed (see docs/dev/google-drive.md Step 5).');
       // Keep the session open — the server might add tools in a future protocol version.
       sessions.push(session);
       continue;


### PR DESCRIPTION
## Summary

- Wires [`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp) (2k+ stars, active) as a local stdio MCP subprocess — gives Curia full access to Drive, Sheets, Docs, Gmail, and Calendar via OAuth 2.0 as Curia's Gmail user
- The official Google-hosted Workspace MCP server is not yet live; this unblocks Drive/Sheets integration now
- Adds actionable error messages for the two most common failure modes: `uvx` not on PATH (ENOENT) and OAuth flow not completed (zero tools)

## Changes

| File | What changed |
|---|---|
| `config/skills.yaml` | Add `google-workspace` stdio server entry (`uvx workspace-mcp --tool-tier extended`) |
| `.env.example` | Add commented-out `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` |
| `Dockerfile` | Install `python3` + `uv` so `uvx` is available in the container |
| `docker-compose.yml` | Add `google_workspace_tokens` named volume at `/root/.workspace-mcp` |
| `docs/dev/google-drive.md` | Full setup runbook for the community server; future Google-hosted path documented below |
| `src/skills/mcp-client.ts` | Surface `ENOENT` spawn failures as actionable "command not found on PATH" errors |
| `src/skills/mcp-loader.ts` | Add OAuth guidance to the zero-tools warning message |

## Not in this PR (follow-up required for production)

The production image uses `curia-deploy/deploy/compose/Dockerfile.curia` — it also needs `uv` installed, and `compose.production.yaml` needs the `google_workspace_tokens` volume. These are `curia-deploy` changes tracked as a TODO in the runbook.

## Test plan

- [ ] Set `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` in `.env`
- [ ] Start Curia locally — confirm startup log shows `MCP server tools registered` with `server: google-workspace` and non-zero `registered` count
- [ ] Ask Curia: *"What Google Workspace tools do you have available?"* — should list Drive, Sheets, Docs, Gmail, Calendar tools
- [ ] Share a test Google Sheet with Curia's Gmail; ask Curia to read it
- [ ] Ask Curia to add a row to the test sheet; verify the change in Google Sheets
- [ ] Test ENOENT path: remove `uvx` from PATH temporarily, confirm the log says "command not found on PATH" (not the generic connection error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Workspace MCP integration with OAuth-based access and support for running the community MCP server locally.
  * Persisted OAuth token cache across container restarts.

* **Documentation**
  * Rewrote setup guide with first-run auth flow, token management, troubleshooting, and deployment notes.

* **Stability**
  * Runtime image now includes required helper binaries for MCP tooling availability.
* **Bug Fixes**
  * Clearer startup warning when the MCP server advertises no tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->