### PR TITLE
feat: lift autonomy draft-fallback to OutboundGateway with action_log tracking (#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`autonomy_action_log` table name** — renamed from `action_log` to `autonomy_action_log` for schema clarity. The `autonomy_` prefix groups it with `autonomy_config` and `autonomy_history`. Updated in ADR-018, issues #427/#428/#429. (spec 14, issue #148)
 - **DreamEngine** — now accepts an optional `AutonomyScoringPass` as a sibling pass, running on its own interval alongside memory decay. (spec 14, issue #148)
 - **Held-message notifications** — coordinator now describes the nature of the sender's request (not just subject/sender). Preview is 500-char plaintext with `totalLength` so the LLM can qualify partial reads. Channel name is now dynamic (email, Signal, etc.) instead of hardcoded.
+- **Outbound autonomy gate** — draft-fallback logic lifted from email adapter to OutboundGateway;
+  email adapter simplified to pure transport. Gateway now writes `autonomy_action_log` rows on
+  gated sends and supports two-step draft linkage. Observation-mode drafts also tracked in
+  action_log for unified pending-actions surface. (#435)
+- **Pending-actions-digest** — short reference codes moved to end of each line for readability
+
+### Removed
+
+- **`autonomy_gated` outbound policy** — replaced by gateway-level autonomy gate on `direct`
+  policy. Deployments using `autonomy_gated` must switch to `direct`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,6 @@ bus event types) are noted explicitly even in the `0.x` range.
   action_log for unified pending-actions surface. (#435)
 - **Pending-actions-digest** — short reference codes moved to end of each line for readability
 
-### Removed
-
-- **`autonomy_gated` outbound policy** — replaced by gateway-level autonomy gate on `direct`
-  policy. Deployments using `autonomy_gated` must switch to `direct`.
-
 ### Fixed
 
 - **Test fixture naming** — replaced `nathan@curia.com` / `Nathan` references in `message-converter.test.ts` with `curia@example.com` / `Curia` to comply with instance-name hygiene rule.
@@ -46,6 +41,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Removed
 
+- **`autonomy_gated` outbound policy** — replaced by gateway-level autonomy gate on `direct`
+  policy. Deployments using `autonomy_gated` must switch to `direct`.
 - **CLI held-message notification** — removed vestigial `[Held] Unknown sender...` terminal printout; the coordinator's proactive mention is the real notification path.
 
 ### Added

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -16,8 +16,6 @@ channels:
 #                     filter enforced by the gateway). This is the default for most accounts.
 #   draft_gate      — save the coordinator's reply as a Nylas draft for human review;
 #                     the notification → approval → send flow is deferred (see issue #278).
-#   autonomy_gated  — check the global autonomy score before sending; if the score meets
-#                     `autonomy_threshold`, send directly; otherwise fall back to draft_gate.
 #
 # Credential values may be supplied inline or as env-var references using the
 # `env:VAR_NAME` syntax (recommended for secrets):
@@ -28,7 +26,7 @@ channels:
 # Backward compatibility: if this block is absent, the email channel falls back to the
 # single-account env-var mode (NYLAS_API_KEY / NYLAS_GRANT_ID / NYLAS_SELF_EMAIL).
 #
-# Example — two accounts, one direct and one autonomy-gated:
+# Example — two accounts, one direct and one draft-gated:
 # (Keys are the logical account names; they become the accountId on bus events.)
 #
 # channel_accounts:
@@ -41,8 +39,7 @@ channels:
 #     personal:
 #       nylas_grant_id: "env:NYLAS_GRANT_ID_PERSONAL"
 #       self_email:     "env:NYLAS_SELF_EMAIL_PERSONAL"
-#       outbound_policy: autonomy_gated
-#       autonomy_threshold: 80   # score out of 100; below this, replies are saved as drafts
+#       outbound_policy: draft_gate
 #
 # channel_accounts: {}
 

--- a/docs/dev/configuration.md
+++ b/docs/dev/configuration.md
@@ -163,11 +163,10 @@ channel_accounts:
       self_email:     "env:NYLAS_SELF_EMAIL"
       outbound_policy: direct
 
-    joseph:
-      nylas_grant_id: "env:NYLAS_GRANT_ID_JOSEPH"
-      self_email:     "env:NYLAS_SELF_EMAIL_JOSEPH"
-      outbound_policy: autonomy_gated
-      autonomy_threshold: 80
+    personal:
+      nylas_grant_id: "env:NYLAS_GRANT_ID_PERSONAL"
+      self_email:     "env:NYLAS_SELF_EMAIL_PERSONAL"
+      outbound_policy: draft_gate
 ```
 
 The `env:VAR_NAME` references are resolved from environment variables at

--- a/docs/wip/2026-05-04-gateway-draft-fallback-design.md
+++ b/docs/wip/2026-05-04-gateway-draft-fallback-design.md
@@ -1,0 +1,295 @@
+# Design: Lift Autonomy Draft-Fallback to OutboundGateway
+
+**Issue:** #435
+**Date:** 2026-05-04
+**Status:** Draft
+
+## Context
+
+When the autonomy gate blocks an outbound email send, the email adapter
+currently handles the fallback to draft creation internally via
+`dispatchByPolicy()`. This creates three problems:
+
+1. **Redundant gating** — the email adapter runs its own autonomy score
+   check (the `autonomy_gated` policy path), duplicating the platform-wide
+   gate in `OutboundGateway.send()` (score < minScoreForActionRisk('medium')).
+2. **Context threading** — the adapter lacks task context (`taskEventId`,
+   `conversationId`), so writing `autonomy_action_log` rows requires
+   extending event payloads to give it information the gateway already has.
+3. **Inconsistent channel layer** — the email adapter does autonomy logic
+   that no other adapter does.
+
+Additionally, observation-mode accounts create drafts as their primary
+output, but these drafts are untracked — the CEO discovers them in Gmail
+rather than through the pending-actions-digest.
+
+This design lifts the draft-fallback decision to the gateway, simplifies
+the email adapter to a pure transport, and unifies draft tracking for both
+autonomy-gated and observation-mode drafts.
+
+## Design
+
+### 1. Gateway: Two-Step Gated Draft Pattern
+
+**Gated result with action_log.** When `OutboundGateway.send()` gates a
+message (score below threshold), it:
+
+- Writes an `autonomy_action_log` row: `outcome = 'pending_approval'`,
+  `source = 'autonomy_gate'` in payload, task context from the existing
+  call chain, a generated `short_ref` (prefix `email-`), and a
+  human-readable description
+- Returns `{ success: false, gated: true, actionRef: '<short_ref>' }`
+
+The row is initially created WITHOUT a `draftId` — the adapter provides
+that in the next step.
+
+**`linkGatedAction(actionRef, payload)` method.** New gateway method that
+updates the action_log row's payload with the adapter's fallback result
+(draft ID, account, recipient, subject). This is the adapter's way of
+saying "here's what I did in response to the gate."
+
+Graceful handling: unknown actionRef is a no-op (no throw), logged at
+warn. This prevents failures if the action_log row expired or was cleaned
+up between the gate and the link.
+
+**Threshold change.** Replace the hardcoded `70` in the gateway's autonomy
+gate with `AutonomyService.minScoreForActionRisk('medium')`. One source
+of truth for the threshold.
+
+### 2. Email Adapter: Pure Transport
+
+**Remove autonomy logic from `dispatchByPolicy()`.** The `autonomy_gated`
+policy path is deleted entirely. The adapter no longer reads autonomy
+scores or has an `autonomyService` dependency.
+
+**New outbound subscriber flow:**
+
+```
+outbound.message received for this account
+  ├── policy == 'draft_gate'
+  │     → createEmailDraft() directly (config-level, no action_log)
+  │
+  └── policy == 'direct'
+        → gateway.send(msg)
+        ├── result.success == true → done, email sent
+        └── result.gated == true
+              → gateway.createEmailDraft(msg) on this account
+              → gateway.linkGatedAction(result.actionRef, {
+                    draftId, accountId, recipientEmail, subject
+                })
+```
+
+**Policy config.** Keep `direct` and `draft_gate` as named policy values.
+Remove `autonomy_gated` from the `OutboundPolicy` type and remove the
+`autonomyThreshold` and `autonomyService` fields from
+`EmailAdapterConfig` (only used by the deleted path). This is a breaking
+config change — any deployment using `autonomy_gated` must switch to
+`direct` (the gateway handles autonomy gating now).
+
+### 3. Observation-Mode Draft Tracking
+
+Observation-mode accounts create drafts as their primary output via skill
+handlers (not via the adapter's policy dispatch). These drafts are
+currently untracked.
+
+**Skill-level action_log write.** When a skill creates a draft because
+`taskMetadata.observationMode === true`, the skill writes an
+`autonomy_action_log` row directly:
+
+- `outcome: 'pending_approval'`
+- `source: 'observation_mode'` in payload
+- Includes `draftId`, `accountId`, `recipientEmail`, `subject`
+- `short_ref` with `email-` prefix
+- Description follows the same format as autonomy-gated drafts
+
+The skill has access to `ctx.taskEventId`, `ctx.conversationId`, and
+`ctx.actionLogRepo` — no context threading needed.
+
+### 4. send-draft Transitions the Action Log Row
+
+When the CEO uses `send-draft` to approve a draft:
+
+1. Skill calls `gateway.sendEmailDraft(draftId, account, meta, { humanApproved: true })` — unchanged
+2. On success, skill queries action_log for rows where `payload.draftId` matches
+3. If found, transitions the row to `outcome: 'approved'`
+4. Publishes `human.decision` event — unchanged
+
+Best-effort: if no matching action_log row exists (pre-existing drafts,
+draft_gate drafts), send-draft still works normally.
+
+### 5. Unified Action Log Row Format
+
+Both autonomy-gated and observation-mode draft rows use the same schema:
+
+**Payload (JSONB):**
+```json
+{
+  "draftId": "nylas-draft-xyz",
+  "source": "autonomy_gate",
+  "accountId": "curia",
+  "recipientEmail": "kevin@example.com",
+  "subject": "Quarterly review meeting"
+}
+```
+
+**Description (human + LLM readable):**
+```
+Draft reply to kevin@example.com — "Quarterly review" (curia). Use send-draft to approve.
+```
+
+The description does NOT include the `short_ref` — the digest line
+format handles placement (see section 7). The `source` field
+distinguishes draft provenance for the digest and future analytics.
+
+### 6. Coordinator Contract
+
+When a send is gated and a draft is created, the skill result returned
+to the coordinator MUST include:
+
+- Clear indication: "draft created" (not "email sent")
+- The `short_ref` for the draft action
+- The draft recipient and subject
+- The account the draft was created on
+- A suggestion to use `send-draft` for approval
+
+This is the testable contract for LLM ergonomics — if the result is
+clear and complete, the coordinator can tell the CEO what happened and
+what to do next.
+
+### 7. Pending Actions Digest
+
+The existing `pending-actions-digest` skill already surfaces all
+`pending_approval` action_log rows. After this refactor, both
+autonomy-gated and observation-mode drafts appear alongside gated
+skill invocations.
+
+**Updated line format** (minor change to `pending-actions-digest`):
+```
+{description} [{skillName}] — {timeRemaining} [{shortRef}]
+```
+
+The current digest format puts `shortRef` first (`EMAIL-A3: ...`).
+Moving it to the end improves scannability — the human-readable
+description leads, the machine-friendly reference trails.
+
+The `source` field in the payload lets the digest group or annotate
+items by provenance if needed in the future.
+
+### 8. Multi-Account Behavior
+
+One EmailAdapter instance per account. The autonomy gate is global
+(one score). When a send is gated:
+
+- The draft is created on the SAME account that received the outbound
+  event (routed by `accountId` in the event payload)
+- The action_log row includes `accountId` in payload for disambiguation
+- Multiple accounts can be gated simultaneously — each gets its own
+  action_log row
+
+Config-level `draft_gate` accounts create drafts without action_log rows
+(static policy, not a dynamic decision).
+
+## Testing Strategy
+
+### Layer 1: Gateway Unit Tests (`outbound-gateway.test.ts`)
+
+| Test | Verifies |
+|------|----------|
+| `send()` returns `{ gated: true, actionRef }` when score < threshold | Result shape contract |
+| `send()` writes action_log row with `pending_approval` on gate | Side effect of gating |
+| Action_log row has correct `taskEventId`, `conversationId`, `short_ref` | Context threading |
+| Action_log payload has message metadata (recipient, subject) | Audit trail |
+| `linkGatedAction(ref, payload)` updates row's payload | Link mechanism |
+| `linkGatedAction()` with unknown ref is no-op | Graceful handling |
+| Gateway uses `minScoreForActionRisk('medium')` not hardcoded 70 | Threshold derivation |
+| Existing `humanApproved: true` tests still pass | Regression guard |
+| `createEmailDraft()` still un-gated | Drafts remain safe |
+
+### Layer 2: Email Adapter Unit Tests (`email-adapter.test.ts`)
+
+| Test | Verifies |
+|------|----------|
+| `direct` policy calls `gateway.send()` | Basic routing |
+| On `{ gated: true }`, adapter calls `createEmailDraft()` | Fallback behavior |
+| On `{ gated: true }`, adapter calls `linkGatedAction()` with draft ID | Link step |
+| `draft_gate` policy calls `createEmailDraft()` directly | Config-level draft |
+| `draft_gate` does NOT write action_log | No tracking for config drafts |
+| No autonomy score reads in adapter | Negative test |
+
+### Layer 3: Observation-Mode Skill Tests
+
+| Test | Verifies |
+|------|----------|
+| Skill writes action_log with `source: 'observation_mode'` | Observation tracking |
+| Action_log row has correct draftId, accountId, recipient, subject | Payload completeness |
+| Skill result message says "draft created" with short_ref | Coordinator contract |
+
+### Layer 4: send-draft Skill Tests (`handler.test.ts`)
+
+| Test | Verifies |
+|------|----------|
+| On success, queries action_log for matching draftId | Transition lookup |
+| If found, transitions to `approved` | State machine |
+| If no row found (pre-existing draft), still succeeds | Graceful degradation |
+| Works for both `autonomy_gate` and `observation_mode` source rows | Unified resolution |
+
+### Layer 5: Flow Integration Test (new file)
+
+Full path test:
+
+```
+Setup:
+  - Wire EventBus, ExecutionLayer, OutboundGateway, EmailAdapter
+  - Set autonomy score below threshold
+  - Mock Nylas API
+
+Autonomy-gated flow:
+  1. Trigger outbound.message → gateway.send() → gated
+  2. Assert: adapter creates draft on correct account
+  3. Assert: adapter links action_log with draftId
+  4. Assert: action_log row: pending_approval, source=autonomy_gate
+  5. Simulate send-draft → assert: row transitions to approved
+
+Observation-mode flow:
+  1. Skill creates draft with observationMode context
+  2. Assert: action_log row: pending_approval, source=observation_mode
+  3. Simulate send-draft → assert: row transitions to approved
+
+Multi-account:
+  - Two adapters (different accounts), both gated
+  - Assert: each creates draft on its own account
+  - Assert: separate action_log rows with correct accountId
+
+Negative cases:
+  - Score >= threshold: sends directly, no draft, no action_log
+  - draft_gate policy: drafts without action_log
+```
+
+### Layer 6: Skill Result Message Tests
+
+| Test | Verifies |
+|------|----------|
+| Gated send returns result distinguishing "draft created" from "sent" | LLM gets clear signal |
+| Result includes short_ref, recipient, subject, account | Coordinator has context |
+| Result suggests send-draft as next action | LLM affordance |
+
+## Files to Modify
+
+- `src/skills/outbound-gateway.ts` — add gated result, linkGatedAction(), derive threshold
+- `src/channels/email/email-adapter.ts` — remove autonomy logic, add gated-fallback handling
+- `src/config.ts` — remove `autonomy_gated` from OutboundPolicy type
+- `skills/send-draft/handler.ts` — add action_log transition on successful send
+- `skills/pending-actions-digest/handler.ts` — move shortRef to end of line format
+- `skills/*/handler.ts` — observation-mode skill(s) that create drafts: add action_log write
+- `tests/unit/skills/outbound-gateway.test.ts` — new gateway tests
+- `tests/unit/channels/email/email-adapter.test.ts` — updated adapter tests
+- `skills/send-draft/handler.test.ts` — updated send-draft tests
+- `skills/pending-actions-digest/handler.test.ts` — updated format test
+- `tests/integration/draft-fallback-flow.test.ts` — new integration test
+
+## Out of Scope
+
+- LLM eval tests (coordinator judgment in gated scenarios) — follow-up
+- Changing the autonomy scoring pass to treat draft outcomes differently
+- Observation-mode as a standalone feature — only the action_log tracking
+  aspect is in scope here

--- a/docs/wip/2026-05-04-gateway-draft-fallback.md
+++ b/docs/wip/2026-05-04-gateway-draft-fallback.md
@@ -1,0 +1,1376 @@
+# Gateway Draft-Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift autonomy draft-fallback from email adapter to OutboundGateway, unify draft tracking for autonomy-gated and observation-mode drafts.
+
+**Architecture:** Two-step gated pattern — gateway gates sends and writes action_log, adapter creates draft and links it back. Observation-mode skills write action_log directly. send-draft transitions rows on approval. All tracked drafts appear in pending-actions-digest.
+
+**Tech Stack:** TypeScript ESM, Vitest, PostgreSQL (JSONB), Nylas API
+
+---
+
+## File Map
+
+| File | Responsibility | Action |
+|------|---------------|--------|
+| `src/bus/events.ts` | Event type definitions | Modify: add `taskEventId` to OutboundMessagePayload |
+| `src/config.ts` | Shared config types | Modify: remove `autonomy_gated` from OutboundPolicy |
+| `src/skills/outbound-gateway.ts` | Outbound safety pipeline | Modify: gated result, linkGatedAction(), derive threshold |
+| `src/autonomy/action-log-repo.ts` | Action log persistence | Modify: add `linkPayload()` method |
+| `src/channels/email/email-adapter.ts` | Email channel transport | Modify: remove autonomy logic, add gated-fallback |
+| `src/dispatch/dispatcher.ts` | Message routing | Modify: stamp taskEventId on outbound.message |
+| `skills/send-draft/handler.ts` | CEO draft approval | Modify: transition action_log on send |
+| `skills/email-draft-save/handler.ts` | Observation-mode drafts | Modify: write action_log on draft creation |
+| `skills/pending-actions-digest/handler.ts` | Daily pending summary | Modify: shortRef at end of line |
+| `tests/unit/skills/outbound-gateway.test.ts` | Gateway unit tests | Modify: add gated-result tests |
+| `tests/unit/channels/email/email-adapter.test.ts` | Adapter unit tests | Modify: add gated-fallback tests |
+| `skills/send-draft/handler.test.ts` | send-draft tests | Modify: add action_log transition tests |
+| `skills/email-draft-save/handler.test.ts` | Draft-save tests | Modify: add action_log tests |
+| `skills/pending-actions-digest/handler.test.ts` | Digest tests | Modify: update format assertion |
+| `tests/integration/draft-fallback-flow.test.ts` | Integration test | Create: full flow test |
+
+---
+
+### Task 1: Type and Interface Changes
+
+**Files:**
+- Modify: `src/skills/outbound-gateway.ts:89-94`
+- Modify: `src/bus/events.ts:76-94`
+- Modify: `src/config.ts:10-18`
+- Modify: `src/channels/email/email-adapter.ts:20-76`
+
+- [ ] **Step 1: Extend OutboundSendResult with gated fields**
+
+In `src/skills/outbound-gateway.ts`, update the interface:
+
+```typescript
+export interface OutboundSendResult {
+  success: boolean;
+  messageId?: string;
+  /** Human-readable reason when success is false */
+  blockedReason?: string;
+  /** True when the autonomy gate blocked this send */
+  gated?: boolean;
+  /** Short reference for the action_log row (e.g. 'email-1'). Present when gated is true. */
+  actionRef?: string;
+}
+```
+
+- [ ] **Step 2: Add taskEventId to OutboundMessagePayload**
+
+In `src/bus/events.ts`, add the field to `OutboundMessagePayload` (after `recipientId`):
+
+```typescript
+interface OutboundMessagePayload {
+  conversationId: string;
+  channelId: string;
+  accountId?: string;
+  content: string;
+  recipientId?: string;
+  /** The agent.task event ID that originated this outbound message.
+   *  Stamped by the dispatcher for traceability and action_log context. */
+  taskEventId?: string;
+}
+```
+
+- [ ] **Step 3: Remove `autonomy_gated` from OutboundPolicy**
+
+In `src/config.ts`, update the type:
+
+```typescript
+/**
+ * Outbound send policy for a named email account.
+ *
+ * - direct:      send via OutboundGateway (autonomy gate applied at gateway level)
+ * - draft_gate:  create a Nylas draft silently; CEO discovers pending drafts via the
+ *                end-of-day Signal digest and reviews in Gmail (#403, #278)
+ */
+export type OutboundPolicy = 'direct' | 'draft_gate';
+```
+
+- [ ] **Step 4: Remove autonomy fields from EmailAdapterConfig**
+
+In `src/channels/email/email-adapter.ts`, remove `autonomyThreshold` and `autonomyService` from the interface:
+
+```typescript
+export interface EmailAdapterConfig {
+  accountId: string;
+  outboundPolicy: OutboundPolicy;
+  // REMOVED: autonomyThreshold?: number;
+  // REMOVED: autonomyService?: AutonomyService;
+  bus: EventBus;
+  logger: Logger;
+  outboundGateway: OutboundGateway;
+  contactService: ContactService;
+  pollingIntervalMs: number;
+  selfEmail: string;
+  observationMode: boolean;
+  excludedSenderEmails: string[];
+  ceoEmail?: string;
+  contactCreationMaxPerMessage: number;
+  contactCreationMaxPerHour: number;
+}
+```
+
+Also remove the `AutonomyService` import at the top of the file.
+
+- [ ] **Step 5: Add send() context options**
+
+In `src/skills/outbound-gateway.ts`, extend the options parameter type on `send()`:
+
+```typescript
+async send(
+  request: OutboundSendRequest,
+  options?: {
+    skipNotificationOnBlock?: boolean;
+    humanApproved?: boolean;
+    /** Task event ID for action_log traceability. Provided by the email adapter from
+     *  the outbound.message event payload. */
+    taskEventId?: string;
+    /** Conversation ID for action_log context. */
+    conversationId?: string;
+  },
+): Promise<OutboundSendResult> {
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/skills/outbound-gateway.ts src/bus/events.ts src/config.ts src/channels/email/email-adapter.ts
+git commit -m "feat(#435): extend types for gated draft-fallback pattern"
+```
+
+---
+
+### Task 2: ActionLogRepo.linkPayload()
+
+**Files:**
+- Modify: `src/autonomy/action-log-repo.ts`
+- Modify: `src/autonomy/action-log-repo.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/autonomy/action-log-repo.test.ts`, add to the existing describe block:
+
+```typescript
+describe('linkPayload', () => {
+  it('merges additional payload into existing row by short_ref', async () => {
+    const { pool, queries } = makePool([{ id: 1, payload: { source: 'autonomy_gate' } }]);
+    const repo = new ActionLogRepo(pool);
+
+    const result = await repo.linkPayload('email-1', { draftId: 'draft-abc', accountId: 'curia' });
+
+    expect(result).toBe(true);
+    expect(queries[0].sql).toContain('UPDATE');
+    expect(queries[0].sql).toContain('short_ref');
+    expect(queries[0].sql).toContain('jsonb');
+    expect(queries[0].params).toContain('email-1');
+  });
+
+  it('returns false when no row matches the short_ref', async () => {
+    const { pool } = makePool([]);  // empty result
+    const repo = new ActionLogRepo(pool);
+
+    const result = await repo.linkPayload('unknown-ref', { draftId: 'draft-xyz' });
+
+    expect(result).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /path/to/worktree run test -- src/autonomy/action-log-repo.test.ts --run`
+Expected: FAIL — `linkPayload is not a function`
+
+- [ ] **Step 3: Implement linkPayload()**
+
+In `src/autonomy/action-log-repo.ts`, add the method:
+
+```typescript
+/**
+ * Merge additional payload fields into an existing action_log row identified
+ * by short_ref. Used by the gateway's two-step draft-fallback pattern: the
+ * initial row is created on gate (with source/context), then the adapter
+ * links the draft ID after creating the draft.
+ *
+ * Returns true if a row was updated, false if no matching pending row exists.
+ */
+async linkPayload(shortRef: string, additionalPayload: Record<string, unknown>): Promise<boolean> {
+  const result = await this.pool.query(
+    `UPDATE autonomy_action_log
+     SET payload = COALESCE(payload, '{}'::jsonb) || $2::jsonb
+     WHERE short_ref = $1
+       AND outcome = 'pending_approval'`,
+    [shortRef, JSON.stringify(additionalPayload)],
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm --prefix /path/to/worktree run test -- src/autonomy/action-log-repo.test.ts --run`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/autonomy/action-log-repo.ts src/autonomy/action-log-repo.test.ts
+git commit -m "feat(#435): add ActionLogRepo.linkPayload() for two-step draft pattern"
+```
+
+---
+
+### Task 3: Gateway Infrastructure — Wire actionLogRepo and Derive Threshold
+
+**Files:**
+- Modify: `src/skills/outbound-gateway.ts:130-225`
+- Modify: `tests/unit/skills/outbound-gateway.test.ts`
+
+- [ ] **Step 1: Write failing test for threshold derivation**
+
+In `tests/unit/skills/outbound-gateway.test.ts`, find the autonomy gate describe block and add:
+
+```typescript
+it('uses AutonomyService.minScoreForActionRisk(medium) as threshold, not hardcoded 70', async () => {
+  // Score 69 should be blocked (minScoreForActionRisk('medium') = 70)
+  const gateway = makeGateway({ autonomyService: makeAutonomyService(69) });
+  const result = await gateway.send(makeEmailRequest());
+  expect(result.success).toBe(false);
+  expect(result.gated).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /path/to/worktree run test -- tests/unit/skills/outbound-gateway.test.ts --run -t "minScoreForActionRisk"`
+Expected: FAIL — `result.gated` is undefined (current code doesn't set it)
+
+- [ ] **Step 3: Add actionLogRepo to OutboundGatewayConfig**
+
+In `src/skills/outbound-gateway.ts`, add to the config interface (around line 155):
+
+```typescript
+/**
+ * Action log repository — used to write pending_approval rows when the
+ * autonomy gate blocks a send and the channel falls back to draft creation.
+ * Optional — when absent, gated sends still return { gated: true } but no
+ * action_log row is written.
+ */
+actionLogRepo?: ActionLogRepo;
+```
+
+Add import at the top:
+```typescript
+import type { ActionLogRepo } from '../autonomy/action-log-repo.js';
+import { AutonomyService } from '../autonomy/autonomy-service.js';
+```
+
+In the constructor, store it:
+```typescript
+this.actionLogRepo = config.actionLogRepo;
+```
+
+And add as a class field:
+```typescript
+private actionLogRepo?: ActionLogRepo;
+```
+
+- [ ] **Step 4: Replace hardcoded 70 with derived threshold**
+
+In `send()` (line 267), replace:
+```typescript
+if (autonomyConfig !== null && autonomyConfig.score < 70) {
+```
+with:
+```typescript
+const sendThreshold = AutonomyService.minScoreForActionRisk('medium');
+if (autonomyConfig !== null && autonomyConfig.score < sendThreshold) {
+```
+
+Similarly in `sendEmailDraft()` (line 832), apply the same change.
+
+Update the log messages to reference `sendThreshold` instead of the literal `70`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm --prefix /path/to/worktree run test -- tests/unit/skills/outbound-gateway.test.ts --run`
+Expected: Existing tests still pass (threshold is still 70 via the service). The new test still fails because `gated` isn't returned yet — that's Task 4.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/skills/outbound-gateway.ts tests/unit/skills/outbound-gateway.test.ts
+git commit -m "feat(#435): wire actionLogRepo into gateway, derive threshold from AutonomyService"
+```
+
+---
+
+### Task 4: Gateway Gated Result + Action Log Write
+
+**Files:**
+- Modify: `src/skills/outbound-gateway.ts` (send() method, lines 264-288)
+- Modify: `tests/unit/skills/outbound-gateway.test.ts`
+
+- [ ] **Step 1: Write failing tests for gated result and action_log write**
+
+In `tests/unit/skills/outbound-gateway.test.ts`:
+
+```typescript
+describe('gated draft-fallback (two-step pattern)', () => {
+  it('returns { gated: true, actionRef } when score < threshold', async () => {
+    const actionLogRepo = makeActionLogRepo();
+    const gateway = makeGateway({
+      autonomyService: makeAutonomyService(65),
+      actionLogRepo,
+    });
+
+    const result = await gateway.send(
+      makeEmailRequest({ to: 'kevin@example.com', subject: 'Hello' }),
+      { taskEventId: 'task-001', conversationId: 'email:thread-abc' },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.gated).toBe(true);
+    expect(result.actionRef).toMatch(/^email-/);
+  });
+
+  it('writes action_log row with pending_approval on gate', async () => {
+    const actionLogRepo = makeActionLogRepo();
+    const gateway = makeGateway({
+      autonomyService: makeAutonomyService(65),
+      actionLogRepo,
+    });
+
+    await gateway.send(
+      makeEmailRequest({ to: 'kevin@example.com', subject: 'Hello' }),
+      { taskEventId: 'task-001', conversationId: 'email:thread-abc' },
+    );
+
+    expect(actionLogRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: 'task-001',
+        conversationId: 'email:thread-abc',
+        outcome: 'pending_approval',
+        skillName: 'outbound-send',
+        shortRef: expect.stringMatching(/^email-/),
+        payload: expect.objectContaining({ source: 'autonomy_gate' }),
+      }),
+    );
+  });
+
+  it('action_log row includes recipient and subject in payload', async () => {
+    const actionLogRepo = makeActionLogRepo();
+    const gateway = makeGateway({
+      autonomyService: makeAutonomyService(65),
+      actionLogRepo,
+    });
+
+    await gateway.send(
+      makeEmailRequest({ to: 'kevin@example.com', subject: 'Quarterly review' }),
+      { taskEventId: 'task-001', conversationId: 'email:thread-abc' },
+    );
+
+    expect(actionLogRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          source: 'autonomy_gate',
+          recipientEmail: 'kevin@example.com',
+          subject: 'Quarterly review',
+        }),
+      }),
+    );
+  });
+
+  it('skips action_log write when actionLogRepo is not wired', async () => {
+    const gateway = makeGateway({
+      autonomyService: makeAutonomyService(65),
+      // no actionLogRepo
+    });
+
+    const result = await gateway.send(
+      makeEmailRequest(),
+      { taskEventId: 'task-001', conversationId: 'conv-1' },
+    );
+
+    expect(result.gated).toBe(true);
+    // No crash — graceful when repo absent
+  });
+
+  it('skips action_log write when taskEventId is missing', async () => {
+    const actionLogRepo = makeActionLogRepo();
+    const gateway = makeGateway({
+      autonomyService: makeAutonomyService(65),
+      actionLogRepo,
+    });
+
+    const result = await gateway.send(makeEmailRequest());
+    // No taskEventId in options — cannot write meaningful row
+
+    expect(result.gated).toBe(true);
+    expect(actionLogRepo.insert).not.toHaveBeenCalled();
+  });
+});
+```
+
+Add this helper to the test file:
+```typescript
+function makeActionLogRepo() {
+  return {
+    insert: vi.fn().mockResolvedValue(1),
+    linkPayload: vi.fn().mockResolvedValue(true),
+    countShortRefsForTask: vi.fn().mockResolvedValue(0),
+  } as unknown as ActionLogRepo;
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm --prefix /path/to/worktree run test -- tests/unit/skills/outbound-gateway.test.ts --run -t "gated draft-fallback"`
+Expected: FAIL — `result.gated` is undefined
+
+- [ ] **Step 3: Implement gated result + action_log write in send()**
+
+In `src/skills/outbound-gateway.ts`, replace the autonomy gate block (lines 264-288) with:
+
+```typescript
+} else if (this.autonomyService) {
+  try {
+    const autonomyConfig = await this.autonomyService.getConfig();
+    const sendThreshold = AutonomyService.minScoreForActionRisk('medium');
+    if (autonomyConfig !== null && autonomyConfig.score < sendThreshold) {
+      this.log.info(
+        { channel: request.channel, currentScore: autonomyConfig.score, sendThreshold },
+        'outbound-gateway: send blocked by autonomy gate — score below threshold',
+      );
+      this.bus.publish('dispatch', createAutonomySendBlocked({
+        channel: request.channel,
+        currentScore: autonomyConfig.score,
+        requiredScore: sendThreshold,
+        parentEventId: options?.taskEventId ?? 'unknown',
+      }));
+
+      // Write action_log row if we have enough context
+      let actionRef: string | undefined;
+      if (this.actionLogRepo && options?.taskEventId) {
+        const counter = await this.actionLogRepo.countShortRefsForTask(options.taskEventId);
+        actionRef = `email-${counter + 1}`;
+        const recipientEmail = request.channel === 'email' ? request.to : undefined;
+        const subject = request.channel === 'email' ? request.subject : undefined;
+        const description = recipientEmail
+          ? `Draft reply to ${recipientEmail}${subject ? ` — "${subject}"` : ''}. Use send-draft to approve.`
+          : 'Outbound message gated by autonomy. Use send-draft to approve.';
+
+        await this.actionLogRepo.insert({
+          taskId: options.taskEventId,
+          conversationId: options.conversationId ?? null,
+          skillName: 'outbound-send',
+          actionRisk: 'medium',
+          outcome: 'pending_approval',
+          shortRef: actionRef,
+          description,
+          payload: {
+            source: 'autonomy_gate',
+            recipientEmail,
+            subject,
+            channel: request.channel,
+          },
+          expiresAt: new Date(Date.now() + 48 * 60 * 60 * 1000), // 48h expiry
+        });
+      }
+
+      return {
+        success: false,
+        gated: true,
+        actionRef,
+        blockedReason: `Autonomy score ${autonomyConfig.score} is below send threshold ${sendThreshold}`,
+      };
+    }
+  } catch (err) {
+    this.log.warn(
+      { err, channel: request.channel },
+      'outbound-gateway: autonomy gate failed to read config — proceeding without gate (fail-open)',
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm --prefix /path/to/worktree run test -- tests/unit/skills/outbound-gateway.test.ts --run`
+Expected: All new and existing tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/skills/outbound-gateway.ts tests/unit/skills/outbound-gateway.test.ts
+git commit -m "feat(#435): gateway writes action_log and returns gated result on autonomy block"
+```
+
+---
+
+### Task 5: Gateway linkGatedAction()
+
+**Files:**
+- Modify: `src/skills/outbound-gateway.ts`
+- Modify: `tests/unit/skills/outbound-gateway.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe('linkGatedAction', () => {
+  it('delegates to actionLogRepo.linkPayload with the actionRef and payload', async () => {
+    const actionLogRepo = makeActionLogRepo();
+    const gateway = makeGateway({ actionLogRepo });
+
+    await gateway.linkGatedAction('email-1', { draftId: 'draft-abc', accountId: 'curia' });
+
+    expect(actionLogRepo.linkPayload).toHaveBeenCalledWith('email-1', {
+      draftId: 'draft-abc',
+      accountId: 'curia',
+    });
+  });
+
+  it('is a no-op when actionLogRepo is not wired', async () => {
+    const gateway = makeGateway({}); // no actionLogRepo
+
+    // Should not throw
+    await gateway.linkGatedAction('email-1', { draftId: 'draft-abc' });
+  });
+
+  it('logs warn and does not throw when linkPayload returns false (unknown ref)', async () => {
+    const actionLogRepo = makeActionLogRepo();
+    actionLogRepo.linkPayload = vi.fn().mockResolvedValue(false);
+    const gateway = makeGateway({ actionLogRepo });
+
+    await gateway.linkGatedAction('unknown-ref', { draftId: 'draft-abc' });
+
+    // Should not throw, just log
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm --prefix /path/to/worktree run test -- tests/unit/skills/outbound-gateway.test.ts --run -t "linkGatedAction"`
+Expected: FAIL — `gateway.linkGatedAction is not a function`
+
+- [ ] **Step 3: Implement linkGatedAction()**
+
+In `src/skills/outbound-gateway.ts`, add the method to the class:
+
+```typescript
+/**
+ * Link a draft (or other fallback result) to a gated action_log row.
+ * Called by channel adapters after they create their fallback artifact
+ * in response to a gated send() result.
+ *
+ * No-op when actionLogRepo is not wired or the actionRef doesn't match
+ * a pending row (graceful — the row may have expired or been cleaned up).
+ */
+async linkGatedAction(actionRef: string, payload: Record<string, unknown>): Promise<void> {
+  if (!this.actionLogRepo) return;
+  const updated = await this.actionLogRepo.linkPayload(actionRef, payload);
+  if (!updated) {
+    this.log.warn(
+      { actionRef },
+      'outbound-gateway: linkGatedAction found no pending row for actionRef — may have expired',
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm --prefix /path/to/worktree run test -- tests/unit/skills/outbound-gateway.test.ts --run -t "linkGatedAction"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/skills/outbound-gateway.ts tests/unit/skills/outbound-gateway.test.ts
+git commit -m "feat(#435): add gateway.linkGatedAction() for two-step draft-fallback"
+```
+
+---
+
+### Task 6: Thread taskEventId Through Dispatcher → Email Adapter
+
+**Files:**
+- Modify: `src/dispatch/dispatcher.ts:888-897`
+- Modify: `src/channels/email/email-adapter.ts` (outbound subscriber + sendOutboundReply)
+
+- [ ] **Step 1: Stamp taskEventId in dispatcher**
+
+In `src/dispatch/dispatcher.ts`, at line 888, add `taskEventId` to the `createOutboundMessage` call. The agent.response event's `parentEventId` is the agent.task event's ID:
+
+```typescript
+const outbound = createOutboundMessage({
+  conversationId: routing.conversationId,
+  channelId: routing.channelId,
+  accountId: routing.accountId,
+  content: event.payload.content,
+  recipientId: routing.senderId,
+  taskEventId: event.parentEventId ?? undefined,  // agent.task event ID
+  parentEventId: event.id,
+});
+```
+
+- [ ] **Step 2: Pass context from email adapter to gateway.send()**
+
+In `src/channels/email/email-adapter.ts`, modify `sendOutboundReply()` to accept and pass task context. The outbound event has `payload.taskEventId` and `payload.conversationId`:
+
+Update `sendOutboundReply` to extract and thread the context:
+
+```typescript
+private async sendOutboundReply(outbound: OutboundMessageEvent): Promise<void> {
+  const { conversationId, content, taskEventId } = outbound.payload;
+  // ... existing logic to resolve threadId, recipient, etc. ...
+
+  await this.dispatchByPolicy(sendRequest, {
+    taskEventId,
+    conversationId,
+  });
+}
+```
+
+Update `dispatchByPolicy` signature to accept context:
+
+```typescript
+private async dispatchByPolicy(
+  sendRequest: EmailSendRequest,
+  context: { taskEventId?: string; conversationId?: string },
+): Promise<void> {
+```
+
+And pass context to `gateway.send()`:
+
+```typescript
+const result = await this.config.outboundGateway.send(sendRequest, {
+  taskEventId: context.taskEventId,
+  conversationId: context.conversationId,
+});
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/dispatch/dispatcher.ts src/channels/email/email-adapter.ts
+git commit -m "feat(#435): thread taskEventId from dispatcher through adapter to gateway"
+```
+
+---
+
+### Task 7: Email Adapter Simplification — Remove Autonomy, Add Gated Fallback
+
+**Files:**
+- Modify: `src/channels/email/email-adapter.ts` (dispatchByPolicy, lines 429-514)
+- Modify: `tests/unit/channels/email/email-adapter.test.ts`
+
+- [ ] **Step 1: Write failing tests for new adapter behavior**
+
+In `tests/unit/channels/email/email-adapter.test.ts`:
+
+```typescript
+describe('dispatchByPolicy gated-fallback', () => {
+  it('calls gateway.send() for direct policy', async () => {
+    const gateway = {
+      send: vi.fn().mockResolvedValue({ success: true, messageId: 'msg-1' }),
+      createEmailDraft: vi.fn(),
+      linkGatedAction: vi.fn(),
+    };
+    const adapter = makeAdapter({ outboundPolicy: 'direct', outboundGateway: gateway });
+    const handler = captureHandler('outbound.message', adapter);
+
+    await handler(makeOutboundEvent({ taskEventId: 'task-1', conversationId: 'conv-1' }));
+
+    expect(gateway.send).toHaveBeenCalled();
+    expect(gateway.createEmailDraft).not.toHaveBeenCalled();
+  });
+
+  it('creates draft and links action when gateway returns gated', async () => {
+    const gateway = {
+      send: vi.fn().mockResolvedValue({ success: false, gated: true, actionRef: 'email-1' }),
+      createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'draft-abc' }),
+      linkGatedAction: vi.fn(),
+    };
+    const adapter = makeAdapter({ outboundPolicy: 'direct', outboundGateway: gateway });
+    const handler = captureHandler('outbound.message', adapter);
+
+    await handler(makeOutboundEvent({ taskEventId: 'task-1', conversationId: 'conv-1' }));
+
+    expect(gateway.createEmailDraft).toHaveBeenCalled();
+    expect(gateway.linkGatedAction).toHaveBeenCalledWith('email-1', expect.objectContaining({
+      draftId: 'draft-abc',
+    }));
+  });
+
+  it('draft_gate policy calls createEmailDraft directly without send()', async () => {
+    const gateway = {
+      send: vi.fn(),
+      createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'draft-xyz' }),
+      linkGatedAction: vi.fn(),
+    };
+    const adapter = makeAdapter({ outboundPolicy: 'draft_gate', outboundGateway: gateway });
+    const handler = captureHandler('outbound.message', adapter);
+
+    await handler(makeOutboundEvent({}));
+
+    expect(gateway.send).not.toHaveBeenCalled();
+    expect(gateway.createEmailDraft).toHaveBeenCalled();
+    expect(gateway.linkGatedAction).not.toHaveBeenCalled();
+  });
+
+  it('draft_gate does NOT write action_log', async () => {
+    const gateway = {
+      send: vi.fn(),
+      createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'draft-xyz' }),
+      linkGatedAction: vi.fn(),
+    };
+    const adapter = makeAdapter({ outboundPolicy: 'draft_gate', outboundGateway: gateway });
+    const handler = captureHandler('outbound.message', adapter);
+
+    await handler(makeOutboundEvent({}));
+
+    expect(gateway.linkGatedAction).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm --prefix /path/to/worktree run test -- tests/unit/channels/email/email-adapter.test.ts --run -t "gated-fallback"`
+Expected: FAIL
+
+- [ ] **Step 3: Rewrite dispatchByPolicy()**
+
+Replace the full `dispatchByPolicy()` method in `email-adapter.ts`:
+
+```typescript
+/**
+ * Route an outbound email through the configured policy.
+ *
+ * - direct:     send via gateway (autonomy gate applied at gateway level).
+ *               If gated, fall back to draft creation and link the action_log row.
+ * - draft_gate: create draft directly (config-level choice, no action_log).
+ */
+private async dispatchByPolicy(
+  sendRequest: EmailSendRequest,
+  context: { taskEventId?: string; conversationId?: string },
+): Promise<void> {
+  const { outboundPolicy, outboundGateway, logger, accountId } = this.config;
+
+  if (outboundPolicy === 'draft_gate') {
+    // Config-level always-draft — no autonomy decision, no action_log
+    await outboundGateway.createEmailDraft(sendRequest);
+    return;
+  }
+
+  // Policy: 'direct' — send through gateway, handle gated fallback
+  const result = await outboundGateway.send(sendRequest, {
+    taskEventId: context.taskEventId,
+    conversationId: context.conversationId,
+  });
+
+  if (result.success) return;
+
+  if (result.gated) {
+    // Gateway blocked the send — create draft as fallback
+    const draftResult = await outboundGateway.createEmailDraft(sendRequest);
+
+    if (draftResult.success && draftResult.draftId && result.actionRef) {
+      await outboundGateway.linkGatedAction(result.actionRef, {
+        draftId: draftResult.draftId,
+        accountId,
+        recipientEmail: sendRequest.to,
+        subject: sendRequest.subject,
+      });
+    }
+
+    logger.info(
+      { accountId, actionRef: result.actionRef, draftId: draftResult.draftId },
+      'email-adapter: send gated by autonomy — draft created as fallback',
+    );
+    return;
+  }
+
+  // Non-gated failure (blocked contact, content filter, etc.) — already logged by gateway
+}
+```
+
+- [ ] **Step 4: Remove the AutonomyService import and any remaining references**
+
+Remove `import type { AutonomyService }` from the top of the file. Remove any references to `this.config.autonomyService` or `this.config.autonomyThreshold`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm --prefix /path/to/worktree run test -- tests/unit/channels/email/email-adapter.test.ts --run`
+Expected: All new and existing tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/channels/email/email-adapter.ts tests/unit/channels/email/email-adapter.test.ts
+git commit -m "feat(#435): simplify email adapter — remove autonomy logic, add gated-fallback"
+```
+
+---
+
+### Task 8: Observation-Mode Draft Tracking
+
+**Files:**
+- Modify: `skills/email-draft-save/handler.ts`
+- Modify: `skills/email-draft-save/handler.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+In `skills/email-draft-save/handler.test.ts`:
+
+```typescript
+describe('observation-mode action_log tracking', () => {
+  it('writes action_log row with source observation_mode when draft is created in obs mode', async () => {
+    const actionLogRepo = {
+      insert: vi.fn().mockResolvedValue(1),
+      countShortRefsForTask: vi.fn().mockResolvedValue(0),
+    };
+    const ctx = makeCtx({
+      taskMetadata: { observationMode: true },
+      taskEventId: 'task-obs-1',
+      conversationId: 'email:thread-xyz',
+      actionLogRepo,
+      // ... other required ctx fields for a successful draft save
+    });
+
+    await handler.execute(ctx);
+
+    expect(actionLogRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: 'task-obs-1',
+        conversationId: 'email:thread-xyz',
+        outcome: 'pending_approval',
+        payload: expect.objectContaining({
+          source: 'observation_mode',
+          draftId: expect.any(String),
+        }),
+        shortRef: expect.stringMatching(/^email-/),
+      }),
+    );
+  });
+
+  it('does NOT write action_log when not in observation mode', async () => {
+    const actionLogRepo = { insert: vi.fn(), countShortRefsForTask: vi.fn() };
+    const ctx = makeCtx({
+      taskMetadata: {},  // no observationMode
+      actionLogRepo,
+    });
+
+    await handler.execute(ctx);
+
+    expect(actionLogRepo.insert).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /path/to/worktree run test -- skills/email-draft-save/handler.test.ts --run -t "observation-mode action_log"`
+Expected: FAIL
+
+- [ ] **Step 3: Implement action_log write in email-draft-save handler**
+
+In `skills/email-draft-save/handler.ts`, after the successful `createEmailDraft()` call, add:
+
+```typescript
+// Track observation-mode drafts in action_log for pending-actions-digest
+if (ctx.taskMetadata?.observationMode === true && ctx.actionLogRepo && ctx.taskEventId) {
+  const counter = await ctx.actionLogRepo.countShortRefsForTask(ctx.taskEventId);
+  const shortRef = `email-${counter + 1}`;
+  const recipientEmail = /* extract from draft request */;
+  const subject = /* extract from draft request */;
+  const description = recipientEmail
+    ? `Draft reply to ${recipientEmail}${subject ? ` — "${subject}"` : ''} (${accountId}). Use send-draft to approve.`
+    : `Observation-mode draft created (${accountId}). Use send-draft to approve.`;
+
+  await ctx.actionLogRepo.insert({
+    taskId: ctx.taskEventId,
+    conversationId: ctx.conversationId ?? null,
+    skillName: 'email-draft-save',
+    actionRisk: 'medium',
+    outcome: 'pending_approval',
+    shortRef,
+    description,
+    payload: {
+      source: 'observation_mode',
+      draftId: draftResult.id,  // from createEmailDraft() result
+      accountId,
+      recipientEmail,
+      subject,
+    },
+    expiresAt: new Date(Date.now() + 48 * 60 * 60 * 1000),
+  });
+}
+```
+
+(Exact variable names depend on how the handler structures the draft request — adapt to match the existing handler's variable names.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm --prefix /path/to/worktree run test -- skills/email-draft-save/handler.test.ts --run`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/email-draft-save/handler.ts skills/email-draft-save/handler.test.ts
+git commit -m "feat(#435): observation-mode drafts write action_log for pending-actions tracking"
+```
+
+---
+
+### Task 9: send-draft Action Log Transition
+
+**Files:**
+- Modify: `skills/send-draft/handler.ts`
+- Modify: `skills/send-draft/handler.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+In `skills/send-draft/handler.test.ts`:
+
+```typescript
+describe('action_log transition on approval', () => {
+  it('transitions matching action_log row to approved on successful send', async () => {
+    const actionLogRepo = {
+      findPendingByPayloadField: vi.fn().mockResolvedValue({
+        id: 42,
+        shortRef: 'email-1',
+        outcome: 'pending_approval',
+      }),
+      resolveById: vi.fn().mockResolvedValue(true),
+    };
+    const ctx = makeCtx({
+      actionLogRepo,
+      gateway: { sendEmailDraft: vi.fn().mockResolvedValue({ success: true, messageId: 'msg-1' }) },
+    });
+
+    await handler.execute(ctx);
+
+    expect(actionLogRepo.findPendingByPayloadField).toHaveBeenCalledWith('draftId', 'draft-abc123');
+    expect(actionLogRepo.resolveById).toHaveBeenCalledWith(42, 'approved', 'ceo');
+  });
+
+  it('still succeeds when no action_log row exists (pre-existing draft)', async () => {
+    const actionLogRepo = {
+      findPendingByPayloadField: vi.fn().mockResolvedValue(null),
+      resolveById: vi.fn(),
+    };
+    const ctx = makeCtx({
+      actionLogRepo,
+      gateway: { sendEmailDraft: vi.fn().mockResolvedValue({ success: true, messageId: 'msg-1' }) },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(actionLogRepo.resolveById).not.toHaveBeenCalled();
+  });
+
+  it('still succeeds when actionLogRepo is not available', async () => {
+    const ctx = makeCtx({
+      // no actionLogRepo
+      gateway: { sendEmailDraft: vi.fn().mockResolvedValue({ success: true, messageId: 'msg-1' }) },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm --prefix /path/to/worktree run test -- skills/send-draft/handler.test.ts --run -t "action_log transition"`
+Expected: FAIL
+
+- [ ] **Step 3: Add findPendingByPayloadField to ActionLogRepo**
+
+In `src/autonomy/action-log-repo.ts`:
+
+```typescript
+/**
+ * Find a pending_approval row where a specific field in the JSONB payload
+ * matches the given value. Used by send-draft to find the action_log row
+ * associated with a draft being approved.
+ */
+async findPendingByPayloadField(
+  field: string,
+  value: string,
+): Promise<ActionLogRow | null> {
+  const result = await this.pool.query(
+    `SELECT * FROM autonomy_action_log
+     WHERE outcome = 'pending_approval'
+       AND payload->>$1 = $2
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [field, value],
+  );
+  return result.rows[0] ? this.mapRow(result.rows[0]) : null;
+}
+```
+
+Also add a `resolve()` method if one doesn't exist (check — `resolvePending` exists but operates on shortRef. We need one that operates by row ID):
+
+```typescript
+/**
+ * Transition a specific action_log row to a terminal outcome.
+ */
+async resolveById(id: number, outcome: string, resolvedBy: string): Promise<boolean> {
+  const result = await this.pool.query(
+    `UPDATE autonomy_action_log
+     SET outcome = $2, resolved_at = NOW(), resolved_by = $3
+     WHERE id = $1 AND outcome = 'pending_approval'`,
+    [id, outcome, resolvedBy],
+  );
+  return (result.rowCount ?? 0) > 0;
+}
+```
+
+- [ ] **Step 4: Implement transition in send-draft handler**
+
+In `skills/send-draft/handler.ts`, after the successful `sendEmailDraft()` call (around line 116), add:
+
+```typescript
+// Transition action_log row from pending_approval → approved (best-effort)
+if (ctx.actionLogRepo) {
+  try {
+    const row = await ctx.actionLogRepo.findPendingByPayloadField('draftId', draftId);
+    if (row) {
+      await ctx.actionLogRepo.resolveById(row.id, 'approved', 'ceo');
+    }
+  } catch (err) {
+    // Best-effort — don't fail the send if action_log transition fails
+    ctx.log.warn({ err, draftId }, 'send-draft: failed to transition action_log row');
+  }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm --prefix /path/to/worktree run test -- skills/send-draft/handler.test.ts --run`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/send-draft/handler.ts skills/send-draft/handler.test.ts src/autonomy/action-log-repo.ts
+git commit -m "feat(#435): send-draft transitions action_log row to approved on CEO send"
+```
+
+---
+
+### Task 10: Pending-Actions-Digest Format — shortRef at End
+
+**Files:**
+- Modify: `skills/pending-actions-digest/handler.ts:71-79`
+- Modify: `skills/pending-actions-digest/handler.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+In `skills/pending-actions-digest/handler.test.ts`, find the test that asserts on the bullet format and update:
+
+```typescript
+it('formats each pending row with shortRef at end of line', async () => {
+  const pending = [
+    makeRow({ shortRef: 'email-1', description: 'Draft reply to kevin@example.com', skillName: 'outbound-send', expiresAt: futureDate(12) }),
+  ];
+  const ctx = makeCtx({ actionLogRepo: { findAllPending: vi.fn().mockResolvedValue(pending) } });
+
+  await handler.execute(ctx);
+
+  const body = getNotificationBody(ctx);
+  expect(body).toContain('Draft reply to kevin@example.com [outbound-send] — 12h remaining [email-1]');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm --prefix /path/to/worktree run test -- skills/pending-actions-digest/handler.test.ts --run`
+Expected: FAIL — current format puts shortRef first (`email-1: Draft reply...`)
+
+- [ ] **Step 3: Update the line format**
+
+In `skills/pending-actions-digest/handler.ts`, change line 77:
+
+From:
+```typescript
+return `• ${r.shortRef ?? '(no ref)'}: ${r.description ?? '(no description)'} [${r.skillName}] — ${timeRemaining}`;
+```
+
+To:
+```typescript
+return `• ${r.description ?? '(no description)'} [${r.skillName}] — ${timeRemaining} [${r.shortRef ?? '—'}]`;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm --prefix /path/to/worktree run test -- skills/pending-actions-digest/handler.test.ts --run`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/pending-actions-digest/handler.ts skills/pending-actions-digest/handler.test.ts
+git commit -m "feat(#435): move shortRef to end of digest line for readability"
+```
+
+---
+
+### Task 11: Flow Integration Test
+
+**Files:**
+- Create: `tests/integration/draft-fallback-flow.test.ts`
+
+- [ ] **Step 1: Write the integration test**
+
+```typescript
+// tests/integration/draft-fallback-flow.test.ts
+//
+// Integration test: validates the full autonomy gate → draft fallback → approval flow.
+// Exercises the contracts between OutboundGateway, EmailAdapter, ActionLogRepo, and send-draft.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OutboundGateway } from '../../src/skills/outbound-gateway.js';
+import { EmailAdapter } from '../../src/channels/email/email-adapter.js';
+import { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import { createSilentLogger } from '../../src/logger.js';
+import { EventBus } from '../../src/bus/bus.js';
+
+describe('draft-fallback flow integration', () => {
+  let bus: EventBus;
+  let actionLogRepo: ActionLogRepo;
+  let gateway: OutboundGateway;
+
+  beforeEach(() => {
+    bus = new EventBus(createSilentLogger());
+    // Use mock pool for action_log
+    actionLogRepo = makeMockActionLogRepo();
+  });
+
+  describe('autonomy-gated flow', () => {
+    it('full path: gate → draft → link → approve', async () => {
+      // Setup: score below threshold
+      const autonomyService = makeAutonomyService(65);
+      const nylasClient = makeMockNylasClient({ draftId: 'draft-abc' });
+
+      gateway = new OutboundGateway({
+        autonomyService,
+        actionLogRepo,
+        nylasClients: new Map([['curia', nylasClient]]),
+        bus,
+        logger: createSilentLogger(),
+        contactService: makeMockContactService(),
+      });
+
+      const adapter = new EmailAdapter({
+        accountId: 'curia',
+        outboundPolicy: 'direct',
+        bus,
+        logger: createSilentLogger(),
+        outboundGateway: gateway,
+        contactService: makeMockContactService(),
+        pollingIntervalMs: 60000,
+        selfEmail: 'curia@example.com',
+        observationMode: false,
+        excludedSenderEmails: [],
+        contactCreationMaxPerMessage: 5,
+        contactCreationMaxPerHour: 100,
+      });
+
+      await adapter.start();
+
+      // Trigger outbound.message
+      await bus.publish('dispatch', createOutboundMessage({
+        conversationId: 'email:thread-1',
+        channelId: 'email',
+        accountId: 'curia',
+        content: 'Hello Kevin',
+        taskEventId: 'task-001',
+        parentEventId: 'response-001',
+      }));
+
+      // Assert: action_log row created with pending_approval
+      expect(actionLogRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: 'pending_approval',
+          payload: expect.objectContaining({ source: 'autonomy_gate' }),
+        }),
+      );
+
+      // Assert: draft was created
+      expect(nylasClient.createDraft).toHaveBeenCalled();
+
+      // Assert: action_log was linked with draftId
+      expect(actionLogRepo.linkPayload).toHaveBeenCalledWith(
+        expect.stringMatching(/^email-/),
+        expect.objectContaining({ draftId: 'draft-abc', accountId: 'curia' }),
+      );
+    });
+
+    it('score >= threshold sends directly without draft or action_log', async () => {
+      const autonomyService = makeAutonomyService(85);
+      const nylasClient = makeMockNylasClient({});
+
+      gateway = new OutboundGateway({
+        autonomyService,
+        actionLogRepo,
+        nylasClients: new Map([['curia', nylasClient]]),
+        bus,
+        logger: createSilentLogger(),
+        contactService: makeMockContactService(),
+      });
+
+      // ... trigger outbound.message ...
+
+      expect(actionLogRepo.insert).not.toHaveBeenCalled();
+      expect(nylasClient.sendEmail).toHaveBeenCalled();  // direct send
+    });
+  });
+
+  describe('multi-account', () => {
+    it('two accounts gated — each creates draft on its own account', async () => {
+      const autonomyService = makeAutonomyService(65);
+      const curiaNylas = makeMockNylasClient({ draftId: 'draft-curia' });
+      const josephNylas = makeMockNylasClient({ draftId: 'draft-joseph' });
+
+      gateway = new OutboundGateway({
+        autonomyService,
+        actionLogRepo,
+        nylasClients: new Map([['curia', curiaNylas], ['joseph', josephNylas]]),
+        bus,
+        logger: createSilentLogger(),
+        contactService: makeMockContactService(),
+      });
+
+      // Create two adapters with different accounts
+      const curiaAdapter = new EmailAdapter({
+        accountId: 'curia',
+        outboundPolicy: 'direct',
+        // ... config ...
+      });
+      const josephAdapter = new EmailAdapter({
+        accountId: 'joseph',
+        outboundPolicy: 'direct',
+        // ... config ...
+      });
+
+      await curiaAdapter.start();
+      await josephAdapter.start();
+
+      // Trigger outbound for each account
+      // Assert: curiaNylas.createDraft called, josephNylas.createDraft called
+      // Assert: two separate action_log rows with different accountIds
+    });
+  });
+
+  describe('draft_gate policy', () => {
+    it('creates draft without action_log or gateway.send()', async () => {
+      const nylasClient = makeMockNylasClient({ draftId: 'draft-cfg' });
+      gateway = new OutboundGateway({
+        nylasClients: new Map([['curia', nylasClient]]),
+        bus,
+        logger: createSilentLogger(),
+        contactService: makeMockContactService(),
+      });
+
+      const adapter = new EmailAdapter({
+        accountId: 'curia',
+        outboundPolicy: 'draft_gate',
+        // ... config ...
+      });
+
+      await adapter.start();
+
+      // Trigger outbound.message
+      // Assert: createDraft called, send NOT called, no action_log
+      expect(actionLogRepo.insert).not.toHaveBeenCalled();
+    });
+  });
+});
+```
+
+(Adapt helper functions to match the existing test utility patterns in the codebase.)
+
+- [ ] **Step 2: Run integration test**
+
+Run: `npm --prefix /path/to/worktree run test -- tests/integration/draft-fallback-flow.test.ts --run`
+Expected: PASS (if all previous tasks are implemented correctly)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/draft-fallback-flow.test.ts
+git commit -m "test(#435): add flow integration test for draft-fallback path"
+```
+
+---
+
+### Task 12: Housekeeping — CHANGELOG and Config Cleanup
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `config/default.yaml` (if it references `autonomy_gated`)
+- Modify: `src/index.ts` (if it wires autonomyService into email adapter)
+
+- [ ] **Step 1: Update CHANGELOG**
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Changed
+
+- **Outbound autonomy gate** — draft-fallback logic lifted from email adapter to OutboundGateway;
+  email adapter simplified to pure transport. Gateway now writes `autonomy_action_log` rows on
+  gated sends and supports two-step draft linkage. Observation-mode drafts also tracked in
+  action_log for unified pending-actions surface. (#435)
+- **Pending-actions-digest** — short reference codes moved to end of each line for readability
+
+### Removed
+
+- **`autonomy_gated` outbound policy** — replaced by gateway-level autonomy gate on `direct`
+  policy. Deployments using `autonomy_gated` must switch to `direct`.
+```
+
+- [ ] **Step 2: Update config/default.yaml if needed**
+
+Check if `config/default.yaml` references `autonomy_gated`. If so, change to `direct`.
+
+- [ ] **Step 3: Update src/index.ts bootstrap**
+
+Remove `autonomyService` from EmailAdapter construction (it's no longer in the config interface). Ensure `actionLogRepo` is wired into `OutboundGateway` construction.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `npm --prefix /path/to/worktree test`
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md config/default.yaml src/index.ts
+git commit -m "chore(#435): update changelog, remove autonomy_gated from config, wire actionLogRepo"
+```
+
+---
+
+## Verification
+
+After all tasks are complete:
+
+1. `npm --prefix /path/to/worktree test` — all unit and integration tests pass
+2. `npm --prefix /path/to/worktree run build` — TypeScript compiles cleanly
+3. `npm --prefix /path/to/worktree run lint` — no lint errors
+4. Manual grep: confirm no remaining references to `autonomy_gated` in source (excluding CHANGELOG/docs)
+5. Manual grep: confirm no remaining hardcoded `70` in outbound-gateway.ts or email-adapter.ts

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -236,9 +236,8 @@
               "self_email": { "type": "string", "minLength": 1 },
               "outbound_policy": {
                 "type": "string",
-                "enum": ["direct", "draft_gate", "autonomy_gated"]
-              },
-              "autonomy_threshold": { "type": "integer", "minimum": 0, "maximum": 100 }
+                "enum": ["direct", "draft_gate"]
+              }
             }
           }
         }

--- a/skills/email-draft-save/handler.test.ts
+++ b/skills/email-draft-save/handler.test.ts
@@ -1,0 +1,365 @@
+// handler.test.ts — unit tests for email-draft-save skill.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EmailDraftSaveHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+// --- Shared test helpers ---
+
+// Minimal valid draft input for non-observation-mode calls
+const BASE_INPUT = {
+  to: 'alice@example.com',
+  subject: 'Hello',
+  body: 'Hi there',
+  account: 'ceo',
+};
+
+// A mock outboundGateway that returns a successful draft creation result
+function makeMockGateway(overrides?: { createEmailDraft?: ReturnType<typeof vi.fn> }) {
+  return {
+    createEmailDraft: overrides?.createEmailDraft
+      ?? vi.fn().mockResolvedValue({ success: true, draftId: 'draft-abc' }),
+    // Other gateway methods are not used by this skill — typed as unknown
+  } as unknown as SkillContext['outboundGateway'];
+}
+
+function makeMockActionLogRepo(overrides?: Partial<ActionLogRepo>): ActionLogRepo {
+  return {
+    insert: vi.fn().mockResolvedValue(42),
+    countShortRefsForTask: vi.fn().mockResolvedValue(0),
+    // Other methods not used by this skill — typed as unknown
+    ...overrides,
+  } as unknown as ActionLogRepo;
+}
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: BASE_INPUT,
+    secret: (name: string) => { throw new Error(`secret '${name}' not configured in test`); },
+    log: createSilentLogger(),
+    outboundGateway: makeMockGateway(),
+    taskMetadata: {},
+    taskEventId: undefined,
+    ...overrides,
+  } as SkillContext;
+}
+
+// --- Baseline behaviour tests ---
+
+describe('EmailDraftSaveHandler — baseline', () => {
+  it('returns error when outboundGateway is missing', async () => {
+    const handler = new EmailDraftSaveHandler();
+    const result = await handler.execute(makeCtx({ outboundGateway: undefined }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('outboundGateway');
+  });
+
+  it('returns error when "to" field is missing', async () => {
+    const handler = new EmailDraftSaveHandler();
+    const result = await handler.execute(makeCtx({ input: { ...BASE_INPUT, to: '' } }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('to');
+  });
+
+  it('returns error when "subject" field is missing', async () => {
+    const handler = new EmailDraftSaveHandler();
+    const result = await handler.execute(makeCtx({ input: { ...BASE_INPUT, subject: '' } }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('subject');
+  });
+
+  it('returns error when "body" field is missing', async () => {
+    const handler = new EmailDraftSaveHandler();
+    const result = await handler.execute(makeCtx({ input: { ...BASE_INPUT, body: '' } }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('body');
+  });
+
+  it('creates a draft and returns draft_id on success', async () => {
+    const handler = new EmailDraftSaveHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(true);
+    expect((result as { data: Record<string, unknown> }).data).toEqual({ draft_id: 'draft-abc' });
+  });
+
+  it('returns error when gateway rejects the draft', async () => {
+    const handler = new EmailDraftSaveHandler();
+    const gateway = makeMockGateway({
+      createEmailDraft: vi.fn().mockResolvedValue({ success: false, blockedReason: 'Contact blocked' }),
+    });
+    const result = await handler.execute(makeCtx({ outboundGateway: gateway }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('Contact blocked');
+  });
+
+  it('returns error when gateway throws', async () => {
+    const handler = new EmailDraftSaveHandler();
+    const gateway = makeMockGateway({
+      createEmailDraft: vi.fn().mockRejectedValue(new Error('Network failure')),
+    });
+    const result = await handler.execute(makeCtx({ outboundGateway: gateway }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('Failed to save draft');
+  });
+});
+
+// --- Observation-mode triage_classification guard ---
+
+describe('EmailDraftSaveHandler — observation-mode guard', () => {
+  it('blocks draft in observation mode when triage_classification is absent', async () => {
+    const handler = new EmailDraftSaveHandler();
+    const result = await handler.execute(makeCtx({
+      taskMetadata: { observationMode: true },
+      input: BASE_INPUT,
+    }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('observation mode');
+  });
+
+  it('blocks draft in observation mode when triage_classification is not "NEEDS DRAFT"', async () => {
+    const handler = new EmailDraftSaveHandler();
+    const result = await handler.execute(makeCtx({
+      taskMetadata: { observationMode: true },
+      input: { ...BASE_INPUT, triage_classification: 'NOISE' },
+    }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('NOISE');
+  });
+
+  it('allows draft in observation mode when triage_classification is "NEEDS DRAFT"', async () => {
+    const handler = new EmailDraftSaveHandler();
+    const result = await handler.execute(makeCtx({
+      taskMetadata: { observationMode: true },
+      input: { ...BASE_INPUT, triage_classification: 'NEEDS DRAFT' },
+    }));
+    expect(result.success).toBe(true);
+  });
+});
+
+// --- Observation-mode action_log tracking ---
+
+describe('EmailDraftSaveHandler — observation-mode action_log tracking', () => {
+  let handler: EmailDraftSaveHandler;
+  let gateway: ReturnType<typeof makeMockGateway>;
+
+  beforeEach(() => {
+    handler = new EmailDraftSaveHandler();
+    gateway = makeMockGateway();
+  });
+
+  it('writes action_log row with source observation_mode when draft is created in obs mode', async () => {
+    const repo = makeMockActionLogRepo();
+    const result = await handler.execute(makeCtx({
+      outboundGateway: gateway,
+      taskMetadata: { observationMode: true },
+      taskEventId: 'task-123',
+      actionLogRepo: repo,
+      input: { ...BASE_INPUT, triage_classification: 'NEEDS DRAFT', subject: 'Quarterly Review' },
+    }));
+
+    expect(result.success).toBe(true);
+
+    // countShortRefsForTask must be called to generate the sequential short_ref
+    expect(repo.countShortRefsForTask).toHaveBeenCalledOnce();
+    expect(repo.countShortRefsForTask).toHaveBeenCalledWith('task-123');
+
+    // insert must be called exactly once
+    expect(repo.insert).toHaveBeenCalledOnce();
+
+    const insertedRow = (repo.insert as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+
+    // Core identity fields
+    expect(insertedRow.taskId).toBe('task-123');
+    // conversationId is not on SkillContext — the handler passes undefined
+    expect(insertedRow.conversationId).toBeUndefined();
+    expect(insertedRow.skillName).toBe('email-draft-save');
+    expect(insertedRow.actionRisk).toBe('medium');
+    expect(insertedRow.outcome).toBe('pending_approval');
+
+    // Short ref is "email-1" when no prior refs exist (count returns 0)
+    expect(insertedRow.shortRef).toBe('email-1');
+
+    // Description includes recipient and subject
+    expect(insertedRow.description).toContain('alice@example.com');
+    expect(insertedRow.description).toContain('Quarterly Review');
+
+    // Payload has source, draftId, accountId, and recipient info
+    expect(insertedRow.payload).toMatchObject({
+      source: 'observation_mode',
+      draftId: 'draft-abc',
+      accountId: 'ceo',
+      recipientEmail: 'alice@example.com',
+      subject: 'Quarterly Review',
+    });
+
+    // Expiry is ~48 hours out (allow ±5s tolerance for test timing)
+    const expectedExpiry = Date.now() + 48 * 60 * 60 * 1000;
+    expect(insertedRow.expiresAt).toBeInstanceOf(Date);
+    expect(Math.abs((insertedRow.expiresAt as Date).getTime() - expectedExpiry)).toBeLessThan(5000);
+  });
+
+  it('increments short_ref counter based on existing short refs for the task', async () => {
+    // Two prior short_refs already exist for this task → next counter is 3 → "email-3"
+    const repo = makeMockActionLogRepo({
+      countShortRefsForTask: vi.fn().mockResolvedValue(2),
+    });
+
+    await handler.execute(makeCtx({
+      outboundGateway: gateway,
+      taskMetadata: { observationMode: true },
+      taskEventId: 'task-999',
+      actionLogRepo: repo,
+      input: { ...BASE_INPUT, triage_classification: 'NEEDS DRAFT' },
+    }));
+
+    const insertedRow = (repo.insert as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(insertedRow.shortRef).toBe('email-3');
+  });
+
+  it('omits subject clause from description when subject is absent', async () => {
+    // Subject is validated as required, so this tests the description logic path
+    // where subject is present but we exercise description formatting edge.
+    // Since subject is required input, we verify description includes subject
+    // when provided — which is covered above. This test verifies payload accuracy
+    // when accountId is absent (no account field).
+    const repo = makeMockActionLogRepo();
+
+    await handler.execute(makeCtx({
+      outboundGateway: gateway,
+      taskMetadata: { observationMode: true },
+      taskEventId: 'task-001',
+      actionLogRepo: repo,
+      input: {
+        to: 'bob@example.com',
+        subject: 'Test',
+        body: 'Body',
+        // account intentionally omitted → accountId is undefined
+        triage_classification: 'NEEDS DRAFT',
+      },
+    }));
+
+    const insertedRow = (repo.insert as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    // No account in description's trailing segment when accountId is undefined
+    expect(insertedRow.payload.accountId).toBeUndefined();
+  });
+
+  it('does NOT write action_log when not in observation mode', async () => {
+    const repo = makeMockActionLogRepo();
+
+    const result = await handler.execute(makeCtx({
+      outboundGateway: gateway,
+      taskMetadata: { observationMode: false },
+      taskEventId: 'task-xyz',
+      actionLogRepo: repo,
+      input: BASE_INPUT,
+    }));
+
+    expect(result.success).toBe(true);
+    expect(repo.insert).not.toHaveBeenCalled();
+    expect(repo.countShortRefsForTask).not.toHaveBeenCalled();
+  });
+
+  it('does NOT write action_log when taskMetadata is absent', async () => {
+    const repo = makeMockActionLogRepo();
+
+    const result = await handler.execute(makeCtx({
+      outboundGateway: gateway,
+      taskMetadata: undefined,
+      taskEventId: 'task-xyz',
+      actionLogRepo: repo,
+      input: BASE_INPUT,
+    }));
+
+    expect(result.success).toBe(true);
+    expect(repo.insert).not.toHaveBeenCalled();
+  });
+
+  it('does NOT write action_log when actionLogRepo is absent (observationMode true)', async () => {
+    // Guard: if the repo capability is not injected, skip silently
+    const result = await handler.execute(makeCtx({
+      outboundGateway: gateway,
+      taskMetadata: { observationMode: true },
+      taskEventId: 'task-xyz',
+      actionLogRepo: undefined,
+      input: { ...BASE_INPUT, triage_classification: 'NEEDS DRAFT' },
+    }));
+
+    // Skill still succeeds — no crash from absent repo
+    expect(result.success).toBe(true);
+  });
+
+  it('does NOT write action_log when taskEventId is absent (observationMode true)', async () => {
+    const repo = makeMockActionLogRepo();
+
+    const result = await handler.execute(makeCtx({
+      outboundGateway: gateway,
+      taskMetadata: { observationMode: true },
+      taskEventId: undefined,
+      actionLogRepo: repo,
+      input: { ...BASE_INPUT, triage_classification: 'NEEDS DRAFT' },
+    }));
+
+    expect(result.success).toBe(true);
+    expect(repo.insert).not.toHaveBeenCalled();
+  });
+
+  it('does not fail the skill if action_log write throws', async () => {
+    const repo = makeMockActionLogRepo({
+      insert: vi.fn().mockRejectedValue(new Error('DB connection lost')),
+    });
+
+    const result = await handler.execute(makeCtx({
+      outboundGateway: gateway,
+      taskMetadata: { observationMode: true },
+      taskEventId: 'task-123',
+      actionLogRepo: repo,
+      input: { ...BASE_INPUT, triage_classification: 'NEEDS DRAFT' },
+    }));
+
+    // The draft was saved successfully — the action_log write failure must not propagate
+    expect(result.success).toBe(true);
+    expect((result as { data: Record<string, unknown> }).data).toEqual({ draft_id: 'draft-abc' });
+  });
+
+  it('does not fail the skill if countShortRefsForTask throws', async () => {
+    const repo = makeMockActionLogRepo({
+      countShortRefsForTask: vi.fn().mockRejectedValue(new Error('DB timeout')),
+    });
+
+    const result = await handler.execute(makeCtx({
+      outboundGateway: gateway,
+      taskMetadata: { observationMode: true },
+      taskEventId: 'task-123',
+      actionLogRepo: repo,
+      input: { ...BASE_INPUT, triage_classification: 'NEEDS DRAFT' },
+    }));
+
+    expect(result.success).toBe(true);
+    // insert should not have been called since countShortRefs threw
+    expect(repo.insert).not.toHaveBeenCalled();
+  });
+
+  it('succeeds and writes action_log when no subject is available (not possible per validation but exercises description without subject branch)', async () => {
+    // subject is validated as required before the action_log write, so we just verify
+    // that the description is built correctly when a subject IS present — the "without
+    // subject" description branch is guarded by the required-field check above.
+    // This test instead exercises the full happy path with a different subject to
+    // confirm description formatting is stable.
+    const repo = makeMockActionLogRepo();
+
+    await handler.execute(makeCtx({
+      outboundGateway: gateway,
+      taskMetadata: { observationMode: true },
+      taskEventId: 'task-888',
+      actionLogRepo: repo,
+      input: { ...BASE_INPUT, subject: 'Board Update', triage_classification: 'NEEDS DRAFT' },
+    }));
+
+    const insertedRow = (repo.insert as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(insertedRow.description).toContain('Board Update');
+    // conversationId is always undefined (not on SkillContext)
+    expect(insertedRow.conversationId).toBeUndefined();
+  });
+});

--- a/skills/email-draft-save/handler.ts
+++ b/skills/email-draft-save/handler.ts
@@ -100,6 +100,57 @@ export class EmailDraftSaveHandler implements SkillHandler {
     }
 
     ctx.log.info({ draftId: result.draftId, to, accountId }, 'email-draft-save: draft saved');
+
+    // Track observation-mode drafts in action_log for pending-actions-digest.
+    //
+    // When the coordinator creates a draft in observation mode, the CEO needs to
+    // know it exists so they can approve (send) or discard it. Writing a
+    // pending_approval row here surfaces the draft in the next digest and
+    // makes it reachable via the send-draft skill using the shortRef.
+    //
+    // We guard on all three prerequisites — missing any one means we either
+    // aren't in obs mode (no tracking needed) or can't form a valid row.
+    // Failures are non-fatal: a failed audit write must not block the draft.
+    if (ctx.taskMetadata?.observationMode === true && ctx.actionLogRepo && ctx.taskEventId) {
+      const recipientEmail = to;
+      try {
+        const counter = await ctx.actionLogRepo.countShortRefsForTask(ctx.taskEventId);
+        const shortRef = `email-${counter + 1}`;
+        const description = `Draft reply to ${recipientEmail}${subject ? ` — "${subject}"` : ''} (${accountId ?? 'default'}). Use send-draft to approve.`;
+
+        await ctx.actionLogRepo.insert({
+          taskId: ctx.taskEventId,
+          // conversationId is not surfaced on SkillContext — omit rather than pass null
+          skillName: 'email-draft-save',
+          actionRisk: 'medium',
+          outcome: 'pending_approval',
+          shortRef,
+          description,
+          payload: {
+            source: 'observation_mode',
+            draftId: result.draftId,
+            accountId,
+            recipientEmail,
+            subject,
+          },
+          expiresAt: new Date(Date.now() + 48 * 60 * 60 * 1000),
+        });
+
+        ctx.log.info(
+          { draftId: result.draftId, shortRef, taskId: ctx.taskEventId },
+          'email-draft-save: observation-mode draft tracked in action_log',
+        );
+      } catch (err) {
+        // Non-fatal — the draft was already created successfully. The coordinator
+        // and CEO can still find it via their email client; the digest just won't
+        // list it. Log at warn so it surfaces for investigation without alarming ops.
+        ctx.log.warn(
+          { err, draftId: result.draftId, taskId: ctx.taskEventId },
+          'email-draft-save: failed to write action_log row for observation-mode draft — draft was saved but will not appear in pending-actions-digest',
+        );
+      }
+    }
+
     return { success: true, data: { draft_id: result.draftId } };
   }
 }

--- a/skills/email-draft-save/handler.ts
+++ b/skills/email-draft-save/handler.ts
@@ -143,10 +143,11 @@ export class EmailDraftSaveHandler implements SkillHandler {
       } catch (err) {
         // Non-fatal — the draft was already created successfully. The coordinator
         // and CEO can still find it via their email client; the digest just won't
-        // list it. Log at warn so it surfaces for investigation without alarming ops.
-        ctx.log.warn(
+        // list it. Log at error (not warn) so the missing digest entry is visible in
+        // alerting and can be investigated before the CEO misses an approval opportunity.
+        ctx.log.error(
           { err, draftId: result.draftId, taskId: ctx.taskEventId },
-          'email-draft-save: failed to write action_log row for observation-mode draft — draft was saved but will not appear in pending-actions-digest',
+          'email-draft-save: failed to write action_log row for observation-mode draft — draft saved but will not appear in pending-actions-digest',
         );
       }
     }

--- a/skills/email-draft-save/skill.json
+++ b/skills/email-draft-save/skill.json
@@ -19,6 +19,7 @@
   "secrets": [],
   "timeout": 20000,
   "capabilities": [
-    "outboundGateway"
+    "outboundGateway",
+    "actionLogRepo"
   ]
 }

--- a/skills/pending-actions-digest/handler.ts
+++ b/skills/pending-actions-digest/handler.ts
@@ -66,15 +66,15 @@ export class PendingActionsDigestHandler implements SkillHandler {
       }
 
       // --- Step 4: Build bullet-list body ---
-      // Each line shows the short reference, description, originating skill, and
-      // time remaining so the CEO can quickly assess urgency without opening each request.
+      // Each line shows the description, originating skill, time remaining, and short
+      // reference (at end) so the CEO can quickly assess urgency without opening each request.
       const body = pending
         .map((r) => {
           // expiresAt is guaranteed non-null by findAllPending() (WHERE expires_at > now()),
           // but the type is Date | null — null-coalesce to avoid calling .getTime() on null.
           const msRemaining = r.expiresAt != null ? r.expiresAt.getTime() - Date.now() : 0;
           const timeRemaining = formatTimeRemaining(msRemaining);
-          return `• ${r.shortRef ?? '(no ref)'}: ${r.description ?? '(no description)'} [${r.skillName}] — ${timeRemaining}`;
+          return `• ${r.description ?? '(no description)'} [${r.skillName}] — ${timeRemaining} [${r.shortRef ?? '—'}]`;
         })
         .join('\n');
 

--- a/skills/send-draft/handler.test.ts
+++ b/skills/send-draft/handler.test.ts
@@ -3,6 +3,7 @@ import { SendDraftHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 import type { OutboundGateway } from '../../src/skills/outbound-gateway.js';
 import type { EventBus } from '../../src/bus/bus.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
 import pino from 'pino';
 
 function makeLogger() {
@@ -31,6 +32,7 @@ function makeCtx(overrides: {
   gateway?: Partial<OutboundGateway>;
   bus?: Partial<EventBus>;
   taskEventId?: string;
+  actionLogRepo?: Partial<ActionLogRepo> | null;
 }): SkillContext {
   const gateway = {
     listEmailMessages: vi.fn().mockResolvedValue([DRAFT_STUB]),
@@ -43,6 +45,14 @@ function makeCtx(overrides: {
     ...overrides.bus,
   } as unknown as EventBus;
 
+  // Build action log repo — undefined by default (matches pre-existing tests),
+  // null means explicitly absent (ctx.actionLogRepo = undefined), or a partial mock.
+  const actionLogRepo = overrides.actionLogRepo === null
+    ? undefined
+    : overrides.actionLogRepo !== undefined
+      ? overrides.actionLogRepo as unknown as ActionLogRepo
+      : undefined;
+
   const ctx = {
     input: overrides.input ?? { draft_id: 'draft-abc123', account: 'joseph' },
     secret: () => '',
@@ -53,6 +63,7 @@ function makeCtx(overrides: {
       ? overrides.taskMetadata
       : { ceoInitiated: true, senderId: '+14155551234', channelId: 'signal' },
     taskEventId: overrides.taskEventId ?? 'task-event-1',
+    actionLogRepo,
   } as unknown as SkillContext;
 
   return ctx;
@@ -238,5 +249,64 @@ describe('SendDraftHandler', () => {
 
     const result = await handler.execute(ctx);
     expect(result.success).toBe(true);
+  });
+
+  // ─── action_log transition on approval ───────────────────────────────────
+
+  describe('action_log transition on approval', () => {
+    it('transitions matching action_log row to approved on successful send', async () => {
+      // Arrange: actionLogRepo finds a matching pending row for the draft
+      const mockRow = { id: 55 };
+      const findPendingByPayloadField = vi.fn().mockResolvedValue(mockRow);
+      const resolveById = vi.fn().mockResolvedValue(true);
+      const ctx = makeCtx({
+        actionLogRepo: { findPendingByPayloadField, resolveById },
+      });
+
+      // Act
+      const result = await handler.execute(ctx);
+
+      // Assert: send succeeded and action_log was transitioned
+      expect(result.success).toBe(true);
+      expect(findPendingByPayloadField).toHaveBeenCalledWith('draftId', 'draft-abc123');
+      expect(resolveById).toHaveBeenCalledWith(55, 'approved', 'ceo');
+    });
+
+    it('still succeeds when no action_log row exists (pre-existing draft)', async () => {
+      // findPendingByPayloadField returns null — draft was not created via the autonomy gate
+      const findPendingByPayloadField = vi.fn().mockResolvedValue(null);
+      const resolveById = vi.fn();
+      const ctx = makeCtx({
+        actionLogRepo: { findPendingByPayloadField, resolveById },
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      // resolveById must NOT be called when no row was found
+      expect(resolveById).not.toHaveBeenCalled();
+    });
+
+    it('still succeeds when actionLogRepo is not available', async () => {
+      // No actionLogRepo in ctx — older code paths, or skills without the capability
+      const ctx = makeCtx({ actionLogRepo: null });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('still succeeds when action_log transition throws', async () => {
+      // Best-effort: failure in the action_log path must not fail the skill —
+      // the email has already been sent at this point.
+      const findPendingByPayloadField = vi.fn().mockRejectedValue(new Error('DB error'));
+      const ctx = makeCtx({
+        actionLogRepo: { findPendingByPayloadField, resolveById: vi.fn() },
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+    });
   });
 });

--- a/skills/send-draft/handler.ts
+++ b/skills/send-draft/handler.ts
@@ -124,7 +124,26 @@ export class SendDraftHandler implements SkillHandler {
     }
 
     // ------------------------------------------------------------------
-    // Step 5: Publish human.decision audit event
+    // Step 5: Transition action_log row from pending_approval → approved
+    // ------------------------------------------------------------------
+    // Best-effort — the email is already sent. Any failure here must not
+    // surface to the CEO as a skill error. The draftId was stored in the
+    // payload by the gateway's two-step draft-fallback pattern (linkPayload).
+    // Rows created outside the autonomy gate will not match and are silently skipped.
+    if (ctx.actionLogRepo) {
+      try {
+        const row = await ctx.actionLogRepo.findPendingByPayloadField('draftId', draftId);
+        if (row) {
+          await ctx.actionLogRepo.resolveById(row.id, 'approved', 'ceo');
+        }
+      } catch (err) {
+        // Best-effort — don't fail the send if action_log transition fails
+        ctx.log.warn({ err, draftId }, 'send-draft: failed to transition action_log row');
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // Step 6: Publish human.decision audit event
     // ------------------------------------------------------------------
     // Non-fatal: the message is already sent. If bus publish fails, log at error
     // so the missing audit trail is visible in alerting, but don't fail the skill.

--- a/skills/send-draft/handler.ts
+++ b/skills/send-draft/handler.ts
@@ -134,11 +134,25 @@ export class SendDraftHandler implements SkillHandler {
       try {
         const row = await ctx.actionLogRepo.findPendingByPayloadField('draftId', draftId);
         if (row) {
-          await ctx.actionLogRepo.resolveById(row.id, 'approved', 'ceo');
+          const updated = await ctx.actionLogRepo.resolveById(row.id, 'approved', 'ceo');
+          if (!updated) {
+            // Row was present during find but couldn't be resolved — likely a concurrent
+            // approval (e.g. two CEO messages sent in quick succession). Log at warn so
+            // the gap is visible, but don't fail the send (draft was already sent above).
+            ctx.log.warn(
+              { draftId, rowId: row.id },
+              'send-draft: action_log row was already resolved — possible concurrent approval; no action taken',
+            );
+          }
         }
       } catch (err) {
-        // Best-effort — don't fail the send if action_log transition fails
-        ctx.log.warn({ err, draftId }, 'send-draft: failed to transition action_log row');
+        // Best-effort — the email was already sent. Failure here leaves the row in
+        // pending_approval, so it will appear in the next digest. Log at error so the
+        // stuck row is visible in alerting and can be cleaned up manually.
+        ctx.log.error(
+          { err, draftId },
+          'send-draft: failed to transition action_log row — row will remain pending_approval and appear in next digest',
+        );
       }
     }
 

--- a/skills/send-draft/skill.json
+++ b/skills/send-draft/skill.json
@@ -18,6 +18,7 @@
   "timeout": 30000,
   "capabilities": [
     "outboundGateway",
-    "bus"
+    "bus",
+    "actionLogRepo"
   ]
 }

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -424,6 +424,65 @@ describe('ActionLogRepo', () => {
     });
   });
 
+  describe('findPendingByPayloadField', () => {
+    it('returns row when payload field matches', async () => {
+      const now = new Date();
+      const { pool } = makePool([
+        {
+          id: 1, task_id: 't-1', conversation_id: null, skill_name: 'send-email',
+          action_risk: 'medium', outcome: 'pending_approval', task_summary: null,
+          competence_flag: null, commitment_flag: null, compatibility: null,
+          scored_by: null, payload: { draftId: 'draft-abc' }, notification_sent_at: null,
+          resolved_at: null, resolved_by: null, expires_at: new Date(Date.now() + 86_400_000),
+          parent_action_id: null, short_ref: 'email-1', description: 'Send email draft',
+          created_at: now,
+        },
+      ]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const result = await repo.findPendingByPayloadField('draftId', 'draft-abc');
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(1);
+    });
+
+    it('returns null when no match', async () => {
+      const { pool } = makePool([]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const result = await repo.findPendingByPayloadField('draftId', 'nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('queries with correct SQL targeting payload JSONB field and pending_approval outcome', async () => {
+      const { pool, queries } = makePool([]);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      await repo.findPendingByPayloadField('draftId', 'draft-xyz');
+      expect(queries[0]!.sql).toContain("outcome = 'pending_approval'");
+      expect(queries[0]!.sql).toContain('payload->>');
+      expect(queries[0]!.params).toContain('draftId');
+      expect(queries[0]!.params).toContain('draft-xyz');
+    });
+  });
+
+  describe('resolveById', () => {
+    it('returns true when row is updated', async () => {
+      const { pool, queries } = makePool([], 1);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const result = await repo.resolveById(42, 'approved', 'ceo');
+      expect(result).toBe(true);
+      expect(queries[0]!.sql).toContain('UPDATE autonomy_action_log');
+      expect(queries[0]!.sql).toContain("outcome = 'pending_approval'");
+      expect(queries[0]!.params).toContain(42);
+      expect(queries[0]!.params).toContain('approved');
+      expect(queries[0]!.params).toContain('ceo');
+    });
+
+    it('returns false when no matching row (already resolved or not found)', async () => {
+      const { pool } = makePool([], 0);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+      const result = await repo.resolveById(99, 'approved', 'ceo');
+      expect(result).toBe(false);
+    });
+  });
+
   describe('expireRows', () => {
     it('batch-transitions rows to expired and returns the updated rows', async () => {
       const now = new Date();

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -399,6 +399,31 @@ describe('ActionLogRepo', () => {
     });
   });
 
+  describe('linkPayload', () => {
+    it('merges additional payload into existing row by short_ref', async () => {
+      // rowCount = 1 signals that one row was updated; rows array is the RETURNING result (unused here)
+      const { pool, queries } = makePool([{ id: 1, payload: { source: 'autonomy_gate' } }], 1);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+
+      const result = await repo.linkPayload('email-1', { draftId: 'draft-abc', accountId: 'curia' });
+
+      expect(result).toBe(true);
+      expect(queries[0]!.sql).toContain('UPDATE');
+      expect(queries[0]!.sql).toContain('short_ref');
+      expect(queries[0]!.sql).toContain('jsonb');
+      expect(queries[0]!.params).toContain('email-1');
+    });
+
+    it('returns false when no row matches the short_ref', async () => {
+      const { pool } = makePool([]);  // empty result — rowCount = 0
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+
+      const result = await repo.linkPayload('unknown-ref', { draftId: 'draft-xyz' });
+
+      expect(result).toBe(false);
+    });
+  });
+
   describe('expireRows', () => {
     it('batch-transitions rows to expired and returns the updated rows', async () => {
       const now = new Date();

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -405,7 +405,7 @@ describe('ActionLogRepo', () => {
       const { pool, queries } = makePool([{ id: 1, payload: { source: 'autonomy_gate' } }], 1);
       const repo = new ActionLogRepo(pool, createSilentLogger());
 
-      const result = await repo.linkPayload('email-1', { draftId: 'draft-abc', accountId: 'curia' });
+      const result = await repo.linkPayload('email-1', 'task-evt-001', { draftId: 'draft-abc', accountId: 'curia' });
 
       expect(result).toBe(true);
       expect(queries[0]!.sql).toContain('UPDATE');
@@ -418,7 +418,7 @@ describe('ActionLogRepo', () => {
       const { pool } = makePool([]);  // empty result — rowCount = 0
       const repo = new ActionLogRepo(pool, createSilentLogger());
 
-      const result = await repo.linkPayload('unknown-ref', { draftId: 'draft-xyz' });
+      const result = await repo.linkPayload('unknown-ref', undefined, { draftId: 'draft-xyz' });
 
       expect(result).toBe(false);
     });

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -238,6 +238,46 @@ export class ActionLogRepo {
   }
 
   /**
+   * Find a pending_approval row where a specific field in the JSONB payload
+   * matches the given value. Used by send-draft to find the action_log row
+   * associated with a draft being approved.
+   */
+  async findPendingByPayloadField(
+    field: string,
+    value: string,
+  ): Promise<ActionLogRow | null> {
+    const result = await this.pool.query(
+      `SELECT * FROM autonomy_action_log
+       WHERE outcome = 'pending_approval'
+         AND payload->>$1 = $2
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [field, value],
+    );
+    return result.rows[0] ? mapRow(result.rows[0]) : null;
+  }
+
+  /**
+   * Transition a specific action_log row to a terminal outcome by ID.
+   * Only updates if the current outcome is still pending_approval — returns
+   * false on double-resolve (concurrent resolution race).
+   *
+   * Unlike resolveRow(), this method accepts a free-form outcome string so
+   * that callers (e.g. send-draft) can pass 'approved' without needing to
+   * import the union type. The WHERE guard on pending_approval ensures
+   * idempotency — a row that was already resolved will not be double-transitioned.
+   */
+  async resolveById(id: number, outcome: string, resolvedBy: string): Promise<boolean> {
+    const result = await this.pool.query(
+      `UPDATE autonomy_action_log
+       SET outcome = $2, resolved_at = NOW(), resolved_by = $3
+       WHERE id = $1 AND outcome = 'pending_approval'`,
+      [id, outcome, resolvedBy],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
    * Merge additional payload fields into an existing action_log row identified
    * by short_ref. Used by the gateway's two-step draft-fallback pattern: the
    * initial row is created on gate (with source/context), then the adapter

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -238,6 +238,25 @@ export class ActionLogRepo {
   }
 
   /**
+   * Merge additional payload fields into an existing action_log row identified
+   * by short_ref. Used by the gateway's two-step draft-fallback pattern: the
+   * initial row is created on gate (with source/context), then the adapter
+   * links the draft ID after creating the draft.
+   *
+   * Returns true if a row was updated, false if no matching pending row exists.
+   */
+  async linkPayload(shortRef: string, additionalPayload: Record<string, unknown>): Promise<boolean> {
+    const result = await this.pool.query(
+      `UPDATE autonomy_action_log
+       SET payload = COALESCE(payload, '{}'::jsonb) || $2::jsonb
+       WHERE short_ref = $1
+         AND outcome = 'pending_approval'`,
+      [shortRef, JSON.stringify(additionalPayload)],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
    * Transition a pending_approval row to a terminal outcome.
    * Only updates if the current outcome is still pending_approval —
    * returns `false` on double-resolve (concurrent resolution race).

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -283,15 +283,29 @@ export class ActionLogRepo {
    * initial row is created on gate (with source/context), then the adapter
    * links the draft ID after creating the draft.
    *
+   * When taskEventId is provided, the WHERE clause scopes the match to that
+   * specific task — short_ref is only unique per task (e.g. 'email-1' in task A
+   * and 'email-1' in task B are different rows). Passing taskEventId prevents
+   * draftId from being smeared across unrelated tasks when short_refs collide.
+   *
+   * When taskEventId is omitted (undefined/null), the filter is bypassed and the
+   * match is by short_ref + outcome alone — kept for backwards compatibility with
+   * callers that lack a taskEventId.
+   *
    * Returns true if a row was updated, false if no matching pending row exists.
    */
-  async linkPayload(shortRef: string, additionalPayload: Record<string, unknown>): Promise<boolean> {
+  async linkPayload(
+    shortRef: string,
+    taskEventId: string | undefined,
+    additionalPayload: Record<string, unknown>,
+  ): Promise<boolean> {
     const result = await this.pool.query(
       `UPDATE autonomy_action_log
-       SET payload = COALESCE(payload, '{}'::jsonb) || $2::jsonb
+       SET payload = COALESCE(payload, '{}'::jsonb) || $3::jsonb
        WHERE short_ref = $1
+         AND ($2::text IS NULL OR task_event_id = $2)
          AND outcome = 'pending_approval'`,
-      [shortRef, JSON.stringify(additionalPayload)],
+      [shortRef, taskEventId ?? null, JSON.stringify(additionalPayload)],
     );
     return (result.rowCount ?? 0) > 0;
   }

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -91,6 +91,9 @@ interface OutboundMessagePayload {
    * Absent for non-reply outbound paths where no inbound routing entry exists.
    */
   recipientId?: string;
+  /** The agent.task event ID that originated this outbound message.
+   *  Stamped by the dispatcher for traceability and action_log context. */
+  taskEventId?: string;
 }
 
 // OutboundPiiRedactedPayload — emitted by the dispatch layer (via PiiRedactor)

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -402,7 +402,10 @@ export class EmailAdapter {
         replyToMessageId: threadMessage.id,
       };
 
-      await this.dispatchByPolicy(sendRequest, { threadId, latestIsOurs, to: recipientEmail });
+      await this.dispatchByPolicy(sendRequest, {
+        taskEventId: outbound.payload.taskEventId,
+        conversationId: outbound.payload.conversationId,
+      });
     } catch (err) {
       logger.error({ err, threadId }, 'Failed to send email reply');
     }
@@ -412,51 +415,54 @@ export class EmailAdapter {
    * Apply this account's outbound policy before dispatching a reply.
    *
    * - direct:      send immediately through the gateway (autonomy gate + blocked-contact +
-   *                content filter all run inside gateway.send)
+   *                content filter all run inside gateway.send). If the gateway returns
+   *                gated (autonomy blocked), fall back to creating a draft and linking
+   *                the action_log row so the CEO can approve-and-send from the digest.
    * - draft_gate:  save as a Nylas draft for human review; no notification is
    *                sent — the CEO discovers drafts via the end-of-day Signal
-   *                digest (#403). Approval + send remain deferred (TODO(#278)).
+   *                digest (#403). No autonomy decision, no action_log.
    */
   private async dispatchByPolicy(
     sendRequest: EmailSendRequest,
-    logCtx: Record<string, unknown>,
+    context: { taskEventId?: string; conversationId?: string },
   ): Promise<void> {
-    const { outboundGateway, logger, outboundPolicy } = this.config;
+    const { outboundPolicy, outboundGateway, logger, accountId } = this.config;
 
-    if (outboundPolicy === 'direct') {
-      // Standard path — gateway enforces autonomy gate, blocked-contact check, and content filter
-      const result = await outboundGateway.send(sendRequest);
-      if (result.success) {
-        logger.info({ ...logCtx, accountId: this.config.accountId }, 'Email reply sent via gateway');
-      } else {
-        logger.warn({ ...logCtx, accountId: this.config.accountId, reason: result.blockedReason }, 'Email reply blocked by gateway');
-      }
+    if (outboundPolicy === 'draft_gate') {
+      // Config-level always-draft — no autonomy decision, no action_log
+      await outboundGateway.createEmailDraft(sendRequest);
       return;
     }
 
-    // draft_gate: save as draft for human review.
-    // The gateway creates the draft silently — no per-draft email notification is sent.
-    // The CEO discovers pending drafts via the end-of-day Signal digest (#403).
-    const draftResult = await outboundGateway.createEmailDraft(sendRequest);
-    if (draftResult.success) {
+    // Policy: 'direct' — send through gateway, handle gated fallback
+    const result = await outboundGateway.send(sendRequest, {
+      taskEventId: context.taskEventId,
+      conversationId: context.conversationId,
+    });
+
+    if (result.success) return;
+
+    if (result.gated) {
+      // Gateway blocked the send — create draft as fallback
+      const draftResult = await outboundGateway.createEmailDraft(sendRequest);
+
+      if (draftResult.success && draftResult.draftId && result.actionRef) {
+        await outboundGateway.linkGatedAction(result.actionRef, {
+          draftId: draftResult.draftId,
+          accountId,
+          recipientEmail: sendRequest.to,
+          subject: sendRequest.subject,
+        });
+      }
+
       logger.info(
-        { ...logCtx, accountId: this.config.accountId, draftId: draftResult.draftId },
-        'Email reply saved as draft for CEO review',
+        { accountId, actionRef: result.actionRef, draftId: draftResult.draftId },
+        'email-adapter: send gated by autonomy — draft created as fallback',
       );
-    } else if (draftResult.blockedReason === 'Recipient is blocked') {
-      // Intentional block — not an infrastructure failure
-      logger.warn(
-        { ...logCtx, accountId: this.config.accountId, reason: draftResult.blockedReason },
-        'Email draft blocked — recipient is on the blocked list',
-      );
-    } else {
-      // Infrastructure failure (Nylas error, contact resolution failure, client not configured).
-      // The reply is permanently lost — log at error so operators can investigate.
-      logger.error(
-        { ...logCtx, accountId: this.config.accountId, reason: draftResult.blockedReason },
-        'Email draft creation failed — reply permanently lost',
-      );
+      return;
     }
+
+    // Non-gated failure (blocked contact, content filter, etc.) — already logged by gateway
   }
 
   /**

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -430,7 +430,13 @@ export class EmailAdapter {
 
     if (outboundPolicy === 'draft_gate') {
       // Config-level always-draft — no autonomy decision, no action_log
-      await outboundGateway.createEmailDraft(sendRequest);
+      const draftResult = await outboundGateway.createEmailDraft(sendRequest);
+      if (!draftResult.success) {
+        logger.error(
+          { accountId, reason: draftResult.blockedReason, to: sendRequest.to },
+          'email-adapter: draft_gate policy — createEmailDraft failed',
+        );
+      }
       return;
     }
 
@@ -443,21 +449,48 @@ export class EmailAdapter {
     if (result.success) return;
 
     if (result.gated) {
-      // Gateway blocked the send — create draft as fallback
-      const draftResult = await outboundGateway.createEmailDraft(sendRequest);
+      // Gateway blocked the send — create draft as fallback.
+      // Guard createEmailDraft explicitly: if it throws, we must not propagate to the
+      // outer sendOutboundReply catch, which would log "Failed to send email reply" even
+      // though the gateway gate is working correctly and no send was attempted.
+      let draftResult: Awaited<ReturnType<typeof outboundGateway.createEmailDraft>> | undefined;
+      try {
+        draftResult = await outboundGateway.createEmailDraft(sendRequest);
+      } catch (err) {
+        logger.error(
+          { err, accountId, actionRef: result.actionRef },
+          'email-adapter: unexpected error creating gated fallback draft — draft not created',
+        );
+        return;
+      }
 
-      if (draftResult.success && draftResult.draftId && result.actionRef) {
-        await outboundGateway.linkGatedAction(result.actionRef, {
-          draftId: draftResult.draftId,
-          accountId,
-          recipientEmail: sendRequest.to,
-          subject: sendRequest.subject,
-        });
+      if (draftResult && draftResult.success && draftResult.draftId) {
+        if (result.actionRef) {
+          // linkGatedAction is internally guarded (no-throw), so no outer try/catch needed here.
+          await outboundGateway.linkGatedAction(result.actionRef, {
+            draftId: draftResult.draftId,
+            accountId,
+            recipientEmail: sendRequest.to,
+            subject: sendRequest.subject,
+          });
+        } else {
+          // actionRef is absent when taskEventId was not passed — draft is created but
+          // won't appear in the pending-actions-digest. Log so the gap is visible.
+          logger.warn(
+            { accountId, draftId: draftResult.draftId },
+            'email-adapter: gated fallback draft created but no actionRef available — draft will not appear in pending-actions-digest (taskEventId was absent)',
+          );
+        }
+      } else if (draftResult && !draftResult.success) {
+        logger.error(
+          { accountId, actionRef: result.actionRef, reason: draftResult.blockedReason },
+          'email-adapter: gated fallback draft creation failed — send blocked, no draft created',
+        );
       }
 
       logger.info(
-        { accountId, actionRef: result.actionRef, draftId: draftResult.draftId },
-        'email-adapter: send gated by autonomy — draft created as fallback',
+        { accountId, draftId: draftResult?.draftId, actionRef: result.actionRef },
+        'email-adapter: send gated — fallback draft created',
       );
       return;
     }

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -11,7 +11,6 @@ import type { EventBus } from '../../bus/bus.js';
 import type { Logger } from '../../logger.js';
 import type { OutboundGateway, EmailSendRequest } from '../../skills/outbound-gateway.js';
 import type { ContactService } from '../../contacts/contact-service.js';
-import type { AutonomyService } from '../../autonomy/autonomy-service.js';
 import type { OutboundPolicy } from '../../config.js';
 import { convertNylasMessage } from './message-converter.js';
 import { createInboundMessage, type OutboundMessageEvent, type OutboundNotificationEvent } from '../../bus/events.js';
@@ -27,16 +26,11 @@ export interface EmailAdapterConfig {
   /**
    * How outbound replies from this account are handled.
    *
-   * - direct:          send immediately via OutboundGateway (current behavior)
-   * - draft_gate:      save as a Nylas draft silently; CEO discovers via end-of-day
-   *                    Signal digest and reviews in Gmail (#403, #278)
-   * - autonomy_gated:  send only when autonomy score >= autonomyThreshold
+   * - direct:      send immediately via OutboundGateway (autonomy gate applied at gateway level)
+   * - draft_gate:  save as a Nylas draft silently; CEO discovers via end-of-day
+   *                Signal digest and reviews in Gmail (#403, #278)
    */
   outboundPolicy: OutboundPolicy;
-  /** Required when outboundPolicy is 'autonomy_gated'. Minimum score (0–100) to send. */
-  autonomyThreshold?: number;
-  /** Required when outboundPolicy is 'autonomy_gated'. Queried before each send. */
-  autonomyService?: AutonomyService;
   bus: EventBus;
   logger: Logger;
   outboundGateway: OutboundGateway;
@@ -330,9 +324,8 @@ export class EmailAdapter {
    * most recent inbound message in that thread and reply to it.
    *
    * The actual send behaviour is controlled by this account's outboundPolicy:
-   *   - direct:         send immediately via OutboundGateway
-   *   - draft_gate:     save as Nylas draft silently; CEO discovers via Signal digest (#403, #278)
-   *   - autonomy_gated: check autonomy score before sending; hold as draft if below threshold
+   *   - direct:      send immediately via OutboundGateway (autonomy gate applied at gateway level)
+   *   - draft_gate:  save as Nylas draft silently; CEO discovers via Signal digest (#403, #278)
    */
   private async sendOutboundReply(outbound: OutboundMessageEvent): Promise<void> {
     const { outboundGateway, logger } = this.config;
@@ -418,22 +411,20 @@ export class EmailAdapter {
   /**
    * Apply this account's outbound policy before dispatching a reply.
    *
-   * - direct:         send immediately through the gateway (blocked-contact +
-   *                   content filter run inside gateway.send)
-   * - draft_gate:     save as a Nylas draft for human review; no notification is
-   *                   sent — the CEO discovers drafts via the end-of-day Signal
-   *                   digest (#403). Approval + send remain deferred (TODO(#278)).
-   * - autonomy_gated: check the current global autonomy score; if it meets the
-   *                   configured threshold, send directly; otherwise draft-gate
+   * - direct:      send immediately through the gateway (autonomy gate + blocked-contact +
+   *                content filter all run inside gateway.send)
+   * - draft_gate:  save as a Nylas draft for human review; no notification is
+   *                sent — the CEO discovers drafts via the end-of-day Signal
+   *                digest (#403). Approval + send remain deferred (TODO(#278)).
    */
   private async dispatchByPolicy(
     sendRequest: EmailSendRequest,
     logCtx: Record<string, unknown>,
   ): Promise<void> {
-    const { outboundGateway, logger, outboundPolicy, autonomyThreshold, autonomyService } = this.config;
+    const { outboundGateway, logger, outboundPolicy } = this.config;
 
     if (outboundPolicy === 'direct') {
-      // Standard path — gateway enforces blocked-contact check + content filter
+      // Standard path — gateway enforces autonomy gate, blocked-contact check, and content filter
       const result = await outboundGateway.send(sendRequest);
       if (result.success) {
         logger.info({ ...logCtx, accountId: this.config.accountId }, 'Email reply sent via gateway');
@@ -443,52 +434,7 @@ export class EmailAdapter {
       return;
     }
 
-    if (outboundPolicy === 'autonomy_gated') {
-      // Check the global autonomy score before committing to a send.
-      // autonomyThreshold and autonomyService are guaranteed to be set when
-      // outboundPolicy is 'autonomy_gated' — validated at startup via config.ts.
-      if (!autonomyService || autonomyThreshold === undefined) {
-        logger.error(
-          { ...logCtx, accountId: this.config.accountId },
-          'autonomy_gated policy requires autonomyService and autonomyThreshold — degrading to draft_gate for this reply',
-        );
-        // Explicit fall-through to draft_gate below (operator sees error log above).
-        // Degrading to draft rather than silently sending or dropping is the safest
-        // choice: the reply is preserved for human review despite the misconfiguration.
-      } else {
-        const autonomyCfg = await autonomyService.getConfig();
-        if (autonomyCfg === null) {
-          // Autonomy not yet configured (pre-migration environment) — preserve for
-          // human review rather than sending autonomously or dropping the reply.
-          logger.warn(
-            { ...logCtx, accountId: this.config.accountId },
-            'Autonomy config not found (pre-migration?) — degrading to draft_gate for this reply',
-          );
-          // Fall through to draft_gate below
-        } else {
-          const score = autonomyCfg.score;
-          if (score >= autonomyThreshold) {
-            const result = await outboundGateway.send(sendRequest);
-            if (result.success) {
-              logger.info(
-                { ...logCtx, accountId: this.config.accountId, autonomyScore: score, threshold: autonomyThreshold },
-                'Email reply sent autonomously (autonomy threshold met)',
-              );
-            } else {
-              logger.warn({ ...logCtx, accountId: this.config.accountId, reason: result.blockedReason }, 'Email reply blocked by gateway');
-            }
-            return;
-          }
-          logger.info(
-            { ...logCtx, accountId: this.config.accountId, autonomyScore: score, threshold: autonomyThreshold },
-            'Autonomy score below threshold — saving reply as draft',
-          );
-          // Score too low: fall through to draft_gate behaviour
-        }
-      }
-    }
-
-    // draft_gate (and autonomy_gated fallback): save as draft for human review.
+    // draft_gate: save as draft for human review.
     // The gateway creates the draft silently — no per-draft email notification is sent.
     // The CEO discovers pending drafts via the end-of-day Signal digest (#403).
     const draftResult = await outboundGateway.createEmailDraft(sendRequest);

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -467,7 +467,9 @@ export class EmailAdapter {
       if (draftResult && draftResult.success && draftResult.draftId) {
         if (result.actionRef) {
           // linkGatedAction is internally guarded (no-throw), so no outer try/catch needed here.
-          await outboundGateway.linkGatedAction(result.actionRef, {
+          // Pass context.taskEventId so linkPayload can scope the update to this specific task,
+          // preventing short_ref collisions across tasks from smearing draftId onto the wrong row.
+          await outboundGateway.linkGatedAction(result.actionRef, context.taskEventId, {
             draftId: draftResult.draftId,
             accountId,
             recipientEmail: sendRequest.to,
@@ -481,17 +483,18 @@ export class EmailAdapter {
             'email-adapter: gated fallback draft created but no actionRef available — draft will not appear in pending-actions-digest (taskEventId was absent)',
           );
         }
+        // Log inside the success branch only — if the draft failed, we already logged
+        // the error below and logging "draft created" would be misleading.
+        logger.info(
+          { accountId, draftId: draftResult.draftId, actionRef: result.actionRef },
+          'email-adapter: send gated — fallback draft created',
+        );
       } else if (draftResult && !draftResult.success) {
         logger.error(
           { accountId, actionRef: result.actionRef, reason: draftResult.blockedReason },
           'email-adapter: gated fallback draft creation failed — send blocked, no draft created',
         );
       }
-
-      logger.info(
-        { accountId, draftId: draftResult?.draftId, actionRef: result.actionRef },
-        'email-adapter: send gated — fallback draft created',
-      );
       return;
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,13 +9,11 @@ import * as path from 'node:path';
 /**
  * Outbound send policy for a named email account.
  *
- * - direct:          send immediately (default for Curia's own account)
- * - draft_gate:      create a Nylas draft silently; CEO discovers pending drafts via the
- *                    end-of-day Signal digest and reviews in Gmail (#403, #278)
- * - autonomy_gated:  send autonomously only when the global autonomy score meets or
- *                    exceeds the account's autonomy_threshold value
+ * - direct:      send via OutboundGateway (autonomy gate applied at gateway level)
+ * - draft_gate:  create a Nylas draft silently; CEO discovers pending drafts via the
+ *                end-of-day Signal digest and reviews in Gmail (#403, #278)
  */
-export type OutboundPolicy = 'direct' | 'draft_gate' | 'autonomy_gated';
+export type OutboundPolicy = 'direct' | 'draft_gate';
 
 /**
  * Raw per-account email entry as read from config/default.yaml.
@@ -25,8 +23,6 @@ export interface RawEmailAccountConfig {
   nylas_grant_id: string;
   self_email: string;
   outbound_policy: OutboundPolicy;
-  /** Required when outbound_policy is 'autonomy_gated'. Integer 0–100. */
-  autonomy_threshold?: number;
   /**
    * When true, Curia monitors this inbox as an observer rather than acting as
    * the recipient. Inbound emails bypass the contact trust flow (no provisional
@@ -59,9 +55,6 @@ export interface ResolvedEmailAccount {
   nylasGrantId: string;
   selfEmail: string;
   outboundPolicy: OutboundPolicy;
-  /** Minimum autonomy score (0–100) required for autonomous sends. Only set when
-   *  outboundPolicy is 'autonomy_gated'. */
-  autonomyThreshold?: number;
   /** See RawEmailAccountConfig.observation_mode. */
   observationMode: boolean;
   /** Resolved sender addresses to suppress in addition to selfEmail. */
@@ -494,7 +487,7 @@ export function loadYamlConfig(configDir: string): YamlConfig {
     if (channelAccounts === null || typeof channelAccounts !== 'object' || Array.isArray(channelAccounts)) {
       throw new Error('channel_accounts.email must be a YAML mapping');
     }
-    const validPolicies: OutboundPolicy[] = ['direct', 'draft_gate', 'autonomy_gated'];
+    const validPolicies: OutboundPolicy[] = ['direct', 'draft_gate'];
     for (const [accountName, rawAccount] of Object.entries(channelAccounts)) {
       if (typeof rawAccount !== 'object' || rawAccount === null || Array.isArray(rawAccount)) {
         throw new Error(`channel_accounts.email.${accountName} must be a YAML mapping`);
@@ -508,23 +501,6 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       if (!validPolicies.includes(rawAccount.outbound_policy)) {
         throw new Error(
           `channel_accounts.email.${accountName}.outbound_policy must be one of: ${validPolicies.join(', ')}, got: "${rawAccount.outbound_policy}"`,
-        );
-      }
-      if (rawAccount.outbound_policy === 'autonomy_gated') {
-        if (rawAccount.autonomy_threshold === undefined) {
-          throw new Error(
-            `channel_accounts.email.${accountName}: outbound_policy 'autonomy_gated' requires autonomy_threshold`,
-          );
-        }
-        if (!Number.isInteger(rawAccount.autonomy_threshold) || rawAccount.autonomy_threshold < 0 || rawAccount.autonomy_threshold > 100) {
-          throw new Error(
-            `channel_accounts.email.${accountName}.autonomy_threshold must be an integer 0–100, got: ${rawAccount.autonomy_threshold}`,
-          );
-        }
-      }
-      if (rawAccount.autonomy_threshold !== undefined && rawAccount.outbound_policy !== 'autonomy_gated') {
-        throw new Error(
-          `channel_accounts.email.${accountName}: autonomy_threshold is only valid when outbound_policy is 'autonomy_gated'`,
         );
       }
       if (rawAccount.observation_mode !== undefined && typeof rawAccount.observation_mode !== 'boolean') {
@@ -767,7 +743,6 @@ export function resolveChannelAccounts(yamlConfig: YamlConfig, config: Config): 
         nylasGrantId,
         selfEmail,
         outboundPolicy: raw.outbound_policy,
-        autonomyThreshold: raw.autonomy_threshold,
         observationMode: raw.observation_mode ?? false,
         excludedSenderEmails,
       };

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -894,6 +894,9 @@ export class Dispatcher {
         // dispatcher can later verify thread-originated trust when their reply arrives.
         recipientId: routing.senderId,
         parentEventId: event.id,
+        // The agent.response's parentEventId is the agent.task that triggered it — thread
+        // this through so the email adapter can pass it to gateway.send() for action_log context.
+        taskEventId: event.parentEventId ?? undefined,
       });
       await this.bus.publish('dispatch', outbound);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -691,6 +691,11 @@ async function main(): Promise<void> {
     'Outbound PII redactor initialized',
   );
 
+  // ActionLogRepo — used by OutboundGateway (autonomy gate logging, draft-linkage) and
+  // later by ApprovalTriggerService and AutonomyScoringPass. Instantiated here so it
+  // can be passed to the gateway at construction time.
+  const actionLogRepo = new ActionLogRepo(pool, logger);
+
   // Outbound gateway — single choke-point for all outbound external communication.
   // Runs blocked-contact checks and content filtering before any message leaves Curia.
   //
@@ -722,6 +727,9 @@ async function main(): Promise<void> {
       logger,
       autonomyService,
       piiRedactor,
+      // Wire action log repo so the gateway can write autonomy_action_log rows on
+      // gated sends and support two-step draft linkage (#435).
+      actionLogRepo,
     });
     logger.info({
       emailAccounts: [...nylasClientMap.keys()],
@@ -811,7 +819,7 @@ async function main(): Promise<void> {
   };
   // Autonomy scoring pass — Phase 3 automatic score adjustment (issue #148).
   // Runs as a sibling DreamEngine pass alongside memory decay.
-  const actionLogRepo = new ActionLogRepo(pool, logger);
+  // actionLogRepo is already instantiated above (before OutboundGateway) — reused here.
   const scoringPassConfig: ScoringPassConfig = {
     intervalMs: yamlConfig.dreaming?.autonomy_scoring?.intervalMs ?? 86_400_000,  // default: daily
     model: yamlConfig.dreaming?.autonomy_scoring?.model ?? 'claude-haiku-4-5',

--- a/src/index.ts
+++ b/src/index.ts
@@ -741,22 +741,9 @@ async function main(): Promise<void> {
     for (const account of resolvedEmailAccounts) {
       if (!nylasClientMap.has(account.name)) continue; // skip accounts with no client (NYLAS_API_KEY missing)
 
-      if (account.outboundPolicy === 'autonomy_gated' && account.autonomyThreshold === undefined) {
-        // This should be caught by config validation, but guard defensively at runtime too.
-        logger.warn(
-          { accountId: account.name },
-          'Email account has outbound_policy=autonomy_gated but no autonomy_threshold — skipping adapter',
-        );
-        continue;
-      }
-
       emailAdapters.push(new EmailAdapter({
         accountId: account.name,
         outboundPolicy: account.outboundPolicy,
-        autonomyThreshold: account.autonomyThreshold,
-        // autonomyService is only injected when the policy actually needs it, to avoid
-        // passing a live service reference to adapters that will never call it.
-        autonomyService: account.outboundPolicy === 'autonomy_gated' ? autonomyService : undefined,
         bus,
         logger,
         outboundGateway,

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -29,7 +29,8 @@ import type { PiiRedactor } from '../dispatch/pii-redactor.js';
 import type { EventBus } from '../bus/bus.js';
 import type { Logger } from '../logger.js';
 import { createOutboundBlocked, createOutboundNotification, createAutonomySendBlocked } from '../bus/events.js';
-import type { AutonomyService } from '../autonomy/autonomy-service.js';
+import { AutonomyService } from '../autonomy/autonomy-service.js';
+import type { ActionLogRepo } from '../autonomy/action-log-repo.js';
 import type { OutboundNotificationPayload } from '../bus/events.js';
 import { markdownToHtml } from '../channels/email/markdown-to-html.js';
 import { scrubPii } from '../pii/scrubber.js';
@@ -151,9 +152,10 @@ export interface OutboundGatewayConfig {
   logger: Logger;
 
   /**
-   * Autonomy service — used to enforce the score < 70 outbound gate.
-   * When the live score is below 70, send() blocks the dispatch and returns
-   * an advisory. Optional — when absent, the gate is skipped (fail-open).
+   * Autonomy service — used to enforce the outbound gate at the 'medium' risk
+   * threshold (currently 70, derived from AutonomyService.minScoreForActionRisk).
+   * When the live score is below the threshold, send() blocks the dispatch and
+   * returns an advisory. Optional — when absent, the gate is skipped (fail-open).
    */
   autonomyService?: AutonomyService;
 
@@ -170,6 +172,17 @@ export interface OutboundGatewayConfig {
    * This preserves backwards compatibility with callers that pre-date PII redaction.
    */
   piiRedactor?: PiiRedactor;
+
+  /**
+   * Action log repository — used to write pending_approval rows when the autonomy
+   * gate blocks a send. Enables the two-step draft-fallback pattern: the gateway
+   * creates an action_log entry on gate, then the channel adapter links the draft
+   * ID after creating the fallback artifact.
+   *
+   * Optional — when absent, gated sends still return { gated: true } but no
+   * action_log row is written and no actionRef is assigned.
+   */
+  actionLogRepo?: ActionLogRepo;
 }
 
 // ---------------------------------------------------------------------------
@@ -213,6 +226,7 @@ export class OutboundGateway {
   private readonly log: Logger;
   private readonly autonomyService?: AutonomyService;
   private readonly piiRedactor?: PiiRedactor;
+  private readonly actionLogRepo?: ActionLogRepo;
 
   constructor(config: OutboundGatewayConfig) {
     this.nylasClients = config.nylasClients ?? new Map();
@@ -226,13 +240,14 @@ export class OutboundGateway {
     this.log = config.logger.child({ component: 'outbound-gateway' });
     this.autonomyService = config.autonomyService;
     this.piiRedactor = config.piiRedactor;
+    this.actionLogRepo = config.actionLogRepo;
   }
 
   /**
    * Send an outbound message through the gateway pipeline.
    *
    * Pipeline steps (channel-agnostic):
-   *   0. Autonomy gate — score < 70 blocks all autonomous sends
+   *   0. Autonomy gate — score below 'medium' risk threshold blocks all autonomous sends
    *      (skipped when options.humanApproved is true — CEO is in the loop)
    *   1. Contact blocked check
    *   2. Content filter (fail-closed)
@@ -259,7 +274,7 @@ export class OutboundGateway {
     },
   ): Promise<OutboundSendResult> {
     // ------------------------------------------------------------------
-    // Step 0: Autonomy gate — score < 70 blocks all outbound sends
+    // Step 0: Autonomy gate — score below 'medium' threshold blocks all outbound sends
     // ------------------------------------------------------------------
     // Belt-and-suspenders for medium+ skills: even if the execution layer
     // allowed the skill, the gateway independently blocks the actual send
@@ -275,15 +290,16 @@ export class OutboundGateway {
     } else if (this.autonomyService) {
       try {
         const autonomyConfig = await this.autonomyService.getConfig();
-        if (autonomyConfig !== null && autonomyConfig.score < 70) {
+        const sendThreshold = AutonomyService.minScoreForActionRisk('medium');
+        if (autonomyConfig !== null && autonomyConfig.score < sendThreshold) {
           this.log.info(
-            { channel: request.channel, currentScore: autonomyConfig.score },
-            'outbound-gateway: send blocked by autonomy gate — score < 70',
+            { channel: request.channel, currentScore: autonomyConfig.score, sendThreshold },
+            `outbound-gateway: send blocked by autonomy gate — score < ${sendThreshold}`,
           );
           this.bus.publish('dispatch', createAutonomySendBlocked({
             channel: request.channel,
             currentScore: autonomyConfig.score,
-            requiredScore: 70,
+            requiredScore: sendThreshold,
           })).catch((err) => {
             this.log.warn(
               { err, channel: request.channel },
@@ -293,7 +309,7 @@ export class OutboundGateway {
           return {
             success: false,
             blockedReason:
-              `Autonomy score is ${autonomyConfig.score} — direct sends require a score of at least 70. ` +
+              `Autonomy score is ${autonomyConfig.score} — direct sends require a score of at least ${sendThreshold}. ` +
               `Use createEmailDraft() for drafts, or ask the CEO to raise the score with set-autonomy.`,
           };
         }
@@ -840,15 +856,16 @@ export class OutboundGateway {
     } else if (this.autonomyService) {
       try {
         const autonomyConfig = await this.autonomyService.getConfig();
-        if (autonomyConfig !== null && autonomyConfig.score < 70) {
+        const sendThreshold = AutonomyService.minScoreForActionRisk('medium');
+        if (autonomyConfig !== null && autonomyConfig.score < sendThreshold) {
           this.log.info(
-            { draftId, currentScore: autonomyConfig.score },
-            'outbound-gateway: draft send blocked by autonomy gate — score < 70',
+            { draftId, currentScore: autonomyConfig.score, sendThreshold },
+            `outbound-gateway: draft send blocked by autonomy gate — score < ${sendThreshold}`,
           );
           this.bus.publish('dispatch', createAutonomySendBlocked({
             channel: 'email',
             currentScore: autonomyConfig.score,
-            requiredScore: 70,
+            requiredScore: sendThreshold,
           })).catch((err) => {
             this.log.warn(
               { err, draftId },
@@ -858,7 +875,7 @@ export class OutboundGateway {
           return {
             success: false,
             blockedReason:
-              `Autonomy score is ${autonomyConfig.score} — direct sends require a score of at least 70. ` +
+              `Autonomy score is ${autonomyConfig.score} — direct sends require a score of at least ${sendThreshold}. ` +
               `Use createEmailDraft() for drafts, or ask the CEO to raise the score with set-autonomy.`,
           };
         }

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -91,6 +91,10 @@ export interface OutboundSendResult {
   messageId?: string;
   /** Human-readable reason when success is false */
   blockedReason?: string;
+  /** True when the autonomy gate blocked this send */
+  gated?: boolean;
+  /** Short reference for the action_log row (e.g. 'email-1'). Present when gated is true. */
+  actionRef?: string;
 }
 
 /** Result from createEmailDraft() — extends send result with the Nylas draft ID. */
@@ -245,7 +249,14 @@ export class OutboundGateway {
    */
   async send(
     request: OutboundSendRequest,
-    options?: { skipNotificationOnBlock?: boolean; humanApproved?: boolean },
+    options?: {
+      skipNotificationOnBlock?: boolean;
+      humanApproved?: boolean;
+      /** Task event ID for action_log traceability. */
+      taskEventId?: string;
+      /** Conversation ID for action_log context. */
+      conversationId?: string;
+    },
   ): Promise<OutboundSendResult> {
     // ------------------------------------------------------------------
     // Step 0: Autonomy gate — score < 70 blocks all outbound sends

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -1133,6 +1133,22 @@ export class OutboundGateway {
     }
   }
 
+  /**
+   * Link a draft (or other fallback result) to a gated action_log row.
+   * Called by channel adapters after they create their fallback artifact.
+   * No-op when actionLogRepo is not wired or actionRef doesn't match a pending row.
+   */
+  async linkGatedAction(actionRef: string, payload: Record<string, unknown>): Promise<void> {
+    if (!this.actionLogRepo) return;
+    const updated = await this.actionLogRepo.linkPayload(actionRef, payload);
+    if (!updated) {
+      this.log.warn(
+        { actionRef },
+        'outbound-gateway: linkGatedAction found no pending row for actionRef — may have expired',
+      );
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -306,6 +306,44 @@ export class OutboundGateway {
               'outbound-gateway: failed to publish autonomy.send_blocked event',
             );
           });
+
+          // Two-step draft-fallback: if actionLogRepo + taskEventId are present,
+          // write a pending_approval row so the approval lifecycle can track the
+          // gated action and link a fallback artifact (e.g. draft ID) later.
+          if (this.actionLogRepo && options?.taskEventId) {
+            const counter = await this.actionLogRepo.countShortRefsForTask(options.taskEventId);
+            const actionRef = `email-${counter + 1}`;
+
+            // Extract recipient and subject (email channel only for now)
+            const recipientEmail = request.channel === 'email' ? request.to : '';
+            const subject = request.channel === 'email' ? request.subject : undefined;
+            const description = `Draft reply to ${recipientEmail}${subject ? ` — "${subject}"` : ''}. Use send-draft to approve.`;
+
+            await this.actionLogRepo.insert({
+              taskId: options.taskEventId,
+              conversationId: options.conversationId ?? undefined,
+              skillName: 'outbound-send',
+              actionRisk: 'medium',
+              outcome: 'pending_approval',
+              shortRef: actionRef,
+              description,
+              payload: {
+                source: 'autonomy_gate',
+                recipientEmail,
+                subject,
+                channel: request.channel,
+              },
+              expiresAt: new Date(Date.now() + 48 * 60 * 60 * 1000),
+            });
+
+            return {
+              success: false,
+              gated: true,
+              actionRef,
+              blockedReason: `Autonomy score ${autonomyConfig.score} is below send threshold ${sendThreshold}`,
+            };
+          }
+
           return {
             success: false,
             blockedReason:

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -288,36 +288,52 @@ export class OutboundGateway {
         'outbound-gateway: autonomy gate skipped — humanApproved flag set (CEO-authorized action, see ADR-017)',
       );
     } else if (this.autonomyService) {
+      // Fail-open on config read only — getConfig() failure must not block sends.
+      // The action_log DB write is kept outside this try/catch so a DB error there
+      // does NOT cause fail-open; the send stays blocked even if we can't write the row.
+      let autonomyConfig: Awaited<ReturnType<typeof this.autonomyService.getConfig>> | null = null;
       try {
-        const autonomyConfig = await this.autonomyService.getConfig();
-        const sendThreshold = AutonomyService.minScoreForActionRisk('medium');
-        if (autonomyConfig !== null && autonomyConfig.score < sendThreshold) {
-          this.log.info(
-            { channel: request.channel, currentScore: autonomyConfig.score, sendThreshold },
-            `outbound-gateway: send blocked by autonomy gate — score < ${sendThreshold}`,
+        autonomyConfig = await this.autonomyService.getConfig();
+      } catch (err) {
+        // DB error — fail-open. Log at warn so anomalies are visible in alerting.
+        this.log.warn(
+          { err, channel: request.channel },
+          'outbound-gateway: autonomy gate failed to read config — proceeding without gate (fail-open)',
+        );
+      }
+
+      const sendThreshold = AutonomyService.minScoreForActionRisk('medium');
+      if (autonomyConfig !== null && autonomyConfig.score < sendThreshold) {
+        this.log.info(
+          { channel: request.channel, currentScore: autonomyConfig.score, sendThreshold },
+          `outbound-gateway: send blocked by autonomy gate — score < ${sendThreshold}`,
+        );
+        this.bus.publish('dispatch', createAutonomySendBlocked({
+          channel: request.channel,
+          currentScore: autonomyConfig.score,
+          requiredScore: sendThreshold,
+        })).catch((err) => {
+          this.log.warn(
+            { err, channel: request.channel },
+            'outbound-gateway: failed to publish autonomy.send_blocked event',
           );
-          this.bus.publish('dispatch', createAutonomySendBlocked({
-            channel: request.channel,
-            currentScore: autonomyConfig.score,
-            requiredScore: sendThreshold,
-          })).catch((err) => {
-            this.log.warn(
-              { err, channel: request.channel },
-              'outbound-gateway: failed to publish autonomy.send_blocked event',
-            );
-          });
+        });
 
-          // Two-step draft-fallback: if actionLogRepo + taskEventId are present,
-          // write a pending_approval row so the approval lifecycle can track the
-          // gated action and link a fallback artifact (e.g. draft ID) later.
-          if (this.actionLogRepo && options?.taskEventId) {
+        // Two-step draft-fallback: if actionLogRepo + taskEventId are present,
+        // write a pending_approval row so the approval lifecycle can track the
+        // gated action and link a fallback artifact (e.g. draft ID) later.
+        // DB failure here must NOT cause fail-open — the send stays blocked even
+        // if the row can't be written (actionRef will just be absent from the result).
+        let actionRef: string | undefined;
+        if (this.actionLogRepo && options?.taskEventId) {
+          // Extract recipient and subject (email channel only for now)
+          const recipientEmail = request.channel === 'email' ? request.to : '';
+          const subject = request.channel === 'email' ? request.subject : undefined;
+          const description = `Draft reply to ${recipientEmail}${subject ? ` — "${subject}"` : ''}. Use send-draft to approve.`;
+
+          try {
             const counter = await this.actionLogRepo.countShortRefsForTask(options.taskEventId);
-            const actionRef = `email-${counter + 1}`;
-
-            // Extract recipient and subject (email channel only for now)
-            const recipientEmail = request.channel === 'email' ? request.to : '';
-            const subject = request.channel === 'email' ? request.subject : undefined;
-            const description = `Draft reply to ${recipientEmail}${subject ? ` — "${subject}"` : ''}. Use send-draft to approve.`;
+            actionRef = `email-${counter + 1}`;
 
             await this.actionLogRepo.insert({
               taskId: options.taskEventId,
@@ -335,29 +351,31 @@ export class OutboundGateway {
               },
               expiresAt: new Date(Date.now() + 48 * 60 * 60 * 1000),
             });
-
-            return {
-              success: false,
-              gated: true,
-              actionRef,
-              blockedReason: `Autonomy score ${autonomyConfig.score} is below send threshold ${sendThreshold}`,
-            };
+          } catch (err) {
+            this.log.error(
+              { err, channel: request.channel, taskEventId: options.taskEventId },
+              'outbound-gateway: failed to write action_log row during gate — send is still blocked, actionRef will be absent',
+            );
+            // actionRef remains undefined — send is still blocked below
           }
+        }
 
+        if (actionRef) {
           return {
             success: false,
             gated: true,
-            blockedReason:
-              `Autonomy score is ${autonomyConfig.score} — direct sends require a score of at least ${sendThreshold}. ` +
-              `Use createEmailDraft() for drafts, or ask the CEO to raise the score with set-autonomy.`,
+            actionRef,
+            blockedReason: `Autonomy score ${autonomyConfig.score} is below send threshold ${sendThreshold}`,
           };
         }
-      } catch (err) {
-        // DB error — fail-open. Log at warn so anomalies are visible in alerting.
-        this.log.warn(
-          { err, channel: request.channel },
-          'outbound-gateway: autonomy gate failed to read config — proceeding without gate (fail-open)',
-        );
+
+        return {
+          success: false,
+          gated: true,
+          blockedReason:
+            `Autonomy score is ${autonomyConfig.score} — direct sends require a score of at least ${sendThreshold}. ` +
+            `Use createEmailDraft() for drafts, or ask the CEO to raise the score with set-autonomy.`,
+        };
       }
     }
 
@@ -1141,11 +1159,18 @@ export class OutboundGateway {
    */
   async linkGatedAction(actionRef: string, payload: Record<string, unknown>): Promise<void> {
     if (!this.actionLogRepo) return;
-    const updated = await this.actionLogRepo.linkPayload(actionRef, payload);
-    if (!updated) {
-      this.log.warn(
-        { actionRef },
-        'outbound-gateway: linkGatedAction found no pending row for actionRef — may have expired',
+    try {
+      const updated = await this.actionLogRepo.linkPayload(actionRef, payload);
+      if (!updated) {
+        this.log.warn(
+          { actionRef },
+          'outbound-gateway: linkGatedAction found no pending row for actionRef — may have expired or been cleaned up',
+        );
+      }
+    } catch (err) {
+      this.log.error(
+        { err, actionRef },
+        'outbound-gateway: linkGatedAction DB call failed — action_log row will not have draftId linked',
       );
     }
   }

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -325,10 +325,12 @@ export class OutboundGateway {
         // DB failure here must NOT cause fail-open — the send stays blocked even
         // if the row can't be written (actionRef will just be absent from the result).
         let actionRef: string | undefined;
-        if (this.actionLogRepo && options?.taskEventId) {
-          // Extract recipient and subject (email channel only for now)
-          const recipientEmail = request.channel === 'email' ? request.to : '';
-          const subject = request.channel === 'email' ? request.subject : undefined;
+        if (this.actionLogRepo && options?.taskEventId && request.channel === 'email') {
+          // Extract recipient and subject — this block is email-only (guarded above).
+          // Non-email gated sends (e.g. Signal) return { gated: true } without an actionRef;
+          // the channel adapter handles them directly without the two-step draft pattern.
+          const recipientEmail = request.to;
+          const subject = request.subject;
           const description = `Draft reply to ${recipientEmail}${subject ? ` — "${subject}"` : ''}. Use send-draft to approve.`;
 
           try {
@@ -1156,20 +1158,28 @@ export class OutboundGateway {
    * Link a draft (or other fallback result) to a gated action_log row.
    * Called by channel adapters after they create their fallback artifact.
    * No-op when actionLogRepo is not wired or actionRef doesn't match a pending row.
+   *
+   * taskEventId scopes the match to a specific task so that colliding short_refs
+   * (e.g. 'email-1' in task A and 'email-1' in task B) don't cross-pollinate.
+   * When absent, the match is by short_ref + outcome alone (backwards compatibility).
    */
-  async linkGatedAction(actionRef: string, payload: Record<string, unknown>): Promise<void> {
+  async linkGatedAction(
+    actionRef: string,
+    taskEventId: string | undefined,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
     if (!this.actionLogRepo) return;
     try {
-      const updated = await this.actionLogRepo.linkPayload(actionRef, payload);
+      const updated = await this.actionLogRepo.linkPayload(actionRef, taskEventId, payload);
       if (!updated) {
         this.log.warn(
-          { actionRef },
+          { actionRef, taskEventId },
           'outbound-gateway: linkGatedAction found no pending row for actionRef — may have expired or been cleaned up',
         );
       }
     } catch (err) {
       this.log.error(
-        { err, actionRef },
+        { err, actionRef, taskEventId },
         'outbound-gateway: linkGatedAction DB call failed — action_log row will not have draftId linked',
       );
     }

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -346,6 +346,7 @@ export class OutboundGateway {
 
           return {
             success: false,
+            gated: true,
             blockedReason:
               `Autonomy score is ${autonomyConfig.score} — direct sends require a score of at least ${sendThreshold}. ` +
               `Use createEmailDraft() for drafts, or ask the CEO to raise the score with set-autonomy.`,

--- a/tests/integration/draft-fallback-flow.test.ts
+++ b/tests/integration/draft-fallback-flow.test.ts
@@ -1,0 +1,454 @@
+// tests/integration/draft-fallback-flow.test.ts
+//
+// Integration test: exercises the full gate → draft → approve path.
+// Verifies contracts BETWEEN layers: the gateway's gated result shape,
+// the adapter's fallback behavior, and the action_log state machine.
+//
+// "Medium-weight" integration: real EventBus + real OutboundGateway + real
+// EmailAdapter, with mocked external services (Nylas, autonomy DB, contacts).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventBus } from '../../src/bus/bus.js';
+import { OutboundGateway } from '../../src/skills/outbound-gateway.js';
+import { EmailAdapter } from '../../src/channels/email/email-adapter.js';
+import { AutonomyService } from '../../src/autonomy/autonomy-service.js';
+import { createOutboundMessage, type OutboundMessageEvent } from '../../src/bus/events.js';
+import { createLogger } from '../../src/logger.js';
+import type { NylasClient, NylasMessage } from '../../src/channels/email/nylas-client.js';
+import type { ContactService } from '../../src/contacts/contact-service.js';
+import type { OutboundContentFilter, FilterResult } from '../../src/dispatch/outbound-filter.js';
+import type { ActionLogRepo } from '../../src/autonomy/action-log-repo.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const logger = createLogger('error');
+
+/** Minimal NylasMessage stub — only the fields the gateway/adapter actually read. */
+function stubMessage(overrides: Partial<NylasMessage> = {}): NylasMessage {
+  return {
+    id: 'msg-001',
+    threadId: 'thread-001',
+    subject: 'Test Subject',
+    from: [{ email: 'alice@example.com' }],
+    to: [{ email: 'curia@company.com' }],
+    cc: [],
+    bcc: [],
+    body: 'hello',
+    snippet: 'hello',
+    date: Math.floor(Date.now() / 1000),
+    unread: true,
+    folders: ['INBOX'],
+    ...overrides,
+  };
+}
+
+/** Create a mock NylasClient with controlled responses. */
+function createMockNylasClient(): NylasClient {
+  return {
+    listMessages: vi.fn().mockResolvedValue([stubMessage()]),
+    getMessage: vi.fn().mockResolvedValue(stubMessage()),
+    sendMessage: vi.fn().mockResolvedValue(stubMessage({ id: 'sent-001' })),
+    createDraft: vi.fn().mockResolvedValue(stubMessage({ id: 'draft-001' })),
+    sendDraft: vi.fn().mockResolvedValue(stubMessage({ id: 'sent-draft-001' })),
+    archiveMessage: vi.fn().mockResolvedValue(undefined),
+  } as unknown as NylasClient;
+}
+
+/** Create a mock ContactService that always passes (no blocked contacts). */
+function createMockContactService(): ContactService {
+  return {
+    resolveByChannelIdentity: vi.fn().mockResolvedValue(null),
+    createContact: vi.fn().mockResolvedValue({ id: 'contact-001' }),
+    linkIdentity: vi.fn().mockResolvedValue(undefined),
+    setTrustLevel: vi.fn().mockResolvedValue(undefined),
+    setStatus: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ContactService;
+}
+
+/** Create a content filter that always passes. */
+function createPassingFilter(): OutboundContentFilter {
+  return {
+    check: vi.fn().mockResolvedValue({ passed: true, findings: [] } as FilterResult),
+  } as unknown as OutboundContentFilter;
+}
+
+/** Create a mock AutonomyService that returns a fixed score via mocked pool. */
+function createMockAutonomyService(score: number): AutonomyService {
+  const band = AutonomyService.bandForScore(score);
+  const mockPool = {
+    query: vi.fn().mockResolvedValue({
+      rows: [{ score, band, updated_at: new Date(), updated_by: 'test' }],
+    }),
+  } as unknown as import('pg').Pool;
+  return new AutonomyService(mockPool, logger);
+}
+
+/** Create a mock ActionLogRepo that captures insert/linkPayload calls. */
+function createMockActionLogRepo(): ActionLogRepo & {
+  _insertedRows: Array<Record<string, unknown>>;
+  _linkedPayloads: Array<{ shortRef: string; payload: Record<string, unknown> }>;
+} {
+  const _insertedRows: Array<Record<string, unknown>> = [];
+  const _linkedPayloads: Array<{ shortRef: string; payload: Record<string, unknown> }> = [];
+  let insertCounter = 0;
+
+  return {
+    _insertedRows,
+    _linkedPayloads,
+    insert: vi.fn().mockImplementation(async (row: Record<string, unknown>) => {
+      _insertedRows.push(row);
+      return ++insertCounter;
+    }),
+    countShortRefsForTask: vi.fn().mockResolvedValue(0),
+    linkPayload: vi.fn().mockImplementation(async (shortRef: string, payload: Record<string, unknown>) => {
+      _linkedPayloads.push({ shortRef, payload });
+      return true;
+    }),
+    findPendingByTaskAndSkill: vi.fn().mockResolvedValue(null),
+    findAllPending: vi.fn().mockResolvedValue([]),
+    resolvePending: vi.fn().mockResolvedValue({ found: false, reason: 'not_found', error: 'No pending' }),
+    resolveRow: vi.fn().mockResolvedValue(true),
+    resolveById: vi.fn().mockResolvedValue(true),
+    findUnscoredTerminal: vi.fn().mockResolvedValue([]),
+    updateScoringFlags: vi.fn().mockResolvedValue(undefined),
+    countScored: vi.fn().mockResolvedValue(0),
+    getRecentCompetenceErrorRate: vi.fn().mockResolvedValue(0),
+    findAllScored: vi.fn().mockResolvedValue([]),
+    setNotificationSentAt: vi.fn().mockResolvedValue(undefined),
+    findExpired: vi.fn().mockResolvedValue([]),
+    expireRows: vi.fn().mockResolvedValue([]),
+    findPendingByPayloadField: vi.fn().mockResolvedValue(null),
+  } as unknown as ActionLogRepo & {
+    _insertedRows: Array<Record<string, unknown>>;
+    _linkedPayloads: Array<{ shortRef: string; payload: Record<string, unknown> }>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Draft Fallback Flow Integration', () => {
+  let bus: EventBus;
+  let mockNylasClient: NylasClient;
+  let mockContactService: ContactService;
+  let contentFilter: OutboundContentFilter;
+
+  beforeEach(() => {
+    bus = new EventBus(logger);
+    mockNylasClient = createMockNylasClient();
+    mockContactService = createMockContactService();
+    contentFilter = createPassingFilter();
+  });
+
+  describe('Test 1: Autonomy-gated flow (full path)', () => {
+    it('gates the send, creates a draft, links the action_log row', async () => {
+      // Low autonomy score (50) — below the 'medium' threshold of 70
+      const autonomyService = createMockAutonomyService(50);
+      const actionLogRepo = createMockActionLogRepo();
+
+      const nylasClients = new Map<string, NylasClient>([['curia', mockNylasClient]]);
+
+      const gateway = new OutboundGateway({
+        nylasClients,
+        contactService: mockContactService,
+        contentFilter,
+        bus,
+        ceoEmail: 'ceo@company.com',
+        logger,
+        autonomyService,
+        actionLogRepo,
+      });
+
+      // Create the email adapter with 'direct' policy — it will call gateway.send()
+      // which will gate, then the adapter falls back to createEmailDraft + linkGatedAction.
+      const adapter = new EmailAdapter({
+        accountId: 'curia',
+        outboundPolicy: 'direct',
+        bus,
+        logger,
+        outboundGateway: gateway,
+        contactService: mockContactService,
+        pollingIntervalMs: 999_999, // no polling in test
+        selfEmail: 'curia@company.com',
+        observationMode: false,
+        excludedSenderEmails: [],
+        ceoEmail: 'ceo@company.com',
+        contactCreationMaxPerMessage: 10,
+        contactCreationMaxPerHour: 100,
+      });
+
+      // start() subscribes to bus events — we need it for the outbound.message handler.
+      // The initial poll will call listMessages — that's fine, it returns our stub.
+      await adapter.start();
+
+      // Publish an outbound.message event as if the dispatcher generated it.
+      const outboundEvent = createOutboundMessage({
+        conversationId: 'email:thread-001',
+        channelId: 'email',
+        accountId: 'curia',
+        content: 'Here is my reply.',
+        taskEventId: 'task-evt-001',
+        parentEventId: 'parent-evt-001',
+      });
+
+      await bus.publish('dispatch', outboundEvent);
+
+      // Assert: gateway.send() was called and returned gated (the adapter handles it)
+      // The adapter should have called createEmailDraft as fallback.
+      const createDraftFn = mockNylasClient.createDraft as ReturnType<typeof vi.fn>;
+      expect(createDraftFn).toHaveBeenCalledTimes(1);
+
+      // Assert: action_log row was inserted with correct shape
+      expect(actionLogRepo._insertedRows).toHaveLength(1);
+      const insertedRow = actionLogRepo._insertedRows[0]!;
+      expect(insertedRow).toMatchObject({
+        taskId: 'task-evt-001',
+        skillName: 'outbound-send',
+        actionRisk: 'medium',
+        outcome: 'pending_approval',
+      });
+      expect((insertedRow.payload as Record<string, unknown>).source).toBe('autonomy_gate');
+
+      // Assert: linkGatedAction was called with the draft ID
+      expect(actionLogRepo._linkedPayloads).toHaveLength(1);
+      expect(actionLogRepo._linkedPayloads[0]!.payload).toMatchObject({
+        draftId: 'draft-001',
+        accountId: 'curia',
+        recipientEmail: 'alice@example.com',
+      });
+
+      await adapter.stop();
+    });
+  });
+
+  describe('Test 2: Score >= threshold sends directly', () => {
+    it('sends the email directly when autonomy score is high', async () => {
+      // High autonomy score (85) — above the 'medium' threshold of 70
+      const autonomyService = createMockAutonomyService(85);
+      const actionLogRepo = createMockActionLogRepo();
+
+      const nylasClients = new Map<string, NylasClient>([['curia', mockNylasClient]]);
+
+      const gateway = new OutboundGateway({
+        nylasClients,
+        contactService: mockContactService,
+        contentFilter,
+        bus,
+        ceoEmail: 'ceo@company.com',
+        logger,
+        autonomyService,
+        actionLogRepo,
+      });
+
+      const adapter = new EmailAdapter({
+        accountId: 'curia',
+        outboundPolicy: 'direct',
+        bus,
+        logger,
+        outboundGateway: gateway,
+        contactService: mockContactService,
+        pollingIntervalMs: 999_999,
+        selfEmail: 'curia@company.com',
+        observationMode: false,
+        excludedSenderEmails: [],
+        ceoEmail: 'ceo@company.com',
+        contactCreationMaxPerMessage: 10,
+        contactCreationMaxPerHour: 100,
+      });
+
+      await adapter.start();
+
+      const outboundEvent = createOutboundMessage({
+        conversationId: 'email:thread-001',
+        channelId: 'email',
+        accountId: 'curia',
+        content: 'Direct reply — score is high.',
+        parentEventId: 'parent-evt-002',
+      });
+
+      await bus.publish('dispatch', outboundEvent);
+
+      // Assert: sendMessage was called (direct send path)
+      const sendMessageFn = mockNylasClient.sendMessage as ReturnType<typeof vi.fn>;
+      expect(sendMessageFn).toHaveBeenCalledTimes(1);
+
+      // Assert: no draft created
+      const createDraftFn = mockNylasClient.createDraft as ReturnType<typeof vi.fn>;
+      expect(createDraftFn).not.toHaveBeenCalled();
+
+      // Assert: no action_log insertion (not gated)
+      expect(actionLogRepo._insertedRows).toHaveLength(0);
+
+      await adapter.stop();
+    });
+  });
+
+  describe('Test 3: draft_gate policy creates draft without action_log', () => {
+    it('creates a draft without gateway.send() or action_log', async () => {
+      // Score doesn't matter for draft_gate — the adapter bypasses gateway.send() entirely
+      const autonomyService = createMockAutonomyService(50);
+      const actionLogRepo = createMockActionLogRepo();
+
+      const nylasClients = new Map<string, NylasClient>([['curia', mockNylasClient]]);
+
+      const gateway = new OutboundGateway({
+        nylasClients,
+        contactService: mockContactService,
+        contentFilter,
+        bus,
+        ceoEmail: 'ceo@company.com',
+        logger,
+        autonomyService,
+        actionLogRepo,
+      });
+
+      // draft_gate policy — adapter calls createEmailDraft directly, no gateway.send()
+      const adapter = new EmailAdapter({
+        accountId: 'curia',
+        outboundPolicy: 'draft_gate',
+        bus,
+        logger,
+        outboundGateway: gateway,
+        contactService: mockContactService,
+        pollingIntervalMs: 999_999,
+        selfEmail: 'curia@company.com',
+        observationMode: false,
+        excludedSenderEmails: [],
+        ceoEmail: 'ceo@company.com',
+        contactCreationMaxPerMessage: 10,
+        contactCreationMaxPerHour: 100,
+      });
+
+      await adapter.start();
+
+      const outboundEvent = createOutboundMessage({
+        conversationId: 'email:thread-001',
+        channelId: 'email',
+        accountId: 'curia',
+        content: 'This should become a draft, not a send.',
+        parentEventId: 'parent-evt-003',
+      });
+
+      await bus.publish('dispatch', outboundEvent);
+
+      // Assert: createDraft was called (draft_gate always drafts)
+      const createDraftFn = mockNylasClient.createDraft as ReturnType<typeof vi.fn>;
+      expect(createDraftFn).toHaveBeenCalledTimes(1);
+
+      // Assert: sendMessage was NOT called (no direct send for draft_gate)
+      const sendMessageFn = mockNylasClient.sendMessage as ReturnType<typeof vi.fn>;
+      expect(sendMessageFn).not.toHaveBeenCalled();
+
+      // Assert: no action_log insert (draft_gate bypasses autonomy decision entirely)
+      expect(actionLogRepo._insertedRows).toHaveLength(0);
+
+      await adapter.stop();
+    });
+  });
+
+  describe('Test 4: Multi-account — each account creates draft on its own Nylas client', () => {
+    it('routes drafts to the correct account when both are gated', async () => {
+      const autonomyService = createMockAutonomyService(50); // low score → gated
+      const actionLogRepo = createMockActionLogRepo();
+
+      // Two separate Nylas clients for two accounts
+      const nylasClientCuria = createMockNylasClient();
+      const nylasClientJoseph = createMockNylasClient();
+
+      const nylasClients = new Map<string, NylasClient>([
+        ['curia', nylasClientCuria],
+        ['joseph', nylasClientJoseph],
+      ]);
+
+      const gateway = new OutboundGateway({
+        nylasClients,
+        contactService: mockContactService,
+        contentFilter,
+        bus,
+        ceoEmail: 'ceo@company.com',
+        logger,
+        autonomyService,
+        actionLogRepo,
+      });
+
+      // Adapter for the 'curia' account
+      const adapterCuria = new EmailAdapter({
+        accountId: 'curia',
+        outboundPolicy: 'direct',
+        bus,
+        logger,
+        outboundGateway: gateway,
+        contactService: mockContactService,
+        pollingIntervalMs: 999_999,
+        selfEmail: 'curia@company.com',
+        observationMode: false,
+        excludedSenderEmails: [],
+        ceoEmail: 'ceo@company.com',
+        contactCreationMaxPerMessage: 10,
+        contactCreationMaxPerHour: 100,
+      });
+
+      // Adapter for the 'joseph' account
+      const adapterJoseph = new EmailAdapter({
+        accountId: 'joseph',
+        outboundPolicy: 'direct',
+        bus,
+        logger,
+        outboundGateway: gateway,
+        contactService: mockContactService,
+        pollingIntervalMs: 999_999,
+        selfEmail: 'joseph@company.com',
+        observationMode: false,
+        excludedSenderEmails: [],
+        ceoEmail: 'ceo@company.com',
+        contactCreationMaxPerMessage: 10,
+        contactCreationMaxPerHour: 100,
+      });
+
+      await adapterCuria.start();
+      await adapterJoseph.start();
+
+      // Send an outbound.message targeted at the 'curia' account
+      const curiaEvent = createOutboundMessage({
+        conversationId: 'email:thread-001',
+        channelId: 'email',
+        accountId: 'curia',
+        content: 'Reply from curia account.',
+        taskEventId: 'task-evt-curia',
+        parentEventId: 'parent-evt-004',
+      });
+
+      // Send an outbound.message targeted at the 'joseph' account
+      const josephEvent = createOutboundMessage({
+        conversationId: 'email:thread-002',
+        channelId: 'email',
+        accountId: 'joseph',
+        content: 'Reply from joseph account.',
+        taskEventId: 'task-evt-joseph',
+        parentEventId: 'parent-evt-005',
+      });
+
+      await bus.publish('dispatch', curiaEvent);
+      await bus.publish('dispatch', josephEvent);
+
+      // Assert: each Nylas client got exactly one createDraft call (gated fallback)
+      const curiaDraftFn = nylasClientCuria.createDraft as ReturnType<typeof vi.fn>;
+      const josephDraftFn = nylasClientJoseph.createDraft as ReturnType<typeof vi.fn>;
+
+      expect(curiaDraftFn).toHaveBeenCalledTimes(1);
+      expect(josephDraftFn).toHaveBeenCalledTimes(1);
+
+      // Assert: two action_log rows inserted (one per gated send)
+      expect(actionLogRepo._insertedRows).toHaveLength(2);
+      const taskIds = actionLogRepo._insertedRows.map((r) => r.taskId);
+      expect(taskIds).toContain('task-evt-curia');
+      expect(taskIds).toContain('task-evt-joseph');
+
+      await adapterCuria.stop();
+      await adapterJoseph.stop();
+    });
+  });
+});

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -53,6 +53,8 @@ function createMocks() {
 
   const outboundGateway = {
     send: vi.fn().mockResolvedValue({ success: true, messageId: 'sent-1' }),
+    createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'draft-1' }),
+    linkGatedAction: vi.fn().mockResolvedValue(undefined),
     listEmailMessages: vi.fn().mockResolvedValue([]),
     sendNotification: vi.fn().mockResolvedValue(undefined),
   } as unknown as OutboundGateway;
@@ -750,6 +752,188 @@ describe('EmailAdapter — contact auto-creation rate limiting', () => {
     await flushPoll();
 
     expect(mocks.contactService.createContact).toHaveBeenCalledTimes(2);
+
+    await adapter.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispatchByPolicy — gated fallback (#435)
+// ---------------------------------------------------------------------------
+
+describe('EmailAdapter — dispatchByPolicy gated-fallback', () => {
+  let mocks: ReturnType<typeof createMocks>;
+  let triggerOutbound: (event: BusEvent) => Promise<void>;
+
+  beforeEach(() => {
+    mocks = createMocks();
+    triggerOutbound = captureHandler('outbound.message', mocks);
+  });
+
+  function makeOutboundEventWithTask(conversationId: string, taskEventId?: string) {
+    return createOutboundMessage({
+      conversationId,
+      channelId: 'email',
+      content: 'Here is my reply.',
+      parentEventId: 'response-1',
+      taskEventId,
+    });
+  }
+
+  it('calls gateway.send() with context for direct policy', async () => {
+    const adapter = makeAdapter(mocks);
+    await adapter.start();
+
+    const humanMessage = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      to: [{ email: SELF_EMAIL }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([humanMessage]);
+
+    await triggerOutbound(makeOutboundEventWithTask('email:thread-abc', 'task-evt-1'));
+
+    expect(mocks.outboundGateway.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: CEO_EMAIL }),
+      expect.objectContaining({ taskEventId: 'task-evt-1', conversationId: 'email:thread-abc' }),
+    );
+
+    await adapter.stop();
+  });
+
+  it('creates draft and links action when gateway returns gated', async () => {
+    // Gateway returns gated result
+    (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false,
+      gated: true,
+      actionRef: 'email-42',
+    });
+    (mocks.outboundGateway.createEmailDraft as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      draftId: 'draft-abc',
+    });
+
+    const adapter = makeAdapter(mocks);
+    await adapter.start();
+
+    const humanMessage = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      to: [{ email: SELF_EMAIL }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([humanMessage]);
+
+    await triggerOutbound(makeOutboundEventWithTask('email:thread-abc', 'task-evt-2'));
+
+    // Draft should be created as fallback
+    expect(mocks.outboundGateway.createEmailDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ to: CEO_EMAIL, channel: 'email' }),
+    );
+
+    // linkGatedAction should be called with the actionRef and draft metadata
+    expect(mocks.outboundGateway.linkGatedAction).toHaveBeenCalledWith(
+      'email-42',
+      expect.objectContaining({
+        draftId: 'draft-abc',
+        accountId: 'curia',
+        recipientEmail: CEO_EMAIL,
+      }),
+    );
+
+    await adapter.stop();
+  });
+
+  it('does not link action when draft creation fails', async () => {
+    (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false,
+      gated: true,
+      actionRef: 'email-99',
+    });
+    (mocks.outboundGateway.createEmailDraft as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false,
+      blockedReason: 'Recipient is blocked',
+    });
+
+    const adapter = makeAdapter(mocks);
+    await adapter.start();
+
+    const humanMessage = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      to: [{ email: SELF_EMAIL }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([humanMessage]);
+
+    await triggerOutbound(makeOutboundEventWithTask('email:thread-abc'));
+
+    // Draft creation attempted
+    expect(mocks.outboundGateway.createEmailDraft).toHaveBeenCalled();
+    // But linkGatedAction should NOT be called because draft failed
+    expect(mocks.outboundGateway.linkGatedAction).not.toHaveBeenCalled();
+
+    await adapter.stop();
+  });
+
+  it('draft_gate policy calls createEmailDraft directly without send()', async () => {
+    const adapter = new EmailAdapter({
+      accountId: 'curia',
+      outboundPolicy: 'draft_gate',
+      bus: mocks.bus,
+      logger: mocks.logger,
+      outboundGateway: mocks.outboundGateway,
+      contactService: mocks.contactService,
+      pollingIntervalMs: 999999,
+      selfEmail: SELF_EMAIL,
+      observationMode: false,
+      excludedSenderEmails: [],
+      contactCreationMaxPerMessage: 10,
+      contactCreationMaxPerHour: 100,
+      ceoEmail: CEO_EMAIL,
+    });
+    await adapter.start();
+
+    const humanMessage = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      to: [{ email: SELF_EMAIL }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([humanMessage]);
+
+    await triggerOutbound(makeOutboundEventWithTask('email:thread-abc', 'task-evt-3'));
+
+    // draft_gate goes straight to createEmailDraft — no send() call
+    expect(mocks.outboundGateway.send).not.toHaveBeenCalled();
+    expect(mocks.outboundGateway.createEmailDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ to: CEO_EMAIL, channel: 'email' }),
+    );
+
+    await adapter.stop();
+  });
+
+  it('draft_gate does NOT call linkGatedAction', async () => {
+    const adapter = new EmailAdapter({
+      accountId: 'curia',
+      outboundPolicy: 'draft_gate',
+      bus: mocks.bus,
+      logger: mocks.logger,
+      outboundGateway: mocks.outboundGateway,
+      contactService: mocks.contactService,
+      pollingIntervalMs: 999999,
+      selfEmail: SELF_EMAIL,
+      observationMode: false,
+      excludedSenderEmails: [],
+      contactCreationMaxPerMessage: 10,
+      contactCreationMaxPerHour: 100,
+      ceoEmail: CEO_EMAIL,
+    });
+    await adapter.start();
+
+    const humanMessage = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      to: [{ email: SELF_EMAIL }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([humanMessage]);
+
+    await triggerOutbound(makeOutboundEventWithTask('email:thread-abc', 'task-evt-4'));
+
+    // draft_gate has no autonomy decision — linkGatedAction should never be called
+    expect(mocks.outboundGateway.linkGatedAction).not.toHaveBeenCalled();
 
     await adapter.stop();
   });

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -828,9 +828,10 @@ describe('EmailAdapter — dispatchByPolicy gated-fallback', () => {
       expect.objectContaining({ to: CEO_EMAIL, channel: 'email' }),
     );
 
-    // linkGatedAction should be called with the actionRef and draft metadata
+    // linkGatedAction should be called with the actionRef, taskEventId, and draft metadata
     expect(mocks.outboundGateway.linkGatedAction).toHaveBeenCalledWith(
       'email-42',
+      'task-evt-2',
       expect.objectContaining({
         draftId: 'draft-abc',
         accountId: 'curia',

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -141,6 +141,7 @@ describe('EmailAdapter — sendOutboundReply', () => {
 
     expect(mocks.outboundGateway.send).toHaveBeenCalledWith(
       expect.objectContaining({ to: CEO_EMAIL }),
+      expect.any(Object),
     );
   });
 
@@ -158,6 +159,7 @@ describe('EmailAdapter — sendOutboundReply', () => {
     // Must NOT send to ourselves — must send to the human
     expect(mocks.outboundGateway.send).toHaveBeenCalledWith(
       expect.objectContaining({ to: CEO_EMAIL }),
+      expect.any(Object),
     );
     const callArg = (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(callArg.to).not.toBe(SELF_EMAIL);
@@ -175,6 +177,7 @@ describe('EmailAdapter — sendOutboundReply', () => {
 
     expect(mocks.outboundGateway.send).toHaveBeenCalledWith(
       expect.objectContaining({ to: CEO_EMAIL }),
+      expect.any(Object),
     );
   });
 
@@ -238,6 +241,7 @@ describe('EmailAdapter — sendOutboundReply', () => {
 
     expect(mocks.outboundGateway.send).toHaveBeenCalledWith(
       expect.objectContaining({ replyToMessageId: 'msg-latest' }),
+      expect.any(Object),
     );
   });
 });

--- a/tests/unit/draft-fallback-flow.test.ts
+++ b/tests/unit/draft-fallback-flow.test.ts
@@ -1,4 +1,4 @@
-// tests/integration/draft-fallback-flow.test.ts
+// tests/unit/draft-fallback-flow.test.ts
 //
 // Integration test: exercises the full gate → draft → approve path.
 // Verifies contracts BETWEEN layers: the gateway's gated result shape,
@@ -6,13 +6,16 @@
 //
 // "Medium-weight" integration: real EventBus + real OutboundGateway + real
 // EmailAdapter, with mocked external services (Nylas, autonomy DB, contacts).
+//
+// Lives in tests/unit/ because all external dependencies are mocked (no real
+// Postgres / Docker required). Convention: integration/ = real Postgres, unit/ = mocks.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventBus } from '../../src/bus/bus.js';
 import { OutboundGateway } from '../../src/skills/outbound-gateway.js';
 import { EmailAdapter } from '../../src/channels/email/email-adapter.js';
 import { AutonomyService } from '../../src/autonomy/autonomy-service.js';
-import { createOutboundMessage, type OutboundMessageEvent } from '../../src/bus/events.js';
+import { createOutboundMessage } from '../../src/bus/events.js';
 import { createLogger } from '../../src/logger.js';
 import type { NylasClient, NylasMessage } from '../../src/channels/email/nylas-client.js';
 import type { ContactService } from '../../src/contacts/contact-service.js';
@@ -102,8 +105,8 @@ function createMockActionLogRepo(): ActionLogRepo & {
       return ++insertCounter;
     }),
     countShortRefsForTask: vi.fn().mockResolvedValue(0),
-    linkPayload: vi.fn().mockImplementation(async (shortRef: string, payload: Record<string, unknown>) => {
-      _linkedPayloads.push({ shortRef, payload });
+    linkPayload: vi.fn().mockImplementation(async (_shortRef: string, _taskEventId: string | undefined, payload: Record<string, unknown>) => {
+      _linkedPayloads.push({ shortRef: _shortRef, payload });
       return true;
     }),
     findPendingByTaskAndSkill: vi.fn().mockResolvedValue(null),

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -1459,3 +1459,80 @@ describe('gated draft-fallback (two-step pattern)', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// linkGatedAction — Task 5
+// ---------------------------------------------------------------------------
+
+describe('OutboundGateway.linkGatedAction', () => {
+  it('delegates to actionLogRepo.linkPayload', async () => {
+    const mocks = createMocks();
+    const actionLogRepo = makeActionLogRepo();
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      actionLogRepo,
+    });
+
+    await gateway.linkGatedAction('email-1', { draftId: 'draft-abc' });
+
+    expect(actionLogRepo.linkPayload).toHaveBeenCalledOnce();
+    expect(actionLogRepo.linkPayload).toHaveBeenCalledWith('email-1', { draftId: 'draft-abc' });
+  });
+
+  it('is a no-op when actionLogRepo is not wired', async () => {
+    const mocks = createMocks();
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      // actionLogRepo intentionally omitted
+    });
+
+    // Should not throw
+    await gateway.linkGatedAction('email-1', { draftId: 'draft-abc' });
+  });
+
+  it('logs warn when linkPayload returns false (unknown ref)', async () => {
+    const mocks = createMocks();
+    const actionLogRepo = makeActionLogRepo();
+    (actionLogRepo.linkPayload as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    // Use a logger that captures log calls
+    const warnSpy = vi.fn();
+    const logger = {
+      child: () => ({
+        info: vi.fn(),
+        warn: warnSpy,
+        error: vi.fn(),
+        debug: vi.fn(),
+      }),
+    } as unknown as import('../../../src/logger.js').Logger;
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger,
+      actionLogRepo,
+    });
+
+    await gateway.linkGatedAction('email-99', { draftId: 'draft-xyz' });
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ actionRef: 'email-99' }),
+      expect.stringContaining('no pending row'),
+    );
+  });
+});

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -8,6 +8,7 @@ import type { EventBus } from '../../../src/bus/bus.js';
 import type { BusEvent } from '../../../src/bus/events.js';
 import type { AutonomyService, AutonomyConfig } from '../../../src/autonomy/autonomy-service.js';
 import type { PiiRedactor } from '../../../src/dispatch/pii-redactor.js';
+import type { ActionLogRepo } from '../../../src/autonomy/action-log-repo.js';
 
 /**
  * Build fresh vi.fn() mocks for each test. Using beforeEach + createMocks()
@@ -1278,3 +1279,183 @@ describe('humanApproved option on send()', () => {
     expect(mocks.nylasClient.sendMessage).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Gated draft-fallback (two-step pattern) — Task 4
+// ---------------------------------------------------------------------------
+
+/** Build a stub ActionLogRepo for testing the two-step draft-fallback pattern. */
+function makeActionLogRepo() {
+  return {
+    insert: vi.fn().mockResolvedValue(1),
+    linkPayload: vi.fn().mockResolvedValue(true),
+    countShortRefsForTask: vi.fn().mockResolvedValue(0),
+  } as unknown as ActionLogRepo;
+}
+
+describe('gated draft-fallback (two-step pattern)', () => {
+  it('returns { gated: true, actionRef } when score < threshold', async () => {
+    const mocks = createMocks();
+    const actionLogRepo = makeActionLogRepo();
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      autonomyService: makeAutonomyService(65),
+      actionLogRepo,
+    });
+
+    const result = await gateway.send(
+      { channel: 'email', to: 'recipient@example.com', subject: 'Hello', body: 'Hi!' },
+      { taskEventId: 'task-123', conversationId: 'conv-456' },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.gated).toBe(true);
+    expect(result.actionRef).toBe('email-1');
+    expect(result.blockedReason).toMatch(/autonomy score.*65.*below.*send threshold/i);
+  });
+
+  it('writes action_log row with pending_approval on gate', async () => {
+    const mocks = createMocks();
+    const actionLogRepo = makeActionLogRepo();
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      autonomyService: makeAutonomyService(65),
+      actionLogRepo,
+    });
+
+    await gateway.send(
+      { channel: 'email', to: 'recipient@example.com', subject: 'Hello', body: 'Hi!' },
+      { taskEventId: 'task-123', conversationId: 'conv-456' },
+    );
+
+    expect(actionLogRepo.insert).toHaveBeenCalledOnce();
+    expect(actionLogRepo.insert).toHaveBeenCalledWith(expect.objectContaining({
+      taskId: 'task-123',
+      conversationId: 'conv-456',
+      skillName: 'outbound-send',
+      actionRisk: 'medium',
+      outcome: 'pending_approval',
+      shortRef: 'email-1',
+    }));
+  });
+
+  it('action_log row includes recipient and subject in payload', async () => {
+    const mocks = createMocks();
+    const actionLogRepo = makeActionLogRepo();
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      autonomyService: makeAutonomyService(65),
+      actionLogRepo,
+    });
+
+    await gateway.send(
+      { channel: 'email', to: 'partner@example.com', subject: 'Project update', body: 'Content' },
+      { taskEventId: 'task-789' },
+    );
+
+    expect(actionLogRepo.insert).toHaveBeenCalledOnce();
+    const insertArg = (actionLogRepo.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(insertArg.payload).toEqual(expect.objectContaining({
+      source: 'autonomy_gate',
+      recipientEmail: 'partner@example.com',
+      subject: 'Project update',
+      channel: 'email',
+    }));
+  });
+
+  it('skips action_log write when actionLogRepo is not wired', async () => {
+    const mocks = createMocks();
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      autonomyService: makeAutonomyService(65),
+      // actionLogRepo intentionally omitted
+    });
+
+    const result = await gateway.send(
+      { channel: 'email', to: 'recipient@example.com', subject: 'Hello', body: 'Hi!' },
+      { taskEventId: 'task-123' },
+    );
+
+    // Still gated, but without actionRef
+    expect(result.success).toBe(false);
+    expect(result.gated).toBeUndefined();
+    expect(result.actionRef).toBeUndefined();
+  });
+
+  it('skips action_log write when taskEventId is missing', async () => {
+    const mocks = createMocks();
+    const actionLogRepo = makeActionLogRepo();
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      autonomyService: makeAutonomyService(65),
+      actionLogRepo,
+    });
+
+    const result = await gateway.send(
+      { channel: 'email', to: 'recipient@example.com', subject: 'Hello', body: 'Hi!' },
+      // taskEventId intentionally omitted
+    );
+
+    // Still gated, but without actionRef — and no insert called
+    expect(result.success).toBe(false);
+    expect(result.gated).toBeUndefined();
+    expect(result.actionRef).toBeUndefined();
+    expect(actionLogRepo.insert).not.toHaveBeenCalled();
+  });
+
+  it('increments actionRef counter based on existing short refs for the task', async () => {
+    const mocks = createMocks();
+    const actionLogRepo = makeActionLogRepo();
+    // Simulate 2 existing short refs for this task
+    (actionLogRepo.countShortRefsForTask as ReturnType<typeof vi.fn>).mockResolvedValue(2);
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      autonomyService: makeAutonomyService(65),
+      actionLogRepo,
+    });
+
+    const result = await gateway.send(
+      { channel: 'email', to: 'recipient@example.com', subject: 'Hello', body: 'Hi!' },
+      { taskEventId: 'task-123' },
+    );
+
+    expect(result.actionRef).toBe('email-3');
+  });
+});
+

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -1402,7 +1402,7 @@ describe('gated draft-fallback (two-step pattern)', () => {
 
     // Still gated, but without actionRef
     expect(result.success).toBe(false);
-    expect(result.gated).toBeUndefined();
+    expect(result.gated).toBe(true);
     expect(result.actionRef).toBeUndefined();
   });
 
@@ -1428,7 +1428,7 @@ describe('gated draft-fallback (two-step pattern)', () => {
 
     // Still gated, but without actionRef — and no insert called
     expect(result.success).toBe(false);
-    expect(result.gated).toBeUndefined();
+    expect(result.gated).toBe(true);
     expect(result.actionRef).toBeUndefined();
     expect(actionLogRepo.insert).not.toHaveBeenCalled();
   });

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -1478,10 +1478,10 @@ describe('OutboundGateway.linkGatedAction', () => {
       actionLogRepo,
     });
 
-    await gateway.linkGatedAction('email-1', { draftId: 'draft-abc' });
+    await gateway.linkGatedAction('email-1', 'task-evt-001', { draftId: 'draft-abc' });
 
     expect(actionLogRepo.linkPayload).toHaveBeenCalledOnce();
-    expect(actionLogRepo.linkPayload).toHaveBeenCalledWith('email-1', { draftId: 'draft-abc' });
+    expect(actionLogRepo.linkPayload).toHaveBeenCalledWith('email-1', 'task-evt-001', { draftId: 'draft-abc' });
   });
 
   it('is a no-op when actionLogRepo is not wired', async () => {
@@ -1498,7 +1498,7 @@ describe('OutboundGateway.linkGatedAction', () => {
     });
 
     // Should not throw
-    await gateway.linkGatedAction('email-1', { draftId: 'draft-abc' });
+    await gateway.linkGatedAction('email-1', undefined, { draftId: 'draft-abc' });
   });
 
   it('logs warn when linkPayload returns false (unknown ref)', async () => {
@@ -1527,7 +1527,7 @@ describe('OutboundGateway.linkGatedAction', () => {
       actionLogRepo,
     });
 
-    await gateway.linkGatedAction('email-99', { draftId: 'draft-xyz' });
+    await gateway.linkGatedAction('email-99', undefined, { draftId: 'draft-xyz' });
 
     expect(warnSpy).toHaveBeenCalledOnce();
     expect(warnSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- Lifts the autonomy draft-fallback decision from the email adapter to `OutboundGateway`, eliminating redundant gating and giving the gateway full task context for `autonomy_action_log` writes
- Simplifies the email adapter to a pure channel transport — no autonomy logic, no `autonomyService` dependency
- Unifies draft tracking for both autonomy-gated and observation-mode accounts under the same `autonomy_action_log` schema (`source: 'autonomy_gate'` vs `source: 'observation_mode'`)
- `send-draft` skill now transitions the action_log row to `approved` when the CEO sends a draft
- Removes the `autonomy_gated` outbound policy (breaking change: deployments must switch to `direct`)
- Moves `shortRef` to the end of each pending-actions-digest line for readability

## What changed

**Gateway (`src/skills/outbound-gateway.ts`)**
- Gated send now writes an `autonomy_action_log` row with `outcome: 'pending_approval'`, task context, and a generated `short_ref`
- Returns `{ success: false, gated: true, actionRef }` on gate
- New `linkGatedAction(actionRef, payload)` method — adapter calls this with the draft ID after creating the fallback draft; unknown refs are a no-op (logged at warn)
- Threshold derived from `AutonomyService.minScoreForActionRisk('medium')` instead of hardcoded `70`
- `getConfig()` failure is still fail-open; action_log DB write failure keeps the send blocked (fail-closed)

**Email adapter (`src/channels/email/email-adapter.ts`)**
- Removed `autonomyThreshold`, `autonomyService` from `EmailAdapterConfig`
- `dispatchByPolicy` now handles `direct` and `draft_gate` only — no score reads
- On `{ gated: true }`, adapter creates draft then calls `linkGatedAction` with the draft ID
- Error handling covers: draft creation failure (error log), link failure (error log with draft ID for manual reconciliation), absent `actionRef` (warn)

**Type changes**
- `OutboundPolicy`: removed `autonomy_gated` (breaking)
- `OutboundMessagePayload`: added `taskEventId?: string` (non-breaking)
- `OutboundSendResult`: added `gated?: boolean`, `actionRef?: string`
- `EmailAdapterConfig`: removed `autonomyThreshold`, `autonomyService`

**Skills**
- `send-draft`: transitions action_log row to `approved` on successful send (best-effort, email already sent)
- `email-draft-save`: writes action_log row when `observationMode === true`
- `pending-actions-digest`: shortRef moved to end of line

## Test plan

- [ ] `tests/unit/skills/outbound-gateway.test.ts` — gateway gate writes action_log, returns `{ gated, actionRef }`, `linkGatedAction` updates payload, threshold derived from service
- [ ] `tests/unit/channels/email/email-adapter.test.ts` — `direct`→gated creates draft + links, `draft_gate` creates draft directly, no autonomy score reads in adapter
- [ ] `tests/integration/draft-fallback-flow.test.ts` — full gate→draft→approve path, score-above-threshold sends directly, multi-account routing
- [ ] `skills/send-draft/handler.test.ts` — action_log row transitions to `approved`, graceful when no row exists
- [ ] `skills/email-draft-save/handler.test.ts` — observation-mode writes action_log row with correct payload

**Migration / deployment note:** Any account configured with `outbound_policy: autonomy_gated` must be updated to `outbound_policy: direct`. The schema validation will reject the old value on startup.

Closes #435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Updates**
  * Removed `autonomy_gated` outbound policy; use `draft_gate` for gated message workflows

* **Improvements**
  * Draft creation and approval transitions now properly tracked with state changes in pending-actions digest
  * Observation-mode drafts tracked for a unified pending-actions view
  * Pending-actions digest formatting improved: short reference codes repositioned to the end of each line

<!-- end of auto-generated comment: release notes by coderabbit.ai -->