### PR TITLE
feat: add contact-rename skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **`contact-rename` skill** — new skill that updates a contact's display name via `ContactService.updateDisplayName()`. Closes the gap where Curia could create contacts and set their role but had no tool to correct or expand a display name (e.g. from "Jodi" to "Jodi Arnott").
 - **LEAVE FOR CEO triage classification** — the observation-mode preamble now defines a fifth category for personal, sensitive, or judgment-dependent email where the CEO will read and handle it themselves. No archive, no draft, no notification. The "when in doubt" default has shifted from URGENT to LEAVE FOR CEO to stop over-notifying. Mirrored in `agents/coordinator.yaml`.
 - **CEO inbox read skills** (`email-list`, `email-get`, `email-draft-save`): account-aware email skills that route through `OutboundGateway`'s named-client map. `email-list` lists messages with folder/sender/search filters; `email-get` fetches the full body of a single message; `email-draft-save` saves a draft (with blocked-contact check) for CEO review. `ListMessagesOptions` extended with `folders`, `from`, `subject`, `searchQueryNative` filters. Coordinator pinned and prompted on all three skills. Closes CEO inbox Tasks 7–9.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/contact-rename/handler.test.ts
+++ b/skills/contact-rename/handler.test.ts
@@ -52,6 +52,19 @@ describe('ContactRenameHandler', () => {
     expect((result as { success: false; error: string }).error).toMatch(/UUID/);
   });
 
