### PR TITLE
fix: system notifications bypass autonomy gate; email-draft-save → low risk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **System notifications bypass autonomy gate** — `OutboundGateway.send()` now accepts `isSystemNotification: true`, which skips Step 0 (autonomy gate) for infrastructure alerts to the CEO (e.g. `approval_requested`). Previously, CEO approval notifications were silenced by the same gate that triggered them — the CEO could not act on a blocked action because the notification never arrived. All other safety checks (blocked-contact, content filter) still apply.
+- **`email-draft-save` action risk downgraded** — changed from `"medium"` to `"low"` (min score 60 instead of 70). Drafts are internal mailbox writes — the CEO still controls sending — and do not constitute autonomous outbound communication.
+
 ### Added
 
 - **Approval expiry sweep** — new `approval-expiry-sweep` skill that hourly expires stale `pending_approval` rows and sends a batched CEO notification for high/critical tier expirations; added `findExpired()` and `expireRows()` to `ActionLogRepo`

--- a/skills/email-draft-save/skill.json
+++ b/skills/email-draft-save/skill.json
@@ -3,7 +3,7 @@
   "description": "Save an email as a draft without sending it. The CEO can review and send the draft from their email client. Use for observation-mode triage (NEEDS DRAFT category) or when composing a reply that needs CEO approval before sending.",
   "version": "1.0.0",
   "sensitivity": "normal",
