### PR TITLE
fix: held-messages-process identify — 23505 crash and missing trust_level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **held-messages-process** — `identify` action (new-contact path) no longer crashes with `23505` when the sender's channel identity already exists in `contact_channel_identities`; the skill now resolves the owning contact, cleans up the orphaned newly-created contact, and marks the held message processed (fixes #406)
+- **held-messages-process** — `identify` action now sets `trust_level = 'high'` on the confirmed contact so subsequent inbound messages from that sender score above the dispatcher trust floor and are not re-held (fixes #407)
+
 ### Changed
 
 - **README** — updated messaging to align with "Digital Office of the CEO" positioning: reframed problem statement around CEO pain points, led with capabilities over technical comparisons, added governance-first framing and autonomy row to comparison table

--- a/skills/held-messages-process/handler.ts
+++ b/skills/held-messages-process/handler.ts
@@ -209,7 +209,20 @@ export class HeldMessagesProcessHandler implements SkillHandler {
           contactId = contact.id;
         } catch (linkErr) {
           const isDuplicate = (linkErr as { code?: string }).code === '23505';
-          if (!isDuplicate) throw linkErr;
+          if (!isDuplicate) {
+            // Any linkIdentity failure (timeout, constraint other than 23505, etc.)
+            // leaves the just-created contact as an orphan. Best-effort cleanup so
+            // retries don't stack orphan rows.
+            try {
+              await ctx.contactService.deleteContact(contact.id);
+            } catch (cleanupErr) {
+              ctx.log.warn(
+                { err: cleanupErr, orphanContactId: contact.id },
+                'held-messages-process: failed to clean up orphan contact after non-duplicate linkIdentity failure',
+              );
+            }
+            throw linkErr;
+          }
 
           // Identity already linked — find the owning contact and use it.
           // The contact we just created is an orphan; clean it up.

--- a/skills/held-messages-process/handler.ts
+++ b/skills/held-messages-process/handler.ts
@@ -220,6 +220,16 @@ export class HeldMessagesProcessHandler implements SkillHandler {
               heldMsg.senderId,
             );
           } catch (resolveErr) {
+            // Best-effort orphan cleanup before surfacing — each stuck retry would
+            // otherwise create a new orphaned contact row.
+            try {
+              await ctx.contactService.deleteContact(contact.id);
+            } catch (cleanupErr) {
+              ctx.log.warn(
+                { err: cleanupErr, orphanContactId: contact.id },
+                'held-messages-process: failed to clean up orphan contact before re-throwing resolveErr',
+              );
+            }
             ctx.log.error(
               { err: resolveErr, channel: heldMsg.channel, senderId: heldMsg.senderId, orphanContactId: contact.id },
               'resolveByChannelIdentity failed after 23505 (new-contact identify path) — orphaned contact exists',
@@ -231,6 +241,16 @@ export class HeldMessagesProcessHandler implements SkillHandler {
               { channel: heldMsg.channel, senderId: heldMsg.senderId, orphanContactId: contact.id },
               'Duplicate-key on linkIdentity (new-contact identify) but resolveByChannelIdentity returned null — possible orphaned identity',
             );
+            // Best-effort orphan cleanup — contact has no linked identity, so it
+            // will never be found by future lookups and should not persist.
+            try {
+              await ctx.contactService.deleteContact(contact.id);
+            } catch (cleanupErr) {
+              ctx.log.warn(
+                { err: cleanupErr, orphanContactId: contact.id },
+                'held-messages-process: failed to clean up orphan contact (null-resolve path) — manual cleanup may be needed',
+              );
+            }
             return {
               success: false,
               error: `Internal error: ${heldMsg.senderId} caused a duplicate-key error but no owning contact was found.`,

--- a/skills/held-messages-process/handler.ts
+++ b/skills/held-messages-process/handler.ts
@@ -195,13 +195,80 @@ export class HeldMessagesProcessHandler implements SkillHandler {
           status: 'confirmed',
           source: 'ceo_stated',
         });
-        await ctx.contactService.linkIdentity({
-          contactId: contact.id,
-          channel: heldMsg.channel,
-          channelIdentifier: heldMsg.senderId,
-          source: 'ceo_stated',
-        });
-        contactId = contact.id;
+        // Wrap linkIdentity with the same duplicate-key guard used by the block
+        // action and the existing_contact_id path: a prior partial run may have
+        // created the identity already (linkIdentity succeeded but markProcessed
+        // failed), leaving us in a retry with the identity already linked.
+        try {
+          await ctx.contactService.linkIdentity({
+            contactId: contact.id,
+            channel: heldMsg.channel,
+            channelIdentifier: heldMsg.senderId,
+            source: 'ceo_stated',
+          });
+          contactId = contact.id;
+        } catch (linkErr) {
+          const isDuplicate = (linkErr as { code?: string }).code === '23505';
+          if (!isDuplicate) throw linkErr;
+
+          // Identity already linked — find the owning contact and use it.
+          // The contact we just created is an orphan; clean it up.
+          let resolved: Awaited<ReturnType<typeof ctx.contactService.resolveByChannelIdentity>>;
+          try {
+            resolved = await ctx.contactService.resolveByChannelIdentity(
+              heldMsg.channel,
+              heldMsg.senderId,
+            );
+          } catch (resolveErr) {
+            ctx.log.error(
+              { err: resolveErr, channel: heldMsg.channel, senderId: heldMsg.senderId, orphanContactId: contact.id },
+              'resolveByChannelIdentity failed after 23505 (new-contact identify path) — orphaned contact exists',
+            );
+            throw resolveErr;
+          }
+          if (!resolved) {
+            ctx.log.error(
+              { channel: heldMsg.channel, senderId: heldMsg.senderId, orphanContactId: contact.id },
+              'Duplicate-key on linkIdentity (new-contact identify) but resolveByChannelIdentity returned null — possible orphaned identity',
+            );
+            return {
+              success: false,
+              error: `Internal error: ${heldMsg.senderId} caused a duplicate-key error but no owning contact was found.`,
+            };
+          }
+          contactId = resolved.contactId;
+          ctx.log.info(
+            { channel: heldMsg.channel, senderId: heldMsg.senderId, contactId, orphanContactId: contact.id },
+            'Channel identity already linked to existing contact — using it; cleaning up orphaned new contact',
+          );
+          // Best-effort orphan cleanup: non-fatal because the held message will
+          // still be processed even if delete fails. The orphan is traceable via
+          // the log above.
+          try {
+            await ctx.contactService.deleteContact(contact.id);
+          } catch (deleteErr) {
+            ctx.log.warn(
+              { err: deleteErr, orphanContactId: contact.id, contactId },
+              'held-messages-process: failed to delete orphaned contact — manual cleanup may be needed',
+            );
+          }
+        }
+      }
+
+      // Set trust_level = 'high' so subsequent messages from this sender score
+      // above the trust floor. contactConfidence starts at 0 for new contacts
+      // (enriched later via KG), so without this override the dispatcher's
+      // formula produces ~0.12 — below the default floor of 0.2 — and the next
+      // email gets re-held even though the CEO explicitly confirmed the contact.
+      // Mirrors the same call in outbound-gateway.enrichContactAfterSend.
+      // Failure is non-fatal: the contact is identified and will be marked processed.
+      try {
+        await ctx.contactService.setTrustLevel(contactId, 'high');
+      } catch (err) {
+        ctx.log.warn(
+          { err, contactId },
+          'held-messages-process: setTrustLevel failed — subsequent messages from this contact may fall below trust floor',
+        );
       }
 
       // Replay the held message through normal processing.

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -670,6 +670,18 @@ export class ContactService {
     };
   }
 
+  /**
+   * Delete a contact by ID. Should only be called after any FK-referenced rows
+   * (identities, auth overrides) have been re-pointed or deleted, otherwise the
+   * DB will reject with a foreign-key constraint error.
+   *
+   * Primarily used during contact merge (to remove the secondary) and during
+   * error recovery (to remove orphaned contacts created by a failed identify).
+   */
+  async deleteContact(id: string): Promise<void> {
+    await this.backend.deleteContact(id);
+  }
+
   private computeGoldenRecord(
     primary: Contact,
     primaryIdentities: ChannelIdentity[],

--- a/tests/unit/skills/held-messages-process.test.ts
+++ b/tests/unit/skills/held-messages-process.test.ts
@@ -372,6 +372,7 @@ describe('HeldMessagesProcessHandler — identify action', () => {
         ),
       ),
       resolveByChannelIdentity: vi.fn().mockResolvedValue(null),
+      deleteContact: vi.fn().mockResolvedValue(undefined),
     };
     const bus = makeBus();
 
@@ -382,6 +383,8 @@ describe('HeldMessagesProcessHandler — identify action', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain('Internal error');
+    // Orphan must still be cleaned up even when resolve returns null
+    expect(contactService.deleteContact).toHaveBeenCalledWith(ORPHAN_ID);
     expect(bus.publish).not.toHaveBeenCalled();
     expect(heldMessages.markProcessed).not.toHaveBeenCalled();
   });

