### PR TITLE
fix: held-messages-process handles pre-linked identity idempotently (v0.19.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`held-messages-process` idempotent identity link** — when `contact-merge` links a sender's channel identity before `held-messages-process` runs (e.g. the CEO merges contacts mid-conversation), the skill now treats the duplicate-key error as a no-op if the identity already belongs to the target contact, and proceeds to `markProcessed`. Previously both calls failed with a unique constraint violation, leaving the held message in `pending` status indefinitely and triggering a false "Held Messages Pending Your Review" alert from the scheduled scanner.
+
 ### Changed
 
 - **Prompt caching** — `AnthropicProvider` now passes the system prompt as a cached `TextBlockParam` and marks the last tool definition with `cache_control: ephemeral`, reducing effective input token cost by 60-80% for repeat calls within the 5-minute TTL (issue #320).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/held-messages-process/handler.ts
+++ b/skills/held-messages-process/handler.ts
@@ -93,9 +93,9 @@ export class HeldMessagesProcessHandler implements SkillHandler {
             source: 'ceo_stated',
           });
         } catch (linkErr) {
-          const isDuplicate =
-            linkErr instanceof Error &&
-            linkErr.message.includes('duplicate key value violates unique constraint');
+          // Check by PG error code (23505) — both the Postgres and in-memory backends
+          // emit this code on unique constraint violations, so it's reliable across envs.
+          const isDuplicate = (linkErr as { code?: string }).code === '23505';
           if (!isDuplicate) throw linkErr;
 
           // Identity already exists — check who owns it.
@@ -103,7 +103,18 @@ export class HeldMessagesProcessHandler implements SkillHandler {
             heldMsg.channel,
             heldMsg.senderId,
           );
-          if (!resolved || resolved.contactId !== contactId) {
+          if (!resolved) {
+            // Unique constraint fired but lookup found nothing — data integrity anomaly.
+            ctx.log.error(
+              { contactId, channel: heldMsg.channel, senderId: heldMsg.senderId },
+              'Duplicate-key on linkIdentity but resolveByChannelIdentity returned null — possible orphaned identity',
+            );
+            return {
+              success: false,
+              error: `Internal error: ${heldMsg.senderId} caused a duplicate-key error but no owning contact was found.`,
+            };
+          }
+          if (resolved.contactId !== contactId) {
             // Belongs to a different contact — this is a real conflict.
             return {
               success: false,
@@ -163,6 +174,7 @@ export class HeldMessagesProcessHandler implements SkillHandler {
       );
       return { success: true, data: { result: 'identified_and_replayed', contact_id: contactId } };
     } catch (err) {
+      ctx.log.error({ err, heldMessageId: held_message_id, action }, 'held-messages-process: unexpected error');
       const message = err instanceof Error ? err.message : String(err);
       return { success: false, error: `Failed to process held message: ${message}` };
     }

--- a/skills/held-messages-process/handler.ts
+++ b/skills/held-messages-process/handler.ts
@@ -80,14 +80,44 @@ export class HeldMessagesProcessHandler implements SkillHandler {
       let contactId: string;
 
       if (existing_contact_id) {
-        // Link to existing contact
+        // Link the sender's channel identity to the specified existing contact.
+        // If the identity is already linked (e.g. contact-merge ran before us), treat
+        // it as a no-op when it's linked to the right contact — otherwise surface the
+        // conflict so the caller can resolve it with contact-merge first.
         contactId = existing_contact_id;
-        await ctx.contactService.linkIdentity({
-          contactId,
-          channel: heldMsg.channel,
-          channelIdentifier: heldMsg.senderId,
-          source: 'ceo_stated',
-        });
+        try {
+          await ctx.contactService.linkIdentity({
+            contactId,
+            channel: heldMsg.channel,
+            channelIdentifier: heldMsg.senderId,
+            source: 'ceo_stated',
+          });
+        } catch (linkErr) {
+          const isDuplicate =
+            linkErr instanceof Error &&
+            linkErr.message.includes('duplicate key value violates unique constraint');
+          if (!isDuplicate) throw linkErr;
+
+          // Identity already exists — check who owns it.
+          const resolved = await ctx.contactService.resolveByChannelIdentity(
+            heldMsg.channel,
+            heldMsg.senderId,
+          );
+          if (!resolved || resolved.contactId !== contactId) {
+            // Belongs to a different contact — this is a real conflict.
+            return {
+              success: false,
+              error:
+                `Cannot link ${heldMsg.senderId} to contact ${contactId} — that identity is already linked to a different contact. Use contact-merge first.`,
+            };
+          }
+          // Already linked to the correct contact (e.g. from contact-merge).
+          // Nothing to do — fall through to markProcessed.
+          ctx.log.info(
+            { contactId, channel: heldMsg.channel, senderId: heldMsg.senderId },
+            'Channel identity already linked to target contact — skipping linkIdentity',
+          );
+        }
       } else {
         // Create new confirmed contact
         if (!contact_name || typeof contact_name !== 'string') {

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -1271,7 +1271,12 @@ class InMemoryContactBackend implements ContactServiceBackend {
     // that Postgres would reject via its unique index.
     for (const existing of this.identities.values()) {
       if (existing.channel === identity.channel && existing.channelIdentifier === identity.channelIdentifier) {
-        throw new Error(`Channel identity already exists: ${identity.channel}:${identity.channelIdentifier}`);
+        // Throw with the same shape as Postgres unique-violation errors (code 23505)
+        // so callers can detect duplicates uniformly across backends.
+        throw Object.assign(
+          new Error(`duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"`),
+          { code: '23505', constraint: 'contact_channel_identities_channel_channel_identifier_key' },
+        );
       }
     }
     this.identities.set(identity.id, identity);

--- a/tests/unit/skills/held-messages-process.test.ts
+++ b/tests/unit/skills/held-messages-process.test.ts
@@ -1,0 +1,207 @@
+// Tests for the held-messages-process skill handler.
+//
+// Focuses on the "identify" action and the idempotent linkIdentity path —
+// specifically the case where contact-merge has already linked the sender's
+// channel identity before held-messages-process runs.
+
+import { describe, it, expect, vi } from 'vitest';
+import { HeldMessagesProcessHandler } from '../../../skills/held-messages-process/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import type { HeldMessage } from '../../../src/contacts/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+const HELD_MSG_ID = '30b0b0be-3825-4039-9698-05b1893abd1c';
+const CONTACT_ID  = '38268ca5-ed50-4a59-a0e4-d7dba13e0eac';
+const OTHER_CONTACT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+const pendingMsg: HeldMessage = {
+  id: HELD_MSG_ID,
+  channel: 'email',
+  senderId: 'donna@example.com',
+  conversationId: 'email:abc123',
+  content: 'Hi!',
+  subject: 'Hello',
+  metadata: {},
+  status: 'pending',
+  resolvedContactId: null,
+  createdAt: new Date('2026-04-13T14:00:00Z'),
+  processedAt: null,
+};
+
+function makeBus() {
+  return { publish: vi.fn().mockResolvedValue(undefined) };
+}
+
+function makeCtx(
+  input: Record<string, unknown>,
+  overrides?: Partial<SkillContext>,
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    ...overrides,
+  };
+}
+
+describe('HeldMessagesProcessHandler — identify action', () => {
+  const handler = new HeldMessagesProcessHandler();
+
+  it('returns failure when required services are missing', async () => {
+    const result = await handler.execute(makeCtx({
+      held_message_id: HELD_MSG_ID,
+      action: 'identify',
+      existing_contact_id: CONTACT_ID,
+    }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Required services');
+  });
+
+  it('returns failure when action is invalid', async () => {
+    const result = await handler.execute(makeCtx({
+      held_message_id: HELD_MSG_ID,
+      action: 'explode',
+    }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Invalid action');
+  });
+
+  it('successfully identifies and replays when linkIdentity succeeds', async () => {
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      markProcessed: vi.fn().mockResolvedValue(true),
+    };
+    const contactService = {
+      linkIdentity: vi.fn().mockResolvedValue({ id: 'identity-1' }),
+      resolveByChannelIdentity: vi.fn(),
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'identify', existing_contact_id: CONTACT_ID },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    expect(result.success).toBe(true);
+    expect(contactService.linkIdentity).toHaveBeenCalledWith(expect.objectContaining({
+      contactId: CONTACT_ID,
+      channel: 'email',
+      channelIdentifier: 'donna@example.com',
+    }));
+    expect(bus.publish).toHaveBeenCalledOnce();
+    expect(heldMessages.markProcessed).toHaveBeenCalledWith(HELD_MSG_ID, CONTACT_ID);
+    if (result.success) expect(result.data).toMatchObject({ result: 'identified_and_replayed' });
+  });
+
+  it('treats duplicate-key error as no-op when identity already belongs to the target contact', async () => {
+    // This is the scenario that caused the prod bug: contact-merge linked
+    // donna@example.com to CONTACT_ID before held-messages-process ran.
+    // linkIdentity throws the unique constraint violation, but the identity
+    // is already on the correct contact — so we should still markProcessed.
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      markProcessed: vi.fn().mockResolvedValue(true),
+    };
+    const contactService = {
+      linkIdentity: vi.fn().mockRejectedValue(
+        new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
+      ),
+      resolveByChannelIdentity: vi.fn().mockResolvedValue({
+        contactId: CONTACT_ID,
+        displayName: 'Donna',
+        role: null,
+        status: 'confirmed',
+        trustLevel: null,
+      }),
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'identify', existing_contact_id: CONTACT_ID },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    expect(result.success).toBe(true);
+    expect(contactService.resolveByChannelIdentity).toHaveBeenCalledWith('email', 'donna@example.com');
+    expect(bus.publish).toHaveBeenCalledOnce();
+    expect(heldMessages.markProcessed).toHaveBeenCalledWith(HELD_MSG_ID, CONTACT_ID);
+    if (result.success) expect(result.data).toMatchObject({ result: 'identified_and_replayed' });
+  });
+
+  it('returns failure when identity belongs to a different contact (real conflict)', async () => {
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      markProcessed: vi.fn(),
+    };
+    const contactService = {
+      linkIdentity: vi.fn().mockRejectedValue(
+        new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
+      ),
+      resolveByChannelIdentity: vi.fn().mockResolvedValue({
+        contactId: OTHER_CONTACT_ID,  // owned by a different contact
+        displayName: 'Someone Else',
+        role: null,
+        status: 'confirmed',
+        trustLevel: null,
+      }),
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'identify', existing_contact_id: CONTACT_ID },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('already linked to a different contact');
+    expect(bus.publish).not.toHaveBeenCalled();
+    expect(heldMessages.markProcessed).not.toHaveBeenCalled();
+  });
+
+  it('re-throws non-duplicate errors from linkIdentity', async () => {
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      markProcessed: vi.fn(),
+    };
+    const contactService = {
+      linkIdentity: vi.fn().mockRejectedValue(new Error('connection timeout')),
+      resolveByChannelIdentity: vi.fn(),
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'identify', existing_contact_id: CONTACT_ID },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    // Non-duplicate errors fall through to the outer catch and return a failure message
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('connection timeout');
+    expect(contactService.resolveByChannelIdentity).not.toHaveBeenCalled();
+    expect(heldMessages.markProcessed).not.toHaveBeenCalled();
+  });
+});
+
+describe('HeldMessagesProcessHandler — dismiss action', () => {
+  const handler = new HeldMessagesProcessHandler();
+
+  it('discards the held message', async () => {
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      discard: vi.fn().mockResolvedValue(true),
+    };
+    const contactService = { linkIdentity: vi.fn() };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'dismiss' },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    expect(result.success).toBe(true);
+    expect(heldMessages.discard).toHaveBeenCalledWith(HELD_MSG_ID);
+    if (result.success) expect(result.data).toMatchObject({ result: 'dismissed' });
+  });
+});

--- a/tests/unit/skills/held-messages-process.test.ts
+++ b/tests/unit/skills/held-messages-process.test.ts
@@ -106,7 +106,10 @@ describe('HeldMessagesProcessHandler — identify action', () => {
     };
     const contactService = {
       linkIdentity: vi.fn().mockRejectedValue(
-        new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
+          { code: '23505' },
+        ),
       ),
       resolveByChannelIdentity: vi.fn().mockResolvedValue({
         contactId: CONTACT_ID,
@@ -137,7 +140,10 @@ describe('HeldMessagesProcessHandler — identify action', () => {
     };
     const contactService = {
       linkIdentity: vi.fn().mockRejectedValue(
-        new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
+          { code: '23505' },
+        ),
       ),
       resolveByChannelIdentity: vi.fn().mockResolvedValue({
         contactId: OTHER_CONTACT_ID,  // owned by a different contact
@@ -156,6 +162,33 @@ describe('HeldMessagesProcessHandler — identify action', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain('already linked to a different contact');
+    expect(bus.publish).not.toHaveBeenCalled();
+    expect(heldMessages.markProcessed).not.toHaveBeenCalled();
+  });
+
+  it('returns data-integrity error when resolveByChannelIdentity returns null after duplicate', async () => {
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      markProcessed: vi.fn(),
+    };
+    const contactService = {
+      linkIdentity: vi.fn().mockRejectedValue(
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
+          { code: '23505' },
+        ),
+      ),
+      resolveByChannelIdentity: vi.fn().mockResolvedValue(null),  // orphaned identity
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'identify', existing_contact_id: CONTACT_ID },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Internal error');
     expect(bus.publish).not.toHaveBeenCalled();
     expect(heldMessages.markProcessed).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Root cause

Investigated from prod conversation `kg-web-a7717246-1d7a-411c-9129-b6feb54bfc22`.

When the CEO merges contacts mid-conversation, `contact-merge` links the sender's channel identity to the merged contact. If `held-messages-process` then runs with `action: identify` + `existing_contact_id`, its `linkIdentity` call hits the unique constraint on `contact_channel_identities(channel, channel_identifier)` and throws. The outer `catch` returned `{ success: false }` on both attempts, so `markProcessed` was never reached. The held message stayed `pending` indefinitely, and the 20-minute scheduled scanner later found it and sent a false "Held Messages Pending Your Review" alert to the CEO.

## Fix

### `skills/held-messages-process/handler.ts`

Wrap `linkIdentity` in a try/catch for the `identify` + `existing_contact_id` path:
- If `code === '23505'` (unique violation): call `resolveByChannelIdentity` to check ownership
  - Identity belongs to the target contact → no-op, fall through to `markProcessed`
  - Identity belongs to a different contact → surface a clear conflict error
  - Identity missing (data integrity anomaly) → log error and return a distinct message
- Any other error → re-throw to outer catch
- Add `ctx.log.error` to the outer catch so unexpected failures appear in structured logs

### `src/contacts/contact-service.ts`

The in-memory `createIdentity` now throws with `code: '23505'` to match Postgres error shape, ensuring duplicate detection is consistent across both backends.

## Tests

New `tests/unit/skills/held-messages-process.test.ts` (8 tests):
- Happy path (linkIdentity succeeds)
- Idempotent no-op (duplicate, right contact) — the prod bug scenario
- Real conflict (duplicate, wrong contact)
- Data integrity anomaly (duplicate, null resolve result)
- Non-duplicate error re-throw
- Input validation and missing-services guards
- Dismiss action

## Prod remediation

The dangling held_message `30b0b0be-3825-4039-9698-05b1893abd1c` (Donna's trail walk email) was manually resolved in production with `status: processed`, `resolved_contact_id: 38268ca5`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue in held message processing occurring during concurrent contact merge operations that previously triggered false pending-review alerts. Duplicate identity scenarios are now handled gracefully when the identity is already associated with the target contact, allowing messages to be marked as processed successfully.

* **Release**
  * Version bumped to 0.19.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->