### PR TITLE
feat: extract observation-mode email triage into dedicated specialist agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **email-triage specialist agent** (`agents/email-triage.yaml`): new specialist that owns
+  observation-mode inbox triage end-to-end. Classifies inbound email into five categories
+  (URGENT, ACTIONABLE, NEEDS DRAFT, LEAVE FOR CEO, NOISE), executes email-domain actions
+  directly, and routes out-of-domain ACTIONABLE items via bullpen. Capability-aware:
+  consults the available-specialists list to determine the current ACTIONABLE scope rather
+  than hardcoding action types.
+- **`inject_specialists` YAML field**: opt-in mechanism for specialist agents that need the
+  `${available_specialists}` runtime injection (previously coordinator-only).
 - **Proactive Signal sends from scheduled jobs** — `signal-send` skill pinned in coordinator's tool list so it is always available during scheduler runs (no extra discovery turn required). Closes #374, unblocks spec 17 item 0 (meeting-debrief prerequisite).
 - **Missing coordinator skills pinned** — `contact-rename`, `contact-set-trust`, `memory-query`, `memory-store`, `image-generate`, and `skill-registry` added to the coordinator's `pinned_skills` list. These skills existed and were functional but were absent from the pinned list, causing the coordinator to claim it lacked capabilities it actually had (e.g. renaming a contact's display name).
 - **CLAUDE.md: pin skills checklist step** — "New Skill" instructions now include an explicit step to add the skill to `pinned_skills` in at least one agent YAML, with a note on the infrastructure-skill exception.
@@ -31,6 +39,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Coordinator**: removed ~45 lines of observation-mode triage protocol; replaced with a
+  ~15-line delegation rule that immediately hands off `[OBSERVATION MODE]` messages to the
+  `email-triage` specialist. Coordinator echoes the classification keyword in its own
+  response so the dispatcher's classification extraction is unchanged.
 - **Channel account injection** — `channelAccounts` (email, phone) and Google Workspace accounts are now injected into ALL agents' system prompts, not just the coordinator. Specialist agents need identity context too.
 - **Agent YAML schema** *(public API surface)* — new optional `expected_duration_seconds` field (integer, minimum 1).
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -354,7 +354,7 @@ system_prompt: |
     [OBSERVATION MODE — email-triage delegation]
     Message ID: <nylasMessageId from preamble>
     Account: <Account identifier from preamble>
-    Timezone: <timezone from your current context>
+    Timezone: <the CEO's IANA timezone — use the timezone value injected into your own system context>
 
     --- Original message ---
     <paste the full email content, preserving the [OBSERVATION MODE] preamble>

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -270,17 +270,11 @@ system_prompt: |
   last resort — they expect you to find this information yourself.
 
   ## Inbox Disambiguation
-  Some email accounts are connected in observation mode — Curia monitors them on behalf
-  of the CEO but is not the intended recipient. When the CEO says "my inbox" or "my
-  email", resolve it as follows:
+  When the CEO says "my inbox" or "my email", resolve it as follows:
 
   - **"my inbox"** (the CEO speaking to you directly) → the CEO's own monitored inbox
   - **"your inbox"** (the CEO speaking to you directly) → Curia's own email account
   - **"Curia's inbox"** → Curia's own email account
-  - **"your inbox"** (in an observed third-party email) → the CEO's monitored inbox;
-    the sender is addressing the CEO, not Curia
-  - **"my inbox"** (in an observed third-party email) → that sender's own inbox;
-    Curia has no access to it — decline or ask the CEO to clarify
 
   ## Calendar Disambiguation
   When the CEO references calendars, resolve as follows:
@@ -295,48 +289,6 @@ system_prompt: |
   register it as part of another task. Instead, flag it to the CEO: "I see a
   calendar I don't recognize yet — [name]. Who does this belong to?" Then
   register it with the correct contact based on their answer.
-
-  ## Observation Mode — Monitored Inboxes
-
-  Some emails arrive from a monitored inbox. These are marked `[OBSERVATION MODE]`
-  in the user content and include a Message ID and Account identifier.
-
-  In observation mode you watch the CEO's inbox on their behalf.
-  You are NOT the recipient. NEVER reply to the sender as yourself or sign with your name.
-  Your final response text is for audit/logging only — the dispatcher will NOT turn
-  it into an outbound email. Keep it brief: just state your classification and action.
-
-  TRIAGE — evaluate in order:
-
-  1. STANDING INSTRUCTIONS: use entity-context to look up the sender. If the CEO has
-     given you a standing instruction for this sender or email type, follow it.
-
-  2. CLASSIFY and act:
-     - URGENT — time-sensitive, requires CEO decision, from a known contact:
-       Send the CEO a message on a high-urgency channel (e.g. Signal): sender, subject,
-       one-sentence summary, key ask. Do NOT reply to the sender.
-     - ACTIONABLE — calendar booking, add attendee, change location, clear task:
-       Do it using your existing skills. No notification. It will appear in the weekly log.
-     - NEEDS DRAFT — a reply is warranted and you can write it:
-       Save a draft with email-draft-save (set `account` to the Account identifier from
-       the task, `reply_to_message_id` to the Message ID, and `triage_classification` to
-       `"NEEDS DRAFT"`). The CEO will review before it sends.
-     - LEAVE FOR CEO — personal, sensitive, relationship-dependent, requires the CEO's
-       own voice or judgment, or you are not confident you understand it:
-       Do NOTHING. No archive, no draft, no notification. The CEO will read and
-       handle it themselves when they next check their inbox. Examples: personal
-       correspondence, LinkedIn DMs from specific individuals, offers/negotiations,
-       anything requiring the CEO's discretion.
-     - NOISE — receipt, newsletter, automated notification, no action needed:
-       Call email-archive using the Message ID and Account from the task. No other action. No notification.
-
-  3. WHEN IN DOUBT: prefer LEAVE FOR CEO over acting. The CEO will see the email in
-     their inbox. URGENT is only for time-sensitive items that need an immediate
-     Signal ping. Do not over-notify.
-
-  When the CEO later asks you to draft a reply to an observed email, write in
-  **the CEO's voice and perspective**, not as Curia. Do not sign with your name or title.
-  Before drafting, check whether the CEO has already replied in the thread.
 
   ${executive_voice_block}
 
@@ -360,15 +312,13 @@ system_prompt: |
   The "default to yourself" rule does NOT apply to email-skill account selection.
   Use these rules IN ORDER:
 
-  1. If an observation-mode preamble is present, use the Account identifier
-     from that preamble.
-  2. If the CEO asks you to draft, read, or archive emails in THEIR inbox,
+  1. If the CEO asks you to draft, read, or archive emails in THEIR inbox,
      use the CEO's account name — not yours. "Draft this from me",
      "check my email", "draft an email for me to send", "save a draft
      for me to review" all mean the CEO's account. The CEO does not want
      drafts appearing in Curia's outbox — they want them in their own
      drafts folder so they can review and send.
-  3. If operating on your own inbox (Curia's messages, Curia's drafts),
+  2. If operating on your own inbox (Curia's messages, Curia's drafts),
      use your own account or omit the param.
 
   When in doubt about whose mailbox to target, ask the CEO.
@@ -392,6 +342,29 @@ system_prompt: |
   something like "This will take a few minutes — I'll reply when it's ready." Then call
   the delegate tool on your next turn. For email (async), delegate silently without
   acknowledgment — the sender doesn't expect an immediate response.
+
+  ## Observation-Mode Email Triage
+
+  When you receive a message containing `[OBSERVATION MODE — monitored inbox]`, delegate
+  immediately to the `email-triage` specialist via the delegate tool. Do not triage the
+  email yourself.
+
+  Pass this task string to email-triage (substitute the values from the preamble):
+
+    [OBSERVATION MODE — email-triage delegation]
+    Message ID: <nylasMessageId from preamble>
+    Account: <Account identifier from preamble>
+    Timezone: <timezone from your current context>
+
+    --- Original message ---
+    <paste the full email content, preserving the [OBSERVATION MODE] preamble>
+
+  After email-triage responds, include its classification keyword verbatim in your own
+  response (e.g. `Classification: NOISE`) so it can be tracked.
+
+  If the email-triage specialist is unavailable (delegate returns an error), respond with
+  `Classification: LEAVE FOR CEO` and note that the triage specialist was unavailable.
+  Do not attempt to triage the email yourself.
 
   Available specialists:
   ${available_specialists}

--- a/agents/email-triage.yaml
+++ b/agents/email-triage.yaml
@@ -48,9 +48,12 @@ system_prompt: |
   1. Check the available specialists below to understand what Curia can currently do.
   2. If a deployed specialist can handle this task, classify as ACTIONABLE and open
      a bullpen thread mentioning that specialist by name with a clear handoff summary.
-  3. If the task is within your own skill set (email archive, draft save), execute directly.
-  4. If no deployed specialist can handle it and it's outside your skill set, prefer
-     LEAVE FOR CEO unless the CEO has a global standing instruction that says otherwise.
+  3. If no deployed specialist can handle it, prefer LEAVE FOR CEO unless the CEO has
+     a global standing instruction that says otherwise.
+
+  Note: email archive and draft-save are NOT ACTIONABLE — they have dedicated categories
+  (NOISE and NEEDS DRAFT respectively). ACTIONABLE is reserved for tasks that require a
+  deployed specialist or autonomous non-email work.
 
   Available specialists:
   ${available_specialists}
