### PR TITLE
fix: approve-action routes outbound-send re-execution to send-draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`approve-action` outbound-send re-execution** — approving a gateway-gated email now correctly invokes `send-draft` with the linked draft ID, instead of attempting to invoke `outbound-send` (a synthetic skill name not in the registry) which produced a registry error. Also added re-execution error logging so failures are visible in the log trail.
 - **Gateway gate notifies CEO** — `OutboundGateway.send()` now sends an `approval_requested` notification to the CEO when the autonomy gate blocks a send and writes a `pending_approval` row. Previously, CEO alerts only came from the execution-layer `ApprovalTriggerService`; gateway-level blocks were silent, leaving the CEO unaware and `notification_sent_at` always NULL.
 - **`linkPayload` wrong column name** — fixed SQL bug in `ActionLogRepo.linkPayload()` where the WHERE clause used `task_event_id` (non-existent) instead of `task_id`, causing every `linkGatedAction()` call to throw a `DatabaseError` and draft IDs to never be linked to pending approval rows.
 

--- a/skills/approve-action/handler.test.ts
+++ b/skills/approve-action/handler.test.ts
@@ -197,3 +197,73 @@ describe('ApproveActionHandler', () => {
     expect(result).toHaveProperty('error', expect.stringContaining('payload'));
   });
 });
+
+// ---------------------------------------------------------------------------
+// outbound-send re-execution — gateway-gated sends route to send-draft
+// ---------------------------------------------------------------------------
+// When skillName === 'outbound-send', the original action was blocked by the
+// OutboundGateway (not a skill registry entry). The correct re-execution path
+// is send-draft using the draftId + accountId stored in payload by linkGatedAction.
+// Invoking 'outbound-send' directly would produce a skill registry error.
+
+describe('ApproveActionHandler — outbound-send re-execution', () => {
+  const OUTBOUND_ROW = {
+    ...PENDING_ROW,
+    skillName: 'outbound-send',
+    actionRisk: 'medium',
+    shortRef: 'email-1',
+    description: 'Draft reply to josephbrnnn@gmail.com — "Re: Reconnecting". Use send-draft to approve.',
+    payload: {
+      source: 'autonomy_gate',
+      channel: 'email',
+      recipientEmail: 'josephbrnnn@gmail.com',
+      subject: 'Re: Reconnecting',
+      draftId: 'draft-abc123',
+      accountId: 'curia',
+    },
+  };
+
+  it('invokes send-draft (not outbound-send) with draftId and accountId from payload', async () => {
+    const repo = makeMockRepo({
+      resolvePending: vi.fn().mockResolvedValue({ found: true, row: OUTBOUND_ROW }),
+    });
+    const bus = makeMockBus();
+    const execLayer = makeMockExecutionLayer({ success: true, data: { message_id: 'msg-1', to: 'josephbrnnn@gmail.com', subject: 'Re: Reconnecting' } });
+    const handler = new ApproveActionHandler();
+
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo, bus, executionLayer: execLayer,
+    }));
+
+    expect(result.success).toBe(true);
+    const invokeArgs = (execLayer.invoke as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    // Must route to send-draft, not the synthetic 'outbound-send' name
+    expect(invokeArgs[0]).toBe('send-draft');
+    expect(invokeArgs[1]).toEqual({ draft_id: 'draft-abc123', account: 'curia' });
+    expect(invokeArgs[3]).toMatchObject({ humanApproved: true });
+  });
+
+  it('returns error without invoking execution layer when draftId is missing from payload', async () => {
+    // linkGatedAction may not have run (e.g. email adapter failed to create draft)
+    const repo = makeMockRepo({
+      resolvePending: vi.fn().mockResolvedValue({
+        found: true,
+        row: {
+          ...OUTBOUND_ROW,
+          payload: { source: 'autonomy_gate', channel: 'email', recipientEmail: 'josephbrnnn@gmail.com' },
+        },
+      }),
+    });
+    const bus = makeMockBus();
+    const execLayer = makeMockExecutionLayer();
+    const handler = new ApproveActionHandler();
+
+    const result = await handler.execute(makeCtx({
+      actionLogRepo: repo, bus, executionLayer: execLayer,
+    }));
+
+    expect(result.success).toBe(false);
+    expect(result).toHaveProperty('error', expect.stringContaining('draft'));
+    expect(execLayer.invoke).not.toHaveBeenCalled();
+  });
+});

