### PR TITLE
feat: memory-store skill — explicit agent-driven KG fact writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **`memory-store` skill** — general-purpose KG fact write path: agents can now explicitly store a named attribute fact about a known entity with full control over confidence, decay class, and sensitivity. Resolves entity by label or node ID; returns one of four outcomes (`created`, `updated`, `conflict`, `rejected`) so the agent can surface contradictions to the CEO before proceeding (closes spec §03, #297)
+- **`StoreFactResult.action`** — `storeFact()` now returns the pipeline outcome (`created | updated | conflict | rejected`) alongside `stored`; attribute-based facts now route through contradiction detection automatically
+- **`StoreFactResult.existingNodeId`** — populated when a fact write produces a `conflict`, letting callers surface the contradicting node to the CEO
+
 - **KG explorer: sensitivity visualization** — node detail drawer (tap any node to inspect all attributes), color-by toggle (Type / Sensitivity / Decay class), degree-based node sizing, and confidence-based opacity (#350)
 - **KG API: `sensitivity` and `properties` fields** — `/api/kg/nodes` and `/api/kg/graph` now return both fields on every node response (#350)
 - **`SensitivityClassifier` unit tests** — 5 tests covering keyword matching, property-value matching, category hint bypass, and most-restrictive-wins behaviour (#350)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/memory-store/handler.test.ts
+++ b/skills/memory-store/handler.test.ts
@@ -1,0 +1,296 @@
+// handler.test.ts — memory-store skill unit tests.
+//
+// Uses real EntityMemory (backed by in-memory KG store) for entity resolution
+// and the full created/conflict pipeline. Uses a mock entityMemory stub for
+// the updated and rejected outcomes, which require state that is hard to
+// construct reliably with the in-memory backend.
+
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { createSilentLogger } from '../../src/logger.js';
+import { MemoryStoreHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+function makeEntityMemory() {
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  return { mem: new EntityMemory(store, validator, embeddingService, createSilentLogger()), store };
+}
+
+function makeCtx(entityMemory: EntityMemory | undefined, input: Record<string, unknown>): SkillContext {
+  return {
+    input,
+    secret: () => 'test-key',
+    log: pino({ level: 'silent' }),
+    entityMemory,
+  } as unknown as SkillContext;
+}
+
+const VALID_INPUT = {
+  entity: 'Jane Doe',
+  field: 'preferred_airline',
+  value: 'Air Canada',
+  source: 'agent:coordinator/task:test123',
+};
+
+describe('MemoryStoreHandler', () => {
+  const handler = new MemoryStoreHandler();
+
+  // ── Input validation ──────────────────────────────────────────────────────
+
+  describe('input validation', () => {
+    it('rejects missing entity', async () => {
+      const { mem } = makeEntityMemory();
+      const result = await handler.execute(makeCtx(mem, { field: 'role', value: 'CEO', source: 's' }));
+      expect(result.success).toBe(false);
+      expect((result as { success: false; error: string }).error).toMatch(/entity/i);
+    });
+
+    it('rejects missing field', async () => {
+      const { mem } = makeEntityMemory();
+      const result = await handler.execute(makeCtx(mem, { entity: 'Jane', value: 'CEO', source: 's' }));
+      expect(result.success).toBe(false);
+      expect((result as { success: false; error: string }).error).toMatch(/field/i);
+    });
+
+    it('rejects missing value', async () => {
+      const { mem } = makeEntityMemory();
+      const result = await handler.execute(makeCtx(mem, { entity: 'Jane', field: 'role', source: 's' }));
+      expect(result.success).toBe(false);
+      expect((result as { success: false; error: string }).error).toMatch(/value/i);
+    });
+
+    it('rejects missing source', async () => {
+      const { mem } = makeEntityMemory();
+      const result = await handler.execute(makeCtx(mem, { entity: 'Jane', field: 'role', value: 'CEO' }));
+      expect(result.success).toBe(false);
+      expect((result as { success: false; error: string }).error).toMatch(/source/i);
+    });
+
+    it('rejects confidence out of range', async () => {
+      const { mem } = makeEntityMemory();
+      const result = await handler.execute(makeCtx(mem, { ...VALID_INPUT, confidence: 1.5 }));
+      expect(result.success).toBe(false);
+      expect((result as { success: false; error: string }).error).toMatch(/confidence/i);
+    });
+
+    it('rejects an unknown decay_class', async () => {
+      const { mem } = makeEntityMemory();
+      const result = await handler.execute(makeCtx(mem, { ...VALID_INPUT, decay_class: 'eternal' }));
+      expect(result.success).toBe(false);
+      expect((result as { success: false; error: string }).error).toMatch(/decay_class/i);
+    });
+
+    it('rejects an unknown sensitivity value', async () => {
+      const { mem } = makeEntityMemory();
+      const result = await handler.execute(makeCtx(mem, { ...VALID_INPUT, sensitivity: 'top_secret' }));
+      expect(result.success).toBe(false);
+      expect((result as { success: false; error: string }).error).toMatch(/sensitivity/i);
+    });
+
+    it('rejects when entityMemory is not available', async () => {
+      const result = await handler.execute(makeCtx(undefined, VALID_INPUT));
+      expect(result.success).toBe(false);
+      expect((result as { success: false; error: string }).error).toMatch(/entity memory not available/i);
+    });
+  });
+
+  // ── Entity resolution ─────────────────────────────────────────────────────
+
+  describe('entity resolution', () => {
+    it('returns rejected when entity label is not found', async () => {
+      const { mem } = makeEntityMemory();
+      const result = await handler.execute(makeCtx(mem, VALID_INPUT));
+
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.stored).toBe(false);
+      expect(data.action).toBe('rejected');
+      expect(String(data.reason)).toMatch(/not found/i);
+    });
+
+    it('resolves entity by direct node ID when label lookup finds nothing', async () => {
+      const { mem } = makeEntityMemory();
+      const { entity } = await mem.createEntity({ type: 'person', label: 'Jane Doe', properties: {}, source: 'test' });
+
+      // Pass the UUID directly instead of the label
+      const result = await handler.execute(makeCtx(mem, { ...VALID_INPUT, entity: entity.id }));
+
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.stored).toBe(true);
+      expect(data.action).toBe('created');
+    });
+
+    it('returns ambiguous when multiple nodes share the same label', async () => {
+      // KG upsert prevents duplicates via createEntity — insert a second node
+      // directly through the store to simulate pre-migration duplicates.
+      const { mem, store } = makeEntityMemory();
+      await mem.createEntity({ type: 'person', label: 'Jane Doe', properties: {}, source: 'test' });
+      await store.createNode({ type: 'person', label: 'Jane Doe', properties: {}, source: 'test' });
+
+      const result = await handler.execute(makeCtx(mem, VALID_INPUT));
+
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: { ambiguous: boolean; candidates: unknown[] } }).data;
+      expect(data.ambiguous).toBe(true);
+      expect(data.candidates).toHaveLength(2);
+    });
+  });
+
+  // ── Successful fact storage ───────────────────────────────────────────────
+
+  describe('action: created', () => {
+    it('stores a new fact and returns created with node_id and sensitivity', async () => {
+      const { mem } = makeEntityMemory();
+      await mem.createEntity({ type: 'person', label: 'Jane Doe', properties: {}, source: 'test' });
+
+      const result = await handler.execute(makeCtx(mem, VALID_INPUT));
+
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.stored).toBe(true);
+      expect(data.action).toBe('created');
+      expect(typeof data.node_id).toBe('string');
+      // Sensitivity defaults to 'internal' without a classifier configured
+      expect(data.sensitivity).toBe('internal');
+    });
+
+    it('accepts all optional inputs and passes them through', async () => {
+      const { mem } = makeEntityMemory();
+      await mem.createEntity({ type: 'person', label: 'Jane Doe', properties: {}, source: 'test' });
+
+      const result = await handler.execute(makeCtx(mem, {
+        ...VALID_INPUT,
+        confidence: 0.95,
+        decay_class: 'permanent',
+        sensitivity: 'confidential',
+        sensitivity_category: 'financial',
+      }));
+
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.stored).toBe(true);
+      expect(data.action).toBe('created');
+      // Explicit sensitivity should be honoured
+      expect(data.sensitivity).toBe('confidential');
+    });
+  });
+
+  describe('action: conflict', () => {
+    it('returns conflict with reason and existing_node_id when facts contradict', async () => {
+      const { mem } = makeEntityMemory();
+      await mem.createEntity({ type: 'person', label: 'Jane Doe', properties: {}, source: 'test' });
+
+      // Store initial fact
+      await handler.execute(makeCtx(mem, {
+        ...VALID_INPUT,
+        field: 'home_city',
+        value: 'Toronto',
+      }));
+
+      // Store contradicting fact for same attribute
+      const result = await handler.execute(makeCtx(mem, {
+        ...VALID_INPUT,
+        field: 'home_city',
+        value: 'Montreal',
+      }));
+
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.stored).toBe(false);
+      expect(data.action).toBe('conflict');
+      expect(typeof data.reason).toBe('string');
+      // existing_node_id lets the caller surface the contradicting node to the CEO
+      expect(typeof data.existing_node_id).toBe('string');
+    });
+  });
+
+  // ── Mocked entityMemory for updated / rejected outcomes ───────────────────
+
+  describe('action: updated', () => {
+    it('returns updated with node_id and sensitivity when storeFact detects a near-duplicate', async () => {
+      const mockEntityMemory = {
+        findEntities: vi.fn().mockResolvedValue([{ id: 'entity-1', label: 'Jane Doe', type: 'person' }]),
+        getEntity: vi.fn(),
+        storeFact: vi.fn().mockResolvedValue({
+          stored: true,
+          action: 'updated',
+          nodeId: 'fact-existing-42',
+          sensitivity: 'internal',
+        }),
+      };
+      const ctx = {
+        input: VALID_INPUT,
+        secret: () => 'test-key',
+        log: pino({ level: 'silent' }),
+        entityMemory: mockEntityMemory,
+      } as unknown as SkillContext;
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.stored).toBe(true);
+      expect(data.action).toBe('updated');
+      expect(data.node_id).toBe('fact-existing-42');
+      expect(data.sensitivity).toBe('internal');
+    });
+  });
+
+  describe('action: rejected', () => {
+    it('returns rejected with reason when storeFact reports rate-limit or entity-gone', async () => {
+      const mockEntityMemory = {
+        findEntities: vi.fn().mockResolvedValue([{ id: 'entity-1', label: 'Jane Doe', type: 'person' }]),
+        getEntity: vi.fn(),
+        storeFact: vi.fn().mockResolvedValue({
+          stored: false,
+          action: 'rejected',
+          conflict: 'Memory write rate limit exceeded (50 per agent per task)',
+        }),
+      };
+      const ctx = {
+        input: VALID_INPUT,
+        secret: () => 'test-key',
+        log: pino({ level: 'silent' }),
+        entityMemory: mockEntityMemory,
+      } as unknown as SkillContext;
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.stored).toBe(false);
+      expect(data.action).toBe('rejected');
+      expect(String(data.reason)).toMatch(/rate limit/i);
+    });
+  });
+
+  // ── Infrastructure error handling ─────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('returns success:false when storeFact throws unexpectedly', async () => {
+      const mockEntityMemory = {
+        findEntities: vi.fn().mockResolvedValue([{ id: 'entity-1', label: 'Jane Doe', type: 'person' }]),
+        getEntity: vi.fn(),
+        storeFact: vi.fn().mockRejectedValue(new Error('DB connection lost')),
+      };
+      const ctx = {
+        input: VALID_INPUT,
+        secret: () => 'test-key',
+        log: pino({ level: 'silent' }),
+        entityMemory: mockEntityMemory,
+      } as unknown as SkillContext;
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(false);
+      expect((result as { success: false; error: string }).error).toContain('DB connection lost');
+    });
+  });
+});