@@ -74,10 +77,10 @@ system_prompt: |
        Include: sender name, subject, one-sentence summary, key ask or deadline.
        Do NOT reply to the sender.
 
-     ACTIONABLE — a task Curia can handle autonomously (see ACTIONABLE Scope above):
-       If in-domain (email archive, draft), execute directly.
-       If out-of-domain, open a bullpen thread mentioning the capable specialist.
+     ACTIONABLE — a task a deployed specialist can handle autonomously (see ACTIONABLE Scope):
+       Open a bullpen thread mentioning the capable specialist with a clear handoff summary.
        No CEO notification needed — it will appear in the activity log.
+       Do NOT use ACTIONABLE for email archive (that is NOISE) or draft-save (that is NEEDS DRAFT).
 
      NEEDS DRAFT — a reply is warranted and the CEO should review before sending:
        Call email-draft-save with:

--- a/agents/email-triage.yaml
+++ b/agents/email-triage.yaml
@@ -1,0 +1,113 @@
+name: email-triage
+role: specialist
+description: >
+  Triages the CEO's inbound email in observation mode. Classifies each message into five
+  categories and takes appropriate action: archives noise, saves draft replies, escalates
+  urgent items via bullpen, and handles or routes actionable items.
+model:
+  provider: anthropic
+  model: claude-sonnet-4-6
+inject_specialists: true
+pinned_skills:
+  - email-list
+  - email-get
+  - email-archive
+  - email-draft-save
+  - entity-context
+  - bullpen
+allow_discovery: false
+memory:
+  scopes: [email-triage]
+system_prompt: |
+  You are the email triage specialist for an executive assistant team. You monitor the
+  CEO's inbound email in observation mode and act on each message according to the
+  triage protocol below.
+
+  You are NOT the sender's intended recipient and you are NOT the coordinator. Your
+  response is logged for audit purposes only — it is not sent to anyone. The coordinator
+  will read your response and echo your classification keyword in its own reply.
+
+  ## Context
+
+  The coordinator delegates observation-mode emails to you with this structure:
+
+    [OBSERVATION MODE — email-triage delegation]
+    Message ID: <nylasMessageId>
+    Account: <accountId>
+    Timezone: <IANA timezone>
+
+    --- Original message ---
+    <email content>
+
+  Always use the Account value for all email skill `account` parameters. Always use
+  the Message ID for `reply_to_message_id` and archive calls.
+
+  ## ACTIONABLE Scope
+
+  Do NOT enumerate a fixed list of action types. Instead:
+  1. Check the available specialists below to understand what Curia can currently do.
+  2. If a deployed specialist can handle this task, classify as ACTIONABLE and open
+     a bullpen thread mentioning that specialist by name with a clear handoff summary.
+  3. If the task is within your own skill set (email archive, draft save), execute directly.
+  4. If no deployed specialist can handle it and it's outside your skill set, prefer
+     LEAVE FOR CEO unless the CEO has a global standing instruction that says otherwise.
+
+  Available specialists:
+  ${available_specialists}
+
+  ## Triage Protocol
+
+  TRIAGE — evaluate in order:
+
+  1. STANDING INSTRUCTIONS
+     Call entity-context on the sender. Check for:
+     - Per-sender instructions: e.g. "always archive receipts from Stripe"
+     - Global/topic instructions: e.g. "track all business expenses", "file health claims"
+     If a matching standing instruction exists, follow it verbatim. The categories below
+     are the fallback when no standing instruction applies.
+
+  2. CLASSIFY — five mutually exclusive categories, evaluated in priority order:
+
+     URGENT — time-sensitive, CEO decision required, from a known contact:
+       Open a bullpen thread mentioning the coordinator. Frame it as "this email needs
+       urgent attention" — do NOT specify which channel to use; the coordinator decides.
+       Include: sender name, subject, one-sentence summary, key ask or deadline.
+       Do NOT reply to the sender.
+
+     ACTIONABLE — a task Curia can handle autonomously (see ACTIONABLE Scope above):
+       If in-domain (email archive, draft), execute directly.
+       If out-of-domain, open a bullpen thread mentioning the capable specialist.
+       No CEO notification needed — it will appear in the activity log.
+
+     NEEDS DRAFT — a reply is warranted and the CEO should review before sending:
+       Call email-draft-save with:
+         account: <Account from context>
+         reply_to_message_id: <Message ID from context>
+         triage_classification: "NEEDS DRAFT"
+       Write the draft in the CEO's voice, not the assistant's. Do not sign with a
+       name or title. Check whether the CEO has already replied in the thread before
+       drafting.
+
+     LEAVE FOR CEO — personal, sensitive, relationship-dependent, or uncertain:
+       Do nothing. No archive, no draft, no notification.
+
+     NOISE — receipt, newsletter, automated notification, no human action needed:
+       Call email-archive with:
+         message_id: <Message ID from context>
+         account: <Account from context>
+       No other action, no notification.
+
+  3. WHEN IN DOUBT
+     Prefer LEAVE FOR CEO. URGENT only for genuinely time-sensitive items with a clear
+     deadline or decision required. Do not over-notify.
+
+  ## Response Format
+
+  Every response must include these three lines:
+
+    Classification: <URGENT|ACTIONABLE|NEEDS DRAFT|LEAVE FOR CEO|NOISE>
+    Rationale: <one or two sentences explaining the decision>
+    Actions taken: <brief list of skill calls made, or "none">
+
+  The coordinator reads this and echoes the classification keyword so the dispatcher
+  can track it. Keep the rest of your response concise.

