### PR TITLE
fix: correct google-workspace token path and rewrite OAuth runbook

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       # Tokens are written here on first OAuth login and auto-refreshed thereafter.
       # Without this volume, re-authentication is required on every container restart.
       # See docs/dev/google-drive.md for first-time OAuth setup.
-      - google_workspace_tokens:/root/.workspace-mcp
+      - google_workspace_tokens:/root/.google_workspace_mcp
 
 volumes:
   pgdata:

--- a/docs/dev/google-drive.md
+++ b/docs/dev/google-drive.md
@@ -76,8 +76,9 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 # Run the server in HTTP mode — this starts an OAuth callback listener
 GOOGLE_OAUTH_CLIENT_ID=<...> GOOGLE_OAUTH_CLIENT_SECRET=<...> uvx workspace-mcp --transport streamable-http
 
-# Open http://localhost:8000 in a browser.
+# Open http://localhost:8000/mcp in a browser.
 # You will be redirected to Google's OAuth consent page.
+# (http://localhost:8000 is just a health check — use /mcp to trigger auth)
 # Log in as Curia's Gmail (nathancuria1@gmail.com) and approve access.
 # Tokens are saved to ~/.workspace-mcp/cli-tokens/ — you can then Ctrl-C the server.
 ```

--- a/docs/dev/google-drive.md
+++ b/docs/dev/google-drive.md
@@ -82,7 +82,7 @@ callback), opens your browser once per service, and waits for you to complete th
 Log in as **Curia's Gmail account** each time.
 
 After all five services are authenticated, tokens are saved to:
-```
+```text
 ~/.google_workspace_mcp/credentials/<curia-gmail>.json
 ```
 
@@ -155,8 +155,10 @@ empty or missing. Repeat Step 5.
 
 **Tools disappear after container restart**
 
-The `google-workspace-tokens` Docker volume is not being persisted. Confirm the volume
+The `google_workspace_tokens` Docker volume is not being persisted. Confirm the volume
 is declared in `docker-compose.yml` and mounted at `/root/.google_workspace_mcp`.
+(Note: the production compose uses `google-workspace-tokens` with a hyphen — the name
+differs between dev and production compose files.)
 
 **Drive calls fail with 403 Forbidden**
 

