### PR TITLE
fix: gateway approval notification + linkPayload column bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Gateway gate notifies CEO** — `OutboundGateway.send()` now sends an `approval_requested` notification to the CEO when the autonomy gate blocks a send and writes a `pending_approval` row. Previously, CEO alerts only came from the execution-layer `ApprovalTriggerService`; gateway-level blocks were silent, leaving the CEO unaware and `notification_sent_at` always NULL.
+- **`linkPayload` wrong column name** — fixed SQL bug in `ActionLogRepo.linkPayload()` where the WHERE clause used `task_event_id` (non-existent) instead of `task_id`, causing every `linkGatedAction()` call to throw a `DatabaseError` and draft IDs to never be linked to pending approval rows.
+
 - **System notifications bypass autonomy gate** — `OutboundGateway.send()` now accepts `isSystemNotification: true`, which skips Step 0 (autonomy gate) for infrastructure alerts to the CEO (e.g. `approval_requested`). Previously, CEO approval notifications were silenced by the same gate that triggered them — the CEO could not act on a blocked action because the notification never arrived. All other safety checks (blocked-contact, content filter) still apply.
 - **`email-draft-save` action risk downgraded** — changed from `"medium"` to `"low"` (min score 60 instead of 70). Drafts are internal mailbox writes — the CEO still controls sending — and do not constitute autonomous outbound communication.
 

--- a/src/autonomy/action-log-repo.test.ts
+++ b/src/autonomy/action-log-repo.test.ts
@@ -422,6 +422,18 @@ describe('ActionLogRepo', () => {
 
       expect(result).toBe(false);
     });