--- a/docs/wip/2026-04-29-email-triage-specialist-design.md
+++ b/docs/wip/2026-04-29-email-triage-specialist-design.md
@@ -1,0 +1,326 @@
+# Email Triage Specialist — Design
+
+**Issue:** josephfung/curia#386
+**Date:** 2026-04-29
+**Status:** Approved
+
+## Goal
+
+Extract the observation-mode email triage protocol from `agents/coordinator.yaml` into a
+dedicated `email-triage` specialist agent. The coordinator retains oversight via a thin
+delegation rule; all triage logic, classification, and email-domain action live in the
+specialist.
+
+## Background
+
+Phase 1 inbox triage (see `docs/wip/2026-04-11-inbox-triage-design.md`) shipped a 4-way
+triage protocol (later expanded to 5 categories) directly in the coordinator system prompt.
+This works, but creates three problems as the protocol grows: auditability (triage decisions
+are buried alongside unrelated coordinator events), context pressure (triage rules compete
+with other coordinator responsibilities for context budget), and separation of concerns
+(triage is a self-contained domain that doesn't need the full coordinator capability set).
+
+## Routing Architecture
+
+**Approach A — coordinator as hub.** The dispatcher continues routing observation-mode
+messages to the coordinator unchanged. The coordinator recognizes the observation-mode flag
+and delegates to `email-triage` via the `delegate` skill. After the specialist responds, the
+coordinator echoes the classification keyword in its own response so the dispatcher's
+existing regex extraction (line 779–782 in `src/dispatch/dispatcher.ts`) continues to work
+without modification. Zero dispatcher changes required.
+
+Considered and rejected: direct dispatcher routing to the specialist (Approach B). Cleaner
+separation, but requires dispatcher changes and breaks the coordinator-as-single-entry-point
+pattern. Natural evolution if observation-mode volume grows to a point where the round-trip
+matters.
+
+## Agent Definition
+
+**New file: `agents/email-triage.yaml`**
+
+```yaml
+name: email-triage
+role: specialist
+description: >
+  Triages the CEO's inbound email in observation mode. Classifies each message into five
+  categories and takes appropriate action: archives noise, saves draft replies, escalates
+  urgent items via bullpen, and handles or routes actionable items.
+model:
+  provider: anthropic
+  model: claude-sonnet-4-6
+inject_specialists: true
+pinned_skills:
+  - email-list
+  - email-get
+  - email-archive
+  - email-draft-save
+  - entity-context
+  - bullpen
+allow_discovery: false
+memory:
+  scopes: [email-triage]
+system_prompt: |
+  <system prompt — see Section below>
+```
+
+**Model:** Sonnet 4.6. Triage is structured classification, not open-ended reasoning. Sonnet
+is fast and appropriately sized for high-volume inbox traffic.
+
+**Pinned skills:**
+- `email-archive`, `email-draft-save` — direct email-domain actions
+- `email-list`, `email-get` — thread context lookup before classifying
+- `entity-context` — sender standing-instruction and global instruction lookup
+- `bullpen` — URGENT escalation and out-of-domain ACTIONABLE routing
+
+**No `signal-send`.** URGENT escalation uses bullpen → coordinator, which selects the
+notification channel. This keeps cross-channel concerns in the coordinator and lets the
+coordinator make the "most urgent available channel" decision using common sense (Signal is
+real-time, email is async — no formal metadata needed).
+
+**`allow_discovery: false`** — specialist stays focused; no runtime-discovered extras.
+
+**`memory.scopes: [email-triage]`** — isolated from coordinator and other specialist memory.
+
+## inject_specialists Flag
+
+`${available_specialists}` is currently injected only for `role: coordinator` agents
+(`src/index.ts:817`). The email-triage specialist needs this list to:
+
+1. **Classify ACTIONABLE correctly** — "Is there a deployed specialist that can handle this
+   task?" Without the list, the specialist cannot know whether a health expense agent, a
+   calendar specialist, or another capability exists in this deployment.
+2. **Route bullpen threads precisely** — instead of posting to the coordinator blindly, the
+   specialist can mention the right specialist by name for out-of-domain ACTIONABLE items.
+
+**New YAML field:** `inject_specialists: true`
+
+The agent loader in `src/index.ts` is updated to also call `interpolateRuntimeContext` for
+any agent that has `inject_specialists: true`, in addition to the existing coordinator path.
+No changes to `interpolateRuntimeContext` itself — it already accepts optional context and
+leaves other placeholders untouched.
+
+URGENT escalations always go to the coordinator via bullpen (not a named specialist), because
+channel selection is the coordinator's responsibility.
+
+## System Prompt
+
+The specialist system prompt absorbs and adapts content currently in `coordinator.yaml`.
+
+### Identity and Role Framing
+
+```
+You are the email triage specialist for an executive assistant team. You monitor the CEO's
+inbound email in observation mode and act on each message according to a triage protocol.
+
+You are NOT the sender's recipient and you are NOT the coordinator. Your response is logged
+for audit; it is not sent to anyone. The coordinator will read your response and echo your
+classification in its own reply.
+```
+
+### Context Block
+
+The coordinator passes observation-mode context in the delegation task string:
+
+```
+[OBSERVATION MODE — email-triage delegation]
+Message ID: <nylasMessageId>
+Account: <accountId>
+Timezone: <IANA timezone>
+
+--- Original message ---
+<full email content>
+```
+
+The specialist uses `Account` for all email skill `account` params and `Message ID` for
+`reply_to_message_id` / archive calls. The dispatcher-injected account override rules
+(coordinator.yaml lines 357–373) simplify to a single rule here: always use the Account
+from the delegation context.
+
+### ACTIONABLE Scope
+
+ACTIONABLE is defined by capability, not enumeration. Do not hardcode a list of action
+types. Instead:
+
+1. Check `${available_specialists}` to understand what Curia can currently do.
+2. If a deployed specialist can handle the task, classify as ACTIONABLE and route via
+   bullpen (mentioning that specialist).
+3. If no deployed specialist can handle the task and it's not in the specialist's own
+   skill set, prefer LEAVE FOR CEO unless the CEO has given a standing instruction to act.
+
+This means the scope of ACTIONABLE grows automatically as new specialists are deployed,
+and shrinks automatically when a specialist is not running.
+
+### Standing Instructions (per-sender and global)
+
+Call `entity-context` on the sender before classifying. Check for:
+- **Per-sender instructions**: "always archive receipts from Stripe"
+- **Global/topic instructions**: "track all business expenses", "file health claims
+  automatically"
+
+If a matching standing instruction exists, follow it verbatim. The triage protocol below
+is the fallback when no standing instruction applies.
+
+### Triage Protocol
+
+```
+TRIAGE — evaluate in order:
+
+1. STANDING INSTRUCTIONS
+   Call entity-context on the sender. If the CEO has given a standing instruction for this
+   sender, email type, or topic, follow it. Global instructions (e.g. "track business
+   expenses") take precedence over the default categories below.
+
+2. CLASSIFY — five mutually exclusive categories, evaluated in priority order:
+
+   URGENT — time-sensitive, CEO decision required, from a known contact:
+     Open a bullpen thread mentioning the coordinator. Frame it as "this email needs urgent
+     notification" — do NOT specify the notification channel; the coordinator decides.
+     Include: sender name, subject, one-sentence summary, key ask or deadline.
+     Do NOT reply to the sender.
+
+   ACTIONABLE — a task Curia can handle autonomously:
+     Check ${available_specialists}. If a specialist can handle this task, open a bullpen
+     thread mentioning that specialist with a clear handoff summary. If the task is within
+     this specialist's skill set (email archive, draft), execute directly.
+     No CEO notification needed — it will appear in the activity log.
+
+   NEEDS DRAFT — a reply is warranted and the CEO should review before sending:
+     Call email-draft-save with:
+       account: <Account from context>
+       reply_to_message_id: <Message ID from context>
+       triage_classification: "NEEDS DRAFT"
+     Write the draft in the CEO's voice, not the assistant's. Do not sign with a name or
+     title. Check whether the CEO has already replied before drafting.
+
+   LEAVE FOR CEO — personal, sensitive, relationship-dependent, or uncertain:
+     Do nothing. No archive, no draft, no notification.
+
+   NOISE — receipt, newsletter, automated notification, no human sender action needed:
+     Call email-archive with the Message ID and Account from context. No notification.
+
+3. WHEN IN DOUBT
+   Prefer LEAVE FOR CEO. URGENT only for genuinely time-sensitive items with a clear
+   deadline or decision required. Do not over-notify.
+```
+
+### Response Format
+
+Every response must include the classification keyword in a structured line:
+
+```
+Classification: <URGENT|ACTIONABLE|NEEDS DRAFT|LEAVE FOR CEO|NOISE>
+Rationale: <one or two sentences explaining the decision>
+Actions taken: <brief list of skill calls made, or "none">
+```
+
+The coordinator reads this response and echoes the classification keyword in its own reply,
+preserving the dispatcher's regex extraction at `src/dispatch/dispatcher.ts:779–782`.
+
+## Coordinator Changes
+
+**Remove from `coordinator.yaml`:**
+- Lines 272–283: Inbox disambiguation rules (simplified into email-triage context block)
+- Lines 299–335: Full observation-mode triage protocol
+- Lines 337–338: CEO voice rule for observed emails (moved to specialist)
+- Lines 357–373: Email-skill account override exception for observation mode
+
+Estimated reduction: ~65 lines from the coordinator system prompt.
+
+**Add to `coordinator.yaml`** (~10 lines in the delegation section):
+
+```
+## Observation Mode — Email Triage Delegation
+
+When you receive a message marked [OBSERVATION MODE — monitored inbox], delegate immediately
+to the email-triage specialist via the delegate skill. Do not triage the email yourself.
+
+Task string to pass:
+  [OBSERVATION MODE — email-triage delegation]
+  Message ID: <nylasMessageId from the preamble>
+  Account: <Account identifier from the preamble>
+  Timezone: <${timezone}>
+
+  --- Original message ---
+  <full email content>
+
+After the specialist responds, echo the classification keyword in your own response
+(e.g. "Classification: NOISE") so the dispatcher can extract it.
+
+If the email-triage specialist is unavailable (delegate skill returns an error), classify
+all observation-mode emails as LEAVE FOR CEO and include a note in your response indicating
+the specialist was unavailable. The audit log will capture this. Do not attempt to triage
+without the specialist.
+```
+
+## Classification Propagation
+
+No dispatcher changes. The existing regex at `src/dispatch/dispatcher.ts:779–782` extracts
+the classification keyword from the coordinator's `agent.response` event. The coordinator
+echoes the keyword it receives from the specialist, so propagation is transparent.
+
+## Testing
+
+**Adapt existing tests:**
+
+`tests/unit/dispatch/dispatcher-observation-triage.test.ts` currently simulates the
+coordinator emitting classification keywords. These tests continue to work unchanged — the
+coordinator still emits the keyword; only the source of truth shifts (specialist → coordinator
+echo rather than coordinator's own triage).
+
+**New unit tests:**
+
+- `tests/unit/agents/email-triage.test.ts` (or `agents/email-triage.handler.test.ts`)
+  - All five classification outcomes with mock entity-context responses
+  - Standing instruction overrides per-sender and global
+  - URGENT → bullpen thread opened mentioning coordinator
+  - ACTIONABLE in-domain → correct skill call
+  - ACTIONABLE out-of-domain → bullpen thread mentioning correct specialist
+  - NEEDS DRAFT → email-draft-save called with correct params
+  - NOISE → email-archive called
+  - LEAVE FOR CEO → zero skill calls
+
+**New unit tests for coordinator delegation:**
+
+- Coordinator receives observation-mode message → delegate skill called with correct task string
+- email-triage unavailable → coordinator classifies as LEAVE FOR CEO, logs warning
+
+**New integration test:**
+
+- Observation-mode message flows from dispatcher → coordinator → email-triage → coordinator
+  echoes classification → dispatcher extracts and emits triage event
+- Add to `tests/integration/multi-agent-delegation.test.ts` or as a new
+  `tests/integration/email-triage-delegation.test.ts`
+
+**Smoke test update:**
+
+Update `tests/smoke/cases/email-triage-urgent.yaml` and `email-triage-batch.yaml` to
+reflect that classification now originates in the email-triage specialist rather than the
+coordinator.
+
+## Files to Create / Modify
+
+| File | Change |
+|------|--------|
+| `agents/email-triage.yaml` | **Create** — new specialist agent definition |
+| `agents/coordinator.yaml` | **Modify** — remove ~65 lines of triage protocol, add ~10 lines of delegation rule |
+| `src/agents/loader.ts` | **Modify** — add `inject_specialists` field to `AgentYamlConfig` type |
+| `src/index.ts` | **Modify** — inject `${available_specialists}` for agents with `inject_specialists: true` |
+| `tests/unit/agents/email-triage.test.ts` | **Create** — unit tests for all 5 classifications + edge cases |
+| `tests/integration/email-triage-delegation.test.ts` | **Create** — end-to-end delegation flow |
+| `tests/smoke/cases/email-triage-urgent.yaml` | **Modify** — update expected response shape |
+| `tests/smoke/cases/email-triage-batch.yaml` | **Modify** — update expected response shape |
+| `CHANGELOG.md` | **Modify** — add entry under `## [Unreleased]` |
+
+No changes to: dispatcher, email adapter, bullpen service, skill manifests, outbound gateway,
+or the bus event schema.
+
+## Out of Scope
+
+Per issue #386, the following are tracked as separate issues:
+
+- **Scheduled observation job** — decoupling triage from the email adapter's primary polling
+  loop into a separate scheduled job with independent cadence
+- **Label management** — future triage complexity (email labels, more categories) lands in
+  the specialist once it exists; label management infrastructure is a separate concern
+- **Interactive-mode email** — stays with coordinator; using Curia's email as a communication
+  channel is architecturally distinct from monitoring the CEO's inbox

--- a/docs/wip/2026-04-29-email-triage-specialist.md
+++ b/docs/wip/2026-04-29-email-triage-specialist.md
@@ -1,0 +1,824 @@
+# Email Triage Specialist Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the observation-mode email triage protocol from the coordinator into a dedicated `email-triage` specialist agent, so triage decisions are auditable in isolation and the coordinator's context window is freed for other responsibilities.
+
+**Architecture:** Coordinator-as-hub (Approach A). The dispatcher continues routing observation-mode messages to the coordinator unchanged. The coordinator recognizes the `[OBSERVATION MODE]` flag and delegates immediately to the `email-triage` specialist via the `delegate` skill. The specialist triages, acts, and returns a structured response including the classification keyword. The coordinator echoes the keyword in its own response so the dispatcher's existing regex extraction at `src/dispatch/dispatcher.ts:779–782` continues to work without modification. Zero dispatcher changes.
+
+**Tech Stack:** TypeScript (ESM), Vitest, YAML agent config, `interpolateRuntimeContext` from `src/agents/loader.ts`, `AgentRuntime` from `src/agents/runtime.ts`.
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/agents/loader.ts` | Modify | Add `inject_specialists?: boolean` to `AgentYamlConfig` |
+| `src/index.ts` | Modify | Inject `${available_specialists}` for agents with `inject_specialists: true` |
+| `agents/email-triage.yaml` | Create | New specialist agent definition with triage protocol |
+| `agents/coordinator.yaml` | Modify | Remove ~45 lines of triage protocol, add ~15 lines of delegation rule |
+| `tests/integration/email-triage-delegation.test.ts` | Create | End-to-end test: observation-mode → coordinator delegates → specialist triages → coordinator echoes |
+| `CHANGELOG.md` | Modify | Add entry under `## [Unreleased]` |
+
+---
+
+### Task 1: Add `inject_specialists` field to `AgentYamlConfig`
+
+**Files:**
+- Modify: `src/agents/loader.ts:15-55`
+
+The `${available_specialists}` placeholder is currently only injected for `role: coordinator` agents (`src/index.ts:817`). The email-triage specialist needs this list to determine what's ACTIONABLE and to name the right specialist in bullpen threads. This task adds the opt-in YAML field and wires up the injection in `src/index.ts`.
+
+- [ ] **Step 1: Add the field to the type**
+
+In `src/agents/loader.ts`, add `inject_specialists?: boolean` to `AgentYamlConfig` after the `error_budget` field:
+
+```typescript
+export interface AgentYamlConfig {
+  name: string;
+  role?: string;
+  description?: string;
+  persona?: {
+    display_name?: string;
+    tone?: string;
+    title?: string;
+    email_signature?: string;
+  };
+  model: {
+    provider: string;
+    model: string;
+    fallback?: {
+      provider: string;
+      model: string;
+    };
+  };
+  system_prompt: string;
+  pinned_skills?: string[];
+  allow_discovery?: boolean;
+  memory?: {
+    scopes?: string[];
+  };
+  schedule?: Array<{
+    cron: string;
+    task: string;
+    agent_id?: string;
+    expectedDurationSeconds?: number;
+  }>;
+  expected_duration_seconds?: number;
+  error_budget?: {
+    max_turns?: number;
+    max_cost_usd?: number;
+    max_errors?: number;
+  };
+  /**
+   * When true, ${available_specialists} in the system_prompt is replaced at bootstrap
+   * with the list of registered specialist agents. Used by specialists that need to
+   * know what other agents are available (e.g. to make ACTIONABLE routing decisions).
+   */
+  inject_specialists?: boolean;
+}
+```
+
+- [ ] **Step 2: Update the injection condition in `src/index.ts`**
+
+Find the block starting at line 817 (`if (agentConfig.role === 'coordinator')`). The current code:
+
+```typescript
+let systemPrompt = agentConfig.system_prompt;
+if (agentConfig.role === 'coordinator') {
+  systemPrompt = interpolateRuntimeContext(systemPrompt, {
+    availableSpecialists: agentRegistry.specialistSummary(),
+    agentContactId: agentIdentityContactId,
+  });
+}
+```
+
+Replace with:
+
+```typescript
+let systemPrompt = agentConfig.system_prompt;
+if (agentConfig.role === 'coordinator') {
+  // Coordinator gets specialist list + its own contact ID.
+  systemPrompt = interpolateRuntimeContext(systemPrompt, {
+    availableSpecialists: agentRegistry.specialistSummary(),
+    agentContactId: agentIdentityContactId,
+  });
+} else if (agentConfig.inject_specialists) {
+  // Specialists that need to know about available agents (e.g. email-triage)
+  // opt in via inject_specialists: true in their YAML.
+  systemPrompt = interpolateRuntimeContext(systemPrompt, {
+    availableSpecialists: agentRegistry.specialistSummary(),
+  });
+}
+```
+
+- [ ] **Step 3: Verify TypeScript compiles clean**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist run build
+```
+
+Expected: no errors. If the build script does not exist, run:
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist run typecheck
+```
+
+- [ ] **Step 4: Run tests to verify nothing regressed**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist test
+```
+
+Expected: `1667 passed` (same as baseline). The `inject_specialists` field is optional and defaults to `undefined`, which is falsy — no existing agent is affected.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist add src/agents/loader.ts src/index.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist commit -m "feat: add inject_specialists opt-in for specialist agents"
+```
+
+---
+
+### Task 2: Create `agents/email-triage.yaml`
+
+**Files:**
+- Create: `agents/email-triage.yaml`
+
+- [ ] **Step 1: Create the agent YAML**
+
+Create `agents/email-triage.yaml` with the following content:
+
+```yaml
+name: email-triage
+role: specialist
+description: >
+  Triages the CEO's inbound email in observation mode. Classifies each message into five
+  categories and takes appropriate action: archives noise, saves draft replies, escalates
+  urgent items via bullpen, and handles or routes actionable items.
+model:
+  provider: anthropic
+  model: claude-sonnet-4-6
+inject_specialists: true
+pinned_skills:
+  - email-list
+  - email-get
+  - email-archive
+  - email-draft-save
+  - entity-context
+  - bullpen
+allow_discovery: false
+memory:
+  scopes: [email-triage]
+system_prompt: |
+  You are the email triage specialist for an executive assistant team. You monitor the
+  CEO's inbound email in observation mode and act on each message according to the
+  triage protocol below.
+
+  You are NOT the sender's intended recipient and you are NOT the coordinator. Your
+  response is logged for audit purposes only — it is not sent to anyone. The coordinator
+  will read your response and echo your classification keyword in its own reply.
+
+  ## Context
+
+  The coordinator delegates observation-mode emails to you with this structure:
+
+    [OBSERVATION MODE — email-triage delegation]
+    Message ID: <nylasMessageId>
+    Account: <accountId>
+    Timezone: <IANA timezone>
+
+    --- Original message ---
+    <email content>
+
+  Always use the Account value for all email skill `account` parameters. Always use
+  the Message ID for `reply_to_message_id` and archive calls.
+
+  ## ACTIONABLE Scope
+
+  Do NOT enumerate a fixed list of action types. Instead:
+  1. Check the available specialists below to understand what Curia can currently do.
+  2. If a deployed specialist can handle this task, classify as ACTIONABLE and open
+     a bullpen thread mentioning that specialist by name with a clear handoff summary.
+  3. If the task is within your own skill set (email archive, draft save), execute directly.
+  4. If no deployed specialist can handle it and it's outside your skill set, prefer
+     LEAVE FOR CEO unless the CEO has a global standing instruction that says otherwise.
+
+  Available specialists:
+  ${available_specialists}
+
+  ## Triage Protocol
+
+  TRIAGE — evaluate in order:
+
+  1. STANDING INSTRUCTIONS
+     Call entity-context on the sender. Check for:
+     - Per-sender instructions: e.g. "always archive receipts from Stripe"
+     - Global/topic instructions: e.g. "track all business expenses", "file health claims"
+     If a matching standing instruction exists, follow it verbatim. The categories below
+     are the fallback when no standing instruction applies.
+
+  2. CLASSIFY — five mutually exclusive categories, evaluated in priority order:
+
+     URGENT — time-sensitive, CEO decision required, from a known contact:
+       Open a bullpen thread mentioning the coordinator. Frame it as "this email needs
+       urgent attention" — do NOT specify which channel to use; the coordinator decides.
+       Include: sender name, subject, one-sentence summary, key ask or deadline.
+       Do NOT reply to the sender.
+
+     ACTIONABLE — a task Curia can handle autonomously (see ACTIONABLE Scope above):
+       If in-domain (email archive, draft), execute directly.
+       If out-of-domain, open a bullpen thread mentioning the capable specialist.
+       No CEO notification needed — it will appear in the activity log.
+
+     NEEDS DRAFT — a reply is warranted and the CEO should review before sending:
+       Call email-draft-save with:
+         account: <Account from context>
+         reply_to_message_id: <Message ID from context>
+         triage_classification: "NEEDS DRAFT"
+       Write the draft in the CEO's voice, not the assistant's. Do not sign with a
+       name or title. Check whether the CEO has already replied in the thread before
+       drafting.
+
+     LEAVE FOR CEO — personal, sensitive, relationship-dependent, or uncertain:
+       Do nothing. No archive, no draft, no notification.
+
+     NOISE — receipt, newsletter, automated notification, no human action needed:
+       Call email-archive with:
+         message_id: <Message ID from context>
+         account: <Account from context>
+       No other action, no notification.
+
+  3. WHEN IN DOUBT
+     Prefer LEAVE FOR CEO. URGENT only for genuinely time-sensitive items with a clear
+     deadline or decision required. Do not over-notify.
+
+  ## Response Format
+
+  Every response must include these three lines:
+
+    Classification: <URGENT|ACTIONABLE|NEEDS DRAFT|LEAVE FOR CEO|NOISE>
+    Rationale: <one or two sentences explaining the decision>
+    Actions taken: <brief list of skill calls made, or "none">
+
+  The coordinator reads this and echoes the classification keyword so the dispatcher
+  can track it. Keep the rest of your response concise.
+```
+
+- [ ] **Step 2: Run tests to verify the new YAML loads cleanly**
+
+The agent registry scans the `agents/` directory at boot. The test suite uses real file reads in some paths. Run:
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist test
+```
+
+Expected: still `1667 passed`. The new agent file will be picked up at runtime but doesn't affect existing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist add agents/email-triage.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist commit -m "feat: add email-triage specialist agent"
+```
+
+---
+
+### Task 3: Update `agents/coordinator.yaml`
+
+**Files:**
+- Modify: `agents/coordinator.yaml`
+
+Remove the observation-mode triage protocol from the coordinator and replace it with a thin delegation rule. Three distinct edits.
+
+**Edit A — Trim Inbox Disambiguation (lines 272–283)**
+
+The current section has five bullets. Remove the two observation-mode-specific bullets (bullets 4 and 5) since the coordinator no longer processes observed emails. Keep bullets 1–3 for interactive-mode inbox references.
+
+Current block (lines 272–283):
+
+```
+  ## Inbox Disambiguation
+  Some email accounts are connected in observation mode — Curia monitors them on behalf
+  of the CEO but is not the intended recipient. When the CEO says "my inbox" or "my
+  email", resolve it as follows:
+
+  - **"my inbox"** (the CEO speaking to you directly) → the CEO's own monitored inbox
+  - **"your inbox"** (the CEO speaking to you directly) → Curia's own email account
+  - **"Curia's inbox"** → Curia's own email account
+  - **"your inbox"** (in an observed third-party email) → the CEO's monitored inbox;
+    the sender is addressing the CEO, not Curia
+  - **"my inbox"** (in an observed third-party email) → that sender's own inbox;
+    Curia has no access to it — decline or ask the CEO to clarify
+```
+
+Replace with:
+
+```
+  ## Inbox Disambiguation
+  When the CEO says "my inbox" or "my email", resolve it as follows:
+
+  - **"my inbox"** (the CEO speaking to you directly) → the CEO's own monitored inbox
+  - **"your inbox"** (the CEO speaking to you directly) → Curia's own email account
+  - **"Curia's inbox"** → Curia's own email account
+```
+
+- [ ] **Step 1: Apply Edit A**
+
+Find the `## Inbox Disambiguation` section in `agents/coordinator.yaml` and replace it with the trimmed version above (removing the two observation-mode bullets and the opening sentence referencing observation mode).
+
+**Edit B — Remove the Observation Mode section (lines 299–339)**
+
+Remove the entire `## Observation Mode — Monitored Inboxes` section, including:
+- The preamble (lines 301–307)
+- The TRIAGE protocol (lines 309–335)
+- The CEO voice rule (lines 337–338)
+
+The `${executive_voice_block}` placeholder on line 341 stays — it follows the removed section and is for interactive-mode voice guidance.
+
+- [ ] **Step 2: Apply Edit B**
+
+Remove all content from `## Observation Mode — Monitored Inboxes` up to (but not including) `${executive_voice_block}`. The result should be that `${executive_voice_block}` directly follows the Calendar Disambiguation section.
+
+**Edit C — Simplify the email-skill account override (lines 357–373)**
+
+The current block has 3 rules. Rule 1 is observation-mode specific and moves to the specialist. Remove it; renumber rules 2 and 3 to 1 and 2.
+
+Current block:
+
+```
+  **Exception — email skills (`email-list`, `email-get`, `email-draft-save`,
+  `email-archive`):**
+  The `account` param on these skills selects which mailbox to operate on.
+  The "default to yourself" rule does NOT apply to email-skill account selection.
+  Use these rules IN ORDER:
+
+  1. If an observation-mode preamble is present, use the Account identifier
+     from that preamble.
+  2. If the CEO asks you to draft, read, or archive emails in THEIR inbox,
+     use the CEO's account name — not yours. "Draft this from me",
+     "check my email", "draft an email for me to send", "save a draft
+     for me to review" all mean the CEO's account. The CEO does not want
+     drafts appearing in Curia's outbox — they want them in their own
+     drafts folder so they can review and send.
+  3. If operating on your own inbox (Curia's messages, Curia's drafts),
+     use your own account or omit the param.
+
+  When in doubt about whose mailbox to target, ask the CEO.
+```
+
+Replace with:
+
+```
+  **Exception — email skills (`email-list`, `email-get`, `email-draft-save`,
+  `email-archive`):**
+  The `account` param on these skills selects which mailbox to operate on.
+  The "default to yourself" rule does NOT apply to email-skill account selection.
+  Use these rules IN ORDER:
+
+  1. If the CEO asks you to draft, read, or archive emails in THEIR inbox,
+     use the CEO's account name — not yours. "Draft this from me",
+     "check my email", "draft an email for me to send", "save a draft
+     for me to review" all mean the CEO's account. The CEO does not want
+     drafts appearing in Curia's outbox — they want them in their own
+     drafts folder so they can review and send.
+  2. If operating on your own inbox (Curia's messages, Curia's drafts),
+     use your own account or omit the param.
+
+  When in doubt about whose mailbox to target, ask the CEO.
+```
+
+- [ ] **Step 3: Apply Edit C**
+
+Find the "Exception — email skills" block and replace with the trimmed 2-rule version above.
+
+**Edit D — Add observation-mode delegation rule**
+
+In the `## Your Team` section (around line 382), add a subsection immediately before `Available specialists:` that instructs the coordinator to delegate observation-mode emails:
+
+```
+  ## Observation-Mode Email Triage
+
+  When you receive a message containing `[OBSERVATION MODE — monitored inbox]`, delegate
+  immediately to the `email-triage` specialist via the delegate tool. Do not triage the
+  email yourself.
+
+  Pass this task string to email-triage (substitute the values from the preamble):
+
+    [OBSERVATION MODE — email-triage delegation]
+    Message ID: <nylasMessageId from preamble>
+    Account: <Account identifier from preamble>
+    Timezone: <timezone from your current context>
+
+    --- Original message ---
+    <paste the full email content, preserving the [OBSERVATION MODE] preamble>
+
+  After email-triage responds, include its classification keyword verbatim in your own
+  response (e.g. `Classification: NOISE`) so it can be tracked.
+
+  If the email-triage specialist is unavailable (delegate returns an error), respond with
+  `Classification: LEAVE FOR CEO` and note that the triage specialist was unavailable.
+  Do not attempt to triage the email yourself.
+```
+
+- [ ] **Step 4: Apply Edit D**
+
+Add this block inside the `## Your Team` section, before the `Available specialists:` line and `${available_specialists}` placeholder.
+
+- [ ] **Step 5: Run tests to confirm nothing regressed**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist test
+```
+
+Expected: still passing. The coordinator YAML changes affect only LLM prompt content, not any TypeScript code paths tested by the suite.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist add agents/coordinator.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist commit -m "feat: coordinator delegates observation-mode email to email-triage specialist"
+```
+
+---
+
+### Task 4: Integration test — observation-mode delegation chain
+
+**Files:**
+- Create: `tests/integration/email-triage-delegation.test.ts`
+
+This test verifies the full routing chain using mock LLMs:
+1. Coordinator receives an observation-mode message → calls `delegate` targeting `email-triage`
+2. Email-triage receives the delegation → returns a structured response with a classification keyword
+3. Coordinator echoes the classification in its own response
+4. Dispatcher sees the coordinator's response and extracts the classification correctly
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/email-triage-delegation.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '../../src/bus/bus.js';
+import { AgentRuntime } from '../../src/agents/runtime.js';
+import { AgentRegistry } from '../../src/agents/agent-registry.js';
+import { SkillRegistry } from '../../src/skills/registry.js';
+import { ExecutionLayer } from '../../src/skills/execution.js';
+import { DelegateHandler } from '../../skills/delegate/handler.js';
+import type { LLMProvider, Message, ContentBlock } from '../../src/agents/llm/provider.js';
+import type { SkillManifest } from '../../src/skills/types.js';
+import { createAgentTask } from '../../src/bus/events.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+// Observation-mode preamble that the dispatcher injects into the task content.
+const OBS_PREAMBLE = `[OBSERVATION MODE — monitored inbox]
+Message ID: msg-abc123
+Account: ceo-inbox
+
+--- Original message ---
+From: investor@example.com
+Subject: Quick call today?
+Body: Hey, can we jump on a call today to discuss the board situation? It's urgent.`;
+
+describe('Email-triage delegation integration', () => {
+  it('coordinator delegates observation-mode email to email-triage and echoes classification', async () => {
+    // 1. Set up registries
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main coordinator' });
+    agentRegistry.register('email-triage', {
+      role: 'specialist',
+      description: 'Triages the CEO inbound email in observation mode',
+    });
+
+    const skillRegistry = new SkillRegistry();
+    const delegateManifest: SkillManifest = {
+      name: 'delegate',
+      description: 'Delegate a task to a specialist agent',
+      version: '1.0.0',
+      sensitivity: 'normal',
+      capabilities: ['bus', 'agentRegistry'],
+      inputs: { agent: 'string', task: 'string', conversation_id: 'string?' },
+      outputs: { response: 'string', agent: 'string' },
+      permissions: [],
+      secrets: [],
+      timeout: 120000,
+    };
+    skillRegistry.register(delegateManifest, new DelegateHandler());
+
+    // 2. Set up bus and execution layer
+    const bus = new EventBus(logger);
+    const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry });
+
+    // 3. Mock coordinator LLM:
+    //    - Turn 1: receives observation-mode message, calls delegate('email-triage', ...)
+    //    - Turn 2: receives delegation result, echoes classification in response
+    let coordinatorCalls = 0;
+    let capturedDelegateInput: { agent?: string; task?: string } = {};
+    const coordinatorProvider: LLMProvider = {
+      id: 'mock-coordinator',
+      chat: async ({ messages }: { messages: Message[] }) => {
+        coordinatorCalls++;
+        if (coordinatorCalls === 1) {
+          // First turn: delegate to email-triage
+          const delegateInput = {
+            agent: 'email-triage',
+            task: `[OBSERVATION MODE — email-triage delegation]
+Message ID: msg-abc123
+Account: ceo-inbox
+Timezone: America/Toronto
+
+--- Original message ---
+From: investor@example.com
+Subject: Quick call today?
+Body: Hey, can we jump on a call today to discuss the board situation? It's urgent.`,
+            conversation_id: 'email:thread-obs-1',
+          };
+          capturedDelegateInput = delegateInput;
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{ id: 'call-delegate-1', name: 'delegate', input: delegateInput }],
+            usage: { inputTokens: 100, outputTokens: 50 },
+          };
+        }
+        // Turn 2: specialist responded — echo the classification
+        const hasToolResult = messages.some(m =>
+          Array.isArray(m.content) &&
+          m.content.some((b: ContentBlock) => b.type === 'tool_result'),
+        );
+        return {
+          type: 'text' as const,
+          content: hasToolResult
+            ? 'The email-triage specialist has reviewed this message. Classification: URGENT'
+            : 'Classification: LEAVE FOR CEO',
+          usage: { inputTokens: 200, outputTokens: 40 },
+        };
+      },
+    };
+
+    // 4. Mock email-triage LLM: returns a structured triage response
+    let triageSpecialistCalls = 0;
+    const triageProvider: LLMProvider = {
+      id: 'mock-email-triage',
+      chat: async () => {
+        triageSpecialistCalls++;
+        return {
+          type: 'text' as const,
+          content: `Classification: URGENT
+Rationale: Time-sensitive request from a known investor contact requesting a same-day call about a board matter.
+Actions taken: bullpen thread opened mentioning coordinator`,
+          usage: { inputTokens: 80, outputTokens: 40 },
+        };
+      },
+    };
+
+    // 5. Create both agent runtimes
+    const toolDefs = skillRegistry.toToolDefinitions(['delegate']);
+
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a coordinator. Delegate observation-mode emails to email-triage.',
+      provider: coordinatorProvider,
+      bus,
+      logger,
+      executionLayer,
+      pinnedSkills: ['delegate'],
+      skillToolDefs: toolDefs,
+    });
+    coordinator.register();
+
+    const triageSpecialist = new AgentRuntime({
+      agentId: 'email-triage',
+      systemPrompt: 'You are the email-triage specialist.',
+      provider: triageProvider,
+      bus,
+      logger,
+    });
+    triageSpecialist.register();
+
+    // 6. Capture coordinator's final response
+    let coordinatorFinalResponse = '';
+    bus.subscribe('agent.response', 'system', async (event) => {
+      if (event.type === 'agent.response' && event.payload.agentId === 'coordinator') {
+        coordinatorFinalResponse = event.payload.content;
+      }
+    });
+
+    // 7. Send an observation-mode task to the coordinator
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'email:thread-obs-1',
+      channelId: 'email',
+      senderId: 'investor@example.com',
+      content: OBS_PREAMBLE,
+      parentEventId: 'inbound-obs-event-1',
+    });
+    await bus.publish('dispatch', task);
+
+    // 8. Verify the full delegation loop ran
+    expect(coordinatorCalls).toBe(2); // coordinator was called twice (delegate + synthesize)
+    expect(triageSpecialistCalls).toBe(1); // email-triage specialist was called
+    expect(capturedDelegateInput.agent).toBe('email-triage'); // coordinator targeted the right agent
+    expect(capturedDelegateInput.task).toContain('msg-abc123'); // Message ID forwarded
+    expect(capturedDelegateInput.task).toContain('ceo-inbox'); // Account forwarded
+
+    // 9. Verify coordinator echoed the classification keyword
+    expect(coordinatorFinalResponse).toContain('Classification: URGENT');
+  });
+
+  it('coordinator responds with LEAVE FOR CEO when email-triage is unavailable', async () => {
+    // Scenario: email-triage is not registered — delegate skill returns an error.
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main coordinator' });
+    // email-triage intentionally NOT registered
+
+    const skillRegistry = new SkillRegistry();
+    const delegateManifest: SkillManifest = {
+      name: 'delegate',
+      description: 'Delegate a task to a specialist agent',
+      version: '1.0.0',
+      sensitivity: 'normal',
+      capabilities: ['bus', 'agentRegistry'],
+      inputs: { agent: 'string', task: 'string', conversation_id: 'string?' },
+      outputs: { response: 'string', agent: 'string' },
+      permissions: [],
+      secrets: [],
+      timeout: 120000,
+    };
+    skillRegistry.register(delegateManifest, new DelegateHandler());
+
+    const bus = new EventBus(logger);
+    const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry });
+
+    // Coordinator: first turn tries to delegate, second turn gets tool error and falls back
+    let coordinatorCalls = 0;
+    const coordinatorProvider: LLMProvider = {
+      id: 'mock-coordinator-fallback',
+      chat: async ({ messages }: { messages: Message[] }) => {
+        coordinatorCalls++;
+        if (coordinatorCalls === 1) {
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{
+              id: 'call-delegate-fail',
+              name: 'delegate',
+              input: { agent: 'email-triage', task: 'triage this email', conversation_id: 'email:thread-obs-2' },
+            }],
+            usage: { inputTokens: 100, outputTokens: 50 },
+          };
+        }
+        // Turn 2: delegate failed — fall back to LEAVE FOR CEO
+        return {
+          type: 'text' as const,
+          content: 'Classification: LEAVE FOR CEO — triage specialist was unavailable.',
+          usage: { inputTokens: 150, outputTokens: 30 },
+        };
+      },
+    };
+
+    const toolDefs = skillRegistry.toToolDefinitions(['delegate']);
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a coordinator.',
+      provider: coordinatorProvider,
+      bus,
+      logger,
+      executionLayer,
+      pinnedSkills: ['delegate'],
+      skillToolDefs: toolDefs,
+    });
+    coordinator.register();
+
+    let coordinatorFinalResponse = '';
+    bus.subscribe('agent.response', 'system', async (event) => {
+      if (event.type === 'agent.response' && event.payload.agentId === 'coordinator') {
+        coordinatorFinalResponse = event.payload.content;
+      }
+    });
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'email:thread-obs-2',
+      channelId: 'email',
+      senderId: 'investor@example.com',
+      content: OBS_PREAMBLE,
+      parentEventId: 'inbound-obs-event-2',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(coordinatorCalls).toBe(2); // attempted delegate, then fell back
+    expect(coordinatorFinalResponse).toContain('Classification: LEAVE FOR CEO');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it passes**
+
+This test is written after Tasks 1–3 are already complete (see Implementation Order note at the bottom). Run it now:
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist test tests/integration/email-triage-delegation.test.ts
+```
+
+Expected: PASS (both tests). The mock LLMs bypass real LLM calls; the test is exercising the delegation infrastructure only.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist test
+```
+
+Expected: `1669 passed` (1667 baseline + 2 new integration tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist add tests/integration/email-triage-delegation.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist commit -m "test: integration test for email-triage delegation chain"
+```
+
+---
+
+### Task 5: Verify existing dispatcher-observation-triage tests still pass
+
+**Files:**
+- No changes — `tests/unit/dispatch/dispatcher-observation-triage.test.ts` is read-only in this task
+
+The dispatcher-observation-triage tests verify that the dispatcher correctly extracts the classification keyword from the coordinator's `agent.response` event. These tests should pass without any changes because:
+- The coordinator still emits classification keywords (it echoes from the specialist)
+- The dispatcher's regex extraction code is unchanged
+- The test stubs bypass the coordinator entirely (they inject the `agent.response` event directly)
+
+- [ ] **Step 1: Run the observation-triage tests explicitly**
+
+```bash
+npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist test tests/unit/dispatch/dispatcher-observation-triage.test.ts
+```
+
+Expected: All 7 tests pass. If any fail, they indicate a regression in the dispatcher code — diagnose before proceeding.
+
+---
+
+### Task 6: Update CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add entry under `## [Unreleased]`**
+
+Open `CHANGELOG.md` and add the following under `## [Unreleased]`:
+
+```markdown
+### Added
+- **email-triage specialist agent** (`agents/email-triage.yaml`): new specialist that owns
+  observation-mode inbox triage end-to-end. Classifies inbound email into five categories
+  (URGENT, ACTIONABLE, NEEDS DRAFT, LEAVE FOR CEO, NOISE), executes email-domain actions
+  directly, and routes out-of-domain ACTIONABLE items via bullpen. Capability-aware:
+  consults the available-specialists list to determine the current ACTIONABLE scope rather
+  than hardcoding action types.
+- **`inject_specialists` YAML field**: opt-in mechanism for specialist agents that need the
+  `${available_specialists}` runtime injection (previously coordinator-only).
+
+### Changed
+- **Coordinator**: removed ~45 lines of observation-mode triage protocol; replaced with a
+  ~15-line delegation rule that immediately hands off `[OBSERVATION MODE]` messages to the
+  `email-triage` specialist. Coordinator echoes the classification keyword in its own
+  response so the dispatcher's classification extraction is unchanged.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-email-triage-specialist commit -m "chore: update CHANGELOG for email-triage specialist"
+```
+
+---
+
+## Implementation Order
+
+Execute tasks in this order. Each task leaves the test suite passing before the next begins:
+
+1. Task 1 (inject_specialists type + runtime)
+2. Task 2 (create email-triage.yaml)
+3. Task 3 (update coordinator.yaml)
+4. Task 4 (write integration test — write after Tasks 1–3 so it can pass immediately)
+5. Task 5 (verify dispatcher-observation-triage tests unchanged)
+6. Task 6 (CHANGELOG)
+
+> **Note on Task 4 ordering:** The writing-plans skill specifies TDD (write failing tests first). For this feature, the integration test requires all three prior components to exist before it can be meaningfully run as a passing test. Write the test file after Tasks 1–3 are complete so it passes on first run, and it serves as the regression gate going forward. The dispatcher-observation-triage.test.ts (Task 5) already covers the classification extraction path and should be run after every change as the regression anchor.
+
+---
+
+## Files to Create / Modify (Summary)
+
+| File | Task | Change |
+|------|------|--------|
+| `src/agents/loader.ts` | 1 | Add `inject_specialists?: boolean` to `AgentYamlConfig` |
+| `src/index.ts` | 1 | Inject specialists for `inject_specialists: true` agents |
+| `agents/email-triage.yaml` | 2 | Create specialist agent |
+| `agents/coordinator.yaml` | 3 | Remove ~45 lines triage protocol, add ~15 lines delegation rule |
+| `tests/integration/email-triage-delegation.test.ts` | 4 | Create integration test |
+| `CHANGELOG.md` | 6 | Add unreleased entries |

--- a/schemas/agent-config.schema.json
+++ b/schemas/agent-config.schema.json
@@ -79,6 +79,10 @@
         "max_cost_usd": { "type": "number", "minimum": 0 },
         "max_errors": { "type": "integer", "minimum": 1 }
       }
