### PR TITLE
fix: scheduler pendingJobs race — completions never recorded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Scheduler never completes job runs** — `pendingJobs.set()` was called after `bus.publish()` in `fireJob()`, but `bus.publish()` awaits all handlers synchronously. The agent would finish and emit `agent.response` before the tracking entry existed, so `handleCompletion` silently dropped every completion. The watchdog then reaped every run as timed-out, accumulating `consecutive_failures` until auto-suspend. All cron jobs were affected. Fix: set the tracking entry before publishing the task event.
 - **Dangling explanatory drafts on NOISE triage** — the coordinator's short final summary (e.g. "The email has been archived. This was a promotional newsletter…") was being wrapped in `outbound.message` by the dispatcher and saved as a draft reply by the email adapter under `draft_gate` policy. PR #304's prompt-only fix targeted `email-reply` (which wasn't being called); the actual mechanism was the dispatch-layer auto-reply of every `agent.response`. Root cause now fixed at the dispatch layer; the preamble's redundant "Do NOT call email-reply" guidance has been trimmed.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -232,6 +232,16 @@ export class Scheduler {
           await this.fireJob(job);
         } catch (err) {
           this.logger.error({ err, jobId: job.id }, 'Failed to fire job — reverting to pending for retry');
+          // Clean up the pendingJobs entry that fireJob sets before publishing.
+          // Without this, a publish failure after pendingJobs.set() leaks an
+          // orphaned entry that the watchdog won't clean (job reverts to 'pending',
+          // not 'running', so the watchdog's WHERE clause never matches).
+          for (const [eventId, pendingJobId] of this.pendingJobs) {
+            if (pendingJobId === job.id) {
+              this.pendingJobs.delete(eventId);
+              break;
+            }
+          }
           // Revert the job to its prior status so it can be retried next poll.
           // If this revert also fails, the job stays in 'running' — logged below.
           await this.pool.query(

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -319,10 +319,13 @@ export class Scheduler {
       expectedDurationSeconds: job.expectedDurationSeconds ?? undefined,
       parentEventId: firedEvent.id,
     });
-    await this.bus.publish('system', taskEvent);
-
-    // Track the mapping so we can correlate the response/error back to this job.
+    // Track the mapping BEFORE publishing — bus.publish() awaits all handlers
+    // synchronously, so the agent may finish and emit agent.response before
+    // publish() returns. If we set the entry after publish, handleCompletion
+    // sees an empty map and silently drops the completion.
     this.pendingJobs.set(taskEvent.id, job.id);
+
+    await this.bus.publish('system', taskEvent);
 
     this.logger.info(
       { jobId: job.id, agentId: job.agentId, taskEventId: taskEvent.id },


### PR DESCRIPTION
## Summary

- **Root cause**: `pendingJobs.set()` was called *after* `bus.publish()` in `fireJob()`. Since `bus.publish()` awaits all handlers synchronously, the agent would finish, emit `agent.response`, and `handleCompletion` would fire — all before the tracking entry existed. Every completion was silently dropped.
- **Effect**: The watchdog reaped every scheduled run as timed-out (70m), accumulating `consecutive_failures` until auto-suspend at 3. All cron jobs were affected despite agents completing their work successfully.
- **Fix**: Move `pendingJobs.set()` before `bus.publish()`. Also clean up orphaned map entries in the catch block if `bus.publish()` throws.

## Test plan

- [x] All 100 scheduler unit tests pass
- [x] Build succeeds
- [ ] After deploy: verify `last_run_at` is populated and `consecutive_failures` resets to 0 on the next cron cycle
- [ ] Unsuspend the two suspended jobs and confirm they complete cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 0.19.1

* **Bug Fixes**
  * Resolved a scheduler regression causing job completion tracking to fail, which previously led to watchdog timeout escalation
  * Corrected an issue where coordinator responses were being incorrectly routed to automatic draft replies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->