### PR TITLE
fix: held-messages-process block action linkIdentity not idempotent on retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`held-messages-process` block idempotency** — `block` action now handles duplicate-key errors from `linkIdentity` the same way `identify` does: if the identity is already linked to a blocked contact on retry, it proceeds to `discard` rather than failing and leaving the held message stuck in `pending` (closes #335)
+
 ---
 
 ## [0.22.0] — 2026-04-26 — "Knowledge Surface"

--- a/skills/held-messages-process/handler.ts
+++ b/skills/held-messages-process/handler.ts
@@ -83,13 +83,24 @@ export class HeldMessagesProcessHandler implements SkillHandler {
           if (!isDuplicate) throw linkErr;
 
           // Identity already linked — check who owns it.
-          const resolved = await ctx.contactService.resolveByChannelIdentity(
-            heldMsg.channel,
-            heldMsg.senderId,
-          );
+          // If resolveByChannelIdentity itself throws, the error propagates to the
+          // outer catch. Log the orphan contact ID here so it's traceable.
+          let resolved: Awaited<ReturnType<typeof ctx.contactService.resolveByChannelIdentity>>;
+          try {
+            resolved = await ctx.contactService.resolveByChannelIdentity(
+              heldMsg.channel,
+              heldMsg.senderId,
+            );
+          } catch (resolveErr) {
+            ctx.log.error(
+              { err: resolveErr, channel: heldMsg.channel, senderId: heldMsg.senderId, orphanContactId: contact.id },
+              'resolveByChannelIdentity failed after 23505 (block path) — contact was created but identity not linked',
+            );
+            throw resolveErr;
+          }
           if (!resolved) {
             ctx.log.error(
-              { channel: heldMsg.channel, senderId: heldMsg.senderId },
+              { channel: heldMsg.channel, senderId: heldMsg.senderId, orphanContactId: contact.id },
               'Duplicate-key on linkIdentity (block) but resolveByChannelIdentity returned null — possible orphaned identity',
             );
             return {
@@ -98,10 +109,14 @@ export class HeldMessagesProcessHandler implements SkillHandler {
             };
           }
           if (resolved.status !== 'blocked') {
+            ctx.log.warn(
+              { channel: heldMsg.channel, senderId: heldMsg.senderId, owningContactId: resolved.contactId, owningStatus: resolved.status, orphanContactId: contact.id },
+              'Cannot block sender — identity already linked to a non-blocked contact',
+            );
             return {
               success: false,
               error:
-                `Cannot block ${heldMsg.senderId} — that identity is already linked to a non-blocked contact. Update the contact status or use contact-merge first.`,
+                `Cannot block ${heldMsg.senderId} — that identity is already linked to contact ${resolved.contactId} (status: ${resolved.status}). Update the contact status or use contact-merge first.`,
             };
           }
           // Already linked to a blocked contact — idempotent, proceed to discard.

--- a/skills/held-messages-process/handler.ts
+++ b/skills/held-messages-process/handler.ts
@@ -65,15 +65,55 @@ export class HeldMessagesProcessHandler implements SkillHandler {
           status: 'blocked',
           source: 'ceo_stated',
         });
-        await ctx.contactService.linkIdentity({
-          contactId: contact.id,
-          channel: heldMsg.channel,
-          channelIdentifier: heldMsg.senderId,
-          source: 'ceo_stated',
-        });
+        // Wrap linkIdentity with the same duplicate-key guard used in the "identify"
+        // path: if a prior partial run already linked this identity (linkIdentity
+        // succeeded but discard failed), a retry will hit the 23505 unique constraint.
+        // Treat it as a no-op when the identity is already on a blocked contact —
+        // the CEO's intent is already satisfied — and proceed to discard.
+        let resolvedContactId = contact.id;
+        try {
+          await ctx.contactService.linkIdentity({
+            contactId: contact.id,
+            channel: heldMsg.channel,
+            channelIdentifier: heldMsg.senderId,
+            source: 'ceo_stated',
+          });
+        } catch (linkErr) {
+          const isDuplicate = (linkErr as { code?: string }).code === '23505';
+          if (!isDuplicate) throw linkErr;
+
+          // Identity already linked — check who owns it.
+          const resolved = await ctx.contactService.resolveByChannelIdentity(
+            heldMsg.channel,
+            heldMsg.senderId,
+          );
+          if (!resolved) {
+            ctx.log.error(
+              { channel: heldMsg.channel, senderId: heldMsg.senderId },
+              'Duplicate-key on linkIdentity (block) but resolveByChannelIdentity returned null — possible orphaned identity',
+            );
+            return {
+              success: false,
+              error: `Internal error: ${heldMsg.senderId} caused a duplicate-key error but no owning contact was found.`,
+            };
+          }
+          if (resolved.status !== 'blocked') {
+            return {
+              success: false,
+              error:
+                `Cannot block ${heldMsg.senderId} — that identity is already linked to a non-blocked contact. Update the contact status or use contact-merge first.`,
+            };
+          }
+          // Already linked to a blocked contact — idempotent, proceed to discard.
+          resolvedContactId = resolved.contactId;
+          ctx.log.info(
+            { channel: heldMsg.channel, senderId: heldMsg.senderId, contactId: resolved.contactId },
+            'Channel identity already linked to a blocked contact — skipping linkIdentity',
+          );
+        }
         await ctx.heldMessages.discard(held_message_id);
-        ctx.log.info({ heldMessageId: held_message_id, contactId: contact.id }, 'Sender blocked');
-        return { success: true, data: { result: 'blocked', contact_id: contact.id } };
+        ctx.log.info({ heldMessageId: held_message_id, contactId: resolvedContactId }, 'Sender blocked');
+        return { success: true, data: { result: 'blocked', contact_id: resolvedContactId } };
       }
 
       // action === 'identify'

--- a/tests/unit/skills/held-messages-process.test.ts
+++ b/tests/unit/skills/held-messages-process.test.ts
@@ -277,12 +277,16 @@ describe('HeldMessagesProcessHandler — block action', () => {
     // Simulates a retry where linkIdentity succeeded in the first attempt but
     // discard failed — so the identity is already on a blocked contact and
     // linkIdentity now throws 23505. We should still proceed to discard.
+    // Use a distinct ORPHAN_CONTACT_ID for createContact so the assertion on
+    // contact_id actually proves the handler returns the resolved contact (the
+    // one that already owns the identity), not the freshly created orphan.
+    const ORPHAN_CONTACT_ID = '11111111-2222-3333-4444-555555555555';
     const heldMessages = {
       getById: vi.fn().mockResolvedValue(pendingMsg),
       discard: vi.fn().mockResolvedValue(true),
     };
     const contactService = {
-      createContact: vi.fn().mockResolvedValue({ id: BLOCKED_CONTACT_ID }),
+      createContact: vi.fn().mockResolvedValue({ id: ORPHAN_CONTACT_ID }),
       linkIdentity: vi.fn().mockRejectedValue(
         Object.assign(
           new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
@@ -307,6 +311,7 @@ describe('HeldMessagesProcessHandler — block action', () => {
     expect(result.success).toBe(true);
     expect(contactService.resolveByChannelIdentity).toHaveBeenCalledWith('email', 'donna@example.com');
     expect(heldMessages.discard).toHaveBeenCalledWith(HELD_MSG_ID);
+    // Must return the resolved contact ID (the existing blocked contact), not the orphan
     if (result.success) expect(result.data).toMatchObject({ result: 'blocked', contact_id: BLOCKED_CONTACT_ID });
   });
 

--- a/tests/unit/skills/held-messages-process.test.ts
+++ b/tests/unit/skills/held-messages-process.test.ts
@@ -339,7 +339,11 @@ describe('HeldMessagesProcessHandler — block action', () => {
     ));
 
     expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain('non-blocked contact');
+    if (!result.success) {
+      // Error includes the owning contact ID and status so the caller knows what to fix
+      expect(result.error).toContain(CONTACT_ID);
+      expect(result.error).toContain('status: confirmed');
+    }
     expect(heldMessages.discard).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/skills/held-messages-process.test.ts
+++ b/tests/unit/skills/held-messages-process.test.ts
@@ -1,7 +1,8 @@
 // Tests for the held-messages-process skill handler.
 //
-// Focuses on the "identify" action and the idempotent linkIdentity path —
-// specifically the case where contact-merge has already linked the sender's
+// Covers the "identify", "dismiss", and "block" actions, including the
+// idempotent linkIdentity paths for both "identify" and "block" — the cases
+// where a prior partial run or contact-merge has already linked the sender's
 // channel identity before held-messages-process runs.
 
 import { describe, it, expect, vi } from 'vitest';
@@ -236,5 +237,159 @@ describe('HeldMessagesProcessHandler — dismiss action', () => {
     expect(result.success).toBe(true);
     expect(heldMessages.discard).toHaveBeenCalledWith(HELD_MSG_ID);
     if (result.success) expect(result.data).toMatchObject({ result: 'dismissed' });
+  });
+});
+
+const BLOCKED_CONTACT_ID = 'cccccccc-dddd-eeee-ffff-000000000000';
+
+describe('HeldMessagesProcessHandler — block action', () => {
+  const handler = new HeldMessagesProcessHandler();
+
+  it('creates a blocked contact, links identity, and discards the message', async () => {
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      discard: vi.fn().mockResolvedValue(true),
+    };
+    const contactService = {
+      createContact: vi.fn().mockResolvedValue({ id: BLOCKED_CONTACT_ID }),
+      linkIdentity: vi.fn().mockResolvedValue({ id: 'identity-1' }),
+      resolveByChannelIdentity: vi.fn(),
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'block', contact_name: 'Spammer' },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    expect(result.success).toBe(true);
+    expect(contactService.createContact).toHaveBeenCalledWith(expect.objectContaining({ status: 'blocked' }));
+    expect(contactService.linkIdentity).toHaveBeenCalledWith(expect.objectContaining({
+      contactId: BLOCKED_CONTACT_ID,
+      channel: 'email',
+      channelIdentifier: 'donna@example.com',
+    }));
+    expect(heldMessages.discard).toHaveBeenCalledWith(HELD_MSG_ID);
+    if (result.success) expect(result.data).toMatchObject({ result: 'blocked', contact_id: BLOCKED_CONTACT_ID });
+  });
+
+  it('treats duplicate-key error as no-op when identity is already linked to a blocked contact (retry scenario)', async () => {
+    // Simulates a retry where linkIdentity succeeded in the first attempt but
+    // discard failed — so the identity is already on a blocked contact and
+    // linkIdentity now throws 23505. We should still proceed to discard.
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      discard: vi.fn().mockResolvedValue(true),
+    };
+    const contactService = {
+      createContact: vi.fn().mockResolvedValue({ id: BLOCKED_CONTACT_ID }),
+      linkIdentity: vi.fn().mockRejectedValue(
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
+          { code: '23505' },
+        ),
+      ),
+      resolveByChannelIdentity: vi.fn().mockResolvedValue({
+        contactId: BLOCKED_CONTACT_ID,
+        displayName: 'Spammer',
+        role: null,
+        status: 'blocked',
+        trustLevel: null,
+      }),
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'block' },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    expect(result.success).toBe(true);
+    expect(contactService.resolveByChannelIdentity).toHaveBeenCalledWith('email', 'donna@example.com');
+    expect(heldMessages.discard).toHaveBeenCalledWith(HELD_MSG_ID);
+    if (result.success) expect(result.data).toMatchObject({ result: 'blocked', contact_id: BLOCKED_CONTACT_ID });
+  });
+
+  it('returns failure when identity is already linked to a non-blocked contact', async () => {
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      discard: vi.fn(),
+    };
+    const contactService = {
+      createContact: vi.fn().mockResolvedValue({ id: BLOCKED_CONTACT_ID }),
+      linkIdentity: vi.fn().mockRejectedValue(
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
+          { code: '23505' },
+        ),
+      ),
+      resolveByChannelIdentity: vi.fn().mockResolvedValue({
+        contactId: CONTACT_ID,
+        displayName: 'Donna',
+        role: null,
+        status: 'confirmed',  // not blocked — real conflict
+        trustLevel: null,
+      }),
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'block' },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('non-blocked contact');
+    expect(heldMessages.discard).not.toHaveBeenCalled();
+  });
+
+  it('returns data-integrity error when resolveByChannelIdentity returns null after duplicate', async () => {
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      discard: vi.fn(),
+    };
+    const contactService = {
+      createContact: vi.fn().mockResolvedValue({ id: BLOCKED_CONTACT_ID }),
+      linkIdentity: vi.fn().mockRejectedValue(
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
+          { code: '23505' },
+        ),
+      ),
+      resolveByChannelIdentity: vi.fn().mockResolvedValue(null),  // orphaned identity
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'block' },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Internal error');
+    expect(heldMessages.discard).not.toHaveBeenCalled();
+  });
+
+  it('re-throws non-duplicate errors from linkIdentity', async () => {
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      discard: vi.fn(),
+    };
+    const contactService = {
+      createContact: vi.fn().mockResolvedValue({ id: BLOCKED_CONTACT_ID }),
+      linkIdentity: vi.fn().mockRejectedValue(new Error('connection timeout')),
+      resolveByChannelIdentity: vi.fn(),
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'block' },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('connection timeout');
+    expect(contactService.resolveByChannelIdentity).not.toHaveBeenCalled();
+    expect(heldMessages.discard).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Root cause

The `block` action in `skills/held-messages-process/handler.ts` called `linkIdentity` with no try/catch for duplicate-key errors. If `linkIdentity` succeeded but `discard` failed (or the whole operation was retried after a partial failure), the second `linkIdentity` call threw a `23505` unique constraint violation. That fell through to the outer catch, returning `{ success: false }` with a generic log message and leaving the held message stuck in `pending` indefinitely.

Identical failure mode to what #334 fixed in the `identify` path.

## Fix

Wrap `linkIdentity` in the `block` path with the same try/catch pattern from #334:

- `code === '23505'` → call `resolveByChannelIdentity` to check ownership
  - Identity belongs to a blocked contact → no-op (idempotent), proceed to `discard`
  - Identity belongs to a non-blocked contact → return a clear error with the owning contact ID and status
  - `resolveByChannelIdentity` returns null → log error with orphan contact ID, return internal error
  - `resolveByChannelIdentity` itself throws → log error with orphan contact ID, re-throw to outer catch
- Non-23505 error → re-throw to outer catch (unchanged)

Observability improvements over the minimum fix: log entries in all failure-to-proceed branches include `orphanContactId` so the newly created blocked contact (which didn't get an identity linked) is traceable and can be cleaned up.

## Tests

5 new tests in `tests/unit/skills/held-messages-process.test.ts`:
- Happy path (`linkIdentity` succeeds)
- Idempotent no-op (duplicate, identity already on a blocked contact) — the retry scenario
- Non-blocked conflict (duplicate, identity on a confirmed contact)
- Data integrity anomaly (duplicate, `resolveByChannelIdentity` returns null)
- Non-duplicate error re-throw

Closes #335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate identity scenarios in the `block` action to prevent held messages from remaining stuck in pending state when attempting to link identities that already exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->