### PR TITLE
fix: executive-profile-update persists sign_off regardless of key casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **executive-profile-update** sign_off field not persisting when LLM emits camelCase key (`signOff`) instead of snake_case (`sign_off`). Added shared `normalizeKeysToSnakeCase` utility in `src/skills/normalize.ts` that any handler can use for bare-object inputs.
+
 ---
 
 ## [0.23.0] — 2026-04-28 — "Own Voice"

--- a/skills/executive-profile-update/handler.ts
+++ b/skills/executive-profile-update/handler.ts
@@ -7,6 +7,7 @@
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { WritingVoice } from '../../src/executive/types.js';
+import { normalizeKeysToSnakeCase } from '../../src/skills/normalize.js';
 
 // Shape of the partial input the LLM provides. All fields are optional —
 // only the fields being changed need to be included.
@@ -27,10 +28,16 @@ export class ExecutiveProfileUpdateHandler implements SkillHandler {
       return { success: false, error: 'executive-profile-update requires executiveProfileService in context. Is the executive profile configured?' };
     }
 
-    const { writing_voice } = ctx.input as { writing_voice?: PartialWritingVoiceInput };
-    if (!writing_voice || typeof writing_voice !== 'object' || Array.isArray(writing_voice)) {
+    const { writing_voice: rawVoice } = ctx.input as { writing_voice?: Record<string, unknown> };
+    if (!rawVoice || typeof rawVoice !== 'object' || Array.isArray(rawVoice)) {
       return { success: false, error: 'Input must include a "writing_voice" object with the fields to update.' };
     }
+
+    // Normalize camelCase keys to snake_case — the tool schema defines writing_voice
+    // as a bare "object" with no nested properties, so the LLM may emit either convention.
+    // sign_off is the only current field affected (all others are single words), but this
+    // guards against future multi-word fields too.
+    const writing_voice = normalizeKeysToSnakeCase(rawVoice) as PartialWritingVoiceInput;
 
     try {
       // Read the current profile as the base for merging.

--- a/src/skills/normalize.test.ts
+++ b/src/skills/normalize.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeKeysToSnakeCase } from './normalize.js';
+
+describe('normalizeKeysToSnakeCase', () => {
+  it('converts camelCase keys to snake_case', () => {
+    expect(normalizeKeysToSnakeCase({ signOff: 'hello' }))
+      .toEqual({ sign_off: 'hello' });
+  });
+
+  it('leaves snake_case keys unchanged', () => {
+    expect(normalizeKeysToSnakeCase({ sign_off: 'hello' }))
+      .toEqual({ sign_off: 'hello' });
+  });
+
+  it('leaves single-word keys unchanged', () => {
+    expect(normalizeKeysToSnakeCase({ tone: ['direct'], formality: 50 }))
+      .toEqual({ tone: ['direct'], formality: 50 });
+  });
+
+  it('handles multiple camelCase keys', () => {
+    expect(normalizeKeysToSnakeCase({
+      signOff: 'Cheers',
+      emailGreeting: 'Hi there',
+      writingStyle: 'formal',
+    })).toEqual({
+      sign_off: 'Cheers',
+      email_greeting: 'Hi there',
+      writing_style: 'formal',
+    });
+  });
+
+  it('prefers snake_case value when both conventions are present', () => {
+    expect(normalizeKeysToSnakeCase({
+      signOff: 'from camelCase',
+      sign_off: 'from snake_case',
+    })).toEqual({ sign_off: 'from snake_case' });
+  });
+
+  it('prefers snake_case regardless of key order', () => {
+    expect(normalizeKeysToSnakeCase({
+      sign_off: 'from snake_case',
+      signOff: 'from camelCase',
+    })).toEqual({ sign_off: 'from snake_case' });
+  });
+
+  it('returns an empty object for empty input', () => {
+    expect(normalizeKeysToSnakeCase({})).toEqual({});
+  });
+
+  it('preserves values of all types', () => {
+    const result = normalizeKeysToSnakeCase({
+      stringVal: 'text',
+      numVal: 42,
+      boolVal: true,
+      arrayVal: [1, 2],
+      objVal: { nested: true },
+      nullVal: null,
+    });
+    expect(result).toEqual({
+      string_val: 'text',
+      num_val: 42,
+      bool_val: true,
+      array_val: [1, 2],
+      obj_val: { nested: true },
+      null_val: null,
+    });
+  });
+
+  it('does not recurse into nested objects', () => {
+    const result = normalizeKeysToSnakeCase({
+      vocabulary: { preferWords: ['hello'], avoidWords: ['bye'] },
+    });
+    // Top-level key unchanged (single word), nested keys NOT converted
+    expect(result).toEqual({
+      vocabulary: { preferWords: ['hello'], avoidWords: ['bye'] },
+    });
+  });
+});

--- a/src/skills/normalize.ts
+++ b/src/skills/normalize.ts
@@ -1,0 +1,39 @@
+// normalize.ts — input key normalization for skill handlers.
+//
+// LLMs call skills via tool_use with JSON objects. When a skill's input schema
+// defines a parameter as a bare "object" (no nested properties), the LLM has
+// no schema guidance for the inner key names and may emit either camelCase or
+// snake_case. This utility normalizes keys to snake_case so handlers can rely
+// on a single convention.
+//
+// Parallel to sanitize.ts (which normalizes *output*), this normalizes *input*.
+
+/**
+ * Shallow-convert camelCase keys to snake_case.
+ *
+ * When both the camelCase and snake_case forms of a key are present
+ * (e.g. `{ signOff: "a", sign_off: "b" }`), the snake_case value wins —
+ * it is the canonical form matching the YAML/manifest convention.
+ *
+ * Only converts top-level keys. Nested objects are left as-is (callers
+ * can apply recursively if needed, but current skills only need one level).
+ */
+export function normalizeKeysToSnakeCase(
+  obj: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    const snakeKey = key.replace(/[A-Z]/g, c => `_${c.toLowerCase()}`);
+    const isAlreadySnakeCase = snakeKey === key;
+
+    // snake_case keys always take precedence — if a snake_case key was
+    // already set by itself (or will be), don't let a camelCase variant
+    // overwrite it.
+    if (isAlreadySnakeCase || !(snakeKey in result)) {
+      result[snakeKey] = value;
+    }
+  }
+
+  return result;
+}

