### PR TITLE
feat(autonomy): CEO-facing approval management skills (#428)

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -418,6 +418,22 @@ system_prompt: |
   When in doubt about the scope of a data request, ask for clarification
   rather than exporting everything that matches.
 
+  ## Pending Approval Requests
+  When the autonomy gate blocks a skill, Curia creates a pending approval
+  request and notifies the CEO. Each request has a short_ref (e.g. "cal-1",
+  "email-2") and a human-readable description.
+
+  When the CEO responds to an approval notification (or asks about pending
+  requests):
+  - Use list-pending-actions to see all pending requests
+  - Match the CEO's natural language to a specific short_ref using the
+    description (e.g. "approve the calendar event" → the cal-* request)
+  - When only one request is pending, short_ref can be omitted
+  - Use approve-action to approve, deny-action to deny, dismiss-action
+    when the CEO handled it outside Curia
+  - If the CEO's intent is ambiguous and multiple requests are pending,
+    show the list and ask which one they mean
+
   ## Guidelines
   - For casual messages, respond naturally and warmly
   - Handle tasks within your capability directly
@@ -483,4 +499,8 @@ pinned_skills:
   - memory-store
   - image-generate
   - skill-registry
+  - approve-action
+  - deny-action
+  - dismiss-action
+  - list-pending-actions
 allow_discovery: true

--- a/docs/wip/2026-05-03-approval-skills-design.md
+++ b/docs/wip/2026-05-03-approval-skills-design.md
@@ -1,0 +1,227 @@
+# Approval Management Skills — Design Spec
+
+**Issue:** #428
+**Depends on:** #427 (approval trigger — merged as PR #436)
+**ADR:** 018 (Curia-initiated approval requests via unified autonomy action log)
+
+## Goal
+
+Implement the CEO-facing side of the approval flow: four skills that let the
+CEO approve, deny, dismiss, or list pending approval requests created by the
+autonomy gate trigger (#427). Also fix the `short_ref` race condition
+identified during #436 review.
+
+## Out of scope
+
+- `send-draft` integration with `autonomy_action_log` — deferred to #435
+- Expiry sweep (scheduler job that transitions expired rows) — separate issue
+- Daily pending-actions digest — separate issue
+
+## Architecture
+
+The four skills follow established patterns: `skill.json` manifest + handler
+class + handler tests, registered via the standard loader. All four are
+`sensitivity: "elevated"` (CEO-only) and `action_risk: "none"`.
+
+The `approve-action` skill re-executes the original blocked skill by calling
+`ExecutionLayer.invoke()` with `humanApproved: true`. This requires adding
+`executionLayer` as a new capability in `SkillContext`.
+
+All four skills need `ActionLogRepo` for row lookups and state transitions.
+`actionLogRepo` is added as a new capability in `SkillContext`.
+
+## Changes
+
+### 1. Migration 032: UNIQUE constraint on `short_ref`
+
+```sql
+ALTER TABLE autonomy_action_log
+  ADD CONSTRAINT uq_aal_task_short_ref UNIQUE (task_id, short_ref);
+```
+
+Partial uniqueness is not needed — `short_ref` is only non-null for approval
+rows, and null values do not violate UNIQUE constraints in Postgres (nulls are
+never equal to each other).
+
+### 2. Retry in `ApprovalTriggerService.request()`
+
+After the UNIQUE constraint lands, the `countShortRefsForTask + 1` pattern can
+collide under concurrency. Wrap the insert block in a retry loop (max 3
+attempts) that catches Postgres error code `23505` (unique_violation) and
+re-counts before retrying.
+
+### 3. New `ActionLogRepo` methods
+
+**`resolvePending(shortRef?: string): Promise<ResolveResult>`**
+
+Discriminated union return type:
+- `{ found: true; row: ActionLogRow }` — single row resolved
+- `{ found: false; reason: 'not_found'; error: string }` — no matching row
+- `{ found: false; reason: 'ambiguous'; error: string; pending: ActionLogRow[] }` — multiple pending, no `short_ref` provided or no match
+- `{ found: false; reason: 'expired'; error: string }` — row exists but past `expires_at`
+- `{ found: false; reason: 'already_resolved'; error: string }` — row already transitioned
+
+When `short_ref` is provided: look up by `short_ref` (uses `idx_aal_short_ref`).
+If the row exists but `outcome` is not `pending_approval`, return
+`already_resolved`. If the row exists but `expires_at <= now()`, return
+`expired`. When omitted: fetch all non-expired `pending_approval` rows — if
+exactly one, resolve to it; if multiple, return `ambiguous` with the list.
+
+**`findAllPending(): Promise<ActionLogRow[]>`**
+
+Returns all `pending_approval` rows where `expires_at > now()`, ordered by
+`created_at ASC`. Used by `list-pending-actions` and internally by
+`resolvePending` when no `short_ref` is provided.
+
+**`resolveRow(id: number, outcome: 'approved' | 'denied' | 'resolved_externally', resolvedBy: string): Promise<void>`**
+
+Sets `outcome`, `resolved_at = now()`, `resolved_by` on the given row. Only
+updates rows where current `outcome = 'pending_approval'` (guard against
+double-resolve — silently no-ops if already resolved).
+
+**Extend `ActionLogInsert`** to include optional `parentActionId?: number`.
+Update `insert()` to write `parent_action_id` when provided. This is used by
+`approve-action` to record the re-execution result linked to the approved row.
+
+### 4. New capabilities
+
+**`executionLayer`**
+- Add `'executionLayer'` to `VALID_CAPABILITIES` in `loader.ts`
+- Add `executionLayer?: ExecutionLayer` to `SkillContext` in `types.ts`
+- In `execution.ts`, add `executionLayer: this` to the `capabilityServices` map
+- Security: only `approve-action` declares this capability; it is `sensitivity: "elevated"` (CEO-only)
+
+**`actionLogRepo`**
+- Add `'actionLogRepo'` to `VALID_CAPABILITIES` in `loader.ts`
+- Add `actionLogRepo?: ActionLogRepo` to `SkillContext` in `types.ts`
+- Add `actionLogRepo` to the `ExecutionLayer` constructor options and `capabilityServices` map
+- Wire in `index.ts` — pass the existing `ActionLogRepo` instance
+
+### 5. New event type: `'dismiss'`
+
+Add `'dismiss'` to the `HumanDecisionPayload.decision` union in
+`src/bus/events.ts`:
+
+```typescript
+decision: 'approve' | 'deny' | 'dismiss' | 'modify' | 'escalate' | 'timeout';
+```
+
+Used by `dismiss-action` when the CEO handled the action outside Curia.
+
+### 6. Skills
+
+#### `approve-action`
+
+- **Directory:** `skills/approve-action/`
+- **Manifest:** `action_risk: "none"`, `sensitivity: "elevated"`, `capabilities: ["bus", "executionLayer", "actionLogRepo"]`
+- **Input:** `short_ref: "string?"`
+- **Output:** `result: "object"` (re-execution result)
+
+Handler flow:
+1. CEO-origin check: `ctx.taskMetadata?.ceoInitiated === true` (same as `send-draft`)
+2. Validate `ctx.executionLayer` and `ctx.actionLogRepo` are present
+3. Call `ctx.actionLogRepo.resolvePending(shortRef)`
+   - On `found: false` → return `{ success: false, error }` with the reason
+4. Call `ctx.actionLogRepo.resolveRow(row.id, 'approved', 'ceo')`
+5. Re-execute: `ctx.executionLayer.invoke(row.skillName, row.payload!, ctx.caller, { humanApproved: true, taskEventId: ctx.taskEventId, conversationId: row.conversationId })`
+6. Write child row: `ctx.actionLogRepo.insert({ taskId: row.taskId, conversationId: row.conversationId, skillName: row.skillName, actionRisk: row.actionRisk, outcome: reResult.success ? 'success' : 'failure', taskSummary: reResult.success ? null : reResult.error, parentActionId: row.id })`
+7. Publish `human.decision` via `ctx.bus`: `decision: 'approve'`, `subjectSummary` from `row.description`
+8. Return the re-execution result (success or failure with reason — so the CEO gets immediate feedback)
+
+#### `deny-action`
+
+- **Directory:** `skills/deny-action/`
+- **Manifest:** `action_risk: "none"`, `sensitivity: "elevated"`, `capabilities: ["bus", "actionLogRepo"]`
+- **Input:** `short_ref: "string?"`
+- **Output:** `result: "string"` (confirmation message)
+
+Handler flow:
+1. CEO-origin check
+2. Validate `ctx.actionLogRepo` and `ctx.bus` are present
+3. Call `ctx.actionLogRepo.resolvePending(shortRef)` — fail on not-found/ambiguous
+4. Call `ctx.actionLogRepo.resolveRow(row.id, 'denied', 'ceo')`
+5. Publish `human.decision`: `decision: 'deny'`
+6. Return success with the denied action's description
+
+#### `dismiss-action`
+
+- **Directory:** `skills/dismiss-action/`
+- **Manifest:** `action_risk: "none"`, `sensitivity: "elevated"`, `capabilities: ["bus", "actionLogRepo"]`
+- **Input:** `short_ref: "string?"`
+- **Output:** `result: "string"` (confirmation message)
+
+Handler flow:
+1. CEO-origin check
+2. Validate `ctx.actionLogRepo` and `ctx.bus` are present
+3. Call `ctx.actionLogRepo.resolvePending(shortRef)` — fail on not-found/ambiguous
+4. Call `ctx.actionLogRepo.resolveRow(row.id, 'resolved_externally', 'ceo')`
+5. Publish `human.decision`: `decision: 'dismiss'`
+6. Return success with the dismissed action's description
+
+#### `list-pending-actions`
+
+- **Directory:** `skills/list-pending-actions/`
+- **Manifest:** `action_risk: "none"`, `sensitivity: "elevated"`, `capabilities: ["actionLogRepo"]`
+- **Input:** (none)
+- **Output:** `pending: "object[]"`
+
+Handler flow:
+1. CEO-origin check
+2. Validate `ctx.actionLogRepo` is present
+3. Call `ctx.actionLogRepo.findAllPending()`
+4. Return the list, mapping each row to: `{ short_ref, description, skill_name, created_at, expires_at }`
+5. If no pending rows, return success with empty list and a message
+
+### 7. Coordinator changes
+
+**Pin skills** — add to `pinned_skills` in `agents/coordinator.yaml`:
+- `approve-action`
+- `deny-action`
+- `dismiss-action`
+- `list-pending-actions`
+
+**Prompt guidance** — add after the existing "Audience Awareness" section:
+
+```
+## Pending Approval Requests
+When the autonomy gate blocks a skill, Curia creates a pending approval
+request and notifies the CEO. Each request has a short_ref (e.g. "cal-1",
+"email-2") and a human-readable description.
+
+When the CEO responds to an approval notification (or asks about pending
+requests):
+- Use list-pending-actions to see all pending requests
+- Match the CEO's natural language to a specific short_ref using the
+  description (e.g. "approve the calendar event" → the cal-* request)
+- When only one request is pending, short_ref can be omitted
+- Use approve-action to approve, deny-action to deny, dismiss-action
+  when the CEO handled it outside Curia
+- If the CEO's intent is ambiguous and multiple requests are pending,
+  show the list and ask which one they mean
+```
+
+### 8. Test coverage
+
+Each skill gets a handler test file covering:
+- Happy path (single pending row, with and without explicit `short_ref`)
+- Ambiguous resolution (multiple pending, no `short_ref` → error listing them)
+- Not-found / expired / already-resolved cases
+- CEO-origin gate rejection (non-CEO caller blocked)
+- Missing capability graceful error
+
+`approve-action` additionally:
+- Re-execution success → child row with `outcome: 'success'`
+- Re-execution failure → child row with `outcome: 'failure'`, CEO gets error
+- `human.decision` event published with correct payload
+
+`ActionLogRepo` new methods:
+- `resolvePending` with each discriminated union case
+- `resolveRow` idempotency (double-resolve is a no-op)
+- `findAllPending` excludes expired rows
+- `insert` with `parentActionId`
+
+Migration 032:
+- Unique constraint prevents duplicate `short_ref` within same `task_id`
+
+`ApprovalTriggerService`:
+- Retry on unique violation succeeds with incremented counter

--- a/docs/wip/2026-05-03-approval-skills.md
+++ b/docs/wip/2026-05-03-approval-skills.md
@@ -1,0 +1,1878 @@
+# Approval Management Skills Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement four CEO-facing skills (approve-action, deny-action, dismiss-action, list-pending-actions) that resolve pending approval requests created by the autonomy gate trigger (#427).
+
+**Architecture:** Skills follow the existing `skill.json` + handler class pattern. All are `sensitivity: "elevated"` (CEO-only), `action_risk: "none"`. `approve-action` re-executes blocked skills via a new `executionLayer` capability. All four skills access `ActionLogRepo` via a new `actionLogRepo` capability. A UNIQUE constraint on `(task_id, short_ref)` fixes the race condition from #436 review.
+
+**Tech Stack:** TypeScript (ESM), Postgres, vitest, node-pg-migrate
+
+**Worktree:** `/Users/josephfung/Projects/worktrees/curia-approval-skills` (branch `feat/approval-skills`)
+
+**Spec:** `docs/wip/2026-05-03-approval-skills-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `src/db/migrations/032_unique_task_short_ref.sql` — UNIQUE constraint migration
+- `skills/approve-action/skill.json` — manifest
+- `skills/approve-action/handler.ts` — handler
+- `skills/approve-action/handler.test.ts` — tests
+- `skills/deny-action/skill.json` — manifest
+- `skills/deny-action/handler.ts` — handler
+- `skills/deny-action/handler.test.ts` — tests
+- `skills/dismiss-action/skill.json` — manifest
+- `skills/dismiss-action/handler.ts` — handler
+- `skills/dismiss-action/handler.test.ts` — tests
+- `skills/list-pending-actions/skill.json` — manifest
+- `skills/list-pending-actions/handler.ts` — handler
+- `skills/list-pending-actions/handler.test.ts` — tests
+
+**Modify:**
+- `src/autonomy/action-log-types.ts` — add `parentActionId` to `ActionLogInsert`, export `ResolveResult` type
+- `src/autonomy/action-log-repo.ts` — add `resolvePending()`, `findAllPending()`, `resolveRow()`, extend `insert()` for `parentActionId`
+- `src/autonomy/action-log-repo.test.ts` — tests for new methods
+- `src/autonomy/approval-trigger.ts` — retry loop on unique violation in `request()`
+- `src/autonomy/approval-trigger.test.ts` — test for retry
+- `src/skills/types.ts` — add `executionLayer` and `actionLogRepo` to `SkillContext`
+- `src/skills/loader.ts` — add `executionLayer` and `actionLogRepo` to `VALID_CAPABILITIES`
+- `src/skills/execution.ts` — add `actionLogRepo` to constructor options and `capabilityServices`, add `executionLayer: this`
+- `src/bus/events.ts` — add `'dismiss'` to `HumanDecisionPayload.decision`
+- `src/index.ts` — pass `actionLogRepo` to `ExecutionLayer`
+- `agents/coordinator.yaml` — pin skills, add prompt guidance
+
+---
+
+### Task 1: Migration — UNIQUE constraint on `(task_id, short_ref)`
+
+**Files:**
+- Create: `src/db/migrations/032_unique_task_short_ref.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- 032_unique_task_short_ref.sql
+--
+-- Adds a UNIQUE constraint on (task_id, short_ref) to prevent race conditions
+-- in short_ref generation. Null short_ref values (non-approval rows) do not
+-- violate the constraint — Postgres treats nulls as never equal.
+--
+-- See issue #428 and the #436 review discussion.
+
+ALTER TABLE autonomy_action_log
+  ADD CONSTRAINT uq_aal_task_short_ref UNIQUE (task_id, short_ref);
+```
+
+- [ ] **Step 2: Verify the migration file exists and is valid SQL**
+
+Run: `cat src/db/migrations/032_unique_task_short_ref.sql`
+Expected: The SQL above, no syntax errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/db/migrations/032_unique_task_short_ref.sql
+git commit -m "feat(db): add UNIQUE(task_id, short_ref) constraint on autonomy_action_log (#428)"
+```
+
+---
+
+### Task 2: Extend `ActionLogInsert` with `parentActionId` and update `insert()`
+
+**Files:**
+- Modify: `src/autonomy/action-log-types.ts:61-74`
+- Modify: `src/autonomy/action-log-repo.ts:23-45`
+- Modify: `src/autonomy/action-log-repo.test.ts`
+
+- [ ] **Step 1: Write the failing test for `insert()` with `parentActionId`**
+
+Add to the `describe('insert', ...)` block in `src/autonomy/action-log-repo.test.ts`:
+
+```typescript
+it('includes parent_action_id in INSERT when provided', async () => {
+  const { pool, queries } = makePool([{ id: 99 }]);
+  const repo = new ActionLogRepo(pool, createSilentLogger());
+  const id = await repo.insert({
+    taskId: 'task-1',
+    skillName: 'calendar-create-event',
+    actionRisk: 'high',
+    outcome: 'success',
+    parentActionId: 42,
+  });
+  expect(id).toBe(99);
+  expect(queries[0]!.sql).toContain('parent_action_id');
+  expect(queries[0]!.params).toContain(42);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test src/autonomy/action-log-repo.test.ts`
+Expected: FAIL — `parentActionId` does not exist on `ActionLogInsert`
+
+- [ ] **Step 3: Add `parentActionId` to `ActionLogInsert`**
+
+In `src/autonomy/action-log-types.ts`, add to the `ActionLogInsert` interface after the existing approval lifecycle fields comment:
+
+```typescript
+/** Fields required to insert a new autonomy_action_log row. */
+export interface ActionLogInsert {
+  taskId: string;
+  conversationId?: string;
+  skillName: string;
+  actionRisk: string;
+  outcome: ActionLogOutcome;
+  taskSummary?: string;
+
+  // Approval lifecycle fields (optional — used by #427/#428)
+  payload?: Record<string, unknown>;
+  expiresAt?: Date;
+  shortRef?: string;
+  description?: string;
+  /** Links a re-execution row back to the approved row. Used by approve-action (#428). */
+  parentActionId?: number;
+}
+```
+
+- [ ] **Step 4: Update `insert()` to include `parent_action_id`**
+
+In `src/autonomy/action-log-repo.ts`, replace the `insert` method:
+
+```typescript
+/** Insert a new row and return the generated id. */
+async insert(row: ActionLogInsert): Promise<number> {
+  const result = await this.pool.query<{ id: number }>(
+    `INSERT INTO autonomy_action_log
+       (task_id, conversation_id, skill_name, action_risk, outcome, task_summary,
+        payload, expires_at, short_ref, description, parent_action_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+     RETURNING id`,
+    [
+      row.taskId,
+      row.conversationId ?? null,
+      row.skillName,
+      row.actionRisk,
+      row.outcome,
+      row.taskSummary ?? null,
+      row.payload ? JSON.stringify(row.payload) : null,
+      row.expiresAt ?? null,
+      row.shortRef ?? null,
+      row.description ?? null,
+      row.parentActionId ?? null,
+    ],
+  );
+  this.logger.debug({ id: result.rows[0]!.id, skillName: row.skillName, outcome: row.outcome }, 'action-log-repo: inserted row');
+  return result.rows[0]!.id;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test src/autonomy/action-log-repo.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/autonomy/action-log-types.ts src/autonomy/action-log-repo.ts src/autonomy/action-log-repo.test.ts
+git commit -m "feat(autonomy): add parentActionId to ActionLogInsert and insert() (#428)"
+```
+
+---
+
+### Task 3: Add `ResolveResult` type, `findAllPending()`, `resolveRow()`, and `resolvePending()` to `ActionLogRepo`
+
+**Files:**
+- Modify: `src/autonomy/action-log-types.ts`
+- Modify: `src/autonomy/action-log-repo.ts`
+- Modify: `src/autonomy/action-log-repo.test.ts`
+
+- [ ] **Step 1: Add `ResolveResult` type to `action-log-types.ts`**
+
+Append after the `DETERMINISTIC_SCORES` block:
+
+```typescript
+/** Result of resolving a short_ref to a pending_approval row. */
+export type ResolveResult =
+  | { found: true; row: ActionLogRow }
+  | { found: false; reason: 'not_found'; error: string }
+  | { found: false; reason: 'ambiguous'; error: string; pending: ActionLogRow[] }
+  | { found: false; reason: 'expired'; error: string }
+  | { found: false; reason: 'already_resolved'; error: string };
+```
+
+- [ ] **Step 2: Write the failing tests for `findAllPending()`**
+
+Add to `src/autonomy/action-log-repo.test.ts`:
+
+```typescript
+describe('findAllPending', () => {
+  it('returns pending rows ordered by created_at asc', async () => {
+    const now = new Date();
+    const { pool } = makePool([
+      {
+        id: 1, task_id: 't1', conversation_id: null, skill_name: 'calendar-create-event',
+        action_risk: 'high', outcome: 'pending_approval', task_summary: null,
+        competence_flag: null, commitment_flag: null, compatibility: null,
+        scored_by: null, payload: { title: 'Lunch' }, notification_sent_at: null,
+        resolved_at: null, resolved_by: null, expires_at: new Date(Date.now() + 86_400_000),
+        parent_action_id: null, short_ref: 'cal-1', description: 'Create calendar event: Lunch',
+        created_at: now,
+      },
+    ]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const rows = await repo.findAllPending();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.shortRef).toBe('cal-1');
+  });
+
+  it('uses the correct SQL filter for pending + non-expired', async () => {
+    const { pool, queries } = makePool([]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    await repo.findAllPending();
+    expect(queries[0]!.sql).toContain("outcome = 'pending_approval'");
+    expect(queries[0]!.sql).toContain('expires_at > now()');
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test src/autonomy/action-log-repo.test.ts`
+Expected: FAIL — `findAllPending` is not a function
+
+- [ ] **Step 4: Implement `findAllPending()`**
+
+Add to `ActionLogRepo` class in `src/autonomy/action-log-repo.ts`, after `setNotificationSentAt()`:
+
+```typescript
+/**
+ * Return all non-expired pending_approval rows, oldest first.
+ * Used by list-pending-actions and by resolvePending() when no short_ref is given.
+ */
+async findAllPending(): Promise<ActionLogRow[]> {
+  const result = await this.pool.query(
+    `SELECT * FROM autonomy_action_log
+     WHERE outcome = 'pending_approval'
+       AND expires_at > now()
+     ORDER BY created_at ASC`,
+  );
+  return result.rows.map(mapRow);
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test src/autonomy/action-log-repo.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 6: Write the failing tests for `resolveRow()`**
+
+Add to `src/autonomy/action-log-repo.test.ts`:
+
+```typescript
+describe('resolveRow', () => {
+  it('updates outcome, resolved_at, and resolved_by for a pending row', async () => {
+    const { pool, queries } = makePool([], 1);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    await repo.resolveRow(42, 'approved', 'ceo');
+    expect(queries).toHaveLength(1);
+    expect(queries[0]!.sql).toContain('UPDATE autonomy_action_log');
+    expect(queries[0]!.sql).toContain("outcome = 'pending_approval'");
+    expect(queries[0]!.params).toContain(42);
+    expect(queries[0]!.params).toContain('approved');
+    expect(queries[0]!.params).toContain('ceo');
+  });
+
+  it('accepts denied outcome', async () => {
+    const { pool, queries } = makePool([], 1);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    await repo.resolveRow(10, 'denied', 'ceo');
+    expect(queries[0]!.params).toContain('denied');
+  });
+
+  it('accepts resolved_externally outcome', async () => {
+    const { pool, queries } = makePool([], 1);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    await repo.resolveRow(10, 'resolved_externally', 'ceo');
+    expect(queries[0]!.params).toContain('resolved_externally');
+  });
+});
+```
+
+- [ ] **Step 7: Run test to verify it fails**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test src/autonomy/action-log-repo.test.ts`
+Expected: FAIL — `resolveRow` is not a function
+
+- [ ] **Step 8: Implement `resolveRow()`**
+
+Add to `ActionLogRepo` class, after `findAllPending()`:
+
+```typescript
+/**
+ * Transition a pending_approval row to a terminal outcome.
+ * Only updates if the current outcome is still pending_approval —
+ * silently no-ops on double-resolve (idempotent).
+ */
+async resolveRow(
+  id: number,
+  outcome: 'approved' | 'denied' | 'resolved_externally',
+  resolvedBy: string,
+): Promise<void> {
+  await this.pool.query(
+    `UPDATE autonomy_action_log
+     SET outcome = $2, resolved_at = now(), resolved_by = $3
+     WHERE id = $1 AND outcome = 'pending_approval'`,
+    [id, outcome, resolvedBy],
+  );
+  this.logger.debug({ id, outcome, resolvedBy }, 'action-log-repo: row resolved');
+}
+```
+
+- [ ] **Step 9: Run test to verify it passes**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test src/autonomy/action-log-repo.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 10: Write the failing tests for `resolvePending()`**
+
+Add to `src/autonomy/action-log-repo.test.ts`. These tests need a `makePool` that can return different results per call, so add a multi-call helper first:
+
+```typescript
+function makeSequentialPool(
+  callResults: Array<Record<string, unknown>[]>,
+): { pool: Pool; queries: Array<{ sql: string; params: unknown[] }> } {
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+  let callIndex = 0;
+  const pool = {
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params: params ?? [] });
+      const rows = callResults[callIndex] ?? [];
+      callIndex++;
+      return { rows, rowCount: rows.length } as unknown as QueryResult;
+    }),
+  } as unknown as Pool;
+  return { pool, queries };
+}
+```
+
+Then the tests:
+
+```typescript
+describe('resolvePending', () => {
+  const pendingRow = {
+    id: 10, task_id: 't1', conversation_id: null, skill_name: 'calendar-create-event',
+    action_risk: 'high', outcome: 'pending_approval', task_summary: null,
+    competence_flag: null, commitment_flag: null, compatibility: null,
+    scored_by: null, payload: { title: 'Lunch' }, notification_sent_at: null,
+    resolved_at: null, resolved_by: null, expires_at: new Date(Date.now() + 86_400_000),
+    parent_action_id: null, short_ref: 'cal-1', description: 'Create calendar event: Lunch',
+    created_at: new Date(),
+  };
+
+  it('resolves by short_ref when provided', async () => {
+    const { pool } = makePool([pendingRow]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const result = await repo.resolvePending('cal-1');
+    expect(result.found).toBe(true);
+    if (result.found) expect(result.row.id).toBe(10);
+  });
+
+  it('returns not_found when short_ref does not match any row', async () => {
+    const { pool } = makePool([]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const result = await repo.resolvePending('cal-99');
+    expect(result).toEqual({
+      found: false,
+      reason: 'not_found',
+      error: expect.stringContaining('cal-99'),
+    });
+  });
+
+  it('returns already_resolved when row exists but is not pending', async () => {
+    const resolvedRow = { ...pendingRow, outcome: 'approved' };
+    // First query (by short_ref, pending only) returns nothing;
+    // second query (by short_ref, any outcome) returns the resolved row.
+    const { pool } = makeSequentialPool([[], [resolvedRow]]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const result = await repo.resolvePending('cal-1');
+    expect(result).toEqual({
+      found: false,
+      reason: 'already_resolved',
+      error: expect.stringContaining('already resolved'),
+    });
+  });
+
+  it('returns expired when row is pending but past expires_at', async () => {
+    const expiredRow = { ...pendingRow, expires_at: new Date(Date.now() - 1000) };
+    // First query (pending + non-expired) returns nothing;
+    // second query (any outcome) returns the expired row.
+    const { pool } = makeSequentialPool([[], [expiredRow]]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const result = await repo.resolvePending('cal-1');
+    expect(result).toEqual({
+      found: false,
+      reason: 'expired',
+      error: expect.stringContaining('expired'),
+    });
+  });
+
+  it('resolves to sole pending row when no short_ref provided', async () => {
+    // findAllPending returns one row
+    const { pool } = makePool([pendingRow]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const result = await repo.resolvePending();
+    expect(result.found).toBe(true);
+    if (result.found) expect(result.row.id).toBe(10);
+  });
+
+  it('returns not_found when no short_ref and no pending rows', async () => {
+    const { pool } = makePool([]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const result = await repo.resolvePending();
+    expect(result).toEqual({
+      found: false,
+      reason: 'not_found',
+      error: expect.stringContaining('No pending'),
+    });
+  });
+
+  it('returns ambiguous when no short_ref and multiple pending rows', async () => {
+    const row2 = { ...pendingRow, id: 11, short_ref: 'email-1', skill_name: 'email-reply' };
+    const { pool } = makePool([pendingRow, row2]);
+    const repo = new ActionLogRepo(pool, createSilentLogger());
+    const result = await repo.resolvePending();
+    expect(result.found).toBe(false);
+    if (!result.found) {
+      expect(result.reason).toBe('ambiguous');
+      expect((result as { pending: unknown[] }).pending).toHaveLength(2);
+    }
+  });
+});
+```
+
+- [ ] **Step 11: Run test to verify it fails**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test src/autonomy/action-log-repo.test.ts`
+Expected: FAIL — `resolvePending` is not a function
+
+- [ ] **Step 12: Implement `resolvePending()`**
+
+Add to `ActionLogRepo` class, after `resolveRow()`. Also add the import for `ResolveResult` at the top of the file:
+
+At the top of `action-log-repo.ts`, update the import:
+
+```typescript
+import type {
+  ActionLogRow,
+  ActionLogInsert,
+  ScoringFlags,
+  ResolveResult,
+} from './action-log-types.js';
+```
+
+Then add the method:
+
+```typescript
+/**
+ * Resolve a short_ref (or the sole pending row) to a single ActionLogRow.
+ *
+ * When short_ref is provided: look up by short_ref. If the row is not
+ * pending_approval, check whether it's already resolved or expired.
+ * When omitted: fetch all non-expired pending rows. If exactly one,
+ * return it. If multiple, return ambiguous with the list.
+ */
+async resolvePending(shortRef?: string): Promise<ResolveResult> {
+  if (shortRef !== undefined) {
+    // Look up by short_ref — pending + non-expired only
+    const pending = await this.pool.query(
+      `SELECT * FROM autonomy_action_log
+       WHERE short_ref = $1
+         AND outcome = 'pending_approval'
+         AND expires_at > now()
+       LIMIT 1`,
+      [shortRef],
+    );
+    if (pending.rows.length > 0) {
+      return { found: true, row: mapRow(pending.rows[0]) };
+    }
+
+    // Not found as pending — check if it exists at all (any outcome)
+    const any = await this.pool.query(
+      `SELECT * FROM autonomy_action_log
+       WHERE short_ref = $1
+       LIMIT 1`,
+      [shortRef],
+    );
+    if (any.rows.length === 0) {
+      return { found: false, reason: 'not_found', error: `No approval request found with reference '${shortRef}'` };
+    }
+
+    const row = mapRow(any.rows[0]);
+    if (row.outcome !== 'pending_approval') {
+      return { found: false, reason: 'already_resolved', error: `Request '${shortRef}' has already been resolved (outcome: ${row.outcome})` };
+    }
+    // outcome is pending_approval but expires_at <= now()
+    return { found: false, reason: 'expired', error: `Request '${shortRef}' has expired` };
+  }
+
+  // No short_ref — resolve to the sole pending row
+  const allPending = await this.findAllPending();
+  if (allPending.length === 0) {
+    return { found: false, reason: 'not_found', error: 'No pending approval requests' };
+  }
+  if (allPending.length === 1) {
+    return { found: true, row: allPending[0]! };
+  }
+  const refs = allPending.map(r => `${r.shortRef}: ${r.description}`).join(', ');
+  return {
+    found: false,
+    reason: 'ambiguous',
+    error: `Multiple pending requests — specify a short_ref. Pending: ${refs}`,
+    pending: allPending,
+  };
+}
+```
+
+- [ ] **Step 13: Run test to verify it passes**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test src/autonomy/action-log-repo.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 14: Run full test suite to check for regressions**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test`
+Expected: ALL PASS
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add src/autonomy/action-log-types.ts src/autonomy/action-log-repo.ts src/autonomy/action-log-repo.test.ts
+git commit -m "feat(autonomy): add resolvePending, findAllPending, resolveRow to ActionLogRepo (#428)"
+```
+
+---
+
+### Task 4: Retry loop in `ApprovalTriggerService.request()`
+
+**Files:**
+- Modify: `src/autonomy/approval-trigger.ts:155-173`
+- Modify: `src/autonomy/approval-trigger.test.ts`
+
+- [ ] **Step 1: Write the failing test for retry on unique violation**
+
+Add to `src/autonomy/approval-trigger.test.ts` inside the `describe('ApprovalTriggerService.request()', ...)` block:
+
+```typescript
+it('retries on unique_violation (23505) and succeeds with incremented counter', async () => {
+  // First insert throws unique_violation; second succeeds.
+  const insertMock = vi.fn()
+    .mockRejectedValueOnce(Object.assign(new Error('unique_violation'), { code: '23505' }))
+    .mockResolvedValueOnce(2);
+  // countShortRefsForTask returns 0 first, then 1 after retry.
+  const countMock = vi.fn()
+    .mockResolvedValueOnce(0)
+    .mockResolvedValueOnce(0)  // second call during retry re-counts
+    .mockResolvedValueOnce(1);
+  const repo = makeMockRepo({
+    insert: insertMock,
+    countShortRefsForTask: countMock,
+  });
+  const gateway = makeMockGateway();
+  const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+  const result = await service.request(BASE_OPTS);
+
+  expect(result.created).toBe(true);
+  if (result.created) {
+    expect(result.shortRef).toBe('cal-2'); // counter was 1 on retry
+  }
+  expect(insertMock).toHaveBeenCalledTimes(2);
+});
+
+it('gives up after 3 retries on persistent unique_violation', async () => {
+  const insertMock = vi.fn().mockRejectedValue(
+    Object.assign(new Error('unique_violation'), { code: '23505' }),
+  );
+  const repo = makeMockRepo({ insert: insertMock });
+  const gateway = makeMockGateway();
+  const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+  await expect(service.request(BASE_OPTS)).rejects.toThrow('unique_violation');
+  expect(insertMock).toHaveBeenCalledTimes(3);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test src/autonomy/approval-trigger.test.ts`
+Expected: FAIL — no retry logic, first insert failure propagates
+
+- [ ] **Step 3: Add retry loop to `request()`**
+
+In `src/autonomy/approval-trigger.ts`, replace the Step 2 + Step 3 block (lines ~154–173) with:
+
+```typescript
+    // Step 2 + 3: Generate short_ref, description, and insert row.
+    // Retry on unique_violation (23505) — the countShortRefsForTask + 1 pattern
+    // can race under concurrency. The UNIQUE(task_id, short_ref) constraint (#428)
+    // catches the collision; we re-count and retry.
+    const MAX_INSERT_RETRIES = 3;
+    let rowId!: number;
+    let shortRef!: string;
+    let description!: string;
+    let expiresAt!: Date;
+
+    for (let attempt = 1; attempt <= MAX_INSERT_RETRIES; attempt++) {
+      const counter = await this.actionLogRepo.countShortRefsForTask(taskId);
+      shortRef = `${shortRefPrefix(skillName)}-${counter + 1}`;
+      // Sanitize description before storing and sending — the input fields come from
+      // LLM-generated skill arguments and may contain dangerous tags.
+      description = sanitizeOutput(buildDescription(skillName, input));
+      expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24h from now
+
+      try {
+        rowId = await this.actionLogRepo.insert({
+          taskId,
+          conversationId,
+          skillName,
+          actionRisk,
+          outcome: 'pending_approval',
+          payload: input,
+          expiresAt,
+          shortRef,
+          description,
+        });
+        break; // Insert succeeded
+      } catch (err) {
+        const isUniqueViolation = (err as { code?: string }).code === '23505';
+        if (isUniqueViolation && attempt < MAX_INSERT_RETRIES) {
+          this.logger.warn(
+            { taskId, shortRef, attempt },
+            'approval-trigger: short_ref collision — retrying with new counter',
+          );
+          continue;
+        }
+        throw err; // Non-unique error, or exhausted retries
+      }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test src/autonomy/approval-trigger.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/autonomy/approval-trigger.ts src/autonomy/approval-trigger.test.ts
+git commit -m "fix(autonomy): retry ApprovalTriggerService insert on short_ref collision (#428)"
+```
+
+---
+
+### Task 5: Add `executionLayer` and `actionLogRepo` capabilities
+
+**Files:**
+- Modify: `src/skills/loader.ts:27-31`
+- Modify: `src/skills/types.ts:113-192`
+- Modify: `src/skills/execution.ts:63-128` (constructor + capabilityServices)
+- Modify: `src/bus/events.ts:405-424`
+- Modify: `src/index.ts:859`
+
+- [ ] **Step 1: Add to `VALID_CAPABILITIES`**
+
+In `src/skills/loader.ts`, update the `VALID_CAPABILITIES` set:
+
+```typescript
+export const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
+  'bus', 'agentRegistry', 'outboundGateway', 'heldMessages',
+  'schedulerService', 'entityMemory', 'nylasCalendarClient',
+  'autonomyService', 'executiveProfileService', 'browserService', 'bullpenService', 'skillSearch',
+  'actionLogRepo', 'executionLayer',
+]);
+```
+
+- [ ] **Step 2: Add to `SkillContext`**
+
+In `src/skills/types.ts`, add two fields to the `SkillContext` interface (after the `timezone` field):
+
+```typescript
+  /** Action log repo — available to skills declaring 'actionLogRepo' in capabilities.
+   *  Provides read/write access to the autonomy_action_log table for approval lifecycle
+   *  management. Used by approve-action, deny-action, dismiss-action, list-pending-actions. */
+  actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
+  /** Execution layer — available to skills declaring 'executionLayer' in capabilities.
+   *  Allows re-invocation of skills with humanApproved bypass. Only approve-action (#428)
+   *  should declare this capability; it is sensitivity: "elevated" (CEO-only). */
+  executionLayer?: import('./execution.js').ExecutionLayer;
+```
+
+- [ ] **Step 3: Add to `ExecutionLayer` constructor and `capabilityServices`**
+
+In `src/skills/execution.ts`, add `actionLogRepo` to the constructor options interface (after `approvalTrigger`):
+
+```typescript
+    actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
+```
+
+Add the field to the class:
+
+```typescript
+  private actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
+```
+
+Add the assignment in the constructor:
+
+```typescript
+    this.actionLogRepo = options?.actionLogRepo;
+```
+
+In the `capabilityServices` map inside `invoke()`, add:
+
+```typescript
+      actionLogRepo: this.actionLogRepo,
+      executionLayer: this,
+```
+
+- [ ] **Step 4: Add `'dismiss'` to `HumanDecisionPayload.decision`**
+
+In `src/bus/events.ts`, update the `decision` field:
+
+```typescript
+  decision: 'approve' | 'deny' | 'dismiss' | 'modify' | 'escalate' | 'timeout';
+```
+
+- [ ] **Step 5: Wire `actionLogRepo` in `index.ts`**
+
+In `src/index.ts`, add `actionLogRepo` to the `ExecutionLayer` constructor call. Find the line:
+
+```typescript
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, timezone: config.timezone, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
+```
+
+Add `actionLogRepo` to the options object (after `approvalTrigger`):
+
+```typescript
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, actionLogRepo, timezone: config.timezone, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
+```
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills run typecheck`
+Expected: No errors (or only pre-existing ones)
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test`
+Expected: ALL PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/skills/loader.ts src/skills/types.ts src/skills/execution.ts src/bus/events.ts src/index.ts
+git commit -m "feat(skills): add executionLayer and actionLogRepo capabilities; add dismiss decision type (#428)"
+```
+
+---
+
+### Task 6: `list-pending-actions` skill
+
+**Files:**
+- Create: `skills/list-pending-actions/skill.json`
+- Create: `skills/list-pending-actions/handler.ts`
+- Create: `skills/list-pending-actions/handler.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `skills/list-pending-actions/handler.test.ts`:
+
+```typescript
+// handler.test.ts — unit tests for list-pending-actions skill.
+
+import { describe, it, expect, vi } from 'vitest';
+import { ListPendingActionsHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: {},
+    secret: () => '',
+    log: createSilentLogger(),
+    taskMetadata: { ceoInitiated: true, senderId: 'ceo-1', channelId: 'cli' },
+    taskEventId: 'task-1',
+    ...overrides,
+  } as SkillContext;
+}
+
+function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
+  return {
+    findAllPending: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  } as unknown as ActionLogRepo;
+}
+
+describe('ListPendingActionsHandler', () => {
+  it('rejects non-CEO callers', async () => {
+    const handler = new ListPendingActionsHandler();
+    const result = await handler.execute(makeCtx({ taskMetadata: {} }));
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error');
+  });
+
+  it('returns error when actionLogRepo is not available', async () => {
+    const handler = new ListPendingActionsHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: undefined }));
+    expect(result.success).toBe(false);
+  });
+
+  it('returns empty list with message when no pending rows', async () => {
+    const repo = makeMockRepo();
+    const handler = new ListPendingActionsHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo }));
+    expect(result.success).toBe(true);
+    expect(result).toHaveProperty('data');
+    const data = (result as { success: true; data: unknown }).data as { pending: unknown[]; message: string };
+    expect(data.pending).toEqual([]);
+    expect(data.message).toContain('No pending');
+  });
+
+  it('returns pending rows mapped to summary fields', async () => {
+    const now = new Date();
+    const expires = new Date(Date.now() + 86_400_000);
+    const repo = makeMockRepo({
+      findAllPending: vi.fn().mockResolvedValue([
+        {
+          id: 1, shortRef: 'cal-1', description: 'Create calendar event: Lunch',
+          skillName: 'calendar-create-event', createdAt: now, expiresAt: expires,
+        },
+        {
+          id: 2, shortRef: 'email-1', description: 'Send email reply: Re: Budget',
+          skillName: 'email-reply', createdAt: now, expiresAt: expires,
+        },
+      ]),
+    });
+    const handler = new ListPendingActionsHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo }));
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: unknown }).data as { pending: Array<Record<string, unknown>> };
+    expect(data.pending).toHaveLength(2);
+    expect(data.pending[0]).toEqual({
+      short_ref: 'cal-1',
+      description: 'Create calendar event: Lunch',
+      skill_name: 'calendar-create-event',
+      created_at: now.toISOString(),
+      expires_at: expires.toISOString(),
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test skills/list-pending-actions/handler.test.ts`
+Expected: FAIL — file not found or module not found
+
+- [ ] **Step 3: Create manifest**
+
+Create `skills/list-pending-actions/skill.json`:
+
+```json
+{
+  "name": "list-pending-actions",
+  "description": "List all pending approval requests awaiting CEO decision. Returns short_ref, description, skill name, and expiry for each.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "action_risk": "none",
+  "inputs": {},
+  "outputs": {
+    "pending": "object[] (list of pending approval requests)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": ["actionLogRepo"]
+}
+```
+
+- [ ] **Step 4: Implement handler**
+
+Create `skills/list-pending-actions/handler.ts`:
+
+```typescript
+// handler.ts — list-pending-actions skill implementation.
+//
+// Returns all non-expired pending approval requests so the CEO can see what's
+// waiting for their decision. Read-only — no state changes.
+//
+// SECURITY: sensitivity: "elevated" ensures only the CEO can call this.
+// The ceoInitiated check is a defense-in-depth secondary gate.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class ListPendingActionsHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    // CEO-origin check — defense-in-depth (elevated gate is primary)
+    if (ctx.taskMetadata?.ceoInitiated !== true) {
+      ctx.log.warn('list-pending-actions: rejected — ceoInitiated flag absent or false');
+      return { success: false, error: 'This skill requires direct CEO authorization.' };
+    }
+
+    if (!ctx.actionLogRepo) {
+      return { success: false, error: 'list-pending-actions requires actionLogRepo capability' };
+    }
+
+    const rows = await ctx.actionLogRepo.findAllPending();
+
+    const pending = rows.map((row) => ({
+      short_ref: row.shortRef,
+      description: row.description,
+      skill_name: row.skillName,
+      created_at: row.createdAt.toISOString(),
+      expires_at: row.expiresAt?.toISOString() ?? null,
+    }));
+
+    if (pending.length === 0) {
+      return { success: true, data: { pending: [], message: 'No pending approval requests.' } };
+    }
+
+    return { success: true, data: { pending } };
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test skills/list-pending-actions/handler.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/list-pending-actions/
+git commit -m "feat(skills): add list-pending-actions skill (#428)"
+```
+
+---
+
+### Task 7: `deny-action` skill
+
+**Files:**
+- Create: `skills/deny-action/skill.json`
+- Create: `skills/deny-action/handler.ts`
+- Create: `skills/deny-action/handler.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `skills/deny-action/handler.test.ts`:
+
+```typescript
+// handler.test.ts — unit tests for deny-action skill.
+
+import { describe, it, expect, vi } from 'vitest';
+import { DenyActionHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import type { EventBus } from '../../src/bus/bus.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+const PENDING_ROW = {
+  id: 10,
+  taskId: 't1',
+  conversationId: 'conv-1',
+  skillName: 'calendar-create-event',
+  actionRisk: 'high',
+  outcome: 'pending_approval' as const,
+  shortRef: 'cal-1',
+  description: 'Create calendar event: Lunch',
+  createdAt: new Date(),
+  expiresAt: new Date(Date.now() + 86_400_000),
+  payload: { title: 'Lunch' },
+  taskSummary: null,
+  competenceFlag: null,
+  commitmentFlag: null,
+  compatibility: null,
+  scoredBy: null,
+  notificationSentAt: null,
+  resolvedAt: null,
+  resolvedBy: null,
+  parentActionId: null,
+};
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: { short_ref: 'cal-1' },
+    secret: () => '',
+    log: createSilentLogger(),
+    taskMetadata: { ceoInitiated: true, senderId: 'ceo-1', channelId: 'cli' },
+    taskEventId: 'task-1',
+    ...overrides,
+  } as SkillContext;
+}
+
+function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
+  return {
+    resolvePending: vi.fn().mockResolvedValue({ found: true, row: PENDING_ROW }),
+    resolveRow: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ActionLogRepo;
+}
+
+function makeMockBus(): EventBus {
+  return {
+    publish: vi.fn().mockResolvedValue(undefined),
+  } as unknown as EventBus;
+}
+
+describe('DenyActionHandler', () => {
+  it('rejects non-CEO callers', async () => {
+    const handler = new DenyActionHandler();
+    const result = await handler.execute(makeCtx({ taskMetadata: {} }));
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error when actionLogRepo is missing', async () => {
+    const handler = new DenyActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: undefined }));
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error when bus is missing', async () => {
+    const repo = makeMockRepo();
+    const handler = new DenyActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, bus: undefined }));
+    expect(result.success).toBe(false);
+  });
+
+  it('denies a pending row and publishes human.decision', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const handler = new DenyActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, bus }));
+
+    expect(result.success).toBe(true);
+    expect(repo.resolveRow).toHaveBeenCalledWith(10, 'denied', 'ceo');
+    expect(bus.publish).toHaveBeenCalledOnce();
+    const event = (bus.publish as ReturnType<typeof vi.fn>).mock.calls[0]![1];
+    expect(event.type).toBe('human.decision');
+    expect(event.payload.decision).toBe('deny');
+  });
+
+  it('forwards resolvePending errors', async () => {
+    const repo = makeMockRepo({
+      resolvePending: vi.fn().mockResolvedValue({
+        found: false, reason: 'not_found', error: 'No approval request found',
+      }),
+    });
+    const bus = makeMockBus();
+    const handler = new DenyActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, bus }));
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error', 'No approval request found');
+  });
+
+  it('resolves sole pending row when short_ref is omitted', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const handler = new DenyActionHandler();
+    const result = await handler.execute(makeCtx({ input: {}, actionLogRepo: repo, bus }));
+    expect(result.success).toBe(true);
+    expect(repo.resolvePending).toHaveBeenCalledWith(undefined);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test skills/deny-action/handler.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Create manifest**
+
+Create `skills/deny-action/skill.json`:
+
+```json
+{
+  "name": "deny-action",
+  "description": "Deny a pending approval request. The blocked action will not be executed. Specify short_ref to target a specific request, or omit when only one is pending.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "action_risk": "none",
+  "inputs": {
+    "short_ref": "string? (reference code from the approval notification, e.g. 'cal-1')"
+  },
+  "outputs": {
+    "result": "string (confirmation message)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": ["bus", "actionLogRepo"]
+}
+```
+
+- [ ] **Step 4: Implement handler**
+
+Create `skills/deny-action/handler.ts`:
+
+```typescript
+// handler.ts — deny-action skill implementation.
+//
+// Denies a pending approval request: transitions the autonomy_action_log row
+// to outcome = 'denied' and publishes a human.decision audit event.
+// No re-execution — the originally blocked skill stays blocked.
+//
+// SECURITY: sensitivity: "elevated" + ceoInitiated check.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { createHumanDecision } from '../../src/bus/events.js';
+
+export class DenyActionHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (ctx.taskMetadata?.ceoInitiated !== true) {
+      ctx.log.warn('deny-action: rejected — ceoInitiated flag absent or false');
+      return { success: false, error: 'This skill requires direct CEO authorization.' };
+    }
+
+    if (!ctx.actionLogRepo) {
+      return { success: false, error: 'deny-action requires actionLogRepo capability' };
+    }
+    if (!ctx.bus) {
+      return { success: false, error: 'deny-action requires bus capability' };
+    }
+
+    const shortRef = typeof ctx.input.short_ref === 'string' && ctx.input.short_ref.trim()
+      ? ctx.input.short_ref.trim()
+      : undefined;
+
+    const resolved = await ctx.actionLogRepo.resolvePending(shortRef);
+    if (!resolved.found) {
+      return { success: false, error: resolved.error };
+    }
+
+    const { row } = resolved;
+
+    await ctx.actionLogRepo.resolveRow(row.id, 'denied', 'ceo');
+
+    // Publish human.decision audit event (best-effort)
+    const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
+    const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
+    try {
+      await ctx.bus.publish(
+        'dispatch',
+        createHumanDecision({
+          decision: 'deny',
+          deciderId: senderId,
+          deciderChannel: channelId,
+          subjectEventId: row.taskId,
+          subjectSummary: `CEO denied: ${row.description ?? row.skillName}`,
+          contextShown: ['short_ref', 'description', 'skill_name'],
+          presentedAt: row.createdAt,
+          decidedAt: new Date(),
+          defaultAction: 'block',
+          parentEventId: ctx.taskEventId ?? '',
+        }),
+      );
+    } catch (err) {
+      ctx.log.error({ err, rowId: row.id }, 'deny-action: failed to publish human.decision event');
+    }
+
+    ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'deny-action: request denied');
+    return { success: true, data: `Denied: ${row.description ?? row.skillName} (${row.shortRef})` };
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test skills/deny-action/handler.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/deny-action/
+git commit -m "feat(skills): add deny-action skill (#428)"
+```
+
+---
+
+### Task 8: `dismiss-action` skill
+
+**Files:**
+- Create: `skills/dismiss-action/skill.json`
+- Create: `skills/dismiss-action/handler.ts`
+- Create: `skills/dismiss-action/handler.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `skills/dismiss-action/handler.test.ts`:
+
+```typescript
+// handler.test.ts — unit tests for dismiss-action skill.
+
+import { describe, it, expect, vi } from 'vitest';
+import { DismissActionHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import type { EventBus } from '../../src/bus/bus.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+const PENDING_ROW = {
+  id: 10,
+  taskId: 't1',
+  conversationId: 'conv-1',
+  skillName: 'calendar-create-event',
+  actionRisk: 'high',
+  outcome: 'pending_approval' as const,
+  shortRef: 'cal-1',
+  description: 'Create calendar event: Lunch',
+  createdAt: new Date(),
+  expiresAt: new Date(Date.now() + 86_400_000),
+  payload: { title: 'Lunch' },
+  taskSummary: null,
+  competenceFlag: null,
+  commitmentFlag: null,
+  compatibility: null,
+  scoredBy: null,
+  notificationSentAt: null,
+  resolvedAt: null,
+  resolvedBy: null,
+  parentActionId: null,
+};
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: { short_ref: 'cal-1' },
+    secret: () => '',
+    log: createSilentLogger(),
+    taskMetadata: { ceoInitiated: true, senderId: 'ceo-1', channelId: 'cli' },
+    taskEventId: 'task-1',
+    ...overrides,
+  } as SkillContext;
+}
+
+function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
+  return {
+    resolvePending: vi.fn().mockResolvedValue({ found: true, row: PENDING_ROW }),
+    resolveRow: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ActionLogRepo;
+}
+
+function makeMockBus(): EventBus {
+  return {
+    publish: vi.fn().mockResolvedValue(undefined),
+  } as unknown as EventBus;
+}
+
+describe('DismissActionHandler', () => {
+  it('rejects non-CEO callers', async () => {
+    const handler = new DismissActionHandler();
+    const result = await handler.execute(makeCtx({ taskMetadata: {} }));
+    expect(result.success).toBe(false);
+  });
+
+  it('dismisses a pending row with resolved_externally', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const handler = new DismissActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, bus }));
+
+    expect(result.success).toBe(true);
+    expect(repo.resolveRow).toHaveBeenCalledWith(10, 'resolved_externally', 'ceo');
+  });
+
+  it('publishes human.decision with dismiss decision type', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const handler = new DismissActionHandler();
+    await handler.execute(makeCtx({ actionLogRepo: repo, bus }));
+
+    const event = (bus.publish as ReturnType<typeof vi.fn>).mock.calls[0]![1];
+    expect(event.type).toBe('human.decision');
+    expect(event.payload.decision).toBe('dismiss');
+  });
+
+  it('forwards resolvePending errors', async () => {
+    const repo = makeMockRepo({
+      resolvePending: vi.fn().mockResolvedValue({
+        found: false, reason: 'expired', error: 'Request has expired',
+      }),
+    });
+    const bus = makeMockBus();
+    const handler = new DismissActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, bus }));
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error', 'Request has expired');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test skills/dismiss-action/handler.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Create manifest**
+
+Create `skills/dismiss-action/skill.json`:
+
+```json
+{
+  "name": "dismiss-action",
+  "description": "Dismiss a pending approval request because the CEO handled the action outside Curia (e.g. created the calendar event directly). Specify short_ref to target a specific request, or omit when only one is pending.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "action_risk": "none",
+  "inputs": {
+    "short_ref": "string? (reference code from the approval notification, e.g. 'cal-1')"
+  },
+  "outputs": {
+    "result": "string (confirmation message)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": ["bus", "actionLogRepo"]
+}
+```
+
+- [ ] **Step 4: Implement handler**
+
+Create `skills/dismiss-action/handler.ts`:
+
+```typescript
+// handler.ts — dismiss-action skill implementation.
+//
+// Dismisses a pending approval request: transitions to outcome = 'resolved_externally'.
+// Used when the CEO handled the action outside Curia.
+//
+// SECURITY: sensitivity: "elevated" + ceoInitiated check.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { createHumanDecision } from '../../src/bus/events.js';
+
+export class DismissActionHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (ctx.taskMetadata?.ceoInitiated !== true) {
+      ctx.log.warn('dismiss-action: rejected — ceoInitiated flag absent or false');
+      return { success: false, error: 'This skill requires direct CEO authorization.' };
+    }
+
+    if (!ctx.actionLogRepo) {
+      return { success: false, error: 'dismiss-action requires actionLogRepo capability' };
+    }
+    if (!ctx.bus) {
+      return { success: false, error: 'dismiss-action requires bus capability' };
+    }
+
+    const shortRef = typeof ctx.input.short_ref === 'string' && ctx.input.short_ref.trim()
+      ? ctx.input.short_ref.trim()
+      : undefined;
+
+    const resolved = await ctx.actionLogRepo.resolvePending(shortRef);
+    if (!resolved.found) {
+      return { success: false, error: resolved.error };
+    }
+
+    const { row } = resolved;
+
+    await ctx.actionLogRepo.resolveRow(row.id, 'resolved_externally', 'ceo');
+
+    // Publish human.decision audit event (best-effort)
+    const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
+    const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
+    try {
+      await ctx.bus.publish(
+        'dispatch',
+        createHumanDecision({
+          decision: 'dismiss',
+          deciderId: senderId,
+          deciderChannel: channelId,
+          subjectEventId: row.taskId,
+          subjectSummary: `CEO dismissed (handled externally): ${row.description ?? row.skillName}`,
+          contextShown: ['short_ref', 'description', 'skill_name'],
+          presentedAt: row.createdAt,
+          decidedAt: new Date(),
+          defaultAction: 'block',
+          parentEventId: ctx.taskEventId ?? '',
+        }),
+      );
+    } catch (err) {
+      ctx.log.error({ err, rowId: row.id }, 'dismiss-action: failed to publish human.decision event');
+    }
+
+    ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'dismiss-action: request dismissed');
+    return { success: true, data: `Dismissed: ${row.description ?? row.skillName} (${row.shortRef})` };
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test skills/dismiss-action/handler.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/dismiss-action/
+git commit -m "feat(skills): add dismiss-action skill (#428)"
+```
+
+---
+
+### Task 9: `approve-action` skill
+
+**Files:**
+- Create: `skills/approve-action/skill.json`
+- Create: `skills/approve-action/handler.ts`
+- Create: `skills/approve-action/handler.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `skills/approve-action/handler.test.ts`:
+
+```typescript
+// handler.test.ts — unit tests for approve-action skill.
+
+import { describe, it, expect, vi } from 'vitest';
+import { ApproveActionHandler } from './handler.js';
+import type { SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import type { EventBus } from '../../src/bus/bus.js';
+import type { ExecutionLayer } from '../../src/skills/execution.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+const PENDING_ROW = {
+  id: 10,
+  taskId: 't1',
+  conversationId: 'conv-1',
+  skillName: 'calendar-create-event',
+  actionRisk: 'high',
+  outcome: 'pending_approval' as const,
+  shortRef: 'cal-1',
+  description: 'Create calendar event: Lunch',
+  createdAt: new Date(),
+  expiresAt: new Date(Date.now() + 86_400_000),
+  payload: { title: 'Lunch with Dana' },
+  taskSummary: null,
+  competenceFlag: null,
+  commitmentFlag: null,
+  compatibility: null,
+  scoredBy: null,
+  notificationSentAt: null,
+  resolvedAt: null,
+  resolvedBy: null,
+  parentActionId: null,
+};
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: { short_ref: 'cal-1' },
+    secret: () => '',
+    log: createSilentLogger(),
+    taskMetadata: { ceoInitiated: true, senderId: 'ceo-1', channelId: 'cli' },
+    taskEventId: 'task-1',
+    caller: { contactId: 'ceo-1', role: 'ceo', channel: 'cli' },
+    ...overrides,
+  } as SkillContext;
+}
+
+function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
+  return {
+    resolvePending: vi.fn().mockResolvedValue({ found: true, row: PENDING_ROW }),
+    resolveRow: vi.fn().mockResolvedValue(undefined),
+    insert: vi.fn().mockResolvedValue(99),
+    ...overrides,
+  } as unknown as ActionLogRepo;
+}
+
+function makeMockBus(): EventBus {
+  return {
+    publish: vi.fn().mockResolvedValue(undefined),
+  } as unknown as EventBus;
+}
+
+function makeMockExecutionLayer(result?: SkillResult): ExecutionLayer {
+  return {
+    invoke: vi.fn().mockResolvedValue(result ?? { success: true, data: { event_id: 'evt-123' } }),
+  } as unknown as ExecutionLayer;
+}
+
+describe('ApproveActionHandler', () => {
+  it('rejects non-CEO callers', async () => {
+    const handler = new ApproveActionHandler();
+    const result = await handler.execute(makeCtx({ taskMetadata: {} }));
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error when executionLayer is missing', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const handler = new ApproveActionHandler();
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo, bus, executionLayer: undefined,
+    }));
+    expect(result.success).toBe(false);
+  });
+
+  it('approves, re-executes, writes child row, publishes audit event', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const execLayer = makeMockExecutionLayer();
+    const handler = new ApproveActionHandler();
+
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo, bus, executionLayer: execLayer,
+    }));
+
+    // Verify approval transition
+    expect(repo.resolveRow).toHaveBeenCalledWith(10, 'approved', 'ceo');
+
+    // Verify re-execution
+    expect(execLayer.invoke).toHaveBeenCalledOnce();
+    const invokeArgs = (execLayer.invoke as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(invokeArgs[0]).toBe('calendar-create-event'); // skillName
+    expect(invokeArgs[1]).toEqual({ title: 'Lunch with Dana' }); // payload
+    expect(invokeArgs[3]).toMatchObject({ humanApproved: true }); // options
+
+    // Verify child row
+    expect(repo.insert).toHaveBeenCalledOnce();
+    const childRow = (repo.insert as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(childRow.parentActionId).toBe(10);
+    expect(childRow.outcome).toBe('success');
+
+    // Verify audit event
+    expect(bus.publish).toHaveBeenCalledOnce();
+    const event = (bus.publish as ReturnType<typeof vi.fn>).mock.calls[0]![1];
+    expect(event.type).toBe('human.decision');
+    expect(event.payload.decision).toBe('approve');
+
+    // Verify return
+    expect(result.success).toBe(true);
+    expect((result as { data: unknown }).data).toHaveProperty('reExecutionResult');
+  });
+
+  it('writes failure child row when re-execution fails', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const execLayer = makeMockExecutionLayer({ success: false, error: 'Calendar slot taken' });
+    const handler = new ApproveActionHandler();
+
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo, bus, executionLayer: execLayer,
+    }));
+
+    // Child row records the failure
+    const childRow = (repo.insert as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(childRow.outcome).toBe('failure');
+    expect(childRow.taskSummary).toBe('Calendar slot taken');
+
+    // Still returns success — the approval itself succeeded, re-execution failed
+    expect(result.success).toBe(true);
+    const data = (result as { data: unknown }).data as Record<string, unknown>;
+    expect(data.reExecutionSuccess).toBe(false);
+  });
+
+  it('forwards resolvePending ambiguous error with pending list', async () => {
+    const repo = makeMockRepo({
+      resolvePending: vi.fn().mockResolvedValue({
+        found: false, reason: 'ambiguous',
+        error: 'Multiple pending requests — specify a short_ref.',
+        pending: [PENDING_ROW, { ...PENDING_ROW, id: 11, shortRef: 'email-1' }],
+      }),
+    });
+    const bus = makeMockBus();
+    const execLayer = makeMockExecutionLayer();
+    const handler = new ApproveActionHandler();
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo, bus, executionLayer: execLayer,
+    }));
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error', expect.stringContaining('Multiple pending'));
+  });
+
+  it('returns error when row has null payload', async () => {
+    const repo = makeMockRepo({
+      resolvePending: vi.fn().mockResolvedValue({
+        found: true,
+        row: { ...PENDING_ROW, payload: null },
+      }),
+    });
+    const bus = makeMockBus();
+    const execLayer = makeMockExecutionLayer();
+    const handler = new ApproveActionHandler();
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo, bus, executionLayer: execLayer,
+    }));
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error', expect.stringContaining('payload'));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test skills/approve-action/handler.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Create manifest**
+
+Create `skills/approve-action/skill.json`:
+
+```json
+{
+  "name": "approve-action",
+  "description": "Approve a pending approval request. Re-executes the originally blocked skill with CEO authorization. Specify short_ref to target a specific request, or omit when only one is pending.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "action_risk": "none",
+  "inputs": {
+    "short_ref": "string? (reference code from the approval notification, e.g. 'cal-1')"
+  },
+  "outputs": {
+    "result": "object (re-execution result and approval status)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 60000,
+  "capabilities": ["bus", "actionLogRepo", "executionLayer"]
+}
+```
+
+- [ ] **Step 4: Implement handler**
+
+Create `skills/approve-action/handler.ts`:
+
+```typescript
+// handler.ts — approve-action skill implementation.
+//
+// Approves a pending approval request: transitions the row to 'approved',
+// re-executes the originally blocked skill with humanApproved: true,
+// writes a child autonomy_action_log row for the re-execution result,
+// and publishes a human.decision audit event.
+//
+// SECURITY: sensitivity: "elevated" + ceoInitiated check.
+// executionLayer capability is restricted to this skill.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { createHumanDecision } from '../../src/bus/events.js';
+
+export class ApproveActionHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    // CEO-origin check
+    if (ctx.taskMetadata?.ceoInitiated !== true) {
+      ctx.log.warn('approve-action: rejected — ceoInitiated flag absent or false');
+      return { success: false, error: 'This skill requires direct CEO authorization.' };
+    }
+
+    if (!ctx.actionLogRepo) {
+      return { success: false, error: 'approve-action requires actionLogRepo capability' };
+    }
+    if (!ctx.bus) {
+      return { success: false, error: 'approve-action requires bus capability' };
+    }
+    if (!ctx.executionLayer) {
+      return { success: false, error: 'approve-action requires executionLayer capability' };
+    }
+
+    // Resolve the pending row
+    const shortRef = typeof ctx.input.short_ref === 'string' && ctx.input.short_ref.trim()
+      ? ctx.input.short_ref.trim()
+      : undefined;
+
+    const resolved = await ctx.actionLogRepo.resolvePending(shortRef);
+    if (!resolved.found) {
+      return { success: false, error: resolved.error };
+    }
+
+    const { row } = resolved;
+
+    // Validate payload exists — re-execution needs the original skill input
+    if (!row.payload) {
+      ctx.log.error({ rowId: row.id }, 'approve-action: row has null payload — cannot re-execute');
+      return { success: false, error: `Cannot approve request '${row.shortRef}': no stored payload for re-execution` };
+    }
+
+    // Step 1: Transition to approved
+    await ctx.actionLogRepo.resolveRow(row.id, 'approved', 'ceo');
+    ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'approve-action: row transitioned to approved');
+
+    // Step 2: Re-execute the original skill with humanApproved bypass
+    const reResult = await ctx.executionLayer.invoke(
+      row.skillName,
+      row.payload,
+      ctx.caller,
+      {
+        humanApproved: true,
+        taskEventId: ctx.taskEventId,
+        conversationId: row.conversationId ?? undefined,
+      },
+    );
+
+    // Step 3: Write child row for the re-execution result
+    const childOutcome = reResult.success ? 'success' : 'failure';
+    try {
+      await ctx.actionLogRepo.insert({
+        taskId: row.taskId,
+        conversationId: row.conversationId ?? undefined,
+        skillName: row.skillName,
+        actionRisk: row.actionRisk,
+        outcome: childOutcome,
+        taskSummary: reResult.success ? null : (reResult as { error: string }).error,
+        parentActionId: row.id,
+      });
+    } catch (err) {
+      // Child row failure is non-fatal — the re-execution already happened.
+      ctx.log.error({ err, rowId: row.id }, 'approve-action: failed to insert child action_log row');
+    }
+
+    // Step 4: Publish human.decision audit event (best-effort)
+    const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
+    const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
+    try {
+      await ctx.bus.publish(
+        'dispatch',
+        createHumanDecision({
+          decision: 'approve',
+          deciderId: senderId,
+          deciderChannel: channelId,
+          subjectEventId: row.taskId,
+          subjectSummary: `CEO approved: ${row.description ?? row.skillName}`,
+          contextShown: ['short_ref', 'description', 'skill_name', 'payload'],
+          presentedAt: row.createdAt,
+          decidedAt: new Date(),
+          defaultAction: 'block',
+          parentEventId: ctx.taskEventId ?? '',
+        }),
+      );
+    } catch (err) {
+      ctx.log.error({ err, rowId: row.id }, 'approve-action: failed to publish human.decision event');
+    }
+
+    ctx.log.info(
+      { rowId: row.id, shortRef: row.shortRef, reExecutionSuccess: reResult.success },
+      'approve-action: completed',
+    );
+
+    return {
+      success: true,
+      data: {
+        approved: row.shortRef,
+        description: row.description,
+        reExecutionSuccess: reResult.success,
+        reExecutionResult: reResult.success ? reResult.data : (reResult as { error: string }).error,
+      },
+    };
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test skills/approve-action/handler.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/approve-action/
+git commit -m "feat(skills): add approve-action skill with re-execution (#428)"
+```
+
+---
+
+### Task 10: Coordinator changes — pin skills and add prompt guidance
+
+**Files:**
+- Modify: `agents/coordinator.yaml`
+
+- [ ] **Step 1: Pin the four new skills**
+
+In `agents/coordinator.yaml`, add after the `skill-registry` entry in `pinned_skills`:
+
+```yaml
+  - approve-action
+  - deny-action
+  - dismiss-action
+  - list-pending-actions
+```
+
+- [ ] **Step 2: Add prompt guidance**
+
+In the `system_prompt` section of `agents/coordinator.yaml`, add the following after the `## Data Protection` section (before `## Guidelines`):
+
+```yaml
+  ## Pending Approval Requests
+  When the autonomy gate blocks a skill, Curia creates a pending approval
+  request and notifies the CEO. Each request has a short_ref (e.g. "cal-1",
+  "email-2") and a human-readable description.
+
+  When the CEO responds to an approval notification (or asks about pending
+  requests):
+  - Use list-pending-actions to see all pending requests
+  - Match the CEO's natural language to a specific short_ref using the
+    description (e.g. "approve the calendar event" → the cal-* request)
+  - When only one request is pending, short_ref can be omitted
+  - Use approve-action to approve, deny-action to deny, dismiss-action
+    when the CEO handled it outside Curia
+  - If the CEO's intent is ambiguous and multiple requests are pending,
+    show the list and ask which one they mean
+```
+
+- [ ] **Step 3: Run full test suite to verify nothing broke**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test`
+Expected: ALL PASS
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills run typecheck`
+Expected: No new errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agents/coordinator.yaml
+git commit -m "feat(coordinator): pin approval skills and add prompt guidance (#428)"
+```
+
+---
+
+### Task 11: Final integration check
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills test`
+Expected: ALL PASS — all existing tests plus new ones
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm --prefix /Users/josephfung/Projects/worktrees/curia-approval-skills run typecheck`
+Expected: No errors
+
+- [ ] **Step 3: Review commit log**
+
+Run: `git -C /Users/josephfung/Projects/worktrees/curia-approval-skills log --oneline feat/approval-skills --not main`
+
+Expected commits (newest first):
+1. `feat(coordinator): pin approval skills and add prompt guidance (#428)`
+2. `feat(skills): add approve-action skill with re-execution (#428)`
+3. `feat(skills): add dismiss-action skill (#428)`
+4. `feat(skills): add deny-action skill (#428)`
+5. `feat(skills): add list-pending-actions skill (#428)`
+6. `feat(skills): add executionLayer and actionLogRepo capabilities; add dismiss decision type (#428)`
+7. `fix(autonomy): retry ApprovalTriggerService insert on short_ref collision (#428)`
+8. `feat(autonomy): add resolvePending, findAllPending, resolveRow to ActionLogRepo (#428)`
+9. `feat(autonomy): add parentActionId to ActionLogInsert and insert() (#428)`
+10. `feat(db): add UNIQUE(task_id, short_ref) constraint on autonomy_action_log (#428)`
+11. `docs: approval management skills design spec (#428)`

--- a/skills/approve-action/handler.test.ts
+++ b/skills/approve-action/handler.test.ts
@@ -1,0 +1,176 @@
+// handler.test.ts — unit tests for approve-action skill.
+
+import { describe, it, expect, vi } from 'vitest';
+import { ApproveActionHandler } from './handler.js';
+import type { SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import type { EventBus } from '../../src/bus/bus.js';
+import type { ExecutionLayer } from '../../src/skills/execution.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+const PENDING_ROW = {
+  id: 10,
+  taskId: 't1',
+  conversationId: 'conv-1',
+  skillName: 'calendar-create-event',
+  actionRisk: 'high',
+  outcome: 'pending_approval' as const,
+  shortRef: 'cal-1',
+  description: 'Create calendar event: Lunch',
+  createdAt: new Date(),
+  expiresAt: new Date(Date.now() + 86_400_000),
+  payload: { title: 'Lunch with Dana' },
+  taskSummary: null,
+  competenceFlag: null,
+  commitmentFlag: null,
+  compatibility: null,
+  scoredBy: null,
+  notificationSentAt: null,
+  resolvedAt: null,
+  resolvedBy: null,
+  parentActionId: null,
+};
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: { short_ref: 'cal-1' },
+    secret: () => '',
+    log: createSilentLogger(),
+    taskMetadata: { ceoInitiated: true, senderId: 'ceo-1', channelId: 'cli' },
+    taskEventId: 'task-1',
+    caller: { contactId: 'ceo-1', role: 'ceo', channel: 'cli' },
+    ...overrides,
+  } as SkillContext;
+}
+
+function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
+  return {
+    resolvePending: vi.fn().mockResolvedValue({ found: true, row: PENDING_ROW }),
+    resolveRow: vi.fn().mockResolvedValue(undefined),
+    insert: vi.fn().mockResolvedValue(99),
+    ...overrides,
+  } as unknown as ActionLogRepo;
+}
+
+function makeMockBus(): EventBus {
+  return {
+    publish: vi.fn().mockResolvedValue(undefined),
+  } as unknown as EventBus;
+}
+
+function makeMockExecutionLayer(result?: SkillResult): ExecutionLayer {
+  return {
+    invoke: vi.fn().mockResolvedValue(result ?? { success: true, data: { event_id: 'evt-123' } }),
+  } as unknown as ExecutionLayer;
+}
+
+describe('ApproveActionHandler', () => {
+  it('rejects non-CEO callers', async () => {
+    const handler = new ApproveActionHandler();
+    const result = await handler.execute(makeCtx({ taskMetadata: {} }));
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error when executionLayer is missing', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const handler = new ApproveActionHandler();
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo, bus, executionLayer: undefined,
+    }));
+    expect(result.success).toBe(false);
+  });
+
+  it('approves, re-executes, writes child row, publishes audit event', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const execLayer = makeMockExecutionLayer();
+    const handler = new ApproveActionHandler();
+
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo, bus, executionLayer: execLayer,
+    }));
+
+    // Verify approval transition
+    expect(repo.resolveRow).toHaveBeenCalledWith(10, 'approved', 'ceo');
+
+    // Verify re-execution
+    expect(execLayer.invoke).toHaveBeenCalledOnce();
+    const invokeArgs = (execLayer.invoke as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(invokeArgs[0]).toBe('calendar-create-event'); // skillName
+    expect(invokeArgs[1]).toEqual({ title: 'Lunch with Dana' }); // payload
+    expect(invokeArgs[3]).toMatchObject({ humanApproved: true }); // options
+
+    // Verify child row
+    expect(repo.insert).toHaveBeenCalledOnce();
+    const childRow = (repo.insert as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(childRow.parentActionId).toBe(10);
+    expect(childRow.outcome).toBe('success');
+
+    // Verify audit event
+    expect(bus.publish).toHaveBeenCalledOnce();
+    const event = (bus.publish as ReturnType<typeof vi.fn>).mock.calls[0]![1];
+    expect(event.type).toBe('human.decision');
+    expect(event.payload.decision).toBe('approve');
+
+    // Verify return
+    expect(result.success).toBe(true);
+    expect((result as { data: unknown }).data).toHaveProperty('reExecutionResult');
+  });
+
+  it('writes failure child row when re-execution fails', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const execLayer = makeMockExecutionLayer({ success: false, error: 'Calendar slot taken' });
+    const handler = new ApproveActionHandler();
+
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo, bus, executionLayer: execLayer,
+    }));
+
+    // Child row records the failure
+    const childRow = (repo.insert as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(childRow.outcome).toBe('failure');
+    expect(childRow.taskSummary).toBe('Calendar slot taken');
+
+    // Still returns success — the approval itself succeeded, re-execution failed
+    expect(result.success).toBe(true);
+    const data = (result as { data: unknown }).data as Record<string, unknown>;
+    expect(data.reExecutionSuccess).toBe(false);
+  });
+
+  it('forwards resolvePending ambiguous error with pending list', async () => {
+    const repo = makeMockRepo({
+      resolvePending: vi.fn().mockResolvedValue({
+        found: false, reason: 'ambiguous',
+        error: 'Multiple pending requests — specify a short_ref.',
+        pending: [PENDING_ROW, { ...PENDING_ROW, id: 11, shortRef: 'email-1' }],
+      }),
+    });
+    const bus = makeMockBus();
+    const execLayer = makeMockExecutionLayer();
+    const handler = new ApproveActionHandler();
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo, bus, executionLayer: execLayer,
+    }));
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error', expect.stringContaining('Multiple pending'));
+  });
+
+  it('returns error when row has null payload', async () => {
+    const repo = makeMockRepo({
+      resolvePending: vi.fn().mockResolvedValue({
+        found: true,
+        row: { ...PENDING_ROW, payload: null },
+      }),
+    });
+    const bus = makeMockBus();
+    const execLayer = makeMockExecutionLayer();
+    const handler = new ApproveActionHandler();
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo, bus, executionLayer: execLayer,
+    }));
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error', expect.stringContaining('payload'));
+  });
+});

