### PR TITLE
fix: unbreak v0.17.10 deploy — rewrite skill manifest inputs to canonical shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,19 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Skill manifest parser crash at startup** — `email-archive`, `bullpen`, and
+  `contact-set-trust` shipped `skill.json` `inputs` blocks using the em-dash or
+  colon shorthand (e.g. `"string — Nylas message ID..."`). The registry's
+  shorthand parser only recognises the canonical `"type (description)"` form,
+  and the recently-added primitive-type allowlist validation at
+  `src/skills/registry.ts:169-175` now throws at agent boot instead of silently
+  emitting a broken JSON Schema. This took the whole container down with
+  `Fatal startup error` and failed its healthcheck, blocking deploys of
+  `0.17.10`. Rewritten all three manifests to use the parenthetical shorthand.
+  A new regression guard in `tests/unit/skills/loader.test.ts` now loads every
+  installed manifest and runs `toToolDefinitions()` on the full set, so any
+  future manifest typo fails CI instead of production boot.
+
 - **Coordinator always uses its own account for third-party tool calls** — added explicit
   system prompt guidance instructing the coordinator to default to its own account identity
   (not the CEO's) when any tool requires an email or account parameter. Prevents tools like

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.17.8",
+  "version": "0.17.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.17.8",
+      "version": "0.17.11",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.17.10",
+  "version": "0.17.11",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/bullpen/skill.json
+++ b/skills/bullpen/skill.json
@@ -6,12 +6,12 @@
   "action_risk": "low",
   "infrastructure": true,
   "inputs": {
-    "action": "string: 'post' | 'reply' | 'get_thread' | 'close'",
-    "topic": "string: thread topic — required for 'post'",
-    "participants": "string[]: agent IDs to include in the thread — required for 'post'",
-    "mentioned_agent_ids": "string[]: agent IDs to @ mention (optional for 'post' and 'reply'; defaults to all participants for 'post')",
-    "content": "string: message content — required for 'post' and 'reply'",
-    "thread_id": "string: thread ID — required for 'reply', 'get_thread', 'close'"
+    "action": "string (one of: 'post', 'reply', 'get_thread', 'close')",
+    "topic": "string? (thread topic; required when action is 'post')",
+    "participants": "string[]? (agent IDs to include in the thread; required when action is 'post')",
+    "mentioned_agent_ids": "string[]? (agent IDs to at-mention; defaults to all participants when action is 'post')",
+    "content": "string? (message body; required when action is 'post' or 'reply')",
+    "thread_id": "string? (thread ID; required when action is 'reply', 'get_thread', or 'close')"
   },
   "outputs": {
     "thread_id": "string: the thread ID",

--- a/skills/contact-set-trust/skill.json
+++ b/skills/contact-set-trust/skill.json
@@ -7,7 +7,7 @@
   "infrastructure": true,
   "inputs": {
     "contact_id": "string (UUID from contact-lookup or contact-create)",
-    "trust_level": "string? — 'high', 'medium', 'low', or null to clear the override"
+    "trust_level": "string? (one of 'high', 'medium', 'low', or null to clear the override)"
   },
   "outputs": {
     "contact_id": "string",

--- a/skills/email-archive/skill.json
+++ b/skills/email-archive/skill.json
@@ -6,8 +6,8 @@
   "action_risk": "low",
   "infrastructure": true,
   "inputs": {
-    "message_id": "string — Nylas message ID of the email to archive",
-    "account": "string (optional) — named account to archive from (e.g. 'curia', 'joseph'). Defaults to the primary account if omitted."
+    "message_id": "string (Nylas message ID of the email to archive)",
+    "account": "string? (named account to archive from, e.g. 'curia' or 'joseph'; defaults to the primary account if omitted)"
   },
   "outputs": {
     "archived": "boolean — true when the message was successfully archived"

--- a/tests/unit/skills/loader.test.ts
+++ b/tests/unit/skills/loader.test.ts
@@ -32,4 +32,34 @@ describe('loadSkillsFromDirectory', () => {
     await expect(loadSkillsFromDirectory('/tmp/nonexistent-dir-xyz', registry, logger))
       .rejects.toThrow();
   });
+
+  // Regression guard: every installed skill manifest must be convertible to a
+  // valid tool definition. A malformed `inputs` shorthand (e.g. using an em-dash
+  // instead of the supported `type (description)` form) only blows up inside
+  // toToolDefinitions() at agent startup, which is too late — it takes down the
+  // whole app and fails the container healthcheck. Running the conversion here
+  // makes any such typo a CI failure instead of a prod-boot crash.
+  //
+  // Context: 2026-04-11 the email-archive manifest shipped with
+  // `"message_id": "string — Nylas message ID..."`. The registry parsed the
+  // entire string as the type, tripped the primitive-type allowlist, and curia
+  // refused to start.
+  it('produces valid tool definitions for every installed skill', async () => {
+    const registry = new SkillRegistry();
+    const skillsDir = path.resolve(import.meta.dirname, '../../../skills');
+
+    await loadSkillsFromDirectory(skillsDir, registry, logger);
+
+    const allSkillNames = registry.list().map(s => s.manifest.name);
+    expect(allSkillNames.length).toBeGreaterThan(0);
+
+    // Will throw with a clear per-skill error if any manifest is malformed.
+    const tools = registry.toToolDefinitions(allSkillNames);
+    expect(tools).toHaveLength(allSkillNames.length);
+
+    for (const tool of tools) {
+      expect(tool.input_schema.type).toBe('object');
+      expect(tool.input_schema.properties).toBeDefined();
+    }
+  });
 });


### PR DESCRIPTION
## Why

The v0.17.10 prod deploy failed — the curia container crashed on boot:

```
{"level":60,"msg":"Fatal startup error","err":{"type":"Error","message":"Skill 'email-archive' input 'message_id': invalid type 'string — Nylas message ID of the email to archive'..."}}
```

Three recently-shipped skill manifests had `inputs` blocks using em-dash or colon shorthand instead of the canonical `"type (description)"` form that `SkillRegistry.toToolDefinitions()` parses. The primitive-type allowlist at [src/skills/registry.ts:169-175](src/skills/registry.ts#L169-L175) — added as a safety net to surface manifest typos — now throws at boot instead of silently emitting a broken JSON Schema, so the whole app refused to start and the container failed its healthcheck. Caddy kept serving the old container while this loop failed, but every deploy attempt was stuck.

## What

### Three manifest rewrites

- **[skills/email-archive/skill.json](skills/email-archive/skill.json)** — was tripping prod (coordinator pins it).
- **[skills/bullpen/skill.json](skills/bullpen/skill.json)** — latent. Not currently pinned by any agent, but any future agent referencing it would have hit the same crash. Caught by the new smoke test.
- **[skills/contact-set-trust/skill.json](skills/contact-set-trust/skill.json)** — latent. `sensitivity: elevated`, not on the hot path, but same class of bug. Also caught by the smoke test.

All three are mechanical rewrites of the input type strings only. No handler changes, no behavioural changes.

A note on [skills/bullpen/skill.json](skills/bullpen/skill.json): the original manifest left `topic`/`participants`/`content`/`thread_id` without `?` markers, implying they were unconditionally required. They aren't — they're conditionally required per `action` value (`post`, `reply`, `get_thread`, `close`), which a flat JSON Schema can't express without `oneOf`. The handler at [skills/bullpen/handler.ts](skills/bullpen/handler.ts) already does structured per-action runtime validation and returns `"Missing required field: X"` with a precise error when a call is malformed. The rewrite marks them `string?`/`string[]?` with descriptions documenting "required when action is X" — the only honest representation of the handler's actual contract.

### Regression guard

New test case in [tests/unit/skills/loader.test.ts](tests/unit/skills/loader.test.ts): loads every installed manifest and calls `registry.toToolDefinitions(allSkillNames)` on the full set. Any future manifest typo — em-dash, colon, typo in a primitive type, bad array item — now fails CI with a per-skill error message instead of taking prod down at boot.

The smoke test caught **both** latent manifests (`bullpen` and `contact-set-trust`) during this fix. Without it they would have been landmines waiting for the next agent to pin them.

## Versioning

Patch bump `0.17.10` → `0.17.11`. Bug fix, no new user-facing capability. Lockfile was also stale from a prior PR (`0.17.8` → `0.17.10`) and is now resynced.

## Verification

- [x] `npm test` — 1389 passed, 44 skipped
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `pr-review-toolkit:code-reviewer` — no blockers
- [x] `pr-review-toolkit:silent-failure-hunter` — no blockers (verified the new test has no error-swallowing seams)
- [ ] Re-run deploy on merge and confirm curia boots healthy

## Test plan

- [ ] After merge, redeploy to `office.josephfung.ca` and confirm curia container reaches the "Healthy" state
- [ ] `curl https://office.josephfung.ca/api/health` returns 200
- [ ] Coordinator can invoke `email-archive` on an observation-mode email without a schema error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a skill manifest parser crash that occurred at startup.

* **Documentation**
  * Updated input schema descriptions and type declarations for several skills: "bullpen", "contact-set-trust", and "email-archive".

* **Tests**
  * Added regression test that validates all installed skill manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->