--- a/skills/memory-store/handler.ts
+++ b/skills/memory-store/handler.ts
@@ -1,0 +1,213 @@
+// handler.ts — memory-store skill.
+//
+// Writes a named fact about a known entity to the knowledge graph.
+// Resolves the entity by label or direct node ID, then delegates to
+// EntityMemory.storeFact() which runs the full validation pipeline
+// (rate limit → contradiction detection → dedup → persist).
+//
+// Possible outcomes:
+//   created   — new fact node created and linked to the entity
+//   updated   — near-duplicate found; existing node merged in place
+//   conflict  — contradicts an existing attribute fact; agent should surface to CEO
+//   rejected  — rate limit exceeded or entity node no longer exists
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { DECAY_CLASSES, SENSITIVITY_LEVELS } from '../../src/memory/types.js';
+import type { DecayClass, Sensitivity } from '../../src/memory/types.js';
+
+const DECAY_CLASSES_SET: ReadonlySet<string> = new Set(DECAY_CLASSES);
+const SENSITIVITY_LEVELS_SET: ReadonlySet<string> = new Set(SENSITIVITY_LEVELS);
+
+export class MemoryStoreHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const {
+      entity,
+      field,
+      value,
+      source,
+      confidence,
+      decay_class,
+      sensitivity,
+      sensitivity_category,
+    } = ctx.input as {
+      entity?: string;
+      field?: string;
+      value?: string;
+      source?: string;
+      confidence?: number;
+      decay_class?: string;
+      sensitivity?: string;
+      sensitivity_category?: string;
+    };
+
+    // --- Input validation ---
+
+    if (!entity || typeof entity !== 'string') {
+      return { success: false, error: 'Missing required input: entity (string)' };
+    }
+    if (!field || typeof field !== 'string') {
+      return { success: false, error: 'Missing required input: field (string)' };
+    }
+    if (value === undefined || value === null || typeof value !== 'string') {
+      return { success: false, error: 'Missing required input: value (string)' };
+    }
+    if (!source || typeof source !== 'string') {
+      return { success: false, error: 'Missing required input: source (string)' };
+    }
+
+    if (confidence !== undefined) {
+      if (typeof confidence !== 'number' || confidence < 0 || confidence > 1) {
+        return { success: false, error: 'confidence must be a number between 0 and 1' };
+      }
+    }
+
+    if (decay_class !== undefined && !DECAY_CLASSES_SET.has(decay_class)) {
+      return {
+        success: false,
+        error: `Unknown decay_class: "${decay_class}". Valid values: ${DECAY_CLASSES.join(', ')}`,
+      };
+    }
+
+    if (sensitivity !== undefined && !SENSITIVITY_LEVELS_SET.has(sensitivity)) {
+      return {
+        success: false,
+        error: `Unknown sensitivity: "${sensitivity}". Valid values: ${SENSITIVITY_LEVELS.join(', ')}`,
+      };
+    }
+
+    if (!ctx.entityMemory) {
+      ctx.log.error('memory-store: entity memory not available');
+      return { success: false, error: 'Entity memory not available — database not configured' };
+    }
+
+    try {
+      // --- Entity resolution ---
+      //
+      // Try label-based lookup first (case-insensitive). If nothing is found,
+      // fall back to a direct ID lookup — this allows callers to pass either
+      // a human-readable name or a UUID obtained from a previous KG query.
+
+      let entityNode = await resolveEntity(ctx, entity);
+
+      if (entityNode === 'ambiguous') {
+        // Multiple nodes share the same label — caller must disambiguate.
+        const matches = await ctx.entityMemory.findEntities(entity);
+        ctx.log.debug({ entity, count: matches.length }, 'memory-store: ambiguous entity label');
+        return {
+          success: true,
+          data: {
+            ambiguous: true,
+            candidates: matches.map(n => ({ id: n.id, label: n.label, type: n.type })),
+          },
+        };
+      }
+
+      if (entityNode === 'not_found') {
+        ctx.log.debug({ entity }, 'memory-store: entity not found in KG');
+        return {
+          success: true,
+          data: {
+            stored: false,
+            action: 'rejected',
+            reason: `Entity not found in knowledge graph: "${entity}". Create the entity first or check the spelling.`,
+          },
+        };
+      }
+
+      // --- Fact storage ---
+      //
+      // Label format "<field>: <value>" is the canonical convention used by
+      // extract-facts and other skills — human-readable and dedup-stable.
+      // Properties carry the structured attribute + value so that
+      // validateContradiction() can detect same-field conflicts.
+      const label = `${field}: ${value}`;
+
+      const result = await ctx.entityMemory.storeFact({
+        entityNodeId: entityNode.id,
+        label,
+        properties: { attribute: field, value },
+        confidence: confidence ?? 0.8,
+        decayClass: (decay_class as DecayClass | undefined) ?? 'slow_decay',
+        source,
+        sensitivity: sensitivity as Sensitivity | undefined,
+        sensitivityCategory: sensitivity_category,
+      });
+
+      if (result.stored) {
+        ctx.log.info(
+          { entity, field, action: result.action, nodeId: result.nodeId },
+          'memory-store: fact stored',
+        );
+        return {
+          success: true,
+          data: {
+            stored: true,
+            action: result.action,
+            node_id: result.nodeId,
+            sensitivity: result.sensitivity,
+          },
+        };
+      }
+
+      // stored === false: conflict or rejected
+      if (result.action === 'conflict') {
+        ctx.log.warn(
+          { entity, field, existingNodeId: result.existingNodeId },
+          'memory-store: fact conflicts with existing KG data — surfacing to agent',
+        );
+        return {
+          success: true,
+          data: {
+            stored: false,
+            action: 'conflict',
+            reason: result.conflict,
+            existing_node_id: result.existingNodeId,
+          },
+        };
+      }
+
+      // action === 'rejected' (rate limit or entity node no longer exists)
+      ctx.log.warn({ entity, field, reason: result.conflict }, 'memory-store: fact rejected');
+      return {
+        success: true,
+        data: {
+          stored: false,
+          action: 'rejected',
+          reason: result.conflict,
+        },
+      };
+    } catch (err) {
+      ctx.log.error({ err, entity, field }, 'memory-store: unexpected error');
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}
+
+// -- Helpers --
+
+/** Resolve an entity by label or direct ID.
+ *
+ * Returns:
+ *   - A KgNode when exactly one match is found (by label or ID)
+ *   - 'ambiguous' when multiple nodes share the same label
+ *   - 'not_found' when no match is found by either method
+ */
+async function resolveEntity(
+  ctx: SkillContext,
+  entity: string,
+): Promise<import('../../src/memory/types.js').KgNode | 'ambiguous' | 'not_found'> {
+  const mem = ctx.entityMemory!;
+
+  const matches = await mem.findEntities(entity);
+
+  if (matches.length === 1) return matches[0]!;
+  if (matches.length > 1) return 'ambiguous';
+
+  // Zero label matches — try interpreting `entity` as a direct node ID.
+  // This handles callers that have a UUID from a previous KG query and
+  // want to attach a fact without doing another findEntities round-trip.
+  const byId = await mem.getEntity(entity);
+  if (byId) return byId;
+
+  return 'not_found';
+}

