### PR TITLE
feat: KG explorer — sensitivity visualization, detail drawer, richer visual encodings (0.20.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **KG explorer: node detail drawer** — tapping any node opens a 320px right-side panel showing all node attributes (label, type, sensitivity, confidence, decay class, source, timestamps, properties); canvas shrinks to accommodate the drawer rather than being overlaid (#350)
-- **KG explorer: color-by toggle** — button group above the graph canvas lets the user switch node colour encoding between Type (default), Sensitivity (public/internal/confidential/restricted), and Decay class (permanent/slow_decay/fast_decay) (#350)
-- **KG explorer: degree-based node sizing** — node size now reflects edge count (more connections = larger node), replacing the previous fixed type-based sizes; makes structural hubs immediately apparent (#350)
-- **KG explorer: confidence opacity** — node opacity now encodes the classifier's confidence score (low confidence = semi-transparent), replacing the previous decay-class-based opacity levels (#350)
+- **KG explorer: sensitivity visualization** — node detail drawer (tap any node to inspect all attributes), color-by toggle (Type / Sensitivity / Decay class), degree-based node sizing, and confidence-based opacity (#350)
 - **KG API: `sensitivity` and `properties` fields** — `/api/kg/nodes` and `/api/kg/graph` now return both fields on every node response (#350)
 - **`SensitivityClassifier` unit tests** — 5 tests covering keyword matching, property-value matching, category hint bypass, and most-restrictive-wins behaviour (#350)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **KG explorer: node detail drawer** — tapping any node opens a 320px right-side panel showing all node attributes (label, type, sensitivity, confidence, decay class, source, timestamps, properties); canvas shrinks to accommodate the drawer rather than being overlaid (#350)
+- **KG explorer: color-by toggle** — button group above the graph canvas lets the user switch node colour encoding between Type (default), Sensitivity (public/internal/confidential/restricted), and Decay class (permanent/slow_decay/fast_decay) (#350)
+- **KG explorer: degree-based node sizing** — node size now reflects edge count (more connections = larger node), replacing the previous fixed type-based sizes; makes structural hubs immediately apparent (#350)
+- **KG explorer: confidence opacity** — node opacity now encodes the classifier's confidence score (low confidence = semi-transparent), replacing the previous decay-class-based opacity levels (#350)
+- **KG API: `sensitivity` and `properties` fields** — `/api/kg/nodes` and `/api/kg/graph` now return both fields on every node response (#350)
+- **`SensitivityClassifier` unit tests** — 5 tests covering keyword matching, property-value matching, category hint bypass, and most-restrictive-wins behaviour (#350)
+
 - **Observation triage event** (`observation.triage.completed`) — structured bus event emitted after every observation-mode triage task, carrying classification, skills called, and action count for monitoring and alerting (#311)
 - **`AgentResponsePayload.skillsCalled`** — optional field listing skills invoked during a task (public API surface: additive, non-breaking)
 - **`TriageClassification` type** — exported union type for triage classification labels, shared across event consumers

--- a/docs/wip/2026-04-25-kg-sensitivity-visualization-design.md
+++ b/docs/wip/2026-04-25-kg-sensitivity-visualization-design.md
@@ -1,6 +1,6 @@
 # KG Sensitivity Visualization — Design Spec
 
-**Issue:** josephfung/curia#200
+**Issue:** josephfung/curia#350
 **Date:** 2026-04-25
 **Status:** Approved for implementation
 
@@ -25,9 +25,10 @@ Existing nodes in the DB have `sensitivity = 'internal'` (the column default app
 ## Scope
 
 1. **API** — expose `sensitivity` and `properties` from both KG routes
-2. **Color toggle** — let the user switch node color encoding between Type and Sensitivity
-3. **Detail drawer** — a right-side panel that shows all node attributes when a node is selected
-4. **Unit tests** — cover the two unchecked AC items from the issue
+2. **Color toggle** — let the user switch node color encoding between Type, Sensitivity, and Decay class
+3. **Visual encodings** — node size encodes edge degree (more connections = larger); opacity encodes confidence (lower confidence = more transparent)
+4. **Detail drawer** — a right-side panel that shows all node attributes when a node is selected
+5. **Unit tests** — cover the two unchecked AC items from the issue
 
 ---
 
@@ -90,7 +91,7 @@ nodes: result.rows.map((row) => ({
 
 ### Placement
 
-A `Color by:` button group sits in a thin toolbar strip above the Cytoscape canvas, left-aligned. Two buttons: **Type** (default, active on load) and **Sensitivity**.
+A `Color by:` button group sits in a thin toolbar strip above the Cytoscape canvas, left-aligned. Three buttons: **Type** (default, active on load), **Sensitivity**, and **Decay**.
 
 ### Sensitivity color palette
 
@@ -101,9 +102,17 @@ A `Color by:` button group sits in a thin toolbar strip above the Cytoscape canv
 | `confidential` | `#C9874A` | Amber — elevated caution |
 | `restricted` | `#E86040` | Red — matches `--destructive` token |
 
+### Decay class color palette
+
+| Class | Hex | Rationale |
+|---|---|---|
+| `permanent` | `#5E9E6B` | Green — never expires |
+| `slow_decay` | `#4174C8` | Blue — fades slowly |
+| `fast_decay` | `#E86040` | Red/orange — fades quickly |
+
 ### Technical implementation
 
-`sensitivity` is added to each Cytoscape element's `data` object in `nodeToElement()`:
+`sensitivity`, `degree`, and other new fields are added to each Cytoscape element's `data` object in `nodeToElement()`:
 
 ```javascript
 function nodeToElement(n) {
@@ -119,27 +128,70 @@ function nodeToElement(n) {
       source: n.source || '',                      // NEW (used by drawer)
       createdAt: n.createdAt || '',                // NEW (used by drawer)
       lastConfirmedAt: n.lastConfirmedAt || '',    // NEW (used by drawer)
+      degree: 0,                                   // NEW — populated by updateDegrees() after cy.add()
     },
   };
 }
 ```
 
-Switching color mode calls `cy.style()` to hot-swap only the node background-color rules. All other styles (size, opacity, edge width) are untouched. A JS variable `colorMode` ('type' | 'sensitivity') tracks the active mode.
+Switching color mode uses per-element `node.style('background-color', color)` overrides (not stylesheet rebuilding). All other styles (size, opacity, edge width) are untouched. A JS variable `colorMode` ('type' | 'sensitivity' | 'decay') tracks the active mode. Reverting to type mode calls `nodes().removeStyle('background-color')` to restore the type stylesheet rules.
 
-Sensitivity-mode selectors added to the stylesheet:
+Color maps:
 
 ```javascript
-{ selector: 'node[sensitivity="public"]',       style: { 'background-color': '#5E9E6B' } },
-{ selector: 'node[sensitivity="internal"]',     style: { 'background-color': '#4174C8' } },
-{ selector: 'node[sensitivity="confidential"]', style: { 'background-color': '#C9874A' } },
-{ selector: 'node[sensitivity="restricted"]',   style: { 'background-color': '#E86040' } },
+const SENS_COLORS = {
+  public: '#5E9E6B', internal: '#4174C8',
+  confidential: '#C9874A', restricted: '#E86040',
+};
+const DECAY_COLORS = {
+  permanent: '#5E9E6B', slow_decay: '#4174C8', fast_decay: '#E86040',
+};
 ```
 
-These are applied only when the mode is `'sensitivity'`; in `'type'` mode the existing type selectors apply.
+In `'sensitivity'` mode each node gets `SENS_COLORS[node.data('sensitivity')]`; in `'decay'` mode each node gets `DECAY_COLORS[node.data('decayClass')]`; in `'type'` mode all per-element overrides are cleared.
 
 ---
 
-## 3. Frontend — Detail Drawer
+## 3. Frontend — Visual Encodings (Size and Opacity)
+
+Two additional channels encode node attributes independently of color, so all three color modes remain informative simultaneously.
+
+### Node size — edge degree
+
+Node size encodes the number of edges touching each node (its degree in the graph). More-connected nodes are visually larger, making structural hubs immediately apparent regardless of which color mode is active.
+
+After every `cy.add()` call (both initial render and neighborhood expansion), an `updateDegrees()` helper stores the computed degree back into each node's data:
+
+```javascript
+function updateDegrees() {
+  cy.nodes().forEach((node) => {
+    node.data('degree', node.degree());
+  });
+}
+```
+
+The Cytoscape stylesheet uses `mapData` to scale size continuously:
+
+```javascript
+{ selector: 'node', style: { width: 'mapData(degree, 0, 15, 20, 52)',
+                              height: 'mapData(degree, 0, 15, 20, 52)' } }
+```
+
+This replaces the previous type-based size rules (which assigned different fixed sizes to `Person`, `Organization`, etc.).
+
+### Node opacity — confidence
+
+Node opacity encodes the classifier's confidence score. Low-confidence nodes are semi-transparent; high-confidence nodes are fully opaque. This lets the user visually filter out uncertain nodes without hiding them entirely.
+
+```javascript
+{ selector: 'node', style: { opacity: 'mapData(confidence, 0, 1, 0.15, 1.0)' } }
+```
+
+This replaces the previous decay-class-based opacity rules (which used two fixed levels for `slow_decay` and `fast_decay`).
+
+---
+
+## 4. Frontend — Detail Drawer  <!-- was §3 before visual-encodings section was added -->
 
 ### Layout
 
@@ -176,7 +228,7 @@ The existing `cy.on('tap', 'node', ...)` already calls `expandNeighborhood()`. T
 
 ---
 
-## 4. Unit Tests
+## 5. Unit Tests
 
 Two tests to close the remaining AC items from the issue:
 
@@ -196,7 +248,7 @@ The second test exercises the classifier directly — no database required, fast
 
 | File | Change |
 |---|---|
-| `src/channels/http/routes/kg.ts` | Add `sensitivity` to `KgNodeRow`, all SQL SELECTs, all response mappings, `nodeToElement()`, color-toggle UI, and detail drawer UI |
+| `src/channels/http/routes/kg.ts` | Add `sensitivity` to `KgNodeRow`, all SQL SELECTs, all response mappings, `nodeToElement()`; add degree-based sizing, confidence opacity, three-button color toggle (type/sensitivity/decay), `updateDegrees()` helper, and detail drawer UI |
 | `src/memory/knowledge-graph.upsert.test.ts` | Add default-sensitivity unit test |
 | `src/memory/sensitivity.test.ts` | New file — add financial auto-classification unit test |
 | `CHANGELOG.md` | Add entry under `[Unreleased]` |

--- a/docs/wip/2026-04-25-kg-sensitivity-visualization-design.md
+++ b/docs/wip/2026-04-25-kg-sensitivity-visualization-design.md
@@ -1,0 +1,205 @@
+# KG Sensitivity Visualization — Design Spec
+
+**Issue:** josephfung/curia#200
+**Date:** 2026-04-25
+**Status:** Approved for implementation
+
+---
+
+## Context
+
+Sensitivity classification on KG nodes is already fully implemented on the storage side:
+
+- Migration `024_add_kg_node_sensitivity.sql` added `sensitivity TEXT NOT NULL DEFAULT 'internal'` with CHECK constraint and index to `kg_nodes`
+- `SensitivityClassifier` is instantiated at startup from `config/default.yaml` and injected into `EntityMemory`
+- `storeFact()` and `createEntity()` auto-classify sensitivity from node label + properties using configurable keyword rules
+- `memory.store` bus events include the `sensitivity` field (required in `MemoryStorePayload`)
+- The coordinator system prompt includes exfiltration-aware directives
+
+The remaining gap is entirely in the KG web explorer UI. The `/api/kg/nodes` and `/api/kg/graph` routes do not select or return `sensitivity` (or `properties`), so there is nothing for the browser to display.
+
+Existing nodes in the DB have `sensitivity = 'internal'` (the column default applied when the migration ran). No backfill is planned — `'internal'` is the correct safe default.
+
+---
+
+## Scope
+
+1. **API** — expose `sensitivity` and `properties` from both KG routes
+2. **Color toggle** — let the user switch node color encoding between Type and Sensitivity
+3. **Detail drawer** — a right-side panel that shows all node attributes when a node is selected
+4. **Unit tests** — cover the two unchecked AC items from the issue
+
+---
+
+## 1. API Changes (`src/channels/http/routes/kg.ts`)
+
+### `KgNodeRow` interface
+
+Add `sensitivity` and ensure `properties` is typed:
+
+```typescript
+interface KgNodeRow {
+  id: string;
+  type: string;
+  label: string;
+  properties: Record<string, unknown>;  // already selected, was silently dropped in response
+  confidence: number;
+  decay_class: string;
+  source: string;
+  created_at: string;
+  last_confirmed_at: string;
+  sensitivity: string;                  // NEW
+}
+```
+
+### SQL — both `/api/kg/nodes` and `/api/kg/graph`
+
+Add `sensitivity` to every `SELECT` list. Example for the fallback (no `node_id`) query:
+
+```sql
+SELECT id, type, label, properties, confidence, decay_class, source,
+       created_at, last_confirmed_at, sensitivity          -- sensitivity added
+FROM kg_nodes
+...
+```
+
+All three queries in the file need this: the flat `/api/kg/nodes` query, the recursive traversal query, and the fallback recent-nodes query.
+
+### Response mapping
+
+Add both fields to every `.map()` that serialises node rows:
+
+```typescript
+nodes: result.rows.map((row) => ({
+  id: row.id,
+  type: row.type,
+  label: row.label,
+  properties: row.properties,          // was selected but dropped — now included
+  confidence: row.confidence,
+  decayClass: row.decay_class,
+  source: row.source,
+  createdAt: row.created_at,
+  lastConfirmedAt: row.last_confirmed_at,
+  sensitivity: row.sensitivity,        // NEW
+})),
+```
+
+---
+
+## 2. Frontend — Color Toggle
+
+### Placement
+
+A `Color by:` button group sits in a thin toolbar strip above the Cytoscape canvas, left-aligned. Two buttons: **Type** (default, active on load) and **Sensitivity**.
+
+### Sensitivity color palette
+
+| Level | Hex | Rationale |
+|---|---|---|
+| `public` | `#5E9E6B` | Green — no restrictions |
+| `internal` | `#4174C8` | Blue-grey — neutral default (matches existing base node color) |
+| `confidential` | `#C9874A` | Amber — elevated caution |
+| `restricted` | `#E86040` | Red — matches `--destructive` token |
+
+### Technical implementation
+
+`sensitivity` is added to each Cytoscape element's `data` object in `nodeToElement()`:
+
+```javascript
+function nodeToElement(n) {
+  return {
+    data: {
+      id: n.id,
+      label: n.label,
+      type: n.type,
+      confidence: n.confidence != null ? n.confidence : 0.5,
+      decayClass: n.decayClass || 'permanent',
+      sensitivity: n.sensitivity || 'internal',   // NEW
+      properties: n.properties || {},              // NEW (used by drawer)
+      source: n.source || '',                      // NEW (used by drawer)
+      createdAt: n.createdAt || '',                // NEW (used by drawer)
+      lastConfirmedAt: n.lastConfirmedAt || '',    // NEW (used by drawer)
+    },
+  };
+}
+```
+
+Switching color mode calls `cy.style()` to hot-swap only the node background-color rules. All other styles (size, opacity, edge width) are untouched. A JS variable `colorMode` ('type' | 'sensitivity') tracks the active mode.
+
+Sensitivity-mode selectors added to the stylesheet:
+
+```javascript
+{ selector: 'node[sensitivity="public"]',       style: { 'background-color': '#5E9E6B' } },
+{ selector: 'node[sensitivity="internal"]',     style: { 'background-color': '#4174C8' } },
+{ selector: 'node[sensitivity="confidential"]', style: { 'background-color': '#C9874A' } },
+{ selector: 'node[sensitivity="restricted"]',   style: { 'background-color': '#E86040' } },
+```
+
+These are applied only when the mode is `'sensitivity'`; in `'type'` mode the existing type selectors apply.
+
+---
+
+## 3. Frontend — Detail Drawer
+
+### Layout
+
+The canvas area (`#main-canvas-area`) becomes a flex row. The canvas (`#cy` container) takes `flex: 1`. The drawer (`#node-detail-drawer`) is `320px` wide, hidden by default (`display: none`), and sits to the right of the canvas. When visible, the canvas genuinely shrinks — the drawer is not overlaid.
+
+```
+┌─────────────┬──────────────────────────────┬──────────────────┐
+│  Left       │                              │  #node-detail    │
+│  Sidebar    │   Cytoscape Canvas (flex:1)  │  -drawer         │
+│  (220px)    │                              │  (320px, hidden  │
+│             │                              │   until node tap)│
+└─────────────┴──────────────────────────────┴──────────────────┘
+```
+
+### Drawer content
+
+| Field | Display |
+|---|---|
+| Label | Large heading (`font-family: Lora`) |
+| Type | Coloured pill using the existing type palette |
+| Sensitivity | Coloured pill using the sensitivity palette above |
+| Confidence | Decimal, e.g. `0.85` |
+| Decay class | Plain text: `permanent` / `slow_decay` / `fast_decay` |
+| Source | Monospace text, full provenance string |
+| Created at | Formatted local date/time |
+| Last confirmed | Formatted local date/time |
+| Properties | Key–value table; omitted entirely if `properties` is empty or `{}` |
+
+A close button (×) in the drawer header sets `display: none` and restores the canvas to full width. Tapping a different node replaces the content without closing.
+
+### Tap handler change
+
+The existing `cy.on('tap', 'node', ...)` already calls `expandNeighborhood()`. The handler is extended to also call `openNodeDrawer(node.data())` — a new function that populates and shows the drawer.
+
+---
+
+## 4. Unit Tests
+
+Two tests to close the remaining AC items from the issue:
+
+**Test 1** — in `src/memory/knowledge-graph.upsert.test.ts` (alongside the existing upsert tests):
+
+- Create a node via `KnowledgeGraphStore.createNode()` without passing `sensitivity`; assert the returned node has `sensitivity === 'internal'`.
+
+**Test 2** — in a new `src/memory/sensitivity.test.ts` (alongside `sensitivity.ts`):
+
+- Instantiate `SensitivityClassifier.fromRules()` with a rule `{ category: 'financial', sensitivity: 'confidential', patterns: ['revenue'] }`; call `classify('Q3 revenue forecast', {})` and assert the result is `'confidential'`.
+
+The second test exercises the classifier directly — no database required, fast unit test.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/channels/http/routes/kg.ts` | Add `sensitivity` to `KgNodeRow`, all SQL SELECTs, all response mappings, `nodeToElement()`, color-toggle UI, and detail drawer UI |
+| `src/memory/knowledge-graph.upsert.test.ts` | Add default-sensitivity unit test |
+| `src/memory/sensitivity.test.ts` | New file — add financial auto-classification unit test |
+| `CHANGELOG.md` | Add entry under `[Unreleased]` |
+| `package.json` | Patch version bump (completing a partially-shipped spec) |
+
+No other files need to change — the storage layer is complete.

--- a/docs/wip/2026-04-25-kg-sensitivity-visualization.md
+++ b/docs/wip/2026-04-25-kg-sensitivity-visualization.md
@@ -310,6 +310,7 @@ function nodeToElement(n) {
       source: n.source || '',
       createdAt: n.createdAt || '',
       lastConfirmedAt: n.lastConfirmedAt || '',
+      degree: 0,  // updated by updateDegrees() after elements are added
     },
   };
 }
@@ -327,31 +328,89 @@ Expected: all tests pass.
 
 ```bash
 git -C /path/to/worktree add src/channels/http/routes/kg.ts
-git -C /path/to/worktree commit -m "feat: pass sensitivity and full node metadata through nodeToElement (#200)"
+git -C /path/to/worktree commit -m "feat: pass sensitivity and full node metadata through nodeToElement"
 ```
 
 ---
 
-## Task 5: Frontend — sensitivity color tokens and Cytoscape styles
+## Task 5: Frontend — color tokens, stylesheet encoding changes, and Cytoscape styles
 
 **Files:**
 - Modify: `src/channels/http/routes/kg.ts` (CSS `:root` block and Cytoscape `initCytoscape()` styles)
 
-- [ ] **Step 5.1: Add sensitivity color tokens to CSS `:root`**
+- [ ] **Step 5.1: Add color tokens to CSS `:root`**
 
-Inside the `<style>` block, find the `:root { ... }` section. Add four new CSS variables after the existing `--chart-*` tokens:
+Inside the `<style>` block, find the `:root { ... }` section. Add these CSS variables after the existing `--chart-*` tokens:
 
 ```css
-/* Sensitivity level colours (issue #200) */
+/* Sensitivity level colours */
 --sens-public:       #5E9E6B;   /* green   — no restrictions */
 --sens-internal:     #4174C8;   /* blue    — neutral default */
 --sens-confidential: #C9874A;   /* amber   — elevated caution */
 --sens-restricted:   #E86040;   /* red     — matches --destructive */
+
+/* Decay class colours */
+--decay-permanent:  #5E9E6B;   /* green — stable, no decay */
+--decay-slow:       #4174C8;   /* blue  — fading slowly */
+--decay-fast:       #E86040;   /* red   — fading quickly, needs reconfirmation */
 ```
 
-- [ ] **Step 5.2: No stylesheet changes needed**
+- [ ] **Step 5.2: Update `initCytoscape()` stylesheet — replace type-size and decay-opacity rules**
 
-Sensitivity colors are applied via per-element style overrides in `setColorMode()` (Step 5.3), not via Cytoscape stylesheet selectors. The existing `initCytoscape()` stylesheet stays unchanged — type colours remain the default and are restored when switching back to type mode by removing the element-level overrides.
+Two sets of existing rules in the `style: [...]` array inside `cy = cytoscape({ ... })` need to be replaced.
+
+**Remove** the seven type-based size rules (they start with `node[type="person"] { width: 44 ...}`):
+
+```javascript
+// DELETE these seven rules:
+{ selector: 'node[type="person"]',       style: { width: 44, height: 44 } },
+{ selector: 'node[type="organization"]',  style: { width: 44, height: 44 } },
+{ selector: 'node[type="project"]',       style: { width: 36, height: 36 } },
+{ selector: 'node[type="decision"]',      style: { width: 32, height: 32 } },
+{ selector: 'node[type="event"]',         style: { width: 28, height: 28 } },
+{ selector: 'node[type="concept"]',       style: { width: 24, height: 24 } },
+{ selector: 'node[type="fact"]',          style: { width: 14, height: 14, 'font-size': 0 } },
+```
+
+**Remove** the two decay-class opacity rules:
+
+```javascript
+// DELETE these two rules:
+{ selector: 'node[decayClass="fast_decay"]', style: { opacity: 0.45 } },
+{ selector: 'node[decayClass="slow_decay"]', style: { opacity: 0.75 } },
+```
+
+**Add** two new rules in their place (insert after the base `node` style block, before the type colour rules):
+
+```javascript
+// Degree-based size: nodes with more edges are visually larger.
+// 'degree' is set as element data by updateDegrees() after every cy.add().
+// Range: isolated node (0 edges) = 20px, hub node (15+ edges) = 52px.
+{
+  selector: 'node',
+  style: {
+    width:  'mapData(degree, 0, 15, 20, 52)',
+    height: 'mapData(degree, 0, 15, 20, 52)',
+  },
+},
+// Confidence-based opacity: lower confidence = more transparent.
+// Replaces the old decay-class opacity encoding.
+{
+  selector: 'node',
+  style: {
+    opacity: 'mapData(confidence, 0, 1, 0.15, 1.0)',
+  },
+},
+```
+
+Also update the fact-node rule that was hiding labels — since type-based sizes are gone, the fact-node label suppression needs a different approach. Replace the old fact size+label rule with just the label rule:
+
+```javascript
+// Facts: hide label at default size; show when selected.
+// (Size is now degree-based — the width/height rule above handles all types.)
+{ selector: 'node[type="fact"]',          style: { 'font-size': 0 } },
+{ selector: 'node[type="fact"]:selected', style: { 'font-size': 9 } },
+```
 
 - [ ] **Step 5.3: Add the `setColorMode()` function and `colorMode` variable**
 
@@ -359,10 +418,11 @@ Find the `// ── KG API helpers` comment that precedes the `setStatus` functi
 
 ```javascript
 // ── Color mode ────────────────────────────────────────────────────────
-// Tracks the active node colour encoding: 'type' (default) or 'sensitivity'.
+// Tracks the active node colour encoding: 'type' (default), 'sensitivity',
+// or 'decay'.
 var colorMode = 'type';
 
-// Sensitivity hex palette — kept in sync with the sensitivity badge colours.
+// Color palette maps — kept in sync with CSS tokens added in Step 5.1.
 var SENS_COLORS = {
   public:       '#5E9E6B',
   internal:     '#4174C8',
@@ -370,35 +430,60 @@ var SENS_COLORS = {
   restricted:   '#E86040',
 };
 
+var DECAY_COLORS = {
+  permanent:  '#5E9E6B',
+  slow_decay: '#4174C8',
+  fast_decay: '#E86040',
+};
+
 function setColorMode(mode) {
   if (!cy) return;
   colorMode = mode;
 
   if (mode === 'sensitivity') {
-    // Apply an inline element-level background-color override to every node.
-    // Element-level styles take precedence over stylesheet selector rules,
-    // so this overrides the type colours without touching the stylesheet.
     cy.nodes().forEach(function(node) {
       var sens = node.data('sensitivity') || 'internal';
       node.style('background-color', SENS_COLORS[sens] || SENS_COLORS.internal);
     });
+  } else if (mode === 'decay') {
+    cy.nodes().forEach(function(node) {
+      var decay = node.data('decayClass') || 'slow_decay';
+      node.style('background-color', DECAY_COLORS[decay] || DECAY_COLORS.slow_decay);
+    });
   } else {
-    // Remove element-level overrides — stylesheet type-colour selectors
-    // (from initCytoscape) will take effect again automatically.
+    // type mode: remove element-level overrides so stylesheet type-colour
+    // selectors take effect again automatically.
     cy.nodes().removeStyle('background-color');
   }
 
   // Update toggle button active state
   document.getElementById('color-btn-type').classList.toggle('active', mode === 'type');
   document.getElementById('color-btn-sensitivity').classList.toggle('active', mode === 'sensitivity');
+  document.getElementById('color-btn-decay').classList.toggle('active', mode === 'decay');
 }
 ```
 
-- [ ] **Step 5.4: Re-apply color mode after graph renders**
+- [ ] **Step 5.4: Add `updateDegrees()` helper**
 
-When `renderGraph()` or `expandNeighborhood()` adds new nodes, those nodes won't have the sensitivity color override if the user is already in sensitivity mode. Fix this by calling `setColorMode(colorMode)` at the end of both functions.
+`mapData(degree, ...)` in the stylesheet reads from `node.data('degree')`. Since degree is not part of the API payload (it's a graph-topology property), it must be computed client-side after every `cy.add()` call.
 
-Find `function renderGraph(payload)` and add the call after `cy.layout(FCOSE_OPTS_FULL).run()`:
+Just after the `setColorMode` function, add:
+
+```javascript
+// Computes the edge-count (degree) for every node and stores it as element
+// data so the mapData(degree, ...) stylesheet rule can size nodes correctly.
+// Must be called after every cy.add() — degree changes as edges are added.
+function updateDegrees() {
+  if (!cy) return;
+  cy.nodes().forEach(function(node) {
+    node.data('degree', node.degree());
+  });
+}
+```
+
+- [ ] **Step 5.5: Hook `updateDegrees()` and `setColorMode()` into render functions**
+
+Find `function renderGraph(payload)`. Replace the whole function body:
 
 ```javascript
 function renderGraph(payload) {
@@ -406,23 +491,25 @@ function renderGraph(payload) {
   var elements = payload.nodes.map(nodeToElement).concat(payload.edges.map(edgeToElement));
   cy.elements().remove();
   cy.add(elements);
+  updateDegrees();          // must run before layout so sizes are correct
   cy.resize();
   cy.layout(FCOSE_OPTS_FULL).run();
   setColorMode(colorMode);  // re-apply active color mode to new nodes
 }
 ```
 
-Find `function expandNeighborhood(nodeId)` and add the call after new elements are added and laid out. Inside the `.then()` callback, after the `cy.layout(...)` call (or after `cy.add(newElements)` if there is no layout in the expansion path), add:
+Find `function expandNeighborhood(nodeId)`. Inside its `.then()` callback, after `cy.add(newElements)` and the layout call, add both calls:
 
 ```javascript
+updateDegrees();          // recalculate all degrees now that edges changed
 setColorMode(colorMode);  // re-apply active color mode to newly added nodes
 ```
 
-- [ ] **Step 5.4: Commit**
+- [ ] **Step 5.6: Commit**
 
 ```bash
 git -C /path/to/worktree add src/channels/http/routes/kg.ts
-git -C /path/to/worktree commit -m "feat: add sensitivity color palette and color mode toggle logic (#200)"
+git -C /path/to/worktree commit -m "feat: add color-by toggle (type/sensitivity/decay), degree-based sizing, confidence opacity"
 ```
 
 ---
@@ -498,6 +585,7 @@ Wrap the canvas wrapper in a column flex container and insert the toolbar above:
     <div class="toggle-btn-group">
       <button id="color-btn-type" class="toggle-btn active" onclick="setColorMode('type')">Type</button>
       <button id="color-btn-sensitivity" class="toggle-btn" onclick="setColorMode('sensitivity')">Sensitivity</button>
+      <button id="color-btn-decay" class="toggle-btn" onclick="setColorMode('decay')">Decay</button>
     </div>
   </div>
   <!-- Cytoscape canvas -->

--- a/docs/wip/2026-04-25-kg-sensitivity-visualization.md
+++ b/docs/wip/2026-04-25-kg-sensitivity-visualization.md
@@ -1,0 +1,933 @@
+# KG Sensitivity Visualization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose sensitivity classification in the KG web explorer via a node detail drawer and a color-by toggle.
+
+**Architecture:** All changes land in two areas: (1) the KG HTTP routes file (`kg.ts`) which owns both the API layer and the embedded single-page UI, and (2) two test files that cover the already-implemented storage behavior. The API changes expose `sensitivity` and `properties` from the DB; the UI changes add a right-side detail drawer and a `Color by` toggle that hot-swaps Cytoscape node color rules.
+
+**Tech Stack:** TypeScript, Node.js, Fastify, Postgres, Cytoscape.js (browser), Vitest
+
+---
+
+> **Worktree required.** Per CLAUDE.md, all development must happen in a git worktree:
+> ```bash
+> git worktree add ../curia-kg-sensitivity -b feat/kg-sensitivity-visualization
+> WORKTREE=/path/to/curia-kg-sensitivity MAIN=/path/to/repos/curia
+> for item in .env; do if [ -e "$MAIN/$item" ]; then ln -sf "$MAIN/$item" "$WORKTREE/$item"; fi; done
+> npm --prefix $WORKTREE install
+> ```
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|---|---|---|
+| `src/memory/sensitivity.test.ts` | **Create** | Unit tests for `SensitivityClassifier` |
+| `src/memory/knowledge-graph.upsert.test.ts` | **Modify** | Add default-sensitivity test |
+| `src/channels/http/routes/kg.ts` | **Modify** | API types, SQL, response mapping, UI (toggle + drawer) |
+| `CHANGELOG.md` | **Modify** | Add entry under `[Unreleased]` |
+| `package.json` | **Modify** | Patch version bump (`0.20.0` → `0.20.1`) |
+
+---
+
+## Task 1: Unit test — SensitivityClassifier classification rules
+
+**Files:**
+- Create: `src/memory/sensitivity.test.ts`
+
+- [ ] **Step 1.1: Create the test file**
+
+```typescript
+// src/memory/sensitivity.test.ts
+import { describe, it, expect } from 'vitest';
+import { SensitivityClassifier } from './sensitivity.js';
+
+describe('SensitivityClassifier', () => {
+  it('classifies financial content as confidential based on keyword rule', () => {
+    const classifier = SensitivityClassifier.fromRules([
+      { category: 'financial', sensitivity: 'confidential', patterns: ['revenue'] },
+    ]);
+    expect(classifier.classify('Q3 revenue forecast', {})).toBe('confidential');
+  });
+
+  it('defaults to internal when no rule matches', () => {
+    const classifier = SensitivityClassifier.fromRules([
+      { category: 'financial', sensitivity: 'confidential', patterns: ['revenue'] },
+    ]);
+    expect(classifier.classify('team standup notes', {})).toBe('internal');
+  });
+
+  it('matches keywords in property values, not just the label', () => {
+    const classifier = SensitivityClassifier.fromRules([
+      { category: 'financial', sensitivity: 'confidential', patterns: ['salary'] },
+    ]);
+    expect(classifier.classify('employee record', { details: 'salary adjustment' })).toBe('confidential');
+  });
+
+  it('category hint bypasses keyword scanning', () => {
+    const classifier = SensitivityClassifier.fromRules([
+      { category: 'hr', sensitivity: 'confidential', patterns: ['performance'] },
+    ]);
+    // Label doesn't contain 'performance' but the category hint matches
+    expect(classifier.classify('annual review', {}, 'hr')).toBe('confidential');
+  });
+
+  it('most restrictive rule wins when multiple patterns match', () => {
+    const classifier = SensitivityClassifier.fromRules([
+      { category: 'financial', sensitivity: 'confidential', patterns: ['revenue'] },
+      { category: 'board', sensitivity: 'restricted', patterns: ['board'] },
+    ]);
+    // Both match — restricted wins
+    expect(classifier.classify('board revenue discussion', {})).toBe('restricted');
+  });
+});
+```
+
+- [ ] **Step 1.2: Run the tests**
+
+```bash
+npm --prefix /path/to/worktree test src/memory/sensitivity.test.ts
+```
+
+Expected: all 5 tests **PASS** (the classifier is already implemented — these tests document existing behaviour).
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git -C /path/to/worktree add src/memory/sensitivity.test.ts
+git -C /path/to/worktree commit -m "test: add SensitivityClassifier unit tests (#200)"
+```
+
+---
+
+## Task 2: Unit test — KnowledgeGraphStore sensitivity default
+
+**Files:**
+- Modify: `src/memory/knowledge-graph.upsert.test.ts`
+
+- [ ] **Step 2.1: Add the test**
+
+Open `src/memory/knowledge-graph.upsert.test.ts`. After the last `describe` block, add a new describe block at the end of the file:
+
+```typescript
+describe('KnowledgeGraphStore sensitivity defaults', () => {
+  it('defaults sensitivity to internal when not specified on createNode', async () => {
+    const store = makeStore();
+    const node = await store.createNode({
+      type: 'fact',
+      label: 'quarterly target',
+      properties: {},
+      source: 'test',
+    });
+    expect(node.sensitivity).toBe('internal');
+  });
+
+  it('preserves explicit sensitivity when provided', async () => {
+    const store = makeStore();
+    const node = await store.createNode({
+      type: 'fact',
+      label: 'board minutes',
+      properties: {},
+      source: 'test',
+      sensitivity: 'restricted',
+    });
+    expect(node.sensitivity).toBe('restricted');
+  });
+});
+```
+
+- [ ] **Step 2.2: Run the tests**
+
+```bash
+npm --prefix /path/to/worktree test src/memory/knowledge-graph.upsert.test.ts
+```
+
+Expected: all tests **PASS**.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git -C /path/to/worktree add src/memory/knowledge-graph.upsert.test.ts
+git -C /path/to/worktree commit -m "test: add KG node sensitivity default tests (#200)"
+```
+
+---
+
+## Task 3: API — expose sensitivity and properties from KG routes
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts`
+
+This task has three sub-changes: update the `KgNodeRow` interface, add `sensitivity` to SQL, and include both fields in response mappings.
+
+- [ ] **Step 3.1: Update the `KgNodeRow` interface**
+
+Find the `interface KgNodeRow` block (near the top of the file, before the `createUiHtml` function). Replace it:
+
+```typescript
+interface KgNodeRow {
+  id: string;
+  type: string;
+  label: string;
+  properties: Record<string, unknown>;
+  confidence: number;
+  decay_class: string;
+  source: string;
+  created_at: string;
+  last_confirmed_at: string;
+  sensitivity: string;
+}
+```
+
+- [ ] **Step 3.2: Add `sensitivity` to the `/api/kg/nodes` query**
+
+Find the `app.get('/api/kg/nodes', ...)` handler. The SQL query selects specific columns — add `sensitivity` to the end of the `SELECT` list:
+
+```sql
+SELECT id, type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity
+FROM kg_nodes
+WHERE ($1::text IS NULL OR type = $1)
+  AND (
+    $2::text IS NULL
+    OR label ILIKE '%' || $2 || '%'
+    OR properties::text ILIKE '%' || $2 || '%'
+  )
+ORDER BY last_confirmed_at DESC
+LIMIT $3
+```
+
+Then update the response mapping in the same handler to include both new fields:
+
+```typescript
+return reply.send({
+  nodes: result.rows.map((row) => ({
+    id: row.id,
+    type: row.type,
+    label: row.label,
+    properties: row.properties,
+    confidence: row.confidence,
+    decayClass: row.decay_class,
+    source: row.source,
+    createdAt: row.created_at,
+    lastConfirmedAt: row.last_confirmed_at,
+    sensitivity: row.sensitivity,
+  })),
+});
+```
+
+- [ ] **Step 3.3: Add `sensitivity` to both `/api/kg/graph` queries**
+
+Find the `app.get('/api/kg/graph', ...)` handler. It has two queries — the recursive traversal (used when `node_id` is provided) and the fallback recent-nodes query. Both need `sensitivity` added.
+
+**Traversal query** — find the `DISTINCT n.id, n.type, n.label ...` SELECT inside the `WITH RECURSIVE traversal AS (...)` query and add `n.sensitivity` to it:
+
+```sql
+SELECT DISTINCT n.id, n.type, n.label, n.properties, n.confidence, n.decay_class, n.source, n.created_at, n.last_confirmed_at, n.sensitivity
+FROM traversal t
+JOIN kg_nodes n ON n.id = t.id
+ORDER BY n.last_confirmed_at DESC
+LIMIT $3
+```
+
+**Fallback query** — find the simple `SELECT id, type, label ...` query and add `sensitivity`:
+
+```sql
+SELECT id, type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity
+FROM kg_nodes
+ORDER BY last_confirmed_at DESC
+LIMIT $1
+```
+
+Then update the response mapping in `/api/kg/graph` (the `return reply.send({ nodes: ..., edges: ... })`) to include both new fields on nodes:
+
+```typescript
+return reply.send({
+  nodes: nodeResult.rows.map((row) => ({
+    id: row.id,
+    type: row.type,
+    label: row.label,
+    properties: row.properties,
+    confidence: row.confidence,
+    decayClass: row.decay_class,
+    source: row.source,
+    createdAt: row.created_at,
+    lastConfirmedAt: row.last_confirmed_at,
+    sensitivity: row.sensitivity,
+  })),
+  edges: edgeResult.rows.map((row) => ({
+    id: row.id,
+    sourceNodeId: row.source_node_id,
+    targetNodeId: row.target_node_id,
+    type: row.type,
+    confidence: row.confidence,
+    decayClass: row.decay_class,
+    source: row.source,
+    createdAt: row.created_at,
+    lastConfirmedAt: row.last_confirmed_at,
+  })),
+});
+```
+
+- [ ] **Step 3.4: Run the full test suite to confirm no regressions**
+
+```bash
+npm --prefix /path/to/worktree test
+```
+
+Expected: all tests pass. (There are no dedicated route tests — the type changes are compile-time safety only. The SQL changes are straightforward additive column selections.)
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git -C /path/to/worktree add src/channels/http/routes/kg.ts
+git -C /path/to/worktree commit -m "feat: expose sensitivity and properties from KG API routes (#200)"
+```
+
+---
+
+## Task 4: Frontend — pass new fields through nodeToElement()
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts` (the embedded JS inside `createUiHtml()`)
+
+- [ ] **Step 4.1: Update `nodeToElement()`**
+
+Find the `function nodeToElement(n)` function inside the `createUiHtml()` template literal. Replace its body:
+
+```javascript
+function nodeToElement(n) {
+  return {
+    data: {
+      id: n.id,
+      label: n.label,
+      type: n.type,
+      confidence: n.confidence != null ? n.confidence : 0.5,
+      decayClass: n.decayClass || 'permanent',
+      sensitivity: n.sensitivity || 'internal',
+      properties: n.properties || {},
+      source: n.source || '',
+      createdAt: n.createdAt || '',
+      lastConfirmedAt: n.lastConfirmedAt || '',
+    },
+  };
+}
+```
+
+- [ ] **Step 4.2: Run the test suite**
+
+```bash
+npm --prefix /path/to/worktree test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git -C /path/to/worktree add src/channels/http/routes/kg.ts
+git -C /path/to/worktree commit -m "feat: pass sensitivity and full node metadata through nodeToElement (#200)"
+```
+
+---
+
+## Task 5: Frontend — sensitivity color tokens and Cytoscape styles
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts` (CSS `:root` block and Cytoscape `initCytoscape()` styles)
+
+- [ ] **Step 5.1: Add sensitivity color tokens to CSS `:root`**
+
+Inside the `<style>` block, find the `:root { ... }` section. Add four new CSS variables after the existing `--chart-*` tokens:
+
+```css
+/* Sensitivity level colours (issue #200) */
+--sens-public:       #5E9E6B;   /* green   — no restrictions */
+--sens-internal:     #4174C8;   /* blue    — neutral default */
+--sens-confidential: #C9874A;   /* amber   — elevated caution */
+--sens-restricted:   #E86040;   /* red     — matches --destructive */
+```
+
+- [ ] **Step 5.2: No stylesheet changes needed**
+
+Sensitivity colors are applied via per-element style overrides in `setColorMode()` (Step 5.3), not via Cytoscape stylesheet selectors. The existing `initCytoscape()` stylesheet stays unchanged — type colours remain the default and are restored when switching back to type mode by removing the element-level overrides.
+
+- [ ] **Step 5.3: Add the `setColorMode()` function and `colorMode` variable**
+
+Find the `// ── KG API helpers` comment that precedes the `setStatus` function. Just before that comment, add:
+
+```javascript
+// ── Color mode ────────────────────────────────────────────────────────
+// Tracks the active node colour encoding: 'type' (default) or 'sensitivity'.
+var colorMode = 'type';
+
+// Sensitivity hex palette — kept in sync with the sensitivity badge colours.
+var SENS_COLORS = {
+  public:       '#5E9E6B',
+  internal:     '#4174C8',
+  confidential: '#C9874A',
+  restricted:   '#E86040',
+};
+
+function setColorMode(mode) {
+  if (!cy) return;
+  colorMode = mode;
+
+  if (mode === 'sensitivity') {
+    // Apply an inline element-level background-color override to every node.
+    // Element-level styles take precedence over stylesheet selector rules,
+    // so this overrides the type colours without touching the stylesheet.
+    cy.nodes().forEach(function(node) {
+      var sens = node.data('sensitivity') || 'internal';
+      node.style('background-color', SENS_COLORS[sens] || SENS_COLORS.internal);
+    });
+  } else {
+    // Remove element-level overrides — stylesheet type-colour selectors
+    // (from initCytoscape) will take effect again automatically.
+    cy.nodes().removeStyle('background-color');
+  }
+
+  // Update toggle button active state
+  document.getElementById('color-btn-type').classList.toggle('active', mode === 'type');
+  document.getElementById('color-btn-sensitivity').classList.toggle('active', mode === 'sensitivity');
+}
+```
+
+- [ ] **Step 5.4: Re-apply color mode after graph renders**
+
+When `renderGraph()` or `expandNeighborhood()` adds new nodes, those nodes won't have the sensitivity color override if the user is already in sensitivity mode. Fix this by calling `setColorMode(colorMode)` at the end of both functions.
+
+Find `function renderGraph(payload)` and add the call after `cy.layout(FCOSE_OPTS_FULL).run()`:
+
+```javascript
+function renderGraph(payload) {
+  if (!cy) return;
+  var elements = payload.nodes.map(nodeToElement).concat(payload.edges.map(edgeToElement));
+  cy.elements().remove();
+  cy.add(elements);
+  cy.resize();
+  cy.layout(FCOSE_OPTS_FULL).run();
+  setColorMode(colorMode);  // re-apply active color mode to new nodes
+}
+```
+
+Find `function expandNeighborhood(nodeId)` and add the call after new elements are added and laid out. Inside the `.then()` callback, after the `cy.layout(...)` call (or after `cy.add(newElements)` if there is no layout in the expansion path), add:
+
+```javascript
+setColorMode(colorMode);  // re-apply active color mode to newly added nodes
+```
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git -C /path/to/worktree add src/channels/http/routes/kg.ts
+git -C /path/to/worktree commit -m "feat: add sensitivity color palette and color mode toggle logic (#200)"
+```
+
+---
+
+## Task 6: Frontend — color toggle toolbar HTML and CSS
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts` (HTML structure and CSS inside `createUiHtml()`)
+
+- [ ] **Step 6.1: Add CSS for the toolbar and toggle buttons**
+
+Inside the `<style>` block, find the `/* ── Cytoscape canvas */` comment. Just above it, add:
+
+```css
+/* ── Graph toolbar (color-by toggle, sits above the canvas) ─────────── */
+.graph-toolbar {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+}
+.graph-toolbar-label {
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+  font-weight: 500;
+  white-space: nowrap;
+}
+.toggle-btn-group {
+  display: flex;
+  gap: 2px;
+}
+.toggle-btn {
+  padding: 3px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: none;
+  color: var(--fg-muted);
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+.toggle-btn:hover  { background: var(--accent); color: var(--fg); }
+.toggle-btn.active { background: var(--muted); color: var(--fg); border-color: var(--teal); }
+```
+
+- [ ] **Step 6.2: Update the KG view HTML to add the toolbar**
+
+In the HTML, find the KG view section — the area containing `<div id="cy">`. It is currently inside a `position: relative` wrapper that holds the Cytoscape canvas. The KG view is identified by `id="view-kg"` or similar.
+
+The current structure looks roughly like:
+
+```html
+<div id="view-kg" ...>
+  <div style="position:relative; flex:1; ...">
+    <div id="cy"></div>
+  </div>
+</div>
+```
+
+Wrap the canvas wrapper in a column flex container and insert the toolbar above:
+
+```html
+<!-- Canvas column: toolbar + cytoscape -->
+<div style="flex:1; display:flex; flex-direction:column; overflow:hidden;">
+  <!-- Color-by toolbar -->
+  <div class="graph-toolbar">
+    <span class="graph-toolbar-label">Color by:</span>
+    <div class="toggle-btn-group">
+      <button id="color-btn-type" class="toggle-btn active" onclick="setColorMode('type')">Type</button>
+      <button id="color-btn-sensitivity" class="toggle-btn" onclick="setColorMode('sensitivity')">Sensitivity</button>
+    </div>
+  </div>
+  <!-- Cytoscape canvas -->
+  <div style="position:relative; flex:1; overflow:hidden;">
+    <div id="cy"></div>
+  </div>
+</div>
+```
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git -C /path/to/worktree add src/channels/http/routes/kg.ts
+git -C /path/to/worktree commit -m "feat: add color-by toolbar above KG graph canvas (#200)"
+```
+
+---
+
+## Task 7: Frontend — detail drawer HTML, CSS, and JS
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts`
+
+- [ ] **Step 7.1: Add CSS for the detail drawer**
+
+Inside the `<style>` block, after the `.graph-toolbar` rules added in Task 6, add:
+
+```css
+/* ── Node detail drawer ──────────────────────────────────────────────── */
+.node-detail-drawer {
+  flex: none;
+  width: 320px;
+  border-left: 1px solid var(--border);
+  background: var(--card);
+  display: none;   /* hidden until a node is tapped */
+  flex-direction: column;
+  overflow: hidden;
+}
+.node-detail-drawer.open { display: flex; }
+
+.drawer-header {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.drawer-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.drawer-close {
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: var(--radius-sm);
+  transition: color 0.1s, background 0.1s;
+}
+.drawer-close:hover { color: var(--fg); background: var(--accent); }
+
+.drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.drawer-node-label {
+  font-family: 'Lora', Georgia, serif;
+  font-size: 1.125rem;
+  font-weight: 500;
+  color: var(--fg);
+  line-height: 1.3;
+  word-break: break-word;
+}
+.drawer-badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #fff;
+}
+.badge-type-person       { background: #478189; }
+.badge-type-organization { background: #6BAED6; color: #111; }
+.badge-type-project      { background: #7E6BA8; }
+.badge-type-decision     { background: #C9874A; }
+.badge-type-event        { background: #5E9E6B; }
+.badge-type-concept      { background: #888888; }
+.badge-type-fact         { background: #444444; }
+.badge-sens-public       { background: #5E9E6B; }
+.badge-sens-internal     { background: #4174C8; }
+.badge-sens-confidential { background: #C9874A; }
+.badge-sens-restricted   { background: #E86040; }
+
+.drawer-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.drawer-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.drawer-field-label {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+}
+.drawer-field-value {
+  font-size: 0.8125rem;
+  color: var(--fg);
+  word-break: break-all;
+}
+.drawer-field-value.mono {
+  font-family: 'Menlo', 'Monaco', 'Consolas', monospace;
+  font-size: 0.75rem;
+}
+
+.drawer-props-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.75rem;
+}
+.drawer-props-table td {
+  padding: 3px 0;
+  vertical-align: top;
+}
+.drawer-props-table td:first-child {
+  color: var(--fg-muted);
+  padding-right: 10px;
+  white-space: nowrap;
+  font-weight: 500;
+}
+.drawer-props-table td:last-child {
+  color: var(--fg);
+  word-break: break-all;
+}
+```
+
+- [ ] **Step 7.2: Add drawer HTML to the KG view**
+
+In the HTML, find the KG view section where you added the canvas column wrapper in Task 6. The full KG view content area (inside `id="view-kg"`) now becomes a flex row of three elements: the existing sidebar panel (search + results), the canvas column, and the new detail drawer.
+
+Add the drawer element as the last child of the KG view's flex row:
+
+```html
+<!-- Node detail drawer (right panel, hidden until node tap) -->
+<div id="node-detail-drawer" class="node-detail-drawer">
+  <div class="drawer-header">
+    <span class="drawer-title">Node detail</span>
+    <button class="drawer-close" onclick="closeNodeDrawer()" title="Close">&times;</button>
+  </div>
+  <div class="drawer-body" id="drawer-body-content">
+    <!-- populated by openNodeDrawer() -->
+  </div>
+</div>
+```
+
+- [ ] **Step 7.3: Add `openNodeDrawer()` and `closeNodeDrawer()` functions**
+
+Inside the `<script>` block, after the `setColorMode()` function added in Task 5, add:
+
+```javascript
+// ── Node detail drawer ────────────────────────────────────────────────
+
+function closeNodeDrawer() {
+  document.getElementById('node-detail-drawer').classList.remove('open');
+}
+
+// Sensitivity badge CSS class lookup
+var SENS_BADGE_CLASS = {
+  public:       'badge-sens-public',
+  internal:     'badge-sens-internal',
+  confidential: 'badge-sens-confidential',
+  restricted:   'badge-sens-restricted',
+};
+
+// Type badge CSS class lookup — mirrors the type colour palette
+var TYPE_BADGE_CLASS = {
+  person:       'badge-type-person',
+  organization: 'badge-type-organization',
+  project:      'badge-type-project',
+  decision:     'badge-type-decision',
+  event:        'badge-type-event',
+  concept:      'badge-type-concept',
+  fact:         'badge-type-fact',
+};
+
+function openNodeDrawer(data) {
+  var drawer = document.getElementById('node-detail-drawer');
+  var body   = document.getElementById('drawer-body-content');
+
+  body.replaceChildren();
+
+  // ── Label ────────────────────────────────────────────────────────────
+  var labelEl = document.createElement('div');
+  labelEl.className = 'drawer-node-label';
+  labelEl.textContent = data.label || '(no label)';
+  body.appendChild(labelEl);
+
+  // ── Type + Sensitivity badges ─────────────────────────────────────────
+  var badges = document.createElement('div');
+  badges.className = 'drawer-badges';
+
+  var typeBadge = document.createElement('span');
+  typeBadge.className = 'badge ' + (TYPE_BADGE_CLASS[data.type] || 'badge-type-fact');
+  typeBadge.textContent = data.type || 'unknown';
+  badges.appendChild(typeBadge);
+
+  var sensBadge = document.createElement('span');
+  var sens = data.sensitivity || 'internal';
+  sensBadge.className = 'badge ' + (SENS_BADGE_CLASS[sens] || 'badge-sens-internal');
+  sensBadge.textContent = sens;
+  badges.appendChild(sensBadge);
+
+  body.appendChild(badges);
+
+  // ── Scalar fields ─────────────────────────────────────────────────────
+  var fields = document.createElement('div');
+  fields.className = 'drawer-fields';
+
+  function addField(labelText, valueText, mono) {
+    var field = document.createElement('div');
+    field.className = 'drawer-field';
+
+    var lbl = document.createElement('div');
+    lbl.className = 'drawer-field-label';
+    lbl.textContent = labelText;
+
+    var val = document.createElement('div');
+    val.className = 'drawer-field-value' + (mono ? ' mono' : '');
+    val.textContent = valueText || '\u2014'; // em-dash for empty values
+    field.append(lbl, val);
+    fields.appendChild(field);
+  }
+
+  addField('Confidence', data.confidence != null ? data.confidence.toFixed(3) : '—');
+  addField('Decay class', data.decayClass || '—');
+  addField('Source', data.source || '—', true);
+
+  function fmtDate(iso) {
+    if (!iso) return '—';
+    try { return new Date(iso).toLocaleString(); } catch (_) { return iso; }
+  }
+  addField('Created', fmtDate(data.createdAt));
+  addField('Last confirmed', fmtDate(data.lastConfirmedAt));
+
+  body.appendChild(fields);
+
+  // ── Properties table (omitted if empty) ───────────────────────────────
+  var props = data.properties;
+  if (props && typeof props === 'object') {
+    var keys = Object.keys(props);
+    if (keys.length > 0) {
+      var propSection = document.createElement('div');
+      propSection.className = 'drawer-field';
+
+      var propLabel = document.createElement('div');
+      propLabel.className = 'drawer-field-label';
+      propLabel.textContent = 'Properties';
+      propSection.appendChild(propLabel);
+
+      var table = document.createElement('table');
+      table.className = 'drawer-props-table';
+
+      keys.forEach(function(key) {
+        var tr = document.createElement('tr');
+        var tdKey = document.createElement('td');
+        tdKey.textContent = key;
+        var tdVal = document.createElement('td');
+        var raw = props[key];
+        tdVal.textContent = (raw !== null && raw !== undefined)
+          ? (typeof raw === 'object' ? JSON.stringify(raw) : String(raw))
+          : '—';
+        tr.append(tdKey, tdVal);
+        table.appendChild(tr);
+      });
+
+      propSection.appendChild(table);
+      body.appendChild(propSection);
+    }
+  }
+
+  drawer.classList.add('open');
+}
+```
+
+- [ ] **Step 7.4: Extend the node tap handler to open the drawer**
+
+Find the `cy.on('tap', 'node', function(evt) {` handler. It currently only calls `expandNeighborhood(evt.target.id())`. Extend it to also open the drawer:
+
+```javascript
+cy.on('tap', 'node', function(evt) {
+  expandNeighborhood(evt.target.id());
+  openNodeDrawer(evt.target.data());
+});
+```
+
+- [ ] **Step 7.5: Run the test suite**
+
+```bash
+npm --prefix /path/to/worktree test
+```
+
+Expected: all tests pass. (The JS changes are in the embedded HTML template, not in TypeScript, so the test suite won't catch UI bugs — that requires a manual smoke test in the browser.)
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git -C /path/to/worktree add src/channels/http/routes/kg.ts
+git -C /path/to/worktree commit -m "feat: add node detail drawer and sensitivity color toggle to KG explorer (#200)"
+```
+
+---
+
+## Task 8: Manual smoke test
+
+Before writing the changelog, verify the features work in the browser.
+
+- [ ] **Step 8.1: Start the app**
+
+```bash
+npm --prefix /path/to/worktree run dev
+```
+
+Open the KG explorer (typically `http://localhost:PORT/kg`).
+
+- [ ] **Step 8.2: Verify the color toggle**
+
+1. Confirm the `Color by: [Type] [Sensitivity]` button group appears above the graph.
+2. Click **Sensitivity** — all nodes should change colour. Nodes with `sensitivity = 'internal'` become blue (#4174C8), which is the same as the default, so the graph may look similar if all nodes are `internal` (expected — the migration defaulted everything to `internal`).
+3. Click **Type** — nodes should revert to their type-based colours.
+
+- [ ] **Step 8.3: Verify the detail drawer**
+
+1. Tap any node in the graph.
+2. Confirm the detail drawer slides in on the right and the canvas shrinks.
+3. Verify all fields show correct values: label, type badge (correct colour), sensitivity badge, confidence, decay class, source, dates.
+4. If the node has properties, verify the key–value table renders.
+5. Click the × to close — drawer should hide and canvas should expand back.
+6. Tap a second node while the drawer is open — content should update in place without closing.
+
+---
+
+## Task 9: CHANGELOG and version bump
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`
+
+- [ ] **Step 9.1: Add CHANGELOG entry**
+
+Open `CHANGELOG.md`. Under `## [Unreleased]`, add to the `### Added` section:
+
+```markdown
+- **KG explorer: sensitivity visualization** — node detail drawer shows all node attributes (label, type, sensitivity, confidence, decay class, source, timestamps, properties) when a node is tapped; color-by toggle lets the user switch node colour encoding between Type and Sensitivity (#200)
+- **KG API: `sensitivity` and `properties` fields** — `/api/kg/nodes` and `/api/kg/graph` now return both fields on every node response
+```
+
+- [ ] **Step 9.2: Bump the version**
+
+Open `package.json`. Change the version from `0.20.0` to `0.20.1` (patch bump — completing a partially-shipped spec per CLAUDE.md versioning rules).
+
+- [ ] **Step 9.3: Commit**
+
+```bash
+git -C /path/to/worktree add CHANGELOG.md package.json
+git -C /path/to/worktree commit -m "chore: changelog and version bump for KG sensitivity visualization (0.20.1) (#200)"
+```
+
+---
+
+## Task 10: Open PR
+
+- [ ] **Step 10.1: Run full test suite one final time**
+
+```bash
+npm --prefix /path/to/worktree test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 10.2: Create PR**
+
+```bash
+gh pr create \
+  --title "feat: KG sensitivity visualization — detail drawer and color toggle (#200)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Exposes `sensitivity` and `properties` from `/api/kg/nodes` and `/api/kg/graph` (both were in the DB but not returned by the API)
+- Adds a right-side detail drawer to the KG explorer that shows all node attributes when a node is tapped (label, type, sensitivity, confidence, decay class, source, timestamps, properties)
+- Adds a `Color by: Type | Sensitivity` toggle above the graph canvas that hot-swaps Cytoscape node colour rules
+- Adds unit tests for `SensitivityClassifier` keyword classification and KG node sensitivity defaults (closes the two unchecked ACs from #200)
+
+## Test plan
+
+- [ ] Run `npm test` — all tests pass
+- [ ] Open KG explorer, verify color toggle switches node colours between type-based and sensitivity-based palettes
+- [ ] Tap a node, verify detail drawer opens with all fields populated correctly
+- [ ] Tap a second node while drawer is open — content updates in place
+- [ ] Click × — drawer closes, canvas expands
+EOF
+)"
+```
+
+- [ ] **Step 10.3: Confirm CI started**
+
+```bash
+gh run list --branch feat/kg-sensitivity-visualization --limit 1
+```
+
+Expected: one run in `queued` or `in_progress` state.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -53,6 +53,7 @@ interface KgNodeRow {
   source: string;
   created_at: string;
   last_confirmed_at: string;
+  sensitivity: string;
 }
 
 interface KgEdgeRow {
@@ -3168,7 +3169,7 @@ export async function knowledgeGraphRoutes(
     const typeFilter = query.type?.trim();
 
     const result = await pool.query<KgNodeRow>(
-      `SELECT id, type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at
+      `SELECT id, type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity
        FROM kg_nodes
        WHERE ($1::text IS NULL OR type = $1)
          AND (
@@ -3186,11 +3187,13 @@ export async function knowledgeGraphRoutes(
         id: row.id,
         type: row.type,
         label: row.label,
+        properties: row.properties,
         confidence: row.confidence,
         decayClass: row.decay_class,
         source: row.source,
         createdAt: row.created_at,
         lastConfirmedAt: row.last_confirmed_at,
+        sensitivity: row.sensitivity,
       })),
     });
   });
@@ -3233,7 +3236,7 @@ export async function knowledgeGraphRoutes(
              WHERE t.depth < $2
                AND NOT (CASE WHEN e.source_node_id = t.id THEN e.target_node_id ELSE e.source_node_id END = ANY(t.visited))
            )
-           SELECT DISTINCT n.id, n.type, n.label, n.properties, n.confidence, n.decay_class, n.source, n.created_at, n.last_confirmed_at
+           SELECT DISTINCT n.id, n.type, n.label, n.properties, n.confidence, n.decay_class, n.source, n.created_at, n.last_confirmed_at, n.sensitivity
            FROM traversal t
            JOIN kg_nodes n ON n.id = t.id
            ORDER BY n.last_confirmed_at DESC
@@ -3241,7 +3244,7 @@ export async function knowledgeGraphRoutes(
           [nodeId, depth, limit],
         )
       : await pool.query<KgNodeRow>(
-          `SELECT id, type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at
+          `SELECT id, type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity
            FROM kg_nodes
            ORDER BY last_confirmed_at DESC
            LIMIT $1`,
@@ -3270,11 +3273,13 @@ export async function knowledgeGraphRoutes(
         id: row.id,
         type: row.type,
         label: row.label,
+        properties: row.properties,
         confidence: row.confidence,
         decayClass: row.decay_class,
         source: row.source,
         createdAt: row.created_at,
         lastConfirmedAt: row.last_confirmed_at,
+        sensitivity: row.sensitivity,
       })),
       edges: edgeResult.rows.map((row) => ({
         id: row.id,

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1087,9 +1087,9 @@ function createUiHtml(): string {
             <div class="graph-toolbar">
               <span class="graph-toolbar-label">Color by:</span>
               <div class="toggle-btn-group">
-                <button id="color-btn-type" class="toggle-btn active" onclick="setColorMode('type')">Type</button>
-                <button id="color-btn-sensitivity" class="toggle-btn" onclick="setColorMode('sensitivity')">Sensitivity</button>
-                <button id="color-btn-decay" class="toggle-btn" onclick="setColorMode('decay')">Decay</button>
+                <button id="color-btn-type" type="button" class="toggle-btn active" aria-pressed="true" onclick="setColorMode('type')">Type</button>
+                <button id="color-btn-sensitivity" type="button" class="toggle-btn" aria-pressed="false" onclick="setColorMode('sensitivity')">Sensitivity</button>
+                <button id="color-btn-decay" type="button" class="toggle-btn" aria-pressed="false" onclick="setColorMode('decay')">Decay</button>
               </div>
             </div>
             <!-- Cytoscape canvas -->
@@ -2299,10 +2299,13 @@ function createUiHtml(): string {
         cy.nodes().removeStyle('background-color');
       }
 
-      // Update toggle button active state
+      // Update toggle button active state and aria-pressed for assistive tech
       btnType.classList.toggle('active', mode === 'type');
       btnSens.classList.toggle('active', mode === 'sensitivity');
       btnDecay.classList.toggle('active', mode === 'decay');
+      btnType.setAttribute('aria-pressed', String(mode === 'type'));
+      btnSens.setAttribute('aria-pressed', String(mode === 'sensitivity'));
+      btnDecay.setAttribute('aria-pressed', String(mode === 'decay'));
     }
 
     // Computes the edge-count (degree) for every node and stores it as element

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -2100,6 +2100,12 @@ function createUiHtml(): string {
           type: n.type,
           confidence: n.confidence != null ? n.confidence : 0.5,
           decayClass: n.decayClass || 'permanent',
+          sensitivity: n.sensitivity || 'internal',
+          properties: n.properties || {},
+          source: n.source || '',
+          createdAt: n.createdAt || '',
+          lastConfirmedAt: n.lastConfirmedAt || '',
+          degree: 0, // updated by updateDegrees() after elements are added
         },
       };
     }

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -2319,6 +2319,9 @@ function createUiHtml(): string {
 
     function closeNodeDrawer() {
       document.getElementById('node-detail-drawer').classList.remove('open');
+      // Defer resize so the browser has painted the narrower layout before
+      // Cytoscape re-measures — without this the canvas still sees the old width.
+      requestAnimationFrame(function() { if (cy) cy.resize(); });
     }
 
     // Sensitivity badge CSS class lookup
@@ -2440,6 +2443,9 @@ function createUiHtml(): string {
       }
 
       drawer.classList.add('open');
+      // Defer resize so the browser has painted the wider layout (drawer now
+      // occupies 320px) before Cytoscape re-measures the shrunken canvas.
+      requestAnimationFrame(function() { if (cy) cy.resize(); });
     }
 
     // ── KG API helpers ─────────────────────────────────────────────────

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -124,6 +124,17 @@ function createUiHtml(): string {
       --chart-2:      #4174C8;   /* default node colour */
       --chart-1:      #6BAED6;   /* organization node */
 
+      /* Sensitivity level colours */
+      --sens-public:       #5E9E6B;   /* green   — no restrictions */
+      --sens-internal:     #4174C8;   /* blue    — neutral default */
+      --sens-confidential: #C9874A;   /* amber   — elevated caution */
+      --sens-restricted:   #E86040;   /* red     — matches --destructive */
+
+      /* Decay class colours */
+      --decay-permanent:  #5E9E6B;   /* green — stable, no decay */
+      --decay-slow:       #4174C8;   /* blue  — fading slowly */
+      --decay-fast:       #E86040;   /* red   — fading quickly, needs reconfirmation */
+
       --radius-sm: 6px;
       --radius-md: 8px;
       --radius-lg: 10px;
@@ -1541,10 +1552,13 @@ function createUiHtml(): string {
               'text-max-width': '90px',
               'font-size': 10,
               'font-family': 'Manrope, system-ui, sans-serif',
-              // Base size is overridden per-type below; confidence scales
-              // add on top of the type base via mapData.
-              width: 32,
-              height: 32,
+              // Degree-based size: nodes with more edges are visually larger.
+              // 'degree' is set as element data by updateDegrees() after every cy.add().
+              // Range: isolated node (0 edges) = 20px, hub node (15+ edges) = 52px.
+              width: 'mapData(degree, 0, 15, 20, 52)',
+              height: 'mapData(degree, 0, 15, 20, 52)',
+              // Confidence-based opacity: lower confidence = more transparent.
+              opacity: 'mapData(confidence, 0, 1, 0.15, 1.0)',
             },
           },
           // ── Type colours ─────────────────────────────────────────────
@@ -1555,24 +1569,10 @@ function createUiHtml(): string {
           { selector: 'node[type="event"]',         style: { 'background-color': '#5E9E6B' } }, // green
           { selector: 'node[type="concept"]',       style: { 'background-color': '#888888' } }, // mid-grey
           { selector: 'node[type="fact"]',          style: { 'background-color': '#444444' } }, // dark grey
-          // ── Type-based base sizes (issue 5) ─────────────────────────
-          // Entities that anchor the graph get more canvas real-estate so
-          // their labels are readable and they visually dominate leaf nodes.
-          { selector: 'node[type="person"]',       style: { width: 44, height: 44 } },
-          { selector: 'node[type="organization"]',  style: { width: 44, height: 44 } },
-          { selector: 'node[type="project"]',       style: { width: 36, height: 36 } },
-          { selector: 'node[type="decision"]',      style: { width: 32, height: 32 } },
-          { selector: 'node[type="event"]',         style: { width: 28, height: 28 } },
-          { selector: 'node[type="concept"]',       style: { width: 24, height: 24 } },
-          // Facts are tiny — they're leaf annotations, not key entities.
-          { selector: 'node[type="fact"]',          style: { width: 14, height: 14, 'font-size': 0 } },
-          // Show fact labels when selected (they're too small to show by default).
+          // Facts: hide label at default size; show when selected.
+          // (Size is now degree-based — the width/height rule above handles all types.)
+          { selector: 'node[type="fact"]',          style: { 'font-size': 0 } },
           { selector: 'node[type="fact"]:selected', style: { 'font-size': 9 } },
-          // ── Confidence-based opacity (issue 2) ──────────────────────
-          // Stale / low-confidence nodes fade out so the high-signal nodes pop.
-          { selector: 'node[decayClass="fast_decay"]', style: { opacity: 0.45 } },
-          { selector: 'node[decayClass="slow_decay"]', style: { opacity: 0.75 } },
-          // permanent nodes keep full opacity (no rule needed — default is 1).
           // ── Focal node highlight (issue 4) ───────────────────────────
           {
             selector: 'node.focal',
@@ -2044,6 +2044,61 @@ function createUiHtml(): string {
         });
     }
 
+    // ── Color mode ────────────────────────────────────────────────────────
+    // Tracks the active node colour encoding: 'type' (default), 'sensitivity',
+    // or 'decay'.
+    var colorMode = 'type';
+
+    // Color palette maps — kept in sync with CSS tokens added to :root.
+    var SENS_COLORS = {
+      public:       '#5E9E6B',
+      internal:     '#4174C8',
+      confidential: '#C9874A',
+      restricted:   '#E86040',
+    };
+
+    var DECAY_COLORS = {
+      permanent:  '#5E9E6B',
+      slow_decay: '#4174C8',
+      fast_decay: '#E86040',
+    };
+
+    function setColorMode(mode) {
+      if (!cy) return;
+      colorMode = mode;
+
+      if (mode === 'sensitivity') {
+        cy.nodes().forEach(function(node) {
+          var sens = node.data('sensitivity') || 'internal';
+          node.style('background-color', SENS_COLORS[sens] || SENS_COLORS.internal);
+        });
+      } else if (mode === 'decay') {
+        cy.nodes().forEach(function(node) {
+          var decay = node.data('decayClass') || 'slow_decay';
+          node.style('background-color', DECAY_COLORS[decay] || DECAY_COLORS.slow_decay);
+        });
+      } else {
+        // type mode: remove element-level overrides so the stylesheet type-colour
+        // selectors take effect again automatically.
+        cy.nodes().removeStyle('background-color');
+      }
+
+      // Update toggle button active state
+      document.getElementById('color-btn-type').classList.toggle('active', mode === 'type');
+      document.getElementById('color-btn-sensitivity').classList.toggle('active', mode === 'sensitivity');
+      document.getElementById('color-btn-decay').classList.toggle('active', mode === 'decay');
+    }
+
+    // Computes the edge-count (degree) for every node and stores it as element
+    // data so the mapData(degree, ...) stylesheet rule can size nodes correctly.
+    // Must be called after every cy.add() — degree changes as edges are added.
+    function updateDegrees() {
+      if (!cy) return;
+      cy.nodes().forEach(function(node) {
+        node.data('degree', node.degree());
+      });
+    }
+
     // ── KG API helpers ─────────────────────────────────────────────────
     function setStatus(msg, isError) {
       statusEl.textContent = msg;
@@ -2134,11 +2189,13 @@ function createUiHtml(): string {
       var elements = payload.nodes.map(nodeToElement).concat(payload.edges.map(edgeToElement));
       cy.elements().remove();
       cy.add(elements);
+      updateDegrees();         // must run before layout so sizes are correct
       // Force Cytoscape to re-measure the container before running layout.
       // Without this, the canvas may still be sized 0×0 from when main-app was
       // display:none (e.g. on first load or after navigating away and back).
       cy.resize();
       cy.layout(FCOSE_OPTS_FULL).run();
+      setColorMode(colorMode); // re-apply active color mode to new nodes
     }
 
     // In-place expansion — adds only new nodes/edges so the existing graph context
@@ -2164,6 +2221,8 @@ function createUiHtml(): string {
             });
 
             cy.add(newElements);
+            updateDegrees();         // recalculate all degrees now that edges changed
+            setColorMode(colorMode); // re-apply active color mode to newly added nodes
 
             var expandOpts = Object.assign({}, FCOSE_OPTS_EXPAND, {
               fixedNodeConstraint: fixedConstraints,

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -240,6 +240,41 @@ function createUiHtml(): string {
     .btn-primary:hover    { opacity: 0.88; }
     .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 
+    /* ── Graph toolbar (color-by toggle, sits above the canvas) ─────────── */
+    .graph-toolbar {
+      flex: none;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 10px;
+      border-bottom: 1px solid var(--border);
+      background: var(--card);
+    }
+    .graph-toolbar-label {
+      font-size: 0.75rem;
+      color: var(--fg-muted);
+      font-weight: 500;
+      white-space: nowrap;
+    }
+    .toggle-btn-group {
+      display: flex;
+      gap: 2px;
+    }
+    .toggle-btn {
+      padding: 3px 10px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--border);
+      background: none;
+      color: var(--fg-muted);
+      font-family: inherit;
+      font-size: 0.75rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.1s, color 0.1s, border-color 0.1s;
+    }
+    .toggle-btn:hover  { background: var(--accent); color: var(--fg); }
+    .toggle-btn.active { background: var(--muted); color: var(--fg); border-color: var(--teal); }
+
     /* ── Cytoscape canvas ─────────────────────────────────────────────── */
     /* Use absolute positioning so #cy fills its position:relative parent
        regardless of whether the flex chain gives the parent a definite height.
@@ -916,9 +951,21 @@ function createUiHtml(): string {
             <div id="results"></div>
           </div>
 
-          <!-- Cytoscape graph -->
-          <div style="flex: 1; position: relative; overflow: hidden;">
-            <div id="cy"></div>
+          <!-- Canvas column: color-by toolbar + cytoscape canvas -->
+          <div style="flex: 1; display: flex; flex-direction: column; overflow: hidden;">
+            <!-- Color-by toolbar -->
+            <div class="graph-toolbar">
+              <span class="graph-toolbar-label">Color by:</span>
+              <div class="toggle-btn-group">
+                <button id="color-btn-type" class="toggle-btn active" onclick="setColorMode('type')">Type</button>
+                <button id="color-btn-sensitivity" class="toggle-btn" onclick="setColorMode('sensitivity')">Sensitivity</button>
+                <button id="color-btn-decay" class="toggle-btn" onclick="setColorMode('decay')">Decay</button>
+              </div>
+            </div>
+            <!-- Cytoscape canvas -->
+            <div style="position: relative; flex: 1; overflow: hidden;">
+              <div id="cy"></div>
+            </div>
           </div>
 
         </div>

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -275,6 +275,136 @@ function createUiHtml(): string {
     .toggle-btn:hover  { background: var(--accent); color: var(--fg); }
     .toggle-btn.active { background: var(--muted); color: var(--fg); border-color: var(--teal); }
 
+    /* ── Node detail drawer ──────────────────────────────────────────────── */
+    .node-detail-drawer {
+      flex: none;
+      width: 320px;
+      border-left: 1px solid var(--border);
+      background: var(--card);
+      display: none;   /* hidden until a node is tapped */
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .node-detail-drawer.open { display: flex; }
+
+    .drawer-header {
+      flex: none;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--border);
+    }
+    .drawer-title {
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: var(--fg-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .drawer-close {
+      background: none;
+      border: none;
+      color: var(--fg-muted);
+      cursor: pointer;
+      font-size: 1.1rem;
+      line-height: 1;
+      padding: 2px 4px;
+      border-radius: var(--radius-sm);
+      transition: color 0.1s, background 0.1s;
+    }
+    .drawer-close:hover { color: var(--fg); background: var(--accent); }
+
+    .drawer-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+    .drawer-node-label {
+      font-family: 'Lora', Georgia, serif;
+      font-size: 1.125rem;
+      font-weight: 500;
+      color: var(--fg);
+      line-height: 1.3;
+      word-break: break-word;
+    }
+    .drawer-badges {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+    .badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 99px;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #fff;
+    }
+    .badge-type-person       { background: #478189; }
+    .badge-type-organization { background: #6BAED6; color: #111; }
+    .badge-type-project      { background: #7E6BA8; }
+    .badge-type-decision     { background: #C9874A; }
+    .badge-type-event        { background: #5E9E6B; }
+    .badge-type-concept      { background: #888888; }
+    .badge-type-fact         { background: #444444; }
+    .badge-sens-public       { background: #5E9E6B; }
+    .badge-sens-internal     { background: #4174C8; }
+    .badge-sens-confidential { background: #C9874A; }
+    .badge-sens-restricted   { background: #E86040; }
+
+    .drawer-fields {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .drawer-field {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+    .drawer-field-label {
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--fg-muted);
+    }
+    .drawer-field-value {
+      font-size: 0.8125rem;
+      color: var(--fg);
+      word-break: break-all;
+    }
+    .drawer-field-value.mono {
+      font-family: 'Menlo', 'Monaco', 'Consolas', monospace;
+      font-size: 0.75rem;
+    }
+
+    .drawer-props-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.75rem;
+    }
+    .drawer-props-table td {
+      padding: 3px 0;
+      vertical-align: top;
+    }
+    .drawer-props-table td:first-child {
+      color: var(--fg-muted);
+      padding-right: 10px;
+      white-space: nowrap;
+      font-weight: 500;
+    }
+    .drawer-props-table td:last-child {
+      color: var(--fg);
+      word-break: break-all;
+    }
+
     /* ── Cytoscape canvas ─────────────────────────────────────────────── */
     /* Use absolute positioning so #cy fills its position:relative parent
        regardless of whether the flex chain gives the parent a definite height.
@@ -968,6 +1098,17 @@ function createUiHtml(): string {
             </div>
           </div>
 
+          <!-- Node detail drawer (right panel, hidden until node tap) -->
+          <div id="node-detail-drawer" class="node-detail-drawer">
+            <div class="drawer-header">
+              <span class="drawer-title">Node detail</span>
+              <button class="drawer-close" onclick="closeNodeDrawer()" title="Close">&times;</button>
+            </div>
+            <div class="drawer-body" id="drawer-body-content">
+              <!-- populated by openNodeDrawer() -->
+            </div>
+          </div>
+
         </div>
       </div>
 
@@ -1658,6 +1799,7 @@ function createUiHtml(): string {
       // Single-tap a node: expand its neighborhood in-place (issue 4).
       cy.on('tap', 'node', function(evt) {
         expandNeighborhood(evt.target.id());
+        openNodeDrawer(evt.target.data());
       });
 
       // Double-tap a node: zoom/pan to fit its immediate neighborhood (issue 4).
@@ -2144,6 +2286,129 @@ function createUiHtml(): string {
       cy.nodes().forEach(function(node) {
         node.data('degree', node.degree());
       });
+    }
+
+    // ── Node detail drawer ────────────────────────────────────────────────
+
+    function closeNodeDrawer() {
+      document.getElementById('node-detail-drawer').classList.remove('open');
+    }
+
+    // Sensitivity badge CSS class lookup
+    var SENS_BADGE_CLASS = {
+      public:       'badge-sens-public',
+      internal:     'badge-sens-internal',
+      confidential: 'badge-sens-confidential',
+      restricted:   'badge-sens-restricted',
+    };
+
+    // Type badge CSS class lookup — mirrors the type colour palette
+    var TYPE_BADGE_CLASS = {
+      person:       'badge-type-person',
+      organization: 'badge-type-organization',
+      project:      'badge-type-project',
+      decision:     'badge-type-decision',
+      event:        'badge-type-event',
+      concept:      'badge-type-concept',
+      fact:         'badge-type-fact',
+    };
+
+    function openNodeDrawer(data) {
+      var drawer = document.getElementById('node-detail-drawer');
+      var body   = document.getElementById('drawer-body-content');
+
+      body.replaceChildren();
+
+      // ── Label ────────────────────────────────────────────────────────────
+      var labelEl = document.createElement('div');
+      labelEl.className = 'drawer-node-label';
+      labelEl.textContent = data.label || '(no label)';
+      body.appendChild(labelEl);
+
+      // ── Type + Sensitivity badges ─────────────────────────────────────────
+      var badges = document.createElement('div');
+      badges.className = 'drawer-badges';
+
+      var typeBadge = document.createElement('span');
+      typeBadge.className = 'badge ' + (TYPE_BADGE_CLASS[data.type] || 'badge-type-fact');
+      typeBadge.textContent = data.type || 'unknown';
+      badges.appendChild(typeBadge);
+
+      var sens = data.sensitivity || 'internal';
+      var sensBadge = document.createElement('span');
+      sensBadge.className = 'badge ' + (SENS_BADGE_CLASS[sens] || 'badge-sens-internal');
+      sensBadge.textContent = sens;
+      badges.appendChild(sensBadge);
+
+      body.appendChild(badges);
+
+      // ── Scalar fields ─────────────────────────────────────────────────────
+      var fields = document.createElement('div');
+      fields.className = 'drawer-fields';
+
+      function addField(labelText, valueText, mono) {
+        var field = document.createElement('div');
+        field.className = 'drawer-field';
+
+        var lbl = document.createElement('div');
+        lbl.className = 'drawer-field-label';
+        lbl.textContent = labelText;
+
+        var val = document.createElement('div');
+        val.className = 'drawer-field-value' + (mono ? ' mono' : '');
+        val.textContent = valueText || '\u2014'; // em-dash for empty values
+        field.append(lbl, val);
+        fields.appendChild(field);
+      }
+
+      addField('Confidence', data.confidence != null ? data.confidence.toFixed(3) : null);
+      addField('Decay class', data.decayClass);
+      addField('Source', data.source, true);
+
+      function fmtDate(iso) {
+        if (!iso) return '\u2014';
+        try { return new Date(iso).toLocaleString(); } catch (_) { return iso; }
+      }
+      addField('Created', fmtDate(data.createdAt));
+      addField('Last confirmed', fmtDate(data.lastConfirmedAt));
+
+      body.appendChild(fields);
+
+      // ── Properties table (omitted if empty) ───────────────────────────────
+      var props = data.properties;
+      if (props && typeof props === 'object') {
+        var keys = Object.keys(props);
+        if (keys.length > 0) {
+          var propSection = document.createElement('div');
+          propSection.className = 'drawer-field';
+
+          var propLabel = document.createElement('div');
+          propLabel.className = 'drawer-field-label';
+          propLabel.textContent = 'Properties';
+          propSection.appendChild(propLabel);
+
+          var table = document.createElement('table');
+          table.className = 'drawer-props-table';
+
+          keys.forEach(function(key) {
+            var tr = document.createElement('tr');
+            var tdKey = document.createElement('td');
+            tdKey.textContent = key;
+            var tdVal = document.createElement('td');
+            var raw = props[key];
+            tdVal.textContent = (raw !== null && raw !== undefined)
+              ? (typeof raw === 'object' ? JSON.stringify(raw) : String(raw))
+              : '\u2014';
+            tr.append(tdKey, tdVal);
+            table.appendChild(tr);
+          });
+
+          propSection.appendChild(table);
+          body.appendChild(propSection);
+        }
+      }
+
+      drawer.classList.add('open');
     }
 
     // ── KG API helpers ─────────────────────────────────────────────────

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -2254,17 +2254,44 @@ function createUiHtml(): string {
 
     function setColorMode(mode) {
       if (!cy) return;
+
+      // Fetch buttons early — if the DOM is not ready (e.g. KG view re-entered while
+      // hidden) these will be null and we bail rather than throwing a silent TypeError.
+      var btnType = document.getElementById('color-btn-type');
+      var btnSens = document.getElementById('color-btn-sensitivity');
+      var btnDecay = document.getElementById('color-btn-decay');
+      if (!btnType || !btnSens || !btnDecay) return;
+
+      // Reject unknown modes rather than silently falling through to type behaviour,
+      // which would leave no toggle button active and mislead the user.
+      if (mode !== 'type' && mode !== 'sensitivity' && mode !== 'decay') {
+        console.warn('[KG] setColorMode: unknown mode', mode);
+        return;
+      }
+
       colorMode = mode;
 
       if (mode === 'sensitivity') {
         cy.nodes().forEach(function(node) {
           var sens = node.data('sensitivity') || 'internal';
-          node.style('background-color', SENS_COLORS[sens] || SENS_COLORS.internal);
+          var color = SENS_COLORS[sens];
+          if (!color) {
+            // Unknown sensitivity tier — show a visually distinct grey rather than
+            // silently defaulting to internal/blue, which would look like a known value.
+            console.warn('[KG] unknown sensitivity value:', sens);
+            color = '#888888';
+          }
+          node.style('background-color', color);
         });
       } else if (mode === 'decay') {
         cy.nodes().forEach(function(node) {
           var decay = node.data('decayClass') || 'slow_decay';
-          node.style('background-color', DECAY_COLORS[decay] || DECAY_COLORS.slow_decay);
+          var color = DECAY_COLORS[decay];
+          if (!color) {
+            console.warn('[KG] unknown decayClass value:', decay);
+            color = '#888888';
+          }
+          node.style('background-color', color);
         });
       } else {
         // type mode: remove element-level overrides so the stylesheet type-colour
@@ -2273,9 +2300,9 @@ function createUiHtml(): string {
       }
 
       // Update toggle button active state
-      document.getElementById('color-btn-type').classList.toggle('active', mode === 'type');
-      document.getElementById('color-btn-sensitivity').classList.toggle('active', mode === 'sensitivity');
-      document.getElementById('color-btn-decay').classList.toggle('active', mode === 'decay');
+      btnType.classList.toggle('active', mode === 'type');
+      btnSens.classList.toggle('active', mode === 'sensitivity');
+      btnDecay.classList.toggle('active', mode === 'decay');
     }
 
     // Computes the edge-count (degree) for every node and stores it as element
@@ -2367,7 +2394,11 @@ function createUiHtml(): string {
 
       function fmtDate(iso) {
         if (!iso) return '\u2014';
-        try { return new Date(iso).toLocaleString(); } catch (_) { return iso; }
+        // new Date() never throws — invalid strings produce a Date with NaN getTime().
+        // Check explicitly so corrupt timestamps render as em-dash, not "Invalid Date".
+        var d = new Date(iso);
+        if (isNaN(d.getTime())) return '\u2014';
+        return d.toLocaleString();
       }
       addField('Created', fmtDate(data.createdAt));
       addField('Last confirmed', fmtDate(data.lastConfirmedAt));
@@ -2448,7 +2479,7 @@ function createUiHtml(): string {
 
         var meta = document.createElement('div');
         meta.style.cssText = 'font-size: 0.75rem; color: var(--fg-muted);';
-        meta.textContent = node.type + ' \u00B7 ' + node.confidence.toFixed(2);
+        meta.textContent = node.type + ' \u00B7 ' + (node.confidence != null ? node.confidence.toFixed(2) : '\u2014');
 
         card.append(label, meta);
         card.addEventListener('click', function() { loadNeighborhood(node.id); });

--- a/src/memory/knowledge-graph.upsert.test.ts
+++ b/src/memory/knowledge-graph.upsert.test.ts
@@ -125,3 +125,28 @@ describe('KnowledgeGraphStore.upsertNode', () => {
     expect(c2).toBe(true); // fact nodes are always new inserts, not upserts
   });
 });
+
+describe('KnowledgeGraphStore sensitivity defaults', () => {
+  it('defaults sensitivity to internal when not specified on createNode', async () => {
+    const store = makeStore();
+    const node = await store.createNode({
+      type: 'fact',
+      label: 'quarterly target',
+      properties: {},
+      source: 'test',
+    });
+    expect(node.sensitivity).toBe('internal');
+  });
+
+  it('preserves explicit sensitivity when provided', async () => {
+    const store = makeStore();
+    const node = await store.createNode({
+      type: 'fact',
+      label: 'board minutes',
+      properties: {},
+      source: 'test',
+      sensitivity: 'restricted',
+    });
+    expect(node.sensitivity).toBe('restricted');
+  });
+});

--- a/src/memory/sensitivity.test.ts
+++ b/src/memory/sensitivity.test.ts
@@ -1,0 +1,43 @@
+// src/memory/sensitivity.test.ts
+import { describe, it, expect } from 'vitest';
+import { SensitivityClassifier } from './sensitivity.js';
+
+describe('SensitivityClassifier', () => {
+  it('classifies financial content as confidential based on keyword rule', () => {
+    const classifier = SensitivityClassifier.fromRules([
+      { category: 'financial', sensitivity: 'confidential', patterns: ['revenue'] },
+    ]);
+    expect(classifier.classify('Q3 revenue forecast', {})).toBe('confidential');
+  });
+
+  it('defaults to internal when no rule matches', () => {
+    const classifier = SensitivityClassifier.fromRules([
+      { category: 'financial', sensitivity: 'confidential', patterns: ['revenue'] },
+    ]);
+    expect(classifier.classify('team standup notes', {})).toBe('internal');
+  });
+
+  it('matches keywords in property values, not just the label', () => {
+    const classifier = SensitivityClassifier.fromRules([
+      { category: 'financial', sensitivity: 'confidential', patterns: ['salary'] },
+    ]);
+    expect(classifier.classify('employee record', { details: 'salary adjustment' })).toBe('confidential');
+  });
+
+  it('category hint bypasses keyword scanning', () => {
+    const classifier = SensitivityClassifier.fromRules([
+      { category: 'hr', sensitivity: 'confidential', patterns: ['performance'] },
+    ]);
+    // Label doesn't contain 'performance' but the category hint matches
+    expect(classifier.classify('annual review', {}, 'hr')).toBe('confidential');
+  });
+
+  it('most restrictive rule wins when multiple patterns match', () => {
+    const classifier = SensitivityClassifier.fromRules([
+      { category: 'financial', sensitivity: 'confidential', patterns: ['revenue'] },
+      { category: 'board', sensitivity: 'restricted', patterns: ['board'] },
+    ]);
+    // Both match — restricted wins
+    expect(classifier.classify('board revenue discussion', {})).toBe('restricted');
+  });
+});


### PR DESCRIPTION
## Summary

- Exposes `sensitivity` and `properties` from `/api/kg/nodes` and `/api/kg/graph` (both were in the DB but dropped from the API response)
- Adds a right-side **node detail drawer** that opens when a node is tapped — shows label, type badge, sensitivity badge, confidence, decay class, source, timestamps, and a properties table
- Adds a **Color by** toolbar above the graph canvas with three modes: **Type** (default), **Sensitivity**, and **Decay class** — hot-swapped via per-element style overrides, no layout disruption
- Replaces type-based fixed node sizes with **degree-based sizing** (`mapData(degree, 0, 15, 20, 52)`) — structural hubs are visually larger
- Replaces decay-class opacity levels with **confidence-based opacity** (`mapData(confidence, 0, 1, 0.15, 1.0)`)
- Adds 7 unit tests: 5 for `SensitivityClassifier` keyword/category/precedence behaviour, 2 for `KnowledgeGraphStore` sensitivity defaults

Closes #350.

## Test plan

- [ ] `npm test` — all tests pass
- [ ] Open KG explorer; verify color-by toolbar appears above the canvas with Type/Sensitivity/Decay buttons
- [ ] Click **Sensitivity** — nodes change colour; click **Decay** — nodes change colour; click **Type** — restores type palette
- [ ] Tap a node — detail drawer opens on the right; canvas shrinks; all fields populate correctly
- [ ] Tap a second node while drawer is open — content updates in place without closing
- [ ] Click × — drawer closes, canvas expands back
- [ ] Verify node sizes vary by connection count (hubs are larger, isolated nodes are smaller)
- [ ] Verify opacity varies by confidence (low-confidence nodes are semi-transparent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Knowledge Graph explorer now includes a node detail drawer displaying comprehensive node information
  * Added "Colour by" toggle to visualize nodes by Type, Sensitivity, or Decay class
  * Node sizing now dynamically derives from node degree; node opacity reflects confidence levels
  * API endpoints now include sensitivity and properties data in Knowledge Graph node responses

* **Tests**
  * Added unit test coverage for sensitivity classification logic
  * Added unit test coverage for Knowledge Graph node sensitivity defaults

* **Chores**
  * Version bumped to 0.20.1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->