--- a/tests/unit/skills/held-messages-process.test.ts
+++ b/tests/unit/skills/held-messages-process.test.ts
@@ -1,9 +1,9 @@
 // Tests for the held-messages-process skill handler.
 //
-// Covers the "identify", "dismiss", and "block" actions, including the
-// idempotent linkIdentity paths for both "identify" and "block" — the cases
-// where a prior partial run or contact-merge has already linked the sender's
-// channel identity before held-messages-process runs.
+// Covers the "identify", "dismiss", and "block" actions, including:
+// - Idempotent linkIdentity paths for both "identify" and "block"
+// - Issue #406: new-contact identify path with duplicate identity (23505)
+// - Issue #407: trust_level is set to 'high' after identify (both paths)
 
 import { describe, it, expect, vi } from 'vitest';
 import { HeldMessagesProcessHandler } from '../../../skills/held-messages-process/handler.js';
@@ -77,6 +77,7 @@ describe('HeldMessagesProcessHandler — identify action', () => {
     const contactService = {
       linkIdentity: vi.fn().mockResolvedValue({ id: 'identity-1' }),
       resolveByChannelIdentity: vi.fn(),
+      setTrustLevel: vi.fn().mockResolvedValue({ id: CONTACT_ID, trustLevel: 'high' }),
     };
     const bus = makeBus();
 
@@ -91,6 +92,7 @@ describe('HeldMessagesProcessHandler — identify action', () => {
       channel: 'email',
       channelIdentifier: 'donna@example.com',
     }));
+    expect(contactService.setTrustLevel).toHaveBeenCalledWith(CONTACT_ID, 'high');
     expect(bus.publish).toHaveBeenCalledOnce();
     expect(heldMessages.markProcessed).toHaveBeenCalledWith(HELD_MSG_ID, CONTACT_ID);
     if (result.success) expect(result.data).toMatchObject({ result: 'identified_and_replayed' });
@@ -119,6 +121,7 @@ describe('HeldMessagesProcessHandler — identify action', () => {
         status: 'confirmed',
         trustLevel: null,
       }),
+      setTrustLevel: vi.fn().mockResolvedValue({ id: CONTACT_ID, trustLevel: 'high' }),
     };
     const bus = makeBus();
 
