### PR TITLE
feat: PII outbound channel redaction policy (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,16 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **Autonomy web UI** — dedicated settings page for viewing and adjusting the autonomy score, with paginated change history. New REST endpoints: `GET/PUT /api/autonomy`, `GET /api/autonomy/history`. Closes #409.
+- **PII outbound redaction** — configurable per-channel PII redaction for outbound messages. Detected PII (credit cards, phone numbers, SSNs, etc.) is redacted in email and Signal replies based on channel policy (`channel_policies` in config). CEO trust level bypasses redaction. Publishes `outbound.pii-redacted` audit event. New `PiiRedactor` class at `src/dispatch/pii-redactor.ts`. (#249)
+- **`detectPii()` function** — shared PII detection foundation extracted from `scrubPii()`. Returns `PiiMatch[]` with labels and positions. Used by both the log/LLM scrubber and the outbound PII redactor. (#249)
 - **Autonomy hard gates (spec 14, Phase 2):** execution layer blocks skill invocations when the live autonomy score is below the skill's declared `action_risk` threshold. Full restriction (score < 60) blocks all non-read skills. `OutboundGateway.send()` independently blocks direct sends when score < 70 — drafts remain available as the intended fallback. Both gates emit audit events (`autonomy.skill_blocked`, `autonomy.send_blocked`) and return advisory failures that surface the required score to the agent.
 - **Logo assets** — added SVG wordmark (`logo-curia-wordmark.svg`) and mark (`logo-curia-mark.svg`) to `docs/assets/`; replaced text-based "CURIA" placeholders in the Knowledge Graph UI (sidebar, auth wall, onboarding wizard) with the inline SVG wordmark; updated README header to use the SVG wordmark and removed the old `curia-header.png`
 - **CC role detection** — `convertNylasMessage` now accepts a `selfEmail` parameter and computes `curiaRole` (`'to'` | `'cc'` | `'bcc'`) and `primaryRecipientEmails` in the converted email metadata, so the dispatcher can distinguish emails addressed directly to Curia from emails where Curia was CC'd.
 
 ### Changed
 
+- **Trust levels** — added `'ceo'` trust level above `'high'` with ordinal comparison via `meetsMinimumTrust()` helper in `src/contacts/types.ts`. CEO bootstrap sets `trust_level = 'ceo'` for the CEO contact. (#249)
+- **`checkContactDataLeak`** — recipient trust now determined via `meetsMinimumTrust(trustLevel, 'high')` instead of direct equality check; CEO identified by trust level rather than email address comparison. (#249)
 - **PII scrubber dependency** — replaced deprecated `@openredaction/openredaction` with the actively maintained unscoped `openredaction` package (v1.1.2); dropped PHONE_UK pattern (v1.1 regex too broad for log scrubbing — PHONE_UK_MOBILE provides UK coverage); reordered CREDIT_CARD before PHONE patterns to prevent partial matches; added PHONE_US regex fixup for parenthesized `(NXX) NXX-XXXX` format (fixes #252)
 - **`action_risk` enforcement:** `SkillRegistry.register()` now throws at startup if a skill manifest is missing the `action_risk` field (previously accepted silently).
 - **README** — updated messaging to align with "Digital Office of the CEO" positioning: reframed problem statement around CEO pain points, led with capabilities over technical comparisons, added governance-first framing and autonomy row to comparison table

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -205,6 +205,28 @@ pii:
   # These patterns run on every LLM-facing error message.
   extra_patterns: []
 
+  # Outbound PII redaction policy - controls which PII patterns are redacted
+  # in outbound channel messages (email, Signal replies).
+  #
+  # Detection uses openredaction (same library as the log/LLM scrubber).
+  # This config controls only policy: which detected patterns pass through
+  # on which channels. Patterns not in a channel's allow list are redacted.
+  #
+  # trust_override: recipients at these trust levels bypass redaction entirely.
+  # CEO can ask "what phone number do we have for X?" without friction.
+  #
+  # default: 'block' means all detected PII not explicitly allowed is redacted.
+  # Configure exceptions, not rules.
+  outbound_redaction:
+    enabled: true
+    trust_override: [ceo]
+    default: block
+    channel_policies:
+      email:
+        allow: [email]         # email addresses are fine in email replies
+      signal:
+        allow: []              # everything blocked for Signal (except CEO)
+
 # Trust-gated action thresholds (spec §06-audit-and-security.md).
 # The Coordinator checks messageTrustScore against these thresholds before
 # taking actions on behalf of a sender. Enforced via the Coordinator's system prompt.

--- a/docs/wip/2026-05-01-pii-outbound-redaction-design.md
+++ b/docs/wip/2026-05-01-pii-outbound-redaction-design.md
@@ -1,0 +1,272 @@
+# PII Outbound Channel Redaction Policy
+
+**Issue:** #249
+**Date:** 2026-05-01
+**Status:** Design
+
+## Summary
+
+Configurable per-channel PII redaction for outbound messages. When the agent sends a reply via email or Signal, detected PII patterns are redacted based on channel policy — unless the recipient is the CEO, who bypasses all redaction.
+
+This is distinct from issue #197's `scrubPii()` which blanket-strips PII from logs and LLM context. This feature controls what PII flows to *external recipients* through *channel replies*.
+
+## Architecture Decision
+
+**Approach: Separate pipeline step in OutboundGateway** (not a content filter rule, not a channel adapter hook).
+
+Rationale:
+- Redaction is a *transformation* (modify content and send), not a *gate* (block or allow). The existing content filter is a gate — changing its contract would mix responsibilities.
+- Placing redaction before the content filter ensures the filter validates what the recipient will actually see.
+- A single pipeline step means one audit point, one failure mode, one place to emit events.
+
+## Outbound Pipeline (Updated)
+
+```
+1. Autonomy gate (score check)
+2. Blocked contact check + capture recipientTrustLevel
+3. PiiRedactor.redact(content, channelId, trustLevel)     ← NEW
+4. Content filter (validates post-redaction content)
+5. Channel dispatch (email or signal adapter)
+```
+
+## Pattern Detection
+
+Detection is delegated entirely to `openredaction` (the library `scrubPii()` already uses). No regex is maintained in Curia config.
+
+The existing `scrubPii()` function is refactored into two layers:
+
+```
+detectPii(text, extraPatterns?) → PiiMatch[]      // detection only (new, shared)
+scrubPii(text, extraPatterns?) → string           // calls detectPii(), replaces all (same API)
+```
+
+`detectPii()` becomes the shared foundation used by both `scrubPii()` (blanket replacement for logs/LLM) and `PiiRedactor` (selective replacement for outbound channels).
+
+### PiiMatch Interface
+
+```typescript
+interface PiiMatch {
+  label: string;      // e.g. "CREDIT_CARD", "PHONE_US", "EMAIL"
+  start: number;      // position in text
+  end: number;
+  matched: string;    // the actual value found
+}
+```
+
+### UUID Shielding
+
+The existing UUID shielding logic (prevents false positives on RFC 4122 UUIDs in application text) is preserved in `detectPii()` and benefits both consumers.
+
+### Extra Patterns
+
+`pii.extra_patterns` in config (which already exists for the scrubber) feeds into `detectPii()` for any patterns openredaction doesn't cover natively. Both the scrubber and the redactor benefit from additions there.
+
+## PiiRedactor Class
+
+New file: `src/dispatch/pii-redactor.ts`
+
+### Interface
+
+```typescript
+interface RedactionResult {
+  content: string;                  // modified content (or original if nothing redacted)
+  redactions: RedactionEntry[];     // what was redacted (for logging/audit)
+}
+
+interface RedactionEntry {
+  patternLabel: string;             // e.g. "CREDIT_CARD"
+  channelId: string;                // e.g. "email"
+  replacedWith: string;             // e.g. "[REDACTED: CREDIT_CARD]"
+  // Original value is NOT stored — that would defeat the purpose
+}
+```
+
+### Redaction Format
+
+Detected PII is replaced with: `[REDACTED: <LABEL>]`
+
+Examples:
+- `4111 1111 1111 1111` → `[REDACTED: CREDIT_CARD]`
+- `+1 555-867-5309` → `[REDACTED: PHONE_US]`
+- `AB1234567` → `[REDACTED: PASSPORT]`
+
+This format:
+- Tells the reader something was redacted
+- Identifies what type of data was removed (aids debugging and testing)
+- Is inert to all existing content filter rules (no false positives — verified against `system-prompt-fragment`, `internal-structure`, `secret-pattern`, and `contact-data-leak`)
+
+### Logic
+
+```
+redact(content, channelId, trustLevel):
+  1. If enabled is false → return content unchanged (no-op)
+  2. If trustLevel is in trust_override list → return content unchanged
+  3. Call detectPii(content, extraPatterns) → matches
+  4. For each match:
+     - Normalize match.label to lowercase for comparison
+     - Look up channel_policies[channelId].allow (if channel not listed, allow = [])
+     - If match.label is in the allow list → skip
+     - Otherwise → replace with [REDACTED: <match.label>]
+  5. If any redactions performed:
+     - Emit pino structured log
+     - Publish 'outbound.pii-redacted' bus event
+  6. Return { content: modifiedContent, redactions }
+```
+
+**Label casing:** Config uses lowercase labels (`email`, `credit_card`). Labels from openredaction are normalized to lowercase before comparison. The replacement string uses the original label casing from openredaction (e.g., `[REDACTED: CREDIT_CARD]`) for readability.
+
+**Unlisted channels:** If a channel has no entry in `channel_policies`, its allow list is treated as empty — meaning all detected PII is blocked on that channel (consistent with `default: block`).
+
+### Failure Behaviour
+
+If `PiiRedactor` throws (openredaction crash, unexpected error):
+- **Fail closed** — block the message, do not send unredacted content
+- Publish `outbound.blocked` with reason `pii_redactor_error`
+- CEO notified via existing blocked-message notification flow
+
+Consistent with the content filter's failure mode.
+
+## Configuration
+
+### config/default.yaml
+
+```yaml
+pii:
+  # Existing — extra patterns for the scrubber (openredaction extensions)
+  extra_patterns: []
+
+  # New — outbound redaction policy
+  outbound_redaction:
+    enabled: true
+    trust_override: [ceo]           # trust levels that bypass all redaction
+    default: block                   # unlisted pattern/channel combos are blocked
+    channel_policies:
+      email:
+        allow: [email]              # email addresses are fine in email replies
+      signal:
+        allow: []                   # everything blocked for signal (except CEO)
+```
+
+### Design Notes
+
+- **`enabled`** — kill switch. If false, PiiRedactor is a no-op pass-through.
+- **`trust_override`** — trust levels that skip redaction entirely. Only `ceo` for now; supports adding `high` later without code changes.
+- **`default: block`** — any detected pattern not in a channel's allow list gets redacted. Configure exceptions, not rules.
+- **`channel_policies`** — per-channel allow lists. Unlisted channels inherit the default (block everything).
+- No regex anywhere in this config — detection is delegated to openredaction.
+
+### TypeScript Schema (src/config.ts)
+
+```typescript
+pii?: {
+  extra_patterns?: Array<{ regex: string; replacement: string }>;
+
+  outbound_redaction?: {
+    enabled?: boolean;                // default: true
+    trust_override?: TrustLevel[];    // default: ['ceo']
+    default?: 'block' | 'allow';     // default: 'block'
+    channel_policies?: Record<string, {
+      allow?: string[];              // pattern labels allowed on this channel
+    }>;
+  };
+};
+```
+
+Validated at startup in `src/startup/validator.ts`. Invalid trust levels, unknown structure, or malformed values = fail-closed startup error.
+
+## Logging and Audit
+
+### Pino Structured Log
+
+Emitted only by the outbound `PiiRedactor` (not by the log/LLM scrubber):
+
+```typescript
+logger.info({
+  event: 'pii_redacted',
+  channelId: 'email',
+  recipientTrustLevel: 'confirmed',
+  redactions: [
+    { patternLabel: 'CREDIT_CARD' },
+    { patternLabel: 'PHONE_US' }
+  ],
+  redactionCount: 2,
+  conversationId: '...'
+});
+```
+
+No original values logged.
+
+### Bus Event
+
+New event type: `outbound.pii-redacted`
+
+```typescript
+{
+  type: 'outbound.pii-redacted',
+  channelId: 'email',
+  recipientId: '...',
+  conversationId: '...',
+  redactions: [
+    { patternLabel: 'CREDIT_CARD', replacedWith: '[REDACTED: CREDIT_CARD]' },
+    { patternLabel: 'PHONE_US', replacedWith: '[REDACTED: PHONE_US]' }
+  ],
+  timestamp: '...'
+}
+```
+
+Published for future audit UI or alerting rules. Nothing subscribes to it initially.
+
+Registered in `src/bus/events.ts` (discriminated union) and authorized for the dispatch layer in `src/bus/permissions.ts`.
+
+### When Events Are NOT Emitted
+
+- CEO recipient (trust override) — silent pass-through
+- No PII detected — silent pass-through
+- `enabled: false` — silent pass-through
+- Log/LLM scrubbing via `scrubPii()` — never emits redaction events (different concern)
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/pii/scrubber.ts` | Extract `detectPii()`, make `scrubPii()` a thin wrapper |
+| `src/dispatch/pii-redactor.ts` | New `PiiRedactor` class |
+| `src/skills/outbound-gateway.ts` | Add redaction as step 3 in pipeline |
+| `src/bus/events.ts` | Add `outbound.pii-redacted` event type |
+| `src/bus/permissions.ts` | Authorize dispatch layer for new event |
+| `src/config.ts` | Extend `pii` interface with `outbound_redaction` |
+| `src/startup/validator.ts` | Validate new config block at startup |
+| `config/default.yaml` | Add `outbound_redaction` section |
+
+## Testing
+
+### Unit Tests (src/pii/)
+
+- `detectPii()` returns correct matches with labels/positions for each openredaction pattern type
+- `detectPii()` UUID shielding prevents false positives (regression)
+- `scrubPii()` works identically after refactor (regression)
+
+### Unit Tests (src/dispatch/pii-redactor.ts)
+
+- Redacts blocked patterns, output contains `[REDACTED: <LABEL>]`
+- Allows patterns in channel's allow list (email addresses in email channel)
+- CEO trust level bypasses all redaction — content unchanged
+- Default-block applies to unlisted channels
+- Multiple matches in one message — all redacted correctly
+- No redactions needed — original content returned, no events emitted
+- Throws on malformed config at construction (fail-closed startup)
+
+### Integration Tests (src/skills/outbound-gateway)
+
+- Redacted content passes content filter without false positives
+- Full pipeline: non-CEO gets redacted content, CEO gets original
+- PiiRedactor crash → message blocked, `outbound.blocked` event published
+- `enabled: false` → no redaction, message passes through
+- Bus event `outbound.pii-redacted` published with correct payload
+
+## Out of Scope
+
+- "Hold for review" mode (message blocked pending CEO approval) — future enhancement
+- Per-recipient policies beyond trust level (e.g., per-contact allow lists) — future
+- Redaction in skill-to-API calls (these bypass the gateway entirely) — by design
+- Changes to the log/LLM scrubber's behaviour — unchanged, separate concern

--- a/docs/wip/2026-05-01-pii-outbound-redaction-design.md
+++ b/docs/wip/2026-05-01-pii-outbound-redaction-design.md
@@ -100,7 +100,7 @@ This format:
 ```
 redact(content, channelId, trustLevel):
   1. If enabled is false → return content unchanged (no-op)
-  2. If trustLevel is in trust_override list → return content unchanged
+  2. If meetsMinimumTrust(trustLevel, <lowest trust_override value>) → return content unchanged
   3. Call detectPii(content, extraPatterns) → matches
   4. For each match:
      - Normalize match.label to lowercase for comparison
@@ -225,18 +225,57 @@ Registered in `src/bus/events.ts` (discriminated union) and authorized for the d
 - `enabled: false` — silent pass-through
 - Log/LLM scrubbing via `scrubPii()` — never emits redaction events (different concern)
 
+## Trust Level Ordinal Comparison
+
+The existing `TrustLevel` type (`'high' | 'medium' | 'low'`) is extended with a `'ceo'` level and ordinal comparison support. This avoids brittle `=== 'high'` checks that break when new levels are added.
+
+### Changes to `src/contacts/types.ts`
+
+```typescript
+export type TrustLevel = 'ceo' | 'high' | 'medium' | 'low';
+
+const TRUST_RANK: Record<TrustLevel, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  ceo: 3,
+};
+
+export function meetsMinimumTrust(
+  actual: TrustLevel | null,
+  required: TrustLevel,
+): boolean {
+  if (actual === null) return false;
+  return TRUST_RANK[actual] >= TRUST_RANK[required];
+}
+```
+
+### Migration
+
+One migration to update the CEO contact from `trustLevel: 'high'` to `trustLevel: 'ceo'`.
+
+### Existing Code Updates
+
+Replace existing `trustLevel === 'high'` checks with `meetsMinimumTrust(trustLevel, 'high')` — semantically identical but now correctly includes `ceo` and any future levels above `high`.
+
+This also removes the special CEO email comparison from the content filter's `checkContactDataLeak` rule — the CEO's `ceo` trust level already implies trust, so the email comparison is redundant.
+
 ## Files Changed
 
 | File | Change |
 |------|--------|
+| `src/contacts/types.ts` | Add `'ceo'` to `TrustLevel`, add `meetsMinimumTrust()` helper |
 | `src/pii/scrubber.ts` | Extract `detectPii()`, make `scrubPii()` a thin wrapper |
 | `src/dispatch/pii-redactor.ts` | New `PiiRedactor` class |
+| `src/dispatch/outbound-filter.ts` | Replace `=== 'high'` + CEO email check with `meetsMinimumTrust()` |
 | `src/skills/outbound-gateway.ts` | Add redaction as step 3 in pipeline |
 | `src/bus/events.ts` | Add `outbound.pii-redacted` event type |
 | `src/bus/permissions.ts` | Authorize dispatch layer for new event |
 | `src/config.ts` | Extend `pii` interface with `outbound_redaction` |
 | `src/startup/validator.ts` | Validate new config block at startup |
+| `schemas/default-config.schema.json` | Add `outbound_redaction` to JSON schema |
 | `config/default.yaml` | Add `outbound_redaction` section |
+| `src/db/migrations/NNN_ceo_trust_level.sql` | Update CEO contact trust level to `'ceo'` |
 
 ## Testing
 

--- a/docs/wip/2026-05-01-pii-outbound-redaction.md
+++ b/docs/wip/2026-05-01-pii-outbound-redaction.md
@@ -1,0 +1,1257 @@
+# PII Outbound Channel Redaction — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add configurable per-channel PII redaction to the outbound gateway, with CEO trust-level bypass and audit events.
+
+**Architecture:** A new `PiiRedactor` pipeline step in `OutboundGateway` uses `openredaction` (via a shared `detectPii()` function extracted from `scrubPii()`) to find PII, then selectively redacts based on channel policy and recipient trust level. A new `'ceo'` trust level with ordinal comparison replaces scattered `=== 'high'` checks.
+
+**Tech Stack:** TypeScript/ESM, Vitest, openredaction, pino, node-pg-migrate
+
+---
+
+### Task 1: Add `'ceo'` trust level and `meetsMinimumTrust()` helper
+
+**Files:**
+- Modify: `src/contacts/types.ts:132`
+- Test: `src/contacts/types.test.ts` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/contacts/types.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { meetsMinimumTrust } from './types.js';
+
+describe('meetsMinimumTrust', () => {
+  it('returns false for null trust level', () => {
+    expect(meetsMinimumTrust(null, 'low')).toBe(false);
+  });
+
+  it('ceo meets all trust levels', () => {
+    expect(meetsMinimumTrust('ceo', 'ceo')).toBe(true);
+    expect(meetsMinimumTrust('ceo', 'high')).toBe(true);
+    expect(meetsMinimumTrust('ceo', 'medium')).toBe(true);
+    expect(meetsMinimumTrust('ceo', 'low')).toBe(true);
+  });
+
+  it('high meets high and below but not ceo', () => {
+    expect(meetsMinimumTrust('high', 'ceo')).toBe(false);
+    expect(meetsMinimumTrust('high', 'high')).toBe(true);
+    expect(meetsMinimumTrust('high', 'medium')).toBe(true);
+    expect(meetsMinimumTrust('high', 'low')).toBe(true);
+  });
+
+  it('medium meets medium and below', () => {
+    expect(meetsMinimumTrust('medium', 'high')).toBe(false);
+    expect(meetsMinimumTrust('medium', 'medium')).toBe(true);
+    expect(meetsMinimumTrust('medium', 'low')).toBe(true);
+  });
+
+  it('low meets only low', () => {
+    expect(meetsMinimumTrust('low', 'medium')).toBe(false);
+    expect(meetsMinimumTrust('low', 'low')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /path/to/worktree test -- src/contacts/types.test.ts`
+Expected: FAIL with `meetsMinimumTrust is not a function` or similar
+
+- [ ] **Step 3: Implement the trust level extension**
+
+In `src/contacts/types.ts`, find the existing `TrustLevel` type at line 132:
+
+```typescript
+export type TrustLevel = 'high' | 'medium' | 'low';
+```
+
+Replace with:
+
+```typescript
+export type TrustLevel = 'ceo' | 'high' | 'medium' | 'low';
+
+// Ordinal ranking for trust level comparison. Higher rank = more trusted.
+// Used by meetsMinimumTrust() so callers don't need to enumerate every level.
+const TRUST_RANK: Record<TrustLevel, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  ceo: 3,
+};
+
+/**
+ * Check whether an actual trust level meets or exceeds a required minimum.
+ * Returns false for null (unknown contacts default to untrusted).
+ */
+export function meetsMinimumTrust(
+  actual: TrustLevel | null,
+  required: TrustLevel,
+): boolean {
+  if (actual === null) return false;
+  return TRUST_RANK[actual] >= TRUST_RANK[required];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm --prefix /path/to/worktree test -- src/contacts/types.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/contacts/types.ts src/contacts/types.test.ts
+git commit -m "feat: add 'ceo' trust level and meetsMinimumTrust() helper (#249)"
+```
+
+---
+
+### Task 2: Migration — update CEO contact to `'ceo'` trust level
+
+**Files:**
+- Create: `src/db/migrations/030_ceo_trust_level_ceo.sql`
+
+- [ ] **Step 1: Check how migration 022 identified the CEO contact**
+
+Read `src/db/migrations/022_ceo_contact_trust_high.sql` and use the same WHERE clause pattern to identify the CEO contact.
+
+- [ ] **Step 2: Write the migration**
+
+Create `src/db/migrations/030_ceo_trust_level_ceo.sql`. Follow the same CEO identification pattern from migration 022:
+
+```sql
+-- Migration 030: Elevate CEO contact trust level from 'high' to 'ceo'
+--
+-- The new 'ceo' level sits above 'high' in the ordinal ranking, enabling
+-- trust-based policy decisions (e.g. PII redaction bypass) that should
+-- only apply to the principal, not all high-trust contacts.
+--
+-- Uses the same CEO identification as migration 022.
+--
+-- Reversal: UPDATE contacts SET trust_level = 'high' WHERE trust_level = 'ceo';
+
+-- NOTE: verify the WHERE clause matches how migration 022 identified
+-- the CEO contact. Adapt if the pattern differs.
+UPDATE contacts
+SET trust_level = 'ceo'
+WHERE trust_level = 'high'
+  AND <same-condition-as-migration-022>;
+```
+
+- [ ] **Step 3: Verify migration numbering is unique**
+
+Run: `ls /path/to/worktree/src/db/migrations/ | sort`
+Expected: No collision with prefix `030`. If taken, use the next available number.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/db/migrations/030_ceo_trust_level_ceo.sql
+git commit -m "feat: migration to elevate CEO contact to 'ceo' trust level (#249)"
+```
+
+---
+
+### Task 3: Update `checkContactDataLeak` to use `meetsMinimumTrust()`
+
+**Files:**
+- Modify: `src/dispatch/outbound-filter.ts:318-323`
+- Modify: `tests/unit/dispatch/outbound-filter.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/dispatch/outbound-filter.test.ts`:
+
+```typescript
+it('allows third-party emails when recipient trust level is ceo', async () => {
+  const result = await filter.check({
+    content: 'Please contact hamilton@other.org for details.',
+    recipientEmail: 'recipient@example.com',
+    conversationId: 'conv-1',
+    channelId: 'email',
+    recipientTrustLevel: 'ceo',
+  });
+  expect(result.passed).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /path/to/worktree test -- tests/unit/dispatch/outbound-filter.test.ts`
+Expected: FAIL — `'ceo'` not recognized as a trusted level
+
+- [ ] **Step 3: Update the content filter**
+
+In `src/dispatch/outbound-filter.ts`, add the import:
+
+```typescript
+import { meetsMinimumTrust } from '../contacts/types.js';
+```
+
+Replace lines 318-323 (the `recipientIsTrusted` block):
+
+```typescript
+    // Determine if the recipient qualifies as trusted.
+    // Uses ordinal trust comparison — any trust level >= 'high' qualifies,
+    // which includes 'high' and 'ceo'. The CEO's own email is covered by
+    // their 'ceo' trust level in the DB (migration 030), so the explicit
+    // ceoEmail comparison is no longer needed here.
+    const recipientIsTrusted = meetsMinimumTrust(recipientTrustLevel, 'high');
+```
+
+Update the JSDoc comment above `checkContactDataLeak` (around line 284-303) to reflect the ordinal comparison.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm --prefix /path/to/worktree test -- tests/unit/dispatch/outbound-filter.test.ts`
+Expected: ALL tests pass (existing + new)
+
+- [ ] **Step 5: Run full test suite for regressions**
+
+Run: `npm --prefix /path/to/worktree test`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/dispatch/outbound-filter.ts tests/unit/dispatch/outbound-filter.test.ts
+git commit -m "refactor: use meetsMinimumTrust() in checkContactDataLeak (#249)"
+```
+
+---
+
+### Task 4: Extract `detectPii()` from `scrubPii()`
+
+**Files:**
+- Modify: `src/pii/scrubber.ts`
+- Modify: `src/pii/scrubber.test.ts`
+
+- [ ] **Step 1: Write the failing tests for `detectPii()`**
+
+Add to `src/pii/scrubber.test.ts`:
+
+```typescript
+import { scrubPii, parseExtraPiiPatterns, detectPii } from './scrubber.js';
+
+describe('detectPii', () => {
+  it('detects an email address with label and position', () => {
+    const text = 'Contact user@example.com for help';
+    const matches = detectPii(text);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].label).toBe('email');
+    expect(matches[0].matched).toBe('user@example.com');
+    expect(matches[0].start).toBe(8);
+    expect(matches[0].end).toBe(24);
+  });
+
+  it('detects a credit card number', () => {
+    const matches = detectPii('Card: 4111 1111 1111 1111');
+    expect(matches.some(m => m.label === 'credit_card')).toBe(true);
+  });
+
+  it('detects multiple PII types in one string', () => {
+    const text = 'Call +1-555-867-5309 or email test@example.com';
+    const matches = detectPii(text);
+    const labels = matches.map(m => m.label);
+    expect(labels).toContain('email');
+    expect(labels).toContain('phone_us');
+  });
+
+  it('does not false-positive on UUIDs', () => {
+    const text = 'Task 550e8400-e29b-41d4-a716-446655440000 failed';
+    const matches = detectPii(text);
+    expect(matches).toHaveLength(0);
+  });
+
+  it('returns empty array for clean text', () => {
+    expect(detectPii('Just a normal message')).toHaveLength(0);
+  });
+
+  it('detects extra patterns when provided', () => {
+    const extra = parseExtraPiiPatterns(
+      [{ regex: 'EMP-\\d{6}', replacement: '[EMPLOYEE_ID]' }],
+      'test-config.yaml',
+    );
+    const matches = detectPii('Employee EMP-123456 reported', extra);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].label).toBe('extra_0');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /path/to/worktree test -- src/pii/scrubber.test.ts`
+Expected: FAIL — `detectPii` is not exported
+
+- [ ] **Step 3: Implement `detectPii()` and refactor `scrubPii()`**
+
+In `src/pii/scrubber.ts`:
+
+1. Add the `PiiMatch` interface after the existing `PiiPattern` interface:
+
+```typescript
+/** A single PII match found by detectPii(). */
+export interface PiiMatch {
+  /** Pattern name in lowercase (e.g. "email", "credit_card", "extra_0"). */
+  label: string;
+  /** Start index in the original text. */
+  start: number;
+  /** End index in the original text (exclusive). */
+  end: number;
+  /** The matched substring. */
+  matched: string;
+}
+```
+
+2. Add the `detectPii()` function before `scrubPii()`:
+
+```typescript
+/**
+ * Detect PII in a string, returning matches with labels and positions.
+ * Uses the same openredaction patterns and UUID shielding as scrubPii(),
+ * but returns structured matches instead of replacing them.
+ *
+ * Shared detection foundation: both scrubPii() (blanket replacement for
+ * logs/LLM context) and PiiRedactor (selective replacement for outbound
+ * channels) call this function.
+ *
+ * @param text          The string to scan.
+ * @param extraPatterns Additional patterns from operator config.
+ */
+export function detectPii(text: string, extraPatterns: PiiPattern[] = []): PiiMatch[] {
+  // 1. Shield UUIDs — replace with null bytes of matching length to preserve indices.
+  const shielded = text.replace(UUID_RE, (match) => '\x00'.repeat(match.length));
+
+  // 2. Scan all patterns and collect matches.
+  const matches: PiiMatch[] = [];
+  const allPatterns = [...BUILT_IN_PATTERNS, ...extraPatterns];
+
+  for (const { name, regex } of allPatterns) {
+    regex.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(shielded)) !== null) {
+      // Skip matches that overlap with shielded UUID regions (null bytes).
+      if (m[0].includes('\x00')) continue;
+      matches.push({
+        label: name,
+        start: m.index,
+        end: m.index + m[0].length,
+        matched: text.slice(m.index, m.index + m[0].length),
+      });
+    }
+  }
+
+  // Sort by position (earliest first) for predictable replacement order.
+  matches.sort((a, b) => a.start - b.start);
+  return matches;
+}
+```
+
+3. Refactor `scrubPii()` to delegate to `detectPii()`:
+
+```typescript
+export function scrubPii(text: string, extraPatterns: PiiPattern[] = []): string {
+  const matches = detectPii(text, extraPatterns);
+  if (matches.length === 0) return text;
+
+  // Build result by replacing matches from end to start (preserves indices).
+  const allPatterns = [...BUILT_IN_PATTERNS, ...extraPatterns];
+  let result = text;
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const match = matches[i];
+    const pattern = allPatterns.find(p => p.name === match.label);
+    const replacement = pattern?.replacement ?? `[${match.label.toUpperCase()}]`;
+    result = result.slice(0, match.start) + replacement + result.slice(match.end);
+  }
+  return result;
+}
+```
+
+- [ ] **Step 4: Run all scrubber tests**
+
+Run: `npm --prefix /path/to/worktree test -- src/pii/scrubber.test.ts`
+Expected: ALL tests pass (existing `scrubPii` regression tests + new `detectPii` tests)
+
+- [ ] **Step 5: Run full test suite for regressions**
+
+Run: `npm --prefix /path/to/worktree test`
+Expected: PASS — `scrubPii()` refactor is behaviour-preserving
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pii/scrubber.ts src/pii/scrubber.test.ts
+git commit -m "refactor: extract detectPii() from scrubPii() for shared detection (#249)"
+```
+
+---
+
+### Task 5: Register `outbound.pii-redacted` bus event
+
+**Files:**
+- Modify: `src/bus/events.ts`
+- Modify: `src/bus/permissions.ts`
+
+- [ ] **Step 1: Add the event payload interface**
+
+In `src/bus/events.ts`, after the `OutboundBlockedPayload` interface (around line 107), add:
+
+```typescript
+// OutboundPiiRedactedPayload — emitted by the dispatch layer (via PiiRedactor)
+// when PII is redacted from an outbound message before delivery. The message is
+// still sent (with redacted content); this event provides an audit trail.
+// No subscriber initially — available for future audit UI and alerting rules.
+interface OutboundPiiRedactedPayload {
+  channelId: string;
+  recipientId: string;
+  conversationId: string;
+  redactions: Array<{
+    patternLabel: string;     // e.g. "credit_card"
+    replacedWith: string;     // e.g. "[REDACTED: CREDIT_CARD]"
+  }>;
+}
+```
+
+- [ ] **Step 2: Add the event interface to the discriminated union**
+
+After `OutboundNotificationEvent` (around line 481), add:
+
+```typescript
+// OutboundPiiRedactedEvent — published by the dispatch layer when PII is redacted
+// from an outbound message. The message still sends; this is audit-only.
+export interface OutboundPiiRedactedEvent extends BaseEvent {
+  type: 'outbound.pii-redacted';
+  sourceLayer: 'dispatch';
+  payload: OutboundPiiRedactedPayload;
+}
+```
+
+- [ ] **Step 3: Add to the `BusEvent` union**
+
+In the `BusEvent` type (around line 670), add:
+
+```typescript
+  | OutboundPiiRedactedEvent  // PII outbound redaction: audit trail for redacted PII (#249)
+```
+
+- [ ] **Step 4: Add the factory function**
+
+After `createOutboundNotification` (around line 797), add:
+
+```typescript
+export function createOutboundPiiRedacted(
+  payload: OutboundPiiRedactedPayload & { parentEventId?: string },
+): OutboundPiiRedactedEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'outbound.pii-redacted',
+    sourceLayer: 'dispatch',
+    payload: rest,
+    parentEventId,
+  };
+}
+```
+
+- [ ] **Step 5: Update permissions**
+
+In `src/bus/permissions.ts`:
+
+1. Add `'outbound.pii-redacted'` to the `dispatch` set in `publishAllowlist`
+2. Add `'outbound.pii-redacted'` to the `system` set in both `publishAllowlist` and `subscribeAllowlist`
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `npm --prefix /path/to/worktree test`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/bus/events.ts src/bus/permissions.ts
+git commit -m "feat: register outbound.pii-redacted bus event (#249)"
+```
+
+---
+
+### Task 6: Config schema and YAML
+
+**Files:**
+- Modify: `src/config.ts:225-237`
+- Modify: `schemas/default-config.schema.json:167-184`
+- Modify: `config/default.yaml:206`
+
+- [ ] **Step 1: Extend the TypeScript config interface**
+
+In `src/config.ts`, replace the `pii` block (lines 225-237) with the expanded version that includes `outbound_redaction`:
+
+```typescript
+  pii?: {
+    /**
+     * Extra PII patterns to scrub from LLM-facing error strings, beyond the
+     * built-in defaults (email, phone, credit card, SSN).
+     *
+     * Each entry must have:
+     *   regex       - a valid JavaScript regex string (gi flags applied automatically)
+     *   replacement - the placeholder to substitute, e.g. "[EMPLOYEE_ID]"
+     *
+     * Changes take effect on restart.
+     */
+    extra_patterns?: Array<{ regex: string; replacement: string }>;
+
+    /**
+     * Outbound PII redaction policy - controls which PII patterns are redacted
+     * in outbound channel messages (email, Signal).
+     *
+     * Detection uses the same openredaction library as the log/LLM scrubber.
+     * This config only controls the policy (block/allow per channel).
+     */
+    outbound_redaction?: {
+      /** Kill switch. Default: true. */
+      enabled?: boolean;
+      /** Trust levels that bypass all redaction. Default: ['ceo']. */
+      trust_override?: string[];
+      /** Default action for unlisted pattern/channel combos. Default: 'block'. */
+      default?: 'block' | 'allow';
+      /** Per-channel allow lists. Patterns listed here pass through unredacted. */
+      channel_policies?: Record<string, {
+        /** Pattern labels (lowercase) allowed on this channel. */
+        allow?: string[];
+      }>;
+    };
+  };
+```
+
+- [ ] **Step 2: Extend the JSON schema**
+
+In `schemas/default-config.schema.json`, replace the `pii` object (lines 167-184):
+
+```json
+    "pii": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "extra_patterns": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["regex", "replacement"],
+            "additionalProperties": false,
+            "properties": {
+              "regex": { "type": "string", "minLength": 1 },
+              "replacement": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "outbound_redaction": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "trust_override": {
+              "type": "array",
+              "items": { "type": "string", "enum": ["ceo", "high", "medium", "low"] }
+            },
+            "default": { "type": "string", "enum": ["block", "allow"] },
+            "channel_policies": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "allow": {
+                    "type": "array",
+                    "items": { "type": "string", "minLength": 1 }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+```
+
+- [ ] **Step 3: Add defaults to config/default.yaml**
+
+In `config/default.yaml`, after `extra_patterns: []` (line 206), add:
+
+```yaml
+
+  # Outbound PII redaction policy - controls which PII patterns are redacted
+  # in outbound channel messages (email, Signal replies).
+  #
+  # Detection uses the same openredaction library as the log/LLM scrubber.
+  # This config controls only the policy: which detected patterns are allowed
+  # on which channels. Patterns not in a channel's allow list are redacted.
+  #
+  # trust_override: trust levels that bypass all redaction (CEO gets unredacted
+  # content so they can ask "what phone number do we have for X?" without friction).
+  #
+  # default: 'block' means any detected PII not explicitly allowed is redacted.
+  # You only configure exceptions, not rules.
+  outbound_redaction:
+    enabled: true
+    trust_override: [ceo]
+    default: block
+    channel_policies:
+      email:
+        allow: [email]         # email addresses are fine in email replies
+      signal:
+        allow: []              # everything blocked for Signal (except CEO)
+```
+
+- [ ] **Step 4: Run startup validation test**
+
+Run: `npm --prefix /path/to/worktree test -- tests/unit/startup`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.ts schemas/default-config.schema.json config/default.yaml
+git commit -m "feat: add outbound_redaction config schema and defaults (#249)"
+```
+
+---
+
+### Task 7: Implement `PiiRedactor` class
+
+**Files:**
+- Create: `src/dispatch/pii-redactor.ts`
+- Create: `src/dispatch/pii-redactor.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/dispatch/pii-redactor.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PiiRedactor } from './pii-redactor.js';
+import { createLogger } from '../logger.js';
+import type { EventBus } from '../bus/bus.js';
+
+function createMockBus(): EventBus {
+  return {
+    publish: vi.fn().mockResolvedValue(undefined),
+    subscribe: vi.fn(),
+  } as unknown as EventBus;
+}
+
+const defaultConfig = {
+  enabled: true,
+  trust_override: ['ceo'] as string[],
+  default: 'block' as const,
+  channel_policies: {
+    email: { allow: ['email'] },
+    signal: { allow: [] },
+  },
+};
+
+describe('PiiRedactor', () => {
+  let bus: EventBus;
+  let redactor: PiiRedactor;
+
+  beforeEach(() => {
+    bus = createMockBus();
+    redactor = new PiiRedactor({
+      config: defaultConfig,
+      bus,
+      logger: createLogger('error'),
+      extraPatterns: [],
+    });
+  });
+
+  it('redacts a credit card number in email channel', async () => {
+    const result = await redactor.redact(
+      'Your card is 4111 1111 1111 1111.',
+      'email',
+      'medium',
+    );
+    expect(result.content).toContain('[REDACTED: CREDIT_CARD]');
+    expect(result.content).not.toContain('4111');
+    expect(result.redactions).toHaveLength(1);
+    expect(result.redactions[0].patternLabel).toBe('credit_card');
+  });
+
+  it('allows email addresses in email channel (in allow list)', async () => {
+    const result = await redactor.redact(
+      'Contact user@example.com for help.',
+      'email',
+      'medium',
+    );
+    expect(result.content).toContain('user@example.com');
+    expect(result.redactions).toHaveLength(0);
+  });
+
+  it('redacts email addresses in signal channel (not in allow list)', async () => {
+    const result = await redactor.redact(
+      'Contact user@example.com for help.',
+      'signal',
+      'medium',
+    );
+    expect(result.content).toContain('[REDACTED: EMAIL]');
+    expect(result.content).not.toContain('user@example.com');
+  });
+
+  it('bypasses redaction for CEO trust level', async () => {
+    const result = await redactor.redact(
+      'Your card is 4111 1111 1111 1111.',
+      'email',
+      'ceo',
+    );
+    expect(result.content).toContain('4111 1111 1111 1111');
+    expect(result.redactions).toHaveLength(0);
+  });
+
+  it('bypasses redaction when disabled', async () => {
+    const disabled = new PiiRedactor({
+      config: { ...defaultConfig, enabled: false },
+      bus,
+      logger: createLogger('error'),
+      extraPatterns: [],
+    });
+    const result = await disabled.redact(
+      'Card: 4111 1111 1111 1111',
+      'email',
+      'medium',
+    );
+    expect(result.content).toContain('4111 1111 1111 1111');
+  });
+
+  it('blocks all PII on unlisted channels (default: block)', async () => {
+    const result = await redactor.redact(
+      'Contact user@example.com',
+      'sms',
+      'medium',
+    );
+    expect(result.content).toContain('[REDACTED: EMAIL]');
+  });
+
+  it('handles multiple PII matches in one message', async () => {
+    const result = await redactor.redact(
+      'Card 4111 1111 1111 1111 and phone +1-555-867-5309',
+      'email',
+      'medium',
+    );
+    expect(result.content).toContain('[REDACTED: CREDIT_CARD]');
+    expect(result.content).toContain('[REDACTED: PHONE]');
+    expect(result.redactions.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('returns original content when no PII detected', async () => {
+    const text = 'Just a normal message with no PII.';
+    const result = await redactor.redact(text, 'email', 'medium');
+    expect(result.content).toBe(text);
+    expect(result.redactions).toHaveLength(0);
+  });
+
+  it('does not publish bus event when no redactions', async () => {
+    await redactor.redact('Clean message', 'email', 'medium');
+    expect(bus.publish).not.toHaveBeenCalled();
+  });
+
+  it('publishes outbound.pii-redacted event on redaction', async () => {
+    await redactor.redact(
+      'Card: 4111 1111 1111 1111',
+      'email',
+      'medium',
+      { conversationId: 'conv-1', recipientId: 'recipient@example.com' },
+    );
+    expect(bus.publish).toHaveBeenCalledWith(
+      'dispatch',
+      expect.objectContaining({
+        type: 'outbound.pii-redacted',
+        payload: expect.objectContaining({
+          channelId: 'email',
+          recipientId: 'recipient@example.com',
+          conversationId: 'conv-1',
+        }),
+      }),
+    );
+  });
+
+  it('does not publish bus event for CEO bypass', async () => {
+    await redactor.redact('Card: 4111 1111 1111 1111', 'email', 'ceo');
+    expect(bus.publish).not.toHaveBeenCalled();
+  });
+
+  it('does not include original PII values in redaction entries', async () => {
+    const result = await redactor.redact(
+      'Card: 4111 1111 1111 1111',
+      'email',
+      'medium',
+    );
+    const entry = result.redactions[0];
+    expect(JSON.stringify(entry)).not.toContain('4111');
+  });
+
+  it('null trust level is treated as untrusted (PII redacted)', async () => {
+    const result = await redactor.redact(
+      'Card: 4111 1111 1111 1111',
+      'email',
+      null,
+    );
+    expect(result.content).toContain('[REDACTED: CREDIT_CARD]');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /path/to/worktree test -- src/dispatch/pii-redactor.test.ts`
+Expected: FAIL — module does not exist
+
+- [ ] **Step 3: Implement `PiiRedactor`**
+
+Create `src/dispatch/pii-redactor.ts`:
+
+```typescript
+// pii-redactor.ts -- context-aware PII redaction for outbound channel messages.
+//
+// Sits as a pipeline step in OutboundGateway between the blocked-contact check
+// and the content filter. Detects PII using openredaction (via the shared
+// detectPii() function) and selectively redacts based on channel policy and
+// recipient trust level.
+//
+// Design: fail-closed. If detection throws, the caller (OutboundGateway)
+// should block the message rather than sending unredacted content.
+
+import { detectPii, type PiiPattern, type PiiMatch } from '../pii/scrubber.js';
+import { meetsMinimumTrust, type TrustLevel } from '../contacts/types.js';
+import { createOutboundPiiRedacted } from '../bus/events.js';
+import type { EventBus } from '../bus/bus.js';
+import type { Logger } from '../logger.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface RedactionEntry {
+  patternLabel: string;     // e.g. "credit_card"
+  channelId: string;        // e.g. "email"
+  replacedWith: string;     // e.g. "[REDACTED: CREDIT_CARD]"
+  // Original value is intentionally NOT stored.
+}
+
+export interface RedactionResult {
+  /** Modified content (or original if nothing was redacted). */
+  content: string;
+  /** What was redacted -- for logging and audit. */
+  redactions: RedactionEntry[];
+}
+
+export interface OutboundRedactionConfig {
+  enabled: boolean;
+  trust_override: string[];
+  default: 'block' | 'allow';
+  channel_policies: Record<string, { allow: string[] }>;
+}
+
+export interface PiiRedactorConfig {
+  config: OutboundRedactionConfig;
+  bus: EventBus;
+  logger: Logger;
+  extraPatterns: PiiPattern[];
+}
+
+// ---------------------------------------------------------------------------
+// PiiRedactor
+// ---------------------------------------------------------------------------
+
+export class PiiRedactor {
+  private readonly config: OutboundRedactionConfig;
+  private readonly bus: EventBus;
+  private readonly log: Logger;
+  private readonly extraPatterns: PiiPattern[];
+
+  constructor(opts: PiiRedactorConfig) {
+    this.config = opts.config;
+    this.bus = opts.bus;
+    this.log = opts.logger.child({ component: 'pii-redactor' });
+    this.extraPatterns = opts.extraPatterns;
+  }
+
+  /**
+   * Scan content for PII and redact based on channel policy and trust level.
+   *
+   * @param content    The outbound message body.
+   * @param channelId  Target channel (e.g. 'email', 'signal').
+   * @param trustLevel Recipient's trust level (null = unknown/untrusted).
+   * @param context    Optional context for the audit event.
+   */
+  async redact(
+    content: string,
+    channelId: string,
+    trustLevel: TrustLevel | null,
+    context?: { conversationId?: string; recipientId?: string },
+  ): Promise<RedactionResult> {
+    // 1. Kill switch.
+    if (!this.config.enabled) {
+      return { content, redactions: [] };
+    }
+
+    // 2. Trust override -- if recipient meets or exceeds any override level,
+    //    skip redaction entirely (CEO gets full PII access).
+    for (const overrideLevel of this.config.trust_override) {
+      if (meetsMinimumTrust(trustLevel, overrideLevel as TrustLevel)) {
+        return { content, redactions: [] };
+      }
+    }
+
+    // 3. Detect PII using shared openredaction-based detection.
+    const matches = detectPii(content, this.extraPatterns);
+    if (matches.length === 0) {
+      return { content, redactions: [] };
+    }
+
+    // 4. Apply channel policy.
+    const channelPolicy = this.config.channel_policies[channelId];
+    const allowList = new Set(
+      (channelPolicy?.allow ?? []).map(l => l.toLowerCase()),
+    );
+
+    // Determine which matches to redact (those not in the allow list).
+    const toRedact: PiiMatch[] = matches.filter(
+      m => !allowList.has(m.label.toLowerCase()),
+    );
+
+    if (toRedact.length === 0) {
+      return { content, redactions: [] };
+    }
+
+    // 5. Redact -- replace from end to start to preserve indices.
+    const redactions: RedactionEntry[] = [];
+    let result = content;
+    for (let i = toRedact.length - 1; i >= 0; i--) {
+      const match = toRedact[i];
+      const replacement = `[REDACTED: ${match.label.toUpperCase()}]`;
+      result = result.slice(0, match.start) + replacement + result.slice(match.end);
+      redactions.push({
+        patternLabel: match.label,
+        channelId,
+        replacedWith: replacement,
+      });
+    }
+    // Reverse so redactions are in document order.
+    redactions.reverse();
+
+    // 6. Log and publish audit event.
+    this.log.info(
+      {
+        event: 'pii_redacted',
+        channelId,
+        recipientTrustLevel: trustLevel,
+        redactions: redactions.map(r => ({ patternLabel: r.patternLabel })),
+        redactionCount: redactions.length,
+        conversationId: context?.conversationId,
+      },
+      'pii-redactor: redacted PII from outbound message',
+    );
+
+    // Publish bus event -- fire-and-forget. Failure does not block the send.
+    this.bus.publish(
+      'dispatch',
+      createOutboundPiiRedacted({
+        channelId,
+        recipientId: context?.recipientId ?? '',
+        conversationId: context?.conversationId ?? '',
+        redactions: redactions.map(r => ({
+          patternLabel: r.patternLabel,
+          replacedWith: r.replacedWith,
+        })),
+      }),
+    ).catch((err) => {
+      this.log.warn(
+        { err, channelId },
+        'pii-redactor: failed to publish outbound.pii-redacted event',
+      );
+    });
+
+    return { content: result, redactions };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm --prefix /path/to/worktree test -- src/dispatch/pii-redactor.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/dispatch/pii-redactor.ts src/dispatch/pii-redactor.test.ts
+git commit -m "feat: implement PiiRedactor with channel-aware redaction (#249)"
+```
+
+---
+
+### Task 8: Wire `PiiRedactor` into `OutboundGateway`
+
+**Files:**
+- Modify: `src/skills/outbound-gateway.ts`
+- Modify: `tests/unit/skills/outbound-gateway.test.ts`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Add to `tests/unit/skills/outbound-gateway.test.ts`:
+
+```typescript
+import { PiiRedactor } from '../../../src/dispatch/pii-redactor.js';
+
+describe('PII redaction step', () => {
+  it('redacts PII for non-CEO recipients before sending', async () => {
+    (mocks.contactService.resolveByChannelIdentity as ReturnType<typeof vi.fn>).mockResolvedValue({
+      contactId: 'contact-1',
+      displayName: 'Test User',
+      role: null,
+      status: 'confirmed',
+      kgNodeId: null,
+      verified: true,
+      trustLevel: 'medium',
+    });
+
+    const piiRedactor = new PiiRedactor({
+      config: {
+        enabled: true,
+        trust_override: ['ceo'],
+        default: 'block',
+        channel_policies: { email: { allow: ['email'] } },
+      },
+      bus: mocks.bus,
+      logger: mocks.logger,
+      extraPatterns: [],
+    });
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      piiRedactor,
+    });
+
+    const result = await gateway.send({
+      channel: 'email',
+      to: 'test@example.com',
+      subject: 'Booking',
+      body: 'Your card 4111 1111 1111 1111 was charged.',
+    });
+
+    expect(result.success).toBe(true);
+    // Verify the content filter received redacted content
+    const filterCall = (mocks.contentFilter.check as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(filterCall.content).toContain('[REDACTED: CREDIT_CARD]');
+    expect(filterCall.content).not.toContain('4111');
+  });
+
+  it('does NOT redact PII for CEO recipients', async () => {
+    (mocks.contactService.resolveByChannelIdentity as ReturnType<typeof vi.fn>).mockResolvedValue({
+      contactId: 'contact-ceo',
+      displayName: 'CEO',
+      role: null,
+      status: 'confirmed',
+      kgNodeId: null,
+      verified: true,
+      trustLevel: 'ceo',
+    });
+
+    const piiRedactor = new PiiRedactor({
+      config: {
+        enabled: true,
+        trust_override: ['ceo'],
+        default: 'block',
+        channel_policies: { email: { allow: ['email'] } },
+      },
+      bus: mocks.bus,
+      logger: mocks.logger,
+      extraPatterns: [],
+    });
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      piiRedactor,
+    });
+
+    const result = await gateway.send({
+      channel: 'email',
+      to: 'ceo@example.com',
+      subject: 'Booking',
+      body: 'Your card 4111 1111 1111 1111 was charged.',
+    });
+
+    expect(result.success).toBe(true);
+    const filterCall = (mocks.contentFilter.check as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(filterCall.content).toContain('4111 1111 1111 1111');
+  });
+
+  it('works without piiRedactor configured (backwards compatible)', async () => {
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      // no piiRedactor
+    });
+
+    const result = await gateway.send({
+      channel: 'email',
+      to: 'test@example.com',
+      subject: 'Test',
+      body: 'Card: 4111 1111 1111 1111',
+    });
+
+    expect(result.success).toBe(true);
+    // Without redactor, content passes through unmodified
+    const filterCall = (mocks.contentFilter.check as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(filterCall.content).toContain('4111 1111 1111 1111');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /path/to/worktree test -- tests/unit/skills/outbound-gateway.test.ts`
+Expected: FAIL — gateway doesn't accept or use `piiRedactor`
+
+- [ ] **Step 3: Add PiiRedactor to the gateway**
+
+In `src/skills/outbound-gateway.ts`:
+
+1. Add imports:
+
+```typescript
+import { PiiRedactor } from '../dispatch/pii-redactor.js';
+```
+
+2. Add to `OutboundGatewayConfig` interface:
+
+```typescript
+  /**
+   * PII redactor -- context-aware redaction for outbound messages.
+   * Runs as a pipeline step after blocked-contact check, before content filter.
+   * Optional -- when absent, no PII redaction is performed.
+   */
+  piiRedactor?: PiiRedactor;
+```
+
+3. Add private field and constructor assignment:
+
+```typescript
+  private readonly piiRedactor?: PiiRedactor;
+```
+
+In constructor:
+```typescript
+    this.piiRedactor = config.piiRedactor;
+```
+
+4. In `send()`, after the blocked-contact check (after line 309 where `recipientTrustLevel` is captured), insert the redaction step. Then update the content filter call and dispatch calls to use `redactedBody`.
+
+See the design spec for the exact pipeline position and fail-closed error handling pattern.
+
+The key changes:
+- Add `let redactedBody = messageBody;` after the blocked-contact check
+- If `this.piiRedactor` exists, call `redact()` and update `redactedBody`
+- Wrap in try/catch with fail-closed behaviour (block on error)
+- Change the content filter's `content:` from `messageBody` to `redactedBody`
+- Change the dispatch method calls from `messageBody` to `redactedBody`
+
+- [ ] **Step 4: Run all gateway tests**
+
+Run: `npm --prefix /path/to/worktree test -- tests/unit/skills/outbound-gateway.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npm --prefix /path/to/worktree test`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/skills/outbound-gateway.ts tests/unit/skills/outbound-gateway.test.ts
+git commit -m "feat: wire PiiRedactor into OutboundGateway pipeline (#249)"
+```
+
+---
+
+### Task 9: Wire `PiiRedactor` in bootstrap (`index.ts`)
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add PiiRedactor initialization**
+
+In `src/index.ts`, after the existing PII pattern loading block (around line 946), add the `PiiRedactor` construction. Import `PiiRedactor` at the top of the file.
+
+The redactor needs:
+- Config from `yamlConfig.pii?.outbound_redaction` (with defaults)
+- The `bus` instance (already available)
+- The `logger` instance (already available)
+- The parsed extra patterns (reuse the variable from the existing PII pattern loading block, or re-parse if the variable is scoped inside the `if` block -- check and adjust)
+
+Then pass `piiRedactor` to the `OutboundGateway` constructor.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `npm --prefix /path/to/worktree test`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: wire PiiRedactor into bootstrap orchestrator (#249)"
+```
+
+---
+
+### Task 10: CHANGELOG and final verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add changelog entries**
+
+Under `## [Unreleased]`, add:
+
+```markdown
+### Added
+- **PII outbound redaction** -- configurable per-channel PII redaction for outbound messages. Detected PII (credit cards, phone numbers, SSNs, etc.) is redacted in email and Signal replies based on channel policy. CEO trust level bypasses redaction. Publishes `outbound.pii-redacted` audit event. (#249)
+
+### Changed
+- **Trust levels** -- added `'ceo'` trust level above `'high'` with ordinal comparison via `meetsMinimumTrust()` helper. Existing `checkContactDataLeak` rule now uses ordinal comparison instead of `=== 'high'`. (#249)
+```
+
+- [ ] **Step 2: Run full test suite one final time**
+
+Run: `npm --prefix /path/to/worktree test`
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: add CHANGELOG entries for PII outbound redaction (#249)"
+```
+
+- [ ] **Step 4: Push branch and run pre-PR review agents**
+
+Push the branch, then run the review agents (code-reviewer, silent-failure-hunter) before creating the PR, per project rules.

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -179,6 +179,31 @@
               "replacement": { "type": "string", "minLength": 1 }
             }
           }
+        },
+        "outbound_redaction": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "trust_override": {
+              "type": "array",
+              "items": { "type": "string", "enum": ["ceo", "high", "medium", "low"] }
+            },
+            "default": { "type": "string", "enum": ["block", "allow"] },
+            "channel_policies": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "allow": {
+                    "type": "array",
+                    "items": { "type": "string", "minLength": 1 }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -93,6 +93,20 @@ interface OutboundMessagePayload {
   recipientId?: string;
 }
 
+// OutboundPiiRedactedPayload — emitted by the dispatch layer (via PiiRedactor)
+// when PII is redacted from an outbound message before delivery. The message is
+// still sent (with redacted content); this event provides an audit trail.
+// No subscriber initially — available for future audit UI and alerting rules.
+interface OutboundPiiRedactedPayload {
+  channelId: string;
+  recipientId: string;
+  conversationId: string;
+  redactions: Array<{
+    patternLabel: string;     // e.g. "credit_card"
+    replacedWith: string;     // e.g. "[REDACTED: CREDIT_CARD]"
+  }>;
+}
+
 // OutboundBlockedPayload — emitted by the dispatch layer's content filter when an outbound
 // message is blocked before delivery. `findings` lists each rule that triggered and why,
 // providing an audit trail for security review and incident response.
@@ -470,6 +484,15 @@ export interface OutboundBlockedEvent extends BaseEvent {
   payload: OutboundBlockedPayload;
 }
 
+// OutboundPiiRedactedEvent — published by the dispatch layer when PII is redacted from
+// an outbound message before delivery. The message is still sent (with redacted content).
+// No subscriber initially — event is available for future audit UI and alerting rules.
+export interface OutboundPiiRedactedEvent extends BaseEvent {
+  type: 'outbound.pii-redacted';
+  sourceLayer: 'dispatch';
+  payload: OutboundPiiRedactedPayload;
+}
+
 // OutboundNotificationEvent — published by the dispatch layer when a system-level CEO
 // notification needs to be sent (blocked-content alert, group-held alert, etc.).
 // Channel adapters subscribe to route it through the outbound safety pipeline.
@@ -685,6 +708,7 @@ export type BusEvent =
   | MessageHeldEvent      // Unknown sender policy: message held for CEO review
   | MessageRejectedEvent  // Unknown sender policy: message rejected, signals HTTP adapter to return 403
   | OutboundBlockedEvent  // Outbound content filter: message blocked before delivery (#38)
+  | OutboundPiiRedactedEvent // Outbound PII redaction: PII scrubbed before delivery (#249)
   | OutboundNotificationEvent // System notifications routed through safety pipeline (#206)
   | ScheduleCreatedEvent   // Scheduler: job created
   | ScheduleFiredEvent     // Scheduler: job fired
@@ -774,6 +798,22 @@ export function createOutboundBlocked(
     id: randomUUID(),
     timestamp: new Date(),
     type: 'outbound.blocked',
+    sourceLayer: 'dispatch',
+    payload: rest,
+    parentEventId,
+  };
+}
+
+export function createOutboundPiiRedacted(
+  // parentEventId is optional — PII redaction events may trace back to the outbound.message
+  // that triggered the redaction, but this link is advisory rather than required.
+  payload: OutboundPiiRedactedPayload & { parentEventId?: string },
+): OutboundPiiRedactedEvent {
+  const { parentEventId, ...rest } = payload;
+  return {
+    id: randomUUID(),
+    timestamp: new Date(),
+    type: 'outbound.pii-redacted',
     sourceLayer: 'dispatch',
     payload: rest,
     parentEventId,

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -19,12 +19,14 @@ import type { Layer, EventType } from './events.js';
 //          system layer gets full access for audit logging and monitoring.
 // Observation mode (#311): dispatch layer publishes observation.triage.completed after each
 //          observation-mode task; system layer subscribes for audit logging and monitoring.
+// PII redaction (#249): dispatch layer publishes outbound.pii-redacted when PII is scrubbed
+//          from an outbound message; system layer gets full access for future audit subscribers.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message']),
-  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'outbound.notification', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint', 'human.decision', 'observation.triage.completed', 'autonomy.send_blocked']),
+  dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'outbound.pii-redacted', 'outbound.notification', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint', 'human.decision', 'observation.triage.completed', 'autonomy.send_blocked']),
   agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss', 'llm.call']),
   execution: new Set(['skill.result', 'secret.accessed', 'autonomy.skill_blocked']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed', 'observation.triage.completed', 'autonomy.skill_blocked', 'autonomy.send_blocked']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.pii-redacted', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed', 'observation.triage.completed', 'autonomy.skill_blocked', 'autonomy.send_blocked']),
 };
 
 // agent.discuss subscribe for 'dispatch': used by BullpenDispatcher (wired in index.ts after agent registration).
@@ -33,7 +35,7 @@ const subscribeAllowlist: Record<Layer, Set<EventType>> = {
   dispatch: new Set(['inbound.message', 'agent.response', 'agent.error', 'agent.discuss']),
   agent: new Set(['agent.task', 'skill.result']),
   execution: new Set(['skill.invoke']),
-  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed', 'observation.triage.completed', 'autonomy.skill_blocked', 'autonomy.send_blocked']),
+  system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.pii-redacted', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed', 'observation.triage.completed', 'autonomy.skill_blocked', 'autonomy.send_blocked']),
 };
 
 export function canPublish(layer: Layer, eventType: EventType): boolean {

--- a/src/config.ts
+++ b/src/config.ts
@@ -234,6 +234,27 @@ export interface YamlConfig {
      * Changes take effect on restart.
      */
     extra_patterns?: Array<{ regex: string; replacement: string }>;
+    /**
+     * Outbound PII redaction policy - controls which PII patterns are redacted
+     * in outbound channel messages (email, Signal).
+     *
+     * Detection uses the same openredaction library as the log/LLM scrubber.
+     * This config controls only the policy: which detected patterns are allowed
+     * on which channels. Patterns not in a channel's allow list are redacted.
+     */
+    outbound_redaction?: {
+      /** Kill switch. Default: true. */
+      enabled?: boolean;
+      /** Trust levels that bypass all redaction entirely. Default: ['ceo']. */
+      trust_override?: string[];
+      /** Default action for unlisted pattern/channel combos. Default: 'block'. */
+      default?: 'block' | 'allow';
+      /** Per-channel allow lists. Patterns listed here pass through unredacted. */
+      channel_policies?: Record<string, {
+        /** Pattern labels (lowercase) allowed on this channel. */
+        allow?: string[];
+      }>;
+    };
   };
   intentDrift?: {
     /** Enable intent drift detection. Default: true. */

--- a/src/contacts/authorization.ts
+++ b/src/contacts/authorization.ts
@@ -26,8 +26,9 @@ export interface AuthEvaluateInput {
   overrides: AuthOverrideInput[];
 }
 
-// Trust level numeric values for comparison.
+// Trust level numeric values for comparison. 'ceo' ranks above 'high'.
 const TRUST_RANK: Record<TrustLevel, number> = {
+  ceo: 4,
   high: 3,
   medium: 2,
   low: 1,

--- a/src/contacts/authorization.ts
+++ b/src/contacts/authorization.ts
@@ -13,6 +13,7 @@ import type {
   ContactStatus,
   TrustLevel,
 } from './types.js';
+import { TRUST_RANK } from './types.js';
 
 interface AuthOverrideInput {
   permission: string;
@@ -25,14 +26,6 @@ export interface AuthEvaluateInput {
   channel: string;
   overrides: AuthOverrideInput[];
 }
-
-// Trust level numeric values for comparison. 'ceo' ranks above 'high'.
-const TRUST_RANK: Record<TrustLevel, number> = {
-  ceo: 4,
-  high: 3,
-  medium: 2,
-  low: 1,
-};
 
 /**
  * Deterministic authorization service.

--- a/src/contacts/authorization.ts
+++ b/src/contacts/authorization.ts
@@ -11,7 +11,6 @@ import type {
   AuthConfig,
   AuthorizationResult,
   ContactStatus,
-  TrustLevel,
 } from './types.js';
 import { TRUST_RANK } from './types.js';
 

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -68,19 +68,19 @@ export async function bootstrapCeoContact(
     const { contact_id, contact_status, identity_verified, display_name: existingName } = existing.rows[0];
     let { kg_node_id } = existing.rows[0];
 
-    // Always ensure role = 'ceo' and trust_level = 'high' on the CEO contact regardless
+    // Always ensure role = 'ceo' and trust_level = 'ceo' on the CEO contact regardless
     // of which path brought us here. This is idempotent — the UPDATE is a no-op when both
-    // are already correct. Without trust_level = 'high', a second CEO email address linked
+    // are already correct. Without trust_level = 'ceo', a second CEO email address linked
     // to the same contact would not match the single CEO_PRIMARY_EMAIL config string and
     // would fail the outbound filter's trust check. Setting role keeps metadata consistent
     // even if the contact was initially auto-created without a role.
     await pool.query(
       `UPDATE contacts
        SET role = 'ceo',
-           trust_level = 'high',
+           trust_level = 'ceo',
            updated_at = now()
        WHERE id = $1
-         AND (role IS DISTINCT FROM 'ceo' OR trust_level IS DISTINCT FROM 'high')`,
+         AND (role IS DISTINCT FROM 'ceo' OR trust_level IS DISTINCT FROM 'ceo')`,
       [contact_id],
     );
 
@@ -142,7 +142,7 @@ export async function bootstrapCeoContact(
     await client.query('BEGIN');
     await client.query(
       `INSERT INTO contacts (id, kg_node_id, display_name, role, status, trust_level, created_at, updated_at)
-       VALUES ($1, $2, $3, 'ceo', 'confirmed', 'high', now(), now())`,
+       VALUES ($1, $2, $3, 'ceo', 'confirmed', 'ceo', now(), now())`,
       [contactId, kgNodeId, displayName],
     );
     await client.query(

--- a/src/contacts/ceo-bootstrap.ts
+++ b/src/contacts/ceo-bootstrap.ts
@@ -74,15 +74,23 @@ export async function bootstrapCeoContact(
     // to the same contact would not match the single CEO_PRIMARY_EMAIL config string and
     // would fail the outbound filter's trust check. Setting role keeps metadata consistent
     // even if the contact was initially auto-created without a role.
-    await pool.query(
-      `UPDATE contacts
-       SET role = 'ceo',
-           trust_level = 'ceo',
-           updated_at = now()
-       WHERE id = $1
-         AND (role IS DISTINCT FROM 'ceo' OR trust_level IS DISTINCT FROM 'ceo')`,
-      [contact_id],
-    );
+    try {
+      await pool.query(
+        `UPDATE contacts
+         SET role = 'ceo',
+             trust_level = 'ceo',
+             updated_at = now()
+         WHERE id = $1
+           AND (role IS DISTINCT FROM 'ceo' OR trust_level IS DISTINCT FROM 'ceo')`,
+        [contact_id],
+      );
+    } catch (err) {
+      logger.error(
+        { err, contactId: contact_id },
+        'ceo-bootstrap: failed to set trust_level=ceo on CEO contact — PII redaction bypass will not apply until this is resolved',
+      );
+      throw err;
+    }
 
     // Backfill KG node if missing. This handles existing deployments where the contact
     // was created without a KG node (pre-#380 fix). Uses the contact's existing display_name

--- a/src/contacts/config-loader.ts
+++ b/src/contacts/config-loader.ts
@@ -55,7 +55,8 @@ export function loadAuthConfig(configDir: string): AuthConfig {
 
   const permissions: Record<string, PermissionDef> = {};
   for (const [permName, entry] of Object.entries(permsTyped.permissions)) {
-    const sensitivity = entry.sensitivity as TrustLevel;
+    // Permission sensitivity uses only high/medium/low — 'ceo' is a contact trust level, not a sensitivity.
+    const sensitivity = entry.sensitivity as 'high' | 'medium' | 'low';
     if (!['high', 'medium', 'low'].includes(sensitivity)) {
       throw new Error(`Invalid sensitivity '${sensitivity}' for permission '${permName}'`);
     }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -14,6 +14,7 @@ import type { DbPool } from '../db/connection.js';
 import type { Logger } from '../logger.js';
 import type { EntityMemory } from '../memory/entity-memory.js';
 import { sanitizeDisplayName } from '../skills/sanitize.js';
+import { TRUST_RANK } from './types.js';
 import type {
   AuthOverride,
   Contact,
@@ -948,7 +949,7 @@ class PostgresContactBackend implements ContactServiceBackend {
       // Validate trust_level against the allowed enum — the DB CHECK constraint prevents
       // invalid values under normal operation, but a direct DB edit or future migration
       // could introduce an unexpected value that produces NaN via an undefined lookup.
-      trustLevel: (['ceo', 'high', 'medium', 'low'] as TrustLevel[]).includes(row.trust_level as TrustLevel)
+      trustLevel: (Object.keys(TRUST_RANK) as TrustLevel[]).includes(row.trust_level as TrustLevel)
         ? row.trust_level as TrustLevel
         : null,
     };
@@ -1154,7 +1155,7 @@ class PostgresContactBackend implements ContactServiceBackend {
         const v = parseFloat(row.contact_confidence);
         return isFinite(v) ? v : 0.0;
       })(),
-      trustLevel: (['ceo', 'high', 'medium', 'low'] as TrustLevel[]).includes(row.trust_level as TrustLevel)
+      trustLevel: (Object.keys(TRUST_RANK) as TrustLevel[]).includes(row.trust_level as TrustLevel)
         ? row.trust_level as TrustLevel
         : null,
       lastSeenAt: row.last_seen_at,

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -948,7 +948,7 @@ class PostgresContactBackend implements ContactServiceBackend {
       // Validate trust_level against the allowed enum — the DB CHECK constraint prevents
       // invalid values under normal operation, but a direct DB edit or future migration
       // could introduce an unexpected value that produces NaN via an undefined lookup.
-      trustLevel: (['high', 'medium', 'low'] as TrustLevel[]).includes(row.trust_level as TrustLevel)
+      trustLevel: (['ceo', 'high', 'medium', 'low'] as TrustLevel[]).includes(row.trust_level as TrustLevel)
         ? row.trust_level as TrustLevel
         : null,
     };
@@ -1154,7 +1154,7 @@ class PostgresContactBackend implements ContactServiceBackend {
         const v = parseFloat(row.contact_confidence);
         return isFinite(v) ? v : 0.0;
       })(),
-      trustLevel: (['high', 'medium', 'low'] as TrustLevel[]).includes(row.trust_level as TrustLevel)
+      trustLevel: (['ceo', 'high', 'medium', 'low'] as TrustLevel[]).includes(row.trust_level as TrustLevel)
         ? row.trust_level as TrustLevel
         : null,
       lastSeenAt: row.last_seen_at,

--- a/src/contacts/types.test.ts
+++ b/src/contacts/types.test.ts
@@ -21,6 +21,7 @@ describe('meetsMinimumTrust', () => {
   });
 
   it('medium meets medium and below', () => {
+    expect(meetsMinimumTrust('medium', 'ceo')).toBe(false);
     expect(meetsMinimumTrust('medium', 'high')).toBe(false);
     expect(meetsMinimumTrust('medium', 'medium')).toBe(true);
     expect(meetsMinimumTrust('medium', 'low')).toBe(true);

--- a/src/contacts/types.test.ts
+++ b/src/contacts/types.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { meetsMinimumTrust } from './types.js';
+
+describe('meetsMinimumTrust', () => {
+  it('returns false for null trust level', () => {
+    expect(meetsMinimumTrust(null, 'low')).toBe(false);
+  });
+
+  it('ceo meets all trust levels', () => {
+    expect(meetsMinimumTrust('ceo', 'ceo')).toBe(true);
+    expect(meetsMinimumTrust('ceo', 'high')).toBe(true);
+    expect(meetsMinimumTrust('ceo', 'medium')).toBe(true);
+    expect(meetsMinimumTrust('ceo', 'low')).toBe(true);
+  });
+
+  it('high meets high and below but not ceo', () => {
+    expect(meetsMinimumTrust('high', 'ceo')).toBe(false);
+    expect(meetsMinimumTrust('high', 'high')).toBe(true);
+    expect(meetsMinimumTrust('high', 'medium')).toBe(true);
+    expect(meetsMinimumTrust('high', 'low')).toBe(true);
+  });
+
+  it('medium meets medium and below', () => {
+    expect(meetsMinimumTrust('medium', 'high')).toBe(false);
+    expect(meetsMinimumTrust('medium', 'medium')).toBe(true);
+    expect(meetsMinimumTrust('medium', 'low')).toBe(true);
+  });
+
+  it('low meets only low', () => {
+    expect(meetsMinimumTrust('low', 'medium')).toBe(false);
+    expect(meetsMinimumTrust('low', 'low')).toBe(true);
+  });
+});

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -133,7 +133,8 @@ export type TrustLevel = 'ceo' | 'high' | 'medium' | 'low';
 
 // Ordinal ranking for trust level comparison. Higher rank = more trusted.
 // Used by meetsMinimumTrust() so callers don't need to enumerate every level.
-const TRUST_RANK: Record<TrustLevel, number> = {
+// Exported so authorization.ts and other consumers share the same single source of truth.
+export const TRUST_RANK: Record<TrustLevel, number> = {
   low: 0,
   medium: 1,
   high: 2,

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -129,7 +129,28 @@ export interface PermissionDef {
   sensitivity: 'high' | 'medium' | 'low';
 }
 
-export type TrustLevel = 'high' | 'medium' | 'low';
+export type TrustLevel = 'ceo' | 'high' | 'medium' | 'low';
+
+// Ordinal ranking for trust level comparison. Higher rank = more trusted.
+// Used by meetsMinimumTrust() so callers don't need to enumerate every level.
+const TRUST_RANK: Record<TrustLevel, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  ceo: 3,
+};
+
+/**
+ * Check whether an actual trust level meets or exceeds a required minimum.
+ * Returns false for null (unknown contacts default to untrusted).
+ */
+export function meetsMinimumTrust(
+  actual: TrustLevel | null,
+  required: TrustLevel,
+): boolean {
+  if (actual === null) return false;
+  return TRUST_RANK[actual] >= TRUST_RANK[required];
+}
 
 export interface AuthorizationResult {
   allowed: string[];

--- a/src/db/migrations/030_ceo_trust_level_ceo.sql
+++ b/src/db/migrations/030_ceo_trust_level_ceo.sql
@@ -1,0 +1,14 @@
+-- Migration 030: Elevate CEO contact trust level from 'high' to 'ceo'
+--
+-- The 'ceo' level sits above 'high' in the ordinal ranking, enabling
+-- trust-based policy decisions (e.g. PII redaction bypass) that should
+-- only apply to the principal, not all high-trust contacts.
+--
+-- Reversal: UPDATE contacts SET trust_level = 'high'
+--           WHERE trust_level = 'ceo' AND role = 'ceo';
+
+UPDATE contacts
+SET    trust_level = 'ceo',
+       updated_at  = now()
+WHERE  trust_level = 'high'
+AND    role = 'ceo';

--- a/src/db/migrations/030_ceo_trust_level_ceo.sql
+++ b/src/db/migrations/030_ceo_trust_level_ceo.sql
@@ -4,9 +4,22 @@
 -- trust-based policy decisions (e.g. PII redaction bypass) that should
 -- only apply to the principal, not all high-trust contacts.
 --
--- Reversal: UPDATE contacts SET trust_level = 'high'
---           WHERE trust_level = 'ceo' AND role = 'ceo';
+-- Requires widening the contacts_trust_level_check constraint (added in
+-- migration 020) to include the new 'ceo' value before the UPDATE can run.
+--
+-- Reversal:
+--   UPDATE contacts SET trust_level = 'high', updated_at = now()
+--     WHERE trust_level = 'ceo' AND role = 'ceo';
+--   ALTER TABLE contacts DROP CONSTRAINT contacts_trust_level_check;
+--   ALTER TABLE contacts ADD CONSTRAINT contacts_trust_level_check
+--     CHECK (trust_level IN ('high', 'medium', 'low') OR trust_level IS NULL);
 
+-- Widen the trust_level constraint to allow the new 'ceo' tier.
+ALTER TABLE contacts DROP CONSTRAINT contacts_trust_level_check;
+ALTER TABLE contacts ADD CONSTRAINT contacts_trust_level_check
+  CHECK (trust_level IN ('ceo', 'high', 'medium', 'low') OR trust_level IS NULL);
+
+-- Elevate the CEO contact to the new 'ceo' trust level.
 UPDATE contacts
 SET    trust_level = 'ceo',
        updated_at  = now()

--- a/src/db/migrations/030_ceo_trust_level_ceo.sql
+++ b/src/db/migrations/030_ceo_trust_level_ceo.sql
@@ -1,27 +1,19 @@
--- Migration 030: Elevate CEO contact trust level from 'high' to 'ceo'
+-- Migration 030: Widen trust_level check constraint to include the 'ceo' tier
 --
--- The 'ceo' level sits above 'high' in the ordinal ranking, enabling
--- trust-based policy decisions (e.g. PII redaction bypass) that should
--- only apply to the principal, not all high-trust contacts.
+-- Schema change only — no data migration. The CEO contact's trust_level is set to
+-- 'ceo' by the bootstrap process (src/contacts/ceo-bootstrap.ts), which resolves
+-- the CEO contact by email address (config.ceoPrimaryEmail) and uses the contact's
+-- own id — not a role/title comparison — to perform the update. The bootstrap is
+-- idempotent and runs on every startup, so no SQL data migration is needed here.
 --
--- Requires widening the contacts_trust_level_check constraint (added in
--- migration 020) to include the new 'ceo' value before the UPDATE can run.
+-- This migration must run before the first startup that expects trust_level = 'ceo'
+-- to be a valid value in the check constraint.
 --
--- Reversal:
---   UPDATE contacts SET trust_level = 'high', updated_at = now()
---     WHERE trust_level = 'ceo' AND role = 'ceo';
+-- Reversal (drops 'ceo' from the allowed set — only safe after bootstrap is reverted):
 --   ALTER TABLE contacts DROP CONSTRAINT contacts_trust_level_check;
 --   ALTER TABLE contacts ADD CONSTRAINT contacts_trust_level_check
 --     CHECK (trust_level IN ('high', 'medium', 'low') OR trust_level IS NULL);
 
--- Widen the trust_level constraint to allow the new 'ceo' tier.
 ALTER TABLE contacts DROP CONSTRAINT contacts_trust_level_check;
 ALTER TABLE contacts ADD CONSTRAINT contacts_trust_level_check
   CHECK (trust_level IN ('ceo', 'high', 'medium', 'low') OR trust_level IS NULL);
-
--- Elevate the CEO contact to the new 'ceo' trust level.
-UPDATE contacts
-SET    trust_level = 'ceo',
-       updated_at  = now()
-WHERE  trust_level = 'high'
-AND    role = 'ceo';

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -364,7 +364,9 @@ export class Dispatcher {
           // Unknown sender — determine routing decision first so the audit event is self-contained.
           // Compute a preliminary trust score (injection risk not yet available — the unknown-sender
           // branch returns early before the scanner runs).
-          const prelimChannelTrust = (this.channelPolicies?.[payload.channelId]?.trust ?? 'low') as TrustLevel;
+          // Channel trust levels are loaded from channel-trust.yaml and validated to 'low' | 'medium' | 'high'.
+          // 'ceo' is a contact-level trust level only — channels themselves are never ceo-trust.
+          const prelimChannelTrust = (this.channelPolicies?.[payload.channelId]?.trust ?? 'low') as 'low' | 'medium' | 'high';
           const prelimScore = computeTrustScore({
             channelTrustLevel: prelimChannelTrust,
             contactConfidence: 0.0,  // unknown sender has no confidence

--- a/src/dispatch/outbound-filter.ts
+++ b/src/dispatch/outbound-filter.ts
@@ -13,6 +13,7 @@
 // the two boundaries and risk one change silently weakening the other.
 
 import type { TrustLevel } from '../contacts/types.js';
+import { meetsMinimumTrust } from '../contacts/types.js';
 
 export interface FilterCheckInput {
   content: string;
@@ -292,10 +293,9 @@ export class OutboundContentFilter {
    * Allow condition:
    *   no third-party email OR recipientIsTrusted
    *
-   * recipientIsTrusted is true when:
-   *   - recipientEmail matches ceoEmail (the principal always qualifies), OR
-   *   - the recipient contact has trustLevel === 'high' in the contact DB
-   *     (e.g. the CEO's EA or CFO, explicitly elevated by the CEO)
+   * recipientIsTrusted is true when meetsMinimumTrust(recipientTrustLevel, 'high').
+   * This covers trustLevel='high' (explicit CEO designation, e.g. EA or CFO) and
+   * trustLevel='ceo' (the principal), both of which outrank the 'high' threshold.
    *
    * Trusted recipients can receive third-party contact data regardless of whether
    * the message was triggered by a user request or a scheduled routine — this
@@ -316,11 +316,10 @@ export class OutboundContentFilter {
     ]);
 
     // Determine if the recipient qualifies as trusted.
-    // The CEO's own email always qualifies (checked via config.ceoEmail comparison).
-    // A high-trust contact also qualifies — trustLevel='high' is an explicit CEO designation.
-    const recipientIsTrusted =
-      (this.config.ceoEmail !== '' && recipientEmail.toLowerCase() === this.config.ceoEmail.toLowerCase()) ||
-      recipientTrustLevel === 'high';
+    // Uses meetsMinimumTrust() against the 'high' threshold so that both
+    // trustLevel='high' (explicit CEO designation, e.g. EA or CFO) and
+    // trustLevel='ceo' (the principal) are accepted. Null (unknown contact) is false.
+    const recipientIsTrusted = meetsMinimumTrust(recipientTrustLevel, 'high');
 
     // Trusted recipient: allow third-party emails in content without scanning.
     // This handles both user-initiated requests ("what is Hamilton's email?") and

--- a/src/dispatch/pii-redactor.test.ts
+++ b/src/dispatch/pii-redactor.test.ts
@@ -115,6 +115,50 @@ describe('PiiRedactor', () => {
     expect(mockBusPublish).not.toHaveBeenCalled();
   });
 
+  it('bypasses redaction when recipientContactId matches ceoContactId', async () => {
+    // Simulates the case where bootstrap resolved the CEO's UUID and stored it.
+    const ceoUUID = 'b1a2c3d4-e5f6-7890-abcd-ef1234567890';
+    const redactorWithCeoId = new PiiRedactor({
+      config: defaultConfig,
+      bus,
+      logger,
+      extraPatterns: [],
+      ceoContactId: ceoUUID,
+    });
+
+    // Recipient is CEO — should pass through unredacted even with null trust level
+    const result = await redactorWithCeoId.redact(
+      'Your card is 4111 1111 1111 1111.',
+      'email',
+      null, // trust level unknown — UUID check must be sufficient
+      { recipientContactId: ceoUUID },
+    );
+    expect(result.content).toContain('4111 1111 1111 1111');
+    expect(result.redactions).toHaveLength(0);
+    expect(mockBusPublish).not.toHaveBeenCalled();
+  });
+
+  it('does NOT bypass redaction when recipientContactId differs from ceoContactId', async () => {
+    const ceoUUID = 'b1a2c3d4-e5f6-7890-abcd-ef1234567890';
+    const redactorWithCeoId = new PiiRedactor({
+      config: defaultConfig,
+      bus,
+      logger,
+      extraPatterns: [],
+      ceoContactId: ceoUUID,
+    });
+
+    // Recipient is someone else — redaction must apply
+    const result = await redactorWithCeoId.redact(
+      'Your card is 4111 1111 1111 1111.',
+      'email',
+      'medium',
+      { recipientContactId: 'ffffffff-ffff-ffff-ffff-ffffffffffff' },
+    );
+    expect(result.content).toContain('[REDACTED: CREDIT_CARD]');
+    expect(result.redactions).toHaveLength(1);
+  });
+
   it('null trust level is treated as untrusted (PII redacted)', async () => {
     const result = await redactor.redact('Card: 4111 1111 1111 1111', 'email', null);
     expect(result.content).toContain('[REDACTED:');

--- a/src/dispatch/pii-redactor.test.ts
+++ b/src/dispatch/pii-redactor.test.ts
@@ -124,4 +124,29 @@ describe('PiiRedactor', () => {
     const result = await redactor.redact('Card: 4111 1111 1111 1111', 'email', 'medium');
     expect(JSON.stringify(result.redactions)).not.toContain('4111');
   });
+
+  it('explicit channel policy fully overrides default: allow (channel policy takes precedence)', async () => {
+    // A channel with an explicit policy entry (even empty allow list) does NOT
+    // inherit default: 'allow'. All PII on that channel follows the channel policy.
+    const redactorWithAllowDefault = new PiiRedactor({
+      config: {
+        ...defaultConfig,
+        default: 'allow',  // would pass everything on channels without a policy
+        channel_policies: {
+          email: { allow: [] },  // explicit empty policy — blocks everything on email
+        },
+      },
+      bus: bus as any,
+      logger: createSilentLogger(),
+      extraPatterns: [],
+    });
+    const result = await redactorWithAllowDefault.redact(
+      'Contact user@example.com',
+      'email',
+      'medium',
+    );
+    // email channel has explicit policy with empty allow list → redacted despite default: 'allow'
+    expect(result.content).toContain('[REDACTED:');
+    expect(result.content).not.toContain('user@example.com');
+  });
 });

--- a/src/dispatch/pii-redactor.test.ts
+++ b/src/dispatch/pii-redactor.test.ts
@@ -169,6 +169,24 @@ describe('PiiRedactor', () => {
     expect(JSON.stringify(result.redactions)).not.toContain('4111');
   });
 
+  it('redacts multiple distinct PII spans, preserving order and both tokens', async () => {
+    // Both credit_card and phone_us are blocked on signal (empty allow list).
+    // This exercises the end-to-start replacement loop for n > 1 matches.
+    const result = await redactor.redact(
+      'Card: 4111 1111 1111 1111 and call +1 (555) 867-5309.',
+      'signal',
+      'medium',
+    );
+    expect(result.content).not.toContain('4111');
+    expect(result.content).not.toContain('867-5309');
+    expect(result.content).toContain('[REDACTED: CREDIT_CARD]');
+    expect(result.content).toMatch(/\[REDACTED: PHONE/);
+    expect(result.redactions).toHaveLength(2);
+    // Redactions must be returned in original start-position order (credit card first)
+    expect(result.redactions[0]!.patternLabel).toMatch(/credit_card/i);
+    expect(result.redactions[1]!.patternLabel).toMatch(/phone/i);
+  });
+
   it('explicit channel policy fully overrides default: allow (channel policy takes precedence)', async () => {
     // A channel with an explicit policy entry (even empty allow list) does NOT
     // inherit default: 'allow'. All PII on that channel follows the channel policy.

--- a/src/dispatch/pii-redactor.test.ts
+++ b/src/dispatch/pii-redactor.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PiiRedactor } from './pii-redactor.js';
+import { createSilentLogger } from '../logger.js';
+import type { Logger } from '../logger.js';
+import type { EventBus } from '../bus/bus.js';
+
+// Minimal mock bus satisfying the EventBus.publish() interface that PiiRedactor uses.
+// PiiRedactor only calls bus.publish(layer, event) — we don't need subscribe or constructor args.
+function createMockBus() {
+  return {
+    publish: vi.fn().mockResolvedValue(undefined),
+    subscribe: vi.fn(),
+  } as unknown as EventBus;
+}
+
+const defaultConfig = {
+  enabled: true,
+  trust_override: ['ceo'],
+  default: 'block' as const,
+  channel_policies: {
+    email: { allow: ['email'] },
+    signal: { allow: [] },
+  },
+};
+
+describe('PiiRedactor', () => {
+  let bus: EventBus;
+  let mockBusPublish: ReturnType<typeof vi.fn>;
+  let redactor: PiiRedactor;
+  let logger: Logger;
+
+  beforeEach(() => {
+    bus = createMockBus();
+    // Cast to access the mock publish for assertion purposes
+    mockBusPublish = (bus as unknown as { publish: ReturnType<typeof vi.fn> }).publish;
+    logger = createSilentLogger();
+    redactor = new PiiRedactor({
+      config: defaultConfig,
+      bus,
+      logger,
+      extraPatterns: [],
+    });
+  });
+
+  it('redacts a credit card number on email channel', async () => {
+    const result = await redactor.redact('Your card is 4111 1111 1111 1111.', 'email', 'medium');
+    expect(result.content).toContain('[REDACTED: CREDIT_CARD]');
+    expect(result.content).not.toContain('4111');
+    expect(result.redactions).toHaveLength(1);
+    expect(result.redactions[0]!.patternLabel).toMatch(/credit_card/i);
+  });
+
+  it('allows email addresses in email channel (in allow list)', async () => {
+    const result = await redactor.redact('Contact user@example.com for help.', 'email', 'medium');
+    expect(result.content).toContain('user@example.com');
+    expect(result.redactions).toHaveLength(0);
+  });
+
+  it('redacts email addresses in signal channel (not in allow list)', async () => {
+    const result = await redactor.redact('Contact user@example.com for help.', 'signal', 'medium');
+    expect(result.content).toContain('[REDACTED:');
+    expect(result.content).not.toContain('user@example.com');
+  });
+
+  it('bypasses redaction for CEO trust level', async () => {
+    const result = await redactor.redact('Your card is 4111 1111 1111 1111.', 'email', 'ceo');
+    expect(result.content).toContain('4111 1111 1111 1111');
+    expect(result.redactions).toHaveLength(0);
+  });
+
+  it('bypasses redaction when disabled', async () => {
+    const disabled = new PiiRedactor({
+      config: { ...defaultConfig, enabled: false },
+      bus,
+      logger,
+      extraPatterns: [],
+    });
+    const result = await disabled.redact('Card: 4111 1111 1111 1111', 'email', 'medium');
+    expect(result.content).toContain('4111');
+  });
+
+  it('blocks all PII on unlisted channels (default: block)', async () => {
+    // 'sms' is not in channel_policies; default is 'block', so email PII must be redacted
+    const result = await redactor.redact('Contact user@example.com', 'sms', 'medium');
+    expect(result.content).toContain('[REDACTED:');
+  });
+
+  it('returns original content when no PII detected', async () => {
+    const text = 'Just a normal message.';
+    const result = await redactor.redact(text, 'email', 'medium');
+    expect(result.content).toBe(text);
+    expect(result.redactions).toHaveLength(0);
+  });
+
+  it('does not publish bus event when no redactions', async () => {
+    await redactor.redact('Clean message', 'email', 'medium');
+    expect(mockBusPublish).not.toHaveBeenCalled();
+  });
+
+  it('publishes outbound.pii-redacted event on redaction', async () => {
+    await redactor.redact(
+      'Card: 4111 1111 1111 1111',
+      'email',
+      'medium',
+      { conversationId: 'conv-1', recipientId: 'r@example.com' },
+    );
+    expect(mockBusPublish).toHaveBeenCalledWith(
+      'dispatch',
+      expect.objectContaining({ type: 'outbound.pii-redacted' }),
+    );
+  });
+
+  it('does not publish bus event for CEO bypass', async () => {
+    await redactor.redact('Card: 4111 1111 1111 1111', 'email', 'ceo');
+    expect(mockBusPublish).not.toHaveBeenCalled();
+  });
+
+  it('null trust level is treated as untrusted (PII redacted)', async () => {
+    const result = await redactor.redact('Card: 4111 1111 1111 1111', 'email', null);
+    expect(result.content).toContain('[REDACTED:');
+  });
+
+  it('redaction entries do not contain the original PII value', async () => {
+    const result = await redactor.redact('Card: 4111 1111 1111 1111', 'email', 'medium');
+    expect(JSON.stringify(result.redactions)).not.toContain('4111');
+  });
+});

--- a/src/dispatch/pii-redactor.test.ts
+++ b/src/dispatch/pii-redactor.test.ts
@@ -136,7 +136,7 @@ describe('PiiRedactor', () => {
           email: { allow: [] },  // explicit empty policy — blocks everything on email
         },
       },
-      bus: bus as any,
+      bus,
       logger: createSilentLogger(),
       extraPatterns: [],
     });

--- a/src/dispatch/pii-redactor.ts
+++ b/src/dispatch/pii-redactor.ts
@@ -1,0 +1,212 @@
+// pii-redactor.ts — channel-aware PII redactor for outbound messages.
+//
+// Sits between the agent response and the channel adapter. For each outbound
+// message it:
+//   1. Checks whether the kill switch is active (enabled: false → pass through)
+//   2. Checks trust override — CEO and other overridden levels bypass entirely (silent)
+//   3. Detects PII using the shared detectPii() core from src/pii/scrubber.ts
+//   4. Filters matches to those not in the channel's allow list
+//   5. Replaces them end-to-start with labelled tokens (e.g. [REDACTED: CREDIT_CARD])
+//   6. Fires an audit bus event (fire-and-forget with .catch(warn))
+//
+// Fail-closed: this class does NOT swallow its own errors. The caller (OutboundGateway
+// in Task 8) is responsible for catching and deciding whether to block delivery.
+
+import type { Logger } from '../logger.js';
+import type { EventBus } from '../bus/bus.js';
+import type { TrustLevel } from '../contacts/types.js';
+import { meetsMinimumTrust } from '../contacts/types.js';
+import type { PiiPattern } from '../pii/scrubber.js';
+import { detectPii } from '../pii/scrubber.js';
+import { createOutboundPiiRedacted } from '../bus/events.js';
+
+// -- Config shape (mirrors the outbound_redaction block from YamlConfig) --
+
+export interface OutboundRedactionConfig {
+  /** Kill switch. When false, all redaction is bypassed. */
+  enabled: boolean;
+  /** Trust level strings that bypass redaction entirely (e.g. ['ceo']). */
+  trust_override: string[];
+  /** Default action for channels / patterns not in channel_policies. */
+  default: 'block' | 'allow';
+  /** Per-channel policy: labels listed here are allowed through unredacted. */
+  channel_policies: Record<string, { allow: string[] }>;
+}
+
+// -- Public result types --
+
+/**
+ * A single redaction that was applied to the message.
+ * Intentionally does NOT store the original matched value — only what it was replaced with.
+ */
+export interface RedactionEntry {
+  /** Pattern label in lowercase (e.g. "credit_card", "email"). */
+  patternLabel: string;
+  /** Channel the message was routed through. */
+  channelId: string;
+  /** The replacement token that was inserted (e.g. "[REDACTED: CREDIT_CARD]"). */
+  replacedWith: string;
+}
+
+/** Result of a redact() call. */
+export interface RedactionResult {
+  /** The content with PII replaced (or the original if nothing was redacted). */
+  content: string;
+  /** List of applied redactions. Empty when nothing was redacted. */
+  redactions: RedactionEntry[];
+}
+
+// -- Constructor options --
+
+export interface PiiRedactorOptions {
+  config: OutboundRedactionConfig;
+  bus: EventBus;
+  logger: Logger;
+  /** Extra patterns from config (loaded once at startup and threaded through). */
+  extraPatterns: PiiPattern[];
+}
+
+// -- Optional context for audit event --
+
+export interface RedactContext {
+  conversationId?: string;
+  recipientId?: string;
+  parentEventId?: string;
+}
+
+// -- PiiRedactor class --
+
+export class PiiRedactor {
+  private readonly config: OutboundRedactionConfig;
+  private readonly bus: EventBus;
+  private readonly logger: Logger;
+  private readonly extraPatterns: PiiPattern[];
+
+  constructor(opts: PiiRedactorOptions) {
+    this.config = opts.config;
+    this.bus = opts.bus;
+    this.logger = opts.logger;
+    this.extraPatterns = opts.extraPatterns;
+  }
+
+  /**
+   * Redact PII from outbound content based on channel policy and trust level.
+   *
+   * Returns the (possibly modified) content and a list of applied redactions.
+   * Returns the original content unchanged if:
+   *   - redaction is disabled (kill switch)
+   *   - the trust level meets or exceeds a configured trust_override level
+   *   - no PII is detected
+   *   - all detected PII is in the channel's allow list
+   *
+   * @param content    The outbound message content.
+   * @param channelId  The destination channel (e.g. 'email', 'signal').
+   * @param trustLevel The resolved trust level of the recipient (null = untrusted).
+   * @param context    Optional metadata for the audit bus event.
+   */
+  async redact(
+    content: string,
+    channelId: string,
+    trustLevel: TrustLevel | null,
+    context: RedactContext = {},
+  ): Promise<RedactionResult> {
+    // Step 1: Kill switch — if disabled, pass through without any inspection.
+    if (!this.config.enabled) {
+      return { content, redactions: [] };
+    }
+
+    // Step 2: Trust override — certain trust levels (typically 'ceo') bypass
+    // redaction entirely. We use meetsMinimumTrust() so that a recipient with
+    // 'ceo' trust also satisfies 'high', 'medium', and 'low' overrides.
+    for (const overrideLevel of this.config.trust_override) {
+      if (meetsMinimumTrust(trustLevel, overrideLevel as TrustLevel)) {
+        return { content, redactions: [] };
+      }
+    }
+
+    // Step 3: Detect PII using the shared scrubber core.
+    const matches = detectPii(content, this.extraPatterns);
+    if (matches.length === 0) {
+      return { content, redactions: [] };
+    }
+
+    // Step 4: Build the allow set for this channel (lowercase comparison).
+    // If the channel is not in channel_policies, fall back to the default action.
+    const channelPolicy = this.config.channel_policies[channelId];
+    const allowSet = new Set(
+      (channelPolicy?.allow ?? []).map((label) => label.toLowerCase()),
+    );
+
+    // If default is 'allow' and the channel has no explicit policy, everything is allowed.
+    // If default is 'block' and the channel has no explicit policy, all PII is blocked.
+    // Filter to matches that are NOT in the allow set.
+    const toRedact = matches.filter((m) => {
+      const label = m.label.toLowerCase();
+      if (allowSet.has(label)) {
+        // Explicitly allowed on this channel — pass through.
+        return false;
+      }
+      // Not in the allow list — check the default action.
+      // 'block' → redact; 'allow' → pass (but only for channels without an explicit policy).
+      if (!channelPolicy && this.config.default === 'allow') {
+        return false;
+      }
+      return true;
+    });
+
+    if (toRedact.length === 0) {
+      return { content, redactions: [] };
+    }
+
+    // Step 5: Apply replacements end-to-start so earlier indices remain valid
+    // as the string length changes with each substitution.
+    let redacted = content;
+    const redactions: RedactionEntry[] = [];
+
+    for (let i = toRedact.length - 1; i >= 0; i--) {
+      const match = toRedact[i]!;
+      const replacedWith = `[REDACTED: ${match.label.toUpperCase()}]`;
+      redacted = redacted.slice(0, match.start) + replacedWith + redacted.slice(match.end);
+      // Build entry without the original matched value — intentional PII-safety design.
+      redactions.unshift({
+        patternLabel: match.label,
+        channelId,
+        replacedWith,
+      });
+    }
+
+    // Step 6: Log the redaction event.
+    this.logger.info(
+      {
+        event: 'pii_redacted',
+        channelId,
+        redactionCount: redactions.length,
+        patternLabels: redactions.map((r) => r.patternLabel),
+        conversationId: context.conversationId,
+      },
+      'PII redacted from outbound message',
+    );
+
+    // Step 7: Publish audit bus event — fire-and-forget. We do not await
+    // because a bus failure must not block delivery of the redacted message.
+    // Errors are caught and logged at warn level (not error) since the message
+    // was already cleaned — audit lag is bad but not a delivery failure.
+    this.bus.publish('dispatch', createOutboundPiiRedacted({
+      channelId,
+      recipientId: context.recipientId ?? '',
+      conversationId: context.conversationId ?? '',
+      redactions: redactions.map((r) => ({
+        patternLabel: r.patternLabel,
+        replacedWith: r.replacedWith,
+      })),
+      parentEventId: context.parentEventId,
+    })).catch((err: unknown) => {
+      this.logger.warn(
+        { err, event: 'pii_redacted_bus_publish_failed', channelId },
+        'Failed to publish outbound.pii-redacted audit event',
+      );
+    });
+
+    return { content: redacted, redactions };
+  }
+}

--- a/src/dispatch/pii-redactor.ts
+++ b/src/dispatch/pii-redactor.ts
@@ -169,7 +169,7 @@ export class PiiRedactor {
       redacted = redacted.slice(0, match.start) + replacedWith + redacted.slice(match.end);
       // Build entry without the original matched value — intentional PII-safety design.
       redactions.unshift({
-        patternLabel: match.label,
+        patternLabel: match.label.toLowerCase(),
         channelId,
         replacedWith,
       });

--- a/src/dispatch/pii-redactor.ts
+++ b/src/dispatch/pii-redactor.ts
@@ -15,7 +15,7 @@
 import type { Logger } from '../logger.js';
 import type { EventBus } from '../bus/bus.js';
 import type { TrustLevel } from '../contacts/types.js';
-import { meetsMinimumTrust } from '../contacts/types.js';
+import { meetsMinimumTrust, TRUST_RANK } from '../contacts/types.js';
 import type { PiiPattern } from '../pii/scrubber.js';
 import { detectPii } from '../pii/scrubber.js';
 import { createOutboundPiiRedacted } from '../bus/events.js';
@@ -119,6 +119,15 @@ export class PiiRedactor {
     // redaction entirely. We use meetsMinimumTrust() so that a recipient with
     // 'ceo' trust also satisfies 'high', 'medium', and 'low' overrides.
     for (const overrideLevel of this.config.trust_override) {
+      // Guard against typos or invalid values from programmatic config construction
+      // (JSON schema validates YAML, but not runtime-constructed configs).
+      if (!(overrideLevel in TRUST_RANK)) {
+        this.logger.warn(
+          { unknownOverrideLevel: overrideLevel },
+          'pii-redactor: unknown trust_override level in config — entry ignored',
+        );
+        continue;
+      }
       if (meetsMinimumTrust(trustLevel, overrideLevel as TrustLevel)) {
         return { content, redactions: [] };
       }

--- a/src/dispatch/pii-redactor.ts
+++ b/src/dispatch/pii-redactor.ts
@@ -64,6 +64,14 @@ export interface PiiRedactorOptions {
   logger: Logger;
   /** Extra patterns from config (loaded once at startup and threaded through). */
   extraPatterns: PiiPattern[];
+  /**
+   * The CEO's contact UUID, resolved from ceoPrimaryEmail at startup by bootstrapCeoContact().
+   * When set, any message destined for this exact contact ID bypasses PII redaction entirely,
+   * regardless of trust_level. This is the primary CEO identification mechanism — more stable
+   * than trust_level because it is an immutable UUID resolved once at startup, not a DB field
+   * that could be accidentally updated by contact-management code paths.
+   */
+  ceoContactId?: string;
 }
 
 // -- Optional context for audit event --
@@ -72,6 +80,11 @@ export interface RedactContext {
   conversationId?: string;
   recipientId?: string;
   parentEventId?: string;
+  /**
+   * The recipient's contact UUID (from the contacts table).
+   * Used to bypass redaction when it matches PiiRedactorOptions.ceoContactId.
+   */
+  recipientContactId?: string;
 }
 
 // -- PiiRedactor class --
@@ -81,12 +94,14 @@ export class PiiRedactor {
   private readonly bus: EventBus;
   private readonly logger: Logger;
   private readonly extraPatterns: PiiPattern[];
+  private readonly ceoContactId: string | undefined;
 
   constructor(opts: PiiRedactorOptions) {
     this.config = opts.config;
     this.bus = opts.bus;
     this.logger = opts.logger;
     this.extraPatterns = opts.extraPatterns;
+    this.ceoContactId = opts.ceoContactId;
   }
 
   /**
@@ -112,6 +127,14 @@ export class PiiRedactor {
   ): Promise<RedactionResult> {
     // Step 1: Kill switch — if disabled, pass through without any inspection.
     if (!this.config.enabled) {
+      return { content, redactions: [] };
+    }
+
+    // Step 1b: CEO contact ID bypass — more reliable than trust_level.
+    // The CEO contact UUID is resolved once from ceoPrimaryEmail at startup and stored here.
+    // A UUID match is tamper-proof: it cannot be accidentally elevated via contact management
+    // code paths (unlike trust_level, which has a setTrustLevel() API).
+    if (this.ceoContactId && context.recipientContactId === this.ceoContactId) {
       return { content, redactions: [] };
     }
 

--- a/src/dispatch/trust-scorer.ts
+++ b/src/dispatch/trust-scorer.ts
@@ -13,7 +13,9 @@
 import type { TrustLevel } from '../contacts/types.js';
 
 // Normalized weight per trust level — used to convert enum → float for the formula.
+// 'ceo' is treated identically to 'high' for scoring (maximally trusted channel weight).
 const CHANNEL_TRUST_NORMALIZED: Record<TrustLevel, number> = {
+  ceo: 1.0,
   high: 1.0,
   medium: 0.6,
   low: 0.3,

--- a/src/index.ts
+++ b/src/index.ts
@@ -664,12 +664,18 @@ async function main(): Promise<void> {
       ),
     ),
   };
-  const piiRedactor = new PiiRedactor({
-    config: outboundRedactionConfig,
-    bus,
-    logger,
-    extraPatterns, // same patterns used by the inbound scrubber
-  });
+  let piiRedactor: PiiRedactor;
+  try {
+    piiRedactor = new PiiRedactor({
+      config: outboundRedactionConfig,
+      bus,
+      logger,
+      extraPatterns, // same patterns used by the inbound scrubber
+    });
+  } catch (err) {
+    logger.fatal({ err }, 'Failed to initialize PiiRedactor — check pii.outbound_redaction config');
+    process.exit(1);
+  }
   logger.info(
     { enabled: outboundRedactionConfig.enabled, trustOverride: outboundRedactionConfig.trust_override },
     'Outbound PII redactor initialized',

--- a/src/index.ts
+++ b/src/index.ts
@@ -625,6 +625,56 @@ async function main(): Promise<void> {
     logger.info({ markerCount: systemPromptMarkers.length }, 'Outbound content filter initialized');
   }
 
+  // PII scrubbing for LLM-facing error strings — loads extra patterns from
+  // config/default.yaml pii.extra_patterns and injects them into classify.ts.
+  // An invalid extra pattern is treated as fatal: the operator's intent was to
+  // protect a specific PII type and silently ignoring their config would mean
+  // that data flows unredacted to the LLM without any warning.
+  //
+  // extraPatterns is also passed to PiiRedactor below for outbound redaction
+  // (outbound redaction reuses the same custom patterns as the inbound scrubber).
+  const piiPatternEntries = yamlConfig.pii?.extra_patterns ?? [];
+  let extraPatterns: PiiPattern[] = [];
+  if (piiPatternEntries.length > 0) {
+    // Errors here are intentionally not caught — parseExtraPiiPatterns throws on
+    // invalid regex or missing fields, which is treated as a startup-blocking misconfiguration.
+    extraPatterns = parseExtraPiiPatterns(
+      piiPatternEntries,
+      path.join(configDir, 'default.yaml'),
+    );
+    setErrorPiiPatterns(extraPatterns);
+  }
+  const extraPiiPatternCount = extraPatterns.length;
+
+  // Outbound PII redactor — sits between the agent response and the channel
+  // adapter. Strips PII from outbound messages based on channel policy and
+  // recipient trust level before content validation or delivery.
+  // Config defaults: enabled=true, trust_override=['ceo'], default='block'.
+  //
+  // Must be constructed BEFORE OutboundGateway, which receives it as a constructor arg.
+  const outboundRedactionConfig = {
+    enabled: yamlConfig.pii?.outbound_redaction?.enabled ?? true,
+    trust_override: yamlConfig.pii?.outbound_redaction?.trust_override ?? ['ceo'],
+    default: (yamlConfig.pii?.outbound_redaction?.default ?? 'block') as 'block' | 'allow',
+    // Normalize channel_policies: the YAML type allows `allow` to be optional on
+    // each entry, but OutboundRedactionConfig requires it. Default to [] per entry.
+    channel_policies: Object.fromEntries(
+      Object.entries(yamlConfig.pii?.outbound_redaction?.channel_policies ?? {}).map(
+        ([ch, policy]) => [ch, { allow: policy.allow ?? [] }],
+      ),
+    ),
+  };
+  const piiRedactor = new PiiRedactor({
+    config: outboundRedactionConfig,
+    bus,
+    logger,
+    extraPatterns, // same patterns used by the inbound scrubber
+  });
+  logger.info(
+    { enabled: outboundRedactionConfig.enabled, trustOverride: outboundRedactionConfig.trust_override },
+    'Outbound PII redactor initialized',
+  );
+
   // Outbound gateway — single choke-point for all outbound external communication.
   // Runs blocked-contact checks and content filtering before any message leaves Curia.
   //
@@ -929,54 +979,6 @@ async function main(): Promise<void> {
   }
   scheduler.start();
   logger.info('Scheduler started');
-
-  // PII scrubbing for LLM-facing error strings — loads extra patterns from
-  // config/default.yaml pii.extra_patterns and injects them into classify.ts.
-  // An invalid extra pattern is treated as fatal: the operator's intent was to
-  // protect a specific PII type and silently ignoring their config would mean
-  // that data flows unredacted to the LLM without any warning.
-  //
-  // extraPatterns is declared at outer scope so it can be passed to PiiRedactor below
-  // (outbound redaction reuses the same custom patterns as the inbound scrubber).
-  const piiPatternEntries = yamlConfig.pii?.extra_patterns ?? [];
-  let extraPatterns: PiiPattern[] = [];
-  if (piiPatternEntries.length > 0) {
-    // Errors here are intentionally not caught — parseExtraPiiPatterns throws on
-    // invalid regex or missing fields, which is treated as a startup-blocking misconfiguration.
-    extraPatterns = parseExtraPiiPatterns(
-      piiPatternEntries,
-      path.join(configDir, 'default.yaml'),
-    );
-    setErrorPiiPatterns(extraPatterns);
-  }
-  const extraPiiPatternCount = extraPatterns.length;
-
-  // Outbound PII redactor — sits between the agent response and the channel
-  // adapter. Strips PII from outbound messages based on channel policy and
-  // recipient trust level before content validation or delivery.
-  // Config defaults: enabled=true, trust_override=['ceo'], default='block'.
-  const outboundRedactionConfig = {
-    enabled: yamlConfig.pii?.outbound_redaction?.enabled ?? true,
-    trust_override: yamlConfig.pii?.outbound_redaction?.trust_override ?? ['ceo'],
-    default: (yamlConfig.pii?.outbound_redaction?.default ?? 'block') as 'block' | 'allow',
-    // Normalize channel_policies: the YAML type allows `allow` to be optional on
-    // each entry, but OutboundRedactionConfig requires it. Default to [] per entry.
-    channel_policies: Object.fromEntries(
-      Object.entries(yamlConfig.pii?.outbound_redaction?.channel_policies ?? {}).map(
-        ([ch, policy]) => [ch, { allow: policy.allow ?? [] }],
-      ),
-    ),
-  };
-  const piiRedactor = new PiiRedactor({
-    config: outboundRedactionConfig,
-    bus,
-    logger,
-    extraPatterns, // same patterns used by the inbound scrubber
-  });
-  logger.info(
-    { enabled: outboundRedactionConfig.enabled, trustOverride: outboundRedactionConfig.trust_override },
-    'Outbound PII redactor initialized',
-  );
 
   // Log the scrubber status after the logger is available (patterns are loaded at module
   // init time, before pino exists, so any load-time failures are deferred to here).

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,8 @@ import { InboundScanner } from './dispatch/inbound-scanner.js';
 import { RateLimiter } from './dispatch/rate-limiter.js';
 import { loadExtraInjectionPatterns, type ExtraInjectionPattern } from './dispatch/security-config-loader.js';
 import { parseExtraPiiPatterns, getMissingBuiltInPatterns, getBuiltInPatternCount } from './pii/scrubber.js';
+import type { PiiPattern } from './pii/scrubber.js';
+import { PiiRedactor } from './dispatch/pii-redactor.js';
 import { setErrorPiiPatterns } from './errors/classify.js';
 import type { TrustScorerWeights } from './dispatch/trust-scorer.js';
 import { SchedulerService } from './scheduler/scheduler-service.js';
@@ -653,6 +655,7 @@ async function main(): Promise<void> {
       ceoEmail: config.ceoPrimaryEmail || undefined,
       logger,
       autonomyService,
+      piiRedactor,
     });
     logger.info({
       emailAccounts: [...nylasClientMap.keys()],
@@ -932,18 +935,48 @@ async function main(): Promise<void> {
   // An invalid extra pattern is treated as fatal: the operator's intent was to
   // protect a specific PII type and silently ignoring their config would mean
   // that data flows unredacted to the LLM without any warning.
+  //
+  // extraPatterns is declared at outer scope so it can be passed to PiiRedactor below
+  // (outbound redaction reuses the same custom patterns as the inbound scrubber).
   const piiPatternEntries = yamlConfig.pii?.extra_patterns ?? [];
-  let extraPiiPatternCount = 0;
+  let extraPatterns: PiiPattern[] = [];
   if (piiPatternEntries.length > 0) {
     // Errors here are intentionally not caught — parseExtraPiiPatterns throws on
     // invalid regex or missing fields, which is treated as a startup-blocking misconfiguration.
-    const extraPiiPatterns = parseExtraPiiPatterns(
+    extraPatterns = parseExtraPiiPatterns(
       piiPatternEntries,
       path.join(configDir, 'default.yaml'),
     );
-    setErrorPiiPatterns(extraPiiPatterns);
-    extraPiiPatternCount = extraPiiPatterns.length;
+    setErrorPiiPatterns(extraPatterns);
   }
+  const extraPiiPatternCount = extraPatterns.length;
+
+  // Outbound PII redactor — sits between the agent response and the channel
+  // adapter. Strips PII from outbound messages based on channel policy and
+  // recipient trust level before content validation or delivery.
+  // Config defaults: enabled=true, trust_override=['ceo'], default='block'.
+  const outboundRedactionConfig = {
+    enabled: yamlConfig.pii?.outbound_redaction?.enabled ?? true,
+    trust_override: yamlConfig.pii?.outbound_redaction?.trust_override ?? ['ceo'],
+    default: (yamlConfig.pii?.outbound_redaction?.default ?? 'block') as 'block' | 'allow',
+    // Normalize channel_policies: the YAML type allows `allow` to be optional on
+    // each entry, but OutboundRedactionConfig requires it. Default to [] per entry.
+    channel_policies: Object.fromEntries(
+      Object.entries(yamlConfig.pii?.outbound_redaction?.channel_policies ?? {}).map(
+        ([ch, policy]) => [ch, { allow: policy.allow ?? [] }],
+      ),
+    ),
+  };
+  const piiRedactor = new PiiRedactor({
+    config: outboundRedactionConfig,
+    bus,
+    logger,
+    extraPatterns, // same patterns used by the inbound scrubber
+  });
+  logger.info(
+    { enabled: outboundRedactionConfig.enabled, trustOverride: outboundRedactionConfig.trust_override },
+    'Outbound PII redactor initialized',
+  );
 
   // Log the scrubber status after the logger is available (patterns are loaded at module
   // init time, before pino exists, so any load-time failures are deferred to here).

--- a/src/index.ts
+++ b/src/index.ts
@@ -348,9 +348,14 @@ async function main(): Promise<void> {
   // provisional (the extractParticipants default), causing their messages to be held.
   // Also creates (or backfills) a KG person node so entity context enrichment works
   // for the CEO. See issue #380.
+  let ceoContactId: string | undefined;
   if (config.ceoPrimaryEmail) {
     try {
       const ceoBootstrap = await bootstrapCeoContact(config.ceoPrimaryEmail, 'CEO', pool, logger);
+      // Persist the CEO's contact UUID so PiiRedactor can bypass redaction using a stable
+      // UUID check rather than relying solely on trust_level. UUID is resolved once at startup
+      // from ceoPrimaryEmail and is tamper-proof (unlike trust_level, which has a setter API).
+      ceoContactId = ceoBootstrap.contactId;
       logger.info({ contactId: ceoBootstrap.contactId, kgNodeId: ceoBootstrap.kgNodeId }, 'CEO identity ready');
     } catch (err) {
       // Non-fatal: log and continue. Severity depends on whether the email adapter is active:
@@ -671,6 +676,7 @@ async function main(): Promise<void> {
       bus,
       logger,
       extraPatterns, // same patterns used by the inbound scrubber
+      ceoContactId,  // resolved from ceoPrimaryEmail at bootstrap; undefined if bootstrap failed or email not set
     });
   } catch (err) {
     logger.fatal({ err }, 'Failed to initialize PiiRedactor — check pii.outbound_redaction config');

--- a/src/pii/scrubber.test.ts
+++ b/src/pii/scrubber.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { scrubPii, parseExtraPiiPatterns } from './scrubber.js';
+import { scrubPii, parseExtraPiiPatterns, detectPii } from './scrubber.js';
 
 describe('scrubPii — built-in patterns', () => {
   // ── Email ──────────────────────────────────────────────────────────────────
@@ -201,5 +201,58 @@ describe('classify.ts integration — PII scrubbing in error messages', () => {
     const result = classifySkillError('payment', 'card 4111 1111 1111 1111 declined');
     expect(result.message).not.toContain('4111 1111 1111 1111');
     expect(result.message).toContain('[CREDIT_CARD]');
+  });
+});
+
+describe('detectPii', () => {
+  it('detects an email address with label and position', () => {
+    const text = 'Contact user@example.com for help';
+    const matches = detectPii(text);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].label).toMatch(/email/i);
+    expect(matches[0].matched).toBe('user@example.com');
+    expect(matches[0].start).toBe(8);
+    expect(matches[0].end).toBe(24);
+  });
+
+  it('detects a credit card number', () => {
+    const matches = detectPii('Card: 4111 1111 1111 1111');
+    expect(matches.some(m => m.label.match(/credit_card/i))).toBe(true);
+  });
+
+  it('does not false-positive on UUIDs', () => {
+    const text = 'Task 550e8400-e29b-41d4-a716-446655440000 failed';
+    const matches = detectPii(text);
+    expect(matches).toHaveLength(0);
+  });
+
+  it('returns empty array for clean text', () => {
+    expect(detectPii('Just a normal message')).toHaveLength(0);
+  });
+
+  it('returns matches sorted by start position', () => {
+    const text = 'from alice@example.com to bob@other.org';
+    const matches = detectPii(text);
+    expect(matches).toHaveLength(2);
+    expect(matches[0].start).toBeLessThan(matches[1].start);
+    expect(matches[0].matched).toBe('alice@example.com');
+    expect(matches[1].matched).toBe('bob@other.org');
+  });
+
+  it('match positions reference the original text', () => {
+    const text = 'error for user@example.com in task';
+    const matches = detectPii(text);
+    expect(matches).toHaveLength(1);
+    const m = matches[0];
+    expect(text.slice(m.start, m.end)).toBe(m.matched);
+  });
+
+  it('accepts extra patterns and detects them', () => {
+    const extras = parseExtraPiiPatterns(
+      [{ regex: 'EMP-\\d{6}', replacement: '[EMPLOYEE_ID]' }],
+      'test',
+    );
+    const matches = detectPii('employee EMP-123456 at step 3', extras);
+    expect(matches.some(m => m.label === 'extra_0')).toBe(true);
   });
 });

--- a/src/pii/scrubber.test.ts
+++ b/src/pii/scrubber.test.ts
@@ -209,10 +209,10 @@ describe('detectPii', () => {
     const text = 'Contact user@example.com for help';
     const matches = detectPii(text);
     expect(matches).toHaveLength(1);
-    expect(matches[0].label).toMatch(/email/i);
-    expect(matches[0].matched).toBe('user@example.com');
-    expect(matches[0].start).toBe(8);
-    expect(matches[0].end).toBe(24);
+    expect(matches[0]!.label).toMatch(/email/i);
+    expect(matches[0]!.matched).toBe('user@example.com');
+    expect(matches[0]!.start).toBe(8);
+    expect(matches[0]!.end).toBe(24);
   });
 
   it('detects a credit card number', () => {
@@ -234,16 +234,16 @@ describe('detectPii', () => {
     const text = 'from alice@example.com to bob@other.org';
     const matches = detectPii(text);
     expect(matches).toHaveLength(2);
-    expect(matches[0].start).toBeLessThan(matches[1].start);
-    expect(matches[0].matched).toBe('alice@example.com');
-    expect(matches[1].matched).toBe('bob@other.org');
+    expect(matches[0]!.start).toBeLessThan(matches[1]!.start);
+    expect(matches[0]!.matched).toBe('alice@example.com');
+    expect(matches[1]!.matched).toBe('bob@other.org');
   });
 
   it('match positions reference the original text', () => {
     const text = 'error for user@example.com in task';
     const matches = detectPii(text);
     expect(matches).toHaveLength(1);
-    const m = matches[0];
+    const m = matches[0]!;
     expect(text.slice(m.start, m.end)).toBe(m.matched);
   });
 

--- a/src/pii/scrubber.ts
+++ b/src/pii/scrubber.ts
@@ -168,6 +168,11 @@ export function detectPii(text: string, extraPatterns: PiiPattern[] = []): PiiMa
 
   const matches: PiiMatch[] = [];
   const allPatterns = [...BUILT_IN_PATTERNS, ...extraPatterns];
+  // Overlap guard: returns true if [start, end) intersects any already-accepted match.
+  // Pattern order in allPatterns is precedence — the first pattern to claim a region wins.
+  // This prevents, e.g., a PHONE pattern from consuming part of an already-matched CREDIT_CARD.
+  const overlapsExisting = (start: number, end: number): boolean =>
+    matches.some((m) => start < m.end && end > m.start);
 
   for (const { name, regex } of allPatterns) {
     // Reset lastIndex — global regexes retain state across calls if reused.
@@ -176,12 +181,16 @@ export function detectPii(text: string, extraPatterns: PiiPattern[] = []): PiiMa
     while ((m = regex.exec(shielded)) !== null) {
       // Skip any match that covers shielded UUID territory.
       if (m[0].includes('\x00')) continue;
+      const start = m.index;
+      const end = m.index + m[0].length;
+      // Skip if this span overlaps an already-accepted match.
+      if (overlapsExisting(start, end)) continue;
       matches.push({
         label: name,
-        start: m.index,
-        end: m.index + m[0].length,
+        start,
+        end,
         // Slice from original text — shielded only used for position tracking.
-        matched: text.slice(m.index, m.index + m[0].length),
+        matched: text.slice(start, end),
       });
     }
   }

--- a/src/pii/scrubber.ts
+++ b/src/pii/scrubber.ts
@@ -216,7 +216,8 @@ export function scrubPii(text: string, extraPatterns: PiiPattern[] = []): string
   // string length changes with each substitution.
   let result = text;
   for (let i = matches.length - 1; i >= 0; i--) {
-    const match = matches[i];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const match = matches[i]!;  // safe: i is a valid index (0 ≤ i < matches.length)
     const replacement = replacementByName.get(match.label) ?? `[${match.label.toUpperCase()}]`;
     result = result.slice(0, match.start) + replacement + result.slice(match.end);
   }

--- a/src/pii/scrubber.ts
+++ b/src/pii/scrubber.ts
@@ -24,6 +24,18 @@ export interface PiiPattern {
   replacement: string;
 }
 
+/** A single PII match found by detectPii(). */
+export interface PiiMatch {
+  /** Pattern name in lowercase (e.g. "email", "credit_card", "extra_0"). */
+  label: string;
+  /** Start index in the original text. */
+  start: number;
+  /** End index (exclusive). */
+  end: number;
+  /** The matched substring from the original text. */
+  matched: string;
+}
+
 // Standard RFC 4122 UUID pattern. UUIDs are extremely common in Curia log
 // output (conversation IDs, task IDs, contact IDs) and must be shielded from
 // PII pattern matching — some patterns (credit card, phone) false-positive on
@@ -132,12 +144,58 @@ export function getBuiltInPatternCount(): number {
 const BUILT_IN_PATTERNS: PiiPattern[] = buildBuiltInPatterns();
 
 /**
+ * Detect PII in text and return an array of matches with position information.
+ *
+ * UUID protection: UUIDs are replaced in the scan buffer with null bytes of
+ * the same length so indices are preserved. Matches overlapping a shielded
+ * UUID region (containing \x00) are skipped. Matched text is always sliced
+ * from the original (unshielded) text so callers get the real characters.
+ *
+ * Results are sorted by start position (ascending).
+ *
+ * This is the shared detection core used by both scrubPii() (for replacement)
+ * and PiiRedactor (for annotation/reporting).
+ *
+ * @param text          The string to scan.
+ * @param extraPatterns Additional patterns from operator config.
+ */
+export function detectPii(text: string, extraPatterns: PiiPattern[] = []): PiiMatch[] {
+  // Shield UUIDs by replacing them with null bytes of the same length. This
+  // preserves byte indices for all text after the UUID, unlike the token
+  // approach used by scrubPii (which changes string length). Matches that
+  // overlap a shielded region will contain \x00 and are skipped below.
+  const shielded = text.replace(UUID_RE, (match) => '\x00'.repeat(match.length));
+
+  const matches: PiiMatch[] = [];
+  const allPatterns = [...BUILT_IN_PATTERNS, ...extraPatterns];
+
+  for (const { name, regex } of allPatterns) {
+    // Reset lastIndex — global regexes retain state across calls if reused.
+    regex.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(shielded)) !== null) {
+      // Skip any match that covers shielded UUID territory.
+      if (m[0].includes('\x00')) continue;
+      matches.push({
+        label: name,
+        start: m.index,
+        end: m.index + m[0].length,
+        // Slice from original text — shielded only used for position tracking.
+        matched: text.slice(m.index, m.index + m[0].length),
+      });
+    }
+  }
+
+  matches.sort((a, b) => a.start - b.start);
+  return matches;
+}
+
+/**
  * Scrub PII from a string using the built-in patterns plus any caller-supplied
  * extra patterns (from config/default.yaml).
  *
- * UUID protection: standard RFC 4122 UUIDs are replaced with stable tokens
- * before scrubbing and restored after, preventing false-positive matches on
- * UUID hex segments.
+ * Delegates detection to detectPii() for shared logic, then applies replacements
+ * end-to-start so that earlier match indices remain valid as the string shrinks.
  *
  * This function is intentionally synchronous — it is called on every error
  * message that enters LLM context and must not introduce async overhead.
@@ -147,28 +205,22 @@ const BUILT_IN_PATTERNS: PiiPattern[] = buildBuiltInPatterns();
  *                      at startup and passed through the call chain).
  */
 export function scrubPii(text: string, extraPatterns: PiiPattern[] = []): string {
-  // 1. Shield UUIDs from PII pattern matching.
-  //    Tokens use a format that cannot be confused with real UUIDs or PII.
-  const uuids: string[] = [];
-  let shielded = text.replace(UUID_RE, (match) => {
-    uuids.push(match);
-    return `\x00UUID${uuids.length - 1}\x00`;
-  });
+  const matches = detectPii(text, extraPatterns);
+  if (matches.length === 0) return text;
 
-  // 2. Apply all patterns (built-in first, then extras).
+  // Build a lookup so we can find each pattern's replacement string by name.
   const allPatterns = [...BUILT_IN_PATTERNS, ...extraPatterns];
-  for (const { regex, replacement } of allPatterns) {
-    // Reset lastIndex — global regexes retain state across calls if reused.
-    regex.lastIndex = 0;
-    shielded = shielded.replace(regex, replacement);
-  }
+  const replacementByName = new Map(allPatterns.map((p) => [p.name, p.replacement]));
 
-  // 3. Restore shielded UUIDs.
-  // Return the raw token on index miss rather than '' — erasing content silently
-  // would be harder to notice than an ugly token in the LLM's context.
-  // An index miss is only possible if the input contained a deliberate
-  // \x00UUID<n>\x00 byte sequence before scrubbing, which is pathological.
-  return shielded.replace(/\x00UUID(\d+)\x00/g, (match, i) => uuids[parseInt(i, 10)] ?? match);
+  // Apply replacements end-to-start so earlier indices stay valid as the
+  // string length changes with each substitution.
+  let result = text;
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const match = matches[i];
+    const replacement = replacementByName.get(match.label) ?? `[${match.label.toUpperCase()}]`;
+    result = result.slice(0, match.start) + replacement + result.slice(match.end);
+  }
+  return result;
 }
 
 /**

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -340,6 +340,9 @@ export class OutboundGateway {
     // Optional: when piiRedactor is not configured, redactedBody == messageBody
     // and the pipeline behaves identically to the pre-redaction behaviour.
     let redactedBody = messageBody;
+    // Email subjects can contain PII just as the body can — track a separate
+    // variable so we can pass the cleaned subject to dispatchEmail() below.
+    let redactedSubject: string | undefined = request.channel === 'email' ? request.subject : undefined;
     if (this.piiRedactor) {
       try {
         const redactionResult = await this.piiRedactor.redact(
@@ -349,6 +352,16 @@ export class OutboundGateway {
           { recipientId, recipientContactId },
         );
         redactedBody = redactionResult.content;
+        // Redact the subject too — same trust level and channel policy apply.
+        if (request.channel === 'email' && request.subject) {
+          const subjectResult = await this.piiRedactor.redact(
+            request.subject,
+            request.channel,
+            recipientTrustLevel,
+            { recipientId, recipientContactId },
+          );
+          redactedSubject = subjectResult.content;
+        }
       } catch (err) {
         this.log.error(
           { err, channel: request.channel, recipientId: redactId(recipientId) },
@@ -512,7 +525,7 @@ export class OutboundGateway {
     // they receive — if we pass the original `request`, the unredacted content
     // reaches Nylas / signal-cli even though redactedBody was computed above.
     if (request.channel === 'email') {
-      const result = await this.dispatchEmail({ ...request, body: redactedBody });
+      const result = await this.dispatchEmail({ ...request, body: redactedBody, subject: redactedSubject });
       if (result.success) {
         await this.promoteOrCreateRecipientContact('email', recipientId);
       }

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -25,6 +25,7 @@ import type { SignalRpcClient } from '../channels/signal/signal-rpc-client.js';
 import type { ContactService } from '../contacts/contact-service.js';
 import type { TrustLevel } from '../contacts/types.js';
 import type { OutboundContentFilter } from '../dispatch/outbound-filter.js';
+import type { PiiRedactor } from '../dispatch/pii-redactor.js';
 import type { EventBus } from '../bus/bus.js';
 import type { Logger } from '../logger.js';
 import { createOutboundBlocked, createOutboundNotification, createAutonomySendBlocked } from '../bus/events.js';
@@ -150,6 +151,20 @@ export interface OutboundGatewayConfig {
    * an advisory. Optional — when absent, the gate is skipped (fail-open).
    */
   autonomyService?: AutonomyService;
+
+  /**
+   * PII redactor — applied between the blocked-contact check (Step 1) and the
+   * content filter (Step 2). Strips PII from the message body based on channel
+   * policy and recipient trust level before content validation runs.
+   *
+   * Fail-closed: if the redactor throws, send() blocks the message and publishes
+   * outbound.blocked. We must never deliver unredacted content through a broken
+   * redactor.
+   *
+   * Optional — when absent, content passes through to the content filter unchanged.
+   * This preserves backwards compatibility with callers that pre-date PII redaction.
+   */
+  piiRedactor?: PiiRedactor;
 }
 
 // ---------------------------------------------------------------------------
@@ -192,6 +207,7 @@ export class OutboundGateway {
   private readonly ceoEmail: string;
   private readonly log: Logger;
   private readonly autonomyService?: AutonomyService;
+  private readonly piiRedactor?: PiiRedactor;
 
   constructor(config: OutboundGatewayConfig) {
     this.nylasClients = config.nylasClients ?? new Map();
@@ -204,6 +220,7 @@ export class OutboundGateway {
     this.ceoEmail = config.ceoEmail ?? '';
     this.log = config.logger.child({ component: 'outbound-gateway' });
     this.autonomyService = config.autonomyService;
+    this.piiRedactor = config.piiRedactor;
   }
 
   /**
@@ -309,6 +326,53 @@ export class OutboundGateway {
     }
 
     // ------------------------------------------------------------------
+    // Step 1.5: PII redaction — strip PII from message body before the content
+    // filter sees it. This ensures the filter operates on clean content and that
+    // any PII-containing message that slips past detection doesn't reach the wire.
+    //
+    // Fail-closed: if the redactor throws, block the message. Sending unredacted
+    // PII through a broken redactor is worse than dropping the message.
+    //
+    // Optional: when piiRedactor is not configured, redactedBody == messageBody
+    // and the pipeline behaves identically to the pre-redaction behaviour.
+    let redactedBody = messageBody;
+    if (this.piiRedactor) {
+      try {
+        const redactionResult = await this.piiRedactor.redact(
+          messageBody,
+          request.channel,
+          recipientTrustLevel,
+          { recipientId },
+        );
+        redactedBody = redactionResult.content;
+      } catch (err) {
+        this.log.error(
+          { err, channel: request.channel, recipientId: redactId(recipientId) },
+          'outbound-gateway: PiiRedactor threw — blocking message (fail-closed)',
+        );
+        const blockId = `block_${randomUUID()}`;
+        try {
+          await this.bus.publish('dispatch', createOutboundBlocked({
+            blockId,
+            conversationId: '',
+            channelId: request.channel,
+            content: messageBody,
+            recipientId,
+            reason: 'pii_redactor_error',
+            findings: [{ rule: 'pii_redactor_error', detail: 'PiiRedactor threw an unexpected error' }],
+            parentEventId: '',
+          }));
+        } catch (publishErr) {
+          this.log.warn(
+            { publishErr, blockId },
+            'outbound-gateway: failed to publish outbound.blocked event for PII redactor error',
+          );
+        }
+        return { success: false, blockedReason: 'pii_redactor_error' };
+      }
+    }
+
+    // ------------------------------------------------------------------
     // Step 2: Content filter
     // ------------------------------------------------------------------
     // Fail-closed: if the filter throws for any reason, treat the message as blocked.
@@ -319,7 +383,7 @@ export class OutboundGateway {
 
     try {
       const filterResult = await this.contentFilter.check({
-        content: messageBody,
+        content: redactedBody,
         // For Signal sends: passing the phone number/groupId as recipientEmail is intentional.
         // The contact-data-leak rule scans for *email addresses* in the content — a phone
         // number passed here will never match an email pattern, so any leaked email address
@@ -358,11 +422,12 @@ export class OutboundGateway {
 
       // Publish the blocked event for audit logging and downstream consumers.
       // Capture the event so we can link the outbound.notification to it via parentEventId.
+      // Use redactedBody so the audit event itself does not contain unredacted PII.
       const blockedEvent = createOutboundBlocked({
         blockId,
         conversationId: '',
         channelId: request.channel,
-        content: messageBody,
+        content: redactedBody,
         recipientId,
         reason: fullReason,
         findings: filterFindings,

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -32,6 +32,7 @@ import { createOutboundBlocked, createOutboundNotification, createAutonomySendBl
 import type { AutonomyService } from '../autonomy/autonomy-service.js';
 import type { OutboundNotificationPayload } from '../bus/events.js';
 import { markdownToHtml } from '../channels/email/markdown-to-html.js';
+import { scrubPii } from '../pii/scrubber.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -356,7 +357,10 @@ export class OutboundGateway {
             blockId,
             conversationId: '',
             channelId: request.channel,
-            content: messageBody,
+            // scrubPii() as a safety fallback — the redactor itself failed, so we apply
+            // a best-effort scrub before writing anything to the audit log. This ensures
+            // no raw PII leaks into the audit trail even on a redactor failure path.
+            content: scrubPii(messageBody),
             recipientId,
             reason: 'pii_redactor_error',
             findings: [{ rule: 'pii_redactor_error', detail: 'PiiRedactor threw an unexpected error' }],

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -303,6 +303,7 @@ export class OutboundGateway {
     // Fail-open on DB errors: an infra failure should not silently prevent
     // sending. We warn so the anomaly is visible in logs/alerting.
     let recipientTrustLevel: TrustLevel | null = null;
+    let recipientContactId: string | undefined;
     try {
       const contact = await this.contactService.resolveByChannelIdentity(request.channel, recipientId);
       if (contact !== null) {
@@ -313,9 +314,11 @@ export class OutboundGateway {
           );
           return { success: false, blockedReason: 'Recipient is blocked' };
         }
-        // Capture trust level for the content filter — used to allow contact data
-        // in user-initiated responses to explicitly trusted recipients (e.g. CEO's EA).
+        // Capture trust level for the content filter, and contact UUID for the PII redactor's
+        // CEO bypass check. Both are used downstream: trust level by the content filter, and
+        // contact UUID by PiiRedactor.redact() so it can match against the stored CEO contact ID.
         recipientTrustLevel = contact.trustLevel;
+        recipientContactId = contact.contactId;
       }
     } catch (err) {
       // DB or service error — log at warn and proceed.
@@ -343,7 +346,7 @@ export class OutboundGateway {
           messageBody,
           request.channel,
           recipientTrustLevel,
-          { recipientId },
+          { recipientId, recipientContactId },
         );
         redactedBody = redactionResult.content;
       } catch (err) {

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -499,14 +499,19 @@ export class OutboundGateway {
     // After a successful send, promote the recipient contact from provisional →
     // confirmed (or create one if none exists). The act of sending is the CEO's
     // implicit trust confirmation — replies from this person should never be held.
+    //
+    // IMPORTANT: pass redactedBody here, not request.body / request.message.
+    // The dispatch methods read the body/message field from the request object
+    // they receive — if we pass the original `request`, the unredacted content
+    // reaches Nylas / signal-cli even though redactedBody was computed above.
     if (request.channel === 'email') {
-      const result = await this.dispatchEmail(request);
+      const result = await this.dispatchEmail({ ...request, body: redactedBody });
       if (result.success) {
         await this.promoteOrCreateRecipientContact('email', recipientId);
       }
       return result;
     } else {
-      const result = await this.dispatchSignal(request);
+      const result = await this.dispatchSignal({ ...request, message: redactedBody });
       // Only promote for 1:1 Signal sends — group sends use a groupId, not an individual
       // phone number. Creating a contact for a group token would pollute the contacts table
       // and would not help with inbound replies (which come from member numbers, not the group ID).

--- a/tests/integration/ceo-bootstrap.test.ts
+++ b/tests/integration/ceo-bootstrap.test.ts
@@ -67,7 +67,7 @@ describeIf('bootstrapCeoContact', () => {
     expect(contact.rows[0].display_name).toBe('Bootstrap Test CEO');
     expect(contact.rows[0].role).toBe('ceo');
     expect(contact.rows[0].status).toBe('confirmed');
-    expect(contact.rows[0].trust_level).toBe('high');
+    expect(contact.rows[0].trust_level).toBe('ceo');
     expect(contact.rows[0].kg_node_id).toBe(result.kgNodeId);
 
     // Verify the KG node was created with correct metadata
@@ -134,13 +134,13 @@ describeIf('bootstrapCeoContact', () => {
     expect(result.contactId).toBe(contactId);
     expect(result.kgNodeId).toBeTruthy();
 
-    // Contact should now be confirmed + high trust
+    // Contact should now be confirmed + ceo trust
     const contact = await pool.query<{ status: string; trust_level: string; kg_node_id: string }>(
       `SELECT status, trust_level, kg_node_id FROM contacts WHERE id = $1`,
       [contactId],
     );
     expect(contact.rows[0].status).toBe('confirmed');
-    expect(contact.rows[0].trust_level).toBe('high');
+    expect(contact.rows[0].trust_level).toBe('ceo');
     expect(contact.rows[0].kg_node_id).toBe(result.kgNodeId);
 
     // Identity should now be verified

--- a/tests/integration/ceo-bootstrap.test.ts
+++ b/tests/integration/ceo-bootstrap.test.ts
@@ -185,6 +185,13 @@ describeIf('bootstrapCeoContact', () => {
     );
     expect(after.rows[0].kg_node_id).toBe(result.kgNodeId);
 
+    // trust_level should have been promoted from 'high' → 'ceo' by the bootstrap UPDATE
+    const trustAfter = await pool.query<{ trust_level: string }>(
+      `SELECT trust_level FROM contacts WHERE id = $1`,
+      [contactId],
+    );
+    expect(trustAfter.rows[0]!.trust_level).toBe('ceo');
+
     // KG node should be a permanent bootstrap person node
     const node = await pool.query<{ type: string; decay_class: string; source: string }>(
       `SELECT type, decay_class, source FROM kg_nodes WHERE id = $1`,

--- a/tests/unit/dispatch/outbound-filter.test.ts
+++ b/tests/unit/dispatch/outbound-filter.test.ts
@@ -368,7 +368,7 @@ describe('OutboundContentFilter', () => {
     // The rule uses a single axis: recipient trust level.
     //
     // Block condition: third-party email AND !recipientIsTrusted
-    // Allow condition: no third-party email OR recipientIsTrusted (ceoEmail match OR trustLevel='high')
+    // Allow condition: no third-party email OR recipientIsTrusted (meetsMinimumTrust(trustLevel, 'high'))
     //
     // The trigger source (routine vs user-initiated) is irrelevant — trusted recipients
     // may receive third-party contact data in both scheduled routines (daily briefing with

--- a/tests/unit/dispatch/outbound-filter.test.ts
+++ b/tests/unit/dispatch/outbound-filter.test.ts
@@ -379,12 +379,14 @@ describe('OutboundContentFilter', () => {
     it('allows a routine message to the CEO containing a third-party email (daily briefing)', async () => {
       const filter = createTestFilter();
       // Daily briefing to CEO lists a calendar attendee's email — allowed (CEO is trusted).
+      // Migration 030 ensures the CEO contact always has trustLevel='ceo' in the DB,
+      // so the contact resolver provides recipientTrustLevel: 'ceo' at runtime.
       const result = await filter.check({
         content: `Here is your daily briefing. Your 2pm meeting includes ${THIRD_PARTY_EMAIL}.`,
         recipientEmail: 'ceo@example.com',
         conversationId: 'scheduler:job-1:run-1',
         channelId: 'email',
-        recipientTrustLevel: null,
+        recipientTrustLevel: 'ceo',
       });
       expect(result.passed).toBe(true);
       expect(result.findings.some((f) => f.rule === 'contact-data-leak')).toBe(false);
@@ -393,12 +395,14 @@ describe('OutboundContentFilter', () => {
     it('allows a user-initiated response to the CEO containing a third-party email', async () => {
       const filter = createTestFilter();
       // CEO asked "what is Hamilton's email?" — should be allowed.
+      // Migration 030 ensures the CEO contact always has trustLevel='ceo' in the DB,
+      // so the contact resolver provides recipientTrustLevel: 'ceo' at runtime.
       const result = await filter.check({
         content: `Hamilton's email is ${THIRD_PARTY_EMAIL}.`,
         recipientEmail: 'ceo@example.com',
         conversationId: 'conv-123',
         channelId: 'email',
-        recipientTrustLevel: null,
+        recipientTrustLevel: 'ceo',
       });
       expect(result.passed).toBe(true);
       expect(result.findings.some((f) => f.rule === 'contact-data-leak')).toBe(false);
@@ -458,6 +462,20 @@ describe('OutboundContentFilter', () => {
       });
       expect(result.passed).toBe(false);
       expect(result.findings.some((f) => f.rule === 'contact-data-leak')).toBe(true);
+    });
+
+    it('allows third-party emails when recipient trust level is ceo', async () => {
+      const filter = createTestFilter();
+      // trustLevel='ceo' meets or exceeds 'high' — meetsMinimumTrust('ceo', 'high') is true.
+      // This test ensures the CEO is trusted via trust level rather than email comparison.
+      const result = await filter.check({
+        content: 'Please contact hamilton@other.org for details.',
+        recipientEmail: 'recipient@example.com',
+        conversationId: 'conv-1',
+        channelId: 'email',
+        recipientTrustLevel: 'ceo',
+      });
+      expect(result.passed).toBe(true);
     });
   });
 });

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -986,7 +986,7 @@ describe('PII redaction pipeline step', () => {
       redactions: [{ patternLabel: 'credit_card', channelId: 'email', replacedWith: '[REDACTED: CREDIT_CARD]' }],
     }));
 
-    const { gateway, contentFilter } = makeGateway(piiRedactor);
+    const { gateway, contentFilter, nylasClient } = makeGateway(piiRedactor);
     const result = await gateway.send(piiRequest);
 
     expect(result.success).toBe(true);
@@ -999,6 +999,14 @@ describe('PII redaction pipeline step', () => {
     expect(contentFilter.check).not.toHaveBeenCalledWith(expect.objectContaining({
       content: piiRequest.body,
     }));
+
+    // Verify dispatch also received redacted content (not the original with PII).
+    // The body goes through markdownToHtml() before reaching Nylas, so we
+    // serialise the entire sendMessage call args and check for the redaction
+    // marker rather than an exact string match.
+    const sendCall = (nylasClient.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(JSON.stringify(sendCall)).toContain('[REDACTED:');
+    expect(JSON.stringify(sendCall)).not.toContain('4111');
   });
 
   it('does NOT redact PII for CEO recipients (trust_override bypasses redaction)', async () => {

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -1028,9 +1028,10 @@ describe('PII redaction pipeline step', () => {
     const result = await gateway.send(piiRequest);
 
     expect(result.success).toBe(true);
-    // The redactor was still called (the gateway always calls it when configured),
-    // but the content filter receives the original body (redactor returned it unchanged).
-    expect(piiRedactor.redact).toHaveBeenCalledOnce();
+    // The redactor is called twice for email — once for the body, once for the subject.
+    // Both calls return unchanged content (CEO trust bypass), so the content filter
+    // receives the original body.
+    expect(piiRedactor.redact).toHaveBeenCalledTimes(2);
     expect(contentFilter.check).toHaveBeenCalledWith(expect.objectContaining({
       content: piiRequest.body,
     }));

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -7,6 +7,7 @@ import type { OutboundContentFilter } from '../../../src/dispatch/outbound-filte
 import type { EventBus } from '../../../src/bus/bus.js';
 import type { BusEvent } from '../../../src/bus/events.js';
 import type { AutonomyService, AutonomyConfig } from '../../../src/autonomy/autonomy-service.js';
+import type { PiiRedactor } from '../../../src/dispatch/pii-redactor.js';
 
 /**
  * Build fresh vi.fn() mocks for each test. Using beforeEach + createMocks()
@@ -921,5 +922,151 @@ describe('autonomy gate on send()', () => {
 
     expect(result.success).toBe(true);
     expect(result.draftId).toBe('draft-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PII redaction pipeline step — wired between blocked-contact check and content filter
+// ---------------------------------------------------------------------------
+
+describe('PII redaction pipeline step', () => {
+  const piiRequest = {
+    channel: 'email' as const,
+    to: 'partner@example.com',
+    subject: 'Payment info',
+    // Credit card number embedded in the message body
+    body: 'Please charge 4111111111111111 for the service.',
+  };
+
+  /** Build a mock PiiRedactor whose redact() function can be controlled per test. */
+  function makePiiRedactor(
+    impl: (content: string) => Promise<{ content: string; redactions: unknown[] }>,
+  ): PiiRedactor {
+    return {
+      redact: vi.fn().mockImplementation((content: string) => impl(content)),
+    } as unknown as PiiRedactor;
+  }
+
+  /** Standard gateway builder used by most cases in this describe block. */
+  function makeGateway(piiRedactor?: PiiRedactor) {
+    const logger = createLogger('error');
+    const nylasClient = {
+      sendMessage: vi.fn().mockResolvedValue({ id: 'msg-pii-1' }),
+    } as unknown as NylasClient;
+    const contactService = {
+      resolveByChannelIdentity: vi.fn().mockResolvedValue(null),
+    } as unknown as ContactService;
+    const contentFilter = {
+      check: vi.fn().mockResolvedValue({ passed: true, findings: [] }),
+    } as unknown as OutboundContentFilter;
+    const bus = {
+      publish: vi.fn().mockResolvedValue(undefined),
+      subscribe: vi.fn(),
+    } as unknown as EventBus;
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', nylasClient]]),
+      contactService,
+      contentFilter,
+      bus,
+      ceoEmail: 'ceo@example.com',
+      logger,
+      piiRedactor,
+    });
+
+    return { gateway, nylasClient, contactService, contentFilter, bus };
+  }
+
+  it('redacts PII for non-CEO recipients before content filter sees it', async () => {
+    // The redactor replaces the credit card with a token.
+    // We verify that the content filter receives the redacted content, not the original.
+    const redactedBody = 'Please charge [REDACTED: CREDIT_CARD] for the service.';
+    const piiRedactor = makePiiRedactor(async (_content) => ({
+      content: redactedBody,
+      redactions: [{ patternLabel: 'credit_card', channelId: 'email', replacedWith: '[REDACTED: CREDIT_CARD]' }],
+    }));
+
+    const { gateway, contentFilter } = makeGateway(piiRedactor);
+    const result = await gateway.send(piiRequest);
+
+    expect(result.success).toBe(true);
+    // The content filter must have seen the redacted content, not the raw PII.
+    expect(contentFilter.check).toHaveBeenCalledOnce();
+    expect(contentFilter.check).toHaveBeenCalledWith(expect.objectContaining({
+      content: redactedBody,
+    }));
+    // The original PII body must NOT have reached the content filter.
+    expect(contentFilter.check).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: piiRequest.body,
+    }));
+  });
+
+  it('does NOT redact PII for CEO recipients (trust_override bypasses redaction)', async () => {
+    // When the recipient has 'ceo' trust level, the redactor returns content unchanged.
+    const piiRedactor = makePiiRedactor(async (content) => ({
+      content,
+      redactions: [],
+    }));
+
+    const { gateway, contentFilter, contactService } = makeGateway(piiRedactor);
+    // Make the contact service return a CEO-level trust contact.
+    (contactService.resolveByChannelIdentity as ReturnType<typeof vi.fn>).mockResolvedValue({
+      contactId: 'contact-ceo',
+      displayName: 'CEO',
+      status: 'confirmed',
+      trustLevel: 'ceo',
+    });
+
+    const result = await gateway.send(piiRequest);
+
+    expect(result.success).toBe(true);
+    // The redactor was still called (the gateway always calls it when configured),
+    // but the content filter receives the original body (redactor returned it unchanged).
+    expect(piiRedactor.redact).toHaveBeenCalledOnce();
+    expect(contentFilter.check).toHaveBeenCalledWith(expect.objectContaining({
+      content: piiRequest.body,
+    }));
+  });
+
+  it('works without piiRedactor configured (backwards compatible)', async () => {
+    // Gateway constructed without piiRedactor → content passes through to filter unchanged.
+    const { gateway, contentFilter } = makeGateway(/* piiRedactor = */ undefined);
+
+    const result = await gateway.send(piiRequest);
+
+    expect(result.success).toBe(true);
+    // The content filter must have received the original body — no redaction.
+    expect(contentFilter.check).toHaveBeenCalledOnce();
+    expect(contentFilter.check).toHaveBeenCalledWith(expect.objectContaining({
+      content: piiRequest.body,
+    }));
+  });
+
+  it('blocks the message when PiiRedactor throws (fail-closed)', async () => {
+    // If the redactor throws, the gateway must block the message rather than
+    // sending unredacted PII. This is the fail-closed contract.
+    const piiRedactor = {
+      redact: vi.fn().mockRejectedValue(new Error('Pattern engine crashed')),
+    } as unknown as PiiRedactor;
+
+    const { gateway, nylasClient, bus } = makeGateway(piiRedactor);
+    const result = await gateway.send(piiRequest);
+
+    // Message must be blocked — never reach Nylas.
+    expect(result.success).toBe(false);
+    expect(nylasClient.sendMessage).not.toHaveBeenCalled();
+
+    // An outbound.blocked event must be published to maintain the audit trail.
+    const publishCalls = (bus.publish as ReturnType<typeof vi.fn>).mock.calls;
+    const blockedCalls = publishCalls.filter(
+      (call: unknown[]) => (call[1] as BusEvent).type === 'outbound.blocked',
+    );
+    expect(blockedCalls).toHaveLength(1);
+    if (blockedCalls[0]) {
+      const blockedEvent = blockedCalls[0][1] as BusEvent;
+      if (blockedEvent.type === 'outbound.blocked') {
+        expect(blockedEvent.payload.reason).toContain('pii_redactor_error');
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **PII outbound redaction** — new `PiiRedactor` pipeline step in `OutboundGateway` redacts detected PII (credit cards, phones, SSNs, etc.) from outbound email and Signal replies based on per-channel policy. CEO trust level bypasses all redaction.
- **`detectPii()` extraction** — shared detection foundation split from `scrubPii()`, returning structured `PiiMatch[]` with labels and positions. Both the log/LLM scrubber and the new redactor use the same openredaction-based detection.
- **`'ceo'` trust level** — new ordinal trust level above `'high'` with `meetsMinimumTrust()` helper replacing scattered `=== 'high'` checks. CEO bootstrap sets `trust_level = 'ceo'`; migration 030 widens the DB check constraint.
- **`outbound.pii-redacted` bus event** — audit trail published on every outbound redaction (no subscribers initially).

## Design decisions

- **Fail-closed**: PiiRedactor crash blocks the message (not sends it unredacted). Blocked audit event uses `scrubPii()` fallback so raw PII never reaches the audit log.
- **CEO identified by trust level, not role field** — `role = 'ceo'` is a job title susceptible to prompt injection; trust level is set by the bootstrap process using `ceoPrimaryEmail` config.
- **Config-only policy, no regex in Curia** — detection delegated entirely to `openredaction`. Config only controls allow/block policy per channel.

## Test plan

- [ ] All 1737 unit tests pass (`npm test`)
- [ ] 2 pre-existing integration test failures (`autonomy-routes`, `autonomy-service-pagination`) are from main — unrelated to this PR
- [ ] `PiiRedactor` unit tests: redaction, allow-list, CEO bypass, disabled kill switch, default-block, bus event, no-PII passthrough
- [ ] `OutboundGateway` integration tests: redacted content reaches Nylas (not just content filter), CEO not redacted, no-redactor backwards compat, fail-closed on throw
- [ ] `meetsMinimumTrust()` unit tests: null, ceo, high, medium, low ordinal matrix
- [ ] `detectPii()` unit tests: email/credit card detection, UUID false-positive shielding, position accuracy

Closes #249
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable per-channel PII redaction for outbound email and Signal messages, with automatic detection and redaction of sensitive data patterns.
  * Introduced new CEO trust level with bypass capability for PII redaction policies.

* **Changed**
  * Enhanced trust level hierarchy to include CEO level with ordinal comparison support.
  * Updated contact data leak detection to use unified trust evaluation.

* **Documentation**
  * Added comprehensive design specifications for PII outbound redaction policies and implementation plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->