--- a/skills/approve-action/handler.test.ts
+++ b/skills/approve-action/handler.test.ts
@@ -34,7 +34,7 @@ const PENDING_ROW = {
 function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
   return {
     input: { short_ref: 'cal-1' },
-    secret: () => '',
+    secret: (name: string) => { throw new Error(`secret '${name}' not configured in test`); },
     log: createSilentLogger(),
     taskMetadata: { ceoInitiated: true, senderId: 'ceo-1', channelId: 'cli' },
     taskEventId: 'task-1',
@@ -46,7 +46,7 @@ function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
 function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
   return {
     resolvePending: vi.fn().mockResolvedValue({ found: true, row: PENDING_ROW }),
-    resolveRow: vi.fn().mockResolvedValue(undefined),
+    resolveRow: vi.fn().mockResolvedValue(true),
     insert: vi.fn().mockResolvedValue(99),
     ...overrides,
   } as unknown as ActionLogRepo;
@@ -67,7 +67,10 @@ function makeMockExecutionLayer(result?: SkillResult): ExecutionLayer {
 describe('ApproveActionHandler', () => {
   it('rejects non-CEO callers', async () => {
     const handler = new ApproveActionHandler();
-    const result = await handler.execute(makeCtx({ taskMetadata: {} }));
+    const result = await handler.execute(makeCtx({
+      taskMetadata: {},
+      caller: { contactId: 'user-99', role: 'contact', channel: 'email' },
+    }));
     expect(result.success).toBe(false);
   });
 
@@ -155,6 +158,26 @@ describe('ApproveActionHandler', () => {
     }));
     expect(result.success).toBe(false);
     expect(result).toHaveProperty('error', expect.stringContaining('Multiple pending'));
+  });
+
+  it('aborts re-execution when resolveRow returns false (concurrent resolve)', async () => {
+    const repo = makeMockRepo({
+      resolveRow: vi.fn().mockResolvedValue(false),
+    });
+    const bus = makeMockBus();
+    const execLayer = makeMockExecutionLayer();
+    const handler = new ApproveActionHandler();
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo, bus, executionLayer: execLayer,
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error', expect.stringContaining('already resolved'));
+    // Critical: re-execution must NOT have fired
+    expect(execLayer.invoke).not.toHaveBeenCalled();
+    // No child row or audit event either
+    expect(repo.insert).not.toHaveBeenCalled();
+    expect(bus.publish).not.toHaveBeenCalled();
   });
 
   it('returns error when row has null payload', async () => {

--- a/skills/approve-action/handler.ts
+++ b/skills/approve-action/handler.ts
@@ -29,93 +29,109 @@ export class ApproveActionHandler implements SkillHandler {
       return { success: false, error: 'approve-action requires executionLayer capability' };
     }
 
-    // Resolve the pending row
-    const shortRef = typeof ctx.input.short_ref === 'string' && ctx.input.short_ref.trim()
-      ? ctx.input.short_ref.trim()
-      : undefined;
-
-    const resolved = await ctx.actionLogRepo.resolvePending(shortRef);
-    if (!resolved.found) {
-      return { success: false, error: resolved.error };
-    }
-
-    const { row } = resolved;
-
-    // Validate payload exists — re-execution needs the original skill input
-    if (!row.payload) {
-      ctx.log.error({ rowId: row.id }, 'approve-action: row has null payload — cannot re-execute');
-      return { success: false, error: `Cannot approve request '${row.shortRef}': no stored payload for re-execution` };
-    }
-
-    // Step 1: Transition to approved
-    await ctx.actionLogRepo.resolveRow(row.id, 'approved', 'ceo');
-    ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'approve-action: row transitioned to approved');
-
-    // Step 2: Re-execute the original skill with humanApproved bypass
-    const reResult = await ctx.executionLayer.invoke(
-      row.skillName,
-      row.payload,
-      ctx.caller,
-      {
-        humanApproved: true,
-        taskEventId: ctx.taskEventId,
-        conversationId: row.conversationId ?? undefined,
-      },
-    );
-
-    // Step 3: Write child row for the re-execution result
-    const childOutcome = reResult.success ? 'success' : 'failure';
     try {
-      await ctx.actionLogRepo.insert({
-        taskId: row.taskId,
-        conversationId: row.conversationId ?? undefined,
-        skillName: row.skillName,
-        actionRisk: row.actionRisk,
-        outcome: childOutcome,
-        taskSummary: reResult.success ? null : (reResult as { error: string }).error,
-        parentActionId: row.id,
-      });
-    } catch (err) {
-      // Child row failure is non-fatal — the re-execution already happened.
-      ctx.log.error({ err, rowId: row.id }, 'approve-action: failed to insert child action_log row');
-    }
+      // Resolve the pending row
+      const shortRef = typeof ctx.input.short_ref === 'string' && ctx.input.short_ref.trim()
+        ? ctx.input.short_ref.trim()
+        : undefined;
 
-    // Step 4: Publish human.decision audit event (best-effort)
-    const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
-    const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
-    try {
-      await ctx.bus.publish(
-        'dispatch',
-        createHumanDecision({
-          decision: 'approve',
-          deciderId: senderId,
-          deciderChannel: channelId,
-          subjectEventId: row.taskId,
-          subjectSummary: `CEO approved: ${row.description ?? row.skillName}`,
-          contextShown: ['short_ref', 'description', 'skill_name', 'payload'],
-          presentedAt: row.createdAt,
-          decidedAt: new Date(),
-          defaultAction: 'block',
-          parentEventId: ctx.taskEventId ?? '',
-        }),
+      const resolved = await ctx.actionLogRepo.resolvePending(shortRef);
+      if (!resolved.found) {
+        return { success: false, error: resolved.error };
+      }
+
+      const { row } = resolved;
+
+      // Validate payload exists — re-execution needs the original skill input
+      if (!row.payload) {
+        ctx.log.error({ rowId: row.id }, 'approve-action: row has null payload — cannot re-execute');
+        return { success: false, error: `Cannot approve request '${row.shortRef}': no stored payload for re-execution` };
+      }
+
+      // Step 1: Transition to approved — returns false if another actor resolved first.
+      // We MUST check this before re-executing to prevent running a skill that was
+      // concurrently denied or dismissed.
+      const transitioned = await ctx.actionLogRepo.resolveRow(row.id, 'approved', 'ceo');
+      if (!transitioned) {
+        ctx.log.warn({ rowId: row.id, shortRef: row.shortRef }, 'approve-action: row was already resolved concurrently — aborting re-execution');
+        return { success: false, error: `Request '${row.shortRef}' was already resolved by another action — approval aborted` };
+      }
+      ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'approve-action: row transitioned to approved');
+
+      // Step 2: Re-execute the original skill with humanApproved bypass
+      const reResult = await ctx.executionLayer.invoke(
+        row.skillName,
+        row.payload,
+        ctx.caller,
+        {
+          humanApproved: true,
+          taskEventId: ctx.taskEventId,
+          conversationId: row.conversationId ?? undefined,
+        },
       );
+
+      // Step 3: Write child row for the re-execution result
+      const childOutcome = reResult.success ? 'success' : 'failure';
+      try {
+        await ctx.actionLogRepo.insert({
+          taskId: row.taskId,
+          conversationId: row.conversationId ?? undefined,
+          skillName: row.skillName,
+          actionRisk: row.actionRisk,
+          outcome: childOutcome,
+          taskSummary: reResult.success ? null : (reResult as { error: string }).error,
+          parentActionId: row.id,
+        });
+      } catch (err) {
+        // Child row failure is non-fatal — the re-execution already happened.
+        ctx.log.error({ err, rowId: row.id }, 'approve-action: failed to insert child action_log row');
+      }
+
+      // Step 4: Publish human.decision audit event (best-effort).
+      // Skip if taskEventId is absent — an empty parentEventId breaks event lineage.
+      if (ctx.taskEventId) {
+        const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
+        const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
+        try {
+          await ctx.bus.publish(
+            'dispatch',
+            createHumanDecision({
+              decision: 'approve',
+              deciderId: senderId,
+              deciderChannel: channelId,
+              subjectEventId: row.taskId,
+              subjectSummary: `CEO approved: ${row.description ?? row.skillName}`,
+              contextShown: ['short_ref', 'description', 'skill_name', 'payload'],
+              presentedAt: row.createdAt,
+              decidedAt: new Date(),
+              defaultAction: 'block',
+              parentEventId: ctx.taskEventId,
+            }),
+          );
+        } catch (err) {
+          ctx.log.error({ err, rowId: row.id }, 'approve-action: failed to publish human.decision event');
+        }
+      } else {
+        ctx.log.warn({ rowId: row.id }, 'approve-action: no taskEventId — skipping human.decision audit event');
+      }
+
+      ctx.log.info(
+        { rowId: row.id, shortRef: row.shortRef, reExecutionSuccess: reResult.success },
+        'approve-action: completed',
+      );
+
+      return {
+        success: true,
+        data: {
+          approved: row.shortRef,
+          description: row.description,
+          reExecutionSuccess: reResult.success,
+          reExecutionResult: reResult.success ? reResult.data : (reResult as { error: string }).error,
+        },
+      };
     } catch (err) {
-      ctx.log.error({ err, rowId: row.id }, 'approve-action: failed to publish human.decision event');
+      ctx.log.error({ err }, 'approve-action: unexpected failure');
+      return { success: false, error: 'approve-action failed unexpectedly' };
     }
-
-    ctx.log.info(
-      { rowId: row.id, shortRef: row.shortRef, reExecutionSuccess: reResult.success },
-      'approve-action: completed',
-    );
-
-    return {
-      success: true,
-      data: {
-        approved: row.shortRef,
-        description: row.description,
-        reExecutionSuccess: reResult.success,
-        reExecutionResult: reResult.success ? reResult.data : (reResult as { error: string }).error,
-      },
-    };
   }
 }

--- a/skills/approve-action/handler.ts
+++ b/skills/approve-action/handler.ts
@@ -1,0 +1,121 @@
+// handler.ts — approve-action skill implementation.
+//
+// Approves a pending approval request: transitions the row to 'approved',
+// re-executes the originally blocked skill with humanApproved: true,
+// writes a child autonomy_action_log row for the re-execution result,
+// and publishes a human.decision audit event.
+//
+// SECURITY: sensitivity: "elevated" + ceoInitiated check.
+// executionLayer capability is restricted to this skill.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { createHumanDecision } from '../../src/bus/events.js';
+
+export class ApproveActionHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    // CEO-origin check
+    if (ctx.taskMetadata?.ceoInitiated !== true) {
+      ctx.log.warn('approve-action: rejected — ceoInitiated flag absent or false');
+      return { success: false, error: 'This skill requires direct CEO authorization.' };
+    }
+
+    if (!ctx.actionLogRepo) {
+      return { success: false, error: 'approve-action requires actionLogRepo capability' };
+    }
+    if (!ctx.bus) {
+      return { success: false, error: 'approve-action requires bus capability' };
+    }
+    if (!ctx.executionLayer) {
+      return { success: false, error: 'approve-action requires executionLayer capability' };
+    }
+
+    // Resolve the pending row
+    const shortRef = typeof ctx.input.short_ref === 'string' && ctx.input.short_ref.trim()
+      ? ctx.input.short_ref.trim()
+      : undefined;
+
+    const resolved = await ctx.actionLogRepo.resolvePending(shortRef);
+    if (!resolved.found) {
+      return { success: false, error: resolved.error };
+    }
+
+    const { row } = resolved;
+
+    // Validate payload exists — re-execution needs the original skill input
+    if (!row.payload) {
+      ctx.log.error({ rowId: row.id }, 'approve-action: row has null payload — cannot re-execute');
+      return { success: false, error: `Cannot approve request '${row.shortRef}': no stored payload for re-execution` };
+    }
+
+    // Step 1: Transition to approved
+    await ctx.actionLogRepo.resolveRow(row.id, 'approved', 'ceo');
+    ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'approve-action: row transitioned to approved');
+
+    // Step 2: Re-execute the original skill with humanApproved bypass
+    const reResult = await ctx.executionLayer.invoke(
+      row.skillName,
+      row.payload,
+      ctx.caller,
+      {
+        humanApproved: true,
+        taskEventId: ctx.taskEventId,
+        conversationId: row.conversationId ?? undefined,
+      },
+    );
+
+    // Step 3: Write child row for the re-execution result
+    const childOutcome = reResult.success ? 'success' : 'failure';
+    try {
+      await ctx.actionLogRepo.insert({
+        taskId: row.taskId,
+        conversationId: row.conversationId ?? undefined,
+        skillName: row.skillName,
+        actionRisk: row.actionRisk,
+        outcome: childOutcome,
+        taskSummary: reResult.success ? null : (reResult as { error: string }).error,
+        parentActionId: row.id,
+      });
+    } catch (err) {
+      // Child row failure is non-fatal — the re-execution already happened.
+      ctx.log.error({ err, rowId: row.id }, 'approve-action: failed to insert child action_log row');
+    }
+
+    // Step 4: Publish human.decision audit event (best-effort)
+    const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
+    const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
+    try {
+      await ctx.bus.publish(
+        'dispatch',
+        createHumanDecision({
+          decision: 'approve',
+          deciderId: senderId,
+          deciderChannel: channelId,
+          subjectEventId: row.taskId,
+          subjectSummary: `CEO approved: ${row.description ?? row.skillName}`,
+          contextShown: ['short_ref', 'description', 'skill_name', 'payload'],
+          presentedAt: row.createdAt,
+          decidedAt: new Date(),
+          defaultAction: 'block',
+          parentEventId: ctx.taskEventId ?? '',
+        }),
+      );
+    } catch (err) {
+      ctx.log.error({ err, rowId: row.id }, 'approve-action: failed to publish human.decision event');
+    }
+
+    ctx.log.info(
+      { rowId: row.id, shortRef: row.shortRef, reExecutionSuccess: reResult.success },
+      'approve-action: completed',
+    );
+
+    return {
+      success: true,
+      data: {
+        approved: row.shortRef,
+        description: row.description,
+        reExecutionSuccess: reResult.success,
+        reExecutionResult: reResult.success ? reResult.data : (reResult as { error: string }).error,
+      },
+    };
+  }
+}

