### PR TITLE
feat: add outbound.notification event type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **`outbound.notification` event type** — system notifications (blocked-content CEO alerts, Signal group-held alerts) now route through the bus and the outbound content filter pipeline instead of bypassing it via direct `dispatchEmail()` calls. New `OutboundGateway.sendNotification()` method publishes the event; EmailAdapter subscribes and delivers via `send()`. Closes the spec deviation noted in the outbound safety design (#206)
 - **draft_gate CEO notification** — when a Nylas draft is created via the `draft_gate` outbound policy, Curia now sends the CEO a brief email notification ("there is a draft reply to X about Y waiting in your Drafts folder"). The CEO reviews and clicks send from their email client. Closes the first piece of #278.
 
 ### Fixed

--- a/docs/specs/15-outbound-safety.md
+++ b/docs/specs/15-outbound-safety.md
@@ -140,7 +140,6 @@ without cross-channel confirmation.
 - Web UI for reviewing `outbound.blocked` events
 - Outbound rate limiting per recipient
 - Blocklist management skills (`outbound-block` / `outbound-unblock`)
-- ~~`outbound.notification` event type~~ — Done (#206). CEO notifications now route through the filter pipeline via `OutboundGateway.sendNotification()` → bus → EmailAdapter → `send()`
 
 > **TODO:** Replace this section with a proper "What's Implemented / What's Planned" table
 > once the feature is complete. The outstanding items above are the main gaps.

--- a/docs/specs/15-outbound-safety.md
+++ b/docs/specs/15-outbound-safety.md
@@ -129,7 +129,7 @@ without cross-channel confirmation.
 | Web UI for reviewing `outbound.blocked` events | Not Done |
 | Outbound rate limiting per recipient | Not Done |
 | Blocklist management skills (`outbound-block` / `outbound-unblock`) | Not Done |
-| `outbound.notification` event type (CEO notifications currently bypass the filter) | Not Done |
+| `outbound.notification` event type (CEO notifications route through the filter pipeline) | Done |
 
 ---
 
@@ -140,8 +140,7 @@ without cross-channel confirmation.
 - Web UI for reviewing `outbound.blocked` events
 - Outbound rate limiting per recipient
 - Blocklist management skills (`outbound-block` / `outbound-unblock`)
-- `outbound.notification` event type (currently CEO notifications bypass the filter pipeline
-  via a hardcoded template — this deviation must not be extended; see `@TODO` in `dispatcher.ts`)
+- ~~`outbound.notification` event type~~ — Done (#206). CEO notifications now route through the filter pipeline via `OutboundGateway.sendNotification()` → bus → EmailAdapter → `send()`
 
 > **TODO:** Replace this section with a proper "What's Implemented / What's Planned" table
 > once the feature is complete. The outstanding items above are the main gaps.

--- a/docs/wip/2026-03-27-outbound-content-filter-design.md
+++ b/docs/wip/2026-03-27-outbound-content-filter-design.md
@@ -156,15 +156,11 @@ When `outbound.blocked` fires, the CEO receives a **short, opaque notification e
   - A note to review via CLI or web app using that ID
 - **No blocked content, no rule details, no thread context in the email**
 
-**Implementation note (spec deviation):** The notification email is sent directly via
-`nylasClient.sendMessage()` rather than routing through the bus → filter → email-adapter
-pipeline. This is a conscious deviation from the original "no bypass" principle, accepted
-because the notification is a fixed template with only an opaque block ID and a sender
-email address — it cannot carry sensitive content by construction.
-
-**This deviation must not be extended.** Before adding any other direct-send path, an
-`outbound.notification` event type must be built so that system notifications route
-through the filter pipeline automatically. See the `@TODO` in `dispatcher.ts`.
+**Implementation note (spec deviation — resolved):** This deviation was closed by #206.
+CEO notifications now route through the bus → filter → email-adapter pipeline via the
+`outbound.notification` event type. `OutboundGateway.sendNotification()` publishes the
+event; the EmailAdapter subscribes and calls `outboundGateway.send()` so the notification
+goes through the same content filter and blocked-contact check as regular outbound messages.
 
 The `blockId` is the handle for future tooling:
 - Today: usable in CLI to inspect the blocked event details
@@ -192,9 +188,7 @@ logging mechanism required.
 
 ### Out of scope (future work)
 
-- `outbound.notification` event type — required before adding any new direct-send paths.
-  The current CEO notification bypasses the filter pipeline (see deviation note above).
-  This is the **first priority** follow-up for this feature.
+- ~~`outbound.notification` event type~~ — Done (#206). See resolved deviation note above.
 - LLM-as-judge implementation (Stage 2 is stub only) — see project memory for intent
 - CEO review-and-approve/edit/discard flow
 - Web app UI for reviewing blocked messages

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -105,6 +105,28 @@ interface OutboundBlockedPayload {
   findings: Array<{ rule: string; detail: string }>;
 }
 
+// OutboundNotificationPayload — published by the dispatch layer (via OutboundGateway.sendNotification)
+// when a system-level CEO alert needs to be sent. Routing through the bus ensures the notification
+// goes through the same safety pipeline as regular outbound messages, closing the prior direct
+// dispatchEmail() bypass. See #206.
+//
+// notificationType discriminates between alert categories:
+//   - 'blocked_content': CEO alert that an outbound message was blocked by the content filter
+//   - 'group_held':      CEO alert that a Signal group message was held due to unverified members
+export interface OutboundNotificationPayload {
+  notificationType: 'blocked_content' | 'group_held';
+  /** Recipient email for this notification (always the CEO email today). */
+  ceoEmail: string;
+  subject: string;
+  body: string;
+  /** Present for blocked_content notifications — links back to the outbound.blocked event. */
+  blockId?: string;
+  /** Channel of the original blocked or held message (e.g. 'email', 'signal'). */
+  originalChannel?: string;
+  /** Intended recipient of the original blocked or held message. */
+  originalRecipientId?: string;
+}
+
 interface SkillInvokePayload {
   agentId: string;
   conversationId: string;
@@ -422,6 +444,16 @@ export interface OutboundBlockedEvent extends BaseEvent {
   payload: OutboundBlockedPayload;
 }
 
+// OutboundNotificationEvent — published by the dispatch layer when a system-level CEO
+// notification needs to be sent (blocked-content alert, group-held alert, etc.).
+// Channel adapters subscribe to route it through the outbound safety pipeline.
+// System layer subscribes for audit logging and security monitoring.
+export interface OutboundNotificationEvent extends BaseEvent {
+  type: 'outbound.notification';
+  sourceLayer: 'dispatch';
+  payload: OutboundNotificationPayload;
+}
+
 export interface SkillInvokeEvent extends BaseEvent {
   type: 'skill.invoke';
   sourceLayer: 'agent';
@@ -611,6 +643,7 @@ export type BusEvent =
   | MessageHeldEvent      // Unknown sender policy: message held for CEO review
   | MessageRejectedEvent  // Unknown sender policy: message rejected, signals HTTP adapter to return 403
   | OutboundBlockedEvent  // Outbound content filter: message blocked before delivery (#38)
+  | OutboundNotificationEvent // System notifications routed through safety pipeline (#206)
   | ScheduleCreatedEvent   // Scheduler: job created
   | ScheduleFiredEvent     // Scheduler: job fired
   | ScheduleSuspendedEvent   // Scheduler: job auto-suspended
@@ -697,6 +730,22 @@ export function createOutboundBlocked(
     id: randomUUID(),
     timestamp: new Date(),
     type: 'outbound.blocked',
+    sourceLayer: 'dispatch',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createOutboundNotification(
+  // parentEventId is optional — blocked_content notifications should pass the outbound.blocked
+  // event's ID for traceability; group_held notifications have no parent bus event.
+  payload: OutboundNotificationPayload & { parentEventId?: string },
+): OutboundNotificationEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'outbound.notification',
     sourceLayer: 'dispatch',
     payload: rest,
     parentEventId,

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -21,19 +21,19 @@ import type { Layer, EventType } from './events.js';
 //          observation-mode task; system layer subscribes for audit logging and monitoring.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message']),
-  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint', 'human.decision', 'observation.triage.completed']),
+  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'outbound.notification', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint', 'human.decision', 'observation.triage.completed']),
   agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss', 'llm.call']),
   execution: new Set(['skill.result', 'secret.accessed']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed', 'observation.triage.completed']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed', 'observation.triage.completed']),
 };
 
 // agent.discuss subscribe for 'dispatch': used by BullpenDispatcher (wired in index.ts after agent registration).
 const subscribeAllowlist: Record<Layer, Set<EventType>> = {
-  channel: new Set(['outbound.message', 'outbound.blocked', 'message.held', 'message.rejected']),
+  channel: new Set(['outbound.message', 'outbound.blocked', 'outbound.notification', 'message.held', 'message.rejected']),
   dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed', 'observation.triage.completed']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed', 'observation.triage.completed']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -14,7 +14,7 @@ import type { ContactService } from '../../contacts/contact-service.js';
 import type { AutonomyService } from '../../autonomy/autonomy-service.js';
 import type { OutboundPolicy } from '../../config.js';
 import { convertNylasMessage } from './message-converter.js';
-import { createInboundMessage, type OutboundMessageEvent } from '../../bus/events.js';
+import { createInboundMessage, type OutboundMessageEvent, type OutboundNotificationEvent } from '../../bus/events.js';
 import { sanitizeOutput } from '../../skills/sanitize.js';
 
 export interface EmailAdapterConfig {
@@ -93,6 +93,56 @@ export class EmailAdapter {
       } catch (err) {
         logger.error({ err, conversationId: outbound.payload.conversationId },
           'Failed to send email response');
+      }
+    });
+
+    // Subscribe to system notification events (blocked-content alerts, group-held alerts).
+    // outbound.notification events are published by OutboundGateway.sendNotification()
+    // and route through the filter pipeline like any other outbound message.
+    //
+    // Only the primary account ('curia') handles notifications to avoid duplicate sends
+    // when multiple email accounts are configured. This matches the accountId fallback
+    // convention used in the outbound.message subscription above.
+    // TODO: replace hardcoded 'curia' with an isPrimaryAccount config flag once
+    // multi-account primary detection is formalized.
+    bus.subscribe('outbound.notification', 'channel', async (event) => {
+      if (this.config.accountId !== 'curia') return;
+
+      const notification = event as OutboundNotificationEvent;
+      try {
+        // skipNotificationOnBlock prevents infinite recursion: if the content filter
+        // is broken and blocks this notification, the gateway will NOT re-publish
+        // outbound.notification, breaking the cycle.
+        const result = await this.config.outboundGateway.send(
+          {
+            channel: 'email',
+            to: notification.payload.ceoEmail,
+            subject: notification.payload.subject,
+            body: notification.payload.body,
+          },
+          { skipNotificationOnBlock: true },
+        );
+        if (!result.success) {
+          logger.error(
+            {
+              notificationType: notification.payload.notificationType,
+              reason: result.blockedReason,
+              blockId: notification.payload.blockId,
+              originalChannel: notification.payload.originalChannel,
+              ceoEmail: notification.payload.ceoEmail,
+            },
+            'EmailAdapter: failed to deliver outbound.notification — CEO will NOT receive this alert',
+          );
+        }
+      } catch (err) {
+        logger.error(
+          {
+            err,
+            notificationType: notification.payload.notificationType,
+            blockId: notification.payload.blockId,
+          },
+          'EmailAdapter: unexpected error delivering outbound.notification',
+        );
       }
     });
 

--- a/src/channels/signal/signal-adapter.ts
+++ b/src/channels/signal/signal-adapter.ts
@@ -373,9 +373,9 @@ export class SignalAdapter {
   }
 
   /**
-   * Send the CEO an email notification when a group message is held due to
-   * unverified members. Uses the outbound gateway so the email goes through
-   * the normal content filter pipeline.
+   * Notify the CEO via email when a group message is held due to unverified members.
+   * Publishes an outbound.notification event through the gateway so the notification
+   * routes through the standard safety pipeline (#206).
    *
    * The CLI is not assumed to be monitored, so email is the reliable async
    * channel for this notification.
@@ -403,15 +403,17 @@ export class SignalAdapter {
     ].join('\n');
 
     try {
-      await outboundGateway.send({
-        channel: 'email',
-        to: ceoEmail,
+      await outboundGateway.sendNotification({
+        notificationType: 'group_held',
+        ceoEmail,
         subject: 'Signal group message held — member verification needed',
         body,
+        originalChannel: 'signal',
+        originalRecipientId: groupId,
       });
     } catch (err) {
       // Non-fatal — the message is still held. Log at error so it's visible in alerting.
-      this.log.error({ err, groupId }, 'Signal adapter: failed to send CEO group-held notification via email');
+      this.log.error({ err, groupId }, 'Signal adapter: failed to publish group-held notification');
     }
   }
 }

--- a/src/dispatch/outbound-filter.ts
+++ b/src/dispatch/outbound-filter.ts
@@ -56,6 +56,7 @@ const BUS_EVENT_TYPE_NAMES: string[] = [
   'agent.response',
   'outbound.message',
   'outbound.blocked',
+  'outbound.notification',
   'skill.invoke',
   'skill.result',
   'memory.store',

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -27,7 +27,8 @@ import type { TrustLevel } from '../contacts/types.js';
 import type { OutboundContentFilter } from '../dispatch/outbound-filter.js';
 import type { EventBus } from '../bus/bus.js';
 import type { Logger } from '../logger.js';
-import { createOutboundBlocked } from '../bus/events.js';
+import { createOutboundBlocked, createOutboundNotification } from '../bus/events.js';
+import type { OutboundNotificationPayload } from '../bus/events.js';
 import { markdownToHtml } from '../channels/email/markdown-to-html.js';
 
 // ---------------------------------------------------------------------------
@@ -205,8 +206,17 @@ export class OutboundGateway {
    *   1. Contact blocked check
    *   2. Content filter (fail-closed)
    *   3. Channel dispatch (email → Nylas, signal → signal-cli RPC)
+   *
+   * @param options.skipNotificationOnBlock  When true, suppress the CEO notification
+   *   if the content filter blocks this message. Used by the EmailAdapter's
+   *   outbound.notification subscriber to break the recursion cycle: without this
+   *   guard, a broken content filter (crash → fail-closed) would trigger
+   *   send → block → sendNotification → EmailAdapter → send → block → ... infinitely.
    */
-  async send(request: OutboundSendRequest): Promise<OutboundSendResult> {
+  async send(
+    request: OutboundSendRequest,
+    options?: { skipNotificationOnBlock?: boolean },
+  ): Promise<OutboundSendResult> {
     // Derive a stable recipient identifier for the blocked-contact check and logging.
     // Email: the To address. Signal: phone number (1:1) or base64 group ID.
     const recipientId = request.channel === 'email'
@@ -319,43 +329,51 @@ export class OutboundGateway {
         );
       }
 
-      // Notify the CEO about the blocked message via email.
-      // We always use the email channel for this notification, even when the blocked
-      // message was a Signal send — this avoids a potential Signal → block → Signal
-      // notification loop, and email is the canonical out-of-band channel for system alerts.
+      // Publish an outbound.notification event so the CEO alert routes through the
+      // standard safety pipeline via EmailAdapter, rather than bypassing the content
+      // filter with a direct dispatchEmail() call (#206).
       //
-      // Uses the primary email account (first in nylasClients map) for notifications.
-      // If email is not configured (no accounts or no ceoEmail), we log.error and rely
-      // on the audit log. A future Signal notification fallback can be added here.
-      // TODO: add Signal-based blocked-content notification when email is absent.
-      if (this.ceoEmail && this.primaryNylasClient) {
-        // dispatchEmail bypasses this.send() to avoid infinite recursion.
-        // The notification body is a hardcoded template — no user-supplied content.
-        // dispatchEmail skips the content filter entirely, so triggerSource is irrelevant.
-        const notifyResult = await this.dispatchEmail({
-          channel: 'email',
-          to: this.ceoEmail,
-          subject: 'Action needed — blocked outbound reply',
-          body: [
-            'An outbound message was blocked by the content filter.',
-            '',
-            `Block ID: ${blockId}`,
-            `Channel: ${request.channel}`,
-            `Intended recipient: ${recipientId}`,
-            '',
-            'Please review the audit log for details.',
-          ].join('\n'),
-        });
-        if (!notifyResult.success) {
-          this.log.error(
-            { blockId, ceoEmail: redactId(this.ceoEmail), reason: notifyResult.blockedReason },
-            'Failed to send CEO notification for blocked outbound content',
-          );
-        }
+      // Recursion safety (two layers):
+      //   1. The notification body is a hardcoded template addressed to ceoEmail (in the
+      //      content filter allowlist), so the filter always passes under normal operation.
+      //   2. The EmailAdapter passes skipNotificationOnBlock: true when calling send() for
+      //      a notification delivery. If the filter is broken (crash → fail-closed), this
+      //      flag prevents send() from re-publishing outbound.notification, breaking the
+      //      cycle: send → block → sendNotification → EmailAdapter → send(skip) → block → stop.
+      if (this.ceoEmail && !options?.skipNotificationOnBlock) {
+        // sendNotification() catches errors internally — await is safe and ensures
+        // the bus.publish call completes before we return the blocked result.
+        await this.sendNotification(
+          {
+            notificationType: 'blocked_content',
+            ceoEmail: this.ceoEmail,
+            subject: 'Action needed — blocked outbound reply',
+            body: [
+              'An outbound message was blocked by the content filter.',
+              '',
+              `Block ID: ${blockId}`,
+              `Channel: ${request.channel}`,
+              `Intended recipient: ${recipientId}`,
+              '',
+              'Please review the audit log for details.',
+            ].join('\n'),
+            blockId,
+            originalChannel: request.channel,
+            originalRecipientId: recipientId,
+          },
+        );
+      } else if (options?.skipNotificationOnBlock) {
+        // This branch fires when a notification delivery itself gets blocked by the
+        // content filter (e.g. the filter is in a broken state). The recursion guard
+        // prevents an infinite loop. The CEO will not receive this alert.
+        this.log.error(
+          { blockId, channel: request.channel },
+          'outbound-gateway: notification delivery was blocked by content filter — recursion guard active, CEO will NOT receive this alert',
+        );
       } else {
         this.log.error(
           { blockId, channel: request.channel, recipientId: redactId(recipientId) },
-          'outbound-gateway: CEO notification skipped — no email client configured. Block recorded in audit log only.',
+          'outbound-gateway: CEO notification skipped — ceoEmail not configured. Block recorded in audit log only.',
         );
       }
       return { success: false, blockedReason: 'Content blocked by filter' };
@@ -382,6 +400,38 @@ export class OutboundGateway {
         await this.promoteOrCreateRecipientContact('signal', request.recipient);
       }
       return result;
+    }
+  }
+
+  /**
+   * Publish a system notification event to the bus so it routes through the standard
+   * outbound safety pipeline (content filter + blocked-contact check) via the
+   * EmailAdapter's outbound.notification subscriber.
+   *
+   * This replaces the former direct dispatchEmail() calls that bypassed the content
+   * filter. The notification body is always a hardcoded template (no LLM-generated
+   * content) addressed to the CEO email (which is in the content filter allowlist),
+   * so the filter will always pass.
+   *
+   * Callers: the blocked-content path in send() and SignalAdapter.notifyCeoGroupHeld().
+   */
+  async sendNotification(
+    payload: OutboundNotificationPayload,
+    parentEventId?: string,
+  ): Promise<void> {
+    try {
+      await this.bus.publish(
+        'dispatch',
+        createOutboundNotification({ ...payload, parentEventId }),
+      );
+    } catch (err) {
+      // Non-fatal — the original block/hold is already recorded. Log so the anomaly
+      // is visible in alerting but do not throw; the caller's primary operation (block
+      // or hold) has already completed successfully.
+      this.log.error(
+        { err, notificationType: payload.notificationType },
+        'outbound-gateway: failed to publish outbound.notification event',
+      );
     }
   }
 

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -309,19 +309,19 @@ export class OutboundGateway {
       const fullReason = filterFindings.map((f) => `${f.rule}: ${f.detail}`).join('; ');
 
       // Publish the blocked event for audit logging and downstream consumers.
+      // Capture the event so we can link the outbound.notification to it via parentEventId.
+      const blockedEvent = createOutboundBlocked({
+        blockId,
+        conversationId: '',
+        channelId: request.channel,
+        content: messageBody,
+        recipientId,
+        reason: fullReason,
+        findings: filterFindings,
+        parentEventId: '',
+      });
       try {
-        await this.bus.publish('dispatch',
-          createOutboundBlocked({
-            blockId,
-            conversationId: '',
-            channelId: request.channel,
-            content: messageBody,
-            recipientId,
-            reason: fullReason,
-            findings: filterFindings,
-            parentEventId: '',
-          }),
-        );
+        await this.bus.publish('dispatch', blockedEvent);
       } catch (publishErr) {
         this.log.warn(
           { publishErr, blockId },
@@ -361,6 +361,7 @@ export class OutboundGateway {
             originalChannel: request.channel,
             originalRecipientId: recipientId,
           },
+          blockedEvent.id,
         );
       } else if (options?.skipNotificationOnBlock) {
         // This branch fires when a notification delivery itself gets blocked by the

--- a/tests/unit/bus/outbound-notification-event.test.ts
+++ b/tests/unit/bus/outbound-notification-event.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { createOutboundNotification } from '../../../src/bus/events.js';
+import { canPublish, canSubscribe } from '../../../src/bus/permissions.js';
+
+describe('outbound.notification event', () => {
+  it('creates a blocked_content notification with correct type and sourceLayer', () => {
+    const event = createOutboundNotification({
+      notificationType: 'blocked_content',
+      ceoEmail: 'ceo@example.com',
+      subject: 'Action needed — blocked outbound reply',
+      body: 'An outbound message was blocked.\n\nBlock ID: block_abc123',
+      blockId: 'block_abc123',
+      originalChannel: 'email',
+      originalRecipientId: 'third-party@example.com',
+      parentEventId: 'evt-blocked-1',
+    });
+
+    expect(event.type).toBe('outbound.notification');
+    expect(event.sourceLayer).toBe('dispatch');
+    expect(event.payload.notificationType).toBe('blocked_content');
+    expect(event.payload.ceoEmail).toBe('ceo@example.com');
+    expect(event.payload.subject).toBe('Action needed — blocked outbound reply');
+    expect(event.payload.blockId).toBe('block_abc123');
+    expect(event.payload.originalChannel).toBe('email');
+    expect(event.payload.originalRecipientId).toBe('third-party@example.com');
+    expect(event.id).toBeTruthy();
+    expect(event.timestamp).toBeInstanceOf(Date);
+    expect(event.parentEventId).toBe('evt-blocked-1');
+  });
+
+  it('creates a group_held notification without parentEventId', () => {
+    const event = createOutboundNotification({
+      notificationType: 'group_held',
+      ceoEmail: 'ceo@example.com',
+      subject: 'Signal group message held — member verification needed',
+      body: 'A Signal group message was held.',
+      originalChannel: 'signal',
+      originalRecipientId: 'groupABCdef==',
+    });
+
+    expect(event.type).toBe('outbound.notification');
+    expect(event.payload.notificationType).toBe('group_held');
+    expect(event.payload.ceoEmail).toBe('ceo@example.com');
+    expect(event.parentEventId).toBeUndefined();
+    expect(event.payload.blockId).toBeUndefined();
+  });
+
+  it('dispatch layer can publish outbound.notification', () => {
+    expect(canPublish('dispatch', 'outbound.notification')).toBe(true);
+  });
+
+  it('channel layer can subscribe to outbound.notification', () => {
+    expect(canSubscribe('channel', 'outbound.notification')).toBe(true);
+  });
+
+  it('system layer can publish and subscribe to outbound.notification', () => {
+    expect(canPublish('system', 'outbound.notification')).toBe(true);
+    expect(canSubscribe('system', 'outbound.notification')).toBe(true);
+  });
+
+  it('agent layer cannot publish outbound.notification', () => {
+    expect(canPublish('agent', 'outbound.notification')).toBe(false);
+  });
+
+  it('channel layer cannot publish outbound.notification', () => {
+    expect(canPublish('channel', 'outbound.notification')).toBe(false);
+  });
+});

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -14,7 +14,7 @@ import type { ContactService } from '../../../../src/contacts/contact-service.js
 import type { EventBus } from '../../../../src/bus/bus.js';
 import type { NylasMessage } from '../../../../src/channels/email/nylas-client.js';
 import type { BusEvent } from '../../../../src/bus/events.js';
-import { createOutboundMessage } from '../../../../src/bus/events.js';
+import { createOutboundMessage, createOutboundNotification } from '../../../../src/bus/events.js';
 
 const SELF_EMAIL = 'curia@example.com';
 const CEO_EMAIL = 'ceo@example.com';
@@ -53,6 +53,7 @@ function createMocks() {
 
   const outboundGateway = {
     send: vi.fn().mockResolvedValue({ success: true, messageId: 'sent-1' }),
+    sendNotification: vi.fn().mockResolvedValue(undefined),
     listEmailMessages: vi.fn().mockResolvedValue([]),
   } as unknown as OutboundGateway;
 
@@ -379,6 +380,122 @@ describe('EmailAdapter — inbound poll: observationMode', () => {
     expect(inboundCall).toBeDefined();
     expect(inboundCall![1].payload.metadata.observationMode).toBeUndefined();
 
+    await adapter.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// outbound.notification subscriber (#206)
+// ---------------------------------------------------------------------------
+
+// Capture the outbound.notification handler registered during start().
+function captureNotificationHandler(mocks: ReturnType<typeof createMocks>): (event: BusEvent) => Promise<void> {
+  let handler: ((event: BusEvent) => Promise<void>) | undefined;
+  (mocks.bus.subscribe as ReturnType<typeof vi.fn>).mockImplementation(
+    (eventType: string, _layer: string, cb: (event: BusEvent) => Promise<void>) => {
+      if (eventType === 'outbound.notification') {
+        handler = cb;
+      }
+    },
+  );
+  return (...args) => {
+    if (!handler) throw new Error('outbound.notification handler not registered — did you call adapter.start()?');
+    return handler(...args);
+  };
+}
+
+describe('EmailAdapter — outbound.notification subscriber', () => {
+  let mocks: ReturnType<typeof createMocks>;
+
+  beforeEach(() => {
+    mocks = createMocks();
+  });
+
+  it('delivers a notification via outboundGateway.send() with skipNotificationOnBlock', async () => {
+    const handleNotification = captureNotificationHandler(mocks);
+    const adapter = makeAdapter(mocks);
+    await adapter.start();
+
+    const event = createOutboundNotification({
+      notificationType: 'blocked_content',
+      ceoEmail: CEO_EMAIL,
+      subject: 'Action needed — blocked outbound reply',
+      body: 'Block ID: block_test123',
+      blockId: 'block_test123',
+      originalChannel: 'email',
+      originalRecipientId: 'target@example.com',
+    });
+
+    await handleNotification(event);
+
+    expect(mocks.outboundGateway.send).toHaveBeenCalledOnce();
+    // Verify skipNotificationOnBlock is passed as the second argument
+    const sendCall = (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(sendCall[0]).toEqual(expect.objectContaining({
+      channel: 'email',
+      to: CEO_EMAIL,
+      subject: 'Action needed — blocked outbound reply',
+    }));
+    expect(sendCall[1]).toEqual({ skipNotificationOnBlock: true });
+
+    await adapter.stop();
+  });
+
+  it('only the primary account (curia) handles notifications', async () => {
+    const handleNotification = captureNotificationHandler(mocks);
+    // Create adapter with non-primary accountId
+    const adapter = new EmailAdapter({
+      accountId: 'joseph',
+      outboundPolicy: 'direct',
+      bus: mocks.bus,
+      logger: mocks.logger,
+      outboundGateway: mocks.outboundGateway,
+      contactService: mocks.contactService,
+      pollingIntervalMs: 999999,
+      selfEmail: 'joseph@example.com',
+      observationMode: false,
+      excludedSenderEmails: [],
+    });
+    await adapter.start();
+
+    const event = createOutboundNotification({
+      notificationType: 'blocked_content',
+      ceoEmail: CEO_EMAIL,
+      subject: 'Test',
+      body: 'Test body',
+    });
+
+    await handleNotification(event);
+
+    // Non-primary adapter should not call send
+    expect(mocks.outboundGateway.send).not.toHaveBeenCalled();
+
+    await adapter.stop();
+  });
+
+  it('logs error when notification delivery fails (send returns success: false)', async () => {
+    (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false,
+      blockedReason: 'Content blocked by filter',
+    });
+
+    const handleNotification = captureNotificationHandler(mocks);
+    const adapter = makeAdapter(mocks);
+    await adapter.start();
+
+    const event = createOutboundNotification({
+      notificationType: 'blocked_content',
+      ceoEmail: CEO_EMAIL,
+      subject: 'Test',
+      body: 'Test body',
+      blockId: 'block_test456',
+      originalChannel: 'email',
+    });
+
+    // Should not throw — errors are caught and logged
+    await handleNotification(event);
+
+    expect(mocks.outboundGateway.send).toHaveBeenCalledOnce();
     await adapter.stop();
   });
 });

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -53,7 +53,6 @@ function createMocks() {
 
   const outboundGateway = {
     send: vi.fn().mockResolvedValue({ success: true, messageId: 'sent-1' }),
-    sendNotification: vi.fn().mockResolvedValue(undefined),
     listEmailMessages: vi.fn().mockResolvedValue([]),
   } as unknown as OutboundGateway;
 
@@ -78,20 +77,23 @@ function makeAdapter(mocks: ReturnType<typeof createMocks>) {
 /** Flush pending microtasks and macrotasks so an initial poll triggered by start() can complete. */
 const flushPoll = () => new Promise<void>(resolve => setTimeout(resolve, 0));
 
-// Trigger the outbound.message handler directly by capturing the subscriber
-// registered during start() and calling it with a synthetic event.
-function captureOutboundHandler(mocks: ReturnType<typeof createMocks>): (event: BusEvent) => Promise<void> {
-  // start() calls bus.subscribe('outbound.message', ...). Capture that callback.
-  let handler: ((event: BusEvent) => Promise<void>) | undefined;
+// Capture the bus.subscribe handler for a given event type by intercepting the
+// subscribe call during start(). Supports multiple event types simultaneously
+// by storing handlers in a shared map keyed by eventType.
+function captureHandler(
+  eventType: string,
+  mocks: ReturnType<typeof createMocks>,
+): (event: BusEvent) => Promise<void> {
+  const handlers = ((mocks.bus.subscribe as ReturnType<typeof vi.fn>).__handlerMap ??= {}) as
+    Record<string, (event: BusEvent) => Promise<void>>;
   (mocks.bus.subscribe as ReturnType<typeof vi.fn>).mockImplementation(
-    (eventType: string, _layer: string, cb: (event: BusEvent) => Promise<void>) => {
-      if (eventType === 'outbound.message') {
-        handler = cb;
-      }
+    (et: string, _layer: string, cb: (event: BusEvent) => Promise<void>) => {
+      handlers[et] = cb;
     },
   );
   return (...args) => {
-    if (!handler) throw new Error('outbound.message handler not registered — did you call adapter.start()?');
+    const handler = handlers[eventType];
+    if (!handler) throw new Error(`${eventType} handler not registered — did you call adapter.start()?`);
     return handler(...args);
   };
 }
@@ -112,7 +114,7 @@ describe('EmailAdapter — sendOutboundReply', () => {
 
   beforeEach(() => {
     mocks = createMocks();
-    triggerOutbound = captureOutboundHandler(mocks);
+    triggerOutbound = captureHandler('outbound.message', mocks);
     adapter = makeAdapter(mocks);
     // start() registers the bus subscriber without starting the poll timer
     // (pollingIntervalMs is huge, and we don't await the initial poll)
@@ -388,22 +390,6 @@ describe('EmailAdapter — inbound poll: observationMode', () => {
 // outbound.notification subscriber (#206)
 // ---------------------------------------------------------------------------
 
-// Capture the outbound.notification handler registered during start().
-function captureNotificationHandler(mocks: ReturnType<typeof createMocks>): (event: BusEvent) => Promise<void> {
-  let handler: ((event: BusEvent) => Promise<void>) | undefined;
-  (mocks.bus.subscribe as ReturnType<typeof vi.fn>).mockImplementation(
-    (eventType: string, _layer: string, cb: (event: BusEvent) => Promise<void>) => {
-      if (eventType === 'outbound.notification') {
-        handler = cb;
-      }
-    },
-  );
-  return (...args) => {
-    if (!handler) throw new Error('outbound.notification handler not registered — did you call adapter.start()?');
-    return handler(...args);
-  };
-}
-
 describe('EmailAdapter — outbound.notification subscriber', () => {
   let mocks: ReturnType<typeof createMocks>;
 
@@ -412,7 +398,7 @@ describe('EmailAdapter — outbound.notification subscriber', () => {
   });
 
   it('delivers a notification via outboundGateway.send() with skipNotificationOnBlock', async () => {
-    const handleNotification = captureNotificationHandler(mocks);
+    const handleNotification = captureHandler('outbound.notification', mocks);
     const adapter = makeAdapter(mocks);
     await adapter.start();
 
@@ -442,7 +428,7 @@ describe('EmailAdapter — outbound.notification subscriber', () => {
   });
 
   it('only the primary account (curia) handles notifications', async () => {
-    const handleNotification = captureNotificationHandler(mocks);
+    const handleNotification = captureHandler('outbound.notification', mocks);
     // Create adapter with non-primary accountId
     const adapter = new EmailAdapter({
       accountId: 'joseph',
@@ -478,8 +464,9 @@ describe('EmailAdapter — outbound.notification subscriber', () => {
       success: false,
       blockedReason: 'Content blocked by filter',
     });
+    const errorSpy = vi.spyOn(mocks.logger, 'error');
 
-    const handleNotification = captureNotificationHandler(mocks);
+    const handleNotification = captureHandler('outbound.notification', mocks);
     const adapter = makeAdapter(mocks);
     await adapter.start();
 
@@ -496,6 +483,13 @@ describe('EmailAdapter — outbound.notification subscriber', () => {
     await handleNotification(event);
 
     expect(mocks.outboundGateway.send).toHaveBeenCalledOnce();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notificationType: 'blocked_content',
+        reason: 'Content blocked by filter',
+      }),
+      expect.stringContaining('failed to deliver outbound.notification'),
+    );
     await adapter.stop();
   });
 });

--- a/tests/unit/channels/signal/signal-adapter.test.ts
+++ b/tests/unit/channels/signal/signal-adapter.test.ts
@@ -51,6 +51,7 @@ function makeMockRpcClient() {
 function makeMockGateway() {
   return {
     send: vi.fn().mockResolvedValue({ success: true }),
+    sendNotification: vi.fn().mockResolvedValue(undefined),
     getSignalGroupMembers: vi.fn().mockRejectedValue(new Error('Signal client not configured')),
   } as unknown as OutboundGateway;
 }
@@ -427,11 +428,13 @@ describe('SignalAdapter', () => {
       await new Promise((r) => setTimeout(r, 30));
 
       expect(published).toHaveLength(0);
-      expect(gateway.send).toHaveBeenCalledWith(
+      // The group-held notification now routes through sendNotification() → bus (#206)
+      expect(gateway.sendNotification).toHaveBeenCalledWith(
         expect.objectContaining({
-          channel: 'email',
-          to: 'ceo@example.com',
+          notificationType: 'group_held',
+          ceoEmail: 'ceo@example.com',
           subject: 'Signal group message held — member verification needed',
+          originalChannel: 'signal',
         }),
       );
     });

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -170,8 +170,8 @@ describe('OutboundGateway', () => {
       const result = await gateway.send(baseRequest);
 
       expect(result.success).toBe(false);
-      // nylasClient.sendMessage may be called once for the CEO notification, but
-      // NOT for the original blocked message. We verify the result is blocked.
+      // The original blocked message must not be sent via nylasClient. The CEO
+      // notification now routes through the bus as outbound.notification (#206).
       expect(result.blockedReason).toBe('Content blocked by filter');
     });
 
@@ -195,20 +195,21 @@ describe('OutboundGateway', () => {
 
       await gateway.send(baseRequest);
 
-      expect(mocks.bus.publish).toHaveBeenCalledOnce();
+      // Two bus.publish calls: outbound.blocked + outbound.notification (#206)
+      expect(mocks.bus.publish).toHaveBeenCalledTimes(2);
       // bus.publish(layer, event) — event is the second argument (index 1)
-      const publishedEvent = (mocks.bus.publish as ReturnType<typeof vi.fn>).mock.calls[0][1] as BusEvent;
-      expect(publishedEvent.type).toBe('outbound.blocked');
+      const blockedEvent = (mocks.bus.publish as ReturnType<typeof vi.fn>).mock.calls[0][1] as BusEvent;
+      expect(blockedEvent.type).toBe('outbound.blocked');
       // The payload must contain the channel and recipient for downstream consumers
-      if (publishedEvent.type === 'outbound.blocked') {
-        expect(publishedEvent.payload.channelId).toBe('email');
-        expect(publishedEvent.payload.recipientId).toBe('recipient@example.com');
+      if (blockedEvent.type === 'outbound.blocked') {
+        expect(blockedEvent.payload.channelId).toBe('email');
+        expect(blockedEvent.payload.recipientId).toBe('recipient@example.com');
       }
     });
 
-    it('sends CEO notification via nylasClient when filter rejects', async () => {
-      // The CEO notification is the human-in-the-loop safety signal. It must
-      // be sent directly (not through the filter pipeline) to avoid recursion.
+    it('publishes outbound.notification event for CEO alert when filter rejects', async () => {
+      // The CEO notification routes through the bus as an outbound.notification event
+      // so it goes through the same safety pipeline as regular outbound messages (#206).
       (mocks.contentFilter.check as ReturnType<typeof vi.fn>).mockResolvedValue({
         passed: false,
         findings: [{ rule: 'secret-pattern', detail: 'API key detected' }],
@@ -226,16 +227,22 @@ describe('OutboundGateway', () => {
 
       await gateway.send(baseRequest);
 
-      // nylasClient.sendMessage should be called exactly once — for the CEO notification
-      expect(mocks.nylasClient.sendMessage).toHaveBeenCalledOnce();
-      const sendArgs = (mocks.nylasClient.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][0];
-      expect(sendArgs.to).toEqual([{ email: 'ceo@example.com' }]);
-      expect(sendArgs.subject).toMatch(/blocked/i);
+      // The second bus.publish call is the outbound.notification event
+      const notificationEvent = (mocks.bus.publish as ReturnType<typeof vi.fn>).mock.calls[1][1] as BusEvent;
+      expect(notificationEvent.type).toBe('outbound.notification');
+      if (notificationEvent.type === 'outbound.notification') {
+        expect(notificationEvent.payload.notificationType).toBe('blocked_content');
+        expect(notificationEvent.payload.ceoEmail).toBe('ceo@example.com');
+        expect(notificationEvent.payload.subject).toMatch(/blocked/i);
+      }
+      // nylasClient.sendMessage must NOT be called — the gateway no longer sends
+      // the notification directly; the EmailAdapter handles delivery.
+      expect(mocks.nylasClient.sendMessage).not.toHaveBeenCalled();
     });
 
-    it('sends CEO notification body with no sensitive content but includes block ID', async () => {
-      // The notification must never echo the blocked body or rule details back to
-      // any inbox — it is purely a "something was blocked, check the logs" signal.
+    it('notification payload contains no sensitive content but includes block ID', async () => {
+      // The notification must never echo the blocked body or rule details —
+      // it is purely a "something was blocked, check the logs" signal.
       // The block ID ties the notification to the outbound.blocked event in the audit trail.
       const sensitiveBody = 'My API key is sk-ant-abcdefghijklmnopqrst1234567890AB';
       (mocks.contentFilter.check as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -255,16 +262,19 @@ describe('OutboundGateway', () => {
 
       await gateway.send({ ...baseRequest, body: sensitiveBody });
 
-      const sendArgs = (mocks.nylasClient.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][0];
-      // Must NOT contain the blocked content
-      expect(sendArgs.body).not.toContain(sensitiveBody);
-      // Must NOT contain the detailed rule finding (could include key value)
-      expect(sendArgs.body).not.toContain('sk-ant-abcdefghijklmnopqrst1234567890AB');
-      // MUST contain the block ID so the CEO can cross-reference with logs
-      expect(sendArgs.body).toMatch(/block_[0-9a-f-]{36}/);
+      const notificationEvent = (mocks.bus.publish as ReturnType<typeof vi.fn>).mock.calls[1][1] as BusEvent;
+      expect(notificationEvent.type).toBe('outbound.notification');
+      if (notificationEvent.type === 'outbound.notification') {
+        // Must NOT contain the blocked content
+        expect(notificationEvent.payload.body).not.toContain(sensitiveBody);
+        // Must NOT contain the detailed rule finding (could include key value)
+        expect(notificationEvent.payload.body).not.toContain('sk-ant-abcdefghijklmnopqrst1234567890AB');
+        // MUST contain a block ID so the CEO can cross-reference with logs
+        expect(notificationEvent.payload.blockId).toMatch(/^block_/);
+      }
     });
 
-    it('fails closed when filter crashes — blocks send and notifies CEO', async () => {
+    it('fails closed when filter crashes — blocks send and publishes notification', async () => {
       // If the content filter itself throws, we must treat it as blocked (fail-closed).
       // A crashing filter is a security anomaly; we'd rather miss a send than let
       // potentially dangerous content through an unchecked pipeline.
@@ -285,8 +295,12 @@ describe('OutboundGateway', () => {
 
       // Filter crash must block the send
       expect(result.success).toBe(false);
-      // CEO notification is sent even when the filter crashes
-      expect(mocks.nylasClient.sendMessage).toHaveBeenCalledOnce();
+      // CEO notification is published to the bus as outbound.notification
+      const publishCalls = (mocks.bus.publish as ReturnType<typeof vi.fn>).mock.calls;
+      const notificationCalls = publishCalls.filter(
+        (call: unknown[]) => (call[1] as BusEvent).type === 'outbound.notification',
+      );
+      expect(notificationCalls).toHaveLength(1);
     });
 
     it('allows send when filter passes and calls check with correct params', async () => {


### PR DESCRIPTION
## Summary

- Adds `outbound.notification` discriminated union event type to the bus so system notifications (CEO blocked-content alerts, Signal group-held alerts) route through the same outbound safety pipeline as regular messages
- Replaces the direct `dispatchEmail()` bypass in OutboundGateway with `sendNotification()` → bus → EmailAdapter → `send()`
- Migrates SignalAdapter's `notifyCeoGroupHeld()` from direct `send()` to `sendNotification()`
- Includes a `skipNotificationOnBlock` recursion guard: if a broken content filter blocks the notification delivery itself, the cycle is broken rather than looping infinitely

Closes #206

## Changes

| File | Change |
|---|---|
| `src/bus/events.ts` | `OutboundNotificationPayload`, `OutboundNotificationEvent`, `createOutboundNotification()` factory, `BusEvent` union entry |
| `src/bus/permissions.ts` | dispatch can publish, channel can subscribe, system gets both |
| `src/dispatch/outbound-filter.ts` | Added to `BUS_EVENT_TYPE_NAMES` leak detection list |
| `src/skills/outbound-gateway.ts` | New `sendNotification()` method, `send()` accepts `skipNotificationOnBlock` option, blocked-content path uses `sendNotification()` |
| `src/channels/email/email-adapter.ts` | New `outbound.notification` subscriber that delivers via `send()` with recursion guard |
| `src/channels/signal/signal-adapter.ts` | `notifyCeoGroupHeld()` calls `sendNotification()` instead of `send()` |
| `docs/specs/15-outbound-safety.md` | Status table updated to Done |
| `docs/wip/...content-filter-design.md` | Spec deviation note marked as resolved |

## Test plan

- [x] New `tests/unit/bus/outbound-notification-event.test.ts` — factory shape, both payload variants, permissions matrix (7 tests)
- [x] Updated `tests/unit/skills/outbound-gateway.test.ts` — blocked-content path now asserts `bus.publish` for `outbound.notification` instead of `nylasClient.sendMessage` (4 tests updated)
- [x] Updated `tests/unit/channels/signal/signal-adapter.test.ts` — group-held path asserts `sendNotification()` call
- [x] New `tests/unit/channels/email/email-adapter.test.ts` — notification delivery via `send()`, primary-account guard, failure logging (3 new tests)
- [x] Full suite: 1575 passed, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CEO system notifications now route through the content-filter pipeline, ensuring consistent safety checks alongside standard messages.

* **Improvements**
  * Notifications about blocked or held content are now event-driven, providing better traceability and consistency across channels.

* **Documentation**
  * Updated specification and changelog to reflect the streamlined notification routing implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->