--- a/docs/dev/google-drive.md
+++ b/docs/dev/google-drive.md
@@ -21,6 +21,7 @@ OAuth 2.0 as Curia's own Gmail user.
 #### Step 1 — Google Cloud Project
 
 1. Go to [console.cloud.google.com](https://console.cloud.google.com) and create a new project (e.g. `curia-workspace`).
+   Use an admin/developer Google account — not Curia's Gmail account.
 2. Enable these APIs (APIs & Services → Library):
    - Google Drive API
    - Google Sheets API
@@ -45,7 +46,7 @@ OAuth 2.0 as Curia's own Gmail user.
 1. APIs & Services → Credentials → Create Credentials → **OAuth client ID**.
 2. Application type: **Desktop app**.
 3. Name it (e.g. `curia-mcp-client`).
-4. Download the credentials JSON — you won't need the file, just the Client ID and Secret.
+4. Note the **Client ID** and **Client Secret** — you will need these in the next step.
 
 #### Step 4 — Set env vars
 
@@ -56,44 +57,40 @@ GOOGLE_OAUTH_CLIENT_ID=<your-client-id>.apps.googleusercontent.com
 GOOGLE_OAUTH_CLIENT_SECRET=GOCSPX-...
 ```
 
-#### Step 5 — Run the first OAuth flow (requires a browser)
+#### Step 5 — Run the first OAuth flow
 
-The MCP server prints an auth URL on its first run. You must open it in a browser
-signed in as Curia's Gmail.
+The OAuth flow must be completed locally (where you have a browser) and the resulting
+token cache copied to the VPS. There is no browser-accessible auth URL — authentication
+is initiated programmatically via the `start_google_auth` MCP tool.
 
-**Option A (recommended): auth locally, copy tokens to VPS**
+A script at `scripts/gdrive-auth.py` handles the full flow.
 
-Use `--transport streamable-http` to run the server as an HTTP process so the
-OAuth flow goes through the browser. Do NOT use the default stdio transport for
-this step — stdio mode expects a JSON-RPC client on stdin, not a human, and will
-log parse errors if run directly in a terminal (those errors are harmless but the
-OAuth flow won't complete).
+**Prerequisites:**
+- `uv` installed locally (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
+
+**Run the script:**
 
 ```bash
-# Install uv locally if not already present
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Run the server in HTTP mode — this starts an OAuth callback listener
-GOOGLE_OAUTH_CLIENT_ID=<...> GOOGLE_OAUTH_CLIENT_SECRET=<...> uvx workspace-mcp --transport streamable-http
-
-# Open http://localhost:8000/mcp in a browser.
-# You will be redirected to Google's OAuth consent page.
-# (http://localhost:8000 is just a health check — use /mcp to trigger auth)
-# Log in as Curia's Gmail (nathancuria1@gmail.com) and approve access.
-# Tokens are saved to ~/.workspace-mcp/cli-tokens/ — you can then Ctrl-C the server.
+GOOGLE_OAUTH_CLIENT_ID=<...> GOOGLE_OAUTH_CLIENT_SECRET=<...> CURIA_GOOGLE_EMAIL=<curia-gmail> \
+  uv run --with mcp scripts/gdrive-auth.py
 ```
 
-Then copy the token cache to the VPS:
+The script connects to a single persistent `workspace-mcp` process (important — each
+service auth call must happen in the same process so the OAuth state survives the
+callback), opens your browser once per service, and waits for you to complete the login.
+
+Log in as **Curia's Gmail account** each time.
+
+After all five services are authenticated, tokens are saved to:
+```
+~/.google_workspace_mcp/credentials/<curia-gmail>.json
+```
+
+**Copy tokens to the VPS:**
 
 ```bash
-# Replace <vps-host> with your server (e.g. ceo-office)
-scp -r ~/.workspace-mcp/cli-tokens <vps-host>:/tmp/cli-tokens
-
-# On the VPS: copy into the Docker volume at the path the server expects.
-# The volume is mounted at /root/.workspace-mcp; the server reads tokens from
-# /root/.workspace-mcp/cli-tokens/, so files must land at _data/cli-tokens/.
-ssh <vps-host> docker volume inspect curia_google_workspace_tokens
-ssh <vps-host> "cp -r /tmp/cli-tokens /var/lib/docker/volumes/curia_google_workspace_tokens/_data/"
+scp -P 2222 -r ~/.google_workspace_mcp/credentials ceo-office:/tmp/google_workspace_credentials
+ssh -p 2222 ceo-office "sudo cp -r /tmp/google_workspace_credentials /var/lib/docker/volumes/curia_google-workspace-tokens/_data/credentials"
 ```
 
 After copying, restart Curia and check the logs for:
@@ -102,9 +99,7 @@ After copying, restart Curia and check the logs for:
 INFO  MCP server tools registered  {"server":"google-workspace","registered":N,"total":N}
 ```
 
-**Option B: auth directly on the VPS** (requires X11 forwarding or port tunneling)
-
-Not recommended for initial setup — Option A is simpler.
+A non-zero `registered` count confirms the server connected and auth is working.
 
 #### Step 6 — Share Drive content with Curia
 
@@ -155,13 +150,13 @@ repeat Step 5 to re-authenticate and copy fresh tokens to the VPS.
 **`INFO MCP server tools registered {"registered":0}`**
 
 The server connected but advertised no tools. This usually means the OAuth flow has
-not been completed — the token cache at `/root/.workspace-mcp/cli-tokens/` is empty
-or missing. Repeat Step 5.
+not been completed — the token cache at `/root/.google_workspace_mcp/credentials/` is
+empty or missing. Repeat Step 5.
 
 **Tools disappear after container restart**
 
-The `google_workspace_tokens` Docker volume is not being persisted. Confirm the volume
-is declared in `docker-compose.yml` and mounted at `/root/.workspace-mcp`.
+The `google-workspace-tokens` Docker volume is not being persisted. Confirm the volume
+is declared in `docker-compose.yml` and mounted at `/root/.google_workspace_mcp`.
 
 **Drive calls fail with 403 Forbidden**
 
@@ -191,16 +186,13 @@ Also add the token volume to `compose.production.yaml` under the `curia` service
 services:
   curia:
     volumes:
-      - google_workspace_tokens:/root/.workspace-mcp
+      - google-workspace-tokens:/root/.google_workspace_mcp
       # ... existing volumes ...
 
 volumes:
-  google_workspace_tokens:
+  google-workspace-tokens:
   # ... existing volumes ...
 ```
-
-> **TODO:** These `curia-deploy` changes are tracked as a follow-up. The community
-> server will not start in production until they are applied.
 
 ---
 
@@ -225,7 +217,7 @@ When it ships, the migration path is:
        Authorization: "Bearer <token>"
    ```
 4. Remove the `uv` install from the Dockerfile (no longer needed).
-5. Remove the `google_workspace_tokens` Docker volume (auth moves to the hosted side).
+5. Remove the `google-workspace-tokens` Docker volume (auth moves to the hosted side).
 
 > **Note on token injection**: `skills.yaml` headers are literal strings — no
 > env-var interpolation. Bearer tokens expire (~1 hour), so a static value isn't

--- a/docs/dev/google-drive.md
+++ b/docs/dev/google-drive.md
@@ -63,15 +63,23 @@ signed in as Curia's Gmail.
 
 **Option A (recommended): auth locally, copy tokens to VPS**
 
+Use `--transport streamable-http` to run the server as an HTTP process so the
+OAuth flow goes through the browser. Do NOT use the default stdio transport for
+this step — stdio mode expects a JSON-RPC client on stdin, not a human, and will
+log parse errors if run directly in a terminal (those errors are harmless but the
+OAuth flow won't complete).
+
 ```bash
 # Install uv locally if not already present
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Run the MCP server — it will print an OAuth URL
-GOOGLE_OAUTH_CLIENT_ID=<...> GOOGLE_OAUTH_CLIENT_SECRET=<...> uvx workspace-mcp
+# Run the server in HTTP mode — this starts an OAuth callback listener
+GOOGLE_OAUTH_CLIENT_ID=<...> GOOGLE_OAUTH_CLIENT_SECRET=<...> uvx workspace-mcp --transport streamable-http
 
-# In the browser: open the printed URL, log in as Curia's Gmail, and approve access.
-# Tokens are saved to ~/.workspace-mcp/cli-tokens/.
+# Open http://localhost:8000 in a browser.
+# You will be redirected to Google's OAuth consent page.
+# Log in as Curia's Gmail (nathancuria1@gmail.com) and approve access.
+# Tokens are saved to ~/.workspace-mcp/cli-tokens/ — you can then Ctrl-C the server.
 ```
 
 Then copy the token cache to the VPS:

--- a/scripts/gdrive-auth.py
+++ b/scripts/gdrive-auth.py
@@ -15,6 +15,7 @@ After it completes, copy the tokens to the VPS — see docs/dev/google-drive.md.
 import asyncio
 import os
 import re
+import sys
 import webbrowser
 
 from mcp import ClientSession, StdioServerParameters
@@ -30,18 +31,27 @@ async def auth_service(session: ClientSession, service: str, email: str) -> None
         "service_name": service,
         "user_google_email": email,
     })