--- a/skills/approve-action/skill.json
+++ b/skills/approve-action/skill.json
@@ -1,0 +1,17 @@
+{
+  "name": "approve-action",
+  "description": "Approve a pending approval request. Re-executes the originally blocked skill with CEO authorization. Specify short_ref to target a specific request, or omit when only one is pending.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "action_risk": "none",
+  "inputs": {
+    "short_ref": "string? (reference code from the approval notification, e.g. 'cal-1')"
+  },
+  "outputs": {
+    "result": "object (re-execution result and approval status)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 60000,
+  "capabilities": ["bus", "actionLogRepo", "executionLayer"]
+}

--- a/skills/deny-action/handler.test.ts
+++ b/skills/deny-action/handler.test.ts
@@ -1,0 +1,113 @@
+// handler.test.ts — unit tests for deny-action skill.
+
+import { describe, it, expect, vi } from 'vitest';
+import { DenyActionHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import type { EventBus } from '../../src/bus/bus.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+const PENDING_ROW = {
+  id: 10,
+  taskId: 't1',
+  conversationId: 'conv-1',
+  skillName: 'calendar-create-event',
+  actionRisk: 'high',
+  outcome: 'pending_approval' as const,
+  shortRef: 'cal-1',
+  description: 'Create calendar event: Lunch',
+  createdAt: new Date(),
+  expiresAt: new Date(Date.now() + 86_400_000),
+  payload: { title: 'Lunch' },
+  taskSummary: null,
+  competenceFlag: null,
+  commitmentFlag: null,
+  compatibility: null,
+  scoredBy: null,
+  notificationSentAt: null,
+  resolvedAt: null,
+  resolvedBy: null,
+  parentActionId: null,
+};
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: { short_ref: 'cal-1' },
+    secret: () => '',
+    log: createSilentLogger(),
+    taskMetadata: { ceoInitiated: true, senderId: 'ceo-1', channelId: 'cli' },
+    taskEventId: 'task-1',
+    ...overrides,
+  } as SkillContext;
+}
+
+function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
+  return {
+    resolvePending: vi.fn().mockResolvedValue({ found: true, row: PENDING_ROW }),
+    resolveRow: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ActionLogRepo;
+}
+
+function makeMockBus(): EventBus {
+  return {
+    publish: vi.fn().mockResolvedValue(undefined),
+  } as unknown as EventBus;
+}
+
+describe('DenyActionHandler', () => {
+  it('rejects non-CEO callers', async () => {
+    const handler = new DenyActionHandler();
+    const result = await handler.execute(makeCtx({ taskMetadata: {} }));
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error when actionLogRepo is missing', async () => {
+    const handler = new DenyActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: undefined }));
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error when bus is missing', async () => {
+    const repo = makeMockRepo();
+    const handler = new DenyActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, bus: undefined }));
+    expect(result.success).toBe(false);
+  });
+
+  it('denies a pending row and publishes human.decision', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const handler = new DenyActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, bus }));
+
+    expect(result.success).toBe(true);
+    expect(repo.resolveRow).toHaveBeenCalledWith(10, 'denied', 'ceo');
+    expect(bus.publish).toHaveBeenCalledOnce();
+    const event = (bus.publish as ReturnType<typeof vi.fn>).mock.calls[0]![1];
+    expect(event.type).toBe('human.decision');
+    expect(event.payload.decision).toBe('deny');
+  });
+
+  it('forwards resolvePending errors', async () => {
+    const repo = makeMockRepo({
+      resolvePending: vi.fn().mockResolvedValue({
+        found: false, reason: 'not_found', error: 'No approval request found',
+      }),
+    });
+    const bus = makeMockBus();
+    const handler = new DenyActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, bus }));
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error', 'No approval request found');
+  });
+
+  it('resolves sole pending row when short_ref is omitted', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const handler = new DenyActionHandler();
+    const result = await handler.execute(makeCtx({ input: {}, actionLogRepo: repo, bus }));
+    expect(result.success).toBe(true);
+    expect(repo.resolvePending).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/skills/deny-action/handler.test.ts
+++ b/skills/deny-action/handler.test.ts
@@ -33,7 +33,7 @@ const PENDING_ROW = {
 function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
   return {
     input: { short_ref: 'cal-1' },
-    secret: () => '',
+    secret: (name: string) => { throw new Error(`secret '${name}' not configured in test`); },
     log: createSilentLogger(),
     taskMetadata: { ceoInitiated: true, senderId: 'ceo-1', channelId: 'cli' },
     taskEventId: 'task-1',
@@ -44,7 +44,7 @@ function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
 function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
   return {
     resolvePending: vi.fn().mockResolvedValue({ found: true, row: PENDING_ROW }),
-    resolveRow: vi.fn().mockResolvedValue(undefined),
+    resolveRow: vi.fn().mockResolvedValue(true),
     ...overrides,
   } as unknown as ActionLogRepo;
 }
@@ -87,6 +87,19 @@ describe('DenyActionHandler', () => {
     const event = (bus.publish as ReturnType<typeof vi.fn>).mock.calls[0]![1];
     expect(event.type).toBe('human.decision');
     expect(event.payload.decision).toBe('deny');
+  });
+
+  it('returns error when resolveRow returns false (concurrent resolve)', async () => {
+    const repo = makeMockRepo({
+      resolveRow: vi.fn().mockResolvedValue(false),
+    });
+    const bus = makeMockBus();
+    const handler = new DenyActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, bus }));
+
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error', expect.stringContaining('already resolved'));
+    expect(bus.publish).not.toHaveBeenCalled();
   });
 
   it('forwards resolvePending errors', async () => {

--- a/skills/deny-action/handler.ts
+++ b/skills/deny-action/handler.ts
@@ -1,0 +1,65 @@
+// handler.ts — deny-action skill implementation.
+//
+// Denies a pending approval request: transitions the autonomy_action_log row
+// to outcome = 'denied' and publishes a human.decision audit event.
+// No re-execution — the originally blocked skill stays blocked.
+//
+// SECURITY: sensitivity: "elevated" + ceoInitiated check.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { createHumanDecision } from '../../src/bus/events.js';
+
+export class DenyActionHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (ctx.taskMetadata?.ceoInitiated !== true) {
+      ctx.log.warn('deny-action: rejected — ceoInitiated flag absent or false');
+      return { success: false, error: 'This skill requires direct CEO authorization.' };
+    }
+
+    if (!ctx.actionLogRepo) {
+      return { success: false, error: 'deny-action requires actionLogRepo capability' };
+    }
+    if (!ctx.bus) {
+      return { success: false, error: 'deny-action requires bus capability' };
+    }
+
+    const shortRef = typeof ctx.input.short_ref === 'string' && ctx.input.short_ref.trim()
+      ? ctx.input.short_ref.trim()
+      : undefined;
+
+    const resolved = await ctx.actionLogRepo.resolvePending(shortRef);
+    if (!resolved.found) {
+      return { success: false, error: resolved.error };
+    }
+
+    const { row } = resolved;
+
+    await ctx.actionLogRepo.resolveRow(row.id, 'denied', 'ceo');
+
+    // Publish human.decision audit event (best-effort)
+    const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
+    const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
+    try {
+      await ctx.bus.publish(
+        'dispatch',
+        createHumanDecision({
+          decision: 'deny',
+          deciderId: senderId,
+          deciderChannel: channelId,
+          subjectEventId: row.taskId,
+          subjectSummary: `CEO denied: ${row.description ?? row.skillName}`,
+          contextShown: ['short_ref', 'description', 'skill_name'],
+          presentedAt: row.createdAt,
+          decidedAt: new Date(),
+          defaultAction: 'block',
+          parentEventId: ctx.taskEventId ?? '',
+        }),
+      );
+    } catch (err) {
+      ctx.log.error({ err, rowId: row.id }, 'deny-action: failed to publish human.decision event');
+    }
+
+    ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'deny-action: request denied');
+    return { success: true, data: `Denied: ${row.description ?? row.skillName} (${row.shortRef})` };
+  }
+}

