### PR TITLE
fix: extract-facts breaks on rate_limited instead of continuing silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Smoke tests** — renamed three `email-triage-*` test cases to `email-prioritization-*` following the CEO inbox redesign; updated the `email-triage` tag to `email-prioritization` in each
 - **ADR-017** — added a note that observation mode has been removed since this ADR was written (v0.25.x, CEO inbox redesign)
 
+### Fixed
+- **extract-facts rate-limit handling** — the per-fact loop now breaks immediately when `storeFact` returns `action:'rate_limited'`, logs at `error` level, and counts the fact as `failed`; previously all rate-limited facts were silently collapsed into the warn log alongside contradictions with no aggregate signal.
+
 ---
 
 ## [0.25.1] — 2026-05-07 — "Clean Lines"

--- a/skills/extract-facts/handler.test.ts
+++ b/skills/extract-facts/handler.test.ts
@@ -204,7 +204,7 @@ describe('ExtractFactsHandler', () => {
     expect(result).toEqual({ success: false, error: 'Extraction returned non-array response' });
   });
 
-  it('handles storeFact returning stored:false (rate-limit or contradiction) — not counted as failed', async () => {
+  it('handles storeFact conflict — fact not stored, not counted as failed', async () => {
     const entityMemory = makeEntityMemory();
     const facts = JSON.stringify([
       { subject: 'Jane Doe', subjectType: 'person', attribute: 'home_city', value: 'Toronto', confidence: 0.9, decayClass: 'slow_decay' },
@@ -212,14 +212,43 @@ describe('ExtractFactsHandler', () => {
     const anthropic = makeMockAnthropicClient(['yes', facts]);
     const handler = new ExtractFactsHandler(anthropic as never);
 
-    // Mock storeFact to return stored:false (simulates rate-limit rejection or contradiction)
-    const storeFact = vi.spyOn(entityMemory, 'storeFact').mockResolvedValueOnce({ stored: false, conflict: 'Rate limit exceeded' });
+    // Mock storeFact to return a conflict (contradicts an existing fact)
+    const storeFact = vi.spyOn(entityMemory, 'storeFact').mockResolvedValueOnce({
+      stored: false,
+      action: 'conflict',
+      conflict: 'contradicts existing value: London',
+    });
 
     const ctx = makeCtx(entityMemory, { text: 'Bob lives in Toronto.', source: 'test' });
     const result = await handler.execute(ctx);
 
-    // stored:false is not counted as failed — it is an expected semantic outcome
+    // conflict is a semantic outcome — not counted as failed
     expect(result).toEqual({ success: true, data: { stored: 0, skipped: false, failed: 0 } });
     expect(storeFact).toHaveBeenCalledOnce();
+  });
+
+  it('breaks immediately on rate_limited mid-batch — increments failed, skips remaining facts', async () => {
+    const entityMemory = makeEntityMemory();
+    // Three facts — first stored successfully, second hits rate limit, third should never be attempted.
+    const facts = JSON.stringify([
+      { subject: 'Jane Doe', subjectType: 'person', attribute: 'home_city', value: 'Toronto', confidence: 0.9, decayClass: 'slow_decay' },
+      { subject: 'Jane Doe', subjectType: 'person', attribute: 'job_title', value: 'CEO', confidence: 0.9, decayClass: 'slow_decay' },
+      { subject: 'Jane Doe', subjectType: 'person', attribute: 'nationality', value: 'Canadian', confidence: 0.9, decayClass: 'permanent' },
+    ]);
+    const anthropic = makeMockAnthropicClient(['yes', facts]);
+    const handler = new ExtractFactsHandler(anthropic as never);
+
+    const storeFact = vi.spyOn(entityMemory, 'storeFact')
+      .mockResolvedValueOnce({ stored: true, action: 'created' })
+      .mockResolvedValueOnce({ stored: false, action: 'rate_limited', conflict: '50-write limit reached' });
+    // No third mock — if the loop doesn't break, storeFact will be called a third time and
+    // the test will fail because the spy has no more configured responses.
+
+    const ctx = makeCtx(entityMemory, { text: 'Jane Doe is the Canadian CEO based in Toronto.', source: 'test' });
+    const result = await handler.execute(ctx);
+
+    // first fact stored, rate-limit counted as failed, loop stopped before fact 3
+    expect(result).toEqual({ success: true, data: { stored: 1, skipped: false, failed: 1 } });
+    expect(storeFact).toHaveBeenCalledTimes(2);
   });
 });

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -152,10 +152,10 @@ ${text}`,
 
       // -- Steps 3 & 4: Entity resolution + fact storage --
       let stored = 0;
-      // failed counts two things: malformed LLM output (skipped in the guard below) and
-      // infrastructure errors thrown during entity resolution or storeFact persistence.
-      // storeFact returning stored:false (rate-limit / contradiction) is NOT counted as
-      // failed — those are expected semantic outcomes logged at warn, not error.
+      // failed counts: malformed LLM output (guard below), rate-limited facts (loop
+      // breaks immediately on first hit), and infrastructure errors from storeFact.
+      // Contradictions (action:'conflict') are NOT counted as failed — they are expected
+      // semantic outcomes logged at warn.
       let failed = 0;
 
       // Entity node types (fact nodes themselves are excluded as subjects —
@@ -235,10 +235,19 @@ ${text}`,
 
           if (result.stored) {
             stored++;
+          } else if (result.action === 'rate_limited') {
+            // The 50-writes-per-task limit is exhausted — all remaining storeFact calls
+            // in this batch will also fail, so break immediately rather than burning
+            // through the rest of the loop and mis-reporting them as conflicts.
+            ctx.log.error(
+              { subject, attribute, source, reason: result.conflict },
+              'extract-facts: write rate limit exceeded — aborting remaining facts in batch',
+            );
+            failed++;
+            break;
           } else {
-            // storeFact returns stored:false on rate-limit rejection or contradiction.
-            // Log at warn (not error) — these are expected semantic outcomes, not infra failures.
-            ctx.log.warn({ subject, attribute, conflict: result.conflict, source }, 'extract-facts: fact rejected or conflicted');
+            // conflict or entity_not_found — expected semantic outcomes, not infra failures.
+            ctx.log.warn({ subject, attribute, conflict: result.conflict, action: result.action, source }, 'extract-facts: fact not stored');
           }
         } catch (err) {
           // Log at error — persistence failures are infrastructure errors (DB outage,


### PR DESCRIPTION
## Summary

- Fixes a silent-failure bug in `skills/extract-facts/handler.ts` where `rate_limited` from `storeFact` was handled identically to `conflict` — same warn log, no break, not counted in `failed`
- On `rate_limited`, the per-fact loop now logs at `error`, increments `failed`, and `break`s immediately (remaining calls would all fail too)
- The non-rate-limited else branch now includes `action` in its log context so `conflict` and `entity_not_found` are distinguishable in logs
- New unit test covers the rate-limited-mid-batch path: verifies the loop breaks after the second fact, `storeFact` is not called a third time, and the result is `{ stored: 1, failed: 1 }`
- Existing conflict test updated to mock `action: 'conflict'` explicitly (was missing the `action` field entirely)

Closes #471

## Test plan

- [x] All existing unit tests pass (`npm test skills/extract-facts/handler.test.ts` — 10 tests)
- [x] New test: `breaks immediately on rate_limited mid-batch — increments failed, skips remaining facts`
- [x] Updated test: `handles storeFact conflict — fact not stored, not counted as failed`
- [x] TypeScript passes (`npm run typecheck`)