+
+    url = None
     for content in result.content:
         text = getattr(content, "text", "")
         if not text:
             continue
-        match = re.search(r"https://accounts\.google\.com\S+", text)
+        match = re.search(r"https://accounts\.google\.com[^\s'\"<>]+", text)
         if match:
-            url = match.group(0).rstrip(".")
-            print(f"  Opening browser for {service}: {url}\n")
-            webbrowser.open(url)
-            input(f"  Complete the {service} login in your browser, then press Enter to continue...")
-        else:
-            print(f"  {text}")
+            url = match.group(0).rstrip(".,;:!?)\"'")
+            break
+        print(f"  {text}")
+
+    if url is None:
+        sys.exit(
+            f"ERROR: no OAuth URL returned for service '{service}'. "
+            "Check the output above for error details."
+        )
+
+    print(f"  Opening browser for {service}: {url}\n")
+    webbrowser.open(url)
+    input(f"  Complete the {service} login in your browser, then press Enter to continue...")
 
 
 async def main() -> None:

--- a/scripts/gdrive-auth.py
+++ b/scripts/gdrive-auth.py
@@ -1,0 +1,86 @@
+"""
+One-time Google Workspace OAuth flow for workspace-mcp.
+
+Run this script once per deployment (or after token revocation) to authenticate
+Curia's Gmail account with the google-workspace MCP server. Tokens are cached
+locally and copied to the VPS — after that, no re-auth is needed unless revoked.
+
+Usage:
+  GOOGLE_OAUTH_CLIENT_ID=<id> GOOGLE_OAUTH_CLIENT_SECRET=<secret> \\
+  CURIA_GOOGLE_EMAIL=<curia-gmail> \\
+    uv run --with mcp scripts/gdrive-auth.py
+
+After it completes, copy the tokens to the VPS — see docs/dev/google-drive.md.
+"""
+import asyncio
+import os
+import re
+import webbrowser
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+# Authenticate all five services so the full tool set is available.
+SERVICES = ["gmail", "drive", "calendar", "docs", "sheets"]
+
+
+async def auth_service(session: ClientSession, service: str, email: str) -> None:
+    print(f"  Authenticating {service}...")
+    result = await session.call_tool("start_google_auth", {
+        "service_name": service,
+        "user_google_email": email,
+    })
+    for content in result.content:
+        text = getattr(content, "text", "")
+        if not text:
+            continue
+        match = re.search(r"https://accounts\.google\.com\S+", text)
+        if match:
+            url = match.group(0).rstrip(".")
+            print(f"  Opening browser for {service}: {url}\n")
+            webbrowser.open(url)
+            input(f"  Complete the {service} login in your browser, then press Enter to continue...")
+        else:
+            print(f"  {text}")
+
+
+async def main() -> None:
+    client_id = os.environ.get("GOOGLE_OAUTH_CLIENT_ID", "")
+    client_secret = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET", "")
+    email = os.environ.get("CURIA_GOOGLE_EMAIL", "")
+
+    missing = [k for k, v in [
+        ("GOOGLE_OAUTH_CLIENT_ID", client_id),
+        ("GOOGLE_OAUTH_CLIENT_SECRET", client_secret),
+        ("CURIA_GOOGLE_EMAIL", email),
+    ] if not v]
+    if missing:
+        raise SystemExit(f"ERROR: Set these env vars before running: {', '.join(missing)}")
+
+    params = StdioServerParameters(
+        command="uvx",
+        args=["workspace-mcp", "--single-user"],
+        env={
+            "GOOGLE_OAUTH_CLIENT_ID": client_id,
+            "GOOGLE_OAUTH_CLIENT_SECRET": client_secret,
+            "HOME": os.environ["HOME"],
+            "PATH": os.environ["PATH"],
+        },
+    )
+
+    print(f"Starting workspace-mcp and authenticating {email}...\n")
+    print("You will be prompted to log in once per service.")
+    print("Use the browser that opens — log in as Curia's Gmail account.\n")
+
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            for service in SERVICES:
+                await auth_service(session, service, email)
+
+    print("\nAll services authenticated.")
+    print(f"Tokens saved to: ~/.google_workspace_mcp/credentials/{email}.json")
+    print("\nNext step — copy tokens to the VPS (see docs/dev/google-drive.md Step 5).")
+
+
+asyncio.run(main())