--- a/skills/deny-action/handler.ts
+++ b/skills/deny-action/handler.ts
@@ -23,43 +23,57 @@ export class DenyActionHandler implements SkillHandler {
       return { success: false, error: 'deny-action requires bus capability' };
     }
 
-    const shortRef = typeof ctx.input.short_ref === 'string' && ctx.input.short_ref.trim()
-      ? ctx.input.short_ref.trim()
-      : undefined;
-
-    const resolved = await ctx.actionLogRepo.resolvePending(shortRef);
-    if (!resolved.found) {
-      return { success: false, error: resolved.error };
-    }
-
-    const { row } = resolved;
-
-    await ctx.actionLogRepo.resolveRow(row.id, 'denied', 'ceo');
-
-    // Publish human.decision audit event (best-effort)
-    const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
-    const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
     try {
-      await ctx.bus.publish(
-        'dispatch',
-        createHumanDecision({
-          decision: 'deny',
-          deciderId: senderId,
-          deciderChannel: channelId,
-          subjectEventId: row.taskId,
-          subjectSummary: `CEO denied: ${row.description ?? row.skillName}`,
-          contextShown: ['short_ref', 'description', 'skill_name'],
-          presentedAt: row.createdAt,
-          decidedAt: new Date(),
-          defaultAction: 'block',
-          parentEventId: ctx.taskEventId ?? '',
-        }),
-      );
-    } catch (err) {
-      ctx.log.error({ err, rowId: row.id }, 'deny-action: failed to publish human.decision event');
-    }
+      const shortRef = typeof ctx.input.short_ref === 'string' && ctx.input.short_ref.trim()
+        ? ctx.input.short_ref.trim()
+        : undefined;
 
