### PR TITLE
chore: release v0.24.0 — Delegated Authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,38 +13,59 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+---
+
+## [0.24.0] — 2026-04-29 — "Delegated Authority"
+
 ### Added
 
-- **email-triage specialist agent** (`agents/email-triage.yaml`): new specialist that owns
+- **Email-triage specialist** (`agents/email-triage.yaml`): new specialist that owns
   observation-mode inbox triage end-to-end. Classifies inbound email into five categories
   (URGENT, ACTIONABLE, NEEDS DRAFT, LEAVE FOR CEO, NOISE), executes email-domain actions
-  directly, and routes out-of-domain ACTIONABLE items via bullpen. Capability-aware:
-  consults the available-specialists list to determine the current ACTIONABLE scope rather
-  than hardcoding action types.
-- **`inject_specialists` YAML field**: opt-in mechanism for specialist agents that need the
-  `${available_specialists}` runtime injection (previously coordinator-only).
-- **Proactive Signal sends from scheduled jobs** — `signal-send` skill pinned in coordinator's tool list so it is always available during scheduler runs (no extra discovery turn required). Closes #374, unblocks spec 17 item 0 (meeting-debrief prerequisite).
-- **Missing coordinator skills pinned** — `contact-rename`, `contact-set-trust`, `memory-query`, `memory-store`, `image-generate`, and `skill-registry` added to the coordinator's `pinned_skills` list. These skills existed and were functional but were absent from the pinned list, causing the coordinator to claim it lacked capabilities it actually had (e.g. renaming a contact's display name).
-- **CLAUDE.md: pin skills checklist step** — "New Skill" instructions now include an explicit step to add the skill to `pinned_skills` in at least one agent YAML, with a note on the infrastructure-skill exception.
+  directly, and routes out-of-domain items via bullpen. Capability-aware: consults the
+  available-specialists list rather than hardcoding action types.
+- **`inject_specialists` agent YAML field** *(public API surface)*: opt-in for any
+  specialist that needs the `${available_specialists}` runtime injection, previously
+  coordinator-only.
+- **`expected_duration_seconds` agent YAML field** *(public API surface)*: agents declare
+  their expected runtime; the coordinator injects a matching `timeout_ms` into delegate
+  calls, replacing the fixed 90s default for long-running specialists.
+- **Proactive signal sends from scheduled jobs** — `signal-send` pinned in the
+  coordinator's tool list so it is always available during scheduler runs. Closes #374,
+  unblocks spec 17.
+- **Missing coordinator skills pinned** — `contact-rename`, `contact-set-trust`,
+  `memory-query`, `memory-store`, `image-generate`, and `skill-registry` added to
+  `pinned_skills`. These capabilities existed but were invisible to the coordinator.
 
 ### Fixed
 