+  it('returns error when display_name is whitespace-only', async () => {
+    const handler = new ContactRenameHandler();
+    const ctx = makeCtx({
+      input: { contact_id: '00000000-0000-0000-0000-000000000001', display_name: '   ' },
+      contactService,
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/blank/);
+  });
+
   it('returns error when display_name exceeds 200 characters', async () => {
     const handler = new ContactRenameHandler();
     const ctx = makeCtx({

--- a/skills/contact-rename/handler.test.ts
+++ b/skills/contact-rename/handler.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import pino from 'pino';
+import { ContactRenameHandler } from './handler.js';
+import { ContactService } from '../../src/contacts/contact-service.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+const silentLog = pino({ level: 'silent' });
+
+function makeCtx(overrides: Partial<SkillContext> = {}): SkillContext {
+  return {
+    input: {},
+    secret: () => 'unused',
+    log: silentLog,
+    ...overrides,
+  } as unknown as SkillContext;
+}
+
+describe('ContactRenameHandler', () => {
+  let contactService: ContactService;
+
+  beforeEach(async () => {
+    contactService = ContactService.createInMemory();
+  });
+
+  it('returns error when contact_id is missing', async () => {
+    const handler = new ContactRenameHandler();
+    const ctx = makeCtx({ input: { display_name: 'Jodi Arnott' }, contactService });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/contact_id/);
+  });
+
+  it('returns error when display_name is missing', async () => {
+    const handler = new ContactRenameHandler();
+    const ctx = makeCtx({ input: { contact_id: '00000000-0000-0000-0000-000000000001' }, contactService });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/display_name/);
+  });
+
+  it('returns error when contact_id is not a UUID', async () => {
+    const handler = new ContactRenameHandler();
+    const ctx = makeCtx({ input: { contact_id: 'not-a-uuid', display_name: 'Jodi Arnott' }, contactService });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/UUID/);
+  });
+
+  it('returns error when display_name exceeds 200 characters', async () => {
+    const handler = new ContactRenameHandler();
+    const ctx = makeCtx({
+      input: { contact_id: '00000000-0000-0000-0000-000000000001', display_name: 'a'.repeat(201) },
+      contactService,
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/200 characters/);
+  });
+
+  it('returns error when contactService is not injected', async () => {
+    const handler = new ContactRenameHandler();
+    const ctx = makeCtx({
+      input: { contact_id: '00000000-0000-0000-0000-000000000001', display_name: 'Jodi Arnott' },
+      contactService: undefined,
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/contactService/);
+  });
+
+  it('returns error for unknown contact ID', async () => {
+    const handler = new ContactRenameHandler();
+    const ctx = makeCtx({
+      input: { contact_id: '00000000-0000-0000-0000-000000000099', display_name: 'Jodi Arnott' },
+      contactService,
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/No contact exists/);
+  });
+
+  it('renames a contact successfully', async () => {
+    // Create a contact with just a first name (as Curia does when first creating from context)
+    const contact = await contactService.createContact({
+      displayName: 'Jodi',
+      source: 'ceo_stated',
+    });
+
+    const handler = new ContactRenameHandler();
+    const ctx = makeCtx({
+      input: { contact_id: contact.id, display_name: 'Jodi Arnott' },
+      contactService,
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { contact_id: string; display_name: string; role: string | null } }).data;
+    expect(data.contact_id).toBe(contact.id);
+    expect(data.display_name).toBe('Jodi Arnott');
+    expect(data.role).toBeNull();
+  });
+
+  it('preserves role when renaming', async () => {
+    const contact = await contactService.createContact({
+      displayName: 'Thusenth',
+      role: 'Co-Founder & CEO at Sociavore',
+      source: 'ceo_stated',
+    });
+
+    const handler = new ContactRenameHandler();
+    const ctx = makeCtx({
+      input: { contact_id: contact.id, display_name: 'Thusenth Dhavaloganathan' },
+      contactService,
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { contact_id: string; display_name: string; role: string | null } }).data;
+    expect(data.display_name).toBe('Thusenth Dhavaloganathan');
+    expect(data.role).toBe('Co-Founder & CEO at Sociavore');
+  });
+});

--- a/skills/contact-rename/handler.ts
+++ b/skills/contact-rename/handler.ts
@@ -33,8 +33,15 @@ export class ContactRenameHandler implements SkillHandler {
       };
     }
 
+    // Reject blank or whitespace-only names — a whitespace display name would break
+    // contact lookup and appear as an invisible entry in the CEO's contact list.
+    const trimmedName = display_name.trim();
+    if (trimmedName.length === 0) {
+      return { success: false, error: 'display_name must not be blank or whitespace-only' };
+    }
+
     // Input length limit — prevent oversized payloads reaching the DB
-    if (display_name.length > 200) {
+    if (trimmedName.length > 200) {
       return { success: false, error: 'Display name must be 200 characters or fewer' };
     }
 
@@ -46,10 +53,22 @@ export class ContactRenameHandler implements SkillHandler {
       };
     }
 
-    ctx.log.info({ contact_id, display_name }, 'Renaming contact');
+    // Pre-check contact existence so we can return a structured not-found response
+    // without relying on error-message string matching to distinguish not-found from
+    // unexpected errors (per project convention: use structured checks, not error text).
+    const existing = await ctx.contactService.getContact(contact_id);
+    if (!existing) {
+      ctx.log.warn({ contact_id }, 'Contact not found during rename — UUID may be stale or incorrect');
+      return {
+        success: false,
+        error: `No contact exists with id ${contact_id}. Use contact-lookup to verify the UUID, or contact-create to create a new contact.`,
+      };
+    }
+
+    ctx.log.info({ contact_id, display_name: trimmedName }, 'Renaming contact');
 
     try {
-      const updated = await ctx.contactService.updateDisplayName(contact_id, display_name);
+      const updated = await ctx.contactService.updateDisplayName(contact_id, trimmedName);
 
       // Log both the input ID and the service-returned ID so any discrepancy is visible
       ctx.log.info(
@@ -66,17 +85,8 @@ export class ContactRenameHandler implements SkillHandler {
         },
       };
     } catch (err) {
-      // ContactService.updateDisplayName() throws "Contact not found: <id>" as a normal
-      // control-flow case. Surface it as a distinct, actionable error so the
-      // agent knows to re-verify the UUID rather than retrying the same call.
-      if (err instanceof Error && err.message.startsWith('Contact not found:')) {
-        return {
-          success: false,
-          error: `No contact exists with id ${contact_id}. Use contact-lookup to verify the UUID, or contact-create to create a new contact.`,
-        };
-      }
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err, contact_id, display_name }, 'Failed to rename contact');
+      ctx.log.error({ err, contact_id, display_name: trimmedName }, 'Failed to rename contact');
       return { success: false, error: `Failed to rename contact: ${message}` };
     }
   }

--- a/skills/contact-rename/handler.ts
+++ b/skills/contact-rename/handler.ts
@@ -1,0 +1,83 @@
+// handler.ts — contact-rename skill implementation.
+//
+// Updates a contact's display name (e.g. correcting "Jodi" to "Jodi Arnott").
+// Returns the updated contact details.
+//
+// This is an infrastructure skill — it requires contactService access.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class ContactRenameHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { contact_id, display_name } = ctx.input as {
+      contact_id?: string;
+      display_name?: string;
+    };
+
+    // Validate required inputs
+    if (!contact_id || typeof contact_id !== 'string') {
+      return { success: false, error: 'Missing required input: contact_id (string)' };
+    }
+    if (!display_name || typeof display_name !== 'string') {
+      return { success: false, error: 'Missing required input: display_name (string)' };
+    }
+
+    // Validate contact_id is a UUID — the DB column is UUID type and will
+    // reject slug-style IDs with a cryptic 22P02 error.
+    // The agent must obtain the real UUID via contact-lookup or contact-list first.
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!UUID_RE.test(contact_id)) {
+      return {
+        success: false,
+        error: "contact_id must be a valid UUID. Use contact-lookup or contact-list to obtain the contact's UUID first.",
+      };
+    }
+
+    // Input length limit — prevent oversized payloads reaching the DB
+    if (display_name.length > 200) {
+      return { success: false, error: 'Display name must be 200 characters or fewer' };
+    }
+
+    // Infrastructure skills need contactService
+    if (!ctx.contactService) {
+      return {
+        success: false,
+        error: 'contact-rename skill requires infrastructure access (contactService). Is infrastructure: true set in the manifest?',
+      };
+    }
+
+    ctx.log.info({ contact_id, display_name }, 'Renaming contact');
+
+    try {
+      const updated = await ctx.contactService.updateDisplayName(contact_id, display_name);
+
+      // Log both the input ID and the service-returned ID so any discrepancy is visible
+      ctx.log.info(
+        { inputContactId: contact_id, contactId: updated.id, displayName: updated.displayName },
+        'Contact display name updated',
+      );
+
+      return {
+        success: true,
+        data: {
+          contact_id: updated.id,
+          display_name: updated.displayName,
+          role: updated.role,
+        },
+      };
+    } catch (err) {
+      // ContactService.updateDisplayName() throws "Contact not found: <id>" as a normal
+      // control-flow case. Surface it as a distinct, actionable error so the
+      // agent knows to re-verify the UUID rather than retrying the same call.
+      if (err instanceof Error && err.message.startsWith('Contact not found:')) {
+        return {
+          success: false,
+          error: `No contact exists with id ${contact_id}. Use contact-lookup to verify the UUID, or contact-create to create a new contact.`,
+        };
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, contact_id, display_name }, 'Failed to rename contact');
+      return { success: false, error: `Failed to rename contact: ${message}` };
+    }
+  }
+}