-    ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'deny-action: request denied');
-    return { success: true, data: `Denied: ${row.description ?? row.skillName} (${row.shortRef})` };
+      const resolved = await ctx.actionLogRepo.resolvePending(shortRef);
+      if (!resolved.found) {
+        return { success: false, error: resolved.error };
+      }
+
+      const { row } = resolved;
+
+      const transitioned = await ctx.actionLogRepo.resolveRow(row.id, 'denied', 'ceo');
+      if (!transitioned) {
+        ctx.log.warn({ rowId: row.id, shortRef: row.shortRef }, 'deny-action: row was already resolved concurrently');
+        return { success: false, error: `Request '${row.shortRef}' was already resolved by another action` };
+      }
+
+      // Publish human.decision audit event (best-effort).
+      // Skip if taskEventId is absent — an empty parentEventId breaks event lineage.
+      if (ctx.taskEventId) {
+        const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
+        const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
+        try {
+          await ctx.bus.publish(
+            'dispatch',
+            createHumanDecision({
+              decision: 'deny',
+              deciderId: senderId,
+              deciderChannel: channelId,
+              subjectEventId: row.taskId,
+              subjectSummary: `CEO denied: ${row.description ?? row.skillName}`,
+              contextShown: ['short_ref', 'description', 'skill_name'],
+              presentedAt: row.createdAt,
+              decidedAt: new Date(),
+              defaultAction: 'block',
+              parentEventId: ctx.taskEventId,
+            }),
+          );
+        } catch (err) {
+          ctx.log.error({ err, rowId: row.id }, 'deny-action: failed to publish human.decision event');
+        }
+      } else {
+        ctx.log.warn({ rowId: row.id }, 'deny-action: no taskEventId — skipping human.decision audit event');
+      }
+
+      ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'deny-action: request denied');
+      return { success: true, data: `Denied: ${row.description ?? row.skillName} (${row.shortRef})` };
+    } catch (err) {
+      ctx.log.error({ err }, 'deny-action: unexpected failure');
+      return { success: false, error: 'deny-action failed unexpectedly' };
+    }
   }
 }

