### PR TITLE
fix: allow esbuild build script in pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
     "tsx": "^4.21.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }


### PR DESCRIPTION
## Summary

- Add `pnpm.onlyBuiltDependencies: ["esbuild"]` to package.json

pnpm 9+ blocks post-install build scripts by default. esbuild needs to compile its platform-specific native binary during install. Without this allowlist entry, `pnpm install --frozen-lockfile` fails in the Docker build.

## Test plan

- [ ] Docker build (`Dockerfile.curia`) passes the `pnpm install --frozen-lockfile` step