### PR TITLE
feat: per-capability skill registry — replace infrastructure: true with capabilities[] (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ---
 
+## [0.19.8] — 2026-04-24
+
+### Security
+
+- **Per-capability skill registry** — replaces the all-or-nothing `infrastructure: true` manifest flag with per-capability `"capabilities": [...]` declarations. Skills now declare only the privileged services they actually need (e.g. `["outboundGateway"]`), eliminating the blast-radius risk where any infrastructure skill got bus, agent registry, calendar, memory, and scheduler access all at once. The loader validates names against a fixed allowlist at startup, rejects unknown capability names hard (crash, not silent skip), and freezes manifests after loading so handlers cannot self-escalate at runtime. Closes #119.
+
+### Changed
+
+- **`skill.json` schema** — `infrastructure: boolean` removed; `capabilities: string[]` added. **Breaking change to public API surface.** Skills that previously declared `infrastructure: true` now declare the specific capabilities they need (or nothing, if they only used universal services). See `docs/dev/adding-a-skill.md` for the full capabilities reference.
+- **`SkillManifest` type** — `infrastructure?: boolean` replaced by `capabilities?: string[]` in `src/skills/types.ts`.
+- **ExecutionLayer** — `if (manifest.infrastructure)` block and three name-gated conditionals replaced by a single capabilities loop with fail-closed behavior.
+
+---
+
 ## [0.19.7] — 2026-04-24 — "The Reading Room"
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ---
 
-## [0.19.8] — 2026-04-24
+## [0.20.0] — 2026-04-24
 
 ### Security
 

--- a/docs/dev/adding-a-skill.md
+++ b/docs/dev/adding-a-skill.md
@@ -109,9 +109,31 @@ A raw integer (0–100) may be used for precision when the named levels are too 
 
 **How Phase 2 gating will work:** When an agent calls a skill, the execution layer compares the skill's minimum required autonomy score against the live global score from `autonomy_config`. If the score is too low, the invocation returns an advisory failure (no throw, same `{ success: false, error }` shape as any other failure) and an audit event is emitted. The autonomy score is CEO-controlled via the `set-autonomy` skill. See `docs/specs/14-autonomy-engine.md` for the full spec.
 
-#### `infrastructure` (optional, default: `false`)
+#### `capabilities` (optional)
 
-Marks skills that are part of Curia's core infrastructure (email, calendar, contacts, scheduling, etc.) rather than user-contributed extensions. Infrastructure skills receive additional `SkillContext` fields: `bus`, `agentRegistry`, `outboundGateway`, `schedulerService`, `entityMemory`, etc. — see the `SkillContext` reference below. Omit this field for contributed skills.
+Declares which privileged `SkillContext` services this skill needs. The loader validates declared names against a fixed allowlist at startup and rejects unknown names. The manifest is frozen after loading — capabilities cannot be changed at runtime.
+
+```json
+"capabilities": ["outboundGateway"]
+```
+
+Valid capability names and what they grant:
+
+| Capability | Service | Use for |
+|---|---|---|
+| `bus` | `EventBus` | Publishing bus events directly (delegate, bullpen) |
+| `agentRegistry` | `AgentRegistry` | Looking up registered agents (delegate) |
+| `outboundGateway` | `OutboundGateway` | Sending email and Signal messages |
+| `heldMessages` | `HeldMessageService` | Reading / releasing held message queues |
+| `schedulerService` | `SchedulerService` | Creating and managing scheduled jobs |
+| `entityMemory` | `EntityMemory` | Reading and writing the knowledge graph |
+| `nylasCalendarClient` | `NylasCalendarClient` | Calendar CRUD operations |
+| `autonomyService` | `AutonomyService` | Reading or setting the autonomy score |
+| `browserService` | `BrowserService` | Controlling a real web browser |
+| `bullpenService` | `BullpenService` | Managing agent conversation threads |
+| `skillSearch` | `skillSearch` closure | Searching the skill registry by keyword |
+
+Services NOT in this list (`contactService`, `entityContextAssembler`, `agentPersona`) are **universal** — available to every skill without declaration. Omit `capabilities` entirely if your skill only uses universal services.
 
 #### `inputs` (required)
 
@@ -236,34 +258,34 @@ interface SkillContext {
   /** Scoped pino child logger (includes skill name and task ID in every line) */
   log: Logger;
 
-  // --- Infrastructure-only fields (only populated when manifest.infrastructure: true) ---
+  // --- Capability-gated fields (only populated when the skill declares the capability) ---
 
-  /** Outbound gateway — use this to send email from infrastructure skills.
+  /** Outbound gateway — declare "outboundGateway" in capabilities.
    *  Never access email credentials directly; go through the gateway. */
   outboundGateway?: OutboundGateway;
 
-  /** Nylas calendar client — for infrastructure skills that read/write calendar events */
+  /** Nylas calendar client — declare "nylasCalendarClient" in capabilities */
   nylasCalendarClient?: NylasCalendarClient;
 
-  /** Bus access — for infrastructure skills that need to publish events */
+  /** Bus access — declare "bus" in capabilities */
   bus?: EventBus;
 
-  /** Scheduler service — for infrastructure skills like scheduler-create */
+  /** Scheduler service — declare "schedulerService" in capabilities */
   schedulerService?: SchedulerService;
 
-  /** Entity memory (knowledge graph) — for infrastructure skills that read/write long-term knowledge */
+  /** Entity memory (knowledge graph) — declare "entityMemory" in capabilities */
   entityMemory?: EntityMemory;
 
-  // --- Available to all skills ---
+  /** Browser service — declare "browserService" in capabilities */
+  browserService?: BrowserService;
+
+  // --- Universal fields (available to all skills) ---
 
   /** Caller identity (role, channel). Guaranteed non-null for elevated skills. */
   caller?: CallerContext;
 
   /** Agent persona (display name, title, email signature) from coordinator config */
   agentPersona?: AgentPersona;
-
-  /** Browser service — warm Playwright instance for JS-rendered pages */
-  browserService?: BrowserService;
 }
 ```
 
@@ -424,6 +446,7 @@ When the risk is between two levels, use the higher one. It's easier to lower au
 
 - [ ] `action_risk` is declared in `skill.json`
 - [ ] `sensitivity` matches whether the skill has external effects (remember: `"elevated"` = CEO-or-CLI-only gate)
+- [ ] `capabilities` declares only the privileged services actually used — omit if using only universal services
 - [ ] All optional inputs are suffixed with `?` in the manifest
 - [ ] Handler exports a **class** implementing `SkillHandler`, not a bare function
 - [ ] Handler never throws — all errors returned as `{ success: false, error }`

--- a/docs/specs/03-skills-and-execution.md
+++ b/docs/specs/03-skills-and-execution.md
@@ -39,7 +39,7 @@ skills/
 - `permissions`: declared capabilities, validated at load time
 - `timeout`: per-invocation timeout in ms; exceeded invocations return a failure result (default 30000)
 
-**Privilege access** — skills receive privileged services (bus, entity memory, calendar client, etc.) only via explicit name-based grants in the execution layer. There is no self-declaration mechanism in `skill.json` that grants privilege — any such declaration is ignored. See `src/skills/execution.ts` for the per-skill capability assignments. Issue #119 will codify these into a dedicated `src/skills/capabilities.ts` registry.
+**Privilege access** — skills declare which privileged services they need via `"capabilities": [...]` in `skill.json`. The loader validates names against a fixed allowlist (`VALID_CAPABILITIES` in `src/skills/loader.ts`) at startup and rejects unknown names. The manifest is frozen after loading. The execution layer injects only declared services into `SkillContext` — skills cannot self-escalate at runtime. Universal services (`contactService`, `entityContextAssembler`, `agentPersona`) are available to all skills without declaration. See the `capabilities` section in `docs/dev/adding-a-skill.md` for the full capability reference.
 
 ### Skill Handler Interface
 
@@ -219,7 +219,7 @@ These are not bundled but documented as recommended integrations:
 | Skill discovery — `allow_discovery: true` wired to runtime tool-list builder | Done — closes #274 |
 | Skill discovery — make discovered-but-not-pinned skills callable (dynamic tool-list expansion) | Done — `AgentRuntime` expands `workingToolDefs` per-task after each `skill-registry` success; `ExecutionLayer.getToolDefinitions()` provides schemas; closes #291 |
 | Safety gate for first-time elevated skill use — per-agent-skill `skill_approvals` table | Partial — role-based elevation gate exists (`caller.role === 'ceo'`); persist-once-ask-once flow not yet built |
-| Privilege scoping — per-skill capability assignments replacing `infrastructure` self-declaration | Partial — name-gated per-skill injection in `execution.ts`; full `capabilities.ts` registry pending (#119) |
+| Privilege scoping — per-skill `capabilities` array, load-time validation, frozen manifest | Done — `src/skills/loader.ts` (`VALID_CAPABILITIES`), `src/skills/execution.ts` (capabilities loop); closes #119 |
 | Resource boundaries — max 5 concurrent skill invocations per agent task | Not Done |
 | Resource boundaries — 1MB buffer cap on streaming skill responses | Not Done |
 | Built-in skill: `memory-query` | Not Done |

--- a/docs/wip/2026-04-24-capability-registry-design.md
+++ b/docs/wip/2026-04-24-capability-registry-design.md
@@ -1,0 +1,332 @@
+# Per-Capability Skill Registry
+
+**Issue:** #119
+**Date:** 2026-04-24
+**Status:** Design approved, pending implementation
+
+## Problem
+
+The `infrastructure: true` flag in `skill.json` is a boolean that grants every
+privileged service in `SkillContext` to any skill that declares it. 50 skills
+currently set this flag. The flag is self-declared and grants: `bus`,
+`agentRegistry`, `outboundGateway`, `heldMessages`, `schedulerService`,
+`entityMemory`, `nylasCalendarClient`, `bullpenService` — all at once,
+regardless of what the skill actually needs.
+
+Two concrete risks:
+
+1. **Over-broad access** — a calendar skill gets `bus` and `agentRegistry`
+   access it never uses, widening blast radius if the handler has a bug or is
+   fed malicious input.
+2. **Accidental escalation** — a developer copy-pasting a skill.json from an
+   existing infrastructure skill carries `infrastructure: true` into a new
+   skill that doesn't need it.
+
+Three additional services (`autonomyService`, `browserService`, `skillSearch`)
+are separately name-gated in `execution.ts` via per-skill `if` blocks. These
+are correct but use a different pattern, making the privilege model harder to
+audit.
+
+## Solution
+
+Replace `infrastructure?: boolean` with `capabilities?: string[]` in the skill
+manifest. Skills declare exactly which privileged services they need:
+
+```json
+{
+  "name": "email-send",
+  "capabilities": ["outboundGateway"]
+}
+```
+
+### Load-time validation
+
+The loader validates declared capabilities against a fixed allowlist of known
+capability names. Unknown names fail hard at startup (crash, not silent skip).
+After validation, the manifest is frozen with `Object.freeze()` — no runtime
+mutation is possible.
+
+```typescript
+const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
+  'bus', 'agentRegistry', 'outboundGateway', 'heldMessages',
+  'schedulerService', 'entityMemory', 'nylasCalendarClient',
+  'autonomyService', 'browserService', 'bullpenService', 'skillSearch',
+]);
+```
+
+This set only changes when a new service type is added to the platform — not
+when a new skill is added. Adding a new skill that needs `outboundGateway` is a
+skill.json-only change.
+
+### ExecutionLayer rewrite
+
+The ~50-line `if (manifest.infrastructure)` block and 3 separate name-gated
+conditionals are replaced by a single loop over `manifest.capabilities`:
+
+```typescript
+const caps = manifest.capabilities ?? [];
+
+for (const cap of caps) {
+  if (cap === 'entityMemory') {
+    if (!this.entityMemory) {
+      // Missing service — fail closed (see error handling below)
+      continue;
+    }
+    // Special case: wrap with audit observer when audit context is available
+    ctx.entityMemory = memAudit && this.bus
+      ? buildEntityMemoryObserver(this.entityMemory, this.bus, memAudit, skillLogger)
+      : this.entityMemory;
+  } else if (cap === 'skillSearch') {
+    // Special case: closure over registry, not a service reference
+    ctx.skillSearch = (query: string) =>
+      this.registry.search(query)
+        .filter(s => s.manifest.name !== 'skill-registry')
+        .map(s => ({ name: s.manifest.name, description: s.manifest.description }));
+  } else {
+    const service = this[cap as keyof this];
+    if (!service) {
+      // Missing service — fail closed (see error handling below)
+      continue;
+    }
+    (ctx as Record<string, unknown>)[cap] = service;
+  }
+}
+```
+
+**Missing service error handling:** After the loop, check whether every declared
+capability was satisfied. If any service was missing, log an error and return a
+skill error before invoking the handler. This is fail-closed — a skill that
+declares a capability it can't receive does not run at all. This replaces the
+existing bus/agentRegistry-specific check with a per-capability version.
+
+### Services that remain universal
+
+These are NOT in the capabilities system — available to every skill:
+
+- **`contactService`** — read-only contact lookups (documented as universal in
+  types.ts, confirmed intentional)
+- **`entityContextAssembler`** — read-only entity context pipeline (injected
+  unconditionally since it's no more privileged than contactService)
+- **`agentPersona`** — agent display name, title, and email signature
+
+### Services that move into the capabilities system
+
+Everything currently behind `if (manifest.infrastructure)`:
+`bus`, `agentRegistry`, `outboundGateway`, `heldMessages`, `schedulerService`,
+`entityMemory`, `nylasCalendarClient`, `bullpenService`
+
+Plus the three currently name-gated in separate conditionals:
+`autonomyService`, `browserService`, `skillSearch`
+
+## Per-Skill Capability Audit
+
+Capabilities inferred from reading each handler. Skills not listed here need no
+privileged services (they only use universal services or no services at all).
+
+### outboundGateway
+
+| Skill | Capabilities |
+|---|---|
+| `email-send` | `outboundGateway` |
+| `email-reply` | `outboundGateway` |
+| `email-get` | `outboundGateway` |
+| `email-list` | `outboundGateway` |
+| `email-archive` | `outboundGateway` |
+| `email-draft-save` | `outboundGateway` |
+| `signal-send` | `outboundGateway` |
+
+### heldMessages
+
+| Skill | Capabilities |
+|---|---|
+| `held-messages-list` | `heldMessages` |
+| `held-messages-process` | `heldMessages`, `outboundGateway` |
+
+### schedulerService
+
+| Skill | Capabilities |
+|---|---|
+| `scheduler-create` | `schedulerService` |
+| `scheduler-list` | `schedulerService` |
+| `scheduler-cancel` | `schedulerService` |
+| `scheduler-report` | `schedulerService` |
+
+### nylasCalendarClient
+
+| Skill | Capabilities |
+|---|---|
+| `calendar-list-calendars` | `nylasCalendarClient` |
+| `calendar-list-events` | `nylasCalendarClient` |
+| `calendar-create-event` | `nylasCalendarClient` |
+| `calendar-update-event` | `nylasCalendarClient` |
+| `calendar-delete-event` | `nylasCalendarClient` |
+| `calendar-check-conflicts` | `nylasCalendarClient` |
+| `calendar-find-free-time` | `nylasCalendarClient` |
+| `calendar-register` | `nylasCalendarClient`, `entityMemory` |
+
+### entityMemory
+
+| Skill | Capabilities |
+|---|---|
+| `extract-relationships` | `entityMemory` |
+| `query-relationships` | `entityMemory` |
+| `delete-relationship` | `entityMemory` |
+| `extract-facts` | `entityMemory` |
+| `context-for-email` | `entityMemory` |
+| `entity-context` | `entityMemory` |
+| `knowledge-meeting-links` | `entityMemory` |
+| `knowledge-loyalty-programs` | `entityMemory` |
+| `knowledge-travel-preferences` | `entityMemory` |
+| `knowledge-company-overview` | `entityMemory` |
+| `contact-create` | `entityMemory` |
+| `contact-list` | `entityMemory` |
+| `contact-lookup` | `entityMemory` |
+| `contact-merge` | `entityMemory` |
+| `contact-find-duplicates` | `entityMemory` |
+| `contact-set-role` | `entityMemory` |
+| `contact-link-identity` | `entityMemory` |
+| `contact-unlink-identity` | `entityMemory` |
+| `contact-grant-permission` | `entityMemory` |
+| `contact-revoke-permission` | `entityMemory` |
+
+### entityMemory + schedulerService
+
+| Skill | Capabilities |
+|---|---|
+| `template-meeting-request` | `entityMemory`, `schedulerService` |
+| `template-cancel` | `entityMemory`, `schedulerService` |
+| `template-reschedule` | `entityMemory`, `schedulerService` |
+| `template-doc-request` | `entityMemory` |
+
+### bus / agentRegistry / bullpenService
+
+| Skill | Capabilities |
+|---|---|
+| `delegate` | `bus`, `agentRegistry` |
+| `bullpen` | `bus`, `bullpenService` |
+
+### autonomyService / browserService / skillSearch
+
+| Skill | Capabilities |
+|---|---|
+| `get-autonomy` | `autonomyService` |
+| `set-autonomy` | `autonomyService` |
+| `web-browser` | `browserService` |
+| `skill-registry` | `skillSearch` |
+
+### No capabilities needed
+
+These skills currently have `infrastructure: true` but only use universal
+services (`contactService`). They lose the flag and gain no capabilities entry:
+
+- `contact-set-trust`
+- `contact-rename`
+
+## Implementation notes
+
+**Verify each handler before finalising its capabilities.** The audit above was
+inferred from handler code reading. Some skills — especially contact and
+template skills — may access more services than identified. Under-declaring is a
+runtime bug (skill silently loses access); over-declaring is a security issue.
+Read each handler at implementation time to confirm.
+
+**`entityContextAssembler` stays universal.** It is a read-only DB pipeline
+injected unconditionally (execution.ts lines 357-363). The issue's original
+registry included it as a privileged service for `entity-context`, but since
+it's already universal with the same justification as `contactService`, it
+remains outside the capabilities system.
+
+**`contactService` stays universal.** Confirmed intentional — read-only contact
+lookups are not a privilege escalation. Skills like `contact-set-trust` and
+`contact-rename` that only use `contactService` need no capabilities entry.
+
+**Error messages in handlers.** Many handlers have error messages referencing
+`infrastructure: true` (e.g. "Is infrastructure: true set in the manifest?").
+These should be updated to reference the specific capability (e.g. "Declare
+'outboundGateway' in capabilities").
+
+## Type changes
+
+**`src/skills/types.ts`:**
+- Remove `infrastructure?: boolean` from `SkillManifest`
+- Add `capabilities?: string[]` to `SkillManifest`
+- Update doc comments on `SkillContext` fields — replace "infrastructure skills"
+  with "skills declaring the corresponding capability"
+
+## Loader changes
+
+**`src/skills/loader.ts`:**
+- Add `VALID_CAPABILITIES` allowlist
+- Validate `manifest.capabilities` entries against allowlist at load time
+- `Object.freeze(manifest)` after validation and default-setting
+- Remove any `infrastructure` defaulting logic
+
+## Test changes
+
+**`src/skills/execution.test.ts` — new test cases:**
+1. A skill declaring `['outboundGateway']` receives `ctx.outboundGateway` but
+   not `ctx.bus`, `ctx.entityMemory`, etc.
+2. A skill with no `capabilities` field receives no privileged services (only
+   universal ones)
+3. A skill declaring `['schedulerService']` when ExecutionLayer has no
+   schedulerService wired returns a clean skill error
+
+**Loader tests (new or in existing test file):**
+1. Unknown capability name causes load failure
+2. Valid capabilities load successfully and manifest is frozen
+3. Frozen manifest cannot be mutated at runtime
+
+Existing execution tests don't set `infrastructure: true` on their manifests, so
+they should pass without changes.
+
+## Documentation updates
+
+**`docs/dev/adding-a-skill.md`:**
+- Replace the `infrastructure` field reference (line 112-114) with a
+  `capabilities` field reference: valid names, when to use each, examples
+- Update the `SkillContext` example (lines 239-266) — replace
+  "Infrastructure-only fields" grouping with "Capability-gated fields"
+- Add `capabilities` to the PR checklist
+
+**`docs/specs/03-skills-and-execution.md`:**
+- Update the "Privilege access" paragraph (line 42) — skills now declare
+  `capabilities` in their manifest (per-capability, validated at load, frozen
+  after load)
+- Update the implementation status entry (line 222) — mark privilege scoping as
+  Done, remove reference to pending `capabilities.ts` registry
+
+## Migration
+
+All 50 skill.json files are updated atomically in the same PR:
+- Remove `"infrastructure": true`
+- Add `"capabilities": [...]` with the per-skill list from the audit above
+
+Two skills (`contact-set-trust`, `contact-rename`) lose `infrastructure: true`
+and gain nothing — they only use universal services.
+
+## Versioning
+
+Patch bump (`0.0.X`) — pre-alpha, breaking changes expected.
+
+Changelog entry under **Security** (eliminates over-broad privilege grant) and
+**Changed** (manifest schema: `infrastructure` replaced by `capabilities`).
+
+## Checklist
+
+- [ ] Add `capabilities?: string[]` to `SkillManifest` in `src/skills/types.ts`
+- [ ] Remove `infrastructure?: boolean` from `SkillManifest`
+- [ ] Add `VALID_CAPABILITIES` allowlist and validation to `src/skills/loader.ts`
+- [ ] Add `Object.freeze(manifest)` to loader after validation
+- [ ] Replace `if (manifest.infrastructure)` block in `src/skills/execution.ts`
+      with capabilities loop
+- [ ] Remove the 3 name-gated conditionals (autonomyService, browserService,
+      skillSearch) — folded into capabilities loop
+- [ ] Update all 50 `skill.json` files: remove `infrastructure`, add
+      `capabilities`
+- [ ] Update handler error messages referencing `infrastructure: true`
+- [ ] Update `docs/dev/adding-a-skill.md`
+- [ ] Update `docs/specs/03-skills-and-execution.md`
+- [ ] Add execution.test.ts tests for capability injection
+- [ ] Add loader tests for validation and freeze
+- [ ] `pnpm typecheck` and `pnpm test` pass
+- [ ] Bump version, update CHANGELOG.md

--- a/docs/wip/2026-04-24-capability-registry-design.md
+++ b/docs/wip/2026-04-24-capability-registry-design.md
@@ -120,8 +120,10 @@ Plus the three currently name-gated in separate conditionals:
 
 ## Per-Skill Capability Audit
 
-Capabilities inferred from reading each handler. Skills not listed here need no
-privileged services (they only use universal services or no services at all).
+Verified by grepping every handler.ts for `ctx.<service>` references. Skills not
+listed here need no privileged services — they only use universal services
+(`contactService`, `entityContextAssembler`, `agentPersona`) or no services at
+all.
 
 ### outboundGateway
 
@@ -140,7 +142,7 @@ privileged services (they only use universal services or no services at all).
 | Skill | Capabilities |
 |---|---|
 | `held-messages-list` | `heldMessages` |
-| `held-messages-process` | `heldMessages`, `outboundGateway` |
+| `held-messages-process` | `heldMessages`, `bus` |
 
 ### schedulerService
 
@@ -162,7 +164,6 @@ privileged services (they only use universal services or no services at all).
 | `calendar-delete-event` | `nylasCalendarClient` |
 | `calendar-check-conflicts` | `nylasCalendarClient` |
 | `calendar-find-free-time` | `nylasCalendarClient` |
-| `calendar-register` | `nylasCalendarClient`, `entityMemory` |
 
 ### entityMemory
 
@@ -173,30 +174,10 @@ privileged services (they only use universal services or no services at all).
 | `delete-relationship` | `entityMemory` |
 | `extract-facts` | `entityMemory` |
 | `context-for-email` | `entityMemory` |
-| `entity-context` | `entityMemory` |
 | `knowledge-meeting-links` | `entityMemory` |
 | `knowledge-loyalty-programs` | `entityMemory` |
 | `knowledge-travel-preferences` | `entityMemory` |
 | `knowledge-company-overview` | `entityMemory` |
-| `contact-create` | `entityMemory` |
-| `contact-list` | `entityMemory` |
-| `contact-lookup` | `entityMemory` |
-| `contact-merge` | `entityMemory` |
-| `contact-find-duplicates` | `entityMemory` |
-| `contact-set-role` | `entityMemory` |
-| `contact-link-identity` | `entityMemory` |
-| `contact-unlink-identity` | `entityMemory` |
-| `contact-grant-permission` | `entityMemory` |
-| `contact-revoke-permission` | `entityMemory` |
-
-### entityMemory + schedulerService
-
-| Skill | Capabilities |
-|---|---|
-| `template-meeting-request` | `entityMemory`, `schedulerService` |
-| `template-cancel` | `entityMemory`, `schedulerService` |
-| `template-reschedule` | `entityMemory`, `schedulerService` |
-| `template-doc-request` | `entityMemory` |
 
 ### bus / agentRegistry / bullpenService
 
@@ -214,21 +195,30 @@ privileged services (they only use universal services or no services at all).
 | `web-browser` | `browserService` |
 | `skill-registry` | `skillSearch` |
 
-### No capabilities needed
+### No capabilities needed (32 skills)
 
 These skills currently have `infrastructure: true` but only use universal
-services (`contactService`). They lose the flag and gain no capabilities entry:
+services. They lose the flag and gain no capabilities entry:
 
-- `contact-set-trust`
-- `contact-rename`
+**Contact skills** (all use only `contactService`):
+`contact-create`, `contact-list`, `contact-lookup`, `contact-merge`,
+`contact-find-duplicates`, `contact-set-role`, `contact-link-identity`,
+`contact-unlink-identity`, `contact-grant-permission`, `contact-revoke-permission`,
+`contact-set-trust`, `contact-rename`
+
+**Template skills** (all use only `agentPersona`):
+`template-meeting-request`, `template-cancel`, `template-reschedule`,
+`template-doc-request`
+
+**Other** (use only universal services):
+`entity-context` (uses `entityContextAssembler`),
+`calendar-register` (uses `contactService`)
 
 ## Implementation notes
 
-**Verify each handler before finalising its capabilities.** The audit above was
-inferred from handler code reading. Some skills — especially contact and
-template skills — may access more services than identified. Under-declaring is a
-runtime bug (skill silently loses access); over-declaring is a security issue.
-Read each handler at implementation time to confirm.
+**The audit above is verified.** Every handler.ts was grepped for privileged
+service references (`ctx.<service>`). The results are definitive — not inferred
+from names.
 
 **`entityContextAssembler` stays universal.** It is a read-only DB pipeline
 injected unconditionally (execution.ts lines 357-363). The issue's original
@@ -301,8 +291,10 @@ All 50 skill.json files are updated atomically in the same PR:
 - Remove `"infrastructure": true`
 - Add `"capabilities": [...]` with the per-skill list from the audit above
 
-Two skills (`contact-set-trust`, `contact-rename`) lose `infrastructure: true`
-and gain nothing — they only use universal services.
+18 skills lose `infrastructure: true` and gain no capabilities entry — they
+only use universal services (`contactService`, `entityContextAssembler`,
+`agentPersona`). The remaining 32 get a `capabilities` array with only the
+specific services they actually use.
 
 ## Versioning
 

--- a/docs/wip/2026-04-24-capability-registry.md
+++ b/docs/wip/2026-04-24-capability-registry.md
@@ -1,0 +1,818 @@
+# Per-Capability Skill Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the all-or-nothing `infrastructure: true` manifest flag with per-capability `capabilities` arrays — validated at load time, frozen after load, and enforced in the execution layer.
+
+**Architecture:** Skills declare needed privileged services in `skill.json` as `"capabilities": ["outboundGateway"]`. The loader validates against a fixed allowlist and freezes the manifest. ExecutionLayer injects only the declared services, replacing the infrastructure block and all name-gated conditionals with a single loop.
+
+**Tech Stack:** TypeScript, Vitest, pino
+
+**Spec:** `docs/wip/2026-04-24-capability-registry-design.md`
+
+---
+
+### Task 1: Update SkillManifest type
+
+**Files:**
+- Modify: `src/skills/types.ts:31-69` (SkillManifest interface)
+- Modify: `src/skills/types.ts:105-173` (SkillContext interface doc comments)
+
+- [ ] **Step 1: Replace `infrastructure` with `capabilities` on SkillManifest**
+
+In `src/skills/types.ts`, replace the `infrastructure` field:
+
+```typescript
+  /** If true, this skill receives bus and agent registry access in its context.
+   *  This grants unrestricted bus publish/subscribe including layer impersonation.
+   *  Only for framework-internal skills like 'delegate' — external skills should never set this. */
+  infrastructure?: boolean;
+```
+
+with:
+
+```typescript
+  /** Declares which privileged SkillContext services this skill needs.
+   *  Only known capability names are accepted — the loader validates against
+   *  a fixed allowlist at startup and rejects unknown names.
+   *  The manifest is frozen after loading — capabilities cannot be mutated at runtime.
+   *
+   *  Valid capabilities: bus, agentRegistry, outboundGateway, heldMessages,
+   *  schedulerService, entityMemory, nylasCalendarClient, autonomyService,
+   *  browserService, bullpenService, skillSearch.
+   *
+   *  Services NOT listed here (contactService, entityContextAssembler, agentPersona)
+   *  are universal — available to every skill without declaration. */
+  capabilities?: string[];
+```
+
+- [ ] **Step 2: Update SkillContext doc comments**
+
+In the same file, update the doc comments on capability-gated fields. Replace every
+occurrence of "only available to infrastructure skills" or similar with the specific
+capability name. For example, on `bus`:
+
+```typescript
+  /** Bus access — available to skills declaring 'bus' in capabilities */
+  bus?: import('../bus/bus.js').EventBus;
+```
+
+Apply the same pattern to: `agentRegistry`, `outboundGateway`, `heldMessages`,
+`schedulerService`, `entityMemory`, `nylasCalendarClient`, `bullpenService`,
+`autonomyService`, `browserService`, `skillSearch`.
+
+For `browserService`, also remove the incorrect claim "available to all skills
+(not infrastructure-gated)" since it IS capability-gated now.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm --prefix <worktree> run typecheck`
+
+Expected: Type errors in `execution.ts` (references `manifest.infrastructure`
+which no longer exists) and possibly `loader.ts`. This is expected — we fix
+those in Tasks 2 and 3.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/skills/types.ts
+git commit -m "feat: replace infrastructure boolean with capabilities array on SkillManifest (#119)"
+```
+
+---
+
+### Task 2: Add loader validation and manifest freeze
+
+**Files:**
+- Modify: `src/skills/loader.ts:1-103`
+- Create: `src/skills/loader.test.ts`
+
+- [ ] **Step 1: Write failing tests for loader validation**
+
+Create `src/skills/loader.test.ts`:
+
+```typescript
+// loader.test.ts — tests for capability validation and manifest freeze.
+
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { loadSkillsFromDirectory } from './loader.js';
+import { SkillRegistry } from './registry.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+// Helper: create a temporary skill directory with a manifest and a trivial handler
+function setupSkillDir(tmpDir: string, skillName: string, manifest: Record<string, unknown>): void {
+  const skillDir = path.join(tmpDir, skillName);
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(path.join(skillDir, 'skill.json'), JSON.stringify(manifest));
+  // Minimal handler that exports a class with execute()
+  fs.writeFileSync(path.join(skillDir, 'handler.ts'), `
+    export class Handler {
+      async execute(ctx) { return { success: true, data: 'ok' }; }
+    }
+  `);
+}
+
+describe('loader: capability validation', () => {
+  it('rejects unknown capability names at load time', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_skills_unknown_cap__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'bad-skill', {
+        name: 'bad-skill',
+        description: 'test',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        capabilities: ['outboundGateway', 'notARealCapability'],
+      });
+      const registry = new SkillRegistry();
+      await expect(loadSkillsFromDirectory(tmpDir, registry, logger))
+        .rejects.toThrow(/unknown capability.*notARealCapability/i);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts valid capability names', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_skills_valid_cap__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'good-skill', {
+        name: 'good-skill',
+        description: 'test',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        capabilities: ['outboundGateway', 'entityMemory'],
+      });
+      const registry = new SkillRegistry();
+      const count = await loadSkillsFromDirectory(tmpDir, registry, logger);
+      expect(count).toBe(1);
+      const skill = registry.get('good-skill');
+      expect(skill?.manifest.capabilities).toEqual(['outboundGateway', 'entityMemory']);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts skills with no capabilities field', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_skills_no_cap__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'simple-skill', {
+        name: 'simple-skill',
+        description: 'test',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+      });
+      const registry = new SkillRegistry();
+      const count = await loadSkillsFromDirectory(tmpDir, registry, logger);
+      expect(count).toBe(1);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('loader: manifest freeze', () => {
+  it('freezes the manifest after loading', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_skills_freeze__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'frozen-skill', {
+        name: 'frozen-skill',
+        description: 'test',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        capabilities: ['entityMemory'],
+      });
+      const registry = new SkillRegistry();
+      await loadSkillsFromDirectory(tmpDir, registry, logger);
+      const skill = registry.get('frozen-skill');
+      expect(Object.isFrozen(skill?.manifest)).toBe(true);
+      // Attempting to mutate should throw in strict mode or silently fail
+      expect(() => { (skill!.manifest as Record<string, unknown>).capabilities = ['bus']; }).toThrow();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --prefix <worktree> test src/skills/loader.test.ts`
+
+Expected: Tests fail because validation and freeze aren't implemented yet.
+
+- [ ] **Step 3: Implement loader validation and freeze**
+
+In `src/skills/loader.ts`, add the `VALID_CAPABILITIES` set near the top (after imports):
+
+```typescript
+/**
+ * Fixed allowlist of valid capability names that skills may declare.
+ * Each name corresponds to a privileged service on SkillContext.
+ * This set only changes when a new service type is added to the platform —
+ * not when a new skill is added.
+ */
+export const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
+  'bus', 'agentRegistry', 'outboundGateway', 'heldMessages',
+  'schedulerService', 'entityMemory', 'nylasCalendarClient',
+  'autonomyService', 'browserService', 'bullpenService', 'skillSearch',
+]);
+```
+
+Then after the existing default-setting block (`manifest.timeout ??= 30000;`
+etc.), add:
+
+```typescript
+      // Default capabilities to empty array
+      manifest.capabilities ??= [];
+
+      // Validate declared capabilities against the allowlist.
+      // Unknown names fail hard at startup — not silently ignored.
+      for (const cap of manifest.capabilities) {
+        if (!VALID_CAPABILITIES.has(cap)) {
+          throw new Error(
+            `Skill '${manifest.name}' declares unknown capability '${cap}'. ` +
+            `Valid capabilities: ${[...VALID_CAPABILITIES].join(', ')}`,
+          );
+        }
+      }
+```
+
+Then, right before `registry.register(manifest, handler)`, freeze the manifest:
+
+```typescript
+      // Freeze the manifest to prevent runtime mutation — a handler cannot
+      // escalate its own privileges by pushing to capabilities[].
+      Object.freeze(manifest);
+      if (manifest.capabilities) Object.freeze(manifest.capabilities);
+```
+
+Note: `Object.freeze` is shallow — we need to freeze the `capabilities` array
+separately to prevent `manifest.capabilities.push('bus')`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --prefix <worktree> test src/skills/loader.test.ts`
+
+Expected: All 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/skills/loader.ts src/skills/loader.test.ts
+git commit -m "feat: add capability validation and manifest freeze to skill loader (#119)"
+```
+
+---
+
+### Task 3: Rewrite ExecutionLayer capability injection
+
+**Files:**
+- Modify: `src/skills/execution.ts:277-354` (infrastructure block + name-gated conditionals)
+- Modify: `src/skills/execution.ts:1-19` (file header comment)
+- Modify: `src/skills/execution.test.ts`
+
+- [ ] **Step 1: Write failing tests for capability injection**
+
+Add these test cases to `src/skills/execution.test.ts`:
+
+```typescript
+import type { EventBus } from '../bus/bus.js';
+import type { AgentRegistry } from '../agents/agent-registry.js';
+import type { OutboundGateway } from './outbound-gateway.js';
+import type { SchedulerService } from '../scheduler/scheduler-service.js';
+
+// ---------------------------------------------------------------------------
+// Capability-gated service injection
+// ---------------------------------------------------------------------------
+
+describe('capability-gated service injection', () => {
+  /** Manifest that declares a specific capability. */
+  function makeCapManifest(name: string, capabilities: string[]): SkillManifest {
+    return {
+      name,
+      description: `${name} description`,
+      version: '1.0.0',
+      sensitivity: 'normal',
+      action_risk: 'none',
+      inputs: {},
+      outputs: {},
+      permissions: [],
+      secrets: [],
+      timeout: 5000,
+      capabilities,
+    };
+  }
+
+  it('injects only declared capabilities into context', async () => {
+    const registry = new SkillRegistry();
+    // Handler captures the context it received so we can inspect it
+    let capturedCtx: Record<string, unknown> = {};
+    const handler: SkillHandler = {
+      execute: vi.fn(async (ctx) => {
+        capturedCtx = ctx as unknown as Record<string, unknown>;
+        return { success: true, data: 'ok' };
+      }),
+    };
+    registry.register(makeCapManifest('outbound-only', ['outboundGateway']), handler);
+
+    const mockGateway = { send: vi.fn() } as unknown as OutboundGateway;
+    const mockBus = { publish: vi.fn() } as unknown as EventBus;
+    const mockScheduler = { createJob: vi.fn() } as unknown as SchedulerService;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      outboundGateway: mockGateway,
+      bus: mockBus,
+      schedulerService: mockScheduler,
+    });
+
+    await layer.invoke('outbound-only', {});
+
+    // Should have outboundGateway
+    expect(capturedCtx.outboundGateway).toBe(mockGateway);
+    // Should NOT have bus or schedulerService — not declared
+    expect(capturedCtx.bus).toBeUndefined();
+    expect(capturedCtx.schedulerService).toBeUndefined();
+  });
+
+  it('injects no privileged services when capabilities is empty', async () => {
+    const registry = new SkillRegistry();
+    let capturedCtx: Record<string, unknown> = {};
+    const handler: SkillHandler = {
+      execute: vi.fn(async (ctx) => {
+        capturedCtx = ctx as unknown as Record<string, unknown>;
+        return { success: true, data: 'ok' };
+      }),
+    };
+    registry.register(makeCapManifest('no-caps', []), handler);
+
+    const mockBus = { publish: vi.fn() } as unknown as EventBus;
+    const mockGateway = { send: vi.fn() } as unknown as OutboundGateway;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      bus: mockBus,
+      outboundGateway: mockGateway,
+    });
+
+    await layer.invoke('no-caps', {});
+
+    expect(capturedCtx.bus).toBeUndefined();
+    expect(capturedCtx.outboundGateway).toBeUndefined();
+    // Universal services should still be present if configured
+    // (contactService, entityContextAssembler, agentPersona)
+  });
+
+  it('returns skill error when declared capability is not available', async () => {
+    const registry = new SkillRegistry();
+    const handler: SkillHandler = {
+      execute: vi.fn(async () => ({ success: true, data: 'ok' })),
+    };
+    registry.register(makeCapManifest('needs-scheduler', ['schedulerService']), handler);
+
+    // ExecutionLayer constructed WITHOUT schedulerService
+    const layer = new ExecutionLayer(registry, logger);
+
+    const result = await layer.invoke('needs-scheduler', {});
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('schedulerService');
+    }
+    // Handler should NOT have been called
+    expect(handler.execute).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --prefix <worktree> test src/skills/execution.test.ts`
+
+Expected: Tests fail because the infrastructure block doesn't read `capabilities`.
+
+- [ ] **Step 3: Rewrite the capability injection in ExecutionLayer.invoke()**
+
+In `src/skills/execution.ts`, replace the entire block from:
+```typescript
+    // Infrastructure skills get bus and agent registry access.
+    // This is intentionally gated behind a manifest flag so normal skills
+    // cannot escalate their privileges by accessing the bus directly.
+    if (manifest.infrastructure) {
+```
+through to the closing `}` of the infrastructure block (around line 328),
+AND remove the three separate name-gated conditionals for `autonomyService`
+(lines 330-334), `browserService` (lines 336-342), and `skillSearch`
+(lines 344-354).
+
+Replace all of that with:
+
+```typescript
+    // Capability-gated service injection.
+    // Skills declare which privileged services they need in manifest.capabilities.
+    // The loader validates the names and freezes the manifest at startup.
+    // We inject only the declared services — skills cannot escalate privilege.
+    const caps = manifest.capabilities ?? [];
+
+    // Fail-closed: if a declared capability is not available on this ExecutionLayer,
+    // refuse to run the skill. This catches configuration errors at invocation time.
+    const missingCaps = caps.filter(cap => {
+      if (cap === 'skillSearch') return false; // skillSearch is synthesised, not a field on `this`
+      return !(this as Record<string, unknown>)[cap];
+    });
+    if (missingCaps.length > 0) {
+      skillLogger.error(
+        { skillName, missingCapabilities: missingCaps },
+        'Skill declares capabilities not available on ExecutionLayer',
+      );
+      return {
+        success: false,
+        error: this.wrapSkillError(
+          `Skill '${skillName}' requires capabilities [${missingCaps.join(', ')}] ` +
+          `but they are not configured on the ExecutionLayer`,
+        ),
+      };
+    }
+
+    // Compute audit context for entityMemory observer (before the loop — used inside it).
+    const memAudit = options?.agentId && options?.conversationId && options?.parentEventId
+      ? { agentId: options.agentId, conversationId: options.conversationId, parentEventId: options.parentEventId, taskEventId: options.taskEventId }
+      : undefined;
+
+    for (const cap of caps) {
+      if (cap === 'entityMemory') {
+        // Special case: wrap with audit observer when audit context is available.
+        // Uses this.bus (ExecutionLayer's bus), not the skill's ctx.bus — the observer
+        // needs bus access for audit events even if the skill didn't declare 'bus'.
+        ctx.entityMemory = memAudit && this.bus
+          ? buildEntityMemoryObserver(this.entityMemory!, this.bus, memAudit, skillLogger)
+          : this.entityMemory;
+      } else if (cap === 'skillSearch') {
+        // Special case: skillSearch is a closure over the registry, not a service field.
+        ctx.skillSearch = (query: string) =>
+          this.registry.search(query)
+            .filter(s => s.manifest.name !== 'skill-registry')
+            .map(s => ({ name: s.manifest.name, description: s.manifest.description }));
+      } else {
+        (ctx as Record<string, unknown>)[cap] = (this as Record<string, unknown>)[cap];
+      }
+    }
+```
+
+- [ ] **Step 4: Update the file header comment**
+
+Replace the existing header comment (lines 1-18) with:
+
+```typescript
+// execution.ts — the execution layer runs skills within controlled boundaries.
+//
+// This is the security boundary between agents and the outside world.
+// It resolves skills from the registry, validates permissions, provides
+// a sandboxed SkillContext, enforces timeouts, and sanitizes outputs.
+//
+// Normal skills get: validated input, scoped secret access, a scoped logger,
+// and universal services (contactService, entityContextAssembler, agentPersona).
+//
+// Privileged services (bus, outboundGateway, entityMemory, etc.) are only
+// injected when the skill declares them in manifest.capabilities[]. The loader
+// validates capability names against a fixed allowlist and freezes the manifest
+// at startup — skills cannot self-escalate at runtime.
+//
+// Entity enrichment (manifest.entity_enrichment): when a skill declares this,
+// the execution layer assembles EntityContext for the declared input parameter
+// before invoking the handler. The handler receives ctx.entityContext[] and
+// never needs to call entity-context itself.
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run: `pnpm --prefix <worktree> test src/skills/execution.test.ts`
+
+Expected: All tests pass (existing + 3 new).
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `pnpm --prefix <worktree> run typecheck`
+
+Expected: Clean. The `infrastructure` field is removed from the type and all
+code references have been updated.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/skills/execution.ts src/skills/execution.test.ts
+git commit -m "feat: replace infrastructure block with per-capability injection loop (#119)"
+```
+
+---
+
+### Task 4: Migrate all 50 skill.json files
+
+**Files:**
+- Modify: all `skills/*/skill.json` that have `"infrastructure": true`
+
+This task is mechanical — remove `"infrastructure": true` and add
+`"capabilities": [...]` based on the verified audit.
+
+- [ ] **Step 1: Migrate the 32 skills that NEED capabilities**
+
+For each skill below, remove `"infrastructure": true` and add the
+`"capabilities"` field with the listed values.
+
+**outboundGateway:**
+```
+email-send:         ["outboundGateway"]
+email-reply:        ["outboundGateway"]
+email-get:          ["outboundGateway"]
+email-list:         ["outboundGateway"]
+email-archive:      ["outboundGateway"]
+email-draft-save:   ["outboundGateway"]
+signal-send:        ["outboundGateway"]
+```
+
+**heldMessages:**
+```
+held-messages-list:    ["heldMessages"]
+held-messages-process: ["heldMessages", "bus"]
+```
+
+**schedulerService:**
+```
+scheduler-create:  ["schedulerService"]
+scheduler-list:    ["schedulerService"]
+scheduler-cancel:  ["schedulerService"]
+scheduler-report:  ["schedulerService"]
+```
+
+**nylasCalendarClient:**
+```
+calendar-list-calendars:  ["nylasCalendarClient"]
+calendar-list-events:     ["nylasCalendarClient"]
+calendar-create-event:    ["nylasCalendarClient"]
+calendar-update-event:    ["nylasCalendarClient"]
+calendar-delete-event:    ["nylasCalendarClient"]
+calendar-check-conflicts: ["nylasCalendarClient"]
+calendar-find-free-time:  ["nylasCalendarClient"]
+```
+
+**entityMemory:**
+```
+extract-relationships:        ["entityMemory"]
+query-relationships:          ["entityMemory"]
+delete-relationship:          ["entityMemory"]
+extract-facts:                ["entityMemory"]
+context-for-email:            ["entityMemory"]
+knowledge-meeting-links:      ["entityMemory"]
+knowledge-loyalty-programs:   ["entityMemory"]
+knowledge-travel-preferences: ["entityMemory"]
+knowledge-company-overview:   ["entityMemory"]
+```
+
+**bus + agentRegistry / bullpenService:**
+```
+delegate: ["bus", "agentRegistry"]
+bullpen:  ["bus", "bullpenService"]
+```
+
+**autonomyService / browserService / skillSearch:**
+```
+get-autonomy:    ["autonomyService"]
+set-autonomy:    ["autonomyService"]
+web-browser:     ["browserService"]
+skill-registry:  ["skillSearch"]
+```
+
+- [ ] **Step 2: Migrate the 18 skills that need NO capabilities**
+
+For each skill below, remove `"infrastructure": true` and do NOT add a
+`capabilities` field (or add `"capabilities": []`):
+
+```
+contact-create, contact-list, contact-lookup, contact-merge,
+contact-find-duplicates, contact-set-role, contact-link-identity,
+contact-unlink-identity, contact-grant-permission, contact-revoke-permission,
+contact-set-trust, contact-rename,
+template-meeting-request, template-cancel, template-reschedule,
+template-doc-request,
+entity-context, calendar-register
+```
+
+- [ ] **Step 3: Verify no infrastructure references remain**
+
+Run: `grep -r '"infrastructure"' skills/*/skill.json`
+
+Expected: No output (all instances removed).
+
+- [ ] **Step 4: Commit**
+
+```
+git add skills/*/skill.json
+git commit -m "feat: migrate all 50 skill.json files from infrastructure to capabilities (#119)"
+```
+
+---
+
+### Task 5: Update handler error messages
+
+**Files:**
+- Modify: handler.ts files that reference `infrastructure: true` in error messages
+
+- [ ] **Step 1: Find all handler error messages referencing infrastructure**
+
+Run: `grep -rn 'infrastructure' skills/*/handler.ts`
+
+This will list every handler that mentions `infrastructure` in its error strings.
+
+- [ ] **Step 2: Update each error message**
+
+Replace messages like:
+```
+'email-get requires outboundGateway (infrastructure: true)'
+```
+with:
+```
+'email-get requires outboundGateway — declare it in capabilities'
+```
+
+Apply the same pattern to every handler found in Step 1. The specific capability
+name should match what the skill actually needs.
+
+- [ ] **Step 3: Commit**
+
+```
+git add skills/*/handler.ts
+git commit -m "fix: update handler error messages to reference capabilities instead of infrastructure (#119)"
+```
+
+---
+
+### Task 6: Update documentation
+
+**Files:**
+- Modify: `docs/dev/adding-a-skill.md`
+- Modify: `docs/specs/03-skills-and-execution.md`
+
+- [ ] **Step 1: Update adding-a-skill.md**
+
+Replace the `infrastructure` field reference (the `#### \`infrastructure\`` section
+around line 112-114) with:
+
+```markdown
+#### `capabilities` (optional, default: `[]`)
+
+Declares which privileged `SkillContext` services this skill needs. The loader
+validates names against a fixed allowlist at startup — unknown names cause a
+hard load failure. The manifest is frozen after loading, so capabilities cannot
+be mutated at runtime.
+
+Valid capability names:
+
+| Capability | Service | Use when your skill needs to... |
+|---|---|---|
+| `bus` | `EventBus` | Publish or subscribe to bus events |
+| `agentRegistry` | `AgentRegistry` | Enumerate or target other agents |
+| `outboundGateway` | `OutboundGateway` | Send email, Signal messages, or other outbound comms |
+| `heldMessages` | `HeldMessageService` | List or process held/deferred messages |
+| `schedulerService` | `SchedulerService` | Create, list, or cancel scheduled jobs |
+| `entityMemory` | `EntityMemory` | Read or write to the knowledge graph |
+| `nylasCalendarClient` | `NylasCalendarClient` | CRUD operations on calendar events |
+| `autonomyService` | `AutonomyService` | Read or write the global autonomy score |
+| `browserService` | `BrowserService` | Interact with a Playwright browser instance |
+| `bullpenService` | `BullpenService` | Open or reply to inter-agent discussion threads |
+| `skillSearch` | closure | Search the skill registry (skill-registry built-in only) |
+
+Services NOT listed here are universal — available to every skill without declaration:
+`contactService` (contact lookups), `entityContextAssembler` (entity context pipeline),
+`agentPersona` (agent identity).
+
+Most skills need zero or one capability. Only declare what your handler actually uses —
+the execution layer will refuse to run a skill if a declared capability is not available.
+
+Example:
+```json
+"capabilities": ["outboundGateway"]
+```
+```
+
+Update the `SkillContext` example (around lines 239-266) — replace the
+"Infrastructure-only fields" comment with "Capability-gated fields (declared in
+manifest capabilities)".
+
+Add to the PR checklist:
+```markdown
+- [ ] If the skill needs privileged services, declare them in `"capabilities"`
+```
+
+- [ ] **Step 2: Update 03-skills-and-execution.md**
+
+Replace the "Privilege access" paragraph (line 42):
+
+```markdown
+**Privilege access** — skills declare which privileged services they need via `"capabilities"` in `skill.json`. The loader validates names against a fixed allowlist at startup and freezes the manifest. The execution layer injects only declared services — skills cannot self-escalate. Universal services (`contactService`, `entityContextAssembler`, `agentPersona`) are available to all skills without declaration.
+```
+
+Update the implementation status entry (line 222):
+
+```markdown
+| Privilege scoping — per-skill capability declarations replacing `infrastructure` self-declaration | Done — `capabilities` array in `skill.json`, validated at load, frozen after load; closes #119 |
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add docs/dev/adding-a-skill.md docs/specs/03-skills-and-execution.md
+git commit -m "docs: update skill guides for capabilities system (#119)"
+```
+
+---
+
+### Task 7: Version bump, changelog, and full test suite
+
+**Files:**
+- Modify: `package.json` (version)
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Bump version**
+
+In `package.json`, change `"version": "0.19.7"` to `"version": "0.19.8"`.
+
+- [ ] **Step 2: Add changelog entry**
+
+Under `## [Unreleased]` in `CHANGELOG.md`, add:
+
+```markdown
+## [0.19.8] — 2026-04-XX
+
+### Security
+
+- **Per-capability skill privileges** — replaced the all-or-nothing `infrastructure: true` manifest flag with a `capabilities` array. Skills declare exactly which privileged services they need; the loader validates against a fixed allowlist and freezes the manifest at startup. 18 skills that only used universal services lost unnecessary privilege access entirely. Closes #119.
+
+### Changed
+
+- **Skill manifest schema** (breaking) — `infrastructure?: boolean` removed, replaced by `capabilities?: string[]`. The loader rejects unknown capability names at startup. Manifests are frozen after loading to prevent runtime mutation.
+```
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `pnpm --prefix <worktree> test`
+
+Expected: All tests pass.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `pnpm --prefix <worktree> run typecheck`
+
+Expected: Clean.
+
+- [ ] **Step 5: Commit**
+
+```
+git add package.json CHANGELOG.md
+git commit -m "chore: bump to 0.19.8, changelog for per-capability privileges (#119)"
+```
+
+---
+
+### Task 8: Pre-PR review and PR creation
+
+- [ ] **Step 1: Run pre-PR review agents**
+
+Launch in parallel:
+- `pr-review-toolkit:code-reviewer` — review all changes on branch vs base
+- `pr-review-toolkit:silent-failure-hunter` — check for swallowed errors
+
+Since this touches the security boundary, also run a security review.
+
+- [ ] **Step 2: Address any findings**
+
+Fix high-priority issues from the reviews. Commit fixes.
+
+- [ ] **Step 3: Create the PR**
+
+```
+gh pr create --title "security: replace infrastructure flag with per-capability skill privileges" \
+  --body "..." --label bug --label P2 --label security
+```
+
+Reference issue #119. Include the summary:
+- Replaced `infrastructure: true` (all-or-nothing) with `capabilities` array
+- Load-time validation + manifest freeze prevents runtime escalation
+- 18 skills lost unnecessary privilege access
+- 32 skills now declare only the specific services they use
+
+- [ ] **Step 4: Verify CI started**
+
+Run: `gh run list --branch fix/capability-registry --limit 1`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.19.8",
+  "version": "0.20.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/schemas/skill-manifest.schema.json
+++ b/schemas/skill-manifest.schema.json
@@ -42,7 +42,10 @@
       "items": { "type": "string" }
     },
     "timeout": { "type": "integer", "minimum": 1 },
-    "infrastructure": { "type": "boolean" },
+    "capabilities": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
     "entity_enrichment": {
       "type": "object",
       "required": ["param", "default"],

--- a/skills/bullpen/handler.ts
+++ b/skills/bullpen/handler.ts
@@ -1,6 +1,6 @@
 // handler.ts — bullpen skill implementation.
 //
-// This is an infrastructure skill that allows agents to open, reply to, read,
+// This skill allows agents to open, reply to, read,
 // and close inter-agent Bullpen discussion threads. It persists thread state
 // via BullpenService and publishes agent.discuss events so the BullpenDispatcher
 // can route reply tasks to mentioned agents.
@@ -24,7 +24,7 @@ export class BullpenHandler implements SkillHandler {
       return { success: false, error: 'BullpenService not available in context' };
     }
     if (!ctx.bus) {
-      return { success: false, error: 'Bus not available in context (infrastructure skill requires bus)' };
+      return { success: false, error: 'Bus not available in context (requires "bus" capability)' };
     }
     if (!ctx.agentId) {
       return { success: false, error: 'agentId not available in context' };

--- a/skills/bullpen/skill.json
+++ b/skills/bullpen/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "action": "string (one of: 'post', 'reply', 'get_thread', 'close')",
     "topic": "string? (thread topic; required when action is 'post')",
@@ -21,5 +20,9 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 10000
+  "timeout": 10000,
+  "capabilities": [
+    "bus",
+    "bullpenService"
+  ]
 }

--- a/skills/calendar-check-conflicts/skill.json
+++ b/skills/calendar-check-conflicts/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "calendarIds": "string[] (list of calendar IDs to check for conflicts)",
     "proposedStart": "timestamp (start of proposed slot)",
@@ -16,5 +15,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 15000
+  "timeout": 15000,
+  "capabilities": [
+    "nylasCalendarClient"
+  ]
 }

--- a/skills/calendar-create-event/skill.json
+++ b/skills/calendar-create-event/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "high",
-  "infrastructure": true,
   "inputs": {
     "calendarId": "string",
     "title": "string",
@@ -22,5 +21,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 30000,
+  "capabilities": [
+    "nylasCalendarClient"
+  ]
 }

--- a/skills/calendar-delete-event/skill.json
+++ b/skills/calendar-delete-event/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "high",
-  "infrastructure": true,
   "inputs": {
     "calendarId": "string",
     "eventId": "string",
@@ -15,5 +14,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 15000
+  "timeout": 15000,
+  "capabilities": [
+    "nylasCalendarClient"
+  ]
 }

--- a/skills/calendar-find-free-time/skill.json
+++ b/skills/calendar-find-free-time/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "calendarIds": "string[] (list of calendar IDs to check for availability)",
     "timeMin": "timestamp (start of search window, inclusive)",
@@ -16,5 +15,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 15000
+  "timeout": 15000,
+  "capabilities": [
+    "nylasCalendarClient"
+  ]
 }

--- a/skills/calendar-list-calendars/handler.ts
+++ b/skills/calendar-list-calendars/handler.ts
@@ -13,7 +13,7 @@ export class CalendarListCalendarsHandler implements SkillHandler {
       return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
     }
     if (!ctx.contactService) {
-      return { success: false, error: 'calendar-list-calendars contactService is a universal service — check ExecutionLayer configuration' };
+      return { success: false, error: 'calendar-list-calendars: contactService not available — this is a universal service, check ExecutionLayer configuration.' };
     }
 
     // Hoisted so the catch block can reference the partial result for log context.

--- a/skills/calendar-list-calendars/handler.ts
+++ b/skills/calendar-list-calendars/handler.ts
@@ -13,7 +13,7 @@ export class CalendarListCalendarsHandler implements SkillHandler {
       return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
     }
     if (!ctx.contactService) {
-      return { success: false, error: 'calendar-list-calendars requires infrastructure access (contactService)' };
+      return { success: false, error: 'calendar-list-calendars contactService is a universal service — check ExecutionLayer configuration' };
     }
 
     // Hoisted so the catch block can reference the partial result for log context.

--- a/skills/calendar-list-calendars/skill.json
+++ b/skills/calendar-list-calendars/skill.json
@@ -4,12 +4,14 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {},
   "outputs": {
     "calendars": "array"
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 15000
+  "timeout": 15000,
+  "capabilities": [
+    "nylasCalendarClient"
+  ]
 }

--- a/skills/calendar-list-events/skill.json
+++ b/skills/calendar-list-events/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "calendarId": "string? (omit to auto-query all caller calendars — only pass when targeting a specific calendar)",
     "timeMin": "timestamp (start of range, inclusive)",
@@ -19,5 +18,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 30000,
+  "capabilities": [
+    "nylasCalendarClient"
+  ]
 }

--- a/skills/calendar-register/handler.ts
+++ b/skills/calendar-register/handler.ts
@@ -16,7 +16,7 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 export class CalendarRegisterHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     if (!ctx.contactService) {
-      return { success: false, error: 'calendar-register contactService is a universal service — check ExecutionLayer configuration' };
+      return { success: false, error: 'calendar-register: contactService not available — this is a universal service, check ExecutionLayer configuration.' };
     }
 
     const { nylas_calendar_id, label, contact_id, is_primary } = ctx.input as {

--- a/skills/calendar-register/handler.ts
+++ b/skills/calendar-register/handler.ts
@@ -16,7 +16,7 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 export class CalendarRegisterHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     if (!ctx.contactService) {
-      return { success: false, error: 'calendar-register requires infrastructure access (contactService)' };
+      return { success: false, error: 'calendar-register contactService is a universal service — check ExecutionLayer configuration' };
     }
 
     const { nylas_calendar_id, label, contact_id, is_primary } = ctx.input as {

--- a/skills/calendar-register/skill.json
+++ b/skills/calendar-register/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "high",
-  "infrastructure": true,
   "inputs": {
     "nylas_calendar_id": "string",
     "label": "string",

--- a/skills/calendar-update-event/skill.json
+++ b/skills/calendar-update-event/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "high",
-  "infrastructure": true,
   "inputs": {
     "calendarId": "string",
     "eventId": "string",
@@ -23,5 +22,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 30000,
+  "capabilities": [
+    "nylasCalendarClient"
+  ]
 }

--- a/skills/contact-create/handler.ts
+++ b/skills/contact-create/handler.ts
@@ -4,7 +4,7 @@
 // signal, telegram). Automatically creates a knowledge graph person node via
 // the ContactService.
 //
-// This is an infrastructure skill — it requires contactService access.
+// This skill uses contactService, which is a universal service.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 
@@ -50,7 +50,7 @@ export class ContactCreateHandler implements SkillHandler {
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-create skill requires infrastructure access (contactService). Is infrastructure: true set in the manifest?',
+        error: 'contact-create skill requires contactService is a universal service — check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-create/handler.ts
+++ b/skills/contact-create/handler.ts
@@ -46,11 +46,11 @@ export class ContactCreateHandler implements SkillHandler {
       }
     }
 
-    // Infrastructure skills need contactService
+    // contactService is a universal service — always injected by ExecutionLayer
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-create skill requires contactService is a universal service — check ExecutionLayer configuration.',
+        error: 'contact-create: contactService not available — this is a universal service, check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-create/skill.json
+++ b/skills/contact-create/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "name": "string",
     "role": "string?",

--- a/skills/contact-find-duplicates/handler.ts
+++ b/skills/contact-find-duplicates/handler.ts
@@ -23,7 +23,7 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-find-duplicates requires contactService is a universal service — check ExecutionLayer configuration.',
+        error: 'contact-find-duplicates: contactService not available — this is a universal service, check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-find-duplicates/handler.ts
+++ b/skills/contact-find-duplicates/handler.ts
@@ -23,7 +23,7 @@ export class ContactFindDuplicatesHandler implements SkillHandler {
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-find-duplicates requires infrastructure access (contactService).',
+        error: 'contact-find-duplicates requires contactService is a universal service — check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-find-duplicates/skill.json
+++ b/skills/contact-find-duplicates/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "min_confidence": "string?"
   },

--- a/skills/contact-grant-permission/handler.ts
+++ b/skills/contact-grant-permission/handler.ts
@@ -27,7 +27,7 @@ export class ContactGrantPermissionHandler implements SkillHandler {
       return { success: false, error: 'Permission name must be lowercase alphanumeric with underscores (e.g., view_financial_reports)' };
     }
     if (!ctx.contactService) {
-      return { success: false, error: 'Contact service not available. contactService is a universal service — check ExecutionLayer configuration.' };
+      return { success: false, error: 'contact-grant-permission: contactService not available — this is a universal service, check ExecutionLayer configuration.' };
     }
 
     // Defensive guard — the execution layer guarantees caller is defined for

--- a/skills/contact-grant-permission/handler.ts
+++ b/skills/contact-grant-permission/handler.ts
@@ -27,7 +27,7 @@ export class ContactGrantPermissionHandler implements SkillHandler {
       return { success: false, error: 'Permission name must be lowercase alphanumeric with underscores (e.g., view_financial_reports)' };
     }
     if (!ctx.contactService) {
-      return { success: false, error: 'Contact service not available. Is infrastructure: true set?' };
+      return { success: false, error: 'Contact service not available. contactService is a universal service — check ExecutionLayer configuration.' };
     }
 
     // Defensive guard — the execution layer guarantees caller is defined for

--- a/skills/contact-grant-permission/skill.json
+++ b/skills/contact-grant-permission/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "elevated",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "contact_id": "string",
     "permission": "string",

--- a/skills/contact-link-identity/handler.ts
+++ b/skills/contact-link-identity/handler.ts
@@ -42,11 +42,11 @@ export class ContactLinkIdentityHandler implements SkillHandler {
       return { success: false, error: `Invalid channel '${channel}'. Allowed: ${ALLOWED_CHANNELS.join(', ')}` };
     }
 
-    // Infrastructure skills need contactService
+    // contactService is a universal service — always injected by ExecutionLayer
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-link-identity skill requires contactService is a universal service — check ExecutionLayer configuration.',
+        error: 'contact-link-identity: contactService not available — this is a universal service, check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-link-identity/handler.ts
+++ b/skills/contact-link-identity/handler.ts
@@ -4,7 +4,7 @@
 // contact. Uses source 'ceo_stated' since the coordinator acts on behalf
 // of the CEO, which means the identity is auto-verified.
 //
-// This is an infrastructure skill — it requires contactService access.
+// This skill uses contactService, which is a universal service.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 
@@ -46,7 +46,7 @@ export class ContactLinkIdentityHandler implements SkillHandler {
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-link-identity skill requires infrastructure access (contactService). Is infrastructure: true set in the manifest?',
+        error: 'contact-link-identity skill requires contactService is a universal service — check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-link-identity/skill.json
+++ b/skills/contact-link-identity/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "contact_id": "string",
     "channel": "string",

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -3,7 +3,7 @@
 // Lists all contacts, optionally filtered by role.
 // Returns an array of contact summaries.
 //
-// This is an infrastructure skill — it requires contactService access.
+// This skill uses contactService, which is a universal service.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 
@@ -22,7 +22,7 @@ export class ContactListHandler implements SkillHandler {
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-list skill requires infrastructure access (contactService). Is infrastructure: true set in the manifest?',
+        error: 'contact-list skill requires contactService is a universal service — check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -18,11 +18,11 @@ export class ContactListHandler implements SkillHandler {
       return { success: false, error: 'Role must be 200 characters or fewer' };
     }
 
-    // Infrastructure skills need contactService
+    // contactService is a universal service — always injected by ExecutionLayer
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-list skill requires contactService is a universal service — check ExecutionLayer configuration.',
+        error: 'contact-list: contactService not available — this is a universal service, check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-list/skill.json
+++ b/skills/contact-list/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "role": "string?"
   },

--- a/skills/contact-lookup/handler.ts
+++ b/skills/contact-lookup/handler.ts
@@ -36,11 +36,11 @@ export class ContactLookupHandler implements SkillHandler {
       return { success: false, error: 'Query must be 500 characters or fewer' };
     }
 
-    // Infrastructure skills need contactService
+    // contactService is a universal service — always injected by ExecutionLayer
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-lookup skill requires contactService is a universal service — check ExecutionLayer configuration.',
+        error: 'contact-lookup: contactService not available — this is a universal service, check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-lookup/handler.ts
+++ b/skills/contact-lookup/handler.ts
@@ -6,7 +6,7 @@
 //   - "role": exact role match via findContactByRole()
 //   - "channel": resolves by "channel:identifier" via resolveByChannelIdentity()
 //
-// This is an infrastructure skill — it requires contactService access.
+// This skill uses contactService, which is a universal service.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 
@@ -40,7 +40,7 @@ export class ContactLookupHandler implements SkillHandler {
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-lookup skill requires infrastructure access (contactService). Is infrastructure: true set in the manifest?',
+        error: 'contact-lookup skill requires contactService is a universal service — check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-lookup/skill.json
+++ b/skills/contact-lookup/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "query": "string",
     "by": "string"

--- a/skills/contact-merge/handler.ts
+++ b/skills/contact-merge/handler.ts
@@ -40,7 +40,7 @@ export class ContactMergeHandler implements SkillHandler {
       return { success: false, error: 'primary_contact_id and secondary_contact_id must not be the same contact.' };
     }
     if (!ctx.contactService) {
-      return { success: false, error: 'contact-merge requires contactService is a universal service — check ExecutionLayer configuration.' };
+      return { success: false, error: 'contact-merge: contactService not available — this is a universal service, check ExecutionLayer configuration.' };
     }
     // Elevated skill — execution layer guarantees caller is set, but guard explicitly
     // so a broken invariant produces a clear error instead of a cryptic TypeError.

--- a/skills/contact-merge/handler.ts
+++ b/skills/contact-merge/handler.ts
@@ -40,7 +40,7 @@ export class ContactMergeHandler implements SkillHandler {
       return { success: false, error: 'primary_contact_id and secondary_contact_id must not be the same contact.' };
     }
     if (!ctx.contactService) {
-      return { success: false, error: 'contact-merge requires infrastructure access (contactService).' };
+      return { success: false, error: 'contact-merge requires contactService is a universal service — check ExecutionLayer configuration.' };
     }
     // Elevated skill — execution layer guarantees caller is set, but guard explicitly
     // so a broken invariant produces a clear error instead of a cryptic TypeError.

--- a/skills/contact-merge/skill.json
+++ b/skills/contact-merge/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "elevated",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "primary_contact_id": "string",
     "secondary_contact_id": "string",

--- a/skills/contact-rename/handler.ts
+++ b/skills/contact-rename/handler.ts
@@ -45,11 +45,11 @@ export class ContactRenameHandler implements SkillHandler {
       return { success: false, error: 'Display name must be 200 characters or fewer' };
     }
 
-    // Infrastructure skills need contactService
+    // contactService is a universal service — always injected by ExecutionLayer
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-rename skill requires contactService is a universal service — check ExecutionLayer configuration.',
+        error: 'contact-rename: contactService not available — this is a universal service, check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-rename/handler.ts
+++ b/skills/contact-rename/handler.ts
@@ -3,7 +3,7 @@
 // Updates a contact's display name (e.g. correcting "Jodi" to "Jodi Arnott").
 // Returns the updated contact details.
 //
-// This is an infrastructure skill — it requires contactService access.
+// This skill uses contactService, which is a universal service.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 
@@ -49,7 +49,7 @@ export class ContactRenameHandler implements SkillHandler {
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-rename skill requires infrastructure access (contactService). Is infrastructure: true set in the manifest?',
+        error: 'contact-rename skill requires contactService is a universal service — check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-rename/skill.json
+++ b/skills/contact-rename/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "elevated",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "contact_id": "string (UUID from contact-lookup or contact-list)",
     "display_name": "string (new display name)"

--- a/skills/contact-revoke-permission/handler.ts
+++ b/skills/contact-revoke-permission/handler.ts
@@ -22,7 +22,7 @@ export class ContactRevokePermissionHandler implements SkillHandler {
       return { success: false, error: 'Permission name must be lowercase alphanumeric with underscores (e.g., view_financial_reports)' };
     }
     if (!ctx.contactService) {
-      return { success: false, error: 'Contact service not available. Is infrastructure: true set?' };
+      return { success: false, error: 'Contact service not available. contactService is a universal service — check ExecutionLayer configuration.' };
     }
 
     try {

--- a/skills/contact-revoke-permission/handler.ts
+++ b/skills/contact-revoke-permission/handler.ts
@@ -22,7 +22,7 @@ export class ContactRevokePermissionHandler implements SkillHandler {
       return { success: false, error: 'Permission name must be lowercase alphanumeric with underscores (e.g., view_financial_reports)' };
     }
     if (!ctx.contactService) {
-      return { success: false, error: 'Contact service not available. contactService is a universal service — check ExecutionLayer configuration.' };
+      return { success: false, error: 'contact-revoke-permission: contactService not available — this is a universal service, check ExecutionLayer configuration.' };
     }
 
     try {

--- a/skills/contact-revoke-permission/skill.json
+++ b/skills/contact-revoke-permission/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "elevated",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "contact_id": "string",
     "permission": "string"

--- a/skills/contact-set-role/handler.ts
+++ b/skills/contact-set-role/handler.ts
@@ -3,7 +3,7 @@
 // Sets or changes a contact's role (e.g., CFO, board member, advisor).
 // Returns the updated contact details.
 //
-// This is an infrastructure skill — it requires contactService access.
+// This skill uses contactService, which is a universal service.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 
@@ -42,7 +42,7 @@ export class ContactSetRoleHandler implements SkillHandler {
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-set-role skill requires infrastructure access (contactService). Is infrastructure: true set in the manifest?',
+        error: 'contact-set-role skill requires contactService is a universal service — check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-set-role/handler.ts
+++ b/skills/contact-set-role/handler.ts
@@ -38,11 +38,11 @@ export class ContactSetRoleHandler implements SkillHandler {
       return { success: false, error: 'Role must be 200 characters or fewer' };
     }
 
-    // Infrastructure skills need contactService
+    // contactService is a universal service — always injected by ExecutionLayer
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-set-role skill requires contactService is a universal service — check ExecutionLayer configuration.',
+        error: 'contact-set-role: contactService not available — this is a universal service, check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-set-role/skill.json
+++ b/skills/contact-set-role/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "elevated",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "contact_id": "string (UUID from contact-lookup or contact-create)",
     "role": "string"

--- a/skills/contact-set-trust/handler.ts
+++ b/skills/contact-set-trust/handler.ts
@@ -44,7 +44,7 @@ export class ContactSetTrustHandler implements SkillHandler {
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-set-trust requires contactService is a universal service — check ExecutionLayer configuration.',
+        error: 'contact-set-trust: contactService not available — this is a universal service, check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-set-trust/handler.ts
+++ b/skills/contact-set-trust/handler.ts
@@ -44,7 +44,7 @@ export class ContactSetTrustHandler implements SkillHandler {
     if (!ctx.contactService) {
       return {
         success: false,
-        error: 'contact-set-trust requires infrastructure access (contactService). Is infrastructure: true set in the manifest?',
+        error: 'contact-set-trust requires contactService is a universal service — check ExecutionLayer configuration.',
       };
     }
 

--- a/skills/contact-set-trust/skill.json
+++ b/skills/contact-set-trust/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "elevated",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "contact_id": "string (UUID from contact-lookup or contact-create)",
     "trust_level": "string? (one of 'high', 'medium', 'low', or null to clear the override)"

--- a/skills/contact-unlink-identity/handler.ts
+++ b/skills/contact-unlink-identity/handler.ts
@@ -14,7 +14,7 @@ export class ContactUnlinkIdentityHandler implements SkillHandler {
       return { success: false, error: 'Missing required input: identity_id (string)' };
     }
     if (!ctx.contactService) {
-      return { success: false, error: 'Contact service not available. contactService is a universal service — check ExecutionLayer configuration.' };
+      return { success: false, error: 'contact-unlink-identity: contactService not available — this is a universal service, check ExecutionLayer configuration.' };
     }
 
     try {

--- a/skills/contact-unlink-identity/handler.ts
+++ b/skills/contact-unlink-identity/handler.ts
@@ -14,7 +14,7 @@ export class ContactUnlinkIdentityHandler implements SkillHandler {
       return { success: false, error: 'Missing required input: identity_id (string)' };
     }
     if (!ctx.contactService) {
-      return { success: false, error: 'Contact service not available. Is infrastructure: true set?' };
+      return { success: false, error: 'Contact service not available. contactService is a universal service — check ExecutionLayer configuration.' };
     }
 
     try {

--- a/skills/contact-unlink-identity/skill.json
+++ b/skills/contact-unlink-identity/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "contact_id": "string",
     "identity_id": "string"

--- a/skills/context-for-email/handler.ts
+++ b/skills/context-for-email/handler.ts
@@ -6,7 +6,7 @@
 // calls (template policy + contact lookup + meeting link + etc.), this skill
 // gathers everything relevant in one call.
 //
-// This is an infrastructure skill because it needs:
+// This skill requires entityMemory because it needs:
 //   - entityMemory (to resolve email policies and meeting links from KG)
 //   - contactService (to look up recipient contact info)
 

--- a/skills/context-for-email/skill.json
+++ b/skills/context-for-email/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "email_type": "string (meeting-request | reschedule | cancel | doc-request)",
     "recipient_name": "string (the recipient's name — used to look up contact info and meeting link)"
@@ -18,5 +17,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 30000,
+  "capabilities": [
+    "entityMemory"
+  ]
 }

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -1,6 +1,6 @@
 // handler.ts — delegate skill implementation.
 //
-// This is an infrastructure skill — it has bus and agentRegistry access
+// This skill has bus and agentRegistry access (declared in capabilities)
 // that normal skills don't get. It publishes an agent.task event for the
 // target specialist, then waits for the specialist's agent.response.
 //
@@ -52,11 +52,12 @@ export class DelegateHandler implements SkillHandler {
       );
     }
 
-    // Infrastructure skills need bus and agent registry
+    // Defensive guard — ExecutionLayer already fails-closed if capabilities are missing,
+    // but guard here too in case the handler is invoked outside the execution layer.
     if (!ctx.bus || !ctx.agentRegistry) {
       return {
         success: false,
-        error: 'Delegate skill requires infrastructure access (bus, agentRegistry). Is infrastructure: true set in the manifest?',
+        error: 'Delegate skill requires bus and agentRegistry. Declare both in capabilities.',
       };
     }
 
@@ -88,7 +89,7 @@ export class DelegateHandler implements SkillHandler {
     // parentEventId uses a delegate-prefixed UUID. Ideally this would trace back
     // to the Coordinator's skill.invoke event, but SkillContext doesn't currently
     // carry the invoking event's ID. TODO: Add invokeEventId to SkillContext so
-    // infrastructure skills can maintain the full audit causal chain.
+    // capability-gated skills can maintain the full audit causal chain.
     const taskEvent = createAgentTask({
       agentId: agent,
       conversationId,

--- a/skills/delegate/skill.json
+++ b/skills/delegate/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "agent": "string",
     "task": "string",
@@ -17,5 +16,9 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 660000
+  "timeout": 660000,
+  "capabilities": [
+    "bus",
+    "agentRegistry"
+  ]
 }

--- a/skills/delete-relationship/skill.json
+++ b/skills/delete-relationship/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "subject": "string (name or label of the source entity, e.g. 'Jane Doe')",
     "predicate": "string (the edge type to delete, e.g. 'spouse' or 'reports_to'. Must be a known edge type.)",
@@ -19,5 +18,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 10000
+  "timeout": 10000,
+  "capabilities": [
+    "entityMemory"
+  ]
 }

--- a/skills/email-archive/handler.ts
+++ b/skills/email-archive/handler.ts
@@ -27,7 +27,7 @@ export class EmailArchiveHandler implements SkillHandler {
       return {
         success: false,
         error:
-          'email-archive skill requires outboundGateway access. Is infrastructure: true set in the manifest and outboundGateway passed to ExecutionLayer?',
+          'email-archive skill requires outboundGateway access. Declare "outboundGateway" in capabilities.',
       };
     }
 

--- a/skills/email-archive/skill.json
+++ b/skills/email-archive/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "message_id": "string (Nylas message ID of the email to archive)",
     "account": "string? (named account to archive from, e.g. 'curia' or 'joseph'; defaults to the primary account if omitted)"
@@ -14,5 +13,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 15000
+  "timeout": 15000,
+  "capabilities": [
+    "outboundGateway"
+  ]
 }

--- a/skills/email-draft-save/handler.ts
+++ b/skills/email-draft-save/handler.ts
@@ -11,7 +11,7 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 export class EmailDraftSaveHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     if (!ctx.outboundGateway) {
-      return { success: false, error: 'email-draft-save requires outboundGateway (infrastructure: true)' };
+      return { success: false, error: 'email-draft-save requires outboundGateway (capabilities: ["outboundGateway"])' };
     }
 
     // Handlers must never throw — destructuring a non-object ctx.input would.

--- a/skills/email-draft-save/skill.json
+++ b/skills/email-draft-save/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "medium",
-  "infrastructure": true,
   "inputs": {
     "to": "string (recipient email address)",
     "subject": "string (email subject line)",
@@ -17,5 +16,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 20000
+  "timeout": 20000,
+  "capabilities": [
+    "outboundGateway"
+  ]
 }

--- a/skills/email-get/handler.ts
+++ b/skills/email-get/handler.ts
@@ -9,7 +9,7 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 export class EmailGetHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     if (!ctx.outboundGateway) {
-      return { success: false, error: 'email-get requires outboundGateway (infrastructure: true)' };
+      return { success: false, error: 'email-get requires outboundGateway (capabilities: ["outboundGateway"])' };
     }
 
     // Handlers must never throw — destructuring a non-object ctx.input would.

--- a/skills/email-get/skill.json
+++ b/skills/email-get/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "message_id": "string (Nylas message ID of the email to fetch)",
     "account": "string? (named account to read from, as configured in channel_accounts.email. Defaults to the primary account.)"
@@ -14,5 +13,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 15000
+  "timeout": 15000,
+  "capabilities": [
+    "outboundGateway"
+  ]
 }

--- a/skills/email-list/handler.ts
+++ b/skills/email-list/handler.ts
@@ -13,7 +13,7 @@ const DEFAULT_LIMIT = 20;
 export class EmailListHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     if (!ctx.outboundGateway) {
-      return { success: false, error: 'email-list requires outboundGateway (infrastructure: true)' };
+      return { success: false, error: 'email-list requires outboundGateway (capabilities: ["outboundGateway"])' };
     }
 
     // Handlers must never throw — destructuring a non-object ctx.input would.

--- a/skills/email-list/skill.json
+++ b/skills/email-list/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "account": "string? (named account to read from, as configured in channel_accounts.email. Defaults to the primary account.)",
     "folder": "string? (folder to filter by, e.g. 'INBOX', 'SENT', 'DRAFTS'. Defaults to all folders.)",
@@ -20,5 +19,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 20000
+  "timeout": 20000,
+  "capabilities": [
+    "outboundGateway"
+  ]
 }

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -32,7 +32,7 @@ export class EmailReplyHandler implements SkillHandler {
     if (!ctx.outboundGateway) {
       return {
         success: false,
-        error: 'email-reply skill requires outboundGateway access. Is infrastructure: true set in the manifest and outboundGateway passed to ExecutionLayer?',
+        error: 'email-reply skill requires outboundGateway access. Declare "outboundGateway" in capabilities.',
       };
     }
 

--- a/skills/email-reply/skill.json
+++ b/skills/email-reply/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "medium",
-  "infrastructure": true,
   "inputs": {
     "reply_to_message_id": "string",
     "body": "string"
@@ -16,5 +15,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 30000,
+  "capabilities": [
+    "outboundGateway"
+  ]
 }

--- a/skills/email-send/handler.ts
+++ b/skills/email-send/handler.ts
@@ -88,7 +88,7 @@ export class EmailSendHandler implements SkillHandler {
     if (!ctx.outboundGateway) {
       return {
         success: false,
-        error: 'email-send skill requires outboundGateway access. Is infrastructure: true set in the manifest and outboundGateway passed to ExecutionLayer?',
+        error: 'email-send skill requires outboundGateway access. Declare "outboundGateway" in capabilities.',
       };
     }
 

--- a/skills/email-send/skill.json
+++ b/skills/email-send/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "medium",
-  "infrastructure": true,
   "inputs": {
     "to": "string",
     "cc": "string?",
@@ -18,5 +17,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 30000,
+  "capabilities": [
+    "outboundGateway"
+  ]
 }

--- a/skills/extract-facts/skill.json
+++ b/skills/extract-facts/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "text": "string (the message or turn text to extract facts from)",
     "source": "string (provenance string, e.g. 'system:checkpoint/conversation:abc/agent:coordinator/channel:cli')"
@@ -15,6 +14,11 @@
     "failed": "number (facts that could not be persisted due to errors)"
   },
   "permissions": [],
-  "secrets": ["ANTHROPIC_API_KEY"],
-  "timeout": 15000
+  "secrets": [
+    "ANTHROPIC_API_KEY"
+  ],
+  "timeout": 15000,
+  "capabilities": [
+    "entityMemory"
+  ]
 }

--- a/skills/extract-relationships/skill.json
+++ b/skills/extract-relationships/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "text": "string (the message or turn text to extract relationships from)",
     "source": "string (provenance string, e.g. 'agent:coordinator/task:abc123/channel:cli')"
@@ -15,6 +14,11 @@
     "skipped": "boolean (true if the classifier gate determined no relationships were present)"
   },
   "permissions": [],
-  "secrets": ["ANTHROPIC_API_KEY"],
-  "timeout": 15000
+  "secrets": [
+    "ANTHROPIC_API_KEY"
+  ],
+  "timeout": 15000,
+  "capabilities": [
+    "entityMemory"
+  ]
 }

--- a/skills/get-autonomy/handler.ts
+++ b/skills/get-autonomy/handler.ts
@@ -8,7 +8,7 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 export class GetAutonomyHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     if (!ctx.autonomyService) {
-      return { success: false, error: 'get-autonomy requires autonomyService in context. Is infrastructure: true set in the manifest?' };
+      return { success: false, error: 'get-autonomy requires autonomyService in context. Declare "autonomyService" in capabilities.' };
     }
 
     try {

--- a/skills/get-autonomy/skill.json
+++ b/skills/get-autonomy/skill.json
@@ -3,11 +3,17 @@
   "description": "Report the agent's current global autonomy score, band, and recent change history. Use this when the CEO asks about autonomy level, trust level, or how independently the agent is operating.",
   "version": "1.0.0",
   "sensitivity": "normal",
-  "infrastructure": true,
   "inputs": {},
-  "outputs": { "score": "number", "band": "string", "summary": "string" },
+  "outputs": {
+    "score": "number",
+    "band": "string",
+    "summary": "string"
+  },
   "permissions": [],
   "secrets": [],
   "timeout": 10000,
-  "action_risk": "none"
+  "action_risk": "none",
+  "capabilities": [
+    "autonomyService"
+  ]
 }

--- a/skills/held-messages-list/handler.ts
+++ b/skills/held-messages-list/handler.ts
@@ -4,14 +4,14 @@
 // Optionally filters by channel. Returns a summary with sender, subject, preview,
 // and timestamp for each message.
 //
-// This is an infrastructure skill — it requires heldMessages service access.
+// This skill requires heldMessages service access — declare "heldMessages" in capabilities.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 
 export class HeldMessagesListHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     if (!ctx.heldMessages) {
-      return { success: false, error: 'Held messages service not available. Is infrastructure: true set?' };
+      return { success: false, error: 'Held messages service not available. Declare "heldMessages" in capabilities.' };
     }
 
     const { channel } = ctx.input as { channel?: string };

--- a/skills/held-messages-list/skill.json
+++ b/skills/held-messages-list/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "channel": "string?"
   },
@@ -14,5 +13,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 10000
+  "timeout": 10000,
+  "capabilities": [
+    "heldMessages"
+  ]
 }

--- a/skills/held-messages-process/handler.ts
+++ b/skills/held-messages-process/handler.ts
@@ -6,7 +6,7 @@
 // - "dismiss" — discard the held message (CEO doesn't care about it).
 // - "block" — create a blocked contact for the sender and discard the message.
 //
-// This is an infrastructure skill — it requires heldMessages, contactService,
+// This skill requires heldMessages and bus (declared in capabilities);
 // and bus access.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
@@ -29,7 +29,7 @@ export class HeldMessagesProcessHandler implements SkillHandler {
       return { success: false, error: 'Invalid action — must be "identify", "dismiss", or "block"' };
     }
     if (!ctx.heldMessages || !ctx.contactService || !ctx.bus) {
-      return { success: false, error: 'Required services not available. Is infrastructure: true set?' };
+      return { success: false, error: 'Required services not available. Declare "heldMessages" and "bus" in capabilities.' };
     }
 
     // Validate input lengths to prevent abuse / storage overflow

--- a/skills/held-messages-process/handler.ts
+++ b/skills/held-messages-process/handler.ts
@@ -6,8 +6,8 @@
 // - "dismiss" — discard the held message (CEO doesn't care about it).
 // - "block" — create a blocked contact for the sender and discard the message.
 //
-// This skill requires heldMessages and bus (declared in capabilities);
-// and bus access.
+// This skill requires heldMessages and bus (declared in capabilities).
+// contactService is a universal service and is always injected by ExecutionLayer.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { createInboundMessage } from '../../src/bus/events.js';
@@ -28,7 +28,7 @@ export class HeldMessagesProcessHandler implements SkillHandler {
     if (!action || !['identify', 'dismiss', 'block'].includes(action)) {
       return { success: false, error: 'Invalid action — must be "identify", "dismiss", or "block"' };
     }
-    if (!ctx.heldMessages || !ctx.contactService || !ctx.bus) {
+    if (!ctx.heldMessages || !ctx.bus) {
       return { success: false, error: 'Required services not available. Declare "heldMessages" and "bus" in capabilities.' };
     }
 

--- a/skills/held-messages-process/skill.json
+++ b/skills/held-messages-process/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "elevated",
   "action_risk": "medium",
-  "infrastructure": true,
   "inputs": {
     "held_message_id": "string",
     "action": "string",
@@ -18,5 +17,9 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 30000,
+  "capabilities": [
+    "heldMessages",
+    "bus"
+  ]
 }

--- a/skills/knowledge-company-overview/skill.json
+++ b/skills/knowledge-company-overview/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "action": "string (store | retrieve)",
     "field": "string? (required for store — the field name, e.g. 'legal_name', 'address', 'officers', 'board_members', 'ein', 'founding_date')",
@@ -17,5 +16,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 30000,
+  "capabilities": [
+    "entityMemory"
+  ]
 }

--- a/skills/knowledge-loyalty-programs/skill.json
+++ b/skills/knowledge-loyalty-programs/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "action": "string (store | retrieve)",
     "program_name": "string? (required for store — e.g. 'Air Canada Aeroplan', 'Marriott Bonvoy', 'United MileagePlus')",
@@ -19,5 +18,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 30000,
+  "capabilities": [
+    "entityMemory"
+  ]
 }

--- a/skills/knowledge-meeting-links/skill.json
+++ b/skills/knowledge-meeting-links/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "action": "string (store | retrieve)",
     "person_name": "string? (required for store, optional for retrieve — filter by person name)",
@@ -18,5 +17,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 30000,
+  "capabilities": [
+    "entityMemory"
+  ]
 }

--- a/skills/knowledge-travel-preferences/skill.json
+++ b/skills/knowledge-travel-preferences/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "action": "string (store | retrieve)",
     "field": "string? (required for store — the preference name, e.g. 'preferred_airline', 'seat_preference', 'hotel_chain', 'dietary_restrictions', 'baggage_notes')",
@@ -17,5 +16,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 30000,
+  "capabilities": [
+    "entityMemory"
+  ]
 }

--- a/skills/query-relationships/skill.json
+++ b/skills/query-relationships/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "entity": "string (the name or label of the entity to query, e.g. 'Jane Doe')",
     "edge_type": "string? (optional edge type filter, e.g. 'spouse' or 'reports_to'. Must be a known edge type.)"
@@ -17,5 +16,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 10000
+  "timeout": 10000,
+  "capabilities": [
+    "entityMemory"
+  ]
 }

--- a/skills/scheduler-cancel/handler.ts
+++ b/skills/scheduler-cancel/handler.ts
@@ -10,7 +10,7 @@ export class SchedulerCancelHandler implements SkillHandler {
     if (!ctx.schedulerService) {
       return {
         success: false,
-        error: 'scheduler-cancel requires schedulerService in context. Is infrastructure: true set in the manifest?',
+        error: 'scheduler-cancel requires schedulerService in context. Declare "schedulerService" in capabilities.',
       };
     }
 

--- a/skills/scheduler-cancel/skill.json
+++ b/skills/scheduler-cancel/skill.json
@@ -4,10 +4,16 @@
   "version": "1.0.0",
   "sensitivity": "elevated",
   "action_risk": "low",
-  "infrastructure": true,
-  "inputs": { "job_id": "string" },
-  "outputs": { "cancelled": "boolean" },
+  "inputs": {
+    "job_id": "string"
+  },
+  "outputs": {
+    "cancelled": "boolean"
+  },
   "permissions": [],
   "secrets": [],
-  "timeout": 15000
+  "timeout": 15000,
+  "capabilities": [
+    "schedulerService"
+  ]
 }

--- a/skills/scheduler-create/handler.ts
+++ b/skills/scheduler-create/handler.ts
@@ -11,7 +11,7 @@ export class SchedulerCreateHandler implements SkillHandler {
     if (!ctx.schedulerService) {
       return {
         success: false,
-        error: 'scheduler-create requires schedulerService in context. Is infrastructure: true set in the manifest?',
+        error: 'scheduler-create requires schedulerService in context. Declare "schedulerService" in capabilities.',
       };
     }
 

--- a/skills/scheduler-create/skill.json
+++ b/skills/scheduler-create/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "elevated",
   "action_risk": "low",
-  "infrastructure": true,
   "inputs": {
     "task": "string",
     "cron_expr": "string?",
@@ -14,8 +13,14 @@
     "error_budget": "object?",
     "timezone": "string? (IANA timezone name, e.g. America/Toronto — overrides Curia's default timezone for this job's cron schedule)"
   },
-  "outputs": { "jobId": "string", "agentTaskId": "string?" },
+  "outputs": {
+    "jobId": "string",
+    "agentTaskId": "string?"
+  },
   "permissions": [],
   "secrets": [],
-  "timeout": 15000
+  "timeout": 15000,
+  "capabilities": [
+    "schedulerService"
+  ]
 }

--- a/skills/scheduler-list/handler.ts
+++ b/skills/scheduler-list/handler.ts
@@ -10,7 +10,7 @@ export class SchedulerListHandler implements SkillHandler {
     if (!ctx.schedulerService) {
       return {
         success: false,
-        error: 'scheduler-list requires schedulerService in context. Is infrastructure: true set in the manifest?',
+        error: 'scheduler-list requires schedulerService in context. Declare "schedulerService" in capabilities.',
       };
     }
 

--- a/skills/scheduler-list/skill.json
+++ b/skills/scheduler-list/skill.json
@@ -4,10 +4,17 @@
   "version": "1.0.0",
   "sensitivity": "elevated",
   "action_risk": "none",
-  "infrastructure": true,
-  "inputs": { "status": "string?", "agent_id": "string?" },
-  "outputs": { "jobs": "array" },
+  "inputs": {
+    "status": "string?",
+    "agent_id": "string?"
+  },
+  "outputs": {
+    "jobs": "array"
+  },
   "permissions": [],
   "secrets": [],
-  "timeout": 15000
+  "timeout": 15000,
+  "capabilities": [
+    "schedulerService"
+  ]
 }

--- a/skills/scheduler-report/handler.ts
+++ b/skills/scheduler-report/handler.ts
@@ -6,7 +6,7 @@ export class SchedulerReportHandler implements SkillHandler {
     if (!ctx.schedulerService) {
       return {
         success: false,
-        error: 'scheduler-report requires schedulerService in context. Is infrastructure: true set in the manifest?',
+        error: 'scheduler-report requires schedulerService in context. Declare "schedulerService" in capabilities.',
       };
     }
 

--- a/skills/scheduler-report/skill.json
+++ b/skills/scheduler-report/skill.json
@@ -4,14 +4,18 @@
   "version": "1.0.0",
   "sensitivity": "elevated",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "job_id": "string",
     "summary": "string",
     "context": "object?"
   },
-  "outputs": { "success": "boolean" },
+  "outputs": {
+    "success": "boolean"
+  },
   "permissions": [],
   "secrets": [],
-  "timeout": 15000
+  "timeout": 15000,
+  "capabilities": [
+    "schedulerService"
+  ]
 }

--- a/skills/set-autonomy/handler.ts
+++ b/skills/set-autonomy/handler.ts
@@ -9,7 +9,7 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 export class SetAutonomyHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     if (!ctx.autonomyService) {
-      return { success: false, error: 'set-autonomy requires autonomyService in context. Is infrastructure: true set in the manifest?' };
+      return { success: false, error: 'set-autonomy requires autonomyService in context. Declare "autonomyService" in capabilities.' };
     }
 
     const { score, reason } = ctx.input as { score?: unknown; reason?: unknown };

--- a/skills/set-autonomy/skill.json
+++ b/skills/set-autonomy/skill.json
@@ -3,14 +3,20 @@
   "description": "Update the agent's global autonomy score (0–100). Requires CEO authorization. Lower scores require more approvals before the agent acts; higher scores allow more independent action. Optionally provide a reason for the change.",
   "version": "1.0.0",
   "sensitivity": "elevated",
-  "infrastructure": true,
   "inputs": {
     "score": "number",
     "reason": "string?"
   },
-  "outputs": { "score": "number", "band": "string", "previous_score": "number" },
+  "outputs": {
+    "score": "number",
+    "band": "string",
+    "previous_score": "number"
+  },
   "permissions": [],
   "secrets": [],
   "timeout": 10000,
-  "action_risk": "high"
+  "action_risk": "high",
+  "capabilities": [
+    "autonomyService"
+  ]
 }

--- a/skills/signal-send/handler.ts
+++ b/skills/signal-send/handler.ts
@@ -62,7 +62,7 @@ export class SignalSendHandler implements SkillHandler {
     if (!ctx.outboundGateway) {
       return {
         success: false,
-        error: 'signal-send skill requires outboundGateway access. Is infrastructure: true set in the manifest and outboundGateway passed to ExecutionLayer?',
+        error: 'signal-send skill requires outboundGateway access. Declare "outboundGateway" in capabilities.',
       };
     }
 

--- a/skills/signal-send/skill.json
+++ b/skills/signal-send/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "medium",
-  "infrastructure": true,
   "inputs": {
     "recipient": "string?",
     "group_id": "string?",
@@ -16,5 +15,8 @@
   },
   "permissions": [],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 30000,
+  "capabilities": [
+    "outboundGateway"
+  ]
 }

--- a/skills/skill-registry/handler.ts
+++ b/skills/skill-registry/handler.ts
@@ -5,7 +5,7 @@
 //
 // The registry reference is injected by the execution layer as ctx.skillSearch —
 // a closure scoped to this skill by name, following the same name-gated pattern
-// used for autonomyService and browserService. No infrastructure: true needed.
+// used for autonomyService and browserService. Declare "skillSearch" in capabilities.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 

--- a/skills/skill-registry/skill.json
+++ b/skills/skill-registry/skill.json
@@ -7,8 +7,13 @@
   "inputs": {
     "query": "string (keyword to search — pass an empty string to list all available skills)"
   },
-  "outputs": { "skills": "array" },
+  "outputs": {
+    "skills": "array"
+  },
   "permissions": [],
   "secrets": [],
-  "timeout": 5000
+  "timeout": 5000,
+  "capabilities": [
+    "skillSearch"
+  ]
 }

--- a/skills/template-cancel/skill.json
+++ b/skills/template-cancel/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "action": "string (generate | update | save | reset)",
     "refinement": "string? (required for update — a natural-language adjustment to the policy)",

--- a/skills/template-doc-request/skill.json
+++ b/skills/template-doc-request/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "action": "string (generate | update | save | reset)",
     "refinement": "string? (required for update — a natural-language adjustment to the policy)",

--- a/skills/template-meeting-request/skill.json
+++ b/skills/template-meeting-request/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "action": "string (generate | update | save | reset)",
     "refinement": "string? (required for update — a natural-language instruction like 'make these less formal' or 'always mention my assistant can help')",

--- a/skills/template-reschedule/skill.json
+++ b/skills/template-reschedule/skill.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "sensitivity": "normal",
   "action_risk": "none",
-  "infrastructure": true,
   "inputs": {
     "action": "string (generate | update | save | reset)",
     "refinement": "string? (required for update — a natural-language adjustment to the policy)",

--- a/skills/web-browser/skill.json
+++ b/skills/web-browser/skill.json
@@ -19,7 +19,12 @@
     "url": "string",
     "screenshot_base64": "string?"
   },
-  "permissions": ["network:https"],
+  "permissions": [
+    "network:https"
+  ],
   "secrets": [],
-  "timeout": 30000
+  "timeout": 30000,
+  "capabilities": [
+    "browserService"
+  ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -705,8 +705,8 @@ async function main(): Promise<void> {
 
   const scheduler = new Scheduler({ pool, bus, logger, schedulerService, driftDetector, dreamEngine });
 
-  // Execution layer — now with bus, agent registry, and outbound gateway for
-  // infrastructure skills. outboundGateway gives email skills their send path.
+  // Execution layer — services wired here are injected per-skill based on their
+  // capability-gated declarations. outboundGateway gives email skills their send path.
   // entityContextAssembler enables entity_enrichment pre-enrichment and the
   // entity-context skill. agentContactId enables entity_enrichment default='agent'.
   const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, browserService, bullpenService, timezone: config.timezone, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -6,12 +6,16 @@
 //   2. Unknown skill names are silently skipped
 //   3. Skills returned by skill-registry can have their tool defs retrieved and
 //      then be invoked — the full discover → call path works end-to-end with mocks
+//   4. Capability-gated service injection: only declared services reach ctx
 
 import { describe, it, expect, vi } from 'vitest';
 import pino from 'pino';
 import { SkillRegistry } from './registry.js';
 import { ExecutionLayer } from './execution.js';
 import type { SkillHandler, SkillManifest } from './types.js';
+import type { EventBus } from '../bus/bus.js';
+import type { OutboundGateway } from './outbound-gateway.js';
+import type { SchedulerService } from '../scheduler/scheduler-service.js';
 
 const logger = pino({ level: 'silent' });
 
@@ -151,5 +155,105 @@ describe('discover → invoke round-trip', () => {
     expect(expandedDefs).toHaveLength(3);
     expect(expandedDefs.map(d => d.name)).toContain('search_drive_files');
     expect(expandedDefs.map(d => d.name)).toContain('get_doc_content');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capability-gated service injection
+// ---------------------------------------------------------------------------
+
+describe('capability-gated service injection', () => {
+  /** Manifest that declares specific capabilities. */
+  function makeCapManifest(name: string, capabilities: string[]): SkillManifest {
+    return {
+      name,
+      description: `${name} description`,
+      version: '1.0.0',
+      sensitivity: 'normal',
+      action_risk: 'none',
+      inputs: {},
+      outputs: {},
+      permissions: [],
+      secrets: [],
+      timeout: 5000,
+      capabilities,
+    };
+  }
+
+  it('injects only declared capabilities into context', async () => {
+    const registry = new SkillRegistry();
+    // Handler captures the context it received so we can inspect it
+    let capturedCtx: Record<string, unknown> = {};
+    const handler: SkillHandler = {
+      execute: vi.fn(async (ctx) => {
+        capturedCtx = ctx as unknown as Record<string, unknown>;
+        return { success: true, data: 'ok' };
+      }),
+    };
+    registry.register(makeCapManifest('outbound-only', ['outboundGateway']), handler);
+
+    const mockGateway = { send: vi.fn() } as unknown as OutboundGateway;
+    const mockBus = { publish: vi.fn() } as unknown as EventBus;
+    const mockScheduler = { createJob: vi.fn() } as unknown as SchedulerService;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      outboundGateway: mockGateway,
+      bus: mockBus,
+      schedulerService: mockScheduler,
+    });
+
+    await layer.invoke('outbound-only', {});
+
+    // Should have outboundGateway — it was declared
+    expect(capturedCtx.outboundGateway).toBe(mockGateway);
+    // Should NOT have bus or schedulerService — not declared in capabilities
+    expect(capturedCtx.bus).toBeUndefined();
+    expect(capturedCtx.schedulerService).toBeUndefined();
+  });
+
+  it('injects no privileged services when capabilities is empty', async () => {
+    const registry = new SkillRegistry();
+    let capturedCtx: Record<string, unknown> = {};
+    const handler: SkillHandler = {
+      execute: vi.fn(async (ctx) => {
+        capturedCtx = ctx as unknown as Record<string, unknown>;
+        return { success: true, data: 'ok' };
+      }),
+    };
+    registry.register(makeCapManifest('no-caps', []), handler);
+
+    const mockBus = { publish: vi.fn() } as unknown as EventBus;
+    const mockGateway = { send: vi.fn() } as unknown as OutboundGateway;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      bus: mockBus,
+      outboundGateway: mockGateway,
+    });
+
+    await layer.invoke('no-caps', {});
+
+    // No privileged services should be injected — capabilities is empty
+    expect(capturedCtx.bus).toBeUndefined();
+    expect(capturedCtx.outboundGateway).toBeUndefined();
+  });
+
+  it('returns skill error when declared capability is not available on ExecutionLayer', async () => {
+    const registry = new SkillRegistry();
+    const handler: SkillHandler = {
+      execute: vi.fn(async () => ({ success: true, data: 'ok' })),
+    };
+    registry.register(makeCapManifest('needs-scheduler', ['schedulerService']), handler);
+
+    // ExecutionLayer constructed WITHOUT schedulerService
+    const layer = new ExecutionLayer(registry, logger);
+
+    const result = await layer.invoke('needs-scheduler', {});
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('schedulerService');
+    }
+    // Handler should NOT have been called — fail-closed
+    expect(handler.execute).not.toHaveBeenCalled();
   });
 });

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, vi } from 'vitest';
 import pino from 'pino';
 import { SkillRegistry } from './registry.js';
 import { ExecutionLayer } from './execution.js';
