### PR TITLE
feat: CEO inbox read skills (email-list, email-get, email-draft-save) — v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **LEAVE FOR CEO triage classification** — the observation-mode preamble now defines a fifth category for personal, sensitive, or judgment-dependent email where the CEO will read and handle it themselves. No archive, no draft, no notification. The "when in doubt" default has shifted from URGENT to LEAVE FOR CEO to stop over-notifying. Mirrored in `agents/coordinator.yaml`.
+- **CEO inbox read skills** (`email-list`, `email-get`, `email-draft-save`): account-aware email skills that route through `OutboundGateway`'s named-client map. `email-list` lists messages with folder/sender/search filters; `email-get` fetches the full body of a single message; `email-draft-save` saves a draft (with blocked-contact check) for CEO review. `ListMessagesOptions` extended with `folders`, `from`, `subject`, `searchQueryNative` filters. Coordinator pinned and prompted on all three skills. Closes CEO inbox Tasks 7–9.
 
 ### Changed
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -313,6 +313,13 @@ system_prompt: |
   This applies to all third-party integrations: Google Workspace, calendar
   services, file storage, or any other tool that takes an account parameter.
 
+  **Exception — `email-list`, `email-get`, `email-draft-save`:** the `account` param
+  on these skills selects which monitored inbox to read from or draft for. Use the
+  account explicitly named in the request or injected via the observation-mode
+  preamble. The "default to yourself" rule above does NOT override an explicit
+  email-account target; it applies only to third-party tools where you're picking
+  an acting identity.
+
   ## Your Team
   You have specialist agents you can delegate to using the "delegate" tool.
   When a request requires specialized expertise, delegate to the right specialist.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -248,7 +248,7 @@ system_prompt: |
   You have your own email account (Curia's account) and can monitor the CEO's inbox when configured in observation mode.
 
   ### Sending and replying
-  - **Replying to an email you received**: use `email-reply` with the `thread_id`. It threads automatically — no address needed.
+  - **Replying to an email you received**: use `email-reply` with `reply_to_message_id` (the Nylas message ID from context or the observation-mode preamble). It threads automatically — no `to` address is needed.
   - **Composing a new email**: use `email-send` with a `to` address. Only use this when the CEO asks you to email someone.
   - **Drafting for the CEO's signature**: use `email-draft-save` with `account` set to the CEO's account name. The CEO reviews and sends from their client.
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -282,7 +282,7 @@ system_prompt: |
 
   - **URGENT** — notify the CEO on a high-urgency channel (e.g. Signal). Do NOT reply to sender.
   - **ACTIONABLE** — act directly using your skills (calendar, contacts, etc.). No notification needed.
-  - **NEEDS DRAFT** — save a draft with email-reply for CEO review. Do not send.
+  - **NEEDS DRAFT** — save a draft with email-draft-save (using `account` set to the CEO's account name and `reply_to_message_id` from the preamble) for CEO review. Do not send.
   - **LEAVE FOR CEO** — personal, sensitive, or requires the CEO's judgment. Do nothing. No archive, no draft, no notification. The CEO will read and handle it themselves.
   - **NOISE** — call email-archive using the Message ID and Account from the injected preamble. No notification.
 
@@ -292,7 +292,7 @@ system_prompt: |
   **Your final response text in observation mode is audit-only.** The dispatcher
   does NOT turn it into a reply to the sender, so keep it brief — just state your
   classification and the action you took. Any outbound communication happens via
-  explicit skill calls (email-archive, notify channels, email-reply for drafts).
+  explicit skill calls (email-archive, notify channels, email-draft-save for drafts).
 
   **Never reply to the sender as yourself or sign with your name in observation mode.**
   You are monitoring on the CEO's behalf — the CEO is the intended recipient, not you.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -250,15 +250,15 @@ system_prompt: |
   ### Sending and replying
   - **Replying to an email you received**: use `email-reply` with the `thread_id`. It threads automatically — no address needed.
   - **Composing a new email**: use `email-send` with a `to` address. Only use this when the CEO asks you to email someone.
-  - **Drafting for the CEO's signature**: use `email-draft-save` with `account` set to the CEO's account name (e.g. `joseph`). The CEO reviews and sends from their client.
+  - **Drafting for the CEO's signature**: use `email-draft-save` with `account` set to the CEO's account name. The CEO reviews and sends from their client.
 
   ### Reading inboxes
-  - Use `email-list` to see recent messages in any account (`account: "joseph"` for the CEO's inbox).
+  - Use `email-list` to see recent messages in any account (pass the CEO's account name in `account` to read the CEO's inbox).
   - Use `email-get` to fetch the full body of a specific message by its `message_id`.
-  - Both skills accept an `account` param — omit it to read Curia's inbox, pass the account name to read another.
+  - Both skills accept an `account` param — omit it to read your own inbox, pass an account name to read another.
 
   ### Account names
-  The `account` param on all email skills maps to the account names configured in `channel_accounts.email`. Common values: `curia` (Curia's inbox), `joseph` (CEO's inbox). When in doubt, check the observation-mode preamble — it always includes the `Account:` line for the current monitored inbox.
+  The `account` param on all email skills maps to the account names configured in `channel_accounts.email` for this deployment. When in doubt, check the observation-mode preamble — it always includes the `Account:` line for the current monitored inbox.
 
   Keep email responses concise and professional.
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -244,14 +244,23 @@ system_prompt: |
     at the end.
 
   ## Email
-  You have your own email account and can send and receive emails.
-  - **When you receive an email and want to respond**: ALWAYS use email-reply with the
-    thread_id from the conversation. It replies to the sender automatically — you do NOT
-    need to look up or provide their email address. Never use email-send to respond to
-    an incoming email.
-  - **email-send is ONLY for composing brand new emails** when the CEO asks you to email
-    someone. It starts a new thread and requires a "to" address.
-  - Keep email responses concise and professional.
+
+  You have your own email account (Curia's account) and can monitor the CEO's inbox when configured in observation mode.
+
+  ### Sending and replying
+  - **Replying to an email you received**: use `email-reply` with the `thread_id`. It threads automatically — no address needed.
+  - **Composing a new email**: use `email-send` with a `to` address. Only use this when the CEO asks you to email someone.
+  - **Drafting for the CEO's signature**: use `email-draft-save` with `account` set to the CEO's account name (e.g. `joseph`). The CEO reviews and sends from their client.
+
+  ### Reading inboxes
+  - Use `email-list` to see recent messages in any account (`account: "joseph"` for the CEO's inbox).
+  - Use `email-get` to fetch the full body of a specific message by its `message_id`.
+  - Both skills accept an `account` param — omit it to read Curia's inbox, pass the account name to read another.
+
+  ### Account names
+  The `account` param on all email skills maps to the account names configured in `channel_accounts.email`. Common values: `curia` (Curia's inbox), `joseph` (CEO's inbox). When in doubt, check the observation-mode preamble — it always includes the `Account:` line for the current monitored inbox.
+
+  Keep email responses concise and professional.
 
   ## Inbox Disambiguation
   Some email accounts are connected in observation mode — Curia monitors them on behalf
@@ -353,6 +362,9 @@ pinned_skills:
   - email-send
   - email-reply
   - email-archive
+  - email-list
+  - email-get
+  - email-draft-save
   - contact-merge
   - contact-find-duplicates
   - contact-unlink-identity

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.18.2",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/email-draft-save/handler.ts
+++ b/skills/email-draft-save/handler.ts
@@ -14,7 +14,10 @@ export class EmailDraftSaveHandler implements SkillHandler {
       return { success: false, error: 'email-draft-save requires outboundGateway (infrastructure: true)' };
     }
 
-    const { to: rawTo, subject, body, account, reply_to_message_id } = ctx.input as {
+    // Handlers must never throw — destructuring a non-object ctx.input would.
+    const input =
+      ctx.input && typeof ctx.input === 'object' ? (ctx.input as Record<string, unknown>) : {};
+    const { to: rawTo, subject, body, account, reply_to_message_id } = input as {
       to?: string;
       subject?: string;
       body?: string;

--- a/skills/email-draft-save/handler.ts
+++ b/skills/email-draft-save/handler.ts
@@ -1,0 +1,60 @@
+// handler.ts — email-draft-save skill implementation.
+//
+// Saves a draft email without sending it. Routes via OutboundGateway.createEmailDraft(),
+// which runs the blocked-contact check and converts markdown to HTML.
+//
+// Use this for the NEEDS DRAFT triage category: coordinator writes the draft,
+// the CEO reviews and sends it from their email client.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class EmailDraftSaveHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.outboundGateway) {
+      return { success: false, error: 'email-draft-save requires outboundGateway (infrastructure: true)' };
+    }
+
+    const { to: rawTo, subject, body, account, reply_to_message_id } = ctx.input as {
+      to?: string;
+      subject?: string;
+      body?: string;
+      account?: string;
+      reply_to_message_id?: string;
+    };
+
+    const to = typeof rawTo === 'string' ? rawTo.trim() : undefined;
+    if (!to) return { success: false, error: 'Missing required input: to (string)' };
+    if (!subject || typeof subject !== 'string') return { success: false, error: 'Missing required input: subject (string)' };
+    if (!body || typeof body !== 'string') return { success: false, error: 'Missing required input: body (string)' };
+
+    const accountId = typeof account === 'string' && account.trim() ? account.trim() : undefined;
+    const replyToMessageId = typeof reply_to_message_id === 'string' && reply_to_message_id.trim()
+      ? reply_to_message_id.trim()
+      : undefined;
+
+    ctx.log.info({ to, subject, accountId, replyToMessageId }, 'email-draft-save: saving draft');
+
+    let result: Awaited<ReturnType<typeof ctx.outboundGateway.createEmailDraft>>;
+    try {
+      result = await ctx.outboundGateway.createEmailDraft({
+        channel: 'email',
+        to,
+        subject,
+        body,
+        accountId,
+        replyToMessageId,
+      });
+    } catch (err) {
+      ctx.log.error({ err, to, accountId }, 'email-draft-save: unexpected error saving draft');
+      return { success: false, error: 'Failed to save draft' };
+    }
+
+    if (!result.success) {
+      ctx.log.error({ to, accountId, reason: result.blockedReason }, 'email-draft-save: gateway rejected draft');
+      return { success: false, error: result.blockedReason ?? 'Failed to save draft' };
+    }
+
+    ctx.log.info({ draftId: result.draftId, to, accountId }, 'email-draft-save: draft saved');
+    return { success: true, data: { draft_id: result.draftId } };
+  }
+}

--- a/skills/email-draft-save/handler.ts
+++ b/skills/email-draft-save/handler.ts
@@ -54,6 +54,13 @@ export class EmailDraftSaveHandler implements SkillHandler {
       return { success: false, error: result.blockedReason ?? 'Failed to save draft' };
     }
 
+    // OutboundDraftResult.draftId is typed optional; guard so we never violate the
+    // declared `draft_id: string` output contract by emitting `undefined`.
+    if (!result.draftId) {
+      ctx.log.error({ to, accountId }, 'email-draft-save: gateway returned success without draftId');
+      return { success: false, error: 'Failed to save draft' };
+    }
+
     ctx.log.info({ draftId: result.draftId, to, accountId }, 'email-draft-save: draft saved');
     return { success: true, data: { draft_id: result.draftId } };
   }

--- a/skills/email-draft-save/skill.json
+++ b/skills/email-draft-save/skill.json
@@ -1,0 +1,21 @@
+{
+  "name": "email-draft-save",
+  "description": "Save an email as a draft without sending it. The CEO can review and send the draft from their email client. Use for observation-mode triage (NEEDS DRAFT category) or when composing a reply that needs CEO approval before sending.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "medium",
+  "infrastructure": true,
+  "inputs": {
+    "to": "string (recipient email address)",
+    "subject": "string (email subject line)",
+    "body": "string (email body; markdown supported, converted to HTML automatically)",
+    "account": "string? (named account to draft from, e.g. 'curia' or 'joseph'. Defaults to the primary account.)",
+    "reply_to_message_id": "string? (Nylas message ID to reply to; threads the draft as a reply when set)"
+  },
+  "outputs": {
+    "draft_id": "string"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 20000
+}

--- a/skills/email-draft-save/skill.json
+++ b/skills/email-draft-save/skill.json
@@ -9,7 +9,7 @@
     "to": "string (recipient email address)",
     "subject": "string (email subject line)",
     "body": "string (email body; markdown supported, converted to HTML automatically)",
-    "account": "string? (named account to draft from, e.g. 'curia' or 'joseph'. Defaults to the primary account.)",
+    "account": "string? (named account to draft from, as configured in channel_accounts.email. Defaults to the primary account.)",
     "reply_to_message_id": "string? (Nylas message ID to reply to; threads the draft as a reply when set)"
   },
   "outputs": {

--- a/skills/email-get/handler.ts
+++ b/skills/email-get/handler.ts
@@ -1,0 +1,55 @@
+// handler.ts — email-get skill implementation.
+//
+// Fetches a single email message (full body) by Nylas message ID.
+// Routes via OutboundGateway.getEmailMessage() — account resolution
+// is handled by the gateway's named-client map.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class EmailGetHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.outboundGateway) {
+      return { success: false, error: 'email-get requires outboundGateway (infrastructure: true)' };
+    }
+
+    const { message_id: rawId, account } = ctx.input as {
+      message_id?: string;
+      account?: string;
+    };
+
+    const messageId = typeof rawId === 'string' ? rawId.trim() : undefined;
+    if (!messageId) {
+      return { success: false, error: 'Missing required input: message_id (string)' };
+    }
+
+    const accountId = typeof account === 'string' && account.trim() ? account.trim() : undefined;
+
+    ctx.log.info({ messageId, accountId }, 'email-get: fetching message');
+
+    let message: Awaited<ReturnType<typeof ctx.outboundGateway.getEmailMessage>>;
+    try {
+      message = await ctx.outboundGateway.getEmailMessage(messageId, accountId);
+    } catch (err) {
+      ctx.log.error({ err, messageId, accountId }, 'email-get: failed to fetch message');
+      return { success: false, error: 'Failed to fetch message' };
+    }
+
+    return {
+      success: true,
+      data: {
+        message: {
+          id: message.id,
+          threadId: message.threadId,
+          subject: message.subject,
+          from: message.from,
+          to: message.to,
+          cc: message.cc,
+          body: message.body,
+          date: message.date,
+          unread: message.unread,
+          folders: message.folders,
+        },
+      },
+    };
+  }
+}

--- a/skills/email-get/handler.ts
+++ b/skills/email-get/handler.ts
@@ -12,7 +12,10 @@ export class EmailGetHandler implements SkillHandler {
       return { success: false, error: 'email-get requires outboundGateway (infrastructure: true)' };
     }
 
-    const { message_id: rawId, account } = ctx.input as {
+    // Handlers must never throw — destructuring a non-object ctx.input would.
+    const input =
+      ctx.input && typeof ctx.input === 'object' ? (ctx.input as Record<string, unknown>) : {};
+    const { message_id: rawId, account } = input as {
       message_id?: string;
       account?: string;
     };

--- a/skills/email-get/skill.json
+++ b/skills/email-get/skill.json
@@ -1,0 +1,18 @@
+{
+  "name": "email-get",
+  "description": "Fetch the full content (including body) of a single email message by its Nylas message ID. Use email-list to find message IDs first.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "infrastructure": true,
+  "inputs": {
+    "message_id": "string (Nylas message ID of the email to fetch)",
+    "account": "string? (named account to read from, e.g. 'curia' or 'joseph'. Defaults to the primary account.)"
+  },
+  "outputs": {
+    "message": "object"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}

--- a/skills/email-get/skill.json
+++ b/skills/email-get/skill.json
@@ -7,7 +7,7 @@
   "infrastructure": true,
   "inputs": {
     "message_id": "string (Nylas message ID of the email to fetch)",
-    "account": "string? (named account to read from, e.g. 'curia' or 'joseph'. Defaults to the primary account.)"
+    "account": "string? (named account to read from, as configured in channel_accounts.email. Defaults to the primary account.)"
   },
   "outputs": {
     "message": "object"

--- a/skills/email-list/handler.ts
+++ b/skills/email-list/handler.ts
@@ -44,7 +44,20 @@ export class EmailListHandler implements SkillHandler {
         ? Math.min(normalizedLimit, MAX_LIMIT)
         : DEFAULT_LIMIT;
 
-    ctx.log.info({ accountId, options }, 'email-list: listing messages');
+    // Avoid logging raw filter values — sender addresses, subject text, and
+    // provider-native search terms can carry PII. Log presence/shape only.
+    ctx.log.info(
+      {
+        accountId,
+        unread: options.unread,
+        limit: options.limit,
+        folderCount: options.folders?.length ?? 0,
+        hasFrom: options.from !== undefined,
+        hasSubject: options.subject !== undefined,
+        hasSearchQueryNative: options.searchQueryNative !== undefined,
+      },
+      'email-list: listing messages',
+    );
 
     let messages: Awaited<ReturnType<typeof ctx.outboundGateway.listEmailMessages>>;
     try {

--- a/skills/email-list/handler.ts
+++ b/skills/email-list/handler.ts
@@ -1,0 +1,66 @@
+// handler.ts — email-list skill implementation.
+//
+// Lists messages from any configured email account via OutboundGateway.
+// Returns lightweight summaries (no body — use email-get for full content).
+// Account resolution is handled by the gateway's named-client map.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { ListMessagesOptions } from '../../src/channels/email/nylas-client.js';
+
+const MAX_LIMIT = 50;
+const DEFAULT_LIMIT = 20;
+
+export class EmailListHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.outboundGateway) {
+      return { success: false, error: 'email-list requires outboundGateway (infrastructure: true)' };
+    }
+
+    const { account, folder, unread_only, from, subject, search, limit } = ctx.input as {
+      account?: string;
+      folder?: string;
+      unread_only?: boolean;
+      from?: string;
+      subject?: string;
+      search?: string;
+      limit?: number;
+    };
+
+    const accountId = typeof account === 'string' && account.trim() ? account.trim() : undefined;
+
+    const options: ListMessagesOptions = {};
+    if (typeof folder === 'string' && folder.trim()) options.folders = [folder.trim()];
+    if (unread_only === true) options.unread = true;
+    if (typeof from === 'string' && from.trim()) options.from = from.trim();
+    if (typeof subject === 'string' && subject.trim()) options.subject = subject.trim();
+    if (typeof search === 'string' && search.trim()) options.searchQueryNative = search.trim();
+    options.limit = typeof limit === 'number' && limit > 0 ? Math.min(limit, MAX_LIMIT) : DEFAULT_LIMIT;
+
+    ctx.log.info({ accountId, options }, 'email-list: listing messages');
+
+    let messages: Awaited<ReturnType<typeof ctx.outboundGateway.listEmailMessages>>;
+    try {
+      messages = await ctx.outboundGateway.listEmailMessages(options, accountId);
+    } catch (err) {
+      ctx.log.error({ err, accountId }, 'email-list: failed to list messages');
+      return { success: false, error: 'Failed to list messages' };
+    }
+
+    return {
+      success: true,
+      data: {
+        messages: messages.map((m) => ({
+          id: m.id,
+          threadId: m.threadId,
+          subject: m.subject,
+          from: m.from,
+          snippet: m.snippet,
+          date: m.date,
+          unread: m.unread,
+          folders: m.folders,
+        })),
+        count: messages.length,
+      },
+    };
+  }
+}

--- a/skills/email-list/handler.ts
+++ b/skills/email-list/handler.ts
@@ -34,7 +34,15 @@ export class EmailListHandler implements SkillHandler {
     if (typeof from === 'string' && from.trim()) options.from = from.trim();
     if (typeof subject === 'string' && subject.trim()) options.subject = subject.trim();
     if (typeof search === 'string' && search.trim()) options.searchQueryNative = search.trim();
-    options.limit = typeof limit === 'number' && limit > 0 ? Math.min(limit, MAX_LIMIT) : DEFAULT_LIMIT;
+    // Coerce to a positive integer before forwarding — LLMs occasionally emit floats
+    // (e.g. 12.7) and Nylas expects an int. Non-finite or non-positive values fall back
+    // to DEFAULT_LIMIT.
+    const normalizedLimit =
+      typeof limit === 'number' && Number.isFinite(limit) ? Math.floor(limit) : undefined;
+    options.limit =
+      normalizedLimit !== undefined && normalizedLimit > 0
+        ? Math.min(normalizedLimit, MAX_LIMIT)
+        : DEFAULT_LIMIT;
 
     ctx.log.info({ accountId, options }, 'email-list: listing messages');
 

--- a/skills/email-list/handler.ts
+++ b/skills/email-list/handler.ts
@@ -16,7 +16,10 @@ export class EmailListHandler implements SkillHandler {
       return { success: false, error: 'email-list requires outboundGateway (infrastructure: true)' };
     }
 
-    const { account, folder, unread_only, from, subject, search, limit } = ctx.input as {
+    // Handlers must never throw — destructuring a non-object ctx.input would.
+    const input =
+      ctx.input && typeof ctx.input === 'object' ? (ctx.input as Record<string, unknown>) : {};
+    const { account, folder, unread_only, from, subject, search, limit } = input as {
       account?: string;
       folder?: string;
       unread_only?: boolean;

--- a/skills/email-list/skill.json
+++ b/skills/email-list/skill.json
@@ -6,7 +6,7 @@
   "action_risk": "none",
   "infrastructure": true,
   "inputs": {
-    "account": "string? (named account to read from, e.g. 'curia' or 'joseph'. Defaults to the primary account.)",
+    "account": "string? (named account to read from, as configured in channel_accounts.email. Defaults to the primary account.)",
     "folder": "string? (folder to filter by, e.g. 'INBOX', 'SENT', 'DRAFTS'. Defaults to all folders.)",
     "unread_only": "boolean? (when true, only return unread messages)",
     "from": "string? (filter to messages from this email address)",

--- a/skills/email-list/skill.json
+++ b/skills/email-list/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "email-list",
+  "description": "List recent emails from any configured email account. Returns message summaries (ID, sender, subject, snippet, date). Use email-get to fetch the full body of a specific message.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "infrastructure": true,
+  "inputs": {
+    "account": "string? (named account to read from, e.g. 'curia' or 'joseph'. Defaults to the primary account.)",
+    "folder": "string? (folder to filter by, e.g. 'INBOX', 'SENT', 'DRAFTS'. Defaults to all folders.)",
+    "unread_only": "boolean? (when true, only return unread messages)",
+    "from": "string? (filter to messages from this email address)",
+    "subject": "string? (filter to messages with this subject)",
+    "search": "string? (provider-native search query, e.g. Gmail search syntax)",
+    "limit": "number? (max results to return, capped at 50, default 20)"
+  },
+  "outputs": {
+    "messages": "object[]",
+    "count": "number"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 20000
+}

--- a/src/channels/email/nylas-client.ts
+++ b/src/channels/email/nylas-client.ts
@@ -114,6 +114,15 @@ export interface ListMessagesOptions {
    * Required to access Authentication-Results for SPF/DKIM/DMARC sender verification.
    */
   fields?: 'include_headers';
+  /** Filter to messages in these folder IDs (maps to Nylas `in` param).
+   *  Standard values: INBOX, DRAFTS, SENT, TRASH. Providers may have custom labels. */
+  folders?: string[];
+  /** Filter to messages from this sender email address */
+  from?: string;
+  /** Filter to messages with this exact subject line */
+  subject?: string;
+  /** Provider-native search query (Gmail search syntax, Outlook KQL, etc.) */
+  searchQueryNative?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -158,6 +167,20 @@ export class NylasClient {
       // Cast needed: our interface uses a string literal to avoid leaking the SDK's
       // MessageFields enum type into the broader codebase.
       queryParams.fields = options.fields as MessageFields;
+    }
+    if (options?.folders !== undefined) {
+      // Nylas uses `in` for folder filtering — maps to our `folders` option.
+      queryParams.in = options.folders;
+    }
+    if (options?.from !== undefined) {
+      // Nylas expects `from` as an array of email strings.
+      queryParams.from = [options.from];
+    }
+    if (options?.subject !== undefined) {
+      queryParams.subject = options.subject;
+    }
+    if (options?.searchQueryNative !== undefined) {
+      queryParams.searchQueryNative = options.searchQueryNative;
     }
 
     this.log.debug({ queryParams }, 'listing messages');

--- a/tests/unit/channels/email/nylas-client-list.test.ts
+++ b/tests/unit/channels/email/nylas-client-list.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockMessages } = vi.hoisted(() => {
+  const mockMessages = { list: vi.fn(), find: vi.fn(), send: vi.fn(), update: vi.fn() };
+  return { mockMessages };
+});
+
+vi.mock('nylas', () => {
+  class MockNylas {
+    messages = mockMessages;
+    drafts = { create: vi.fn() };
+  }
+  return { default: MockNylas };
+});
+
+import { NylasClient } from '../../../../src/channels/email/nylas-client.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function emptyListResponse(items: unknown[] = []) {
+  return { data: items, requestId: 'req-1', nextCursor: undefined };
+}
+
+describe('NylasClient.listMessages — folder/search filters', () => {
+  let client: NylasClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new NylasClient('api-key', 'grant-id', logger);
+    mockMessages.list.mockResolvedValue(emptyListResponse());
+  });
+
+  it('passes folders to Nylas as queryParams.in', async () => {
+    await client.listMessages({ folders: ['INBOX', 'IMPORTANT'] });
+    expect(mockMessages.list).toHaveBeenCalledWith(
+      expect.objectContaining({ queryParams: expect.objectContaining({ in: ['INBOX', 'IMPORTANT'] }) }),
+    );
+  });
+
+  it('passes from to Nylas as queryParams.from array', async () => {
+    await client.listMessages({ from: 'sender@example.com' });
+    expect(mockMessages.list).toHaveBeenCalledWith(
+      expect.objectContaining({ queryParams: expect.objectContaining({ from: ['sender@example.com'] }) }),
+    );
+  });
+
+  it('passes subject to Nylas queryParams', async () => {
+    await client.listMessages({ subject: 'Meeting follow-up' });
+    expect(mockMessages.list).toHaveBeenCalledWith(
+      expect.objectContaining({ queryParams: expect.objectContaining({ subject: 'Meeting follow-up' }) }),
+    );
+  });
+
+  it('passes searchQueryNative to Nylas queryParams', async () => {
+    await client.listMessages({ searchQueryNative: 'in:inbox is:unread' });
+    expect(mockMessages.list).toHaveBeenCalledWith(
+      expect.objectContaining({ queryParams: expect.objectContaining({ searchQueryNative: 'in:inbox is:unread' }) }),
+    );
+  });
+
+  it('omits new params from queryParams when not provided', async () => {
+    await client.listMessages({ unread: true });
+    const callArg = mockMessages.list.mock.calls[0]![0] as { queryParams: Record<string, unknown> };
+    expect(callArg.queryParams).not.toHaveProperty('in');
+    expect(callArg.queryParams).not.toHaveProperty('from');
+    expect(callArg.queryParams).not.toHaveProperty('subject');
+    expect(callArg.queryParams).not.toHaveProperty('searchQueryNative');
+  });
+});

--- a/tests/unit/skills/email-draft-save.test.ts
+++ b/tests/unit/skills/email-draft-save.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EmailDraftSaveHandler } from '../../../skills/email-draft-save/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(input: Record<string, unknown>, gateway?: Partial<{
+  createEmailDraft: (...args: unknown[]) => unknown;
+}>): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    outboundGateway: gateway as never,
+  };
+}
+
+describe('EmailDraftSaveHandler', () => {
+  const handler = new EmailDraftSaveHandler();
+
+  it('returns failure when outboundGateway is not configured', async () => {
+    const result = await handler.execute(makeCtx({ to: 'r@example.com', subject: 'Hi', body: 'Hello' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('outboundGateway');
+  });
+
+  it('returns failure when to is missing', async () => {
+    const gateway = { createEmailDraft: vi.fn() };
+    const result = await handler.execute(makeCtx({ subject: 'Hi', body: 'Hello' }, gateway));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('to');
+  });
+
+  it('returns failure when subject is missing', async () => {
+    const gateway = { createEmailDraft: vi.fn() };
+    const result = await handler.execute(makeCtx({ to: 'r@example.com', body: 'Hello' }, gateway));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('subject');
+  });
+
+  it('returns failure when body is missing', async () => {
+    const gateway = { createEmailDraft: vi.fn() };
+    const result = await handler.execute(makeCtx({ to: 'r@example.com', subject: 'Hi' }, gateway));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('body');
+  });
+
+  it('calls createEmailDraft with channel: email and correct fields', async () => {
+    const gateway = { createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'draft-1' }) };
+    await handler.execute(makeCtx({ to: 'r@example.com', subject: 'Hi', body: 'Hello' }, gateway));
+    expect(gateway.createEmailDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'email', to: 'r@example.com', subject: 'Hi', body: 'Hello' }),
+    );
+  });
+
+  it('passes account as accountId', async () => {
+    const gateway = { createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-1' }) };
+    await handler.execute(makeCtx({ to: 'r@example.com', subject: 'Hi', body: 'Hello', account: 'joseph' }, gateway));
+    expect(gateway.createEmailDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: 'joseph' }),
+    );
+  });
+
+  it('passes reply_to_message_id as replyToMessageId', async () => {
+    const gateway = { createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-1' }) };
+    await handler.execute(makeCtx(
+      { to: 'r@example.com', subject: 'Re: Hi', body: 'Hello', reply_to_message_id: 'msg-orig' },
+      gateway,
+    ));
+    expect(gateway.createEmailDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ replyToMessageId: 'msg-orig' }),
+    );
+  });
+
+  it('returns draft_id on success', async () => {
+    const gateway = { createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'draft-99' }) };
+    const result = await handler.execute(makeCtx({ to: 'r@example.com', subject: 'Hi', body: 'Hello' }, gateway));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as { draft_id: string }).draft_id).toBe('draft-99');
+    }
+  });
+
+  it('returns failure when gateway returns success: false (blocked recipient)', async () => {
+    const gateway = { createEmailDraft: vi.fn().mockResolvedValue({ success: false, blockedReason: 'Recipient is blocked' }) };
+    const result = await handler.execute(makeCtx({ to: 'blocked@example.com', subject: 'Hi', body: 'Hello' }, gateway));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('blocked');
+  });
+
+  it('returns failure when gateway throws unexpectedly', async () => {
+    const gateway = { createEmailDraft: vi.fn().mockRejectedValue(new Error('Nylas timeout')) };
+    const result = await handler.execute(makeCtx({ to: 'r@example.com', subject: 'Hi', body: 'Hello' }, gateway));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Failed to save draft');
+  });
+});

