### PR TITLE
feat: memory-query skill — freeform semantic search over KG (spec §03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`memory-store` skill** — general-purpose KG fact write path: agents can now explicitly store a named attribute fact about a known entity with full control over confidence, decay class, and sensitivity. Resolves entity by label or node ID; returns one of four outcomes (`created`, `updated`, `conflict`, `rejected`) so the agent can surface contradictions to the CEO before proceeding (closes spec §03, #297)
 - **`StoreFactResult.action`** — `storeFact()` now returns the pipeline outcome (`created | updated | conflict | rejected`) alongside `stored`; attribute-based facts now route through contradiction detection automatically
 - **`StoreFactResult.existingNodeId`** — populated when a fact write produces a `conflict`, letting callers surface the contradicting node to the CEO
+- **`memory-query` skill** — freeform semantic search over the knowledge graph via pgvector cosine similarity; supports optional `type`, `max_sensitivity` ceiling, and `limit` filters; returns `decay_class` and `sensitivity` on every result node (spec §03, #298)
+- **`semanticSearch` filter options** — `KnowledgeGraphStore.semanticSearch()`, `EntityMemory.search()`, and both backends now accept `type` and `maxSensitivity` filter options applied in-query before results are returned
 
 - **KG explorer: sensitivity visualization** — node detail drawer (tap any node to inspect all attributes), color-by toggle (Type / Sensitivity / Decay class), degree-based node sizing, and confidence-based opacity (#350)
 - **KG API: `sensitivity` and `properties` fields** — `/api/kg/nodes` and `/api/kg/graph` now return both fields on every node response (#350)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curia",
-  "version": "0.19.7",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "curia",
-      "version": "0.19.7",
+      "version": "0.21.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {

--- a/skills/memory-query/handler.test.ts
+++ b/skills/memory-query/handler.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import pino from 'pino';
+import { KnowledgeGraphStore } from '../../src/memory/knowledge-graph.js';
+import { EmbeddingService } from '../../src/memory/embedding.js';
+import { EntityMemory } from '../../src/memory/entity-memory.js';
+import { MemoryValidator } from '../../src/memory/validation.js';
+import { createSilentLogger } from '../../src/logger.js';
+import { MemoryQueryHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+function makeEntityMemory(): EntityMemory {
+  const embeddingService = EmbeddingService.createForTesting();
+  const store = KnowledgeGraphStore.createInMemory(embeddingService);
+  const validator = new MemoryValidator(store, embeddingService);
+  return new EntityMemory(store, validator, embeddingService, createSilentLogger());
+}
+
+function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {
+  return {
+    input,
+    secret: () => 'test-key',
+    log: pino({ level: 'silent' }),
+    entityMemory,
+  } as unknown as SkillContext;
+}
+
+describe('MemoryQueryHandler', () => {
+  it('returns empty results when KG is empty', async () => {
+    const mem = makeEntityMemory();
+    const handler = new MemoryQueryHandler();
+    const ctx = makeCtx(mem, { query: 'investor relations' });
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { results: [], count: 0 } });
+  });
+
+  it('returns error when query is missing', async () => {
+    const mem = makeEntityMemory();
+    const handler = new MemoryQueryHandler();
+    const ctx = makeCtx(mem, {});
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/missing required input: query/i);
+  });
+
+  it('returns error when entityMemory is not available', async () => {
+    const handler = new MemoryQueryHandler();
+    const ctx = {
+      input: { query: 'something' },
+      secret: () => 'test-key',
+      log: pino({ level: 'silent' }),
+      entityMemory: undefined,
+    } as unknown as SkillContext;
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/entity memory not available/i);
+  });
+
+  it('returns error for an unknown node type', async () => {
+    const mem = makeEntityMemory();
+    const handler = new MemoryQueryHandler();
+    const ctx = makeCtx(mem, { query: 'test', type: 'spaceship' });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/unknown node type/i);
+  });
+
+  it('returns error for an unknown sensitivity level', async () => {
+    const mem = makeEntityMemory();
+    const handler = new MemoryQueryHandler();
+    const ctx = makeCtx(mem, { query: 'test', max_sensitivity: 'topsecret' });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/unknown sensitivity level/i);
+  });
+
+  it('returns matched nodes with required output fields', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'person', label: 'Alice Investor', properties: {}, source: 'test' });
+
+    const handler = new MemoryQueryHandler();
+    const ctx = makeCtx(mem, { query: 'Alice Investor' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { results: Record<string, unknown>[]; count: number } }).data;
+    expect(data.count).toBeGreaterThan(0);
+
+    const node = data.results[0]!;
+    expect(node).toHaveProperty('id');
+    expect(node).toHaveProperty('type');
+    expect(node).toHaveProperty('label');
+    expect(node).toHaveProperty('properties');
+    expect(node).toHaveProperty('confidence');
+    expect(node).toHaveProperty('decay_class');
+    expect(node).toHaveProperty('sensitivity');
+    expect(node).toHaveProperty('last_confirmed_at');
+    expect(node).toHaveProperty('score');
+  });
+
+  it('filters results by type', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'organization', label: 'Alice Corp', properties: {}, source: 'test' });
+
+    const handler = new MemoryQueryHandler();
+    const ctx = makeCtx(mem, { query: 'Alice', type: 'organization' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { results: Array<{ type: string }> } }).data;
+    // Every returned node must be of the requested type
+    expect(data.results.every((n) => n.type === 'organization')).toBe(true);
+  });
+
+  it('filters results by max_sensitivity ceiling', async () => {
+    const mem = makeEntityMemory();
+    // Create one public and one restricted node
+    await mem.createEntity({ type: 'person', label: 'Public Person', properties: {}, source: 'test', sensitivity: 'public' });
+    await mem.createEntity({ type: 'person', label: 'Restricted Person', properties: {}, source: 'test', sensitivity: 'restricted' });
+
+    const handler = new MemoryQueryHandler();
+    // Ask for results with max_sensitivity: internal — should exclude restricted
+    const ctx = makeCtx(mem, { query: 'Person', max_sensitivity: 'internal' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { results: Array<{ sensitivity: string }> } }).data;
+    // No restricted nodes should appear
+    expect(data.results.every((n) => n.sensitivity !== 'restricted')).toBe(true);
+  });
+
+  it('caps limit at 50', async () => {
+    const mem = makeEntityMemory();
+    // Create a handful of nodes — enough to confirm capping logic without being slow
+    for (let i = 0; i < 5; i++) {
+      await mem.createEntity({ type: 'concept', label: `Concept ${i}`, properties: {}, source: 'test' });
+    }
+
+    const handler = new MemoryQueryHandler();
+    // Request more than 50 — should be silently capped
+    const ctx = makeCtx(mem, { query: 'Concept', limit: 999 });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    // With only 5 nodes the cap doesn't truncate, but the call itself must succeed
+    expect((result as { success: true; data: { count: number } }).data.count).toBeLessThanOrEqual(50);
+  });
+
+  it('returns results sorted by score descending', async () => {
+    const mem = makeEntityMemory();
+    await mem.createEntity({ type: 'concept', label: 'Board Meeting Agenda', properties: {}, source: 'test' });
+    await mem.createEntity({ type: 'person', label: 'Jane Smith', properties: {}, source: 'test' });
+
+    const handler = new MemoryQueryHandler();
+    const ctx = makeCtx(mem, { query: 'Board Meeting Agenda' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const nodes = (result as { success: true; data: { results: Array<{ score: number }> } }).data.results;
+    for (let i = 1; i < nodes.length; i++) {
+      expect(nodes[i - 1]!.score).toBeGreaterThanOrEqual(nodes[i]!.score);
+    }
+  });
+});