--- a/skills/deny-action/skill.json
+++ b/skills/deny-action/skill.json
@@ -1,0 +1,17 @@
+{
+  "name": "deny-action",
+  "description": "Deny a pending approval request. The blocked action will not be executed. Specify short_ref to target a specific request, or omit when only one is pending.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "action_risk": "none",
+  "inputs": {
+    "short_ref": "string? (reference code from the approval notification, e.g. 'cal-1')"
+  },
+  "outputs": {
+    "result": "string (confirmation message)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": ["bus", "actionLogRepo"]
+}

--- a/skills/dismiss-action/handler.test.ts
+++ b/skills/dismiss-action/handler.test.ts
@@ -1,0 +1,121 @@
+// handler.test.ts — unit tests for dismiss-action skill.
+
+import { describe, it, expect, vi } from 'vitest';
+import { DismissActionHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import type { EventBus } from '../../src/bus/bus.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+const PENDING_ROW = {
+  id: 10,
+  taskId: 't1',
+  conversationId: 'conv-1',
+  skillName: 'calendar-create-event',
+  actionRisk: 'high',
+  outcome: 'pending_approval' as const,
+  shortRef: 'cal-1',
+  description: 'Create calendar event: Lunch',
+  createdAt: new Date(),
+  expiresAt: new Date(Date.now() + 86_400_000),
+  payload: { title: 'Lunch' },
+  taskSummary: null,
+  competenceFlag: null,
+  commitmentFlag: null,
+  compatibility: null,
+  scoredBy: null,
+  notificationSentAt: null,
+  resolvedAt: null,
+  resolvedBy: null,
+  parentActionId: null,
+};
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: { short_ref: 'cal-1' },
+    secret: () => '',
+    log: createSilentLogger(),
+    taskMetadata: { ceoInitiated: true, senderId: 'ceo-1', channelId: 'cli' },
+    taskEventId: 'task-1',
+    ...overrides,
+  } as SkillContext;
+}
+
+function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
+  return {
+    resolvePending: vi.fn().mockResolvedValue({ found: true, row: PENDING_ROW }),
+    resolveRow: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ActionLogRepo;
+}
+
+function makeMockBus(): EventBus {
+  return {
+    publish: vi.fn().mockResolvedValue(undefined),
+  } as unknown as EventBus;
+}
+
+describe('DismissActionHandler', () => {
+  it('rejects non-CEO callers', async () => {
+    const handler = new DismissActionHandler();
+    const result = await handler.execute(makeCtx({ taskMetadata: {} }));
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error when actionLogRepo is missing', async () => {
+    const handler = new DismissActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: undefined }));
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error when bus is missing', async () => {
+    const repo = makeMockRepo();
+    const handler = new DismissActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, bus: undefined }));
+    expect(result.success).toBe(false);
+  });
+
+  it('dismisses a pending row with resolved_externally', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const handler = new DismissActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, bus }));
+
+    expect(result.success).toBe(true);
+    expect(repo.resolveRow).toHaveBeenCalledWith(10, 'resolved_externally', 'ceo');
+  });
+
+  it('publishes human.decision with dismiss decision type', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const handler = new DismissActionHandler();
+    await handler.execute(makeCtx({ actionLogRepo: repo, bus }));
+
+    expect(bus.publish).toHaveBeenCalledOnce();
+    const event = (bus.publish as ReturnType<typeof vi.fn>).mock.calls[0]![1];
+    expect(event.type).toBe('human.decision');
+    expect(event.payload.decision).toBe('dismiss');
+  });
+
+  it('forwards resolvePending errors', async () => {
+    const repo = makeMockRepo({
+      resolvePending: vi.fn().mockResolvedValue({
+        found: false, reason: 'expired', error: 'Request has expired',
+      }),
+    });
+    const bus = makeMockBus();
+    const handler = new DismissActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, bus }));
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error', 'Request has expired');
+  });
+
+  it('resolves sole pending row when short_ref is omitted', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const handler = new DismissActionHandler();
+    const result = await handler.execute(makeCtx({ input: {}, actionLogRepo: repo, bus }));
+    expect(result.success).toBe(true);
+    expect(repo.resolvePending).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/skills/dismiss-action/handler.test.ts
+++ b/skills/dismiss-action/handler.test.ts
@@ -33,7 +33,7 @@ const PENDING_ROW = {
 function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
   return {
     input: { short_ref: 'cal-1' },
-    secret: () => '',
+    secret: (name: string) => { throw new Error(`secret '${name}' not configured in test`); },
     log: createSilentLogger(),
     taskMetadata: { ceoInitiated: true, senderId: 'ceo-1', channelId: 'cli' },
     taskEventId: 'task-1',
@@ -44,7 +44,7 @@ function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
 function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
   return {
     resolvePending: vi.fn().mockResolvedValue({ found: true, row: PENDING_ROW }),
-    resolveRow: vi.fn().mockResolvedValue(undefined),
+    resolveRow: vi.fn().mockResolvedValue(true),
     ...overrides,
   } as unknown as ActionLogRepo;
 }
@@ -95,6 +95,19 @@ describe('DismissActionHandler', () => {
     const event = (bus.publish as ReturnType<typeof vi.fn>).mock.calls[0]![1];
     expect(event.type).toBe('human.decision');
     expect(event.payload.decision).toBe('dismiss');
+  });
+
+  it('returns error when resolveRow returns false (concurrent resolve)', async () => {
+    const repo = makeMockRepo({
+      resolveRow: vi.fn().mockResolvedValue(false),
+    });
+    const bus = makeMockBus();
+    const handler = new DismissActionHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, bus }));
+
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error', expect.stringContaining('already resolved'));
+    expect(bus.publish).not.toHaveBeenCalled();
   });
 
   it('forwards resolvePending errors', async () => {

--- a/skills/dismiss-action/handler.ts
+++ b/skills/dismiss-action/handler.ts
@@ -1,0 +1,64 @@
+// handler.ts — dismiss-action skill implementation.
+//
+// Dismisses a pending approval request: transitions to outcome = 'resolved_externally'.
+// Used when the CEO handled the action outside Curia.
+//
+// SECURITY: sensitivity: "elevated" + ceoInitiated check.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { createHumanDecision } from '../../src/bus/events.js';
+
+export class DismissActionHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (ctx.taskMetadata?.ceoInitiated !== true) {
+      ctx.log.warn('dismiss-action: rejected — ceoInitiated flag absent or false');
+      return { success: false, error: 'This skill requires direct CEO authorization.' };
+    }
+
+    if (!ctx.actionLogRepo) {
+      return { success: false, error: 'dismiss-action requires actionLogRepo capability' };
+    }
+    if (!ctx.bus) {
+      return { success: false, error: 'dismiss-action requires bus capability' };
+    }
+
+    const shortRef = typeof ctx.input.short_ref === 'string' && ctx.input.short_ref.trim()
+      ? ctx.input.short_ref.trim()
+      : undefined;
+
+    const resolved = await ctx.actionLogRepo.resolvePending(shortRef);
+    if (!resolved.found) {
+      return { success: false, error: resolved.error };
+    }
+
+    const { row } = resolved;
+
+    await ctx.actionLogRepo.resolveRow(row.id, 'resolved_externally', 'ceo');
+
+    // Publish human.decision audit event (best-effort)
+    const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
+    const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
+    try {
+      await ctx.bus.publish(
+        'dispatch',
+        createHumanDecision({
+          decision: 'dismiss',
+          deciderId: senderId,
+          deciderChannel: channelId,
+          subjectEventId: row.taskId,
+          subjectSummary: `CEO dismissed (handled externally): ${row.description ?? row.skillName}`,
+          contextShown: ['short_ref', 'description', 'skill_name'],
+          presentedAt: row.createdAt,
+          decidedAt: new Date(),
+          defaultAction: 'block',
+          parentEventId: ctx.taskEventId ?? '',
+        }),
+      );
+    } catch (err) {
+      ctx.log.error({ err, rowId: row.id }, 'dismiss-action: failed to publish human.decision event');
+    }
+
+    ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'dismiss-action: request dismissed');
+    return { success: true, data: `Dismissed: ${row.description ?? row.skillName} (${row.shortRef})` };
+  }
+}

--- a/skills/dismiss-action/handler.ts
+++ b/skills/dismiss-action/handler.ts
@@ -22,43 +22,57 @@ export class DismissActionHandler implements SkillHandler {
       return { success: false, error: 'dismiss-action requires bus capability' };
     }
 
-    const shortRef = typeof ctx.input.short_ref === 'string' && ctx.input.short_ref.trim()
-      ? ctx.input.short_ref.trim()
-      : undefined;
-
-    const resolved = await ctx.actionLogRepo.resolvePending(shortRef);
-    if (!resolved.found) {
-      return { success: false, error: resolved.error };
-    }
-
-    const { row } = resolved;
-
-    await ctx.actionLogRepo.resolveRow(row.id, 'resolved_externally', 'ceo');
-
-    // Publish human.decision audit event (best-effort)
-    const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
-    const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
     try {
-      await ctx.bus.publish(
-        'dispatch',
-        createHumanDecision({
-          decision: 'dismiss',
-          deciderId: senderId,
-          deciderChannel: channelId,
-          subjectEventId: row.taskId,
-          subjectSummary: `CEO dismissed (handled externally): ${row.description ?? row.skillName}`,
-          contextShown: ['short_ref', 'description', 'skill_name'],
-          presentedAt: row.createdAt,
-          decidedAt: new Date(),
-          defaultAction: 'block',
-          parentEventId: ctx.taskEventId ?? '',
-        }),
-      );
-    } catch (err) {
-      ctx.log.error({ err, rowId: row.id }, 'dismiss-action: failed to publish human.decision event');
-    }
+      const shortRef = typeof ctx.input.short_ref === 'string' && ctx.input.short_ref.trim()
+        ? ctx.input.short_ref.trim()
+        : undefined;
 
-    ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'dismiss-action: request dismissed');
-    return { success: true, data: `Dismissed: ${row.description ?? row.skillName} (${row.shortRef})` };
+      const resolved = await ctx.actionLogRepo.resolvePending(shortRef);
+      if (!resolved.found) {
+        return { success: false, error: resolved.error };
+      }
+
+      const { row } = resolved;
+
+      const transitioned = await ctx.actionLogRepo.resolveRow(row.id, 'resolved_externally', 'ceo');
+      if (!transitioned) {
+        ctx.log.warn({ rowId: row.id, shortRef: row.shortRef }, 'dismiss-action: row was already resolved concurrently');
+        return { success: false, error: `Request '${row.shortRef}' was already resolved by another action` };
+      }
+
+      // Publish human.decision audit event (best-effort).
+      // Skip if taskEventId is absent — an empty parentEventId breaks event lineage.
+      if (ctx.taskEventId) {
+        const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
+        const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
+        try {
+          await ctx.bus.publish(
+            'dispatch',
+            createHumanDecision({
+              decision: 'dismiss',
+              deciderId: senderId,
+              deciderChannel: channelId,
+              subjectEventId: row.taskId,
+              subjectSummary: `CEO dismissed (handled externally): ${row.description ?? row.skillName}`,
+              contextShown: ['short_ref', 'description', 'skill_name'],
+              presentedAt: row.createdAt,
+              decidedAt: new Date(),
+              defaultAction: 'block',
+              parentEventId: ctx.taskEventId,
+            }),
+          );
+        } catch (err) {
+          ctx.log.error({ err, rowId: row.id }, 'dismiss-action: failed to publish human.decision event');
+        }
+      } else {
+        ctx.log.warn({ rowId: row.id }, 'dismiss-action: no taskEventId — skipping human.decision audit event');
+      }
+
+      ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'dismiss-action: request dismissed');
+      return { success: true, data: `Dismissed: ${row.description ?? row.skillName} (${row.shortRef})` };
+    } catch (err) {
+      ctx.log.error({ err }, 'dismiss-action: unexpected failure');
+      return { success: false, error: 'dismiss-action failed unexpectedly' };
+    }
   }
 }

--- a/skills/dismiss-action/skill.json
+++ b/skills/dismiss-action/skill.json
@@ -1,0 +1,17 @@
+{
+  "name": "dismiss-action",
+  "description": "Dismiss a pending approval request because the CEO handled the action outside Curia (e.g. created the calendar event directly). Specify short_ref to target a specific request, or omit when only one is pending.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "action_risk": "none",
+  "inputs": {
+    "short_ref": "string? (reference code from the approval notification, e.g. 'cal-1')"
+  },
+  "outputs": {
+    "result": "string (confirmation message)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": ["bus", "actionLogRepo"]
+}

--- a/skills/list-pending-actions/handler.test.ts
+++ b/skills/list-pending-actions/handler.test.ts
@@ -1,0 +1,80 @@
+// handler.test.ts — unit tests for list-pending-actions skill.
+
+import { describe, it, expect, vi } from 'vitest';
+import { ListPendingActionsHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: {},
+    secret: () => '',
+    log: createSilentLogger(),
+    taskMetadata: { ceoInitiated: true, senderId: 'ceo-1', channelId: 'cli' },
+    taskEventId: 'task-1',
+    ...overrides,
+  } as SkillContext;
+}
+
+function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
+  return {
+    findAllPending: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  } as unknown as ActionLogRepo;
+}
+
+describe('ListPendingActionsHandler', () => {
+  it('rejects non-CEO callers', async () => {
+    const handler = new ListPendingActionsHandler();
+    const result = await handler.execute(makeCtx({ taskMetadata: {} }));
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error');
+  });
+
+  it('returns error when actionLogRepo is not available', async () => {
+    const handler = new ListPendingActionsHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: undefined }));
+    expect(result.success).toBe(false);
+  });
+
+  it('returns empty list with message when no pending rows', async () => {
+    const repo = makeMockRepo();
+    const handler = new ListPendingActionsHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo }));
+    expect(result.success).toBe(true);
+    expect(result).toHaveProperty('data');
+    const data = (result as { success: true; data: unknown }).data as { pending: unknown[]; message: string };
+    expect(data.pending).toEqual([]);
+    expect(data.message).toContain('No pending');
+  });
+
+  it('returns pending rows mapped to summary fields', async () => {
+    const now = new Date();
+    const expires = new Date(Date.now() + 86_400_000);
+    const repo = makeMockRepo({
+      findAllPending: vi.fn().mockResolvedValue([
+        {
+          id: 1, shortRef: 'cal-1', description: 'Create calendar event: Lunch',
+          skillName: 'calendar-create-event', createdAt: now, expiresAt: expires,
+        },
+        {
+          id: 2, shortRef: 'email-1', description: 'Send email reply: Re: Budget',
+          skillName: 'email-reply', createdAt: now, expiresAt: expires,
+        },
+      ]),
+    });
+    const handler = new ListPendingActionsHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo }));
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: unknown }).data as { pending: Array<Record<string, unknown>> };
+    expect(data.pending).toHaveLength(2);
+    expect(data.pending[0]).toEqual({
+      short_ref: 'cal-1',
+      description: 'Create calendar event: Lunch',
+      skill_name: 'calendar-create-event',
+      created_at: now.toISOString(),
+      expires_at: expires.toISOString(),
+    });
+  });
+});

--- a/skills/list-pending-actions/handler.test.ts
+++ b/skills/list-pending-actions/handler.test.ts
@@ -9,10 +9,11 @@ import { createSilentLogger } from '../../src/logger.js';
 function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
   return {
     input: {},
-    secret: () => '',
+    secret: (name: string) => { throw new Error(`secret '${name}' not configured in test`); },
     log: createSilentLogger(),
     taskMetadata: { ceoInitiated: true, senderId: 'ceo-1', channelId: 'cli' },
     taskEventId: 'task-1',
+    timezone: 'UTC',
     ...overrides,
   } as SkillContext;
 }
@@ -44,9 +45,11 @@ describe('ListPendingActionsHandler', () => {
     const result = await handler.execute(makeCtx({ actionLogRepo: repo }));
     expect(result.success).toBe(true);
     expect(result).toHaveProperty('data');
-    const data = (result as { success: true; data: unknown }).data as { pending: unknown[]; message: string };
+    const data = (result as { success: true; data: unknown }).data as { pending: unknown[]; message: string; displayTimezone?: string };
     expect(data.pending).toEqual([]);
     expect(data.message).toContain('No pending');
+    // displayTimezone should be present when timezone is set
+    expect(data.displayTimezone).toBeDefined();
   });
 
   it('returns pending rows mapped to summary fields', async () => {
@@ -65,16 +68,29 @@ describe('ListPendingActionsHandler', () => {
       ]),
     });
     const handler = new ListPendingActionsHandler();
-    const result = await handler.execute(makeCtx({ actionLogRepo: repo }));
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, timezone: 'UTC' }));
     expect(result.success).toBe(true);
-    const data = (result as { success: true; data: unknown }).data as { pending: Array<Record<string, unknown>> };
+    const data = (result as { success: true; data: unknown }).data as { pending: Array<Record<string, unknown>>; displayTimezone?: string };
     expect(data.pending).toHaveLength(2);
-    expect(data.pending[0]).toEqual({
+    expect(data.pending[0]).toMatchObject({
       short_ref: 'cal-1',
       description: 'Create calendar event: Lunch',
       skill_name: 'calendar-create-event',
-      created_at: now.toISOString(),
-      expires_at: expires.toISOString(),
     });
+    // Timestamps should be localized ISO strings (not raw UTC Z-suffix)
+    expect(data.pending[0]!.created_at).toBeDefined();
+    expect(data.pending[0]!.expires_at).toBeDefined();
+    // displayTimezone should be present
+    expect(data.displayTimezone).toBe('UTC');
+  });
+
+  it('returns SkillResult error when findAllPending throws', async () => {
+    const repo = makeMockRepo({
+      findAllPending: vi.fn().mockRejectedValue(new Error('DB connection lost')),
+    });
+    const handler = new ListPendingActionsHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo }));
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error', expect.stringContaining('Unable to list'));
   });
 });

