### PR TITLE
docs: release process workflow and version bump policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **Release process** — CLAUDE.md now documents the full release workflow: version bumps happen only when cutting a release (not per-PR), with a dedicated "Preparing a release" section covering naming, CHANGELOG condensing, version updates, release PR, tagging, and GitHub release publication including a thematic haiku
+
 ### Fixed
 
 - **Smoke test timeouts** — increased per-turn response timeout from 60s to 120s (configurable via `SMOKE_TIMEOUT_MS`); added a warm-up message before the first test case to absorb cold-start latency; error output now shows the actual timeout value and per-turn timings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,9 +124,9 @@ Do **not** create `docs/superpowers/`, `docs/plans/`, or `docs/specs/designs/` �
 
 ### Every PR must update CHANGELOG.md
 
-Add entries under `## [Unreleased]` before creating the PR. Exception: PRs that are
-solely bumping the version and moving `[Unreleased]` to a release heading (like this one)
-don't need a separate entry — the release heading itself is the record.
+Add entries under `## [Unreleased]` before creating the PR. Exception: the release PR
+itself (see *Preparing a release* below) doesn't need a separate CHANGELOG entry — the
+new release heading is the record.
 
 Use these sections as needed:
 - **Added** — new skills, agents, channels, specs, or features
@@ -140,7 +140,9 @@ Reference spec numbers where relevant (e.g. "spec 14").
 
 ### When to bump the version number
 
-Bump `package.json` version in the same PR as the changelog entry. If the version number is bumped, be sure to tag the PR with the version number. Use this table:
+**Do not bump the version during regular commits or PRs.** All in-progress work accumulates in CHANGELOG under `## [Unreleased]`. The version is bumped only when deliberately cutting a release — see *Preparing a release* below.
+
+When cutting a release, use this table to determine the bump size:
 
 | Change type | Bump | Examples |
 |---|---|---|
@@ -160,6 +162,62 @@ Bump `package.json` version in the same PR as the changelog entry. If the versio
 **1.0.0** is reserved for when these surfaces are stable enough to commit to — do not bump to
 1.0.0 without explicit discussion. The milestone is API stability + production deployment,
 not just "it works."
+
+### Preparing a release
+
+A release is a deliberate, standalone step — separate from day-to-day PR work. Follow these steps in order.
+
+**1. Read the unreleased changes**
+
+Open `CHANGELOG.md` and review all entries under `## [Unreleased]`. Read for themes: what capabilities shipped, what was fixed, what changed under the hood.
+
+**2. Name the release and determine the version bump**
+
+Pick a short, evocative release name that captures the dominant theme (e.g. "Memory Stabilization", "Autonomy Foundations", "Signal Clarity"). Keep it dignified — not whimsical, not corporate.
+
+Use the bump table above to determine the version bump. If the unreleased batch mixes types, the highest applicable bump wins (any minor → minor; all patches → patch).
+
+**3. Update CHANGELOG.md**
+
+- Create a new heading immediately after `## [Unreleased]`:
+  ```
+  ## [X.Y.Z] — Release Name — YYYY-MM-DD
+  ```
+- Move all `[Unreleased]` bullets under it. Leave `## [Unreleased]` in place above it, empty, ready for the next batch.
+- Condense and group the bullets — aim for clarity over completeness. Merge related entries, cut implementation detail, and make it readable to someone who uses Curia but didn't write the code. The CHANGELOG is a reader document, not a commit log.
+
+**4. Update version numbers**
+
+- `package.json` → `"version": "X.Y.Z"`
+- `README.md` → update any version badge or version reference
+
+**5. Generate a release haiku**
+
+Write a haiku thematically aligned with the release — drawn from the changes, the fixes, the dominant mood. It should feel like a small hidden gift at the end of the release notes, not a gimmick. Tone: quiet, precise, a little wry.
+
+**6. Open a release PR**
+
+- Branch: `chore/release-X.Y.Z`
+- PR title: `chore: release vX.Y.Z — Release Name`
+- PR body: the new CHANGELOG section, followed by the haiku
+- No other code changes — this PR is the release commit only
+- Watch CI; wait for merge before proceeding
+
+**7. After merge: tag and publish**
+
+Once the release PR is merged, fetch and tag the merge commit:
+
+```bash
+git -C /path/to/repo fetch origin main
+git -C /path/to/repo pull origin main
+git -C /path/to/repo tag -a vX.Y.Z -m "vX.Y.Z — Release Name"
+git -C /path/to/repo push origin vX.Y.Z
+```
+
+Then create a GitHub release (`gh release create`):
+- **Title:** `vX.Y.Z — Release Name`
+- **Tag:** `vX.Y.Z`
+- **Body:** rewrite the CHANGELOG bullets into natural, friendly prose — past tense, as if narrating what changed. Prioritize what a user of Curia would care about. Close with a horizontal rule and the haiku.
 
 ## Scope Discipline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ Use the bump table above to determine the version bump. If the unreleased batch 
 
 - Create a new heading immediately after `## [Unreleased]`:
   ```
-  ## [X.Y.Z] — Release Name — YYYY-MM-DD
+  ## [X.Y.Z] — YYYY-MM-DD — "Release Name"
   ```
 - Move all `[Unreleased]` bullets under it. Leave `## [Unreleased]` in place above it, empty, ready for the next batch.
 - Condense and group the bullets — aim for clarity over completeness. Merge related entries, cut implementation detail, and make it readable to someone who uses Curia but didn't write the code. The CHANGELOG is a reader document, not a commit log.
