### PR TITLE
fix: smoke test reliability — timeout, warm-up, and harness API drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Smoke test timeouts** — increased per-turn response timeout from 60s to 120s (configurable via `SMOKE_TIMEOUT_MS`); added a warm-up message before the first test case to absorb cold-start latency; error output now shows the actual timeout value and per-turn timings
+
 ### Added
 
 - **Observation triage event** (`observation.triage.completed`) — structured bus event emitted after every observation-mode triage task, carrying classification, skills called, and action count for monitoring and alerting (#311)

--- a/tests/smoke/cli.ts
+++ b/tests/smoke/cli.ts
@@ -2,7 +2,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
 import * as path from 'node:path';
 import { loadTestCases } from './loader.js';
-import { createHarness } from './harness.js';
+import { createHarness, RESPONSE_TIMEOUT_MS } from './harness.js';
 import { runTestCases } from './runner.js';
 import { evaluateCases } from './evaluator.js';
 import { generateReport } from './report.js';
@@ -39,8 +39,10 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  const timeoutSec = Math.round(RESPONSE_TIMEOUT_MS / 1000);
   process.stdout.write(`\nCuria Smoke Test\n`);
-  process.stdout.write(`   ${cases.length} test cases loaded\n\n`);
+  process.stdout.write(`   ${cases.length} test cases loaded\n`);
+  process.stdout.write(`   Response timeout: ${timeoutSec}s (override with SMOKE_TIMEOUT_MS)\n\n`);
 
   // Boot harness
   process.stdout.write('   Booting Curia stack...\n');
@@ -58,10 +60,13 @@ async function main(): Promise<void> {
   // Run test cases
   process.stdout.write('-- Running Test Cases --\n\n');
   const executions = await runTestCases(harness, cases, {
+    onWarmUp: () => {
+      process.stdout.write('   Warming up stack...\n');
+    },
     onCaseComplete: (exec, index, total) => {
       const status = exec.error
-        ? 'ERROR'
-        : `${exec.responses.reduce((sum, r) => sum + r.durationMs, 0)}ms`;
+        ? `ERROR (${exec.error})`
+        : exec.responses.map(r => `${r.durationMs}ms`).join(' + ');
       process.stdout.write(`   [${index}/${total}] ${exec.testCase.name}... ${status}\n`);
     },
   });

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -32,15 +32,31 @@ import { OutboundGateway } from '../../src/skills/outbound-gateway.js';
 import { createInboundMessage, type OutboundMessageEvent } from '../../src/bus/events.js';
 import type { Logger } from '../../src/logger.js';
 
+// How long each sendMessage() call waits for an outbound.message response.
+// Agentic flows that invoke multiple skills (contact lookup → KG search →
+// calendar check) can legitimately take 60-90s. Default is 120s, tunable
+// via SMOKE_TIMEOUT_MS without code changes.
+export const RESPONSE_TIMEOUT_MS = Number(process.env.SMOKE_TIMEOUT_MS ?? '120000');
+
 export interface CuriaHarness {
   bus: EventBus;
   logger: Logger;
+  /**
+   * Send a single user message and wait for the outbound response.
+   * Rejects if no response arrives within RESPONSE_TIMEOUT_MS.
+   */
   sendMessage(options: {
     conversationId: string;
     content: string;
     senderId?: string;
     channelId?: string;
   }): Promise<{ content: string; durationMs: number }>;
+  /**
+   * Send a no-op warm-up message to absorb cold-start latency (DB pool
+   * warm-up, first LLM API round-trip) before real test cases run.
+   * The response is discarded — we only care that the stack is primed.
+   */
+  warmUp(): Promise<void>;
   shutdown(): Promise<void>;
 }
 
@@ -219,12 +235,13 @@ export async function createHarness(): Promise<CuriaHarness> {
     return new Promise((resolve, reject) => {
       const start = Date.now();
 
+      const timeoutSec = Math.round(RESPONSE_TIMEOUT_MS / 1000);
       const timeout = setTimeout(() => {
         if (pendingResponses.has(options.conversationId)) {
           pendingResponses.delete(options.conversationId);
-          reject(new Error('Timeout waiting for response (60s)'));
+          reject(new Error(`Timeout waiting for response (${timeoutSec}s)`));
         }
-      }, 60_000);
+      }, RESPONSE_TIMEOUT_MS);
 
       pendingResponses.set(options.conversationId, { resolve, reject, start, timeout });
 
@@ -253,9 +270,24 @@ export async function createHarness(): Promise<CuriaHarness> {
     });
   }
 
+  async function warmUp(): Promise<void> {
+    // Send a throwaway message to absorb cold-start latency: DB connection pool
+    // warm-up, first Anthropic API round-trip, skill registry init, etc.
+    // Failures are swallowed — if the stack is broken, real test cases will
+    // surface it with clearer context.
+    try {
+      await sendMessage({
+        conversationId: `smoke-warmup-${Date.now()}`,
+        content: 'hello',
+      });
+    } catch {
+      // intentionally ignored — warm-up is best-effort
+    }
+  }
+
   async function shutdown(): Promise<void> {
     await pool.end();
   }
 
-  return { bus, logger, sendMessage, shutdown };
+  return { bus, logger, sendMessage, warmUp, shutdown };
 }

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -113,7 +113,11 @@ export async function createHarness(): Promise<CuriaHarness> {
   // Keyed by grantId, mirroring how src/index.ts builds its nylasClientMap.
   const nylasClientMap = new Map<string, NylasClient>();
   if (config.nylasApiKey && config.nylasGrantId) {
-    nylasClientMap.set(config.nylasGrantId, new NylasClient(config.nylasApiKey, config.nylasGrantId, logger));
+    // Key must match the backward-compat account name from resolveChannelAccounts
+    // (which resolves to 'curia', not the raw grant ID). Skills pass a logical
+    // account name as accountId when targeting a specific account; the primary-client
+    // path (no accountId) uses the first map entry regardless of key.
+    nylasClientMap.set('curia', new NylasClient(config.nylasApiKey, config.nylasGrantId, logger));
   }
 
   // Outbound gateway — wraps nylasClients with contact-blocked checks and content

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -106,16 +106,17 @@ export async function createHarness(): Promise<CuriaHarness> {
   // Agent registry — tracks all running agents for delegation and listing.
   const agentRegistry = new AgentRegistry();
 
-  // Nylas client — optional, same as src/index.ts. EmailAdapter is intentionally
+  // Nylas clients — optional, same as src/index.ts. EmailAdapter is intentionally
   // skipped here: smoke tests should not start polling for real emails during runs.
-  // The nylasClient is used to construct an OutboundGateway so email skills can be
-  // invoked if a smoke test explicitly calls email-send or email-reply.
-  let nylasClient: NylasClient | undefined;
+  // The nylasClientMap is used to construct an OutboundGateway so email skills can
+  // be invoked if a smoke test explicitly exercises email-send or email-reply.
+  // Keyed by grantId, mirroring how src/index.ts builds its nylasClientMap.
+  const nylasClientMap = new Map<string, NylasClient>();
   if (config.nylasApiKey && config.nylasGrantId) {
-    nylasClient = new NylasClient(config.nylasApiKey, config.nylasGrantId, logger);
+    nylasClientMap.set(config.nylasGrantId, new NylasClient(config.nylasApiKey, config.nylasGrantId, logger));
   }
 
-  // Outbound gateway — wraps nylasClient with contact-blocked checks and content
+  // Outbound gateway — wraps nylasClients with contact-blocked checks and content
   // filtering. Constructed here (without Nylas credentials) using an empty content
   // filter so smoke tests that don't exercise email sending don't crash.
   // When Nylas credentials ARE present the gateway is fully functional.
@@ -127,9 +128,9 @@ export async function createHarness(): Promise<CuriaHarness> {
     ceoEmail: config.nylasSelfEmail ?? '',
   });
   let outboundGateway: OutboundGateway | undefined;
-  if (nylasClient && config.nylasSelfEmail) {
+  if (nylasClientMap.size > 0 && config.nylasSelfEmail) {
     outboundGateway = new OutboundGateway({
-      nylasClient,
+      nylasClients: nylasClientMap,
       contactService,
       contentFilter,
       bus,
@@ -164,18 +165,11 @@ export async function createHarness(): Promise<CuriaHarness> {
 
     let systemPrompt = agentConfig.system_prompt;
     if (agentConfig.role === 'coordinator') {
-      const now = new Date();
-      const currentDate = now.toLocaleDateString('en-CA', {
-        timeZone: config.timezone,
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        weekday: 'long',
-      });
+      // currentDate and timezone are no longer baked in here — AgentRuntime injects
+      // them fresh on every task turn via the timezone option below, keeping them
+      // current for long-running smoke runs. See src/index.ts pass-2 comment.
       systemPrompt = interpolateRuntimeContext(systemPrompt, {
         availableSpecialists: agentRegistry.specialistSummary(),
-        currentDate,
-        timezone: config.timezone,
       });
     }
 
@@ -190,6 +184,9 @@ export async function createHarness(): Promise<CuriaHarness> {
       executionLayer,
       pinnedSkills: agentPinnedSkills,
       skillToolDefs: agentToolDefs,
+      // Coordinator gets per-turn date/timezone injection so the agent always
+      // has a current date (replacing the old baked-in currentDate approach).
+      timezone: agentConfig.role === 'coordinator' ? config.timezone : undefined,
     });
     agent.register();
   }

--- a/tests/smoke/harness.ts
+++ b/tests/smoke/harness.ts
@@ -36,7 +36,15 @@ import type { Logger } from '../../src/logger.js';
 // Agentic flows that invoke multiple skills (contact lookup → KG search →
 // calendar check) can legitimately take 60-90s. Default is 120s, tunable
 // via SMOKE_TIMEOUT_MS without code changes.
-export const RESPONSE_TIMEOUT_MS = Number(process.env.SMOKE_TIMEOUT_MS ?? '120000');
+//
+// Defensive parse: Number('') === 0 and Number('30s') === NaN, both of which
+// would cause setTimeout to fire immediately. Validate and fall back to the
+// default so a misconfigured env var fails loudly at parse time rather than
+// silently making every test time out.
+const _rawTimeout = parseInt(process.env.SMOKE_TIMEOUT_MS ?? '', 10);
+export const RESPONSE_TIMEOUT_MS = Number.isFinite(_rawTimeout) && _rawTimeout > 0
+  ? _rawTimeout
+  : 120_000;
 
 export interface CuriaHarness {
   bus: EventBus;
@@ -110,7 +118,9 @@ export async function createHarness(): Promise<CuriaHarness> {
   // skipped here: smoke tests should not start polling for real emails during runs.
   // The nylasClientMap is used to construct an OutboundGateway so email skills can
   // be invoked if a smoke test explicitly exercises email-send or email-reply.
-  // Keyed by grantId, mirroring how src/index.ts builds its nylasClientMap.
+  // Keyed by account name (not grantId), mirroring how src/index.ts uses
+  // account.name from resolveChannelAccounts. The backward-compat single-account
+  // path in resolveChannelAccounts resolves to the name 'curia'.
   const nylasClientMap = new Map<string, NylasClient>();
   if (config.nylasApiKey && config.nylasGrantId) {
     // Key must match the backward-compat account name from resolveChannelAccounts

--- a/tests/smoke/runner.ts
+++ b/tests/smoke/runner.ts
@@ -5,14 +5,24 @@ import type { TestCase, CaseExecution, CapturedResponse } from './types.js';
 
 /**
  * Execute all test cases against a live Curia harness.
- * Each case gets a unique conversationId to avoid cross-contamination.
+ * Sends a warm-up message first to absorb cold-start latency (DB pool warm-up,
+ * first Anthropic API round-trip), then runs each case with a unique
+ * conversationId to avoid cross-contamination.
  * Multi-turn cases send turns sequentially with configured delays.
  */
 export async function runTestCases(
   harness: CuriaHarness,
   cases: TestCase[],
-  options?: { onCaseComplete?: (exec: CaseExecution, index: number, total: number) => void },
+  options?: {
+    onCaseComplete?: (exec: CaseExecution, index: number, total: number) => void;
+    onWarmUp?: () => void;
+  },
 ): Promise<CaseExecution[]> {
+  // Prime the stack so the first real test case doesn't pay cold-start cost.
+  // warmUp() swallows its own errors — harness failures surface through cases.
+  options?.onWarmUp?.();
+  await harness.warmUp();
+
   const results: CaseExecution[] = [];
 
   for (let i = 0; i < cases.length; i++) {


### PR DESCRIPTION
## Summary

Three related issues were causing the smoke test suite to fail or produce misleading results:

- **60s timeout too short** — agentic flows that chain multiple skills (contact lookup → KG search → calendar check) exceed it. "Pre-Meeting Prep Brief" and "Speaking Engagement Intake" were both timing out consistently.
- **No warm-up before first case** — the first test case always paid cold-start latency (DB pool init, first Anthropic API round-trip), skewing its timing and occasionally pushing it over the timeout.
- **Harness API drift vs. main** — two bugs introduced when `src/index.ts` was updated post-harness:
  1. `OutboundGateway` config changed from `nylasClient: NylasClient` to `nylasClients: Map<string, NylasClient>`. The harness was silently passing the old field, so the gateway had no email clients even when Nylas was configured — all email skills returned "Email client not configured".
  2. `interpolateRuntimeContext` no longer accepts `currentDate`/`timezone` (now injected per-turn by `AgentRuntime`). The coordinator was getting stale date context.

## Changes

- `harness.ts` — timeout raised from 60s to 120s, configurable via `SMOKE_TIMEOUT_MS`; `nylasClient` → `nylasClients: Map`; `interpolateRuntimeContext` call updated; `timezone` added to coordinator `AgentRuntime`; `warmUp()` method added
- `runner.ts` — calls `harness.warmUp()` before the first test case
- `cli.ts` — shows configured timeout at startup; per-turn timings in case output (not just total); "Warming up stack..." line

## Test plan

- [ ] `pnpm smoke --case "speaking"` — should no longer timeout
- [ ] `pnpm smoke --case "meeting prep"` — should no longer timeout
- [ ] `pnpm smoke` — full suite should run without timeout errors
- [ ] `SMOKE_TIMEOUT_MS=30000 pnpm smoke --case "briefing"` — verifies env var override works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Increased response timeout from 60 to 120 seconds for smoke tests (configurable via environment variable).
  * Added warm-up phase before test execution to mitigate cold-start latency.
  * Improved error messages to include actual timeout values and per-turn timing details.

* **Tests**
  * Enhanced test progress reporting with individual response durations and better error diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->