--- a/skills/memory-store/handler.ts
+++ b/skills/memory-store/handler.ts
@@ -87,22 +87,23 @@ export class MemoryStoreHandler implements SkillHandler {
       // fall back to a direct ID lookup — this allows callers to pass either
       // a human-readable name or a UUID obtained from a previous KG query.
 
-      let entityNode = await resolveEntity(ctx, entity);
+      const resolved = await resolveEntity(ctx, entity);
 
-      if (entityNode === 'ambiguous') {
+      if (resolved.kind === 'ambiguous') {
         // Multiple nodes share the same label — caller must disambiguate.
-        const matches = await ctx.entityMemory.findEntities(entity);
-        ctx.log.debug({ entity, count: matches.length }, 'memory-store: ambiguous entity label');
+        // We reuse the candidates already fetched by resolveEntity rather than
+        // calling findEntities a second time (avoids a race window and extra DB round-trip).
+        ctx.log.debug({ entity, count: resolved.candidates.length }, 'memory-store: ambiguous entity label');
         return {
           success: true,
           data: {
             ambiguous: true,
-            candidates: matches.map(n => ({ id: n.id, label: n.label, type: n.type })),
+            candidates: resolved.candidates.map(n => ({ id: n.id, label: n.label, type: n.type })),
           },
         };
       }
 
-      if (entityNode === 'not_found') {
+      if (resolved.kind === 'not_found') {
         ctx.log.debug({ entity }, 'memory-store: entity not found in KG');
         return {
           success: true,
@@ -113,6 +114,8 @@ export class MemoryStoreHandler implements SkillHandler {
           },
         };
       }
+
+      const entityNode = resolved.node;
 
       // --- Fact storage ---
       //
@@ -134,6 +137,15 @@ export class MemoryStoreHandler implements SkillHandler {
       });
 
       if (result.stored) {
+        // The execution-layer observer logs sensitivityFallback via the audit event,
+        // but if this handler is called outside that observer (e.g. in a direct test or
+        // future CLI integration), the fallback would otherwise be silent. Log defensively.
+        if (result.sensitivityFallback) {
+          ctx.log.warn(
+            { entity, field, nodeId: result.nodeId, sensitivity: result.sensitivity },
+            'memory-store: sensitivity in result may be inaccurate — stored node was unreadable after update (race/transient DB error)',
+          );
+        }
         ctx.log.info(
           { entity, field, action: result.action, nodeId: result.nodeId },
           'memory-store: fact stored',
@@ -185,29 +197,33 @@ export class MemoryStoreHandler implements SkillHandler {
 
 // -- Helpers --
 
+type KgNode = import('../../src/memory/types.js').KgNode;
+
+/** Discriminated result from entity resolution. */
+type ResolveResult =
+  | { kind: 'found'; node: KgNode }
+  | { kind: 'ambiguous'; candidates: KgNode[] }
+  | { kind: 'not_found' };
+
 /** Resolve an entity by label or direct ID.
  *
- * Returns:
- *   - A KgNode when exactly one match is found (by label or ID)
- *   - 'ambiguous' when multiple nodes share the same label
- *   - 'not_found' when no match is found by either method
+ * Returns candidates directly in the ambiguous case so the handler can build
+ * the response without a second findEntities call, which would introduce a
+ * race window and duplicate DB work.
  */
-async function resolveEntity(
-  ctx: SkillContext,
-  entity: string,
-): Promise<import('../../src/memory/types.js').KgNode | 'ambiguous' | 'not_found'> {
+async function resolveEntity(ctx: SkillContext, entity: string): Promise<ResolveResult> {
   const mem = ctx.entityMemory!;
 
   const matches = await mem.findEntities(entity);
 
-  if (matches.length === 1) return matches[0]!;
-  if (matches.length > 1) return 'ambiguous';
+  if (matches.length === 1) return { kind: 'found', node: matches[0]! };
+  if (matches.length > 1) return { kind: 'ambiguous', candidates: matches };
 
   // Zero label matches — try interpreting `entity` as a direct node ID.
   // This handles callers that have a UUID from a previous KG query and
   // want to attach a fact without doing another findEntities round-trip.
   const byId = await mem.getEntity(entity);
-  if (byId) return byId;
+  if (byId) return { kind: 'found', node: byId };
 
-  return 'not_found';
+  return { kind: 'not_found' };
 }

--- a/skills/memory-store/skill.json
+++ b/skills/memory-store/skill.json
@@ -1,0 +1,33 @@
+{
+  "name": "memory-store",
+  "description": "Write a named fact about a known entity to the knowledge graph. Resolves the entity by name or node ID. Returns one of four outcomes: created (new fact node), updated (near-duplicate merged), conflict (contradicts an existing attribute fact — surface to CEO before proceeding), or rejected (rate limit exceeded or entity not found). When multiple entities share the same name, returns an ambiguous response with candidates for disambiguation.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "entity": "string (the entity name or knowledge-graph node ID to attach the fact to, e.g. 'Jane Doe' or 'uuid-...')",
+    "field": "string (the attribute name, e.g. 'preferred_airline' or 'current_role')",
+    "value": "string (the value to store, e.g. 'Air Canada' or 'VP of Engineering')",
+    "source": "string (provenance string, e.g. 'agent:coordinator/task:abc123/channel:cli')",
+    "confidence": "number? (confidence score 0–1, defaults to 0.8)",
+    "decay_class": "string? (one of: permanent, slow_decay, fast_decay; defaults to slow_decay)",
+    "sensitivity": "string? (one of: public, internal, confidential, restricted; when omitted the engine auto-classifies from content and defaults to internal)",
+    "sensitivity_category": "string? (optional category hint for the auto-classifier, e.g. 'financial'; only used when sensitivity is omitted)"
+  },
+  "outputs": {
+    "stored": "boolean — true when the fact was persisted (created or updated)",
+    "action": "string — one of: created, updated, conflict, rejected",
+    "node_id": "string — ID of the persisted or existing fact node (present when stored is true)",
+    "sensitivity": "string — the sensitivity level actually assigned to the node (present when stored is true)",
+    "reason": "string — human-readable explanation when action is conflict or rejected",
+    "existing_node_id": "string — ID of the contradicting fact node (present when action is conflict)",
+    "ambiguous": "boolean — true when multiple entities matched the given name",
+    "candidates": "array of {id, label, type} — populated when ambiguous is true"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": [
+    "entityMemory"
+  ]
+}

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -45,6 +45,9 @@ export interface CreateEntityOptions {
 
 export interface StoreFactResult {
   stored: boolean;
+  /** The pipeline outcome — lets callers distinguish create/update from conflict/rejected
+   *  and take action accordingly (e.g. surfacing a conflict to the CEO). */
+  action: 'created' | 'updated' | 'conflict' | 'rejected';
   /** The ID of the persisted (or existing) fact node, if stored is true. */
   nodeId?: string;
   /** The sensitivity level that was assigned to the node (for audit event emission). */
@@ -56,6 +59,10 @@ export interface StoreFactResult {
   sensitivityFallback?: boolean;
   /** Human-readable reason for a conflict or rate-limit rejection. */
   conflict?: string;
+  /** The ID of the existing fact node that conflicts with the incoming fact.
+   *  Populated only when action === 'conflict' — lets the caller surface the
+   *  conflict to the CEO along with the contradicting node's details. */
+  existingNodeId?: string;
 }
 
 export interface QueryResult {
@@ -250,7 +257,20 @@ export class EntityMemory {
    * they have attribute metadata and a confidence value to compare against.
    */
   async storeFact(options: StoreFactOptions): Promise<StoreFactResult> {
-    const result = await this.validator.validate(options);
+    // Use contradiction detection when the fact carries `attribute` metadata,
+    // since an attribute-based fact can directly contradict an existing one
+    // (same entity, same attribute, different value). For facts without attribute
+    // metadata, fall back to plain dedup + rate-limit validation.
+    const hasAttribute = (options.properties as Record<string, unknown> | undefined)?.attribute !== undefined;
+    const result = hasAttribute
+      ? await this.validator.validateContradiction({
+          ...options,
+          // validateContradiction requires a concrete confidence value for its
+          // conflict reason message; use the caller's value or the same default
+          // that storeFact would apply when persisting the node.
+          confidence: options.confidence ?? 0.7,
+        })
+      : await this.validator.validate(options);
 
     switch (result.action) {
       case 'create': {
@@ -308,7 +328,7 @@ export class EntityMemory {
         }
 
         this.validator.recordWrite(options.source);
-        return { stored: true, nodeId: persistedNode.id, sensitivity };
+        return { stored: true, action: 'created', nodeId: persistedNode.id, sensitivity };
       }
 
       case 'update': {
@@ -342,14 +362,19 @@ export class EntityMemory {
           await this.store.updateNode(result.existingNodeId, { sensitivity });
         }
 
-        return { stored: true, nodeId: result.existingNodeId, sensitivity, sensitivityFallback };
+        return { stored: true, action: 'updated', nodeId: result.existingNodeId, sensitivity, sensitivityFallback };
       }
 
       case 'conflict':
-        return { stored: false, conflict: result.reason };
+        return {
+          stored: false,
+          action: 'conflict',
+          conflict: result.reason,
+          existingNodeId: result.existingNodeId,
+        };
 
       case 'rejected':
-        return { stored: false, conflict: result.reason };
+        return { stored: false, action: 'rejected', conflict: result.reason };
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #297.

- **`skills/memory-store/`** — new skill with `skill.json`, `handler.ts`, and 17 tests in `handler.test.ts`
- **`EntityMemory.storeFact()` refinements** — attribute-based facts now automatically route through `validateContradiction()` (previously only `validate()` was called, so same-field contradictions were silently missed); `StoreFactResult` gains `action: 'created' | 'updated' | 'conflict' | 'rejected'` and `existingNodeId` (for the conflict case)

### Skill behaviour

Agents write a named attribute fact about a known entity. The skill:

1. Resolves entity by label (case-insensitive) or direct node ID
2. Returns `{ ambiguous: true, candidates }` when multiple nodes share the label
3. Returns `{ stored: false, action: 'rejected' }` when no entity is found
4. Calls `storeFact()` and maps all four outcomes to distinct response shapes:
   - `created` — new fact node, returns `node_id` + `sensitivity`
   - `updated` — near-duplicate merged in place, same fields
   - `conflict` — contradicting attribute fact, returns `reason` + `existing_node_id` for CEO escalation
   - `rejected` — rate limit or entity no longer exists, returns `reason`

### Pre-existing issues flagged (not touched, scope discipline)

- `mergeEntities` discards `storeFact` return values in its loop — facts can be silently lost during an entity merge if the rate limiter fires
- `validateContradiction` delegates to `validate()` after finding no contradiction, causing a double edge-walk
- `recordWrite` is called before `getNode` in the update branch — a throw inflates the rate-limit counter

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (1520 tests, 17 new)
- [ ] Skill loads correctly at startup (skill registry smoke test covers this)
- [ ] Manual: call `memory-store` with a known entity name, verify `created` response
- [ ] Manual: call again with a different value for the same field, verify `conflict` response with `existing_node_id`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `memory-store` skill for storing named attribute facts about entities with configurable confidence, decay class, and sensitivity. Returns four action outcomes (created, updated, conflict, rejected) with enhanced conflict reporting for contradicting entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->