--- a/tests/unit/skills/email-get.test.ts
+++ b/tests/unit/skills/email-get.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EmailGetHandler } from '../../../skills/email-get/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+const mockMessage = {
+  id: 'msg-1',
+  threadId: 'thread-1',
+  subject: 'Hello',
+  from: [{ email: 'sender@example.com', name: 'Sender' }],
+  to: [{ email: 'ceo@example.com' }],
+  cc: [],
+  bcc: [],
+  body: '<p>Full body here</p>',
+  snippet: 'Full body here',
+  date: 1700000000,
+  unread: true,
+  folders: ['INBOX'],
+};
+
+function makeCtx(input: Record<string, unknown>, gateway?: Partial<{
+  getEmailMessage: (...args: unknown[]) => unknown;
+}>): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    outboundGateway: gateway as never,
+  };
+}
+
+describe('EmailGetHandler', () => {
+  const handler = new EmailGetHandler();
+
+  it('returns failure when message_id is missing', async () => {
+    const gateway = { getEmailMessage: vi.fn() };
+    const result = await handler.execute(makeCtx({}, gateway));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('message_id');
+  });
+
+  it('returns failure when outboundGateway is not configured', async () => {
+    const result = await handler.execute(makeCtx({ message_id: 'msg-1' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('outboundGateway');
+  });
+
+  it('fetches message using default (primary) account when account is omitted', async () => {
+    const gateway = { getEmailMessage: vi.fn().mockResolvedValue(mockMessage) };
+    const result = await handler.execute(makeCtx({ message_id: 'msg-1' }, gateway));
+    expect(result.success).toBe(true);
+    expect(gateway.getEmailMessage).toHaveBeenCalledWith('msg-1', undefined);
+  });
+
+  it('passes account as accountId when provided', async () => {
+    const gateway = { getEmailMessage: vi.fn().mockResolvedValue(mockMessage) };
+    await handler.execute(makeCtx({ message_id: 'msg-1', account: 'joseph' }, gateway));
+    expect(gateway.getEmailMessage).toHaveBeenCalledWith('msg-1', 'joseph');
+  });
+
+  it('trims whitespace from message_id', async () => {
+    const gateway = { getEmailMessage: vi.fn().mockResolvedValue(mockMessage) };
+    await handler.execute(makeCtx({ message_id: '  msg-1  ' }, gateway));
+    expect(gateway.getEmailMessage).toHaveBeenCalledWith('msg-1', undefined);
+  });
+
+  it('returns the full message including body', async () => {
+    const gateway = { getEmailMessage: vi.fn().mockResolvedValue(mockMessage) };
+    const result = await handler.execute(makeCtx({ message_id: 'msg-1' }, gateway));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { message: { id: string; body: string } };
+      expect(data.message.id).toBe('msg-1');
+      expect(data.message.body).toBe('<p>Full body here</p>');
+    }
+  });
+
+  it('returns failure when gateway throws (message not found)', async () => {
+    const gateway = { getEmailMessage: vi.fn().mockRejectedValue(new Error('Nylas 404')) };
+    const result = await handler.execute(makeCtx({ message_id: 'msg-missing' }, gateway));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Failed to fetch');
+  });
+});

--- a/tests/unit/skills/email-list.test.ts
+++ b/tests/unit/skills/email-list.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EmailListHandler } from '../../../skills/email-list/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+const mockMessage = {
+  id: 'msg-1',
+  threadId: 'thread-1',
+  subject: 'Hello',
+  from: [{ email: 'sender@example.com', name: 'Sender' }],
+  to: [{ email: 'ceo@example.com' }],
+  cc: [],
+  bcc: [],
+  body: 'Full body here',
+  snippet: 'Hello...',
+  date: 1700000000,
+  unread: true,
+  folders: ['INBOX'],
+};
+
+function makeCtx(input: Record<string, unknown>, gateway?: Partial<{
+  listEmailMessages: (...args: unknown[]) => unknown;
+}>): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    outboundGateway: gateway as never,
+  };
+}
+
+describe('EmailListHandler', () => {
+  const handler = new EmailListHandler();
+
+  it('returns failure when outboundGateway is not configured', async () => {
+    const result = await handler.execute(makeCtx({}));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('outboundGateway');
+  });
+
+  it('returns failure when gateway throws (no client configured)', async () => {
+    const gateway = { listEmailMessages: vi.fn().mockRejectedValue(new Error('no nylasClient is configured')) };
+    const result = await handler.execute(makeCtx({}, gateway));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Failed to list');
+  });
+
+  it('calls listEmailMessages with no options when no params given', async () => {
+    const gateway = { listEmailMessages: vi.fn().mockResolvedValue([]) };
+    const result = await handler.execute(makeCtx({}, gateway));
+    expect(result.success).toBe(true);
+    expect(gateway.listEmailMessages).toHaveBeenCalledWith(expect.objectContaining({ limit: 20 }), undefined);
+  });
+
+  it('passes account param as accountId', async () => {
+    const gateway = { listEmailMessages: vi.fn().mockResolvedValue([]) };
+    await handler.execute(makeCtx({ account: 'joseph' }, gateway));
+    expect(gateway.listEmailMessages).toHaveBeenCalledWith(expect.anything(), 'joseph');
+  });
+
+  it('passes folder param as folders array', async () => {
+    const gateway = { listEmailMessages: vi.fn().mockResolvedValue([]) };
+    await handler.execute(makeCtx({ folder: 'DRAFTS' }, gateway));
+    expect(gateway.listEmailMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ folders: ['DRAFTS'] }),
+      undefined,
+    );
+  });
+
+  it('passes unread_only as unread option', async () => {
+    const gateway = { listEmailMessages: vi.fn().mockResolvedValue([]) };
+    await handler.execute(makeCtx({ unread_only: true }, gateway));
+    expect(gateway.listEmailMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ unread: true }),
+      undefined,
+    );
+  });
+
+  it('passes from filter', async () => {
+    const gateway = { listEmailMessages: vi.fn().mockResolvedValue([]) };
+    await handler.execute(makeCtx({ from: 'boss@example.com' }, gateway));
+    expect(gateway.listEmailMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ from: 'boss@example.com' }),
+      undefined,
+    );
+  });
+
+  it('passes search as searchQueryNative', async () => {
+    const gateway = { listEmailMessages: vi.fn().mockResolvedValue([]) };
+    await handler.execute(makeCtx({ search: 'in:inbox is:unread' }, gateway));
+    expect(gateway.listEmailMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ searchQueryNative: 'in:inbox is:unread' }),
+      undefined,
+    );
+  });
+
+  it('caps limit at 50 and passes it through', async () => {
+    const gateway = { listEmailMessages: vi.fn().mockResolvedValue([]) };
+    await handler.execute(makeCtx({ limit: 200 }, gateway));
+    expect(gateway.listEmailMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 50 }),
+      undefined,
+    );
+  });
+
+  it('returns normalised messages array with count', async () => {
+    const gateway = { listEmailMessages: vi.fn().mockResolvedValue([mockMessage]) };
+    const result = await handler.execute(makeCtx({}, gateway));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { messages: unknown[]; count: number };
+      expect(data.messages).toHaveLength(1);
+      expect(data.count).toBe(1);
+    }
+  });
+
+  it('omits body from listed messages (snippet only)', async () => {
+    const gateway = { listEmailMessages: vi.fn().mockResolvedValue([mockMessage]) };
+    const result = await handler.execute(makeCtx({}, gateway));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const messages = (result.data as { messages: Record<string, unknown>[] }).messages;
+      expect(messages[0]).not.toHaveProperty('body');
+      expect(messages[0]).toHaveProperty('snippet');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds three account-aware email skills: `email-list`, `email-get`, `email-draft-save` — thin handlers over `OutboundGateway` methods that already exist.
- Extends `ListMessagesOptions` in `NylasClient` with `folders`, `from`, `subject`, `searchQueryNative` so `email-list` can filter.
- Pins the three skills in `coordinator.yaml` and rewrites the `## Email` section with account-aware guidance (reading + drafting for the CEO).
- Version bump `0.18.1` → `0.19.0` (three new skills = minor).

Closes #301.

## Risk surface

- `email-list` / `email-get`: `action_risk: none` (read-only).
- `email-draft-save`: `action_risk: medium` — saves draft only, never sends. Routes through existing blocked-contact check in `OutboundGateway.createEmailDraft`.
- No schema changes, no new config, no new channel adapter.

## Test plan

- [x] All existing tests pass (1422 passed, 44 skipped).
- [x] New unit tests: 5 for `nylas-client` list filters, 11 for `email-list`, 7 for `email-get`, 10 for `email-draft-save`.
- [ ] Manual: in Curia session, ask coordinator to `email-list account: "joseph" unread_only: true`.
- [ ] Manual: ask coordinator to `email-get` a specific message ID from the CEO inbox.
- [ ] Manual: ask coordinator to draft a reply on the CEO's behalf — confirm draft appears in CEO's Drafts folder, nothing is sent.

## Pre-merge review

- `pr-review-toolkit:code-reviewer`: no high-priority issues.
- `pr-review-toolkit:silent-failure-hunter`: no HIGH/CRITICAL; medium nit (generic error messages) matches existing skill pattern, not addressed here to avoid scope creep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CEO inbox: list emails with folder/sender/subject/provider-native search, fetch full message contents, and save CEO review drafts with account/thread support.
* **Documentation**
  * Changelog updated with CEO inbox entries and task references.
* **Tests**
  * Unit tests added for listing, retrieval, and draft-save flows.
* **Chores**
  * Package version bumped to 0.19.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->