--- a/skills/list-pending-actions/handler.ts
+++ b/skills/list-pending-actions/handler.ts
@@ -1,0 +1,39 @@
+// handler.ts — list-pending-actions skill implementation.
+//
+// Returns all non-expired pending approval requests so the CEO can see what's
+// waiting for their decision. Read-only — no state changes.
+//
+// SECURITY: sensitivity: "elevated" ensures only the CEO can call this.
+// The ceoInitiated check is a defense-in-depth secondary gate.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class ListPendingActionsHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    // CEO-origin check — defense-in-depth (elevated gate is primary)
+    if (ctx.taskMetadata?.ceoInitiated !== true) {
+      ctx.log.warn('list-pending-actions: rejected — ceoInitiated flag absent or false');
+      return { success: false, error: 'This skill requires direct CEO authorization.' };
+    }
+
+    if (!ctx.actionLogRepo) {
+      return { success: false, error: 'list-pending-actions requires actionLogRepo capability' };
+    }
+
+    const rows = await ctx.actionLogRepo.findAllPending();
+
+    const pending = rows.map((row) => ({
+      short_ref: row.shortRef,
+      description: row.description,
+      skill_name: row.skillName,
+      created_at: row.createdAt.toISOString(),
+      expires_at: row.expiresAt?.toISOString() ?? null,
+    }));
+
+    if (pending.length === 0) {
+      return { success: true, data: { pending: [], message: 'No pending approval requests.' } };
+    }
+
+    return { success: true, data: { pending } };
+  }
+}

--- a/skills/list-pending-actions/handler.ts
+++ b/skills/list-pending-actions/handler.ts
@@ -7,6 +7,7 @@
 // The ceoInitiated check is a defense-in-depth secondary gate.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 
 export class ListPendingActionsHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -20,20 +21,41 @@ export class ListPendingActionsHandler implements SkillHandler {
       return { success: false, error: 'list-pending-actions requires actionLogRepo capability' };
     }
 
-    const rows = await ctx.actionLogRepo.findAllPending();
+    try {
+      const rows = await ctx.actionLogRepo.findAllPending();
 
-    const pending = rows.map((row) => ({
-      short_ref: row.shortRef,
-      description: row.description,
-      skill_name: row.skillName,
-      created_at: row.createdAt.toISOString(),
-      expires_at: row.expiresAt?.toISOString() ?? null,
-    }));
+      const tz = ctx.timezone;
+      const pending = rows.map((row) => ({
+        short_ref: row.shortRef,
+        description: row.description,
+        skill_name: row.skillName,
+        created_at: tz ? toLocalIso(Math.floor(row.createdAt.getTime() / 1000), tz) : row.createdAt.toISOString(),
+        expires_at: row.expiresAt
+          ? (tz ? toLocalIso(Math.floor(row.expiresAt.getTime() / 1000), tz) : row.expiresAt.toISOString())
+          : null,
+      }));
 
-    if (pending.length === 0) {
-      return { success: true, data: { pending: [], message: 'No pending approval requests.' } };
+      if (pending.length === 0) {
+        return {
+          success: true,
+          data: {
+            pending: [],
+            message: 'No pending approval requests.',
+            displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : undefined,
+          },
+        };
+      }
+
+      return {
+        success: true,
+        data: {
+          pending,
+          displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : undefined,
+        },
+      };
+    } catch (err) {
+      ctx.log.error({ err }, 'list-pending-actions: failed to query pending approvals');
+      return { success: false, error: 'Unable to list pending approval requests right now.' };
     }
-
-    return { success: true, data: { pending } };
   }
 }

