### PR TITLE
fix: coordinator no longer calls email-reply for direct inbound emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+- **Email reply threading** — coordinator no longer calls `email-reply` when responding to a direct inbound email. Previously, it would attempt to use Nylas message IDs from the CEO's inbox (a different Nylas grant) via Curia's account, receive a 404, fall back to `email-send` (creating a new thread), and then also send a meta-commentary "Replied." message in the original thread via its `agent.response`. Now it returns the reply content directly; the dispatcher threads it correctly via `sendOutboundReply()`.
+
 ---
 
 ## [0.25.0] — 2026-05-05 — "By Your Leave"

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -340,8 +340,9 @@ system_prompt: |
   You have your own email account (Curia's account) and can monitor the CEO's inbox when configured in observation mode.
 
   ### Sending and replying
-  - **Replying to an email you received**: use `email-reply` with `reply_to_message_id` (the Nylas message ID from context or the observation-mode preamble). It threads automatically — no `to` address is needed.
-  - **Composing a new email**: use `email-send` with a `to` address. Only use this when the CEO asks you to email someone.
+  - **Replying to a direct inbound email** (no `[OBSERVATION MODE]` or `[OWNER CC —]` prefix — someone emailed you directly and you want to reply): just compose your reply text and return it as your response. The system automatically sends it as a threaded reply in the original email thread. Do NOT call `email-reply` or `email-send` — calling those skills here results in a new email thread AND a separate meta-commentary message landing in the original thread.
+  - **Replying from a non-conversational context** (CC'd email with `[OWNER CC —]` preamble, or a scheduled task where you have an explicit Message ID): use `email-reply` with `reply_to_message_id` set to the Nylas Message ID from the preamble or task context. Only use this when a Message ID is explicitly available in context.
+  - **Composing a new email**: use `email-send` with a `to` address. Only use this when the CEO asks you to email someone, or when you need to send a proactive outbound email (e.g. from a scheduled task).
   - **Drafting for the CEO's signature**: use `email-draft-save` with `account` set to the CEO's account name. The CEO reviews and sends from their client.
 
   ### Reading inboxes


### PR DESCRIPTION
## Summary

- When the CEO replies to a proactive email from Curia (e.g. a scheduled writing-scout report), the reply arrives as a direct inbound email with no observation-mode or CC preamble
- The coordinator prompt told it to call `email-reply` with a Nylas message ID — but no message ID is injected into the task for direct emails
- The coordinator would search `email-list` on the CEO's account, retrieve message IDs from that Nylas grant, and try to use them via Curia's account → 404 Not Found
- Fallback: `email-send` (new thread) + the `agent.response` "Replied. Here's the summary…" landing in the original thread via `sendOutboundReply()`
- Fix: for direct inbound emails, just compose the reply and return it; the dispatcher's `sendOutboundReply()` already handles threading correctly via `email:{threadId}`

## Root cause (from audit log)

```
20:29:50 skill.invoke  email-reply  {"reply_to_message_id": "message_id_placeholder"}  → 404
20:30:40 skill.invoke  email-reply  {"reply_to_message_id": "19dfef85aa12d07f"}        → 404 (CEO's Nylas grant, not Curia's)
20:31:19 skill.invoke  email-send   {"to": "joseph@josephfung.ca", ...}                 → new thread
20:31:28 agent.response "Replied. Here's the summary..." → sendOutboundReply → original thread
```

## Test plan

- [ ] Reply to a proactive Curia email (e.g. next writing-scout run) — verify reply lands in the original thread, no meta-commentary message
- [ ] CC a third-party email to Curia (`[OWNER CC —]` path) — verify coordinator still calls `email-reply` correctly
- [ ] Observation-mode email — unchanged path, still delegates to email-triage