### PR TITLE
feat(autonomy): gate-level approval trigger + humanApproved on execution layer (#427)

### DIFF
--- a/docs/wip/2026-05-03-approval-trigger-design.md
+++ b/docs/wip/2026-05-03-approval-trigger-design.md
@@ -1,0 +1,308 @@
+# Gate-level approval trigger + humanApproved on execution layer
+
+Issue: #427
+ADR: 018 (Curia-initiated approval requests)
+Date: 2026-05-03
+
+## Summary
+
+When the autonomy gate blocks a skill, the execution layer writes a
+`pending_approval` row to `autonomy_action_log`, notifies the CEO, and returns
+an enriched advisory failure to the coordinator. This also adds
+`humanApproved` to `InvokeOptions` — the mechanism the `approve-action` skill
+(#428) uses to re-execute approved skills past the gate.
+
+## Decisions from brainstorming
+
+1. **Every gate block creates an approval request** — no minimum action_risk
+   threshold. Gate A (score < 60) and Gate B (per action_risk) both trigger the
+   same approval flow. The CEO set a low score because they want visibility.
+2. **Email-only notifications** via `outboundGateway.sendNotification()`. Signal
+   notification routing deferred to a future issue.
+3. **Email adapter integration deferred** to #435 — no `autonomy_action_log`
+   writes from `dispatchByPolicy()` in this issue.
+4. **Approach A: dedicated ApprovalTriggerService** rather than inline logic in
+   execution.ts. Clean separation of concerns, independently testable, reusable
+   by #435 later.
+
+## Section 1: `humanApproved` on InvokeOptions
+
+Add `humanApproved?: boolean` to `InvokeOptions` in `src/skills/execution.ts`.
+
+When `humanApproved` is `true`:
+
+- Gates A and B are skipped entirely. The guard condition becomes:
+  ```typescript
+  if (this.autonomyService
+      && manifest.sensitivity !== 'elevated'
+      && !options?.humanApproved) {
+    // ... gate logic
+  }
+  ```
+- The elevated-skill gate still runs — `approve-action` is
+  `sensitivity: 'elevated'`, so it must pass the CEO caller check.
+- All other checks run normally: capability injection, content filter,
+  blocked-contact, timeout.
+- Every `humanApproved` invocation is logged at info level:
+  `"autonomy gates skipped — humanApproved flag set (CEO-authorized re-execution)"`
+
+Only the `approve-action` skill (#428) sets this flag. The runtime's `invoke()`
+call in `runtime.ts` passes `InvokeOptions` through unchanged — no runtime
+changes needed.
+
+## Section 2: ApprovalTriggerService
+
+New file: `src/autonomy/approval-trigger.ts`
+
+### Constructor dependencies
+
+- `ActionLogRepo` — dedup queries and row insertion
+- `OutboundGateway` — `sendNotification()` to the CEO
+- `Logger`
+- `ceoEmail?: string` — needed in the `OutboundNotificationPayload` sent to
+  `sendNotification()`. If absent, notification is skipped (same as if
+  notification fails — row still created, `notification_sent_at` stays null).
+  Sourced from the same config value that the gateway uses.
+
+### Primary method
+
+```typescript
+async request(opts: {
+  taskId: string;
+  conversationId?: string;
+  skillName: string;
+  actionRisk: string;
+  input: Record<string, unknown>;
+  currentScore: number;
+  requiredScore: number;
+}): Promise<ApprovalRequestResult>
+```
+
+Return type:
+```typescript
+type ApprovalRequestResult =
+  | { created: true; shortRef: string; notificationSent: boolean }
+  | { created: false; reason: 'duplicate'; existingShortRef: string }
+```
+
+### Flow inside `request()`
+
+1. **Dedup check** — query `autonomy_action_log` for an existing
+   `pending_approval` row with the same `skill_name` and `task_id` where
+   `payload::jsonb = $1::jsonb` (value-level comparison, key-order
+   independent). If found, return `{ created: false, reason: 'duplicate',
+   existingShortRef }`.
+
+2. **Generate `short_ref`** — abbreviate the skill name to a prefix and
+   append a sequential counter scoped to the task. Query
+   `countShortRefsForTask(taskId)`, use count + 1. Produces refs like
+   `cal-1`, `email-2`.
+
+3. **Generate `description`** — human-readable one-liner from skill name +
+   key input fields. See Section 5 for details.
+
+4. **Insert row** — call `ActionLogRepo.insert()` with
+   `outcome: 'pending_approval'`, `payload: input`,
+   `expiresAt: now + 24h`, the generated `shortRef` and `description`.
+
+5. **Notify CEO** — if `ceoEmail` is configured, call
+   `outboundGateway.sendNotification()` with payload:
+   - `notificationType: 'approval_requested'` (new value — add to
+     `OutboundNotificationPayload.notificationType` union in `events.ts`)
+   - `ceoEmail`: from constructor
+   - `subject: 'Approval needed — {description}'`
+   - `body`: includes description, current score vs required, short_ref,
+     expiry time, and a note to reply to approve/deny/dismiss
+
+   If notification succeeds, update the row with
+   `setNotificationSentAt(id)`. If notification fails or `ceoEmail` is not
+   configured, log a warning — `notification_sent_at` stays null, the row
+   still exists, and the CEO will see it in the daily digest (#429).
+
+## Section 3: Execution layer integration
+
+`ApprovalTriggerService` is injected as a new optional constructor dependency
+on `ExecutionLayer`, same pattern as `autonomyService`.
+
+### Gate A and Gate B modification
+
+Both gates follow the same flow after detecting a block:
+
+1. Gate detects the block (existing logic, unchanged).
+2. Publish `autonomy.skill_blocked` event (existing logic, unchanged).
+3. If `approvalTrigger` is wired and `options?.taskEventId` is present, call
+   `approvalTrigger.request()` with skill name, input, task context, scores.
+4. Build the error message based on the result:
+   - **Created + notification sent:**
+     `"Skill '{name}' blocked — autonomy score is {current}, requires
+     {required}. An approval request has been sent to the CEO (ref:
+     {shortRef})."`
+   - **Created + notification failed:**
+     `"Skill '{name}' blocked — autonomy score is {current}, requires
+     {required}. An approval request was created (ref: {shortRef}) but
+     notification could not be delivered — the CEO will see it in the next
+     digest."`
+   - **Duplicate:**
+     `"Skill '{name}' blocked — an approval request for this action is
+     already pending (ref: {existingShortRef})."`
+5. If `approvalTrigger` is not wired or `taskEventId` is missing, fall through
+   to the existing error message unchanged (fail-open).
+
+Gate A and Gate B call the same `approvalTrigger.request()` — no branching by
+gate type. The only difference is how `requiredScore` is determined (60 for
+Gate A, `minScoreForActionRisk()` for Gate B), which is already computed before
+the trigger call.
+
+## Section 4: ActionLogRepo additions
+
+Three new methods in `src/autonomy/action-log-repo.ts`:
+
+### `findPendingByTaskAndSkill(taskId, skillName, payload)`
+
+```sql
+SELECT * FROM autonomy_action_log
+WHERE task_id = $1
+  AND skill_name = $2
+  AND outcome = 'pending_approval'
+  AND payload::jsonb = $3::jsonb
+LIMIT 1
+```
+
+Returns `ActionLogRow | null`. Uses JSONB equality for key-order-independent
+payload comparison.
+
+### `countShortRefsForTask(taskId)`
+
+```sql
+SELECT COUNT(*) FROM autonomy_action_log
+WHERE task_id = $1
+  AND short_ref IS NOT NULL
+```
+
+Returns `number`. Used for sequential short_ref counter generation.
+
+### `setNotificationSentAt(id)`
+
+```sql
+UPDATE autonomy_action_log
+SET notification_sent_at = now()
+WHERE id = $1
+```
+
+Called after successful `sendNotification()`. If notification fails, this is
+never called — the column stays null.
+
+The existing `insert()` method already accepts all needed fields via
+`ActionLogInsert` — no changes needed.
+
+## Section 5: Short ref generation and description building
+
+Both are pure functions inside `approval-trigger.ts`.
+
+### Short ref prefixes
+
+| Skill name pattern | Prefix |
+|---|---|
+| `calendar-*` | `cal` |
+| `email-*` | `email` |
+| `signal-*` | `signal` |
+| `store-fact`, `*-memory-*` | `mem` |
+| `*-contact*` | `contact` |
+| `schedule-*` | `sched` |
+| Everything else | first word of skill name, truncated to 6 chars |
+
+Combined with per-task counter: `cal-1`, `email-2`, `contact-3`.
+
+### Description generation
+
+Builds a human-readable one-liner from skill name and input fields:
+
+- Look for common input fields (`title`, `subject`, `to`, `body`, `name`,
+  `start`, `query`) and include their values
+- Truncate any single value to 80 chars
+- Truncate the full description to 200 chars
+- Format: `"{verb} {context}"` where the verb derives from the skill name
+  (e.g., `calendar-create-event` -> "Create calendar event",
+  `email-reply` -> "Send email reply")
+- Fallback: `"Run {skill_name}"`
+
+Examples:
+
+- `calendar-create-event` + `{ title: "Lunch with Dana", start: "..." }`
+  -> `"Create calendar event: Lunch with Dana, Tue May 6 at 12:00"`
+- `email-reply` + `{ to: "dana@example.com", subject: "Re: Budget" }`
+  -> `"Send email reply to dana@example.com: Re: Budget"`
+- `store-fact` + `{ label: "Dana prefers mornings" }`
+  -> `"Store fact: Dana prefers mornings"`
+- `some-unknown-skill` + `{}`
+  -> `"Run some-unknown-skill"`
+
+Neither function needs to be perfect — the description is for human readability
+in notifications and coordinator context. The `payload` column stores the full
+input for re-execution.
+
+## Section 6: Wiring and testing
+
+### Wiring in `src/index.ts`
+
+Construct `ApprovalTriggerService` after `ActionLogRepo` and
+`OutboundGateway` are created (both already exist at that point). Pass it
+into `ExecutionLayer`'s constructor options as `approvalTrigger`. Same
+optional pattern as other services — if not wired, the execution layer skips
+the trigger (fail-open).
+
+### Test plan
+
+**`approval-trigger.test.ts`** (unit, new file) — bulk of coverage:
+
+- Happy path: creates row, generates short_ref, sends notification, returns
+  `{ created: true }`
+- Dedup: returns `{ created: false, reason: 'duplicate' }` when matching
+  pending row exists
+- Dedup allows different payloads for same skill in same task (separate
+  approval requests)
+- Notification failure: row still created, `notification_sent_at` stays null,
+  returns `{ notificationSent: false }`
+- Short ref counter increments correctly across multiple requests in same task
+- Description generation for known skill patterns + generic fallback
+- Missing `ceoEmail` on gateway (notification fails gracefully)
+
+**`execution.test.ts`** (extend existing):
+
+- Gate A block with trigger wired -> error message includes "approval request
+  sent" + short_ref
+- Gate B block with trigger wired -> same enriched error message
+- Gate block with trigger not wired -> existing error message unchanged
+  (backwards compatible)
+- `humanApproved: true` -> gates skipped, trigger never called, info log
+  emitted
+- `humanApproved: true` + elevated skill -> elevated gate still runs (not
+  bypassed)
+- Missing `taskEventId` -> trigger skipped, existing error message returned
+
+**`action-log-repo.test.ts`** (extend existing):
+
+- `findPendingByTaskAndSkill` returns matching row / null
+- `findPendingByTaskAndSkill` uses JSONB equality (key order independent)
+- `countShortRefsForTask` returns correct count
+- `setNotificationSentAt` updates the timestamp
+
+### Out of scope for #427
+
+- `approve-action` / `deny-action` / `dismiss-action` skills (#428)
+- Expiry sweep and daily digest (#429)
+- Email adapter draft -> action log integration (#435)
+- `autonomy_action_log` row transitions (approved/denied/expired) — #428/#429
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/skills/execution.ts` | Add `humanApproved` to `InvokeOptions`, gate bypass, approval trigger call |
+| `src/autonomy/approval-trigger.ts` | **New** — ApprovalTriggerService |
+| `src/autonomy/action-log-repo.ts` | Add `findPendingByTaskAndSkill`, `countShortRefsForTask`, `setNotificationSentAt` |
+| `src/bus/events.ts` | Add `'approval_requested'` to `OutboundNotificationPayload.notificationType` union |
+| `src/index.ts` | Wire ApprovalTriggerService into ExecutionLayer |
+| `src/autonomy/approval-trigger.test.ts` | **New** — unit tests |
+| `src/skills/execution.test.ts` | Extend with humanApproved + trigger integration tests |
+| `src/autonomy/action-log-repo.test.ts` | Extend with new method tests |

--- a/docs/wip/2026-05-03-approval-trigger.md
+++ b/docs/wip/2026-05-03-approval-trigger.md
@@ -1,0 +1,1212 @@
+# Gate-level Approval Trigger Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the autonomy gate blocks a skill, write a `pending_approval` row, notify the CEO, and return an enriched advisory. Add `humanApproved` to `InvokeOptions` so approved skills can bypass the gate.
+
+**Architecture:** A new `ApprovalTriggerService` owns the approval request flow (dedup, insert, short_ref generation, description, notification). The execution layer calls it from Gate A/B block paths. `humanApproved` on `InvokeOptions` skips autonomy gates for re-execution. All notification goes through the existing `outboundGateway.sendNotification()`.
+
+**Tech Stack:** TypeScript (ESM), Vitest, Postgres (via `ActionLogRepo`), existing `OutboundGateway`, `EventBus`, `OutboundNotificationPayload` from `src/bus/events.ts`
+
+---
+
+## File Map
+
+**Created:**
+- `src/autonomy/approval-trigger.ts` — ApprovalTriggerService (dedup, insert, short_ref, description, notification)
+- `src/autonomy/approval-trigger.test.ts` — unit tests for ApprovalTriggerService
+
+**Modified:**
+- `src/bus/events.ts:132-133` — add `'approval_requested'` to `OutboundNotificationPayload.notificationType` union
+- `src/autonomy/action-log-repo.ts` — add `findPendingByTaskAndSkill`, `countShortRefsForTask`, `setNotificationSentAt`
+- `src/autonomy/action-log-repo.test.ts` — tests for new repo methods
+- `src/skills/execution.ts:46-55` — add `humanApproved` to `InvokeOptions`
+- `src/skills/execution.ts:249-323` — modify gate A/B to call approval trigger and enrich error messages
+- `src/skills/execution.ts:57-119` — add `approvalTrigger` to constructor
+- `src/skills/execution.test.ts` — extend with `humanApproved` and approval trigger tests
+- `src/index.ts:826,849` — construct `ApprovalTriggerService`, pass to `ExecutionLayer`
+
+---
+
+## Task 1: Add `'approval_requested'` to notification type union
+
+**Files:**
+- Modify: `src/bus/events.ts:132-133`
+
+- [ ] **Step 1: Update the type**
+
+In `src/bus/events.ts`, find the `OutboundNotificationPayload` interface (line 132) and add `'approval_requested'` to the `notificationType` union. Also update the comment block above it (lines 128-131).
+
+```typescript
+// notificationType discriminates between alert categories:
+//   - 'blocked_content': CEO alert that an outbound message was blocked by the content filter
+//   - 'group_held':      CEO alert that a Signal group message was held due to unverified members
+//   - 'contact_rate_limited': CEO alert that contact auto-creation was throttled due to rate limits
+//   - 'approval_requested':   CEO alert that Curia wants to take an action that requires approval
+export interface OutboundNotificationPayload {
+  notificationType: 'blocked_content' | 'group_held' | 'contact_rate_limited' | 'approval_requested';
+```
+
+- [ ] **Step 2: Verify the project compiles**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-trigger run build 2>&1 | tail -5`
+Expected: Clean compilation (no type errors from existing code — this type is only consumed, never switched exhaustively).
+
+- [ ] **Step 3: Commit**
+
+```
+git -C /Users/josephfung/Projects/worktrees/curia-approval-trigger add src/bus/events.ts
+git -C /Users/josephfung/Projects/worktrees/curia-approval-trigger commit -m "feat(autonomy): add 'approval_requested' to OutboundNotificationPayload type union"
+```
+
+---
+
+## Task 2: ActionLogRepo — add new query methods
+
+**Files:**
+- Modify: `src/autonomy/action-log-repo.ts`
+- Modify: `src/autonomy/action-log-repo.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these test blocks at the end of the `describe('ActionLogRepo', ...)` block in `src/autonomy/action-log-repo.test.ts`:
+
+```typescript
+describe('findPendingByTaskAndSkill', () => {
+  it('returns the matching pending row when one exists', async () => {
+    const now = new Date();
+    const { pool } = makePool([
+      {
+        id: 10, task_id: 't1', conversation_id: null, skill_name: 'calendar-create-event',
+        action_risk: 'high', outcome: 'pending_approval', task_summary: null,
+        competence_flag: null, commitment_flag: null, compatibility: null,
+        scored_by: null, payload: { title: 'Lunch' }, notification_sent_at: null,
+        resolved_at: null, resolved_by: null, expires_at: null,
+        parent_action_id: null, short_ref: 'cal-1', description: 'Create calendar event: Lunch',
+        created_at: now,
+      },
+    ]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const row = await repo.findPendingByTaskAndSkill('t1', 'calendar-create-event', { title: 'Lunch' });
+    expect(row).not.toBeNull();
+    expect(row!.id).toBe(10);
+    expect(row!.shortRef).toBe('cal-1');
+  });
+
+  it('returns null when no matching row exists', async () => {
+    const { pool } = makePool([]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const row = await repo.findPendingByTaskAndSkill('t1', 'calendar-create-event', { title: 'Lunch' });
+    expect(row).toBeNull();
+  });
+
+  it('uses JSONB equality for payload comparison', async () => {
+    const { pool, queries } = makePool([]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    await repo.findPendingByTaskAndSkill('t1', 'send-email', { to: 'a@b.com', subject: 'Hi' });
+    expect(queries[0]!.sql).toContain('payload::jsonb = $3::jsonb');
+    expect(queries[0]!.params[2]).toBe(JSON.stringify({ to: 'a@b.com', subject: 'Hi' }));
+  });
+});
+
+describe('countShortRefsForTask', () => {
+  it('returns the count of short_ref rows for a task', async () => {
+    const { pool } = makePool([{ count: '3' }]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const count = await repo.countShortRefsForTask('t1');
+    expect(count).toBe(3);
+  });
+
+  it('returns 0 when no short_ref rows exist', async () => {
+    const { pool } = makePool([{ count: '0' }]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const count = await repo.countShortRefsForTask('t1');
+    expect(count).toBe(0);
+  });
+});
+
+describe('setNotificationSentAt', () => {
+  it('updates the notification_sent_at column', async () => {
+    const { pool, queries } = makePool([], 1);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    await repo.setNotificationSentAt(42);
+    expect(queries).toHaveLength(1);
+    expect(queries[0]!.sql).toContain('UPDATE autonomy_action_log');
+    expect(queries[0]!.sql).toContain('notification_sent_at');
+    expect(queries[0]!.params).toContain(42);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-trigger test -- src/autonomy/action-log-repo.test.ts 2>&1 | tail -20`
+Expected: FAIL — `findPendingByTaskAndSkill`, `countShortRefsForTask`, `setNotificationSentAt` are not defined.
+
+- [ ] **Step 3: Implement the three methods**
+
+Add these methods to the `ActionLogRepo` class in `src/autonomy/action-log-repo.ts`, before the closing `}` of the class (before line 125):
+
+```typescript
+  /**
+   * Find a pending_approval row for the given task + skill + payload.
+   * Used by ApprovalTriggerService for deduplication — same skill with
+   * same input in the same task should not generate a duplicate request.
+   * Uses JSONB equality for key-order-independent payload comparison.
+   */
+  async findPendingByTaskAndSkill(
+    taskId: string,
+    skillName: string,
+    payload: Record<string, unknown>,
+  ): Promise<ActionLogRow | null> {
+    const result = await this.pool.query(
+      `SELECT * FROM autonomy_action_log
+       WHERE task_id = $1
+         AND skill_name = $2
+         AND outcome = 'pending_approval'
+         AND payload::jsonb = $3::jsonb
+       LIMIT 1`,
+      [taskId, skillName, JSON.stringify(payload)],
+    );
+    if (result.rows.length === 0) return null;
+    return mapRow(result.rows[0] as Record<string, unknown>);
+  }
+
+  /**
+   * Count rows with a non-null short_ref for this task.
+   * Used by ApprovalTriggerService to generate sequential short_ref
+   * counters (e.g. cal-1, email-2).
+   */
+  async countShortRefsForTask(taskId: string): Promise<number> {
+    const result = await this.pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM autonomy_action_log
+       WHERE task_id = $1
+         AND short_ref IS NOT NULL`,
+      [taskId],
+    );
+    return parseInt(result.rows[0]!.count, 10);
+  }
+
+  /**
+   * Mark that the CEO notification was successfully delivered.
+   * Called after a successful sendNotification(). If notification fails,
+   * this is never called — notification_sent_at stays null.
+   */
+  async setNotificationSentAt(id: number): Promise<void> {
+    await this.pool.query(
+      `UPDATE autonomy_action_log
+       SET notification_sent_at = now()
+       WHERE id = $1`,
+      [id],
+    );
+    this.logger.debug({ id }, 'action-log-repo: notification_sent_at updated');
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-trigger test -- src/autonomy/action-log-repo.test.ts 2>&1 | tail -20`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git -C /Users/josephfung/Projects/worktrees/curia-approval-trigger add src/autonomy/action-log-repo.ts src/autonomy/action-log-repo.test.ts
+git -C /Users/josephfung/Projects/worktrees/curia-approval-trigger commit -m "feat(autonomy): add dedup, counter, and notification queries to ActionLogRepo"
+```
+
+---
+
+## Task 3: ApprovalTriggerService — short_ref and description pure functions
+
+**Files:**
+- Create: `src/autonomy/approval-trigger.ts`
+- Create: `src/autonomy/approval-trigger.test.ts`
+
+This task creates the file with the pure helper functions only. The `request()` method comes in Task 4.
+
+- [ ] **Step 1: Write the failing tests for pure functions**
+
+Create `src/autonomy/approval-trigger.test.ts`:
+
+```typescript
+// approval-trigger.test.ts — unit tests for ApprovalTriggerService.
+//
+// Tests are structured in two groups:
+//   1. Pure functions (shortRefPrefix, buildDescription) — no mocks needed
+//   2. request() method (Task 4) — mocks ActionLogRepo and OutboundGateway
+
+import { describe, it, expect } from 'vitest';
+import { shortRefPrefix, buildDescription } from './approval-trigger.js';
+
+describe('shortRefPrefix', () => {
+  it('maps calendar-* skills to "cal"', () => {
+    expect(shortRefPrefix('calendar-create-event')).toBe('cal');
+    expect(shortRefPrefix('calendar-update-event')).toBe('cal');
+  });
+
+  it('maps email-* skills to "email"', () => {
+    expect(shortRefPrefix('email-reply')).toBe('email');
+    expect(shortRefPrefix('email-draft-save')).toBe('email');
+  });
+
+  it('maps signal-* skills to "signal"', () => {
+    expect(shortRefPrefix('signal-send')).toBe('signal');
+  });
+
+  it('maps store-fact to "mem"', () => {
+    expect(shortRefPrefix('store-fact')).toBe('mem');
+  });
+
+  it('maps *-memory-* skills to "mem"', () => {
+    expect(shortRefPrefix('entity-memory-store')).toBe('mem');
+  });
+
+  it('maps *-contact* skills to "contact"', () => {
+    expect(shortRefPrefix('update-contact')).toBe('contact');
+    expect(shortRefPrefix('contact-merge')).toBe('contact');
+  });
+
+  it('maps schedule-* skills to "sched"', () => {
+    expect(shortRefPrefix('schedule-job')).toBe('sched');
+  });
+
+  it('falls back to first word of skill name, truncated to 6 chars', () => {
+    expect(shortRefPrefix('something-unusual')).toBe('someth');
+    expect(shortRefPrefix('web-search')).toBe('web');
+  });
+});
+
+describe('buildDescription', () => {
+  it('formats calendar-create-event with title', () => {
+    const desc = buildDescription('calendar-create-event', { title: 'Lunch with Dana', start: '2026-05-06T12:00:00-04:00' });
+    expect(desc).toContain('Create calendar event');
+    expect(desc).toContain('Lunch with Dana');
+  });
+
+  it('formats email-reply with to and subject', () => {
+    const desc = buildDescription('email-reply', { to: 'dana@example.com', subject: 'Re: Budget' });
+    expect(desc).toContain('Send email reply');
+    expect(desc).toContain('dana@example.com');
+    expect(desc).toContain('Re: Budget');
+  });
+
+  it('formats store-fact with label', () => {
+    const desc = buildDescription('store-fact', { label: 'Dana prefers mornings' });
+    expect(desc).toContain('Store fact');
+    expect(desc).toContain('Dana prefers mornings');
+  });
+
+  it('falls back to "Run {skill_name}" for unknown skills', () => {
+    const desc = buildDescription('some-unknown-skill', {});
+    expect(desc).toBe('Run some-unknown-skill');
+  });
+
+  it('truncates individual values to 80 chars', () => {
+    const longTitle = 'A'.repeat(100);
+    const desc = buildDescription('calendar-create-event', { title: longTitle });
+    // The value portion should be truncated, not the full description
+    expect(desc.length).toBeLessThanOrEqual(200);
+    expect(desc).not.toContain(longTitle);
+  });
+
+  it('truncates the full description to 200 chars', () => {
+    const desc = buildDescription('email-reply', {
+      to: 'very-long-email-address-that-goes-on-forever@example.com',
+      subject: 'Re: A very long subject line that keeps going and going and going',
+      body: 'This body is also very long and should not appear in the description',
+    });
+    expect(desc.length).toBeLessThanOrEqual(200);
+  });
+});
+```
+
+- [ ] **Step 2: Create the module with pure functions**
+
+Create `src/autonomy/approval-trigger.ts`:
+
+```typescript
+// approval-trigger.ts — ApprovalTriggerService.
+//
+// Owns the approval request flow when the autonomy gate blocks a skill:
+// dedup check, row insertion, short_ref generation, description building,
+// and CEO notification. See ADR-018 and issue #427.
+
+import type { ActionLogRepo } from './action-log-repo.js';
+import type { OutboundGateway } from '../skills/outbound-gateway.js';
+import type { Logger } from '../logger.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type ApprovalRequestResult =
+  | { created: true; shortRef: string; notificationSent: boolean }
+  | { created: false; reason: 'duplicate'; existingShortRef: string };
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for testing
+// ---------------------------------------------------------------------------
+
+/** Skill name prefix mapping for short_ref generation. */
+const PREFIX_RULES: Array<{ test: (name: string) => boolean; prefix: string }> = [
+  { test: (n) => n.startsWith('calendar-'), prefix: 'cal' },
+  { test: (n) => n.startsWith('email-'), prefix: 'email' },
+  { test: (n) => n.startsWith('signal-'), prefix: 'signal' },
+  { test: (n) => n === 'store-fact' || n.includes('-memory-'), prefix: 'mem' },
+  { test: (n) => n.includes('contact'), prefix: 'contact' },
+  { test: (n) => n.startsWith('schedule-'), prefix: 'sched' },
+];
+
+/** Return a short prefix for a skill name (e.g. "cal", "email"). */
+export function shortRefPrefix(skillName: string): string {
+  for (const rule of PREFIX_RULES) {
+    if (rule.test(skillName)) return rule.prefix;
+  }
+  // Fallback: first word (before first hyphen), truncated to 6 chars
+  const firstWord = skillName.split('-')[0] ?? skillName;
+  return firstWord.slice(0, 6);
+}
+
+const MAX_VALUE_LENGTH = 80;
+const MAX_DESCRIPTION_LENGTH = 200;
+
+/** Truncate a string to maxLen, appending "…" if truncated. */
+function truncate(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  return s.slice(0, maxLen - 1) + '…';
+}
+
+/** Verb + label mapping for known skill name patterns. */
+const VERB_RULES: Array<{ test: (name: string) => boolean; verb: string }> = [
+  { test: (n) => n === 'calendar-create-event', verb: 'Create calendar event' },
+  { test: (n) => n === 'calendar-update-event', verb: 'Update calendar event' },
+  { test: (n) => n === 'calendar-delete-event', verb: 'Delete calendar event' },
+  { test: (n) => n === 'email-reply', verb: 'Send email reply' },
+  { test: (n) => n === 'email-draft-save', verb: 'Save email draft' },
+  { test: (n) => n === 'store-fact', verb: 'Store fact' },
+  { test: (n) => n.startsWith('signal-'), verb: 'Send Signal message' },
+  { test: (n) => n.startsWith('schedule-'), verb: 'Schedule job' },
+];
+
+/**
+ * Build a human-readable one-liner from skill name and input fields.
+ * Used in CEO notifications, the pending-actions digest, and the
+ * coordinator's advisory failure message.
+ */
+export function buildDescription(
+  skillName: string,
+  input: Record<string, unknown>,
+): string {
+  // Determine verb
+  let verb = '';
+  for (const rule of VERB_RULES) {
+    if (rule.test(skillName)) { verb = rule.verb; break; }
+  }
+  if (!verb) return `Run ${skillName}`;
+
+  // Pick context fields in priority order
+  const contextParts: string[] = [];
+  const fieldPriority = ['title', 'subject', 'to', 'label', 'name', 'query'];
+  for (const field of fieldPriority) {
+    const val = input[field];
+    if (typeof val === 'string' && val.trim()) {
+      contextParts.push(truncate(val.trim(), MAX_VALUE_LENGTH));
+    }
+  }
+
+  if (contextParts.length === 0) return `Run ${skillName}`;
+
+  const context = contextParts.join(', ');
+  const full = `${verb}: ${context}`;
+  return truncate(full, MAX_DESCRIPTION_LENGTH);
+}
+
+// ---------------------------------------------------------------------------
+// Service class — request() added in Task 4
+// ---------------------------------------------------------------------------
+
+export class ApprovalTriggerService {
+  constructor(
+    private readonly actionLogRepo: ActionLogRepo,
+    private readonly outboundGateway: OutboundGateway,
+    private readonly logger: Logger,
+    private readonly ceoEmail?: string,
+  ) {}
+
+  // request() is implemented in Task 4
+}
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-trigger test -- src/autonomy/approval-trigger.test.ts 2>&1 | tail -20`
+Expected: All pure function tests PASS. (The service class has no methods yet to test.)
+
+- [ ] **Step 4: Commit**
+
+```
+git -C /Users/josephfung/Projects/worktrees/curia-approval-trigger add src/autonomy/approval-trigger.ts src/autonomy/approval-trigger.test.ts
+git -C /Users/josephfung/Projects/worktrees/curia-approval-trigger commit -m "feat(autonomy): add short_ref prefix and description builder for approval trigger"
+```
+
+---
+
+## Task 4: ApprovalTriggerService — `request()` method
+
+**Files:**
+- Modify: `src/autonomy/approval-trigger.ts`
+- Modify: `src/autonomy/approval-trigger.test.ts`
+
+- [ ] **Step 1: Write the failing tests for `request()`**
+
+Add this `describe` block at the end of `src/autonomy/approval-trigger.test.ts`:
+
+```typescript
+import { vi } from 'vitest';
+import { ApprovalTriggerService } from './approval-trigger.js';
+import type { ActionLogRepo } from './action-log-repo.js';
+import type { OutboundGateway } from '../skills/outbound-gateway.js';
+import { createSilentLogger } from '../logger.js';
+
+function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
+  return {
+    findPendingByTaskAndSkill: vi.fn().mockResolvedValue(null),
+    countShortRefsForTask: vi.fn().mockResolvedValue(0),
+    insert: vi.fn().mockResolvedValue(1),
+    setNotificationSentAt: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ActionLogRepo;
+}
+
+function makeMockGateway(overrides?: Partial<OutboundGateway>): OutboundGateway {
+  return {
+    sendNotification: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as OutboundGateway;
+}
+
+const BASE_OPTS = {
+  taskId: 'task-1',
+  conversationId: 'conv-1',
+  skillName: 'calendar-create-event',
+  actionRisk: 'high',
+  input: { title: 'Lunch with Dana' },
+  currentScore: 65,
+  requiredScore: 80,
+};
+
+describe('ApprovalTriggerService.request()', () => {
+  it('creates row, generates short_ref, sends notification, returns created: true', async () => {
+    const repo = makeMockRepo();
+    const gateway = makeMockGateway();
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+    const result = await service.request(BASE_OPTS);
+
+    expect(result).toEqual({
+      created: true,
+      shortRef: 'cal-1',
+      notificationSent: true,
+    });
+    expect(repo.insert).toHaveBeenCalledOnce();
+    expect(repo.setNotificationSentAt).toHaveBeenCalledWith(1);
+    expect(gateway.sendNotification).toHaveBeenCalledOnce();
+    // Verify notification payload
+    const notifPayload = (gateway.sendNotification as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(notifPayload.notificationType).toBe('approval_requested');
+    expect(notifPayload.ceoEmail).toBe('ceo@example.com');
+    expect(notifPayload.subject).toContain('Approval needed');
+  });
+
+  it('returns duplicate when matching pending row exists', async () => {
+    const repo = makeMockRepo({
+      findPendingByTaskAndSkill: vi.fn().mockResolvedValue({ shortRef: 'cal-1' }),
+    });
+    const gateway = makeMockGateway();
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+    const result = await service.request(BASE_OPTS);
+
+    expect(result).toEqual({
+      created: false,
+      reason: 'duplicate',
+      existingShortRef: 'cal-1',
+    });
+    expect(repo.insert).not.toHaveBeenCalled();
+    expect(gateway.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('allows different payloads for same skill in same task', async () => {
+    const repo = makeMockRepo({
+      // First call: no match (different payload). Second call: count returns 1.
+      findPendingByTaskAndSkill: vi.fn().mockResolvedValue(null),
+      countShortRefsForTask: vi.fn().mockResolvedValue(1),
+    });
+    const gateway = makeMockGateway();
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+    const result = await service.request({
+      ...BASE_OPTS,
+      input: { title: 'Dinner with Bob' },
+    });
+
+    expect(result).toEqual({
+      created: true,
+      shortRef: 'cal-2',  // counter is 1, so next is 2
+      notificationSent: true,
+    });
+  });
+
+  it('handles notification failure gracefully', async () => {
+    const repo = makeMockRepo();
+    const gateway = makeMockGateway({
+      sendNotification: vi.fn().mockRejectedValue(new Error('SMTP down')),
+    });
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+    const result = await service.request(BASE_OPTS);
+
+    expect(result).toEqual({
+      created: true,
+      shortRef: 'cal-1',
+      notificationSent: false,
+    });
+    // Row was still inserted
+    expect(repo.insert).toHaveBeenCalledOnce();
+    // setNotificationSentAt was NOT called (notification failed)
+    expect(repo.setNotificationSentAt).not.toHaveBeenCalled();
+  });
+
+  it('skips notification when ceoEmail is not configured', async () => {
+    const repo = makeMockRepo();
+    const gateway = makeMockGateway();
+    // No ceoEmail
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger());
+
+    const result = await service.request(BASE_OPTS);
+
+    expect(result).toEqual({
+      created: true,
+      shortRef: 'cal-1',
+      notificationSent: false,
+    });
+    expect(repo.insert).toHaveBeenCalledOnce();
+    expect(gateway.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('inserts row with correct fields', async () => {
+    const repo = makeMockRepo();
+    const gateway = makeMockGateway();
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+    await service.request(BASE_OPTS);
+
+    const insertCall = (repo.insert as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(insertCall.taskId).toBe('task-1');
+    expect(insertCall.conversationId).toBe('conv-1');
+    expect(insertCall.skillName).toBe('calendar-create-event');
+    expect(insertCall.actionRisk).toBe('high');
+    expect(insertCall.outcome).toBe('pending_approval');
+    expect(insertCall.payload).toEqual({ title: 'Lunch with Dana' });
+    expect(insertCall.shortRef).toBe('cal-1');
+    expect(insertCall.description).toContain('Create calendar event');
+    expect(insertCall.expiresAt).toBeInstanceOf(Date);
+    // Expires roughly 24h from now (within 5s tolerance)
+    const diffMs = insertCall.expiresAt.getTime() - Date.now();
+    expect(diffMs).toBeGreaterThan(86_400_000 - 5000);
+    expect(diffMs).toBeLessThan(86_400_000 + 5000);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-trigger test -- src/autonomy/approval-trigger.test.ts 2>&1 | tail -20`
+Expected: FAIL — `request` is not a function (method not yet implemented).
+
+- [ ] **Step 3: Implement `request()` method**
+
+Replace the placeholder comment in `ApprovalTriggerService` in `src/autonomy/approval-trigger.ts`:
+
+```typescript
+export class ApprovalTriggerService {
+  constructor(
+    private readonly actionLogRepo: ActionLogRepo,
+    private readonly outboundGateway: OutboundGateway,
+    private readonly logger: Logger,
+    private readonly ceoEmail?: string,
+  ) {}
+
+  /**
+   * Trigger an approval request when an autonomy gate blocks a skill.
+   *
+   * Steps:
+   *   1. Dedup — check for existing pending_approval row with same skill + payload in same task
+   *   2. Generate short_ref and description
+   *   3. Insert autonomy_action_log row
+   *   4. Notify CEO (best-effort — failure does not prevent row creation)
+   *
+   * Returns the result so the execution layer can enrich the advisory error message.
+   */
+  async request(opts: {
+    taskId: string;
+    conversationId?: string;
+    skillName: string;
+    actionRisk: string;
+    input: Record<string, unknown>;
+    currentScore: number;
+    requiredScore: number;
+  }): Promise<ApprovalRequestResult> {
+    const { taskId, conversationId, skillName, actionRisk, input, currentScore, requiredScore } = opts;
+
+    // Step 1: Dedup check
+    const existing = await this.actionLogRepo.findPendingByTaskAndSkill(taskId, skillName, input);
+    if (existing) {
+      this.logger.info(
+        { taskId, skillName, existingShortRef: existing.shortRef },
+        'approval-trigger: duplicate request — pending_approval row already exists',
+      );
+      return { created: false, reason: 'duplicate', existingShortRef: existing.shortRef ?? 'unknown' };
+    }
+
+    // Step 2: Generate short_ref and description
+    const counter = await this.actionLogRepo.countShortRefsForTask(taskId);
+    const shortRef = `${shortRefPrefix(skillName)}-${counter + 1}`;
+    const description = buildDescription(skillName, input);
+
+    // Step 3: Insert row
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24h from now
+    const rowId = await this.actionLogRepo.insert({
+      taskId,
+      conversationId,
+      skillName,
+      actionRisk,
+      outcome: 'pending_approval',
+      payload: input,
+      expiresAt,
+      shortRef,
+      description,
+    });
+
+    this.logger.info(
+      { rowId, taskId, skillName, shortRef, currentScore, requiredScore },
+      'approval-trigger: pending_approval row created',
+    );
+
+    // Step 4: Notify CEO (best-effort)
+    let notificationSent = false;
+    if (this.ceoEmail) {
+      try {
+        await this.outboundGateway.sendNotification({
+          notificationType: 'approval_requested',
+          ceoEmail: this.ceoEmail,
+          subject: `Approval needed — ${description}`,
+          body:
+            `Curia wanted to ${description.charAt(0).toLowerCase() + description.slice(1)}, ` +
+            `but the autonomy score (${currentScore}) is below the required threshold (${requiredScore}).\n\n` +
+            `Reference: ${shortRef}\n` +
+            `Expires: ${expiresAt.toISOString()}\n\n` +
+            `Reply to approve, deny, or dismiss this request.`,
+        });
+        await this.actionLogRepo.setNotificationSentAt(rowId);
+        notificationSent = true;
+        this.logger.info({ rowId, shortRef }, 'approval-trigger: CEO notification sent');
+      } catch (err) {
+        this.logger.warn(
+          { err, rowId, shortRef },
+          'approval-trigger: CEO notification failed — row exists, CEO will see it in digest',
+        );
+      }
+    } else {
+      this.logger.warn(
+        { rowId, shortRef },
+        'approval-trigger: ceoEmail not configured — skipping notification',
+      );
+    }
+
+    return { created: true, shortRef, notificationSent };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-trigger test -- src/autonomy/approval-trigger.test.ts 2>&1 | tail -20`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git -C /Users/josephfung/Projects/worktrees/curia-approval-trigger add src/autonomy/approval-trigger.ts src/autonomy/approval-trigger.test.ts
+git -C /Users/josephfung/Projects/worktrees/curia-approval-trigger commit -m "feat(autonomy): implement ApprovalTriggerService.request() with dedup and notification"
+```
+
+---
+
+## Task 5: ExecutionLayer — `humanApproved` bypass + approval trigger integration
+
+**Files:**
+- Modify: `src/skills/execution.ts`
+- Modify: `src/skills/execution.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these test blocks at the end of `src/skills/execution.test.ts`, after the existing `describe('autonomy gates', ...)` block:
+
+```typescript
+import type { ApprovalTriggerService, ApprovalRequestResult } from '../autonomy/approval-trigger.js';
+
+/** Build a stub ApprovalTriggerService that returns a fixed result. */
+function makeApprovalTrigger(result: ApprovalRequestResult): ApprovalTriggerService {
+  return {
+    request: vi.fn().mockResolvedValue(result),
+  } as unknown as ApprovalTriggerService;
+}
+
+describe('humanApproved on InvokeOptions', () => {
+  it('skips autonomy gates when humanApproved is true', async () => {
+    const registry = new SkillRegistry();
+    const handler = makeHandler('approved result');
+    registry.register(makeRiskyManifest('calendar-create-event', 'high'), handler); // requires 80
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65), // well below 80
+    });
+
+    const result = await layer.invoke('calendar-create-event', {}, undefined, {
+      humanApproved: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(handler.execute).toHaveBeenCalledOnce();
+  });
+
+  it('still enforces elevated-skill gate when humanApproved is true', async () => {
+    const registry = new SkillRegistry();
+    const handler = makeHandler('should not run');
+    const manifest: SkillManifest = {
+      ...makeRiskyManifest('approve-action', 'high'),
+      sensitivity: 'elevated',
+    };
+    registry.register(manifest, handler);
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65),
+    });
+
+    // humanApproved but no caller context — elevated gate should block
+    const result = await layer.invoke('approve-action', {}, undefined, {
+      humanApproved: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(handler.execute).not.toHaveBeenCalled();
+  });
+});
+
+describe('approval trigger on gate block', () => {
+  it('Gate B calls trigger and enriches error with shortRef', async () => {
+    const registry = new SkillRegistry();
+    registry.register(makeRiskyManifest('send-email', 'medium'), makeHandler('no'));
+
+    const trigger = makeApprovalTrigger({ created: true, shortRef: 'email-1', notificationSent: true });
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65),
+      bus: mockBus,
+      approvalTrigger: trigger,
+    });
+
+    const result = await layer.invoke('send-email', { to: 'a@b.com' }, undefined, {
+      taskEventId: 'task-1',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('email-1');
+      expect(result.error).toContain('approval request has been sent');
+    }
+    expect(trigger.request).toHaveBeenCalledOnce();
+  });
+
+  it('Gate A calls trigger and enriches error with shortRef', async () => {
+    const registry = new SkillRegistry();
+    registry.register(makeRiskyManifest('store-fact', 'low'), makeHandler('no'));
+
+    const trigger = makeApprovalTrigger({ created: true, shortRef: 'fact-1', notificationSent: true });
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(55), // triggers Gate A (< 60)
+      bus: mockBus,
+      approvalTrigger: trigger,
+    });
+
+    const result = await layer.invoke('store-fact', { label: 'test' }, undefined, {
+      taskEventId: 'task-1',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('fact-1');
+      expect(result.error).toContain('approval request has been sent');
+    }
+    expect(trigger.request).toHaveBeenCalledOnce();
+  });
+
+  it('returns duplicate message when trigger finds existing pending row', async () => {
+    const registry = new SkillRegistry();
+    registry.register(makeRiskyManifest('send-email', 'medium'), makeHandler('no'));
+
+    const trigger = makeApprovalTrigger({ created: false, reason: 'duplicate', existingShortRef: 'email-1' });
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65),
+      bus: mockBus,
+      approvalTrigger: trigger,
+    });
+
+    const result = await layer.invoke('send-email', { to: 'a@b.com' }, undefined, {
+      taskEventId: 'task-1',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('already pending');
+      expect(result.error).toContain('email-1');
+    }
+  });
+
+  it('includes notification failure note when notificationSent is false', async () => {
+    const registry = new SkillRegistry();
+    registry.register(makeRiskyManifest('send-email', 'medium'), makeHandler('no'));
+
+    const trigger = makeApprovalTrigger({ created: true, shortRef: 'email-1', notificationSent: false });
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65),
+      bus: mockBus,
+      approvalTrigger: trigger,
+    });
+
+    const result = await layer.invoke('send-email', {}, undefined, {
+      taskEventId: 'task-1',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('notification could not be delivered');
+    }
+  });
+
+  it('falls back to existing error when trigger is not wired', async () => {
+    const registry = new SkillRegistry();
+    registry.register(makeRiskyManifest('send-email', 'medium'), makeHandler('no'));
+
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65),
+      bus: mockBus,
+      // No approvalTrigger
+    });
+
+    const result = await layer.invoke('send-email', {}, undefined, {
+      taskEventId: 'task-1',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // Original message — no approval ref
+      expect(result.error).toContain('set-autonomy');
+      expect(result.error).not.toContain('approval request');
+    }
+  });
+
+  it('falls back to existing error when taskEventId is missing', async () => {
+    const registry = new SkillRegistry();
+    registry.register(makeRiskyManifest('send-email', 'medium'), makeHandler('no'));
+
+    const trigger = makeApprovalTrigger({ created: true, shortRef: 'email-1', notificationSent: true });
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65),
+      bus: mockBus,
+      approvalTrigger: trigger,
+    });
+
+    // No taskEventId in options
+    const result = await layer.invoke('send-email', {});
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('set-autonomy');
+    }
+    expect(trigger.request).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-trigger test -- src/skills/execution.test.ts 2>&1 | tail -30`
+Expected: FAIL — `humanApproved` not on `InvokeOptions`, `approvalTrigger` not a constructor option.
+
+- [ ] **Step 3: Add `humanApproved` to `InvokeOptions`**
+
+In `src/skills/execution.ts`, update the `InvokeOptions` interface (line 46-55):
+
+```typescript
+/** Options passed to ExecutionLayer.invoke() by the agent runtime. */
+export interface InvokeOptions {
+  taskEventId?: string;
+  agentId?: string;
+  conversationId?: string;
+  parentEventId?: string;
+  /** Task-level metadata forwarded from the agent.task event payload.
+   *  Used by skill handlers to inspect task-wide signals (e.g. observationMode). */
+  taskMetadata?: Record<string, unknown>;
+  /** When true, autonomy gates (A and B) are skipped — the skill runs as if the
+   *  score were sufficient. Only the approve-action skill (#428) should set this.
+   *  All other checks (elevated-skill gate, content filter, blocked-contact) still run.
+   *  See ADR-018. */
+  humanApproved?: boolean;
+}
+```
+
+- [ ] **Step 4: Add `approvalTrigger` to the constructor**
+
+In `src/skills/execution.ts`, add the field and constructor option.
+
+Add the import at the top of the file (after the existing autonomy imports around line 37):
+
+```typescript
+import type { ApprovalTriggerService } from '../autonomy/approval-trigger.js';
+```
+
+Add the private field after `private bullpenService` (around line 73):
+
+```typescript
+  private approvalTrigger?: ApprovalTriggerService;
+```
+
+Add the constructor option to the options type (after `bullpenService` in the options object, around line 95):
+
+```typescript
+    approvalTrigger?: ApprovalTriggerService;
+```
+
+Add the assignment in the constructor body (after `this.bullpenService`, around line 115):
+
+```typescript
+    this.approvalTrigger = options?.approvalTrigger;
+```
+
+- [ ] **Step 5: Add `humanApproved` gate bypass and approval trigger calls**
+
+In `src/skills/execution.ts`, modify the autonomy gate block (lines 242-323).
+
+Replace the outer guard condition on line 249:
+
+```typescript
+    if (this.autonomyService && manifest.sensitivity !== 'elevated' && !options?.humanApproved) {
+```
+
+Add the `humanApproved` info log right before the autonomy gate block (before line 242):
+
+```typescript
+    // humanApproved bypass — log every occurrence for operator traceability.
+    // Gate logic below is skipped entirely; all other checks still run.
+    if (options?.humanApproved) {
+      skillLogger.info(
+        { skillName, agentId: options.agentId },
+        'autonomy gates skipped — humanApproved flag set (CEO-authorized re-execution, see ADR-018)',
+      );
+    }
+```
+
+Then extract the gate block return logic into a helper. Replace the Gate A return block (lines 281-288) with:
+
+```typescript
+          const gateAError = await this.buildGateError(
+            skillName, input, currentScore, 60, manifest.action_risk, options, skillLogger,
+          );
+          return {
+            success: false,
+            error: this.wrapSkillError(gateAError),
+          };
+```
+
+And replace the Gate B return block (lines 310-317) with:
+
+```typescript
+          const gateBError = await this.buildGateError(
+            skillName, input, currentScore, requiredScore, manifest.action_risk, options, skillLogger,
+          );
+          return {
+            success: false,
+            error: this.wrapSkillError(gateBError),
+          };
+```
+
+- [ ] **Step 6: Add the `buildGateError` private method**
+
+Add this method to the `ExecutionLayer` class, after the `setAgentContactId` method (after line 149):
+
+```typescript
+  /**
+   * Build the advisory error message for a gate block, optionally triggering
+   * an approval request via ApprovalTriggerService.
+   *
+   * When the trigger is wired and taskEventId is available, creates a
+   * pending_approval row and enriches the error with the approval status.
+   * Otherwise, returns the existing error message unchanged (fail-open).
+   */
+  private async buildGateError(
+    skillName: string,
+    input: Record<string, unknown>,
+    currentScore: number,
+    requiredScore: number,
+    actionRisk: string | number,
+    options: InvokeOptions | undefined,
+    skillLogger: Logger,
+  ): Promise<string> {
+    const baseMsg =
+      `Skill '${skillName}' blocked — autonomy score is ${currentScore}, ` +
+      `but this skill (action_risk: ${String(actionRisk)}) requires ${requiredScore}. `;
+
+    // Approval trigger — only if wired and task context is available.
+    if (this.approvalTrigger && options?.taskEventId) {
+      try {
+        const result = await this.approvalTrigger.request({
+          taskId: options.taskEventId,
+          conversationId: options.conversationId,
+          skillName,
+          actionRisk: String(actionRisk),
+          input,
+          currentScore,
+          requiredScore,
+        });
+        if (!result.created) {
+          return (
+            `Skill '${skillName}' blocked — an approval request for this action ` +
+            `is already pending (ref: ${result.existingShortRef}).`
+          );
+        }
+        if (result.notificationSent) {
+          return baseMsg + `An approval request has been sent to the CEO (ref: ${result.shortRef}).`;
+        }
+        return (
+          baseMsg +
+          `An approval request was created (ref: ${result.shortRef}) but ` +
+          `notification could not be delivered — the CEO will see it in the next digest.`
+        );
+      } catch (err) {
+        // Approval trigger failure should not change the gate behavior.
+        // The skill is still blocked; we just can't create the approval row.
+        skillLogger.warn(
+          { err, skillName },
+          'approval trigger failed — returning standard gate error',
+        );
+      }
+    }
+
+    // Fallback: no trigger, no taskEventId, or trigger failed
+    return baseMsg + `The CEO can raise the score with the set-autonomy skill.`;
+  }
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-trigger test -- src/skills/execution.test.ts 2>&1 | tail -30`
+Expected: All tests PASS (both existing and new).
+
+- [ ] **Step 8: Run the full test suite**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-trigger test 2>&1 | tail -30`
+Expected: No regressions.
+
+- [ ] **Step 9: Commit**
+
+```
+git -C /Users/josephfung/Projects/worktrees/curia-approval-trigger add src/skills/execution.ts src/skills/execution.test.ts
+git -C /Users/josephfung/Projects/worktrees/curia-approval-trigger commit -m "feat(autonomy): humanApproved bypass + approval trigger on gate block (#427)"
+```
+
+---
+
+## Task 6: Wire ApprovalTriggerService in index.ts
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add import**
+
+Add this import near the other autonomy imports (around line 75-76 of `src/index.ts`):
+
+```typescript
+import { ApprovalTriggerService } from './autonomy/approval-trigger.js';
+```
+
+- [ ] **Step 2: Construct ApprovalTriggerService**
+
+After the `actionLogRepo` construction (line 826) and before the `executionLayer` construction (line 849), add:
+
+```typescript
+  // Approval trigger — creates pending_approval rows and notifies CEO
+  // when autonomy gates block a skill. See ADR-018 and issue #427.
+  const approvalTrigger = outboundGateway
+    ? new ApprovalTriggerService(actionLogRepo, outboundGateway, logger, config.ceoPrimaryEmail || undefined)
+    : undefined;
+```
+
+- [ ] **Step 3: Pass to ExecutionLayer**
+
+On line 849, add `approvalTrigger` to the constructor options object. Find the existing `ExecutionLayer` construction and add the new option:
+
+```typescript
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, timezone: config.timezone, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-trigger run build 2>&1 | tail -10`
+Expected: Clean compilation.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-trigger test 2>&1 | tail -30`
+Expected: All tests pass, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```
+git -C /Users/josephfung/Projects/worktrees/curia-approval-trigger add src/index.ts
+git -C /Users/josephfung/Projects/worktrees/curia-approval-trigger commit -m "feat(autonomy): wire ApprovalTriggerService into ExecutionLayer (#427)"
+```
+
+---
+
+## Task 7: Final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite one more time**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-trigger test 2>&1 | tail -30`
+Expected: All tests pass.
+
+- [ ] **Step 2: Run build**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-trigger run build 2>&1 | tail -10`
+Expected: Clean compilation.
+
+- [ ] **Step 3: Verify git log looks clean**
+
+Run: `git -C /Users/josephfung/Projects/worktrees/curia-approval-trigger log --oneline feat/approval-trigger --not main`
+Expected: 7 commits (docs + 6 implementation commits), all on `feat/approval-trigger`.

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -104,4 +104,69 @@ describe('ActionLogRepo', () => {
       expect(rate).toBe(0);
     });
   });
+
+  describe('findPendingByTaskAndSkill', () => {
+    it('returns the matching pending row when one exists', async () => {
+      const now = new Date();
+      const { pool } = makePool([
+        {
+          id: 10, task_id: 't1', conversation_id: null, skill_name: 'calendar-create-event',
+          action_risk: 'high', outcome: 'pending_approval', task_summary: null,
+          competence_flag: null, commitment_flag: null, compatibility: null,
+          scored_by: null, payload: { title: 'Lunch' }, notification_sent_at: null,
+          resolved_at: null, resolved_by: null, expires_at: null,
+          parent_action_id: null, short_ref: 'cal-1', description: 'Create calendar event: Lunch',
+          created_at: now,
+        },
+      ]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const row = await repo.findPendingByTaskAndSkill('t1', 'calendar-create-event', { title: 'Lunch' });
+      expect(row).not.toBeNull();
+      expect(row!.id).toBe(10);
+      expect(row!.shortRef).toBe('cal-1');
+    });
+
+    it('returns null when no matching row exists', async () => {
+      const { pool } = makePool([]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const row = await repo.findPendingByTaskAndSkill('t1', 'calendar-create-event', { title: 'Lunch' });
+      expect(row).toBeNull();
+    });
+
+    it('uses JSONB equality for payload comparison', async () => {
+      const { pool, queries } = makePool([]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      await repo.findPendingByTaskAndSkill('t1', 'send-email', { to: 'a@b.com', subject: 'Hi' });
+      expect(queries[0]!.sql).toContain('payload::jsonb = $3::jsonb');
+      expect(queries[0]!.params[2]).toBe(JSON.stringify({ to: 'a@b.com', subject: 'Hi' }));
+    });
+  });
+
+  describe('countShortRefsForTask', () => {
+    it('returns the count of short_ref rows for a task', async () => {
+      const { pool } = makePool([{ count: '3' }]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const count = await repo.countShortRefsForTask('t1');
+      expect(count).toBe(3);
+    });
+
+    it('returns 0 when no short_ref rows exist', async () => {
+      const { pool } = makePool([{ count: '0' }]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const count = await repo.countShortRefsForTask('t1');
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('setNotificationSentAt', () => {
+    it('updates the notification_sent_at column', async () => {
+      const { pool, queries } = makePool([], 1);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      await repo.setNotificationSentAt(42);
+      expect(queries).toHaveLength(1);
+      expect(queries[0]!.sql).toContain('UPDATE autonomy_action_log');
+      expect(queries[0]!.sql).toContain('notification_sent_at');
+      expect(queries[0]!.params).toContain(42);
+    });
+  });
 });

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -144,7 +144,7 @@ export class ActionLogRepo {
       [taskId, skillName, JSON.stringify(payload)],
     );
     if (result.rows.length === 0) return null;
-    return mapRow(result.rows[0] as Record<string, unknown>);
+    return mapRow(result.rows[0]);
   }
 
   /**

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -122,6 +122,60 @@ export class ActionLogRepo {
     );
     return result.rows.map(mapRow);
   }
+
+  /**
+   * Find a pending_approval row for the given task + skill + payload.
+   * Used by ApprovalTriggerService for deduplication — same skill with
+   * same input in the same task should not generate a duplicate request.
+   * Uses JSONB equality for key-order-independent payload comparison.
+   */
+  async findPendingByTaskAndSkill(
+    taskId: string,
+    skillName: string,
+    payload: Record<string, unknown>,
+  ): Promise<ActionLogRow | null> {
+    const result = await this.pool.query(
+      `SELECT * FROM autonomy_action_log
+       WHERE task_id = $1
+         AND skill_name = $2
+         AND outcome = 'pending_approval'
+         AND payload::jsonb = $3::jsonb
+       LIMIT 1`,
+      [taskId, skillName, JSON.stringify(payload)],
+    );
+    if (result.rows.length === 0) return null;
+    return mapRow(result.rows[0] as Record<string, unknown>);
+  }
+
+  /**
+   * Count rows with a non-null short_ref for this task.
+   * Used by ApprovalTriggerService to generate sequential short_ref
+   * counters (e.g. cal-1, email-2).
+   */
+  async countShortRefsForTask(taskId: string): Promise<number> {
+    const result = await this.pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM autonomy_action_log
+       WHERE task_id = $1
+         AND short_ref IS NOT NULL`,
+      [taskId],
+    );
+    return parseInt(result.rows[0]!.count, 10);
+  }
+
+  /**
+   * Mark that the CEO notification was successfully delivered.
+   * Called after a successful sendNotification(). If notification fails,
+   * this is never called — notification_sent_at stays null.
+   */
+  async setNotificationSentAt(id: number): Promise<void> {
+    await this.pool.query(
+      `UPDATE autonomy_action_log
+       SET notification_sent_at = now()
+       WHERE id = $1`,
+      [id],
+    );
+    this.logger.debug({ id }, 'action-log-repo: notification_sent_at updated');
+  }
 }
 
 /** Map a snake_case DB row to a camelCase ActionLogRow. */

--- a/src/autonomy/approval-trigger.test.ts
+++ b/src/autonomy/approval-trigger.test.ts
@@ -70,12 +70,16 @@ describe('buildDescription', () => {
     expect(desc).toBe('Run some-unknown-skill');
   });
 
-  it('truncates individual values to 80 chars', () => {
+  it('returns just the verb for a known skill with no recognized context fields', () => {
+    const desc = buildDescription('store-fact', { value: 'something', raw: 'other' });
+    expect(desc).toBe('Store fact');
+  });
+
+  it('truncates individual values to exactly 80 chars including ellipsis', () => {
     const longTitle = 'A'.repeat(100);
     const desc = buildDescription('calendar-create-event', { title: longTitle });
-    // The value portion should be truncated, not the full description
-    expect(desc.length).toBeLessThanOrEqual(200);
-    expect(desc).not.toContain(longTitle);
+    // "Create calendar event: " (23 chars) + 79 A's + "…" (1 char) = 103 chars
+    expect(desc).toBe('Create calendar event: ' + 'A'.repeat(79) + '…');
   });
 
   it('truncates the full description to 200 chars', () => {

--- a/src/autonomy/approval-trigger.test.ts
+++ b/src/autonomy/approval-trigger.test.ts
@@ -111,7 +111,7 @@ function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
 
 function makeMockGateway(overrides?: Partial<OutboundGateway>): OutboundGateway {
   return {
-    sendNotification: vi.fn().mockResolvedValue(undefined),
+    sendNotification: vi.fn().mockResolvedValue(true),
     ...overrides,
   } as unknown as OutboundGateway;
 }
@@ -193,8 +193,9 @@ describe('ApprovalTriggerService.request()', () => {
 
   it('handles notification failure gracefully', async () => {
     const repo = makeMockRepo();
+    // sendNotification() catches publish errors internally and returns false rather than throwing
     const gateway = makeMockGateway({
-      sendNotification: vi.fn().mockRejectedValue(new Error('SMTP down')),
+      sendNotification: vi.fn().mockResolvedValue(false),
     });
     const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
 
@@ -228,26 +229,46 @@ describe('ApprovalTriggerService.request()', () => {
     expect(gateway.sendNotification).not.toHaveBeenCalled();
   });
 
-  it('inserts row with correct fields', async () => {
+  it('creates row successfully when outboundGateway is undefined', async () => {
     const repo = makeMockRepo();
-    const gateway = makeMockGateway();
-    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+    // No gateway at all — row creation must not depend on the outbound stack
+    const service = new ApprovalTriggerService(repo, undefined, createSilentLogger(), 'ceo@example.com');
 
-    await service.request(BASE_OPTS);
+    const result = await service.request(BASE_OPTS);
 
-    const insertCall = (repo.insert as ReturnType<typeof vi.fn>).mock.calls[0]![0];
-    expect(insertCall.taskId).toBe('task-1');
-    expect(insertCall.conversationId).toBe('conv-1');
-    expect(insertCall.skillName).toBe('calendar-create-event');
-    expect(insertCall.actionRisk).toBe('high');
-    expect(insertCall.outcome).toBe('pending_approval');
-    expect(insertCall.payload).toEqual({ title: 'Lunch with Dana' });
-    expect(insertCall.shortRef).toBe('cal-1');
-    expect(insertCall.description).toContain('Create calendar event');
-    expect(insertCall.expiresAt).toBeInstanceOf(Date);
-    // Expires roughly 24h from now (within 5s tolerance)
-    const diffMs = insertCall.expiresAt.getTime() - Date.now();
-    expect(diffMs).toBeGreaterThan(86_400_000 - 5000);
-    expect(diffMs).toBeLessThan(86_400_000 + 5000);
+    expect(result).toEqual({
+      created: true,
+      shortRef: 'cal-1',
+      notificationSent: false,
+    });
+    expect(repo.insert).toHaveBeenCalledOnce();
+  });
+
+  it('inserts row with correct fields', async () => {
+    const FIXED_NOW = 1_746_000_000_000; // 2025-04-30T06:40:00Z — arbitrary fixed point
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    try {
+      const repo = makeMockRepo();
+      const gateway = makeMockGateway();
+      const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+      await service.request(BASE_OPTS);
+
+      const insertCall = (repo.insert as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      expect(insertCall.taskId).toBe('task-1');
+      expect(insertCall.conversationId).toBe('conv-1');
+      expect(insertCall.skillName).toBe('calendar-create-event');
+      expect(insertCall.actionRisk).toBe('high');
+      expect(insertCall.outcome).toBe('pending_approval');
+      expect(insertCall.payload).toEqual({ title: 'Lunch with Dana' });
+      expect(insertCall.shortRef).toBe('cal-1');
+      expect(insertCall.description).toContain('Create calendar event');
+      expect(insertCall.expiresAt).toBeInstanceOf(Date);
+      // Expires exactly 24h from the frozen now — deterministic, no tolerance needed
+      expect(insertCall.expiresAt.getTime()).toBe(FIXED_NOW + 86_400_000);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/autonomy/approval-trigger.test.ts
+++ b/src/autonomy/approval-trigger.test.ts
@@ -4,8 +4,11 @@
 //   1. Pure functions (shortRefPrefix, buildDescription) — no mocks needed
 //   2. request() method (Task 4) — mocks ActionLogRepo and OutboundGateway
 
-import { describe, it, expect } from 'vitest';
-import { shortRefPrefix, buildDescription } from './approval-trigger.js';
+import { describe, it, expect, vi } from 'vitest';
+import { shortRefPrefix, buildDescription, ApprovalTriggerService } from './approval-trigger.js';
+import type { ActionLogRepo } from './action-log-repo.js';
+import type { OutboundGateway } from '../skills/outbound-gateway.js';
+import { createSilentLogger } from '../logger.js';
 
 describe('shortRefPrefix', () => {
   it('maps calendar-* skills to "cal"', () => {
@@ -89,5 +92,159 @@ describe('buildDescription', () => {
       body: 'This body is also very long and should not appear in the description',
     });
     expect(desc.length).toBeLessThanOrEqual(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers for request() tests
+// ---------------------------------------------------------------------------
+
+function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
+  return {
+    findPendingByTaskAndSkill: vi.fn().mockResolvedValue(null),
+    countShortRefsForTask: vi.fn().mockResolvedValue(0),
+    insert: vi.fn().mockResolvedValue(1),
+    setNotificationSentAt: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ActionLogRepo;
+}
+
+function makeMockGateway(overrides?: Partial<OutboundGateway>): OutboundGateway {
+  return {
+    sendNotification: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as OutboundGateway;
+}
+
+const BASE_OPTS = {
+  taskId: 'task-1',
+  conversationId: 'conv-1',
+  skillName: 'calendar-create-event',
+  actionRisk: 'high',
+  input: { title: 'Lunch with Dana' },
+  currentScore: 65,
+  requiredScore: 80,
+};
+
+describe('ApprovalTriggerService.request()', () => {
+  it('creates row, generates short_ref, sends notification, returns created: true', async () => {
+    const repo = makeMockRepo();
+    const gateway = makeMockGateway();
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+    const result = await service.request(BASE_OPTS);
+
+    expect(result).toEqual({
+      created: true,
+      shortRef: 'cal-1',
+      notificationSent: true,
+    });
+    expect(repo.insert).toHaveBeenCalledOnce();
+    expect(repo.setNotificationSentAt).toHaveBeenCalledWith(1);
+    expect(gateway.sendNotification).toHaveBeenCalledOnce();
+    // Verify notification payload
+    const notifPayload = (gateway.sendNotification as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(notifPayload.notificationType).toBe('approval_requested');
+    expect(notifPayload.ceoEmail).toBe('ceo@example.com');
+    expect(notifPayload.subject).toContain('Approval needed');
+  });
+
+  it('returns duplicate when matching pending row exists', async () => {
+    const repo = makeMockRepo({
+      findPendingByTaskAndSkill: vi.fn().mockResolvedValue({ shortRef: 'cal-1' }),
+    });
+    const gateway = makeMockGateway();
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+    const result = await service.request(BASE_OPTS);
+
+    expect(result).toEqual({
+      created: false,
+      reason: 'duplicate',
+      existingShortRef: 'cal-1',
+    });
+    expect(repo.insert).not.toHaveBeenCalled();
+    expect(gateway.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('allows different payloads for same skill in same task', async () => {
+    const repo = makeMockRepo({
+      // First call: no match (different payload). countShortRefs returns 1 (one already exists).
+      findPendingByTaskAndSkill: vi.fn().mockResolvedValue(null),
+      countShortRefsForTask: vi.fn().mockResolvedValue(1),
+    });
+    const gateway = makeMockGateway();
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+    const result = await service.request({
+      ...BASE_OPTS,
+      input: { title: 'Dinner with Bob' },
+    });
+
+    expect(result).toEqual({
+      created: true,
+      shortRef: 'cal-2',  // counter is 1, so next is 2
+      notificationSent: true,
+    });
+  });
+
+  it('handles notification failure gracefully', async () => {
+    const repo = makeMockRepo();
+    const gateway = makeMockGateway({
+      sendNotification: vi.fn().mockRejectedValue(new Error('SMTP down')),
+    });
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+    const result = await service.request(BASE_OPTS);
+
+    expect(result).toEqual({
+      created: true,
+      shortRef: 'cal-1',
+      notificationSent: false,
+    });
+    // Row was still inserted
+    expect(repo.insert).toHaveBeenCalledOnce();
+    // setNotificationSentAt was NOT called (notification failed)
+    expect(repo.setNotificationSentAt).not.toHaveBeenCalled();
+  });
+
+  it('skips notification when ceoEmail is not configured', async () => {
+    const repo = makeMockRepo();
+    const gateway = makeMockGateway();
+    // No ceoEmail
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger());
+
+    const result = await service.request(BASE_OPTS);
+
+    expect(result).toEqual({
+      created: true,
+      shortRef: 'cal-1',
+      notificationSent: false,
+    });
+    expect(repo.insert).toHaveBeenCalledOnce();
+    expect(gateway.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('inserts row with correct fields', async () => {
+    const repo = makeMockRepo();
+    const gateway = makeMockGateway();
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+    await service.request(BASE_OPTS);
+
+    const insertCall = (repo.insert as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(insertCall.taskId).toBe('task-1');
+    expect(insertCall.conversationId).toBe('conv-1');
+    expect(insertCall.skillName).toBe('calendar-create-event');
+    expect(insertCall.actionRisk).toBe('high');
+    expect(insertCall.outcome).toBe('pending_approval');
+    expect(insertCall.payload).toEqual({ title: 'Lunch with Dana' });
+    expect(insertCall.shortRef).toBe('cal-1');
+    expect(insertCall.description).toContain('Create calendar event');
+    expect(insertCall.expiresAt).toBeInstanceOf(Date);
+    // Expires roughly 24h from now (within 5s tolerance)
+    const diffMs = insertCall.expiresAt.getTime() - Date.now();
+    expect(diffMs).toBeGreaterThan(86_400_000 - 5000);
+    expect(diffMs).toBeLessThan(86_400_000 + 5000);
   });
 });

--- a/src/autonomy/approval-trigger.test.ts
+++ b/src/autonomy/approval-trigger.test.ts
@@ -142,11 +142,14 @@ describe('ApprovalTriggerService.request()', () => {
     expect(repo.insert).toHaveBeenCalledOnce();
     expect(repo.setNotificationSentAt).toHaveBeenCalledWith(1);
     expect(gateway.sendNotification).toHaveBeenCalledOnce();
-    // Verify notification payload
+    // Verify notification payload — type, recipient, subject, and required body fields
     const notifPayload = (gateway.sendNotification as ReturnType<typeof vi.fn>).mock.calls[0]![0];
     expect(notifPayload.notificationType).toBe('approval_requested');
     expect(notifPayload.ceoEmail).toBe('ceo@example.com');
     expect(notifPayload.subject).toContain('Approval needed');
+    expect(notifPayload.body).toContain('cal-1');           // short_ref
+    expect(notifPayload.body).toMatch(/Expires:/);          // expiry line
+    expect(notifPayload.body).toContain('Reply to approve'); // call to action
   });
 
   it('returns duplicate when matching pending row exists', async () => {

--- a/src/autonomy/approval-trigger.test.ts
+++ b/src/autonomy/approval-trigger.test.ts
@@ -1,0 +1,89 @@
+// approval-trigger.test.ts — unit tests for ApprovalTriggerService.
+//
+// Tests are structured in two groups:
+//   1. Pure functions (shortRefPrefix, buildDescription) — no mocks needed
+//   2. request() method (Task 4) — mocks ActionLogRepo and OutboundGateway
+
+import { describe, it, expect } from 'vitest';
+import { shortRefPrefix, buildDescription } from './approval-trigger.js';
+
+describe('shortRefPrefix', () => {
+  it('maps calendar-* skills to "cal"', () => {
+    expect(shortRefPrefix('calendar-create-event')).toBe('cal');
+    expect(shortRefPrefix('calendar-update-event')).toBe('cal');
+  });
+
+  it('maps email-* skills to "email"', () => {
+    expect(shortRefPrefix('email-reply')).toBe('email');
+    expect(shortRefPrefix('email-draft-save')).toBe('email');
+  });
+
+  it('maps signal-* skills to "signal"', () => {
+    expect(shortRefPrefix('signal-send')).toBe('signal');
+  });
+
+  it('maps store-fact to "mem"', () => {
+    expect(shortRefPrefix('store-fact')).toBe('mem');
+  });
+
+  it('maps *-memory-* skills to "mem"', () => {
+    expect(shortRefPrefix('entity-memory-store')).toBe('mem');
+  });
+
+  it('maps *-contact* skills to "contact"', () => {
+    expect(shortRefPrefix('update-contact')).toBe('contact');
+    expect(shortRefPrefix('contact-merge')).toBe('contact');
+  });
+
+  it('maps schedule-* skills to "sched"', () => {
+    expect(shortRefPrefix('schedule-job')).toBe('sched');
+  });
+
+  it('falls back to first word of skill name, truncated to 6 chars', () => {
+    expect(shortRefPrefix('something-unusual')).toBe('someth');
+    expect(shortRefPrefix('web-search')).toBe('web');
+  });
+});
+
+describe('buildDescription', () => {
+  it('formats calendar-create-event with title', () => {
+    const desc = buildDescription('calendar-create-event', { title: 'Lunch with Dana', start: '2026-05-06T12:00:00-04:00' });
+    expect(desc).toContain('Create calendar event');
+    expect(desc).toContain('Lunch with Dana');
+  });
+
+  it('formats email-reply with to and subject', () => {
+    const desc = buildDescription('email-reply', { to: 'dana@example.com', subject: 'Re: Budget' });
+    expect(desc).toContain('Send email reply');
+    expect(desc).toContain('dana@example.com');
+    expect(desc).toContain('Re: Budget');
+  });
+
+  it('formats store-fact with label', () => {
+    const desc = buildDescription('store-fact', { label: 'Dana prefers mornings' });
+    expect(desc).toContain('Store fact');
+    expect(desc).toContain('Dana prefers mornings');
+  });
+
+  it('falls back to "Run {skill_name}" for unknown skills', () => {
+    const desc = buildDescription('some-unknown-skill', {});
+    expect(desc).toBe('Run some-unknown-skill');
+  });
+
+  it('truncates individual values to 80 chars', () => {
+    const longTitle = 'A'.repeat(100);
+    const desc = buildDescription('calendar-create-event', { title: longTitle });
+    // The value portion should be truncated, not the full description
+    expect(desc.length).toBeLessThanOrEqual(200);
+    expect(desc).not.toContain(longTitle);
+  });
+
+  it('truncates the full description to 200 chars', () => {
+    const desc = buildDescription('email-reply', {
+      to: 'very-long-email-address-that-goes-on-forever@example.com',
+      subject: 'Re: A very long subject line that keeps going and going and going',
+      body: 'This body is also very long and should not appear in the description',
+    });
+    expect(desc.length).toBeLessThanOrEqual(200);
+  });
+});

--- a/src/autonomy/approval-trigger.ts
+++ b/src/autonomy/approval-trigger.ts
@@ -108,5 +108,93 @@ export class ApprovalTriggerService {
     private readonly ceoEmail?: string,
   ) {}
 
-  // request() is implemented in Task 4
+  /**
+   * Trigger an approval request when an autonomy gate blocks a skill.
+   *
+   * Steps:
+   *   1. Dedup — check for existing pending_approval row with same skill + payload in same task
+   *   2. Generate short_ref and description
+   *   3. Insert autonomy_action_log row
+   *   4. Notify CEO (best-effort — failure does not prevent row creation)
+   *
+   * Returns the result so the execution layer can enrich the advisory error message.
+   */
+  async request(opts: {
+    taskId: string;
+    conversationId?: string;
+    skillName: string;
+    actionRisk: string;
+    input: Record<string, unknown>;
+    currentScore: number;
+    requiredScore: number;
+  }): Promise<ApprovalRequestResult> {
+    const { taskId, conversationId, skillName, actionRisk, input, currentScore, requiredScore } = opts;
+
+    // Step 1: Dedup check
+    const existing = await this.actionLogRepo.findPendingByTaskAndSkill(taskId, skillName, input);
+    if (existing) {
+      this.logger.info(
+        { taskId, skillName, existingShortRef: existing.shortRef },
+        'approval-trigger: duplicate request — pending_approval row already exists',
+      );
+      return { created: false, reason: 'duplicate', existingShortRef: existing.shortRef ?? 'unknown' };
+    }
+
+    // Step 2: Generate short_ref and description
+    const counter = await this.actionLogRepo.countShortRefsForTask(taskId);
+    const shortRef = `${shortRefPrefix(skillName)}-${counter + 1}`;
+    const description = buildDescription(skillName, input);
+
+    // Step 3: Insert row
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24h from now
+    const rowId = await this.actionLogRepo.insert({
+      taskId,
+      conversationId,
+      skillName,
+      actionRisk,
+      outcome: 'pending_approval',
+      payload: input,
+      expiresAt,
+      shortRef,
+      description,
+    });
+
+    this.logger.info(
+      { rowId, taskId, skillName, shortRef, currentScore, requiredScore },
+      'approval-trigger: pending_approval row created',
+    );
+
+    // Step 4: Notify CEO (best-effort)
+    let notificationSent = false;
+    if (this.ceoEmail) {
+      try {
+        await this.outboundGateway.sendNotification({
+          notificationType: 'approval_requested',
+          ceoEmail: this.ceoEmail,
+          subject: `Approval needed — ${description}`,
+          body:
+            `Curia wanted to ${description.charAt(0).toLowerCase() + description.slice(1)}, ` +
+            `but the autonomy score (${currentScore}) is below the required threshold (${requiredScore}).\n\n` +
+            `Reference: ${shortRef}\n` +
+            `Expires: ${expiresAt.toISOString()}\n\n` +
+            `Reply to approve, deny, or dismiss this request.`,
+        });
+        await this.actionLogRepo.setNotificationSentAt(rowId);
+        notificationSent = true;
+        this.logger.info({ rowId, shortRef }, 'approval-trigger: CEO notification sent');
+      } catch (err) {
+        this.logger.warn(
+          { err, rowId, shortRef },
+          'approval-trigger: CEO notification failed — row exists, CEO will see it in digest',
+        );
+      }
+    } else {
+      this.logger.warn(
+        { rowId, shortRef },
+        'approval-trigger: ceoEmail not configured — skipping notification',
+      );
+    }
+
+    return { created: true, shortRef, notificationSent };
+  }
 }

--- a/src/autonomy/approval-trigger.ts
+++ b/src/autonomy/approval-trigger.ts
@@ -177,27 +177,29 @@ export class ApprovalTriggerService {
       'approval-trigger: pending_approval row created',
     );
 
-    // Step 4: Notify CEO (best-effort)
+    // Step 4: Notify CEO (best-effort).
+    // sendNotification() catches publish errors internally and returns false rather than
+    // throwing, so we check the return value to know whether to stamp notification_sent_at.
     let notificationSent = false;
     if (this.ceoEmail && this.outboundGateway) {
-      try {
-        await this.outboundGateway.sendNotification({
-          notificationType: 'approval_requested',
-          ceoEmail: this.ceoEmail,
-          subject: `Approval needed — ${description}`,
-          body:
-            `Curia wanted to ${description.charAt(0).toLowerCase() + description.slice(1)}, ` +
-            `but the autonomy score (${currentScore}) is below the required threshold (${requiredScore}).\n\n` +
-            `Reference: ${shortRef}\n` +
-            `Expires: ${expiresAt.toISOString()}\n\n` +
-            `Reply to approve, deny, or dismiss this request.`,
-        });
+      const sent = await this.outboundGateway.sendNotification({
+        notificationType: 'approval_requested',
+        ceoEmail: this.ceoEmail,
+        subject: `Approval needed — ${description}`,
+        body:
+          `Curia wanted to ${description.charAt(0).toLowerCase() + description.slice(1)}, ` +
+          `but the autonomy score (${currentScore}) is below the required threshold (${requiredScore}).\n\n` +
+          `Reference: ${shortRef}\n` +
+          `Expires: ${expiresAt.toISOString()}\n\n` +
+          `Reply to approve, deny, or dismiss this request.`,
+      });
+      if (sent) {
         await this.actionLogRepo.setNotificationSentAt(rowId);
         notificationSent = true;
         this.logger.info({ rowId, shortRef }, 'approval-trigger: CEO notification sent');
-      } catch (err) {
+      } else {
         this.logger.warn(
-          { err, rowId, shortRef },
+          { rowId, shortRef },
           'approval-trigger: CEO notification failed — row exists, CEO will see it in digest',
         );
       }

--- a/src/autonomy/approval-trigger.ts
+++ b/src/autonomy/approval-trigger.ts
@@ -133,11 +133,19 @@ export class ApprovalTriggerService {
     // Step 1: Dedup check
     const existing = await this.actionLogRepo.findPendingByTaskAndSkill(taskId, skillName, input);
     if (existing) {
+      const existingShortRef = existing.shortRef ?? 'unknown';
+      if (!existing.shortRef) {
+        // A pending_approval row without a short_ref should not happen — flag it.
+        this.logger.warn(
+          { taskId, skillName },
+          'approval-trigger: existing pending_approval row has null short_ref — data inconsistency',
+        );
+      }
       this.logger.info(
-        { taskId, skillName, existingShortRef: existing.shortRef },
+        { taskId, skillName, existingShortRef },
         'approval-trigger: duplicate request — pending_approval row already exists',
       );
-      return { created: false, reason: 'duplicate', existingShortRef: existing.shortRef ?? 'unknown' };
+      return { created: false, reason: 'duplicate', existingShortRef };
     }
 
     // Step 2: Generate short_ref and description

--- a/src/autonomy/approval-trigger.ts
+++ b/src/autonomy/approval-trigger.ts
@@ -87,7 +87,9 @@ export function buildDescription(
     }
   }
 
-  if (contextParts.length === 0) return `Run ${skillName}`;
+  // Known skill but no recognizable context fields — return just the verb.
+  // (Fallback to "Run {skillName}" is only for truly unknown skills above.)
+  if (contextParts.length === 0) return verb;
 
   const context = contextParts.join(', ');
   const full = `${verb}: ${context}`;

--- a/src/autonomy/approval-trigger.ts
+++ b/src/autonomy/approval-trigger.ts
@@ -7,6 +7,7 @@
 import type { ActionLogRepo } from './action-log-repo.js';
 import type { OutboundGateway } from '../skills/outbound-gateway.js';
 import type { Logger } from '../logger.js';
+import { sanitizeOutput } from '../skills/sanitize.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -103,7 +104,9 @@ export function buildDescription(
 export class ApprovalTriggerService {
   constructor(
     private readonly actionLogRepo: ActionLogRepo,
-    private readonly outboundGateway: OutboundGateway,
+    // outboundGateway is optional — row creation does not depend on the outbound stack.
+    // If absent, notification is skipped (same as when ceoEmail is not configured).
+    private readonly outboundGateway: OutboundGateway | undefined,
     private readonly logger: Logger,
     private readonly ceoEmail?: string,
   ) {}
@@ -148,10 +151,12 @@ export class ApprovalTriggerService {
       return { created: false, reason: 'duplicate', existingShortRef };
     }
 
-    // Step 2: Generate short_ref and description
+    // Step 2: Generate short_ref and description.
+    // Sanitize description before storing and sending — the input fields come from
+    // LLM-generated skill arguments and may contain dangerous tags.
     const counter = await this.actionLogRepo.countShortRefsForTask(taskId);
     const shortRef = `${shortRefPrefix(skillName)}-${counter + 1}`;
-    const description = buildDescription(skillName, input);
+    const description = sanitizeOutput(buildDescription(skillName, input));
 
     // Step 3: Insert row
     const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24h from now
@@ -174,7 +179,7 @@ export class ApprovalTriggerService {
 
     // Step 4: Notify CEO (best-effort)
     let notificationSent = false;
-    if (this.ceoEmail) {
+    if (this.ceoEmail && this.outboundGateway) {
       try {
         await this.outboundGateway.sendNotification({
           notificationType: 'approval_requested',

--- a/src/autonomy/approval-trigger.ts
+++ b/src/autonomy/approval-trigger.ts
@@ -1,0 +1,110 @@
+// approval-trigger.ts — ApprovalTriggerService.
+//
+// Owns the approval request flow when the autonomy gate blocks a skill:
+// dedup check, row insertion, short_ref generation, description building,
+// and CEO notification. See ADR-018 and issue #427.
+
+import type { ActionLogRepo } from './action-log-repo.js';
+import type { OutboundGateway } from '../skills/outbound-gateway.js';
+import type { Logger } from '../logger.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type ApprovalRequestResult =
+  | { created: true; shortRef: string; notificationSent: boolean }
+  | { created: false; reason: 'duplicate'; existingShortRef: string };
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for testing
+// ---------------------------------------------------------------------------
+
+/** Skill name prefix mapping for short_ref generation. */
+const PREFIX_RULES: Array<{ test: (name: string) => boolean; prefix: string }> = [
+  { test: (n) => n.startsWith('calendar-'), prefix: 'cal' },
+  { test: (n) => n.startsWith('email-'), prefix: 'email' },
+  { test: (n) => n.startsWith('signal-'), prefix: 'signal' },
+  { test: (n) => n === 'store-fact' || n.includes('-memory-'), prefix: 'mem' },
+  { test: (n) => n.includes('contact'), prefix: 'contact' },
+  { test: (n) => n.startsWith('schedule-'), prefix: 'sched' },
+];
+
+/** Return a short prefix for a skill name (e.g. "cal", "email"). */
+export function shortRefPrefix(skillName: string): string {
+  for (const rule of PREFIX_RULES) {
+    if (rule.test(skillName)) return rule.prefix;
+  }
+  // Fallback: first word (before first hyphen), truncated to 6 chars
+  const firstWord = skillName.split('-')[0] ?? skillName;
+  return firstWord.slice(0, 6);
+}
+
+const MAX_VALUE_LENGTH = 80;
+const MAX_DESCRIPTION_LENGTH = 200;
+
+/** Truncate a string to maxLen, appending "…" if truncated. */
+function truncate(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  return s.slice(0, maxLen - 1) + '…';
+}
+
+/** Verb + label mapping for known skill name patterns. */
+const VERB_RULES: Array<{ test: (name: string) => boolean; verb: string }> = [
+  { test: (n) => n === 'calendar-create-event', verb: 'Create calendar event' },
+  { test: (n) => n === 'calendar-update-event', verb: 'Update calendar event' },
+  { test: (n) => n === 'calendar-delete-event', verb: 'Delete calendar event' },
+  { test: (n) => n === 'email-reply', verb: 'Send email reply' },
+  { test: (n) => n === 'email-draft-save', verb: 'Save email draft' },
+  { test: (n) => n === 'store-fact', verb: 'Store fact' },
+  { test: (n) => n.startsWith('signal-'), verb: 'Send Signal message' },
+  { test: (n) => n.startsWith('schedule-'), verb: 'Schedule job' },
+];
+
+/**
+ * Build a human-readable one-liner from skill name and input fields.
+ * Used in CEO notifications, the pending-actions digest, and the
+ * coordinator's advisory failure message.
+ */
+export function buildDescription(
+  skillName: string,
+  input: Record<string, unknown>,
+): string {
+  // Determine verb
+  let verb = '';
+  for (const rule of VERB_RULES) {
+    if (rule.test(skillName)) { verb = rule.verb; break; }
+  }
+  if (!verb) return `Run ${skillName}`;
+
+  // Pick context fields in priority order
+  const contextParts: string[] = [];
+  const fieldPriority = ['title', 'subject', 'to', 'label', 'name', 'query'];
+  for (const field of fieldPriority) {
+    const val = input[field];
+    if (typeof val === 'string' && val.trim()) {
+      contextParts.push(truncate(val.trim(), MAX_VALUE_LENGTH));
+    }
+  }
+
+  if (contextParts.length === 0) return `Run ${skillName}`;
+
+  const context = contextParts.join(', ');
+  const full = `${verb}: ${context}`;
+  return truncate(full, MAX_DESCRIPTION_LENGTH);
+}
+
+// ---------------------------------------------------------------------------
+// Service class — request() added in Task 4
+// ---------------------------------------------------------------------------
+
+export class ApprovalTriggerService {
+  constructor(
+    private readonly actionLogRepo: ActionLogRepo,
+    private readonly outboundGateway: OutboundGateway,
+    private readonly logger: Logger,
+    private readonly ceoEmail?: string,
+  ) {}
+
+  // request() is implemented in Task 4
+}

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -129,8 +129,9 @@ interface OutboundBlockedPayload {
 //   - 'blocked_content': CEO alert that an outbound message was blocked by the content filter
 //   - 'group_held':      CEO alert that a Signal group message was held due to unverified members
 //   - 'contact_rate_limited': CEO alert that contact auto-creation was throttled due to rate limits
+//   - 'approval_requested':   CEO alert that an autonomy gate blocked a skill and approval is needed
 export interface OutboundNotificationPayload {
-  notificationType: 'blocked_content' | 'group_held' | 'contact_rate_limited';
+  notificationType: 'blocked_content' | 'group_held' | 'contact_rate_limited' | 'approval_requested';
   /** Recipient email for this notification (always the CEO email today). */
   ceoEmail: string;
   subject: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ import { bootstrapAgentIdentity } from './entity-context/bootstrap.js';
 import { bootstrapCeoContact } from './contacts/ceo-bootstrap.js';
 import { AutonomyService } from './autonomy/autonomy-service.js';
 import { ActionLogRepo } from './autonomy/action-log-repo.js';
+import { ApprovalTriggerService } from './autonomy/approval-trigger.js';
 import { AutonomyScoringPass } from './autonomy/scoring-pass.js';
 import type { ScoringPassConfig } from './autonomy/scoring-pass.js';
 import { BrowserService } from './browser/browser-service.js';
@@ -842,11 +843,17 @@ async function main(): Promise<void> {
 
   const scheduler = new Scheduler({ pool, bus, logger, schedulerService, driftDetector, dreamEngine });
 
+  // Approval trigger — creates pending_approval rows and notifies CEO
+  // when autonomy gates block a skill. See ADR-018 and issue #427.
+  const approvalTrigger = outboundGateway
+    ? new ApprovalTriggerService(actionLogRepo, outboundGateway, logger, config.ceoPrimaryEmail || undefined)
+    : undefined;
+
   // Execution layer — services wired here are injected per-skill based on their
   // capability-gated declarations. outboundGateway gives email skills their send path.
   // entityContextAssembler enables entity_enrichment pre-enrichment and the
   // entity-context skill. agentContactId enables entity_enrichment default='agent'.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, timezone: config.timezone, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, timezone: config.timezone, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete

--- a/src/index.ts
+++ b/src/index.ts
@@ -845,9 +845,12 @@ async function main(): Promise<void> {
 
   // Approval trigger — creates pending_approval rows and notifies CEO
   // when autonomy gates block a skill. See ADR-018 and issue #427.
-  const approvalTrigger = outboundGateway
-    ? new ApprovalTriggerService(actionLogRepo, outboundGateway, logger, config.ceoPrimaryEmail || undefined)
-    : undefined;
+  // Constructed unconditionally — row creation does not depend on the outbound stack.
+  // outboundGateway and ceoEmail are optional: if absent, the row is created but
+  // notification is skipped (CEO will see it in the next digest, #429).
+  const approvalTrigger = new ApprovalTriggerService(
+    actionLogRepo, outboundGateway, logger, config.ceoPrimaryEmail || undefined,
+  );
 
   // Execution layer — services wired here are injected per-skill based on their
   // capability-gated declarations. outboundGateway gives email skills their send path.

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -710,7 +710,7 @@ describe('approval trigger on gate block', () => {
     }
   });
 
-  it('falls back to existing error when taskEventId is missing', async () => {
+  it('falls back to existing error when taskEventId is missing (Gate B path)', async () => {
     const registry = new SkillRegistry();
     registry.register(makeRiskyManifest('send-email', 'medium'), makeHandler('no'));
 
@@ -725,6 +725,30 @@ describe('approval trigger on gate block', () => {
 
     // No taskEventId in options
     const result = await layer.invoke('send-email', {});
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('set-autonomy');
+    }
+    expect(trigger.request).not.toHaveBeenCalled();
+  });
+
+  it('falls back to existing error when taskEventId is missing (Gate A path)', async () => {
+    // Gate A triggers when score < 60 and action_risk !== 'none'
+    const registry = new SkillRegistry();
+    registry.register(makeRiskyManifest('store-fact', 'low'), makeHandler('no'));
+
+    const trigger = makeApprovalTrigger({ created: true, shortRef: 'mem-1', notificationSent: true });
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(55), // below 60 — Gate A triggers
+      bus: mockBus,
+      approvalTrigger: trigger,
+    });
+
+    // No taskEventId — trigger should not be called
+    const result = await layer.invoke('store-fact', { label: 'test' });
 
     expect(result.success).toBe(false);
     if (!result.success) {

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -17,6 +17,7 @@ import type { EventBus } from '../bus/bus.js';
 import type { OutboundGateway } from './outbound-gateway.js';
 import type { SchedulerService } from '../scheduler/scheduler-service.js';
 import type { AutonomyService, AutonomyConfig } from '../autonomy/autonomy-service.js';
+import type { ApprovalTriggerService, ApprovalRequestResult } from '../autonomy/approval-trigger.js';
 
 const logger = pino({ level: 'silent' });
 
@@ -426,7 +427,9 @@ describe('autonomy gates', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toContain('restricted');
+      // Gate A now uses buildGateError — message includes score and set-autonomy reference
+      expect(result.error).toContain('55');
+      expect(result.error).toContain('set-autonomy');
     }
     expect(handler.execute).not.toHaveBeenCalled();
   });
@@ -526,5 +529,207 @@ describe('autonomy gates', () => {
     const result = await layer.invoke('send-email', {});
 
     expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// humanApproved bypass tests
+// ---------------------------------------------------------------------------
+
+describe('humanApproved on InvokeOptions', () => {
+  it('skips autonomy gates when humanApproved is true', async () => {
+    const registry = new SkillRegistry();
+    const handler = makeHandler('approved result');
+    registry.register(makeRiskyManifest('calendar-create-event', 'high'), handler);
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65), // well below any threshold
+    });
+
+    const result = await layer.invoke('calendar-create-event', {}, undefined, {
+      humanApproved: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(handler.execute).toHaveBeenCalledOnce();
+  });
+
+  it('still enforces elevated-skill gate when humanApproved is true', async () => {
+    const registry = new SkillRegistry();
+    const handler = makeHandler('should not run');
+    // Make a manifest with sensitivity: 'elevated' — the elevated gate is NOT bypassed
+    const manifest: SkillManifest = {
+      ...makeRiskyManifest('approve-action', 'high'),
+      sensitivity: 'elevated',
+    };
+    registry.register(manifest, handler);
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65),
+    });
+
+    // humanApproved but no CEO caller context — elevated gate should still block
+    const result = await layer.invoke('approve-action', {}, undefined, {
+      humanApproved: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(handler.execute).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Approval trigger on gate block tests
+// ---------------------------------------------------------------------------
+
+function makeApprovalTrigger(result: ApprovalRequestResult): ApprovalTriggerService {
+  return {
+    request: vi.fn().mockResolvedValue(result),
+  } as unknown as ApprovalTriggerService;
+}
+
+describe('approval trigger on gate block', () => {
+  it('Gate B calls trigger and enriches error with shortRef when notification sent', async () => {
+    const registry = new SkillRegistry();
+    registry.register(makeRiskyManifest('send-email', 'medium'), makeHandler('no'));
+
+    const trigger = makeApprovalTrigger({ created: true, shortRef: 'email-1', notificationSent: true });
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65),
+      bus: mockBus,
+      approvalTrigger: trigger,
+    });
+
+    const result = await layer.invoke('send-email', { to: 'a@b.com' }, undefined, {
+      taskEventId: 'task-1',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('email-1');
+      expect(result.error).toContain('approval request has been sent');
+    }
+    expect(trigger.request).toHaveBeenCalledOnce();
+  });
+
+  it('Gate A calls trigger and enriches error with shortRef', async () => {
+    const registry = new SkillRegistry();
+    registry.register(makeRiskyManifest('store-fact', 'low'), makeHandler('no'));
+
+    const trigger = makeApprovalTrigger({ created: true, shortRef: 'mem-1', notificationSent: true });
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(55), // triggers Gate A (< 60)
+      bus: mockBus,
+      approvalTrigger: trigger,
+    });
+
+    const result = await layer.invoke('store-fact', { label: 'test' }, undefined, {
+      taskEventId: 'task-1',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('mem-1');
+      expect(result.error).toContain('approval request has been sent');
+    }
+    expect(trigger.request).toHaveBeenCalledOnce();
+  });
+
+  it('returns duplicate message when trigger finds existing pending row', async () => {
+    const registry = new SkillRegistry();
+    registry.register(makeRiskyManifest('send-email', 'medium'), makeHandler('no'));
+
+    const trigger = makeApprovalTrigger({ created: false, reason: 'duplicate', existingShortRef: 'email-1' });
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65),
+      bus: mockBus,
+      approvalTrigger: trigger,
+    });
+
+    const result = await layer.invoke('send-email', { to: 'a@b.com' }, undefined, {
+      taskEventId: 'task-1',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('already pending');
+      expect(result.error).toContain('email-1');
+    }
+  });
+
+  it('includes notification failure note when notificationSent is false', async () => {
+    const registry = new SkillRegistry();
+    registry.register(makeRiskyManifest('send-email', 'medium'), makeHandler('no'));
+
+    const trigger = makeApprovalTrigger({ created: true, shortRef: 'email-1', notificationSent: false });
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65),
+      bus: mockBus,
+      approvalTrigger: trigger,
+    });
+
+    const result = await layer.invoke('send-email', {}, undefined, {
+      taskEventId: 'task-1',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('notification could not be delivered');
+    }
+  });
+
+  it('falls back to existing error when trigger is not wired', async () => {
+    const registry = new SkillRegistry();
+    registry.register(makeRiskyManifest('send-email', 'medium'), makeHandler('no'));
+
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65),
+      bus: mockBus,
+      // No approvalTrigger
+    });
+
+    const result = await layer.invoke('send-email', {}, undefined, {
+      taskEventId: 'task-1',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // Original message — no approval ref
+      expect(result.error).toContain('set-autonomy');
+      expect(result.error).not.toContain('approval request');
+    }
+  });
+
+  it('falls back to existing error when taskEventId is missing', async () => {
+    const registry = new SkillRegistry();
+    registry.register(makeRiskyManifest('send-email', 'medium'), makeHandler('no'));
+
+    const trigger = makeApprovalTrigger({ created: true, shortRef: 'email-1', notificationSent: true });
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(65),
+      bus: mockBus,
+      approvalTrigger: trigger,
+    });
+
+    // No taskEventId in options
+    const result = await layer.invoke('send-email', {});
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('set-autonomy');
+    }
+    expect(trigger.request).not.toHaveBeenCalled();
   });
 });

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -37,6 +37,7 @@ import type { EntityContextAssembler } from '../entity-context/assembler.js';
 import { AutonomyService } from '../autonomy/autonomy-service.js';
 import type { AutonomyConfig } from '../autonomy/autonomy-service.js';
 import type { BrowserService } from '../browser/browser-service.js';
+import type { ApprovalTriggerService } from '../autonomy/approval-trigger.js';
 
 // Default max output length — used when no value is configured in default.yaml.
 // Skills returning more than this will have their output truncated before it
@@ -52,6 +53,11 @@ export interface InvokeOptions {
   /** Task-level metadata forwarded from the agent.task event payload.
    *  Used by skill handlers to inspect task-wide signals (e.g. observationMode). */
   taskMetadata?: Record<string, unknown>;
+  /** When true, autonomy gates (A and B) are skipped — the skill runs as if the
+   *  score were sufficient. Only the approve-action skill (#428) should set this.
+   *  All other checks (elevated-skill gate, content filter, blocked-contact) still run.
+   *  See ADR-018. */
+  humanApproved?: boolean;
 }
 
 export class ExecutionLayer {
@@ -71,6 +77,7 @@ export class ExecutionLayer {
   private executiveProfileService?: import('../executive/service.js').ExecutiveProfileService;
   private browserService?: BrowserService;
   private bullpenService?: import('../memory/bullpen.js').BullpenService;
+  private approvalTrigger?: ApprovalTriggerService;
   /** The agent's own contactId — injected into ctx.agentContactId for entity_enrichment default='agent' */
   private agentContactId?: string;
   /** IANA timezone name used for normalizing offset-less timestamp inputs from the LLM. */
@@ -93,6 +100,7 @@ export class ExecutionLayer {
     executiveProfileService?: import('../executive/service.js').ExecutiveProfileService;
     browserService?: BrowserService;
     bullpenService?: import('../memory/bullpen.js').BullpenService;
+    approvalTrigger?: ApprovalTriggerService;
     agentContactId?: string;
     timezone?: string;
     skillOutputMaxLength?: number;
@@ -113,6 +121,7 @@ export class ExecutionLayer {
     this.executiveProfileService = options?.executiveProfileService;
     this.browserService = options?.browserService;
     this.bullpenService = options?.bullpenService;
+    this.approvalTrigger = options?.approvalTrigger;
     this.agentContactId = options?.agentContactId;
     this.timezone = options?.timezone ?? 'UTC';
     this.skillOutputMaxLength = options?.skillOutputMaxLength ?? DEFAULT_SKILL_OUTPUT_MAX_LENGTH;
@@ -146,6 +155,67 @@ export class ExecutionLayer {
    */
   setAgentContactId(contactId: string): void {
     this.agentContactId = contactId;
+  }
+
+  /**
+   * Build the advisory error message for a gate block, optionally triggering
+   * an approval request via ApprovalTriggerService.
+   *
+   * When the trigger is wired and taskEventId is available, creates a
+   * pending_approval row and enriches the error with the approval status.
+   * Otherwise, returns the existing error message unchanged (fail-open).
+   */
+  private async buildGateError(
+    skillName: string,
+    input: Record<string, unknown>,
+    currentScore: number,
+    requiredScore: number,
+    actionRisk: string | number,
+    options: InvokeOptions | undefined,
+    skillLogger: Logger,
+  ): Promise<string> {
+    const baseMsg =
+      `Skill '${skillName}' blocked — autonomy score is ${currentScore}, ` +
+      `but this skill (action_risk: ${String(actionRisk)}) requires ${requiredScore}. `;
+
+    // Approval trigger — only if wired and task context is available.
+    if (this.approvalTrigger && options?.taskEventId) {
+      try {
+        const result = await this.approvalTrigger.request({
+          taskId: options.taskEventId,
+          conversationId: options.conversationId,
+          skillName,
+          actionRisk: String(actionRisk),
+          input,
+          currentScore,
+          requiredScore,
+        });
+        if (!result.created) {
+          return (
+            `Skill '${skillName}' blocked — an approval request for this action ` +
+            `is already pending (ref: ${result.existingShortRef}).`
+          );
+        }
+        if (result.notificationSent) {
+          return baseMsg + `An approval request has been sent to the CEO (ref: ${result.shortRef}).`;
+        }
+        return (
+          baseMsg +
+          `An approval request was created (ref: ${result.shortRef}) but ` +
+          `notification could not be delivered — the CEO will see it in the next digest.`
+        );
+      } catch (err) {
+        // Approval trigger failure should not change the gate behavior.
+        // The skill is still blocked; we just can't create the approval row.
+        skillLogger.warn(
+          { err, skillName },
+          'approval trigger failed — returning standard gate error',
+        );
+      }
+    }
+
+    // Fallback: no trigger, no taskEventId, or trigger failed
+    return baseMsg + `The CEO can raise the score with the set-autonomy skill.`;
   }
 
   /**
@@ -239,6 +309,15 @@ export class ExecutionLayer {
       }
     }
 
+    // Log every humanApproved invocation for operator traceability.
+    // The gate logic below is skipped when this flag is set.
+    if (options?.humanApproved) {
+      skillLogger.info(
+        { skillName, agentId: options.agentId },
+        'autonomy gates skipped — humanApproved flag set (CEO-authorized re-execution, see ADR-018)',
+      );
+    }
+
     // Autonomy gates — Phase 2 hard enforcement.
     // Elevated skills are exempt — they have their own, stricter access control
     // via CallerContext (sensitivity: 'elevated' gate above). Gating them on
@@ -246,7 +325,8 @@ export class ExecutionLayer {
     // but is the only way to raise the score.
     // Read the live score once per invocation. Fail-open if the service is not
     // wired or the config table doesn't exist yet (getConfig returns null).
-    if (this.autonomyService && manifest.sensitivity !== 'elevated') {
+    // humanApproved bypasses gates A and B — the skill runs as CEO-authorized.
+    if (this.autonomyService && manifest.sensitivity !== 'elevated' && !options?.humanApproved) {
       let autonomyConfig: AutonomyConfig | null = null;
       try {
         autonomyConfig = await this.autonomyService.getConfig();
@@ -278,13 +358,12 @@ export class ExecutionLayer {
               skillLogger.warn({ err, skillName }, 'autonomy gate: failed to publish autonomy.skill_blocked event');
             });
           }
+          const gateAError = await this.buildGateError(
+            skillName, input, currentScore, 60, manifest.action_risk, options, skillLogger,
+          );
           return {
             success: false,
-            error: this.wrapSkillError(
-              `Skill '${skillName}' blocked — autonomy score is ${currentScore} (restricted mode). ` +
-              `All non-read skills require a score of at least 60. ` +
-              `The CEO can raise the score with the set-autonomy skill.`,
-            ),
+            error: this.wrapSkillError(gateAError),
           };
         }
 
@@ -307,13 +386,12 @@ export class ExecutionLayer {
               skillLogger.warn({ err, skillName }, 'autonomy gate: failed to publish autonomy.skill_blocked event');
             });
           }
+          const gateBError = await this.buildGateError(
+            skillName, input, currentScore, requiredScore, manifest.action_risk, options, skillLogger,
+          );
           return {
             success: false,
-            error: this.wrapSkillError(
-              `Skill '${skillName}' blocked — autonomy score is ${currentScore}, ` +
-              `but this skill (action_risk: ${String(manifest.action_risk)}) requires ${requiredScore}. ` +
-              `The CEO can raise the score with the set-autonomy skill.`,
-            ),
+            error: this.wrapSkillError(gateBError),
           };
         }
       } else {

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -358,6 +358,9 @@ export class ExecutionLayer {
               skillLogger.warn({ err, skillName }, 'autonomy gate: failed to publish autonomy.skill_blocked event');
             });
           }
+          // Note: `input` here is post-timestamp-normalization (mutated in-place above).
+          // The stored payload in autonomy_action_log will contain normalized timestamps,
+          // which is correct — re-normalization on approve-action re-invocation is a no-op.
           const gateAError = await this.buildGateError(
             skillName, input, currentScore, 60, manifest.action_risk, options, skillLogger,
           );
@@ -386,6 +389,7 @@ export class ExecutionLayer {
               skillLogger.warn({ err, skillName }, 'autonomy gate: failed to publish autonomy.skill_blocked event');
             });
           }
+          // Note: same post-normalization `input` as Gate A — see comment above.
           const gateBError = await this.buildGateError(
             skillName, input, currentScore, requiredScore, manifest.action_risk, options, skillLogger,
           );

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -569,12 +569,13 @@ export class OutboundGateway {
   async sendNotification(
     payload: OutboundNotificationPayload,
     parentEventId?: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       await this.bus.publish(
         'dispatch',
         createOutboundNotification({ ...payload, parentEventId }),
       );
+      return true;
     } catch (err) {
       // Non-fatal — the original block/hold is already recorded. Log so the anomaly
       // is visible in alerting but do not throw; the caller's primary operation (block
@@ -583,6 +584,7 @@ export class OutboundGateway {
         { err, notificationType: payload.notificationType },
         'outbound-gateway: failed to publish outbound.notification event',
       );
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds `humanApproved?: boolean` to `InvokeOptions` — when set, autonomy Gates A and B are bypassed entirely (elevated-skill gate, content filter, and blocked-contact checks still run). Used by the upcoming `approve-action` skill (#428) for CEO-authorized re-executions. Every `humanApproved` invocation is logged at info level for operator traceability.
- When Gate A or Gate B blocks a skill, a new `ApprovalTriggerService` creates a `pending_approval` row in `autonomy_action_log`, notifies the CEO via `outboundGateway.sendNotification()`, and returns an enriched advisory error message with a short reference (e.g. `cal-1`, `email-2`).
- Dedup: same `skill_name` + `task_id` + `payload` → no duplicate row; returns the existing short_ref instead.
- `outboundGateway` is optional in `ApprovalTriggerService` — row creation always succeeds regardless of the outbound stack; notification is best-effort (failure logs a warn, `notification_sent_at` stays null, CEO sees it in the next digest per #429).

## Files changed

| File | Change |
|---|---|
| `src/bus/events.ts` | Add `'approval_requested'` to `OutboundNotificationPayload.notificationType` union |
| `src/autonomy/approval-trigger.ts` | **New** — `ApprovalTriggerService`, `shortRefPrefix`, `buildDescription`, `ApprovalRequestResult` |
| `src/autonomy/approval-trigger.test.ts` | **New** — 21 unit tests |
| `src/autonomy/action-log-repo.ts` | Add `findPendingByTaskAndSkill`, `countShortRefsForTask`, `setNotificationSentAt` |
| `src/autonomy/action-log-repo.test.ts` | Tests for new repo methods |
| `src/skills/execution.ts` | `humanApproved` on `InvokeOptions`, `approvalTrigger` constructor, `buildGateError` helper |
| `src/skills/execution.test.ts` | 9 new tests (humanApproved bypass + gate trigger integration) |
| `src/index.ts` | Wire `ApprovalTriggerService` into `ExecutionLayer` |

## Test plan

- [ ] 1,840 unit tests pass (`npm test`) — 2 pre-existing DB integration failures unrelated to this change
- [ ] `npm run typecheck` — clean
- [ ] Gate A block (score < 60): verify error message contains short_ref and "approval request has been sent"
- [ ] Gate B block (score below per-skill threshold): same
- [ ] Duplicate block (same skill + payload + task): verify "already pending" message with existing short_ref
- [ ] `humanApproved: true` on a blocked skill: verify skill executes and info log is emitted
- [ ] `humanApproved: true` on an elevated skill: verify elevated gate still blocks

## Known follow-up required before #428 merges

The `short_ref` counter (via `countShortRefsForTask` + sequential increment) is not atomic. Two concurrent gate blocks in the same task can race and produce duplicate `short_ref` values for the same `task_id`. This is safe today (no code depends on short_ref uniqueness yet), but once `approve-action` (#428) uses short_ref as an authorization lookup key, a `UNIQUE(task_id, short_ref)` constraint + retry in `ApprovalTriggerService.request()` is required before merging #428.

Closes #427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added autonomy-gate approval-request mechanism: when autonomous skills are blocked, a CEO notification is sent and a pending approval row is created for tracking.
  * Introduced `humanApproved` option to bypass autonomy gates while maintaining elevated-skill security checks.
  * Added new `'approval_requested'` notification type for approval requests.
  * Enhanced autonomy-gate error messages with approval request details and reference identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->