### PR TITLE
feat: Dream Engine — memory decay pass (issue #27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,26 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
-### Fixed
-
-- **Coordinator always uses its own account for third-party tool calls** — added explicit
-  system prompt guidance instructing the coordinator to default to its own account identity
-  (not the CEO's) when any tool requires an email or account parameter. Prevents tools like
-  `user_google_email` from being populated with the CEO's address, which caused workspace-mcp
-  to request a new OAuth flow for an account it has no credentials for.
-
 ### Added
 
+- **Dream Engine** (spec 17): background KG maintenance system with memory decay pass. Confidence on `slow_decay` and `fast_decay` nodes/edges decays exponentially using configurable half-lives (180 days / 21 days). Rows at or below the archive threshold are soft-deleted via `archived_at`; edges cascade when their endpoints are archived. All KG read paths filter archived rows. Wired as an internal system job in the Scheduler. Config under `dreaming.decay.*` in `config/default.yaml`. Implements issue #27; decay warning (#280) deferred to a follow-up.
 - **Google Workspace tools wired to coordinator** — Drive, Docs, Sheets, and Gmail read/search/write tools from the `google-workspace` MCP server are now pinned to the coordinator's skill list, making them available as LLM tools on every request. Gmail outbound (send/reply) continues to use the existing local skills; the MCP Gmail tools cover search, read, threads, labels, and drafts. Temporary measure until spec #274 (allow_discovery) is fully implemented.
-
-### Changed
-
-### Fixed
-### Fixed
-
-- **Migration prefix conflicts** — resolved duplicate `014_*` and `015_*` migration prefixes that caused `node-pg-migrate` to throw an ordering error and blocked all integration tests. `014_add_kg_node_sensitivity.sql` renumbered to `024_`. PR `#284` incorrectly renamed `020_add_contact_trust_fields.sql` to `019_`, but prod's `pgmigrations` table records it as `020_`, causing a `checkOrder` startup failure. Renamed back to `020_add_contact_trust_fields.sql`. Closes `#284`, `#286`.
-
-### Added
 - **MCP HTTP transport migration** — the `sse` transport in `config/skills.yaml` now uses `StreamableHTTPClientTransport` (the recommended SDK transport for hosted MCP servers) instead of the deprecated `SSEClientTransport`. Behaviour is unchanged for existing configs. Resolves the ADR 016 migration note. Closes #271.
 - **MCP `headers` config field** — SSE server entries in `config/skills.yaml` now accept an optional `headers: Record<string, string>` field. Enables `Authorization: Bearer <token>` for authenticated hosted MCP servers (Google, etc.) without any code changes. See `docs/dev/google-drive.md` for the Google Workspace path forward.
 - **Multi-account email channel** (spec §03) — `channel_accounts.email` YAML block supports N named Nylas-backed email accounts, each with its own grant ID, `self_email`, and `outbound_policy` (`direct | draft_gate | autonomy_gated`). One `EmailAdapter` instance is constructed per account at startup; inbound events are stamped with the receiving `accountId` and replies are routed back through the same account. Closes #272.
@@ -41,6 +25,17 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`accountId` on bus events** — optional `accountId` field added to `InboundMessagePayload`, `AgentTaskPayload`, and `OutboundMessagePayload`. Propagated through the dispatch routing table so replies are always sent from the account that received the original message. This is an additive change; existing handlers that do not destructure `accountId` are unaffected.
 - **`createEmailDraft` on `OutboundGateway`** — creates a Nylas draft without sending; runs the blocked-contact check but skips the content filter (drafts stay in the mailbox until explicitly sent by a human).
 - **Backward-compatible single-account fallback** — if `channel_accounts.email` is absent, the email channel falls back to the existing `NYLAS_GRANT_ID` / `NYLAS_SELF_EMAIL` env-var mode; no config changes needed for existing deployments.
+
+### Changed
+
+### Fixed
+
+- **Coordinator always uses its own account for third-party tool calls** — added explicit
+  system prompt guidance instructing the coordinator to default to its own account identity
+  (not the CEO's) when any tool requires an email or account parameter. Prevents tools like
+  `user_google_email` from being populated with the CEO's address, which caused workspace-mcp
+  to request a new OAuth flow for an account it has no credentials for.
+- **Migration prefix conflicts** — resolved duplicate `014_*` and `015_*` migration prefixes that caused `node-pg-migrate` to throw an ordering error and blocked all integration tests. `014_add_kg_node_sensitivity.sql` renumbered to `024_`. PR `#284` incorrectly renamed `020_add_contact_trust_fields.sql` to `019_`, but prod's `pgmigrations` table records it as `020_`, causing a `checkOrder` startup failure. Renamed back to `020_add_contact_trust_fields.sql`. Closes `#284`, `#286`.
 
 ---
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -206,6 +206,25 @@ intentDrift:
   checkEveryNBursts: 1
   minConfidenceToPause: high
 
+# Dream engine — background knowledge graph maintenance (issue #27).
+# The decay pass runs on a configurable interval and reduces the confidence of
+# slow_decay and fast_decay nodes/edges using an exponential half-life model.
+# When confidence drops to or below archiveThreshold, the row is soft-deleted
+# (archived_at is set); it no longer appears in queries but is retained for audit.
+#
+# halfLifeDays: the number of days for a fact's confidence to halve.
+#   permanent: null — these nodes are never touched by the decay pass.
+#   slow_decay: 180  — employer, residence; reliable for months/years.
+#   fast_decay: 21   — coffee preference, current focus; unreliable after weeks.
+dreaming:
+  decay:
+    intervalMs: 86400000     # daily
+    archiveThreshold: 0.05
+    halfLifeDays:
+      permanent: null
+      slow_decay: 180
+      fast_decay: 21
+
 # Sensitivity classification rules for KG nodes (issue #200).
 # Rules are evaluated in descending sensitivity order — 'restricted' rules are
 # checked before 'confidential', so the most protective rule always wins.

--- a/docs/wip/2026-04-11-dream-engine-design.md
+++ b/docs/wip/2026-04-11-dream-engine-design.md
@@ -1,0 +1,219 @@
+# Dream Engine — Design
+
+**Issue:** josephfung/curia#27
+**Date:** 2026-04-11
+**Status:** Approved
+
+---
+
+## Overview
+
+The Dream Engine is a background maintenance system that runs periodic passes on the knowledge graph when the system is not actively serving a conversation. The name reflects the neuroscience analogy: sleep is when the brain consolidates short-term experiences into long-term memory, prunes weak connections, and resolves conflicts.
+
+This spec covers the first pass: **memory decay**. Future passes (contradiction resolution, working-memory synthesis, etc.) will be added as sibling passes under the same engine. See [Future Passes](#future-passes) below.
+
+---
+
+## Design Decisions
+
+### Soft-delete, not hard-delete
+
+When a node's confidence falls below the archive threshold, it is soft-deleted: `archived_at` is set to the current timestamp. The row remains in the database for audit purposes and can be restored if the fact is later re-confirmed.
+
+Hard delete was rejected because it permanently destroys information that may still be useful for audit, debugging, or re-confirmation flows.
+
+### Edges follow their endpoints
+
+When a node is archived, any edge where it is the source or target is also archived in the same pass. A dangling edge pointing to an archived node has no queryable meaning and would corrupt traversal results.
+
+Edges also decay and archive independently based on their own confidence — an edge between two active nodes can still decay to the point of archiving.
+
+### All read paths filter archived rows
+
+`WHERE archived_at IS NULL` is added to every query that reads `kg_nodes` or `kg_edges`:
+- `semanticSearch`
+- `traverse` (both the recursive CTE and the node join)
+- `findNodesByType`, `findNodesByLabel`, `getNode`
+- `getEdgesForNode`
+
+Without this, archived facts would continue to surface in agent context.
+
+### Exponential confidence decay
+
+Confidence decays using a half-life model:
+
+```
+new_confidence = current_confidence × 0.5^(days_since_last_confirmed / half_life_days)
+```
+
+This means confidence halves after one half-life, quarters after two, etc. `permanent` nodes are never touched by the decay pass.
+
+Half-lives are configurable per decay class (see [Configuration](#configuration)).
+
+### EventBus injected from day one
+
+`DreamEngine` accepts `EventBus` as a required constructor argument even though the first implementation does not publish events. This reserves the wiring for the future decay warning pass (josephfung/curia#280), which will emit `memory.decay_warning` before archiving important nodes, without requiring a signature change.
+
+### Single engine, per-pass intervals (Approach B)
+
+Each pass runs on its own configurable interval. This avoids forcing all maintenance work onto a single cadence while keeping all background maintenance under one roof. Future passes slot in as sibling config keys under `dreaming`.
+
+---
+
+## Configuration
+
+New block in `config/default.yaml`:
+
+```yaml
+dreaming:
+  decay:
+    intervalMs: 86400000     # how often the decay pass runs (default: daily)
+    archiveThreshold: 0.05   # confidence at or below this → archived
+    halfLifeDays:
+      permanent: null        # never decays
+      slow_decay: 180        # reliable for months/years; halves every 6 months
+      fast_decay: 21         # unreliable after weeks; halves every 3 weeks
+```
+
+---
+
+## Database Migration
+
+Add `archived_at TIMESTAMPTZ` (nullable, default NULL) to both `kg_nodes` and `kg_edges`.
+
+Partial indexes for efficient filtering:
+
+```sql
+ALTER TABLE kg_nodes ADD COLUMN archived_at TIMESTAMPTZ;
+ALTER TABLE kg_edges ADD COLUMN archived_at TIMESTAMPTZ;
+
+CREATE INDEX idx_kg_nodes_archived_at ON kg_nodes (archived_at) WHERE archived_at IS NULL;
+CREATE INDEX idx_kg_edges_archived_at ON kg_edges (archived_at) WHERE archived_at IS NULL;
+```
+
+---
+
+## `DreamEngine` Class
+
+**File:** `src/memory/dream-engine.ts`
+
+```typescript
+class DreamEngine {
+  constructor(pool: Pool, bus: EventBus, logger: Logger, config: DreamEngineConfig)
+  
+  // Run the full decay pass: decay → archive nodes → archive edges
+  async runDecayPass(): Promise<DecayPassResult>
+  
+  // Start the recurring interval timer
+  start(): void
+  
+  // Stop the timer (for clean shutdown)
+  stop(): void
+}
+```
+
+### `runDecayPass()` — three SQL passes in order
+
+**Pass 1 — Confidence decay**
+
+For all non-archived `slow_decay` and `fast_decay` nodes and edges, reduce confidence:
+
+```sql
+UPDATE kg_nodes
+SET confidence = confidence * power(0.5, 
+    EXTRACT(EPOCH FROM (now() - last_confirmed_at)) / 86400 / $half_life_days)
+WHERE archived_at IS NULL
+  AND decay_class = $decay_class
+  AND confidence > $archive_threshold
+```
+
+Run once for `slow_decay` (180-day half-life) and once for `fast_decay` (21-day half-life). `permanent` nodes are skipped entirely.
+
+The `confidence > $archive_threshold` guard means nodes already below the threshold are not decayed further — they are simply archived in Pass 2. This avoids unnecessary writes on already-condemned rows.
+
+Same pass runs on `kg_edges`.
+
+**Pass 2 — Archive nodes**
+
+```sql
+UPDATE kg_nodes
+SET archived_at = now()
+WHERE archived_at IS NULL
+  AND decay_class != 'permanent'
+  AND confidence <= $archive_threshold
+```
+
+**Pass 3 — Archive edges**
+
+Archive edges whose own confidence is at or below threshold, OR whose source or target node was just archived:
+
+```sql
+UPDATE kg_edges
+SET archived_at = now()
+WHERE archived_at IS NULL
+  AND (
+    confidence <= $archive_threshold
+    OR source_node_id IN (SELECT id FROM kg_nodes WHERE archived_at IS NOT NULL)
+    OR target_node_id IN (SELECT id FROM kg_nodes WHERE archived_at IS NOT NULL)
+  )
+```
+
+### `DecayPassResult`
+
+```typescript
+interface DecayPassResult {
+  nodesDecayed: number;    // rows updated in pass 1 (nodes)
+  edgesDecayed: number;    // rows updated in pass 1 (edges)
+  nodesArchived: number;   // rows updated in pass 2
+  edgesArchived: number;   // rows updated in pass 3
+  durationMs: number;
+}
+```
+
+Result is logged at `info` level after each run.
+
+---
+
+## Wiring
+
+In `Scheduler.start()`, after the job poll and watchdog intervals are registered:
+
+```typescript
+const dreamEngine = new DreamEngine(pool, bus, logger, config.dreaming);
+dreamEngine.start();
+```
+
+Startup logs the decay interval so operators can verify configuration.
+
+---
+
+## Future Passes
+
+The following passes are planned but not in scope for this spec. They will be added as sibling methods on `DreamEngine` with their own config keys under `dreaming`:
+
+| Pass | Config key | Trigger | Issue |
+|---|---|---|---|
+| Decay warning | `dreaming.decayWarning` | Before archiving important nodes | josephfung/curia#280 |
+| Contradiction resolution | `dreaming.contradictions` | Periodic | TBD |
+| Working-memory synthesis | `dreaming.synthesis` | Post-conversation checkpoint | TBD |
+
+---
+
+## Testing
+
+### Unit tests (`src/memory/dream-engine.test.ts`)
+
+- Decay pass reduces confidence by the correct factor for `slow_decay` and `fast_decay` nodes at known ages
+- `permanent` nodes are never touched
+- Nodes at or below `archiveThreshold` after decay are archived
+- Edges with archived endpoints are archived in pass 3
+- Edges with their own confidence at threshold are archived independently
+- `DecayPassResult` counts are accurate
+- Config with `permanent: null` half-life does not produce a SQL call for permanent nodes
+
+### Integration tests (real Postgres)
+
+- Seed nodes with varied `last_confirmed_at` and decay classes; run `runDecayPass()`; assert final confidence values and `archived_at` state
+- Verify archived nodes do not appear in `semanticSearch`, `traverse`, `findNodesByType`, or `findNodesByLabel`
+- Verify archived edges do not appear in `getEdgesForNode` or `traverse`
+- Verify a re-confirmed node (manually update `last_confirmed_at` + raise confidence) survives subsequent decay runs

--- a/docs/wip/2026-04-11-dream-engine-design.md
+++ b/docs/wip/2026-04-11-dream-engine-design.md
@@ -42,7 +42,7 @@ Without this, archived facts would continue to surface in agent context.
 
 Confidence decays using a half-life model:
 
-```
+```text
 new_confidence = current_confidence × 0.5^(days_since_last_confirmed / half_life_days)
 ```
 

--- a/docs/wip/2026-04-11-dream-engine.md
+++ b/docs/wip/2026-04-11-dream-engine.md
@@ -1,0 +1,1251 @@
+# Dream Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the DreamEngine — a background system that runs exponential confidence decay on knowledge graph nodes and edges, soft-deleting (archiving) items whose confidence falls below a threshold.
+
+**Architecture:** A dedicated `DreamEngine` class in `src/memory/` runs three SQL passes on a configurable interval: decay confidence on `slow_decay`/`fast_decay` nodes and edges, archive nodes at or below the threshold, archive edges whose endpoints were archived or whose own confidence crossed the threshold. All KG read paths are updated to filter out archived rows via `WHERE archived_at IS NULL`. The engine is wired into `Scheduler.start()` alongside the existing poll and watchdog intervals.
+
+**Tech Stack:** TypeScript/ESM, Node 22+, PostgreSQL 16+ with node-postgres (`pg`), Vitest for tests.
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|---|---|---|
+| `src/db/migrations/024_add_kg_archived_at.sql` | Create | Adds `archived_at` column + indexes to both KG tables |
+| `src/memory/dream-engine.ts` | Create | `DreamEngine` class — decay + archive passes |
+| `src/memory/dream-engine.test.ts` | Create | Unit tests for decay math and pass logic |
+| `tests/integration/dream-engine.test.ts` | Create | Integration tests against real Postgres |
+| `src/memory/knowledge-graph.ts` | Modify | Add `WHERE archived_at IS NULL` to all read paths; add `archived_at` to `PgNodeRow`/`PgEdgeRow` |
+| `src/config.ts` | Modify | Add `dreaming` block to `YamlConfig` interface + validation |
+| `config/default.yaml` | Modify | Add `dreaming.decay` config block with defaults |
+| `src/scheduler/scheduler.ts` | Modify | Wire `DreamEngine` into `start()` and `stop()` |
+| `src/index.ts` | Modify | Construct `DreamEngine` and pass to `Scheduler` |
+| `CHANGELOG.md` | Modify | Add entry under `[Unreleased]` |
+
+---
+
+## Task 1: Database migration
+
+**Files:**
+- Create: `src/db/migrations/024_add_kg_archived_at.sql`
+
+- [ ] **Step 1: Write the migration**
+
+Create `src/db/migrations/024_add_kg_archived_at.sql`:
+
+```sql
+-- Up Migration
+
+-- Add soft-delete column to knowledge graph nodes and edges (dream engine, issue #27).
+-- archived_at is NULL for active rows; set to the archiving timestamp for soft-deleted rows.
+-- Partial indexes on the NULL case keep read-path performance equivalent to the pre-migration
+-- full-table scan — the planner uses these indexes for all WHERE archived_at IS NULL queries.
+
+ALTER TABLE kg_nodes ADD COLUMN archived_at TIMESTAMPTZ;
+ALTER TABLE kg_edges ADD COLUMN archived_at TIMESTAMPTZ;
+
+-- Partial index covering active nodes only (the overwhelming majority of rows).
+CREATE INDEX idx_kg_nodes_archived_at ON kg_nodes (archived_at) WHERE archived_at IS NULL;
+-- Partial index covering active edges only.
+CREATE INDEX idx_kg_edges_archived_at ON kg_edges (archived_at) WHERE archived_at IS NULL;
+```
+
+- [ ] **Step 2: Run the migration against your local DB**
+
+```bash
+npm --prefix /path/to/worktree run db:migrate
+```
+
+Expected: migration runs without error, `\d kg_nodes` in psql shows `archived_at timestamptz` column.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add src/db/migrations/024_add_kg_archived_at.sql
+git -C /path/to/worktree commit -m "chore: add archived_at column to kg_nodes and kg_edges (issue #27)"
+```
+
+---
+
+## Task 2: Update KG read paths to filter archived rows
+
+**Files:**
+- Modify: `src/memory/knowledge-graph.ts`
+
+All query methods inside `PostgresBackend` need `WHERE archived_at IS NULL`. The in-memory backend needs matching filter logic. `PgNodeRow` and `PgEdgeRow` interfaces need the new column.
+
+- [ ] **Step 1: Write failing unit tests**
+
+Add a new file `src/memory/dream-engine-kg-filter.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { KnowledgeGraphStore } from './knowledge-graph.js';
+import { EmbeddingService } from './embedding.js';
+
+function makeStore() {
+  return KnowledgeGraphStore.createInMemory(EmbeddingService.createForTesting());
+}
+
+describe('KnowledgeGraphStore: archived row filtering', () => {
+  it('getNode returns undefined for an archived node', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'fact', label: 'stale fact', properties: {}, source: 'test' });
+    await store.archiveNode(node.id);
+    const result = await store.getNode(node.id);
+    expect(result).toBeUndefined();
+  });
+
+  it('findNodesByType excludes archived nodes', async () => {
+    const store = makeStore();
+    const active = await store.createNode({ type: 'fact', label: 'active fact', properties: {}, source: 'test' });
+    const archived = await store.createNode({ type: 'fact', label: 'archived fact', properties: {}, source: 'test' });
+    await store.archiveNode(archived.id);
+    const results = await store.findNodesByType('fact');
+    expect(results.map(n => n.id)).toContain(active.id);
+    expect(results.map(n => n.id)).not.toContain(archived.id);
+  });
+
+  it('findNodesByLabel excludes archived nodes', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'fact', label: 'decayed coffee pref', properties: {}, source: 'test' });
+    await store.archiveNode(node.id);
+    const results = await store.findNodesByLabel('decayed coffee pref');
+    expect(results).toHaveLength(0);
+  });
+
+  it('getEdgesForNode excludes archived edges', async () => {
+    const store = makeStore();
+    const a = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'person', label: 'Bob', properties: {}, source: 'test' });
+    const edge = await store.createEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'collaborates_with', properties: {}, source: 'test' });
+    await store.archiveEdge(edge.id);
+    const edges = await store.getEdgesForNode(a.id);
+    expect(edges).toHaveLength(0);
+  });
+
+  it('traverse excludes archived nodes and edges', async () => {
+    const store = makeStore();
+    const a = await store.createNode({ type: 'person', label: 'Traverse-A', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'project', label: 'Traverse-B', properties: {}, source: 'test' });
+    await store.createEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'works_on', properties: {}, source: 'test' });
+    await store.archiveNode(b.id);
+    const result = await store.traverse(a.id, { maxDepth: 2 });
+    expect(result.nodes.map(n => n.id)).not.toContain(b.id);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm --prefix /path/to/worktree test src/memory/dream-engine-kg-filter.test.ts
+```
+
+Expected: FAIL — `store.archiveNode` and `store.archiveEdge` do not exist yet.
+
+- [ ] **Step 3: Add `archiveNode` and `archiveEdge` to the `KnowledgeGraphBackend` interface**
+
+In `src/memory/knowledge-graph.ts`, add two methods to the `KnowledgeGraphBackend` interface (around line 58):
+
+```typescript
+/** Soft-delete a node by setting archived_at = now(). Used by DreamEngine. */
+archiveNode(id: string): Promise<void>;
+/** Soft-delete an edge by setting archived_at = now(). Used by DreamEngine. */
+archiveEdge(id: string): Promise<void>;
+```
+
+- [ ] **Step 4: Add `archiveNode` and `archiveEdge` to the public `KnowledgeGraphStore` class**
+
+After the existing `deleteNode` method (around line 215):
+
+```typescript
+/** Soft-delete a node — sets archived_at, does not remove the row. */
+async archiveNode(id: string): Promise<void> {
+  return this.backend.archiveNode(id);
+}
+
+/** Soft-delete an edge — sets archived_at, does not remove the row. */
+async archiveEdge(id: string): Promise<void> {
+  return this.backend.archiveEdge(id);
+}
+```
+
+- [ ] **Step 5: Add `archived_at` to `PgNodeRow` and `PgEdgeRow`**
+
+In the `PgNodeRow` interface (around line 585):
+
+```typescript
+archived_at: Date | null;
+```
+
+In the `PgEdgeRow` interface (around line 599):
+
+```typescript
+archived_at: Date | null;
+```
+
+(The `pgRowToNode` and `pgRowToEdge` converters don't need to expose `archived_at` on `KgNode`/`KgEdge` — it's an internal storage concern. The `KgNode` and `KgEdge` types in `types.ts` don't need updating.)
+
+- [ ] **Step 6: Implement `archiveNode` and `archiveEdge` in `PostgresBackend`**
+
+Add after `deleteNode` in `PostgresBackend`:
+
+```typescript
+async archiveNode(id: string): Promise<void> {
+  this.logger.debug({ nodeId: id }, 'kg: archiving node');
+  await this.pool.query('UPDATE kg_nodes SET archived_at = now() WHERE id = $1', [id]);
+}
+
+async archiveEdge(id: string): Promise<void> {
+  this.logger.debug({ edgeId: id }, 'kg: archiving edge');
+  await this.pool.query('UPDATE kg_edges SET archived_at = now() WHERE id = $1', [id]);
+}
+```
+
+- [ ] **Step 7: Implement `archiveNode` and `archiveEdge` in the in-memory backend**
+
+The in-memory backend stores nodes in a `Map`. Add an `archivedNodes` Set and `archivedEdges` Set, then implement the methods and update all read paths in the in-memory backend to filter on those sets.
+
+Find the in-memory backend class (it's a private class inside `knowledge-graph.ts`). Add:
+
+```typescript
+private archivedNodes = new Set<string>();
+private archivedEdges = new Set<string>();
+
+async archiveNode(id: string): Promise<void> {
+  this.archivedNodes.add(id);
+}
+
+async archiveEdge(id: string): Promise<void> {
+  this.archivedEdges.add(id);
+}
+```
+
+Then update each read method in the in-memory backend to filter:
+
+`getNode`: return `undefined` if `this.archivedNodes.has(id)`.
+
+`findNodesByType`: filter out archived nodes.
+
+`findNodesByLabel`: filter out archived nodes.
+
+`getEdgesForNode`: filter out archived edges.
+
+`traverse`: filter archived nodes and edges from traversal results.
+
+`semanticSearch`: filter out archived nodes.
+
+`upsertNode`: check that the existing node (if found by label) is not archived before returning it as a match — an archived node should be treated as non-existent for the purposes of upsert.
+
+- [ ] **Step 8: Update `PostgresBackend` read queries to add `WHERE archived_at IS NULL`**
+
+Update each method:
+
+`getNode` (line ~385):
+```typescript
+'SELECT * FROM kg_nodes WHERE id = $1 AND archived_at IS NULL'
+```
+
+`findNodesByType` (line ~418):
+```typescript
+'SELECT * FROM kg_nodes WHERE type = $1 AND archived_at IS NULL'
+```
+
+`findNodesByLabel` (line ~426):
+```typescript
+'SELECT * FROM kg_nodes WHERE lower(label) = lower($1) AND archived_at IS NULL'
+```
+
+`getEdgesForNode` (line ~455):
+```typescript
+'SELECT * FROM kg_edges WHERE (source_node_id = $1 OR target_node_id = $1) AND archived_at IS NULL'
+```
+
+`traverse` — update the recursive CTE to filter both nodes and edges (lines ~526–561):
+```typescript
+`WITH RECURSIVE reachable AS (
+  SELECT $1::uuid AS node_id, 0 AS depth, ARRAY[$1::uuid] AS visited
+  UNION ALL
+  SELECT
+    CASE WHEN e.source_node_id = r.node_id THEN e.target_node_id ELSE e.source_node_id END,
+    r.depth + 1,
+    r.visited || CASE WHEN e.source_node_id = r.node_id THEN e.target_node_id ELSE e.source_node_id END
+  FROM reachable r
+  JOIN kg_edges e ON (e.source_node_id = r.node_id OR e.target_node_id = r.node_id)
+  WHERE r.depth < $2
+    AND e.archived_at IS NULL
+    AND NOT (CASE WHEN e.source_node_id = r.node_id THEN e.target_node_id ELSE e.source_node_id END) = ANY(r.visited)
+)
+SELECT DISTINCT n.* FROM reachable r JOIN kg_nodes n ON n.id = r.node_id WHERE n.archived_at IS NULL`
+```
+
+Edge collection step in `traverse`:
+```typescript
+`SELECT e.* FROM kg_edges e
+ WHERE e.source_node_id = ANY($1::uuid[])
+   AND e.target_node_id = ANY($1::uuid[])
+   AND e.archived_at IS NULL`
+```
+
+`semanticSearch` (line ~564):
+```typescript
+`SELECT *, 1 - (embedding <=> $1::vector) AS similarity
+ FROM kg_nodes
+ WHERE embedding IS NOT NULL
+   AND archived_at IS NULL
+ ORDER BY embedding <=> $1::vector
+ LIMIT $2`
+```
+
+`upsertNode` — the `ON CONFLICT` clause matches on `lower(label), type WHERE type != 'fact'`. When there's a conflict, add a check: if the existing node is archived, treat it as a miss and insert a new row. Add `AND archived_at IS NULL` to the conflict-resolution `DO UPDATE` condition:
+
+The existing upsert SQL uses `ON CONFLICT (lower(label), type) WHERE type != 'fact'`. Change the DO UPDATE to only fire for non-archived rows by adding a guard in the WHERE clause. The simplest approach: after upsert, check if the returned row has `archived_at IS NOT NULL` — if so, do a fresh INSERT (the archived row is treated as non-existent). This avoids rewriting the complex upsert SQL.
+
+Actually, the cleaner approach: add `AND archived_at IS NULL` to the partial unique index in the migration. This way conflicts only trigger for active nodes, and a new node with the same label as an archived one inserts fresh. Update the migration:
+
+```sql
+-- In 024_add_kg_archived_at.sql, after the ALTER TABLE statements, add:
+-- Drop the existing uniqueness index and recreate it scoped to active nodes only.
+-- This ensures a new node with the same label as an archived node inserts as a new row
+-- rather than triggering the ON CONFLICT path.
+DROP INDEX IF EXISTS idx_kg_nodes_label_type_unique;
+CREATE UNIQUE INDEX idx_kg_nodes_label_type_unique
+  ON kg_nodes (lower(label), type)
+  WHERE type != 'fact' AND archived_at IS NULL;
+```
+
+Check the actual index name first — look in `src/db/migrations/016_kg_node_uniqueness.sql` before writing the DROP.
+
+- [ ] **Step 9: Run tests to verify they pass**
+
+```bash
+npm --prefix /path/to/worktree test src/memory/dream-engine-kg-filter.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 10: Run the full test suite to check for regressions**
+
+```bash
+npm --prefix /path/to/worktree test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git -C /path/to/worktree add src/memory/knowledge-graph.ts src/memory/dream-engine-kg-filter.test.ts
+git -C /path/to/worktree commit -m "feat: filter archived nodes/edges from all KG read paths (issue #27)"
+```
+
+---
+
+## Task 3: Config — add `dreaming` block to `YamlConfig`
+
+**Files:**
+- Modify: `src/config.ts`
+- Modify: `config/default.yaml`
+
+- [ ] **Step 1: Write failing config validation tests**
+
+Add a new file `src/config.dreaming.test.ts` (alongside other config tests if any, otherwise place in `src/`):
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { loadYamlConfig } from './config.js';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+function writeTempConfig(content: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-config-'));
+  fs.writeFileSync(path.join(dir, 'default.yaml'), content);
+  return dir;
+}
+
+describe('loadYamlConfig: dreaming block', () => {
+  it('accepts valid dreaming.decay config', () => {
+    const dir = writeTempConfig(`
+dreaming:
+  decay:
+    intervalMs: 86400000
+    archiveThreshold: 0.05
+    halfLifeDays:
+      permanent: null
+      slow_decay: 180
+      fast_decay: 21
+`);
+    const config = loadYamlConfig(dir);
+    expect(config.dreaming?.decay?.intervalMs).toBe(86400000);
+    expect(config.dreaming?.decay?.archiveThreshold).toBe(0.05);
+    expect(config.dreaming?.decay?.halfLifeDays?.slow_decay).toBe(180);
+    expect(config.dreaming?.decay?.halfLifeDays?.permanent).toBeNull();
+  });
+
+  it('rejects intervalMs that is not a positive integer', () => {
+    const dir = writeTempConfig(`
+dreaming:
+  decay:
+    intervalMs: -1
+`);
+    expect(() => loadYamlConfig(dir)).toThrow('dreaming.decay.intervalMs');
+  });
+
+  it('rejects archiveThreshold outside 0-1', () => {
+    const dir = writeTempConfig(`
+dreaming:
+  decay:
+    archiveThreshold: 1.5
+`);
+    expect(() => loadYamlConfig(dir)).toThrow('dreaming.decay.archiveThreshold');
+  });
+
+  it('rejects non-positive halfLifeDays', () => {
+    const dir = writeTempConfig(`
+dreaming:
+  decay:
+    halfLifeDays:
+      slow_decay: 0
+`);
+    expect(() => loadYamlConfig(dir)).toThrow('dreaming.decay.halfLifeDays.slow_decay');
+  });
+
+  it('accepts absent dreaming block (uses defaults)', () => {
+    const dir = writeTempConfig('agents: {}');
+    const config = loadYamlConfig(dir);
+    expect(config.dreaming).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm --prefix /path/to/worktree test src/config.dreaming.test.ts
+```
+
+Expected: FAIL — `dreaming` property does not exist on `YamlConfig`.
+
+- [ ] **Step 3: Add `dreaming` to `YamlConfig` interface in `src/config.ts`**
+
+Add after the `intentDrift` block (around line 193):
+
+```typescript
+dreaming?: {
+  decay?: {
+    /** How often the decay pass runs in milliseconds. Default: 86400000 (daily). */
+    intervalMs?: number;
+    /** Confidence at or below this value triggers soft-delete. Default: 0.05. */
+    archiveThreshold?: number;
+    /** Half-life in days per decay class. null = never decays. */
+    halfLifeDays?: {
+      permanent?: null;
+      slow_decay?: number;
+      fast_decay?: number;
+    };
+  };
+};
+```
+
+- [ ] **Step 4: Add validation for the `dreaming` block in `loadYamlConfig`**
+
+Add after the `intentDrift` validation block (around line 354):
+
+```typescript
+const dreaming = config.dreaming;
+if (dreaming !== undefined) {
+  if (typeof dreaming !== 'object' || dreaming === null || Array.isArray(dreaming)) {
+    throw new Error('dreaming must be a YAML mapping');
+  }
+  const decay = dreaming.decay;
+  if (decay !== undefined) {
+    if (typeof decay !== 'object' || decay === null || Array.isArray(decay)) {
+      throw new Error('dreaming.decay must be a YAML mapping');
+    }
+    if (decay.intervalMs !== undefined && (!Number.isInteger(decay.intervalMs) || decay.intervalMs <= 0)) {
+      throw new Error(`dreaming.decay.intervalMs must be a positive integer, got: ${decay.intervalMs}`);
+    }
+    if (decay.archiveThreshold !== undefined && (typeof decay.archiveThreshold !== 'number' || decay.archiveThreshold < 0 || decay.archiveThreshold > 1)) {
+      throw new Error(`dreaming.decay.archiveThreshold must be a number between 0 and 1, got: ${decay.archiveThreshold}`);
+    }
+    const halfLifeDays = decay.halfLifeDays;
+    if (halfLifeDays !== undefined) {
+      for (const key of ['slow_decay', 'fast_decay'] as const) {
+        const val = halfLifeDays[key];
+        if (val !== undefined && (!Number.isInteger(val) || val <= 0)) {
+          throw new Error(`dreaming.decay.halfLifeDays.${key} must be a positive integer, got: ${val}`);
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Add the `dreaming` block to `config/default.yaml`**
+
+Add after the `intentDrift` block:
+
+```yaml
+# Dream engine — background knowledge graph maintenance (issue #27).
+# The decay pass runs on a configurable interval and reduces the confidence of
+# slow_decay and fast_decay nodes/edges using an exponential half-life model.
+# When confidence drops to or below archiveThreshold, the row is soft-deleted
+# (archived_at is set); it no longer appears in queries but is retained for audit.
+#
+# halfLifeDays: the number of days for a fact's confidence to halve.
+#   permanent: null — these nodes are never touched by the decay pass.
+#   slow_decay: 180  — employer, residence; reliable for months/years.
+#   fast_decay: 21   — coffee preference, current focus; unreliable after weeks.
+dreaming:
+  decay:
+    intervalMs: 86400000     # daily
+    archiveThreshold: 0.05
+    halfLifeDays:
+      permanent: null
+      slow_decay: 180
+      fast_decay: 21
+```
+
+- [ ] **Step 6: Run config tests to verify they pass**
+
+```bash
+npm --prefix /path/to/worktree test src/config.dreaming.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Run full test suite**
+
+```bash
+npm --prefix /path/to/worktree test
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C /path/to/worktree add src/config.ts src/config.dreaming.test.ts config/default.yaml
+git -C /path/to/worktree commit -m "feat: add dreaming.decay config block (issue #27)"
+```
+
+---
+
+## Task 4: Implement `DreamEngine`
+
+**Files:**
+- Create: `src/memory/dream-engine.ts`
+- Create: `src/memory/dream-engine.test.ts`
+
+- [ ] **Step 1: Write failing unit tests**
+
+Create `src/memory/dream-engine.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Pool, QueryResult } from 'pg';
+import type { EventBus } from '../bus/bus.js';
+import { DreamEngine } from './dream-engine.js';
+import { createSilentLogger } from '../logger.js';
+
+// Minimal mock pool that records queries
+function makePool(rowCounts: number[] = []): { pool: Pool; queries: Array<{ sql: string; params: unknown[] }> } {
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+  let callIndex = 0;
+  const pool = {
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params: params ?? [] });
+      const rowCount = rowCounts[callIndex++] ?? 0;
+      return { rowCount, rows: [] } as unknown as QueryResult;
+    }),
+  } as unknown as Pool;
+  return { pool, queries };
+}
+
+function makeBus(): EventBus {
+  return { publish: vi.fn(), subscribe: vi.fn() } as unknown as EventBus;
+}
+
+const defaultConfig = {
+  intervalMs: 86400000,
+  archiveThreshold: 0.05,
+  halfLifeDays: {
+    permanent: null as null,
+    slow_decay: 180,
+    fast_decay: 21,
+  },
+};
+
+describe('DreamEngine.runDecayPass', () => {
+  it('runs all three passes and returns counts', async () => {
+    const { pool, queries } = makePool([5, 3, 2, 1, 4]); // rowCounts for each query
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    const result = await engine.runDecayPass();
+
+    // Should have executed: slow_decay nodes, fast_decay nodes, slow_decay edges, fast_decay edges, archive nodes, archive edges
+    expect(queries.length).toBe(6);
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not run any SQL for permanent nodes (halfLifeDays.permanent is null)', async () => {
+    const { queries } = makePool();
+    const engine = new DreamEngine(makePool().pool, makeBus(), createSilentLogger(), defaultConfig);
+    await engine.runDecayPass();
+    // No query should reference 'permanent' as a decay_class parameter
+    const permanentQueries = queries.filter(q =>
+      q.params.some(p => p === 'permanent'),
+    );
+    expect(permanentQueries).toHaveLength(0);
+  });
+
+  it('uses the configured half-life for slow_decay nodes', async () => {
+    const { pool, queries } = makePool();
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    await engine.runDecayPass();
+    // Find the slow_decay node decay query — it should include 180 (the half-life)
+    const slowDecayNodeQuery = queries.find(q =>
+      q.params.includes('slow_decay') && q.sql.includes('kg_nodes'),
+    );
+    expect(slowDecayNodeQuery).toBeDefined();
+    expect(slowDecayNodeQuery!.params).toContain(180);
+  });
+
+  it('uses the configured half-life for fast_decay nodes', async () => {
+    const { pool, queries } = makePool();
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    await engine.runDecayPass();
+    const fastDecayNodeQuery = queries.find(q =>
+      q.params.includes('fast_decay') && q.sql.includes('kg_nodes'),
+    );
+    expect(fastDecayNodeQuery).toBeDefined();
+    expect(fastDecayNodeQuery!.params).toContain(21);
+  });
+
+  it('uses the configured archiveThreshold in the archive pass', async () => {
+    const { pool, queries } = makePool();
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    await engine.runDecayPass();
+    const archiveNodeQuery = queries.find(q =>
+      q.sql.includes('kg_nodes') && q.sql.includes('archived_at = now()'),
+    );
+    expect(archiveNodeQuery).toBeDefined();
+    expect(archiveNodeQuery!.params).toContain(0.05);
+  });
+
+  it('archives edges whose endpoints were archived in the same pass', async () => {
+    const { pool, queries } = makePool();
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    await engine.runDecayPass();
+    const archiveEdgeQuery = queries.find(q =>
+      q.sql.includes('kg_edges') && q.sql.includes('archived_at = now()'),
+    );
+    expect(archiveEdgeQuery).toBeDefined();
+    // The edge archive query must reference archived node endpoints
+    expect(archiveEdgeQuery!.sql).toMatch(/source_node_id|target_node_id/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm --prefix /path/to/worktree test src/memory/dream-engine.test.ts
+```
+
+Expected: FAIL — `DreamEngine` does not exist.
+
+- [ ] **Step 3: Implement `DreamEngine`**
+
+Create `src/memory/dream-engine.ts`:
+
+```typescript
+import type { Pool } from 'pg';
+import type { EventBus } from '../bus/bus.js';
+import type { Logger } from '../logger.js';
+
+// Config shape mirrors YamlConfig.dreaming.decay — all fields required at construction
+// time (caller resolves defaults before passing in).
+export interface DecayConfig {
+  intervalMs: number;
+  archiveThreshold: number;
+  halfLifeDays: {
+    permanent: null;
+    slow_decay: number;
+    fast_decay: number;
+  };
+}
+
+export interface DecayPassResult {
+  nodesDecayed: number;
+  edgesDecayed: number;
+  nodesArchived: number;
+  edgesArchived: number;
+  durationMs: number;
+}
+
+/**
+ * DreamEngine — background knowledge graph maintenance.
+ *
+ * Named after the neuroscience analogy: sleep is when the brain consolidates
+ * short-term experiences into long-term memory and prunes weak connections.
+ *
+ * Currently implements one pass: memory decay (issue #27).
+ * Future passes (decay warning #280, contradiction resolution, synthesis) will
+ * be added as sibling methods with their own config keys under `dreaming`.
+ *
+ * EventBus is injected now but unused — reserved for the decay warning pass (#280)
+ * which will emit `memory.decay_warning` before archiving important nodes.
+ */
+export class DreamEngine {
+  private pool: Pool;
+  // EventBus reserved for decay warning pass (issue #280) — injected now so the
+  // constructor signature doesn't need to change when that feature lands.
+  private _bus: EventBus;
+  private logger: Logger;
+  private config: DecayConfig;
+  private intervalHandle: ReturnType<typeof setInterval> | null = null;
+
+  constructor(pool: Pool, bus: EventBus, logger: Logger, config: DecayConfig) {
+    this.pool = pool;
+    this._bus = bus;
+    this.logger = logger;
+    this.config = config;
+  }
+
+  /**
+   * Start the recurring decay interval.
+   * Logs the configured cadence so operators can verify the schedule at startup.
+   */
+  start(): void {
+    this.intervalHandle = setInterval(() => {
+      this.runDecayPass().catch((err) => {
+        this.logger.error({ err }, 'DreamEngine: unhandled error in runDecayPass');
+      });
+    }, this.config.intervalMs);
+
+    this.logger.info(
+      { intervalMs: this.config.intervalMs, archiveThreshold: this.config.archiveThreshold },
+      'DreamEngine started (decay pass scheduled)',
+    );
+  }
+
+  /** Stop the interval timer for clean shutdown. */
+  stop(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+    this.logger.info('DreamEngine stopped');
+  }
+
+  /**
+   * Run one full decay pass:
+   *   1. Decay confidence on slow_decay and fast_decay nodes and edges
+   *   2. Archive nodes whose confidence is at or below archiveThreshold
+   *   3. Archive edges whose endpoints were archived, or whose own confidence crossed the threshold
+   */
+  async runDecayPass(): Promise<DecayPassResult> {
+    const start = Date.now();
+    this.logger.info('DreamEngine: decay pass starting');
+
+    const { archiveThreshold, halfLifeDays } = this.config;
+
+    // Pass 1a: Decay slow_decay nodes
+    // confidence × 0.5^(days_since_confirmed / half_life_days)
+    // The guard confidence > archiveThreshold skips already-condemned rows to avoid
+    // unnecessary writes — they will be archived in Pass 2 regardless.
+    const slowNodeResult = await this.pool.query(
+      `UPDATE kg_nodes
+         SET confidence = confidence * power(0.5,
+             EXTRACT(EPOCH FROM (now() - last_confirmed_at)) / 86400.0 / $1)
+       WHERE archived_at IS NULL
+         AND decay_class = $2
+         AND confidence > $3`,
+      [halfLifeDays.slow_decay, 'slow_decay', archiveThreshold],
+    );
+
+    // Pass 1b: Decay fast_decay nodes
+    const fastNodeResult = await this.pool.query(
+      `UPDATE kg_nodes
+         SET confidence = confidence * power(0.5,
+             EXTRACT(EPOCH FROM (now() - last_confirmed_at)) / 86400.0 / $1)
+       WHERE archived_at IS NULL
+         AND decay_class = $2
+         AND confidence > $3`,
+      [halfLifeDays.fast_decay, 'fast_decay', archiveThreshold],
+    );
+
+    // Pass 1c: Decay slow_decay edges
+    const slowEdgeResult = await this.pool.query(
+      `UPDATE kg_edges
+         SET confidence = confidence * power(0.5,
+             EXTRACT(EPOCH FROM (now() - last_confirmed_at)) / 86400.0 / $1)
+       WHERE archived_at IS NULL
+         AND decay_class = $2
+         AND confidence > $3`,
+      [halfLifeDays.slow_decay, 'slow_decay', archiveThreshold],
+    );
+
+    // Pass 1d: Decay fast_decay edges
+    const fastEdgeResult = await this.pool.query(
+      `UPDATE kg_edges
+         SET confidence = confidence * power(0.5,
+             EXTRACT(EPOCH FROM (now() - last_confirmed_at)) / 86400.0 / $1)
+       WHERE archived_at IS NULL
+         AND decay_class = $2
+         AND confidence > $3`,
+      [halfLifeDays.fast_decay, 'fast_decay', archiveThreshold],
+    );
+
+    const nodesDecayed = (slowNodeResult.rowCount ?? 0) + (fastNodeResult.rowCount ?? 0);
+    const edgesDecayed = (slowEdgeResult.rowCount ?? 0) + (fastEdgeResult.rowCount ?? 0);
+
+    // Pass 2: Archive nodes at or below threshold (permanent nodes are never archived)
+    const archiveNodeResult = await this.pool.query(
+      `UPDATE kg_nodes
+         SET archived_at = now()
+       WHERE archived_at IS NULL
+         AND decay_class != 'permanent'
+         AND confidence <= $1`,
+      [archiveThreshold],
+    );
+
+    const nodesArchived = archiveNodeResult.rowCount ?? 0;
+
+    // Pass 3: Archive edges whose endpoint was just archived, OR whose own confidence
+    // is at or below threshold. Using archived_at IS NOT NULL for nodes catches both
+    // the just-archived nodes from Pass 2 and any previously archived nodes, ensuring
+    // no edge is left dangling to an archived endpoint.
+    const archiveEdgeResult = await this.pool.query(
+      `UPDATE kg_edges
+         SET archived_at = now()
+       WHERE archived_at IS NULL
+         AND (
+           confidence <= $1
+           OR source_node_id IN (SELECT id FROM kg_nodes WHERE archived_at IS NOT NULL)
+           OR target_node_id IN (SELECT id FROM kg_nodes WHERE archived_at IS NOT NULL)
+         )`,
+      [archiveThreshold],
+    );
+
+    const edgesArchived = archiveEdgeResult.rowCount ?? 0;
+    const durationMs = Date.now() - start;
+
+    this.logger.info(
+      { nodesDecayed, edgesDecayed, nodesArchived, edgesArchived, durationMs },
+      'DreamEngine: decay pass complete',
+    );
+
+    return { nodesDecayed, edgesDecayed, nodesArchived, edgesArchived, durationMs };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm --prefix /path/to/worktree test src/memory/dream-engine.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+npm --prefix /path/to/worktree test
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /path/to/worktree add src/memory/dream-engine.ts src/memory/dream-engine.test.ts
+git -C /path/to/worktree commit -m "feat: implement DreamEngine with memory decay pass (issue #27)"
+```
+
+---
+
+## Task 5: Wire `DreamEngine` into `Scheduler` and `index.ts`
+
+**Files:**
+- Modify: `src/scheduler/scheduler.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add `dreamEngine` to `SchedulerConfig` and `Scheduler`**
+
+In `src/scheduler/scheduler.ts`, import `DreamEngine`:
+
+```typescript
+import type { DreamEngine } from '../memory/dream-engine.js';
+```
+
+Add `dreamEngine` to `SchedulerConfig` (around line 76):
+
+```typescript
+/** Dream engine for background KG maintenance. When absent, no background decay runs. */
+dreamEngine?: DreamEngine;
+```
+
+Add the field to the `Scheduler` class (after `driftDetector`, around line 90):
+
+```typescript
+private dreamEngine?: DreamEngine;
+```
+
+Set it in the constructor (after `this.driftDetector = config.driftDetector`):
+
+```typescript
+this.dreamEngine = config.dreamEngine;
+```
+
+- [ ] **Step 2: Start and stop the `DreamEngine` alongside the scheduler**
+
+In `Scheduler.start()`, after the watchdog `setInterval` block (around line 152):
+
+```typescript
+// Dream engine — background KG maintenance (decay, and future passes).
+if (this.dreamEngine) {
+  this.dreamEngine.start();
+}
+```
+
+In `Scheduler.stop()`, after clearing `watchdogHandle` (around line 165):
+
+```typescript
+if (this.dreamEngine) {
+  this.dreamEngine.stop();
+}
+```
+
+- [ ] **Step 3: Construct `DreamEngine` in `index.ts`**
+
+In `src/index.ts`, add the import near the other memory imports:
+
+```typescript
+import { DreamEngine } from './memory/dream-engine.js';
+import type { DecayConfig } from './memory/dream-engine.js';
+```
+
+After the `driftDetector` construction block (around line 685), add:
+
+```typescript
+// Dream engine — background KG maintenance (spec 17 / issue #27).
+// Defaults are intentionally conservative: daily cadence, 5% archive threshold,
+// 180-day slow-decay half-life, 21-day fast-decay half-life.
+const decayConfig: DecayConfig = {
+  intervalMs: yamlConfig.dreaming?.decay?.intervalMs ?? 86_400_000,
+  archiveThreshold: yamlConfig.dreaming?.decay?.archiveThreshold ?? 0.05,
+  halfLifeDays: {
+    permanent: null,
+    slow_decay: yamlConfig.dreaming?.decay?.halfLifeDays?.slow_decay ?? 180,
+    fast_decay: yamlConfig.dreaming?.decay?.halfLifeDays?.fast_decay ?? 21,
+  },
+};
+const dreamEngine = new DreamEngine(pool, bus, logger, decayConfig);
+logger.info({ decayConfig }, 'DreamEngine configured');
+```
+
+Pass `dreamEngine` to the `Scheduler` constructor (around line 687):
+
+```typescript
+const scheduler = new Scheduler({ pool, bus, logger, schedulerService, driftDetector, dreamEngine });
+```
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+npm --prefix /path/to/worktree test
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /path/to/worktree add src/scheduler/scheduler.ts src/index.ts
+git -C /path/to/worktree commit -m "feat: wire DreamEngine into Scheduler start/stop (issue #27)"
+```
+
+---
+
+## Task 6: Integration tests
+
+**Files:**
+- Create: `tests/integration/dream-engine.test.ts`
+
+- [ ] **Step 1: Write integration tests**
+
+Create `tests/integration/dream-engine.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { DreamEngine } from '../../src/memory/dream-engine.js';
+import { createSilentLogger } from '../../src/logger.js';
+import type { EventBus } from '../../src/bus/bus.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+function makeBus(): EventBus {
+  return { publish: async () => {}, subscribe: () => {} } as unknown as EventBus;
+}
+
+const testConfig = {
+  intervalMs: 86400000,
+  archiveThreshold: 0.05,
+  halfLifeDays: { permanent: null as null, slow_decay: 180, fast_decay: 21 },
+};
+
+describeIf('DreamEngine integration', () => {
+  let pool: pg.Pool;
+  let store: KnowledgeGraphStore;
+  let engine: DreamEngine;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    const embeddingService = EmbeddingService.createForTesting();
+    store = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, createSilentLogger());
+    engine = new DreamEngine(pool, makeBus(), createSilentLogger(), testConfig);
+    await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
+  });
+
+  afterAll(async () => {
+    await pool.query('DELETE FROM kg_edges');
+    await pool.query('DELETE FROM kg_nodes');
+    await pool.end();
+  });
+
+  it('decays confidence on a fast_decay node based on age', async () => {
+    // Insert a node whose last_confirmed_at is 21 days ago (one full half-life)
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity)
+       VALUES ('fact', 'decay-test-fast', '{}', 0.8, 'fast_decay', 'test',
+               now() - interval '21 days', now() - interval '21 days', 'internal')
+       RETURNING id`,
+    );
+    const nodeId = rows[0]!.id;
+
+    await engine.runDecayPass();
+
+    const result = await pool.query<{ confidence: number }>(
+      'SELECT confidence FROM kg_nodes WHERE id = $1',
+      [nodeId],
+    );
+    // After one half-life (21 days), confidence should be ~0.4 (half of 0.8).
+    // Allow ±0.02 tolerance for floating point.
+    expect(result.rows[0]!.confidence).toBeCloseTo(0.4, 1);
+  });
+
+  it('archives a node whose confidence falls at or below archiveThreshold', async () => {
+    // Insert a node already at the threshold
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity)
+       VALUES ('fact', 'decay-test-archive', '{}', 0.05, 'fast_decay', 'test',
+               now() - interval '1 day', now() - interval '1 day', 'internal')
+       RETURNING id`,
+    );
+    const nodeId = rows[0]!.id;
+
+    await engine.runDecayPass();
+
+    const result = await pool.query<{ archived_at: Date | null }>(
+      'SELECT archived_at FROM kg_nodes WHERE id = $1',
+      [nodeId],
+    );
+    expect(result.rows[0]!.archived_at).not.toBeNull();
+  });
+
+  it('archived node does not appear in semanticSearch', async () => {
+    // Insert a node and manually archive it, then check search excludes it
+    const node = await store.createNode({
+      type: 'fact', label: 'archived-search-test', properties: {}, source: 'test',
+    });
+    await store.archiveNode(node.id);
+
+    const results = await store.semanticSearch('archived-search-test');
+    expect(results.map(r => r.node.id)).not.toContain(node.id);
+  });
+
+  it('archived node does not appear in findNodesByType', async () => {
+    const node = await store.createNode({
+      type: 'concept', label: 'archived-type-test', properties: {}, source: 'test',
+    });
+    await store.archiveNode(node.id);
+
+    const results = await store.findNodesByType('concept');
+    expect(results.map(n => n.id)).not.toContain(node.id);
+  });
+
+  it('archived node does not appear in traverse', async () => {
+    const a = await store.createNode({ type: 'person', label: 'traversal-source', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'project', label: 'traversal-archived-target', properties: {}, source: 'test' });
+    await store.createEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'works_on', properties: {}, source: 'test' });
+    await store.archiveNode(b.id);
+
+    const result = await store.traverse(a.id, { maxDepth: 2 });
+    expect(result.nodes.map(n => n.id)).not.toContain(b.id);
+  });
+
+  it('archives edges when their source node is archived in the decay pass', async () => {
+    const a = await store.createNode({ type: 'person', label: 'edge-cascade-source', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'project', label: 'edge-cascade-target', properties: {}, source: 'test' });
+    const edge = await store.createEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'works_on', properties: {}, source: 'test' });
+
+    // Archive node a directly to simulate decay pass
+    await pool.query('UPDATE kg_nodes SET archived_at = now() WHERE id = $1', [a.id]);
+
+    // Run the pass — Pass 3 should cascade to the edge
+    await engine.runDecayPass();
+
+    const { rows } = await pool.query<{ archived_at: Date | null }>(
+      'SELECT archived_at FROM kg_edges WHERE id = $1',
+      [edge.id],
+    );
+    expect(rows[0]!.archived_at).not.toBeNull();
+  });
+
+  it('does not archive permanent nodes regardless of age', async () => {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity)
+       VALUES ('fact', 'permanent-test', '{}', 0.9, 'permanent', 'test',
+               now() - interval '1000 days', now() - interval '1000 days', 'internal')
+       RETURNING id`,
+    );
+    const nodeId = rows[0]!.id;
+
+    await engine.runDecayPass();
+
+    const result = await pool.query<{ confidence: number; archived_at: Date | null }>(
+      'SELECT confidence, archived_at FROM kg_nodes WHERE id = $1',
+      [nodeId],
+    );
+    expect(result.rows[0]!.archived_at).toBeNull();
+    expect(result.rows[0]!.confidence).toBe(0.9); // unchanged
+  });
+});
+```
+
+- [ ] **Step 2: Run integration tests (requires DATABASE_URL)**
+
+```bash
+DATABASE_URL=postgres://localhost/curia_test npm --prefix /path/to/worktree test tests/integration/dream-engine.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+npm --prefix /path/to/worktree test
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /path/to/worktree add tests/integration/dream-engine.test.ts
+git -C /path/to/worktree commit -m "test: add DreamEngine integration tests (issue #27)"
+```
+
+---
+
+## Task 7: Update CHANGELOG and version, then open PR
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`
+
+- [ ] **Step 1: Check current version**
+
+```bash
+grep '"version"' /path/to/worktree/package.json
+```
+
+- [ ] **Step 2: Update `CHANGELOG.md`**
+
+Under `## [Unreleased]`, add:
+
+```markdown
+### Added
+- **Dream Engine** (spec 17): background KG maintenance system with memory decay pass. Confidence on `slow_decay` and `fast_decay` nodes/edges decays exponentially using configurable half-lives (180 days / 21 days). Rows at or below the archive threshold are soft-deleted via `archived_at`; edges cascade when their endpoints are archived. All KG read paths filter archived rows. Wired as an internal system job in the Scheduler. Config under `dreaming.decay.*` in `config/default.yaml`. Implements issue #27; decay warning (#280) deferred to a follow-up.
+```
+
+- [ ] **Step 3: Bump version in `package.json`**
+
+This is the first time spec 17 ships, so bump minor (e.g. `0.X.0 → 0.(X+1).0`):
+
+```bash
+npm --prefix /path/to/worktree version minor --no-git-tag-version
+```
+
+- [ ] **Step 4: Commit changelog and version**
+
+```bash
+git -C /path/to/worktree add CHANGELOG.md package.json
+git -C /path/to/worktree commit -m "chore: changelog and version bump for dream engine (issue #27)"
+```
+
+- [ ] **Step 5: Open PR**
+
+```bash
+gh pr create --repo josephfung/curia \
+  --base main \
+  --head feat/dream-engine \
+  --title "feat: Dream Engine — memory decay pass (issue #27)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `DreamEngine` class (`src/memory/dream-engine.ts`) with a configurable exponential confidence decay pass
+- Adds `archived_at` column to `kg_nodes` and `kg_edges` (migration 024); all KG read paths filter archived rows
+- Configurable under `dreaming.decay.*` in `config/default.yaml` (half-lives: 180 days slow, 21 days fast; archive threshold: 0.05)
+- EventBus injected but unused — reserved for decay warning follow-up (#280)
+- Closes #27
+
+## Test plan
+
+- [ ] Unit tests pass: `npm test src/memory/dream-engine.test.ts`
+- [ ] KG filter tests pass: `npm test src/memory/dream-engine-kg-filter.test.ts`
+- [ ] Config validation tests pass: `npm test src/config.dreaming.test.ts`
+- [ ] Integration tests pass (requires DATABASE_URL): `npm test tests/integration/dream-engine.test.ts`
+- [ ] Full test suite passes: `npm test`
+- [ ] Migration applied cleanly to local DB
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Task |
+|---|---|
+| `archived_at` column on both tables + partial indexes | Task 1 |
+| All read paths filter `WHERE archived_at IS NULL` | Task 2 |
+| Config block `dreaming.decay.*` in YAML + validation | Task 3 |
+| `DreamEngine` class with `runDecayPass()` | Task 4 |
+| Pass 1: exponential decay on `slow_decay`/`fast_decay` nodes and edges | Task 4 |
+| Pass 2: archive nodes ≤ archiveThreshold | Task 4 |
+| Pass 3: archive edges with archived endpoints or own confidence ≤ threshold | Task 4 |
+| `permanent` nodes never touched | Task 4 |
+| `EventBus` injected, unused, reserved for #280 | Task 4 |
+| `DreamEngine` wired into `Scheduler.start()` / `stop()` | Task 5 |
+| Config resolved with defaults in `index.ts` | Task 5 |
+| Unit tests: decay math, pass counts, permanent skip | Task 4 |
+| Integration tests: real Postgres, age-based decay, archiving, read path exclusion | Task 6 |
+
+**Upsert edge case (Task 2, Step 8):** The plan notes to check `016_kg_node_uniqueness.sql` for the exact index name before writing the DROP — this is a reminder, not a TBD. The implementer must do this lookup before executing Step 8.
+
+**Type consistency:** `DecayConfig`, `DecayPassResult`, `DreamEngine` — used consistently across Tasks 3, 4, and 5.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -123,6 +123,29 @@
         "minConfidenceToPause": { "type": "string", "enum": ["high", "medium", "low"] }
       }
     },
+    "dreaming": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "decay": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "intervalMs": { "type": "integer", "minimum": 1 },
+            "archiveThreshold": { "type": "number", "minimum": 0, "maximum": 1 },
+            "halfLifeDays": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "permanent": { "type": "null" },
+                "slow_decay": { "type": "integer", "minimum": 1 },
+                "fast_decay": { "type": "integer", "minimum": 1 }
+              }
+            }
+          }
+        }
+      }
+    },
     "sensitivity_rules": {
       "type": "array",
       "minItems": 1,

--- a/src/config.dreaming.test.ts
+++ b/src/config.dreaming.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { loadYamlConfig } from './config.js';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+function writeTempConfig(content: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-config-'));
+  fs.writeFileSync(path.join(dir, 'default.yaml'), content);
+  return dir;
+}
+
+describe('loadYamlConfig: dreaming block', () => {
+  it('accepts valid dreaming.decay config', () => {
+    const dir = writeTempConfig(`
+dreaming:
+  decay:
+    intervalMs: 86400000
+    archiveThreshold: 0.05
+    halfLifeDays:
+      permanent: null
+      slow_decay: 180
+      fast_decay: 21
+`);
+    const config = loadYamlConfig(dir);
+    expect(config.dreaming?.decay?.intervalMs).toBe(86400000);
+    expect(config.dreaming?.decay?.archiveThreshold).toBe(0.05);
+    expect(config.dreaming?.decay?.halfLifeDays?.slow_decay).toBe(180);
+    expect(config.dreaming?.decay?.halfLifeDays?.permanent).toBeNull();
+  });
+
+  it('rejects intervalMs that is not a positive integer', () => {
+    const dir = writeTempConfig(`
+dreaming:
+  decay:
+    intervalMs: -1
+`);
+    expect(() => loadYamlConfig(dir)).toThrow('dreaming.decay.intervalMs');
+  });
+
+  it('rejects archiveThreshold outside 0-1', () => {
+    const dir = writeTempConfig(`
+dreaming:
+  decay:
+    archiveThreshold: 1.5
+`);
+    expect(() => loadYamlConfig(dir)).toThrow('dreaming.decay.archiveThreshold');
+  });
+
+  it('rejects non-positive halfLifeDays', () => {
+    const dir = writeTempConfig(`
+dreaming:
+  decay:
+    halfLifeDays:
+      slow_decay: 0
+`);
+    expect(() => loadYamlConfig(dir)).toThrow('dreaming.decay.halfLifeDays.slow_decay');
+  });
+
+  it('accepts absent dreaming block (uses defaults)', () => {
+    const dir = writeTempConfig('agents: {}');
+    const config = loadYamlConfig(dir);
+    expect(config.dreaming).toBeUndefined();
+  });
+});

--- a/src/config.dreaming.test.ts
+++ b/src/config.dreaming.test.ts
@@ -57,6 +57,16 @@ dreaming:
     expect(() => loadYamlConfig(dir)).toThrow('dreaming.decay.halfLifeDays.slow_decay');
   });
 
+  it('rejects non-null permanent halfLifeDays', () => {
+    const dir = writeTempConfig(`
+dreaming:
+  decay:
+    halfLifeDays:
+      permanent: 365
+`);
+    expect(() => loadYamlConfig(dir)).toThrow('dreaming.decay.halfLifeDays.permanent');
+  });
+
   it('accepts absent dreaming block (uses defaults)', () => {
     const dir = writeTempConfig('agents: {}');
     const config = loadYamlConfig(dir);

--- a/src/config.ts
+++ b/src/config.ts
@@ -191,6 +191,20 @@ export interface YamlConfig {
     /** Minimum LLM confidence required to pause the task. Default: 'high'. */
     minConfidenceToPause?: 'high' | 'medium' | 'low';
   };
+  dreaming?: {
+    decay?: {
+      /** How often the decay pass runs in milliseconds. Default: 86400000 (daily). */
+      intervalMs?: number;
+      /** Confidence at or below this value triggers soft-delete. Default: 0.05. */
+      archiveThreshold?: number;
+      /** Half-life in days per decay class. null = never decays. */
+      halfLifeDays?: {
+        permanent?: null;
+        slow_decay?: number;
+        fast_decay?: number;
+      };
+    };
+  };
 }
 
 /**
@@ -350,6 +364,34 @@ export function loadYamlConfig(configDir: string): YamlConfig {
         throw new Error(
           `intentDrift.minConfidenceToPause must be one of: ${validConfidences.join(', ')}, got: "${drift.minConfidenceToPause}"`,
         );
+      }
+    }
+
+    const dreaming = config.dreaming;
+    if (dreaming !== undefined) {
+      if (typeof dreaming !== 'object' || dreaming === null || Array.isArray(dreaming)) {
+        throw new Error('dreaming must be a YAML mapping');
+      }
+      const decay = dreaming.decay;
+      if (decay !== undefined) {
+        if (typeof decay !== 'object' || decay === null || Array.isArray(decay)) {
+          throw new Error('dreaming.decay must be a YAML mapping');
+        }
+        if (decay.intervalMs !== undefined && (!Number.isInteger(decay.intervalMs) || decay.intervalMs <= 0)) {
+          throw new Error(`dreaming.decay.intervalMs must be a positive integer, got: ${decay.intervalMs}`);
+        }
+        if (decay.archiveThreshold !== undefined && (typeof decay.archiveThreshold !== 'number' || decay.archiveThreshold < 0 || decay.archiveThreshold > 1)) {
+          throw new Error(`dreaming.decay.archiveThreshold must be a number between 0 and 1, got: ${decay.archiveThreshold}`);
+        }
+        const halfLifeDays = decay.halfLifeDays;
+        if (halfLifeDays !== undefined) {
+          for (const key of ['slow_decay', 'fast_decay'] as const) {
+            const val = halfLifeDays[key];
+            if (val !== undefined && (!Number.isInteger(val) || val <= 0)) {
+              throw new Error(`dreaming.decay.halfLifeDays.${key} must be a positive integer, got: ${val}`);
+            }
+          }
+        }
       }
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -391,6 +391,12 @@ export function loadYamlConfig(configDir: string): YamlConfig {
               throw new Error(`dreaming.decay.halfLifeDays.${key} must be a positive integer, got: ${val}`);
             }
           }
+          // permanent must be null (meaning it never decays) — any non-null value
+          // would be silently ignored by the decay engine, which only loops over
+          // slow_decay and fast_decay, making a non-null permanent a misconfiguration.
+          if (halfLifeDays.permanent !== undefined && halfLifeDays.permanent !== null) {
+            throw new Error(`dreaming.decay.halfLifeDays.permanent must be null (permanent nodes never decay), got: ${String(halfLifeDays.permanent)}`);
+          }
         }
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -385,6 +385,9 @@ export function loadYamlConfig(configDir: string): YamlConfig {
         }
         const halfLifeDays = decay.halfLifeDays;
         if (halfLifeDays !== undefined) {
+          if (typeof halfLifeDays !== 'object' || halfLifeDays === null || Array.isArray(halfLifeDays)) {
+            throw new Error('dreaming.decay.halfLifeDays must be a YAML mapping');
+          }
           for (const key of ['slow_decay', 'fast_decay'] as const) {
             const val = halfLifeDays[key];
             if (val !== undefined && (!Number.isInteger(val) || val <= 0)) {

--- a/src/db/migrations/024_add_kg_archived_at.sql
+++ b/src/db/migrations/024_add_kg_archived_at.sql
@@ -21,3 +21,16 @@ DROP INDEX IF EXISTS idx_kg_nodes_unique;
 CREATE UNIQUE INDEX idx_kg_nodes_unique
   ON kg_nodes (lower(label), type)
   WHERE type != 'fact' AND archived_at IS NULL;
+
+-- Recreate the edge uniqueness index to exclude archived rows.
+-- Without this, upsertEdge's ON CONFLICT clause would match archived edges and
+-- revive them via DO UPDATE — the old index covers all rows regardless of archived_at.
+-- After this migration, uniqueness is enforced only among active (non-archived) edges.
+DROP INDEX IF EXISTS idx_kg_edges_unique;
+CREATE UNIQUE INDEX idx_kg_edges_unique
+  ON kg_edges (
+    LEAST(source_node_id::text, target_node_id::text),
+    GREATEST(source_node_id::text, target_node_id::text),
+    type
+  )
+  WHERE archived_at IS NULL;

--- a/src/db/migrations/024_add_kg_archived_at.sql
+++ b/src/db/migrations/024_add_kg_archived_at.sql
@@ -1,0 +1,23 @@
+-- Up Migration
+
+-- Add soft-delete column to knowledge graph nodes and edges (dream engine, issue #27).
+-- archived_at is NULL for active rows; set to the archiving timestamp for soft-deleted rows.
+-- Partial indexes on the NULL case keep read-path performance equivalent to the pre-migration
+-- full-table scan — the planner uses these indexes for all WHERE archived_at IS NULL queries.
+
+ALTER TABLE kg_nodes ADD COLUMN archived_at TIMESTAMPTZ;
+ALTER TABLE kg_edges ADD COLUMN archived_at TIMESTAMPTZ;
+
+-- Partial index covering active nodes only (the overwhelming majority of rows).
+CREATE INDEX idx_kg_nodes_archived_at ON kg_nodes (archived_at) WHERE archived_at IS NULL;
+-- Partial index covering active edges only.
+CREATE INDEX idx_kg_edges_archived_at ON kg_edges (archived_at) WHERE archived_at IS NULL;
+
+-- Recreate the node uniqueness index to exclude archived rows.
+-- Without this, inserting a new node with the same label as an archived node would
+-- trigger a unique violation — the old index has no knowledge of archived_at.
+-- After this migration, uniqueness is enforced only among active (non-archived) nodes.
+DROP INDEX IF EXISTS idx_kg_nodes_unique;
+CREATE UNIQUE INDEX idx_kg_nodes_unique
+  ON kg_nodes (lower(label), type)
+  WHERE type != 'fact' AND archived_at IS NULL;

--- a/src/db/migrations/025_add_kg_node_sensitivity.sql
+++ b/src/db/migrations/025_add_kg_node_sensitivity.sql
@@ -12,11 +12,14 @@
 -- (Sensitivity type in src/memory/types.ts) so that direct SQL writes and
 -- future code paths cannot persist an invalid value that would confuse export gates.
 
-ALTER TABLE kg_nodes ADD COLUMN sensitivity TEXT NOT NULL DEFAULT 'internal'
+-- ADD COLUMN IF NOT EXISTS — idempotent for databases where this migration
+-- was already applied under the name 024_add_kg_node_sensitivity before that
+-- prefix was renumbered to 025 to avoid the 024_add_kg_archived_at conflict.
+ALTER TABLE kg_nodes ADD COLUMN IF NOT EXISTS sensitivity TEXT NOT NULL DEFAULT 'internal'
   CHECK (sensitivity IN ('public', 'internal', 'confidential', 'restricted'));
 
 -- Index for export gate queries: "give me all nodes above sensitivity X"
-CREATE INDEX idx_kg_nodes_sensitivity ON kg_nodes (sensitivity);
+CREATE INDEX IF NOT EXISTS idx_kg_nodes_sensitivity ON kg_nodes (sensitivity);
 
 -- Down Migration
 

--- a/src/db/migrations/026_add_last_decayed_at.sql
+++ b/src/db/migrations/026_add_last_decayed_at.sql
@@ -1,0 +1,25 @@
+-- Up Migration
+
+-- Add last_decayed_at to track when the DreamEngine last applied decay to each row.
+--
+-- Without this column the decay formula reapplies the full decay factor from
+-- last_confirmed_at to the already-decayed confidence on every run, compounding
+-- faster than intended. With last_decayed_at, each run only applies decay for
+-- the interval since the previous run:
+--
+--   new_confidence = confidence
+--                    × 0.5^(days_since_last_decayed / half_life_days)
+--
+-- Incremental decay is mathematically equivalent to continuous decay:
+--   0.8 × 0.5^(d1/T) × 0.5^(d2/T) = 0.8 × 0.5^((d1+d2)/T)
+--
+-- Defaults to NULL so COALESCE(last_decayed_at, last_confirmed_at) is used on
+-- the first pass — no backfill required.
+
+ALTER TABLE kg_nodes ADD COLUMN last_decayed_at TIMESTAMPTZ;
+ALTER TABLE kg_edges ADD COLUMN last_decayed_at TIMESTAMPTZ;
+
+-- Down Migration
+
+ALTER TABLE kg_nodes DROP COLUMN IF EXISTS last_decayed_at;
+ALTER TABLE kg_edges DROP COLUMN IF EXISTS last_decayed_at;

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,8 @@ import { AutonomyService } from './autonomy/autonomy-service.js';
 import { BrowserService } from './browser/browser-service.js';
 import { OfficeIdentityService } from './identity/service.js';
 import { SensitivityClassifier } from './memory/sensitivity.js';
+import { DreamEngine } from './memory/dream-engine.js';
+import type { DecayConfig } from './memory/dream-engine.js';
 import type { AgentPersona } from './skills/types.js';
 import type { ConfigChangeEvent } from './bus/events.js';
 import { BullpenService } from './memory/bullpen.js';
@@ -684,7 +686,22 @@ async function main(): Promise<void> {
     logger.info('Intent drift detection disabled via config');
   }
 
-  const scheduler = new Scheduler({ pool, bus, logger, schedulerService, driftDetector });
+  // Dream engine — background KG maintenance (spec 17 / issue #27).
+  // Defaults are intentionally conservative: daily cadence, 5% archive threshold,
+  // 180-day slow-decay half-life, 21-day fast-decay half-life.
+  const decayConfig: DecayConfig = {
+    intervalMs: yamlConfig.dreaming?.decay?.intervalMs ?? 86_400_000,
+    archiveThreshold: yamlConfig.dreaming?.decay?.archiveThreshold ?? 0.05,
+    halfLifeDays: {
+      permanent: null,
+      slow_decay: yamlConfig.dreaming?.decay?.halfLifeDays?.slow_decay ?? 180,
+      fast_decay: yamlConfig.dreaming?.decay?.halfLifeDays?.fast_decay ?? 21,
+    },
+  };
+  const dreamEngine = new DreamEngine(pool, bus, logger, decayConfig);
+  logger.info({ decayConfig }, 'DreamEngine configured');
+
+  const scheduler = new Scheduler({ pool, bus, logger, schedulerService, driftDetector, dreamEngine });
 
   // Execution layer — now with bus, agent registry, and outbound gateway for
   // infrastructure skills. outboundGateway gives email skills their send path.

--- a/src/memory/dream-engine-kg-filter.test.ts
+++ b/src/memory/dream-engine-kg-filter.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { KnowledgeGraphStore } from './knowledge-graph.js';
+import { EmbeddingService } from './embedding.js';
+
+function makeStore() {
+  return KnowledgeGraphStore.createInMemory(EmbeddingService.createForTesting());
+}
+
+describe('KnowledgeGraphStore: archived row filtering', () => {
+  it('getNode returns undefined for an archived node', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'fact', label: 'stale fact', properties: {}, source: 'test' });
+    await store.archiveNode(node.id);
+    const result = await store.getNode(node.id);
+    expect(result).toBeUndefined();
+  });
+
+  it('findNodesByType excludes archived nodes', async () => {
+    const store = makeStore();
+    const active = await store.createNode({ type: 'fact', label: 'active fact', properties: {}, source: 'test' });
+    const archived = await store.createNode({ type: 'fact', label: 'archived fact', properties: {}, source: 'test' });
+    await store.archiveNode(archived.id);
+    const results = await store.findNodesByType('fact');
+    expect(results.map(n => n.id)).toContain(active.id);
+    expect(results.map(n => n.id)).not.toContain(archived.id);
+  });
+
+  it('findNodesByLabel excludes archived nodes', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'fact', label: 'decayed coffee pref', properties: {}, source: 'test' });
+    await store.archiveNode(node.id);
+    const results = await store.findNodesByLabel('decayed coffee pref');
+    expect(results).toHaveLength(0);
+  });
+
+  it('getEdgesForNode excludes archived edges', async () => {
+    const store = makeStore();
+    const a = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'person', label: 'Bob', properties: {}, source: 'test' });
+    const edge = await store.createEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'collaborates_with', properties: {}, source: 'test' });
+    await store.archiveEdge(edge.id);
+    const edges = await store.getEdgesForNode(a.id);
+    expect(edges).toHaveLength(0);
+  });
+
+  it('traverse excludes archived nodes and edges', async () => {
+    const store = makeStore();
+    const a = await store.createNode({ type: 'person', label: 'Traverse-A', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'project', label: 'Traverse-B', properties: {}, source: 'test' });
+    await store.createEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'works_on', properties: {}, source: 'test' });
+    await store.archiveNode(b.id);
+    const result = await store.traverse(a.id, { maxDepth: 2 });
+    expect(result.nodes.map(n => n.id)).not.toContain(b.id);
+  });
+});

--- a/src/memory/dream-engine.test.ts
+++ b/src/memory/dream-engine.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Pool, QueryResult } from 'pg';
+import type { EventBus } from '../bus/bus.js';
+import { DreamEngine } from './dream-engine.js';
+import { createSilentLogger } from '../logger.js';
+
+// Minimal mock pool that records queries
+function makePool(rowCounts: number[] = []): { pool: Pool; queries: Array<{ sql: string; params: unknown[] }> } {
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+  let callIndex = 0;
+  const pool = {
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params: params ?? [] });
+      const rowCount = rowCounts[callIndex++] ?? 0;
+      return { rowCount, rows: [] } as unknown as QueryResult;
+    }),
+  } as unknown as Pool;
+  return { pool, queries };
+}
+
+function makeBus(): EventBus {
+  return { publish: vi.fn(), subscribe: vi.fn() } as unknown as EventBus;
+}
+
+const defaultConfig = {
+  intervalMs: 86400000,
+  archiveThreshold: 0.05,
+  halfLifeDays: {
+    permanent: null as null,
+    slow_decay: 180,
+    fast_decay: 21,
+  },
+};
+
+describe('DreamEngine.runDecayPass', () => {
+  it('runs all three passes and returns counts', async () => {
+    const { pool, queries } = makePool([5, 3, 2, 1, 4, 2]);
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    const result = await engine.runDecayPass();
+
+    // Should have executed: slow_decay nodes, fast_decay nodes, slow_decay edges, fast_decay edges, archive nodes, archive edges
+    expect(queries.length).toBe(6);
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not run any SQL for permanent nodes (halfLifeDays.permanent is null)', async () => {
+    const { pool, queries } = makePool();
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    await engine.runDecayPass();
+    // No query should reference 'permanent' as a decay_class parameter
+    const permanentQueries = queries.filter(q =>
+      q.params.some(p => p === 'permanent'),
+    );
+    expect(permanentQueries).toHaveLength(0);
+  });
+
+  it('uses the configured half-life for slow_decay nodes', async () => {
+    const { pool, queries } = makePool();
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    await engine.runDecayPass();
+    // Find the slow_decay node decay query — it should include 180 (the half-life)
+    const slowDecayNodeQuery = queries.find(q =>
+      q.params.includes('slow_decay') && q.sql.includes('kg_nodes'),
+    );
+    expect(slowDecayNodeQuery).toBeDefined();
+    expect(slowDecayNodeQuery!.params).toContain(180);
+  });
+
+  it('uses the configured half-life for fast_decay nodes', async () => {
+    const { pool, queries } = makePool();
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    await engine.runDecayPass();
+    const fastDecayNodeQuery = queries.find(q =>
+      q.params.includes('fast_decay') && q.sql.includes('kg_nodes'),
+    );
+    expect(fastDecayNodeQuery).toBeDefined();
+    expect(fastDecayNodeQuery!.params).toContain(21);
+  });
+
+  it('uses the configured archiveThreshold in the archive pass', async () => {
+    const { pool, queries } = makePool();
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    await engine.runDecayPass();
+    const archiveNodeQuery = queries.find(q =>
+      q.sql.includes('kg_nodes') && q.sql.includes('archived_at = now()'),
+    );
+    expect(archiveNodeQuery).toBeDefined();
+    expect(archiveNodeQuery!.params).toContain(0.05);
+  });
+
+  it('archives edges whose endpoints were archived in the same pass', async () => {
+    const { pool, queries } = makePool();
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    await engine.runDecayPass();
+    const archiveEdgeQuery = queries.find(q =>
+      q.sql.includes('kg_edges') && q.sql.includes('archived_at = now()'),
+    );
+    expect(archiveEdgeQuery).toBeDefined();
+    // The edge archive query must reference archived node endpoints
+    expect(archiveEdgeQuery!.sql).toMatch(/source_node_id|target_node_id/);
+  });
+});

--- a/src/memory/dream-engine.test.ts
+++ b/src/memory/dream-engine.test.ts
@@ -1,20 +1,36 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Pool, QueryResult } from 'pg';
+import { describe, it, expect, vi } from 'vitest';
+import type { Pool, PoolClient, QueryResult } from 'pg';
 import type { EventBus } from '../bus/bus.js';
 import { DreamEngine } from './dream-engine.js';
 import { createSilentLogger } from '../logger.js';
 
-// Minimal mock pool that records queries
-function makePool(rowCounts: number[] = []): { pool: Pool; queries: Array<{ sql: string; params: unknown[] }> } {
+// Mock a pool that returns a client whose query() records calls and returns configured rowCounts.
+// runDecayPass issues: BEGIN, 4 decay queries, 2 archive queries, COMMIT = 8 total client calls.
+// rowCounts applies only to the 6 data queries (indices 1-6); BEGIN and COMMIT return 0 rows.
+function makePool(rowCounts: number[] = []): {
+  pool: Pool;
+  queries: Array<{ sql: string; params: unknown[] }>;
+} {
   const queries: Array<{ sql: string; params: unknown[] }> = [];
-  let callIndex = 0;
-  const pool = {
+  let dataCallIndex = 0;
+
+  const client = {
     query: vi.fn(async (sql: string, params?: unknown[]) => {
       queries.push({ sql, params: params ?? [] });
-      const rowCount = rowCounts[callIndex++] ?? 0;
+      // BEGIN and COMMIT always return 0 rowCount
+      if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+        return { rowCount: 0, rows: [] } as unknown as QueryResult;
+      }
+      const rowCount = rowCounts[dataCallIndex++] ?? 0;
       return { rowCount, rows: [] } as unknown as QueryResult;
     }),
+    release: vi.fn(),
+  } as unknown as PoolClient;
+
+  const pool = {
+    connect: vi.fn(async () => client),
   } as unknown as Pool;
+
   return { pool, queries };
 }
 
@@ -38,8 +54,9 @@ describe('DreamEngine.runDecayPass', () => {
     const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
     const result = await engine.runDecayPass();
 
-    // Should have executed: slow_decay nodes, fast_decay nodes, slow_decay edges, fast_decay edges, archive nodes, archive edges
-    expect(queries.length).toBe(6);
+    // Should have executed: BEGIN, slow_decay nodes, fast_decay nodes, slow_decay edges,
+    // fast_decay edges, archive nodes, archive edges, COMMIT = 8 total
+    expect(queries.length).toBe(8);
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
     // Row counts from the mock: [5, 3, 2, 1, 4, 2]
     // nodesDecayed = slow_decay nodes (5) + fast_decay nodes (3)
@@ -54,7 +71,7 @@ describe('DreamEngine.runDecayPass', () => {
     const { pool, queries } = makePool();
     const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
     await engine.runDecayPass();
-    // No query should reference 'permanent' as a decay_class parameter
+    // No data query should reference 'permanent' as a decay_class parameter
     const permanentQueries = queries.filter(q =>
       q.params.some(p => p === 'permanent'),
     );
@@ -105,5 +122,23 @@ describe('DreamEngine.runDecayPass', () => {
     expect(archiveEdgeQuery).toBeDefined();
     // The edge archive query must reference archived node endpoints
     expect(archiveEdgeQuery!.sql).toMatch(/source_node_id|target_node_id/);
+  });
+
+  it('wraps the pass in a transaction and releases the client on success', async () => {
+    const { pool } = makePool([1, 1, 1, 1, 1, 1]);
+    const engine = new DreamEngine(pool, makeBus(), createSilentLogger(), defaultConfig);
+    await engine.runDecayPass();
+
+    // pool.connect() should have been called once to get the client
+    expect(pool.connect).toHaveBeenCalledTimes(1);
+    const client = await (pool.connect as ReturnType<typeof vi.fn>).mock.results[0]!.value;
+    // client.release() should be called in the finally block
+    expect(client.release).toHaveBeenCalledTimes(1);
+    // The first query should be BEGIN and last data-less query should be COMMIT
+    const allSqls = (client.query as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c: unknown[]) => (c as [string])[0],
+    );
+    expect(allSqls[0]).toBe('BEGIN');
+    expect(allSqls[allSqls.length - 1]).toBe('COMMIT');
   });
 });

--- a/src/memory/dream-engine.test.ts
+++ b/src/memory/dream-engine.test.ts
@@ -41,6 +41,13 @@ describe('DreamEngine.runDecayPass', () => {
     // Should have executed: slow_decay nodes, fast_decay nodes, slow_decay edges, fast_decay edges, archive nodes, archive edges
     expect(queries.length).toBe(6);
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    // Row counts from the mock: [5, 3, 2, 1, 4, 2]
+    // nodesDecayed = slow_decay nodes (5) + fast_decay nodes (3)
+    // edgesDecayed = slow_decay edges (2) + fast_decay edges (1)
+    expect(result.nodesDecayed).toBe(8);   // 5 + 3
+    expect(result.edgesDecayed).toBe(3);   // 2 + 1
+    expect(result.nodesArchived).toBe(4);
+    expect(result.edgesArchived).toBe(2);
   });
 
   it('does not run any SQL for permanent nodes (halfLifeDays.permanent is null)', async () => {

--- a/src/memory/dream-engine.ts
+++ b/src/memory/dream-engine.ts
@@ -1,4 +1,4 @@
-import type { Pool } from 'pg';
+import type { Pool, PoolClient } from 'pg';
 import type { EventBus } from '../bus/bus.js';
 import type { Logger } from '../logger.js';
 
@@ -82,6 +82,10 @@ export class DreamEngine {
    *   1. Decay confidence on slow_decay and fast_decay nodes and edges
    *   2. Archive nodes whose confidence is at or below archiveThreshold
    *   3. Archive edges whose endpoints were archived, or whose own confidence crossed the threshold
+   *
+   * All queries run inside a single transaction so partial failures leave no torn state
+   * (e.g. nodes archived but their dangling edges left live).
+   * Per node-postgres docs, all statements in a transaction must share the same client.
    */
   async runDecayPass(): Promise<DecayPassResult> {
     const start = Date.now();
@@ -89,14 +93,45 @@ export class DreamEngine {
 
     const { archiveThreshold, halfLifeDays } = this.config;
 
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const result = await this._runDecayPassOnClient(client, archiveThreshold, halfLifeDays);
+
+      await client.query('COMMIT');
+
+      const durationMs = Date.now() - start;
+      this.logger.info(
+        { ...result, durationMs },
+        'DreamEngine: decay pass complete',
+      );
+
+      return { ...result, durationMs };
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  private async _runDecayPassOnClient(
+    client: PoolClient,
+    archiveThreshold: number,
+    halfLifeDays: DecayConfig['halfLifeDays'],
+  ): Promise<Omit<DecayPassResult, 'durationMs'>> {
     // Pass 1a: Decay slow_decay nodes
-    // confidence × 0.5^(days_since_confirmed / half_life_days)
-    // The guard confidence > archiveThreshold skips already-condemned rows to avoid
-    // unnecessary writes — they will be archived in Pass 2 regardless.
-    const slowNodeResult = await this.pool.query(
+    // Uses COALESCE(last_decayed_at, last_confirmed_at) so each run only applies
+    // decay for the interval since the last run rather than re-applying the full
+    // decay from last_confirmed_at to the already-decayed value (which would
+    // compound faster than intended). Also sets last_decayed_at = now() so the
+    // next run uses this timestamp as the reference point.
+    const slowNodeResult = await client.query(
       `UPDATE kg_nodes
          SET confidence = confidence * power(0.5,
-             EXTRACT(EPOCH FROM (now() - last_confirmed_at)) / 86400.0 / $1)
+             EXTRACT(EPOCH FROM (now() - COALESCE(last_decayed_at, last_confirmed_at))) / 86400.0 / $1),
+             last_decayed_at = now()
        WHERE archived_at IS NULL
          AND decay_class = $2
          AND confidence > $3`,
@@ -104,10 +139,11 @@ export class DreamEngine {
     );
 
     // Pass 1b: Decay fast_decay nodes
-    const fastNodeResult = await this.pool.query(
+    const fastNodeResult = await client.query(
       `UPDATE kg_nodes
          SET confidence = confidence * power(0.5,
-             EXTRACT(EPOCH FROM (now() - last_confirmed_at)) / 86400.0 / $1)
+             EXTRACT(EPOCH FROM (now() - COALESCE(last_decayed_at, last_confirmed_at))) / 86400.0 / $1),
+             last_decayed_at = now()
        WHERE archived_at IS NULL
          AND decay_class = $2
          AND confidence > $3`,
@@ -115,10 +151,11 @@ export class DreamEngine {
     );
 
     // Pass 1c: Decay slow_decay edges
-    const slowEdgeResult = await this.pool.query(
+    const slowEdgeResult = await client.query(
       `UPDATE kg_edges
          SET confidence = confidence * power(0.5,
-             EXTRACT(EPOCH FROM (now() - last_confirmed_at)) / 86400.0 / $1)
+             EXTRACT(EPOCH FROM (now() - COALESCE(last_decayed_at, last_confirmed_at))) / 86400.0 / $1),
+             last_decayed_at = now()
        WHERE archived_at IS NULL
          AND decay_class = $2
          AND confidence > $3`,
@@ -126,10 +163,11 @@ export class DreamEngine {
     );
 
     // Pass 1d: Decay fast_decay edges
-    const fastEdgeResult = await this.pool.query(
+    const fastEdgeResult = await client.query(
       `UPDATE kg_edges
          SET confidence = confidence * power(0.5,
-             EXTRACT(EPOCH FROM (now() - last_confirmed_at)) / 86400.0 / $1)
+             EXTRACT(EPOCH FROM (now() - COALESCE(last_decayed_at, last_confirmed_at))) / 86400.0 / $1),
+             last_decayed_at = now()
        WHERE archived_at IS NULL
          AND decay_class = $2
          AND confidence > $3`,
@@ -140,7 +178,7 @@ export class DreamEngine {
     const edgesDecayed = (slowEdgeResult.rowCount ?? 0) + (fastEdgeResult.rowCount ?? 0);
 
     // Pass 2: Archive nodes at or below threshold (permanent nodes are never archived)
-    const archiveNodeResult = await this.pool.query(
+    const archiveNodeResult = await client.query(
       `UPDATE kg_nodes
          SET archived_at = now()
        WHERE archived_at IS NULL
