### PR TITLE
fix: pin missing coordinator skills + CLAUDE.md reminder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **Proactive Signal sends from scheduled jobs** — `signal-send` skill pinned in coordinator's tool list so it is always available during scheduler runs (no extra discovery turn required). Closes #374, unblocks spec 17 item 0 (meeting-debrief prerequisite).
+- **Missing coordinator skills pinned** — `contact-rename`, `contact-set-trust`, `memory-query`, `memory-store`, `image-generate`, and `skill-registry` added to the coordinator's `pinned_skills` list. These skills existed and were functional but were absent from the pinned list, causing the coordinator to claim it lacked capabilities it actually had (e.g. renaming a contact's display name).
+- **CLAUDE.md: pin skills checklist step** — "New Skill" instructions now include an explicit step to add the skill to `pinned_skills` in at least one agent YAML, with a note on the infrastructure-skill exception.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,8 @@ Cross-cutting: Audit Logger, Memory Engine, Scheduler.
 1. Create `skills/<name>/skill.json` (manifest) + `handler.ts`
 2. Declare permissions and secrets in the manifest
 3. Write `handler.test.ts`
-4. **Timestamps:** When a skill returns timestamps for user-facing display, use `toLocalIso()` from `src/time/timestamp.ts` to convert to the user's local timezone (available as `ctx.timezone`). Never return raw UTC Z-suffix strings for times the user will see — LLMs cannot reliably perform timezone conversion. Include `displayTimezone: formatDisplayTimezone(ctx.timezone)` in the result data so the LLM can label its output.
+4. **Pin it to at least one agent.** Add the skill name to `pinned_skills` in the relevant agent YAML (`agents/coordinator.yaml` for most skills). A skill that isn't pinned to any agent is invisible to that agent unless dynamic discovery happens to surface it — which is unreliable. Exception: pure infrastructure skills invoked by the system (e.g. `extract-facts`, `extract-relationships`, `scheduler-report`) intentionally have no agent owner.
+5. **Timestamps:** When a skill returns timestamps for user-facing display, use `toLocalIso()` from `src/time/timestamp.ts` to convert to the user's local timezone (available as `ctx.timezone`). Never return raw UTC Z-suffix strings for times the user will see — LLMs cannot reliably perform timezone conversion. Include `displayTimezone: formatDisplayTimezone(ctx.timezone)` in the result data so the LLM can label its output.
 
 ### Autonomy Awareness
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -434,6 +434,8 @@ pinned_skills:
   - contact-lookup
   - contact-link-identity
   - contact-set-role
+  - contact-set-trust
+  - contact-rename
   - contact-list
   - email-send
   - email-reply
@@ -474,4 +476,8 @@ pinned_skills:
   - set-autonomy
   - query-relationships
   - delete-relationship
+  - memory-query
+  - memory-store
+  - image-generate
+  - skill-registry
 allow_discovery: true


### PR DESCRIPTION
## Summary

- 6 skills were built and merged but never added to the coordinator's `pinned_skills`: `contact-rename`, `contact-set-trust`, `memory-query`, `memory-store`, `image-generate`, and `skill-registry`
- The coordinator was falling back to dynamic discovery, which is unreliable — causing it to claim it couldn't perform actions it had tools for (e.g. renaming a contact's display name, which was reported as broken despite PR #341 shipping the skill on Apr 24)
- Adds an explicit pinning step to the **New Skill** checklist in `CLAUDE.md` to prevent recurrence

## What's pinned and why

| Skill | Reason |
|---|---|
| `contact-rename` | Bug trigger — coordinator said it had no name-change tool |
| `contact-set-trust` | Same tier as contact-set-role, contact-grant-permission — should have been pinned with those |
| `memory-query` | Coordinator should be able to search the knowledge graph in conversation |
| `memory-store` | Coordinator should be able to persist facts it learns |
| `image-generate` | User-facing capability — coordinator should know it can generate images |
| `skill-registry` | Useful for explicit self-directed discovery, even with `allow_discovery: true` |

Not pinned (intentionally): `extract-facts`, `extract-relationships` (invoked automatically by the checkpoint processor), `scheduler-report` (only valid inside a running scheduled job).

## Test plan

- [ ] Restart Curia and ask it to rename a contact — confirm it uses `contact-rename` directly without claiming it has no tool
- [ ] Ask Curia to set trust on a contact — confirm it uses `contact-set-trust`
- [ ] Ask Curia what it remembers about a person — confirm it uses `memory-query`
- [ ] Ask Curia to remember a fact — confirm it uses `memory-store`
- [ ] Ask Curia to generate an image — confirm it uses `image-generate`