### PR TITLE
fix: calendar ownership — require explicit contact_id, add disambiguation prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Scheduler never completes job runs** — `pendingJobs.set()` was called after `bus.publish()` in `fireJob()`, but `bus.publish()` awaits all handlers synchronously. The agent would finish and emit `agent.response` before the tracking entry existed, so `handleCompletion` silently dropped every completion. The watchdog then reaped every run as timed-out, accumulating `consecutive_failures` until auto-suspend. All cron jobs were affected. Fix: set the tracking entry before publishing the task event.
 - **Dangling explanatory drafts on NOISE triage** — the coordinator's short final summary (e.g. "The email has been archived. This was a promotional newsletter…") was being wrapped in `outbound.message` by the dispatcher and saved as a draft reply by the email adapter under `draft_gate` policy. PR #304's prompt-only fix targeted `email-reply` (which wasn't being called); the actual mechanism was the dispatch-layer auto-reply of every `agent.response`. Root cause now fixed at the dispatch layer; the preamble's redundant "Do NOT call email-reply" guidance has been trimmed.
+- **Calendar ownership** — `calendar-register` now requires an explicit `contact_id`; the previous default to `ctx.caller?.contactId` caused Curia's own calendar to be registered under the CEO's contact during a CEO conversation (incident `kg-web-a7717246-1d7a-411c-9129-b6feb54bfc22`)
+- **Calendar disambiguation** — coordinator prompt now includes calendar disambiguation rules (parallel to inbox disambiguation) and a calendar exception in the Account Identity section, ensuring events are created on the CEO's calendar by default when scheduling on their behalf
+- **Calendar smoke test** — added `use-ceo-calendar` expectation to `calendar-create-event` smoke test to catch regressions
 
 ---
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -275,6 +275,19 @@ system_prompt: |
   - **"my inbox"** (in an observed third-party email) → that sender's own inbox;
     Curia has no access to it — decline or ask the CEO to clarify
 
+  ## Calendar Disambiguation
+  When the CEO references calendars, resolve as follows:
+
+  - **"my calendar"** (the CEO speaking to you directly) → the CEO's own calendar
+  - **"your calendar"** (the CEO speaking to you directly) → Curia's own calendar
+  - **Default for scheduling on behalf of the CEO** → always use the CEO's
+    calendar unless the CEO explicitly says to use Curia's
+
+  When calendar-list-calendars returns an unregistered calendar, do NOT silently
+  register it as part of another task. Instead, flag it to the CEO: "I see a
+  calendar I don't recognize yet — [name]. Who does this belong to?" Then
+  register it with the correct contact based on their answer.
+
   ## Observation Mode — Monitored Inboxes
   When a message arrives tagged `observationMode: true`, the dispatcher injects a
   full triage protocol into the task. Follow that protocol exactly — it classifies

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -333,6 +333,12 @@ system_prompt: |
   email-account target; it applies only to third-party tools where you're picking
   an acting identity.
 
+  **Exception — calendar skills:** When creating, updating, or deleting events
+  on behalf of the CEO, use the CEO's calendar. Only use Curia's own calendar
+  for events that are genuinely Curia's (e.g., internal reminders, blocked time
+  for Curia's own tasks). When unsure which calendar to use, look up the CEO's
+  contact first and use their registered calendar.
+
   ## Your Team
   You have specialist agents you can delegate to using the "delegate" tool.
   When a request requires specialized expertise, delegate to the right specialist.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -280,6 +280,7 @@ system_prompt: |
 
   - **"my calendar"** (the CEO speaking to you directly) → the CEO's own calendar
   - **"your calendar"** (the CEO speaking to you directly) → Curia's own calendar
+  - **"Curia's calendar"** → Curia's own calendar
   - **Default for scheduling on behalf of the CEO** → always use the CEO's
     calendar unless the CEO explicitly says to use Curia's
 

--- a/docs/wip/2026-04-23-calendar-ownership-design.md
+++ b/docs/wip/2026-04-23-calendar-ownership-design.md
@@ -1,0 +1,159 @@
+# Calendar Ownership Fix — Design Spec
+
+**Date:** 2026-04-23
+**Status:** Draft
+**Conversation:** `kg-web-a7717246-1d7a-411c-9129-b6feb54bfc22`
+
+## Problem
+
+On April 23, 2026, the coordinator created a calendar event on Curia's own
+calendar (`nathancuria1@gmail.com`) instead of the CEO's calendar
+(`joseph@josephfung.ca`). The CEO had confirmed "Yes please" to the
+coordinator's own suggestion of "Want me to put that on your calendar as a
+trail walk with Donna?" — the coordinator used the right language ("your
+calendar" = the CEO's) but executed against the wrong calendar.
+
+Three compounding causes:
+
+1. **Bad registry data.** `nathancuria1@gmail.com` is registered under the
+   CEO's contact ID (`6b9c41c5-fadb-4110-a8e6-025b1a2c091e`) in the
+   `contact_calendars` table. This happened on April 4 when the coordinator
+   registered its own calendar during a CEO conversation about a timezone bug.
+   The `calendar-register` handler defaulted the owner to `ctx.caller?.contactId`
+   (the CEO) because no explicit `contact_id` was provided.
+
+2. **Unsafe handler default.** The `calendar-register` handler
+   (`skills/calendar-register/handler.ts:40-41`) defaults `contact_id` to
+   `ctx.caller?.contactId` when not explicitly provided. The comment says
+   "the CEO saying 'that calendar is mine'" — but the common case going
+   forward will be calendars from colleagues, external contacts, or event
+   feeds where defaulting to the caller is wrong.
+
+3. **System prompt gaps.** The coordinator's system prompt
+   (`agents/coordinator.yaml`) has two gaps:
+   - No calendar disambiguation rules (unlike the "Inbox Disambiguation"
+     section that exists for email).
+   - The "Account Identity for Tool Calls" rule (lines 304-321) tells the
+     coordinator to "always use your own account first" for third-party
+     integrations. Calendar skills are not exempted (unlike email skills,
+     which have an explicit carve-out at lines 316-321).
+
+## Changes
+
+### 1. Production Data Fix
+
+Update the `contact_calendars` row for `nathancuria1@gmail.com` to point to
+Curia's own contact ID instead of the CEO's.
+
+```sql
+-- Dry-run: verify current state
+SELECT nylas_calendar_id, contact_id, label, is_primary
+  FROM contact_calendars
+ WHERE nylas_calendar_id = 'nathancuria1@gmail.com';
+
+-- Fix: re-assign to Curia's contact
+UPDATE contact_calendars
+   SET contact_id = '<curia_agent_contact_id>',
+       updated_at = now()
+ WHERE nylas_calendar_id = 'nathancuria1@gmail.com';
+```
+
+The actual Curia agent contact ID must be looked up before running. This is
+a manual operation, reviewed before execution.
+
+### 2. Make `contact_id` Required in `calendar-register`
+
+**File:** `skills/calendar-register/handler.ts`
+
+Remove the `ctx.caller?.contactId` fallback on lines 40-41. Make `contact_id`
+a required input. When it's missing, return a skill error:
+
+```
+Missing required input: contact_id — specify which contact owns this calendar.
+```
+
+This forces the coordinator to explicitly decide ownership before registering
+any calendar. The coordinator can (and should) ask the CEO when it encounters
+an unregistered calendar it can't identify.
+
+**File:** `skills/calendar-register/skill.json`
+
+Update the `inputs` section to mark `contact_id` as required (remove the `?`
+suffix if present, or add it to the description as "required").
+
+### 3. Add Calendar Disambiguation to System Prompt
+
+**File:** `agents/coordinator.yaml`
+
+Add a new "Calendar Disambiguation" section after the existing "Inbox
+Disambiguation" block (~line 276). Content:
+
+```
+## Calendar Disambiguation
+When the CEO references calendars, resolve as follows:
+
+- **"my calendar"** (the CEO speaking to you directly) → the CEO's own calendar
+- **"your calendar"** (the CEO speaking to you directly) → Curia's own calendar
+- **Default for scheduling on behalf of the CEO** → always use the CEO's
+  calendar unless the CEO explicitly says to use Curia's
+
+When calendar-list-calendars returns an unregistered calendar, do NOT
+silently register it as part of another task. Instead, flag it to the CEO:
+"I see a calendar I don't recognize yet — [name]. Who does this belong to?"
+Then register it with the correct contact based on their answer.
+```
+
+### 4. Add Calendar Exception to "Account Identity for Tool Calls"
+
+**File:** `agents/coordinator.yaml`
+
+Expand the existing exception block (lines 316-321) to include calendar
+skills alongside email skills. Add after the email exception:
+
+```
+**Exception — calendar skills:** When creating, updating, or deleting events
+on behalf of the CEO, use the CEO's calendar. Only use Curia's own calendar
+for events that are genuinely Curia's (e.g., internal reminders, blocked time
+for Curia's own tasks). When unsure which calendar to use, look up the CEO's
+contact first and use their registered calendar.
+```
+
+### 5. Update Smoke Test
+
+**File:** `tests/smoke/cases/calendar-create-event.yaml`
+
+Add an expected behavior that the agent uses the CEO's calendar, not its own,
+when creating events on behalf of the CEO:
+
+```yaml
+- id: use-ceo-calendar
+  description: Creates the event on the CEO's calendar, not on Curia's own calendar
+  weight: critical
+```
+
+Add a failure mode:
+
+```yaml
+- Creates the event on Curia's own calendar instead of the CEO's
+```
+
+## What This Does NOT Change
+
+- No changes to `calendar-create-event`, `calendar-list-calendars`, or any
+  other calendar skill handler — the issue is ownership data and coordinator
+  behavior, not event creation logic.
+- No new database tables or migrations — just updating one row in
+  `contact_calendars`.
+- No changes to the Nylas client or calendar data model.
+
+## Verification
+
+After all changes are applied:
+
+1. `calendar-list-calendars` should show `nathancuria1@gmail.com` linked to
+   Curia's contact (not the CEO's).
+2. `calendar-register` should reject calls without an explicit `contact_id`.
+3. The smoke test for `calendar-create-event` should include the CEO-calendar
+   expectation.
+4. Manual test: ask Curia to schedule an event via the web UI and confirm it
+   lands on the CEO's calendar.