@@ -155,7 +193,7 @@ export class DreamEngine {
     // is at or below threshold. Using archived_at IS NOT NULL for nodes catches both
     // the just-archived nodes from Pass 2 and any previously archived nodes, ensuring
     // no edge is left dangling to an archived endpoint.
-    const archiveEdgeResult = await this.pool.query(
+    const archiveEdgeResult = await client.query(
       `UPDATE kg_edges
          SET archived_at = now()
        WHERE archived_at IS NULL
@@ -168,13 +206,7 @@ export class DreamEngine {
     );
 
     const edgesArchived = archiveEdgeResult.rowCount ?? 0;
-    const durationMs = Date.now() - start;
 
-    this.logger.info(
-      { nodesDecayed, edgesDecayed, nodesArchived, edgesArchived, durationMs },
-      'DreamEngine: decay pass complete',
-    );
-
-    return { nodesDecayed, edgesDecayed, nodesArchived, edgesArchived, durationMs };
+    return { nodesDecayed, edgesDecayed, nodesArchived, edgesArchived };
   }
 }

--- a/src/memory/dream-engine.ts
+++ b/src/memory/dream-engine.ts
@@ -1,0 +1,180 @@
+import type { Pool } from 'pg';
+import type { EventBus } from '../bus/bus.js';
+import type { Logger } from '../logger.js';
+
+// Config shape mirrors YamlConfig.dreaming.decay — all fields required at construction
+// time (caller resolves defaults before passing in).
+export interface DecayConfig {
+  intervalMs: number;
+  archiveThreshold: number;
+  halfLifeDays: {
+    permanent: null;
+    slow_decay: number;
+    fast_decay: number;
+  };
+}
+
+export interface DecayPassResult {
+  nodesDecayed: number;
+  edgesDecayed: number;
+  nodesArchived: number;
+  edgesArchived: number;
+  durationMs: number;
+}
+
+/**
+ * DreamEngine — background knowledge graph maintenance.
+ *
+ * Named after the neuroscience analogy: sleep is when the brain consolidates
+ * short-term experiences into long-term memory and prunes weak connections.
+ *
+ * Currently implements one pass: memory decay (issue #27).
+ * Future passes (decay warning #280, contradiction resolution, synthesis) will
+ * be added as sibling methods with their own config keys under `dreaming`.
+ *
+ * EventBus is injected now but unused — reserved for the decay warning pass (#280)
+ * which will emit `memory.decay_warning` before archiving important nodes.
+ */
+export class DreamEngine {
+  private pool: Pool;
+  // EventBus reserved for decay warning pass (issue #280) — injected now so the
+  // constructor signature doesn't need to change when that feature lands.
+  private _bus: EventBus;
+  private logger: Logger;
+  private config: DecayConfig;
+  private intervalHandle: ReturnType<typeof setInterval> | null = null;
+
+  constructor(pool: Pool, bus: EventBus, logger: Logger, config: DecayConfig) {
+    this.pool = pool;
+    this._bus = bus;
+    this.logger = logger;
+    this.config = config;
+  }
+
+  /**
+   * Start the recurring decay interval.
+   * Logs the configured cadence so operators can verify the schedule at startup.
+   */
+  start(): void {
+    this.intervalHandle = setInterval(() => {
+      this.runDecayPass().catch((err) => {
+        this.logger.error({ err }, 'DreamEngine: unhandled error in runDecayPass');
+      });
+    }, this.config.intervalMs);
+
+    this.logger.info(
+      { intervalMs: this.config.intervalMs, archiveThreshold: this.config.archiveThreshold },
+      'DreamEngine started (decay pass scheduled)',
+    );
+  }
+
+  /** Stop the interval timer for clean shutdown. */
+  stop(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+    this.logger.info('DreamEngine stopped');
+  }
+
+  /**
+   * Run one full decay pass:
+   *   1. Decay confidence on slow_decay and fast_decay nodes and edges
+   *   2. Archive nodes whose confidence is at or below archiveThreshold
+   *   3. Archive edges whose endpoints were archived, or whose own confidence crossed the threshold
+   */
+  async runDecayPass(): Promise<DecayPassResult> {
+    const start = Date.now();
+    this.logger.info('DreamEngine: decay pass starting');
+
+    const { archiveThreshold, halfLifeDays } = this.config;
+
+    // Pass 1a: Decay slow_decay nodes
+    // confidence × 0.5^(days_since_confirmed / half_life_days)
+    // The guard confidence > archiveThreshold skips already-condemned rows to avoid
+    // unnecessary writes — they will be archived in Pass 2 regardless.
+    const slowNodeResult = await this.pool.query(
+      `UPDATE kg_nodes
+         SET confidence = confidence * power(0.5,
+             EXTRACT(EPOCH FROM (now() - last_confirmed_at)) / 86400.0 / $1)
+       WHERE archived_at IS NULL
+         AND decay_class = $2
+         AND confidence > $3`,
+      [halfLifeDays.slow_decay, 'slow_decay', archiveThreshold],
+    );
+
+    // Pass 1b: Decay fast_decay nodes
+    const fastNodeResult = await this.pool.query(
+      `UPDATE kg_nodes
+         SET confidence = confidence * power(0.5,
+             EXTRACT(EPOCH FROM (now() - last_confirmed_at)) / 86400.0 / $1)
+       WHERE archived_at IS NULL
+         AND decay_class = $2
+         AND confidence > $3`,
+      [halfLifeDays.fast_decay, 'fast_decay', archiveThreshold],
+    );
+
+    // Pass 1c: Decay slow_decay edges
+    const slowEdgeResult = await this.pool.query(
+      `UPDATE kg_edges
+         SET confidence = confidence * power(0.5,
+             EXTRACT(EPOCH FROM (now() - last_confirmed_at)) / 86400.0 / $1)
+       WHERE archived_at IS NULL
+         AND decay_class = $2
+         AND confidence > $3`,
+      [halfLifeDays.slow_decay, 'slow_decay', archiveThreshold],
+    );
+
+    // Pass 1d: Decay fast_decay edges
+    const fastEdgeResult = await this.pool.query(
+      `UPDATE kg_edges
+         SET confidence = confidence * power(0.5,
+             EXTRACT(EPOCH FROM (now() - last_confirmed_at)) / 86400.0 / $1)
+       WHERE archived_at IS NULL
+         AND decay_class = $2
+         AND confidence > $3`,
+      [halfLifeDays.fast_decay, 'fast_decay', archiveThreshold],
+    );
+
+    const nodesDecayed = (slowNodeResult.rowCount ?? 0) + (fastNodeResult.rowCount ?? 0);
+    const edgesDecayed = (slowEdgeResult.rowCount ?? 0) + (fastEdgeResult.rowCount ?? 0);
+
+    // Pass 2: Archive nodes at or below threshold (permanent nodes are never archived)
+    const archiveNodeResult = await this.pool.query(
+      `UPDATE kg_nodes
+         SET archived_at = now()
+       WHERE archived_at IS NULL
+         AND decay_class != 'permanent'
+         AND confidence <= $1`,
+      [archiveThreshold],
+    );
+
+    const nodesArchived = archiveNodeResult.rowCount ?? 0;
+
+    // Pass 3: Archive edges whose endpoint was just archived, OR whose own confidence
+    // is at or below threshold. Using archived_at IS NOT NULL for nodes catches both
+    // the just-archived nodes from Pass 2 and any previously archived nodes, ensuring
+    // no edge is left dangling to an archived endpoint.
+    const archiveEdgeResult = await this.pool.query(
+      `UPDATE kg_edges
+         SET archived_at = now()
+       WHERE archived_at IS NULL
+         AND (
+           confidence <= $1
+           OR source_node_id IN (SELECT id FROM kg_nodes WHERE archived_at IS NOT NULL)
+           OR target_node_id IN (SELECT id FROM kg_nodes WHERE archived_at IS NOT NULL)
+         )`,
+      [archiveThreshold],
+    );
+
+    const edgesArchived = archiveEdgeResult.rowCount ?? 0;
+    const durationMs = Date.now() - start;
+
+    this.logger.info(
+      { nodesDecayed, edgesDecayed, nodesArchived, edgesArchived, durationMs },
+      'DreamEngine: decay pass complete',
+    );
+
+    return { nodesDecayed, edgesDecayed, nodesArchived, edgesArchived, durationMs };
+  }
+}

--- a/src/memory/dream-engine.ts
+++ b/src/memory/dream-engine.ts
@@ -37,16 +37,15 @@ export interface DecayPassResult {
  */
 export class DreamEngine {
   private pool: Pool;
-  // EventBus reserved for decay warning pass (issue #280) — injected now so the
-  // constructor signature doesn't need to change when that feature lands.
-  private _bus: EventBus;
   private logger: Logger;
   private config: DecayConfig;
   private intervalHandle: ReturnType<typeof setInterval> | null = null;
 
-  constructor(pool: Pool, bus: EventBus, logger: Logger, config: DecayConfig) {
+  // _bus is accepted but not stored — it is reserved for the decay warning pass
+  // (#280) which will emit `memory.decay_warning` before archiving important nodes.
+  // The underscore prefix signals intentional non-use to TypeScript.
+  constructor(pool: Pool, _bus: EventBus, logger: Logger, config: DecayConfig) {
     this.pool = pool;
-    this._bus = bus;
     this.logger = logger;
     this.config = config;
   }

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -53,6 +53,10 @@ interface KnowledgeGraphBackend {
   getNode(id: string): Promise<KgNode | undefined>;
   updateNode(id: string, node: KgNode): Promise<void>;
   deleteNode(id: string): Promise<void>;
+  /** Soft-delete a node by setting archived_at = now(). Used by DreamEngine. */
+  archiveNode(id: string): Promise<void>;
+  /** Soft-delete an edge by setting archived_at = now(). Used by DreamEngine. */
+  archiveEdge(id: string): Promise<void>;
   findNodesByType(type: NodeType): Promise<KgNode[]>;
   findNodesByLabel(label: string): Promise<KgNode[]>;
   createEdge(edge: KgEdge): Promise<void>;
@@ -219,6 +223,16 @@ export class KnowledgeGraphStore {
     await this.backend.deleteNode(id);
   }
 
+  /** Soft-delete a node — sets archived_at, does not remove the row. */
+  async archiveNode(id: string): Promise<void> {
+    return this.backend.archiveNode(id);
+  }
+
+  /** Soft-delete an edge — sets archived_at, does not remove the row. */
+  async archiveEdge(id: string): Promise<void> {
+    return this.backend.archiveEdge(id);
+  }
+
   /** Find all nodes of a given type */
   async findNodesByType(type: NodeType): Promise<KgNode[]> {
     return this.backend.findNodesByType(type);
@@ -383,7 +397,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
 
   async getNode(id: string): Promise<KgNode | undefined> {
     const result = await this.pool.query<PgNodeRow>(
-      'SELECT * FROM kg_nodes WHERE id = $1',
+      'SELECT * FROM kg_nodes WHERE id = $1 AND archived_at IS NULL',
       [id],
     );
     const row = result.rows[0];
@@ -414,9 +428,19 @@ class PostgresBackend implements KnowledgeGraphBackend {
     await this.pool.query('DELETE FROM kg_nodes WHERE id = $1', [id]);
   }
 
+  async archiveNode(id: string): Promise<void> {
+    this.logger.debug({ nodeId: id }, 'kg: archiving node');
+    await this.pool.query('UPDATE kg_nodes SET archived_at = now() WHERE id = $1', [id]);
+  }
+
+  async archiveEdge(id: string): Promise<void> {
+    this.logger.debug({ edgeId: id }, 'kg: archiving edge');
+    await this.pool.query('UPDATE kg_edges SET archived_at = now() WHERE id = $1', [id]);
+  }
+
   async findNodesByType(type: NodeType): Promise<KgNode[]> {
     const result = await this.pool.query<PgNodeRow>(
-      'SELECT * FROM kg_nodes WHERE type = $1',
+      'SELECT * FROM kg_nodes WHERE type = $1 AND archived_at IS NULL',
       [type],
     );
     return result.rows.map(pgRowToNode);
@@ -426,7 +450,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
     // Case-insensitive exact match using lower() to leverage the idx_kg_nodes_label index.
     // ILIKE would require a pg_trgm index; lower() = lower() uses the btree on lower(label).
     const result = await this.pool.query<PgNodeRow>(
-      'SELECT * FROM kg_nodes WHERE lower(label) = lower($1)',
+      'SELECT * FROM kg_nodes WHERE lower(label) = lower($1) AND archived_at IS NULL',
       [label],
     );
     return result.rows.map(pgRowToNode);
@@ -454,7 +478,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
 
   async getEdgesForNode(nodeId: string): Promise<KgEdge[]> {
     const result = await this.pool.query<PgEdgeRow>(
-      'SELECT * FROM kg_edges WHERE source_node_id = $1 OR target_node_id = $1',
+      'SELECT * FROM kg_edges WHERE (source_node_id = $1 OR target_node_id = $1) AND archived_at IS NULL',
       [nodeId],
     );
     return result.rows.map(pgRowToEdge);
@@ -524,7 +548,9 @@ class PostgresBackend implements KnowledgeGraphBackend {
   }
 
   async traverse(startNodeId: string, maxDepth: number): Promise<TraversalResult> {
-    // Step 1: Collect reachable nodes via recursive CTE (cycle-safe)
+    // Step 1: Collect reachable nodes via recursive CTE (cycle-safe).
+    // Both the edge join and the final node select filter out archived rows
+    // so that archived nodes and their edges are invisible to traversal.
     const nodesResult = await this.pool.query<PgNodeRow>(
       `WITH RECURSIVE reachable AS (
         SELECT $1::uuid AS node_id, 0 AS depth, ARRAY[$1::uuid] AS visited
@@ -536,9 +562,10 @@ class PostgresBackend implements KnowledgeGraphBackend {
         FROM reachable r
         JOIN kg_edges e ON (e.source_node_id = r.node_id OR e.target_node_id = r.node_id)
         WHERE r.depth < $2
+          AND e.archived_at IS NULL
           AND NOT (CASE WHEN e.source_node_id = r.node_id THEN e.target_node_id ELSE e.source_node_id END) = ANY(r.visited)
       )
-      SELECT DISTINCT n.* FROM reachable r JOIN kg_nodes n ON n.id = r.node_id`,
+      SELECT DISTINCT n.* FROM reachable r JOIN kg_nodes n ON n.id = r.node_id WHERE n.archived_at IS NULL`,
       [startNodeId, maxDepth],
     );
 
@@ -549,11 +576,12 @@ class PostgresBackend implements KnowledgeGraphBackend {
       return { nodes: [], edges: [] };
     }
 
-    // Step 2: Collect edges between reachable nodes
+    // Step 2: Collect edges between reachable nodes (archived edges excluded)
     const edgesResult = await this.pool.query<PgEdgeRow>(
       `SELECT e.* FROM kg_edges e
        WHERE e.source_node_id = ANY($1::uuid[])
-         AND e.target_node_id = ANY($1::uuid[])`,
+         AND e.target_node_id = ANY($1::uuid[])
+         AND e.archived_at IS NULL`,
       [nodeIds],
     );
 
@@ -567,6 +595,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
       `SELECT *, 1 - (embedding <=> $1::vector) AS similarity
        FROM kg_nodes
        WHERE embedding IS NOT NULL
+         AND archived_at IS NULL
        ORDER BY embedding <=> $1::vector
        LIMIT $2`,
       [embeddingStr, limit],
@@ -594,6 +623,7 @@ interface PgNodeRow {
   created_at: Date;
   last_confirmed_at: Date;
   sensitivity: string;
+  archived_at: Date | null;
 }
 
 interface PgEdgeRow {
@@ -607,6 +637,7 @@ interface PgEdgeRow {
   source: string;
   created_at: Date;
   last_confirmed_at: Date;
+  archived_at: Date | null;
 }
 
 function pgRowToNode(row: PgNodeRow): KgNode {
@@ -671,6 +702,9 @@ function parseVector(vectorStr: string): number[] {
 class InMemoryBackend implements KnowledgeGraphBackend {
   private nodes = new Map<string, KgNode>();
   private edges = new Map<string, KgEdge>();
+  // Soft-deleted IDs — rows are retained but invisible to all read paths
+  private archivedNodes = new Set<string>();
+  private archivedEdges = new Set<string>();
 
   async createNode(node: KgNode): Promise<void> {
     this.nodes.set(node.id, node);
@@ -686,7 +720,8 @@ class InMemoryBackend implements KnowledgeGraphBackend {
     const lowerLabel = node.label.toLowerCase();
     let existing: KgNode | undefined;
     for (const n of this.nodes.values()) {
-      if (n.type !== 'fact' && n.label.toLowerCase() === lowerLabel && n.type === node.type) {
+      // Archived nodes are treated as non-existent — don't merge with them
+      if (n.type !== 'fact' && n.label.toLowerCase() === lowerLabel && n.type === node.type && !this.archivedNodes.has(n.id)) {
         existing = n;
         break;
       }
@@ -710,6 +745,7 @@ class InMemoryBackend implements KnowledgeGraphBackend {
   }
 
   async getNode(id: string): Promise<KgNode | undefined> {
+    if (this.archivedNodes.has(id)) return undefined;
     return this.nodes.get(id);
   }
 
@@ -727,10 +763,18 @@ class InMemoryBackend implements KnowledgeGraphBackend {
     }
   }
 
+  async archiveNode(id: string): Promise<void> {
+    this.archivedNodes.add(id);
+  }
+
+  async archiveEdge(id: string): Promise<void> {
+    this.archivedEdges.add(id);
+  }
+
   async findNodesByType(type: NodeType): Promise<KgNode[]> {
     const results: KgNode[] = [];
     for (const node of this.nodes.values()) {
-      if (node.type === type) {
+      if (node.type === type && !this.archivedNodes.has(node.id)) {
         results.push(node);
       }
     }
@@ -741,7 +785,7 @@ class InMemoryBackend implements KnowledgeGraphBackend {
     const lowerLabel = label.toLowerCase();
     const results: KgNode[] = [];
     for (const node of this.nodes.values()) {
-      if (node.label.toLowerCase() === lowerLabel) {
+      if (node.label.toLowerCase() === lowerLabel && !this.archivedNodes.has(node.id)) {
         results.push(node);
       }
     }
@@ -789,7 +833,10 @@ class InMemoryBackend implements KnowledgeGraphBackend {
   async getEdgesForNode(nodeId: string): Promise<KgEdge[]> {
     const results: KgEdge[] = [];
     for (const edge of this.edges.values()) {
-      if (edge.sourceNodeId === nodeId || edge.targetNodeId === nodeId) {
+      if (
+        (edge.sourceNodeId === nodeId || edge.targetNodeId === nodeId) &&
+        !this.archivedEdges.has(edge.id)
+      ) {
         results.push(edge);
       }
     }
@@ -817,7 +864,8 @@ class InMemoryBackend implements KnowledgeGraphBackend {
 
   /**
    * BFS traversal from startNodeId, limited to maxDepth hops.
-   * Uses a visited set to prevent cycles.
+   * Uses a visited set to prevent cycles. Archived nodes and edges are
+   * invisible — traversal will not cross an archived edge or visit an archived node.
    */
   async traverse(startNodeId: string, maxDepth: number): Promise<TraversalResult> {
     const visited = new Set<string>();
@@ -832,8 +880,11 @@ class InMemoryBackend implements KnowledgeGraphBackend {
       // Don't explore neighbors if we're at the depth limit
       if (depth >= maxDepth) continue;
 
-      // Find all edges connected to this node
+      // Find all non-archived edges connected to this node
       for (const edge of this.edges.values()) {
+        // Skip archived edges — they must not contribute to traversal
+        if (this.archivedEdges.has(edge.id)) continue;
+
         let neighborId: string | undefined;
         if (edge.sourceNodeId === currentNodeId) {
           neighborId = edge.targetNodeId;
@@ -841,26 +892,32 @@ class InMemoryBackend implements KnowledgeGraphBackend {
           neighborId = edge.sourceNodeId;
         }
 
-        if (neighborId && !visited.has(neighborId)) {
+        // Skip archived neighbor nodes
+        if (neighborId && !visited.has(neighborId) && !this.archivedNodes.has(neighborId)) {
           visited.add(neighborId);
           queue.push([neighborId, depth + 1]);
         }
       }
     }
 
-    // Collect all visited nodes
+    // Collect all visited nodes, excluding any that were archived after being visited
     const nodes: KgNode[] = [];
     for (const nodeId of visited) {
+      if (this.archivedNodes.has(nodeId)) continue;
       const node = this.nodes.get(nodeId);
       if (node) {
         nodes.push(node);
       }
     }
 
-    // Collect edges where both endpoints are in the visited set
+    // Collect non-archived edges where both endpoints are in the visited set
     const edges: KgEdge[] = [];
     for (const edge of this.edges.values()) {
-      if (visited.has(edge.sourceNodeId) && visited.has(edge.targetNodeId)) {
+      if (
+        !this.archivedEdges.has(edge.id) &&
+        visited.has(edge.sourceNodeId) &&
+        visited.has(edge.targetNodeId)
+      ) {
         edges.push(edge);
       }
     }
@@ -871,12 +928,15 @@ class InMemoryBackend implements KnowledgeGraphBackend {
   /**
    * Semantic search: compute cosine similarity between the query embedding
    * and all node embeddings, return top results sorted by similarity.
+   * Archived nodes are excluded from results.
    */
   async semanticSearch(queryEmbedding: number[], limit: number): Promise<SearchResult[]> {
     const scored: SearchResult[] = [];
 
     for (const node of this.nodes.values()) {
       if (!node.embedding) continue;
+      // Archived nodes must not appear in semantic search results
+      if (this.archivedNodes.has(node.id)) continue;
       const score = EmbeddingService.cosineSimilarity(queryEmbedding, node.embedding);
       scored.push({ node, score, edges: [] });
     }

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -431,6 +431,13 @@ class PostgresBackend implements KnowledgeGraphBackend {
   async archiveNode(id: string): Promise<void> {
     this.logger.debug({ nodeId: id }, 'kg: archiving node');
     await this.pool.query('UPDATE kg_nodes SET archived_at = now() WHERE id = $1', [id]);
+    // Cascade: any active edge touching this node is also archived so it cannot
+    // be returned by getEdgesForNode before the next DreamEngine decay pass runs.
+    const edgeResult = await this.pool.query(
+      'UPDATE kg_edges SET archived_at = now() WHERE (source_node_id = $1 OR target_node_id = $1) AND archived_at IS NULL',
+      [id],
+    );
+    this.logger.debug({ nodeId: id, edgesArchived: edgeResult.rowCount ?? 0 }, 'kg: cascaded archive to incident edges');
   }
 
   async archiveEdge(id: string): Promise<void> {
@@ -502,7 +509,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
          LEAST(source_node_id::text, target_node_id::text),
          GREATEST(source_node_id::text, target_node_id::text),
          type
-       ) DO UPDATE SET
+       ) WHERE archived_at IS NULL DO UPDATE SET
          confidence = GREATEST(kg_edges.confidence, EXCLUDED.confidence),
          last_confirmed_at = EXCLUDED.last_confirmed_at
        RETURNING *, (xmax = 0) AS is_new`,
@@ -765,6 +772,13 @@ class InMemoryBackend implements KnowledgeGraphBackend {
 
   async archiveNode(id: string): Promise<void> {
     this.archivedNodes.add(id);
+    // Cascade: archive all active edges touching this node so getEdgesForNode
+    // cannot return dangling edges to the newly archived node.
+    for (const edge of this.edges.values()) {
+      if ((edge.sourceNodeId === id || edge.targetNodeId === id) && !this.archivedEdges.has(edge.id)) {
+        this.archivedEdges.add(edge.id);
+      }
+    }
   }
 
   async archiveEdge(id: string): Promise<void> {

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -797,10 +797,13 @@ class InMemoryBackend implements KnowledgeGraphBackend {
   }
 
   async upsertEdge(edge: KgEdge): Promise<{ edge: KgEdge; created: boolean }> {
-    // Check for an existing edge of the same type in either direction
+    // Check for an existing *active* edge of the same type in either direction.
+    // Archived edges are invisible for conflict detection — a new edge should be
+    // created fresh rather than reviving a soft-deleted row.
     let existing: KgEdge | undefined;
     for (const e of this.edges.values()) {
       if (
+        !this.archivedEdges.has(e.id) &&
         e.type === edge.type &&
         (
           (e.sourceNodeId === edge.sourceNodeId && e.targetNodeId === edge.targetNodeId) ||

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -366,7 +366,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
     const result = await this.pool.query<PgNodeRow & { is_new: boolean }>(
       `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity)
        VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $9, $10)
-       ON CONFLICT (lower(label), type) WHERE type != 'fact'
+       ON CONFLICT (lower(label), type) WHERE type != 'fact' AND archived_at IS NULL
        DO UPDATE SET
          confidence = GREATEST(kg_nodes.confidence, EXCLUDED.confidence),
          last_confirmed_at = EXCLUDED.last_confirmed_at

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -13,6 +13,7 @@ import {
 } from '../bus/events.js';
 import type { AgentResponseEvent, AgentErrorEvent } from '../bus/events.js';
 import type { DriftDetector } from './drift-detector.js';
+import type { DreamEngine } from '../memory/dream-engine.js';
 import type { JobRow } from './scheduler-service.js';
 
 // Poll every 30 seconds for due jobs.
@@ -80,6 +81,8 @@ export interface SchedulerConfig {
   schedulerService: SchedulerService;
   /** Optional drift detector — when absent, the drift check is skipped entirely. */
   driftDetector?: DriftDetector;
+  /** Dream engine for background KG maintenance. When absent, no background decay runs. */
+  dreamEngine?: DreamEngine;
 }
 
 export class Scheduler {
@@ -88,6 +91,7 @@ export class Scheduler {
   private logger: Logger;
   private schedulerService: SchedulerService;
   private driftDetector?: DriftDetector;
+  private dreamEngine?: DreamEngine;
   private intervalHandle: ReturnType<typeof setInterval> | null = null;
   private watchdogHandle: ReturnType<typeof setInterval> | null = null;
 
@@ -105,6 +109,7 @@ export class Scheduler {
     this.logger = config.logger;
     this.schedulerService = config.schedulerService;
     this.driftDetector = config.driftDetector;
+    this.dreamEngine = config.dreamEngine;
   }
 
   /**
@@ -149,6 +154,11 @@ export class Scheduler {
       });
     }, WATCHDOG_INTERVAL_MS);
 
+    // Dream engine — background KG maintenance (decay, and future passes).
+    if (this.dreamEngine) {
+      this.dreamEngine.start();
+    }
+
     this.logger.info({ intervalMs: POLL_INTERVAL_MS }, 'Scheduler started');
   }
 
@@ -163,6 +173,9 @@ export class Scheduler {
     if (this.watchdogHandle) {
       clearInterval(this.watchdogHandle);
       this.watchdogHandle = null;
+    }
+    if (this.dreamEngine) {
+      this.dreamEngine.stop();
     }
     this.logger.info('Scheduler stopped');
   }

--- a/tests/integration/dream-engine.test.ts
+++ b/tests/integration/dream-engine.test.ts
@@ -107,6 +107,16 @@ describeIf('DreamEngine integration', () => {
     expect(results.map(n => n.id)).not.toContain(node.id);
   });
 
+  it('archived node does not appear in findNodesByLabel', async () => {
+    const node = await store.createNode({
+      type: 'fact', label: 'archived-label-test', properties: {}, source: 'test',
+    });
+    await store.archiveNode(node.id);
+
+    const results = await store.findNodesByLabel('archived-label-test');
+    expect(results).toHaveLength(0);
+  });
+
   it('archived node does not appear in traverse', async () => {
     const a = await store.createNode({ type: 'person', label: 'traversal-source', properties: {}, source: 'test' });
     const b = await store.createNode({ type: 'project', label: 'traversal-archived-target', properties: {}, source: 'test' });

--- a/tests/integration/dream-engine.test.ts
+++ b/tests/integration/dream-engine.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { DreamEngine } from '../../src/memory/dream-engine.js';
+import { createSilentLogger } from '../../src/logger.js';
+import type { EventBus } from '../../src/bus/bus.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+// Minimal EventBus stub — bus is injected now but unused until decay warning pass (#280).
+function makeBus(): EventBus {
+  return { publish: async () => {}, subscribe: () => {} } as unknown as EventBus;
+}
+
+const testConfig = {
+  intervalMs: 86400000,
+  archiveThreshold: 0.05,
+  halfLifeDays: { permanent: null as null, slow_decay: 180, fast_decay: 21 },
+};
+
+describeIf('DreamEngine integration', () => {
+  let pool: pg.Pool;
+  let store: KnowledgeGraphStore;
+  let engine: DreamEngine;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    const embeddingService = EmbeddingService.createForTesting();
+    store = KnowledgeGraphStore.createWithPostgres(pool, embeddingService, createSilentLogger());
+    engine = new DreamEngine(pool, makeBus(), createSilentLogger(), testConfig);
+    // Verify tables are accessible (migration has been run)
+    await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
+  });
+
+  afterAll(async () => {
+    // Clean up all test data in FK-safe order.
+    // Contacts tables may reference kg_nodes, so clear them first.
+    await pool.query('DELETE FROM contact_auth_overrides');
+    await pool.query('DELETE FROM contact_channel_identities');
+    await pool.query('DELETE FROM contacts');
+    await pool.query('DELETE FROM kg_edges');
+    await pool.query('DELETE FROM kg_nodes');
+    await pool.end();
+  });
+
+  it('decays confidence on a fast_decay node based on age', async () => {
+    // Insert a node whose last_confirmed_at is 21 days ago (one full half-life).
+    // After one half-life the formula gives confidence × 0.5^1 = 0.8 × 0.5 = 0.4.
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity)
+       VALUES ('fact', 'decay-test-fast', '{}', 0.8, 'fast_decay', 'test',
+               now() - interval '21 days', now() - interval '21 days', 'internal')
+       RETURNING id`,
+    );
+    const nodeId = rows[0]!.id;
+
+    await engine.runDecayPass();
+
+    const result = await pool.query<{ confidence: number }>(
+      'SELECT confidence FROM kg_nodes WHERE id = $1',
+      [nodeId],
+    );
+    // After one half-life (21 days), confidence should be ~0.4 (half of 0.8).
+    // Allow ±0.05 tolerance for floating point.
+    expect(result.rows[0]!.confidence).toBeCloseTo(0.4, 1);
+  });
+
+  it('archives a node whose confidence falls at or below archiveThreshold', async () => {
+    // Insert a node already at the threshold — runDecayPass Pass 2 should archive it.
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity)
+       VALUES ('fact', 'decay-test-archive', '{}', 0.05, 'fast_decay', 'test',
+               now() - interval '1 day', now() - interval '1 day', 'internal')
+       RETURNING id`,
+    );
+    const nodeId = rows[0]!.id;
+
+    await engine.runDecayPass();
+
+    const result = await pool.query<{ archived_at: Date | null }>(
+      'SELECT archived_at FROM kg_nodes WHERE id = $1',
+      [nodeId],
+    );
+    expect(result.rows[0]!.archived_at).not.toBeNull();
+  });
+
+  it('archived node does not appear in semanticSearch', async () => {
+    const node = await store.createNode({
+      type: 'fact', label: 'archived-search-test', properties: {}, source: 'test',
+    });
+    await store.archiveNode(node.id);
+
+    const results = await store.semanticSearch('archived-search-test');
+    expect(results.map(r => r.node.id)).not.toContain(node.id);
+  });
+
+  it('archived node does not appear in findNodesByType', async () => {
+    const node = await store.createNode({
+      type: 'concept', label: 'archived-type-test', properties: {}, source: 'test',
+    });
+    await store.archiveNode(node.id);
+
+    const results = await store.findNodesByType('concept');
+    expect(results.map(n => n.id)).not.toContain(node.id);
+  });
+
+  it('archived node does not appear in traverse', async () => {
+    const a = await store.createNode({ type: 'person', label: 'traversal-source', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'project', label: 'traversal-archived-target', properties: {}, source: 'test' });
+    await store.createEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'works_on', properties: {}, source: 'test' });
+    await store.archiveNode(b.id);
+
+    const result = await store.traverse(a.id, { maxDepth: 2 });
+    expect(result.nodes.map(n => n.id)).not.toContain(b.id);
+  });
+
+  it('archives edges when their source node is archived in the decay pass', async () => {
+    const a = await store.createNode({ type: 'person', label: 'edge-cascade-source', properties: {}, source: 'test' });
+    const b = await store.createNode({ type: 'project', label: 'edge-cascade-target', properties: {}, source: 'test' });
+    const edge = await store.createEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'works_on', properties: {}, source: 'test' });
+
+    // Archive node a directly to simulate a prior decay pass having condemned it.
+    // Pass 3 of runDecayPass should then cascade the archive to any edges touching a.
+    await pool.query('UPDATE kg_nodes SET archived_at = now() WHERE id = $1', [a.id]);
+
+    await engine.runDecayPass();
+
+    const { rows } = await pool.query<{ archived_at: Date | null }>(
+      'SELECT archived_at FROM kg_edges WHERE id = $1',
+      [edge.id],
+    );
+    expect(rows[0]!.archived_at).not.toBeNull();
+  });
+
+  it('does not archive permanent nodes regardless of age', async () => {
+    // A node 1000 days old with permanent decay should never be touched.
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity)
+       VALUES ('fact', 'permanent-test', '{}', 0.9, 'permanent', 'test',
+               now() - interval '1000 days', now() - interval '1000 days', 'internal')
+       RETURNING id`,
+    );
+    const nodeId = rows[0]!.id;
+
+    await engine.runDecayPass();
+
+    const result = await pool.query<{ confidence: number; archived_at: Date | null }>(
+      'SELECT confidence, archived_at FROM kg_nodes WHERE id = $1',
+      [nodeId],
+    );
+    expect(result.rows[0]!.archived_at).toBeNull();
+    expect(result.rows[0]!.confidence).toBe(0.9); // unchanged
+  });
+});

--- a/tests/integration/dream-engine.test.ts
+++ b/tests/integration/dream-engine.test.ts
@@ -25,6 +25,9 @@ describeIf('DreamEngine integration', () => {
   let pool: pg.Pool;
   let store: KnowledgeGraphStore;
   let engine: DreamEngine;
+  // Track every node ID inserted during this test run so afterAll can delete only
+  // those rows, leaving unrelated dev data intact.
+  const createdNodeIds: string[] = [];
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: DATABASE_URL });
@@ -36,13 +39,15 @@ describeIf('DreamEngine integration', () => {
   });
 
   afterAll(async () => {
-    // Clean up all test data in FK-safe order.
-    // Contacts tables may reference kg_nodes, so clear them first.
-    await pool.query('DELETE FROM contact_auth_overrides');
-    await pool.query('DELETE FROM contact_channel_identities');
-    await pool.query('DELETE FROM contacts');
-    await pool.query('DELETE FROM kg_edges');
-    await pool.query('DELETE FROM kg_nodes');
+    // Delete only the rows this test run created, in FK-safe order.
+    // We never touch the contacts tables — no test in this suite creates contact rows.
+    if (createdNodeIds.length > 0) {
+      await pool.query(
+        'DELETE FROM kg_edges WHERE source_node_id = ANY($1) OR target_node_id = ANY($1)',
+        [createdNodeIds],
+      );
+      await pool.query('DELETE FROM kg_nodes WHERE id = ANY($1)', [createdNodeIds]);
+    }
     await pool.end();
   });
 
@@ -56,6 +61,7 @@ describeIf('DreamEngine integration', () => {
        RETURNING id`,
     );
     const nodeId = rows[0]!.id;
+    createdNodeIds.push(nodeId);
 
     await engine.runDecayPass();
 
@@ -77,6 +83,7 @@ describeIf('DreamEngine integration', () => {
        RETURNING id`,
     );
     const nodeId = rows[0]!.id;
+    createdNodeIds.push(nodeId);
 
     await engine.runDecayPass();
 
@@ -91,6 +98,7 @@ describeIf('DreamEngine integration', () => {
     const node = await store.createNode({
       type: 'fact', label: 'archived-search-test', properties: {}, source: 'test',
     });
+    createdNodeIds.push(node.id);
     await store.archiveNode(node.id);
 
     const results = await store.semanticSearch('archived-search-test');
@@ -101,6 +109,7 @@ describeIf('DreamEngine integration', () => {
     const node = await store.createNode({
       type: 'concept', label: 'archived-type-test', properties: {}, source: 'test',
     });
+    createdNodeIds.push(node.id);
     await store.archiveNode(node.id);
 
     const results = await store.findNodesByType('concept');
@@ -111,6 +120,7 @@ describeIf('DreamEngine integration', () => {
     const node = await store.createNode({
       type: 'fact', label: 'archived-label-test', properties: {}, source: 'test',
     });
+    createdNodeIds.push(node.id);
     await store.archiveNode(node.id);
 
     const results = await store.findNodesByLabel('archived-label-test');
@@ -120,6 +130,7 @@ describeIf('DreamEngine integration', () => {
   it('archived node does not appear in traverse', async () => {
     const a = await store.createNode({ type: 'person', label: 'traversal-source', properties: {}, source: 'test' });
     const b = await store.createNode({ type: 'project', label: 'traversal-archived-target', properties: {}, source: 'test' });
+    createdNodeIds.push(a.id, b.id);
     await store.createEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'works_on', properties: {}, source: 'test' });
     await store.archiveNode(b.id);
 
@@ -130,6 +141,7 @@ describeIf('DreamEngine integration', () => {
   it('archives edges when their source node is archived in the decay pass', async () => {
     const a = await store.createNode({ type: 'person', label: 'edge-cascade-source', properties: {}, source: 'test' });
     const b = await store.createNode({ type: 'project', label: 'edge-cascade-target', properties: {}, source: 'test' });
+    createdNodeIds.push(a.id, b.id);
     const edge = await store.createEdge({ sourceNodeId: a.id, targetNodeId: b.id, type: 'works_on', properties: {}, source: 'test' });
 
     // Archive node a directly to simulate a prior decay pass having condemned it.
@@ -154,6 +166,7 @@ describeIf('DreamEngine integration', () => {
        RETURNING id`,
     );
     const nodeId = rows[0]!.id;
+    createdNodeIds.push(nodeId);
 
     await engine.runDecayPass();
 


### PR DESCRIPTION
## Summary

- Adds `DreamEngine` class (`src/memory/dream-engine.ts`) with configurable exponential confidence decay
- Adds `archived_at` column to `kg_nodes` and `kg_edges` (migration 024); all KG read paths filter archived rows via `WHERE archived_at IS NULL`
- Uniqueness indexes on both tables updated to scope to active rows only (archived nodes/edges can be re-inserted with the same label)
- Config under `dreaming.decay.*` in `config/default.yaml` with sensible defaults (half-lives: 180 days slow, 21 days fast; archive threshold: 0.05; interval: daily)
- EventBus injected but unused — reserved for decay warning follow-up (#280)
- Wired into `Scheduler.start()` / `stop()`
- Pre-existing migration ordering issue (duplicate 014_*/015_* prefixes) blocks `db:migrate` and integration tests locally; this is not introduced by this PR
- Closes #27

## Test plan

- [ ] Unit tests: `npm test src/memory/dream-engine.test.ts`
- [ ] KG filter tests: `npm test src/memory/dream-engine-kg-filter.test.ts`
- [ ] Config validation tests: `npm test src/config.dreaming.test.ts`
- [ ] Integration tests (requires migration applied): `DATABASE_URL=... npm test tests/integration/dream-engine.test.ts`
- [ ] Full test suite: `npm test`
- [ ] Migration applied cleanly: `npm run db:migrate` (requires resolving pre-existing 014_*/015_* prefix conflict first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a background "Dream Engine" that periodically decays confidences and soft‑archives low‑confidence knowledge‑graph entries, cascading archive to related edges.

* **Configuration**
  * New settings to control decay interval, archive threshold and per‑class half‑life parameters.

* **Documentation**
  * Added design/spec and WIP docs describing the Dream Engine and migration approach.

* **Tests**
  * New unit and integration tests validating decay, archiving, and read‑path exclusion.

* **Chores**
  * Version bumped to 0.17.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->