### PR TITLE
feat: pin Google Workspace MCP tools to coordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **Google Workspace tools wired to coordinator** — Drive, Docs, Sheets, and Gmail read/search/write tools from the `google-workspace` MCP server are now pinned to the coordinator's skill list, making them available as LLM tools on every request. Gmail outbound (send/reply) continues to use the existing local skills; the MCP Gmail tools cover search, read, threads, labels, and drafts. Temporary measure until spec #274 (allow_discovery) is fully implemented.
+
 ### Fixed
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
-### Changed
+### Added
 
 - **Google Workspace tools wired to coordinator** — Drive, Docs, Sheets, and Gmail read/search/write tools from the `google-workspace` MCP server are now pinned to the coordinator's skill list, making them available as LLM tools on every request. Gmail outbound (send/reply) continues to use the existing local skills; the MCP Gmail tools cover search, read, threads, labels, and drafts. Temporary measure until spec #274 (allow_discovery) is fully implemented.
+
+### Changed
 
 ### Fixed
 ### Fixed

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -332,4 +332,49 @@ pinned_skills:
   - set-autonomy
   - query-relationships
   - delete-relationship
+  # Google Workspace MCP tools (taylorwilsdon/google_workspace_mcp, core+extended tier)
+  # TODO: remove manual pinning once spec #274 (allow_discovery) is fully implemented
+  # Drive
+  - search_drive_files
+  - get_drive_file_content
+  - get_drive_file_download_url
+  - create_drive_file
+  - create_drive_folder
+  - import_to_google_doc
+  - get_drive_shareable_link
+  - list_drive_items
+  - copy_drive_file
+  - update_drive_file
+  - manage_drive_access
+  - set_drive_file_permissions
+  # Docs
+  - get_doc_content
+  - create_doc
+  - modify_doc_text
+  - export_doc_to_pdf
+  - search_docs
+  - find_and_replace_doc
+  - list_docs_in_folder
+  - insert_doc_elements
+  - update_paragraph_style
+  - get_doc_as_markdown
+  - list_document_comments
+  - manage_document_comment
+  # Sheets
+  - create_spreadsheet
+  - read_sheet_values
+  - modify_sheet_values
+  - list_spreadsheets
+  - get_spreadsheet_info
+  - format_sheet_range
+  - list_sheet_tables
+  # Gmail (search/read/thread — outbound handled by email-send/email-reply local skills)
+  - search_gmail_messages
+  - get_gmail_message_content
+  - get_gmail_messages_content_batch
+  - get_gmail_attachment_content
+  - get_gmail_thread_content
+  - modify_gmail_message_labels
+  - list_gmail_labels
+  - draft_gmail_message
 allow_discovery: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- Wires Drive, Docs, Sheets, and Gmail tools from the `google-workspace` MCP server into the coordinator's `pinned_skills`
- Outbound email (send/reply) stays with existing local skills; MCP Gmail adds search, read, threads, labels, and drafts
- Marked with a TODO comment to remove manual pinning once spec #274 (allow_discovery) is fully implemented

## Test plan

- [ ] Deploy and ask Curia "What Google Workspace tools do you have available?" — should list Drive, Docs, Sheets, Gmail capabilities
- [ ] Share a Google Sheet with Curia's Gmail and ask it to read the contents
- [ ] Ask Curia to search Gmail for a recent email

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Workspace tools (Drive, Docs, Sheets, Gmail search/read/threads/labels/drafts) are now available on every request via the coordinator’s pinned tools.
  * Gmail outbound send/reply remains handled by existing local skills; MCP Gmail tools are used for search/read/drafts temporarily.

* **Chores**
  * Version bumped to 0.17.3

* **Documentation**
  * CHANGELOG updated with the above additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->