-- **CEO entity context enrichment** — `bootstrapCeoContact()` now creates a KG person node and links it via `kg_node_id` on the CEO contact. Previously the contact was created with `kg_node_id = NULL`, making entity enrichment, standing instructions, and relationship queries non-functional for the CEO. Existing contacts without a KG node are backfilled automatically on next startup. Closes #380.
-
-- **Specialist delegation** — three compounding failures that caused essay-editor (and any long-running specialist) to fail reliably (#387):
-  - **Google Workspace account hallucination** — agents now receive their Google Workspace account list in the system prompt, eliminating LLM-guessed email addresses for MCP tools. New `channel_accounts.google_workspace` config section with env-var resolution.
-  - **Delegate timeout too short** — agents can now declare `expected_duration_seconds` in their YAML config. The runtime injects the appropriate `timeout_ms` into delegate calls, replacing the fixed 90s default for agents that need more time.
-  - **No acknowledgment on synchronous channels** — the coordinator now sends a brief ack before delegating long-running tasks on cli/http/signal channels, so the user isn't left watching a dead screen.
-- **executive-profile-update** sign_off field not persisting when LLM emits camelCase key (`signOff`) instead of snake_case (`sign_off`). Added shared `normalizeKeysToSnakeCase` utility in `src/skills/normalize.ts` that any handler can use for bare-object inputs.
+- **CEO entity context enrichment** — `bootstrapCeoContact()` now creates a KG person node
+  and links it on the CEO contact. Previously `kg_node_id` was `NULL`, making entity
+  enrichment, standing instructions, and relationship queries non-functional for the CEO.
+  Existing contacts are backfilled automatically on next startup. Closes #380.
+- **Specialist delegation reliability** — three compounding failures that caused
+  long-running specialists (essay-editor and others) to fail reliably (#387):
+  - Agents now receive their Google Workspace account list in the system prompt,
+    eliminating LLM-guessed email addresses for MCP tools.
+  - `expected_duration_seconds` in agent YAML controls delegate timeout (see Added above).
+  - The coordinator sends a brief acknowledgment before delegating long-running tasks on
+    synchronous channels so the user isn't left watching a dead screen.
+- **`executive-profile-update`** — `sign_off` no longer silently dropped when the LLM
+  emits camelCase (`signOff`). Added `normalizeKeysToSnakeCase()` utility for skill
+  handlers.
 
 ### Changed
 
-- **Coordinator**: removed ~45 lines of observation-mode triage protocol; replaced with a
-  ~15-line delegation rule that immediately hands off `[OBSERVATION MODE]` messages to the
-  `email-triage` specialist. Coordinator echoes the classification keyword in its own
-  response so the dispatcher's classification extraction is unchanged.
-- **Channel account injection** — `channelAccounts` (email, phone) and Google Workspace accounts are now injected into ALL agents' system prompts, not just the coordinator. Specialist agents need identity context too.
-- **Agent YAML schema** *(public API surface)* — new optional `expected_duration_seconds` field (integer, minimum 1).
+- **Coordinator observation-mode protocol** — ~45 lines of triage logic replaced with a
+  ~15-line delegation rule; the email-triage specialist owns the full protocol now.
+- **Channel account injection** — `channelAccounts` and Google Workspace accounts injected
+  into all agents' system prompts, not just the coordinator's.
+
+---
+
+*the inbox hands off —*
+*each specialist knows its weight;*
+*authority flows*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.23.0-blueviolet" alt="Version: 0.23.0" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.24.0-blueviolet" alt="Version: 0.24.0" /></a>
   <img src="https://img.shields.io/badge/status-pre--alpha-orange" alt="Status: Pre-Alpha" />
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License: MIT" />
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node >= 22" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## [0.24.0] — 2026-04-29 — "Delegated Authority"

### Added

- **Email-triage specialist** (`agents/email-triage.yaml`): new specialist that owns observation-mode inbox triage end-to-end. Classifies inbound email into five categories (URGENT, ACTIONABLE, NEEDS DRAFT, LEAVE FOR CEO, NOISE), executes email-domain actions directly, and routes out-of-domain items via bullpen. Capability-aware: consults the available-specialists list rather than hardcoding action types.
- **`inject_specialists` agent YAML field** *(public API surface)*: opt-in for any specialist that needs the `${available_specialists}` runtime injection, previously coordinator-only.
- **`expected_duration_seconds` agent YAML field** *(public API surface)*: agents declare their expected runtime; the coordinator injects a matching `timeout_ms` into delegate calls, replacing the fixed 90s default for long-running specialists.
- **Proactive signal sends from scheduled jobs** — `signal-send` pinned in the coordinator's tool list so it is always available during scheduler runs. Closes #374, unblocks spec 17.
- **Missing coordinator skills pinned** — `contact-rename`, `contact-set-trust`, `memory-query`, `memory-store`, `image-generate`, and `skill-registry` added to `pinned_skills`. These capabilities existed but were invisible to the coordinator.

### Fixed

- **CEO entity context enrichment** — `bootstrapCeoContact()` now creates a KG person node and links it on the CEO contact. Previously `kg_node_id` was `NULL`, making entity enrichment, standing instructions, and relationship queries non-functional for the CEO. Existing contacts are backfilled automatically on next startup. Closes #380.
- **Specialist delegation reliability** — three compounding failures that caused long-running specialists (essay-editor and others) to fail reliably (#387):
  - Agents now receive their Google Workspace account list in the system prompt, eliminating LLM-guessed email addresses for MCP tools.
  - `expected_duration_seconds` in agent YAML controls delegate timeout (see Added above).
  - The coordinator sends a brief acknowledgment before delegating long-running tasks on synchronous channels so the user isn't left watching a dead screen.
- **`executive-profile-update`** — `sign_off` no longer silently dropped when the LLM emits camelCase (`signOff`). Added `normalizeKeysToSnakeCase()` utility for skill handlers.

### Changed

- **Coordinator observation-mode protocol** — ~45 lines of triage logic replaced with a ~15-line delegation rule; the email-triage specialist owns the full protocol now.
- **Channel account injection** — `channelAccounts` and Google Workspace accounts injected into all agents' system prompts, not just the coordinator's.

---

*the inbox hands off —*
*each specialist knows its weight;*
*authority flows*