-  "action_risk": "medium",
+  "action_risk": "low",
   "inputs": {
     "to": "string (recipient email address)",
     "subject": "string (email subject line)",

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -136,6 +136,10 @@ export class EmailAdapter {
         // threshold — the notification must not be silenced by the gate it's reporting.
         // skipNotificationOnBlock prevents infinite recursion if the content filter
         // crashes and blocks this notification delivery itself.
+        logger.info(
+          { notificationType: notification.payload.notificationType, channel: 'email' },
+          'EmailAdapter: delivering system notification with autonomy gate bypass',
+        );
         const result = await this.config.outboundGateway.send(
           {
             channel: 'email',

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -131,9 +131,11 @@ export class EmailAdapter {
 
       const notification = event as OutboundNotificationEvent;
       try {
-        // skipNotificationOnBlock prevents infinite recursion: if the content filter
-        // is broken and blocks this notification, the gateway will NOT re-publish
-        // outbound.notification, breaking the cycle.
+        // isSystemNotification bypasses the autonomy gate so the CEO still receives
+        // alerts (e.g. approval_requested) even when the score is below the send
+        // threshold — the notification must not be silenced by the gate it's reporting.
+        // skipNotificationOnBlock prevents infinite recursion if the content filter
+        // crashes and blocks this notification delivery itself.
         const result = await this.config.outboundGateway.send(
           {
             channel: 'email',
@@ -141,7 +143,7 @@ export class EmailAdapter {
             subject: notification.payload.subject,
             body: notification.payload.body,
           },
-          { skipNotificationOnBlock: true },
+          { skipNotificationOnBlock: true, isSystemNotification: true },
         );
         if (!result.success) {
           logger.error(

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -248,7 +248,7 @@ export class OutboundGateway {
    *
    * Pipeline steps (channel-agnostic):
    *   0. Autonomy gate — score below 'medium' risk threshold blocks all autonomous sends
-   *      (skipped when options.humanApproved is true — CEO is in the loop)
+   *      (skipped when options.humanApproved or options.isSystemNotification is true)
    *   1. Contact blocked check
    *   2. Content filter (fail-closed)
    *   3. Channel dispatch (email → Nylas, signal → signal-cli RPC)
@@ -261,12 +261,18 @@ export class OutboundGateway {
    * @param options.humanApproved  When true, skip Step 0 (autonomy gate) only.
    *   The CEO is explicitly in the loop. All other safety checks (blocked-contact,
    *   content filter) run normally. See ADR-017.
+   * @param options.isSystemNotification  When true, skip Step 0 (autonomy gate) only.
+   *   Used for infrastructure alerts sent TO the CEO (e.g. approval_requested,
+   *   blocked_content). These must never be silenced by the same gate they report on —
+   *   if the score is too low to send autonomously, the CEO still needs to know about it.
+   *   All other safety checks (blocked-contact, content filter) run normally.
    */
   async send(
     request: OutboundSendRequest,
     options?: {
       skipNotificationOnBlock?: boolean;
       humanApproved?: boolean;
+      isSystemNotification?: boolean;
       /** Task event ID for action_log traceability. */
       taskEventId?: string;
       /** Conversation ID for action_log context. */
@@ -286,6 +292,14 @@ export class OutboundGateway {
       this.log.info(
         { channel: request.channel },
         'outbound-gateway: autonomy gate skipped — humanApproved flag set (CEO-authorized action, see ADR-017)',
+      );
+    } else if (this.autonomyService && options?.isSystemNotification) {
+      // Infrastructure alert to the CEO — gate must not silence its own alarm bell.
+      // A notification about a blocked action still needs to reach the CEO regardless
+      // of the score that caused the block. All other safety checks still run below.
+      this.log.info(
+        { channel: request.channel },
+        'outbound-gateway: autonomy gate skipped — isSystemNotification flag set (infrastructure alert to CEO)',
       );
     } else if (this.autonomyService) {
       // Fail-open on config read only — getConfig() failure must not block sends.

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -448,7 +448,7 @@ describe('EmailAdapter — outbound.notification subscriber', () => {
       to: CEO_EMAIL,
       subject: 'Action needed — blocked outbound reply',
     }));
-    expect(sendCall[1]).toEqual({ skipNotificationOnBlock: true });
+    expect(sendCall[1]).toEqual({ skipNotificationOnBlock: true, isSystemNotification: true });
 
     await adapter.stop();
   });

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -1536,3 +1536,94 @@ describe('OutboundGateway.linkGatedAction', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// isSystemNotification option on send() — system alerts bypass the autonomy gate
+// ---------------------------------------------------------------------------
+// System notifications (e.g. approval_requested, blocked_content alerts sent TO
+// the CEO) must never be silenced by the same autonomy gate they are reporting on.
+// isSystemNotification: true skips Step 0 only; all other safety checks still run.
+
+describe('isSystemNotification option on send()', () => {
+  it('bypasses the autonomy gate when isSystemNotification: true and score < 70', async () => {
+    const mocks = createMocks();
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      autonomyService: makeAutonomyService(65), // below 70 — would normally block
+    });
+
+    const result = await gateway.send(
+      { channel: 'email', to: 'ceo@example.com', subject: 'Action needed', body: 'Approval required.' },
+      { isSystemNotification: true },
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.nylasClient.sendMessage).toHaveBeenCalledOnce();
+    // autonomy.send_blocked must NOT fire — we bypassed the gate
+    expect(mocks.bus.publish).not.toHaveBeenCalledWith(
+      'dispatch',
+      expect.objectContaining({ type: 'autonomy.send_blocked' }),
+    );
+  });
+
+  it('still enforces the blocked-contact check when isSystemNotification: true', async () => {
+    const mocks = createMocks();
+    (mocks.contactService.resolveByChannelIdentity as ReturnType<typeof vi.fn>).mockResolvedValue({
+      contactId: 'contact-1',
+      displayName: 'Blocked',
+      role: null,
+      status: 'blocked',
+      kgNodeId: null,
+      verified: true,
+    });
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      autonomyService: makeAutonomyService(65),
+    });
+
+    const result = await gateway.send(
+      { channel: 'email', to: 'blocked@example.com', subject: 'Hi', body: 'Hi.' },
+      { isSystemNotification: true },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.blockedReason).toBe('Recipient is blocked');
+    expect(mocks.nylasClient.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('still enforces the content filter when isSystemNotification: true', async () => {
+    const mocks = createMocks();
+    (mocks.contentFilter.check as ReturnType<typeof vi.fn>).mockResolvedValue({
+      passed: false,
+      findings: [{ rule: 'test-rule', detail: 'blocked in test' }],
+    });
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      autonomyService: makeAutonomyService(65),
+    });
+
+    const result = await gateway.send(
+      { channel: 'email', to: 'ceo@example.com', subject: 'Hi', body: 'Hi.' },
+      { isSystemNotification: true },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.blockedReason).toBe('Content blocked by filter');
+    expect(mocks.nylasClient.sendMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug fix — system notifications blocked by own gate.** CEO approval notifications (e.g. `approval_requested`) were going through `OutboundGateway.send()` without bypassing the autonomy gate, so when the score was below 70, the very notification telling the CEO to approve a blocked action was itself silenced. The CEO couldn't act because they never knew the action was waiting. Added `isSystemNotification?: boolean` to `send()` options — skips Step 0 (autonomy gate) only; blocked-contact check and content filter still run. Wired `isSystemNotification: true` in `EmailAdapter`'s `outbound.notification` subscriber.

- **`email-draft-save` action risk downgraded `"medium"` → `"low"`.** Drafts are internal mailbox writes — the CEO controls whether to send. They are not autonomous outbound communications, so `"medium"` (min score 70) was wrong; `"low"` (min score 60) is correct. At score 69, drafting is now allowed while autonomous direct sends remain gated.

## Test plan

- [ ] All 2018 tests pass locally
- [ ] Three new unit tests in `outbound-gateway.test.ts`: gate bypassed at score 65, blocked-contact check still enforced, content filter still enforced
- [ ] Existing `email-adapter.test.ts` assertion updated to verify both `skipNotificationOnBlock: true` and `isSystemNotification: true` are passed
- [ ] Manual production verification: with autonomy score at 69, trigger a gated action and confirm the `approval_requested` notification arrives in the CEO inbox