### PR TITLE
chore: bump default Anthropic model to claude-sonnet-4-6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **Default Anthropic model** bumped from `claude-sonnet-4-20250514` to `claude-sonnet-4-6` across agent configs, runtime fallback, tests, and docs. The old model reaches EOL on 2026-06-15.
+
 ### Added
 
 - **LEAVE FOR CEO triage classification** — the observation-mode preamble now defines a fifth category for personal, sensitive, or judgment-dependent email where the CEO will read and handle it themselves. No archive, no draft, no notification. The "when in doubt" default has shifted from URGENT to LEAVE FOR CEO to stop over-notifying. Mirrored in `agents/coordinator.yaml`.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ description: Tracks and categorizes expenses from receipts and emails
 
 model:
   provider: anthropic
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
   fallback:
     provider: openai
     model: gpt-4o

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -3,7 +3,7 @@ role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
   provider: anthropic
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
 system_prompt: |
   ${office_identity_block}
 

--- a/agents/research-analyst.yaml
+++ b/agents/research-analyst.yaml
@@ -3,7 +3,7 @@ role: specialist
 description: Conducts web research, summarizes findings, and provides analysis on topics the CEO asks about
 model:
   provider: anthropic
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
 system_prompt: |
   You are a research analyst working as part of an executive assistant team.
   Your role is to conduct thorough research and provide clear, actionable summaries.

--- a/docs/adr/014-capability-tier-model-routing.md
+++ b/docs/adr/014-capability-tier-model-routing.md
@@ -10,7 +10,7 @@ The current agent config schema (`agents/*.yaml`) requires each agent to declare
 ```yaml
 model:
   provider: anthropic
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
   fallback:
     provider: openai
     model: gpt-4o
@@ -18,7 +18,7 @@ model:
 
 This design has several problems:
 
-**Portability.** A shared or third-party agent that hardcodes `claude-sonnet-4-20250514` will fail or silently degrade on any instance that doesn't have that model enabled, or on a deployment targeting a different cloud provider (e.g., a Bedrock model ID means nothing on GCP).
+**Portability.** A shared or third-party agent that hardcodes `claude-sonnet-4-6` will fail or silently degrade on any instance that doesn't have that model enabled, or on a deployment targeting a different cloud provider (e.g., a Bedrock model ID means nothing on GCP).
 
 **Operator control.** When model IDs live in agent YAML files, the instance operator cannot centrally change which model is used for a class of agents. Upgrading to a new model requires touching every agent file. Cost routing, model pinning during outages, and A/B testing require per-file edits rather than a config change.
 

--- a/docs/dev/adding-an-agent.md
+++ b/docs/dev/adding-an-agent.md
@@ -34,7 +34,7 @@ description: |                 # human-readable purpose; shown in the admin UI a
 
 model:
   provider: anthropic          # "anthropic" | "openai" | "ollama"
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
 
   # Optional: fallback provider if primary is unavailable
   fallback:
@@ -127,7 +127,7 @@ Specifies which LLM to use.
 | Field | Values |
 |---|---|
 | `provider` | `"anthropic"`, `"openai"`, `"ollama"` |
-| `model` | Provider-specific model ID (e.g., `claude-sonnet-4-20250514`, `gpt-4o`, `llama3.2`) |
+| `model` | Provider-specific model ID (e.g., `claude-sonnet-4-6`, `gpt-4o`, `llama3.2`) |
 
 The optional `fallback` block specifies an alternate provider+model to use if the primary provider returns an error or is unavailable. The fallback is used transparently — the agent does not need to be aware of the switch.
 

--- a/docs/specs/02-agent-system.md
+++ b/docs/specs/02-agent-system.md
@@ -26,7 +26,7 @@ persona:
     Office of the CEO
 model:
   provider: anthropic
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
 system_prompt: |
   You are ${persona.display_name}, executive assistant to the CEO.
   You are the single point of contact for all communications.
@@ -62,7 +62,7 @@ name: expense-tracker
 description: Tracks and categorizes expenses from receipts and emails
 model:
   provider: anthropic
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
 system_prompt: |
   You are an expense tracking assistant for a CEO.
   Extract amounts, vendors, categories, and dates from receipts.
@@ -213,7 +213,7 @@ Agents specify provider + model in their config. A `fallback` provider can be co
 ```yaml
 model:
   provider: anthropic
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
   fallback:
     provider: openai
     model: gpt-4o