### PR DESCRIPTION
## Summary

Follow-up to #282 — corrections discovered during first-run OAuth bootstrap:

- **Token volume mount path corrected**: `/root/.workspace-mcp` → `/root/.google_workspace_mcp` (actual path workspace-mcp writes to at runtime)
- **Auth script added** at `scripts/gdrive-auth.py`: handles the full OAuth flow in a single persistent process, fixing the state-loss problem that occurs when anything restarts the MCP server between the `start_google_auth` tool call and the OAuth callback
- **Runbook rewritten** (`docs/dev/google-drive.md`): correct token path, correct volume mount, Step 5 replaced with the script approach, documents that `start_google_auth` requires `service_name` and `user_google_email` args; deployment-specific config (Gmail address) moved out of repo files into env vars

## Test plan

- [ ] `CURIA_GOOGLE_EMAIL=<addr> ... uv run --with mcp scripts/gdrive-auth.py` completes without OAuth state errors
- [ ] Token file appears at `~/.google_workspace_mcp/credentials/<email>.json`
- [ ] `docker-compose.yml` volume mounts at `/root/.google_workspace_mcp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the browser-based Google Workspace OAuth walkthrough with a streamlined programmatic authentication flow, updated troubleshooting and migration guidance, and clarified the new local token cache location and copy steps.

* **Chores**
  * Updated OAuth token persistence naming and production configuration references.
  * Added a one-time setup tool to automate Google Workspace OAuth bootstrap and removed the alternate VPS-auth option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->