@@ -189,7 +189,7 @@ Use the bump table above to determine the version bump. If the unreleased batch 
 **4. Update version numbers**
 
 - `package.json` → `"version": "X.Y.Z"`
-- `README.md` → update any version badge or version reference
+- `README.md` line 18 → update the shields.io badge URL (`version-X.Y.Z`) and its `alt` attribute (`Version: X.Y.Z`)
 
 **5. Generate a release haiku**
 
@@ -205,19 +205,32 @@ Write a haiku thematically aligned with the release — drawn from the changes, 
 
 **7. After merge: tag and publish**
 
-Once the release PR is merged, fetch and tag the merge commit:
+Once the release PR is merged, first confirm the merge landed, then tag `origin/main` directly (do not rely on local branch state — the release worktree is on `chore/release-X.Y.Z`, not `main`):
 
 ```bash
+# Confirm the merge landed — grep must return a result before proceeding
 git -C /path/to/repo fetch origin main
-git -C /path/to/repo pull origin main
-git -C /path/to/repo tag -a vX.Y.Z -m "vX.Y.Z — Release Name"
+git -C /path/to/repo show origin/main:CHANGELOG.md | grep "X.Y.Z"
+
+# Tag origin/main directly — no checkout or pull needed
+git -C /path/to/repo tag -a vX.Y.Z -m "vX.Y.Z — Release Name" origin/main
 git -C /path/to/repo push origin vX.Y.Z
 ```
 
-Then create a GitHub release (`gh release create`):
-- **Title:** `vX.Y.Z — Release Name`
-- **Tag:** `vX.Y.Z`
-- **Body:** rewrite the CHANGELOG bullets into natural, friendly prose — past tense, as if narrating what changed. Prioritize what a user of Curia would care about. Close with a horizontal rule and the haiku.
+Then write the release notes (rewrite the CHANGELOG bullets into natural, friendly prose — past tense, as if narrating what changed; prioritize what a user of Curia would care about; close with a horizontal rule and the haiku) and create the GitHub release:
+
+```bash
+gh release create vX.Y.Z \
+  --title 'vX.Y.Z — "Release Name"' \
+  --notes "$(cat <<'EOF'
+[release prose here]
+
+---
+
+[haiku here]
+EOF
+)"
+```
 
 ## Scope Discipline
 


### PR DESCRIPTION
## Summary

- **Version bump policy corrected**: bumps no longer happen per-PR. All in-progress work accumulates under `## [Unreleased]` in CHANGELOG. Versions are bumped only when deliberately cutting a release.
- **New "Preparing a release" section**: 7-step workflow covering naming, bump sizing, CHANGELOG condensing, version updates, release PR, post-merge tagging, and GitHub release publication.
- **Haiku easter egg**: each release ends with a thematically aligned haiku in the release notes.

## Changelog entry

Added under `## [Unreleased] → Changed`:
> **Release process** — CLAUDE.md now documents the full release workflow...

## What's in the release workflow

1. Read unreleased changes, find the dominant theme
2. Name the release + determine minor vs patch
3. Condense CHANGELOG bullets into the new dated heading
4. Update `package.json` and `README.md` badge
5. Generate a release haiku
6. Open a `chore/release-X.Y.Z` PR; wait for merge
7. Verify merge, tag `origin/main` directly, publish GitHub release with prose notes + haiku

Key correctness notes addressed in review:
- Tags `origin/main` directly after fetch (not `HEAD`) — avoids tagging the wrong commit from a worktree branch
- Explicit merge verification step before tagging
- Concrete `gh release create` command template
- README badge step points to exact line and attributes
- Heading format matches existing convention: `## [X.Y.Z] — YYYY-MM-DD — "Release Name"`