--- a/skills/memory-query/handler.ts
+++ b/skills/memory-query/handler.ts
@@ -35,7 +35,7 @@ export class MemoryQueryHandler implements SkillHandler {
     }
 
     if (!ctx.entityMemory) {
-      ctx.log.error('memory-query: entity memory not available');
+      ctx.log.error({ query }, 'memory-query: entity memory not available');
       return { success: false, error: 'Entity memory not available — database not configured' };
     }
 
@@ -53,7 +53,12 @@ export class MemoryQueryHandler implements SkillHandler {
       };
     }
 
-    // Cap limit at MAX_LIMIT; apply default when not provided
+    // Cap limit at MAX_LIMIT; apply default when not provided.
+    // Guard against NaN/Infinity: a non-finite value would reach the SQL LIMIT
+    // parameter and cause a driver error rather than a clear validation message.
+    if (limitInput !== undefined && !Number.isFinite(limitInput)) {
+      return { success: false, error: 'Invalid limit: must be a finite number' };
+    }
     const limit = limitInput !== undefined
       ? Math.min(Math.max(1, Math.floor(limitInput)), MAX_LIMIT)
       : DEFAULT_LIMIT;

--- a/skills/memory-query/handler.ts
+++ b/skills/memory-query/handler.ts
@@ -85,7 +85,7 @@ export class MemoryQueryHandler implements SkillHandler {
         // confidential/restricted facts must not be included in outbound messages
         // without explicit CEO approval.
         sensitivity: node.sensitivity,
-        last_confirmed_at: node.temporal.lastConfirmedAt,
+        last_confirmed_at: node.temporal.lastConfirmedAt.toISOString(),
         score,
       }));
 