--- a/skills/contact-rename/skill.json
+++ b/skills/contact-rename/skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "contact-rename",
+  "description": "Update a contact's display name (e.g. from 'Jodi' to 'Jodi Arnott'). contact_id must be a UUID obtained from contact-lookup or contact-list — do not invent or infer IDs.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "action_risk": "low",
+  "infrastructure": true,
+  "inputs": {
+    "contact_id": "string (UUID from contact-lookup or contact-list)",
+    "display_name": "string (new display name)"
+  },
+  "outputs": {
+    "contact_id": "string",
+    "display_name": "string",
+    "role": "string | null"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}


### PR DESCRIPTION
## Summary

- Adds `skills/contact-rename/` — a new skill that updates a contact's display name via `ContactService.updateDisplayName()`
- Closes the capability gap where Curia could create contacts and set their role but had no tool to correct or expand a display name (e.g. "Jodi" → "Jodi Arnott")
- Follows the same pattern as `contact-set-role` and `contact-set-trust`

## What was broken

`ContactService.updateDisplayName()` has existed since PR #63 but was never exposed as a skill. When asked to rename a contact, Curia correctly reported it had no tool available.

## Implementation notes

- Pre-flight `getContact()` check for structured not-found detection (no error-message string matching — same convention as `contact-set-trust`)
- Whitespace-only display names are rejected before hitting the service
- Leading/trailing whitespace is trimmed before storing
- `log.warn` on not-found so stale-UUID attempts are auditable
- 9 unit tests covering all validation paths and success cases

## Known gap (pre-existing, not in scope)

The `updateContact()` Postgres implementation does not check `rowCount` after the UPDATE, so a phantom write (row deleted between the pre-flight read and the write) would silently return success. This affects all contact-update skills equally — tracked for a separate fix.

## Test plan

- [x] All 1448 unit tests pass (`npm test`)
- [x] Typecheck clean (`npm run typecheck`)
- [ ] In Curia chat: create a contact with a first name only, then ask Curia to rename it — should succeed
- [ ] Ask Curia to update name + title for Jodi, Barb, and Thusenth in a single message — Curia should call `contact-rename` and `contact-set-role` for each

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to update a contact's display name with built-in validation for contact identification and name formatting.

* **Chores**
  * Updated package version to 0.19.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->