### PR TITLE
chore: release v0.22.0 — Knowledge Surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,38 +13,33 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
-### Changed
+---
 
-- **Release process** — CLAUDE.md now documents the full release workflow: version bumps happen only when cutting a release (not per-PR), with a dedicated "Preparing a release" section covering naming, CHANGELOG condensing, version updates, release PR, tagging, and GitHub release publication including a thematic haiku
-
-### Fixed
-
-- **Smoke test timeouts** — increased per-turn response timeout from 60s to 120s (configurable via `SMOKE_TIMEOUT_MS`); added a warm-up message before the first test case to absorb cold-start latency; error output now shows the actual timeout value and per-turn timings
+## [0.22.0] — 2026-04-26 — "Knowledge Surface"
 
 ### Added
 
-- **`memory-store` skill** — general-purpose KG fact write path: agents can now explicitly store a named attribute fact about a known entity with full control over confidence, decay class, and sensitivity. Resolves entity by label or node ID; returns one of four outcomes (`created`, `updated`, `conflict`, `rejected`) so the agent can surface contradictions to the CEO before proceeding (closes spec §03, #297)
-- **`StoreFactResult.action`** — `storeFact()` now returns the pipeline outcome (`created | updated | conflict | rejected`) alongside `stored`; attribute-based facts now route through contradiction detection automatically
-- **`StoreFactResult.existingNodeId`** — populated when a fact write produces a `conflict`, letting callers surface the contradicting node to the CEO
-- **`memory-query` skill** — freeform semantic search over the knowledge graph via pgvector cosine similarity; supports optional `type`, `max_sensitivity` ceiling, and `limit` filters; returns `decay_class` and `sensitivity` on every result node (spec §03, #298)
-- **`semanticSearch` filter options** — `KnowledgeGraphStore.semanticSearch()`, `EntityMemory.search()`, and both backends now accept `type` and `maxSensitivity` filter options applied in-query before results are returned
-- **`config-store` skill** — Generic namespaced key-value configuration store backed by the knowledge graph. Agents declare a namespace in their system prompt (`writing_config`, `travel`, etc.) and call `store`/`retrieve`/`list_namespaces` without needing a bespoke `knowledge-*` skill. Values use permanent decay class. Supersedes the per-domain `knowledge-*` pattern for new agents; existing `knowledge-*` skills are unchanged (cleanup tracked in #357).
-- **`image-generate` skill** — Wraps DALL-E 3 via OpenAI API. Generates an image from a text prompt; returns a temporary CDN URL. Generic skill, not essay-specific. Prerequisite for the essay-editor specialist agent.
-- **KG explorer: sensitivity visualization** — node detail drawer (tap any node to inspect all attributes), color-by toggle (Type / Sensitivity / Decay class), degree-based node sizing, and confidence-based opacity (#350)
-- **KG API: `sensitivity` and `properties` fields** — `/api/kg/nodes` and `/api/kg/graph` now return both fields on every node response (#350)
-- **`SensitivityClassifier` unit tests** — 5 tests covering keyword matching, property-value matching, category hint bypass, and most-restrictive-wins behaviour (#350)
-
-- **Observation triage event** (`observation.triage.completed`) — structured bus event emitted after every observation-mode triage task, carrying classification, skills called, and action count for monitoring and alerting (#311)
-- **`AgentResponsePayload.skillsCalled`** — optional field listing skills invoked during a task (public API surface: additive, non-breaking)
-- **`TriageClassification` type** — exported union type for triage classification labels, shared across event consumers
+- **`memory-store` skill** — agents can now write facts directly to the knowledge graph: store named attribute facts about any entity with explicit control over confidence, decay class, and sensitivity. Returns one of four outcomes (`created`, `updated`, `conflict`, `rejected`), surfacing contradictions to the CEO before writing (spec §03, #297).
+- **`memory-query` skill** — freeform semantic search over the knowledge graph via pgvector cosine similarity; supports `type`, `max_sensitivity`, and `limit` filters (spec §03, #298).
+- **`config-store` skill** — generic namespaced key-value store backed by the knowledge graph. Agents declare a namespace in their system prompt and call `store`/`retrieve`/`list_namespaces` without a bespoke per-domain skill. Supersedes the `knowledge-*` pattern for new agents.
+- **`image-generate` skill** — generates images via DALL-E 3; returns a CDN URL. General-purpose prerequisite for the upcoming essay-editor agent.
+- **KG explorer: sensitivity visualization** — node detail drawer, color-by toggle (type / sensitivity / decay class), degree-based node sizing, and confidence-based opacity (#350). `/api/kg/nodes` and `/api/kg/graph` now return `sensitivity` and `properties` on every node.
+- **Observation triage event** (`observation.triage.completed`) — structured bus event emitted after every observation-mode triage task, carrying classification, skills called, and action count (#311). `AgentResponsePayload.skillsCalled` added to the public API (additive, non-breaking).
 
 ### Changed
 
-- **Dispatcher observation-mode branch** — now emits a `warn`-level log when a non-`LEAVE FOR CEO` classification completes with zero skill calls (defensive check for coordinator stalls)
-- **Defense-in-depth: skill-layer block for observation-mode triage** (closes #305)
-  - `email-reply` is hard-blocked when `observationMode` is set in task metadata — the skill returns a structured error rather than silently sending a reply from the CEO's inbox.
-  - `email-draft-save` requires `triage_classification: "NEEDS DRAFT"` in observation mode. Calls with NOISE, LEAVE FOR CEO, or no classification are rejected with an auditable error.
-  - Task metadata (`observationMode`, future signals) is now threaded from the `agent.task` event through `ExecutionLayer.invoke()` into `SkillContext`, making task-level context available to any handler without bus access.
+- **Observation-mode hardening** — `email-reply` is hard-blocked in observation mode at the skill layer; `email-draft-save` requires `triage_classification: "NEEDS DRAFT"`. Task metadata is now threaded end-to-end from the `agent.task` event into `SkillContext`, making task-level signals available to any handler (closes #305).
+- **Release process** — CLAUDE.md now documents the full release workflow: version bump timing, CHANGELOG condensing, PR format, tag and publish steps.
+
+### Fixed
+
+- **Smoke test timeouts** — per-turn timeout raised from 60s to 120s (configurable via `SMOKE_TIMEOUT_MS`); a warm-up message absorbs cold-start latency; error output now includes per-turn timings.
+
+---
+
+*Facts inscribed in graph —*  
+*agent writes, the record keeps,*  
+*intent stays its course.*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.19.7-blueviolet" alt="Version: 0.19.7" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.22.0-blueviolet" alt="Version: 0.22.0" /></a>
   <img src="https://img.shields.io/badge/status-pre--alpha-orange" alt="Status: Pre-Alpha" />
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License: MIT" />
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node >= 22" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## [0.22.0] — 2026-04-26 — "Knowledge Surface"

### Added

- **`memory-store` skill** — agents can now write facts directly to the knowledge graph: store named attribute facts about any entity with explicit control over confidence, decay class, and sensitivity. Returns one of four outcomes (`created`, `updated`, `conflict`, `rejected`), surfacing contradictions to the CEO before writing (spec §03, #297).
- **`memory-query` skill** — freeform semantic search over the knowledge graph via pgvector cosine similarity; supports `type`, `max_sensitivity`, and `limit` filters (spec §03, #298).
- **`config-store` skill** — generic namespaced key-value store backed by the knowledge graph. Agents declare a namespace in their system prompt and call `store`/`retrieve`/`list_namespaces` without a bespoke per-domain skill. Supersedes the `knowledge-*` pattern for new agents.
- **`image-generate` skill** — generates images via DALL-E 3; returns a CDN URL. General-purpose prerequisite for the upcoming essay-editor agent.
- **KG explorer: sensitivity visualization** — node detail drawer, color-by toggle (type / sensitivity / decay class), degree-based node sizing, and confidence-based opacity (#350). `/api/kg/nodes` and `/api/kg/graph` now return `sensitivity` and `properties` on every node.
- **Observation triage event** (`observation.triage.completed`) — structured bus event emitted after every observation-mode triage task, carrying classification, skills called, and action count (#311). `AgentResponsePayload.skillsCalled` added to the public API (additive, non-breaking).

### Changed

- **Observation-mode hardening** — `email-reply` is hard-blocked in observation mode at the skill layer; `email-draft-save` requires `triage_classification: "NEEDS DRAFT"`. Task metadata is now threaded end-to-end from the `agent.task` event into `SkillContext`, making task-level signals available to any handler (closes #305).
- **Release process** — CLAUDE.md now documents the full release workflow: version bump timing, CHANGELOG condensing, PR format, tag and publish steps.

### Fixed

- **Smoke test timeouts** — per-turn timeout raised from 60s to 120s (configurable via `SMOKE_TIMEOUT_MS`); a warm-up message absorbs cold-start latency; error output now includes per-turn timings.

---

*Facts inscribed in graph —*
*agent writes, the record keeps,*
*intent stays its course.*

---

**Note on version gap:** The CHANGELOG jumps from 0.20.0 to 0.22.0 with no 0.21.x entries. Those bumps were informal mid-flight version increments during development that violated the release workflow (no tag, no changelog, no release PR). They were not actual releases. The last real release remains v0.19.7; this PR is the next one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 0.22.0 — Knowledge Surface

* **New Features**
  - Enhanced knowledge-graph capabilities with memory configuration, image skills, sensitivity controls, and API additions
  - Added observation triage event and skills-called tracking in agent responses

* **Bug Fixes**
  - Improved email skill reliability with enhanced metadata threading
  - Strengthened smoke-test timeout diagnostics and warm-up messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->