### PR TITLE
fix: coordinator defaults to its own account for third-party tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Coordinator always uses its own account for third-party tool calls** — added explicit
+  system prompt guidance instructing the coordinator to default to its own account identity
+  (not the CEO's) when any tool requires an email or account parameter. Prevents tools like
+  `user_google_email` from being populated with the CEO's address, which caused workspace-mcp
+  to request a new OAuth flow for an account it has no credentials for.
+
 ### Added
 
 - **Google Workspace tools wired to coordinator** — Drive, Docs, Sheets, and Gmail read/search/write tools from the `google-workspace` MCP server are now pinned to the coordinator's skill list, making them available as LLM tools on every request. Gmail outbound (send/reply) continues to use the existing local skills; the MCP Gmail tools cover search, read, threads, labels, and drafts. Temporary measure until spec #274 (allow_discovery) is fully implemented.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -253,6 +253,18 @@ system_prompt: |
     someone. It starts a new thread and requires a "to" address.
   - Keep email responses concise and professional.
 
+  ## Account Identity for Tool Calls
+  When any tool requires an email address, account identifier, or similar
+  "acting as" parameter (e.g. user_google_email, user_email, account_id),
+  always use your own account first — not the CEO's.
+
+  Only fall back to the CEO's email if the tool call explicitly fails with an
+  authorization or not-found error, AND the CEO has directed you to act on
+  their behalf using their credentials. Never assume — default to yourself.
+
+  This applies to all third-party integrations: Google Workspace, calendar
+  services, file storage, or any other tool that takes an account parameter.
+
   ## Your Team
   You have specialist agents you can delegate to using the "delegate" tool.
   When a request requires specialized expertise, delegate to the right specialist.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- Adds a `## Account Identity for Tool Calls` section to the coordinator system prompt
- Instructs the coordinator to always use its own account (not the CEO's) when any tool requires an email or account parameter (e.g. `user_google_email`)
- Falls back to CEO credentials only on explicit tool failure + CEO direction
- Generic — applies to Google Workspace and any future integration with an account parameter

## Background

workspace-mcp was being called with `user_google_email: joseph@josephfung.ca` because the LLM inferred the CEO's email from context. The server has credentials only for Curia's own Gmail, so every tool call triggered a fresh OAuth flow instead of using the existing token.

Hot-patched live on prod via `docker cp` + `docker restart` to unblock immediately. This PR makes it permanent in the image.

## Test plan

- [ ] Deploy to prod and ask Curia to read a Google Doc shared with its Gmail — should work without an OAuth prompt
- [ ] Confirm logs show `list_docs_in_folder` (or similar) succeeding, not returning an auth challenge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a credential routing issue where the coordinator was incorrectly using the CEO's account identity for third-party tool calls. The coordinator now properly uses its own account identity for integrations like Google Workspace and calendar services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->