### PR TITLE
fix: robust specialist delegation — Google Workspace accounts, agent timeouts, ack on sync channels (#387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,16 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Specialist delegation** — three compounding failures that caused essay-editor (and any long-running specialist) to fail reliably (#387):
+  - **Google Workspace account hallucination** — agents now receive their Google Workspace account list in the system prompt, eliminating LLM-guessed email addresses for MCP tools. New `channel_accounts.google_workspace` config section with env-var resolution.
+  - **Delegate timeout too short** — agents can now declare `expected_duration_seconds` in their YAML config. The runtime injects the appropriate `timeout_ms` into delegate calls, replacing the fixed 90s default for agents that need more time.
+  - **No acknowledgment on synchronous channels** — the coordinator now sends a brief ack before delegating long-running tasks on cli/http/signal channels, so the user isn't left watching a dead screen.
 - **executive-profile-update** sign_off field not persisting when LLM emits camelCase key (`signOff`) instead of snake_case (`sign_off`). Added shared `normalizeKeysToSnakeCase` utility in `src/skills/normalize.ts` that any handler can use for bare-object inputs.
+
+### Changed
+
+- **Channel account injection** — `channelAccounts` (email, phone) and Google Workspace accounts are now injected into ALL agents' system prompts, not just the coordinator. Specialist agents need identity context too.
+- **Agent YAML schema** *(public API surface)* — new optional `expected_duration_seconds` field (integer, minimum 1).
 
 ---
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -384,6 +384,14 @@ system_prompt: |
   Always synthesize their response into your own voice — the user should never
   know multiple agents were involved.
 
+  ### Delegation acknowledgment on synchronous channels
+  When delegating a task that will take significant time (essay polishing, research,
+  multi-step workflows) and the message arrived via a synchronous channel (cli, http,
+  signal), send a brief acknowledgment first in your own words. Communicate the intent:
+  something like "This will take a few minutes — I'll reply when it's ready." Then call
+  the delegate tool on your next turn. For email (async), delegate silently without
+  acknowledgment — the sender doesn't expect an immediate response.
+
   Available specialists:
   ${available_specialists}
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -61,7 +61,7 @@ channels:
 #       curia:
 #         google_email: "env:PRIMARY_GOOGLE_EMAIL"
 #         primary: true
-#       joseph:
+#       secondary:
 #         google_email: "env:SECONDARY_GOOGLE_EMAIL"
 #
 # Environment variable names must be generic and role-based — never use

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -46,6 +46,27 @@ channels:
 #
 # channel_accounts: {}
 
+# Google Workspace account configuration.
+#
+# channel_accounts.google_workspace defines one or more named Google Workspace accounts
+# available to all agents for Google Drive, Google Docs, and other Workspace MCP tools.
+# Each account has a google_email and an optional primary flag. The primary account is
+# used by default when tools require a `user_google_email` parameter.
+#
+# Credential values may be supplied inline or as env-var references using the
+# `env:VAR_NAME` syntax (recommended):
+#
+#   channel_accounts:
+#     google_workspace:
+#       curia:
+#         google_email: "env:PRIMARY_GOOGLE_EMAIL"
+#         primary: true
+#       joseph:
+#         google_email: "env:SECONDARY_GOOGLE_EMAIL"
+#
+# Environment variable names must be generic and role-based — never use
+# deployment-specific names (no personal names) in env vars.
+
 browser:
   # How long a browser session stays alive after its last action (ms).
   sessionTtlMs: 600000   # 10 minutes

--- a/docs/wip/2026-04-28-robust-specialist-delegation-design.md
+++ b/docs/wip/2026-04-28-robust-specialist-delegation-design.md
@@ -1,0 +1,204 @@
+# Robust Specialist Delegation
+
+**Date:** 2026-04-28
+**Status:** Proposed
+**Scope:** Config, runtime injection, agent YAML, coordinator prompt
+
+## Problem
+
+When the CEO asks Curia to polish an essay, the essay-editor specialist agent
+fails repeatedly due to three compounding issues:
+
+1. **Google account hallucination.** The Google Workspace MCP tools require a
+   `user_google_email` parameter on every call. No system-level infrastructure
+   tells agents which accounts exist. The LLM guesses, and guesses wrong
+   (observed hallucinations: `joseph@kuhuai.co.nz`, `joseph@josephkrauss.com`).
+   Only when the coordinator explicitly stated "use nathancuria1@gmail.com" did
+   the MCP tools succeed.
+
+2. **Delegate timeout too short.** The delegate skill defaults to 90 seconds.
+   The essay-editor pipeline (read docs, verify citations, create folders, copy
+   files, generate cover art, then edit the full essay) exceeds this easily.
+   After the tool-call steps complete, the LLM enters a long pure-text
+   generation for the actual essay edit. The delegate times out, the coordinator
+   retries from scratch, and the cycle repeats.
+
+3. **No expectation-setting on synchronous channels.** When the CEO sends the
+   request via chat, the coordinator says "delegating" and then goes silent for
+   90 seconds before timing out. No acknowledgment that this is a long-running
+   task. Via email (async) this is acceptable, but on synchronous channels
+   (chat, CLI, Signal) the CEO is left watching a dead screen.
+
+## Evidence
+
+Six essay-editor delegations on 2026-04-27, all for the Private Credit essay.
+Full audit trail in `audit_log` table, `source_id = 'essay-editor'`.
+
+- Runs 1-3: LLM used wrong Google email or bypassed MCP tools entirely.
+  All Google Doc reads failed with AUTH errors.
+- Run 4-5: Coordinator told essay-editor "use nathancuria1@gmail.com". MCP
+  tools worked. Read all docs, verified citations, created Drive folder,
+  copied v1, generated cover art via DALL-E. Then the delegate timed out
+  during the essay-editing generation step (pure LLM, no tool calls).
+- Run 6: Coordinator retried without explicit email. LLM hallucinated
+  `joseph@josephkrauss.com`. AUTH failure again.
+
+## Design
+
+### 1. Google Workspace Account Awareness
+
+Extend the existing `channel_accounts` pattern (proven for email) to cover
+Google Workspace.
+
+**Config (`config/default.yaml`):**
+
+```yaml
+channel_accounts:
+  email:
+    curia: { ... }   # existing
+    joseph: { ... }   # existing
+  google_workspace:
+    curia:
+      google_email: "env:PRIMARY_GOOGLE_EMAIL"
+      primary: true
+    joseph:
+      google_email: "env:SECONDARY_GOOGLE_EMAIL"
+```
+
+Environment variable names must be generic and role-based. Never use
+deployment-specific names (no "Nathan", "Joseph", etc.) in env vars. The
+logical account names (`curia`, `joseph`) live in YAML only and map to
+generic env vars.
+
+**Runtime injection (`src/agents/runtime.ts`):**
+
+The runtime already builds a "Your Contact Details" block for the coordinator
+from resolved `channelAccounts`. Two changes:
+
+1. Include `google_workspace` accounts in that block, marking which is primary.
+2. Inject this block into **all agents**, not just the coordinator. Specialists
+   like essay-editor need it too.
+
+The injected section in the system prompt:
+
+```
+## Your Google Workspace Accounts
+- curia: nathancuria1@gmail.com (primary)
+- joseph: joseph@josephfung.ca
+```
+
+(Actual values resolved from env vars at boot.)
+
+**Prompt guidance (applied to coordinator and Google Workspace specialists):**
+
+> When calling Google Drive or Google Docs tools that require
+> `user_google_email`, use your primary Google Workspace account. If the tool
+> returns an authentication error, retry with the next available account before
+> reporting failure.
+
+**Files changed:**
+
+- `config/default.yaml` -- add `google_workspace` section under
+  `channel_accounts`
+- `src/config.ts` -- extend `resolveChannelAccounts()` to handle the new
+  section (same env-var resolution pattern as email)
+- `src/agents/runtime.ts` -- extend the contact details injection to include
+  Google Workspace accounts; apply to all agents, not just coordinator
+- `src/index.ts` -- pass resolved Google Workspace accounts through to the
+  runtime
+- `.env` / `.env.example` -- add `PRIMARY_GOOGLE_EMAIL`,
+  `SECONDARY_GOOGLE_EMAIL`
+- Agent YAMLs -- no changes needed; the runtime injects account info
+  automatically
+
+### 2. Per-Agent Delegation Timeout
+
+Add an optional `expected_duration_seconds` field to the agent config schema.
+
+**Agent YAML (`essay-editor.yaml`):**
+
+```yaml
+expected_duration_seconds: 600  # 10 minutes
+```
+
+**Runtime wiring (`src/agents/runtime.ts`):**
+
+When the runtime detects a `delegate` skill invocation, it looks up the target
+agent's config from the agent registry. If the delegate call does not already
+include a `timeout_ms` parameter, inject one based on the target agent's
+`expected_duration_seconds`.
+
+This mirrors the existing path for scheduled tasks, which already injects
+`timeout_ms` from `expectedDurationSeconds` on the job.
+
+**Fallback behavior:**
+
+- Target agent declares `expected_duration_seconds`: use it
+  (`expected_duration_seconds * 1000` as `timeout_ms`)
+- Target agent does not declare it: fall back to
+  `DEFAULT_SPECIALIST_TIMEOUT_MS` (90s), same as today
+- Caller explicitly passes `timeout_ms`: caller wins (existing behavior
+  preserved)
+
+**Files changed:**
+
+- Agent YAML schema (and the Ajv startup validator) -- add optional
+  `expected_duration_seconds` field
+- `src/agents/runtime.ts` -- when invoking the `delegate` skill, look up
+  target agent config and inject `timeout_ms` if not already provided
+- `repos/curia-deploy/custom/agents/essay-editor.yaml` -- add
+  `expected_duration_seconds: 600`
+- No changes to `skills/delegate/handler.ts` -- it already accepts and
+  respects `timeout_ms`
+
+### 3. Expectation-Setting on Synchronous Channels
+
+Prompt-only change to the coordinator. No code changes.
+
+**Coordinator prompt guidance (`agents/coordinator.yaml`):**
+
+> When delegating a task that will take significant time (essay polishing,
+> research, multi-step workflows) and the message arrived via a synchronous
+> channel (cli, http, signal), send a brief acknowledgment first in your own
+> words. Communicate the intent: "This will take some time and I'll reply when
+> I'm done." For email, delegate silently without acknowledgment.
+
+**What this means mechanically:**
+
+The coordinator generates a text response (the ack) before calling the
+delegate tool. The LLM loop publishes this as `agent.response` /
+`outbound.message`, which reaches the user immediately via SSE or CLI. Then on
+the next turn, the coordinator calls the delegate skill. When the specialist
+finishes, the coordinator sends a second response with the result.
+
+This works today with no infrastructure changes. The coordinator can already
+emit multiple responses across turns within a single conversation.
+
+**Files changed:**
+
+- `agents/coordinator.yaml` (or the curia-deploy override) -- add delegation
+  acknowledgment guidance to the system prompt
+
+## Out of Scope
+
+- Real-time progress streaming (showing individual pipeline steps as they
+  happen). Valuable future work but not needed now.
+- MCP-layer auto-injection of `user_google_email` (removing the parameter from
+  LLM control entirely). More rigid than needed; the prompt-based approach
+  solves the hallucination problem while preserving multi-account flexibility.
+- Background task architecture (delegate returns immediately, specialist
+  delivers result as a separate message later). Would be a larger refactor;
+  the timeout + ack approach solves the immediate UX problem.
+
+## Testing
+
+- Unit tests for `resolveChannelAccounts()` with `google_workspace` section
+  (extend existing `config.channel-accounts.test.ts`)
+- Unit test for runtime injection: verify Google Workspace accounts appear in
+  system prompt for both coordinator and specialist agents
+- Unit test for timeout injection: verify delegate calls to agents with
+  `expected_duration_seconds` get the correct `timeout_ms`
+- Integration/smoke test: delegate to essay-editor, confirm it uses the
+  primary Google account without explicit instruction
+- Manual verification: send essay polish request via chat, confirm
+  acknowledgment appears before delegation begins

--- a/schemas/agent-config.schema.json
+++ b/schemas/agent-config.schema.json
@@ -66,6 +66,11 @@
         }
       }
     },
