### PR TITLE
fix: create KG person node for CEO contact in bootstrap (#380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **CEO entity context enrichment** — `bootstrapCeoContact()` now creates a KG person node and links it via `kg_node_id` on the CEO contact. Previously the contact was created with `kg_node_id = NULL`, making entity enrichment, standing instructions, and relationship queries non-functional for the CEO. Existing contacts without a KG node are backfilled automatically on next startup. Closes #380.
+
 - **Specialist delegation** — three compounding failures that caused essay-editor (and any long-running specialist) to fail reliably (#387):
   - **Google Workspace account hallucination** — agents now receive their Google Workspace account list in the system prompt, eliminating LLM-guessed email addresses for MCP tools. New `channel_accounts.google_workspace` config section with env-var resolution.
   - **Delegate timeout too short** — agents can now declare `expected_duration_seconds` in their YAML config. The runtime injects the appropriate `timeout_ms` into delegate calls, replacing the fixed 90s default for agents that need more time.

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -7,12 +7,16 @@
 // from the CEO triggers auto-creation via extractParticipants(), which always
 // creates contacts as provisional — causing their messages to be held.
 //
+// Also ensures the CEO contact has a KG person node (kg_node_id). Without one,
+// entity context enrichment is non-functional for the CEO: no facts, standing
+// instructions, or relationship data can be stored or retrieved. See issue #380.
+//
 // This module is called once at startup. It is idempotent under serial execution
 // (safe for single-process deployments, consistent with the migration runner).
 // Handles three cases:
-//   1. Contact + identity already exist as confirmed/verified → no-op
-//   2. Contact + identity exist as provisional/unverified → promote in-place
-//   3. Neither exists → create fresh contact + identity (in a transaction)
+//   1. Contact + identity already exist as confirmed/verified → ensure kg_node_id, no-op otherwise
+//   2. Contact + identity exist as provisional/unverified → promote in-place, ensure kg_node_id
+//   3. Neither exists → create KG node, then create contact + identity in a transaction
 
 import { randomUUID } from 'crypto';
 import type { DbPool } from '../db/connection.js';
@@ -20,12 +24,14 @@ import type { Logger } from '../logger.js';
 
 export interface CeoContactBootstrapResult {
   contactId: string;
+  kgNodeId: string;
   /** true if the contact already existed (possibly promoted), false if newly created */
   alreadyExisted: boolean;
 }
 
 /**
- * Ensure the CEO's primary email contact exists and is confirmed + verified.
+ * Ensure the CEO's primary email contact exists, is confirmed + verified, and has a
+ * linked KG person node.
  *
  * @param ceoPrimaryEmail  The CEO's primary email address (from CEO_PRIMARY_EMAIL env)
  * @param displayName      Display name to use if creating a new contact (defaults to "CEO")
@@ -39,8 +45,19 @@ export async function bootstrapCeoContact(
   logger: Logger,
 ): Promise<CeoContactBootstrapResult> {
   // Look up by channel identity first — this is the authoritative key for email senders.
-  const existing = await pool.query<{ contact_id: string; contact_status: string; identity_verified: boolean }>(
-    `SELECT ci.contact_id, c.status AS contact_status, ci.verified AS identity_verified
+  // Also fetch kg_node_id and display_name so we can detect and fix the missing-KG-node case.
+  const existing = await pool.query<{
+    contact_id: string;
+    contact_status: string;
+    identity_verified: boolean;
+    kg_node_id: string | null;
+    display_name: string;
+  }>(
+    `SELECT ci.contact_id,
+            c.status        AS contact_status,
+            ci.verified     AS identity_verified,
+            c.kg_node_id,
+            c.display_name
      FROM contact_channel_identities ci
      JOIN contacts c ON c.id = ci.contact_id
      WHERE ci.channel = 'email' AND ci.channel_identifier = $1`,
@@ -48,7 +65,8 @@ export async function bootstrapCeoContact(
   );
 
   if (existing.rows[0]) {
-    const { contact_id, contact_status, identity_verified } = existing.rows[0];
+    const { contact_id, contact_status, identity_verified, display_name: existingName } = existing.rows[0];
+    let { kg_node_id } = existing.rows[0];
 
     // Always ensure role = 'ceo' and trust_level = 'high' on the CEO contact regardless
     // of which path brought us here. This is idempotent — the UPDATE is a no-op when both
@@ -66,10 +84,21 @@ export async function bootstrapCeoContact(
       [contact_id],
     );
 
+    // Backfill KG node if missing. This handles existing deployments where the contact
+    // was created without a KG node (pre-#380 fix). Uses the contact's existing display_name
+    // rather than the passed-in default so we don't overwrite a name that was already set.
+    if (!kg_node_id) {
+      kg_node_id = await createAndLinkKgNode(contact_id, existingName, pool);
+      logger.info(
+        { contactId: contact_id, kgNodeId: kg_node_id, email: ceoPrimaryEmail },
+        'ceo-bootstrap: backfilled KG person node for existing CEO contact',
+      );
+    }
+
     // Already confirmed + verified — nothing else to do.
     if (contact_status === 'confirmed' && identity_verified) {
-      logger.info({ contactId: contact_id, email: ceoPrimaryEmail }, 'ceo-bootstrap: CEO contact already confirmed and verified');
-      return { contactId: contact_id, alreadyExisted: true };
+      logger.info({ contactId: contact_id, kgNodeId: kg_node_id, email: ceoPrimaryEmail }, 'ceo-bootstrap: CEO contact already confirmed and verified');
+      return { contactId: contact_id, kgNodeId: kg_node_id, alreadyExisted: true };
     }
 
     // Promote in-place: update contact status and/or identity verified flag.
@@ -90,27 +119,31 @@ export async function bootstrapCeoContact(
     }
 
     logger.info(
-      { contactId: contact_id, email: ceoPrimaryEmail, wasStatus: contact_status, wasVerified: identity_verified },
+      { contactId: contact_id, kgNodeId: kg_node_id, email: ceoPrimaryEmail, wasStatus: contact_status, wasVerified: identity_verified },
       'ceo-bootstrap: CEO contact promoted to confirmed + verified',
     );
-    return { contactId: contact_id, alreadyExisted: true };
+    return { contactId: contact_id, kgNodeId: kg_node_id, alreadyExisted: true };
   }
 
-  // No existing record — create contact and link the email identity in a single
-  // transaction so a partial failure cannot leave an orphaned contacts row.
+  // No existing record — create the KG person node first, then create the contact and
+  // channel identity in a single transaction so a partial failure cannot leave an orphaned
+  // contacts row. The KG node is created outside the transaction intentionally: if the
+  // transaction fails with 23505 (concurrent startup race), we rescue the orphaned KG node
+  // by linking it to the winning contact (see below).
   //
-  // If two instances start simultaneously and both reach this point, one will win
-  // and the other will hit a 23505 unique constraint violation on channel_identifier.
-  // In that case we re-query for the winning row and return it as-is — the CEO contact
-  // exists and is correct, so this is an idempotent success, not an error.
+  // Note: creating the KG node before the transaction means a failed transaction leaves an
+  // unlinked kg_nodes row. This is acceptable for single-process deployments — next startup
+  // will find the contact (via the winning process) and take the existing-contact path above.
+  const kgNodeId = await insertKgPersonNode(displayName, pool);
+
   const contactId = randomUUID();
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
     await client.query(
-      `INSERT INTO contacts (id, display_name, role, status, trust_level, created_at, updated_at)
-       VALUES ($1, $2, 'ceo', 'confirmed', 'high', now(), now())`,
-      [contactId, displayName],
+      `INSERT INTO contacts (id, kg_node_id, display_name, role, status, trust_level, created_at, updated_at)
+       VALUES ($1, $2, $3, 'ceo', 'confirmed', 'high', now(), now())`,
+      [contactId, kgNodeId, displayName],
     );
     await client.query(
       `INSERT INTO contact_channel_identities
@@ -123,16 +156,29 @@ export async function bootstrapCeoContact(
     await client.query('ROLLBACK');
     // 23505 = unique_violation: another instance won the race and already created the
     // identity. Re-query for the winning row and treat as idempotent success.
+    // We also rescue the KG node we created above by linking it to the winner's contact
+    // if the winner ran old code and has no kg_node_id yet.
     const pgCode = (err as { code?: string }).code;
     if (pgCode === '23505') {
-      const winner = await pool.query<{ contact_id: string }>(
-        `SELECT contact_id FROM contact_channel_identities
-         WHERE channel = 'email' AND channel_identifier = $1`,
+      const winner = await pool.query<{ contact_id: string; kg_node_id: string | null }>(
+        `SELECT c.id AS contact_id, c.kg_node_id
+         FROM contact_channel_identities ci
+         JOIN contacts c ON c.id = ci.contact_id
+         WHERE ci.channel = 'email' AND ci.channel_identifier = $1`,
         [ceoPrimaryEmail],
       );
       if (winner.rows[0]) {
-        logger.info({ contactId: winner.rows[0].contact_id, email: ceoPrimaryEmail }, 'ceo-bootstrap: concurrent startup race resolved — existing CEO contact used');
-        return { contactId: winner.rows[0].contact_id, alreadyExisted: true };
+        let winnerKgNodeId = winner.rows[0].kg_node_id;
+        if (!winnerKgNodeId) {
+          // Winner ran old code — link the orphaned KG node we already created to them.
+          await pool.query(
+            `UPDATE contacts SET kg_node_id = $1, updated_at = now() WHERE id = $2 AND kg_node_id IS NULL`,
+            [kgNodeId, winner.rows[0].contact_id],
+          );
+          winnerKgNodeId = kgNodeId;
+        }
+        logger.info({ contactId: winner.rows[0].contact_id, kgNodeId: winnerKgNodeId, email: ceoPrimaryEmail }, 'ceo-bootstrap: concurrent startup race resolved — existing CEO contact used');
+        return { contactId: winner.rows[0].contact_id, kgNodeId: winnerKgNodeId, alreadyExisted: true };
       }
     }
     throw err;
@@ -140,6 +186,47 @@ export async function bootstrapCeoContact(
     client.release();
   }
 
-  logger.info({ contactId, email: ceoPrimaryEmail }, 'ceo-bootstrap: CEO contact created');
-  return { contactId, alreadyExisted: false };
+  logger.info({ contactId, kgNodeId, email: ceoPrimaryEmail }, 'ceo-bootstrap: CEO contact created with KG person node');
+  return { contactId, kgNodeId, alreadyExisted: false };
+}
+
+/**
+ * Insert a new KG person node for the CEO and return its id.
+ * Uses decay_class='permanent' and confidence=1.0 to match the agent identity pattern —
+ * bootstrap nodes are never decayed by the DreamEngine.
+ */
+async function insertKgPersonNode(displayName: string, pool: DbPool): Promise<string> {
+  const result = await pool.query<{ id: string }>(
+    `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at)
+     VALUES ('person', $1, '{}', 1.0, 'permanent', 'bootstrap', now(), now())
+     RETURNING id`,
+    [displayName],
+  );
+  if (!result.rows[0]) {
+    throw new Error('ceo-bootstrap: INSERT INTO kg_nodes returned no rows — check migration 004 was applied');
+  }
+  return result.rows[0].id;
+}
+
+/**
+ * Create a KG person node and link it to an existing contact that has kg_node_id = NULL.
+ * Returns the actual kg_node_id that ended up on the contact (which may differ from the
+ * newly-created node if a concurrent process already set kg_node_id before our UPDATE).
+ */
+async function createAndLinkKgNode(contactId: string, displayName: string, pool: DbPool): Promise<string> {
+  const newKgNodeId = await insertKgPersonNode(displayName, pool);
+  await pool.query(
+    `UPDATE contacts SET kg_node_id = $1, updated_at = now() WHERE id = $2 AND kg_node_id IS NULL`,
+    [newKgNodeId, contactId],
+  );
+  // Re-select to get whichever node actually ended up linked — another process may have
+  // won the race and set kg_node_id to a different value before our UPDATE fired.
+  const result = await pool.query<{ kg_node_id: string }>(
+    `SELECT kg_node_id FROM contacts WHERE id = $1`,
+    [contactId],
+  );
+  if (!result.rows[0]?.kg_node_id) {
+    throw new Error(`ceo-bootstrap: contact ${contactId} still has no kg_node_id after UPDATE — possible concurrent conflict`);
+  }
+  return result.rows[0].kg_node_id;
 }

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -168,18 +168,36 @@ export async function bootstrapCeoContact(
         [ceoPrimaryEmail],
       );
       if (winner.rows[0]) {
+        const winnerContactId = winner.rows[0].contact_id;
         let winnerKgNodeId = winner.rows[0].kg_node_id;
         if (!winnerKgNodeId) {
           // Winner ran old code — link the orphaned KG node we already created to them.
           await pool.query(
             `UPDATE contacts SET kg_node_id = $1, updated_at = now() WHERE id = $2 AND kg_node_id IS NULL`,
-            [kgNodeId, winner.rows[0].contact_id],
+            [kgNodeId, winnerContactId],
           );
-          winnerKgNodeId = kgNodeId;
+          // Re-SELECT to confirm the rescue UPDATE landed — a third concurrent process may
+          // have beaten us to it, in which case the winner's kg_node_id is theirs, not ours.
+          const recheck = await pool.query<{ kg_node_id: string | null }>(
+            `SELECT kg_node_id FROM contacts WHERE id = $1`,
+            [winnerContactId],
+          );
+          winnerKgNodeId = recheck.rows[0]?.kg_node_id ?? null;
+          if (!winnerKgNodeId) {
+            throw new Error(
+              `ceo-bootstrap: winner contact ${winnerContactId} still has no kg_node_id after rescue UPDATE — inspect contacts table`,
+            );
+          }
         }
-        logger.info({ contactId: winner.rows[0].contact_id, kgNodeId: winnerKgNodeId, email: ceoPrimaryEmail }, 'ceo-bootstrap: concurrent startup race resolved — existing CEO contact used');
-        return { contactId: winner.rows[0].contact_id, kgNodeId: winnerKgNodeId, alreadyExisted: true };
+        logger.info({ contactId: winnerContactId, kgNodeId: winnerKgNodeId, email: ceoPrimaryEmail }, 'ceo-bootstrap: concurrent startup race resolved — existing CEO contact used');
+        return { contactId: winnerContactId, kgNodeId: winnerKgNodeId, alreadyExisted: true };
       }
+      // 23505 fired but the winner re-query returned no rows — the winning contact may have
+      // been deleted between the violation and the re-query, or a different constraint fired.
+      logger.warn(
+        { pgCode, email: ceoPrimaryEmail },
+        'ceo-bootstrap: 23505 unique violation but winner re-query returned no rows — re-throwing',
+      );
     }
     throw err;
   } finally {
@@ -202,10 +220,11 @@ async function insertKgPersonNode(displayName: string, pool: DbPool): Promise<st
      RETURNING id`,
     [displayName],
   );
-  if (!result.rows[0]) {
-    throw new Error('ceo-bootstrap: INSERT INTO kg_nodes returned no rows — check migration 004 was applied');
+  const id = result.rows[0]?.id;
+  if (!id) {
+    throw new Error('ceo-bootstrap: INSERT INTO kg_nodes returned no rows or no id — check migration 004 was applied');
   }
-  return result.rows[0].id;
+  return id;
 }
 
 /**

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -209,20 +209,28 @@ export async function bootstrapCeoContact(
 }
 
 /**
- * Insert a new KG person node for the CEO and return its id.
+ * Upsert a KG person node for the CEO and return its id.
  * Uses decay_class='permanent' and confidence=1.0 to match the agent identity pattern —
  * bootstrap nodes are never decayed by the DreamEngine.
+ *
+ * Uses ON CONFLICT on the idx_kg_nodes_unique index (migration 016) rather than a blind
+ * INSERT, because a person node with the same label may already exist — either from a
+ * concurrent startup or from email-based contact extraction that ran before bootstrap.
+ * Without this, a blind INSERT would 23505 outside the contact-identity recovery block
+ * and propagate as an unhandled error.
  */
 async function insertKgPersonNode(displayName: string, pool: DbPool): Promise<string> {
   const result = await pool.query<{ id: string }>(
     `INSERT INTO kg_nodes (type, label, properties, confidence, decay_class, source, created_at, last_confirmed_at)
      VALUES ('person', $1, '{}', 1.0, 'permanent', 'bootstrap', now(), now())
+     ON CONFLICT (lower(label), type) WHERE type != 'fact' AND archived_at IS NULL
+     DO UPDATE SET last_confirmed_at = now()
      RETURNING id`,
     [displayName],
   );
   const id = result.rows[0]?.id;
   if (!id) {
-    throw new Error('ceo-bootstrap: INSERT INTO kg_nodes returned no rows or no id — check migration 004 was applied');
+    throw new Error('ceo-bootstrap: INSERT INTO kg_nodes returned no rows or no id — check migrations 004 and 016 were applied');
   }
   return id;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,9 +344,12 @@ async function main(): Promise<void> {
   // status=confirmed and verified=true before the email adapter starts polling.
   // Without this, the first inbound email from the CEO auto-creates them as
   // provisional (the extractParticipants default), causing their messages to be held.
+  // Also creates (or backfills) a KG person node so entity context enrichment works
+  // for the CEO. See issue #380.
   if (config.ceoPrimaryEmail) {
     try {
-      await bootstrapCeoContact(config.ceoPrimaryEmail, 'CEO', pool, logger);
+      const ceoBootstrap = await bootstrapCeoContact(config.ceoPrimaryEmail, 'CEO', pool, logger);
+      logger.info({ contactId: ceoBootstrap.contactId, kgNodeId: ceoBootstrap.kgNodeId }, 'CEO identity ready');
     } catch (err) {
       // Non-fatal: log and continue. Severity depends on whether the email adapter is active:
       // - With email configured: the CEO's first message will be held if the contact doesn't

--- a/tests/integration/ceo-bootstrap.test.ts
+++ b/tests/integration/ceo-bootstrap.test.ts
@@ -1,0 +1,197 @@
+// tests/integration/ceo-bootstrap.test.ts
+//
+// Integration tests for bootstrapCeoContact.
+// Verifies that the CEO contact is created with a linked KG person node in all
+// three cases, and that existing contacts with kg_node_id = NULL are backfilled.
+//
+// Requires a running Postgres with migrations applied.
+// Skips gracefully when DATABASE_URL is not set.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import { bootstrapCeoContact } from '../../src/contacts/ceo-bootstrap.js';
+import { createLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('bootstrapCeoContact', () => {
+  let pool: pg.Pool;
+  const testEmail = 'ceo-bootstrap-test@example.com';
+  const logger = createLogger('silent');
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    // Verify required tables exist
+    await pool.query('SELECT 1 FROM contacts LIMIT 0');
+    await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  // Clean up test rows before each test so cases don't bleed into each other
+  beforeEach(async () => {
+    await pool.query(
+      `DELETE FROM contact_channel_identities WHERE channel = 'email' AND channel_identifier = $1`,
+      [testEmail],
+    );
+    await pool.query(
+      `DELETE FROM contacts WHERE role = 'ceo' AND display_name LIKE 'Bootstrap Test%'`,
+    );
+    // kg_nodes rows created during tests are cleaned up via FK cascade when contacts are deleted
+    // (if kg_node_id FK has ON DELETE SET NULL we need to clean separately)
+    await pool.query(
+      `DELETE FROM kg_nodes WHERE source = 'bootstrap' AND label LIKE 'Bootstrap Test%'`,
+    );
+  });
+
+  it('case 3: creates contact, channel identity, and KG person node from scratch', async () => {
+    const result = await bootstrapCeoContact(testEmail, 'Bootstrap Test CEO', pool, logger);
+
+    expect(result.alreadyExisted).toBe(false);
+    expect(result.contactId).toBeTruthy();
+    expect(result.kgNodeId).toBeTruthy();
+
+    // Verify the contact row was created with the correct fields
+    const contact = await pool.query<{
+      id: string; display_name: string; role: string; status: string; trust_level: string; kg_node_id: string;
+    }>(
+      `SELECT id, display_name, role, status, trust_level, kg_node_id FROM contacts WHERE id = $1`,
+      [result.contactId],
+    );
+    expect(contact.rows[0]).toBeDefined();
+    expect(contact.rows[0].display_name).toBe('Bootstrap Test CEO');
+    expect(contact.rows[0].role).toBe('ceo');
+    expect(contact.rows[0].status).toBe('confirmed');
+    expect(contact.rows[0].trust_level).toBe('high');
+    expect(contact.rows[0].kg_node_id).toBe(result.kgNodeId);
+
+    // Verify the KG node was created with correct metadata
+    const node = await pool.query<{
+      id: string; type: string; label: string; decay_class: string; source: string; confidence: number;
+    }>(
+      `SELECT id, type, label, decay_class, source, confidence FROM kg_nodes WHERE id = $1`,
+      [result.kgNodeId],
+    );
+    expect(node.rows[0]).toBeDefined();
+    expect(node.rows[0].type).toBe('person');
+    expect(node.rows[0].label).toBe('Bootstrap Test CEO');
+    expect(node.rows[0].decay_class).toBe('permanent');
+    expect(node.rows[0].source).toBe('bootstrap');
+    expect(node.rows[0].confidence).toBe(1);
+
+    // Verify the channel identity was created and verified
+    const identity = await pool.query<{ verified: boolean; source: string }>(
+      `SELECT verified, source FROM contact_channel_identities
+       WHERE contact_id = $1 AND channel = 'email' AND channel_identifier = $2`,
+      [result.contactId, testEmail],
+    );
+    expect(identity.rows[0]).toBeDefined();
+    expect(identity.rows[0].verified).toBe(true);
+    expect(identity.rows[0].source).toBe('bootstrap');
+  });
+
+  it('case 1: returns existing IDs when contact is already confirmed + verified', async () => {
+    // Seed via the first call
+    const first = await bootstrapCeoContact(testEmail, 'Bootstrap Test CEO', pool, logger);
+    expect(first.alreadyExisted).toBe(false);
+
+    // Second call should be a no-op
+    const second = await bootstrapCeoContact(testEmail, 'Bootstrap Test CEO', pool, logger);
+    expect(second.alreadyExisted).toBe(true);
+    expect(second.contactId).toBe(first.contactId);
+    expect(second.kgNodeId).toBe(first.kgNodeId);
+
+    // No duplicate KG nodes should exist for this contact
+    const nodeCount = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM kg_nodes WHERE label = 'Bootstrap Test CEO' AND source = 'bootstrap'`,
+    );
+    expect(Number(nodeCount.rows[0].count)).toBe(1);
+  });
+
+  it('case 2: promotes provisional contact and assigns KG node', async () => {
+    // Insert a provisional contact + unverified identity directly (simulates
+    // the auto-creation path from extractParticipants)
+    const contactId = crypto.randomUUID();
+    await pool.query(
+      `INSERT INTO contacts (id, display_name, role, status, trust_level, created_at, updated_at)
+       VALUES ($1, 'Bootstrap Test CEO', null, 'provisional', null, now(), now())`,
+      [contactId],
+    );
+    await pool.query(
+      `INSERT INTO contact_channel_identities (id, contact_id, channel, channel_identifier, verified, source, created_at, updated_at)
+       VALUES ($1, $2, 'email', $3, false, 'auto', now(), now())`,
+      [crypto.randomUUID(), contactId, testEmail],
+    );
+
+    const result = await bootstrapCeoContact(testEmail, 'Bootstrap Test CEO', pool, logger);
+
+    expect(result.alreadyExisted).toBe(true);
+    expect(result.contactId).toBe(contactId);
+    expect(result.kgNodeId).toBeTruthy();
+
+    // Contact should now be confirmed + high trust
+    const contact = await pool.query<{ status: string; trust_level: string; kg_node_id: string }>(
+      `SELECT status, trust_level, kg_node_id FROM contacts WHERE id = $1`,
+      [contactId],
+    );
+    expect(contact.rows[0].status).toBe('confirmed');
+    expect(contact.rows[0].trust_level).toBe('high');
+    expect(contact.rows[0].kg_node_id).toBe(result.kgNodeId);
+
+    // Identity should now be verified
+    const identity = await pool.query<{ verified: boolean }>(
+      `SELECT verified FROM contact_channel_identities WHERE contact_id = $1 AND channel = 'email'`,
+      [contactId],
+    );
+    expect(identity.rows[0].verified).toBe(true);
+  });
+
+  it('backfills kg_node_id on a confirmed contact that has none', async () => {
+    // Simulate a contact created by old code: confirmed + verified but kg_node_id = NULL
+    const contactId = crypto.randomUUID();
+    await pool.query(
+      `INSERT INTO contacts (id, display_name, role, status, trust_level, created_at, updated_at)
+       VALUES ($1, 'Bootstrap Test CEO', 'ceo', 'confirmed', 'high', now(), now())`,
+      [contactId],
+    );
+    await pool.query(
+      `INSERT INTO contact_channel_identities (id, contact_id, channel, channel_identifier, verified, verified_at, source, created_at, updated_at)
+       VALUES ($1, $2, 'email', $3, true, now(), 'bootstrap', now(), now())`,
+      [crypto.randomUUID(), contactId, testEmail],
+    );
+
+    // Confirm kg_node_id starts as NULL
+    const before = await pool.query<{ kg_node_id: string | null }>(
+      `SELECT kg_node_id FROM contacts WHERE id = $1`,
+      [contactId],
+    );
+    expect(before.rows[0].kg_node_id).toBeNull();
+
+    const result = await bootstrapCeoContact(testEmail, 'Bootstrap Test CEO', pool, logger);
+
+    expect(result.alreadyExisted).toBe(true);
+    expect(result.contactId).toBe(contactId);
+    expect(result.kgNodeId).toBeTruthy();
+
+    // kg_node_id should now be set
+    const after = await pool.query<{ kg_node_id: string }>(
+      `SELECT kg_node_id FROM contacts WHERE id = $1`,
+      [contactId],
+    );
+    expect(after.rows[0].kg_node_id).toBe(result.kgNodeId);
+
+    // KG node should be a permanent bootstrap person node
+    const node = await pool.query<{ type: string; decay_class: string; source: string }>(
+      `SELECT type, decay_class, source FROM kg_nodes WHERE id = $1`,
+      [result.kgNodeId],
+    );
+    expect(node.rows[0].type).toBe('person');
+    expect(node.rows[0].decay_class).toBe('permanent');
+    expect(node.rows[0].source).toBe('bootstrap');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #380.

`bootstrapCeoContact()` was creating the CEO contact with `kg_node_id = NULL`, making entity context enrichment completely non-functional for the CEO — no facts, standing instructions, or relationship queries could be stored or retrieved.

- **Case 3 (fresh install):** Creates a KG person node (`type='person'`, `decay_class='permanent'`, `confidence=1.0`, `source='bootstrap'`) before inserting the CEO contact, and includes `kg_node_id` in the contacts INSERT
- **Cases 1 & 2 (existing contact):** Backfills `kg_node_id` on startup if the contact has none — handles all pre-fix deployments automatically on next restart
- **23505 race recovery:** Rescues the orphaned KG node created before a lost concurrent-startup race by linking it to the winning contact; re-SELECTs to confirm the link landed
- **`CeoContactBootstrapResult`:** Now returns `kgNodeId: string` alongside `contactId`, consistent with `AgentIdentity` from `bootstrapAgentIdentity()`
- **4 integration tests** covering all three bootstrap cases and the backfill path

No migration required — the bootstrap handles backfill at runtime.

## Test plan

- [ ] All 4 new integration tests in `tests/integration/ceo-bootstrap.test.ts` pass
- [ ] Full test suite passes (155 files, 1712 tests)
- [ ] On a deployment with an existing CEO contact that has `kg_node_id = NULL`: startup log shows `ceo-bootstrap: backfilled KG person node for existing CEO contact` with a valid `kgNodeId`
- [ ] After fix: CEO contact resolves through entity context enrichment (facts, standing instructions, relationships work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Restored knowledge graph entity context enrichment for CEO contacts. CEO contacts are now properly linked to knowledge graph person nodes, with automatic backfilling of existing contacts missing this connection during startup.

* **Tests**
  * Added comprehensive integration tests validating CEO contact creation, verification, and knowledge graph linkage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->