### PR TITLE
fix: remove per-draft CEO email notification (#403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Coordinator: contact-lookup-first** — strengthened rule prohibiting any comment on a contact record (role, existence, details) before running `contact-lookup`.
 - **Coordinator: trust narration suppression** — coordinator no longer proactively informs the CEO that their message arrived via a lower-trust channel; channel trust is only raised when declining a specific request because of it.
 
+### Fixed
+- **Silent email drafts** — `OutboundGateway.createEmailDraft()` no longer sends an immediate per-draft email notification to the CEO after every observation-mode triage draft. The notification was counterproductive: if the CEO wasn't going to see the original email, they weren't going to see the notification either. Drafts are now created silently; discovery moves to the end-of-day Signal digest (see issue #403). Removes `notifyCeoDraftCreated` and its private `primaryAccountId` field from `OutboundGateway`.
+
 ---
 
 ## [0.24.0] — 2026-04-29 — "Delegated Authority"

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -387,8 +387,9 @@ export class EmailAdapter {
    *
    * - direct:         send immediately through the gateway (blocked-contact +
    *                   content filter run inside gateway.send)
-   * - draft_gate:     save as a Nylas draft for human review; the notification +
-   *                   approval + send flow is deferred (TODO(#278))
+   * - draft_gate:     save as a Nylas draft for human review; no notification is
+   *                   sent — the CEO discovers drafts via the end-of-day Signal
+   *                   digest (#403). Approval + send remain deferred (TODO(#278)).
    * - autonomy_gated: check the current global autonomy score; if it meets the
    *                   configured threshold, send directly; otherwise draft-gate
    */
@@ -455,12 +456,13 @@ export class EmailAdapter {
     }
 
     // draft_gate (and autonomy_gated fallback): save as draft for human review.
-    // The gateway notifies the CEO via email after a successful draft creation (#278).
+    // The gateway creates the draft silently — no per-draft email notification is sent.
+    // The CEO discovers pending drafts via the end-of-day Signal digest (#403).
     const draftResult = await outboundGateway.createEmailDraft(sendRequest);
     if (draftResult.success) {
       logger.info(
         { ...logCtx, accountId: this.config.accountId, draftId: draftResult.draftId },
-        'Email reply saved as draft — CEO notification queued',
+        'Email reply saved as draft for CEO review',
       );
     } else if (draftResult.blockedReason === 'Recipient is blocked') {
       // Intentional block — not an infrastructure failure

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -28,8 +28,8 @@ export interface EmailAdapterConfig {
    * How outbound replies from this account are handled.
    *
    * - direct:          send immediately via OutboundGateway (current behavior)
-   * - draft_gate:      save as a Nylas draft; CEO is notified and reviews in Gmail
-   *                    (approval interface + send-on-approval deferred — see #278)
+   * - draft_gate:      save as a Nylas draft silently; CEO discovers via end-of-day
+   *                    Signal digest and reviews in Gmail (#403, #278)
    * - autonomy_gated:  send only when autonomy score >= autonomyThreshold
    */
   outboundPolicy: OutboundPolicy;
@@ -298,7 +298,7 @@ export class EmailAdapter {
    *
    * The actual send behaviour is controlled by this account's outboundPolicy:
    *   - direct:         send immediately via OutboundGateway
-   *   - draft_gate:     save as Nylas draft; CEO notified and reviews in Gmail (#278)
+   *   - draft_gate:     save as Nylas draft silently; CEO discovers via Signal digest (#403, #278)
    *   - autonomy_gated: check autonomy score before sending; hold as draft if below threshold
    */
   private async sendOutboundReply(outbound: OutboundMessageEvent): Promise<void> {

--- a/src/channels/email/nylas-client.ts
+++ b/src/channels/email/nylas-client.ts
@@ -255,8 +255,8 @@ export class NylasClient {
    * Draft and Message share the same BaseMessage shape in the Nylas SDK, so the
    * response can be normalised with the same helper as a sent message.
    *
-   * After this returns, OutboundGateway.createEmailDraft() notifies the CEO via email.
-   * The CEO reviews the draft in their Gmail Drafts folder and clicks send when ready (#278).
+   * Drafts are created silently — no per-draft notification is sent. The CEO discovers
+   * pending drafts via the end-of-day Signal digest and reviews them in Gmail (#403, #278).
    */
   async createDraft(options: SendEmailOptions): Promise<NylasMessage> {
     this.log.debug(

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,8 +10,8 @@ import * as path from 'node:path';
  * Outbound send policy for a named email account.
  *
  * - direct:          send immediately (default for Curia's own account)
- * - draft_gate:      create a Nylas draft and notify the CEO via email; CEO reviews in
- *                    Gmail and clicks send when ready (approval interface deferred — #278)
+ * - draft_gate:      create a Nylas draft silently; CEO discovers pending drafts via the
+ *                    end-of-day Signal digest and reviews in Gmail (#403, #278)
  * - autonomy_gated:  send autonomously only when the global autonomy score meets or
  *                    exceeds the account's autonomy_threshold value
  */

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -176,8 +176,6 @@ export class OutboundGateway {
    * notifications (blocked-content CEO alerts) when no accountId is specified.
    */
   private readonly primaryNylasClient: NylasClient | undefined;
-  /** Account name that owns primaryNylasClient (first key in nylasClients). */
-  private readonly primaryAccountId: string | undefined;
   private readonly signalClient?: SignalRpcClient;
   private readonly signalPhoneNumber?: string;
   private readonly contactService: ContactService;
@@ -189,7 +187,6 @@ export class OutboundGateway {
   constructor(config: OutboundGatewayConfig) {
     this.nylasClients = config.nylasClients ?? new Map();
     this.primaryNylasClient = this.nylasClients.values().next().value;
-    this.primaryAccountId = this.nylasClients.keys().next().value;
     this.signalClient = config.signalClient;
     this.signalPhoneNumber = config.signalPhoneNumber;
     this.contactService = config.contactService;
@@ -593,20 +590,20 @@ export class OutboundGateway {
   }
 
   /**
-   * Create a Nylas draft without sending it — used by the draft_gate outbound policy.
+   * Create a Nylas draft without sending it — used by the draft_gate outbound policy
+   * and by observation-mode email triage (NEEDS DRAFT classification).
    *
    * Runs the same blocked-contact check as send() but skips the content filter
    * (the filter is designed for messages leaving Curia's control; drafts stay in the
    * mailbox until explicitly sent). The reply goes through the full pipeline when the
    * draft is eventually approved and sent.
    *
-   * After a successful draft creation, notifies the CEO via email so they know a reply
-   * is waiting in their Drafts folder. The CEO reviews and clicks send from their email
-   * client when ready (approval + send is intentionally human-operated for draft_gate).
+   * Drafts are created silently — no notification is sent. The CEO discovers them
+   * through the end-of-day Signal digest (see the scheduled digest job) or by checking
+   * their Drafts folder directly.
    *
    * TODO(#278): approval interface and send-on-approval remain deferred — see issue for
-   * future options (CLI command, Signal reply, webhook). The notification + Gmail flow
-   * is the first piece of the three-part plan described in issue #278.
+   * future options (CLI command, Signal reply, webhook).
    */
   async createEmailDraft(request: EmailSendRequest): Promise<OutboundDraftResult> {
     const recipientId = request.to;
@@ -634,22 +631,7 @@ export class OutboundGateway {
       return { success: false, blockedReason: 'Contact resolution failed; draft not created' };
     }
 
-    const result = await this.dispatchEmailDraft(request);
-
-    // Notify the CEO that a draft is waiting for their review. Non-fatal — the draft
-    // was created successfully regardless of whether the notification sends.
-    // Use .catch() (not await) so any unexpected throw inside notifyCeoDraftCreated
-    // cannot propagate here and break the returned draft result.
-    if (result.success && result.draftId) {
-      this.notifyCeoDraftCreated(request, result.draftId).catch((err) => {
-        this.log.error(
-          { err, draftId: result.draftId },
-          'outbound-gateway: notifyCeoDraftCreated threw unexpectedly — draft result unaffected',
-        );
-      });
-    }
-
-    return result;
+    return this.dispatchEmailDraft(request);
   }
 
   /**
@@ -779,73 +761,6 @@ export class OutboundGateway {
         'outbound-gateway: Nylas createDraft failed',
       );
       return { success: false, blockedReason: `Draft creation failed: ${message}` };
-    }
-  }
-
-  /**
-   * Send the CEO a brief email letting them know a draft reply is waiting in their
-   * Drafts folder. Called immediately after a successful draft creation.
-   *
-   * Uses dispatchEmail() directly (bypasses send() to avoid infinite recursion and the
-   * content filter — the notification body is a hardcoded template, not user content).
-   * Uses the primary email account regardless of which account created the draft, so
-   * the notification always lands in the same inbox (consistent with the blocked-content
-   * alert pattern). Non-fatal: errors are logged but do not affect the draft result.
-   *
-   * Future: if a CEO Signal phone number is added to OutboundGatewayConfig, this method
-   * can be extended to notify via Signal instead of (or in addition to) email.
-   */
-  private async notifyCeoDraftCreated(request: EmailSendRequest, draftId: string): Promise<void> {
-    if (!this.ceoEmail) {
-      this.log.warn(
-        { accountId: request.accountId, draftId },
-        'outbound-gateway: draft-created notification skipped — ceoEmail not configured',
-      );
-      return;
-    }
-    if (!this.primaryNylasClient) {
-      this.log.warn(
-        { accountId: request.accountId, draftId },
-        'outbound-gateway: draft-created notification skipped — no primary email client configured',
-      );
-      return;
-    }
-
-    const subject = request.subject ?? '(no subject)';
-    // Resolve the drafting account name for the notification body. Falls back to the
-    // primary account name (cached at construction time), not the string literal
-    // 'primary' which has no meaning to the CEO reading the notification email.
-    const accountId = request.accountId ?? this.primaryAccountId ?? 'unknown';
-
-    // Wrap interpolated values in backticks so markdownToHtml renders them as
-    // literal code spans. Subject and recipient come from inbound thread metadata
-    // which could contain markdown-significant characters (links, emphasis, etc.).
-    const body = [
-      `There is a draft email reply to \`${request.to}\` about \`${subject}\` waiting in your Drafts folder on account \`${accountId}\`.`,
-      '',
-      'Please review it and click send when you are ready.',
-      '',
-      `Draft ID: \`${draftId}\``,
-    ].join('\n');
-
-    try {
-      const result = await this.dispatchEmail({
-        channel: 'email',
-        to: this.ceoEmail,
-        subject: `Draft reply awaiting review — ${subject}`,
-        body,
-      });
-      if (!result.success) {
-        this.log.error(
-          { draftId, accountId, ceoEmail: redactId(this.ceoEmail), reason: result.blockedReason },
-          'outbound-gateway: failed to send CEO draft-created notification',
-        );
-      }
-    } catch (err) {
-      this.log.error(
-        { err, draftId, accountId },
-        'outbound-gateway: unexpected error sending CEO draft-created notification',
-      );
     }
   }
 

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -377,16 +377,10 @@ describe('OutboundGateway', () => {
 });
 
 // ---------------------------------------------------------------------------
-// createEmailDraft + CEO notification
+// createEmailDraft — silent draft creation (no CEO notification)
 // ---------------------------------------------------------------------------
 
 describe('OutboundGateway.createEmailDraft', () => {
-  // The notification is fire-and-forget (.catch(), not await). After
-  // createEmailDraft returns, the notification promise is still in-flight.
-  // Flushing a macrotask ensures all pending microtasks (mock promise chains
-  // inside notifyCeoDraftCreated → dispatchEmail → sendMessage) have settled.
-  const flushNotification = () => new Promise<void>((r) => setTimeout(r, 0));
-
   const draftRequest = {
     channel: 'email' as const,
     to: 'partner@example.com',
@@ -395,17 +389,16 @@ describe('OutboundGateway.createEmailDraft', () => {
     body: 'Thanks for the meeting!',
   };
 
-  /** Build a gateway with full email + CEO notification capability. */
+  /** Build a gateway with email capability. */
   function makeGateway(overrides: {
     nylasClient?: Partial<NylasClient>;
     contactService?: Partial<ContactService>;
-    ceoEmail?: string;
     nylasClients?: Map<string, NylasClient>;
   } = {}) {
     const logger = createLogger('error');
     const nylasClient = {
       createDraft: vi.fn().mockResolvedValue({ id: 'draft-abc' }),
-      sendMessage: vi.fn().mockResolvedValue({ id: 'notif-1' }),
+      sendMessage: vi.fn().mockResolvedValue({ id: 'msg-1' }),
       ...overrides.nylasClient,
     } as unknown as NylasClient;
     const contactService = {
@@ -427,7 +420,7 @@ describe('OutboundGateway.createEmailDraft', () => {
       contactService,
       contentFilter,
       bus,
-      ceoEmail: overrides.ceoEmail ?? 'ceo@example.com',
+      ceoEmail: 'ceo@example.com',
       logger,
     });
 
@@ -443,90 +436,22 @@ describe('OutboundGateway.createEmailDraft', () => {
     expect(nylasClient.createDraft).toHaveBeenCalledOnce();
   });
 
-  it('sends CEO a notification email after successful draft creation', async () => {
+  it('does not send any notification email after successful draft creation', async () => {
+    // Drafts are silent — no per-draft email is sent to the CEO.
+    // Discovery happens via the end-of-day Signal digest.
     const { gateway, nylasClient } = makeGateway();
     await gateway.createEmailDraft(draftRequest);
-    await flushNotification();
 
-    // sendMessage is called once — for the CEO notification (not for the draft itself,
-    // which goes through createDraft). Verify the notification targets the CEO.
-    expect(nylasClient.sendMessage).toHaveBeenCalledOnce();
-    const sendArgs = (nylasClient.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(sendArgs.to).toEqual([{ email: 'ceo@example.com' }]);
-    expect(sendArgs.subject).toContain('Draft reply awaiting review');
-    expect(sendArgs.subject).toContain('Partnership follow-up');
-  });
-
-  it('notification body includes recipient, subject, account, and draft ID', async () => {
-    const { gateway, nylasClient } = makeGateway();
-    await gateway.createEmailDraft(draftRequest);
-    await flushNotification();
-
-    const sendArgs = (nylasClient.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    // Body is HTML (markdownToHtml converts the plain-text template), so check
-    // for the key content fragments without assuming exact HTML structure.
-    expect(sendArgs.body).toContain('partner@example.com');
-    expect(sendArgs.body).toContain('Partnership follow-up');
-    expect(sendArgs.body).toContain('joseph');
-    expect(sendArgs.body).toContain('draft-abc');
-  });
-
-  it('returns success even when the CEO notification email fails to send', async () => {
-    const { gateway } = makeGateway({
-      nylasClient: {
-        createDraft: vi.fn().mockResolvedValue({ id: 'draft-456' }),
-        // Notification send fails — must not affect the draft result
-        sendMessage: vi.fn().mockRejectedValue(new Error('SMTP timeout')),
-      },
-    });
-
-    const result = await gateway.createEmailDraft(draftRequest);
-    await flushNotification();
-
-    // Draft creation succeeded — the notification failure is swallowed
-    expect(result.success).toBe(true);
-    expect(result.draftId).toBe('draft-456');
-  });
-
-  it('returns success even when notification sendMessage resolves with no messageId', async () => {
-    const { gateway } = makeGateway({
-      nylasClient: {
-        createDraft: vi.fn().mockResolvedValue({ id: 'draft-789' }),
-        // sendMessage resolves but returns no id — dispatchEmail treats this as
-        // { success: true, messageId: undefined }, so the notification "succeeds"
-        // with a missing id. Draft result must still be unaffected.
-        sendMessage: vi.fn().mockResolvedValue({ id: undefined }),
-      },
-    });
-
-    const result = await gateway.createEmailDraft(draftRequest);
-    await flushNotification();
-
-    expect(result.success).toBe(true);
-    expect(result.draftId).toBe('draft-789');
-  });
-
-  it('skips CEO notification when ceoEmail is not configured', async () => {
-    const { gateway, nylasClient } = makeGateway({ ceoEmail: '' });
-
-    const result = await gateway.createEmailDraft(draftRequest);
-    await flushNotification();
-
-    expect(result.success).toBe(true);
-    expect(result.draftId).toBe('draft-abc');
-    // sendMessage should never be called — notification was skipped
     expect(nylasClient.sendMessage).not.toHaveBeenCalled();
   });
 
-  it('skips CEO notification when no email client is configured', async () => {
+  it('returns false when no email client is configured', async () => {
     const { gateway } = makeGateway({
       nylasClients: new Map(), // empty — no primary client
     });
 
     const result = await gateway.createEmailDraft(draftRequest);
-    await flushNotification();
 
-    // Draft creation fails (no client) — notification never attempted
     expect(result.success).toBe(false);
     expect(result.blockedReason).toBe('Email client not configured');
   });
@@ -543,11 +468,9 @@ describe('OutboundGateway.createEmailDraft', () => {
     });
 
     const result = await gateway.createEmailDraft(draftRequest);
-    await flushNotification();
 
     expect(result.success).toBe(false);
     expect(result.blockedReason).toBe('Recipient is blocked');
-    // Neither draft nor notification should be attempted
     expect(nylasClient.createDraft).not.toHaveBeenCalled();
     expect(nylasClient.sendMessage).not.toHaveBeenCalled();
   });
@@ -560,7 +483,6 @@ describe('OutboundGateway.createEmailDraft', () => {
     });
 
     const result = await gateway.createEmailDraft(draftRequest);
-    await flushNotification();
 
     // Unlike send() which fail-opens on contact resolution errors, createEmailDraft
     // fail-closes: a draft for a blocked contact could be sent by a human later.
@@ -568,26 +490,6 @@ describe('OutboundGateway.createEmailDraft', () => {
     expect(result.blockedReason).toContain('Contact resolution failed');
     expect(nylasClient.createDraft).not.toHaveBeenCalled();
     expect(nylasClient.sendMessage).not.toHaveBeenCalled();
-  });
-
-  it('uses the actual primary account name when request.accountId is absent', async () => {
-    const nylasClient = {
-      createDraft: vi.fn().mockResolvedValue({ id: 'draft-no-acct' }),
-      sendMessage: vi.fn().mockResolvedValue({ id: 'notif-1' }),
-    } as unknown as NylasClient;
-    // Primary account is named "curia" — this is what should appear in the notification
-    const nylasClients = new Map([['curia', nylasClient]]);
-    const { gateway } = makeGateway({ nylasClients });
-
-    const requestWithoutAccountId = { ...draftRequest, accountId: undefined };
-    await gateway.createEmailDraft(requestWithoutAccountId);
-    await flushNotification();
-
-    const sendArgs = (nylasClient.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    // The notification body should say "curia" not "primary" or "unknown"
-    expect(sendArgs.body).toContain('curia');
-    expect(sendArgs.body).not.toContain('"primary"');
-    expect(sendArgs.body).not.toContain('"unknown"');
   });
 });
 


### PR DESCRIPTION
## Summary

- Removes `OutboundGateway.notifyCeoDraftCreated()` — the method that sent an immediate email to the CEO every time a draft was saved during observation-mode email triage
- Drafts are now created silently; `createEmailDraft()` returns the result of `dispatchEmailDraft()` directly with no side effects
- Also removes the `primaryAccountId` field that existed solely to support the notification method
- Updates all stale `draft_gate` doc comments in `nylas-client.ts`, `config.ts`, and `email-adapter.ts` that still described the old "notify via email" behavior

## Why

The per-draft email notification was counterproductive: if the CEO wasn't going to see the original email in their monitored inbox, they weren't going to see the notification either. Discovery of pending drafts moves to the end-of-day Signal digest (to be scheduled separately as part of #403).

## Test plan

- [x] `createEmailDraft()` creates draft and returns `draftId` as before
- [x] New test asserts `sendMessage` is never called after a successful draft — no notification email sent
- [x] Blocked-contact and fail-closed tests retained and pass
- [x] All 1678 tests pass
- [x] Pre-PR code review: no issues
- [x] Pre-PR silent-failure review: no new issues (doc fixes added in response to findings)

Closes part 1 of #403.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Email draft creation no longer triggers per-draft CEO notifications. Drafts are now created silently, with CEO discovery handled through the end-of-day Signal digest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->