--- a/src/skills/normalize.ts
+++ b/src/skills/normalize.ts
@@ -21,7 +21,7 @@
 export function normalizeKeysToSnakeCase(
   obj: Record<string, unknown>,
 ): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
+  const result: Record<string, unknown> = Object.create(null);
 
   for (const [key, value] of Object.entries(obj)) {
     const snakeKey = key.replace(/[A-Z]/g, c => `_${c.toLowerCase()}`);
@@ -30,7 +30,7 @@ export function normalizeKeysToSnakeCase(
     // snake_case keys always take precedence — if a snake_case key was
     // already set by itself (or will be), don't let a camelCase variant
     // overwrite it.
-    if (isAlreadySnakeCase || !(snakeKey in result)) {
+    if (isAlreadySnakeCase || !Object.hasOwn(result, snakeKey)) {
       result[snakeKey] = value;
     }
   }

--- a/tests/unit/skills/executive-profile-update.test.ts
+++ b/tests/unit/skills/executive-profile-update.test.ts
@@ -126,6 +126,36 @@ describe('ExecutiveProfileUpdateHandler', () => {
     expect(updatedConfig.writingVoice.signOff).toBe('Best, Joseph');
   });
 
+  it('handles signOff update (camelCase — LLM may emit either convention)', async () => {
+    const service = {
+      get: () => baseProfile,
+      update: vi.fn(async () => {}),
+    };
+
+    await handler.execute(makeCtx(
+      { writing_voice: { signOff: 'Cheers,\n\nJoseph' } },
+      service,
+    ));
+
+    const updatedConfig = service.update.mock.calls[0][0] as ExecutiveProfile;
+    expect(updatedConfig.writingVoice.signOff).toBe('Cheers,\n\nJoseph');
+  });
+
+  it('prefers sign_off over signOff when both are present', async () => {
+    const service = {
+      get: () => baseProfile,
+      update: vi.fn(async () => {}),
+    };
+
+    await handler.execute(makeCtx(
+      { writing_voice: { sign_off: 'from snake_case', signOff: 'from camelCase' } },
+      service,
+    ));
+
+    const updatedConfig = service.update.mock.calls[0][0] as ExecutiveProfile;
+    expect(updatedConfig.writingVoice.signOff).toBe('from snake_case');
+  });
+
   it('includes changes description in output', async () => {
     const service = {
       get: () => baseProfile,


### PR DESCRIPTION
## Summary

- **Bug:** `sign_off` is the only `writing_voice` field where snake_case and camelCase differ. The handler only checked `sign_off`, so when the LLM emitted `signOff` (camelCase) the value silently fell through to the existing empty default.
- **Fix:** Adds a shared `normalizeKeysToSnakeCase` utility (`src/skills/normalize.ts`) that any handler can import for bare-object inputs, and wires it into the update handler before the merge logic.
- **Future:** josephfung/curia#388 tracks adding nested property definitions to tool schemas so the LLM gets explicit key guidance (defense-in-depth, P5).

## Test plan

- [x] New utility tests (9 cases): basic conversion, identity, precedence when both forms present, empty input, type preservation, no recursion into nested objects
- [x] New handler tests (2 cases): camelCase `signOff` persists correctly, snake_case wins when both present
- [x] Existing handler tests still pass (no regressions)
- [x] Full test suite passes (1652 tests, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed a persistence issue in the executive profile update skill where the sign_off field would not save correctly when using camelCase input naming conventions instead of the expected snake_case format. This fix ensures all profile updates persist reliably and consistently, regardless of the naming convention or format used in the input data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->