### PR TITLE
feat: observation.triage.completed event for monitored-inbox observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
-- **Dispatcher observation-mode branch** — now emits a `warn`-level log when a non-LEAVE_FOR_CEO classification completes with zero skill calls (defensive check for coordinator stalls)
+- **Dispatcher observation-mode branch** — now emits a `warn`-level log when a non-`LEAVE FOR CEO` classification completes with zero skill calls (defensive check for coordinator stalls)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **Observation triage event** (`observation.triage.completed`) — structured bus event emitted after every observation-mode triage task, carrying classification, skills called, and action count for monitoring and alerting (#311)
+- **`AgentResponsePayload.skillsCalled`** — optional field listing skills invoked during a task (public API surface: additive, non-breaking)
+- **`TriageClassification` type** — exported union type for triage classification labels, shared across event consumers
+
+### Changed
+
+- **Dispatcher observation-mode branch** — now emits a `warn`-level log when a non-LEAVE_FOR_CEO classification completes with zero skill calls (defensive check for coordinator stalls)
+
 ---
 
 ## [0.19.7] — 2026-04-24 — "The Reading Room"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -440,6 +440,11 @@ export class AgentRuntime {
       ? { contactId: callerSenderCtx.contactId, role: callerSenderCtx.role, channel: taskEvent.payload.channelId }
       : undefined;
 
+    // Accumulate skill names across all tool-use turns so we can report them
+    // on the agent.response event. Consumers (e.g. the dispatcher's observation-mode
+    // triage event) use this to know what the agent actually did during the task.
+    const skillsCalled: string[] = [];
+
     while (response.type === 'tool_use' && executionLayer) {
       // Check turn budget before processing this round of tool calls
       budget.turnsUsed++;
@@ -475,6 +480,7 @@ export class AgentRuntime {
       const toolResultBlocks: ContentBlock[] = [];
       for (const toolCall of response.toolCalls) {
         logger.info({ agentId, skill: toolCall.name, callId: toolCall.id }, 'Invoking skill');
+        skillsCalled.push(toolCall.name);
 
         // For delegate calls from scheduled tasks: inject timeout_ms from the task event's
         // expectedDurationSeconds so the specialist gets an appropriate wait window.
@@ -703,6 +709,7 @@ export class AgentRuntime {
       // isResponseError propagates to consumers (delegate, scheduler) so they can
       // distinguish a fallback message from a real agent result.
       ...(isResponseError && { isError: true }),
+      skillsCalled,
       parentEventId: taskEvent.id,
     });
     await bus.publish('agent', responseEvent);

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -66,6 +66,10 @@ interface AgentResponsePayload {
   // is a generic fallback message rather than a real response. Consumers (e.g. the
   // delegate skill) should treat this as a failure rather than a usable result.
   isError?: boolean;
+  // Names of skills invoked during the task (in call order, may contain duplicates).
+  // Populated by the agent runtime's tool-use loop; absent on error-path responses
+  // where the runtime bailed before completing the loop.
+  skillsCalled?: string[];
 }
 
 interface OutboundMessagePayload {
@@ -357,6 +361,23 @@ interface HumanDecisionPayload {
 }
 
 
+// Observation-mode triage classification categories. Shared type so downstream consumers
+// (#299 triage routing, monitoring) use the same vocabulary as the event payload.
+export type TriageClassification = 'URGENT' | 'ACTIONABLE' | 'NEEDS DRAFT' | 'LEAVE FOR CEO' | 'NOISE' | 'unknown';
+
+// ObservationTriageCompletedPayload — emitted by the dispatch layer at the end of every
+// observation-mode task. Captures the coordinator's classification decision and which
+// skills it invoked, providing an operational signal for monitoring, alerting, and
+// trend analysis without requiring log scraping.
+interface ObservationTriageCompletedPayload {
+  conversationId: string;
+  accountId?: string;
+  senderId: string;
+  classification: TriageClassification;
+  skillsCalled: string[];       // skills invoked during the task (from agent.response)
+  outboundActions: number;      // === skillsCalled.length
+}
+
 // -- Discriminated union --
 // The `type` field is the discriminant; `sourceLayer` records which layer emitted the event.
 
@@ -536,6 +557,15 @@ export interface SecretAccessedEvent extends BaseEvent {
   payload: SecretAccessedPayload;
 }
 
+// ObservationTriageCompletedEvent — published by the dispatch layer after every observation-mode
+// triage task completes. Subscribers (audit logger, future monitoring) use this to detect
+// misclassifications, zero-action failures, and classification drift over time.
+export interface ObservationTriageCompletedEvent extends BaseEvent {
+  type: 'observation.triage.completed';
+  sourceLayer: 'dispatch';
+  payload: ObservationTriageCompletedPayload;
+}
+
 interface ConversationCheckpointPayload {
   conversationId: string;
   agentId: string;
@@ -583,7 +613,8 @@ export type BusEvent =
   | ConversationCheckpointEvent // Checkpoint pipeline: Dispatch fires after inactivity window
   | LlmCallEvent             // Spec 10: LLM API call provenance (model, tokens, cost, hashes)
   | HumanDecisionEvent       // Spec 10: human-in-the-loop decision record (approve/deny/etc.)
-  | SecretAccessedEvent;     // Spec 06: secrets isolation audit trail (name only, never value)
+  | SecretAccessedEvent      // Spec 06: secrets isolation audit trail (name only, never value)
+  | ObservationTriageCompletedEvent; // Observation mode: triage classification + action summary (#311)
 
 // Convenience alias for use in handler maps / switch statements.
 export type EventType = BusEvent['type'];
@@ -979,6 +1010,21 @@ export function createSecretAccessed(
     type: 'secret.accessed',
     sourceLayer: 'execution',
     payload,
+    parentEventId,
+  };
+}
+
+export function createObservationTriageCompleted(
+  // parentEventId is required — triage completion must trace back to the agent.task that triggered it.
+  payload: ObservationTriageCompletedPayload & { parentEventId: string },
+): ObservationTriageCompletedEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'observation.triage.completed',
+    sourceLayer: 'dispatch',
+    payload: rest,
     parentEventId,
   };
 }

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -361,8 +361,15 @@ interface HumanDecisionPayload {
 }
 
 
-// Observation-mode triage classification categories. Shared type so downstream consumers
-// (#299 triage routing, monitoring) use the same vocabulary as the event payload.
+/**
+ * Observation-mode triage classification categories. Shared type so downstream consumers
+ * (#299 triage routing, monitoring) use the same vocabulary as the event payload.
+ *
+ * Token forms use spaces (e.g. `'NEEDS DRAFT'`, `'LEAVE FOR CEO'`) — these match the
+ * exact labels the coordinator emits and the dispatcher regex extracts. Log messages
+ * and prose may use underscored shorthand (`LEAVE_FOR_CEO`) for readability, but
+ * string-literal comparisons must use the spaced form defined here.
+ */
 export type TriageClassification = 'URGENT' | 'ACTIONABLE' | 'NEEDS DRAFT' | 'LEAVE FOR CEO' | 'NOISE' | 'unknown';
 
 // ObservationTriageCompletedPayload — emitted by the dispatch layer at the end of every

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -17,12 +17,14 @@ import type { Layer, EventType } from './events.js';
 //          system layer gets full access to both for audit logging and monitoring.
 // Spec 06 (secrets isolation): execution layer publishes secret.accessed for every ctx.secret() call;
 //          system layer gets full access for audit logging and monitoring.
+// Observation mode (#311): dispatch layer publishes observation.triage.completed after each
+//          observation-mode task; system layer subscribes for audit logging and monitoring.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message']),
-  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint', 'human.decision']),
+  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint', 'human.decision', 'observation.triage.completed']),
   agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss', 'llm.call']),
   execution: new Set(['skill.result', 'secret.accessed']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed', 'observation.triage.completed']),
 };
 
 // agent.discuss subscribe for 'dispatch': used by BullpenDispatcher (wired in index.ts after agent registration).
@@ -31,7 +33,7 @@ const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed', 'observation.triage.completed']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -1,6 +1,7 @@
 import type { EventBus } from '../bus/bus.js';
 import type { InboundMessageEvent, AgentResponseEvent, AgentErrorEvent } from '../bus/events.js';
-import { createAgentTask, createOutboundMessage, createContactResolved, createContactUnknown, createMessageHeld, createMessageRejected, createConversationCheckpoint } from '../bus/events.js';
+import { createAgentTask, createOutboundMessage, createContactResolved, createContactUnknown, createMessageHeld, createMessageRejected, createConversationCheckpoint, createObservationTriageCompleted } from '../bus/events.js';
+import type { TriageClassification } from '../bus/events.js';
 import type { Logger } from '../logger.js';
 import type { ContactResolver } from '../contacts/contact-resolver.js';
 import type { ContactService } from '../contacts/contact-service.js';
@@ -754,6 +755,16 @@ export class Dispatcher {
     // the task — not via this auto-reply path. We still schedule a checkpoint
     // below so working memory is persisted.
     if (routing.observationMode) {
+      // Skip triage processing for error-path responses — isError means the runtime
+      // bailed before the coordinator produced a real classification. Emitting a
+      // triage event here would pollute monitoring with runtime failures.
+      if (event.payload.isError) {
+        this.logger.warn(
+          { conversationId: routing.conversationId, agentId: event.payload.agentId },
+          'observation-mode: skipping triage event for error-path response (isError)',
+        );
+        // Fall through to scheduleCheckpoint below.
+      } else {
       // Log at info (not debug) so the suppression is visible in default prod
       // log streams. If observationMode is ever flipped incorrectly (misrouted
       // metadata, config mistake, future refactor), real replies would vanish —
@@ -765,10 +776,12 @@ export class Dispatcher {
       // must not become a sensitive-data sink. We log only a bounded classification
       // token extracted from the response; full rationale stays in the
       // llm_call_archive (which has stricter retention + access controls).
-      const classification =
-        event.payload.content?.match(
+      const classification: TriageClassification =
+        (event.payload.content?.match(
           /\b(URGENT|ACTIONABLE|NEEDS DRAFT|LEAVE FOR CEO|NOISE)\b/,
-        )?.[0] ?? 'unknown';
+        )?.[0] as TriageClassification | undefined) ?? 'unknown';
+      const skillsCalled = event.payload.skillsCalled ?? [];
+
       this.logger.info(
         {
           conversationId: routing.conversationId,
@@ -781,6 +794,31 @@ export class Dispatcher {
         },
         'observation-mode: suppressed auto-reply outbound.message (audit-only response)',
       );
+
+      // Defensive check: zero skill calls for a non-LEAVE_FOR_CEO classification means
+      // the coordinator decided to do nothing when it should have taken action (archive,
+      // notify, draft). Warn so operators can detect prompt regressions or silent failures.
+      if (skillsCalled.length === 0 && classification !== 'LEAVE FOR CEO') {
+        this.logger.warn(
+          { conversationId: routing.conversationId, classification, senderId: routing.senderId },
+          'observation-mode: zero skill calls for non-LEAVE_FOR_CEO classification — possible coordinator stall',
+        );
+      }
+
+      // Emit structured triage completion event for downstream consumers (audit log,
+      // future monitoring/alerting). parentEventId traces back to the agent.task —
+      // safe to assert non-null because routing was found via event.parentEventId.
+      const triageEvent = createObservationTriageCompleted({
+        conversationId: routing.conversationId,
+        accountId: routing.accountId,
+        senderId: routing.senderId,
+        classification,
+        skillsCalled,
+        outboundActions: skillsCalled.length,
+        parentEventId: event.parentEventId!,
+      });
+      await this.bus.publish('dispatch', triageEvent);
+      }
     } else {
       // Publish outbound.message to the bus — the email adapter will pick it up
       // and route it through OutboundGateway (blocked-contact check + content filter).

--- a/tests/unit/dispatch/dispatcher-observation-triage.test.ts
+++ b/tests/unit/dispatch/dispatcher-observation-triage.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
+import type { EventBus } from '../../../src/bus/bus.js';
+import type { Logger } from '../../../src/logger.js';
+import { createAgentResponse, type BusEvent, type ObservationTriageCompletedEvent } from '../../../src/bus/events.js';
+
+function isTriageEvent(e: BusEvent): e is ObservationTriageCompletedEvent {
+  return e.type === 'observation.triage.completed';
+}
+
+function makeStubs() {
+  const publishedEvents: BusEvent[] = [];
+  const subscribeHandlers = new Map<string, (event: BusEvent) => Promise<void>>();
+
+  const bus = {
+    subscribe: vi.fn((eventType: string, _layer: string, handler: (e: BusEvent) => Promise<void>) => {
+      subscribeHandlers.set(eventType, handler);
+    }),
+    publish: vi.fn(async (_layer: string, event: BusEvent) => {
+      publishedEvents.push(event);
+    }),
+  } as unknown as EventBus;
+
+  const logger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+  } as unknown as Logger;
+
+  const dispatcher = new Dispatcher({ bus, logger });
+
+  return { dispatcher, bus, logger, publishedEvents, subscribeHandlers };
+}
+
+/** Seeds the Dispatcher's private taskRouting map with observationMode enabled. */
+function seedRouting(
+  dispatcher: Dispatcher,
+  taskEventId: string,
+  opts: { conversationId?: string; senderId?: string; accountId?: string } = {},
+) {
+  const routing = {
+    channelId: 'email',
+    conversationId: opts.conversationId ?? 'email:thread-1',
+    senderId: opts.senderId ?? 'sender@example.com',
+    accountId: opts.accountId ?? 'ceo-inbox',
+    observationMode: true,
+  };
+  (dispatcher as unknown as { taskRouting: Map<string, typeof routing> })
+    .taskRouting.set(taskEventId, routing);
+}
+
+async function fireAgentResponse(
+  subscribeHandlers: Map<string, (event: BusEvent) => Promise<void>>,
+  opts: {
+    taskEventId: string;
+    content: string;
+    skillsCalled?: string[];
+    isError?: boolean;
+    agentId?: string;
+    conversationId?: string;
+  },
+) {
+  const event = createAgentResponse({
+    agentId: opts.agentId ?? 'coordinator',
+    conversationId: opts.conversationId ?? 'email:thread-1',
+    content: opts.content,
+    skillsCalled: opts.skillsCalled,
+    ...(opts.isError && { isError: true }),
+    parentEventId: opts.taskEventId,
+  });
+  const handler = subscribeHandlers.get('agent.response');
+  if (!handler) throw new Error('No agent.response handler registered');
+  await handler(event);
+}
+
+describe('Dispatcher observation-mode triage event', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('emits observation.triage.completed with URGENT classification', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-1');
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-1',
+      content: 'Classification: URGENT — CEO needs to respond to this investor email immediately.',
+      skillsCalled: ['entity-context', 'signal-send'],
+    });
+
+    const triageEvents = publishedEvents.filter(isTriageEvent);
+    expect(triageEvents).toHaveLength(1);
+
+    const payload = triageEvents[0]!.payload;
+    expect(payload.classification).toBe('URGENT');
+    expect(payload.skillsCalled).toEqual(['entity-context', 'signal-send']);
+    expect(payload.outboundActions).toBe(2);
+    expect(payload.conversationId).toBe('email:thread-1');
+    expect(payload.senderId).toBe('sender@example.com');
+    expect(payload.accountId).toBe('ceo-inbox');
+    expect(triageEvents[0]!.parentEventId).toBe('task-1');
+  });
+
+  it('emits observation.triage.completed with ACTIONABLE classification', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-2');
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-2',
+      content: 'ACTIONABLE — calendar invite processed.',
+      skillsCalled: ['entity-context', 'email-reply'],
+    });
+
+    const triageEvents = publishedEvents.filter(isTriageEvent);
+    expect(triageEvents).toHaveLength(1);
+    expect(triageEvents[0]!.payload.classification).toBe('ACTIONABLE');
+    expect(triageEvents[0]!.payload.skillsCalled).toEqual(['entity-context', 'email-reply']);
+  });
+
+  it('emits observation.triage.completed with NEEDS DRAFT classification', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-3');
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-3',
+      content: 'NEEDS DRAFT — a polite decline is warranted.',
+      skillsCalled: ['email-draft-save'],
+    });
+
+    const triageEvents = publishedEvents.filter(isTriageEvent);
+    expect(triageEvents).toHaveLength(1);
+    expect(triageEvents[0]!.payload.classification).toBe('NEEDS DRAFT');
+    expect(triageEvents[0]!.payload.outboundActions).toBe(1);
+  });
+
+  it('emits observation.triage.completed with NOISE classification', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-4');
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-4',
+      content: 'NOISE — automated shipping notification, archived.',
+      skillsCalled: ['email-archive'],
+    });
+
+    const triageEvents = publishedEvents.filter(isTriageEvent);
+    expect(triageEvents).toHaveLength(1);
+    expect(triageEvents[0]!.payload.classification).toBe('NOISE');
+    expect(triageEvents[0]!.payload.skillsCalled).toEqual(['email-archive']);
+  });
+
+  it('emits observation.triage.completed with LEAVE FOR CEO and zero skills — no warning', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents, logger } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-5');
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-5',
+      content: 'LEAVE FOR CEO — personal email from a family member.',
+      skillsCalled: [],
+    });
+
+    const triageEvents = publishedEvents.filter(isTriageEvent);
+    expect(triageEvents).toHaveLength(1);
+    expect(triageEvents[0]!.payload.classification).toBe('LEAVE FOR CEO');
+    expect(triageEvents[0]!.payload.skillsCalled).toEqual([]);
+    expect(triageEvents[0]!.payload.outboundActions).toBe(0);
+    // No warn about zero skill calls — zero skills is expected for LEAVE FOR CEO.
+    // (logger.warn may have been called for unrelated reasons during register(),
+    // so assert on the specific message string rather than call count.)
+    const warnCalls = (logger.warn as ReturnType<typeof vi.fn>).mock.calls;
+    const triageWarnCalls = warnCalls.filter(
+      (args: unknown[]) => typeof args[1] === 'string' && args[1].includes('zero skill calls'),
+    );
+    expect(triageWarnCalls).toHaveLength(0);
+  });
+
+  it('warns on zero skill calls with non-LEAVE_FOR_CEO classification', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents, logger } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-6');
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-6',
+      content: 'URGENT — investor needs response but I could not reach the notification service.',
+      skillsCalled: [],
+    });
+
+    // Triage event is still emitted
+    const triageEvents = publishedEvents.filter(isTriageEvent);
+    expect(triageEvents).toHaveLength(1);
+    expect(triageEvents[0]!.payload.classification).toBe('URGENT');
+    expect(triageEvents[0]!.payload.outboundActions).toBe(0);
+
+    // Defensive warn was logged
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ classification: 'URGENT', conversationId: 'email:thread-1' }),
+      expect.stringContaining('zero skill calls'),
+    );
+  });
+
+  it('defaults skillsCalled to empty array when not present on agent response', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-7');
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-7',
+      content: 'LEAVE FOR CEO — ambiguous message.',
+      // skillsCalled omitted — simulates error-path responses from runtime
+    });
+
+    const triageEvents = publishedEvents.filter(isTriageEvent);
+    expect(triageEvents).toHaveLength(1);
+    expect(triageEvents[0]!.payload.skillsCalled).toEqual([]);
+  });
+
+  it('extracts unknown classification when no label matches', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents, logger } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-8');
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-8',
+      content: 'I was unable to classify this email.',
+      skillsCalled: [],
+    });
+
+    const triageEvents = publishedEvents.filter(isTriageEvent);
+    expect(triageEvents).toHaveLength(1);
+    expect(triageEvents[0]!.payload.classification).toBe('unknown');
+
+    // unknown + zero skills → warn
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ classification: 'unknown' }),
+      expect.stringContaining('zero skill calls'),
+    );
+  });
+
+  it('does not emit triage event for non-observation-mode responses', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents } = makeStubs();
+    dispatcher.register();
+
+    // Seed with observationMode: false (use the checkpoint test's seedRouting pattern)
+    const routing = {
+      channelId: 'email',
+      conversationId: 'email:thread-9',
+      senderId: 'user@example.com',
+      observationMode: false,
+    };
+    (dispatcher as unknown as { taskRouting: Map<string, typeof routing> })
+      .taskRouting.set('task-9', routing);
+
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-9',
+      conversationId: 'email:thread-9',
+      content: 'Here is my reply.',
+      skillsCalled: ['email-reply'],
+    });
+
+    const triageEvents = publishedEvents.filter(isTriageEvent);
+    expect(triageEvents).toHaveLength(0);
+  });
+
+  it('skips triage event for isError responses (runtime failure)', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents, logger } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-10');
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-10',
+      content: "I'm sorry, I was unable to process that request. Please try again.",
+      isError: true,
+    });
+
+    // No triage event — isError responses are runtime failures, not triage decisions
+    const triageEvents = publishedEvents.filter(isTriageEvent);
+    expect(triageEvents).toHaveLength(0);
+
+    // A warn is logged about skipping
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: 'email:thread-1' }),
+      expect.stringContaining('skipping triage event'),
+    );
+  });
+
+  it('does not warn for LEAVE FOR CEO with skill calls', async () => {
+    const { dispatcher, subscribeHandlers, publishedEvents, logger } = makeStubs();
+    dispatcher.register();
+
+    seedRouting(dispatcher, 'task-11');
+    await fireAgentResponse(subscribeHandlers, {
+      taskEventId: 'task-11',
+      content: 'LEAVE FOR CEO — looked up sender context first.',
+      skillsCalled: ['entity-context'],
+    });
+
+    const triageEvents = publishedEvents.filter(isTriageEvent);
+    expect(triageEvents).toHaveLength(1);
+    expect(triageEvents[0]!.payload.classification).toBe('LEAVE FOR CEO');
+    expect(triageEvents[0]!.payload.skillsCalled).toEqual(['entity-context']);
+
+    // No stall warn — LEAVE FOR CEO never triggers the zero-action warning
+    const warnCalls = (logger.warn as ReturnType<typeof vi.fn>).mock.calls;
+    const triageWarnCalls = warnCalls.filter(
+      (args: unknown[]) => typeof args[1] === 'string' && args[1].includes('zero skill calls'),
+    );
+    expect(triageWarnCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #311

- Adds `observation.triage.completed` bus event emitted after every observation-mode triage task, carrying classification, skills called, and action count — provides operational signal for monitoring, alerting, and trend analysis without log scraping
- Adds `skillsCalled?: string[]` to `AgentResponsePayload` (public API surface, additive/non-breaking) — the runtime accumulates skill names during the tool-use loop
- Adds defensive `warn`-level log when a non-LEAVE_FOR_CEO classification completes with zero skill calls (detects coordinator stalls)
- Skips triage event emission for `isError` responses to avoid polluting monitoring with runtime failures

## Public API surface changes

- `AgentResponsePayload.skillsCalled?: string[]` — new optional field (additive, non-breaking)
- `observation.triage.completed` event type added to `BusEvent` union
- `TriageClassification` type exported from `src/bus/events.ts`

## Test plan

- [x] 11 unit tests covering all 5 triage classifications (URGENT, ACTIONABLE, NEEDS DRAFT, LEAVE FOR CEO, NOISE)
- [x] Zero-action defensive warn for non-LEAVE_FOR_CEO
- [x] `unknown` classification when no label matches
- [x] `skillsCalled` defaults to `[]` when absent
- [x] `isError` responses skip triage event
- [x] LEAVE FOR CEO with skills called does not warn
- [x] Non-observation-mode responses produce no triage event
- [x] Full test suite passes (1471 tests, 0 failures)
- [x] Build passes clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added observation-mode telemetry that emits structured triage completion events after each task.
  * Introduced `skillsCalled` field to track which skills the agent executed during task processing.
  * Exported new `TriageClassification` type for consistent triage labelling across consumers.

* **Improvements**
  * Added defensive warning when triage tasks complete with zero skill calls (excluding CEO escalations), signalling potential coordinator stalls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->