### PR TITLE
fix: resolve conflicting prompt rules that misrouted CEO drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,13 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`outbound.notification` event type** — system notifications (blocked-content CEO alerts, Signal group-held alerts) now route through the bus and the outbound content filter pipeline instead of bypassing it via direct `dispatchEmail()` calls. New `OutboundGateway.sendNotification()` method publishes the event; EmailAdapter subscribes and delivers via `send()`. Closes the spec deviation noted in the outbound safety design (#206)
 - **draft_gate CEO notification** — when a Nylas draft is created via the `draft_gate` outbound policy, Curia now sends the CEO a brief email notification ("there is a draft reply to X about Y waiting in your Drafts folder"). The CEO reviews and clicks send from their email client. Closes the first piece of #278.
 
+### Changed
+
+- **Coordinator email account selection** — rewrote the "Account Identity for Tool Calls" section in the coordinator prompt to eliminate a conflicting-rules ambiguity that caused drafts to land in Curia's outbox instead of the CEO's. The email-skill `account` param now has explicit ordered rules: observation-mode preamble first, then CEO intent ("draft from me" = CEO's account), then fallback to Curia's own. Also added a "Before composing any email" prompt reinforcement requiring contact-lookup before drafting.
+
 ### Fixed
 
+- **email-draft-save missing-account warning** — the handler now logs a warning when a non-observation-mode draft omits the `account` parameter, flagging likely misrouted drafts that will land in the primary (agent) account instead of the CEO's.
 - **Calendar timezone display** — calendar skill handlers (`calendar-list-events`, `calendar-find-free-time`, `calendar-check-conflicts`) now return timestamps in the user's local timezone instead of UTC. Previously, event times were returned as UTC Z-suffix strings and the LLM was expected to convert them, which it did unreliably — causing all events to display shifted by the UTC offset. Added `toLocalIso()` and `formatDisplayTimezone()` utilities, and exposed `timezone` on `SkillContext` (additive, non-breaking public API surface change). Fixes #362
 - **`held-messages-process` block idempotency** — `block` action now handles duplicate-key errors from `linkIdentity` the same way `identify` does: if the identity is already linked to a blocked contact on retry, it proceeds to `discard` rather than failing and leaving the held message stuck in `pending` (closes #335)
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -262,6 +262,12 @@ system_prompt: |
 
   Keep email responses concise and professional.
 
+  ### Before composing any email
+  Before drafting or sending any email, resolve ALL recipients and CC contacts
+  using contact-lookup. If a contact is not found by name, search email-list and
+  calendar history for their address. Only ask the CEO for contact details as a
+  last resort — they expect you to find this information yourself.
+
   ## Inbox Disambiguation
   Some email accounts are connected in observation mode — Curia monitors them on behalf
   of the CEO but is not the intended recipient. When the CEO says "my inbox" or "my
@@ -345,12 +351,24 @@ system_prompt: |
   services, file storage, messaging, or any other tool that takes an account
   parameter.
 
-  **Exception — `email-list`, `email-get`, `email-draft-save`:** the `account` param
-  on these skills selects which monitored inbox to read from or draft for. Use the
-  account explicitly named in the request or injected via the observation-mode
-  preamble. The "default to yourself" rule above does NOT override an explicit
-  email-account target; it applies only to third-party tools where you're picking
-  an acting identity.
+  **Exception — email skills (`email-list`, `email-get`, `email-draft-save`,
+  `email-archive`):**
+  The `account` param on these skills selects which mailbox to operate on.
+  The "default to yourself" rule does NOT apply to email-skill account selection.
+  Use these rules IN ORDER:
+
+  1. If an observation-mode preamble is present, use the Account identifier
+     from that preamble.
+  2. If the CEO asks you to draft, read, or archive emails in THEIR inbox,
+     use the CEO's account name — not yours. "Draft this from me",
+     "check my email", "draft an email for me to send", "save a draft
+     for me to review" all mean the CEO's account. The CEO does not want
+     drafts appearing in Curia's outbox — they want them in their own
+     drafts folder so they can review and send.
+  3. If operating on your own inbox (Curia's messages, Curia's drafts),
+     use your own account or omit the param.
+
+  When in doubt about whose mailbox to target, ask the CEO.
 
   **Exception — calendar skills:** When creating, updating, or deleting events
   on behalf of the CEO, use the CEO's calendar. Only use Curia's own calendar

--- a/skills/email-draft-save/handler.ts
+++ b/skills/email-draft-save/handler.ts
@@ -57,6 +57,19 @@ export class EmailDraftSaveHandler implements SkillHandler {
       ? reply_to_message_id.trim()
       : undefined;
 
+    // Warn when a non-observation-mode draft omits the account param. In practice this
+    // means a CEO-initiated request ("draft this from me") fell through without the
+    // coordinator specifying which account to target — the draft will silently land in
+    // the primary (Curia) account, which is almost never what the CEO intended.
+    if (!accountId && ctx.taskMetadata?.observationMode !== true) {
+      ctx.log.warn(
+        { to, subject },
+        'email-draft-save: no account specified for non-observation-mode draft — '
+        + 'draft will land in the primary (agent) account. '
+        + 'Did the coordinator mean to pass the CEO account name?',
+      );
+    }
+
     ctx.log.info({ to, subject, accountId, replyToMessageId }, 'email-draft-save: saving draft');
 
     let result: Awaited<ReturnType<typeof ctx.outboundGateway.createEmailDraft>>;

--- a/tests/unit/skills/email-draft-save.test.ts
+++ b/tests/unit/skills/email-draft-save.test.ts
@@ -165,4 +165,51 @@ describe('EmailDraftSaveHandler', () => {
       expect(gateway.createEmailDraft).toHaveBeenCalled();
     });
   });
+
+  describe('missing-account warning for non-observation-mode drafts', () => {
+    it('logs a warning when account is omitted and not in observation mode', async () => {
+      const gateway = { createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-1' }) };
+      const warnSpy = vi.fn();
+      const ctx = makeCtx(
+        { to: 'r@example.com', subject: 'Hi', body: 'Hello' },
+        gateway,
+      );
+      // Override the warn method to capture the call
+      ctx.log = { ...logger, warn: warnSpy } as never;
+      await handler.execute(ctx);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'r@example.com', subject: 'Hi' }),
+        expect.stringContaining('no account specified'),
+      );
+    });
+
+    it('does not warn when account is provided', async () => {
+      const gateway = { createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-1' }) };
+      const warnSpy = vi.fn();
+      const ctx = makeCtx(
+        { to: 'r@example.com', subject: 'Hi', body: 'Hello', account: 'ceo-account' },
+        gateway,
+      );
+      ctx.log = { ...logger, warn: warnSpy } as never;
+      await handler.execute(ctx);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn in observation mode (even without account)', async () => {
+      const gateway = { createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-1' }) };
+      const warnSpy = vi.fn();
+      const ctx = makeCtx(
+        { to: 'r@example.com', subject: 'Hi', body: 'Hello', triage_classification: 'NEEDS DRAFT' },
+        gateway,
+        { observationMode: true },
+      );
+      ctx.log = { ...logger, warn: warnSpy } as never;
+      await handler.execute(ctx);
+      // The obs-mode guard warn may fire, but the missing-account warn should not
+      const missingAccountWarns = warnSpy.mock.calls.filter(
+        (args: unknown[]) => typeof args[1] === 'string' && (args[1] as string).includes('no account specified'),
+      );
+      expect(missingAccountWarns).toHaveLength(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Rewrites the coordinator's "Account Identity for Tool Calls" email-skill exception as explicit ordered rules, eliminating a conflicting-rules ambiguity that caused `email-draft-save` to silently create drafts in Curia's outbox instead of the CEO's when the CEO said "draft from me" in a direct (non-observation-mode) message
- Adds a "Before composing any email" prompt reinforcement requiring `contact-lookup` before drafting, preventing the agent from asking the CEO for contact details it can find itself
- Adds a warning log in `email-draft-save` when the `account` param is omitted for a non-observation-mode draft, creating an auditable signal for misrouted drafts

Related issues for follow-up work:
- #376 — store standing instruction marking the defunct CEO email address
- #377 — add `status` field to contact identities (active/defunct/bounced)

## Test plan

- [x] All 1610 existing tests pass (0 failures)
- [x] 3 new tests for the missing-account warning behavior
- [ ] Manual verification: email Curia asking to "draft an email from me to [contact]" and confirm the draft lands in the CEO's drafts folder