### PR TITLE
fix: prevent NOISE triage from creating dangling drafts (0.18.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Observation-mode NOISE drafts** — the triage preamble now explicitly prohibits calling `email-reply` (or any draft/send skill) when classifying an email as NOISE. Previously the coordinator sometimes created an explanatory draft alongside the archive call, which became a dangling draft in the CEO's inbox under the `draft_gate` outbound policy. Classification rationale is already persisted via the LLM call archive and `agent.response` audit events, so the draft is redundant.
+
 ---
 
 ## [0.18.0] — 2026-04-11

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.17.11",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.17.11",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -622,7 +622,9 @@ export class Dispatcher {
         `   - NEEDS DRAFT — a reply is warranted and you can write it:\n` +
         `     Save a draft with email-reply. The CEO will review before it sends.\n` +
         `   - NOISE — receipt, newsletter, automated notification, no action needed:\n` +
-        `     Call email-archive. No notification.\n\n` +
+        `     Call email-archive. Do NOT call email-reply or any draft/send skill — archiving\n` +
+        `     is the only action. Your classification rationale is already captured in the\n` +
+        `     audit log; do not leave an explanatory draft in the CEO's inbox. No notification.\n\n` +
         `3. WHEN IN DOUBT: default to URGENT (notify) rather than acting silently.\n` +
         `   It is better to surface something than to quietly act on it incorrectly.\n\n` +
         `--- Original message ---\n` +

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -774,6 +774,10 @@ describe('Dispatcher — observation mode preamble', () => {
     expect(content).toContain('URGENT');
     expect(content).toContain('NOISE');
     expect(content).toContain('email-archive');
+    // NOISE classification must not create a draft — the outbound_policy: draft_gate
+    // on observation-mode accounts would turn any email-reply call into a dangling
+    // draft in the CEO's inbox. Lock in the explicit prohibition.
+    expect(content).toContain('Do NOT call email-reply');
   });
 
   it('includes nylasMessageId and accountId in preamble when present in metadata', async () => {


### PR DESCRIPTION
## Summary

When the coordinator classified a monitored-inbox email as **NOISE**, it was sometimes calling `email-reply` to explain its reasoning ("this is a generic account notification, archiving…") *in addition to* `email-archive`. Because observation-mode accounts enforce `outbound_policy: draft_gate`, that reply became a dangling draft in the CEO's Gmail.

The triage preamble in `src/dispatch/dispatcher.ts` said "Call email-archive. No notification." but didn't explicitly forbid creating a draft. This PR adds that explicit prohibition:

> Call email-archive. Do NOT call email-reply or any draft/send skill — archiving is the only action. Your classification rationale is already captured in the audit log; do not leave an explanatory draft in the CEO's inbox.

## Why this is safe

- Classification rationale is already persisted via `llm_call_archive` (full prompt/response) and `agent.response` audit events — no information is lost by skipping the draft.
- Other triage categories (URGENT / ACTIONABLE / NEEDS_DRAFT) are untouched.
- Test assertion added to lock in the new language.

## Follow-up

Prompt-only enforcement is fragile. A durable defense-in-depth would short-circuit `email-reply` at the skill handler when `metadata.observationMode === true`. Tracked as a follow-up issue.

## Test plan

- [x] npm test — 1389 passed, 44 skipped (no regressions)
- [x] npm run typecheck — clean
- [ ] Manually verify in prod: send a test newsletter to a monitored inbox, confirm only archive happens, no draft appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed observation-mode triage to prevent dangling draft emails from appearing in the inbox when classifying messages as NOISE. Previously, explanatory drafts could be created alongside the archive action; now only archiving occurs without generating drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->