### PR TITLE
feat: detect CC role in email and surface to coordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+- **CC role detection** — `convertNylasMessage` now accepts a `selfEmail` parameter and computes `curiaRole` (`'to'` | `'cc'` | `'bcc'`) and `primaryRecipientEmails` in the converted email metadata, so the dispatcher can distinguish emails addressed directly to Curia from emails where Curia was CC'd.
+
+### Changed
+- **CC role preamble in dispatcher** — when Curia is CC'd on an email (non-observation mode), the coordinator task content is prepended with `[OWNER CC — addressed to <recipients>; you were CC'd]`, giving the coordinator unambiguous context about its role without polluting the email body.
+- **Coordinator: CC'd email behavior** — new principle-based guidance for `[OWNER CC]` tasks: read holistically, look up third parties before responding, infer intent without asking the CEO to repeat themselves, and raise clarifications out-of-band only when genuinely irresolvable.
+- **Coordinator: contact-lookup-first** — strengthened rule prohibiting any comment on a contact record (role, existence, details) before running `contact-lookup`.
+- **Coordinator: trust narration suppression** — coordinator no longer proactively informs the CEO that their message arrived via a lower-trust channel; channel trust is only raised when declining a specific request because of it.
+
 ---
 
 ## [0.24.0] — 2026-04-29 — "Delegated Authority"

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -55,6 +55,20 @@ system_prompt: |
   **Talking to the CEO** (any channel — cli, email, http):
   - Be candid. Share internal details if helpful. Ask clarifying questions freely.
   - You can mention contacts, tools, or system state if it helps the CEO.
+  - Do not proactively tell the CEO that their message arrived via a lower-trust
+    channel. Only raise channel trust as a topic if you are about to decline a
+    specific request because of it. The CEO knows what channel they used.
+  - When the task begins with `[OWNER CC —]`, you were copied on an email the CEO
+    sent to someone else — you are not the primary recipient. Read the email
+    holistically and use judgment about what the CEO is communicating. The CEO may
+    be looping you in, making an introduction, delegating something, or simply
+    keeping you informed. Infer what's expected from the context — don't ask the
+    CEO to repeat themselves. Always look up any third parties named or addressed
+    in the email before responding. If and only if there is genuine ambiguity and
+    it's impossible to infer next steps (e.g. two clearly contradictory
+    interpretations), you may ask the CEO for clarification — but do so via a
+    separate channel (e.g. Signal) or a new email thread, never by replying to
+    the original thread where third parties could receive your clarification request.
 
   **Talking to anyone who is NOT the CEO** (typically email from external contacts):
   - You are representing the CEO's office. Be professional and competent.
@@ -156,6 +170,11 @@ system_prompt: |
   first (contact-lookup by name) before asking for information you might already have.
 
   ## Contact Lookup Best Practices
+  - **NEVER claim you don't know someone, or comment on their contact record, until
+    you have run contact-lookup.** This includes phrases like "I don't think I have
+    Nik", "no role on file", or "I don't see them on file." Run the lookup first,
+    then respond based on what it returns. Skipping this step and guessing is not
+    acceptable.
   - contact-lookup supports partial name matching. "Joe" will find "Joe Brennan".
   - Always search your contacts before asking the CEO for someone's details.
   - The lookup returns channel identities (email, phone, etc.) alongside the contact,

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -222,7 +222,7 @@ export class EmailAdapter {
         }
 
         try {
-          const converted = convertNylasMessage(msg);
+          const converted = convertNylasMessage(msg, this.config.selfEmail);
 
           if (this.config.observationMode) {
             // Observation mode: Curia monitors this inbox on behalf of the CEO but is

--- a/src/channels/email/message-converter.ts
+++ b/src/channels/email/message-converter.ts
@@ -51,7 +51,9 @@ export interface ConvertedEmail {
     /**
      * Email addresses from the To field, excluding Curia's own address.
      * Populated only when selfEmail is provided to convertNylasMessage.
-     * Empty array when selfEmail is unknown or the email was sent directly to Curia.
+     * Empty array when selfEmail is unknown, or when Curia is the only To recipient.
+     * If Curia appears in To alongside other recipients, those other To addresses
+     * are retained.
      */
     primaryRecipientEmails: string[];
   };

--- a/src/channels/email/message-converter.ts
+++ b/src/channels/email/message-converter.ts
@@ -34,6 +34,26 @@ export interface ConvertedEmail {
      * to messages that failed sender verification.
      */
     senderVerified: boolean;
+    /**
+     * Curia's role in this email's recipient fields.
+     * - 'to': Curia was directly addressed as a primary recipient
+     * - 'cc': Curia was copied; someone else is the primary recipient
+     * - 'bcc': Curia was blind-copied — not currently detectable from MIME headers
+     *          alone, so this value is never set by the converter today.
+     *
+     * @TODO: BCC detection requires a provider-level signal (e.g. Nylas injecting a
+     *        dedicated header when the grant email appears only in the BCC envelope).
+     *        Until that signal is available, emails where Curia appears in neither To
+     *        nor CC (i.e. genuine BCC) are indistinguishable from direct sends and
+     *        default to 'to'. Track in a GitHub issue.
+     */
+    curiaRole: 'to' | 'cc' | 'bcc';
+    /**
+     * Email addresses from the To field, excluding Curia's own address.
+     * Populated only when selfEmail is provided to convertNylasMessage.
+     * Empty array when selfEmail is unknown or the email was sent directly to Curia.
+     */
+    primaryRecipientEmails: string[];
   };
 }
 
@@ -72,6 +92,43 @@ export function parseSenderVerified(headers?: Array<{ name: string; value: strin
 }
 
 /**
+ * Determine Curia's role in the email (To vs CC) and collect the primary recipients.
+ *
+ * Case-insensitive comparison — email addresses are case-insensitive per RFC 5321.
+ *
+ * Returns 'to' as the fail-safe default when selfEmail is absent or not found in
+ * either To or CC (e.g. genuine BCC, which is not currently detectable).
+ */
+function resolveCuriaRole(
+  toList: Array<{ email: string }>,
+  ccList: Array<{ email: string }>,
+  selfEmail: string,
+): { curiaRole: 'to' | 'cc' | 'bcc'; primaryRecipientEmails: string[] } {
+  const self = selfEmail.toLowerCase();
+
+  const inTo = toList.some((p) => p.email.toLowerCase() === self);
+  if (inTo) {
+    // Curia is a primary recipient — other To addresses (if any) are also primary.
+    const primaryRecipientEmails = toList
+      .map((p) => p.email)
+      .filter((e) => e.toLowerCase() !== self);
+    return { curiaRole: 'to', primaryRecipientEmails };
+  }
+
+  const inCc = ccList.some((p) => p.email.toLowerCase() === self);
+  if (inCc) {
+    // Curia was copied — the To addresses are the true primary recipients.
+    const primaryRecipientEmails = toList.map((p) => p.email);
+    return { curiaRole: 'cc', primaryRecipientEmails };
+  }
+
+  // selfEmail not found in To or CC — likely BCC, which MIME headers don't expose.
+  // Default to 'to' (fail-safe: treat as a direct message rather than silently
+  // misclassifying). BCC detection requires provider-level support; see @TODO above.
+  return { curiaRole: 'to', primaryRecipientEmails: [] };
+}
+
+/**
  * Convert a Nylas message to a Curia inbound message shape.
  *
  * Decisions made here:
@@ -83,8 +140,16 @@ export function parseSenderVerified(headers?: Array<{ name: string; value: strin
  * - All participants (from/to/cc) are surfaced so the contact system can
  *   upsert or update relationship records in one pass.
  * - senderVerified is derived from the Authentication-Results header (if present).
+ * - curiaRole and primaryRecipientEmails are derived from selfEmail when provided,
+ *   allowing the dispatcher to surface whether Curia was directly addressed or CC'd.
+ *
+ * @param msg - The Nylas message to convert.
+ * @param selfEmail - Curia's own email address for this account. When provided,
+ *   the converter determines whether Curia appears in the To or CC field and
+ *   populates curiaRole and primaryRecipientEmails accordingly. When omitted,
+ *   curiaRole defaults to 'to' and primaryRecipientEmails is empty.
  */
-export function convertNylasMessage(msg: NylasMessage): ConvertedEmail {
+export function convertNylasMessage(msg: NylasMessage, selfEmail?: string): ConvertedEmail {
   // Use ?? 'unknown' so an empty from array doesn't throw
   const fromEmail = msg.from[0]?.email ?? 'unknown';
 
@@ -113,6 +178,12 @@ export function convertNylasMessage(msg: NylasMessage): ConvertedEmail {
     ...msg.cc.map((p) => ({ email: p.email, name: p.name, role: 'cc' as const })),
   ];
 
+  // Determine Curia's role in this email (To vs CC) when selfEmail is known.
+  // Defaults to 'to' / empty primary recipients when selfEmail is not provided.
+  const { curiaRole, primaryRecipientEmails } = selfEmail
+    ? resolveCuriaRole(msg.to, msg.cc, selfEmail)
+    : { curiaRole: 'to' as const, primaryRecipientEmails: [] };
+
   return {
     conversationId,
     channelId: 'email',
@@ -126,6 +197,8 @@ export function convertNylasMessage(msg: NylasMessage): ConvertedEmail {
       // Nylas stores timestamps as Unix seconds; Date expects milliseconds
       receivedAt: new Date(msg.date * 1000),
       senderVerified: parseSenderVerified(msg.headers),
+      curiaRole,
+      primaryRecipientEmails,
     },
   };
 }

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -700,12 +700,18 @@ export class Dispatcher {
         // the injection scanner has already run on payload.content. Without sanitization,
         // a crafted email address could embed prompt injection patterns that bypass Layer 1.
         // RFC 5321 limits email addresses to 254 characters; anything longer is malformed.
-        const sanitizedRecipients = primaryRecipients.map((addr) =>
-          String(addr).replace(/[\n\r\[\]<>]/g, '').slice(0, 254),
-        );
-        const recipientList = sanitizedRecipients.length > 0
+        const MAX_RECIPIENTS_IN_PREAMBLE = 10;
+        const sanitizedRecipients = primaryRecipients
+          .map((addr) => String(addr).replace(/[\n\r\[\]<>]/g, '').trim().slice(0, 254))
+          .filter((addr) => addr.length > 0)
+          .slice(0, MAX_RECIPIENTS_IN_PREAMBLE);
+        const omittedCount = Math.max(0, primaryRecipients.length - sanitizedRecipients.length);
+        const recipientListBase = sanitizedRecipients.length > 0
           ? sanitizedRecipients.join(', ')
           : 'unknown recipients';
+        const recipientList = omittedCount > 0
+          ? `${recipientListBase}, +${omittedCount} more`
+          : recipientListBase;
         this.logger.info(
           { channelId: payload.channelId, senderId: payload.senderId, primaryRecipients: recipientList },
           'CC role preamble injected — Curia was not the primary recipient',

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -680,6 +680,26 @@ export class Dispatcher {
         taskContent;
     }
 
+    // CC role marker: when the email adapter determined that Curia was CC'd rather than
+    // directly addressed, prepend a context block so the coordinator knows it was an
+    // observer on this email (e.g. the CEO looping Curia in on a message to a third party).
+    // Injected after the observation-mode block so it always appears first in the task
+    // content. Not injected for observation-mode emails — those already have their own
+    // preamble and are processed by the email-triage specialist, not the main CC logic.
+    if (!isObservationMode && payload.channelId === 'email') {
+      const meta = payload.metadata as Record<string, unknown> | undefined;
+      const curiaRole = meta?.curiaRole as string | undefined;
+      if (curiaRole === 'cc') {
+        const primaryRecipients = (meta?.primaryRecipientEmails as string[] | undefined) ?? [];
+        const recipientList = primaryRecipients.length > 0
+          ? primaryRecipients.join(', ')
+          : 'unknown recipients';
+        taskContent =
+          `[OWNER CC — this email was addressed to ${recipientList}; you were CC'd, not the primary recipient]\n\n` +
+          taskContent;
+      }
+    }
+
     const taskEvent = createAgentTask({
       agentId: 'coordinator',
       conversationId: payload.conversationId,

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -690,10 +690,26 @@ export class Dispatcher {
       const meta = payload.metadata as Record<string, unknown> | undefined;
       const curiaRole = meta?.curiaRole as string | undefined;
       if (curiaRole === 'cc') {
-        const primaryRecipients = (meta?.primaryRecipientEmails as string[] | undefined) ?? [];
-        const recipientList = primaryRecipients.length > 0
-          ? primaryRecipients.join(', ')
+        // Runtime type guard — metadata values cross a Record<string, unknown> boundary,
+        // so a bare `as string[]` cast could silently accept a non-array from a future
+        // code path. Mirrors the isFinite guard on injectionRiskScore above.
+        const rawRecipients = meta?.primaryRecipientEmails;
+        const primaryRecipients = Array.isArray(rawRecipients) ? (rawRecipients as string[]) : [];
+        // Sanitize each address before interpolation — primaryRecipientEmails comes from
+        // the Nylas To-field (attacker-controlled) and is injected into taskContent AFTER
+        // the injection scanner has already run on payload.content. Without sanitization,
+        // a crafted email address could embed prompt injection patterns that bypass Layer 1.
+        // RFC 5321 limits email addresses to 254 characters; anything longer is malformed.
+        const sanitizedRecipients = primaryRecipients.map((addr) =>
+          String(addr).replace(/[\n\r\[\]<>]/g, '').slice(0, 254),
+        );
+        const recipientList = sanitizedRecipients.length > 0
+          ? sanitizedRecipients.join(', ')
           : 'unknown recipients';
+        this.logger.info(
+          { channelId: payload.channelId, senderId: payload.senderId, primaryRecipients: recipientList },
+          'CC role preamble injected — Curia was not the primary recipient',
+        );
         taskContent =
           `[OWNER CC — this email was addressed to ${recipientList}; you were CC'd, not the primary recipient]\n\n` +
           taskContent;

--- a/tests/unit/channels/email/message-converter.test.ts
+++ b/tests/unit/channels/email/message-converter.test.ts
@@ -165,6 +165,105 @@ describe('convertNylasMessage', () => {
 });
 
 // ---------------------------------------------------------------------------
+// curiaRole and primaryRecipientEmails — CC role detection
+// ---------------------------------------------------------------------------
+
+describe('convertNylasMessage — curiaRole and primaryRecipientEmails', () => {
+  const SELF_EMAIL = 'nathan@curia.com';
+
+  it('sets curiaRole to "to" when selfEmail is in the To field', () => {
+    const result = convertNylasMessage(
+      mockMessage({ to: [{ email: SELF_EMAIL, name: 'Nathan' }] }),
+      SELF_EMAIL,
+    );
+    expect(result.metadata.curiaRole).toBe('to');
+  });
+
+  it('sets primaryRecipientEmails to empty when only selfEmail is in To', () => {
+    const result = convertNylasMessage(
+      mockMessage({ to: [{ email: SELF_EMAIL, name: 'Nathan' }] }),
+      SELF_EMAIL,
+    );
+    expect(result.metadata.primaryRecipientEmails).toEqual([]);
+  });
+
+  it('sets curiaRole to "cc" when selfEmail is in the CC field', () => {
+    const result = convertNylasMessage(
+      mockMessage({
+        to: [{ email: 'nik@example.com', name: 'Nik' }],
+        cc: [{ email: SELF_EMAIL, name: 'Nathan' }],
+      }),
+      SELF_EMAIL,
+    );
+    expect(result.metadata.curiaRole).toBe('cc');
+  });
+
+  it('populates primaryRecipientEmails from To when curiaRole is "cc"', () => {
+    const result = convertNylasMessage(
+      mockMessage({
+        to: [
+          { email: 'nik@example.com', name: 'Nik' },
+          { email: 'alice@example.com', name: 'Alice' },
+        ],
+        cc: [{ email: SELF_EMAIL, name: 'Nathan' }],
+      }),
+      SELF_EMAIL,
+    );
+    expect(result.metadata.primaryRecipientEmails).toEqual([
+      'nik@example.com',
+      'alice@example.com',
+    ]);
+  });
+
+  it('excludes selfEmail from primaryRecipientEmails when curiaRole is "to" with multiple To addresses', () => {
+    const result = convertNylasMessage(
+      mockMessage({
+        to: [
+          { email: SELF_EMAIL, name: 'Nathan' },
+          { email: 'nik@example.com', name: 'Nik' },
+        ],
+        cc: [],
+      }),
+      SELF_EMAIL,
+    );
+    expect(result.metadata.curiaRole).toBe('to');
+    expect(result.metadata.primaryRecipientEmails).toEqual(['nik@example.com']);
+  });
+
+  it('is case-insensitive when matching selfEmail', () => {
+    const result = convertNylasMessage(
+      mockMessage({
+        to: [{ email: 'nik@example.com' }],
+        cc: [{ email: 'NATHAN@CURIA.COM' }],
+      }),
+      'nathan@curia.com',
+    );
+    expect(result.metadata.curiaRole).toBe('cc');
+  });
+
+  it('defaults curiaRole to "to" when selfEmail is not found in To or CC (BCC fallback)', () => {
+    const result = convertNylasMessage(
+      mockMessage({
+        to: [{ email: 'nik@example.com' }],
+        cc: [],
+      }),
+      SELF_EMAIL,
+    );
+    // selfEmail is not in To or CC — genuine BCC; defaults to 'to' (fail-safe)
+    expect(result.metadata.curiaRole).toBe('to');
+    expect(result.metadata.primaryRecipientEmails).toEqual([]);
+  });
+
+  it('defaults curiaRole to "to" and primaryRecipientEmails to [] when selfEmail is omitted', () => {
+    // Backward-compatible: calling without selfEmail should not throw and
+    // should produce stable defaults.
+    const result = convertNylasMessage(mockMessage());
+    expect(result.metadata.curiaRole).toBe('to');
+    expect(result.metadata.primaryRecipientEmails).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // parseSenderVerified — Authentication-Results header parsing
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -881,6 +881,160 @@ describe('Dispatcher — observation mode preamble', () => {
   });
 });
 
+describe('Dispatcher — CC role preamble', () => {
+  it('prepends [OWNER CC] preamble when curiaRole is "cc"', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    const event = createInboundMessage({
+      conversationId: 'email:thread-cc-intro',
+      channelId: 'email',
+      senderId: 'joseph@example.com',
+      content: 'Hey Nik, feel free to hit up my EA.',
+      metadata: { curiaRole: 'cc', primaryRecipientEmails: ['nik@example.com'] },
+    });
+
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    const content = tasks[0]!.payload.content;
+    expect(content).toContain('[OWNER CC');
+    expect(content).toContain('nik@example.com');
+    expect(content).toContain('Hey Nik, feel free to hit up my EA.');
+  });
+
+  it('does not prepend [OWNER CC] preamble when curiaRole is "to"', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    const event = createInboundMessage({
+      conversationId: 'email:thread-direct',
+      channelId: 'email',
+      senderId: 'joseph@example.com',
+      content: 'Can you look up Nik for me?',
+      metadata: { curiaRole: 'to', primaryRecipientEmails: [] },
+    });
+
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    const content = tasks[0]!.payload.content;
+    expect(content).not.toContain('[OWNER CC');
+    expect(content).toBe('Can you look up Nik for me?');
+  });
+
+  it('does not prepend [OWNER CC] preamble when curiaRole metadata is absent', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    const event = createInboundMessage({
+      conversationId: 'email:thread-no-role',
+      channelId: 'email',
+      senderId: 'joseph@example.com',
+      content: 'Just a plain email.',
+    });
+
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]!.payload.content).not.toContain('[OWNER CC');
+  });
+
+  it('does not prepend [OWNER CC] preamble for non-email channels', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    const event = createInboundMessage({
+      conversationId: 'signal:conv-1',
+      channelId: 'signal',
+      senderId: '+15551234567',
+      content: 'Hey, check this out.',
+      metadata: { curiaRole: 'cc' }, // curiaRole on non-email channel should be ignored
+    });
+
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]!.payload.content).not.toContain('[OWNER CC');
+  });
+
+  it('does not prepend [OWNER CC] preamble for observation-mode emails (they have their own marker)', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    const event = createInboundMessage({
+      conversationId: 'email:thread-obs-cc',
+      channelId: 'email',
+      senderId: 'someone@example.com',
+      content: 'An observed email where Curia is also CC\'d.',
+      metadata: { observationMode: true, curiaRole: 'cc', primaryRecipientEmails: ['joseph@example.com'] },
+    });
+
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    const content = tasks[0]!.payload.content;
+    expect(content).toContain('[OBSERVATION MODE');
+    expect(content).not.toContain('[OWNER CC');
+  });
+
+  it('handles missing primaryRecipientEmails gracefully', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    const event = createInboundMessage({
+      conversationId: 'email:thread-cc-no-list',
+      channelId: 'email',
+      senderId: 'joseph@example.com',
+      content: 'CC\'d without recipient list.',
+      metadata: { curiaRole: 'cc' }, // no primaryRecipientEmails
+    });
+
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    const content = tasks[0]!.payload.content;
+    expect(content).toContain('[OWNER CC');
+    expect(content).toContain('unknown recipients');
+  });
+});
+
 describe('Dispatcher — observation mode outbound suppression', () => {
   /**
    * These tests verify the dispatcher does NOT turn the coordinator's final


### PR DESCRIPTION
## Summary

- **CC role detection**: `convertNylasMessage` now accepts `selfEmail` and computes `curiaRole` (`'to'` | `'cc'` | `'bcc'`) and `primaryRecipientEmails` in email metadata, so the dispatcher knows whether Curia was directly addressed or CC'd.
- **CC preamble injection**: When `curiaRole === 'cc'` on non-observation-mode emails, the dispatcher prepends `[OWNER CC — addressed to <recipients>; you were CC'd]` to the coordinator task content — mirroring the existing `[OBSERVATION MODE]` pattern.
- **Coordinator prompt improvements**: Three additions — CC'd email guidance (principle-based: read holistically, infer intent, look up third parties first), contact-lookup-first (never comment on a contact record before running lookup), and trust-narration suppression (don't tell the CEO their email arrived via lower-trust channel).
- **Security**: Recipient emails in the CC preamble are sanitized (newlines/brackets stripped, capped at 254 chars) since they're attacker-controlled and injected after the scanner runs.

**Motivation:** When Joseph CC'd Curia on an email to Nik introducing him, Curia treated it as a direct message — narrating the channel trust, claiming ignorance about Nik without checking contacts, and missing the implicit permission grant. Root cause: Curia had no metadata about its own role in the email (To vs CC).

Refs: #400 (held message notification quality), #401 (meeting-links idempotency) filed as out-of-scope follow-ups.

## Test plan

- [x] 8 new unit tests for `curiaRole` detection in `message-converter.test.ts` (To, CC, BCC fallback, case sensitivity, backward compat)
- [x] 6 new unit tests for CC preamble injection in `dispatcher.test.ts` (preamble present/absent for CC/To/missing/non-email/observation-mode/missing-recipients)
- [x] Full suite: 1683 tests passing, 48 skipped (14 new tests added to baseline of 1669)
- [ ] Manual smoke test: replay the Nik introduction scenario after deployment and verify Curia responds with brief confirmation rather than trust narration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Email system now detects whether you are directly addressed or CC'd on incoming messages, with a clear notification when you're CC'd alongside other recipients.

* **Improvements**
  * Strengthened contact lookup validation to prevent assumptions before lookup is performed.
  * Refined handling of messages involving leadership communication.

* **Tests**
  * Added comprehensive test coverage for recipient role detection and CC message notification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->