### PR TITLE
fix: query-relationships last_confirmed_at as ISO 8601 string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`SkillManifest` type** — `infrastructure?: boolean` replaced by `capabilities?: string[]` in `src/skills/types.ts`.
 - **ExecutionLayer** — `if (manifest.infrastructure)` block and three name-gated conditionals replaced by a single capabilities loop with fail-closed behavior.
 
+### Fixed
+
+- **`query-relationships` skill** — `last_confirmed_at` in relationship output now serializes as an ISO 8601 string instead of a raw `Date` object, consistent with all other skills that surface timestamps (#359)
+
 ---
 
 ## [0.19.7] — 2026-04-24 — "The Reading Room"

--- a/skills/query-relationships/handler.test.ts
+++ b/skills/query-relationships/handler.test.ts
@@ -109,6 +109,26 @@ describe('QueryRelationshipsHandler', () => {
     expect((result as { success: false; error: string }).error).toMatch(/unknown edge type/i);
   });
 
+  it('returns last_confirmed_at as an ISO 8601 string, not a Date object', async () => {
+    const mem = makeEntityMemory();
+    const { entity: a } = await mem.createEntity({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    const { entity: b } = await mem.createEntity({ type: 'person', label: 'Bob', properties: {}, source: 'test' });
+    await mem.upsertEdge(a.id, b.id, 'colleague', {}, 'test', 0.7);
+
+    const handler = new QueryRelationshipsHandler();
+    const ctx = makeCtx(mem, { entity: 'Alice' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: { relationships: Array<{ last_confirmed_at: unknown }> } }).data;
+    const ts = data.relationships[0]!.last_confirmed_at;
+    // Must be a string, not a Date object
+    expect(typeof ts).toBe('string');
+    // Must be a valid ISO 8601 date string
+    expect(() => new Date(ts as string).toISOString()).not.toThrow();
+    expect(new Date(ts as string).toISOString()).toBe(ts);
+  });
+
   it('labels outbound and inbound direction correctly', async () => {
     const mem = makeEntityMemory();
     const { entity: joseph } = await mem.createEntity({ type: 'person', label: 'Jane Doe', properties: {}, source: 'test' });

--- a/skills/query-relationships/handler.ts
+++ b/skills/query-relationships/handler.ts
@@ -65,7 +65,7 @@ export class QueryRelationshipsHandler implements SkillHandler {
         object: direction === 'outbound' ? node.label : entity,
         direction,
         confidence: edge.temporal.confidence,
-        last_confirmed_at: edge.temporal.lastConfirmedAt,
+        last_confirmed_at: edge.temporal.lastConfirmedAt.toISOString(),
       }));
 
       ctx.log.info({ entity, count: relationships.length }, 'query-relationships: complete');


### PR DESCRIPTION
## Summary

- **`query-relationships` skill** — `last_confirmed_at` in relationship output was returned as a raw `Date` object instead of an ISO 8601 string. Adds `.toISOString()` call to match the established pattern across all other skills that surface timestamps (`knowledge-*` family).
- **Regression test** — new test asserts `typeof last_confirmed_at === 'string'` and that the value round-trips through `new Date().toISOString()` correctly.
- Bumps version to `0.19.9`.

Closes #359.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (all 1472 unit tests, including new test)
- [ ] `last_confirmed_at` in query-relationships output is a string, not `[object Object]`