### PR TITLE
chore: release v0.23.0 — "Own Voice"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,22 +13,32 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+---
+
+## [0.23.0] — 2026-04-28 — "Own Voice"
+
 ### Added
 
-- **`outbound.notification` event type** — system notifications (blocked-content CEO alerts, Signal group-held alerts) now route through the bus and the outbound content filter pipeline instead of bypassing it via direct `dispatchEmail()` calls. New `OutboundGateway.sendNotification()` method publishes the event; EmailAdapter subscribes and delivers via `send()`. Closes the spec deviation noted in the outbound safety design (#206)
-- **draft_gate CEO notification** — when a Nylas draft is created via the `draft_gate` outbound policy, Curia now sends the CEO a brief email notification ("there is a draft reply to X about Y waiting in your Drafts folder"). The CEO reviews and clicks send from their email client. Closes the first piece of #278.
-- **Executive profile** — new `config/executive-profile.yaml` + `ExecutiveProfileService` for defining the CEO's writing voice (tone, formality, patterns, vocabulary, sign-off). Injected into the coordinator system prompt via `${executive_voice_block}` on every turn, with hot-reload support. Separate from office identity (assistant persona) — the executive's identity lives in the contact system. HTTP API at `/api/executive` for programmatic access. DB-versioned with audit trail, same lifecycle as office identity (spec 13).
-- **Executive profile skills** — `executive-profile-get` (read current profile) and `executive-profile-update` (partial updates, CEO-only). Enables conversational profile setup and iterative refinement without editing YAML.
+- **Executive profile** — CEO writing voice (tone, formality, patterns, vocabulary, sign-off) defined in `config/executive-profile.yaml` and managed by `ExecutiveProfileService`. Injected into the coordinator system prompt on every turn with hot-reload support. DB-versioned with audit trail, HTTP API at `/api/executive` (spec 13).
+- **Executive profile skills** — `executive-profile-get` and `executive-profile-update` for conversational profile setup and iterative refinement without editing YAML.
+- **`outbound.notification` event type** — system notifications now route through the bus and outbound content filter pipeline instead of bypassing it. Closes #206.
+- **Draft-gate CEO notification** — when a Nylas draft is created, CEO receives an email notification to review and send from their client (#278).
 
 ### Changed
 
-- **Coordinator email account selection** — rewrote the "Account Identity for Tool Calls" section in the coordinator prompt to eliminate a conflicting-rules ambiguity that caused drafts to land in Curia's outbox instead of the CEO's. The email-skill `account` param now has explicit ordered rules: observation-mode preamble first, then CEO intent ("draft from me" = CEO's account), then fallback to Curia's own. Also added a "Before composing any email" prompt reinforcement requiring contact-lookup before drafting.
+- **Coordinator email account selection** — eliminated conflicting prompt rules that caused drafts to land in the agent's outbox instead of the CEO's. Account selection now follows explicit ordered rules with contact-lookup reinforcement.
 
 ### Fixed
 
-- **email-draft-save missing-account warning** — the handler now logs a warning when a non-observation-mode draft omits the `account` parameter, flagging likely misrouted drafts that will land in the primary (agent) account instead of the CEO's.
-- **Calendar timezone display** — calendar skill handlers (`calendar-list-events`, `calendar-find-free-time`, `calendar-check-conflicts`) now return timestamps in the user's local timezone instead of UTC. Previously, event times were returned as UTC Z-suffix strings and the LLM was expected to convert them, which it did unreliably — causing all events to display shifted by the UTC offset. Added `toLocalIso()` and `formatDisplayTimezone()` utilities, and exposed `timezone` on `SkillContext` (additive, non-breaking public API surface change). Fixes #362
-- **`held-messages-process` block idempotency** — `block` action now handles duplicate-key errors from `linkIdentity` the same way `identify` does: if the identity is already linked to a blocked contact on retry, it proceeds to `discard` rather than failing and leaving the held message stuck in `pending` (closes #335)
+- **Calendar timezone display** — all three calendar skills now return timestamps in the user's local timezone instead of UTC. Added `toLocalIso()` and `formatDisplayTimezone()` utilities; exposed `timezone` on `SkillContext` (additive, non-breaking API change). Fixes #362.
+- **`held-messages-process` block idempotency** — `block` action handles duplicate-key errors on retry the same way `identify` does, preventing held messages from getting stuck in `pending` (#335).
+- **email-draft-save observability** — handler logs a warning when a non-observation-mode draft omits the `account` parameter, flagging likely misrouted drafts.
+
+---
+
+*Tone set in the seed —*  
+*the clock now learns where you stand,*  
+*drafts wait for your hand.*
 
 ---
 
@@ -445,7 +455,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Bootstrap orchestrator** — `src/index.ts` wires all layers in dependency order
 - Architecture specs 00–08, contributor docs (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
 
-[Unreleased]: https://github.com/josephfung/curia/compare/v0.19.7...HEAD
+[Unreleased]: https://github.com/josephfung/curia/compare/v0.23.0...HEAD
+[0.23.0]: https://github.com/josephfung/curia/compare/v0.22.0...v0.23.0
+[0.22.0]: https://github.com/josephfung/curia/compare/v0.20.0...v0.22.0
+[0.20.0]: https://github.com/josephfung/curia/compare/v0.19.7...v0.20.0
 [0.19.7]: https://github.com/josephfung/curia/compare/v0.18.1...v0.19.7
 [0.18.1]: https://github.com/josephfung/curia/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/josephfung/curia/compare/v0.17.0...v0.18.0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.22.0-blueviolet" alt="Version: 0.22.0" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.23.0-blueviolet" alt="Version: 0.23.0" /></a>
   <img src="https://img.shields.io/badge/status-pre--alpha-orange" alt="Status: Pre-Alpha" />
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License: MIT" />
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node >= 22" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## [0.23.0] — 2026-04-28 — "Own Voice"

### Added

- **Executive profile** — CEO writing voice (tone, formality, patterns, vocabulary, sign-off) defined in `config/executive-profile.yaml` and managed by `ExecutiveProfileService`. Injected into the coordinator system prompt on every turn with hot-reload support. DB-versioned with audit trail, HTTP API at `/api/executive` (spec 13).
- **Executive profile skills** — `executive-profile-get` and `executive-profile-update` for conversational profile setup and iterative refinement without editing YAML.
- **`outbound.notification` event type** — system notifications now route through the bus and outbound content filter pipeline instead of bypassing it. Closes #206.
- **Draft-gate CEO notification** — when a Nylas draft is created, CEO receives an email notification to review and send from their client (#278).

### Changed

- **Coordinator email account selection** — eliminated conflicting prompt rules that caused drafts to land in the agent's outbox instead of the CEO's. Account selection now follows explicit ordered rules with contact-lookup reinforcement.

### Fixed

- **Calendar timezone display** — all three calendar skills now return timestamps in the user's local timezone instead of UTC. Added `toLocalIso()` and `formatDisplayTimezone()` utilities; exposed `timezone` on `SkillContext` (additive, non-breaking API change). Fixes #362.
- **`held-messages-process` block idempotency** — `block` action handles duplicate-key errors on retry the same way `identify` does, preventing held messages from getting stuck in `pending` (#335).
- **email-draft-save observability** — handler logs a warning when a non-observation-mode draft omits the `account` parameter, flagging likely misrouted drafts.

---

*Tone set in the seed —*
*the clock now learns where you stand,*
*drafts wait for your hand.*