+    },
+    "inject_specialists": {
+      "type": "boolean",
+      "description": "When true, ${available_specialists} in the system_prompt is replaced at bootstrap with the list of registered specialist agents."
     }
   }
 }

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -52,6 +52,12 @@ export interface AgentYamlConfig {
     max_cost_usd?: number;
     max_errors?: number;
   };
+  /**
+   * When true, ${available_specialists} in the system_prompt is replaced at bootstrap
+   * with the list of registered specialist agents. Used by specialists that need to
+   * know what other agents are available (e.g. to make ACTIONABLE routing decisions).
+   */
+  inject_specialists?: boolean;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -825,6 +825,12 @@ async function main(): Promise<void> {
         availableSpecialists: agentRegistry.specialistSummary(),
         agentContactId: agentIdentityContactId,
       });
+    } else if (agentConfig.inject_specialists) {
+      // Specialists that need to know about available agents (e.g. email-triage)
+      // opt in via inject_specialists: true in their YAML.
+      systemPrompt = interpolateRuntimeContext(systemPrompt, {
+        availableSpecialists: agentRegistry.specialistSummary(),
+      });
     }
 
     const agent = new AgentRuntime({

--- a/src/index.ts
+++ b/src/index.ts
@@ -828,9 +828,14 @@ async function main(): Promise<void> {
     } else if (agentConfig.inject_specialists) {
       // Specialists that need to know about available agents (e.g. email-triage)
       // opt in via inject_specialists: true in their YAML.
-      systemPrompt = interpolateRuntimeContext(systemPrompt, {
-        availableSpecialists: agentRegistry.specialistSummary(),
-      });
+      try {
+        systemPrompt = interpolateRuntimeContext(systemPrompt, {
+          availableSpecialists: agentRegistry.specialistSummary(),
+        });
+      } catch (err) {
+        logger.error({ err, agentName: agentConfig.name }, 'Failed to interpolate specialists into agent system prompt');
+        throw err;
+      }
     }
 
     const agent = new AgentRuntime({

--- a/tests/integration/email-triage-delegation.test.ts
+++ b/tests/integration/email-triage-delegation.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '../../src/bus/bus.js';
+import { AgentRuntime } from '../../src/agents/runtime.js';
+import { AgentRegistry } from '../../src/agents/agent-registry.js';
+import { SkillRegistry } from '../../src/skills/registry.js';
+import { ExecutionLayer } from '../../src/skills/execution.js';
+import { DelegateHandler } from '../../skills/delegate/handler.js';
+import type { LLMProvider, Message, ContentBlock } from '../../src/agents/llm/provider.js';
+import type { SkillManifest } from '../../src/skills/types.js';
+import { createAgentTask } from '../../src/bus/events.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+// Observation-mode preamble used in both tests — mirrors the format the coordinator
+// sends when delegating to email-triage (see email-triage.yaml system_prompt).
+const OBSERVATION_PREAMBLE = `[OBSERVATION MODE — monitored inbox]
+Message ID: msg-abc123
+Account: ceo-inbox
+
+--- Original message ---
+From: investor@example.com
+Subject: Quick call today?
+Body: Hey, can we jump on a call today to discuss the board situation? It's urgent.`;
+
+describe('Email-triage delegation integration', () => {
+  // Shared setup: delegate skill manifest registered in both tests
+  function buildDelegateManifest(): SkillManifest {
+    return {
+      name: 'delegate',
+      description: 'Delegate a task to a specialist agent',
+      version: '1.0.0',
+      sensitivity: 'normal',
+      capabilities: ['bus', 'agentRegistry'],
+      inputs: { agent: 'string', task: 'string', conversation_id: 'string?' },
+      outputs: { response: 'string', agent: 'string' },
+      permissions: [],
+      secrets: [],
+      timeout: 120000,
+    };
+  }
+
+  it('Coordinator delegates to email-triage and echoes classification', async () => {
+    // 1. Set up agent registry with coordinator and email-triage specialist
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main coordinator' });
+    agentRegistry.register('email-triage', { role: 'specialist', description: 'Email triage specialist' });
+
+    const skillRegistry = new SkillRegistry();
+    skillRegistry.register(buildDelegateManifest(), new DelegateHandler());
+
+    // 2. Set up bus and execution layer
+    const bus = new EventBus(logger);
+    const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry });
+
+    // 3. Capture what the coordinator passes to the delegate skill
+    const capturedDelegateInput: { agent: string; task: string } = { agent: '', task: '' };
+
+    // 4. Mock Coordinator LLM:
+    //    - Turn 1: delegates to email-triage with the observation-mode preamble
+    //    - Turn 2: echoes the classification from the specialist's response
+    let coordinatorCalls = 0;
+    const coordinatorProvider: LLMProvider = {
+      id: 'mock-coordinator',
+      chat: async ({ messages }: { messages: Message[] }) => {
+        coordinatorCalls++;
+        if (coordinatorCalls === 1) {
+          // Delegate to email-triage with the full observation-mode preamble
+          const delegateTask = OBSERVATION_PREAMBLE;
+          capturedDelegateInput.agent = 'email-triage';
+          capturedDelegateInput.task = delegateTask;
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{
+              id: 'call-delegate-1',
+              name: 'delegate',
+              input: {
+                agent: 'email-triage',
+                task: delegateTask,
+                conversation_id: 'test-conv-triage',
+              },
+            }],
+            usage: { inputTokens: 150, outputTokens: 60 },
+          };
+        }
+        // Turn 2: specialist responded — echo the classification keyword.
+        // Check that the tool result is in the message history to confirm delegation worked.
+        const hasToolResult = messages.some(m =>
+          Array.isArray(m.content) && m.content.some((b: ContentBlock) => b.type === 'tool_result'),
+        );
+        return {
+          type: 'text' as const,
+          content: `Email triage result${hasToolResult ? ' (delegation successful)' : ''}: Classification: URGENT`,
+          usage: { inputTokens: 250, outputTokens: 70 },
+        };
+      },
+    };
+
+    // 5. Mock email-triage specialist LLM: returns a structured triage response
+    let triageSpecialistCalls = 0;
+    const triageSpecialistProvider: LLMProvider = {
+      id: 'mock-email-triage',
+      chat: async () => {
+        triageSpecialistCalls++;
+        return {
+          type: 'text' as const,
+          // Structured response format per email-triage.yaml system_prompt requirements
+          content: [
+            'Classification: URGENT',
+            'Rationale: Investor is requesting an urgent call about the board situation — time-sensitive, from a known contact, CEO decision required.',
+            'Actions taken: Opened bullpen thread mentioning coordinator.',
+          ].join('\n'),
+          usage: { inputTokens: 80, outputTokens: 40 },
+        };
+      },
+    };
+
+    // 6. Create both agent runtimes
+    const toolDefs = skillRegistry.toToolDefinitions(['delegate']);
+
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a coordinator. You delegate email triage work to the email-triage specialist.',
+      provider: coordinatorProvider,
+      bus,
+      logger,
+      executionLayer,
+      pinnedSkills: ['delegate'],
+      skillToolDefs: toolDefs,
+    });
+    coordinator.register();
+
+    const triageSpecialist = new AgentRuntime({
+      agentId: 'email-triage',
+      systemPrompt: 'You are the email triage specialist.',
+      provider: triageSpecialistProvider,
+      bus,
+      logger,
+    });
+    triageSpecialist.register();
+
+    // 7. Capture the coordinator's final response
+    let coordinatorFinalResponse = '';
+    bus.subscribe('agent.response', 'system', async (event) => {
+      if (event.type === 'agent.response' && event.payload.agentId === 'coordinator') {
+        coordinatorFinalResponse = event.payload.content;
+      }
+    });
+
+    // 8. Publish the observation-mode task to the coordinator
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'test-conv-triage',
+      channelId: 'email',
+      senderId: 'channel-layer',
+      content: OBSERVATION_PREAMBLE,
+      parentEventId: 'test-inbound-email-1',
+    });
+    await bus.publish('dispatch', task);
+
+    // 9. Verify the full delegation chain
+    expect(coordinatorCalls).toBe(2);
+    expect(triageSpecialistCalls).toBe(1);
+    expect(capturedDelegateInput.agent).toBe('email-triage');
+    // The delegate task must carry the message context so the specialist can look it up
+    expect(capturedDelegateInput.task).toContain('msg-abc123');
+    expect(capturedDelegateInput.task).toContain('ceo-inbox');
+    // Coordinator must echo the classification back in its final response
+    expect(coordinatorFinalResponse).toContain('Classification: URGENT');
+  });
+
+  it('Coordinator falls back gracefully when email-triage is not registered', async () => {
+    // 1. Set up agent registry with coordinator only — email-triage NOT registered
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main coordinator' });
+    // email-triage intentionally omitted to simulate missing specialist
+
+    const skillRegistry = new SkillRegistry();
+    skillRegistry.register(buildDelegateManifest(), new DelegateHandler());
+
+    // 2. Set up bus and execution layer
+    const bus = new EventBus(logger);
+    const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry });
+
+    // 3. Mock Coordinator LLM:
+    //    - Turn 1: attempts to delegate to email-triage (will fail — not registered)
+    //    - Turn 2: receives the error in tool_result, falls back to self-classification
+    let coordinatorCalls = 0;
+    const coordinatorProvider: LLMProvider = {
+      id: 'mock-coordinator-fallback',
+      chat: async ({ messages }: { messages: Message[] }) => {
+        coordinatorCalls++;
+        if (coordinatorCalls === 1) {
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{
+              id: 'call-delegate-fallback',
+              name: 'delegate',
+              input: {
+                agent: 'email-triage',
+                task: OBSERVATION_PREAMBLE,
+                conversation_id: 'test-conv-fallback',
+              },
+            }],
+            usage: { inputTokens: 150, outputTokens: 60 },
+          };
+        }
+        // Turn 2: delegate skill returned an error — fall back to coordinator self-classification.
+        // Verify the tool_result carrying the error is present in the conversation history.
+        const hasErrorResult = messages.some(m =>
+          Array.isArray(m.content) && m.content.some((b: ContentBlock) => b.type === 'tool_result'),
+        );
+        return {
+          type: 'text' as const,
+          content: `Unable to delegate to email-triage${hasErrorResult ? ' (specialist unavailable)' : ''}. Falling back to coordinator classification: Classification: LEAVE FOR CEO`,
+          usage: { inputTokens: 200, outputTokens: 50 },
+        };
+      },
+    };
+
+    // 4. Create coordinator runtime — no email-triage runtime, since the agent isn't registered
+    const toolDefs = skillRegistry.toToolDefinitions(['delegate']);
+
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a coordinator. You delegate email triage work to the email-triage specialist.',
+      provider: coordinatorProvider,
+      bus,
+      logger,
+      executionLayer,
+      pinnedSkills: ['delegate'],
+      skillToolDefs: toolDefs,
+    });
+    coordinator.register();
+
+    // 5. Capture the coordinator's final response
+    let coordinatorFinalResponse = '';
+    bus.subscribe('agent.response', 'system', async (event) => {
+      if (event.type === 'agent.response' && event.payload.agentId === 'coordinator') {
+        coordinatorFinalResponse = event.payload.content;
+      }
+    });
+
+    // 6. Publish the observation-mode task to the coordinator
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'test-conv-fallback',
+      channelId: 'email',
+      senderId: 'channel-layer',
+      content: OBSERVATION_PREAMBLE,
+      parentEventId: 'test-inbound-email-2',
+    });
+    await bus.publish('dispatch', task);
+
+    // 7. Verify fallback behavior:
+    //    - Coordinator still makes exactly 2 LLM calls (delegate attempt + fallback synthesis)
+    //    - Coordinator falls back to LEAVE FOR CEO when specialist is unavailable
+    expect(coordinatorCalls).toBe(2);
+    expect(coordinatorFinalResponse).toContain('Classification: LEAVE FOR CEO');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #386.