--- a/skills/approve-action/handler.ts
+++ b/skills/approve-action/handler.ts
@@ -58,17 +58,33 @@ export class ApproveActionHandler implements SkillHandler {
       }
       ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'approve-action: row transitioned to approved');
 
-      // Step 2: Re-execute the original skill with humanApproved bypass
-      const reResult = await ctx.executionLayer.invoke(
-        row.skillName,
-        row.payload,
-        ctx.caller,
-        {
-          humanApproved: true,
-          taskEventId: ctx.taskEventId,
-          conversationId: row.conversationId ?? undefined,
-        },
-      );
+      // Step 2: Re-execute the original skill with humanApproved bypass.
+      //
+      // Special case: 'outbound-send' is a synthetic name used by OutboundGateway for
+      // gate blocks — it is not a registered skill. The correct re-execution path is
+      // send-draft using the draftId + accountId that linkGatedAction stored in payload.
+      let reResult: SkillResult;
+      if (row.skillName === 'outbound-send') {
+        const draftId = typeof row.payload.draftId === 'string' ? row.payload.draftId : null;
+        const accountId = typeof row.payload.accountId === 'string' ? row.payload.accountId : null;
+        if (!draftId || !accountId) {
+          ctx.log.error({ rowId: row.id, shortRef: row.shortRef }, 'approve-action: outbound-send row has no linked draft — cannot re-execute');
+          return { success: false, error: `Cannot approve '${row.shortRef}': no draft was linked to this approval request. The draft may not have been created.` };
+        }
+        reResult = await ctx.executionLayer.invoke(
+          'send-draft',
+          { draft_id: draftId, account: accountId },
+          ctx.caller,
+          { humanApproved: true, taskEventId: ctx.taskEventId, conversationId: row.conversationId ?? undefined },
+        );
+      } else {
+        reResult = await ctx.executionLayer.invoke(
+          row.skillName,
+          row.payload,
+          ctx.caller,
+          { humanApproved: true, taskEventId: ctx.taskEventId, conversationId: row.conversationId ?? undefined },
+        );
+      }
 
       // Step 3: Write child row for the re-execution result
       const childOutcome = reResult.success ? 'success' : 'failure';
@@ -115,6 +131,12 @@ export class ApproveActionHandler implements SkillHandler {
         ctx.log.warn({ rowId: row.id }, 'approve-action: no taskEventId — skipping human.decision audit event');
       }
 
+      if (!reResult.success) {
+        ctx.log.warn(
+          { rowId: row.id, shortRef: row.shortRef, reExecutionError: (reResult as { error: string }).error },
+          'approve-action: re-execution failed',
+        );
+      }
       ctx.log.info(
         { rowId: row.id, shortRef: row.shortRef, reExecutionSuccess: reResult.success },
         'approve-action: completed',


### PR DESCRIPTION
## Summary

- **Root cause:** `approve-action` always called `ctx.executionLayer.invoke(row.skillName, ...)`. For gateway-gated sends, `skillName` is `'outbound-send'` — a synthetic label, not a registered skill. The execution layer couldn't find it, producing a registry error and `reExecutionSuccess: false`.
- **Fix:** When `skillName === 'outbound-send'`, route to `send-draft` instead, using `draftId` and `accountId` from the payload (written there by `linkGatedAction`). If the payload has no `draftId`, return a clear error rather than a confusing registry message.
- **Bonus:** Log the actual re-execution error when `reResult.success === false` — previously only `reExecutionSuccess: false` appeared, making failures invisible in the log trail.

## Test plan

- [ ] `npm test skills/approve-action/handler.test.ts` — 2 new tests pass: routes to `send-draft` with correct args, returns error when `draftId` missing
- [ ] All 9 tests in the file pass
- [ ] Full suite: no regressions