### PR TITLE
feat: defense-in-depth skill-layer block for observation mode (closes #305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 
 - **Dispatcher observation-mode branch** — now emits a `warn`-level log when a non-`LEAVE FOR CEO` classification completes with zero skill calls (defensive check for coordinator stalls)
+- **Defense-in-depth: skill-layer block for observation-mode triage** (closes #305)
+  - `email-reply` is hard-blocked when `observationMode` is set in task metadata — the skill returns a structured error rather than silently sending a reply from the CEO's inbox.
+  - `email-draft-save` requires `triage_classification: "NEEDS DRAFT"` in observation mode. Calls with NOISE, LEAVE FOR CEO, or no classification are rejected with an auditable error.
+  - Task metadata (`observationMode`, future signals) is now threaded from the `agent.task` event through `ExecutionLayer.invoke()` into `SkillContext`, making task-level context available to any handler without bus access.
 
 ---
 
@@ -406,8 +410,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Bootstrap orchestrator** — `src/index.ts` wires all layers in dependency order
 - Architecture specs 00–08, contributor docs (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
 
-[Unreleased]: https://github.com/josephfung/curia/compare/v0.19.9...HEAD
-[0.19.9]: https://github.com/josephfung/curia/compare/v0.19.8...v0.19.9
+[Unreleased]: https://github.com/josephfung/curia/compare/v0.19.7...HEAD
 [0.19.7]: https://github.com/josephfung/curia/compare/v0.18.1...v0.19.7
 [0.18.1]: https://github.com/josephfung/curia/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/josephfung/curia/compare/v0.17.0...v0.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,7 +406,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Bootstrap orchestrator** — `src/index.ts` wires all layers in dependency order
 - Architecture specs 00–08, contributor docs (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
 
-[Unreleased]: https://github.com/josephfung/curia/compare/v0.19.7...HEAD
+[Unreleased]: https://github.com/josephfung/curia/compare/v0.19.9...HEAD
+[0.19.9]: https://github.com/josephfung/curia/compare/v0.19.8...v0.19.9
 [0.19.7]: https://github.com/josephfung/curia/compare/v0.18.1...v0.19.7
 [0.18.1]: https://github.com/josephfung/curia/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/josephfung/curia/compare/v0.17.0...v0.18.0

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -312,7 +312,8 @@ system_prompt: |
        Do it using your existing skills. No notification. It will appear in the weekly log.
      - NEEDS DRAFT — a reply is warranted and you can write it:
        Save a draft with email-draft-save (set `account` to the Account identifier from
-       the task and `reply_to_message_id` to the Message ID). The CEO will review before it sends.
+       the task, `reply_to_message_id` to the Message ID, and `triage_classification` to
+       `"NEEDS DRAFT"`). The CEO will review before it sends.
      - LEAVE FOR CEO — personal, sensitive, relationship-dependent, requires the CEO's
        own voice or judgment, or you are not confident you understand it:
        Do NOTHING. No archive, no draft, no notification. The CEO will read and

--- a/skills/email-draft-save/handler.ts
+++ b/skills/email-draft-save/handler.ts
@@ -48,7 +48,7 @@ export class EmailDraftSaveHandler implements SkillHandler {
       );
       return {
         success: false,
-        error: `email-draft-save blocked in observation mode: triage_classification must be "NEEDS DRAFT" (got: "${triageClassification ?? 'absent'}")`,
+        error: `email-draft-save blocked in observation mode: triage_classification must be "NEEDS DRAFT" (got: ${triageClassification !== undefined ? `"${triageClassification}"` : '(field absent)'})`,
       };
     }
 

--- a/skills/email-draft-save/handler.ts
+++ b/skills/email-draft-save/handler.ts
@@ -17,18 +17,36 @@ export class EmailDraftSaveHandler implements SkillHandler {
     // Handlers must never throw — destructuring a non-object ctx.input would.
     const input =
       ctx.input && typeof ctx.input === 'object' ? (ctx.input as Record<string, unknown>) : {};
-    const { to: rawTo, subject, body, account, reply_to_message_id } = input as {
+    const { to: rawTo, subject, body, account, reply_to_message_id, triage_classification } = input as {
       to?: string;
       subject?: string;
       body?: string;
       account?: string;
       reply_to_message_id?: string;
+      triage_classification?: string;
     };
 
     const to = typeof rawTo === 'string' ? rawTo.trim() : undefined;
     if (!to) return { success: false, error: 'Missing required input: to (string)' };
     if (!subject || typeof subject !== 'string') return { success: false, error: 'Missing required input: subject (string)' };
     if (!body || typeof body !== 'string') return { success: false, error: 'Missing required input: body (string)' };
+
+    // Observation mode guard — the coordinator must only save drafts for NEEDS DRAFT emails.
+    // Calling email-draft-save for NOISE or LEAVE FOR CEO (or without declaring a classification)
+    // is a model slip: block it hard so the error is auditable rather than silently creating
+    // a draft the CEO did not request. Outside observation mode, triage_classification is ignored.
+    const triageClassification =
+      typeof triage_classification === 'string' ? triage_classification.trim() : undefined;
+    if (ctx.taskMetadata?.observationMode === true && triageClassification !== 'NEEDS DRAFT') {
+      ctx.log.warn(
+        { triageClassification: triageClassification ?? '(absent)' },
+        'email-draft-save: blocked in observation mode — triage_classification must be "NEEDS DRAFT"',
+      );
+      return {
+        success: false,
+        error: `email-draft-save blocked in observation mode: triage_classification must be "NEEDS DRAFT" (got: "${triageClassification ?? 'absent'}")`,
+      };
+    }
 
     const accountId = typeof account === 'string' && account.trim() ? account.trim() : undefined;
     const replyToMessageId = typeof reply_to_message_id === 'string' && reply_to_message_id.trim()

--- a/skills/email-draft-save/handler.ts
+++ b/skills/email-draft-save/handler.ts
@@ -35,8 +35,12 @@ export class EmailDraftSaveHandler implements SkillHandler {
     // Calling email-draft-save for NOISE or LEAVE FOR CEO (or without declaring a classification)
     // is a model slip: block it hard so the error is auditable rather than silently creating
     // a draft the CEO did not request. Outside observation mode, triage_classification is ignored.
+    // Treat whitespace-only strings as absent — mirrors the pattern used for accountId and
+    // replyToMessageId below, and ensures the error message emits 'absent' rather than '""'.
     const triageClassification =
-      typeof triage_classification === 'string' ? triage_classification.trim() : undefined;
+      typeof triage_classification === 'string' && triage_classification.trim()
+        ? triage_classification.trim()
+        : undefined;
     if (ctx.taskMetadata?.observationMode === true && triageClassification !== 'NEEDS DRAFT') {
       ctx.log.warn(
         { triageClassification: triageClassification ?? '(absent)' },

--- a/skills/email-draft-save/skill.json
+++ b/skills/email-draft-save/skill.json
@@ -9,7 +9,8 @@
     "subject": "string (email subject line)",
     "body": "string (email body; markdown supported, converted to HTML automatically)",
     "account": "string? (named account to draft from, as configured in channel_accounts.email. Defaults to the primary account.)",
-    "reply_to_message_id": "string? (Nylas message ID to reply to; threads the draft as a reply when set)"
+    "reply_to_message_id": "string? (Nylas message ID to reply to; threads the draft as a reply when set)",
+    "triage_classification": "string? (Required in observation mode. Must be 'NEEDS DRAFT' to allow the draft. Any other value — or omitting this field in observation mode — blocks the call with an auditable error. Not required outside observation mode.)"
   },
   "outputs": {
     "draft_id": "string"

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -24,7 +24,7 @@ export class EmailReplyHandler implements SkillHandler {
     // reviews before anything is sent. This produces an auditable error rather than
     // a silent reply that the CEO did not request.
     if (ctx.taskMetadata?.observationMode === true) {
-      ctx.log.warn('email-reply blocked: called in observation mode');
+      ctx.log.warn({ replyToMessageId }, 'email-reply blocked: called in observation mode');
       return {
         success: false,
         error: 'email-reply is blocked in observation mode. Use email-draft-save with triage_classification: "NEEDS DRAFT" to save a draft for CEO review.',

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -18,6 +18,19 @@ export class EmailReplyHandler implements SkillHandler {
       body?: string;
     };
 
+    // Hard block in observation mode — email-reply sends immediately, which is never
+    // appropriate when Curia is monitoring the CEO's inbox on their behalf.
+    // All obs-mode outbound drafts must go through email-draft-save so the CEO
+    // reviews before anything is sent. This produces an auditable error rather than
+    // a silent reply that the CEO did not request.
+    if (ctx.taskMetadata?.observationMode === true) {
+      ctx.log.warn('email-reply blocked: called in observation mode');
+      return {
+        success: false,
+        error: 'email-reply is blocked in observation mode. Use email-draft-save with triage_classification: "NEEDS DRAFT" to save a draft for CEO review.',
+      };
+    }
+
     if (!replyToMessageId || typeof replyToMessageId !== 'string') {
       return { success: false, error: 'Missing required input: reply_to_message_id (string)' };
     }

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -531,6 +531,9 @@ export class AgentRuntime {
           parentEventId: invokeEvent.id,
           // Pass task-level metadata (e.g. observationMode) so skill handlers can
           // inspect task-wide signals without bus or dispatcher access.
+          // metadata is undefined for non-email tasks (Signal, CLI, scheduler) — when
+          // undefined, skill-layer obs-mode guards treat the task as non-obs-mode (safe,
+          // since those paths never set observationMode on the task event).
           taskMetadata: taskEvent.payload.metadata,
         });
         const durationMs = Date.now() - startTime;

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -529,6 +529,9 @@ export class AgentRuntime {
           agentId,
           conversationId,
           parentEventId: invokeEvent.id,
+          // Pass task-level metadata (e.g. observationMode) so skill handlers can
+          // inspect task-wide signals without bus or dispatcher access.
+          taskMetadata: taskEvent.payload.metadata,
         });
         const durationMs = Date.now() - startTime;
 

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -295,4 +295,34 @@ describe('taskMetadata pass-through', () => {
 
     expect(capturedCtx?.taskMetadata).toEqual({ observationMode: true, extra: 'value' });
   });
+
+  it('leaves taskMetadata undefined when options omit it', async () => {
+    const registry = new SkillRegistry();
+    const layer = new ExecutionLayer(registry, logger);
+
+    let capturedCtx: SkillContext | undefined;
+    const capturingHandler: SkillHandler = {
+      async execute(ctx) { capturedCtx = ctx; return { success: true, data: 'ok' }; },
+    };
+
+    registry.register(
+      {
+        name: 'test-meta-absent',
+        description: '',
+        version: '1.0.0',
+        sensitivity: 'normal',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        permissions: [],
+        secrets: [],
+        timeout: 5000,
+      },
+      capturingHandler,
+    );
+
+    await layer.invoke('test-meta-absent', {}, undefined, {});
+
+    expect(capturedCtx?.taskMetadata).toBeUndefined();
+  });
 });

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, vi } from 'vitest';
 import pino from 'pino';
 import { SkillRegistry } from './registry.js';
 import { ExecutionLayer } from './execution.js';
-import type { SkillHandler, SkillManifest, SkillResult } from './types.js';
+import type { SkillHandler, SkillManifest, SkillResult, SkillContext } from './types.js';
 import type { EventBus } from '../bus/bus.js';
 import type { OutboundGateway } from './outbound-gateway.js';
 import type { SchedulerService } from '../scheduler/scheduler-service.js';
@@ -255,5 +255,44 @@ describe('capability-gated service injection', () => {
     }
     // Handler should NOT have been called — fail-closed
     expect(handler.execute).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// taskMetadata pass-through
+// ---------------------------------------------------------------------------
+
+describe('taskMetadata pass-through', () => {
+  it('passes taskMetadata to the skill context', async () => {
+    const registry = new SkillRegistry();
+    const layer = new ExecutionLayer(registry, logger);
+
+    let capturedCtx: SkillContext | undefined;
+    const capturingHandler: SkillHandler = {
+      async execute(ctx) { capturedCtx = ctx; return { success: true, data: 'ok' }; },
+    };
+
+    // Register a test skill with the capturing handler
+    registry.register(
+      {
+        name: 'test-meta',
+        description: '',
+        version: '1.0.0',
+        sensitivity: 'normal',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        permissions: [],
+        secrets: [],
+        timeout: 5000,
+      },
+      capturingHandler,
+    );
+
+    await layer.invoke('test-meta', {}, undefined, {
+      taskMetadata: { observationMode: true, extra: 'value' },
+    });
+
+    expect(capturedCtx?.taskMetadata).toEqual({ observationMode: true, extra: 'value' });
   });
 });

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -42,6 +42,17 @@ import type { BrowserService } from '../browser/browser-service.js';
 // reaches the LLM context window.
 const DEFAULT_SKILL_OUTPUT_MAX_LENGTH = 200_000;
 
+/** Options passed to ExecutionLayer.invoke() by the agent runtime. */
+export interface InvokeOptions {
+  taskEventId?: string;
+  agentId?: string;
+  conversationId?: string;
+  parentEventId?: string;
+  /** Task-level metadata forwarded from the agent.task event payload.
+   *  Used by skill handlers to inspect task-wide signals (e.g. observationMode). */
+  taskMetadata?: Record<string, unknown>;
+}
+
 export class ExecutionLayer {
   private registry: SkillRegistry;
   private logger: Logger;
@@ -164,7 +175,7 @@ export class ExecutionLayer {
     skillName: string,
     input: Record<string, unknown>,
     caller?: CallerContext,
-    options?: { taskEventId?: string; agentId?: string; conversationId?: string; parentEventId?: string; taskMetadata?: Record<string, unknown> },
+    options?: InvokeOptions,
   ): Promise<SkillResult> {
     const skill = this.registry.get(skillName);
 

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -164,7 +164,7 @@ export class ExecutionLayer {
     skillName: string,
     input: Record<string, unknown>,
     caller?: CallerContext,
-    options?: { taskEventId?: string; agentId?: string; conversationId?: string; parentEventId?: string },
+    options?: { taskEventId?: string; agentId?: string; conversationId?: string; parentEventId?: string; taskMetadata?: Record<string, unknown> },
   ): Promise<SkillResult> {
     const skill = this.registry.get(skillName);
 
@@ -272,6 +272,9 @@ export class ExecutionLayer {
       // skills (bullpen) need these for event publishing; harmless for others.
       agentId: options?.agentId,
       taskEventId: options?.taskEventId,
+      // Forward task-level metadata (e.g. observationMode) so skills can adjust
+      // their behaviour without needing a separate out-of-band signalling channel.
+      taskMetadata: options?.taskMetadata,
     };
 
     // Capability-gated service injection.

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -176,6 +176,12 @@ export interface SkillContext {
   /** Skill search — available to skills declaring 'skillSearch' in capabilities.
    *  Searches all registered skills by keyword, excluding skill-registry itself. */
   skillSearch?: (query: string) => Array<{ name: string; description: string }>;
+  /** Arbitrary task-level metadata forwarded from the agent.task event payload.
+   *  Currently used to carry observationMode (whether the task was dispatched in
+   *  observation-only mode) so skills can adjust their behaviour accordingly —
+   *  e.g. suppressing outbound sends when observationMode === true.
+   *  Skills that do not need it can ignore this field entirely. */
+  taskMetadata?: Record<string, unknown>;
 }
 
 /**

--- a/tests/unit/skills/email-draft-save.test.ts
+++ b/tests/unit/skills/email-draft-save.test.ts
@@ -153,5 +153,16 @@ describe('EmailDraftSaveHandler', () => {
       ));
       expect(result.success).toBe(true);
     });
+
+    it('does not apply obs mode guard when observationMode is false', async () => {
+      const gateway = { createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-not-obs' }) };
+      const result = await handler.execute(makeCtx(
+        { to: 'r@example.com', subject: 'Hi', body: 'Hello' },
+        gateway,
+        { observationMode: false },
+      ));
+      expect(result.success).toBe(true);
+      expect(gateway.createEmailDraft).toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/skills/email-draft-save.test.ts
+++ b/tests/unit/skills/email-draft-save.test.ts
@@ -7,12 +7,13 @@ const logger = pino({ level: 'silent' });
 
 function makeCtx(input: Record<string, unknown>, gateway?: Partial<{
   createEmailDraft: (...args: unknown[]) => unknown;
-}>): SkillContext {
+}>, taskMetadata?: Record<string, unknown>): SkillContext {
   return {
     input,
     secret: () => { throw new Error('no secrets'); },
     log: logger,
     outboundGateway: gateway as never,
+    taskMetadata,
   };
 }
 
@@ -94,5 +95,63 @@ describe('EmailDraftSaveHandler', () => {
     const result = await handler.execute(makeCtx({ to: 'r@example.com', subject: 'Hi', body: 'Hello' }, gateway));
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain('Failed to save draft');
+  });
+
+  describe('observation mode guard', () => {
+    it('blocks when observationMode is true and triage_classification is absent', async () => {
+      const gateway = { createEmailDraft: vi.fn() };
+      const result = await handler.execute(makeCtx(
+        { to: 'ceo@example.com', subject: 'Re: Hi', body: 'Hello', account: 'joseph', reply_to_message_id: 'msg-1' },
+        gateway,
+        { observationMode: true },
+      ));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/observation mode/i);
+      expect(gateway.createEmailDraft).not.toHaveBeenCalled();
+    });
+
+    it('blocks when observationMode is true and triage_classification is NOISE', async () => {
+      const gateway = { createEmailDraft: vi.fn() };
+      const result = await handler.execute(makeCtx(
+        { to: 'ceo@example.com', subject: 'Re: Hi', body: 'Hello', account: 'joseph', triage_classification: 'NOISE' },
+        gateway,
+        { observationMode: true },
+      ));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/observation mode/i);
+      expect(gateway.createEmailDraft).not.toHaveBeenCalled();
+    });
+
+    it('blocks when observationMode is true and triage_classification is LEAVE FOR CEO', async () => {
+      const gateway = { createEmailDraft: vi.fn() };
+      const result = await handler.execute(makeCtx(
+        { to: 'ceo@example.com', subject: 'Re: Hi', body: 'Hello', account: 'joseph', triage_classification: 'LEAVE FOR CEO' },
+        gateway,
+        { observationMode: true },
+      ));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/observation mode/i);
+      expect(gateway.createEmailDraft).not.toHaveBeenCalled();
+    });
+
+    it('allows the call when observationMode is true and triage_classification is NEEDS DRAFT', async () => {
+      const gateway = { createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-obs-1' }) };
+      const result = await handler.execute(makeCtx(
+        { to: 'ceo@example.com', subject: 'Re: Hi', body: 'Hello', account: 'joseph', reply_to_message_id: 'msg-1', triage_classification: 'NEEDS DRAFT' },
+        gateway,
+        { observationMode: true },
+      ));
+      expect(result.success).toBe(true);
+      if (result.success) expect((result.data as { draft_id: string }).draft_id).toBe('d-obs-1');
+    });
+
+    it('does not apply obs mode guard when taskMetadata is absent', async () => {
+      const gateway = { createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-normal' }) };
+      const result = await handler.execute(makeCtx(
+        { to: 'r@example.com', subject: 'Hi', body: 'Hello' },
+        gateway,
+      ));
+      expect(result.success).toBe(true);
+    });
   });
 });

--- a/tests/unit/skills/email-reply.test.ts
+++ b/tests/unit/skills/email-reply.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EmailReplyHandler } from '../../../skills/email-reply/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(
+  input: Record<string, unknown>,
+  gateway?: Partial<{
+    getEmailMessage: (...args: unknown[]) => unknown;
+    send: (...args: unknown[]) => unknown;
+  }>,
+  taskMetadata?: Record<string, unknown>,
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    outboundGateway: gateway as never,
+    taskMetadata,
+  };
+}
+
+describe('EmailReplyHandler', () => {
+  const handler = new EmailReplyHandler();
+
+  // --- Observation mode block ---
+
+  it('blocks in observation mode and does not call gateway', async () => {
+    const gateway = { getEmailMessage: vi.fn(), send: vi.fn() };
+    const result = await handler.execute(
+      makeCtx(
+        { reply_to_message_id: 'msg-1', body: 'Hello' },
+        gateway,
+        { observationMode: true },
+      ),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/observation mode/i);
+    expect(gateway.getEmailMessage).not.toHaveBeenCalled();
+    expect(gateway.send).not.toHaveBeenCalled();
+  });
+
+  it('does not block when observationMode is false', async () => {
+    const gateway = {
+      getEmailMessage: vi.fn().mockResolvedValue({
+        from: [{ email: 'sender@example.com' }],
+        subject: 'Test',
+      }),
+      send: vi.fn().mockResolvedValue({ success: true, messageId: 'msg-out-1' }),
+    };
+    const result = await handler.execute(
+      makeCtx(
+        { reply_to_message_id: 'msg-1', body: 'Hello' },
+        gateway,
+        { observationMode: false },
+      ),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('does not block when taskMetadata is absent', async () => {
+    const gateway = {
+      getEmailMessage: vi.fn().mockResolvedValue({
+        from: [{ email: 'sender@example.com' }],
+        subject: 'Test',
+      }),
+      send: vi.fn().mockResolvedValue({ success: true, messageId: 'msg-out-2' }),
+    };
+    const result = await handler.execute(
+      makeCtx({ reply_to_message_id: 'msg-1', body: 'Hello' }, gateway),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  // --- Input validation (non-obs-mode) ---
+
+  it('returns failure when outboundGateway is not configured', async () => {
+    const result = await handler.execute(
+      makeCtx({ reply_to_message_id: 'msg-1', body: 'Hello' }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('outboundGateway');
+  });
+
+  it('returns failure when reply_to_message_id is missing', async () => {
+    const gateway = { getEmailMessage: vi.fn(), send: vi.fn() };
+    const result = await handler.execute(makeCtx({ body: 'Hello' }, gateway));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('reply_to_message_id');
+  });
+
+  it('returns failure when body is missing', async () => {
+    const gateway = { getEmailMessage: vi.fn(), send: vi.fn() };
+    const result = await handler.execute(
+      makeCtx({ reply_to_message_id: 'msg-1' }, gateway),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('body');
+  });
+
+  it('returns failure when original message has no sender address', async () => {
+    const gateway = {
+      getEmailMessage: vi.fn().mockResolvedValue({ from: [], subject: 'Test' }),
+      send: vi.fn(),
+    };
+    const result = await handler.execute(
+      makeCtx({ reply_to_message_id: 'msg-1', body: 'Hello' }, gateway),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('no sender');
+  });
+
+  it('returns failure when gateway send is blocked', async () => {
+    const gateway = {
+      getEmailMessage: vi.fn().mockResolvedValue({
+        from: [{ email: 's@example.com' }],
+        subject: 'Test',
+      }),
+      send: vi.fn().mockResolvedValue({ success: false, blockedReason: 'Recipient blocked' }),
+    };
+    const result = await handler.execute(
+      makeCtx({ reply_to_message_id: 'msg-1', body: 'Hello' }, gateway),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('blocked');
+  });
+
+  it('returns message_id, to, and subject on success', async () => {
+    const gateway = {
+      getEmailMessage: vi.fn().mockResolvedValue({
+        from: [{ email: 'alice@example.com' }],
+        subject: 'Meeting',
+      }),
+      send: vi.fn().mockResolvedValue({ success: true, messageId: 'sent-42' }),
+    };
+    const result = await handler.execute(
+      makeCtx({ reply_to_message_id: 'msg-orig', body: 'Confirmed!' }, gateway),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { message_id: string; to: string; subject: string };
+      expect(data.message_id).toBe('sent-42');
+      expect(data.to).toBe('alice@example.com');
+      expect(data.subject).toBe('Re: Meeting');
+    }
+  });
+
+  it('strips existing Re: prefix before adding Re:', async () => {
+    const gateway = {
+      getEmailMessage: vi.fn().mockResolvedValue({
+        from: [{ email: 's@example.com' }],
+        subject: 'Re: Something',
+      }),
+      send: vi.fn().mockResolvedValue({ success: true, messageId: 'sent-43' }),
+    };
+    const result = await handler.execute(
+      makeCtx({ reply_to_message_id: 'msg-1', body: 'Got it' }, gateway),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as { subject: string }).subject).toBe('Re: Something');
+    }
+  });
+});

--- a/tests/unit/skills/email-reply.test.ts
+++ b/tests/unit/skills/email-reply.test.ts
@@ -37,7 +37,11 @@ describe('EmailReplyHandler', () => {
       ),
     );
     expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toMatch(/observation mode/i);
+    if (!result.success) {
+      expect(result.error).toMatch(/observation mode/i);
+      // Verify the error redirects callers to the correct alternative
+      expect(result.error).toMatch(/email-draft-save/i);
+    }
     expect(gateway.getEmailMessage).not.toHaveBeenCalled();
     expect(gateway.send).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- **Threads `taskMetadata`** from the `agent.task` event through `ExecutionLayer.invoke()` into `SkillContext`, making task-level signals (e.g. `observationMode`) available to any skill handler
- **Hard-blocks `email-reply`** when `observationMode === true` — the skill returns a structured error before any gateway call, since `email-reply` always sends immediately and is never appropriate in observation mode
- **Classification-aware block on `email-draft-save`** in observation mode — only `triage_classification: "NEEDS DRAFT"` is allowed through; NOISE, LEAVE FOR CEO, or absent classification returns an auditable error
- **Updates coordinator prompt** to always pass `triage_classification: "NEEDS DRAFT"` when saving a draft in observation mode
- Bumps version to `0.19.9`, adds CHANGELOG entry

## Why

Prompt-only enforcement is fragile — a model slip can cause the coordinator to call `email-reply` or `email-draft-save` for emails it should leave alone. This adds a second enforcement layer at the skill layer so that mistakes produce auditable `{ success: false, error }` results rather than unintended sends or drafts from the CEO's inbox.

## Test plan

- [ ] Full test suite passes (`npm test`) — 1489 tests, 0 failures
- [ ] `email-reply` blocks with a structured error in obs mode; gateway never called
- [ ] `email-draft-save` allows `NEEDS DRAFT` through in obs mode; blocks NOISE, LEAVE FOR CEO, absent
- [ ] Both skills behave normally when `observationMode` is absent or `false`
- [ ] `taskMetadata` pass-through verified via `execution.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced observation-mode support with task metadata propagation, enabling smarter email handling; email reply is now blocked in observation mode, and email draft save validates triage classification to prevent incorrect operations.

* **Tests**
  * Added comprehensive test coverage for observation-mode guards and email draft/reply validation logic.

* **Documentation**
  * Updated changelog documenting new observation-mode defense-in-depth behaviours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->