### PR TITLE
fix: calendar skills return local timezone timestamps (#362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Calendar timezone display** — calendar skill handlers (`calendar-list-events`, `calendar-find-free-time`, `calendar-check-conflicts`) now return timestamps in the user's local timezone instead of UTC. Previously, event times were returned as UTC Z-suffix strings and the LLM was expected to convert them, which it did unreliably — causing all events to display shifted by the UTC offset. Added `toLocalIso()` and `formatDisplayTimezone()` utilities, and exposed `timezone` on `SkillContext` (additive, non-breaking public API surface change). Fixes #362
 - **`held-messages-process` block idempotency** — `block` action now handles duplicate-key errors from `linkIdentity` the same way `identify` does: if the identity is already linked to a blocked contact on retry, it proceeds to `discard` rather than failing and leaving the held message stuck in `pending` (closes #335)
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Cross-cutting: Audit Logger, Memory Engine, Scheduler.
 1. Create `skills/<name>/skill.json` (manifest) + `handler.ts`
 2. Declare permissions and secrets in the manifest
 3. Write `handler.test.ts`
+4. **Timestamps:** When a skill returns timestamps for user-facing display, use `toLocalIso()` from `src/time/timestamp.ts` to convert to the user's local timezone (available as `ctx.timezone`). Never return raw UTC Z-suffix strings for times the user will see — LLMs cannot reliably perform timezone conversion. Include `displayTimezone: formatDisplayTimezone(ctx.timezone)` in the result data so the LLM can label its output.
 
 ### Autonomy Awareness
 

--- a/docs/wip/2026-04-26-calendar-timezone-display-design.md
+++ b/docs/wip/2026-04-26-calendar-timezone-display-design.md
@@ -1,0 +1,176 @@
+# Calendar Timezone Display Conversion
+
+**Date:** 2026-04-26
+**Issue:** #362
+**Branch:** fix/calendar-timezone-display
+
+## Problem
+
+Calendar skill handlers return UTC Z-suffix timestamps (e.g. `"2026-04-06T15:30:00.000Z"`) to the LLM and trust it to convert them to the user's local timezone for display. The LLM does not reliably perform this conversion — it reads the wall-clock digits directly from the ISO string, causing every event to display shifted by the UTC offset (4 hours ahead in EDT).
+
+An 8:00 AM EDT meeting shows as 12:00 PM. For an executive assistant, incorrect calendar times are a critical trust failure.
+
+## Root Cause
+
+The `toIso()` helper in `calendar-list-events/handler.ts` (line 139) calls `new Date(unix * 1000).toISOString()`, which always produces UTC Z-suffix strings. The same pattern exists in `calendar-find-free-time` and `calendar-check-conflicts`. The comment at handler.ts:126-128 assumes the LLM can handle conversion — it cannot.
+
+The infrastructure to fix this mostly exists: the `ExecutionLayer` already carries `this.timezone` from `config.timezone`, and luxon is already a dependency used for DST-safe conversions on the input side (`normalizeTimestamp()`). But there is no output-side conversion utility, and `SkillContext` does not expose the timezone to handlers.
+
+## Design
+
+### 1. `toLocalIso()` utility
+
+Add to `src/time/timestamp.ts` alongside the existing `normalizeTimestamp()`:
+
+```typescript
+/**
+ * Convert Unix seconds to an ISO 8601 string in the given IANA timezone,
+ * with the local UTC offset baked in.
+ *
+ * Example: toLocalIso(1775489400, 'America/Toronto') → "2026-04-06T11:30:00.000-04:00"
+ *
+ * This is the output-side complement to normalizeTimestamp() (which handles inputs).
+ * The wall-clock digits in the returned string match the user's local time, so LLMs
+ * read them correctly without needing to perform timezone arithmetic.
+ */
+export function toLocalIso(unixSeconds: number, timezone: string): string
+```
+
+Implementation:
+- `DateTime.fromSeconds(unixSeconds, { zone: timezone })`
+- Validate the resulting DateTime (throw on invalid timezone, same pattern as `formatTimeContextBlock`)
+- Return `dt.toISO()` which includes the local offset (e.g. `-04:00`)
+
+### 2. `formatDisplayTimezone()` utility
+
+Add to `src/time/timestamp.ts`:
+
+```typescript
+/**
+ * Format a timezone label for inclusion in skill result data.
+ * Example: formatDisplayTimezone('America/Toronto') → "EDT (UTC-04:00)"
+ */
+export function formatDisplayTimezone(timezone: string): string
+```
+
+Uses the same abbreviation + offset logic as `formatTimeContextBlock` in `time-context.ts`. Skills include this in their result data so the LLM can state which timezone times are displayed in.
+
+### 3. `timezone` on `SkillContext`
+
+Add an optional field to the `SkillContext` interface in `src/skills/types.ts`:
+
+```typescript
+/** IANA timezone name (e.g. "America/Toronto") for formatting user-facing timestamps.
+ *  Populated from the global config timezone. Skills returning timestamps for display
+ *  should use toLocalIso() with this value rather than returning raw UTC strings. */
+timezone?: string;
+```
+
+Wire in `ExecutionLayer`: when building the SkillContext for each invocation, set `ctx.timezone = this.timezone`. The ExecutionLayer already has `this.timezone` from config — this just exposes it to handlers.
+
+This is an additive change to a public API surface (SkillContext). Non-breaking — existing skills that don't use it are unaffected.
+
+### 4. Handler updates
+
+#### calendar-list-events/handler.ts
+
+Replace the `toIso()` helper:
+
+```typescript
+// Before:
+const toIso = (unix: number | null, field: string, eventId: string): string | null => {
+  if (unix === null) return null;
+  if (!Number.isFinite(unix) || unix <= 0) { /* warn and return null */ }
+  return new Date(unix * 1000).toISOString();
+};
+
+// After:
+const tz = ctx.timezone;
+const toIso = (unix: number | null, field: string, eventId: string): string | null => {
+  if (unix === null) return null;
+  if (!Number.isFinite(unix) || unix <= 0) { /* warn and return null — unchanged */ }
+  return tz ? toLocalIso(unix, tz) : new Date(unix * 1000).toISOString();
+};
+```
+
+Add `displayTimezone` to the result data:
+
+```typescript
+const data: Record<string, unknown> = {
+  events: formattedEvents,
+  count: formattedEvents.length,
+  displayTimezone: ctx.timezone ? formatDisplayTimezone(ctx.timezone) : null,
+};
+```
+
+Update the comment block (lines 123-128) to reflect the new approach.
+
+#### calendar-find-free-time/handler.ts
+
+Same pattern — convert the free window timestamps:
+
+```typescript
+const tz = ctx.timezone;
+const freeWindowsFormatted = filtered.map((w) => ({
+  start: tz ? toLocalIso(w.start, tz) : new Date(w.start * 1000).toISOString(),
+  end: tz ? toLocalIso(w.end, tz) : new Date(w.end * 1000).toISOString(),
+}));
+```
+
+Add `displayTimezone` to result data.
+
+#### calendar-check-conflicts/handler.ts
+
+Same pattern — convert conflict timestamps:
+
+```typescript
+const tz = ctx.timezone;
+// In the conflict push:
+startTime: tz ? toLocalIso(slot.startTime, tz) : new Date(slot.startTime * 1000).toISOString(),
+endTime: tz ? toLocalIso(slot.endTime, tz) : new Date(slot.endTime * 1000).toISOString(),
+```
+
+Add `displayTimezone` to result data.
+
+### 5. Tests
+
+#### New: `toLocalIso()` unit tests
+
+- Basic conversion: `toLocalIso(1775489400, 'America/Toronto')` → `"2026-04-06T11:30:00.000-04:00"`
+- DST boundary: verify correct offset during EST vs EDT
+- UTC passthrough: `toLocalIso(1775489400, 'UTC')` → `"2026-04-06T15:30:00.000+00:00"` (luxon uses `+00:00`, not `Z`)
+- Invalid timezone: throws
+
+#### New: `formatDisplayTimezone()` unit tests
+
+- `formatDisplayTimezone('America/Toronto')` → contains "EDT" and "UTC-04:00" (during EDT)
+- `formatDisplayTimezone('UTC')` → contains "UTC"
+
+#### Updated: `calendar-list-events.test.ts`
+
+- The test at line 221 ("formats timed event timestamps as UTC ISO strings") currently expects `"2026-04-06T15:30:00.000Z"`. Update to pass `timezone` in the mock context and expect the local-offset string.
+- Add a test verifying fallback to UTC when timezone is not provided.
+- Add a test verifying `displayTimezone` is present in result data.
+
+#### Updated: `calendar-find-free-time.test.ts` and `calendar-check-conflicts.test.ts`
+
+- Add timezone-aware assertions for output timestamps.
+
+### 6. Documentation
+
+Add a note to the "Adding a New Skill" section in `CLAUDE.md`:
+
+> **Timestamps:** When a skill returns timestamps for user-facing display, use `toLocalIso()` from `src/time/timestamp.ts` to convert to the user's local timezone (available as `ctx.timezone`). Never return raw UTC Z-suffix strings for times the user will see — LLMs cannot reliably perform timezone conversion. Include `displayTimezone: formatDisplayTimezone(ctx.timezone)` in the result data so the LLM can label its output.
+
+### 7. Changelog
+
+Entry under `## [Unreleased]` in the **Fixed** section:
+
+> **Calendar timezone display** — calendar skill handlers now return timestamps in the user's local timezone instead of UTC. Previously, event times were returned as UTC Z-suffix strings and the LLM was expected to convert them, which it did unreliably — causing all events to display shifted by the UTC offset. Fixes #362.
+
+## Out of Scope
+
+- **Travel-aware timezone resolution** — using profile travel data to determine effective timezone. Separate feature, separate spec.
+- **Per-calendar timezone** — calendars store a timezone field but the user wants all events in their local time. Not relevant here.
+- **Out-of-hours sanity checking** — flagging events outside 5 AM–11 PM. Separate enhancement.
+- **Coordinator prompt changes** — the code fix makes prompt-based conversion unnecessary.

--- a/docs/wip/2026-04-26-calendar-timezone-display.md
+++ b/docs/wip/2026-04-26-calendar-timezone-display.md
@@ -1,0 +1,673 @@
+# Calendar Timezone Display Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix calendar skill handlers to return timestamps in the user's local timezone instead of UTC, so the LLM displays correct wall-clock times.
+
+**Architecture:** Add a `toLocalIso()` output utility (complement to the existing `normalizeTimestamp()` input utility), expose `timezone` on `SkillContext`, and update all three calendar handlers to convert before returning. Defensive fallback to UTC when timezone is unavailable.
+
+**Tech Stack:** TypeScript/ESM, luxon (already a dependency), vitest
+
+**Worktree:** `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-calendar-tz`
+**Branch:** `fix/calendar-timezone-display`
+**Design:** `docs/wip/2026-04-26-calendar-timezone-display-design.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `src/time/timestamp.ts` | Add `toLocalIso()` and `formatDisplayTimezone()` |
+| Modify | `src/skills/types.ts` | Add `timezone?: string` to `SkillContext` |
+| Modify | `src/skills/execution.ts` | Wire `this.timezone` into ctx |
+| Modify | `skills/calendar-list-events/handler.ts` | Use `toLocalIso()` for output timestamps |
+| Modify | `skills/calendar-find-free-time/handler.ts` | Use `toLocalIso()` for output timestamps |
+| Modify | `skills/calendar-check-conflicts/handler.ts` | Use `toLocalIso()` for output timestamps |
+| Create | `tests/unit/time/timestamp.test.ts` | Tests for `toLocalIso()` and `formatDisplayTimezone()` |
+| Modify | `tests/unit/skills/calendar-list-events.test.ts` | Update timestamp expectations, add timezone tests |
+| Modify | `tests/unit/skills/calendar-find-free-time.test.ts` | Add timezone-aware assertions |
+| Modify | `tests/unit/skills/calendar-check-conflicts.test.ts` | Add timezone-aware assertions |
+| Modify | `CLAUDE.md` | Add timestamp guidance to "New Skill" section |
+| Modify | `CHANGELOG.md` | Add entry under [Unreleased] > Fixed |
+
+---
+
+## Task 1: Add `toLocalIso()` and `formatDisplayTimezone()` utilities
+
+**Files:**
+- Modify: `src/time/timestamp.ts`
+- Create: `tests/unit/time/timestamp.test.ts`
+
+- [ ] **Step 1: Write failing tests for `toLocalIso()`**
+
+Create `tests/unit/time/timestamp.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { toLocalIso, formatDisplayTimezone } from '../../../src/time/timestamp.js';
+
+describe('toLocalIso', () => {
+  it('converts Unix seconds to local ISO with offset for America/Toronto in EDT', () => {
+    // 1775489400 = 2026-04-06T15:30:00Z = 2026-04-06T11:30:00 EDT (UTC-4)
+    expect(toLocalIso(1775489400, 'America/Toronto')).toBe('2026-04-06T11:30:00.000-04:00');
+  });
+
+  it('converts Unix seconds to local ISO with offset for America/Toronto in EST', () => {
+    // 1738350600 = 2025-01-31T18:30:00Z = 2025-01-31T13:30:00 EST (UTC-5)
+    expect(toLocalIso(1738350600, 'America/Toronto')).toBe('2025-01-31T13:30:00.000-05:00');
+  });
+
+  it('handles UTC timezone', () => {
+    // luxon uses +00:00 for UTC, not Z
+    expect(toLocalIso(1775489400, 'UTC')).toBe('2026-04-06T15:30:00.000+00:00');
+  });
+
+  it('handles non-hour-aligned timezone offsets', () => {
+    // Asia/Kolkata is UTC+05:30
+    // 1775489400 = 2026-04-06T15:30:00Z = 2026-04-06T21:00:00+05:30
+    expect(toLocalIso(1775489400, 'Asia/Kolkata')).toBe('2026-04-06T21:00:00.000+05:30');
+  });
+
+  it('throws on invalid timezone', () => {
+    expect(() => toLocalIso(1775489400, 'Not/A/Zone')).toThrow('invalid timezone');
+  });
+});
+
+describe('formatDisplayTimezone', () => {
+  it('formats EDT timezone label', () => {
+    // April 2026 — EDT is active
+    const label = formatDisplayTimezone('America/Toronto', new Date('2026-04-06T15:30:00Z'));
+    expect(label).toContain('EDT');
+    expect(label).toContain('UTC-04:00');
+  });
+
+  it('formats EST timezone label', () => {
+    // January 2025 — EST is active
+    const label = formatDisplayTimezone('America/Toronto', new Date('2025-01-31T18:30:00Z'));
+    expect(label).toContain('EST');
+    expect(label).toContain('UTC-05:00');
+  });
+
+  it('formats UTC timezone label', () => {
+    const label = formatDisplayTimezone('UTC', new Date('2026-04-06T15:30:00Z'));
+    expect(label).toContain('UTC');
+  });
+
+  it('throws on invalid timezone', () => {
+    expect(() => formatDisplayTimezone('Not/A/Zone', new Date())).toThrow('invalid timezone');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-calendar-tz test -- tests/unit/time/timestamp.test.ts`
+
+Expected: FAIL — `toLocalIso` and `formatDisplayTimezone` are not exported from `timestamp.ts`.
+
+- [ ] **Step 3: Implement `toLocalIso()` and `formatDisplayTimezone()`**
+
+Add to the end of `src/time/timestamp.ts` (after the existing `normalizeTimestamp` function):
+
+```typescript
+/**
+ * Convert Unix seconds to an ISO 8601 string in the given IANA timezone,
+ * with the local UTC offset baked in.
+ *
+ * Example: toLocalIso(1775489400, 'America/Toronto') → "2026-04-06T11:30:00.000-04:00"
+ *
+ * This is the output-side complement to normalizeTimestamp() (which handles inputs).
+ * The wall-clock digits in the returned string match the user's local time, so LLMs
+ * read them correctly without needing to perform timezone arithmetic.
+ *
+ * @param unixSeconds  Unix epoch seconds (as returned by Nylas calendar API)
+ * @param timezone     IANA timezone name (e.g. "America/Toronto")
+ */
+export function toLocalIso(unixSeconds: number, timezone: string): string {
+  const dt = DateTime.fromSeconds(unixSeconds, { zone: timezone });
+  if (!dt.isValid) {
+    throw new Error(`toLocalIso: invalid timezone "${timezone}" (${dt.invalidReason ?? 'unknown reason'})`);
+  }
+  return dt.toISO()!;
+}
+
+/**
+ * Format a timezone label for inclusion in skill result data, so the LLM can
+ * state which timezone event times are displayed in.
+ *
+ * Example: formatDisplayTimezone('America/Toronto', now) → "EDT (UTC-04:00)"
+ *
+ * @param timezone  IANA timezone name
+ * @param now       Reference date for resolving DST abbreviation and offset
+ */
+export function formatDisplayTimezone(timezone: string, now: Date): string {
+  const dt = DateTime.fromJSDate(now, { zone: timezone });
+  if (!dt.isValid) {
+    throw new Error(`formatDisplayTimezone: invalid timezone "${timezone}" (${dt.invalidReason ?? 'unknown reason'})`);
+  }
+  const abbr = dt.toFormat('ZZZZ');
+  const sign = dt.offset >= 0 ? '+' : '-';
+  const absMin = Math.abs(dt.offset);
+  const hh = String(Math.floor(absMin / 60)).padStart(2, '0');
+  const mm = String(absMin % 60).padStart(2, '0');
+  const offsetLabel = dt.offset === 0 ? 'UTC' : `UTC${sign}${hh}:${mm}`;
+  // When abbr equals the offset string (some zones lack named abbreviations),
+  // just return the offset to avoid redundancy like "UTC+05:30 (UTC+05:30)".
+  if (abbr === dt.toFormat('ZZ') || abbr === offsetLabel) {
+    return offsetLabel;
+  }
+  return `${abbr} (${offsetLabel})`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-calendar-tz test -- tests/unit/time/timestamp.test.ts`
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /path/to/worktree add src/time/timestamp.ts tests/unit/time/timestamp.test.ts
+git -C /path/to/worktree commit -m "feat: add toLocalIso() and formatDisplayTimezone() utilities (#362)"
+```
+
+---
+
+## Task 2: Add `timezone` to `SkillContext` and wire through `ExecutionLayer`
+
+**Files:**
+- Modify: `src/skills/types.ts:113` (SkillContext interface)
+- Modify: `src/skills/execution.ts:289` (ctx object construction)
+
+- [ ] **Step 1: Add `timezone` to `SkillContext` interface**
+
+In `src/skills/types.ts`, add after the `taskMetadata` field (line 184):
+
+```typescript
+  /** IANA timezone name (e.g. "America/Toronto") for formatting user-facing timestamps.
+   *  Populated from the global config timezone. Skills returning timestamps for display
+   *  should use toLocalIso() with this value rather than returning raw UTC strings. */
+  timezone?: string;
+```
+
+- [ ] **Step 2: Wire `timezone` into the ctx object in `ExecutionLayer.invoke()`**
+
+In `src/skills/execution.ts`, add `timezone: this.timezone,` to the ctx object construction block. Add it after the `taskMetadata` assignment (line 288), before the closing brace of the ctx object:
+
+```typescript
+      taskMetadata: options?.taskMetadata,
+      // Expose the configured timezone so skills can format output timestamps
+      // in the user's local time. See toLocalIso() in src/time/timestamp.ts.
+      timezone: this.timezone,
+    };
+```
+
+- [ ] **Step 3: Run the full test suite to verify no regressions**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-calendar-tz test`
+
+Expected: All existing tests pass. The new field is optional and unused by existing code, so nothing should break.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /path/to/worktree add src/skills/types.ts src/skills/execution.ts
+git -C /path/to/worktree commit -m "feat: expose timezone on SkillContext for output formatting (#362)"
+```
+
+---
+
+## Task 3: Update `calendar-list-events` handler
+
+**Files:**
+- Modify: `skills/calendar-list-events/handler.ts`
+- Modify: `tests/unit/skills/calendar-list-events.test.ts`
+
+- [ ] **Step 1: Update the test for timestamp formatting to expect local-offset strings**
+
+In `tests/unit/skills/calendar-list-events.test.ts`, replace the test at line 221 ("formats timed event timestamps as UTC ISO strings for LLM consumption"):
+
+```typescript
+  it('formats timed event timestamps in the configured timezone', async () => {
+    // 1775489400 Unix seconds = 2026-04-06T15:30:00Z = 11:30 AM EDT (UTC-4)
+    // 1775491200 Unix seconds = 2026-04-06T16:00:00Z = 12:00 PM EDT (UTC-4)
+    const timedEvent = {
+      id: 'evt-timed',
+      title: 'Catchup',
+      description: '',
+      participants: [],
+      startTime: 1775489400,
+      endTime: 1775491200,
+      startDate: null,
+      endDate: null,
+      location: '',
+      conferencing: null,
+      status: 'confirmed',
+      calendarId: 'cal-1',
+      busy: true,
+    };
+    const nylasCalendarClient = {
+      listEvents: vi.fn().mockResolvedValue([timedEvent]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', timeMin: '2026-04-06T00:00:00Z', timeMax: '2026-04-07T00:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never, timezone: 'America/Toronto' },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: Array<{ startTime: string; endTime: string }>; displayTimezone: string };
+      // Wall-clock digits should be in EDT (UTC-4), not UTC
+      expect(data.events[0].startTime).toBe('2026-04-06T11:30:00.000-04:00');
+      expect(data.events[0].endTime).toBe('2026-04-06T12:00:00.000-04:00');
+      expect(data.displayTimezone).toContain('EDT');
+    }
+  });
+```
+
+- [ ] **Step 2: Add a test for UTC fallback when timezone is not provided**
+
+Add after the previous test:
+
+```typescript
+  it('falls back to UTC ISO strings when timezone is not provided', async () => {
+    const timedEvent = {
+      id: 'evt-timed',
+      title: 'Catchup',
+      description: '',
+      participants: [],
+      startTime: 1775489400,
+      endTime: 1775491200,
+      startDate: null,
+      endDate: null,
+      location: '',
+      conferencing: null,
+      status: 'confirmed',
+      calendarId: 'cal-1',
+      busy: true,
+    };
+    const nylasCalendarClient = {
+      listEvents: vi.fn().mockResolvedValue([timedEvent]),
+    };
+
+    // No timezone in context — should fall back to UTC Z-suffix
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', timeMin: '2026-04-06T00:00:00Z', timeMax: '2026-04-07T00:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: Array<{ startTime: string }>; displayTimezone: null };
+      expect(data.events[0].startTime).toBe('2026-04-06T15:30:00.000Z');
+      expect(data.displayTimezone).toBeNull();
+    }
+  });
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-calendar-tz test -- tests/unit/skills/calendar-list-events.test.ts`
+
+Expected: FAIL — handler still returns UTC Z-suffix and no `displayTimezone`.
+
+- [ ] **Step 4: Update the handler**
+
+In `skills/calendar-list-events/handler.ts`:
+
+Add the import at line 2 (after the existing imports):
+
+```typescript
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+```
+
+Replace the comment block and `toIso` helper (lines 123-140) with:
+
+```typescript
+      // Format events for LLM consumption.
+      // Nylas returns timed event timestamps as Unix seconds. Convert to the user's
+      // local timezone so the wall-clock digits in the ISO string match local time.
+      // The LLM reads these digits directly — it cannot reliably do UTC conversion.
+      // Falls back to UTC Z-suffix when timezone is not configured (defensive).
+      //
+      // Guard non-finite and non-positive values: Unix 0 is never a real calendar
+      // event time, and passing "1970-01-01T00:00:00Z" to the LLM would be silently
+      // wrong. Log and null-out rather than propagate corrupted data.
+      const tz = ctx.timezone;
+      const toIso = (unix: number | null, field: string, eventId: string): string | null => {
+        if (unix === null) return null;
+        if (!Number.isFinite(unix) || unix <= 0) {
+          ctx.log.warn({ eventId, field, value: unix }, `calendar-list-events: suspicious ${field} value — omitting`);
+          return null;
+        }
+        return tz ? toLocalIso(unix, tz) : new Date(unix * 1000).toISOString();
+      };
+```
+
+Replace the `data` construction (line 148) with:
+
+```typescript
+      const data: Record<string, unknown> = {
+        events: formattedEvents,
+        count: formattedEvents.length,
+        displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : null,
+      };
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-calendar-tz test -- tests/unit/skills/calendar-list-events.test.ts`
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /path/to/worktree add skills/calendar-list-events/handler.ts tests/unit/skills/calendar-list-events.test.ts
+git -C /path/to/worktree commit -m "fix: calendar-list-events returns local timezone timestamps (#362)"
+```
+
+---
+
+## Task 4: Update `calendar-find-free-time` handler
+
+**Files:**
+- Modify: `skills/calendar-find-free-time/handler.ts`
+- Modify: `tests/unit/skills/calendar-find-free-time.test.ts`
+
+- [ ] **Step 1: Add timezone-aware test**
+
+Add to the end of the `describe` block in `tests/unit/skills/calendar-find-free-time.test.ts`:
+
+```typescript
+  it('formats free window timestamps in the configured timezone', async () => {
+    // Use realistic timestamps: busy 9:00-10:00 AM EDT on 2026-04-06
+    // 1775480400 = 2026-04-06T13:00:00Z = 9:00 AM EDT
+    // 1775484000 = 2026-04-06T14:00:00Z = 10:00 AM EDT
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([{
+        email: 'cal-1',
+        timeSlots: [{ startTime: 1775480400, endTime: 1775484000, status: 'busy' }],
+      }]),
+    };
+
+    // Query range: 8:00 AM - 12:00 PM EDT
+    // 1775476800 = 2026-04-06T12:00:00Z = 8:00 AM EDT
+    // 1775491200 = 2026-04-06T16:00:00Z = 12:00 PM EDT
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'], timeMin: '2026-04-06T12:00:00Z', timeMax: '2026-04-06T16:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never, timezone: 'America/Toronto' },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { freeWindows: Array<{ start: string; end: string }>; displayTimezone: string };
+      // Free: 8:00-9:00 AM EDT, 10:00 AM-12:00 PM EDT
+      expect(data.freeWindows[0].start).toBe('2026-04-06T08:00:00.000-04:00');
+      expect(data.freeWindows[0].end).toBe('2026-04-06T09:00:00.000-04:00');
+      expect(data.freeWindows[1].start).toBe('2026-04-06T10:00:00.000-04:00');
+      expect(data.freeWindows[1].end).toBe('2026-04-06T12:00:00.000-04:00');
+      expect(data.displayTimezone).toContain('EDT');
+    }
+  });
+
+  it('falls back to UTC when timezone is not provided', async () => {
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([{
+        email: 'cal-1',
+        timeSlots: [{ startTime: 1775480400, endTime: 1775484000, status: 'busy' }],
+      }]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'], timeMin: '2026-04-06T12:00:00Z', timeMax: '2026-04-06T16:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { freeWindows: Array<{ start: string; end: string }>; displayTimezone: null };
+      // UTC Z-suffix when no timezone configured
+      expect(data.freeWindows[0].start).toBe('2026-04-06T12:00:00.000Z');
+      expect(data.displayTimezone).toBeNull();
+    }
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify the new ones fail**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-calendar-tz test -- tests/unit/skills/calendar-find-free-time.test.ts`
+
+Expected: New tests FAIL (handler still returns UTC, no `displayTimezone`). Existing tests still pass.
+
+- [ ] **Step 3: Update the handler**
+
+In `skills/calendar-find-free-time/handler.ts`:
+
+Add the import after the existing import (line 6):
+
+```typescript
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+```
+
+Replace lines 84-88 (the comment and `freeWindowsIso` mapping):
+
+```typescript
+      // Format timestamps in the user's local timezone so the LLM reads correct
+      // wall-clock times. Falls back to UTC Z-suffix when timezone is not configured.
+      const tz = ctx.timezone;
+      const freeWindowsFormatted = filtered.map((w) => ({
+        start: tz ? toLocalIso(w.start, tz) : new Date(w.start * 1000).toISOString(),
+        end: tz ? toLocalIso(w.end, tz) : new Date(w.end * 1000).toISOString(),
+      }));
+```
+
+Update the return statement (line 91) — replace `freeWindowsIso` with `freeWindowsFormatted` and add `displayTimezone`:
+
+```typescript
+      ctx.log.info({ calendarCount: calendarIds.length, freeWindowCount: freeWindowsFormatted.length }, 'Found free time');
+      return { success: true, data: { freeWindows: freeWindowsFormatted, displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : null } };
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-calendar-tz test -- tests/unit/skills/calendar-find-free-time.test.ts`
+
+Expected: All tests PASS (including the existing ones — they don't pass `timezone`, so they get UTC fallback which matches their current expectations).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /path/to/worktree add skills/calendar-find-free-time/handler.ts tests/unit/skills/calendar-find-free-time.test.ts
+git -C /path/to/worktree commit -m "fix: calendar-find-free-time returns local timezone timestamps (#362)"
+```
+
+---
+
+## Task 5: Update `calendar-check-conflicts` handler
+
+**Files:**
+- Modify: `skills/calendar-check-conflicts/handler.ts`
+- Modify: `tests/unit/skills/calendar-check-conflicts.test.ts`
+
+- [ ] **Step 1: Add timezone-aware test**
+
+Add to the end of the `describe` block in `tests/unit/skills/calendar-check-conflicts.test.ts`:
+
+```typescript
+  it('formats conflict timestamps in the configured timezone', async () => {
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([{
+        email: 'cal-1',
+        timeSlots: [
+          // Busy: 2026-04-06T13:00:00Z - 14:00:00Z = 9:00-10:00 AM EDT
+          { startTime: 1775480400, endTime: 1775484000, status: 'busy' },
+        ],
+      }]),
+    };
+    const contactService = {
+      resolveCalendar: vi.fn().mockResolvedValue({ contactId: 'c1' }),
+      getContact: vi.fn().mockResolvedValue({ id: 'c1', displayName: 'Jane Doe' }),
+    };
+
+    // Proposed time overlaps the busy period
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'], proposedStart: '2026-04-06T12:30:00Z', proposedEnd: '2026-04-06T13:30:00Z' },
+      {
+        nylasCalendarClient: nylasCalendarClient as never,
+        contactService: contactService as never,
+        timezone: 'America/Toronto',
+      },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as {
+        conflicts: Array<{ startTime: string; endTime: string }>;
+        clear: boolean;
+        displayTimezone: string;
+      };
+      expect(data.clear).toBe(false);
+      expect(data.conflicts).toHaveLength(1);
+      // Timestamps should be in EDT (UTC-4), not UTC
+      expect(data.conflicts[0].startTime).toBe('2026-04-06T09:00:00.000-04:00');
+      expect(data.conflicts[0].endTime).toBe('2026-04-06T10:00:00.000-04:00');
+      expect(data.displayTimezone).toContain('EDT');
+    }
+  });
+
+  it('falls back to UTC when timezone is not provided', async () => {
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([{
+        email: 'cal-1',
+        timeSlots: [
+          { startTime: 1775480400, endTime: 1775484000, status: 'busy' },
+        ],
+      }]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'], proposedStart: '2026-04-06T12:30:00Z', proposedEnd: '2026-04-06T13:30:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { conflicts: Array<{ startTime: string }>; displayTimezone: null };
+      // UTC Z-suffix when no timezone configured
+      expect(data.conflicts[0].startTime).toBe('2026-04-06T13:00:00.000Z');
+      expect(data.displayTimezone).toBeNull();
+    }
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify the new ones fail**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-calendar-tz test -- tests/unit/skills/calendar-check-conflicts.test.ts`
+
+Expected: New tests FAIL. Existing tests still pass.
+
+- [ ] **Step 3: Update the handler**
+
+In `skills/calendar-check-conflicts/handler.ts`:
+
+Add the import after line 6:
+
+```typescript
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+```
+
+Inside the `try` block, add this after the `proposedEndTs` line (line 35):
+
+```typescript
+      const tz = ctx.timezone;
+```
+
+Replace the comment and timestamp formatting inside the conflict push (lines 59-64):
+
+```typescript
+            // Format timestamps in the user's local timezone so the LLM reads correct
+            // wall-clock times. Falls back to UTC Z-suffix when timezone is not configured.
+            conflicts.push({
+              calendarId: result.email,
+              contactName,
+              startTime: tz ? toLocalIso(slot.startTime, tz) : new Date(slot.startTime * 1000).toISOString(),
+              endTime: tz ? toLocalIso(slot.endTime, tz) : new Date(slot.endTime * 1000).toISOString(),
+              status: slot.status,
+            });
+```
+
+Update the return statement (line 73) to include `displayTimezone`:
+
+```typescript
+      ctx.log.info({ calendarCount: calendarIds.length, conflictCount: conflicts.length }, 'Checked conflicts');
+      return { success: true, data: { conflicts, clear, displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : null } };
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-calendar-tz test -- tests/unit/skills/calendar-check-conflicts.test.ts`
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /path/to/worktree add skills/calendar-check-conflicts/handler.ts tests/unit/skills/calendar-check-conflicts.test.ts
+git -C /path/to/worktree commit -m "fix: calendar-check-conflicts returns local timezone timestamps (#362)"
+```
+
+---
+
+## Task 6: Documentation and changelog
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add timestamp guidance to the "New Skill" section in CLAUDE.md**
+
+In `CLAUDE.md`, after line 70 (the end of the "New Skill" subsection, before "### Autonomy Awareness"), add:
+
+```markdown
+4. **Timestamps:** When a skill returns timestamps for user-facing display, use `toLocalIso()` from `src/time/timestamp.ts` to convert to the user's local timezone (available as `ctx.timezone`). Never return raw UTC Z-suffix strings for times the user will see — LLMs cannot reliably perform timezone conversion. Include `displayTimezone: formatDisplayTimezone(ctx.timezone)` in the result data so the LLM can label its output.
+```
+
+- [ ] **Step 2: Add changelog entry**
+
+In `CHANGELOG.md`, add to the existing `### Fixed` section under `## [Unreleased]` (after line 22):
+
+```markdown
+- **Calendar timezone display** — calendar skill handlers (`calendar-list-events`, `calendar-find-free-time`, `calendar-check-conflicts`) now return timestamps in the user's local timezone instead of UTC. Previously, event times were returned as UTC Z-suffix strings and the LLM was expected to convert them, which it did unreliably — causing all events to display shifted by the UTC offset. Added `toLocalIso()` and `formatDisplayTimezone()` utilities, and exposed `timezone` on `SkillContext` (additive, non-breaking public API surface change). Fixes #362
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add CLAUDE.md CHANGELOG.md
+git -C /path/to/worktree commit -m "docs: add timezone guidance for skills and changelog entry (#362)"
+```
+
+---
+
+## Task 7: Full test suite and typecheck
+
+- [ ] **Step 1: Run typecheck**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-calendar-tz run typecheck`
+
+Expected: Clean — no type errors.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-calendar-tz test`
+
+Expected: All tests pass with no regressions.
+
+- [ ] **Step 3: Fix any failures and commit**
+
+If any failures, fix and commit with an appropriate message.

--- a/skills/calendar-check-conflicts/handler.ts
+++ b/skills/calendar-check-conflicts/handler.ts
@@ -59,6 +59,11 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
         for (const slot of result.timeSlots) {
           // Check overlap: busy slot overlaps the proposed range
           if (slot.startTime < proposedEndTs && slot.endTime > proposedStartTs) {
+            // Guard non-finite and non-positive values the same way calendar-list-events does.
+            if (!Number.isFinite(slot.startTime) || slot.startTime <= 0 || !Number.isFinite(slot.endTime) || slot.endTime <= 0) {
+              ctx.log.warn({ calendarId: result.email, startTime: slot.startTime, endTime: slot.endTime }, 'calendar-check-conflicts: suspicious slot timestamp — skipping');
+              continue;
+            }
             // Format timestamps in the user's local timezone so the LLM reads correct
             // wall-clock times. Falls back to UTC Z-suffix when timezone is not configured.
             conflicts.push({
@@ -73,8 +78,11 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
       }
 
       const clear = conflicts.length === 0;
+      // Derive displayTimezone from the proposed start time rather than "now" so
+      // the label's DST offset matches the offsets baked into the conflict timestamps.
+      const labelDate = new Date(proposedStart);
       ctx.log.info({ calendarCount: calendarIds.length, conflictCount: conflicts.length }, 'Checked conflicts');
-      return { success: true, data: { conflicts, clear, displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : null } };
+      return { success: true, data: { conflicts, clear, displayTimezone: tz && !clear ? formatDisplayTimezone(tz, labelDate) : null } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       ctx.log.error({ err }, 'Failed to check conflicts');

--- a/skills/calendar-check-conflicts/handler.ts
+++ b/skills/calendar-check-conflicts/handler.ts
@@ -5,6 +5,7 @@
 // Returns an empty array (clear=true) if the time is free.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 
 export class CalendarCheckConflictsHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -34,6 +35,8 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
       const proposedStartTs = Math.floor(new Date(proposedStart).getTime() / 1000);
       const proposedEndTs = Math.floor(new Date(proposedEnd).getTime() / 1000);
 
+      const tz = ctx.timezone;
+
       const conflicts: Array<{
         calendarId: string;
         contactName: string | null;
@@ -56,12 +59,13 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
         for (const slot of result.timeSlots) {
           // Check overlap: busy slot overlaps the proposed range
           if (slot.startTime < proposedEndTs && slot.endTime > proposedStartTs) {
-            // Format timestamps as UTC ISO strings — LLMs can't reliably convert raw Unix seconds.
+            // Format timestamps in the user's local timezone so the LLM reads correct
+            // wall-clock times. Falls back to UTC Z-suffix when timezone is not configured.
             conflicts.push({
               calendarId: result.email,
               contactName,
-              startTime: new Date(slot.startTime * 1000).toISOString(),
-              endTime: new Date(slot.endTime * 1000).toISOString(),
+              startTime: tz ? toLocalIso(slot.startTime, tz) : new Date(slot.startTime * 1000).toISOString(),
+              endTime: tz ? toLocalIso(slot.endTime, tz) : new Date(slot.endTime * 1000).toISOString(),
               status: slot.status,
             });
           }
@@ -70,7 +74,7 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
 
       const clear = conflicts.length === 0;
       ctx.log.info({ calendarCount: calendarIds.length, conflictCount: conflicts.length }, 'Checked conflicts');
-      return { success: true, data: { conflicts, clear } };
+      return { success: true, data: { conflicts, clear, displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : null } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       ctx.log.error({ err }, 'Failed to check conflicts');

--- a/skills/calendar-find-free-time/handler.ts
+++ b/skills/calendar-find-free-time/handler.ts
@@ -4,6 +4,7 @@
 // the busy periods returned by the Nylas free/busy API.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 
 export class CalendarFindFreeTimeHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -81,14 +82,16 @@ export class CalendarFindFreeTimeHandler implements SkillHandler {
         ? freeWindows.filter((w) => w.end - w.start >= minSeconds)
         : freeWindows;
 
-      // Format timestamps as UTC ISO strings — LLMs can't reliably convert raw Unix seconds.
-      const freeWindowsIso = filtered.map((w) => ({
-        start: new Date(w.start * 1000).toISOString(),
-        end: new Date(w.end * 1000).toISOString(),
+      // Format timestamps in the user's local timezone so the LLM reads correct
+      // wall-clock times. Falls back to UTC Z-suffix when timezone is not configured.
+      const tz = ctx.timezone;
+      const freeWindowsFormatted = filtered.map((w) => ({
+        start: tz ? toLocalIso(w.start, tz) : new Date(w.start * 1000).toISOString(),
+        end: tz ? toLocalIso(w.end, tz) : new Date(w.end * 1000).toISOString(),
       }));
 
-      ctx.log.info({ calendarCount: calendarIds.length, freeWindowCount: freeWindowsIso.length }, 'Found free time');
-      return { success: true, data: { freeWindows: freeWindowsIso } };
+      ctx.log.info({ calendarCount: calendarIds.length, freeWindowCount: freeWindowsFormatted.length }, 'Found free time');
+      return { success: true, data: { freeWindows: freeWindowsFormatted, displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : null } };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       ctx.log.error({ err }, 'Failed to find free time');

--- a/skills/calendar-find-free-time/handler.ts
+++ b/skills/calendar-find-free-time/handler.ts
@@ -84,10 +84,18 @@ export class CalendarFindFreeTimeHandler implements SkillHandler {
 
       // Format timestamps in the user's local timezone so the LLM reads correct
       // wall-clock times. Falls back to UTC Z-suffix when timezone is not configured.
+      // Guard non-finite and non-positive values the same way calendar-list-events does.
       const tz = ctx.timezone;
+      const formatTs = (unix: number, field: string): string | null => {
+        if (!Number.isFinite(unix) || unix <= 0) {
+          ctx.log.warn({ value: unix, field }, 'calendar-find-free-time: suspicious timestamp — omitting');
+          return null;
+        }
+        return tz ? toLocalIso(unix, tz) : new Date(unix * 1000).toISOString();
+      };
       const freeWindowsFormatted = filtered.map((w) => ({
-        start: tz ? toLocalIso(w.start, tz) : new Date(w.start * 1000).toISOString(),
-        end: tz ? toLocalIso(w.end, tz) : new Date(w.end * 1000).toISOString(),
+        start: formatTs(w.start, 'start'),
+        end: formatTs(w.end, 'end'),
       }));
 
       ctx.log.info({ calendarCount: calendarIds.length, freeWindowCount: freeWindowsFormatted.length }, 'Found free time');

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -13,6 +13,7 @@
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { NylasCalendarEvent } from '../../src/channels/calendar/nylas-calendar-client.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 
 export class CalendarListEventsHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -121,22 +122,22 @@ export class CalendarListEventsHandler implements SkillHandler {
       }
 
       // Format events for LLM consumption.
-      // Nylas returns timed event timestamps as Unix seconds. LLMs can't reliably
-      // do Unix epoch arithmetic (they produce wrong wall-clock times), so we
-      // convert to UTC ISO 8601 strings here. The LLM already knows the user's
-      // timezone from the system prompt's time context block and can display ISO
-      // strings correctly.
+      // Nylas returns timed event timestamps as Unix seconds. Convert to the user's
+      // local timezone so the wall-clock digits in the ISO string match local time.
+      // The LLM reads these digits directly — it cannot reliably do UTC conversion.
+      // Falls back to UTC Z-suffix when timezone is not configured (defensive).
       //
       // Guard non-finite and non-positive values: Unix 0 is never a real calendar
       // event time, and passing "1970-01-01T00:00:00Z" to the LLM would be silently
       // wrong. Log and null-out rather than propagate corrupted data.
+      const tz = ctx.timezone;
       const toIso = (unix: number | null, field: string, eventId: string): string | null => {
         if (unix === null) return null;
         if (!Number.isFinite(unix) || unix <= 0) {
           ctx.log.warn({ eventId, field, value: unix }, `calendar-list-events: suspicious ${field} value — omitting`);
           return null;
         }
-        return new Date(unix * 1000).toISOString();
+        return tz ? toLocalIso(unix, tz) : new Date(unix * 1000).toISOString();
       };
       const formattedEvents = events.map((evt) => ({
         ...evt,
@@ -145,7 +146,11 @@ export class CalendarListEventsHandler implements SkillHandler {
       }));
 
       ctx.log.info({ calendarIds, count: formattedEvents.length, failedCalendarIds }, 'Listed events');
-      const data: Record<string, unknown> = { events: formattedEvents, count: formattedEvents.length };
+      const data: Record<string, unknown> = {
+        events: formattedEvents,
+        count: formattedEvents.length,
+        displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : null,
+      };
       // Surface partial failures so the LLM can inform the user
       if (failedCalendarIds.length > 0) {
         data.warnings = [`Failed to fetch events from ${failedCalendarIds.length} calendar(s): ${failedCalendarIds.join(', ')}`];

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -286,6 +286,9 @@ export class ExecutionLayer {
       // Forward task-level metadata (e.g. observationMode) so skills can adjust
       // their behaviour without needing a separate out-of-band signalling channel.
       taskMetadata: options?.taskMetadata,
+      // Expose the configured timezone so skills can format output timestamps
+      // in the user's local time. See toLocalIso() in src/time/timestamp.ts.
+      timezone: this.timezone,
     };
 
     // Capability-gated service injection.

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -182,6 +182,10 @@ export interface SkillContext {
    *  e.g. suppressing outbound sends when observationMode === true.
    *  Skills that do not need it can ignore this field entirely. */
   taskMetadata?: Record<string, unknown>;
+  /** IANA timezone name (e.g. "America/Toronto") for formatting user-facing timestamps.
+   *  Populated from the global config timezone. Skills returning timestamps for display
+   *  should use toLocalIso() with this value rather than returning raw UTC strings. */
+  timezone?: string;
 }
 
 /**

--- a/src/time/timestamp.ts
+++ b/src/time/timestamp.ts
@@ -71,3 +71,52 @@ export function normalizeTimestamp(iso: string, defaultZone: string): string {
   }
   return dt.toUTC().toISO()!;
 }
+
+/**
+ * Convert Unix seconds to an ISO 8601 string in the given IANA timezone,
+ * with the local UTC offset baked in.
+ *
+ * Example: toLocalIso(1775489400, 'America/Toronto') → "2026-04-06T11:30:00.000-04:00"
+ *
+ * This is the output-side complement to normalizeTimestamp() (which handles inputs).
+ * The wall-clock digits in the returned string match the user's local time, so LLMs
+ * read them correctly without needing to perform timezone arithmetic.
+ *
+ * @param unixSeconds  Unix epoch seconds (as returned by Nylas calendar API)
+ * @param timezone     IANA timezone name (e.g. "America/Toronto")
+ */
+export function toLocalIso(unixSeconds: number, timezone: string): string {
+  const dt = DateTime.fromSeconds(unixSeconds, { zone: timezone });
+  if (!dt.isValid) {
+    throw new Error(`toLocalIso: invalid timezone "${timezone}" (${dt.invalidReason ?? 'unknown reason'})`);
+  }
+  return dt.toISO()!;
+}
+
+/**
+ * Format a timezone label for inclusion in skill result data, so the LLM can
+ * state which timezone event times are displayed in.
+ *
+ * Example: formatDisplayTimezone('America/Toronto', now) → "EDT (UTC-04:00)"
+ *
+ * @param timezone  IANA timezone name
+ * @param now       Reference date for resolving DST abbreviation and offset
+ */
+export function formatDisplayTimezone(timezone: string, now: Date): string {
+  const dt = DateTime.fromJSDate(now, { zone: timezone });
+  if (!dt.isValid) {
+    throw new Error(`formatDisplayTimezone: invalid timezone "${timezone}" (${dt.invalidReason ?? 'unknown reason'})`);
+  }
+  const abbr = dt.toFormat('ZZZZ');
+  const sign = dt.offset >= 0 ? '+' : '-';
+  const absMin = Math.abs(dt.offset);
+  const hh = String(Math.floor(absMin / 60)).padStart(2, '0');
+  const mm = String(absMin % 60).padStart(2, '0');
+  const offsetLabel = dt.offset === 0 ? 'UTC' : `UTC${sign}${hh}:${mm}`;
+  // When abbr equals the offset string (some zones lack named abbreviations),
+  // just return the offset to avoid redundancy like "UTC+05:30 (UTC+05:30)".
+  if (abbr === dt.toFormat('ZZ') || abbr === offsetLabel) {
+    return offsetLabel;
+  }
+  return `${abbr} (${offsetLabel})`;
+}

--- a/tests/unit/skills/calendar-check-conflicts.test.ts
+++ b/tests/unit/skills/calendar-check-conflicts.test.ts
@@ -95,4 +95,69 @@ describe('CalendarCheckConflictsHandler', () => {
       expect(data.clear).toBe(true);
     }
   });
+
+  it('formats conflict timestamps in the configured timezone', async () => {
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([{
+        email: 'cal-1',
+        timeSlots: [
+          // Busy: 2026-04-06T13:00:00Z - 14:00:00Z = 9:00-10:00 AM EDT
+          { startTime: 1775480400, endTime: 1775484000, status: 'busy' },
+        ],
+      }]),
+    };
+    const contactService = {
+      resolveCalendar: vi.fn().mockResolvedValue({ contactId: 'c1' }),
+      getContact: vi.fn().mockResolvedValue({ id: 'c1', displayName: 'Jane Doe' }),
+    };
+
+    // Proposed time overlaps the busy period
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'], proposedStart: '2026-04-06T12:30:00Z', proposedEnd: '2026-04-06T13:30:00Z' },
+      {
+        nylasCalendarClient: nylasCalendarClient as never,
+        contactService: contactService as never,
+        timezone: 'America/Toronto',
+      },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as {
+        conflicts: Array<{ startTime: string; endTime: string }>;
+        clear: boolean;
+        displayTimezone: string;
+      };
+      expect(data.clear).toBe(false);
+      expect(data.conflicts).toHaveLength(1);
+      // Timestamps should be in EDT (UTC-4), not UTC
+      expect(data.conflicts[0].startTime).toBe('2026-04-06T09:00:00.000-04:00');
+      expect(data.conflicts[0].endTime).toBe('2026-04-06T10:00:00.000-04:00');
+      expect(data.displayTimezone).toContain('EDT');
+    }
+  });
+
+  it('falls back to UTC when timezone is not provided', async () => {
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([{
+        email: 'cal-1',
+        timeSlots: [
+          { startTime: 1775480400, endTime: 1775484000, status: 'busy' },
+        ],
+      }]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'], proposedStart: '2026-04-06T12:30:00Z', proposedEnd: '2026-04-06T13:30:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { conflicts: Array<{ startTime: string }>; displayTimezone: null };
+      // UTC Z-suffix when no timezone configured
+      expect(data.conflicts[0].startTime).toBe('2026-04-06T13:00:00.000Z');
+      expect(data.displayTimezone).toBeNull();
+    }
+  });
 });

--- a/tests/unit/skills/calendar-find-free-time.test.ts
+++ b/tests/unit/skills/calendar-find-free-time.test.ts
@@ -9,15 +9,15 @@ function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContex
   return { input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
 }
 
-// Times as Unix timestamps (seconds)
-// Range: 9am-5pm = 32400-61200 seconds (relative, for test purposes we use small numbers)
-// Busy: 10-11am = 36000-39600
+// Realistic Unix timestamps (seconds) on 2026-04-06.
+// 1775476800 = 2026-04-06T12:00:00Z (8:00 AM EDT)
+// Busy: 12:30Z–13:00Z and 14:30Z–15:00Z
 const mockFreeBusy = [
   {
     email: 'cal-1',
     timeSlots: [
-      { startTime: 200, endTime: 400, status: 'busy' }, // busy 200-400
-      { startTime: 700, endTime: 900, status: 'busy' }, // busy 700-900
+      { startTime: 1775478600, endTime: 1775480400, status: 'busy' }, // 12:30Z–13:00Z
+      { startTime: 1775485800, endTime: 1775487600, status: 'busy' }, // 14:30Z–15:00Z
     ],
   },
 ];
@@ -46,23 +46,51 @@ describe('CalendarFindFreeTimeHandler', () => {
       getFreeBusy: vi.fn().mockResolvedValue(mockFreeBusy),
     };
 
-    // Range is 0-1000, busy at 200-400 and 700-900
-    // Free windows: 0-200, 400-700, 900-1000
+    // Range: 12:00Z–16:00Z, busy at 12:30Z–13:00Z and 14:30Z–15:00Z
+    // Free windows: 12:00Z–12:30Z, 13:00Z–14:30Z, 15:00Z–16:00Z
     const result = await handler.execute(makeCtx(
-      { calendarIds: ['cal-1'], timeMin: '1970-01-01T00:00:00Z', timeMax: '1970-01-01T00:16:40Z' },
+      { calendarIds: ['cal-1'], timeMin: '2026-04-06T12:00:00Z', timeMax: '2026-04-06T16:00:00Z' },
       { nylasCalendarClient: nylasCalendarClient as never },
     ));
 
     expect(result.success).toBe(true);
     if (result.success) {
       const data = result.data as { freeWindows: Array<{ start: string; end: string }> };
-      // Range 0-1000 seconds (epoch), busy 200-400 and 700-900 → free windows: 0-200, 400-700, 900-1000
-      // Returned as UTC ISO strings
       expect(data.freeWindows).toEqual([
-        { start: '1970-01-01T00:00:00.000Z', end: '1970-01-01T00:03:20.000Z' },
-        { start: '1970-01-01T00:06:40.000Z', end: '1970-01-01T00:11:40.000Z' },
-        { start: '1970-01-01T00:15:00.000Z', end: '1970-01-01T00:16:40.000Z' },
+        { start: '2026-04-06T12:00:00.000Z', end: '2026-04-06T12:30:00.000Z' },
+        { start: '2026-04-06T13:00:00.000Z', end: '2026-04-06T14:30:00.000Z' },
+        { start: '2026-04-06T15:00:00.000Z', end: '2026-04-06T16:00:00.000Z' },
       ]);
+    }
+  });
+
+  it('omits free windows with suspicious timestamps (epoch-zero guard)', async () => {
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([{
+        email: 'cal-1',
+        timeSlots: [
+          // A corrupt slot with startTime=0 from Nylas would produce a free window starting at 0
+          { startTime: 0, endTime: 1775476800, status: 'busy' },
+        ],
+      }]),
+    };
+
+    // Range: 12:00Z–13:00Z, entire range is "busy" from 0–12:00Z
+    // No free windows at all
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'], timeMin: '2026-04-06T12:00:00Z', timeMax: '2026-04-06T13:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { freeWindows: Array<{ start: string | null; end: string | null }> };
+      // The free window after the busy period (12:00Z–13:00Z) should have valid timestamps
+      // but there should be no window starting at epoch 0
+      for (const w of data.freeWindows) {
+        expect(w.start).not.toContain('1970');
+        expect(w.end).not.toContain('1970');
+      }
     }
   });
 
@@ -71,15 +99,17 @@ describe('CalendarFindFreeTimeHandler', () => {
       getFreeBusy: vi.fn().mockResolvedValue([{
         email: 'cal-1',
         timeSlots: [
-          { startTime: 100, endTime: 200, status: 'busy' },
+          // Busy 12:10Z–12:20Z (10 min) — splits into a short window (10 min) and a long one
+          { startTime: 1775477400, endTime: 1775478000, status: 'busy' },
         ],
       }]),
     };
 
-    // With a range of 0-1000 and busy at 100-200, free windows are 0-100 (100s) and 200-1000 (800s)
-    // With duration filter of 5 minutes minimum (converted to 300 seconds), only the 200-1000 window qualifies
+    // Range: 12:00Z–13:00Z, busy 12:10Z–12:20Z
+    // Free: 12:00Z–12:10Z (600s) and 12:20Z–13:00Z (2400s)
+    // 5 min = 300s filter keeps both; but using 15 min = 900s keeps only the longer window
     const result = await handler.execute(makeCtx(
-      { calendarIds: ['cal-1'], timeMin: '1970-01-01T00:00:00Z', timeMax: '1970-01-01T00:16:40Z', duration: 5 },
+      { calendarIds: ['cal-1'], timeMin: '2026-04-06T12:00:00Z', timeMax: '2026-04-06T13:00:00Z', duration: 15 },
       { nylasCalendarClient: nylasCalendarClient as never },
     ));
 
@@ -87,7 +117,7 @@ describe('CalendarFindFreeTimeHandler', () => {
     if (result.success) {
       const data = result.data as { freeWindows: Array<{ start: string; end: string }> };
       expect(data.freeWindows).toEqual([
-        { start: '1970-01-01T00:03:20.000Z', end: '1970-01-01T00:16:40.000Z' },
+        { start: '2026-04-06T12:20:00.000Z', end: '2026-04-06T13:00:00.000Z' },
       ]);
     }
   });

--- a/tests/unit/skills/calendar-find-free-time.test.ts
+++ b/tests/unit/skills/calendar-find-free-time.test.ts
@@ -91,4 +91,57 @@ describe('CalendarFindFreeTimeHandler', () => {
       ]);
     }
   });
+
+  it('formats free window timestamps in the configured timezone', async () => {
+    // Use realistic timestamps: busy 9:00-10:00 AM EDT on 2026-04-06
+    // 1775480400 = 2026-04-06T13:00:00Z = 9:00 AM EDT
+    // 1775484000 = 2026-04-06T14:00:00Z = 10:00 AM EDT
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([{
+        email: 'cal-1',
+        timeSlots: [{ startTime: 1775480400, endTime: 1775484000, status: 'busy' }],
+      }]),
+    };
+
+    // Query range: 8:00 AM - 12:00 PM EDT
+    // 1775476800 = 2026-04-06T12:00:00Z = 8:00 AM EDT
+    // 1775491200 = 2026-04-06T16:00:00Z = 12:00 PM EDT
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'], timeMin: '2026-04-06T12:00:00Z', timeMax: '2026-04-06T16:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never, timezone: 'America/Toronto' },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { freeWindows: Array<{ start: string; end: string }>; displayTimezone: string };
+      // Free: 8:00-9:00 AM EDT, 10:00 AM-12:00 PM EDT
+      expect(data.freeWindows[0].start).toBe('2026-04-06T08:00:00.000-04:00');
+      expect(data.freeWindows[0].end).toBe('2026-04-06T09:00:00.000-04:00');
+      expect(data.freeWindows[1].start).toBe('2026-04-06T10:00:00.000-04:00');
+      expect(data.freeWindows[1].end).toBe('2026-04-06T12:00:00.000-04:00');
+      expect(data.displayTimezone).toContain('EDT');
+    }
+  });
+
+  it('falls back to UTC when timezone is not provided', async () => {
+    const nylasCalendarClient = {
+      getFreeBusy: vi.fn().mockResolvedValue([{
+        email: 'cal-1',
+        timeSlots: [{ startTime: 1775480400, endTime: 1775484000, status: 'busy' }],
+      }]),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { calendarIds: ['cal-1'], timeMin: '2026-04-06T12:00:00Z', timeMax: '2026-04-06T16:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { freeWindows: Array<{ start: string; end: string }>; displayTimezone: null };
+      // UTC Z-suffix when no timezone configured
+      expect(data.freeWindows[0].start).toBe('2026-04-06T12:00:00.000Z');
+      expect(data.displayTimezone).toBeNull();
+    }
+  });
 });

--- a/tests/unit/skills/calendar-list-events.test.ts
+++ b/tests/unit/skills/calendar-list-events.test.ts
@@ -218,8 +218,9 @@ describe('CalendarListEventsHandler', () => {
     }
   });
 
-  it('formats timed event timestamps as UTC ISO strings for LLM consumption', async () => {
-    // 1775489400 Unix seconds = 2026-04-06T15:30:00.000Z (11:30 AM EDT)
+  it('formats timed event timestamps in the configured timezone', async () => {
+    // 1775489400 Unix seconds = 2026-04-06T15:30:00Z = 11:30 AM EDT (UTC-4)
+    // 1775491200 Unix seconds = 2026-04-06T16:00:00Z = 12:00 PM EDT (UTC-4)
     const timedEvent = {
       id: 'evt-timed',
       title: 'Catchup',
@@ -241,14 +242,50 @@ describe('CalendarListEventsHandler', () => {
 
     const result = await handler.execute(makeCtx(
       { calendarId: 'cal-1', timeMin: '2026-04-06T00:00:00Z', timeMax: '2026-04-07T00:00:00Z' },
+      { nylasCalendarClient: nylasCalendarClient as never, timezone: 'America/Toronto' },
+    ));
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { events: Array<{ startTime: string; endTime: string }>; displayTimezone: string };
+      // Wall-clock digits should be in EDT (UTC-4), not UTC
+      expect(data.events[0].startTime).toBe('2026-04-06T11:30:00.000-04:00');
+      expect(data.events[0].endTime).toBe('2026-04-06T12:00:00.000-04:00');
+      expect(data.displayTimezone).toContain('EDT');
+    }
+  });
+
+  it('falls back to UTC ISO strings when timezone is not provided', async () => {
+    const timedEvent = {
+      id: 'evt-timed',
+      title: 'Catchup',
+      description: '',
+      participants: [],
+      startTime: 1775489400,
+      endTime: 1775491200,
+      startDate: null,
+      endDate: null,
+      location: '',
+      conferencing: null,
+      status: 'confirmed',
+      calendarId: 'cal-1',
+      busy: true,
+    };
+    const nylasCalendarClient = {
+      listEvents: vi.fn().mockResolvedValue([timedEvent]),
+    };
+
+    // No timezone in context — should fall back to UTC Z-suffix
+    const result = await handler.execute(makeCtx(
+      { calendarId: 'cal-1', timeMin: '2026-04-06T00:00:00Z', timeMax: '2026-04-07T00:00:00Z' },
       { nylasCalendarClient: nylasCalendarClient as never },
     ));
 
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { events: Array<{ startTime: string; endTime: string }> };
+      const data = result.data as { events: Array<{ startTime: string }>; displayTimezone: null };
       expect(data.events[0].startTime).toBe('2026-04-06T15:30:00.000Z');
-      expect(data.events[0].endTime).toBe('2026-04-06T16:00:00.000Z');
+      expect(data.displayTimezone).toBeNull();
     }
   });
 

--- a/tests/unit/skills/calendar-list-events.test.ts
+++ b/tests/unit/skills/calendar-list-events.test.ts
@@ -283,8 +283,9 @@ describe('CalendarListEventsHandler', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { events: Array<{ startTime: string }>; displayTimezone: null };
+      const data = result.data as { events: Array<{ startTime: string; endTime: string }>; displayTimezone: null };
       expect(data.events[0].startTime).toBe('2026-04-06T15:30:00.000Z');
+      expect(data.events[0].endTime).toBe('2026-04-06T16:00:00.000Z');
       expect(data.displayTimezone).toBeNull();
     }
   });

--- a/tests/unit/time/timestamp.test.ts
+++ b/tests/unit/time/timestamp.test.ts
@@ -48,6 +48,15 @@ describe('formatDisplayTimezone', () => {
     expect(label).toBe('UTC');
   });
 
+  it('handles zones without a named abbreviation', () => {
+    // Asia/Kolkata has no DST; luxon's ZZZZ returns "GMT+5:30" (not a named abbr).
+    // The dedup guard doesn't catch this format, so the output includes both.
+    // Mildly redundant but not incorrect — only matters if Curia is deployed
+    // in a zone without a standard abbreviation.
+    const label = formatDisplayTimezone('Asia/Kolkata', new Date('2026-04-06T15:30:00Z'));
+    expect(label).toBe('GMT+5:30 (UTC+05:30)');
+  });
+
   it('throws on invalid timezone', () => {
     expect(() => formatDisplayTimezone('Not/A/Zone', new Date())).toThrow('invalid timezone');
   });

--- a/tests/unit/time/timestamp.test.ts
+++ b/tests/unit/time/timestamp.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { toLocalIso, formatDisplayTimezone } from '../../../src/time/timestamp.js';
+
+describe('toLocalIso', () => {
+  it('converts Unix seconds to local ISO with offset for America/Toronto in EDT', () => {
+    // 1775489400 = 2026-04-06T15:30:00Z = 2026-04-06T11:30:00 EDT (UTC-4)
+    expect(toLocalIso(1775489400, 'America/Toronto')).toBe('2026-04-06T11:30:00.000-04:00');
+  });
+
+  it('converts Unix seconds to local ISO with offset for America/Toronto in EST', () => {
+    // 1738348200 = 2025-01-31T18:30:00Z = 2025-01-31T13:30:00 EST (UTC-5)
+    expect(toLocalIso(1738348200, 'America/Toronto')).toBe('2025-01-31T13:30:00.000-05:00');
+  });
+
+  it('handles UTC timezone', () => {
+    // luxon emits 'Z' suffix for UTC (not +00:00)
+    expect(toLocalIso(1775489400, 'UTC')).toBe('2026-04-06T15:30:00.000Z');
+  });
+
+  it('handles non-hour-aligned timezone offsets', () => {
+    // Asia/Kolkata is UTC+05:30
+    // 1775489400 = 2026-04-06T15:30:00Z = 2026-04-06T21:00:00+05:30
+    expect(toLocalIso(1775489400, 'Asia/Kolkata')).toBe('2026-04-06T21:00:00.000+05:30');
+  });
+
+  it('throws on invalid timezone', () => {
+    expect(() => toLocalIso(1775489400, 'Not/A/Zone')).toThrow('invalid timezone');
+  });
+});
+
+describe('formatDisplayTimezone', () => {
+  it('formats EDT timezone label', () => {
+    // April 2026 — EDT is active
+    const label = formatDisplayTimezone('America/Toronto', new Date('2026-04-06T15:30:00Z'));
+    expect(label).toContain('EDT');
+    expect(label).toContain('UTC-04:00');
+  });
+
+  it('formats EST timezone label', () => {
+    // January 2025 — EST is active
+    const label = formatDisplayTimezone('America/Toronto', new Date('2025-01-31T18:30:00Z'));
+    expect(label).toContain('EST');
+    expect(label).toContain('UTC-05:00');
+  });
+
+  it('formats UTC timezone label', () => {
+    const label = formatDisplayTimezone('UTC', new Date('2026-04-06T15:30:00Z'));
+    expect(label).toContain('UTC');
+  });
+
+  it('throws on invalid timezone', () => {
+    expect(() => formatDisplayTimezone('Not/A/Zone', new Date())).toThrow('invalid timezone');
+  });
+});

--- a/tests/unit/time/timestamp.test.ts
+++ b/tests/unit/time/timestamp.test.ts
@@ -45,7 +45,7 @@ describe('formatDisplayTimezone', () => {
 
   it('formats UTC timezone label', () => {
     const label = formatDisplayTimezone('UTC', new Date('2026-04-06T15:30:00Z'));
-    expect(label).toContain('UTC');
+    expect(label).toBe('UTC');
   });
 
   it('throws on invalid timezone', () => {


### PR DESCRIPTION
## Summary

- Calendar skill handlers (`calendar-list-events`, `calendar-find-free-time`, `calendar-check-conflicts`) now return timestamps in the user's local timezone instead of UTC
- Added `toLocalIso()` and `formatDisplayTimezone()` utilities to `src/time/timestamp.ts` — the output-side complement to the existing `normalizeTimestamp()` input utility
- Exposed `timezone?: string` on `SkillContext` (additive, non-breaking public API surface change) and wired it from `ExecutionLayer`
- Each handler falls back to UTC Z-suffix when timezone is not configured (defensive)
- Added `displayTimezone` field to all calendar skill results so the LLM can label its output (e.g. "EDT (UTC-04:00)")
- Updated CLAUDE.md with timezone guidance for new skills
- 15 new tests across 4 test files; 1579 tests passing, typecheck clean

**Root cause:** Handlers called `new Date(unix * 1000).toISOString()` producing UTC Z-suffix strings like `"2026-04-06T15:30:00.000Z"`. The LLM read "15:30" and displayed "3:30 PM" instead of converting to "11:30 AM EDT". Fix: `toLocalIso()` uses luxon to produce `"2026-04-06T11:30:00.000-04:00"` — the wall-clock digits are already correct.

## Known follow-ups

- **`calendar-create-event` and `calendar-update-event`** still return UTC timestamps in their confirmation responses. Same two-line fix pattern — import utilities, apply `tz ?` branch. Not in scope for this PR since the bug report was about read-path display.
- **Epoch-zero guard** in `calendar-find-free-time` and `calendar-check-conflicts` — `calendar-list-events` guards `unix <= 0` and nulls out corrupt timestamps. The other two handlers don't have this guard (pre-existing gap, not introduced by this PR).

## Test plan

- [x] `toLocalIso()` unit tests: EDT, EST (DST boundary), UTC, Asia/Kolkata (+05:30), invalid timezone
- [x] `formatDisplayTimezone()` unit tests: EDT, EST, UTC, Asia/Kolkata (no-abbreviation zone), invalid timezone
- [x] `calendar-list-events`: timezone-aware formatting test + UTC fallback test
- [x] `calendar-find-free-time`: timezone-aware formatting test + UTC fallback test
- [x] `calendar-check-conflicts`: timezone-aware formatting test + UTC fallback test
- [x] All 1579 tests pass, typecheck clean
- [x] Existing tests unaffected (they don't provide timezone, so they exercise the UTC fallback path)

Fixes #362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Calendar events and free-time windows now display timestamps in your local timezone instead of UTC, improving readability and accuracy.
  
* **New Features**
  * Calendar results now include timezone information to clarify which timezone is being used for time displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->