--- a/docs/wip/2026-04-23-calendar-ownership.md
+++ b/docs/wip/2026-04-23-calendar-ownership.md
@@ -1,0 +1,354 @@
+# Calendar Ownership Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the calendar ownership bug where Curia creates events on its own calendar instead of the CEO's, and prevent it from recurring.
+
+**Architecture:** Data fix in prod + handler change to require explicit `contact_id` + system prompt additions for calendar disambiguation and account identity exceptions + smoke test update.
+
+**Tech Stack:** TypeScript (handler), YAML (coordinator prompt, smoke test), SQL (prod data fix)
+
+**Design spec:** `docs/wip/2026-04-23-calendar-ownership-design.md`
+
+---
+
+### Task 1: Make `contact_id` Required in `calendar-register` Handler
+
+**Files:**
+- Modify: `skills/calendar-register/handler.ts:38-52`
+- Modify: `skills/calendar-register/skill.json:12`
+
+- [ ] **Step 1: Update the handler to require `contact_id`**
+
+In `skills/calendar-register/handler.ts`, replace lines 38-52 (the `resolvedContactId` block) with a required-input check:
+
+```typescript
+    // contact_id is required — the coordinator must explicitly specify which
+    // contact owns this calendar. This prevents silent mis-assignment when the
+    // caller (e.g. the CEO) is not the calendar's actual owner.
+    if (!contact_id || typeof contact_id !== 'string') {
+      return { success: false, error: 'Missing required input: contact_id — specify which contact owns this calendar.' };
+    }
+
+    const resolvedContactId = contact_id;
+```
+
+Also update the file header comment (lines 1-11). Replace:
+```
+// contact_id defaults to the caller's own contact when omitted — the common case
+// when the CEO is claiming ownership of their own calendar.
+```
+with:
+```
+// contact_id is required — the coordinator must always specify which contact
+// owns the calendar. This prevents silent mis-assignment (see incident
+// kg-web-a7717246-1d7a-411c-9129-b6feb54bfc22).
+```
+
+- [ ] **Step 2: Update the skill manifest to mark `contact_id` as required**
+
+In `skills/calendar-register/skill.json`, change `contact_id` from optional to required. Replace:
+```json
+    "contact_id": "string?",
+```
+with:
+```json
+    "contact_id": "string (required — which contact owns this calendar)",
+```
+
+Also update the skill `description` to remove the defaulting language. Replace:
+```json
+  "description": "Register a Nylas calendar in the contact registry, linking it to a contact. Use this after calendar-list-calendars identifies an unregistered calendar and the CEO confirms which contact it belongs to. Defaults contact_id to the caller's own contact when omitted — the common case when the CEO is claiming their own calendar.",
+```
+with:
+```json
+  "description": "Register a Nylas calendar in the contact registry, linking it to a contact. Use this after calendar-list-calendars identifies an unregistered calendar and the CEO confirms which contact it belongs to. Always requires an explicit contact_id — ask the CEO who owns the calendar if unsure.",
+```
+
+- [ ] **Step 3: Run the existing tests to see which ones break**
+
+Run: `npm --prefix /path/to/worktree run test -- tests/unit/skills/calendar-register.test.ts`
+
+Expected: Two tests should now fail:
+- `defaults contact_id to the caller when not provided` — this tested the old defaulting behavior
+- `uses null contact_id when no contact_id and no caller` — this tested the org-wide fallback
+
+- [ ] **Step 4: Update the failing tests**
+
+In `tests/unit/skills/calendar-register.test.ts`:
+
+Replace the test `defaults contact_id to the caller when not provided` (lines 89-117) with:
+
+```typescript
+  it('returns failure when contact_id is missing', async () => {
+    const contactService = { linkCalendar: vi.fn() };
+    const result = await handler.execute(
+      makeCtx(
+        { nylas_calendar_id: 'cal-1', label: 'Personal', is_primary: true },
+        {
+          contactService: contactService as never,
+          caller: { contactId: 'caller-contact', role: 'ceo', channel: 'email' },
+        },
+      ),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('contact_id');
+    }
+    // Crucially: linkCalendar should NOT have been called
+    expect(contactService.linkCalendar).not.toHaveBeenCalled();
+  });
+```
+
+Replace the test `uses null contact_id when no contact_id and no caller` (lines 119-144) with:
+
+```typescript
+  it('returns failure when contact_id is missing even without caller context', async () => {
+    const contactService = { linkCalendar: vi.fn() };
+    const result = await handler.execute(
+      makeCtx(
+        { nylas_calendar_id: 'cal-holidays', label: 'Holidays' },
+        { contactService: contactService as never },
+      ),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('contact_id');
+    }
+    expect(contactService.linkCalendar).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npm --prefix /path/to/worktree run test -- tests/unit/skills/calendar-register.test.ts`
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /path/to/worktree add skills/calendar-register/handler.ts skills/calendar-register/skill.json tests/unit/skills/calendar-register.test.ts
+git -C /path/to/worktree commit -m "fix: require explicit contact_id in calendar-register
+
+The handler previously defaulted to ctx.caller?.contactId when contact_id
+was omitted, which caused Curia's own calendar to be registered under the
+CEO's contact during a CEO conversation. Now requires the coordinator to
+always specify which contact owns the calendar."
+```
+
+---
+
+### Task 2: Add Calendar Disambiguation to Coordinator System Prompt
+
+**Files:**
+- Modify: `agents/coordinator.yaml:277` (insert after Inbox Disambiguation section)
+
+- [ ] **Step 1: Add the Calendar Disambiguation section**
+
+In `agents/coordinator.yaml`, insert the following block after line 276 (the last line of the "Inbox Disambiguation" section, ending with `Curia has no access to it — decline or ask the CEO to clarify`), and before line 278 (`## Observation Mode — Monitored Inboxes`):
+
+```yaml
+
+  ## Calendar Disambiguation
+  When the CEO references calendars, resolve as follows:
+
+  - **"my calendar"** (the CEO speaking to you directly) → the CEO's own calendar
+  - **"your calendar"** (the CEO speaking to you directly) → Curia's own calendar
+  - **Default for scheduling on behalf of the CEO** → always use the CEO's
+    calendar unless the CEO explicitly says to use Curia's
+
+  When calendar-list-calendars returns an unregistered calendar, do NOT silently
+  register it as part of another task. Instead, flag it to the CEO: "I see a
+  calendar I don't recognize yet — [name]. Who does this belong to?" Then
+  register it with the correct contact based on their answer.
+
+```
+
+- [ ] **Step 2: Verify the YAML is valid**
+
+Run: `node -e "const fs = require('fs'); const yaml = require('js-yaml'); yaml.load(fs.readFileSync('/path/to/worktree/agents/coordinator.yaml', 'utf8')); console.log('YAML valid')"`
+
+If `js-yaml` isn't available, use: `npx js-yaml /path/to/worktree/agents/coordinator.yaml > /dev/null`
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add agents/coordinator.yaml
+git -C /path/to/worktree commit -m "fix: add Calendar Disambiguation to coordinator prompt
+
+Parallel to the existing Inbox Disambiguation section. Clarifies that
+scheduling on behalf of the CEO defaults to the CEO's calendar, and that
+unregistered calendars should be flagged to the CEO rather than silently
+registered."
+```
+
+---
+
+### Task 3: Add Calendar Exception to "Account Identity for Tool Calls"
+
+**Files:**
+- Modify: `agents/coordinator.yaml:321` (insert after the email exception block)
+
+- [ ] **Step 1: Add the calendar exception**
+
+In `agents/coordinator.yaml`, find the end of the email exception block (line 321, ending with `it applies only to third-party tools where you're picking an acting identity.`). Insert the following immediately after:
+
+```yaml
+
+  **Exception — calendar skills:** When creating, updating, or deleting events
+  on behalf of the CEO, use the CEO's calendar. Only use Curia's own calendar
+  for events that are genuinely Curia's (e.g., internal reminders, blocked time
+  for Curia's own tasks). When unsure which calendar to use, look up the CEO's
+  contact first and use their registered calendar.
+```
+
+Note: line numbers may have shifted after Task 2's insertion. Find the anchor text `it applies only to third-party tools where you're picking` and insert after the line that ends that paragraph.
+
+- [ ] **Step 2: Verify the YAML is valid**
+
+Run the same YAML validation as Task 2 Step 2.
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add agents/coordinator.yaml
+git -C /path/to/worktree commit -m "fix: add calendar exception to Account Identity for Tool Calls
+
+Calendar writes on behalf of the CEO should target the CEO's calendar,
+not Curia's. This mirrors the existing email exception."
+```
+
+---
+
+### Task 4: Update Smoke Test
+
+**Files:**
+- Modify: `tests/smoke/cases/calendar-create-event.yaml`
+
+- [ ] **Step 1: Add CEO-calendar expected behavior and failure mode**
+
+In `tests/smoke/cases/calendar-create-event.yaml`, add the following entry to `expected_behaviors` (after the last existing entry):
+
+```yaml
+  - id: use-ceo-calendar
+    description: Creates the event on the CEO's calendar, not on Curia's own calendar
+    weight: critical
+```
+
+Add the following entry to `failure_modes` (after the last existing entry):
+
+```yaml
+  - Creates the event on Curia's own calendar instead of the CEO's
+```
+
+- [ ] **Step 2: Verify the YAML is valid**
+
+Run: `npx js-yaml /path/to/worktree/tests/smoke/cases/calendar-create-event.yaml > /dev/null`
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add tests/smoke/cases/calendar-create-event.yaml
+git -C /path/to/worktree commit -m "fix: add CEO-calendar expectation to calendar-create-event smoke test
+
+Ensures the agent uses the CEO's calendar when scheduling on their behalf,
+catching regressions like the trail-walk incident."
+```
+
+---
+
+### Task 5: Production Data Fix
+
+This task is executed manually against the production database, **not** in the worktree. The implementer should draft the SQL and present it for review before execution.
+
+**Files:**
+- None (manual SQL against prod)
+
+- [ ] **Step 1: Look up Curia's agent contact ID**
+
+SSH into prod and query:
+
+```bash
+ssh -i ~/.ssh/ceo_office_vps -p 2222 -o IdentitiesOnly=yes ceo@204.168.176.150 \
+  "docker exec curia-postgres-1 psql -U curia -d curia -c \
+  \"SELECT contact_id, display_name, role FROM contacts WHERE display_name ILIKE '%curia%' OR role = 'agent' ORDER BY created_at ASC;\""
+```
+
+If that doesn't find it, check the config or the `agent_contact_id` injection in the codebase. The goal is to find the contact ID that represents Curia itself (not the CEO's contact `6b9c41c5-fadb-4110-a8e6-025b1a2c091e`).
+
+- [ ] **Step 2: Verify current state**
+
+```sql
+SELECT nylas_calendar_id, contact_id, label, is_primary
+  FROM contact_calendars
+ WHERE nylas_calendar_id = 'nathancuria1@gmail.com';
+```
+
+Expected: `contact_id` = `6b9c41c5-fadb-4110-a8e6-025b1a2c091e` (the CEO's — this is the bug).
+
+- [ ] **Step 3: Draft and present the UPDATE statement**
+
+```sql
+UPDATE contact_calendars
+   SET contact_id = '<curia_agent_contact_id_from_step_1>',
+       updated_at = now()
+ WHERE nylas_calendar_id = 'nathancuria1@gmail.com';
+```
+
+**Do not execute this without presenting it to the user for review first.**
+
+- [ ] **Step 4: Execute the fix after user approval**
+
+Run the UPDATE. Then verify:
+
+```sql
+SELECT nylas_calendar_id, contact_id, label, is_primary
+  FROM contact_calendars;
+```
+
+Expected: `nathancuria1@gmail.com` now has Curia's contact ID. `joseph@josephfung.ca` still has the CEO's contact ID (`6b9c41c5`).
+
+- [ ] **Step 5: Verify via the skill**
+
+Trigger a `calendar-list-calendars` call (e.g., ask Curia "what calendars do you see?" via the web UI) and confirm:
+- `nathancuria1@gmail.com` shows `contactName` as Curia (not Joseph Fung)
+- `joseph@josephfung.ca` still shows `contactName` as Joseph Fung
+
+---
+
+### Task 6: CHANGELOG and Version Bump
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json` (version bump)
+
+- [ ] **Step 1: Add changelog entries**
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Fixed
+- **Calendar ownership** — `calendar-register` no longer defaults `contact_id` to the caller; it is now required, preventing silent mis-assignment of calendar ownership
+- **Calendar disambiguation** — coordinator prompt now includes calendar disambiguation rules (parallel to inbox disambiguation) and a calendar exception in the Account Identity section, ensuring events are created on the CEO's calendar by default
+- **Calendar smoke test** — added CEO-calendar expectation to `calendar-create-event` smoke test
+```
+
+- [ ] **Step 2: Bump version (patch)**
+
+This is a bug fix. Bump the patch version in `package.json`. Check the current version first and increment the patch number.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add CHANGELOG.md package.json
+git -C /path/to/worktree commit -m "chore: changelog and version bump for calendar ownership fix"
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/calendar-register/handler.ts
+++ b/skills/calendar-register/handler.ts
@@ -39,11 +39,11 @@ export class CalendarRegisterHandler implements SkillHandler {
     // contact_id is required — the coordinator must explicitly specify which
     // contact owns this calendar. This prevents silent mis-assignment when the
     // caller (e.g. the CEO) is not the calendar's actual owner.
-    if (!contact_id || typeof contact_id !== 'string') {
+    if (!contact_id || typeof contact_id !== 'string' || contact_id.trim() === '') {
       return { success: false, error: 'Missing required input: contact_id — specify which contact owns this calendar.' };
     }
 
-    const resolvedContactId = contact_id;
+    const resolvedContactId = contact_id.trim();
 
     ctx.log.info(
       { nylasCalendarId: nylas_calendar_id, contactId: resolvedContactId, label, isPrimary: is_primary ?? false },

--- a/skills/calendar-register/handler.ts
+++ b/skills/calendar-register/handler.ts
@@ -7,8 +7,9 @@
 //   2. The CEO confirms which contact owns it (usually themselves)
 //   3. This skill persists that mapping so calendar-list-events can auto-resolve it
 //
-// contact_id defaults to the caller's own contact when omitted — the common case
-// when the CEO is claiming ownership of their own calendar.
+// contact_id is required — the coordinator must always specify which contact
+// owns the calendar. This prevents silent mis-assignment (see incident
+// kg-web-a7717246-1d7a-411c-9129-b6feb54bfc22).
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 
@@ -35,21 +36,14 @@ export class CalendarRegisterHandler implements SkillHandler {
       return { success: false, error: 'label must be 200 characters or fewer' };
     }
 
-    // Default to the caller's contact when contact_id is not provided.
-    // This is the most common case: the CEO saying "that calendar is mine."
-    const resolvedContactId: string | null =
-      typeof contact_id === 'string' ? contact_id : (ctx.caller?.contactId ?? null);
-
-    // Warn when neither contact_id nor caller context is present — the calendar
-    // will be registered as org-wide (null contact). This is valid for shared
-    // calendars (holidays, rooms) but is probably a routing bug if it happens
-    // during a CEO conversation.
-    if (resolvedContactId === null && typeof contact_id !== 'string') {
-      ctx.log.warn(
-        { nylasCalendarId: nylas_calendar_id },
-        'calendar-register: no contact_id and no caller — registering as org-wide (no contact association)',
-      );
+    // contact_id is required — the coordinator must explicitly specify which
+    // contact owns this calendar. This prevents silent mis-assignment when the
+    // caller (e.g. the CEO) is not the calendar's actual owner.
+    if (!contact_id || typeof contact_id !== 'string') {
+      return { success: false, error: 'Missing required input: contact_id — specify which contact owns this calendar.' };
     }
+
+    const resolvedContactId = contact_id;
 
     ctx.log.info(
       { nylasCalendarId: nylas_calendar_id, contactId: resolvedContactId, label, isPrimary: is_primary ?? false },

--- a/skills/calendar-register/skill.json
+++ b/skills/calendar-register/skill.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar-register",
-  "description": "Register a Nylas calendar in the contact registry, linking it to a contact. Use this after calendar-list-calendars identifies an unregistered calendar and the CEO confirms which contact it belongs to. Defaults contact_id to the caller's own contact when omitted — the common case when the CEO is claiming their own calendar.",
+  "description": "Register a Nylas calendar in the contact registry, linking it to a contact. Use this after calendar-list-calendars identifies an unregistered calendar and the CEO confirms which contact it belongs to. Always requires an explicit contact_id — ask the CEO who owns the calendar if unsure.",
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "low",
@@ -8,7 +8,7 @@
   "inputs": {
     "nylas_calendar_id": "string",
     "label": "string",
-    "contact_id": "string?",
+    "contact_id": "string (required — which contact owns this calendar)",
     "is_primary": "boolean?"
   },
   "outputs": {

--- a/skills/calendar-register/skill.json
+++ b/skills/calendar-register/skill.json
@@ -3,18 +3,18 @@
   "description": "Register a Nylas calendar in the contact registry, linking it to a contact. Use this after calendar-list-calendars identifies an unregistered calendar and the CEO confirms which contact it belongs to. Always requires an explicit contact_id — ask the CEO who owns the calendar if unsure.",
   "version": "1.0.0",
   "sensitivity": "normal",
-  "action_risk": "low",
+  "action_risk": "high",
   "infrastructure": true,
   "inputs": {
     "nylas_calendar_id": "string",
     "label": "string",
-    "contact_id": "string (required — which contact owns this calendar)",
+    "contact_id": "string",
     "is_primary": "boolean?"
   },
   "outputs": {
     "calendar_id": "string",
     "nylas_calendar_id": "string",
-    "contact_id": "string | null",
+    "contact_id": "string",
     "label": "string",
     "is_primary": "boolean"
   },

--- a/tests/smoke/cases/calendar-create-event.yaml
+++ b/tests/smoke/cases/calendar-create-event.yaml
@@ -24,9 +24,13 @@ expected_behaviors:
   - id: confirm-specifics
     description: Confirms back the specifics of what will be created before or after acting
     weight: important
+  - id: use-ceo-calendar
+    description: Creates the event on the CEO's calendar, not on Curia's own calendar
+    weight: critical
 
 failure_modes:
   - Drops one or more details (wrong date, missing timezone, forgets duration)
   - Ignores the Zoom link instruction
   - Creates the event without confirming details with the user
   - Treats this as informational rather than an actionable request
+  - Creates the event on Curia's own calendar instead of the CEO's

--- a/tests/unit/skills/calendar-register.test.ts
+++ b/tests/unit/skills/calendar-register.test.ts
@@ -106,6 +106,22 @@ describe('CalendarRegisterHandler', () => {
     expect(contactService.linkCalendar).not.toHaveBeenCalled();
   });
 
+  it('returns failure when contact_id is whitespace-only', async () => {
+    const contactService = { linkCalendar: vi.fn() };
+    const result = await handler.execute(
+      makeCtx(
+        { nylas_calendar_id: 'cal-1', label: 'Personal', contact_id: '   ' },
+        { contactService: contactService as never },
+      ),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('contact_id');
+    }
+    expect(contactService.linkCalendar).not.toHaveBeenCalled();
+  });
+
   it('returns failure when contact_id is missing even without caller context', async () => {
     const contactService = { linkCalendar: vi.fn() };
     const result = await handler.execute(

--- a/tests/unit/skills/calendar-register.test.ts
+++ b/tests/unit/skills/calendar-register.test.ts
@@ -86,20 +86,8 @@ describe('CalendarRegisterHandler', () => {
     );
   });
 
-  it('defaults contact_id to the caller when not provided', async () => {
-    const linkedCalendar = {
-      id: 'link-uuid',
-      nylasCalendarId: 'cal-1',
-      contactId: 'caller-contact',
-      label: 'Personal',
-      isPrimary: true,
-      readOnly: false,
-      timezone: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-    const contactService = { linkCalendar: vi.fn().mockResolvedValue(linkedCalendar) };
-
+  it('returns failure when contact_id is missing', async () => {
+    const contactService = { linkCalendar: vi.fn() };
     const result = await handler.execute(
       makeCtx(
         { nylas_calendar_id: 'cal-1', label: 'Personal', is_primary: true },
@@ -110,26 +98,16 @@ describe('CalendarRegisterHandler', () => {
       ),
     );
 
-    expect(result.success).toBe(true);
-    expect(contactService.linkCalendar).toHaveBeenCalledWith(
-      expect.objectContaining({ contactId: 'caller-contact', isPrimary: true }),
-    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('contact_id');
+    }
+    // Crucially: linkCalendar should NOT have been called
+    expect(contactService.linkCalendar).not.toHaveBeenCalled();
   });
 
-  it('uses null contact_id when no contact_id and no caller', async () => {
-    const linkedCalendar = {
-      id: 'link-uuid',
-      nylasCalendarId: 'cal-holidays',
-      contactId: null,
-      label: 'Holidays',
-      isPrimary: false,
-      readOnly: true,
-      timezone: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-    const contactService = { linkCalendar: vi.fn().mockResolvedValue(linkedCalendar) };
-
+  it('returns failure when contact_id is missing even without caller context', async () => {
+    const contactService = { linkCalendar: vi.fn() };
     const result = await handler.execute(
       makeCtx(
         { nylas_calendar_id: 'cal-holidays', label: 'Holidays' },
@@ -137,10 +115,11 @@ describe('CalendarRegisterHandler', () => {
       ),
     );
 
-    expect(result.success).toBe(true);
-    expect(contactService.linkCalendar).toHaveBeenCalledWith(
-      expect.objectContaining({ contactId: null }),
-    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('contact_id');
+    }
+    expect(contactService.linkCalendar).not.toHaveBeenCalled();
   });
 
   it('returns failure when label exceeds 200 characters', async () => {
@@ -167,7 +146,7 @@ describe('CalendarRegisterHandler', () => {
 
     const result = await handler.execute(
       makeCtx(
-        { nylas_calendar_id: 'cal-1', label: 'Work' },
+        { nylas_calendar_id: 'cal-1', label: 'Work', contact_id: 'contact-abc' },
         { contactService: contactService as never },
       ),
     );
@@ -208,7 +187,7 @@ describe('CalendarRegisterHandler', () => {
 
     const result = await handler.execute(
       makeCtx(
-        { nylas_calendar_id: 'cal-1', label: 'Work' },
+        { nylas_calendar_id: 'cal-1', label: 'Work', contact_id: 'contact-abc' },
         { contactService: contactService as never },
       ),
     );


### PR DESCRIPTION
## Summary

- **`calendar-register` handler** — `contact_id` is now required; the previous default to `ctx.caller?.contactId` caused Curia's own calendar to be registered under the CEO's contact (incident `kg-web-a7717246-1d7a-411c-9129-b6feb54bfc22`)
- **`calendar-register` skill manifest** — `action_risk` raised from `low` to `high` (calendar ownership write per CLAUDE.md taxonomy); output schema corrected from `string | null` to `string`
- **Coordinator prompt** — added Calendar Disambiguation section (parallel to Inbox Disambiguation) and a calendar exception to the Account Identity for Tool Calls rule
- **Smoke test** — added `use-ceo-calendar: critical` expected behavior and failure mode to `calendar-create-event.yaml`
- **Prod data fix** — `nathancuria1@gmail.com` re-registered under Curia's contact (`53a382c0`) instead of the CEO's (`6b9c41c5`); applied directly to prod

## Test plan

- [ ] All unit tests pass (`calendar-register.test.ts` — 11 tests)
- [ ] YAML files valid (coordinator.yaml, smoke test)
- [ ] Manual: ask Curia to schedule an event via web UI; confirm it lands on `joseph@josephfung.ca`, not `nathancuria1@gmail.com`
- [ ] Manual: ask Curia to register a calendar without specifying a contact; confirm it asks who owns it