--- a/docs/specs/10-audit-log-hardening.md
+++ b/docs/specs/10-audit-log-hardening.md
@@ -111,7 +111,7 @@ interface LlmCallPayload {
   agentId: string;
   conversationId: string;
   // Model provenance — what was requested vs. what actually ran
-  requestedModel: string;       // e.g. 'claude-sonnet-4-20250514'
+  requestedModel: string;       // e.g. 'claude-sonnet-4-6'
   actualModel: string;          // from the API response (may differ if provider aliases)
   provider: string;             // 'anthropic' | 'openai' | 'ollama'
   // Token accounting

--- a/docs/specs/13-office-identity.md
+++ b/docs/specs/13-office-identity.md
@@ -264,7 +264,7 @@ role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
   provider: anthropic
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
 system_prompt: |
   ${office_identity_block}
 

--- a/src/agents/llm/anthropic.ts
+++ b/src/agents/llm/anthropic.ts
@@ -103,7 +103,7 @@ export class AnthropicProvider implements LLMProvider {
 
     // Default to the latest Claude Sonnet; callers can override via options.model.
     // Using a default here ensures we never accidentally call without a model.
-    const model = (options?.model as string) ?? 'claude-sonnet-4-20250514';
+    const model = (options?.model as string) ?? 'claude-sonnet-4-6';
 
     try {
       const createParams: Anthropic.Messages.MessageCreateParamsNonStreaming = {

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -289,7 +289,7 @@ interface LlmCallPayload {
   agentId: string;
   conversationId: string;
   // Model provenance — what was requested vs. what actually ran (provider may alias)
-  requestedModel: string;       // e.g. 'claude-sonnet-4-20250514'
+  requestedModel: string;       // e.g. 'claude-sonnet-4-6'
   actualModel: string;          // from the API response (may differ if provider aliases)
   provider: string;             // 'anthropic' | 'openai' | 'ollama'
   // Token accounting

--- a/tests/unit/agents/loader.test.ts
+++ b/tests/unit/agents/loader.test.ts
@@ -44,7 +44,7 @@ describe('loadAgentConfig', () => {
 name: test-agent
 model:
   provider: anthropic
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
 system_prompt: "Test agent"
 error_budget:
   max_turns: 10
@@ -65,7 +65,7 @@ error_budget:
 name: writing-scout
 model:
   provider: anthropic
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
 system_prompt: "Scout agent"
 schedule:
   - cron: "30 8 * * 2"
@@ -90,7 +90,7 @@ schedule:
 name: test-sched
 model:
   provider: anthropic
-  model: claude-sonnet-4-20250514
+  model: claude-sonnet-4-6
 system_prompt: "Test"
 schedule:
   - cron: "0 9 * * 1"

--- a/tests/unit/bus/bus-layer-enforcement.test.ts
+++ b/tests/unit/bus/bus-layer-enforcement.test.ts
@@ -108,8 +108,8 @@ describe('Bus Layer Enforcement (integration)', () => {
     const llmEvent = createLlmCall({
       agentId: 'coordinator',
       conversationId: 'conv-1',
-      requestedModel: 'claude-sonnet-4-20250514',
-      actualModel: 'claude-sonnet-4-20250514',
+      requestedModel: 'claude-sonnet-4-6',
+      actualModel: 'claude-sonnet-4-6',
       provider: 'anthropic',
       inputTokens: 150,
       outputTokens: 75,


### PR DESCRIPTION
## Summary

- Replaces all references to deprecated `claude-sonnet-4-20250514` with `claude-sonnet-4-6` across agent configs, runtime fallback, tests, and docs
- The old model reaches EOL on 2026-06-15; `claude-sonnet-4-6` is the recommended replacement
- Historic WIP plans in `docs/wip/` left unchanged per issue scope

## Test plan

- [x] `grep -r claude-sonnet-4-20250514 src/ agents/ tests/` returns nothing
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1424 tests, 0 failures)
- [ ] Smoke-test a coordinator conversation locally against the live Anthropic API

Closes #313