--- a/skills/memory-query/handler.ts
+++ b/skills/memory-query/handler.ts
@@ -1,0 +1,94 @@
+// handler.ts — memory-query skill.
+//
+// Performs freeform semantic search over the knowledge graph. Embeds the
+// query string via text-embedding-3-small and returns the most similar nodes
+// by cosine similarity (highest score first).
+//
+// Supports three optional filters applied before the results are returned:
+//   - type          — restrict to a specific node type (person, fact, etc.)
+//   - max_sensitivity — restrict to nodes at or below a sensitivity ceiling
+//   - limit         — cap the number of results (default 10, max 50)
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { NODE_TYPES, SENSITIVITY_LEVELS } from '../../src/memory/types.js';
+import type { NodeType, Sensitivity } from '../../src/memory/types.js';
+
+const MAX_LIMIT = 50;
+const DEFAULT_LIMIT = 10;
+
+const NODE_TYPES_SET: ReadonlySet<string> = new Set(NODE_TYPES);
+const SENSITIVITY_LEVELS_SET: ReadonlySet<string> = new Set(SENSITIVITY_LEVELS);
+
+export class MemoryQueryHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { query, type, limit: limitInput, max_sensitivity } = ctx.input as {
+      query?: string;
+      type?: string;
+      limit?: number;
+      max_sensitivity?: string;
+    };
+
+    // -- Input validation --
+
+    if (!query || typeof query !== 'string') {
+      return { success: false, error: 'Missing required input: query (string)' };
+    }
+
+    if (!ctx.entityMemory) {
+      ctx.log.error('memory-query: entity memory not available');
+      return { success: false, error: 'Entity memory not available — database not configured' };
+    }
+
+    if (type !== undefined && !NODE_TYPES_SET.has(type)) {
+      return {
+        success: false,
+        error: `Unknown node type: "${type}". Valid types: ${NODE_TYPES.join(', ')}`,
+      };
+    }
+
+    if (max_sensitivity !== undefined && !SENSITIVITY_LEVELS_SET.has(max_sensitivity)) {
+      return {
+        success: false,
+        error: `Unknown sensitivity level: "${max_sensitivity}". Valid levels: ${SENSITIVITY_LEVELS.join(', ')}`,
+      };
+    }
+
+    // Cap limit at MAX_LIMIT; apply default when not provided
+    const limit = limitInput !== undefined
+      ? Math.min(Math.max(1, Math.floor(limitInput)), MAX_LIMIT)
+      : DEFAULT_LIMIT;
+
+    try {
+      const results = await ctx.entityMemory.search(query, {
+        limit,
+        type: type as NodeType | undefined,
+        maxSensitivity: max_sensitivity as Sensitivity | undefined,
+      });
+
+      // Map SearchResult[] to flat output objects so agents see a clean,
+      // self-contained record for each node rather than nested KgNode shapes.
+      const nodes = results.map(({ node, score }) => ({
+        id: node.id,
+        type: node.type,
+        label: node.label,
+        properties: node.properties,
+        confidence: node.temporal.confidence,
+        // decay_class tells the agent how stable this fact is expected to be;
+        // fast_decay nodes with degraded confidence should be treated as potentially stale.
+        decay_class: node.temporal.decayClass,
+        // sensitivity tells the agent whether results can be shared or exported;
+        // confidential/restricted facts must not be included in outbound messages
+        // without explicit CEO approval.
+        sensitivity: node.sensitivity,
+        last_confirmed_at: node.temporal.lastConfirmedAt,
+        score,
+      }));
+
+      ctx.log.info({ query, count: nodes.length, type, max_sensitivity }, 'memory-query: complete');
+      return { success: true, data: { results: nodes, count: nodes.length } };
+    } catch (err) {
+      ctx.log.error({ err, query }, 'memory-query: unexpected error');
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}

