### PR TITLE
fix: inject coordinator's own email and phone into system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
-### Changed
-
-- **KG Explorer UX overhaul** — knowledge graph visualization is now explorable by click. Graph auto-loads the 20 most recently active nodes on first entry (no more blank canvas). Single-tap a node expands its neighbors in-place; double-tap zooms to fit the local neighborhood. Node size and edge width are now proportional to confidence; fast-decay nodes fade visually. Labels move below nodes with dark outlines for readability. Fact nodes are rendered as small indicators that only show labels when selected. Layout switched from `cose` to `fcose` for better separation and less overlap. Adds `cytoscape-fcose`, `cose-base`, and `layout-base` as runtime dependencies.
-
 ### Added
 
 - **`contact-rename` skill** — new skill that updates a contact's display name via `ContactService.updateDisplayName()`. Closes the gap where Curia could create contacts and set their role but had no tool to correct or expand a display name (e.g. from "Jodi" to "Jodi Arnott").
@@ -25,6 +21,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **KG Explorer UX overhaul** — knowledge graph visualization is now explorable by click. Graph auto-loads the 20 most recently active nodes on first entry (no more blank canvas). Single-tap a node expands its neighbors in-place; double-tap zooms to fit the local neighborhood. Node size and edge width are now proportional to confidence; fast-decay nodes fade visually. Labels move below nodes with dark outlines for readability. Fact nodes are rendered as small indicators that only show labels when selected. Layout switched from `cose` to `fcose` for better separation and less overlap. Adds `cytoscape-fcose`, `cose-base`, and `layout-base` as runtime dependencies.
 - **Observation mode triage protocol moved to system prompt** — the ~40-line triage protocol (URGENT / ACTIONABLE / NEEDS DRAFT / LEAVE FOR CEO / NOISE classifications) has been moved from per-message user content into `agents/coordinator.yaml`'s system prompt. Only the `[OBSERVATION MODE]` marker and per-message identifiers (Message ID, Account) remain in user content. This makes the static protocol cacheable once prompt caching is active (issue #321, follows #320).
 - **Prompt caching** — `AnthropicProvider` now passes the system prompt as a cached `TextBlockParam` and marks the last tool definition with `cache_control: ephemeral`, reducing effective input token cost by 60-80% for repeat calls within the 5-minute TTL (issue #320).
 - **Default Anthropic model** bumped from `claude-sonnet-4-20250514` to `claude-sonnet-4-6` across agent configs, runtime fallback, tests, and docs. The old model reaches EOL on 2026-06-15.
@@ -32,6 +29,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Coordinator now uses its own email and phone for tool calls** — `AgentConfig` gains a `channelAccounts` field (email, phone) sourced from `NYLAS_SELF_EMAIL` and `SIGNAL_PHONE_NUMBER`. The coordinator runtime appends a "Your Contact Details" block to the system prompt each turn, giving the LLM concrete values for its own accounts. Prevents the coordinator from guessing or falling back to the CEO's email when MCP tools (e.g. `workspace-mcp`'s `user_google_email`) ask for an account identifier.
 - **Outbound trust propagation** — replies to Curia-initiated emails no longer get held when the recipient's contact is still `provisional` or unknown (issue #330). Two complementary fixes: (A) the outbound gateway now promotes the recipient contact to `confirmed` (or creates one if none exists) after every successful send — the act of sending is the implicit trust confirmation; (B) the dispatcher checks the `audit_log` for a prior `outbound.message` in the same thread addressed to the same sender before holding a provisional/unknown message, and upgrades the contact to `confirmed` when found. The recipient filter on the thread check prevents the forwarding attack: a reply forwarded into the thread by a third party does not bypass the hold.
 - **`held-messages-process` idempotent identity link** — when `contact-merge` links a sender's channel identity before `held-messages-process` runs (e.g. the CEO merges contacts mid-conversation), the skill now treats the duplicate-key error as a no-op if the identity already belongs to the target contact, and proceeds to `markProcessed`. Previously both calls failed with a unique constraint violation, leaving the held message in `pending` status indefinitely and triggering a false "Held Messages Pending Your Review" alert from the scheduled scanner.
 - **research-analyst context flooding** — the research-analyst specialist now has `web-search` (Tavily) in its pinned skills and its system prompt instructs it to prefer search for broad discovery and limit `web-fetch` to at most 3–4 targeted follow-up fetches. Previously, having only `web-fetch` caused it to accumulate 50 KB/page of raw HTML until the context window was exhausted, stalling the coordinator. Closes #329.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -331,16 +331,18 @@ system_prompt: |
   Before drafting, check whether the CEO has already replied in the thread.
 
   ## Account Identity for Tool Calls
-  When any tool requires an email address, account identifier, or similar
-  "acting as" parameter (e.g. user_google_email, user_email, account_id),
-  always use your own account first — not the CEO's.
+  Your concrete email address and phone number are in the **"Your Contact Details"**
+  block injected into this prompt. Use those values when any tool requires an email
+  address, phone number, account identifier, or similar "acting as" parameter
+  (e.g. user_google_email, user_email, account_id, phone).
 
-  Only fall back to the CEO's email if the tool call explicitly fails with an
-  authorization or not-found error, AND the CEO has directed you to act on
-  their behalf using their credentials. Never assume — default to yourself.
+  Default to your own accounts — never the CEO's. Only use the CEO's details if a
+  tool call explicitly fails with an authorization or not-found error AND the CEO
+  has directed you to act on their behalf. Never assume — default to yourself.
 
   This applies to all third-party integrations: Google Workspace, calendar
