### PR TITLE
chore: release v0.25.1 — Clean Lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,31 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+---
+
+## [0.25.1] — 2026-05-07 — "Clean Lines"
+
 ### Removed
 
-- **Observation mode** — removed the `observationMode` flag, observation-mode preamble injection, outbound suppression, and all 12+ branch points across the channel, dispatch, agent, and execution layers. CEO inbox monitoring is now a dedicated skill domain in curia-deploy, not a channel concept. This eliminates the cross-grant Nylas ID bugs and identity confusion that occurred when a single coordinator handled both Curia's email and the CEO's email.
-- **`email-triage` agent** — deleted. Triage functionality moves to a dedicated `ceo-inbox` agent in curia-deploy.
-- **`outbound_policy` / `draft_gate`** — removed from config types, validation, schema, and email adapter. All channel accounts now send directly (autonomy-gated). The autonomy gate's fallback-to-draft mechanism handles low-score cases.
-- **`ObservationTriageCompletedEvent`** — removed from bus events and permissions. No longer emitted.
-- **`triage_classification`** — removed from `email-draft-save` skill inputs. Observation-mode guard removed from both `email-draft-save` and `email-reply`.
+- **Observation mode** — removed the `observationMode` flag, preamble injection, outbound suppression, and all 12+ branch points across channel, dispatch, agent, and execution layers. CEO inbox monitoring is now a dedicated skill domain in curia-deploy, not a channel concept. Eliminates the cross-grant Nylas ID bugs and identity confusion that plagued v0.24.
+- **`email-triage` agent** — deleted. Triage moves to the dedicated `ceo-inbox` agent in curia-deploy.
+- **`outbound_policy` / `draft_gate`** — removed from config types, validation, schema, and email adapter. All channel accounts now send directly (autonomy-gated).
+- **`ObservationTriageCompletedEvent`** — removed from bus events and permissions.
+- **`triage_classification`** — removed from `email-draft-save` and `email-reply` skill inputs.
 
 ### Changed
 
-- **Coordinator email instructions** — simplified. Direct inbound replies use the response content (dispatcher threads via `sendOutboundReply`). CC'd emails use `email-reply` with the preamble's Message ID. No observation-mode delegation or identity branching.
+- **Coordinator email instructions** — simplified. Direct inbound replies use the response content; CC'd emails use `email-reply` with the preamble's Message ID. No observation-mode delegation or identity branching.
+
+### Fixed
+
+- **CI pnpm 11 compatibility** — pinned pnpm 11, removed stale `onlyBuiltDependencies` config, and applied esbuild workaround for the CI workflow.
+
+---
+
+*old branches pruned away —*
+*one voice, one mailbox, clear.*
+*the lines hold their own.*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.25.0-blueviolet" alt="Version: 0.25.0" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.25.1-blueviolet" alt="Version: 0.25.1" /></a>
   <img src="https://img.shields.io/badge/status-pre--alpha-orange" alt="Status: Pre-Alpha" />
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License: MIT" />
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node >= 22" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "packageManager": "pnpm@11.0.8",


### PR DESCRIPTION
## [0.25.1] — 2026-05-07 — "Clean Lines"

### Removed

- **Observation mode** — removed the `observationMode` flag, preamble injection, outbound suppression, and all 12+ branch points across channel, dispatch, agent, and execution layers. CEO inbox monitoring is now a dedicated skill domain in curia-deploy, not a channel concept. Eliminates the cross-grant Nylas ID bugs and identity confusion that plagued v0.24.
- **`email-triage` agent** — deleted. Triage moves to the dedicated `ceo-inbox` agent in curia-deploy.
- **`outbound_policy` / `draft_gate`** — removed from config types, validation, schema, and email adapter. All channel accounts now send directly (autonomy-gated).
- **`ObservationTriageCompletedEvent`** — removed from bus events and permissions.
- **`triage_classification`** — removed from `email-draft-save` and `email-reply` skill inputs.

### Changed

- **Coordinator email instructions** — simplified. Direct inbound replies use the response content; CC'd emails use `email-reply` with the preamble's Message ID. No observation-mode delegation or identity branching.

### Fixed

- **CI pnpm 11 compatibility** — pinned pnpm 11, removed stale `onlyBuiltDependencies` config, and applied esbuild workaround for the CI workflow.

---

*old branches pruned away —*
*one voice, one mailbox, clear.*
*the lines hold their own.*