+
+    it('scopes update to task_id column (not task_event_id) when taskEventId is provided', async () => {
+      // Bug fix: the WHERE clause previously used task_event_id which doesn't exist —
+      // the actual column is task_id. Verify the SQL uses the correct column name.
+      const { pool, queries } = makePool([], 1);
+      const repo = new ActionLogRepo(pool, createSilentLogger());
+
+      await repo.linkPayload('email-1', 'task-evt-001', { draftId: 'draft-abc' });
+
+      expect(queries[0]!.sql).toContain('task_id');
+      expect(queries[0]!.sql).not.toContain('task_event_id');
+    });
   });
 
   describe('findPendingByPayloadField', () => {

--- a/src/autonomy/action-log-repo.ts
+++ b/src/autonomy/action-log-repo.ts
@@ -303,7 +303,7 @@ export class ActionLogRepo {
       `UPDATE autonomy_action_log
        SET payload = COALESCE(payload, '{}'::jsonb) || $3::jsonb
        WHERE short_ref = $1
-         AND ($2::text IS NULL OR task_event_id = $2)
+         AND ($2::text IS NULL OR task_id = $2)
          AND outcome = 'pending_approval'`,
       [shortRef, taskEventId ?? null, JSON.stringify(additionalPayload)],
     );

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -347,11 +347,15 @@ export class OutboundGateway {
           const subject = request.subject;
           const description = `Draft reply to ${recipientEmail}${subject ? ` — "${subject}"` : ''}. Use send-draft to approve.`;
 
+          // Hoist expiresAt so both the insert row and the notification body use the
+          // same value — if the 48h window ever changes, only one line needs updating.
+          const expiresAt = new Date(Date.now() + 48 * 60 * 60 * 1000);
+          let rowId: number | undefined;
           try {
             const counter = await this.actionLogRepo.countShortRefsForTask(options.taskEventId);
             actionRef = `email-${counter + 1}`;
 
-            await this.actionLogRepo.insert({
+            rowId = await this.actionLogRepo.insert({
               taskId: options.taskEventId,
               conversationId: options.conversationId ?? undefined,
               skillName: 'outbound-send',
@@ -365,7 +369,7 @@ export class OutboundGateway {
                 subject,
                 channel: request.channel,
               },
-              expiresAt: new Date(Date.now() + 48 * 60 * 60 * 1000),
+              expiresAt,
             });
           } catch (err) {
             this.log.error(
@@ -373,6 +377,43 @@ export class OutboundGateway {
               'outbound-gateway: failed to write action_log row during gate — send is still blocked, actionRef will be absent',
             );
             // actionRef remains undefined — send is still blocked below
+          }
+
+          // Notify CEO (best-effort) — mirrors ApprovalTriggerService.request() pattern.
+          // sendNotification() has its own try-catch and returns false on failure, so it
+          // never throws. Only stamp notification_sent_at if the publish succeeded.
+          // setNotificationSentAt is wrapped separately so a DB failure there does not
+          // discard the fact that the insert (and the notification delivery) succeeded.
+          if (rowId !== undefined && this.ceoEmail) {
+            const sent = await this.sendNotification({
+              notificationType: 'approval_requested',
+              ceoEmail: this.ceoEmail,
+              subject: `Approval needed — reply to ${recipientEmail}`,
+              body: [
+                `An outbound email reply was blocked by the autonomy gate.`,
+                '',
+                `To: ${recipientEmail}`,
+                subject ? `Subject: ${subject}` : null,
+                '',
+                `Autonomy score: ${autonomyConfig.score} (threshold: ${sendThreshold})`,
+                `Reference: ${actionRef}`,
+                `Expires: ${expiresAt.toISOString()}`,
+                '',
+                `Reply with the reference to approve, deny, or dismiss this request.`,
+              ].filter((line): line is string => line !== null).join('\n'),
+            });
+            if (sent) {
+              try {
+                await this.actionLogRepo.setNotificationSentAt(rowId);
+              } catch (err) {
+                // Non-fatal: the pending_approval row exists and gating is correct.
+                // Only notification_sent_at is missing — the CEO still received the alert.
+                this.log.warn(
+                  { err, rowId, taskEventId: options.taskEventId },
+                  'outbound-gateway: setNotificationSentAt failed after successful notification — notification_sent_at will be null',
+                );
+              }
+            }
           }
         }
 

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -1290,6 +1290,7 @@ function makeActionLogRepo() {
     insert: vi.fn().mockResolvedValue(1),
     linkPayload: vi.fn().mockResolvedValue(true),
     countShortRefsForTask: vi.fn().mockResolvedValue(0),
+    setNotificationSentAt: vi.fn().mockResolvedValue(undefined),
   } as unknown as ActionLogRepo;
 }
 
@@ -1456,6 +1457,96 @@ describe('gated draft-fallback (two-step pattern)', () => {
     );
 
     expect(result.actionRef).toBe('email-3');
+  });
+
+  it('notifies CEO when autonomy gate blocks a send and actionLogRepo + taskEventId are present', async () => {
+    // Bug fix: gateway-level gate blocks must notify the CEO — previously only the
+    // execution-layer ApprovalTriggerService sent notifications, leaving gateway blocks silent.
+    const mocks = createMocks();
+    const actionLogRepo = makeActionLogRepo();
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      autonomyService: makeAutonomyService(65),
+      actionLogRepo,
+    });
+
+    await gateway.send(
+      { channel: 'email', to: 'recipient@example.com', subject: 'Hello', body: 'Hi!' },
+      { taskEventId: 'task-123', conversationId: 'conv-456' },
+    );
+
+    const publishCalls = (mocks.bus.publish as ReturnType<typeof vi.fn>).mock.calls;
+    const notificationCalls = publishCalls.filter(
+      (call: unknown[]) => (call[1] as BusEvent).type === 'outbound.notification',
+    );
+    expect(notificationCalls).toHaveLength(1);
+    const notificationEvent = notificationCalls[0]![1] as BusEvent;
+    if (notificationEvent.type === 'outbound.notification') {
+      expect(notificationEvent.payload.notificationType).toBe('approval_requested');
+      expect(notificationEvent.payload.ceoEmail).toBe('ceo@example.com');
+    }
+  });
+
+  it('calls setNotificationSentAt with the row id after successful notification', async () => {
+    const mocks = createMocks();
+    const actionLogRepo = makeActionLogRepo();
+    // insert returns row id 42 so we can assert setNotificationSentAt is called with 42
+    (actionLogRepo.insert as ReturnType<typeof vi.fn>).mockResolvedValue(42);
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      autonomyService: makeAutonomyService(65),
+      actionLogRepo,
+    });
+
+    await gateway.send(
+      { channel: 'email', to: 'recipient@example.com', subject: 'Hello', body: 'Hi!' },
+      { taskEventId: 'task-123' },
+    );
+
+    expect(actionLogRepo.setNotificationSentAt).toHaveBeenCalledOnce();
+    expect(actionLogRepo.setNotificationSentAt).toHaveBeenCalledWith(42);
+  });
+
+  it('does not throw and still returns gated result when sendNotification fails', async () => {
+    // sendNotification() has an internal try-catch, so a bus.publish failure must not
+    // surface as a gateway error — the send is still blocked and gated: true is returned.
+    const mocks = createMocks();
+    const actionLogRepo = makeActionLogRepo();
+    (mocks.bus.publish as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Bus error'));
+
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', mocks.nylasClient]]),
+      contactService: mocks.contactService,
+      contentFilter: mocks.contentFilter,
+      bus: mocks.bus,
+      ceoEmail: 'ceo@example.com',
+      logger: mocks.logger,
+      autonomyService: makeAutonomyService(65),
+      actionLogRepo,
+    });
+
+    const result = await gateway.send(
+      { channel: 'email', to: 'recipient@example.com', subject: 'Hello', body: 'Hi!' },
+      { taskEventId: 'task-123' },
+    );
+
+    // Gate must still fire correctly despite the notification failure
+    expect(result.success).toBe(false);
+    expect(result.gated).toBe(true);
+    // Notification failed → setNotificationSentAt must NOT be called
+    expect(actionLogRepo.setNotificationSentAt).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

- **Gateway gate now notifies CEO** — when `OutboundGateway.send()` blocks a send and writes a `pending_approval` row, it now calls `sendNotification()` with `approval_requested` and stamps `notification_sent_at` on success. Previously only the execution-layer `ApprovalTriggerService` sent these notifications; gateway-level blocks were completely silent.
- **`linkPayload` column fix** — `ActionLogRepo.linkPayload()` used `task_event_id` in its SQL WHERE clause instead of the actual column `task_id`, causing every `linkGatedAction()` call to throw a `DatabaseError` and draft IDs to never be linked to pending approval rows.

## Design notes

- The notification block is split from the insert try-catch — a `setNotificationSentAt` DB failure logs a warn but does not affect the gated result (the row exists, the CEO still got the alert).
- `expiresAt` is now computed once before both the `insert()` and the notification body — they reference the same value.
- `sendNotification()` has its own try-catch and returns `false` on failure, so the notification path never throws.
- Mirrors `ApprovalTriggerService.request()` pattern exactly.

## Test plan

- [ ] `npm test src/autonomy/action-log-repo.test.ts` — new test asserts `task_id` column used
- [ ] `npm test tests/unit/skills/outbound-gateway.test.ts` — 3 new tests: notification published with `approval_requested`, `setNotificationSentAt` called with correct row id, gated result still returned when notification fails
- [ ] All 98 tests in the two files pass
- [ ] Full suite: no regressions beyond pre-existing integration test failures (no DB in CI)