--- a/skills/memory-query/skill.json
+++ b/skills/memory-query/skill.json
@@ -1,0 +1,23 @@
+{
+  "name": "memory-query",
+  "description": "Freeform semantic search across the knowledge graph. Embeds the query and returns the most similar nodes by cosine similarity. Use this when you need to find everything known about a topic without knowing which specific entity to target — e.g. 'find everything related to investor relations'. Optionally filter by node type or sensitivity ceiling.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "query": "string (natural language search string, e.g. 'investor relations' or 'Q3 board meeting')",
+    "type": "string? (optional node type filter — one of: person, organization, project, decision, event, concept, fact)",
+    "limit": "number? (max results to return; defaults to 10, capped at 50)",
+    "max_sensitivity": "string? (optional sensitivity ceiling — one of: public, internal, confidential, restricted. When provided, only nodes at or below this level are returned. Omit to return nodes of any sensitivity.)"
+  },
+  "outputs": {
+    "results": "array of {id, type, label, properties, confidence, decay_class, sensitivity, last_confirmed_at, score}",
+    "count": "number — total results returned"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": [
+    "entityMemory"
+  ]
+}

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -663,7 +663,10 @@ export class EntityMemory {
    *
    * Returns SearchResult[] sorted by score descending (most similar first).
    */
-  async search(query: string, options?: { limit?: number }): Promise<SearchResult[]> {
+  async search(
+    query: string,
+    options?: { limit?: number; type?: NodeType; maxSensitivity?: Sensitivity },
+  ): Promise<SearchResult[]> {
     return this.store.semanticSearch(query, options);
   }
 

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -10,7 +10,7 @@ import type {
   SearchResult,
   TraversalResult,
 } from './types.js';
-import { createNodeId, createEdgeId } from './types.js';
+import { createNodeId, createEdgeId, SENSITIVITY_LEVELS } from './types.js';
 import { EmbeddingService } from './embedding.js';
 
 // -- Public option interfaces --
@@ -70,7 +70,11 @@ interface KnowledgeGraphBackend {
   // fact nodes always insert as new regardless of label collision.
   upsertNode(node: KgNode): Promise<{ node: KgNode; created: boolean }>;
   traverse(startNodeId: string, maxDepth: number): Promise<TraversalResult>;
-  semanticSearch(queryEmbedding: number[], limit: number): Promise<SearchResult[]>;
+  semanticSearch(
+    queryEmbedding: number[],
+    limit: number,
+    filters?: { type?: NodeType; maxSensitivity?: Sensitivity },
+  ): Promise<SearchResult[]>;
 }
 
 /**
@@ -321,11 +325,14 @@ export class KnowledgeGraphStore {
    */
   async semanticSearch(
     query: string,
-    options?: { limit?: number },
+    options?: { limit?: number; type?: NodeType; maxSensitivity?: Sensitivity },
   ): Promise<SearchResult[]> {
     const limit = options?.limit ?? 10;
     const queryEmbedding = await this.embeddingService.embed(query);
-    return this.backend.semanticSearch(queryEmbedding, limit);
+    return this.backend.semanticSearch(queryEmbedding, limit, {
+      type: options?.type,
+      maxSensitivity: options?.maxSensitivity,
+    });
   }
 }
 
@@ -596,16 +603,39 @@ class PostgresBackend implements KnowledgeGraphBackend {
     return { nodes, edges };
   }
 
-  async semanticSearch(queryEmbedding: number[], limit: number): Promise<SearchResult[]> {
+  async semanticSearch(
+    queryEmbedding: number[],
+    limit: number,
+    filters?: { type?: NodeType; maxSensitivity?: Sensitivity },
+  ): Promise<SearchResult[]> {
     const embeddingStr = `[${queryEmbedding.join(',')}]`;
+    const params: unknown[] = [embeddingStr, limit];
+    const extraClauses: string[] = [];
+
+    if (filters?.type) {
+      params.push(filters.type);
+      extraClauses.push(`AND type = $${params.length}`);
+    }
+
+    if (filters?.maxSensitivity !== undefined) {
+      // Build the allowed sensitivity set from the ordered SENSITIVITY_LEVELS array.
+      // SENSITIVITY_LEVELS is ['public','internal','confidential','restricted'], so
+      // slice(0, rank+1) gives all levels at or below the ceiling.
+      const maxRank = SENSITIVITY_LEVELS.indexOf(filters.maxSensitivity);
+      const allowedLevels = SENSITIVITY_LEVELS.slice(0, maxRank + 1) as string[];
+      params.push(allowedLevels);
+      extraClauses.push(`AND sensitivity = ANY($${params.length}::text[])`);
+    }
+
     const result = await this.pool.query<PgNodeRow & { similarity: number }>(
       `SELECT *, 1 - (embedding <=> $1::vector) AS similarity
        FROM kg_nodes
        WHERE embedding IS NOT NULL
          AND archived_at IS NULL
+         ${extraClauses.join('\n         ')}
        ORDER BY embedding <=> $1::vector
        LIMIT $2`,
-      [embeddingStr, limit],
+      params,
     );
 
     return result.rows.map((row) => ({
@@ -947,13 +977,31 @@ class InMemoryBackend implements KnowledgeGraphBackend {
    * and all node embeddings, return top results sorted by similarity.
    * Archived nodes are excluded from results.
    */
-  async semanticSearch(queryEmbedding: number[], limit: number): Promise<SearchResult[]> {
+  async semanticSearch(
+    queryEmbedding: number[],
+    limit: number,
+    filters?: { type?: NodeType; maxSensitivity?: Sensitivity },
+  ): Promise<SearchResult[]> {
     const scored: SearchResult[] = [];
+    // Pre-compute sensitivity ceiling rank once outside the loop
+    const maxSensitivityRank =
+      filters?.maxSensitivity !== undefined
+        ? SENSITIVITY_LEVELS.indexOf(filters.maxSensitivity)
+        : undefined;
 
     for (const node of this.nodes.values()) {
       if (!node.embedding) continue;
       // Archived nodes must not appear in semantic search results
       if (this.archivedNodes.has(node.id)) continue;
+      // Apply type filter
+      if (filters?.type && node.type !== filters.type) continue;
+      // Apply sensitivity ceiling filter
+      if (
+        maxSensitivityRank !== undefined &&
+        SENSITIVITY_LEVELS.indexOf(node.sensitivity) > maxSensitivityRank
+      ) {
+        continue;
+      }
       const score = EmbeddingService.cosineSimilarity(queryEmbedding, node.embedding);
       scored.push({ node, score, edges: [] });
     }

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -622,6 +622,12 @@ class PostgresBackend implements KnowledgeGraphBackend {
       // SENSITIVITY_LEVELS is ['public','internal','confidential','restricted'], so
       // slice(0, rank+1) gives all levels at or below the ceiling.
       const maxRank = SENSITIVITY_LEVELS.indexOf(filters.maxSensitivity);
+      // Fail loudly rather than silently returning an empty result set.
+      // An unrecognized value means the caller has a bug — returning zero rows
+      // with no error would make that invisible.
+      if (maxRank === -1) {
+        throw new Error(`semanticSearch: unknown maxSensitivity value "${filters.maxSensitivity}"`);
+      }
       const allowedLevels = SENSITIVITY_LEVELS.slice(0, maxRank + 1) as string[];
       params.push(allowedLevels);
       extraClauses.push(`AND sensitivity = ANY($${params.length}::text[])`);
@@ -983,11 +989,16 @@ class InMemoryBackend implements KnowledgeGraphBackend {
     filters?: { type?: NodeType; maxSensitivity?: Sensitivity },
   ): Promise<SearchResult[]> {
     const scored: SearchResult[] = [];
-    // Pre-compute sensitivity ceiling rank once outside the loop
+    // Pre-compute sensitivity ceiling rank once outside the loop.
+    // Throw on an unrecognized value rather than silently returning an empty set —
+    // a caller with a bad maxSensitivity bug should see an error, not ghost results.
     const maxSensitivityRank =
       filters?.maxSensitivity !== undefined
         ? SENSITIVITY_LEVELS.indexOf(filters.maxSensitivity)
         : undefined;
+    if (maxSensitivityRank === -1) {
+      throw new Error(`semanticSearch: unknown maxSensitivity value "${filters!.maxSensitivity}"`);
+    }
 
     for (const node of this.nodes.values()) {
       if (!node.embedding) continue;
@@ -995,12 +1006,13 @@ class InMemoryBackend implements KnowledgeGraphBackend {
       if (this.archivedNodes.has(node.id)) continue;
       // Apply type filter
       if (filters?.type && node.type !== filters.type) continue;
-      // Apply sensitivity ceiling filter
-      if (
-        maxSensitivityRank !== undefined &&
-        SENSITIVITY_LEVELS.indexOf(node.sensitivity) > maxSensitivityRank
-      ) {
-        continue;
+      // Apply sensitivity ceiling filter.
+      // Nodes with unrecognized sensitivity values are treated as fail-closed:
+      // indexOf returns -1, which is never <= any valid ceiling rank, so they
+      // are excluded rather than leaked through the filter.
+      if (maxSensitivityRank !== undefined) {
+        const nodeRank = SENSITIVITY_LEVELS.indexOf(node.sensitivity);
+        if (nodeRank === -1 || nodeRank > maxSensitivityRank) continue;
       }
       const score = EmbeddingService.cosineSimilarity(queryEmbedding, node.embedding);
       scored.push({ node, score, edges: [] });


### PR DESCRIPTION
## Summary

- **`memory-query` skill** (`skills/memory-query/`) — freeform semantic search over `kg_nodes` via pgvector cosine similarity. Supports optional `type` filter, `max_sensitivity` ceiling, and configurable `limit` (default 10, cap 50). Returns `id`, `type`, `label`, `properties`, `confidence`, `decay_class`, `sensitivity`, `last_confirmed_at`, and `score` on every result node.
- **Extended `semanticSearch` filter options** — `KnowledgeGraphStore.semanticSearch()`, `EntityMemory.search()`, `KnowledgeGraphBackend` interface, `PostgresBackend`, and `InMemoryBackend` all now accept `{ type?, maxSensitivity? }` filters. Sensitivity filter uses `ANY($N::text[])` with a pre-sliced allowed-levels array. Both backends throw on unrecognized `maxSensitivity` values (fail loudly, not silently). `InMemoryBackend` treats nodes with unknown sensitivity values as fail-closed (excluded).
- Bumps version to `0.20.2`.

Closes #298.

## Test plan

- [ ] `pnpm typecheck` passes (no type errors)
- [ ] `pnpm test` passes (1513 unit tests + 10 new `memory-query` tests)
- [ ] Empty KG returns `{ results: [], count: 0 }`
- [ ] Nodes are returned with all required output fields (`decay_class`, `sensitivity`, `score`, etc.)
- [ ] `type` filter excludes nodes of other types
- [ ] `max_sensitivity: internal` excludes `restricted` nodes
- [ ] `limit: 999` is silently capped to 50
- [ ] Results are sorted by score descending
- [ ] Unknown `type` or `max_sensitivity` values return `{ success: false, error }`
- [ ] `limit: NaN` returns a clear validation error rather than a driver failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added semantic search capability with optional filtering by node type and sensitivity level
  * Search results now include confidence scores, decay classification, and sensitivity metadata
  * Configurable result limits with maximum of 50 results per query

* **Chores**
  * Version bump to 0.21.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->