### PR TITLE
chore: post-deploy cleanup after CEO inbox redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+- **Smoke tests** — renamed three `email-triage-*` test cases to `email-prioritization-*` following the CEO inbox redesign; updated the `email-triage` tag to `email-prioritization` in each
+- **ADR-017** — added a note that observation mode has been removed since this ADR was written (v0.25.x, CEO inbox redesign)
+
 ---
 
 ## [0.25.1] — 2026-05-07 — "Clean Lines"

--- a/docs/adr/017-ceo-authorized-action-pattern.md
+++ b/docs/adr/017-ceo-authorized-action-pattern.md
@@ -94,9 +94,11 @@ legitimate CEO-directed sends.
 
 **Harder / accepted trade-offs:**
 - The `ceoInitiated` stamping logic must be correct. If it fires too broadly
-  (e.g., stamps all tasks, or stamps observation-mode tasks), CEO-authorized skills
-  become reachable without genuine CEO approval. This logic should have its own
-  unit tests.
+  (e.g., stamps all tasks), CEO-authorized skills become reachable without genuine
+  CEO approval. This logic should have its own unit tests.
+  *(Note: "observation-mode tasks" was a concern at the time this ADR was written;
+  observation mode was removed in v0.25.x as part of the CEO inbox redesign — the
+  CEO's email is now a skill domain, not a channel.)*
 - `action_risk: "none"` on a skill that sends email looks surprising in isolation.
   Implementers who encounter it without context may be tempted to raise it. This
   ADR is the explanation; the skill manifest description should also include a

--- a/tests/smoke/cases/email-prioritization-batch.yaml
+++ b/tests/smoke/cases/email-prioritization-batch.yaml
@@ -1,7 +1,7 @@
 name: Triage Batch of Mixed Emails
 description: Agent should prioritize and categorize a batch of emails by urgency and action type, surfacing what needs CEO attention first
 tags:
-  - email-triage
+  - email-prioritization
   - urgency
   - multi-task
   - single-turn

--- a/tests/smoke/cases/email-prioritization-thread-summary.yaml
+++ b/tests/smoke/cases/email-prioritization-thread-summary.yaml
@@ -1,7 +1,7 @@
 name: Summarize Long Email Thread
 description: Agent should ask for thread details, then produce a structured summary that identifies the core decision point and suggests next steps
 tags:
-  - email-triage
+  - email-prioritization
   - summarization
   - multi-turn
 

--- a/tests/smoke/cases/email-prioritization-urgent.yaml
+++ b/tests/smoke/cases/email-prioritization-urgent.yaml
@@ -1,7 +1,7 @@
 name: Classify Urgent Investor Email
 description: Agent should correctly classify an email from a lead investor about an unexpected board matter as urgent and recommend immediate action
 tags:
-  - email-triage
+  - email-prioritization
   - urgency
   - single-turn
 


### PR DESCRIPTION
## Summary

Housekeeping items following the CEO inbox architectural redesign (observation mode removed in v0.25.x):

- Rename three smoke test cases from `email-triage-*` to `email-prioritization-*` and update their internal tag accordingly — the email-triage agent no longer exists, and these tests now exercise the broader email prioritization capability via the coordinator
- Add a note to ADR-017 clarifying that the "observation-mode tasks" concern mentioned in the trade-offs section no longer applies — observation mode was removed as part of the CEO inbox redesign

## Test plan
- [ ] Smoke test runner can discover and load the renamed files
- [ ] No remaining `email-triage` references in `tests/smoke/cases/`