@@ -214,6 +217,172 @@ describe('HeldMessagesProcessHandler — identify action', () => {
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain('connection timeout');
     expect(contactService.resolveByChannelIdentity).not.toHaveBeenCalled();
+    expect(heldMessages.markProcessed).not.toHaveBeenCalled();
+  });
+
+  // --- Issue #407: trust_level must be set to 'high' after identify ---
+
+  it('sets trust_level = high after identify so future messages clear the trust floor', async () => {
+    // Regression: held-messages-process was creating contacts without setting
+    // trust_level, so subsequent emails from confirmed contacts were re-held.
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      markProcessed: vi.fn().mockResolvedValue(true),
+    };
+    const contactService = {
+      linkIdentity: vi.fn().mockResolvedValue({ id: 'identity-1' }),
+      resolveByChannelIdentity: vi.fn(),
+      setTrustLevel: vi.fn().mockResolvedValue({ id: CONTACT_ID, trustLevel: 'high' }),
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'identify', existing_contact_id: CONTACT_ID },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    expect(result.success).toBe(true);
+    expect(contactService.setTrustLevel).toHaveBeenCalledWith(CONTACT_ID, 'high');
+    // setTrustLevel must be called before markProcessed — the trust annotation is
+    // a prerequisite for the contact being fully set up, even if non-fatal.
+    const setTrustOrder = contactService.setTrustLevel.mock.invocationCallOrder[0];
+    const markProcessedOrder = heldMessages.markProcessed.mock.invocationCallOrder[0];
+    expect(setTrustOrder).toBeLessThan(markProcessedOrder);
+  });
+
+  it('setTrustLevel failure is non-fatal — identify still succeeds', async () => {
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      markProcessed: vi.fn().mockResolvedValue(true),
+    };
+    const contactService = {
+      linkIdentity: vi.fn().mockResolvedValue({ id: 'identity-1' }),
+      resolveByChannelIdentity: vi.fn(),
+      setTrustLevel: vi.fn().mockRejectedValue(new Error('DB connection lost')),
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'identify', existing_contact_id: CONTACT_ID },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    // The identify still succeeds — setTrustLevel failure is non-fatal
+    expect(result.success).toBe(true);
+    expect(contactService.setTrustLevel).toHaveBeenCalledWith(CONTACT_ID, 'high');
+    expect(bus.publish).toHaveBeenCalledOnce();
+    expect(heldMessages.markProcessed).toHaveBeenCalledWith(HELD_MSG_ID, CONTACT_ID);
+  });
+
+  // --- Issue #406: new-contact path must handle duplicate identity (23505) ---
+
+  const NEW_CONTACT_ID = 'dddddddd-eeee-ffff-aaaa-bbbbbbbbbbbb';
+  const ORPHAN_ID = '99999999-8888-7777-6666-555555555555';
+
+  it('new-contact identify: succeeds when sender identity already exists (23505), uses existing contact and cleans up orphan', async () => {
+    // Regression: held-messages-process created a contact then crashed when
+    // linkIdentity threw 23505, leaving the message permanently stuck.
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      markProcessed: vi.fn().mockResolvedValue(true),
+    };
+    const contactService = {
+      createContact: vi.fn().mockResolvedValue({ id: ORPHAN_ID }),
+      linkIdentity: vi.fn().mockRejectedValue(
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
+          { code: '23505' },
+        ),
+      ),
+      resolveByChannelIdentity: vi.fn().mockResolvedValue({
+        contactId: NEW_CONTACT_ID,
+        displayName: 'Donna',
+        role: null,
+        status: 'confirmed',
+        trustLevel: null,
+      }),
+      deleteContact: vi.fn().mockResolvedValue(undefined),
+      setTrustLevel: vi.fn().mockResolvedValue({ id: NEW_CONTACT_ID, trustLevel: 'high' }),
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'identify', contact_name: 'Donna' },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    expect(result.success).toBe(true);
+    // The existing contact (not the orphan) must be used for processing
+    expect(heldMessages.markProcessed).toHaveBeenCalledWith(HELD_MSG_ID, NEW_CONTACT_ID);
+    // Orphan must be cleaned up
+    expect(contactService.deleteContact).toHaveBeenCalledWith(ORPHAN_ID);
+    // trust_level must still be set on the existing contact
+    expect(contactService.setTrustLevel).toHaveBeenCalledWith(NEW_CONTACT_ID, 'high');
+    expect(bus.publish).toHaveBeenCalledOnce();
+    if (result.success) expect(result.data).toMatchObject({ result: 'identified_and_replayed', contact_id: NEW_CONTACT_ID });
+  });
+
+  it('new-contact identify: orphan delete failure is non-fatal — message still processed', async () => {
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      markProcessed: vi.fn().mockResolvedValue(true),
+    };
+    const contactService = {
+      createContact: vi.fn().mockResolvedValue({ id: ORPHAN_ID }),
+      linkIdentity: vi.fn().mockRejectedValue(
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
+          { code: '23505' },
+        ),
+      ),
+      resolveByChannelIdentity: vi.fn().mockResolvedValue({
+        contactId: NEW_CONTACT_ID,
+        displayName: 'Donna',
+        role: null,
+        status: 'confirmed',
+        trustLevel: null,
+      }),
+      deleteContact: vi.fn().mockRejectedValue(new Error('delete failed')),
+      setTrustLevel: vi.fn().mockResolvedValue({ id: NEW_CONTACT_ID, trustLevel: 'high' }),
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'identify', contact_name: 'Donna' },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    // Orphan delete failure must NOT prevent the held message from being processed
+    expect(result.success).toBe(true);
+    expect(heldMessages.markProcessed).toHaveBeenCalledWith(HELD_MSG_ID, NEW_CONTACT_ID);
+    expect(bus.publish).toHaveBeenCalledOnce();
+  });
+
+  it('new-contact identify: returns internal error when resolveByChannelIdentity returns null after 23505', async () => {
+    const heldMessages = {
+      getById: vi.fn().mockResolvedValue(pendingMsg),
+      markProcessed: vi.fn(),
+    };
+    const contactService = {
+      createContact: vi.fn().mockResolvedValue({ id: ORPHAN_ID }),
+      linkIdentity: vi.fn().mockRejectedValue(
+        Object.assign(
+          new Error('duplicate key value violates unique constraint "contact_channel_identities_channel_channel_identifier_key"'),
+          { code: '23505' },
+        ),
+      ),
+      resolveByChannelIdentity: vi.fn().mockResolvedValue(null),
+    };
+    const bus = makeBus();
+
+    const result = await handler.execute(makeCtx(
+      { held_message_id: HELD_MSG_ID, action: 'identify', contact_name: 'Donna' },
+      { heldMessages: heldMessages as never, contactService: contactService as never, bus: bus as never },
+    ));
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Internal error');
+    expect(bus.publish).not.toHaveBeenCalled();
     expect(heldMessages.markProcessed).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Fixes two P2 bugs in `held-messages-process` that left a sender's messages permanently stuck and re-held on every subsequent email from a confirmed contact (root-caused from Nik Skavinskii's emails on 2026-04-29).

**#406 — New-contact identify crashes on duplicate identity, leaving held message permanently stuck**

The new-contact path called `createContact` then `linkIdentity`. If the sender's identity already existed in `contact_channel_identities` (e.g. from a prior partial run where `linkIdentity` succeeded but `markProcessed` did not), `linkIdentity` threw a `23505` unique constraint error that propagated to the outer catch — `markProcessed()` was never called and the message stayed `pending` indefinitely, with an orphaned contact left in the DB.

Fix: wraps `linkIdentity` with the same `23505` idempotency guard the `block` action and `existing_contact_id` path already have. On duplicate: resolves the owning contact, cleans up the orphaned new contact, and falls through to `markProcessed`. Also adds best-effort orphan cleanup to the two error paths that previously abandoned the orphan before returning/throwing.

**#407 — identify never sets trust_level, so confirmed contacts still trigger holds**

The `identify` path created or resolved a contact but never called `setTrustLevel`. `contactConfidence` starts at 0 for new contacts, so the dispatcher's trust formula produces ~0.12 — below the 0.20 floor — and every subsequent email from the now-confirmed sender is re-held.

Fix: calls `setTrustLevel(contactId, 'high')` after both identify branches converge, before replay. Same non-fatal pattern as `outbound-gateway.enrichContactAfterSend`. Also adds `ContactService.deleteContact()` public method (previously only on the backend, causing `TypeError` at runtime in orphan cleanup).

## Test plan

- [ ] New-contact identify: duplicate identity → succeeds, uses existing contact, cleans orphan
- [ ] Orphan delete failure → non-fatal, message still processed  
- [ ] `resolveByChannelIdentity` null after 23505 → failure, orphan cleanup attempted
- [ ] `setTrustLevel` called after identify (both paths)
- [ ] `setTrustLevel` failure → non-fatal, identify still succeeds
- [ ] All 1683 existing tests pass

Closes #406, closes #407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved crash that occurred during held message processing when sender channel identities already existed in the system.
  * Confirmed contacts now receive proper trust level assignments to ensure future inbound messages bypass re-holding and process reliably.

* **Tests**
  * Expanded test coverage for held message processing scenarios, including duplicate identity handling and trust level resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->