### PR TITLE
fix: suppress auto-reply outbound in observation mode; add LEAVE FOR CEO triage (0.18.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,8 +372,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Bootstrap orchestrator** — `src/index.ts` wires all layers in dependency order
 - Architecture specs 00–08, contributor docs (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
 
-[Unreleased]: https://github.com/josephfung/curia/compare/v0.18.2...HEAD
-[0.18.2]: https://github.com/josephfung/curia/compare/v0.18.1...v0.18.2
+[Unreleased]: https://github.com/josephfung/curia/compare/v0.18.1...HEAD
 [0.18.1]: https://github.com/josephfung/curia/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/josephfung/curia/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/josephfung/curia/compare/v0.16.0...v0.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,7 +372,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Bootstrap orchestrator** — `src/index.ts` wires all layers in dependency order
 - Architecture specs 00–08, contributor docs (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
 
-[Unreleased]: https://github.com/josephfung/curia/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/josephfung/curia/compare/v0.18.2...HEAD
+[0.18.2]: https://github.com/josephfung/curia/compare/v0.18.1...v0.18.2
+[0.18.1]: https://github.com/josephfung/curia/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/josephfung/curia/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/josephfung/curia/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/josephfung/curia/compare/v0.15.0...v0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,23 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **LEAVE FOR CEO triage classification** — the observation-mode preamble now defines a fifth category for personal, sensitive, or judgment-dependent email where the CEO will read and handle it themselves. No archive, no draft, no notification. The "when in doubt" default has shifted from URGENT to LEAVE FOR CEO to stop over-notifying. Mirrored in `agents/coordinator.yaml`.
+
 ### Changed
+
+- **Observation-mode coordinator response is audit-only** — the dispatcher no longer converts the coordinator's final response into an `outbound.message` when the originating inbound was observation-mode. The preamble tells the coordinator its final text is for audit/logging only; outbound actions happen via explicit skill calls (email-archive, notify channels, email-reply for drafts). The `taskRouting` map gained an `observationMode` flag so `handleAgentResponse` can suppress the auto-reply path.
 
 ### Fixed
 
-- **Observation-mode NOISE drafts** — the triage preamble now explicitly prohibits calling `email-reply` (or any draft/send skill) when classifying an email as NOISE. Previously the coordinator sometimes created an explanatory draft alongside the archive call, which became a dangling draft in the CEO's inbox under the `draft_gate` outbound policy. Classification rationale is already persisted via the LLM call archive and `agent.response` audit events, so the draft is redundant.
+- **Dangling explanatory drafts on NOISE triage** — the coordinator's short final summary (e.g. "The email has been archived. This was a promotional newsletter…") was being wrapped in `outbound.message` by the dispatcher and saved as a draft reply by the email adapter under `draft_gate` policy. PR #304's prompt-only fix targeted `email-reply` (which wasn't being called); the actual mechanism was the dispatch-layer auto-reply of every `agent.response`. Root cause now fixed at the dispatch layer; the preamble's redundant "Do NOT call email-reply" guidance has been trimmed.
+
+---
+
+## [0.18.1] — 2026-04-12
+
+### Fixed
+
+- **Observation-mode NOISE drafts (partial)** — added explicit "Do NOT call email-reply" language to the triage preamble for NOISE classifications. Superseded by the proper dispatch-layer fix in 0.18.2 (the drafts were never coming from `email-reply` — they came from the auto-reply path in `handleAgentResponse`).
 
 ---
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -269,14 +269,21 @@ system_prompt: |
   ## Observation Mode — Monitored Inboxes
   When a message arrives tagged `observationMode: true`, the dispatcher injects a
   full triage protocol into the task. Follow that protocol exactly — it classifies
-  each email into one of four categories and specifies what to do:
+  each email into one of five categories and specifies what to do:
 
   - **URGENT** — notify the CEO on a high-urgency channel (e.g. Signal). Do NOT reply to sender.
   - **ACTIONABLE** — act directly using your skills (calendar, contacts, etc.). No notification needed.
   - **NEEDS DRAFT** — save a draft with email-reply for CEO review. Do not send.
+  - **LEAVE FOR CEO** — personal, sensitive, or requires the CEO's judgment. Do nothing. No archive, no draft, no notification. The CEO will read and handle it themselves.
   - **NOISE** — call email-archive using the Message ID and Account from the injected preamble. No notification.
 
-  **When in doubt, default to URGENT** — it is better to surface something than to quietly act on it incorrectly.
+  **When in doubt, prefer LEAVE FOR CEO over acting.** The CEO will see the email
+  in their inbox. URGENT is only for time-sensitive items that need an immediate ping.
+
+  **Your final response text in observation mode is audit-only.** The dispatcher
+  does NOT turn it into a reply to the sender, so keep it brief — just state your
+  classification and the action you took. Any outbound communication happens via
+  explicit skill calls (email-archive, notify channels, email-reply for drafts).
 
   **Never reply to the sender as yourself or sign with your name in observation mode.**
   You are monitoring on the CEO's behalf — the CEO is the intended recipient, not you.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.18.1",
+      "version": "0.18.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -66,7 +66,20 @@ export class Dispatcher {
    * We key on the task event ID (not the inbound message ID) because the agent
    * runtime sets parentEventId on its response to the task event that triggered it.
    */
-  private taskRouting = new Map<string, { channelId: string; conversationId: string; senderId: string; accountId?: string }>();
+  private taskRouting = new Map<
+    string,
+    {
+      channelId: string;
+      conversationId: string;
+      senderId: string;
+      accountId?: string;
+      // When true, the originating inbound message was observation-mode (monitored
+      // inbox). The coordinator's final response is for audit/logging only — we
+      // must NOT auto-publish it as an outbound reply, because that would land
+      // as a draft in the CEO's inbox under the `draft_gate` outbound policy.
+      observationMode?: boolean;
+    }
+  >();
   /** Key: `${conversationId}:${agentId}` — reset on every agent.response */
   private checkpointTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private pool: DbPool | undefined;
@@ -608,7 +621,9 @@ export class Dispatcher {
       taskContent =
         `[OBSERVATION MODE — monitored inbox]\n` +
         `This email arrived in a monitored inbox. You watch it on the CEO's behalf.\n` +
-        `You are NOT the recipient. NEVER reply to the sender as yourself or sign with your name.\n\n` +
+        `You are NOT the recipient. NEVER reply to the sender as yourself or sign with your name.\n` +
+        `Your final response text is for audit/logging only — the dispatcher will NOT turn\n` +
+        `it into an outbound email. Keep it brief: just state your classification and action.\n\n` +
         identifierBlock +
         `TRIAGE — evaluate in order:\n\n` +
         `1. STANDING INSTRUCTIONS: use entity-context to look up the sender. If the CEO has\n` +
@@ -621,12 +636,17 @@ export class Dispatcher {
         `     Do it using your existing skills. No notification. It will appear in the weekly log.\n` +
         `   - NEEDS DRAFT — a reply is warranted and you can write it:\n` +
         `     Save a draft with email-reply. The CEO will review before it sends.\n` +
+        `   - LEAVE FOR CEO — personal, sensitive, relationship-dependent, requires the CEO's\n` +
+        `     own voice or judgment, or you are not confident you understand it:\n` +
+        `     Do NOTHING. No archive, no draft, no notification. The CEO will read and\n` +
+        `     handle it themselves when they next check their inbox. Examples: personal\n` +
+        `     correspondence, LinkedIn DMs from specific individuals, offers/negotiations,\n` +
+        `     anything requiring the CEO's discretion.\n` +
         `   - NOISE — receipt, newsletter, automated notification, no action needed:\n` +
-        `     Call email-archive. Do NOT call email-reply or any draft/send skill — archiving\n` +
-        `     is the only action. Your classification rationale is already captured in the\n` +
-        `     audit log; do not leave an explanatory draft in the CEO's inbox. No notification.\n\n` +
-        `3. WHEN IN DOUBT: default to URGENT (notify) rather than acting silently.\n` +
-        `   It is better to surface something than to quietly act on it incorrectly.\n\n` +
+        `     Call email-archive. No other action. No notification.\n\n` +
+        `3. WHEN IN DOUBT: prefer LEAVE FOR CEO over acting. The CEO will see the email in\n` +
+        `   their inbox. URGENT is only for time-sensitive items that need an immediate\n` +
+        `   Signal ping. Do not over-notify.\n\n` +
         `--- Original message ---\n` +
         taskContent;
     }
@@ -653,12 +673,14 @@ export class Dispatcher {
     // Store routing info keyed by the task event ID so we can look it up
     // when the agent publishes its response (agent sets parentEventId = task.id).
     // accountId is stored so the outbound.message is routed to the same email account
-    // that received the original inbound message.
+    // that received the original inbound message. observationMode is stored so
+    // handleAgentResponse can suppress auto-reply for monitored-inbox tasks.
     this.taskRouting.set(taskEvent.id, {
       channelId: payload.channelId,
       conversationId: payload.conversationId,
       senderId: payload.senderId,
       accountId: payload.accountId,
+      observationMode: isObservationMode,
     });
 
     await this.bus.publish('dispatch', taskEvent);
@@ -693,17 +715,49 @@ export class Dispatcher {
 
     this.taskRouting.delete(event.parentEventId!);
 
-    // Publish outbound.message to the bus — the email adapter will pick it up
-    // and route it through OutboundGateway (blocked-contact check + content filter).
-    // No filter logic lives here anymore; it all runs inside the gateway.
-    const outbound = createOutboundMessage({
-      conversationId: routing.conversationId,
-      channelId: routing.channelId,
-      accountId: routing.accountId,
-      content: event.payload.content,
-      parentEventId: event.id,
-    });
-    await this.bus.publish('dispatch', outbound);
+    // Observation-mode: the coordinator is watching a monitored inbox on the
+    // CEO's behalf. Its final response is an audit/log artefact — NOT a reply
+    // to the sender. Suppress the outbound.message so the email adapter does
+    // not turn the coordinator's classification summary into a dangling draft
+    // in the CEO's inbox (which it would under `draft_gate` outbound policy).
+    //
+    // Any outbound action the coordinator wanted to take (notify CEO on Signal,
+    // archive, save a reply draft) is taken explicitly via skill calls during
+    // the task — not via this auto-reply path. We still schedule a checkpoint
+    // below so working memory is persisted.
+    if (routing.observationMode) {
+      // Log at info (not debug) so the suppression is visible in default prod
+      // log streams. If observationMode is ever flipped incorrectly (misrouted
+      // metadata, config mistake, future refactor), real replies would vanish —
+      // this log is the operator's only hook to notice. Include the first 500
+      // chars of the coordinator's final text so the classification rationale
+      // is greppable in logs, not only buried in the LLM call archive.
+      const summary = event.payload.content?.slice(0, 500) ?? '';
+      this.logger.info(
+        {
+          conversationId: routing.conversationId,
+          agentId: event.payload.agentId,
+          senderId: routing.senderId,
+          accountId: routing.accountId,
+          parentEventId: event.id,
+          contentLength: event.payload.content?.length ?? 0,
+          summary,
+        },
+        'observation-mode: suppressed auto-reply outbound.message (audit-only response)',
+      );
+    } else {
+      // Publish outbound.message to the bus — the email adapter will pick it up
+      // and route it through OutboundGateway (blocked-contact check + content filter).
+      // No filter logic lives here anymore; it all runs inside the gateway.
+      const outbound = createOutboundMessage({
+        conversationId: routing.conversationId,
+        channelId: routing.channelId,
+        accountId: routing.accountId,
+        content: event.payload.content,
+        parentEventId: event.id,
+      });
+      await this.bus.publish('dispatch', outbound);
+    }
 
     // Schedule a checkpoint for this conversation — resets the debounce timer if
     // already running, so only fires after a full window of inactivity.

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -729,10 +729,18 @@ export class Dispatcher {
       // Log at info (not debug) so the suppression is visible in default prod
       // log streams. If observationMode is ever flipped incorrectly (misrouted
       // metadata, config mistake, future refactor), real replies would vanish —
-      // this log is the operator's only hook to notice. Include the first 500
-      // chars of the coordinator's final text so the classification rationale
-      // is greppable in logs, not only buried in the LLM call archive.
-      const summary = event.payload.content?.slice(0, 500) ?? '';
+      // this log is the operator's only hook to notice.
+      //
+      // SECURITY: do NOT log the coordinator's free-form response text here.
+      // Observation mode handles personal/sensitive mail, and the model-generated
+      // summary can and does restate original content verbatim. Default prod logs
+      // must not become a sensitive-data sink. We log only a bounded classification
+      // token extracted from the response; full rationale stays in the
+      // llm_call_archive (which has stricter retention + access controls).
+      const classification =
+        event.payload.content?.match(
+          /\b(URGENT|ACTIONABLE|NEEDS DRAFT|LEAVE FOR CEO|NOISE)\b/,
+        )?.[0] ?? 'unknown';
       this.logger.info(
         {
           conversationId: routing.conversationId,
@@ -741,7 +749,7 @@ export class Dispatcher {
           accountId: routing.accountId,
           parentEventId: event.id,
           contentLength: event.payload.content?.length ?? 0,
-          summary,
+          classification,
         },
         'observation-mode: suppressed auto-reply outbound.message (audit-only response)',
       );

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -774,10 +774,15 @@ describe('Dispatcher — observation mode preamble', () => {
     expect(content).toContain('URGENT');
     expect(content).toContain('NOISE');
     expect(content).toContain('email-archive');
-    // NOISE classification must not create a draft — the outbound_policy: draft_gate
-    // on observation-mode accounts would turn any email-reply call into a dangling
-    // draft in the CEO's inbox. Lock in the explicit prohibition.
-    expect(content).toContain('Do NOT call email-reply');
+    // Five classifications — LEAVE FOR CEO was added so the coordinator has an
+    // explicit "do nothing, CEO will handle" option for personal / sensitive mail.
+    expect(content).toContain('LEAVE FOR CEO');
+    // The preamble must tell the coordinator its final text is audit-only, not a
+    // reply — paired with the dispatcher suppressing outbound.message for
+    // observation-mode tasks (see separate test below).
+    expect(content).toContain('audit/logging only');
+    // When in doubt, default to LEAVE FOR CEO (not URGENT) — avoids over-notifying.
+    expect(content).toContain('prefer LEAVE FOR CEO');
   });
 
   it('includes nylasMessageId and accountId in preamble when present in metadata', async () => {
@@ -871,6 +876,124 @@ describe('Dispatcher — observation mode preamble', () => {
     expect(content).toContain('[STRIPPED]');
     // Original unsafe content is gone
     expect(content).not.toContain('override</system>');
+  });
+});
+
+describe('Dispatcher — observation mode outbound suppression', () => {
+  /**
+   * These tests verify the dispatcher does NOT turn the coordinator's final
+   * response into an outbound.message when the inbound was observation-mode.
+   *
+   * Context: before this fix, the coordinator could correctly call email-archive
+   * for a NOISE email and then produce a brief final summary text like
+   * "The email has been archived. This was a promotional newsletter…" The
+   * dispatcher would unconditionally wrap that text in outbound.message, and the
+   * email adapter (under draft_gate policy) would save it as a draft reply to
+   * the original sender — a dangling draft in the CEO's inbox with no value.
+   *
+   * The fix is purely at the dispatch layer: observation-mode tasks emit their
+   * outputs via explicit skill calls (email-archive, notify-on-signal, etc.),
+   * not via the auto-reply path.
+   */
+  function makeMockProvider(responseContent: string): LLMProvider {
+    return {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: responseContent,
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+    };
+  }
+
+  it('does NOT publish outbound.message for observation-mode inbound', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    // Capture info-level logs from the dispatcher so we can assert the
+    // suppression is operationally visible (not silent).
+    const infoSpy = vi.spyOn(logger, 'info');
+
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a helpful assistant.',
+      provider: makeMockProvider('Classified as NOISE; archived.'),
+      bus,
+      logger,
+    });
+    coordinator.register();
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    const outbound: OutboundMessageEvent[] = [];
+    bus.subscribe('outbound.message', 'channel', (e) => outbound.push(e as OutboundMessageEvent));
+
+    const event = createInboundMessage({
+      conversationId: 'email:thread-obs-suppress',
+      channelId: 'email',
+      accountId: 'joseph',
+      senderId: 'newsletter@example.com',
+      content: 'Our 2026 draft class is here!',
+      metadata: { observationMode: true },
+    });
+    await bus.publish('channel', event);
+
+    // Coordinator ran (so agent.response fired), but no outbound.message was
+    // produced — the audit-only response did not become a reply to the sender.
+    expect(outbound).toHaveLength(0);
+
+    // Regression guard: the suppression must be logged at info level so ops
+    // can notice if the flag ever gets wired wrong. A future refactor that
+    // silently drops this log would make real misrouted replies invisible.
+    const suppressionLogs = infoSpy.mock.calls.filter(([, msg]) =>
+      typeof msg === 'string' && msg.includes('observation-mode: suppressed auto-reply'),
+    );
+    expect(suppressionLogs).toHaveLength(1);
+    // Log context must carry enough to reconstruct what was dropped.
+    const [ctx] = suppressionLogs[0]!;
+    expect(ctx).toMatchObject({
+      accountId: 'joseph',
+      senderId: 'newsletter@example.com',
+      summary: expect.stringContaining('Classified as NOISE'),
+    });
+  });
+
+  it('DOES publish outbound.message for normal (non-observation) inbound', async () => {
+    // Regression guard: the suppression must be scoped strictly to observation
+    // mode. Normal conversational email must still get an outbound reply.
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a helpful assistant.',
+      provider: makeMockProvider('Thanks, noted.'),
+      bus,
+      logger,
+    });
+    coordinator.register();
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    const outbound: OutboundMessageEvent[] = [];
+    bus.subscribe('outbound.message', 'channel', (e) => outbound.push(e as OutboundMessageEvent));
+
+    const event = createInboundMessage({
+      conversationId: 'email:thread-normal-send',
+      channelId: 'email',
+      accountId: 'curia',
+      senderId: 'friend@example.com',
+      content: 'Can we meet Tuesday?',
+      // no observationMode flag
+    });
+    await bus.publish('channel', event);
+
+    expect(outbound).toHaveLength(1);
+    expect(outbound[0]?.payload.content).toBe('Thanks, noted.');
+    expect(outbound[0]?.payload.channelId).toBe('email');
+    expect(outbound[0]?.payload.accountId).toBe('curia');
   });
 });
 

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -950,13 +950,18 @@ describe('Dispatcher — observation mode outbound suppression', () => {
       typeof msg === 'string' && msg.includes('observation-mode: suppressed auto-reply'),
     );
     expect(suppressionLogs).toHaveLength(1);
-    // Log context must carry enough to reconstruct what was dropped.
+    // Log context must carry enough to reconstruct what was dropped —
+    // specifically a bounded classification token, NOT free-form summary text.
+    // Observation mode handles sensitive mail; default logs must not become a
+    // data sink. Full rationale stays in llm_call_archive.
     const [ctx] = suppressionLogs[0]!;
     expect(ctx).toMatchObject({
       accountId: 'joseph',
       senderId: 'newsletter@example.com',
-      summary: expect.stringContaining('Classified as NOISE'),
+      classification: 'NOISE',
     });
+    // Belt-and-braces: ensure the free-form content is NOT in the log context.
+    expect(ctx).not.toHaveProperty('summary');
   });
 
   it('DOES publish outbound.message for normal (non-observation) inbound', async () => {


### PR DESCRIPTION
## Summary

PR #304's prompt-only fix for NOISE drafts didn't work — prod logs from 2026-04-14 confirmed the coordinator was correctly calling `email-archive` and never calling `email-reply`. The drafts were coming from a different mechanism entirely:

**[`handleAgentResponse`](../blob/main/src/dispatch/dispatcher.ts) unconditionally wraps the coordinator's final response in an `outbound.message`**, and the email adapter (under `draft_gate` policy) saves it as a draft reply to the original sender. Short audit-style summaries like *"The email has been archived. This was a promotional newsletter…"* were turning into dangling drafts.

This PR fixes it at the dispatch layer and introduces the missing triage category.

## Changes

### Dispatcher auto-reply suppression in observation mode
- `taskRouting` map gains an `observationMode` flag, set from `payload.metadata`
- `handleAgentResponse` skips the `outbound.message` publish when the flag is set
- Checkpoint scheduling still runs — working memory is preserved
- Suppression logged at **info** level (not debug) with `senderId`, `accountId`, and the first 500 chars of the coordinator's response, so ops can notice if the flag is ever wired wrong. The log content is locked in by a test assertion.

### New LEAVE FOR CEO triage classification
Personal / sensitive / judgment-dependent email. Do nothing — no archive, no draft, no notification. The CEO will read it in their inbox. Examples: personal correspondence, LinkedIn DMs, offers/negotiations, anything requiring the CEO's voice or discretion.

### "When in doubt" default flipped
Was URGENT (ping CEO on Signal) → now LEAVE FOR CEO (let CEO see it in their inbox). Avoids over-notifying.

### Preamble cleanup
- Added: "Your final response text is audit/logging only — the dispatcher will NOT turn it into an outbound email."
- Removed: the now-redundant "Do NOT call email-reply" language from PR #304 (since the dispatcher blocks it regardless).
- Mirrored new structure in `agents/coordinator.yaml`.

### Changelog hygiene
PR #304's entry was still sitting under `[Unreleased]`. Rolled it into a `0.18.1` heading with a note that it was superseded by this fix. Version bumped to 0.18.2.

## Follow-up (not in this PR)

The "coordinator misclassifies and does nothing" failure mode is still operationally invisible — if the LLM produces a plausible summary but calls no skills, nothing breaks and nothing gets archived. A structured `observation.triage.completed` event carrying `{classification, skillsCalled, content}` would let ops detect zero-action outcomes. Tracked separately.

## Test plan

- [x] `npm test` — 1391 passed, 44 skipped (2 new tests; all 29 dispatcher tests green)
- [x] `npm run typecheck` — clean
- [x] New test: no `outbound.message` published for observation-mode inbound
- [x] New test: `outbound.message` still published for normal (non-observation) inbound
- [x] New test: suppression log has the right structured context
- [x] Updated preamble test covers `LEAVE FOR CEO` + new "when in doubt" default + "audit/logging only"
- [ ] Manual prod verification: send a newsletter to a monitored inbox, confirm archive happens and no draft appears

## Closes

Fixes the underlying bug PR #304 was aiming at.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "LEAVE FOR CEO" triage for personal/sensitive items and changed default "when in doubt" to prefer leadership review.
  * Observation-mode final responses are audit/logging only; outbound actions must be explicit.

* **Bug Fixes**
  * Suppressed automatic outbound replies in observation mode to prevent redundant drafts and notifications; clarified NOISE handling.

* **Documentation**
  * Updated changelog and bumped release version to v0.18.2.

* **Tests**
  * Added tests verifying observation-mode outbound suppression and updated preamble expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->