-  services, file storage, or any other tool that takes an account parameter.
+  services, file storage, messaging, or any other tool that takes an account
+  parameter.
 
   **Exception — `email-list`, `email-get`, `email-draft-save`:** the `account` param
   on these skills selects which monitored inbox to read from or draft for. Use the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.19.6",
+      "version": "0.19.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -43,6 +43,15 @@ export interface AgentConfig {
    *  block is appended to the system prompt on every task so the date is always fresh.
    *  If omitted, no time block is injected. */
   timezone?: string;
+  /** Curia's own channel contact details, sourced from deployment env vars (NYLAS_SELF_EMAIL,
+   *  SIGNAL_PHONE_NUMBER). When provided, a "Your Contact Details" block is appended to the
+   *  system prompt so the LLM knows which accounts to use when tools ask for an email address
+   *  or phone number. Only the coordinator receives this — specialist agents work with
+   *  structured data and don't need self-identity injection. */
+  channelAccounts?: {
+    email?: string;
+    phone?: string;
+  };
   /** Error budget config — turn and consecutive error limits per task.
    * maxTurns is checked at the start of each tool-use iteration, so
    * the effective number of tool-calling rounds is maxTurns - 1. */
@@ -206,6 +215,20 @@ export class AgentRuntime {
         // Log at error (operator signal) and proceed without the time block.
         logger.error({ err, agentId, timezone }, 'formatTimeContextBlock failed — time context not injected; check TIMEZONE config');
       }
+    }
+
+    // Append Curia's own contact details — email and phone sourced from deployment env vars.
+    // This gives the LLM a concrete "acting as" identity so it doesn't guess or fall back
+    // to the CEO's details when tools require an account parameter.
+    const { channelAccounts } = this.config;
+    if (channelAccounts && (channelAccounts.email || channelAccounts.phone)) {
+      const lines: string[] = ['## Your Contact Details'];
+      lines.push('These are your own accounts. Use them when tools require an email address, phone number,');
+      lines.push('or similar "acting as" identifier — never substitute the CEO\'s details.');
+      lines.push('');
+      if (channelAccounts.email) lines.push(`- Email: ${channelAccounts.email}`);
+      if (channelAccounts.phone) lines.push(`- Phone: ${channelAccounts.phone}`);
+      effectiveSystemPrompt += '\n\n' + lines.join('\n');
     }
 
     // Append intent anchor — present only for persistent scheduler tasks that have a

--- a/src/index.ts
+++ b/src/index.ts
@@ -802,6 +802,14 @@ async function main(): Promise<void> {
       // every task, so identity hot-reloads (file watcher or API PUT) take effect on the
       // next turn without a restart.
       officeIdentityService: agentConfig.role === 'coordinator' ? officeIdentityService : undefined,
+      // Curia's own contact details — sourced from NYLAS_SELF_EMAIL and SIGNAL_PHONE_NUMBER.
+      // Injected per-task so the coordinator knows which accounts to use when MCP tools
+      // ask for an email address or phone number (e.g. workspace-mcp's user_google_email).
+      // Only set for the coordinator; specialist agents work with structured data.
+      channelAccounts: agentConfig.role === 'coordinator' ? {
+        email: config.nylasSelfEmail || undefined,
+        phone: config.signalPhoneNumber || undefined,
+      } : undefined,
       // Map YAML snake_case fields to AgentConfig camelCase, falling back to
       // DEFAULT_ERROR_BUDGET values for any omitted fields.
       errorBudget: agentConfig.error_budget ? {


### PR DESCRIPTION
## Summary

- Adds `channelAccounts?: { email?, phone? }` to `AgentConfig`, sourced from the existing `NYLAS_SELF_EMAIL` and `SIGNAL_PHONE_NUMBER` env vars — no new configuration required
- The coordinator runtime appends a **"Your Contact Details"** block to the effective system prompt each turn, giving the LLM concrete values for its own accounts
- Updates `agents/coordinator.yaml` to reference the injected block explicitly instead of the vague "your own account" language
- Follows the exact same per-task injection pattern as `timezone` and `autonomyService`

## Why

Curia was guessing the CEO's email when MCP tools (e.g. `workspace-mcp`'s `user_google_email`) asked for an account identifier. The system prompt already said "use your own account" but never said what that was concretely. The LLM fell back to the sender's email, which has no tokens cached in the MCP server.

This is the generic fix for the pattern: any future tool that takes an "acting as" parameter will see the correct values in the system prompt.

## Test plan

- [ ] Boot Curia locally; confirm "Your Contact Details" block appears in coordinator's effective system prompt
- [ ] Ask Curia "Can you create a Google Doc?" — should now succeed using `nathancuria1@gmail.com` rather than erroring with an auth prompt for the CEO's email
- [ ] Confirm `channelAccounts` is only passed to the coordinator (specialist agents omitted), matching the `timezone` pattern
- [ ] Confirm that if `NYLAS_SELF_EMAIL` is unset, the email line is omitted rather than emitting a blank bullet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 0.19.7

* **Changed**
  * Enhanced agent identity handling for tool calls—the coordinator now uses provided contact details (email/phone) instead of defaulting to CEO credentials, improving account routing accuracy for third-party integrations like messaging and calendar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->