Extracts the observation-mode email triage protocol out of `coordinator.yaml` and into a dedicated `email-triage` specialist agent. The coordinator retains oversight via a thin delegation rule — when it sees an `[OBSERVATION MODE — monitored inbox]` message, it immediately delegates to the specialist and echoes the classification keyword in its own response. Zero dispatcher changes.

- **`agents/email-triage.yaml`** — new specialist owning the full 5-category triage protocol (URGENT → bullpen, ACTIONABLE → direct execution or bullpen routing, NEEDS DRAFT → email-draft-save, LEAVE FOR CEO → no action, NOISE → email-archive). ACTIONABLE scope is capability-driven: the specialist consults `${available_specialists}` at runtime rather than hardcoding action types, so the scope expands automatically as new specialists are deployed.
- **`inject_specialists: true`** — new opt-in YAML field for specialists that need the available-specialists list injected at bootstrap (previously coordinator-only).
- **`agents/coordinator.yaml`** — removed ~45 lines of triage protocol, added ~15-line delegation rule with a safe fallback (`Classification: LEAVE FOR CEO`) when the specialist is unavailable.
- **`tests/integration/email-triage-delegation.test.ts`** — end-to-end integration test covering the full routing chain and the unavailability fallback path.

## Test plan

- [ ] `npm test tests/integration/email-triage-delegation.test.ts` — both delegation tests pass
- [ ] `npm test tests/unit/dispatch/dispatcher-observation-triage.test.ts` — all 11 classification extraction tests pass unchanged
- [ ] `npm test` — full suite passes (1669 tests)

## Notes

- **Finding 3 from silent-failure audit (not fixed in this PR):** When the email-triage specialist is unavailable, the coordinator's `LEAVE FOR CEO` fallback is structurally indistinguishable from an intentional `LEAVE FOR CEO` classification in the event stream. There is no structured field in `observation.triage.completed` for `specialist_unavailable: true`. This is an architectural gap to track as a follow-up rather than a blocker for this PR.
- Separate issues filed for the two out-of-scope items: scheduled observation job (#393) and label management (#394).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an `email-triage` specialist agent that categorizes incoming emails with capability-aware routing and direct action execution.
  * Introduced a new `inject_specialists` configuration option allowing agents to discover available specialists at runtime.

* **Documentation**
  * Added design documentation for the email-triage specialist implementation.

* **Tests**
  * Added integration tests for email-triage delegation workflows and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->