### PR TITLE
fix: trust floor no longer holds confirmed contacts with contact_confidence=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **ADR-017** — added a note that observation mode has been removed since this ADR was written (v0.25.x, CEO inbox redesign)
 
 ### Fixed
+- **Trust floor confirmed-contact exemption** — confirmed contacts with `contact_confidence=0` and no `trust_level` override are no longer incorrectly held by the trust floor; the floor now exempts contacts with `status='confirmed'` since they have passed explicit CEO approval.
 - **extract-facts rate-limit handling** — the per-fact loop now breaks immediately when `storeFact` returns `action:'rate_limited'`, logs at `error` level, and counts the fact as `failed`; previously all rate-limited facts were silently collapsed into the warn log alongside contradictions with no aggregate signal.
 
 ---

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -605,7 +605,7 @@ export class Dispatcher {
       const policy = this.channelPolicies[payload.channelId];
       if (
         !threadTrusted &&
-        senderContext?.status !== 'confirmed' &&
+        !(senderContext?.resolved && senderContext.status === 'confirmed') &&
         messageTrustScore < this.trustScoreFloor &&
         policy?.unknownSender !== 'ignore' &&
         this.heldMessages

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -597,9 +597,15 @@ export class Dispatcher {
       // This overrides per-channel 'allow' policies for very low-trust messages — including unknown
       // senders on 'allow' channels. Unknown senders on 'hold_and_notify' and 'ignore' channels
       // already returned early above, so there is no risk of double-holding here.
+      //
+      // Confirmed contacts are exempt: a contact with status='confirmed' has passed explicit CEO
+      // approval and should route unconditionally regardless of contact_confidence. The floor is
+      // designed for unknown or provisional senders, not explicitly approved contacts. Provisional
+      // contacts still go through the floor check.
       const policy = this.channelPolicies[payload.channelId];
       if (
         !threadTrusted &&
+        senderContext?.status !== 'confirmed' &&
         messageTrustScore < this.trustScoreFloor &&
         policy?.unknownSender !== 'ignore' &&
         this.heldMessages

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -431,6 +431,14 @@ describe('Dispatcher — messageTrustScore', () => {
   });
 
   it('trust floor does not hold messages on ignore channels', async () => {
+    // Uses a confirmed contact because that is the only resolved-sender type that can reach
+    // the trust floor in a controlled test scenario (provisional contacts on ignore channels are
+    // caught by the provisional gate before they reach the trust floor). Before issue #459 was
+    // fixed, the confirmed-contact path was also the only way to trigger the floor's 'ignore'
+    // exemption for a resolved sender. After the fix, confirmed contacts are exempt via the new
+    // guard and the 'ignore' check fires second — this test retains coverage of the guard as a
+    // belt-and-suspenders defense against future regressions where a non-confirmed resolved sender
+    // might reach the trust floor on an 'ignore' channel.
     const logger = createLogger('error');
     const bus = new EventBus(logger);
     const heldMessages = makeInMemoryHeldMessages();

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -333,10 +333,70 @@ describe('Dispatcher — messageTrustScore', () => {
     expect(tasks[0]!.payload.messageTrustScore).toBeCloseTo(0.12);
   });
 
-  it('trust floor triggers hold_and_notify for low-scoring known sender', async () => {
+  it('trust floor triggers hold_and_notify for provisional sender with low score', async () => {
+    // Provisional contacts still go through the floor — they have not yet been explicitly approved.
     const logger = createLogger('error');
     const bus = new EventBus(logger);
     const heldMessages = makeInMemoryHeldMessages();
+    const resolver = makeResolverWithContact({
+      contactConfidence: 0.0,
+      trustLevel: null,
+      status: 'provisional',
+    });
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      contactResolver: resolver,
+      heldMessages,
+      channelPolicies: { email: { trust: 'low', unknownSender: 'allow' } },
+      trustScoreFloor: 0.2,
+    });
+    dispatcher.register();
+
+    const held: MessageHeldEvent[] = [];
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('message.held', 'channel', (e) => { held.push(e as MessageHeldEvent); });
+    bus.subscribe('agent.task', 'agent', (e) => { tasks.push(e as AgentTaskEvent); });
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'conv-floor-1',
+      channelId: 'email',
+      senderId: 'provisional@example.com',
+      content: 'Hello',
+    }));
+
+    // email low=0.3, contactConfidence=0.0 → 0.3*0.4=0.12, below floor of 0.2 → held
+    expect(held).toHaveLength(1);
+    expect(tasks).toHaveLength(0);
+  });
+
+  it('trust floor does not hold confirmed contact with contact_confidence=0 (issue #459)', async () => {
+    // Regression test: a confirmed contact with contact_confidence=0 and trust_level=null was
+    // incorrectly held by the trust floor. Confirmed contacts have explicit CEO approval and
+    // must route unconditionally regardless of contact_confidence.
+    //
+    // Production incident: xiaopu@xiaopu.ca (status=confirmed, verified, source=ceo_stated)
+    // was held because contact_confidence=0.00 caused trust score=0.12 < floor(0.2).
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const heldMessages = makeInMemoryHeldMessages();
+    const mockProvider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn().mockResolvedValue({
+        type: 'text' as const,
+        content: 'OK',
+        usage: { inputTokens: 1, outputTokens: 1 },
+      }),
+    };
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a helpful assistant.',
+      provider: mockProvider,
+      bus,
+      logger,
+    });
+    coordinator.register();
+
     const resolver = makeResolverWithContact({
       contactConfidence: 0.0,
       trustLevel: null,
@@ -358,15 +418,16 @@ describe('Dispatcher — messageTrustScore', () => {
     bus.subscribe('agent.task', 'agent', (e) => { tasks.push(e as AgentTaskEvent); });
 
     await bus.publish('channel', createInboundMessage({
-      conversationId: 'conv-floor-1',
+      conversationId: 'conv-floor-confirmed-exempt',
       channelId: 'email',
-      senderId: 'lowscore@example.com',
+      senderId: 'confirmed@example.com',
       content: 'Hello',
     }));
 
-    // email low=0.3, contactConfidence=0.0 → 0.3*0.4=0.12, below floor of 0.2 → held
-    expect(held).toHaveLength(1);
-    expect(tasks).toHaveLength(0);
+    // email low=0.3, contactConfidence=0.0 → score=0.12, below floor of 0.2
+    // BUT contact is confirmed → trust floor is skipped → routes to coordinator
+    expect(held).toHaveLength(0);
+    expect(tasks).toHaveLength(1);
   });
 
   it('trust floor does not hold messages on ignore channels', async () => {


### PR DESCRIPTION
## Summary

- Adds `!(senderContext?.resolved && senderContext.status === 'confirmed')` guard to the trust floor condition in `Dispatcher.handleInbound` — confirmed contacts bypass the floor unconditionally
- Uses the `resolved` discriminant (established pattern in the file) to remain type-safe across the `SenderContext | UnknownSenderContext` union
- Updates the existing provisional-sender floor test (was using `status: 'confirmed'`, which was testing the wrong thing) and adds a regression test covering the production incident

## Test plan

- [ ] All 41 dispatcher unit tests pass (including 1 new regression test)
- [ ] All 149 dispatch unit tests pass
- [ ] TypeScript compiles clean (`tsc --noEmit`)
- [ ] Confirmed contact with `contact_confidence=0`, `trust_level=null` on a low-trust channel → NOT held (new regression test)
- [ ] Provisional contact with same values → IS held (updated existing test)
- [ ] Unknown sender on allow channel → IS held by floor (existing test unchanged)

Closes #459