+    "expected_duration_seconds": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Expected wall-clock duration for tasks delegated to this agent, in seconds. Used by the runtime to inject timeout_ms into delegate calls."
+    },
     "error_budget": {
       "type": "object",
       "additionalProperties": false,

--- a/src/agents/agent-registry.ts
+++ b/src/agents/agent-registry.ts
@@ -10,12 +10,16 @@ export interface AgentRegistryEntry {
   name: string;
   role: string;
   description: string;
+  /** Expected wall-clock duration for delegate calls targeting this agent, in seconds.
+   *  When set, the runtime injects timeout_ms into delegate calls that don't already
+   *  carry an explicit timeout. See issue #387. */
+  expectedDurationSeconds?: number;
 }
 
 export class AgentRegistry {
   private agents = new Map<string, AgentRegistryEntry>();
 
-  register(name: string, info: { role: string; description: string }): void {
+  register(name: string, info: { role: string; description: string; expectedDurationSeconds?: number }): void {
     if (this.agents.has(name)) {
       throw new Error(`Agent '${name}' is already registered`);
     }

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -43,6 +43,10 @@ export interface AgentYamlConfig {
     /** Expected wall-clock duration in seconds. Drives stuck-job recovery timeout. */
     expectedDurationSeconds?: number;
   }>;
+  /** Expected wall-clock duration for delegate calls targeting this agent, in seconds.
+   *  When set, the runtime injects timeout_ms = expected_duration_seconds * 1000 into
+   *  delegate calls that don't already carry an explicit timeout. */
+  expected_duration_seconds?: number;
   error_budget?: {
     max_turns?: number;
     max_cost_usd?: number;

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -15,6 +15,8 @@ import { formatTimeContextBlock } from '../time/time-context.js';
 import type { OfficeIdentityService } from '../identity/service.js';
 import type { ExecutiveProfileService } from '../executive/service.js';
 import { formatBullpenContext, type BullpenService } from '../memory/bullpen.js';
+import type { AgentRegistry } from './agent-registry.js';
+import type { ResolvedGoogleWorkspaceAccount } from '../config.js';
 
 export interface AgentConfig {
   agentId: string;
@@ -54,12 +56,19 @@ export interface AgentConfig {
   /** Curia's own channel contact details, sourced from deployment env vars (NYLAS_SELF_EMAIL,
    *  SIGNAL_PHONE_NUMBER). When provided, a "Your Contact Details" block is appended to the
    *  system prompt so the LLM knows which accounts to use when tools ask for an email address
-   *  or phone number. Only the coordinator receives this — specialist agents work with
-   *  structured data and don't need self-identity injection. */
+   *  or phone number. Injected into all agents — specialists need this too (#387). */
   channelAccounts?: {
     email?: string;
     phone?: string;
   };
+  /** Resolved Google Workspace accounts from config. When provided, a "Your Google Workspace
+   *  Accounts" block is appended to the system prompt so agents know which account to use when
+   *  Google Workspace MCP tools require a `user_google_email` parameter. Injected into all
+   *  agents to prevent LLM hallucination of email addresses (#387). */
+  googleWorkspaceAccounts?: ResolvedGoogleWorkspaceAccount[];
+  /** Agent registry — used to look up target agent's expectedDurationSeconds when a delegate
+   *  call is made, so the runtime can inject an appropriate timeout_ms. See #387. */
+  agentRegistry?: AgentRegistry;
   /** Error budget config — turn and consecutive error limits per task.
    * maxTurns is checked at the start of each tool-use iteration, so
    * the effective number of tool-calling rounds is maxTurns - 1. */
@@ -244,6 +253,7 @@ export class AgentRuntime {
     // Append Curia's own contact details — email and phone sourced from deployment env vars.
     // This gives the LLM a concrete "acting as" identity so it doesn't guess or fall back
     // to the CEO's details when tools require an account parameter.
+    // Injected into ALL agents (coordinator + specialists) so every agent knows its identity.
     const { channelAccounts } = this.config;
     if (channelAccounts && (channelAccounts.email || channelAccounts.phone)) {
       const lines: string[] = ['## Your Contact Details'];
@@ -252,6 +262,25 @@ export class AgentRuntime {
       lines.push('');
       if (channelAccounts.email) lines.push(`- Email: ${channelAccounts.email}`);
       if (channelAccounts.phone) lines.push(`- Phone: ${channelAccounts.phone}`);
+      effectiveSystemPrompt += '\n\n' + lines.join('\n');
+    }
+
+    // Append Google Workspace account details so agents know which account to use when
+    // Google Drive, Docs, or other Workspace MCP tools require a `user_google_email` param.
+    // Without this, the LLM hallucinates email addresses (#387 root cause 1).
+    // Injected into ALL agents — specialists like essay-editor need this too.
+    const { googleWorkspaceAccounts } = this.config;
+    if (googleWorkspaceAccounts && googleWorkspaceAccounts.length > 0) {
+      const lines: string[] = ['## Your Google Workspace Accounts'];
+      lines.push('When calling Google Drive, Google Docs, or other Google Workspace tools that');
+      lines.push('require a `user_google_email` parameter, use your primary account. If the tool');
+      lines.push('returns an authentication error, retry with the next available account before');
+      lines.push('reporting failure.');
+      lines.push('');
+      for (const acct of googleWorkspaceAccounts) {
+        const marker = acct.primary ? ' (primary)' : '';
+        lines.push(`- ${acct.name}: ${acct.googleEmail}${marker}`);
+      }
       effectiveSystemPrompt += '\n\n' + lines.join('\n');
     }
 
@@ -506,29 +535,42 @@ export class AgentRuntime {
         logger.info({ agentId, skill: toolCall.name, callId: toolCall.id }, 'Invoking skill');
         skillsCalled.push(toolCall.name);
 
-        // For delegate calls from scheduled tasks: inject timeout_ms from the task event's
-        // expectedDurationSeconds so the specialist gets an appropriate wait window.
-        // Only injected when: (a) the skill is 'delegate', (b) the task carries a duration
-        // hint from the scheduler, and (c) the LLM hasn't already supplied a timeout_ms.
+        // For delegate calls: inject timeout_ms so the specialist gets an appropriate wait
+        // window. Two sources, checked in priority order:
+        //   1. Scheduled task: the task event's expectedDurationSeconds (from the scheduler)
+        //   2. Target agent config: the target agent's expected_duration_seconds (from YAML)
+        // The LLM's explicit timeout_ms always wins if provided.
         // This is transparent to the LLM — it doesn't need to know about scheduling internals.
         let skillInput = toolCall.input;
-        if (
-          toolCall.name === 'delegate' &&
-          taskEvent.payload.expectedDurationSeconds !== undefined
-        ) {
+        if (toolCall.name === 'delegate') {
           const inputRecord = skillInput as Record<string, unknown>;
           if (!('timeout_ms' in inputRecord) || inputRecord['timeout_ms'] === undefined) {
-            const timeoutMs = taskEvent.payload.expectedDurationSeconds * 1000;
-            // Guard against non-integer results from floating-point expectedDurationSeconds
-            // stored via out-of-band DB writes — the delegate handler would silently fall back,
-            // but we log here so the root cause is visible in audit logs.
-            if (Number.isInteger(timeoutMs) && timeoutMs > 0) {
-              skillInput = { ...inputRecord, timeout_ms: timeoutMs };
-            } else {
-              logger.warn(
-                { agentId, taskEventId: taskEvent.id, expectedDurationSeconds: taskEvent.payload.expectedDurationSeconds, computedTimeoutMs: timeoutMs },
-                'Computed timeout_ms from expectedDurationSeconds is not a valid positive integer — skipping injection; delegate will use default timeout',
-              );
+            // Source 1: scheduler's expectedDurationSeconds on the task event
+            let durationSeconds = taskEvent.payload.expectedDurationSeconds;
+
+            // Source 2: target agent's expected_duration_seconds from agent YAML config
+            // Only used when the scheduler didn't provide a value.
+            if (durationSeconds === undefined && this.config.agentRegistry) {
+              const targetAgentName = typeof inputRecord['agent'] === 'string' ? inputRecord['agent'] : undefined;
+              if (targetAgentName) {
+                const targetEntry = this.config.agentRegistry.get(targetAgentName);
+                durationSeconds = targetEntry?.expectedDurationSeconds;
+              }
+            }
+
+            if (durationSeconds !== undefined) {
+              const timeoutMs = durationSeconds * 1000;
+              // Guard against non-integer results from floating-point expectedDurationSeconds
+              // stored via out-of-band DB writes — the delegate handler would silently fall back,
+              // but we log here so the root cause is visible in audit logs.
+              if (Number.isInteger(timeoutMs) && timeoutMs > 0) {
+                skillInput = { ...inputRecord, timeout_ms: timeoutMs };
+              } else {
+                logger.warn(
+                  { agentId, taskEventId: taskEvent.id, expectedDurationSeconds: durationSeconds, computedTimeoutMs: timeoutMs },
+                  'Computed timeout_ms from expectedDurationSeconds is not a valid positive integer — skipping injection; delegate will use default timeout',
+                );
+              }
             }
           }
         }

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -543,49 +543,58 @@ export class AgentRuntime {
         // This is transparent to the LLM — it doesn't need to know about scheduling internals.
         let skillInput = toolCall.input;
         if (toolCall.name === 'delegate') {
-          const inputRecord = skillInput as Record<string, unknown>;
-          if (!('timeout_ms' in inputRecord) || inputRecord['timeout_ms'] === undefined) {
-            // Source 1: scheduler's expectedDurationSeconds on the task event
-            let durationSeconds = taskEvent.payload.expectedDurationSeconds;
+          // Guard: only proceed if the input is a plain non-null object. The `in` operator
+          // throws a TypeError on null or primitives, and an array input is malformed anyway.
+          if (typeof skillInput !== 'object' || skillInput === null || Array.isArray(skillInput)) {
+            logger.warn(
+              { agentId, taskEventId: taskEvent.id, inputType: Array.isArray(skillInput) ? 'array' : typeof skillInput },
+              'delegate call has non-object input — skipping timeout injection; delegate will use default timeout',
+            );
+          } else {
+            const inputRecord = skillInput as Record<string, unknown>;
+            if (!('timeout_ms' in inputRecord) || inputRecord['timeout_ms'] === undefined) {
+              // Source 1: scheduler's expectedDurationSeconds on the task event
+              let durationSeconds = taskEvent.payload.expectedDurationSeconds;
 
-            // Source 2: target agent's expected_duration_seconds from agent YAML config
-            // Only used when the scheduler didn't provide a value.
-            if (durationSeconds === undefined && this.config.agentRegistry) {
-              const rawAgent = inputRecord['agent'];
-              if (typeof rawAgent !== 'string') {
-                // LLM produced a malformed delegate call — agent field missing or non-string.
-                // Warn so the audit log shows the root cause rather than a silent timeout miss.
-                logger.warn(
-                  { agentId, taskEventId: taskEvent.id, agentFieldType: typeof rawAgent },
-                  'delegate call has non-string agent field — cannot look up expected_duration_seconds; delegate will use default timeout',
-                );
-              } else {
-                const targetEntry = this.config.agentRegistry.get(rawAgent);
-                if (targetEntry === undefined) {
-                  // Agent name is valid but unknown to the registry — likely a YAML typo or a
-                  // newly added agent that hasn't been registered yet.
+              // Source 2: target agent's expected_duration_seconds from agent YAML config
+              // Only used when the scheduler didn't provide a value.
+              if (durationSeconds === undefined && this.config.agentRegistry) {
+                const rawAgent = inputRecord['agent'];
+                if (typeof rawAgent !== 'string') {
+                  // LLM produced a malformed delegate call — agent field missing or non-string.
+                  // Warn so the audit log shows the root cause rather than a silent timeout miss.
                   logger.warn(
-                    { agentId, taskEventId: taskEvent.id, targetAgent: rawAgent },
-                    'delegate target agent not found in registry — cannot look up expected_duration_seconds; delegate will use default timeout',
+                    { agentId, taskEventId: taskEvent.id, agentFieldType: typeof rawAgent },
+                    'delegate call has non-string agent field — cannot look up expected_duration_seconds; delegate will use default timeout',
                   );
                 } else {
-                  durationSeconds = targetEntry.expectedDurationSeconds;
+                  const targetEntry = this.config.agentRegistry.get(rawAgent);
+                  if (targetEntry === undefined) {
+                    // Agent name is valid but unknown to the registry — likely a YAML typo or a
+                    // newly added agent that hasn't been registered yet.
+                    logger.warn(
+                      { agentId, taskEventId: taskEvent.id, targetAgent: rawAgent },
+                      'delegate target agent not found in registry — cannot look up expected_duration_seconds; delegate will use default timeout',
+                    );
+                  } else {
+                    durationSeconds = targetEntry.expectedDurationSeconds;
+                  }
                 }
               }
-            }
 
-            if (durationSeconds !== undefined) {
-              const timeoutMs = durationSeconds * 1000;
-              // Guard against non-integer results from floating-point expectedDurationSeconds
-              // stored via out-of-band DB writes — the delegate handler would silently fall back,
-              // but we log here so the root cause is visible in audit logs.
-              if (Number.isInteger(timeoutMs) && timeoutMs > 0) {
-                skillInput = { ...inputRecord, timeout_ms: timeoutMs };
-              } else {
-                logger.warn(
-                  { agentId, taskEventId: taskEvent.id, expectedDurationSeconds: durationSeconds, computedTimeoutMs: timeoutMs },
-                  'Computed timeout_ms from expectedDurationSeconds is not a valid positive integer — skipping injection; delegate will use default timeout',
-                );
+              if (durationSeconds !== undefined) {
+                const timeoutMs = durationSeconds * 1000;
+                // Guard against non-integer results from floating-point expectedDurationSeconds
+                // stored via out-of-band DB writes — the delegate handler would silently fall back,
+                // but we log here so the root cause is visible in audit logs.
+                if (Number.isInteger(timeoutMs) && timeoutMs > 0) {
+                  skillInput = { ...inputRecord, timeout_ms: timeoutMs };
+                } else {
+                  logger.warn(
+                    { agentId, taskEventId: taskEvent.id, expectedDurationSeconds: durationSeconds, computedTimeoutMs: timeoutMs },
+                    'Computed timeout_ms from expectedDurationSeconds is not a valid positive integer — skipping injection; delegate will use default timeout',
+                  );
+                }
               }
             }
           }

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -551,10 +551,26 @@ export class AgentRuntime {
             // Source 2: target agent's expected_duration_seconds from agent YAML config
             // Only used when the scheduler didn't provide a value.
             if (durationSeconds === undefined && this.config.agentRegistry) {
-              const targetAgentName = typeof inputRecord['agent'] === 'string' ? inputRecord['agent'] : undefined;
-              if (targetAgentName) {
-                const targetEntry = this.config.agentRegistry.get(targetAgentName);
-                durationSeconds = targetEntry?.expectedDurationSeconds;
+              const rawAgent = inputRecord['agent'];
+              if (typeof rawAgent !== 'string') {
+                // LLM produced a malformed delegate call — agent field missing or non-string.
+                // Warn so the audit log shows the root cause rather than a silent timeout miss.
+                logger.warn(
+                  { agentId, taskEventId: taskEvent.id, agentFieldType: typeof rawAgent },
+                  'delegate call has non-string agent field — cannot look up expected_duration_seconds; delegate will use default timeout',
+                );
+              } else {
+                const targetEntry = this.config.agentRegistry.get(rawAgent);
+                if (targetEntry === undefined) {
+                  // Agent name is valid but unknown to the registry — likely a YAML typo or a
+                  // newly added agent that hasn't been registered yet.
+                  logger.warn(
+                    { agentId, taskEventId: taskEvent.id, targetAgent: rawAgent },
+                    'delegate target agent not found in registry — cannot look up expected_duration_seconds; delegate will use default timeout',
+                  );
+                } else {
+                  durationSeconds = targetEntry.expectedDurationSeconds;
+                }
               }
             }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -721,7 +721,7 @@ export function resolveGoogleWorkspaceAccounts(yamlConfig: YamlConfig): Resolved
     return [];
   }
 
-  return Object.entries(googleAccounts).map(([name, raw]) => {
+  const resolved = Object.entries(googleAccounts).map(([name, raw]) => {
     const googleEmail = resolveEnvValue(
       raw.google_email,
       `channel_accounts.google_workspace.${name}.google_email`,
@@ -732,6 +732,15 @@ export function resolveGoogleWorkspaceAccounts(yamlConfig: YamlConfig): Resolved
       primary: raw.primary ?? false,
     };
   });
+
+  // If no account is explicitly marked primary, promote the first one.
+  // The runtime prompt instructs agents to "use your primary account" — without
+  // a primary marker the LLM has no guidance on which account to default to.
+  if (resolved.length > 0 && !resolved.some(a => a.primary)) {
+    resolved[0]!.primary = true;
+  }
+
+  return resolved;
 }
 
 export function loadConfig(): Config {

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,33 @@ export interface ResolvedEmailAccount {
   excludedSenderEmails: string[];
 }
 
+// ---------------------------------------------------------------------------
+// Google Workspace account config types
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw per-account Google Workspace entry as read from config/default.yaml.
+ * Values may be literal strings or "env:VAR_NAME" env-var references.
+ */
+export interface RawGoogleWorkspaceAccountConfig {
+  google_email: string;
+  /** When true, this is the default account for Google Workspace MCP tools. */
+  primary?: boolean;
+}
+
+/**
+ * Fully resolved Google Workspace account config with env-var references expanded.
+ * Injected into all agent system prompts so LLMs know which account to use when
+ * Google Workspace tools require a `user_google_email` parameter.
+ */
+export interface ResolvedGoogleWorkspaceAccount {
+  /** Logical name for this account as declared in the YAML (e.g. "curia", "joseph"). */
+  name: string;
+  googleEmail: string;
+  /** When true, this is the default account for Google Workspace MCP tools. */
+  primary: boolean;
+}
+
 export interface Config {
   databaseUrl: string;
   anthropicApiKey: string | undefined;
@@ -142,6 +169,7 @@ export interface YamlConfig {
    */
   channel_accounts?: {
     email?: Record<string, RawEmailAccountConfig>;
+    google_workspace?: Record<string, RawGoogleWorkspaceAccountConfig>;
   };
   browser?: {
     sessionTtlMs?: number;
@@ -491,6 +519,38 @@ export function loadYamlConfig(configDir: string): YamlConfig {
     }
   }
 
+  // Validate channel_accounts.google_workspace if present
+  const googleWorkspaceAccounts = config.channel_accounts?.google_workspace;
+  if (googleWorkspaceAccounts !== undefined) {
+    if (googleWorkspaceAccounts === null || typeof googleWorkspaceAccounts !== 'object' || Array.isArray(googleWorkspaceAccounts)) {
+      throw new Error('channel_accounts.google_workspace must be a YAML mapping');
+    }
+    let primaryCount = 0;
+    for (const [accountName, rawAccount] of Object.entries(googleWorkspaceAccounts)) {
+      if (typeof rawAccount !== 'object' || rawAccount === null || Array.isArray(rawAccount)) {
+        throw new Error(`channel_accounts.google_workspace.${accountName} must be a YAML mapping`);
+      }
+      if (typeof rawAccount.google_email !== 'string' || !rawAccount.google_email) {
+        throw new Error(`channel_accounts.google_workspace.${accountName}.google_email must be a non-empty string`);
+      }
+      if (rawAccount.primary !== undefined && typeof rawAccount.primary !== 'boolean') {
+        throw new Error(
+          `channel_accounts.google_workspace.${accountName}.primary must be a boolean, got: ${typeof rawAccount.primary}`,
+        );
+      }
+      if (rawAccount.primary === true) {
+        primaryCount++;
+      }
+    }
+    // At most one account may be marked primary. If none is marked, the runtime
+    // will use the first account in iteration order as the default.
+    if (primaryCount > 1) {
+      throw new Error(
+        `channel_accounts.google_workspace: at most one account may be marked primary, found ${primaryCount}`,
+      );
+    }
+  }
+
   const drift = config.intentDrift;
   if (drift !== undefined) {
     // Reject non-object roots (e.g. `intentDrift: false`, `intentDrift: "off"`, `intentDrift: []`).
@@ -647,6 +707,31 @@ export function resolveChannelAccounts(yamlConfig: YamlConfig, config: Config): 
 
   // No credentials available — email channel will be disabled
   return [];
+}
+
+/**
+ * Resolve Google Workspace accounts from the YAML config.
+ *
+ * Returns an empty array when the google_workspace section is absent — agents
+ * will not receive Google Workspace account injection, matching pre-#387 behavior.
+ */
+export function resolveGoogleWorkspaceAccounts(yamlConfig: YamlConfig): ResolvedGoogleWorkspaceAccount[] {
+  const googleAccounts = yamlConfig.channel_accounts?.google_workspace;
+  if (googleAccounts === undefined) {
+    return [];
+  }
+
+  return Object.entries(googleAccounts).map(([name, raw]) => {
+    const googleEmail = resolveEnvValue(
+      raw.google_email,
+      `channel_accounts.google_workspace.${name}.google_email`,
+    );
+    return {
+      name,
+      googleEmail,
+      primary: raw.primary ?? false,
+    };
+  });
 }
 
 export function loadConfig(): Config {

--- a/src/index.ts
+++ b/src/index.ts
@@ -854,12 +854,14 @@ async function main(): Promise<void> {
       // fresh each turn for hot-reload support. The display name comes from the contact system.
       executiveProfileService: agentConfig.role === 'coordinator' ? executiveProfileService : undefined,
       executiveDisplayName: agentConfig.role === 'coordinator' ? executiveDisplayName : undefined,
-      // Curia's own contact details — sourced from NYLAS_SELF_EMAIL and SIGNAL_PHONE_NUMBER.
-      // Injected per-task so agents know which accounts to use when MCP tools ask for an
-      // email address or phone number. Injected into ALL agents (#387) — specialists like
-      // essay-editor need this to avoid hallucinating account identifiers.
+      // Curia's own contact details — injected per-task so agents know which accounts to
+      // use when MCP tools ask for an email address or phone number. Injected into ALL
+      // agents (#387) — specialists like essay-editor need this to avoid hallucinating
+      // account identifiers.
+      // Email: use the first non-observation-mode account (Curia's direct send account),
+      // not the legacy config.nylasSelfEmail, so multi-account setups stay consistent.
       channelAccounts: {
-        email: config.nylasSelfEmail || undefined,
+        email: resolvedEmailAccounts.find(a => !a.observationMode)?.selfEmail || undefined,
         phone: config.signalPhoneNumber || undefined,
       },
       // Google Workspace accounts — injected into ALL agents so they know which account

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@
 
 import * as path from 'node:path';
 import { runner } from 'node-pg-migrate';
-import { loadConfig, loadYamlConfig, resolveChannelAccounts } from './config.js';
+import { loadConfig, loadYamlConfig, resolveChannelAccounts, resolveGoogleWorkspaceAccounts } from './config.js';
 import { createLogger } from './logger.js';
 import { HttpAdapter } from './channels/http/http-adapter.js';
 import { createPool } from './db/connection.js';
@@ -410,6 +410,13 @@ async function main(): Promise<void> {
   // EmailAdapters are constructed further below, after OutboundGateway is ready,
   // and started after the dispatcher is registered to avoid dropping inbound messages.
   const resolvedEmailAccounts = resolveChannelAccounts(yamlConfig, config);
+  const resolvedGoogleWorkspaceAccounts = resolveGoogleWorkspaceAccounts(yamlConfig);
+  if (resolvedGoogleWorkspaceAccounts.length > 0) {
+    logger.info(
+      { accounts: resolvedGoogleWorkspaceAccounts.map(a => ({ name: a.name, primary: a.primary })) },
+      `Google Workspace: ${resolvedGoogleWorkspaceAccounts.length} account(s) configured`,
+    );
+  }
   const nylasClientMap = new Map<string, NylasClient>();
 
   if (!config.nylasApiKey) {
@@ -763,6 +770,7 @@ async function main(): Promise<void> {
       agentRegistry.register(agentConfig.name, {
         role: agentConfig.role ?? 'specialist',
         description: agentConfig.description ?? agentConfig.name,
+        expectedDurationSeconds: agentConfig.expected_duration_seconds,
       });
     }
   } catch (err) {
@@ -847,13 +855,20 @@ async function main(): Promise<void> {
       executiveProfileService: agentConfig.role === 'coordinator' ? executiveProfileService : undefined,
       executiveDisplayName: agentConfig.role === 'coordinator' ? executiveDisplayName : undefined,
       // Curia's own contact details — sourced from NYLAS_SELF_EMAIL and SIGNAL_PHONE_NUMBER.
-      // Injected per-task so the coordinator knows which accounts to use when MCP tools
-      // ask for an email address or phone number (e.g. workspace-mcp's user_google_email).
-      // Only set for the coordinator; specialist agents work with structured data.
-      channelAccounts: agentConfig.role === 'coordinator' ? {
+      // Injected per-task so agents know which accounts to use when MCP tools ask for an
+      // email address or phone number. Injected into ALL agents (#387) — specialists like
+      // essay-editor need this to avoid hallucinating account identifiers.
+      channelAccounts: {
         email: config.nylasSelfEmail || undefined,
         phone: config.signalPhoneNumber || undefined,
-      } : undefined,
+      },
+      // Google Workspace accounts — injected into ALL agents so they know which account
+      // to use for Google Drive/Docs MCP tools, preventing email hallucination (#387).
+      googleWorkspaceAccounts: resolvedGoogleWorkspaceAccounts.length > 0
+        ? resolvedGoogleWorkspaceAccounts : undefined,
+      // Agent registry — allows the runtime to look up the target agent's
+      // expected_duration_seconds when injecting delegate timeouts (#387).
+      agentRegistry,
       // Map YAML snake_case fields to AgentConfig camelCase, falling back to
       // DEFAULT_ERROR_BUDGET values for any omitted fields.
       errorBudget: agentConfig.error_budget ? {

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -1354,4 +1354,273 @@ describe('AgentRuntime chatWithRetry', () => {
       expect(systemText).not.toContain('risk score');
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Google Workspace account injection (#387)
+  // ---------------------------------------------------------------------------
+
+  describe('Google Workspace account injection', () => {
+    it('injects Google Workspace accounts into system prompt for all agents', async () => {
+      const logger = createLogger('error');
+      const bus = new EventBus(logger);
+      const capturedMessages: Array<{ role: string; content: string | unknown }> = [];
+      const provider: LLMProvider = {
+        id: 'mock',
+        chat: vi.fn().mockImplementation(async (params: { messages: Array<{ role: string; content: string | unknown }> }) => {
+          capturedMessages.push(...params.messages);
+          return { type: 'text' as const, content: 'ok', usage: { inputTokens: 10, outputTokens: 5 } };
+        }),
+      };
+
+      // Specialist agent (not coordinator) — should still get Google Workspace accounts
+      const agent = new AgentRuntime({
+        agentId: 'essay-editor',
+        systemPrompt: 'You are an essay editor.',
+        provider,
+        bus,
+        logger,
+        googleWorkspaceAccounts: [
+          { name: 'curia', googleEmail: 'curia@gmail.com', primary: true },
+          { name: 'joseph', googleEmail: 'joseph@example.com', primary: false },
+        ],
+      });
+      agent.register();
+
+      const task = createAgentTask({
+        agentId: 'essay-editor',
+        conversationId: 'conv-gw',
+        channelId: 'internal',
+        senderId: 'coordinator',
+        content: 'Polish this essay',
+        parentEventId: 'parent-gw',
+      });
+      await bus.publish('dispatch', task);
+
+      const systemPrompt = capturedMessages.find(m => m.role === 'system')?.content as string;
+      expect(systemPrompt).toContain('Your Google Workspace Accounts');
+      expect(systemPrompt).toContain('curia: curia@gmail.com (primary)');
+      expect(systemPrompt).toContain('joseph: joseph@example.com');
+      // Non-primary should NOT have (primary) marker
+      expect(systemPrompt).not.toContain('joseph@example.com (primary)');
+    });
+
+    it('does not inject Google Workspace block when no accounts configured', async () => {
+      const logger = createLogger('error');
+      const bus = new EventBus(logger);
+      const capturedMessages: Array<{ role: string; content: string | unknown }> = [];
+      const provider: LLMProvider = {
+        id: 'mock',
+        chat: vi.fn().mockImplementation(async (params: { messages: Array<{ role: string; content: string | unknown }> }) => {
+          capturedMessages.push(...params.messages);
+          return { type: 'text' as const, content: 'ok', usage: { inputTokens: 10, outputTokens: 5 } };
+        }),
+      };
+
+      const agent = new AgentRuntime({
+        agentId: 'coordinator',
+        systemPrompt: 'You are an assistant.',
+        provider,
+        bus,
+        logger,
+        // googleWorkspaceAccounts omitted
+      });
+      agent.register();
+
+      const task = createAgentTask({
+        agentId: 'coordinator',
+        conversationId: 'conv-no-gw',
+        channelId: 'cli',
+        senderId: 'user',
+        content: 'Hello',
+        parentEventId: 'parent-no-gw',
+      });
+      await bus.publish('dispatch', task);
+
+      const systemPrompt = capturedMessages.find(m => m.role === 'system')?.content as string;
+      expect(systemPrompt).not.toContain('Google Workspace');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Delegate timeout injection from agent config (#387)
+  // ---------------------------------------------------------------------------
+
+  describe('delegate timeout injection from agent registry', () => {
+    it('injects timeout_ms from target agent expectedDurationSeconds', async () => {
+      const logger = createLogger('error');
+      const bus = new EventBus(logger);
+
+      // Mock provider: first call returns delegate tool_use, second call returns text
+      let callCount = 0;
+      const provider: LLMProvider = {
+        id: 'mock',
+        chat: vi.fn().mockImplementation(async () => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              type: 'tool_use' as const,
+              toolCalls: [{ id: 'call-delegate', name: 'delegate', input: { agent: 'essay-editor', task: 'polish essay' } }],
+              usage: { inputTokens: 100, outputTokens: 50 },
+            };
+          }
+          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60 } };
+        }),
+      };
+
+      // Mock agent registry with expectedDurationSeconds
+      const { AgentRegistry } = await import('../../../src/agents/agent-registry.js');
+      const agentRegistry = new AgentRegistry();
+      agentRegistry.register('essay-editor', { role: 'specialist', description: 'Essay editor', expectedDurationSeconds: 600 });
+
+      const mockExecution = {
+        invoke: vi.fn().mockResolvedValue({ success: true, data: { response: 'Polished!', agent: 'essay-editor' } }),
+      } as unknown as ExecutionLayer;
+
+      const agent = new AgentRuntime({
+        agentId: 'coordinator',
+        systemPrompt: 'You are an assistant.',
+        provider,
+        bus,
+        logger,
+        executionLayer: mockExecution,
+        skillToolDefs: [{ name: 'delegate', description: 'Delegate', input_schema: { type: 'object' as const, properties: { agent: { type: 'string' }, task: { type: 'string' } }, required: ['agent', 'task'] } }],
+        agentRegistry,
+      });
+      agent.register();
+
+      const task = createAgentTask({
+        agentId: 'coordinator',
+        conversationId: 'conv-timeout',
+        channelId: 'cli',
+        senderId: 'user',
+        content: 'Polish my essay',
+        parentEventId: 'parent-timeout',
+      });
+      await bus.publish('dispatch', task);
+
+      // Verify the execution layer received the injected timeout_ms
+      expect(mockExecution.invoke).toHaveBeenCalledWith(
+        'delegate',
+        expect.objectContaining({ timeout_ms: 600000 }),
+        undefined,
+        expect.any(Object),
+      );
+    });
+
+    it('does not inject timeout_ms when LLM already provides one', async () => {
+      const logger = createLogger('error');
+      const bus = new EventBus(logger);
+
+      let callCount = 0;
+      const provider: LLMProvider = {
+        id: 'mock',
+        chat: vi.fn().mockImplementation(async () => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              type: 'tool_use' as const,
+              toolCalls: [{ id: 'call-delegate-2', name: 'delegate', input: { agent: 'essay-editor', task: 'polish', timeout_ms: 30000 } }],
+              usage: { inputTokens: 100, outputTokens: 50 },
+            };
+          }
+          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60 } };
+        }),
+      };
+
+      const { AgentRegistry } = await import('../../../src/agents/agent-registry.js');
+      const agentRegistry = new AgentRegistry();
+      agentRegistry.register('essay-editor', { role: 'specialist', description: 'Essay editor', expectedDurationSeconds: 600 });
+
+      const mockExecution = {
+        invoke: vi.fn().mockResolvedValue({ success: true, data: { response: 'Polished!', agent: 'essay-editor' } }),
+      } as unknown as ExecutionLayer;
+
+      const agent = new AgentRuntime({
+        agentId: 'coordinator',
+        systemPrompt: 'You are an assistant.',
+        provider,
+        bus,
+        logger,
+        executionLayer: mockExecution,
+        skillToolDefs: [{ name: 'delegate', description: 'Delegate', input_schema: { type: 'object' as const, properties: {}, required: [] } }],
+        agentRegistry,
+      });
+      agent.register();
+
+      const task = createAgentTask({
+        agentId: 'coordinator',
+        conversationId: 'conv-timeout-2',
+        channelId: 'cli',
+        senderId: 'user',
+        content: 'Polish essay',
+        parentEventId: 'parent-timeout-2',
+      });
+      await bus.publish('dispatch', task);
+
+      // LLM's explicit timeout_ms should be preserved, not overwritten
+      expect(mockExecution.invoke).toHaveBeenCalledWith(
+        'delegate',
+        expect.objectContaining({ timeout_ms: 30000 }),
+        undefined,
+        expect.any(Object),
+      );
+    });
+
+    it('falls back to default when agent has no expectedDurationSeconds', async () => {
+      const logger = createLogger('error');
+      const bus = new EventBus(logger);
+
+      let callCount = 0;
+      const provider: LLMProvider = {
+        id: 'mock',
+        chat: vi.fn().mockImplementation(async () => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              type: 'tool_use' as const,
+              toolCalls: [{ id: 'call-delegate-3', name: 'delegate', input: { agent: 'research-analyst', task: 'research' } }],
+              usage: { inputTokens: 100, outputTokens: 50 },
+            };
+          }
+          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60 } };
+        }),
+      };
+
+      const { AgentRegistry } = await import('../../../src/agents/agent-registry.js');
+      const agentRegistry = new AgentRegistry();
+      // No expectedDurationSeconds — should fall through to delegate handler's default
+      agentRegistry.register('research-analyst', { role: 'specialist', description: 'Research' });
+
+      const mockExecution = {
+        invoke: vi.fn().mockResolvedValue({ success: true, data: { response: 'Found info', agent: 'research-analyst' } }),
+      } as unknown as ExecutionLayer;
+
+      const agent = new AgentRuntime({
+        agentId: 'coordinator',
+        systemPrompt: 'You are an assistant.',
+        provider,
+        bus,
+        logger,
+        executionLayer: mockExecution,
+        skillToolDefs: [{ name: 'delegate', description: 'Delegate', input_schema: { type: 'object' as const, properties: {}, required: [] } }],
+        agentRegistry,
+      });
+      agent.register();
+
+      const task = createAgentTask({
+        agentId: 'coordinator',
+        conversationId: 'conv-timeout-3',
+        channelId: 'cli',
+        senderId: 'user',
+        content: 'Research this',
+        parentEventId: 'parent-timeout-3',
+      });
+      await bus.publish('dispatch', task);
+
+      // No timeout_ms should be injected — the delegate handler will use its 90s default
+      const invokeCall = (mockExecution.invoke as ReturnType<typeof vi.fn>).mock.calls[0];
+      const inputArg = invokeCall?.[1] as Record<string, unknown>;
+      expect(inputArg).not.toHaveProperty('timeout_ms');
+    });
+  });
 });

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -1404,6 +1404,47 @@ describe('AgentRuntime chatWithRetry', () => {
       expect(systemPrompt).not.toContain('joseph@example.com (primary)');
     });
 
+    it('injects channelAccounts email block without Google Workspace accounts', async () => {
+      // Regression guard: agents with channelAccounts.email but no googleWorkspaceAccounts
+      // should still get the "Your Contact Details" identity block in their system prompt.
+      const logger = createLogger('error');
+      const bus = new EventBus(logger);
+      const capturedMessages: Array<{ role: string; content: string | unknown }> = [];
+      const provider: LLMProvider = {
+        id: 'mock',
+        chat: vi.fn().mockImplementation(async (params: { messages: Array<{ role: string; content: string | unknown }> }) => {
+          capturedMessages.push(...params.messages);
+          return { type: 'text' as const, content: 'ok', usage: { inputTokens: 10, outputTokens: 5 } };
+        }),
+      };
+
+      const agent = new AgentRuntime({
+        agentId: 'essay-editor',
+        systemPrompt: 'You are an essay editor.',
+        provider,
+        bus,
+        logger,
+        channelAccounts: { email: 'curia@example.com' },
+        // googleWorkspaceAccounts intentionally omitted
+      });
+      agent.register();
+
+      const task = createAgentTask({
+        agentId: 'essay-editor',
+        conversationId: 'conv-ch-only',
+        channelId: 'internal',
+        senderId: 'coordinator',
+        content: 'Polish this',
+        parentEventId: 'parent-ch-only',
+      });
+      await bus.publish('dispatch', task);
+
+      const systemPrompt = capturedMessages.find(m => m.role === 'system')?.content as string;
+      expect(systemPrompt).toContain('Your Contact Details');
+      expect(systemPrompt).toContain('curia@example.com');
+      expect(systemPrompt).not.toContain('Google Workspace');
+    });
+
     it('does not inject Google Workspace block when no accounts configured', async () => {
       const logger = createLogger('error');
       const bus = new EventBus(logger);
@@ -1561,6 +1602,71 @@ describe('AgentRuntime chatWithRetry', () => {
       expect(mockExecution.invoke).toHaveBeenCalledWith(
         'delegate',
         expect.objectContaining({ timeout_ms: 30000 }),
+        undefined,
+        expect.any(Object),
+      );
+    });
+
+    it('task scheduler expectedDurationSeconds takes precedence over agent YAML', async () => {
+      // Priority chain: LLM explicit > task scheduler > agent YAML > default.
+      // This test verifies the scheduler slot (source 1) beats the agent YAML slot (source 2).
+      const logger = createLogger('error');
+      const bus = new EventBus(logger);
+
+      let callCount = 0;
+      const provider: LLMProvider = {
+        id: 'mock',
+        chat: vi.fn().mockImplementation(async () => {
+          callCount++;
+          if (callCount === 1) {
+            // LLM does NOT provide timeout_ms — so injection logic should run
+            return {
+              type: 'tool_use' as const,
+              toolCalls: [{ id: 'call-delegate-sched', name: 'delegate', input: { agent: 'essay-editor', task: 'polish essay' } }],
+              usage: { inputTokens: 100, outputTokens: 50 },
+            };
+          }
+          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60 } };
+        }),
+      };
+
+      const { AgentRegistry } = await import('../../../src/agents/agent-registry.js');
+      const agentRegistry = new AgentRegistry();
+      // Agent YAML declares 600s — scheduler overrides with 120s
+      agentRegistry.register('essay-editor', { role: 'specialist', description: 'Essay editor', expectedDurationSeconds: 600 });
+
+      const mockExecution = {
+        invoke: vi.fn().mockResolvedValue({ success: true, data: { response: 'Polished!', agent: 'essay-editor' } }),
+      } as unknown as ExecutionLayer;
+
+      const agent = new AgentRuntime({
+        agentId: 'coordinator',
+        systemPrompt: 'You are an assistant.',
+        provider,
+        bus,
+        logger,
+        executionLayer: mockExecution,
+        skillToolDefs: [{ name: 'delegate', description: 'Delegate', input_schema: { type: 'object' as const, properties: { agent: { type: 'string' }, task: { type: 'string' } }, required: ['agent', 'task'] } }],
+        agentRegistry,
+      });
+      agent.register();
+
+      const task = createAgentTask({
+        agentId: 'coordinator',
+        conversationId: 'conv-timeout-sched',
+        channelId: 'cli',
+        senderId: 'user',
+        content: 'Polish my essay',
+        parentEventId: 'parent-timeout-sched',
+        // Scheduler provides 120s — should win over the agent YAML's 600s
+        expectedDurationSeconds: 120,
+      });
+      await bus.publish('dispatch', task);
+
+      // Scheduler's 120s (120000ms) must win over agent YAML's 600s (600000ms)
+      expect(mockExecution.invoke).toHaveBeenCalledWith(
+        'delegate',
+        expect.objectContaining({ timeout_ms: 120000 }),
         undefined,
         expect.any(Object),
       );

--- a/tests/unit/config.channel-accounts.test.ts
+++ b/tests/unit/config.channel-accounts.test.ts
@@ -2,7 +2,7 @@
 // excluded_sender_emails fields added for CEO inbox monitoring (#273).
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { resolveChannelAccounts, loadYamlConfig } from '../../src/config.js';
+import { resolveChannelAccounts, resolveGoogleWorkspaceAccounts, loadYamlConfig } from '../../src/config.js';
 import type { Config } from '../../src/config.js';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -207,5 +207,112 @@ describe('resolveChannelAccounts — backward-compat single-account path', () =>
     expect(accounts[0]?.name).toBe('curia');
     expect(accounts[0]?.observationMode).toBe(false);
     expect(accounts[0]?.excludedSenderEmails).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Google Workspace account resolution (#387)
+// ---------------------------------------------------------------------------
+
+describe('resolveGoogleWorkspaceAccounts', () => {
+  it('returns empty array when google_workspace section is absent', () => {
+    const yamlConfig = loadYamlConfig(tempDir); // default.yaml is empty
+    const accounts = resolveGoogleWorkspaceAccounts(yamlConfig);
+    expect(accounts).toEqual([]);
+  });
+
+  it('resolves literal google_email values', () => {
+    writeLocalYaml(`
+channel_accounts:
+  google_workspace:
+    curia:
+      google_email: curia@gmail.com
+      primary: true
+    joseph:
+      google_email: joseph@example.com
+`);
+    const yamlConfig = loadYamlConfig(tempDir);
+    const accounts = resolveGoogleWorkspaceAccounts(yamlConfig);
+    expect(accounts).toHaveLength(2);
+    expect(accounts[0]).toEqual({ name: 'curia', googleEmail: 'curia@gmail.com', primary: true });
+    expect(accounts[1]).toEqual({ name: 'joseph', googleEmail: 'joseph@example.com', primary: false });
+  });
+
+  it('resolves env: references in google_email', () => {
+    const prev = process.env['TEST_GOOGLE_EMAIL'];
+    process.env['TEST_GOOGLE_EMAIL'] = 'resolved@gmail.com';
+    try {
+      writeLocalYaml(`
+channel_accounts:
+  google_workspace:
+    curia:
+      google_email: "env:TEST_GOOGLE_EMAIL"
+      primary: true
+`);
+      const yamlConfig = loadYamlConfig(tempDir);
+      const accounts = resolveGoogleWorkspaceAccounts(yamlConfig);
+      expect(accounts[0]?.googleEmail).toBe('resolved@gmail.com');
+    } finally {
+      if (prev === undefined) {
+        delete process.env['TEST_GOOGLE_EMAIL'];
+      } else {
+        process.env['TEST_GOOGLE_EMAIL'] = prev;
+      }
+    }
+  });
+
+  it('defaults primary to false when omitted', () => {
+    writeLocalYaml(`
+channel_accounts:
+  google_workspace:
+    curia:
+      google_email: curia@gmail.com
+`);
+    const yamlConfig = loadYamlConfig(tempDir);
+    const accounts = resolveGoogleWorkspaceAccounts(yamlConfig);
+    expect(accounts[0]?.primary).toBe(false);
+  });
+
+  it('throws when google_email is missing', () => {
+    writeLocalYaml(`
+channel_accounts:
+  google_workspace:
+    curia:
+      primary: true
+`);
+    expect(() => loadYamlConfig(tempDir)).toThrow('google_email must be a non-empty string');
+  });
+
+  it('throws when primary is not a boolean', () => {
+    writeLocalYaml(`
+channel_accounts:
+  google_workspace:
+    curia:
+      google_email: curia@gmail.com
+      primary: "yes"
+`);
+    expect(() => loadYamlConfig(tempDir)).toThrow('primary must be a boolean');
+  });
+
+  it('throws when multiple accounts are marked primary', () => {
+    writeLocalYaml(`
+channel_accounts:
+  google_workspace:
+    curia:
+      google_email: curia@gmail.com
+      primary: true
+    joseph:
+      google_email: joseph@example.com
+      primary: true
+`);
+    expect(() => loadYamlConfig(tempDir)).toThrow('at most one account may be marked primary');
+  });
+
+  it('throws when google_workspace is not a mapping', () => {
+    writeLocalYaml(`
+channel_accounts:
+  google_workspace: "invalid"
+`);
+    expect(() => loadYamlConfig(tempDir)).toThrow('google_workspace must be a YAML mapping');
   });
 });

--- a/tests/unit/config.channel-accounts.test.ts
+++ b/tests/unit/config.channel-accounts.test.ts
@@ -261,7 +261,10 @@ channel_accounts:
     }
   });
 
-  it('defaults primary to false when omitted', () => {
+  it('auto-assigns primary to the first account when none is marked', () => {
+    // If no account declares primary: true, resolveGoogleWorkspaceAccounts promotes the
+    // first entry — the runtime prompt says "use your primary account", so at least one
+    // account must be identifiable as primary.
     writeLocalYaml(`
 channel_accounts:
   google_workspace:
@@ -270,7 +273,7 @@ channel_accounts:
 `);
     const yamlConfig = loadYamlConfig(tempDir);
     const accounts = resolveGoogleWorkspaceAccounts(yamlConfig);
-    expect(accounts[0]?.primary).toBe(false);
+    expect(accounts[0]?.primary).toBe(true);
   });
 
   it('throws when google_email is missing', () => {


### PR DESCRIPTION
## Summary

Fixes three compounding failures that caused `essay-editor` (and any long-running specialist) to reliably fail (#387):

- **Google Workspace account hallucination** — agents were guessing email addresses for MCP tools. Adds a new `channel_accounts.google_workspace` config section with env-var resolution and validation. The runtime now injects the resolved account list into every agent's system prompt, so the LLM always has the correct email.
- **Delegate timeout too short** — the fixed 90 s default wasn't enough for long-running tasks. Adds an optional `expected_duration_seconds` field to agent YAML. The runtime injects the appropriate `timeout_ms` into delegate calls, with a priority chain: LLM-explicit > task scheduler > agent YAML > default.
- **No acknowledgment on synchronous channels** — on CLI/HTTP/Signal, the user saw a frozen screen while the specialist ran. The coordinator now sends a brief ack before delegating long tasks.

**Also:** `channelAccounts` and Google Workspace accounts are now injected into all agents, not just the coordinator — specialists need identity context too.

## Changed files

| File | Change |
|---|---|
| `config/default.yaml` | Documents the new `google_workspace` config section |
| `src/config.ts` | Types, validation, and env-var resolution for `google_workspace` |
| `schemas/agent-config.schema.json` | New `expected_duration_seconds` field |
| `src/agents/loader.ts` | `AgentYamlConfig` type update |
| `src/agents/agent-registry.ts` | Registry entry type + `register` method |
| `src/agents/runtime.ts` | Google Workspace injection, delegate timeout lookup, diagnostic warns |
| `src/index.ts` | Wires resolved accounts and agent registry through bootstrap |
| `agents/coordinator.yaml` | Delegation acknowledgment guidance |
| `tests/unit/config.channel-accounts.test.ts` | Google Workspace config tests |
| `tests/unit/agents/runtime.test.ts` | Injection and timeout tests |
| `CHANGELOG.md` | Updated |

## Test plan

- [ ] `npm test` — all 1654 unit tests pass, 8 integration tests skipped (require Docker)
- [ ] Verify `channel_accounts.google_workspace` section in `local.yaml` resolves correctly on the dev instance
- [ ] Trigger a delegate to `essay-editor` on CLI; confirm ack appears immediately, specialist completes with the injected timeout
- [ ] Confirm Google Workspace email is present in the coordinator and specialist system prompts (check debug logs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added configurable expected duration settings for delegation tasks to optimise timeout handling.
- Enhanced synchronous channel delegation to include task acknowledgement before processing long-running requests.
- Support for configuring and managing multiple Google Workspace accounts with primary account designation.

**Chores**
- Updated configuration documentation for Google Workspace account setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->