### PR TITLE
feat: approval expiry sweep + pending-actions daily digest (#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Approval expiry sweep** — new `approval-expiry-sweep` skill that hourly expires stale `pending_approval` rows and sends a batched CEO notification for high/critical tier expirations; added `findExpired()` and `expireRows()` to `ActionLogRepo`
+- **Pending-actions digest** — new `pending-actions-digest` skill that sends a daily 8 AM summary of all open approval requests to the CEO; added two scheduler entries to `agents/coordinator.yaml`
+- **Notification types** — added `approval_expired` and `pending_actions_digest` to `OutboundNotificationPayload.notificationType` union in `src/bus/events.ts`
 - **Autonomy Phase 3 scoring foundation** — `autonomy_action_log` table (migration 031) records skill invocations and outcomes, serving as the foundation for automatic score adjustment and the approval lifecycle (ADR-018). TypeScript types and repo in `src/autonomy/`. (spec 14, issue #148)
 - **Automatic autonomy score adjustment** — daily `AutonomyScoringPass` runs as a DreamEngine sibling pass. Scores completed actions on Competence/Commitment/Compatibility (deterministic for approval outcomes, LLM judge for success/failure), computes a time-decay-weighted capability score, and nudges the autonomy score ±5 via a delta formula. Guards: 30-action minimum, CEO cooldown (7 days), error rate threshold (20%). (spec 14, issue #148)
 - **`get-autonomy` trend surfacing** — skill now reports `lastSetBy` (CEO or system), trend direction (improving/declining/stable), and scored action count. (spec 14, issue #148)

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -504,3 +504,11 @@ pinned_skills:
   - dismiss-action
   - list-pending-actions
 allow_discovery: true
+schedule:
+  - cron: "0 * * * *"
+    task: "Run the approval expiry sweep — find and expire any pending approval requests that have passed their expiry time."
+    expectedDurationSeconds: 120
+
+  - cron: "0 8 * * *"
+    task: "Run the pending-actions digest — if any approval requests are still awaiting a decision, send a summary to the CEO."
+    expectedDurationSeconds: 120

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -503,6 +503,8 @@ pinned_skills:
   - deny-action
   - dismiss-action
   - list-pending-actions
+  - approval-expiry-sweep
+  - pending-actions-digest
 allow_discovery: true
 schedule:
   - cron: "0 * * * *"

--- a/docs/wip/2026-05-04-approval-lifecycle-jobs-design.md
+++ b/docs/wip/2026-05-04-approval-lifecycle-jobs-design.md
@@ -1,0 +1,256 @@
+# Approval Lifecycle Jobs — Design Spec
+
+**Issue:** [#429](https://github.com/josephfung/curia/issues/429)
+**Depends on:** #427 (approval trigger), #428 (approval management skills)
+**Date:** 2026-05-04
+
+## Summary
+
+Two background scheduler jobs that close the approval request lifecycle:
+
+1. **Expiry sweep** — hourly job that transitions stale `pending_approval` rows to
+   `expired` and sends a batched notification for high/critical tier expirations.
+2. **Pending-actions digest** — daily morning job that surfaces all open approval
+   requests to the CEO as a single summary email.
+
+Both run as declarative YAML-based scheduler jobs on the coordinator agent. The
+coordinator receives a task description, discovers the corresponding skill via
+`allow_discovery: true`, and invokes it. This keeps the pattern consistent with
+all other scheduled work — no new execution model.
+
+## Approach
+
+Two standalone skills (`approval-expiry-sweep` and `pending-actions-digest`),
+each with its own manifest + handler + tests. Both consume existing repo-layer
+methods on `ActionLogRepo` plus two new query methods. Notifications go through
+the existing `OutboundGateway.sendNotification()` pipeline.
+
+Alternatives considered and rejected:
+- **Single skill with sub-actions** — muddies responsibility, fragile parameter
+  inference from task description.
+- **Shared service layer + thin skill wrappers** — over-abstraction for logic
+  this simple; the repo layer already provides the shared data access.
+
+## Detailed Design
+
+### 1. Repo Layer — New Methods on `ActionLogRepo`
+
+**File:** `src/autonomy/action-log-repo.ts`
+
+#### `findExpired(): Promise<ActionLogRow[]>`
+
+Returns all rows where `outcome = 'pending_approval' AND expires_at <= now()`,
+ordered by `created_at ASC`. These are the inverse of `findAllPending()` which
+filters `expires_at > now()`.
+
+```sql
+SELECT * FROM autonomy_action_log
+WHERE outcome = 'pending_approval'
+  AND expires_at <= now()
+ORDER BY created_at ASC
+```
+
+#### `expireRows(ids: number[]): Promise<number>`
+
+Batch-transitions the given rows to expired state. Returns the count of rows
+actually updated.
+
+```sql
+UPDATE autonomy_action_log
+SET outcome = 'expired', resolved_by = 'system', resolved_at = now()
+WHERE id = ANY($1) AND outcome = 'pending_approval'
+```
+
+The `AND outcome = 'pending_approval'` guard ensures idempotency — if a row was
+concurrently resolved (approved/denied/dismissed), it won't be double-transitioned.
+Empty `ids` array is a no-op (returns 0).
+
+### 2. Expiry Sweep Skill
+
+**Files:**
+- `skills/approval-expiry-sweep/skill.json`
+- `skills/approval-expiry-sweep/handler.ts`
+- `skills/approval-expiry-sweep/handler.test.ts`
+
+#### Manifest
+
+```json
+{
+  "name": "approval-expiry-sweep",
+  "description": "Expire stale pending approval requests and notify the CEO of high/critical expirations.",
+  "version": "1.0.0",
+  "action_risk": "none",
+  "inputs": {},
+  "outputs": {
+    "expired": "number (count of rows transitioned to expired)",
+    "notified": "number (count of high/critical expirations included in notification)"
+  },
+  "permissions": [],
+  "secrets": ["CEO_PRIMARY_EMAIL"],
+  "timeout": 30000,
+  "capabilities": ["actionLogRepo", "outboundGateway"]
+}
+```
+
+No `sensitivity: "elevated"` — this is a system job, not CEO-initiated. No pinning
+to coordinator's `pinned_skills` — it's a system infrastructure skill discovered via
+the scheduler task description (same pattern as `extract-facts`, `scheduler-report`).
+
+`outboundGateway` is a valid skill capability (declared in `SkillContext` and the
+loader's allowlist). The gateway's `sendNotification()` handles try/catch internally
+and returns a boolean — cleaner than publishing raw bus events.
+
+The `ceoEmail` field required by `OutboundNotificationPayload` comes from
+`ctx.secret('CEO_PRIMARY_EMAIL')`. If not configured, the handler skips notification
+(same pattern as approval-trigger: rows are expired regardless, CEO sees them in
+next digest).
+
+#### Handler Flow
+
+1. `actionLogRepo.findExpired()` — get all stale rows.
+2. Early return if none: `{ success: true, data: { expired: 0, notified: 0 } }`.
+3. `actionLogRepo.expireRows(ids)` — batch transition.
+4. Log each expired row at info level: `{ id, shortRef, skillName, actionRisk }`.
+5. Partition by `actionRisk`:
+   - **`high` / `critical`**: collect into a notification list.
+   - **`low` / `medium`**: no notification.
+6. If any high/critical rows exist, send a **single batched notification** via
+   `ctx.outboundGateway.sendNotification()`:
+   - `notificationType: 'approval_expired'`
+   - `ceoEmail`: from `ctx.secret('CEO_PRIMARY_EMAIL')`
+   - Subject: `"Approval expired — {count} request(s) expired without response"`
+   - Body: bullet list of each expired request with `shortRef`, `description`,
+     and `skillName`.
+7. Return `{ success: true, data: { expired: totalCount, notified: highCriticalCount } }`.
+
+### 3. Pending-Actions Digest Skill
+
+**Files:**
+- `skills/pending-actions-digest/skill.json`
+- `skills/pending-actions-digest/handler.ts`
+- `skills/pending-actions-digest/handler.test.ts`
+
+#### Manifest
+
+```json
+{
+  "name": "pending-actions-digest",
+  "description": "Send a daily digest of open approval requests awaiting CEO decision.",
+  "version": "1.0.0",
+  "action_risk": "none",
+  "inputs": {},
+  "outputs": {
+    "pending": "number (count of open requests included in digest)",
+    "skipped": "boolean (true if no open requests — digest not sent)"
+  },
+  "permissions": [],
+  "secrets": ["CEO_PRIMARY_EMAIL"],
+  "timeout": 30000,
+  "capabilities": ["actionLogRepo", "outboundGateway"]
+}
+```
+
+Same rationale as expiry sweep — no sensitivity, no pinning, system infrastructure.
+Same `outboundGateway` capability and `CEO_PRIMARY_EMAIL` secret for notifications.
+
+#### Handler Flow
+
+1. `actionLogRepo.findAllPending()` — get all non-expired pending rows (existing method).
+2. Early return if empty: `{ success: true, data: { pending: 0, skipped: true } }`.
+3. For each row, compute time remaining: `row.expiresAt - Date.now()`, formatted as
+   human-readable (e.g. "14h remaining", "2h remaining", "<1h remaining").
+4. Format a digest body as a list, each entry showing:
+   - `shortRef` (e.g. "cal-1")
+   - `description` (e.g. "Create calendar event: Lunch with Dana")
+   - `skillName`
+   - Time remaining before expiry
+5. Send a single notification via `ctx.outboundGateway.sendNotification()`:
+   - `notificationType: 'pending_actions_digest'`
+   - `ceoEmail`: from `ctx.secret('CEO_PRIMARY_EMAIL')`
+   - Subject: `"Pending approvals — {count} request(s) awaiting your decision"`
+   - Body: the formatted list.
+6. Return `{ success: true, data: { pending: count, skipped: false } }`.
+
+### 4. Declarative Schedule Entries
+
+**File:** `agents/coordinator.yaml` — new top-level `schedule:` block.
+
+```yaml
+schedule:
+  - cron: "0 * * * *"
+    task: "Run the approval expiry sweep — find and expire any pending approval requests that have passed their expiry time."
+    expectedDurationSeconds: 120
+
+  - cron: "0 8 * * *"
+    task: "Run the pending-actions digest — if any approval requests are still awaiting a decision, send a summary to the CEO."
+    expectedDurationSeconds: 120
+```
+
+- Cron times resolve using the per-job timezone (defaults to system timezone,
+  which is configured as the CEO's timezone).
+- `expectedDurationSeconds: 120` — generous for simple DB + notification ops.
+  Watchdog timeout: `min(120 * 7.5, 120 + 3600)` = 900s (15 minutes).
+- The coordinator has `allow_discovery: true`, so it discovers the skills by
+  name from the natural-language task description.
+
+### 5. Event Type Changes
+
+**File:** `src/bus/events.ts`
+
+Add two new values to the `OutboundNotificationPayload.notificationType` union:
+
+```typescript
+notificationType:
+  | 'blocked_content'
+  | 'group_held'
+  | 'contact_rate_limited'
+  | 'approval_requested'
+  | 'approval_expired'          // NEW — batched expiry notification
+  | 'pending_actions_digest';   // NEW — daily digest
+```
+
+Backwards-compatible additive change — no existing values modified.
+
+### 6. Testing
+
+#### Repo layer (`src/autonomy/action-log-repo.test.ts`)
+
+- `findExpired()` returns only rows where `expires_at <= now()` and
+  `outcome = 'pending_approval'`
+- `findExpired()` excludes rows already resolved to other outcomes
+- `expireRows([])` with empty array returns 0
+- `expireRows(ids)` only updates rows still in `pending_approval` state
+- `expireRows(ids)` is idempotent — second call returns 0
+
+#### Expiry sweep (`skills/approval-expiry-sweep/handler.test.ts`)
+
+- No expired rows -> returns `{ expired: 0, notified: 0 }`, no notification sent
+- Mixed tiers: `low`/`medium` expire silently; `high`/`critical` appear in a
+  single batched notification
+- All rows transition to `outcome = 'expired'`, `resolved_by = 'system'`
+- Notification body contains all high/critical items as a list
+- Handles `sendNotification()` returning `false` gracefully (non-fatal — expiry
+  still happened)
+
+#### Digest (`skills/pending-actions-digest/handler.test.ts`)
+
+- No pending rows -> returns `{ pending: 0, skipped: true }`, no notification sent
+- Multiple pending rows -> single digest notification listing all
+- Each entry includes `shortRef`, `description`, `skillName`, time remaining
+- Time remaining calculation is correct (mock `Date.now()`)
+- Handles notification failure gracefully
+
+## File Change Summary
+
+| File | Change |
+|------|--------|
+| `src/autonomy/action-log-repo.ts` | Add `findExpired()` and `expireRows()` |
+| `src/autonomy/action-log-repo.test.ts` | Tests for new repo methods |
+| `src/bus/events.ts` | Add `'approval_expired'`, `'pending_actions_digest'` to notification type union |
+| `skills/approval-expiry-sweep/skill.json` | New manifest |
+| `skills/approval-expiry-sweep/handler.ts` | New handler |
+| `skills/approval-expiry-sweep/handler.test.ts` | New tests |
+| `skills/pending-actions-digest/skill.json` | New manifest |
+| `skills/pending-actions-digest/handler.ts` | New handler |
+| `skills/pending-actions-digest/handler.test.ts` | New tests |
+| `agents/coordinator.yaml` | Add `schedule:` block with two cron entries |

--- a/docs/wip/2026-05-04-approval-lifecycle-jobs.md
+++ b/docs/wip/2026-05-04-approval-lifecycle-jobs.md
@@ -1,0 +1,1006 @@
+# Approval Lifecycle Jobs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement two scheduler jobs — an hourly expiry sweep and a daily pending-actions digest — that close the approval request lifecycle (issue #429).
+
+**Architecture:** Two standalone skills (`approval-expiry-sweep` and `pending-actions-digest`) invoked by the coordinator via declarative YAML schedule entries. Both use `ActionLogRepo` for data access and `OutboundGateway.sendNotification()` for CEO notifications. Two new notification types are added to the event bus union.
+
+**Tech Stack:** TypeScript (ESM), Vitest, Postgres (via `ActionLogRepo`), pino logging
+
+---
+
+### Task 1: Add `findExpired()` to `ActionLogRepo`
+
+**Files:**
+- Modify: `src/autonomy/action-log-repo.ts` (after `findAllPending` method, ~line 194)
+- Modify: `src/autonomy/action-log-repo.test.ts` (new describe block)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/autonomy/action-log-repo.test.ts` at the end of the `ActionLogRepo` describe block (before the closing `});`):
+
+```typescript
+  describe('findExpired', () => {
+    it('returns expired pending_approval rows ordered by created_at asc', async () => {
+      const now = new Date();
+      const { pool } = makePool([
+        {
+          id: 5, task_id: 't1', conversation_id: null, skill_name: 'email-send',
+          action_risk: 'medium', outcome: 'pending_approval', task_summary: null,
+          competence_flag: null, commitment_flag: null, compatibility: null,
+          scored_by: null, payload: { to: 'a@b.com' }, notification_sent_at: null,
+          resolved_at: null, resolved_by: null, expires_at: new Date(Date.now() - 1000),
+          parent_action_id: null, short_ref: 'email-1', description: 'Send email to a@b.com',
+          created_at: now,
+        },
+      ]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const rows = await repo.findExpired();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.id).toBe(5);
+      expect(rows[0]!.shortRef).toBe('email-1');
+    });
+
+    it('uses correct SQL filter for pending + expired', async () => {
+      const { pool, queries } = makePool([]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      await repo.findExpired();
+      expect(queries[0]!.sql).toContain("outcome = 'pending_approval'");
+      expect(queries[0]!.sql).toContain('expires_at <= now()');
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle test src/autonomy/action-log-repo.test.ts`
+
+Expected: FAIL — `repo.findExpired is not a function`
+
+- [ ] **Step 3: Implement `findExpired()`**
+
+Add to `src/autonomy/action-log-repo.ts` after the `findAllPending()` method (after line 194):
+
+```typescript
+  /**
+   * Return all pending_approval rows that have passed their expiry time.
+   * These are the inverse of findAllPending() — rows where expires_at <= now().
+   * Used by the approval-expiry-sweep skill to transition stale requests.
+   */
+  async findExpired(): Promise<ActionLogRow[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM autonomy_action_log
+       WHERE outcome = 'pending_approval'
+         AND expires_at <= now()
+       ORDER BY created_at ASC`,
+    );
+    return result.rows.map(mapRow);
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle test src/autonomy/action-log-repo.test.ts`
+
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle add src/autonomy/action-log-repo.ts src/autonomy/action-log-repo.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle commit -m "feat(action-log): add findExpired() method for approval expiry sweep"
+```
+
+---
+
+### Task 2: Add `expireRows()` to `ActionLogRepo`
+
+**Files:**
+- Modify: `src/autonomy/action-log-repo.ts` (after `findExpired` method)
+- Modify: `src/autonomy/action-log-repo.test.ts` (new describe block)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/autonomy/action-log-repo.test.ts` after the `findExpired` describe block:
+
+```typescript
+  describe('expireRows', () => {
+    it('batch-transitions rows to expired and returns count', async () => {
+      const { pool, queries } = makePool([], 3);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const count = await repo.expireRows([1, 2, 3]);
+      expect(count).toBe(3);
+      expect(queries[0]!.sql).toContain("outcome = 'expired'");
+      expect(queries[0]!.sql).toContain("resolved_by = 'system'");
+      expect(queries[0]!.sql).toContain('resolved_at = now()');
+      expect(queries[0]!.sql).toContain("outcome = 'pending_approval'");
+      expect(queries[0]!.params[0]).toEqual([1, 2, 3]);
+    });
+
+    it('returns 0 for empty ids array', async () => {
+      const { pool, queries } = makePool([], 0);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const count = await repo.expireRows([]);
+      expect(count).toBe(0);
+      // Should still issue the query (Postgres handles ANY('{}') gracefully)
+      expect(queries).toHaveLength(1);
+    });
+
+    it('only updates rows still in pending_approval state (idempotency)', async () => {
+      // rowCount 0 means no rows matched the WHERE clause
+      const { pool } = makePool([], 0);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const count = await repo.expireRows([42]);
+      expect(count).toBe(0);
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle test src/autonomy/action-log-repo.test.ts`
+
+Expected: FAIL — `repo.expireRows is not a function`
+
+- [ ] **Step 3: Implement `expireRows()`**
+
+Add to `src/autonomy/action-log-repo.ts` after the `findExpired()` method:
+
+```typescript
+  /**
+   * Batch-transition pending_approval rows to expired state.
+   * Sets outcome = 'expired', resolved_by = 'system', resolved_at = now().
+   * Returns the count of rows actually updated.
+   *
+   * The WHERE outcome = 'pending_approval' guard ensures idempotency — if a row
+   * was concurrently resolved (approved/denied/dismissed), it won't be
+   * double-transitioned.
+   */
+  async expireRows(ids: number[]): Promise<number> {
+    const result = await this.pool.query(
+      `UPDATE autonomy_action_log
+       SET outcome = 'expired', resolved_by = 'system', resolved_at = now()
+       WHERE id = ANY($1) AND outcome = 'pending_approval'`,
+      [ids],
+    );
+    const count = result.rowCount ?? 0;
+    if (count > 0) {
+      this.logger.info({ count, ids }, 'action-log-repo: expired rows');
+    }
+    return count;
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle test src/autonomy/action-log-repo.test.ts`
+
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle add src/autonomy/action-log-repo.ts src/autonomy/action-log-repo.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle commit -m "feat(action-log): add expireRows() method for batch expiry transitions"
+```
+
+---
+
+### Task 3: Add new notification types to event bus
+
+**Files:**
+- Modify: `src/bus/events.ts` (~line 134, the `notificationType` union)
+
+- [ ] **Step 1: Update the `OutboundNotificationPayload` type**
+
+In `src/bus/events.ts`, find the `notificationType` field on `OutboundNotificationPayload` (line 134) and add two new union members. Change:
+
+```typescript
+  notificationType: 'blocked_content' | 'group_held' | 'contact_rate_limited' | 'approval_requested';
+```
+
+to:
+
+```typescript
+  notificationType: 'blocked_content' | 'group_held' | 'contact_rate_limited' | 'approval_requested' | 'approval_expired' | 'pending_actions_digest';
+```
+
+- [ ] **Step 2: Update the comment block above the interface**
+
+In `src/bus/events.ts`, find the comment block above `OutboundNotificationPayload` (lines 123-132) and add two new lines to the notificationType listing. After the `'approval_requested'` line, add:
+
+```typescript
+//   - 'approval_expired':      CEO alert that pending approval requests expired without response
+//   - 'pending_actions_digest': Daily summary of open approval requests awaiting CEO decision
+```
+
+- [ ] **Step 3: Run type check to verify no breakage**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle run typecheck`
+
+If no `typecheck` script exists, run: `npx --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle tsc --noEmit`
+
+Expected: No errors (additive change to a union — backwards compatible)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle add src/bus/events.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle commit -m "feat(events): add approval_expired and pending_actions_digest notification types"
+```
+
+---
+
+### Task 4: Create `approval-expiry-sweep` skill — manifest + handler
+
+**Files:**
+- Create: `skills/approval-expiry-sweep/skill.json`
+- Create: `skills/approval-expiry-sweep/handler.ts`
+
+- [ ] **Step 1: Create the skill manifest**
+
+Create `skills/approval-expiry-sweep/skill.json`:
+
+```json
+{
+  "name": "approval-expiry-sweep",
+  "description": "Expire stale pending approval requests and notify the CEO of high/critical expirations.",
+  "version": "1.0.0",
+  "action_risk": "none",
+  "inputs": {},
+  "outputs": {
+    "expired": "number (count of rows transitioned to expired)",
+    "notified": "number (count of high/critical expirations included in notification)"
+  },
+  "permissions": [],
+  "secrets": ["CEO_PRIMARY_EMAIL"],
+  "timeout": 30000,
+  "capabilities": ["actionLogRepo", "outboundGateway"]
+}
+```
+
+- [ ] **Step 2: Create the handler**
+
+Create `skills/approval-expiry-sweep/handler.ts`:
+
+```typescript
+// handler.ts — approval-expiry-sweep skill implementation.
+//
+// Runs hourly via the coordinator's declarative schedule. Finds all
+// pending_approval rows that have passed their expires_at, transitions
+// them to 'expired', and sends a single batched notification to the CEO
+// for any high/critical tier expirations.
+//
+// Low/medium tier expirations are silent — at low autonomy scores the
+// volume would be noisy.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+/** Risk tiers that warrant a CEO notification on expiry. */
+const NOTIFIABLE_TIERS = new Set(['high', 'critical']);
+
+export class ApprovalExpirySweepHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.actionLogRepo) {
+      return { success: false, error: 'approval-expiry-sweep requires actionLogRepo capability' };
+    }
+
+    try {
+      const expired = await ctx.actionLogRepo.findExpired();
+      if (expired.length === 0) {
+        ctx.log.info('approval-expiry-sweep: no expired rows found');
+        return { success: true, data: { expired: 0, notified: 0 } };
+      }
+
+      // Batch-transition all expired rows
+      const ids = expired.map((row) => row.id);
+      const transitioned = await ctx.actionLogRepo.expireRows(ids);
+
+      // Log each expiry at info level
+      for (const row of expired) {
+        ctx.log.info(
+          { id: row.id, shortRef: row.shortRef, skillName: row.skillName, actionRisk: row.actionRisk },
+          'approval-expiry-sweep: row expired',
+        );
+      }
+
+      // Partition by tier — only high/critical get notified
+      const notifiable = expired.filter((row) => NOTIFIABLE_TIERS.has(row.actionRisk));
+
+      if (notifiable.length > 0 && ctx.outboundGateway) {
+        let ceoEmail: string | undefined;
+        try {
+          ceoEmail = ctx.secret('CEO_PRIMARY_EMAIL');
+        } catch {
+          // secret() throws if the env var is not set
+        }
+
+        if (ceoEmail) {
+          const lines = notifiable.map(
+            (row) => `- ${row.shortRef ?? '(no ref)'}: ${row.description ?? row.skillName}`,
+          );
+          const subject = notifiable.length === 1
+            ? `Approval expired — ${notifiable[0]!.description ?? notifiable[0]!.skillName}`
+            : `Approval expired — ${notifiable.length} request(s) expired without response`;
+          const body =
+            'The following approval request(s) expired without a response:\n\n' +
+            lines.join('\n') +
+            '\n\nThese requests have been automatically closed.';
+
+          const sent = await ctx.outboundGateway.sendNotification({
+            notificationType: 'approval_expired',
+            ceoEmail,
+            subject,
+            body,
+          });
+
+          if (!sent) {
+            // Non-fatal — the rows are already expired. CEO will see them in next digest.
+            ctx.log.warn('approval-expiry-sweep: notification send failed — CEO will see expired items in next digest');
+          }
+        } else {
+          ctx.log.warn('approval-expiry-sweep: CEO_PRIMARY_EMAIL not configured — skipping expiry notification');
+        }
+      }
+
+      return {
+        success: true,
+        data: { expired: transitioned, notified: notifiable.length },
+      };
+    } catch (err) {
+      ctx.log.error({ err }, 'approval-expiry-sweep: unexpected failure');
+      return { success: false, error: 'approval-expiry-sweep failed unexpectedly' };
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle add skills/approval-expiry-sweep/skill.json skills/approval-expiry-sweep/handler.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle commit -m "feat: add approval-expiry-sweep skill — manifest + handler"
+```
+
+---
+
+### Task 5: Write tests for `approval-expiry-sweep`
+
+**Files:**
+- Create: `skills/approval-expiry-sweep/handler.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `skills/approval-expiry-sweep/handler.test.ts`:
+
+```typescript
+// handler.test.ts — unit tests for approval-expiry-sweep skill.
+
+import { describe, it, expect, vi } from 'vitest';
+import { ApprovalExpirySweepHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import type { OutboundGateway } from '../../src/skills/outbound-gateway.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+function makeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 10,
+    taskId: 't1',
+    conversationId: null,
+    skillName: 'calendar-create-event',
+    actionRisk: 'high',
+    outcome: 'pending_approval' as const,
+    shortRef: 'cal-1',
+    description: 'Create calendar event: Lunch',
+    createdAt: new Date(),
+    expiresAt: new Date(Date.now() - 3600_000), // expired 1h ago
+    payload: { title: 'Lunch' },
+    taskSummary: null,
+    competenceFlag: null,
+    commitmentFlag: null,
+    compatibility: null,
+    scoredBy: null,
+    notificationSentAt: null,
+    resolvedAt: null,
+    resolvedBy: null,
+    parentActionId: null,
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: {},
+    secret: (name: string) => {
+      if (name === 'CEO_PRIMARY_EMAIL') return 'ceo@example.com';
+      throw new Error(`secret '${name}' not configured in test`);
+    },
+    log: createSilentLogger(),
+    ...overrides,
+  } as SkillContext;
+}
+
+function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
+  return {
+    findExpired: vi.fn().mockResolvedValue([]),
+    expireRows: vi.fn().mockResolvedValue(0),
+    ...overrides,
+  } as unknown as ActionLogRepo;
+}
+
+function makeMockGateway(sendResult = true): OutboundGateway {
+  return {
+    sendNotification: vi.fn().mockResolvedValue(sendResult),
+  } as unknown as OutboundGateway;
+}
+
+describe('ApprovalExpirySweepHandler', () => {
+  it('returns error when actionLogRepo is missing', async () => {
+    const handler = new ApprovalExpirySweepHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: undefined }));
+    expect(result.success).toBe(false);
+  });
+
+  it('returns early with expired: 0 when no expired rows exist', async () => {
+    const repo = makeMockRepo();
+    const handler = new ApprovalExpirySweepHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo }));
+    expect(result.success).toBe(true);
+    expect((result as { data: unknown }).data).toEqual({ expired: 0, notified: 0 });
+    expect(repo.expireRows).not.toHaveBeenCalled();
+  });
+
+  it('expires rows and sends batched notification for high/critical tiers', async () => {
+    const highRow = makeRow({ id: 1, actionRisk: 'high', shortRef: 'cal-1', description: 'Create event' });
+    const criticalRow = makeRow({ id: 2, actionRisk: 'critical', shortRef: 'pay-1', description: 'Process payment', skillName: 'process-payment' });
+    const repo = makeMockRepo({
+      findExpired: vi.fn().mockResolvedValue([highRow, criticalRow]),
+      expireRows: vi.fn().mockResolvedValue(2),
+    });
+    const gateway = makeMockGateway();
+    const handler = new ApprovalExpirySweepHandler();
+
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, outboundGateway: gateway }));
+
+    expect(result.success).toBe(true);
+    expect((result as { data: unknown }).data).toEqual({ expired: 2, notified: 2 });
+    expect(repo.expireRows).toHaveBeenCalledWith([1, 2]);
+    expect(gateway.sendNotification).toHaveBeenCalledOnce();
+
+    const payload = (gateway.sendNotification as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(payload.notificationType).toBe('approval_expired');
+    expect(payload.ceoEmail).toBe('ceo@example.com');
+    expect(payload.subject).toContain('2 request(s)');
+    expect(payload.body).toContain('cal-1');
+    expect(payload.body).toContain('pay-1');
+  });
+
+  it('expires low/medium rows silently — no notification', async () => {
+    const lowRow = makeRow({ id: 3, actionRisk: 'low', shortRef: 'mem-1' });
+    const medRow = makeRow({ id: 4, actionRisk: 'medium', shortRef: 'email-1' });
+    const repo = makeMockRepo({
+      findExpired: vi.fn().mockResolvedValue([lowRow, medRow]),
+      expireRows: vi.fn().mockResolvedValue(2),
+    });
+    const gateway = makeMockGateway();
+    const handler = new ApprovalExpirySweepHandler();
+
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, outboundGateway: gateway }));
+
+    expect(result.success).toBe(true);
+    expect((result as { data: unknown }).data).toEqual({ expired: 2, notified: 0 });
+    expect(gateway.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('handles mixed tiers — only high/critical in notification', async () => {
+    const lowRow = makeRow({ id: 1, actionRisk: 'low', shortRef: 'mem-1' });
+    const highRow = makeRow({ id: 2, actionRisk: 'high', shortRef: 'cal-1', description: 'Create event' });
+    const repo = makeMockRepo({
+      findExpired: vi.fn().mockResolvedValue([lowRow, highRow]),
+      expireRows: vi.fn().mockResolvedValue(2),
+    });
+    const gateway = makeMockGateway();
+    const handler = new ApprovalExpirySweepHandler();
+
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, outboundGateway: gateway }));
+
+    expect(result.success).toBe(true);
+    expect((result as { data: unknown }).data).toEqual({ expired: 2, notified: 1 });
+    expect(gateway.sendNotification).toHaveBeenCalledOnce();
+    const payload = (gateway.sendNotification as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(payload.body).toContain('cal-1');
+    expect(payload.body).not.toContain('mem-1');
+  });
+
+  it('still succeeds when notification send fails (non-fatal)', async () => {
+    const highRow = makeRow({ id: 1, actionRisk: 'high', shortRef: 'cal-1', description: 'Create event' });
+    const repo = makeMockRepo({
+      findExpired: vi.fn().mockResolvedValue([highRow]),
+      expireRows: vi.fn().mockResolvedValue(1),
+    });
+    const gateway = makeMockGateway(false); // sendNotification returns false
+    const handler = new ApprovalExpirySweepHandler();
+
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, outboundGateway: gateway }));
+
+    // Expiry still succeeded even though notification failed
+    expect(result.success).toBe(true);
+    expect((result as { data: unknown }).data).toEqual({ expired: 1, notified: 1 });
+  });
+
+  it('skips notification when CEO_PRIMARY_EMAIL is not configured', async () => {
+    const highRow = makeRow({ id: 1, actionRisk: 'high', shortRef: 'cal-1', description: 'Create event' });
+    const repo = makeMockRepo({
+      findExpired: vi.fn().mockResolvedValue([highRow]),
+      expireRows: vi.fn().mockResolvedValue(1),
+    });
+    const gateway = makeMockGateway();
+    const handler = new ApprovalExpirySweepHandler();
+
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo,
+      outboundGateway: gateway,
+      secret: () => { throw new Error('not configured'); },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(gateway.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('uses singular subject when only one high/critical row expires', async () => {
+    const highRow = makeRow({ id: 1, actionRisk: 'high', shortRef: 'cal-1', description: 'Create event: Lunch' });
+    const repo = makeMockRepo({
+      findExpired: vi.fn().mockResolvedValue([highRow]),
+      expireRows: vi.fn().mockResolvedValue(1),
+    });
+    const gateway = makeMockGateway();
+    const handler = new ApprovalExpirySweepHandler();
+
+    await handler.execute(makeCtx({ actionLogRepo: repo, outboundGateway: gateway }));
+
+    const payload = (gateway.sendNotification as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(payload.subject).toBe('Approval expired — Create event: Lunch');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle test skills/approval-expiry-sweep/handler.test.ts`
+
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle add skills/approval-expiry-sweep/handler.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle commit -m "test: add tests for approval-expiry-sweep skill"
+```
+
+---
+
+### Task 6: Create `pending-actions-digest` skill — manifest + handler
+
+**Files:**
+- Create: `skills/pending-actions-digest/skill.json`
+- Create: `skills/pending-actions-digest/handler.ts`
+
+- [ ] **Step 1: Create the skill manifest**
+
+Create `skills/pending-actions-digest/skill.json`:
+
+```json
+{
+  "name": "pending-actions-digest",
+  "description": "Send a daily digest of open approval requests awaiting CEO decision.",
+  "version": "1.0.0",
+  "action_risk": "none",
+  "inputs": {},
+  "outputs": {
+    "pending": "number (count of open requests included in digest)",
+    "skipped": "boolean (true if no open requests — digest not sent)"
+  },
+  "permissions": [],
+  "secrets": ["CEO_PRIMARY_EMAIL"],
+  "timeout": 30000,
+  "capabilities": ["actionLogRepo", "outboundGateway"]
+}
+```
+
+- [ ] **Step 2: Create the handler**
+
+Create `skills/pending-actions-digest/handler.ts`:
+
+```typescript
+// handler.ts — pending-actions-digest skill implementation.
+//
+// Runs daily at 8 AM via the coordinator's declarative schedule. Queries
+// all non-expired pending_approval rows and sends a single digest email
+// to the CEO listing each request with its short_ref, description, skill
+// name, and time remaining before expiry.
+//
+// This is the safety net for notification failures (ADR-018 §3c): even if
+// the original notification didn't reach the CEO, the daily digest will.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+/**
+ * Format milliseconds remaining as a human-readable string.
+ * Examples: "23h remaining", "2h remaining", "<1h remaining"
+ */
+function formatTimeRemaining(ms: number): string {
+  if (ms <= 0) return 'expiring now';
+  const hours = Math.floor(ms / (1000 * 60 * 60));
+  if (hours < 1) return '<1h remaining';
+  return `${hours}h remaining`;
+}
+
+export class PendingActionsDigestHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.actionLogRepo) {
+      return { success: false, error: 'pending-actions-digest requires actionLogRepo capability' };
+    }
+
+    try {
+      const pending = await ctx.actionLogRepo.findAllPending();
+      if (pending.length === 0) {
+        ctx.log.info('pending-actions-digest: no pending rows — skipping digest');
+        return { success: true, data: { pending: 0, skipped: true } };
+      }
+
+      const now = Date.now();
+      const lines = pending.map((row) => {
+        const remaining = row.expiresAt
+          ? formatTimeRemaining(row.expiresAt.getTime() - now)
+          : 'no expiry';
+        return `- ${row.shortRef ?? '(no ref)'}: ${row.description ?? row.skillName} [${row.skillName}] (${remaining})`;
+      });
+
+      if (!ctx.outboundGateway) {
+        ctx.log.warn('pending-actions-digest: outboundGateway not available — cannot send digest');
+        return { success: true, data: { pending: pending.length, skipped: true } };
+      }
+
+      let ceoEmail: string | undefined;
+      try {
+        ceoEmail = ctx.secret('CEO_PRIMARY_EMAIL');
+      } catch {
+        // secret() throws if the env var is not set
+      }
+
+      if (!ceoEmail) {
+        ctx.log.warn('pending-actions-digest: CEO_PRIMARY_EMAIL not configured — skipping digest');
+        return { success: true, data: { pending: pending.length, skipped: true } };
+      }
+
+      const subject = pending.length === 1
+        ? 'Pending approval — 1 request awaiting your decision'
+        : `Pending approvals — ${pending.length} request(s) awaiting your decision`;
+      const body =
+        'The following approval request(s) are waiting for your decision:\n\n' +
+        lines.join('\n') +
+        '\n\nReply with the short reference code to approve, deny, or dismiss each request.';
+
+      const sent = await ctx.outboundGateway.sendNotification({
+        notificationType: 'pending_actions_digest',
+        ceoEmail,
+        subject,
+        body,
+      });
+
+      if (!sent) {
+        ctx.log.warn('pending-actions-digest: notification send failed');
+      }
+
+      ctx.log.info({ count: pending.length }, 'pending-actions-digest: digest sent');
+      return { success: true, data: { pending: pending.length, skipped: false } };
+    } catch (err) {
+      ctx.log.error({ err }, 'pending-actions-digest: unexpected failure');
+      return { success: false, error: 'pending-actions-digest failed unexpectedly' };
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle add skills/pending-actions-digest/skill.json skills/pending-actions-digest/handler.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle commit -m "feat: add pending-actions-digest skill — manifest + handler"
+```
+
+---
+
+### Task 7: Write tests for `pending-actions-digest`
+
+**Files:**
+- Create: `skills/pending-actions-digest/handler.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `skills/pending-actions-digest/handler.test.ts`:
+
+```typescript
+// handler.test.ts — unit tests for pending-actions-digest skill.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PendingActionsDigestHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import type { OutboundGateway } from '../../src/skills/outbound-gateway.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+// Fix Date.now() for deterministic time-remaining calculations
+const FIXED_NOW = new Date('2026-05-04T12:00:00Z').getTime();
+
+function makeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 10,
+    taskId: 't1',
+    conversationId: null,
+    skillName: 'calendar-create-event',
+    actionRisk: 'high',
+    outcome: 'pending_approval' as const,
+    shortRef: 'cal-1',
+    description: 'Create calendar event: Lunch',
+    createdAt: new Date('2026-05-04T08:00:00Z'),
+    expiresAt: new Date('2026-05-05T08:00:00Z'), // 20h from FIXED_NOW
+    payload: { title: 'Lunch' },
+    taskSummary: null,
+    competenceFlag: null,
+    commitmentFlag: null,
+    compatibility: null,
+    scoredBy: null,
+    notificationSentAt: null,
+    resolvedAt: null,
+    resolvedBy: null,
+    parentActionId: null,
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: {},
+    secret: (name: string) => {
+      if (name === 'CEO_PRIMARY_EMAIL') return 'ceo@example.com';
+      throw new Error(`secret '${name}' not configured in test`);
+    },
+    log: createSilentLogger(),
+    ...overrides,
+  } as SkillContext;
+}
+
+function makeMockRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
+  return {
+    findAllPending: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  } as unknown as ActionLogRepo;
+}
+
+function makeMockGateway(sendResult = true): OutboundGateway {
+  return {
+    sendNotification: vi.fn().mockResolvedValue(sendResult),
+  } as unknown as OutboundGateway;
+}
+
+describe('PendingActionsDigestHandler', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns error when actionLogRepo is missing', async () => {
+    const handler = new PendingActionsDigestHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: undefined }));
+    expect(result.success).toBe(false);
+  });
+
+  it('skips digest when no pending rows exist', async () => {
+    const repo = makeMockRepo();
+    const gateway = makeMockGateway();
+    const handler = new PendingActionsDigestHandler();
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, outboundGateway: gateway }));
+    expect(result.success).toBe(true);
+    expect((result as { data: unknown }).data).toEqual({ pending: 0, skipped: true });
+    expect(gateway.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('sends digest with all pending rows', async () => {
+    const row1 = makeRow({ id: 1, shortRef: 'cal-1', description: 'Create event: Lunch', skillName: 'calendar-create-event' });
+    const row2 = makeRow({ id: 2, shortRef: 'email-1', description: 'Send follow-up email', skillName: 'email-send' });
+    const repo = makeMockRepo({
+      findAllPending: vi.fn().mockResolvedValue([row1, row2]),
+    });
+    const gateway = makeMockGateway();
+    const handler = new PendingActionsDigestHandler();
+
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, outboundGateway: gateway }));
+
+    expect(result.success).toBe(true);
+    expect((result as { data: unknown }).data).toEqual({ pending: 2, skipped: false });
+    expect(gateway.sendNotification).toHaveBeenCalledOnce();
+
+    const payload = (gateway.sendNotification as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(payload.notificationType).toBe('pending_actions_digest');
+    expect(payload.ceoEmail).toBe('ceo@example.com');
+    expect(payload.subject).toContain('2 request(s)');
+    expect(payload.body).toContain('cal-1');
+    expect(payload.body).toContain('email-1');
+    expect(payload.body).toContain('calendar-create-event');
+    expect(payload.body).toContain('email-send');
+  });
+
+  it('includes correct time remaining in digest body', async () => {
+    // expiresAt is 20h from FIXED_NOW
+    const row = makeRow({ expiresAt: new Date(FIXED_NOW + 20 * 60 * 60 * 1000) });
+    const repo = makeMockRepo({
+      findAllPending: vi.fn().mockResolvedValue([row]),
+    });
+    const gateway = makeMockGateway();
+    const handler = new PendingActionsDigestHandler();
+
+    await handler.execute(makeCtx({ actionLogRepo: repo, outboundGateway: gateway }));
+
+    const payload = (gateway.sendNotification as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(payload.body).toContain('20h remaining');
+  });
+
+  it('shows <1h remaining for rows expiring within the hour', async () => {
+    const row = makeRow({ expiresAt: new Date(FIXED_NOW + 30 * 60 * 1000) }); // 30 min
+    const repo = makeMockRepo({
+      findAllPending: vi.fn().mockResolvedValue([row]),
+    });
+    const gateway = makeMockGateway();
+    const handler = new PendingActionsDigestHandler();
+
+    await handler.execute(makeCtx({ actionLogRepo: repo, outboundGateway: gateway }));
+
+    const payload = (gateway.sendNotification as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(payload.body).toContain('<1h remaining');
+  });
+
+  it('uses singular subject when only one pending row', async () => {
+    const row = makeRow();
+    const repo = makeMockRepo({
+      findAllPending: vi.fn().mockResolvedValue([row]),
+    });
+    const gateway = makeMockGateway();
+    const handler = new PendingActionsDigestHandler();
+
+    await handler.execute(makeCtx({ actionLogRepo: repo, outboundGateway: gateway }));
+
+    const payload = (gateway.sendNotification as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(payload.subject).toBe('Pending approval — 1 request awaiting your decision');
+  });
+
+  it('skips digest when CEO_PRIMARY_EMAIL is not configured', async () => {
+    const row = makeRow();
+    const repo = makeMockRepo({
+      findAllPending: vi.fn().mockResolvedValue([row]),
+    });
+    const gateway = makeMockGateway();
+    const handler = new PendingActionsDigestHandler();
+
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo,
+      outboundGateway: gateway,
+      secret: () => { throw new Error('not configured'); },
+    }));
+
+    expect(result.success).toBe(true);
+    expect((result as { data: unknown }).data).toEqual({ pending: 1, skipped: true });
+    expect(gateway.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('handles notification send failure gracefully', async () => {
+    const row = makeRow();
+    const repo = makeMockRepo({
+      findAllPending: vi.fn().mockResolvedValue([row]),
+    });
+    const gateway = makeMockGateway(false); // returns false
+    const handler = new PendingActionsDigestHandler();
+
+    const result = await handler.execute(makeCtx({ actionLogRepo: repo, outboundGateway: gateway }));
+
+    // Still succeeds — notification failure is non-fatal
+    expect(result.success).toBe(true);
+    expect((result as { data: unknown }).data).toEqual({ pending: 1, skipped: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle test skills/pending-actions-digest/handler.test.ts`
+
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle add skills/pending-actions-digest/handler.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle commit -m "test: add tests for pending-actions-digest skill"
+```
+
+---
+
+### Task 8: Add declarative schedule entries to coordinator YAML
+
+**Files:**
+- Modify: `agents/coordinator.yaml` (add `schedule:` block at the end of the file)
+
+- [ ] **Step 1: Add the schedule block**
+
+Append to the end of `agents/coordinator.yaml`:
+
+```yaml
+schedule:
+  - cron: "0 * * * *"
+    task: "Run the approval expiry sweep — find and expire any pending approval requests that have passed their expiry time."
+    expectedDurationSeconds: 120
+  - cron: "0 8 * * *"
+    task: "Run the pending-actions digest — if any approval requests are still awaiting a decision, send a summary to the CEO."
+    expectedDurationSeconds: 120
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+Run: `node -e "const fs = require('fs'); const yaml = require('yaml'); yaml.parse(fs.readFileSync('/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle/agents/coordinator.yaml', 'utf8')); console.log('YAML valid')"`
+
+If `yaml` is not installed, use: `npx --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle yaml-cli lint agents/coordinator.yaml` or verify by reading the file and checking structure visually.
+
+Expected: No parse errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle add agents/coordinator.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle commit -m "feat: add approval expiry sweep and daily digest to coordinator schedule"
+```
+
+---
+
+### Task 9: Run full test suite + update CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md` (add entry under `## [Unreleased]`)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle test`
+
+Expected: ALL PASS. If any tests fail, fix them before proceeding.
+
+- [ ] **Step 2: Run type check**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle run typecheck`
+
+Or: `npx --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle tsc --noEmit`
+
+Expected: No errors
+
+- [ ] **Step 3: Update CHANGELOG.md**
+
+Add under `## [Unreleased]` in the **Added** section:
+
+```markdown
+### Added
+
+- **Approval expiry sweep** scheduled job — hourly sweep that transitions stale `pending_approval` rows to `expired` and sends a batched CEO notification for high/critical tier expirations (#429)
+- **Pending-actions daily digest** scheduled job — morning digest that surfaces all open approval requests to the CEO as a safety net for missed notifications (#429)
+- `findExpired()` and `expireRows()` methods on `ActionLogRepo` for approval lifecycle management
+- `approval_expired` and `pending_actions_digest` notification types on the event bus
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-approval-lifecycle commit -m "docs: update CHANGELOG for approval lifecycle jobs (#429)"
+```

--- a/skills/approval-expiry-sweep/handler.test.ts
+++ b/skills/approval-expiry-sweep/handler.test.ts
@@ -1,0 +1,205 @@
+// handler.test.ts — unit tests for approval-expiry-sweep skill handler.
+//
+// Tests cover: no-op on empty results, batch expiry, notification filtering
+// by risk tier, batched single notification, missing CEO email, non-fatal
+// sendNotification failure, and unexpected DB errors.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ApprovalExpirySweepHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { ActionLogRow } from '../../src/autonomy/action-log-types.js';
+
+// --- Fixtures ---
+
+function makeRow(overrides: Partial<ActionLogRow> = {}): ActionLogRow {
+  return {
+    id: 1,
+    shortRef: 'cal-1',
+    skillName: 'create-calendar-event',
+    description: 'Create event: Lunch',
+    actionRisk: 'medium',
+    outcome: 'pending_approval',
+    createdAt: new Date(),
+    expiresAt: new Date(Date.now() - 1000), // already expired
+    resolvedAt: null,
+    resolvedBy: null,
+    taskId: 'task-1',
+    conversationId: null,
+    taskSummary: null,
+    competenceFlag: null,
+    commitmentFlag: null,
+    compatibility: null,
+    scoredBy: null,
+    payload: {},
+    notificationSentAt: null,
+    parentActionId: null,
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides: {
+  findExpiredRows?: ActionLogRow[];
+  expireRowsCount?: number;
+  sendNotificationResult?: boolean;
+  ceoEmail?: string;
+} = {}): SkillContext {
+  const {
+    findExpiredRows = [],
+    expireRowsCount = findExpiredRows.length,
+    sendNotificationResult = true,
+    ceoEmail = 'ceo@example.com',
+  } = overrides;
+
+  // The handler reads CEO_PRIMARY_EMAIL from process.env directly (not ctx.secret),
+  // so set it here. Tests that need it absent should pass ceoEmail: ''.
+  process.env['CEO_PRIMARY_EMAIL'] = ceoEmail;
+
+  return {
+    input: {},
+    secret: vi.fn().mockReturnValue(''),
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    actionLogRepo: {
+      findExpired: vi.fn().mockResolvedValue(findExpiredRows),
+      expireRows: vi.fn().mockResolvedValue(expireRowsCount),
+    } as any,
+    outboundGateway: {
+      sendNotification: vi.fn().mockResolvedValue(sendNotificationResult),
+    } as any,
+  } as SkillContext;
+}
+
+afterEach(() => {
+  // Clean up the env var between tests so they don't bleed into each other.
+  delete process.env['CEO_PRIMARY_EMAIL'];
+});
+
+// --- Tests ---
+
+describe('ApprovalExpirySweepHandler', () => {
+  it('returns {expired:0, notified:0} and sends no notification when no expired rows', async () => {
+    const handler = new ApprovalExpirySweepHandler();
+    const ctx = makeCtx({ findExpiredRows: [] });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ expired: 0, notified: 0 });
+    expect((ctx.outboundGateway as any).sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('expires all found rows and logs each', async () => {
+    const rows = [
+      makeRow({ id: 1, shortRef: 'cal-1', actionRisk: 'low' }),
+      makeRow({ id: 2, shortRef: 'email-1', actionRisk: 'medium' }),
+    ];
+    const handler = new ApprovalExpirySweepHandler();
+    const ctx = makeCtx({ findExpiredRows: rows });
+
+    const result = await handler.execute(ctx);
+
+    // expireRows should be called with the IDs of all expired rows
+    expect((ctx.actionLogRepo as any).expireRows).toHaveBeenCalledWith([1, 2]);
+
+    // One info log per expired row
+    expect((ctx.log as any).info).toHaveBeenCalledTimes(2);
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data.expired).toBe(2);
+  });
+
+  it('sends no notification for low/medium tier expirations', async () => {
+    const rows = [
+      makeRow({ id: 1, shortRef: 'cal-1', actionRisk: 'low' }),
+      makeRow({ id: 2, shortRef: 'email-1', actionRisk: 'medium' }),
+    ];
+    const handler = new ApprovalExpirySweepHandler();
+    const ctx = makeCtx({ findExpiredRows: rows });
+
+    const result = await handler.execute(ctx);
+
+    expect((ctx.outboundGateway as any).sendNotification).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data.notified).toBe(0);
+  });
+
+  it('sends a single batched notification for high/critical expirations', async () => {
+    const rows = [
+      makeRow({ id: 1, shortRef: 'low-ref', actionRisk: 'low' }),
+      makeRow({ id: 2, shortRef: 'high-ref', actionRisk: 'high' }),
+      makeRow({ id: 3, shortRef: 'crit-ref', actionRisk: 'critical' }),
+    ];
+    const handler = new ApprovalExpirySweepHandler();
+    const ctx = makeCtx({ findExpiredRows: rows, ceoEmail: 'ceo@example.com' });
+
+    const result = await handler.execute(ctx);
+
+    // Exactly one batched notification covering the high + critical rows
+    expect((ctx.outboundGateway as any).sendNotification).toHaveBeenCalledTimes(1);
+
+    const payload = (ctx.outboundGateway as any).sendNotification.mock.calls[0][0];
+    expect(payload.notificationType).toBe('approval_expired');
+    expect(payload.ceoEmail).toBe('ceo@example.com');
+
+    // Subject should mention the count of notifiable rows (high + critical = 2)
+    expect(payload.subject).toContain('2 request(s)');
+
+    // Body must include both high/critical refs but NOT the low ref
+    expect(payload.body).toContain('high-ref');
+    expect(payload.body).toContain('crit-ref');
+    expect(payload.body).not.toContain('low-ref');
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data.notified).toBe(2);
+  });
+
+  it('skips notification when CEO_PRIMARY_EMAIL is not set', async () => {
+    const rows = [makeRow({ id: 1, shortRef: 'high-ref', actionRisk: 'high' })];
+    const handler = new ApprovalExpirySweepHandler();
+    // Passing ceoEmail: '' causes the helper to set process.env['CEO_PRIMARY_EMAIL'] = ''
+    const ctx = makeCtx({ findExpiredRows: rows, ceoEmail: '' });
+
+    const result = await handler.execute(ctx);
+
+    // No notification sent because the email is blank
+    expect((ctx.outboundGateway as any).sendNotification).not.toHaveBeenCalled();
+
+    // A warning should be emitted about the missing email
+    expect((ctx.log as any).warn).toHaveBeenCalled();
+
+    // Expiry itself still succeeds
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ expired: 1, notified: 0 });
+  });
+
+  it('returns notified:0 when sendNotification returns false (non-fatal)', async () => {
+    const rows = [makeRow({ id: 1, shortRef: 'crit-ref', actionRisk: 'critical' })];
+    const handler = new ApprovalExpirySweepHandler();
+    const ctx = makeCtx({ findExpiredRows: rows, sendNotificationResult: false });
+
+    const result = await handler.execute(ctx);
+
+    // The skill should not fail — sendNotification returning false is non-fatal
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ expired: 1, notified: 0 });
+  });
+
+  it('returns success:false on unexpected error', async () => {
+    const handler = new ApprovalExpirySweepHandler();
+    const ctx = makeCtx();
+
+    // Override findExpired to throw unexpectedly
+    (ctx.actionLogRepo as any).findExpired = vi.fn().mockRejectedValue(new Error('DB down'));
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    expect(result.error).toContain('DB down');
+  });
+});

--- a/skills/approval-expiry-sweep/handler.test.ts
+++ b/skills/approval-expiry-sweep/handler.test.ts
@@ -1,12 +1,14 @@
 // handler.test.ts — unit tests for approval-expiry-sweep skill handler.
 //
 // Tests cover: no-op on empty results, batch expiry, notification filtering
-// by risk tier, batched single notification, missing CEO email, non-fatal
-// sendNotification failure, and unexpected DB errors.
+// by risk tier, batched single notification, missing CEO email, missing
+// outbound gateway, non-fatal sendNotification failure, and unexpected DB errors.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { ApprovalExpirySweepHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import type { OutboundGateway } from '../../src/skills/outbound-gateway.js';
 import type { ActionLogRow } from '../../src/autonomy/action-log-types.js';
 
 // --- Fixtures ---
@@ -39,33 +41,52 @@ function makeRow(overrides: Partial<ActionLogRow> = {}): ActionLogRow {
 
 function makeCtx(overrides: {
   findExpiredRows?: ActionLogRow[];
-  expireRowsCount?: number;
+  // Rows actually returned by expireRows (RETURNING *). Defaults to findExpiredRows —
+  // the common case where no concurrent resolution happened.
+  expireRowsResult?: ActionLogRow[];
   sendNotificationResult?: boolean;
   ceoEmail?: string;
-} = {}): SkillContext {
+  withoutOutboundGateway?: boolean;
+} = {}) {
   const {
     findExpiredRows = [],
-    expireRowsCount = findExpiredRows.length,
+    expireRowsResult = findExpiredRows,
     sendNotificationResult = true,
     ceoEmail = 'ceo@example.com',
+    withoutOutboundGateway = false,
   } = overrides;
 
   // The handler reads CEO_PRIMARY_EMAIL from process.env directly (not ctx.secret),
   // so set it here. Tests that need it absent should pass ceoEmail: ''.
   process.env['CEO_PRIMARY_EMAIL'] = ceoEmail;
 
-  return {
+  // Keep explicit references so tests can assert on mock calls without casts.
+  const findExpiredMock = vi.fn().mockResolvedValue(findExpiredRows);
+  const expireRowsMock = vi.fn().mockResolvedValue(expireRowsResult);
+  const sendNotificationMock = vi.fn().mockResolvedValue(sendNotificationResult);
+  const logInfoMock = vi.fn();
+  const logWarnMock = vi.fn();
+  const logErrorMock = vi.fn();
+
+  const ctx: SkillContext = {
     input: {},
-    secret: vi.fn().mockReturnValue(''),
-    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    // ctx.secret() throws in production when the var is unset — mirror that here.
+    // The handlers read CEO_PRIMARY_EMAIL via process.env directly, so this stub
+    // is present for shape correctness only.
+    secret: vi.fn().mockImplementation((name: string) => {
+      throw new Error(`secret ${name} not configured`);
+    }),
+    log: { info: logInfoMock, warn: logWarnMock, error: logErrorMock, debug: vi.fn() } as unknown as SkillContext['log'],
     actionLogRepo: {
-      findExpired: vi.fn().mockResolvedValue(findExpiredRows),
-      expireRows: vi.fn().mockResolvedValue(expireRowsCount),
-    } as any,
-    outboundGateway: {
-      sendNotification: vi.fn().mockResolvedValue(sendNotificationResult),
-    } as any,
+      findExpired: findExpiredMock,
+      expireRows: expireRowsMock,
+    } as unknown as ActionLogRepo,
+    outboundGateway: withoutOutboundGateway
+      ? undefined
+      : ({ sendNotification: sendNotificationMock } as unknown as OutboundGateway),
   } as SkillContext;
+
+  return { ctx, findExpiredMock, expireRowsMock, sendNotificationMock, logInfoMock, logWarnMock, logErrorMock };
 }
 
 afterEach(() => {
@@ -78,31 +99,31 @@ afterEach(() => {
 describe('ApprovalExpirySweepHandler', () => {
   it('returns {expired:0, notified:0} and sends no notification when no expired rows', async () => {
     const handler = new ApprovalExpirySweepHandler();
-    const ctx = makeCtx({ findExpiredRows: [] });
+    const { ctx, sendNotificationMock } = makeCtx({ findExpiredRows: [] });
 
     const result = await handler.execute(ctx);
 
     expect(result.success).toBe(true);
     if (!result.success) throw new Error('unreachable');
     expect(result.data).toEqual({ expired: 0, notified: 0 });
-    expect((ctx.outboundGateway as any).sendNotification).not.toHaveBeenCalled();
+    expect(sendNotificationMock).not.toHaveBeenCalled();
   });
 
-  it('expires all found rows and logs each', async () => {
+  it('expires all found rows and logs each actually-expired row', async () => {
     const rows = [
       makeRow({ id: 1, shortRef: 'cal-1', actionRisk: 'low' }),
       makeRow({ id: 2, shortRef: 'email-1', actionRisk: 'medium' }),
     ];
     const handler = new ApprovalExpirySweepHandler();
-    const ctx = makeCtx({ findExpiredRows: rows });
+    const { ctx, expireRowsMock, logInfoMock } = makeCtx({ findExpiredRows: rows });
 
     const result = await handler.execute(ctx);
 
-    // expireRows should be called with the IDs of all expired rows
-    expect((ctx.actionLogRepo as any).expireRows).toHaveBeenCalledWith([1, 2]);
+    // expireRows should be called with the IDs of all candidate rows
+    expect(expireRowsMock).toHaveBeenCalledWith([1, 2]);
 
-    // One info log per expired row
-    expect((ctx.log as any).info).toHaveBeenCalledTimes(2);
+    // One info log per actually-expired row (expireRowsResult defaults to findExpiredRows)
+    expect(logInfoMock).toHaveBeenCalledTimes(2);
 
     expect(result.success).toBe(true);
     if (!result.success) throw new Error('unreachable');
@@ -115,11 +136,11 @@ describe('ApprovalExpirySweepHandler', () => {
       makeRow({ id: 2, shortRef: 'email-1', actionRisk: 'medium' }),
     ];
     const handler = new ApprovalExpirySweepHandler();
-    const ctx = makeCtx({ findExpiredRows: rows });
+    const { ctx, sendNotificationMock } = makeCtx({ findExpiredRows: rows });
 
     const result = await handler.execute(ctx);
 
-    expect((ctx.outboundGateway as any).sendNotification).not.toHaveBeenCalled();
+    expect(sendNotificationMock).not.toHaveBeenCalled();
     expect(result.success).toBe(true);
     if (!result.success) throw new Error('unreachable');
     expect(result.data.notified).toBe(0);
@@ -132,14 +153,14 @@ describe('ApprovalExpirySweepHandler', () => {
       makeRow({ id: 3, shortRef: 'crit-ref', actionRisk: 'critical' }),
     ];
     const handler = new ApprovalExpirySweepHandler();
-    const ctx = makeCtx({ findExpiredRows: rows, ceoEmail: 'ceo@example.com' });
+    const { ctx, sendNotificationMock } = makeCtx({ findExpiredRows: rows, ceoEmail: 'ceo@example.com' });
 
     const result = await handler.execute(ctx);
 
     // Exactly one batched notification covering the high + critical rows
-    expect((ctx.outboundGateway as any).sendNotification).toHaveBeenCalledTimes(1);
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
 
-    const payload = (ctx.outboundGateway as any).sendNotification.mock.calls[0][0];
+    const payload = sendNotificationMock.mock.calls[0][0];
     expect(payload.notificationType).toBe('approval_expired');
     expect(payload.ceoEmail).toBe('ceo@example.com');
 
@@ -156,19 +177,47 @@ describe('ApprovalExpirySweepHandler', () => {
     expect(result.data.notified).toBe(2);
   });
 
+  it('only notifies about rows that actually expired (concurrent resolution)', async () => {
+    // findExpired returns 2 candidates, but expireRows only commits 1 (the high one);
+    // the critical row was concurrently resolved before the UPDATE ran.
+    const highRow = makeRow({ id: 1, shortRef: 'high-ref', actionRisk: 'high' });
+    const critRow = makeRow({ id: 2, shortRef: 'crit-ref', actionRisk: 'critical' });
+    const handler = new ApprovalExpirySweepHandler();
+    const { ctx, sendNotificationMock, logWarnMock } = makeCtx({
+      findExpiredRows: [highRow, critRow],
+      expireRowsResult: [highRow], // only 1 row actually updated
+    });
+
+    const result = await handler.execute(ctx);
+
+    // Warn emitted for concurrent resolution
+    expect(logWarnMock).toHaveBeenCalled();
+
+    // Notification built from the 1 actually-expired row only
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+    const payload = sendNotificationMock.mock.calls[0][0];
+    expect(payload.subject).toContain('1 request(s)');
+    expect(payload.body).toContain('high-ref');
+    expect(payload.body).not.toContain('crit-ref');
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data.expired).toBe(1);
+  });
+
   it('skips notification when CEO_PRIMARY_EMAIL is not set', async () => {
     const rows = [makeRow({ id: 1, shortRef: 'high-ref', actionRisk: 'high' })];
     const handler = new ApprovalExpirySweepHandler();
     // Passing ceoEmail: '' causes the helper to set process.env['CEO_PRIMARY_EMAIL'] = ''
-    const ctx = makeCtx({ findExpiredRows: rows, ceoEmail: '' });
+    const { ctx, sendNotificationMock, logWarnMock } = makeCtx({ findExpiredRows: rows, ceoEmail: '' });
 
     const result = await handler.execute(ctx);
 
     // No notification sent because the email is blank
-    expect((ctx.outboundGateway as any).sendNotification).not.toHaveBeenCalled();
+    expect(sendNotificationMock).not.toHaveBeenCalled();
 
     // A warning should be emitted about the missing email
-    expect((ctx.log as any).warn).toHaveBeenCalled();
+    expect(logWarnMock).toHaveBeenCalled();
 
     // Expiry itself still succeeds
     expect(result.success).toBe(true);
@@ -176,10 +225,29 @@ describe('ApprovalExpirySweepHandler', () => {
     expect(result.data).toEqual({ expired: 1, notified: 0 });
   });
 
+  it('skips notification but still expires when outboundGateway is absent', async () => {
+    const rows = [makeRow({ id: 1, shortRef: 'high-ref', actionRisk: 'high' })];
+    const handler = new ApprovalExpirySweepHandler();
+    const { ctx, sendNotificationMock, logWarnMock } = makeCtx({ findExpiredRows: rows, withoutOutboundGateway: true });
+
+    const result = await handler.execute(ctx);
+
+    // Expiry committed regardless of gateway absence
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ expired: 1, notified: 0 });
+
+    // sendNotification never called (gateway unavailable)
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+
+    // Warning emitted for the skipped notification
+    expect(logWarnMock).toHaveBeenCalled();
+  });
+
   it('returns notified:0 when sendNotification returns false (non-fatal)', async () => {
     const rows = [makeRow({ id: 1, shortRef: 'crit-ref', actionRisk: 'critical' })];
     const handler = new ApprovalExpirySweepHandler();
-    const ctx = makeCtx({ findExpiredRows: rows, sendNotificationResult: false });
+    const { ctx } = makeCtx({ findExpiredRows: rows, sendNotificationResult: false });
 
     const result = await handler.execute(ctx);
 
@@ -191,10 +259,10 @@ describe('ApprovalExpirySweepHandler', () => {
 
   it('returns success:false on unexpected error', async () => {
     const handler = new ApprovalExpirySweepHandler();
-    const ctx = makeCtx();
+    const { ctx, findExpiredMock } = makeCtx();
 
     // Override findExpired to throw unexpectedly
-    (ctx.actionLogRepo as any).findExpired = vi.fn().mockRejectedValue(new Error('DB down'));
+    findExpiredMock.mockRejectedValue(new Error('DB down'));
 
     const result = await handler.execute(ctx);
 

--- a/skills/approval-expiry-sweep/handler.ts
+++ b/skills/approval-expiry-sweep/handler.ts
@@ -53,8 +53,16 @@ export class ApprovalExpirySweepHandler implements SkillHandler {
       const notifiable = expired.filter((r) => NOTIFIABLE_TIERS.has(r.actionRisk));
 
       // --- Step 4: Send batched notification if warranted ---
+      // Track whether the notification was actually delivered so we can return
+      // an accurate `notified` count. Defaults to 0 — only set when sendNotification()
+      // returns true.
+      let notifiedCount = 0;
+
       if (notifiable.length > 0 && ctx.outboundGateway !== undefined) {
-        const ceoEmail = ctx.secret('CEO_PRIMARY_EMAIL');
+        // Read directly from process.env rather than ctx.secret() — ctx.secret()
+        // throws on a missing variable, which would surface as skill failure even
+        // though expiry already committed. A missing email should be a silent skip.
+        const ceoEmail = process.env['CEO_PRIMARY_EMAIL'] ?? '';
 
         if (!ceoEmail) {
           // Not configured — expiry is already done, just skip the notification.
@@ -66,8 +74,9 @@ export class ApprovalExpirySweepHandler implements SkillHandler {
           const subject = `Approval expired — ${notifiable.length} request(s) expired without response`;
 
           // Bullet list: one line per expired request so the CEO can quickly scan.
+          // shortRef and description are nullable — fall back to readable placeholders.
           const body = notifiable
-            .map((r) => `• ${r.shortRef}: ${r.description} [${r.skillName}]`)
+            .map((r) => `• ${r.shortRef ?? '(no ref)'}: ${r.description ?? '(no description)'} [${r.skillName}]`)
             .join('\n');
 
           const sent = await ctx.outboundGateway.sendNotification({
@@ -77,7 +86,9 @@ export class ApprovalExpirySweepHandler implements SkillHandler {
             body,
           });
 
-          if (!sent) {
+          if (sent) {
+            notifiedCount = notifiable.length;
+          } else {
             // Non-fatal — the expiry rows are already transitioned. A failure here means
             // the CEO won't receive the alert for this sweep cycle, but the audit log
             // (via individual row logs above) still has the full record.
@@ -89,7 +100,7 @@ export class ApprovalExpirySweepHandler implements SkillHandler {
         }
       }
 
-      return { success: true, data: { expired: expired.length, notified: notifiable.length } };
+      return { success: true, data: { expired: expired.length, notified: notifiedCount } };
     } catch (e) {
       return { success: false, error: String(e) };
     }

--- a/skills/approval-expiry-sweep/handler.ts
+++ b/skills/approval-expiry-sweep/handler.ts
@@ -36,22 +36,23 @@ export class ApprovalExpirySweepHandler implements SkillHandler {
         return { success: true, data: { expired: 0, notified: 0 } };
       }
 
-      // --- Step 2: Batch-transition all stale rows to 'expired' ---
-      // expireRows() uses WHERE outcome = 'pending_approval' for idempotency —
-      // any row concurrently resolved will simply be skipped (rowCount < ids.length).
-      const actualExpired = await ctx.actionLogRepo.expireRows(expired.map((r) => r.id));
+      // --- Step 2: Batch-transition stale rows, capturing which were actually updated ---
+      // expireRows() uses RETURNING * and WHERE outcome = 'pending_approval' —
+      // rows concurrently resolved between findExpired() and here are absent from the result.
+      // We log and notify only from actuallyExpiredRows, not the candidate set.
+      const actuallyExpiredRows: ActionLogRow[] = await ctx.actionLogRepo.expireRows(expired.map((r) => r.id));
 
-      // Warn when fewer rows were updated than found — indicates concurrent resolution
-      // between the findExpired() read and the expireRows() write.
-      if (actualExpired < expired.length) {
+      // Warn when the result is smaller than the candidate set — indicates concurrent
+      // resolution between the findExpired() read and the expireRows() write.
+      if (actuallyExpiredRows.length < expired.length) {
         ctx.log.warn(
-          { found: expired.length, actuallyExpired: actualExpired },
+          { found: expired.length, actuallyExpired: actuallyExpiredRows.length },
           'approval-expiry-sweep: fewer rows expired than found — some may have been concurrently resolved',
         );
       }
 
-      // Log each expired row individually for auditability and debugging.
-      for (const r of expired) {
+      // Log each actually-expired row for auditability — not the candidate set.
+      for (const r of actuallyExpiredRows) {
         ctx.log.info(
           { id: r.id, shortRef: r.shortRef, skillName: r.skillName, actionRisk: r.actionRisk },
           'approval-expiry-sweep: row expired',
@@ -59,7 +60,8 @@ export class ApprovalExpirySweepHandler implements SkillHandler {
       }
 
       // --- Step 3: Filter to notifiable (high/critical) tiers ---
-      const notifiable = expired.filter((r) => NOTIFIABLE_TIERS.has(r.actionRisk));
+      // Built from actuallyExpiredRows — rows not actually expired are excluded.
+      const notifiable = actuallyExpiredRows.filter((r) => NOTIFIABLE_TIERS.has(r.actionRisk));
 
       // --- Step 4: Send batched notification if warranted ---
       // Track whether the notification was actually delivered so we can return
@@ -116,7 +118,7 @@ export class ApprovalExpirySweepHandler implements SkillHandler {
         }
       }
 
-      return { success: true, data: { expired: actualExpired, notified: notifiedCount } };
+      return { success: true, data: { expired: actuallyExpiredRows.length, notified: notifiedCount } };
     } catch (e) {
       ctx.log.error({ err: e }, 'approval-expiry-sweep: unexpected error');
       return { success: false, error: e instanceof Error ? e.message : String(e) };

--- a/skills/approval-expiry-sweep/handler.ts
+++ b/skills/approval-expiry-sweep/handler.ts
@@ -1,0 +1,97 @@
+// handler.ts — approval-expiry-sweep skill implementation.
+//
+// Background sweep skill: finds all pending_approval rows whose expires_at has
+// passed, batch-transitions them to 'expired', and sends a single batched email
+// notification to the CEO for any high/critical-risk expirations.
+//
+// This skill is designed to be called by the system scheduler on a regular
+// interval (e.g. every 15 minutes). It is idempotent — calling it multiple
+// times with no new expired rows returns early with { expired: 0, notified: 0 }.
+//
+// Non-fatal failure modes:
+//   - CEO_PRIMARY_EMAIL not configured → expiry still happens, notification skipped
+//   - outboundGateway absent → expiry still happens, notification skipped
+//   - sendNotification() returns false → logged at warn, not propagated (expiry is done)
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { ActionLogRow } from '../../src/autonomy/action-log-types.js';
+
+// Tiers that warrant a CEO notification on expiry.
+// 'none' and 'low' expirations are recorded in the log but not surfaced as alerts —
+// they represent low-stakes actions the CEO didn't need to weigh in on urgently.
+const NOTIFIABLE_TIERS = new Set(['high', 'critical']);
+
+export class ApprovalExpirySweepHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    try {
+      if (!ctx.actionLogRepo) {
+        return { success: false, error: 'approval-expiry-sweep requires actionLogRepo capability' };
+      }
+
+      // --- Step 1: Find all stale pending_approval rows ---
+      const expired: ActionLogRow[] = await ctx.actionLogRepo.findExpired();
+
+      // Early return when nothing to do — avoids unnecessary DB writes and noise.
+      if (expired.length === 0) {
+        return { success: true, data: { expired: 0, notified: 0 } };
+      }
+
+      // --- Step 2: Batch-transition all stale rows to 'expired' ---
+      // expireRows() uses WHERE outcome = 'pending_approval' for idempotency —
+      // any row concurrently resolved will simply be skipped (rowCount < ids.length).
+      await ctx.actionLogRepo.expireRows(expired.map((r) => r.id));
+
+      // Log each expired row individually for auditability and debugging.
+      for (const r of expired) {
+        ctx.log.info(
+          { id: r.id, shortRef: r.shortRef, skillName: r.skillName, actionRisk: r.actionRisk },
+          'approval-expiry-sweep: row expired',
+        );
+      }
+
+      // --- Step 3: Filter to notifiable (high/critical) tiers ---
+      const notifiable = expired.filter((r) => NOTIFIABLE_TIERS.has(r.actionRisk));
+
+      // --- Step 4: Send batched notification if warranted ---
+      if (notifiable.length > 0 && ctx.outboundGateway !== undefined) {
+        const ceoEmail = ctx.secret('CEO_PRIMARY_EMAIL');
+
+        if (!ceoEmail) {
+          // Not configured — expiry is already done, just skip the notification.
+          ctx.log.warn(
+            { notifiableCount: notifiable.length },
+            'approval-expiry-sweep: CEO_PRIMARY_EMAIL not configured — skipping expiry notification',
+          );
+        } else {
+          const subject = `Approval expired — ${notifiable.length} request(s) expired without response`;
+
+          // Bullet list: one line per expired request so the CEO can quickly scan.
+          const body = notifiable
+            .map((r) => `• ${r.shortRef}: ${r.description} [${r.skillName}]`)
+            .join('\n');
+
+          const sent = await ctx.outboundGateway.sendNotification({
+            notificationType: 'approval_expired',
+            ceoEmail,
+            subject,
+            body,
+          });
+
+          if (!sent) {
+            // Non-fatal — the expiry rows are already transitioned. A failure here means
+            // the CEO won't receive the alert for this sweep cycle, but the audit log
+            // (via individual row logs above) still has the full record.
+            ctx.log.warn(
+              { notifiableCount: notifiable.length },
+              'approval-expiry-sweep: sendNotification returned false — CEO notification not delivered (expiry committed)',
+            );
+          }
+        }
+      }
+
+      return { success: true, data: { expired: expired.length, notified: notifiable.length } };
+    } catch (e) {
+      return { success: false, error: String(e) };
+    }
+  }
+}

--- a/skills/approval-expiry-sweep/handler.ts
+++ b/skills/approval-expiry-sweep/handler.ts
@@ -39,7 +39,16 @@ export class ApprovalExpirySweepHandler implements SkillHandler {
       // --- Step 2: Batch-transition all stale rows to 'expired' ---
       // expireRows() uses WHERE outcome = 'pending_approval' for idempotency —
       // any row concurrently resolved will simply be skipped (rowCount < ids.length).
-      await ctx.actionLogRepo.expireRows(expired.map((r) => r.id));
+      const actualExpired = await ctx.actionLogRepo.expireRows(expired.map((r) => r.id));
+
+      // Warn when fewer rows were updated than found — indicates concurrent resolution
+      // between the findExpired() read and the expireRows() write.
+      if (actualExpired < expired.length) {
+        ctx.log.warn(
+          { found: expired.length, actuallyExpired: actualExpired },
+          'approval-expiry-sweep: fewer rows expired than found — some may have been concurrently resolved',
+        );
+      }
 
       // Log each expired row individually for auditability and debugging.
       for (const r of expired) {
@@ -58,51 +67,59 @@ export class ApprovalExpirySweepHandler implements SkillHandler {
       // returns true.
       let notifiedCount = 0;
 
-      if (notifiable.length > 0 && ctx.outboundGateway !== undefined) {
-        // Read directly from process.env rather than ctx.secret() — ctx.secret()
-        // throws on a missing variable, which would surface as skill failure even
-        // though expiry already committed. A missing email should be a silent skip.
-        const ceoEmail = process.env['CEO_PRIMARY_EMAIL'] ?? '';
-
-        if (!ceoEmail) {
-          // Not configured — expiry is already done, just skip the notification.
+      if (notifiable.length > 0) {
+        if (ctx.outboundGateway === undefined) {
           ctx.log.warn(
             { notifiableCount: notifiable.length },
-            'approval-expiry-sweep: CEO_PRIMARY_EMAIL not configured — skipping expiry notification',
+            'approval-expiry-sweep: outboundGateway not available — skipping expiry notification for high/critical rows',
           );
         } else {
-          const subject = `Approval expired — ${notifiable.length} request(s) expired without response`;
+          // Read directly from process.env rather than ctx.secret() — ctx.secret()
+          // throws on a missing variable, which would surface as skill failure even
+          // though expiry already committed. A missing email should be a silent skip.
+          const ceoEmail = process.env['CEO_PRIMARY_EMAIL'] ?? '';
 
-          // Bullet list: one line per expired request so the CEO can quickly scan.
-          // shortRef and description are nullable — fall back to readable placeholders.
-          const body = notifiable
-            .map((r) => `• ${r.shortRef ?? '(no ref)'}: ${r.description ?? '(no description)'} [${r.skillName}]`)
-            .join('\n');
-
-          const sent = await ctx.outboundGateway.sendNotification({
-            notificationType: 'approval_expired',
-            ceoEmail,
-            subject,
-            body,
-          });
-
-          if (sent) {
-            notifiedCount = notifiable.length;
-          } else {
-            // Non-fatal — the expiry rows are already transitioned. A failure here means
-            // the CEO won't receive the alert for this sweep cycle, but the audit log
-            // (via individual row logs above) still has the full record.
+          if (!ceoEmail) {
+            // Not configured — expiry is already done, just skip the notification.
             ctx.log.warn(
               { notifiableCount: notifiable.length },
-              'approval-expiry-sweep: sendNotification returned false — CEO notification not delivered (expiry committed)',
+              'approval-expiry-sweep: CEO_PRIMARY_EMAIL not configured — skipping expiry notification',
             );
+          } else {
+            const subject = `Approval expired — ${notifiable.length} request(s) expired without response`;
+
+            // Bullet list: one line per expired request so the CEO can quickly scan.
+            // shortRef and description are nullable — fall back to readable placeholders.
+            const body = notifiable
+              .map((r) => `• ${r.shortRef ?? '(no ref)'}: ${r.description ?? '(no description)'} [${r.skillName}]`)
+              .join('\n');
+
+            const sent = await ctx.outboundGateway.sendNotification({
+              notificationType: 'approval_expired',
+              ceoEmail,
+              subject,
+              body,
+            });
+
+            if (sent) {
+              notifiedCount = notifiable.length;
+            } else {
+              // Non-fatal — the expiry rows are already transitioned. A failure here means
+              // the CEO won't receive the alert for this sweep cycle, but the audit log
+              // (via individual row logs above) still has the full record.
+              ctx.log.warn(
+                { notifiableCount: notifiable.length },
+                'approval-expiry-sweep: sendNotification returned false — CEO notification not delivered (expiry committed)',
+              );
+            }
           }
         }
       }
 
-      return { success: true, data: { expired: expired.length, notified: notifiedCount } };
+      return { success: true, data: { expired: actualExpired, notified: notifiedCount } };
     } catch (e) {
-      return { success: false, error: String(e) };
+      ctx.log.error({ err: e }, 'approval-expiry-sweep: unexpected error');
+      return { success: false, error: e instanceof Error ? e.message : String(e) };
     }
   }
 }

--- a/skills/approval-expiry-sweep/skill.json
+++ b/skills/approval-expiry-sweep/skill.json
@@ -1,0 +1,16 @@
+{
+  "name": "approval-expiry-sweep",
+  "description": "Expire stale pending approval requests and notify the CEO of high/critical expirations.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {},
+  "outputs": {
+    "expired": "number — count of rows transitioned to expired",
+    "notified": "number — count of high/critical expirations included in notification"
+  },
+  "permissions": [],
+  "secrets": ["CEO_PRIMARY_EMAIL"],
+  "timeout": 30000,
+  "capabilities": ["actionLogRepo", "outboundGateway"]
+}

--- a/skills/pending-actions-digest/handler.test.ts
+++ b/skills/pending-actions-digest/handler.test.ts
@@ -1,0 +1,223 @@
+// handler.test.ts — unit tests for pending-actions-digest skill handler.
+//
+// Tests cover: no-op on empty pending rows, single digest notification,
+// time-remaining formatting, missing CEO email, missing outbound gateway,
+// non-fatal sendNotification failure, and unexpected DB errors.
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { PendingActionsDigestHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { ActionLogRow } from '../../src/autonomy/action-log-types.js';
+
+// --- Fixed time anchor ---
+// Pinning Date.now() makes all expiresAt calculations deterministic.
+const FIXED_NOW = 1_000_000_000_000;
+
+// --- Fixtures ---
+
+function makeRow(overrides: Partial<ActionLogRow> = {}): ActionLogRow {
+  return {
+    id: 1,
+    taskId: 'task-1',
+    conversationId: null,
+    skillName: 'create-calendar-event',
+    actionRisk: 'medium',
+    outcome: 'pending_approval',
+    taskSummary: null,
+    competenceFlag: null,
+    commitmentFlag: null,
+    compatibility: null,
+    scoredBy: null,
+    payload: {},
+    notificationSentAt: null,
+    resolvedAt: null,
+    resolvedBy: null,
+    // Default: 2 hours in the future from FIXED_NOW
+    expiresAt: new Date(FIXED_NOW + 7_200_000),
+    parentActionId: null,
+    shortRef: 'cal-1',
+    description: 'Create event: Lunch',
+    createdAt: new Date(FIXED_NOW - 3_600_000),
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides: {
+  pendingRows?: ActionLogRow[];
+  sendResult?: boolean;
+  ceoEmail?: string;
+  noOutboundGateway?: boolean;
+} = {}): SkillContext {
+  const {
+    pendingRows = [],
+    sendResult = true,
+    ceoEmail = 'ceo@example.com',
+    noOutboundGateway = false,
+  } = overrides;
+
+  // The handler reads CEO_PRIMARY_EMAIL from process.env directly (not ctx.secret()),
+  // so set it here. Tests that need it absent should pass ceoEmail: ''.
+  process.env['CEO_PRIMARY_EMAIL'] = ceoEmail;
+
+  const ctx: Partial<SkillContext> = {
+    input: {},
+    secret: vi.fn(),
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    actionLogRepo: {
+      findAllPending: vi.fn().mockResolvedValue(pendingRows),
+    } as any,
+    outboundGateway: noOutboundGateway
+      ? undefined
+      : ({
+          sendNotification: vi.fn().mockResolvedValue(sendResult),
+        } as any),
+  };
+
+  return ctx as SkillContext;
+}
+
+// --- Lifecycle hooks ---
+
+let dateSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  dateSpy = vi.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
+});
+
+afterEach(() => {
+  dateSpy.mockRestore();
+  delete process.env['CEO_PRIMARY_EMAIL'];
+});
+
+// --- Tests ---
+
+describe('PendingActionsDigestHandler', () => {
+  it('returns {pending:0, skipped:true} and sends no notification when no pending rows', async () => {
+    const handler = new PendingActionsDigestHandler();
+    const ctx = makeCtx({ pendingRows: [] });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ pending: 0, skipped: true });
+    expect((ctx.outboundGateway as any).sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('sends a single digest notification listing all pending rows', async () => {
+    const rows = [
+      makeRow({ id: 1, shortRef: 'cal-1', description: 'Create event: Lunch', skillName: 'create-calendar-event' }),
+      makeRow({ id: 2, shortRef: 'email-2', description: 'Send weekly update', skillName: 'send-email' }),
+    ];
+    const handler = new PendingActionsDigestHandler();
+    const ctx = makeCtx({ pendingRows: rows, ceoEmail: 'ceo@example.com' });
+
+    const result = await handler.execute(ctx);
+
+    expect((ctx.outboundGateway as any).sendNotification).toHaveBeenCalledTimes(1);
+
+    const payload = (ctx.outboundGateway as any).sendNotification.mock.calls[0][0];
+    expect(payload.notificationType).toBe('pending_actions_digest');
+    expect(payload.ceoEmail).toBe('ceo@example.com');
+    expect(payload.subject).toBe('Pending approvals — 2 request(s) awaiting your decision');
+
+    // Both shortRefs must appear in the digest body
+    expect(payload.body).toContain('cal-1');
+    expect(payload.body).toContain('email-2');
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ pending: 2, skipped: false });
+  });
+
+  it('each entry includes shortRef, description, skillName, and time remaining', async () => {
+    const row = makeRow({
+      shortRef: 'ref-abc',
+      description: 'Book flight to NYC',
+      skillName: 'book-travel',
+      expiresAt: new Date(FIXED_NOW + 7_200_000), // exactly 2h remaining
+    });
+    const handler = new PendingActionsDigestHandler();
+    const ctx = makeCtx({ pendingRows: [row] });
+
+    await handler.execute(ctx);
+
+    const payload = (ctx.outboundGateway as any).sendNotification.mock.calls[0][0];
+    expect(payload.body).toContain('ref-abc');
+    expect(payload.body).toContain('Book flight to NYC');
+    expect(payload.body).toContain('book-travel');
+    expect(payload.body).toContain('2h remaining');
+  });
+
+  it('formatTimeRemaining: shows <1h remaining when under 1 hour', async () => {
+    const row = makeRow({
+      expiresAt: new Date(FIXED_NOW + 1_800_000), // 30 min in the future
+    });
+    const handler = new PendingActionsDigestHandler();
+    const ctx = makeCtx({ pendingRows: [row] });
+
+    await handler.execute(ctx);
+
+    const payload = (ctx.outboundGateway as any).sendNotification.mock.calls[0][0];
+    expect(payload.body).toContain('<1h remaining');
+  });
+
+  it('skips notification when CEO_PRIMARY_EMAIL is not set', async () => {
+    const row = makeRow({ id: 1, shortRef: 'cal-1' });
+    const handler = new PendingActionsDigestHandler();
+    // Setting ceoEmail: '' causes makeCtx to set process.env['CEO_PRIMARY_EMAIL'] = ''
+    const ctx = makeCtx({ pendingRows: [row], ceoEmail: '' });
+
+    const result = await handler.execute(ctx);
+
+    expect((ctx.outboundGateway as any).sendNotification).not.toHaveBeenCalled();
+    expect((ctx.log as any).warn).toHaveBeenCalled();
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ pending: 1, skipped: true });
+  });
+
+  it('skips notification when outboundGateway is not available', async () => {
+    const row = makeRow({ id: 1, shortRef: 'cal-1' });
+    const handler = new PendingActionsDigestHandler();
+    const ctx = makeCtx({ pendingRows: [row], noOutboundGateway: true });
+
+    const result = await handler.execute(ctx);
+
+    // ctx.outboundGateway is undefined — verify no crash and warn emitted
+    expect((ctx.log as any).warn).toHaveBeenCalled();
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ pending: 1, skipped: true });
+  });
+
+  it('handles sendNotification returning false gracefully', async () => {
+    const row = makeRow({ id: 1, shortRef: 'cal-1' });
+    const handler = new PendingActionsDigestHandler();
+    // sendResult: false means the gateway accepted the call but returned false
+    const ctx = makeCtx({ pendingRows: [row], sendResult: false });
+
+    const result = await handler.execute(ctx);
+
+    // Non-fatal — skill should still succeed and report skipped:false (the send was attempted)
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error('unreachable');
+    expect(result.data).toEqual({ pending: 1, skipped: false });
+  });
+
+  it('returns success:false on unexpected error', async () => {
+    const handler = new PendingActionsDigestHandler();
+    const ctx = makeCtx();
+
+    // Override findAllPending to simulate an unexpected DB error
+    (ctx.actionLogRepo as any).findAllPending = vi.fn().mockRejectedValue(new Error('DB error'));
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('unreachable');
+    expect(result.error).toContain('DB error');
+  });
+});

--- a/skills/pending-actions-digest/handler.test.ts
+++ b/skills/pending-actions-digest/handler.test.ts
@@ -7,6 +7,8 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { PendingActionsDigestHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import type { OutboundGateway } from '../../src/skills/outbound-gateway.js';
 import type { ActionLogRow } from '../../src/autonomy/action-log-types.js';
 
 // --- Fixed time anchor ---
@@ -47,7 +49,7 @@ function makeCtx(overrides: {
   sendResult?: boolean;
   ceoEmail?: string;
   noOutboundGateway?: boolean;
-} = {}): SkillContext {
+} = {}) {
   const {
     pendingRows = [],
     sendResult = true,
@@ -59,21 +61,30 @@ function makeCtx(overrides: {
   // so set it here. Tests that need it absent should pass ceoEmail: ''.
   process.env['CEO_PRIMARY_EMAIL'] = ceoEmail;
 
-  const ctx: Partial<SkillContext> = {
+  // Keep explicit references so tests can assert on mock calls without casts.
+  const findAllPendingMock = vi.fn().mockResolvedValue(pendingRows);
+  const sendNotificationMock = vi.fn().mockResolvedValue(sendResult);
+  const logWarnMock = vi.fn();
+  const logErrorMock = vi.fn();
+
+  const ctx: SkillContext = {
     input: {},
-    secret: vi.fn(),
-    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    // ctx.secret() throws in production when the var is unset — mirror that here.
+    // The handler reads CEO_PRIMARY_EMAIL via process.env directly, so this stub
+    // is present for shape correctness only.
+    secret: vi.fn().mockImplementation((name: string) => {
+      throw new Error(`secret ${name} not configured`);
+    }),
+    log: { info: vi.fn(), warn: logWarnMock, error: logErrorMock, debug: vi.fn() } as unknown as SkillContext['log'],
     actionLogRepo: {
-      findAllPending: vi.fn().mockResolvedValue(pendingRows),
-    } as any,
+      findAllPending: findAllPendingMock,
+    } as unknown as ActionLogRepo,
     outboundGateway: noOutboundGateway
       ? undefined
-      : ({
-          sendNotification: vi.fn().mockResolvedValue(sendResult),
-        } as any),
-  };
+      : ({ sendNotification: sendNotificationMock } as unknown as OutboundGateway),
+  } as SkillContext;
 
-  return ctx as SkillContext;
+  return { ctx, findAllPendingMock, sendNotificationMock, logWarnMock, logErrorMock };
 }
 
 // --- Lifecycle hooks ---
@@ -94,14 +105,14 @@ afterEach(() => {
 describe('PendingActionsDigestHandler', () => {
   it('returns {pending:0, skipped:true} and sends no notification when no pending rows', async () => {
     const handler = new PendingActionsDigestHandler();
-    const ctx = makeCtx({ pendingRows: [] });
+    const { ctx, sendNotificationMock } = makeCtx({ pendingRows: [] });
 
     const result = await handler.execute(ctx);
 
     expect(result.success).toBe(true);
     if (!result.success) throw new Error('unreachable');
     expect(result.data).toEqual({ pending: 0, skipped: true });
-    expect((ctx.outboundGateway as any).sendNotification).not.toHaveBeenCalled();
+    expect(sendNotificationMock).not.toHaveBeenCalled();
   });
 
   it('sends a single digest notification listing all pending rows', async () => {
@@ -110,13 +121,13 @@ describe('PendingActionsDigestHandler', () => {
       makeRow({ id: 2, shortRef: 'email-2', description: 'Send weekly update', skillName: 'send-email' }),
     ];
     const handler = new PendingActionsDigestHandler();
-    const ctx = makeCtx({ pendingRows: rows, ceoEmail: 'ceo@example.com' });
+    const { ctx, sendNotificationMock } = makeCtx({ pendingRows: rows, ceoEmail: 'ceo@example.com' });
 
     const result = await handler.execute(ctx);
 
-    expect((ctx.outboundGateway as any).sendNotification).toHaveBeenCalledTimes(1);
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
 
-    const payload = (ctx.outboundGateway as any).sendNotification.mock.calls[0][0];
+    const payload = sendNotificationMock.mock.calls[0][0];
     expect(payload.notificationType).toBe('pending_actions_digest');
     expect(payload.ceoEmail).toBe('ceo@example.com');
     expect(payload.subject).toBe('Pending approvals — 2 request(s) awaiting your decision');
@@ -138,11 +149,11 @@ describe('PendingActionsDigestHandler', () => {
       expiresAt: new Date(FIXED_NOW + 7_200_000), // exactly 2h remaining
     });
     const handler = new PendingActionsDigestHandler();
-    const ctx = makeCtx({ pendingRows: [row] });
+    const { ctx, sendNotificationMock } = makeCtx({ pendingRows: [row] });
 
     await handler.execute(ctx);
 
-    const payload = (ctx.outboundGateway as any).sendNotification.mock.calls[0][0];
+    const payload = sendNotificationMock.mock.calls[0][0];
     expect(payload.body).toContain('ref-abc');
     expect(payload.body).toContain('Book flight to NYC');
     expect(payload.body).toContain('book-travel');
@@ -154,11 +165,11 @@ describe('PendingActionsDigestHandler', () => {
       expiresAt: new Date(FIXED_NOW + 1_800_000), // 30 min in the future
     });
     const handler = new PendingActionsDigestHandler();
-    const ctx = makeCtx({ pendingRows: [row] });
+    const { ctx, sendNotificationMock } = makeCtx({ pendingRows: [row] });
 
     await handler.execute(ctx);
 
-    const payload = (ctx.outboundGateway as any).sendNotification.mock.calls[0][0];
+    const payload = sendNotificationMock.mock.calls[0][0];
     expect(payload.body).toContain('<1h remaining');
   });
 
@@ -166,12 +177,12 @@ describe('PendingActionsDigestHandler', () => {
     const row = makeRow({ id: 1, shortRef: 'cal-1' });
     const handler = new PendingActionsDigestHandler();
     // Setting ceoEmail: '' causes makeCtx to set process.env['CEO_PRIMARY_EMAIL'] = ''
-    const ctx = makeCtx({ pendingRows: [row], ceoEmail: '' });
+    const { ctx, sendNotificationMock, logWarnMock } = makeCtx({ pendingRows: [row], ceoEmail: '' });
 
     const result = await handler.execute(ctx);
 
-    expect((ctx.outboundGateway as any).sendNotification).not.toHaveBeenCalled();
-    expect((ctx.log as any).warn).toHaveBeenCalled();
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+    expect(logWarnMock).toHaveBeenCalled();
 
     expect(result.success).toBe(true);
     if (!result.success) throw new Error('unreachable');
@@ -181,12 +192,12 @@ describe('PendingActionsDigestHandler', () => {
   it('skips notification when outboundGateway is not available', async () => {
     const row = makeRow({ id: 1, shortRef: 'cal-1' });
     const handler = new PendingActionsDigestHandler();
-    const ctx = makeCtx({ pendingRows: [row], noOutboundGateway: true });
+    const { ctx, logWarnMock } = makeCtx({ pendingRows: [row], noOutboundGateway: true });
 
     const result = await handler.execute(ctx);
 
     // ctx.outboundGateway is undefined — verify no crash and warn emitted
-    expect((ctx.log as any).warn).toHaveBeenCalled();
+    expect(logWarnMock).toHaveBeenCalled();
 
     expect(result.success).toBe(true);
     if (!result.success) throw new Error('unreachable');
@@ -197,7 +208,7 @@ describe('PendingActionsDigestHandler', () => {
     const row = makeRow({ id: 1, shortRef: 'cal-1' });
     const handler = new PendingActionsDigestHandler();
     // sendResult: false means the gateway accepted the call but returned false
-    const ctx = makeCtx({ pendingRows: [row], sendResult: false });
+    const { ctx } = makeCtx({ pendingRows: [row], sendResult: false });
 
     const result = await handler.execute(ctx);
 
@@ -209,10 +220,10 @@ describe('PendingActionsDigestHandler', () => {
 
   it('returns success:false on unexpected error', async () => {
     const handler = new PendingActionsDigestHandler();
-    const ctx = makeCtx();
+    const { ctx, findAllPendingMock } = makeCtx();
 
     // Override findAllPending to simulate an unexpected DB error
-    (ctx.actionLogRepo as any).findAllPending = vi.fn().mockRejectedValue(new Error('DB error'));
+    findAllPendingMock.mockRejectedValue(new Error('DB error'));
 
     const result = await handler.execute(ctx);
 

--- a/skills/pending-actions-digest/handler.ts
+++ b/skills/pending-actions-digest/handler.ts
@@ -1,0 +1,100 @@
+// handler.ts — pending-actions-digest skill implementation.
+//
+// Digest skill: fetches all non-expired pending_approval rows and sends a
+// single summary email to the CEO so they can see all outstanding requests
+// in one place. Designed to be run on a daily schedule.
+//
+// Non-fatal failure modes:
+//   - CEO_PRIMARY_EMAIL not configured → returns skipped: true
+//   - outboundGateway absent → returns skipped: true
+//   - sendNotification() returns false → logged at warn, not propagated
+//   - No pending rows → returns skipped: true, no email sent
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { ActionLogRow } from '../../src/autonomy/action-log-types.js';
+
+/**
+ * Format time remaining until expiry into a human-readable string.
+ * Used to show the CEO how much time is left to act on each request.
+ *
+ * Thresholds:
+ *   ms <= 0 or ms < 1h → '<1h remaining' (treat as critical, same label)
+ *   else               → '<N>h remaining'
+ */
+function formatTimeRemaining(ms: number): string {
+  if (ms <= 0) return '<1h remaining';
+  if (ms < 3_600_000) return '<1h remaining';
+  return `${Math.floor(ms / 3_600_000)}h remaining`;
+}
+
+export class PendingActionsDigestHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    try {
+      // --- Step 1: Load all non-expired pending_approval rows ---
+      const pending: ActionLogRow[] = await ctx.actionLogRepo!.findAllPending();
+
+      // Early return when nothing to digest — avoid sending an empty email.
+      if (pending.length === 0) {
+        return { success: true, data: { pending: 0, skipped: true } };
+      }
+
+      // --- Step 2: Read CEO email from env (not ctx.secret()) ---
+      // ctx.secret() throws on a missing variable, which would surface as skill
+      // failure rather than a clean skip. Reading from env gives us a graceful
+      // fallback path when the variable is not configured.
+      const ceoEmail = process.env['CEO_PRIMARY_EMAIL'] ?? '';
+
+      if (!ceoEmail) {
+        ctx.log.warn(
+          { pendingCount: pending.length },
+          'pending-actions-digest: CEO_PRIMARY_EMAIL not configured, skipping digest',
+        );
+        return { success: true, data: { pending: pending.length, skipped: true } };
+      }
+
+      // --- Step 3: Check outbound gateway is available ---
+      if (ctx.outboundGateway === undefined) {
+        ctx.log.warn(
+          { pendingCount: pending.length },
+          'pending-actions-digest: outboundGateway not available, skipping digest',
+        );
+        return { success: true, data: { pending: pending.length, skipped: true } };
+      }
+
+      // --- Step 4: Build bullet-list body ---
+      // Each line shows the short reference, description, originating skill, and
+      // time remaining so the CEO can quickly assess urgency without opening each request.
+      const body = pending
+        .map((r) => {
+          // expiresAt is guaranteed non-null by findAllPending() (WHERE expires_at > now()),
+          // but the type is Date | null — null-coalesce to avoid calling .getTime() on null.
+          const msRemaining = r.expiresAt != null ? r.expiresAt.getTime() - Date.now() : 0;
+          const timeRemaining = formatTimeRemaining(msRemaining);
+          return `• ${r.shortRef ?? '(no ref)'}: ${r.description ?? '(no description)'} [${r.skillName}] — ${timeRemaining}`;
+        })
+        .join('\n');
+
+      const subject = `Pending approvals — ${pending.length} request(s) awaiting your decision`;
+
+      // --- Step 5: Send digest notification ---
+      const sent = await ctx.outboundGateway.sendNotification({
+        notificationType: 'pending_actions_digest',
+        ceoEmail,
+        subject,
+        body,
+      });
+
+      if (!sent) {
+        // Non-fatal — the pending rows are unchanged, digest can retry next cycle.
+        ctx.log.warn(
+          { pendingCount: pending.length },
+          'pending-actions-digest: sendNotification returned false — CEO digest not delivered',
+        );
+      }
+
+      return { success: true, data: { pending: pending.length, skipped: false } };
+    } catch (e) {
+      return { success: false, error: String(e) };
+    }
+  }
+}

--- a/skills/pending-actions-digest/handler.ts
+++ b/skills/pending-actions-digest/handler.ts
@@ -30,8 +30,12 @@ function formatTimeRemaining(ms: number): string {
 export class PendingActionsDigestHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     try {
+      if (!ctx.actionLogRepo) {
+        return { success: false, error: 'pending-actions-digest requires actionLogRepo capability' };
+      }
+
       // --- Step 1: Load all non-expired pending_approval rows ---
-      const pending: ActionLogRow[] = await ctx.actionLogRepo!.findAllPending();
+      const pending: ActionLogRow[] = await ctx.actionLogRepo.findAllPending();
 
       // Early return when nothing to digest — avoid sending an empty email.
       if (pending.length === 0) {
@@ -94,7 +98,8 @@ export class PendingActionsDigestHandler implements SkillHandler {
 
       return { success: true, data: { pending: pending.length, skipped: false } };
     } catch (e) {
-      return { success: false, error: String(e) };
+      ctx.log.error({ err: e }, 'pending-actions-digest: unexpected error');
+      return { success: false, error: e instanceof Error ? e.message : String(e) };
     }
   }
 }

--- a/skills/pending-actions-digest/skill.json
+++ b/skills/pending-actions-digest/skill.json
@@ -1,0 +1,16 @@
+{
+  "name": "pending-actions-digest",
+  "description": "Send a daily digest of open approval requests awaiting CEO decision.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {},
+  "outputs": {
+    "pending": "number — count of open requests included in digest",
+    "skipped": "boolean — true if no open requests and digest was not sent"
+  },
+  "permissions": [],
+  "secrets": ["CEO_PRIMARY_EMAIL"],
+  "timeout": 30000,
+  "capabilities": ["actionLogRepo", "outboundGateway"]
+}

--- a/skills/pending-actions-digest/skill.json
+++ b/skills/pending-actions-digest/skill.json
@@ -7,7 +7,7 @@
   "inputs": {},
   "outputs": {
     "pending": "number — count of open requests included in digest",
-    "skipped": "boolean — true if no open requests and digest was not sent"
+    "skipped": "boolean — true if digest was not sent (no open requests, or CEO_PRIMARY_EMAIL / outboundGateway not configured)"
   },
   "permissions": [],
   "secrets": ["CEO_PRIMARY_EMAIL"],

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -368,4 +368,34 @@ describe('ActionLogRepo', () => {
       }
     });
   });
+
+  describe('findExpired', () => {
+    it('returns expired pending_approval rows ordered by created_at asc', async () => {
+      const now = new Date();
+      const { pool } = makePool([
+        {
+          id: 5, task_id: 't1', conversation_id: null, skill_name: 'email-send',
+          action_risk: 'medium', outcome: 'pending_approval', task_summary: null,
+          competence_flag: null, commitment_flag: null, compatibility: null,
+          scored_by: null, payload: { to: 'a@b.com' }, notification_sent_at: null,
+          resolved_at: null, resolved_by: null, expires_at: new Date(Date.now() - 1000),
+          parent_action_id: null, short_ref: 'email-1', description: 'Send email to a@b.com',
+          created_at: now,
+        },
+      ]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const rows = await repo.findExpired();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.id).toBe(5);
+      expect(rows[0]!.shortRef).toBe('email-1');
+    });
+
+    it('uses correct SQL filter for pending + expired', async () => {
+      const { pool, queries } = makePool([]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      await repo.findExpired();
+      expect(queries[0]!.sql).toContain("outcome = 'pending_approval'");
+      expect(queries[0]!.sql).toContain('expires_at <= now()');
+    });
+  });
 });

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -400,33 +400,59 @@ describe('ActionLogRepo', () => {
   });
 
   describe('expireRows', () => {
-    it('batch-transitions rows to expired and returns count', async () => {
-      const { pool, queries } = makePool([], 3);
+    it('batch-transitions rows to expired and returns the updated rows', async () => {
+      const now = new Date();
+      const returnedRows = [
+        {
+          id: 1, task_id: 't1', conversation_id: null, skill_name: 'email-send',
+          action_risk: 'medium', outcome: 'expired', task_summary: null,
+          competence_flag: null, commitment_flag: null, compatibility: null,
+          scored_by: null, payload: null, notification_sent_at: null,
+          resolved_at: now, resolved_by: 'system',
+          expires_at: new Date(now.getTime() - 1000),
+          parent_action_id: null, short_ref: 'email-1', description: 'Send email', created_at: now,
+        },
+        {
+          id: 2, task_id: 't1', conversation_id: null, skill_name: 'create-calendar-event',
+          action_risk: 'high', outcome: 'expired', task_summary: null,
+          competence_flag: null, commitment_flag: null, compatibility: null,
+          scored_by: null, payload: null, notification_sent_at: null,
+          resolved_at: now, resolved_by: 'system',
+          expires_at: new Date(now.getTime() - 1000),
+          parent_action_id: null, short_ref: 'cal-1', description: 'Create event', created_at: now,
+        },
+      ];
+      const { pool, queries } = makePool(returnedRows);
       const repo = new ActionLogRepo(pool, createSilentLogger());
-      const count = await repo.expireRows([1, 2, 3]);
-      expect(count).toBe(3);
+      const rows = await repo.expireRows([1, 2]);
+      expect(rows).toHaveLength(2);
+      expect(rows[0]!.id).toBe(1);
+      expect(rows[0]!.outcome).toBe('expired');
+      expect(rows[0]!.resolvedBy).toBe('system');
+      expect(rows[1]!.id).toBe(2);
       expect(queries[0]!.sql).toContain("outcome = 'expired'");
       expect(queries[0]!.sql).toContain("resolved_by = 'system'");
       expect(queries[0]!.sql).toContain('resolved_at = now()');
       expect(queries[0]!.sql).toContain("outcome = 'pending_approval'");
-      expect(queries[0]!.params[0]).toEqual([1, 2, 3]);
+      expect(queries[0]!.sql).toContain('RETURNING');
+      expect(queries[0]!.params[0]).toEqual([1, 2]);
     });
 
-    it('returns 0 for empty ids array', async () => {
+    it('returns empty array for empty ids (no-op — no query issued)', async () => {
       const { pool, queries } = makePool([], 0);
       const repo = new ActionLogRepo(pool, createSilentLogger());
-      const count = await repo.expireRows([]);
-      expect(count).toBe(0);
-      // Should still issue the query (Postgres handles ANY('{}') gracefully)
-      expect(queries).toHaveLength(1);
+      const rows = await repo.expireRows([]);
+      expect(rows).toEqual([]);
+      // Early return path — no DB query issued for empty input
+      expect(queries).toHaveLength(0);
     });
 
-    it('only updates rows still in pending_approval state (idempotency)', async () => {
-      // rowCount 0 means no rows matched the WHERE clause
+    it('returns empty array when no rows matched (idempotency — all concurrently resolved)', async () => {
+      // RETURNING returns 0 rows when WHERE clause matches nothing
       const { pool } = makePool([], 0);
       const repo = new ActionLogRepo(pool, createSilentLogger());
-      const count = await repo.expireRows([42]);
-      expect(count).toBe(0);
+      const rows = await repo.expireRows([42]);
+      expect(rows).toHaveLength(0);
     });
   });
 });

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -398,4 +398,35 @@ describe('ActionLogRepo', () => {
       expect(queries[0]!.sql).toContain('expires_at <= now()');
     });
   });
+
+  describe('expireRows', () => {
+    it('batch-transitions rows to expired and returns count', async () => {
+      const { pool, queries } = makePool([], 3);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const count = await repo.expireRows([1, 2, 3]);
+      expect(count).toBe(3);
+      expect(queries[0]!.sql).toContain("outcome = 'expired'");
+      expect(queries[0]!.sql).toContain("resolved_by = 'system'");
+      expect(queries[0]!.sql).toContain('resolved_at = now()');
+      expect(queries[0]!.sql).toContain("outcome = 'pending_approval'");
+      expect(queries[0]!.params[0]).toEqual([1, 2, 3]);
+    });
+
+    it('returns 0 for empty ids array', async () => {
+      const { pool, queries } = makePool([], 0);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const count = await repo.expireRows([]);
+      expect(count).toBe(0);
+      // Should still issue the query (Postgres handles ANY('{}') gracefully)
+      expect(queries).toHaveLength(1);
+    });
+
+    it('only updates rows still in pending_approval state (idempotency)', async () => {
+      // rowCount 0 means no rows matched the WHERE clause
+      const { pool } = makePool([], 0);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const count = await repo.expireRows([42]);
+      expect(count).toBe(0);
+    });
+  });
 });

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -194,6 +194,21 @@ export class ActionLogRepo {
   }
 
   /**
+   * Return all pending_approval rows that have passed their expiry time.
+   * These are the inverse of findAllPending() — rows where expires_at <= now().
+   * Used by the approval-expiry-sweep skill to transition stale requests.
+   */
+  async findExpired(): Promise<ActionLogRow[]> {
+    const result = await this.pool.query(
+      `SELECT * FROM autonomy_action_log
+       WHERE outcome = 'pending_approval'
+         AND expires_at <= now()
+       ORDER BY created_at ASC`,
+    );
+    return result.rows.map(mapRow);
+  }
+
+  /**
    * Transition a pending_approval row to a terminal outcome.
    * Only updates if the current outcome is still pending_approval —
    * returns `false` on double-resolve (concurrent resolution race).

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -211,26 +211,30 @@ export class ActionLogRepo {
   /**
    * Batch-transition pending_approval rows to expired state.
    * Sets outcome = 'expired', resolved_by = 'system', resolved_at = now().
-   * Returns the count of rows actually updated.
+   * Returns the rows that were actually updated (via RETURNING *).
    *
    * The WHERE outcome = 'pending_approval' guard ensures idempotency — if a row
    * was concurrently resolved (approved/denied/dismissed), it won't be
-   * double-transitioned.
+   * double-transitioned and won't appear in the returned set.
+   *
+   * Empty ids array is a no-op — returns [] without issuing a query.
    */
-  async expireRows(ids: number[]): Promise<number> {
+  async expireRows(ids: number[]): Promise<ActionLogRow[]> {
+    if (ids.length === 0) return [];
     const result = await this.pool.query(
       `UPDATE autonomy_action_log
        SET outcome = 'expired', resolved_by = 'system', resolved_at = now()
-       WHERE id = ANY($1) AND outcome = 'pending_approval'`,
+       WHERE id = ANY($1) AND outcome = 'pending_approval'
+       RETURNING *`,
       [ids],
     );
-    const count = result.rowCount ?? 0;
-    if (count > 0) {
-      this.logger.info({ count, totalRequested: ids.length, ids }, 'action-log-repo: expired rows');
-    } else if (ids.length > 0) {
+    const rows = result.rows.map(mapRow);
+    if (rows.length > 0) {
+      this.logger.info({ count: rows.length, totalRequested: ids.length, ids }, 'action-log-repo: expired rows');
+    } else {
       this.logger.debug({ ids }, 'action-log-repo: expireRows affected 0 rows — all may have been concurrently resolved');
     }
-    return count;
+    return rows;
   }
 
   /**

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -226,7 +226,9 @@ export class ActionLogRepo {
     );
     const count = result.rowCount ?? 0;
     if (count > 0) {
-      this.logger.info({ count, ids }, 'action-log-repo: expired rows');
+      this.logger.info({ count, totalRequested: ids.length, ids }, 'action-log-repo: expired rows');
+    } else if (ids.length > 0) {
+      this.logger.debug({ ids }, 'action-log-repo: expireRows affected 0 rows — all may have been concurrently resolved');
     }
     return count;
   }

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -209,6 +209,29 @@ export class ActionLogRepo {
   }
 
   /**
+   * Batch-transition pending_approval rows to expired state.
+   * Sets outcome = 'expired', resolved_by = 'system', resolved_at = now().
+   * Returns the count of rows actually updated.
+   *
+   * The WHERE outcome = 'pending_approval' guard ensures idempotency — if a row
+   * was concurrently resolved (approved/denied/dismissed), it won't be
+   * double-transitioned.
+   */
+  async expireRows(ids: number[]): Promise<number> {
+    const result = await this.pool.query(
+      `UPDATE autonomy_action_log
+       SET outcome = 'expired', resolved_by = 'system', resolved_at = now()
+       WHERE id = ANY($1) AND outcome = 'pending_approval'`,
+      [ids],
+    );
+    const count = result.rowCount ?? 0;
+    if (count > 0) {
+      this.logger.info({ count, ids }, 'action-log-repo: expired rows');
+    }
+    return count;
+  }
+
+  /**
    * Transition a pending_approval row to a terminal outcome.
    * Only updates if the current outcome is still pending_approval —
    * returns `false` on double-resolve (concurrent resolution race).

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -130,6 +130,8 @@ interface OutboundBlockedPayload {
 //   - 'group_held':      CEO alert that a Signal group message was held due to unverified members
 //   - 'contact_rate_limited': CEO alert that contact auto-creation was throttled due to rate limits
 //   - 'approval_requested':   CEO alert that an autonomy gate blocked a skill and approval is needed
+//   - 'approval_expired':     CEO alert that pending approvals expired without response (approval-expiry-sweep)
+//   - 'pending_actions_digest': Daily summary of open approvals awaiting CEO decision (pending-actions-digest)
 export interface OutboundNotificationPayload {
   notificationType:
     | 'blocked_content'

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -131,7 +131,13 @@ interface OutboundBlockedPayload {
 //   - 'contact_rate_limited': CEO alert that contact auto-creation was throttled due to rate limits
 //   - 'approval_requested':   CEO alert that an autonomy gate blocked a skill and approval is needed
 export interface OutboundNotificationPayload {
-  notificationType: 'blocked_content' | 'group_held' | 'contact_rate_limited' | 'approval_requested';
+  notificationType:
+    | 'blocked_content'
+    | 'group_held'
+    | 'contact_rate_limited'
+    | 'approval_requested'
+    | 'approval_expired'        // batched expiry notification (approval-expiry-sweep)
+    | 'pending_actions_digest'; // daily pending-actions summary (pending-actions-digest)
   /** Recipient email for this notification (always the CEO email today). */
   ceoEmail: string;
   subject: string;


### PR DESCRIPTION
## Summary

- **Approval expiry sweep** — new `approval-expiry-sweep` skill that runs hourly, expires stale `pending_approval` rows, and sends a single batched email to the CEO for any high/critical tier expirations. Added `findExpired()` and `expireRows()` to `ActionLogRepo` with idempotency guard.
- **Pending-actions digest** — new `pending-actions-digest` skill that runs daily at 8 AM, surfaces all open approval requests as a single summary email to the CEO (safety net for missed notifications). Both skills discovered by the coordinator via the new `schedule:` block in `agents/coordinator.yaml`.
- **Event types** — added `approval_expired` and `pending_actions_digest` to `OutboundNotificationPayload.notificationType` union.

Closes #429. Depends on #427 (approval trigger) and #428 (approval management skills).

## Test plan

- [ ] `npm test` passes (1,904 unit tests, 0 failures)
- [ ] `npm run typecheck` passes clean
- [ ] `skills/approval-expiry-sweep/handler.test.ts` — 7 cases covering: empty sweep, batch expiry + logging, low/medium silent, high/critical batched notification, missing email skip, missing gateway skip, send-failure non-fatal, unexpected error
- [ ] `skills/pending-actions-digest/handler.test.ts` — 8 cases covering: empty digest skip, multi-row digest, entry field formatting (shortRef/description/skillName/time-remaining), <1h formatting, missing email skip, missing gateway skip, send-failure non-fatal, unexpected error
- [ ] `src/autonomy/action-log-repo.test.ts` — covers `findExpired()` and `expireRows()` including idempotency and empty-array no-op

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic hourly approval expiry sweep that expires overdue pending requests and sends batched notifications to the CEO.
  * Added daily digest feature that summarizes all open approval requests awaiting decision and sends it to the CEO at 8:00 AM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->