-import type { SkillHandler, SkillManifest } from './types.js';
+import type { SkillHandler, SkillManifest, SkillResult } from './types.js';
 import type { EventBus } from '../bus/bus.js';
 import type { OutboundGateway } from './outbound-gateway.js';
 import type { SchedulerService } from '../scheduler/scheduler-service.js';
@@ -185,7 +185,7 @@ describe('capability-gated service injection', () => {
     // Handler captures the context it received so we can inspect it
     let capturedCtx: Record<string, unknown> = {};
     const handler: SkillHandler = {
-      execute: vi.fn(async (ctx) => {
+      execute: vi.fn(async (ctx): Promise<SkillResult> => {
         capturedCtx = ctx as unknown as Record<string, unknown>;
         return { success: true, data: 'ok' };
       }),
@@ -215,7 +215,7 @@ describe('capability-gated service injection', () => {
     const registry = new SkillRegistry();
     let capturedCtx: Record<string, unknown> = {};
     const handler: SkillHandler = {
-      execute: vi.fn(async (ctx) => {
+      execute: vi.fn(async (ctx): Promise<SkillResult> => {
         capturedCtx = ctx as unknown as Record<string, unknown>;
         return { success: true, data: 'ok' };
       }),
@@ -240,7 +240,7 @@ describe('capability-gated service injection', () => {
   it('returns skill error when declared capability is not available on ExecutionLayer', async () => {
     const registry = new SkillRegistry();
     const handler: SkillHandler = {
-      execute: vi.fn(async () => ({ success: true, data: 'ok' })),
+      execute: vi.fn(async (): Promise<SkillResult> => ({ success: true, data: 'ok' })),
     };
     registry.register(makeCapManifest('needs-scheduler', ['schedulerService']), handler);
 

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -280,11 +280,28 @@ export class ExecutionLayer {
     // We inject only the declared services — skills cannot escalate privilege.
     const caps = manifest.capabilities ?? [];
 
+    // Explicit lookup map — enumerates every capability-gated service by name.
+    // Using a map rather than `(this as Record<string, unknown>)[cap]` keeps TypeScript
+    // aware that each field is read, satisfying noUnusedLocals.
+    // Field names here MUST match the VALID_CAPABILITIES set in loader.ts.
+    const capabilityServices: Record<string, unknown> = {
+      bus: this.bus,
+      agentRegistry: this.agentRegistry,
+      outboundGateway: this.outboundGateway,
+      heldMessages: this.heldMessages,
+      schedulerService: this.schedulerService,
+      entityMemory: this.entityMemory,
+      nylasCalendarClient: this.nylasCalendarClient,
+      autonomyService: this.autonomyService,
+      browserService: this.browserService,
+      bullpenService: this.bullpenService,
+    };
+
     // Fail-closed: if a declared capability is not available on this ExecutionLayer,
     // refuse to run the skill. This catches configuration errors at invocation time.
     const missingCaps = caps.filter(cap => {
       if (cap === 'skillSearch') return false; // skillSearch is synthesized, not a field on `this`
-      return (this as Record<string, unknown>)[cap] === undefined;
+      return capabilityServices[cap] === undefined;
     });
     if (missingCaps.length > 0) {
       skillLogger.error(
@@ -321,7 +338,7 @@ export class ExecutionLayer {
             .filter(s => s.manifest.name !== 'skill-registry')
             .map(s => ({ name: s.manifest.name, description: s.manifest.description }));
       } else {
-        (ctx as Record<string, unknown>)[cap] = (this as Record<string, unknown>)[cap];
+        (ctx as unknown as Record<string, unknown>)[cap] = capabilityServices[cap];
       }
     }
 

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -4,13 +4,13 @@
 // It resolves skills from the registry, validates permissions, provides
 // a sandboxed SkillContext, enforces timeouts, and sanitizes outputs.
 //
-// Normal skills get: validated input, scoped secret access, a scoped logger.
-// They cannot access the bus, database, or filesystem directly.
+// Normal skills get: validated input, scoped secret access, a scoped logger,
+// and universal services (contactService, entityContextAssembler, agentPersona).
 //
-// Infrastructure skills (manifest.infrastructure: true) additionally receive
-// bus and agent registry access. This effectively grants unrestricted bus
-// publish/subscribe including layer impersonation. Only framework-internal
-// skills like 'delegate' should use this — it is a privileged escape hatch.
+// Privileged services (bus, outboundGateway, entityMemory, etc.) are only
+// injected when the skill declares them in manifest.capabilities[]. The loader
+// validates capability names against a fixed allowlist and freezes the manifest
+// at startup — skills cannot self-escalate at runtime.
 //
 // Entity enrichment (manifest.entity_enrichment): when a skill declares this,
 // the execution layer assembles EntityContext for the declared input parameter
@@ -274,83 +274,55 @@ export class ExecutionLayer {
       taskEventId: options?.taskEventId,
     };
 
-    // Infrastructure skills get bus and agent registry access.
-    // This is intentionally gated behind a manifest flag so normal skills
-    // cannot escalate their privileges by accessing the bus directly.
-    if (manifest.infrastructure) {
-      if (!this.bus || !this.agentRegistry) {
-        skillLogger.error(
-          { skillName },
-          'Infrastructure skill invoked but ExecutionLayer was not constructed with bus/agentRegistry/contactService',
-        );
-        return {
-          success: false,
-          error: this.wrapSkillError(`Infrastructure skill '${skillName}' cannot run: bus, agent registry, or contactService not available in ExecutionLayer — ensure all three are passed to the ExecutionLayer constructor`),
-        };
-      }
-      ctx.bus = this.bus;
-      ctx.agentRegistry = this.agentRegistry;
-      // outboundGateway is optional — only skills that send external messages need it.
-      // All outbound communication goes through the gateway, which enforces contact
-      // blocked checks and content filtering before dispatch.
-      if (this.outboundGateway) {
-        ctx.outboundGateway = this.outboundGateway;
-      }
-      // heldMessages is optional — only held-message skills need it
-      if (this.heldMessages) {
-        ctx.heldMessages = this.heldMessages;
-      }
-      // schedulerService is optional — only scheduler skills need it
-      if (this.schedulerService) {
-        ctx.schedulerService = this.schedulerService;
-      }
-      // entityMemory is optional — only skills that read/write the knowledge graph need it.
-      // When all three audit context fields and bus are available, wrap entityMemory in an
-      // observer that emits memory.store audit events after each node creation (#200).
-      // All three fields are required by createMemoryStore — guard all three together so the
-      // narrowed type flows into buildEntityMemoryObserver without unsafe casts.
-      if (this.entityMemory) {
-        const memAudit = options?.agentId && options?.conversationId && options?.parentEventId
-          ? { agentId: options.agentId, conversationId: options.conversationId, parentEventId: options.parentEventId, taskEventId: options.taskEventId }
-          : undefined;
+    // Capability-gated service injection.
+    // Skills declare which privileged services they need in manifest.capabilities.
+    // The loader validates the names and freezes the manifest at startup.
+    // We inject only the declared services — skills cannot escalate privilege.
+    const caps = manifest.capabilities ?? [];
+
+    // Fail-closed: if a declared capability is not available on this ExecutionLayer,
+    // refuse to run the skill. This catches configuration errors at invocation time.
+    const missingCaps = caps.filter(cap => {
+      if (cap === 'skillSearch') return false; // skillSearch is synthesized, not a field on `this`
+      return !(this as Record<string, unknown>)[cap];
+    });
+    if (missingCaps.length > 0) {
+      skillLogger.error(
+        { skillName, missingCapabilities: missingCaps },
+        'Skill declares capabilities not available on ExecutionLayer',
+      );
+      return {
+        success: false,
+        error: this.wrapSkillError(
+          `Skill '${skillName}' requires capabilities [${missingCaps.join(', ')}] ` +
+          `but they are not configured on the ExecutionLayer`,
+        ),
+      };
+    }
+
+    // Compute audit context for entityMemory observer (before the loop — used inside it).
+    const memAudit = options?.agentId && options?.conversationId && options?.parentEventId
+      ? { agentId: options.agentId, conversationId: options.conversationId, parentEventId: options.parentEventId, taskEventId: options.taskEventId }
+      : undefined;
+
+    for (const cap of caps) {
+      if (cap === 'entityMemory') {
+        // Special case: wrap with audit observer when audit context is available.
+        // Uses this.bus (ExecutionLayer's bus), not the skill's ctx.bus — the observer
+        // needs bus access for audit events even if the skill didn't declare 'bus'.
         ctx.entityMemory = memAudit && this.bus
-          ? buildEntityMemoryObserver(this.entityMemory, this.bus, memAudit, skillLogger)
+          ? buildEntityMemoryObserver(this.entityMemory!, this.bus, memAudit, skillLogger)
           : this.entityMemory;
+      } else if (cap === 'skillSearch') {
+        // Special case: skillSearch is a closure over the registry, not a service field.
+        // Filters out skill-registry itself to avoid circular self-discovery results.
+        ctx.skillSearch = (query: string) =>
+          this.registry.search(query)
+            .filter(s => s.manifest.name !== 'skill-registry')
+            .map(s => ({ name: s.manifest.name, description: s.manifest.description }));
+      } else {
+        (ctx as Record<string, unknown>)[cap] = (this as Record<string, unknown>)[cap];
       }
-      // nylasCalendarClient is optional — only calendar skills need it
-      if (this.nylasCalendarClient) {
-        ctx.nylasCalendarClient = this.nylasCalendarClient;
-      }
-      // bullpenService is optional — only the bullpen skill needs it
-      if (this.bullpenService) {
-        ctx.bullpenService = this.bullpenService;
-      }
-    }
-
-    // autonomyService is scoped to the autonomy skills only — not granted to all infrastructure skills.
-    // Limiting access here reduces blast radius if any other infrastructure skill is ever compromised.
-    if (this.autonomyService && (manifest.name === 'get-autonomy' || manifest.name === 'set-autonomy')) {
-      ctx.autonomyService = this.autonomyService;
-    }
-
-    // browserService is scoped to the web-browser skill only — not granted to all skills.
-    // A real browser can navigate to internal network addresses, exfiltrate page content,
-    // and fill forms. Limiting access here prevents any other skill (even if compromised
-    // or buggy) from invoking browser capabilities it never declared.
-    if (this.browserService && manifest.name === 'web-browser') {
-      ctx.browserService = this.browserService;
-    }
-
-    // skillSearch is scoped to the skill-registry built-in only.
-    // The closure captures this.registry at invocation time and filters out
-    // skill-registry itself to avoid circular self-discovery results.
-    // When #119 lands, this moves into SKILL_CAPABILITIES alongside the other
-    // name-gated services.
-    if (manifest.name === 'skill-registry') {
-      ctx.skillSearch = (query: string) =>
-        this.registry.search(query)
-          .filter(s => s.manifest.name !== 'skill-registry')
-          .map(s => ({ name: s.manifest.name, description: s.manifest.description }));
     }
 
     // entityContextAssembler — available to ALL skills (not just infrastructure).

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -268,7 +268,7 @@ export class ExecutionLayer {
       // contactService is available to all skills — read-only contact lookups
       // (calendars, display names, etc.) are not a privilege escalation.
       contactService: this.contactService,
-      // Thread agentId and taskEventId into context unconditionally — infrastructure
+      // Thread agentId and taskEventId into context unconditionally — capability-gated
       // skills (bullpen) need these for event publishing; harmless for others.
       agentId: options?.agentId,
       taskEventId: options?.taskEventId,
@@ -284,7 +284,7 @@ export class ExecutionLayer {
     // refuse to run the skill. This catches configuration errors at invocation time.
     const missingCaps = caps.filter(cap => {
       if (cap === 'skillSearch') return false; // skillSearch is synthesized, not a field on `this`
-      return !(this as Record<string, unknown>)[cap];
+      return (this as Record<string, unknown>)[cap] === undefined;
     });
     if (missingCaps.length > 0) {
       skillLogger.error(
@@ -325,11 +325,10 @@ export class ExecutionLayer {
       }
     }
 
-    // entityContextAssembler — available to ALL skills (not just infrastructure).
+    // entityContextAssembler — universal (not capability-gated).
     // The assembler is a read-only DB pipeline; granting it unconditionally is no
-    // more privileged than contactService. Keeping it outside the infrastructure
-    // block means the entity-context skill does not need infrastructure: true,
-    // which would otherwise grant it full bus/registry access it doesn't need.
+    // more privileged than contactService. Keeping it universal means the
+    // entity-context skill needs no capabilities declaration at all.
     if (this.entityContextAssembler) {
       ctx.entityContextAssembler = this.entityContextAssembler;
     }

--- a/src/skills/loader.test.ts
+++ b/src/skills/loader.test.ts
@@ -95,11 +95,7 @@ describe('loader: capability validation', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Test 3: Frozen manifest cannot be mutated at runtime
-  // ---------------------------------------------------------------------------
-
-  // ---------------------------------------------------------------------------
-  // Test 3b: Manifest is frozen even when no capabilities are declared
+  // Test 3: Manifest is frozen even when no capabilities are declared
   // ---------------------------------------------------------------------------
 
   it('freezes the manifest even when no capabilities field is present', async () => {

--- a/src/skills/loader.test.ts
+++ b/src/skills/loader.test.ts
@@ -98,6 +98,40 @@ describe('loader: capability validation', () => {
   // Test 3: Frozen manifest cannot be mutated at runtime
   // ---------------------------------------------------------------------------
 
+  // ---------------------------------------------------------------------------
+  // Test 3b: Manifest is frozen even when no capabilities are declared
+  // ---------------------------------------------------------------------------
+
+  it('freezes the manifest even when no capabilities field is present', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_cap_none__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'nocap-skill', {
+        name: 'nocap-skill',
+        description: 'test skill with no capabilities',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        // no 'capabilities' key — skill uses only universal services
+      });
+      const registry = new SkillRegistry();
+      const count = await loadSkillsFromDirectory(tmpDir, registry, logger);
+      expect(count).toBe(1);
+
+      const skill = registry.get('nocap-skill');
+      // capabilities should be absent (not defaulted to []), and manifest must still be frozen
+      expect(skill?.manifest.capabilities).toBeUndefined();
+      expect(Object.isFrozen(skill?.manifest)).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 4: Frozen manifest cannot be mutated at runtime
+  // ---------------------------------------------------------------------------
+
   it('throws when attempting to mutate a frozen capabilities array', async () => {
     const tmpDir = path.join(import.meta.dirname, '__test_cap_freeze__');
     fs.mkdirSync(tmpDir, { recursive: true });

--- a/src/skills/loader.test.ts
+++ b/src/skills/loader.test.ts
@@ -1,0 +1,127 @@
+// loader.test.ts — tests for capability validation and manifest freeze in the skill loader.
+//
+// Covers three security-critical properties:
+//   1. Unknown capability names cause a hard load failure at startup
+//   2. Valid capabilities load successfully and the manifest is frozen
+//   3. Frozen manifests reject mutation attempts at runtime
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import pino from 'pino';
+import { loadSkillsFromDirectory } from './loader.js';
+import { SkillRegistry } from './registry.js';
+
+// Silent logger — these tests do not assert on log output
+const logger = pino({ level: 'silent' });
+
+/**
+ * Write a minimal skill directory (skill.json + trivial handler) into tmpDir.
+ *
+ * The handler is written as a .js (ESM) file — not .ts — because the loader
+ * imports handlers via `import('file://...')` which bypasses vitest's transform
+ * pipeline. Plain ESM .js files work natively with Node's module loader.
+ *
+ * The loader checks for handler.ts first; since we only write handler.js,
+ * it falls back to the .js path (the correct fallback behavior).
+ */
+function setupSkillDir(tmpDir: string, skillName: string, manifest: Record<string, unknown>): void {
+  const skillDir = path.join(tmpDir, skillName);
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(path.join(skillDir, 'skill.json'), JSON.stringify(manifest));
+  // Named export matching the HandlerClass path in loader.ts
+  fs.writeFileSync(
+    path.join(skillDir, 'handler.js'),
+    "export class Handler {\n  async execute() { return { success: true, data: 'ok' }; }\n}\n",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Unknown capability name causes load failure
+// ---------------------------------------------------------------------------
+
+describe('loader: capability validation', () => {
+  it('rejects unknown capability names with a hard error at load time', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_cap_unknown__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'bad-skill', {
+        name: 'bad-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        capabilities: ['outboundGateway', 'notARealCapability'],
+      });
+      const registry = new SkillRegistry();
+      // The loader wraps the inner error; the bad capability name must appear
+      // in the final message so operators know what to fix.
+      await expect(loadSkillsFromDirectory(tmpDir, registry, logger))
+        .rejects.toThrow('notARealCapability');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 2: Valid capabilities load successfully and manifest is frozen
+  // ---------------------------------------------------------------------------
+
+  it('accepts valid capability names and freezes both manifest and capabilities array', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_cap_valid__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'good-skill', {
+        name: 'good-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        capabilities: ['outboundGateway'],
+      });
+      const registry = new SkillRegistry();
+      const count = await loadSkillsFromDirectory(tmpDir, registry, logger);
+      expect(count).toBe(1);
+
+      const skill = registry.get('good-skill');
+      // Both the manifest and its capabilities array must be frozen after loading
+      expect(Object.isFrozen(skill?.manifest.capabilities)).toBe(true);
+      expect(Object.isFrozen(skill?.manifest)).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 3: Frozen manifest cannot be mutated at runtime
+  // ---------------------------------------------------------------------------
+
+  it('throws when attempting to mutate a frozen capabilities array', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_cap_freeze__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'frozen-skill', {
+        name: 'frozen-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        capabilities: ['outboundGateway'],
+      });
+      const registry = new SkillRegistry();
+      await loadSkillsFromDirectory(tmpDir, registry, logger);
+
+      const skill = registry.get('frozen-skill');
+      // ESM modules run in strict mode — pushing to a frozen array throws TypeError.
+      // This verifies that a handler cannot self-escalate privileges at runtime.
+      expect(() => {
+        skill!.manifest.capabilities!.push('bus');
+      }).toThrow(TypeError);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -14,6 +14,23 @@ import type { SkillRegistry } from './registry.js';
 import type { Logger } from '../logger.js';
 
 /**
+ * Fixed allowlist of valid capability names that skills may declare in their manifest.
+ * Each name corresponds to a privileged service on SkillContext.
+ *
+ * This set only changes when a new service type is added to the platform —
+ * not when a new skill is added. Adding a new skill that needs an existing
+ * capability is a skill.json-only change.
+ *
+ * Services NOT in this list (contactService, entityContextAssembler, agentPersona)
+ * are universal — available to every skill without declaration.
+ */
+export const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
+  'bus', 'agentRegistry', 'outboundGateway', 'heldMessages',
+  'schedulerService', 'entityMemory', 'nylasCalendarClient',
+  'autonomyService', 'browserService', 'bullpenService', 'skillSearch',
+]);
+
+/**
  * Load all skills from a directory into the registry.
  *
  * Expects directory structure:
@@ -61,6 +78,20 @@ export async function loadSkillsFromDirectory(
       manifest.inputs ??= {};
       manifest.outputs ??= {};
 
+      // Validate declared capabilities against the fixed allowlist.
+      // Unknown names fail hard at startup — a typo in skill.json is a configuration
+      // error that must surface at boot, not silently produce a skill with wrong privileges.
+      if (manifest.capabilities !== undefined) {
+        for (const cap of manifest.capabilities) {
+          if (!VALID_CAPABILITIES.has(cap)) {
+            throw new Error(
+              `Skill '${manifest.name}' declares unknown capability '${cap}'. ` +
+              `Valid capabilities: ${[...VALID_CAPABILITIES].join(', ')}`,
+            );
+          }
+        }
+      }
+
       // Dynamically import the handler.
       // We look for handler.ts first (for tsx/development) then handler.js (for compiled).
       const handlerPath = fs.existsSync(path.join(skillDir, 'handler.ts'))
@@ -89,6 +120,13 @@ export async function loadSkillsFromDirectory(
         }
         handler = new HandlerClass();
       }
+
+      // Freeze the manifest to prevent runtime mutation — a handler cannot
+      // escalate its own privileges by pushing to capabilities[] or reassigning
+      // any manifest field. Object.freeze is shallow, so we freeze the capabilities
+      // array separately before freezing the manifest itself.
+      if (manifest.capabilities) Object.freeze(manifest.capabilities);
+      Object.freeze(manifest);
 
       registry.register(manifest, handler);
       logger.info({ skill: manifest.name, version: manifest.version }, 'Skill loaded');

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -125,7 +125,7 @@ export async function loadSkillsFromDirectory(
       // escalate its own privileges by pushing to capabilities[] or reassigning
       // any manifest field. Object.freeze is shallow, so we freeze the capabilities
       // array separately before freezing the manifest itself.
-      if (manifest.capabilities) Object.freeze(manifest.capabilities);
+      if (manifest.capabilities !== undefined) Object.freeze(manifest.capabilities);
       Object.freeze(manifest);
 
       registry.register(manifest, handler);

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -49,10 +49,18 @@ export interface SkillManifest {
   secrets: string[];
   /** Per-invocation timeout in ms. Default 30000. */
   timeout: number;
-  /** If true, this skill receives bus and agent registry access in its context.
-   *  This grants unrestricted bus publish/subscribe including layer impersonation.
-   *  Only for framework-internal skills like 'delegate' — external skills should never set this. */
-  infrastructure?: boolean;
+  /** Declares which privileged SkillContext services this skill needs.
+   *  Only known capability names are accepted — the loader validates against
+   *  a fixed allowlist at startup and rejects unknown names.
+   *  The manifest is frozen after loading — capabilities cannot be mutated at runtime.
+   *
+   *  Valid capabilities: bus, agentRegistry, outboundGateway, heldMessages,
+   *  schedulerService, entityMemory, nylasCalendarClient, autonomyService,
+   *  browserService, bullpenService, skillSearch.
+   *
+   *  Services NOT listed here (contactService, entityContextAssembler, agentPersona)
+   *  are universal — available to every skill without declaration. */
+  capabilities?: string[];
   /** Declares that the execution layer should automatically assemble entity context
    *  before invoking this skill's handler. The assembled EntityContext[] is injected
    *  into ctx.entityContext so the handler doesn't need to call entity-context directly.
@@ -109,23 +117,23 @@ export interface SkillContext {
   secret(name: string): string;
   /** Scoped pino child logger */
   log: Logger;
-  /** Bus access — only available to infrastructure skills (manifest.infrastructure: true) */
+  /** Bus access — available to skills declaring 'bus' in capabilities */
   bus?: import('../bus/bus.js').EventBus;
-  /** Agent registry — only available to infrastructure skills */
+  /** Agent registry — available to skills declaring 'agentRegistry' in capabilities */
   agentRegistry?: import('../agents/agent-registry.js').AgentRegistry;
   /** Contact service — available to all skills for caller-scoped lookups
    *  (e.g., resolving a caller's registered calendars, looking up contacts).
    *  Populated whenever the ExecutionLayer has a contactService instance. */
   contactService?: import('../contacts/contact-service.js').ContactService;
-  /** Outbound gateway — only available to infrastructure skills. All external
-   *  communication (email, future Signal/Telegram) goes through the gateway,
+  /** Outbound gateway — available to skills declaring 'outboundGateway' in capabilities.
+   *  All external communication (email, future Signal/Telegram) goes through the gateway,
    *  which enforces contact blocked checks and content filtering. */
   outboundGateway?: import('./outbound-gateway.js').OutboundGateway;
-  /** Held message service for infrastructure skills that manage held messages */
+  /** Held message service — available to skills declaring 'heldMessages' in capabilities */
   heldMessages?: import('../contacts/held-messages.js').HeldMessageService;
-  /** Scheduler service — only available to infrastructure skills */
+  /** Scheduler service — available to skills declaring 'schedulerService' in capabilities */
   schedulerService?: import('../scheduler/scheduler-service.js').SchedulerService;
-  /** Entity memory (knowledge graph) — only available to infrastructure skills.
+  /** Entity memory (knowledge graph) — available to skills declaring 'entityMemory' in capabilities.
    *  Provides semantic search, entity CRUD, and fact storage for skills that
    *  need to read or write long-term knowledge (templates, preferences, etc.). */
   entityMemory?: import('../memory/entity-memory.js').EntityMemory;
@@ -133,11 +141,11 @@ export interface SkillContext {
    *  coordinator's persona config. Available to all skills (not infrastructure-gated)
    *  so templates can reference the agent's identity without hardcoding it. */
   agentPersona?: AgentPersona;
-  /** Nylas calendar client — only available to infrastructure skills.
+  /** Nylas calendar client — available to skills declaring 'nylasCalendarClient' in capabilities.
    *  Provides CRUD operations on calendar events and free/busy queries
    *  via the Nylas unified API (provider-agnostic). */
   nylasCalendarClient?: import('../channels/calendar/nylas-calendar-client.js').NylasCalendarClient;
-  /** Bullpen service — available to infrastructure skills for inter-agent discussion threads */
+  /** Bullpen service — available to skills declaring 'bullpenService' in capabilities for inter-agent discussion threads */
   bullpenService?: import('../memory/bullpen.js').BullpenService;
   /** ID of the agent invoking this skill — injected by the execution layer */
   agentId?: string;
@@ -158,17 +166,15 @@ export interface SkillContext {
   /** The agent's own contactId — used by entity_enrichment when default is 'agent'.
    *  Seeded at bootstrap and injected by the execution layer. */
   agentContactId?: string;
-  /** Autonomy service — available to infrastructure skills that manage the global
-   *  autonomy score (get-autonomy, set-autonomy). Not available to normal skills. */
+  /** Autonomy service — available to skills declaring 'autonomyService' in capabilities.
+   *  Manages the global autonomy score (get-autonomy, set-autonomy). */
   autonomyService?: import('../autonomy/autonomy-service.js').AutonomyService;
-  /** Browser service — available to all skills (not infrastructure-gated).
+  /** Browser service — available to skills declaring 'browserService' in capabilities.
    *  Provides a warm Playwright Chromium instance with session management.
    *  Skills use this to interact with JS-rendered pages and web forms. */
   browserService?: import('../browser/browser-service.js').BrowserService;
-  /** Skill search — injected only for the skill-registry built-in.
-   *  Searches all registered skills by keyword, excluding skill-registry itself.
-   *  Follows the same name-gated injection pattern as autonomyService and browserService.
-   *  When #119 lands, this will move into the SKILL_CAPABILITIES registry. */
+  /** Skill search — available to skills declaring 'skillSearch' in capabilities.
+   *  Searches all registered skills by keyword, excluding skill-registry itself. */
   skillSearch?: (query: string) => Array<{ name: string; description: string }>;
 }
 

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -93,8 +93,8 @@ export interface CallerContext {
 /**
  * The agent persona — display name, title, and optional email signature.
  * Sourced from the coordinator's persona config in agents/coordinator.yaml.
- * Available to all skills (not gated behind infrastructure) so templates
- * and outbound-facing skills can reference the agent's identity without
+ * Universal (not capability-gated) so templates and outbound-facing skills
+ * can reference the agent's identity without
  * hardcoding it.
  */
 export interface AgentPersona {

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -138,7 +138,7 @@ export interface SkillContext {
    *  need to read or write long-term knowledge (templates, preferences, etc.). */
   entityMemory?: import('../memory/entity-memory.js').EntityMemory;
   /** Agent persona — display name, title, and email signature from the
-   *  coordinator's persona config. Available to all skills (not infrastructure-gated)
+   *  coordinator's persona config. Universal (not capability-gated)
    *  so templates can reference the agent's identity without hardcoding it. */
   agentPersona?: AgentPersona;
   /** Nylas calendar client — available to skills declaring 'nylasCalendarClient' in capabilities.

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -155,7 +155,7 @@ export interface SkillContext {
    *  Guaranteed to be defined for elevated skills (execution layer rejects without it).
    *  Available but optional for normal skills. */
   caller?: CallerContext;
-  /** Entity context assembler — available to infrastructure skills.
+  /** Entity context assembler — available to all skills (universal, not capability-gated).
    *  Used by the entity-context skill to assemble EntityContext payloads on demand.
    *  Also used by the execution layer for entity_enrichment pre-enrichment. */
   entityContextAssembler?: import('../entity-context/assembler.js').EntityContextAssembler;

--- a/tests/integration/multi-agent-delegation.test.ts
+++ b/tests/integration/multi-agent-delegation.test.ts
@@ -25,7 +25,7 @@ describe('Multi-agent delegation integration', () => {
       description: 'Delegate a task to a specialist agent',
       version: '1.0.0',
       sensitivity: 'normal',
-      infrastructure: true,
+      capabilities: ['bus', 'agentRegistry'],
       inputs: { agent: 'string', task: 'string', conversation_id: 'string?' },
       outputs: { response: 'string', agent: 'string' },
       permissions: [],

--- a/tests/unit/skills/calendar-register.test.ts
+++ b/tests/unit/skills/calendar-register.test.ts
@@ -25,7 +25,7 @@ describe('CalendarRegisterHandler', () => {
     const result = await handler.execute(makeCtx({ nylas_calendar_id: 'cal-1', label: 'Work' }));
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toContain('infrastructure access');
+      expect(result.error).toContain('universal service');
     }
   });
 

--- a/tests/unit/skills/delegate.test.ts
+++ b/tests/unit/skills/delegate.test.ts
@@ -27,7 +27,7 @@ describe('DelegateHandler', () => {
     const result = await handler.execute(makeCtx({ agent: 'research-analyst', task: 'do something' }));
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toContain('infrastructure');
+      expect(result.error).toContain('capabilities');
     }
   });
 


### PR DESCRIPTION
## Summary

Replaces the all-or-nothing `infrastructure: true` manifest boolean with per-capability `"capabilities": [...]` declarations. Skills now declare only the privileged services they actually need, eliminating blast-radius risk where any infrastructure skill got bus, agent registry, calendar, memory, and scheduler access simultaneously.

- **`SkillManifest`** — `infrastructure?: boolean` removed; `capabilities?: string[]` added with doc-comment listing all 11 valid names
- **Loader** — validates declared names against a fixed `VALID_CAPABILITIES` allowlist at startup (unknown name = hard crash, not silent skip); freezes manifests after loading so handlers cannot self-escalate at runtime
- **ExecutionLayer** — `if (manifest.infrastructure)` block + 3 name-gated conditionals replaced by a single capabilities loop with fail-closed behavior (`missingCaps` check rejects before the handler runs)
- **52 `skill.json` files** migrated to explicit `capabilities` arrays
- **`schemas/skill-manifest.schema.json`** updated — `additionalProperties: false` means old `infrastructure` field now fails schema validation at startup
- **Documentation** updated — `adding-a-skill.md` capabilities reference table, `03-skills-and-execution.md` spec section

**Breaking change to public API surface** — `skill.json` manifest schema change. Version bumped to `0.20.0`.

## Test plan

- [ ] `npm test` — 133 test files pass, 0 failures
- [ ] Skills that previously had `infrastructure: true` now declare only the capabilities they actually use
- [ ] Skills with no privileged services (contact-*, template-*, calendar-register) have no `capabilities` array
- [ ] Unknown capability name in `skill.json` causes startup crash (loader test)
- [ ] Manifest is frozen after loading — mutations throw `TypeError` in strict mode (loader test)
- [ ] Skill declaring unavailable capability gets `{ success: false }`, handler not invoked (execution test)

Closes #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced capability-based privilege model for skills. Skills now declare required capabilities (e.g., `bus`, `entityMemory`, `outboundGateway`) instead of using a generic infrastructure flag, enabling more granular permission control.
  * Added validation of declared capabilities at startup with hard rejection for unknown names, preventing runtime privilege escalation.
  * Manifests are now frozen after loading to prevent runtime capability changes.

* **Documentation**
  * Updated guides and specifications to reflect the new capability-based privilege system and clarify which services are universally available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->