### PR TITLE
fix: strip leading @ from delegate agent names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Delegate @-prefix normalization** — LLMs sometimes pass agent names with a leading `@` (e.g. `@essay-editor` instead of `essay-editor`), causing registry lookup misses and lost timeout injection. The runtime now strips leading `@` from delegate agent names before registry lookup and handler dispatch.
+
 ### Added
 
 - **Autonomy hard gates (spec 14, Phase 2):** execution layer blocks skill invocations when the live autonomy score is below the skill's declared `action_risk` threshold. Full restriction (score < 60) blocks all non-read skills. `OutboundGateway.send()` independently blocks direct sends when score < 70 — drafts remain available as the intended fallback. Both gates emit audit events (`autonomy.skill_blocked`, `autonomy.send_blocked`) and return advisory failures that surface the required score to the agent.

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -552,6 +552,19 @@ export class AgentRuntime {
             );
           } else {
             const inputRecord = skillInput as Record<string, unknown>;
+
+            // Normalize agent name: LLMs sometimes produce "@agent-name" (bullpen @-mention
+            // style). Strip the leading '@' so the registry lookup and downstream handler
+            // see the canonical registered name.
+            if (typeof inputRecord['agent'] === 'string' && (inputRecord['agent'] as string).startsWith('@')) {
+              const rawName = inputRecord['agent'] as string;
+              inputRecord['agent'] = rawName.slice(1);
+              logger.info(
+                { agentId, rawAgent: rawName, normalizedAgent: inputRecord['agent'] },
+                'Stripped leading @ from delegate agent name',
+              );
+            }
+
             if (!('timeout_ms' in inputRecord) || inputRecord['timeout_ms'] === undefined) {
               // Source 1: scheduler's expectedDurationSeconds on the task event
               let durationSeconds = taskEvent.payload.expectedDurationSeconds;

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -1728,5 +1728,66 @@ describe('AgentRuntime chatWithRetry', () => {
       const inputArg = invokeCall?.[1] as Record<string, unknown>;
       expect(inputArg).not.toHaveProperty('timeout_ms');
     });
+
+    it('strips leading @ from agent name and still injects timeout_ms', async () => {
+      const logger = createLogger('error');
+      const bus = new EventBus(logger);
+
+      let callCount = 0;
+      const provider: LLMProvider = {
+        id: 'mock',
+        chat: vi.fn().mockImplementation(async () => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              type: 'tool_use' as const,
+              // LLM uses @-mention style — runtime should strip the '@'
+              toolCalls: [{ id: 'call-delegate-at', name: 'delegate', input: { agent: '@essay-editor', task: 'polish essay' } }],
+              usage: { inputTokens: 100, outputTokens: 50 },
+            };
+          }
+          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60 } };
+        }),
+      };
+
+      const { AgentRegistry } = await import('../../../src/agents/agent-registry.js');
+      const agentRegistry = new AgentRegistry();
+      agentRegistry.register('essay-editor', { role: 'specialist', description: 'Essay editor', expectedDurationSeconds: 600 });
+
+      const mockExecution = {
+        invoke: vi.fn().mockResolvedValue({ success: true, data: { response: 'Polished!', agent: 'essay-editor' } }),
+      } as unknown as ExecutionLayer;
+
+      const agent = new AgentRuntime({
+        agentId: 'coordinator',
+        systemPrompt: 'You are an assistant.',
+        provider,
+        bus,
+        logger,
+        executionLayer: mockExecution,
+        skillToolDefs: [{ name: 'delegate', description: 'Delegate', input_schema: { type: 'object' as const, properties: { agent: { type: 'string' }, task: { type: 'string' } }, required: ['agent', 'task'] } }],
+        agentRegistry,
+      });
+      agent.register();
+
+      const task = createAgentTask({
+        agentId: 'coordinator',
+        conversationId: 'conv-at-prefix',
+        channelId: 'cli',
+        senderId: 'user',
+        content: 'Polish my essay',
+        parentEventId: 'parent-at-prefix',
+      });
+      await bus.publish('dispatch', task);
+
+      // The execution layer should receive the normalized agent name (no @)
+      // AND the injected timeout_ms (proving registry lookup worked after stripping @)
+      expect(mockExecution.invoke).toHaveBeenCalledWith(
+        'delegate',
+        expect.objectContaining({ agent: 'essay-editor', timeout_ms: 600000 }),
+        undefined,
+        expect.any(Object),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

- LLMs sometimes pass agent names with a leading `@` (e.g. `@essay-editor` instead of `essay-editor`) — particularly likely with the bullpen's `@`-mention conventions
- This caused the agent registry lookup to miss, preventing `timeout_ms` injection from `expected_duration_seconds`
- The runtime now strips leading `@` from delegate agent names before the registry lookup and handler dispatch
- Observed in production: coordinator called `delegate({ agent: "@essay-editor" })`, registry returned undefined, timeout injection failed, and the 90s default fired before the essay-editor could complete its 8+ minute pipeline

## Test plan

- [x] New test: `strips leading @ from agent name and still injects timeout_ms` — verifies `@essay-editor` is normalized to `essay-editor` and timeout_ms is correctly injected from the registry
- [x] All 33 existing runtime tests pass (no regressions)

Companion PR: josephfung/curia-deploy#24 (adds `expected_duration_seconds: 1200` to essay-editor)