--- a/skills/list-pending-actions/skill.json
+++ b/skills/list-pending-actions/skill.json
@@ -1,0 +1,15 @@
+{
+  "name": "list-pending-actions",
+  "description": "List all pending approval requests awaiting CEO decision. Returns short_ref, description, skill name, and expiry for each.",
+  "version": "1.0.0",
+  "sensitivity": "elevated",
+  "action_risk": "none",
+  "inputs": {},
+  "outputs": {
+    "pending": "object[] (list of pending approval requests)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": ["actionLogRepo"]
+}

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -235,10 +235,11 @@ describe('ActionLogRepo', () => {
   });
 
   describe('resolveRow', () => {
-    it('updates outcome, resolved_at, and resolved_by for a pending row', async () => {
+    it('updates outcome and returns true when row was pending', async () => {
       const { pool, queries } = makePool([], 1);
       const repo = new ActionLogRepo(pool, createSilentLogger());
-      await repo.resolveRow(42, 'approved', 'ceo');
+      const updated = await repo.resolveRow(42, 'approved', 'ceo');
+      expect(updated).toBe(true);
       expect(queries).toHaveLength(1);
       expect(queries[0]!.sql).toContain('UPDATE autonomy_action_log');
       expect(queries[0]!.sql).toContain("outcome = 'pending_approval'");
@@ -247,17 +248,26 @@ describe('ActionLogRepo', () => {
       expect(queries[0]!.params).toContain('ceo');
     });
 
+    it('returns false when row was already resolved (rowCount 0)', async () => {
+      const { pool } = makePool([], 0);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const updated = await repo.resolveRow(42, 'approved', 'ceo');
+      expect(updated).toBe(false);
+    });
+
     it('accepts denied outcome', async () => {
       const { pool, queries } = makePool([], 1);
       const repo = new ActionLogRepo(pool, createSilentLogger());
-      await repo.resolveRow(10, 'denied', 'ceo');
+      const updated = await repo.resolveRow(10, 'denied', 'ceo');
+      expect(updated).toBe(true);
       expect(queries[0]!.params).toContain('denied');
     });
 
     it('accepts resolved_externally outcome', async () => {
       const { pool, queries } = makePool([], 1);
       const repo = new ActionLogRepo(pool, createSilentLogger());
-      await repo.resolveRow(10, 'resolved_externally', 'ceo');
+      const updated = await repo.resolveRow(10, 'resolved_externally', 'ceo');
+      expect(updated).toBe(true);
       expect(queries[0]!.params).toContain('resolved_externally');
     });
   });

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -275,11 +275,13 @@ describe('ActionLogRepo', () => {
     };
 
     it('resolves by short_ref when provided', async () => {
-      const { pool } = makePool([pendingRow]);
+      const { pool, queries } = makeSequentialPool([[pendingRow]]);
       const repo = new ActionLogRepo(pool, createSilentLogger());
       const result = await repo.resolvePending('cal-1');
       expect(result.found).toBe(true);
       if (result.found) expect(result.row.id).toBe(10);
+      // Query 1 should include ORDER BY created_at ASC for deterministic resolution
+      expect(queries[0]!.sql).toContain('ORDER BY created_at ASC');
     });
 
     it('returns not_found when short_ref does not match any row', async () => {
@@ -298,7 +300,7 @@ describe('ActionLogRepo', () => {
       const resolvedRow = { ...pendingRow, outcome: 'approved' };
       // Query 1 (pending + non-expired) returns nothing;
       // Query 2 (any outcome) returns the resolved row.
-      const { pool } = makeSequentialPool([[], [resolvedRow]]);
+      const { pool, queries } = makeSequentialPool([[], [resolvedRow]]);
       const repo = new ActionLogRepo(pool, createSilentLogger());
       const result = await repo.resolvePending('cal-1');
       expect(result).toEqual({
@@ -306,6 +308,8 @@ describe('ActionLogRepo', () => {
         reason: 'already_resolved',
         error: expect.stringContaining('already resolved'),
       });
+      // Query 2 should include ORDER BY created_at DESC for most recent row
+      expect(queries[1]!.sql).toContain('ORDER BY created_at DESC');
     });
 
     it('returns expired when row is pending but past expires_at', async () => {

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -39,6 +39,21 @@ describe('ActionLogRepo', () => {
       expect(queries[0]!.params).toContain('task-1');
       expect(queries[0]!.params).toContain('conv-1');
     });
+
+    it('includes parent_action_id in INSERT when provided', async () => {
+      const { pool, queries } = makePool([{ id: 99 }]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const id = await repo.insert({
+        taskId: 'task-1',
+        skillName: 'calendar-create-event',
+        actionRisk: 'high',
+        outcome: 'success',
+        parentActionId: 42,
+      });
+      expect(id).toBe(99);
+      expect(queries[0]!.sql).toContain('parent_action_id');
+      expect(queries[0]!.params).toContain(42);
+    });
   });
 
   describe('findUnscoredTerminal', () => {

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -20,6 +20,26 @@ function makePool(rows: Record<string, unknown>[] = [], rowCount = 0): {
   return { pool, queries };
 }
 
+/**
+ * Like makePool, but returns different rows for each successive query call.
+ * Used to test methods that make multiple DB round-trips (e.g. resolvePending).
+ */
+function makeSequentialPool(
+  callResults: Array<Record<string, unknown>[]>,
+): { pool: Pool; queries: Array<{ sql: string; params: unknown[] }> } {
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+  let callIndex = 0;
+  const pool = {
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params: params ?? [] });
+      const rows = callResults[callIndex] ?? [];
+      callIndex++;
+      return { rows, rowCount: rows.length } as unknown as QueryResult;
+    }),
+  } as unknown as Pool;
+  return { pool, queries };
+}
+
 describe('ActionLogRepo', () => {
   describe('insert', () => {
     it('inserts a row and returns the id', async () => {
@@ -182,6 +202,156 @@ describe('ActionLogRepo', () => {
       expect(queries[0]!.sql).toContain('UPDATE autonomy_action_log');
       expect(queries[0]!.sql).toContain('notification_sent_at');
       expect(queries[0]!.params).toContain(42);
+    });
+  });
+
+  describe('findAllPending', () => {
+    it('returns pending rows ordered by created_at asc', async () => {
+      const now = new Date();
+      const { pool } = makePool([
+        {
+          id: 1, task_id: 't1', conversation_id: null, skill_name: 'calendar-create-event',
+          action_risk: 'high', outcome: 'pending_approval', task_summary: null,
+          competence_flag: null, commitment_flag: null, compatibility: null,
+          scored_by: null, payload: { title: 'Lunch' }, notification_sent_at: null,
+          resolved_at: null, resolved_by: null, expires_at: new Date(Date.now() + 86_400_000),
+          parent_action_id: null, short_ref: 'cal-1', description: 'Create calendar event: Lunch',
+          created_at: now,
+        },
+      ]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const rows = await repo.findAllPending();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.shortRef).toBe('cal-1');
+    });
+
+    it('uses the correct SQL filter for pending + non-expired', async () => {
+      const { pool, queries } = makePool([]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      await repo.findAllPending();
+      expect(queries[0]!.sql).toContain("outcome = 'pending_approval'");
+      expect(queries[0]!.sql).toContain('expires_at > now()');
+    });
+  });
+
+  describe('resolveRow', () => {
+    it('updates outcome, resolved_at, and resolved_by for a pending row', async () => {
+      const { pool, queries } = makePool([], 1);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      await repo.resolveRow(42, 'approved', 'ceo');
+      expect(queries).toHaveLength(1);
+      expect(queries[0]!.sql).toContain('UPDATE autonomy_action_log');
+      expect(queries[0]!.sql).toContain("outcome = 'pending_approval'");
+      expect(queries[0]!.params).toContain(42);
+      expect(queries[0]!.params).toContain('approved');
+      expect(queries[0]!.params).toContain('ceo');
+    });
+
+    it('accepts denied outcome', async () => {
+      const { pool, queries } = makePool([], 1);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      await repo.resolveRow(10, 'denied', 'ceo');
+      expect(queries[0]!.params).toContain('denied');
+    });
+
+    it('accepts resolved_externally outcome', async () => {
+      const { pool, queries } = makePool([], 1);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      await repo.resolveRow(10, 'resolved_externally', 'ceo');
+      expect(queries[0]!.params).toContain('resolved_externally');
+    });
+  });
+
+  describe('resolvePending', () => {
+    // A representative pending row fixture used across multiple tests.
+    const pendingRow = {
+      id: 10, task_id: 't1', conversation_id: null, skill_name: 'calendar-create-event',
+      action_risk: 'high', outcome: 'pending_approval', task_summary: null,
+      competence_flag: null, commitment_flag: null, compatibility: null,
+      scored_by: null, payload: { title: 'Lunch' }, notification_sent_at: null,
+      resolved_at: null, resolved_by: null, expires_at: new Date(Date.now() + 86_400_000),
+      parent_action_id: null, short_ref: 'cal-1', description: 'Create calendar event: Lunch',
+      created_at: new Date(),
+    };
+
+    it('resolves by short_ref when provided', async () => {
+      const { pool } = makePool([pendingRow]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const result = await repo.resolvePending('cal-1');
+      expect(result.found).toBe(true);
+      if (result.found) expect(result.row.id).toBe(10);
+    });
+
+    it('returns not_found when short_ref does not match any row', async () => {
+      // Both queries (pending-only and any-outcome) return nothing.
+      const { pool } = makeSequentialPool([[], []]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const result = await repo.resolvePending('cal-99');
+      expect(result).toEqual({
+        found: false,
+        reason: 'not_found',
+        error: expect.stringContaining('cal-99'),
+      });
+    });
+
+    it('returns already_resolved when row exists but is not pending', async () => {
+      const resolvedRow = { ...pendingRow, outcome: 'approved' };
+      // Query 1 (pending + non-expired) returns nothing;
+      // Query 2 (any outcome) returns the resolved row.
+      const { pool } = makeSequentialPool([[], [resolvedRow]]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const result = await repo.resolvePending('cal-1');
+      expect(result).toEqual({
+        found: false,
+        reason: 'already_resolved',
+        error: expect.stringContaining('already resolved'),
+      });
+    });
+
+    it('returns expired when row is pending but past expires_at', async () => {
+      const expiredRow = { ...pendingRow, expires_at: new Date(Date.now() - 1000) };
+      // Query 1 (pending + non-expired) returns nothing;
+      // Query 2 (any outcome) returns the expired-but-still-pending row.
+      const { pool } = makeSequentialPool([[], [expiredRow]]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const result = await repo.resolvePending('cal-1');
+      expect(result).toEqual({
+        found: false,
+        reason: 'expired',
+        error: expect.stringContaining('expired'),
+      });
+    });
+
+    it('resolves to sole pending row when no short_ref provided', async () => {
+      // findAllPending returns one row
+      const { pool } = makePool([pendingRow]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const result = await repo.resolvePending();
+      expect(result.found).toBe(true);
+      if (result.found) expect(result.row.id).toBe(10);
+    });
+
+    it('returns not_found when no short_ref and no pending rows', async () => {
+      const { pool } = makePool([]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const result = await repo.resolvePending();
+      expect(result).toEqual({
+        found: false,
+        reason: 'not_found',
+        error: expect.stringContaining('No pending'),
+      });
+    });
+
+    it('returns ambiguous when no short_ref and multiple pending rows', async () => {
+      const row2 = { ...pendingRow, id: 11, short_ref: 'email-1', skill_name: 'email-reply' };
+      const { pool } = makePool([pendingRow, row2]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const result = await repo.resolvePending();
+      expect(result.found).toBe(false);
+      if (!result.found) {
+        expect(result.reason).toBe('ambiguous');
+        expect((result as { pending: unknown[] }).pending).toHaveLength(2);
+      }
     });
   });
 });

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -196,25 +196,31 @@ export class ActionLogRepo {
   /**
    * Transition a pending_approval row to a terminal outcome.
    * Only updates if the current outcome is still pending_approval —
-   * silently no-ops on double-resolve (idempotent).
+   * returns `false` on double-resolve (concurrent resolution race).
+   *
+   * Callers MUST check the return value and skip side effects (re-execution,
+   * audit events) when `false` — otherwise a concurrently denied/dismissed
+   * action could still trigger re-execution.
    */
   async resolveRow(
     id: number,
     outcome: 'approved' | 'denied' | 'resolved_externally',
     resolvedBy: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const result = await this.pool.query(
       `UPDATE autonomy_action_log
        SET outcome = $2, resolved_at = now(), resolved_by = $3
        WHERE id = $1 AND outcome = 'pending_approval'`,
       [id, outcome, resolvedBy],
     );
-    if ((result.rowCount ?? 0) === 0) {
+    const updated = (result.rowCount ?? 0) > 0;
+    if (!updated) {
       // Row was already resolved by a concurrent call — idempotent no-op.
       this.logger.warn({ id, outcome, resolvedBy }, 'action-log-repo: resolveRow affected 0 rows — row may have been resolved concurrently');
     } else {
       this.logger.debug({ id, outcome, resolvedBy }, 'action-log-repo: row resolved');
     }
+    return updated;
   }
 
   /**
@@ -229,20 +235,31 @@ export class ActionLogRepo {
    */
   async resolvePending(shortRef?: string): Promise<ResolveResult> {
     if (shortRef !== undefined) {
-      // Query 1: look up by short_ref — pending + non-expired only
-      // ORDER BY created_at ASC ensures deterministic resolution of oldest pending row
-      // when multiple rows share the same short_ref across different tasks.
+      // Query 1: look up by short_ref — pending + non-expired only.
+      // LIMIT 2 (not 1): short_ref is unique per (task_id, short_ref), so the same
+      // short_ref can exist in multiple tasks. If two pending rows match, return
+      // ambiguous rather than silently picking one (could approve/deny the wrong request).
       const pending = await this.pool.query(
         `SELECT * FROM autonomy_action_log
          WHERE short_ref = $1
            AND outcome = 'pending_approval'
            AND expires_at > now()
          ORDER BY created_at ASC
-         LIMIT 1`,
+         LIMIT 2`,
         [shortRef],
       );
-      if (pending.rows.length > 0) {
+      if (pending.rows.length === 1) {
         return { found: true, row: mapRow(pending.rows[0]) };
+      }
+      if (pending.rows.length > 1) {
+        const rows = pending.rows.map(mapRow);
+        const refs = rows.map(r => `${r.shortRef} (task: ${r.taskId}): ${r.description}`).join(', ');
+        return {
+          found: false,
+          reason: 'ambiguous',
+          error: `Reference '${shortRef}' matches multiple pending requests — specify more context. Pending: ${refs}`,
+          pending: rows,
+        };
       }
 
       // Query 2: not found as pending — check if it exists at all (any outcome)

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -10,6 +10,7 @@ import type {
   ActionLogRow,
   ActionLogInsert,
   ScoringFlags,
+  ResolveResult,
 } from './action-log-types.js';
 import { TERMINAL_OUTCOMES } from './action-log-types.js';
 
@@ -176,6 +177,103 @@ export class ActionLogRepo {
       [id],
     );
     this.logger.debug({ id }, 'action-log-repo: notification_sent_at updated');
+  }
+
+  /**
+   * Return all non-expired pending_approval rows, oldest first.
+   * Used by list-pending-actions and by resolvePending() when no short_ref is given.
+   */
+  async findAllPending(): Promise<ActionLogRow[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM autonomy_action_log
+       WHERE outcome = 'pending_approval'
+         AND expires_at > now()
+       ORDER BY created_at ASC`,
+    );
+    return result.rows.map(mapRow);
+  }
+
+  /**
+   * Transition a pending_approval row to a terminal outcome.
+   * Only updates if the current outcome is still pending_approval —
+   * silently no-ops on double-resolve (idempotent).
+   */
+  async resolveRow(
+    id: number,
+    outcome: 'approved' | 'denied' | 'resolved_externally',
+    resolvedBy: string,
+  ): Promise<void> {
+    await this.pool.query(
+      `UPDATE autonomy_action_log
+       SET outcome = $2, resolved_at = now(), resolved_by = $3
+       WHERE id = $1 AND outcome = 'pending_approval'`,
+      [id, outcome, resolvedBy],
+    );
+    this.logger.debug({ id, outcome, resolvedBy }, 'action-log-repo: row resolved');
+  }
+
+  /**
+   * Resolve a short_ref (or the sole pending row) to a single ActionLogRow.
+   *
+   * When short_ref is provided: look up by short_ref among pending + non-expired rows.
+   * If not found there, make a second query (any outcome) to distinguish between
+   * not_found, already_resolved, and expired.
+   *
+   * When omitted: fetch all non-expired pending rows. If exactly one, return it.
+   * If multiple, return ambiguous with the full list so the caller can show options.
+   */
+  async resolvePending(shortRef?: string): Promise<ResolveResult> {
+    if (shortRef !== undefined) {
+      // Query 1: look up by short_ref — pending + non-expired only
+      const pending = await this.pool.query(
+        `SELECT * FROM autonomy_action_log
+         WHERE short_ref = $1
+           AND outcome = 'pending_approval'
+           AND expires_at > now()
+         LIMIT 1`,
+        [shortRef],
+      );
+      if (pending.rows.length > 0) {
+        return { found: true, row: mapRow(pending.rows[0]) };
+      }
+
+      // Query 2: not found as pending — check if it exists at all (any outcome)
+      // to give a more precise error reason
+      const any = await this.pool.query(
+        `SELECT * FROM autonomy_action_log
+         WHERE short_ref = $1
+         LIMIT 1`,
+        [shortRef],
+      );
+      if (any.rows.length === 0) {
+        return { found: false, reason: 'not_found', error: `No approval request found with reference '${shortRef}'` };
+      }
+
+      const row = mapRow(any.rows[0]);
+      if (row.outcome !== 'pending_approval') {
+        // Row exists but has already resolved to a terminal outcome
+        return { found: false, reason: 'already_resolved', error: `Request '${shortRef}' is already resolved (outcome: ${row.outcome})` };
+      }
+      // outcome is still pending_approval but expires_at <= now() (expired)
+      return { found: false, reason: 'expired', error: `Request '${shortRef}' has expired` };
+    }
+
+    // No short_ref — try to auto-resolve to the sole pending row
+    const allPending = await this.findAllPending();
+    if (allPending.length === 0) {
+      return { found: false, reason: 'not_found', error: 'No pending approval requests' };
+    }
+    if (allPending.length === 1) {
+      return { found: true, row: allPending[0]! };
+    }
+    // Multiple pending rows — caller must specify a short_ref
+    const refs = allPending.map(r => `${r.shortRef}: ${r.description}`).join(', ');
+    return {
+      found: false,
+      reason: 'ambiguous',
+      error: `Multiple pending requests — specify a short_ref. Pending: ${refs}`,
+      pending: allPending,
+    };
   }
 }
 

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -225,11 +225,14 @@ export class ActionLogRepo {
   async resolvePending(shortRef?: string): Promise<ResolveResult> {
     if (shortRef !== undefined) {
       // Query 1: look up by short_ref — pending + non-expired only
+      // ORDER BY created_at ASC ensures deterministic resolution of oldest pending row
+      // when multiple rows share the same short_ref across different tasks.
       const pending = await this.pool.query(
         `SELECT * FROM autonomy_action_log
          WHERE short_ref = $1
            AND outcome = 'pending_approval'
            AND expires_at > now()
+         ORDER BY created_at ASC
          LIMIT 1`,
         [shortRef],
       );
@@ -238,10 +241,12 @@ export class ActionLogRepo {
       }
 
       // Query 2: not found as pending — check if it exists at all (any outcome)
-      // to give a more precise error reason
+      // to give a more precise error reason (not_found vs already_resolved vs expired).
+      // ORDER BY created_at DESC ensures the most recent row is returned (most relevant to CEO).
       const any = await this.pool.query(
         `SELECT * FROM autonomy_action_log
          WHERE short_ref = $1
+         ORDER BY created_at DESC
          LIMIT 1`,
         [shortRef],
       );

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -24,8 +24,8 @@ export class ActionLogRepo {
     const result = await this.pool.query<{ id: number }>(
       `INSERT INTO autonomy_action_log
          (task_id, conversation_id, skill_name, action_risk, outcome, task_summary,
-          payload, expires_at, short_ref, description)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+          payload, expires_at, short_ref, description, parent_action_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING id`,
       [
         row.taskId,
@@ -38,6 +38,7 @@ export class ActionLogRepo {
         row.expiresAt ?? null,
         row.shortRef ?? null,
         row.description ?? null,
+        row.parentActionId ?? null,
       ],
     );
     this.logger.debug({ id: result.rows[0]!.id, skillName: row.skillName, outcome: row.outcome }, 'action-log-repo: inserted row');

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -203,13 +203,18 @@ export class ActionLogRepo {
     outcome: 'approved' | 'denied' | 'resolved_externally',
     resolvedBy: string,
   ): Promise<void> {
-    await this.pool.query(
+    const result = await this.pool.query(
       `UPDATE autonomy_action_log
        SET outcome = $2, resolved_at = now(), resolved_by = $3
        WHERE id = $1 AND outcome = 'pending_approval'`,
       [id, outcome, resolvedBy],
     );
-    this.logger.debug({ id, outcome, resolvedBy }, 'action-log-repo: row resolved');
+    if ((result.rowCount ?? 0) === 0) {
+      // Row was already resolved by a concurrent call — idempotent no-op.
+      this.logger.warn({ id, outcome, resolvedBy }, 'action-log-repo: resolveRow affected 0 rows — row may have been resolved concurrently');
+    } else {
+      this.logger.debug({ id, outcome, resolvedBy }, 'action-log-repo: row resolved');
+    }
   }
 
   /**

--- a/src/autonomy/action-log-types.ts
+++ b/src/autonomy/action-log-types.ts
@@ -66,11 +66,13 @@ export interface ActionLogInsert {
   outcome: ActionLogOutcome;
   taskSummary?: string;
 
-  // Approval lifecycle fields (optional — used by #427)
+  // Approval lifecycle fields (optional — used by #427/#428)
   payload?: Record<string, unknown>;
   expiresAt?: Date;
   shortRef?: string;
   description?: string;
+  /** Links a re-execution row back to the approved row. Used by approve-action (#428). */
+  parentActionId?: number;
 }
 
 /** Scoring flags written by the scoring pass or deterministic scorer. */

--- a/src/autonomy/action-log-types.ts
+++ b/src/autonomy/action-log-types.ts
@@ -98,3 +98,11 @@ export const DETERMINISTIC_SCORES: Record<string, ScoringFlags> = {
   resolved_externally: { competenceFlag: 1, commitmentFlag: 1, compatibility: null, scoredBy: 'deterministic' },
   rejected:            { competenceFlag: 0, commitmentFlag: 1, compatibility: null, scoredBy: 'deterministic' },
 };
+
+/** Result of resolving a short_ref to a pending_approval row. */
+export type ResolveResult =
+  | { found: true; row: ActionLogRow }
+  | { found: false; reason: 'not_found'; error: string }
+  | { found: false; reason: 'ambiguous'; error: string; pending: ActionLogRow[] }
+  | { found: false; reason: 'expired'; error: string }
+  | { found: false; reason: 'already_resolved'; error: string };

--- a/src/autonomy/approval-trigger.test.ts
+++ b/src/autonomy/approval-trigger.test.ts
@@ -244,6 +244,43 @@ describe('ApprovalTriggerService.request()', () => {
     expect(repo.insert).toHaveBeenCalledOnce();
   });
 
+  it('retries on unique_violation (23505) and succeeds with incremented counter', async () => {
+    // First insert throws unique_violation; second succeeds.
+    const insertMock = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('unique_violation'), { code: '23505' }))
+      .mockResolvedValueOnce(2);
+    // countShortRefsForTask is called once per attempt: 0 on attempt 1, 1 on attempt 2.
+    const countMock = vi.fn()
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(1);
+    const repo = makeMockRepo({
+      insert: insertMock,
+      countShortRefsForTask: countMock,
+    });
+    const gateway = makeMockGateway();
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+    const result = await service.request(BASE_OPTS);
+
+    expect(result.created).toBe(true);
+    if (result.created) {
+      expect(result.shortRef).toBe('cal-2'); // counter was 1 on retry
+    }
+    expect(insertMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after 3 retries on persistent unique_violation', async () => {
+    const insertMock = vi.fn().mockRejectedValue(
+      Object.assign(new Error('unique_violation'), { code: '23505' }),
+    );
+    const repo = makeMockRepo({ insert: insertMock });
+    const gateway = makeMockGateway();
+    const service = new ApprovalTriggerService(repo, gateway, createSilentLogger(), 'ceo@example.com');
+
+    await expect(service.request(BASE_OPTS)).rejects.toThrow('unique_violation');
+    expect(insertMock).toHaveBeenCalledTimes(3);
+  });
+
   it('inserts row with correct fields', async () => {
     const FIXED_NOW = 1_746_000_000_000; // 2025-04-30T06:40:00Z — arbitrary fixed point
     vi.useFakeTimers();

--- a/src/autonomy/approval-trigger.ts
+++ b/src/autonomy/approval-trigger.ts
@@ -151,26 +151,49 @@ export class ApprovalTriggerService {
       return { created: false, reason: 'duplicate', existingShortRef };
     }
 
-    // Step 2: Generate short_ref and description.
-    // Sanitize description before storing and sending — the input fields come from
-    // LLM-generated skill arguments and may contain dangerous tags.
-    const counter = await this.actionLogRepo.countShortRefsForTask(taskId);
-    const shortRef = `${shortRefPrefix(skillName)}-${counter + 1}`;
-    const description = sanitizeOutput(buildDescription(skillName, input));
+    // Step 2 + 3: Generate short_ref, description, and insert row.
+    // Retry on unique_violation (23505) — the countShortRefsForTask + 1 pattern
+    // can race under concurrency. The UNIQUE(task_id, short_ref) constraint (#428)
+    // catches the collision; we re-count and retry.
+    const MAX_INSERT_RETRIES = 3;
+    let rowId!: number;
+    let shortRef!: string;
+    let description!: string;
+    let expiresAt!: Date;
 
-    // Step 3: Insert row
-    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24h from now
-    const rowId = await this.actionLogRepo.insert({
-      taskId,
-      conversationId,
-      skillName,
-      actionRisk,
-      outcome: 'pending_approval',
-      payload: input,
-      expiresAt,
-      shortRef,
-      description,
-    });
+    for (let attempt = 1; attempt <= MAX_INSERT_RETRIES; attempt++) {
+      const counter = await this.actionLogRepo.countShortRefsForTask(taskId);
+      shortRef = `${shortRefPrefix(skillName)}-${counter + 1}`;
+      // Sanitize description before storing and sending — the input fields come from
+      // LLM-generated skill arguments and may contain dangerous tags.
+      description = sanitizeOutput(buildDescription(skillName, input));
+      expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24h from now
+
+      try {
+        rowId = await this.actionLogRepo.insert({
+          taskId,
+          conversationId,
+          skillName,
+          actionRisk,
+          outcome: 'pending_approval',
+          payload: input,
+          expiresAt,
+          shortRef,
+          description,
+        });
+        break; // Insert succeeded
+      } catch (err) {
+        const isUniqueViolation = (err as { code?: string }).code === '23505';
+        if (isUniqueViolation && attempt < MAX_INSERT_RETRIES) {
+          this.logger.warn(
+            { taskId, shortRef, attempt },
+            'approval-trigger: short_ref collision — retrying with new counter',
+          );
+          continue;
+        }
+        throw err; // Non-unique error, or exhausted retries
+      }
+    }
 
     this.logger.info(
       { rowId, taskId, skillName, shortRef, currentScore, requiredScore },

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -404,7 +404,7 @@ interface AutonomySendBlockedPayload {
 // and any future human-in-the-loop gate. Timeout decisions use decision: 'timeout'.
 interface HumanDecisionPayload {
   // What was decided
-  decision: 'approve' | 'deny' | 'modify' | 'escalate' | 'timeout';
+  decision: 'approve' | 'deny' | 'dismiss' | 'modify' | 'escalate' | 'timeout';
   // Who decided
   deciderId: string;            // sender ID of the human who made the decision
   deciderChannel: string;       // channel through which the decision was made

--- a/src/db/migrations/032_unique_task_short_ref.sql
+++ b/src/db/migrations/032_unique_task_short_ref.sql
@@ -8,6 +8,25 @@
 --
 -- See issue #428 and the #436 review discussion.
 
+-- Pre-check: abort if legacy duplicates exist.
+-- The table was introduced in PR #436 (1-2 days before this migration), so
+-- duplicates are unlikely but this guard prevents a confusing ALTER TABLE failure.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM autonomy_action_log
+    WHERE short_ref IS NOT NULL
+    GROUP BY task_id, short_ref
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'Cannot add UNIQUE constraint: duplicate (task_id, short_ref) rows exist. '
+      'Run: SELECT task_id, short_ref, COUNT(*) FROM autonomy_action_log '
+      'WHERE short_ref IS NOT NULL GROUP BY task_id, short_ref HAVING COUNT(*) > 1; '
+      'to find and manually resolve duplicates before re-running this migration.';
+  END IF;
+END
+$$;
+
 ALTER TABLE autonomy_action_log
   ADD CONSTRAINT uq_aal_task_short_ref UNIQUE (task_id, short_ref);
 

--- a/src/db/migrations/032_unique_task_short_ref.sql
+++ b/src/db/migrations/032_unique_task_short_ref.sql
@@ -1,0 +1,17 @@
+-- Up Migration
+
+-- 032_unique_task_short_ref.sql
+--
+-- Adds a UNIQUE constraint on (task_id, short_ref) to prevent race conditions
+-- in short_ref generation. Null short_ref values (non-approval rows) do not
+-- violate the constraint — Postgres treats nulls as never equal.
+--
+-- See issue #428 and the #436 review discussion.
+
+ALTER TABLE autonomy_action_log
+  ADD CONSTRAINT uq_aal_task_short_ref UNIQUE (task_id, short_ref);
+
+-- Down Migration
+
+ALTER TABLE autonomy_action_log
+  DROP CONSTRAINT uq_aal_task_short_ref;

--- a/src/index.ts
+++ b/src/index.ts
@@ -856,7 +856,7 @@ async function main(): Promise<void> {
   // capability-gated declarations. outboundGateway gives email skills their send path.
   // entityContextAssembler enables entity_enrichment pre-enrichment and the
   // entity-context skill. agentContactId enables entity_enrichment default='agent'.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, timezone: config.timezone, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, actionLogRepo, timezone: config.timezone, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -491,6 +491,25 @@ export class ExecutionLayer {
       executionLayer: this,
     };
 
+    // Hard-restrict executionLayer to approve-action only.
+    // executionLayer grants invoke() with humanApproved: true, which bypasses autonomy
+    // gates A and B. This capability MUST NOT be available to any other skill — a
+    // compromised or misconfigured skill with executionLayer could execute arbitrary
+    // actions as if the CEO approved them. The manifest comment is advisory; this
+    // guard is the enforcement boundary.
+    if (caps.includes('executionLayer') && manifest.name !== 'approve-action') {
+      skillLogger.error(
+        { skillName, manifestName: manifest.name },
+        'SECURITY: executionLayer capability is restricted to approve-action — refusing to run skill',
+      );
+      return {
+        success: false,
+        error: this.wrapSkillError(
+          `Skill '${skillName}' declares capability 'executionLayer' but only 'approve-action' is permitted to use it`,
+        ),
+      };
+    }
+
     // Fail-closed: if a declared capability is not available on this ExecutionLayer,
     // refuse to run the skill. This catches configuration errors at invocation time.
     const missingCaps = caps.filter(cap => {

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -78,6 +78,7 @@ export class ExecutionLayer {
   private browserService?: BrowserService;
   private bullpenService?: import('../memory/bullpen.js').BullpenService;
   private approvalTrigger?: ApprovalTriggerService;
+  private actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
   /** The agent's own contactId — injected into ctx.agentContactId for entity_enrichment default='agent' */
   private agentContactId?: string;
   /** IANA timezone name used for normalizing offset-less timestamp inputs from the LLM. */
@@ -101,6 +102,7 @@ export class ExecutionLayer {
     browserService?: BrowserService;
     bullpenService?: import('../memory/bullpen.js').BullpenService;
     approvalTrigger?: ApprovalTriggerService;
+    actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
     agentContactId?: string;
     timezone?: string;
     skillOutputMaxLength?: number;
@@ -122,6 +124,7 @@ export class ExecutionLayer {
     this.browserService = options?.browserService;
     this.bullpenService = options?.bullpenService;
     this.approvalTrigger = options?.approvalTrigger;
+    this.actionLogRepo = options?.actionLogRepo;
     this.agentContactId = options?.agentContactId;
     this.timezone = options?.timezone ?? 'UTC';
     this.skillOutputMaxLength = options?.skillOutputMaxLength ?? DEFAULT_SKILL_OUTPUT_MAX_LENGTH;
@@ -482,6 +485,10 @@ export class ExecutionLayer {
       browserService: this.browserService,
       bullpenService: this.bullpenService,
       executiveProfileService: this.executiveProfileService,
+      actionLogRepo: this.actionLogRepo,
+      // executionLayer injects `this` so approve-action can re-invoke blocked skills
+      // with humanApproved: true (see ADR-018). Only approve-action should declare this.
+      executionLayer: this,
     };
 
     // Fail-closed: if a declared capability is not available on this ExecutionLayer,

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -28,6 +28,7 @@ export const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
   'bus', 'agentRegistry', 'outboundGateway', 'heldMessages',
   'schedulerService', 'entityMemory', 'nylasCalendarClient',
   'autonomyService', 'executiveProfileService', 'browserService', 'bullpenService', 'skillSearch',
+  'actionLogRepo', 'executionLayer',
 ]);
 
 /**

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -189,6 +189,14 @@ export interface SkillContext {
    *  Populated from the global config timezone. Skills returning timestamps for display
    *  should use toLocalIso() with this value rather than returning raw UTC strings. */
   timezone?: string;
+  /** Action log repo — available to skills declaring 'actionLogRepo' in capabilities.
+   *  Provides read/write access to the autonomy_action_log table for approval lifecycle
+   *  management. Used by approve-action, deny-action, dismiss-action, list-pending-actions. */
+  actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
+  /** Execution layer — available to skills declaring 'executionLayer' in capabilities.
+   *  Allows re-invocation of skills with humanApproved bypass. Only approve-action (#428)
+   *  should declare this capability; it is sensitivity: "elevated" (CEO-only). */
+  executionLayer?: import('./execution.js').ExecutionLayer;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds four CEO-facing skills for resolving pending approval requests: `approve-action`, `deny-action`, `dismiss-action`, `list-pending-actions`
- Fixes the `short_ref` race condition from the #436 review: adds `UNIQUE(task_id, short_ref)` constraint (migration 032) and a retry loop in `ApprovalTriggerService.request()` that catches Postgres error 23505
- Adds `resolvePending()`, `findAllPending()`, and `resolveRow()` to `ActionLogRepo`, plus a `ResolveResult` discriminated union for safe branch exhaustion
- Wires two new capabilities (`executionLayer`, `actionLogRepo`) through the skill platform; adds `'dismiss'` to `HumanDecisionPayload.decision`
- Pins all four skills in the coordinator and adds a Pending Approval Requests guidance section to the coordinator prompt

## Test Plan

- [ ] All 1879 unit tests pass (`npm test`)
- [ ] Typecheck clean (`npm run typecheck`)
- [ ] Trigger an autonomy gate block (high-risk skill) → `list-pending-actions` returns the pending row with correct `short_ref` and description
- [ ] `approve-action <short_ref>` → blocked skill re-executes with `humanApproved: true`, child row linked via `parent_action_id`, `human.decision` audit event published
- [ ] `deny-action <short_ref>` → row transitions to `denied`, `human.decision` event published, no re-execution
- [ ] `dismiss-action <short_ref>` → row transitions to `resolved_externally`, `human.decision` event with `decision: 'dismiss'`
- [ ] Omitting `short_ref` when exactly one request is pending → resolved automatically
- [ ] Omitting `short_ref` when multiple are pending → ambiguous error with list
- [ ] Non-CEO caller → rejected by all four skills
- [ ] Run migration 032 against test DB and verify constraint blocks duplicate `(task_id, short_ref)` inserts

## Notes

- `scoring-pass.ts` has a pre-existing issue where `callLlmJudge` doesn't validate the parsed JSON fields before use (can silently store all-zero scores). Out of scope for this PR — tracked separately.
- `senderId`/`channelId` fallback to `'unknown'` in audit events is a low-risk edge case (only occurs under misconfiguration, since all four skills require `ceoInitiated: true`).

Closes #428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CEO approval workflow: approve, deny, dismiss, or list pending action requests.
  * Approved actions now trigger automatic re-execution of previously blocked skills.
  * New audit event tracking for human decision dismissals.

* **Documentation**
  * Added approval flow design specification and implementation guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->