### PR TITLE
feat: contact-register skill — CEO inbox ↔ contact system bridge (#485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 - **`contact.resolved` bus event** — `sourceLayer` widened from `'dispatch'` to `'dispatch' | 'execution'`; `createContactResolved()` factory accepts an optional `sourceLayer` parameter (defaults to `'dispatch'` for backward compatibility). This is a public API surface change.
 - **`IdentitySource`** — new value `'agent_called'` for contacts registered by agents outside the normal dispatcher pipeline
-
-### Changed
 - **Outbound gateway** — removed `setTrustLevel('high')` band-aid; outbound sends now trigger the confidence scoring pipeline instead, giving contacts a real `contact_confidence` value
 - **Smoke tests** — renamed three `email-triage-*` test cases to `email-prioritization-*` following the CEO inbox redesign; updated the `email-triage` tag to `email-prioritization` in each
 - **ADR-017** — added a note that observation mode has been removed since this ADR was written (v0.25.x, CEO inbox redesign)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 - **Contact confidence scoring pipeline** — `contact_confidence` is now updated on each qualifying event (inbound/outbound message, CEO trust grant, verified identity pairing). Supports incremental and full-recompute modes with convergence guarantee (spec 06, #460)
+- **`contact-register` skill** — integration point for agents that read channels directly (e.g. the ceo-inbox agent) rather than through the dispatcher. Resolves or creates contacts, updates `last_seen_at`, triggers a confidence scoring delta, and emits a `contact.resolved` bus event (#485)
+
+### Changed
+- **`contact.resolved` bus event** — `sourceLayer` widened from `'dispatch'` to `'dispatch' | 'execution'`; `createContactResolved()` factory accepts an optional `sourceLayer` parameter (defaults to `'dispatch'` for backward compatibility). This is a public API surface change.
+- **`IdentitySource`** — new value `'agent_called'` for contacts registered by agents outside the normal dispatcher pipeline
 
 ### Changed
 - **Outbound gateway** — removed `setTrustLevel('high')` band-aid; outbound sends now trigger the confidence scoring pipeline instead, giving contacts a real `contact_confidence` value

--- a/skills/contact-register/handler.test.ts
+++ b/skills/contact-register/handler.test.ts
@@ -279,6 +279,71 @@ describe('ContactRegisterHandler — last_seen_at idempotency (pipeline absent)'
   });
 });
 
+describe('ContactRegisterHandler — confidence pipeline (pipeline present)', () => {
+  let handler: ContactRegisterHandler;
+  let contactService: ContactService;
+  let contactId: string;
+
+  beforeEach(async () => {
+    handler = new ContactRegisterHandler();
+    contactService = ContactService.createInMemory();
+
+    const contact = await contactService.createContact({
+      displayName: 'Dave Evans',
+      status: 'confirmed',
+      source: 'ceo_stated',
+    });
+    contactId = contact.id;
+    await contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: 'dave@example.com',
+      source: 'email_participant',
+    });
+  });
+
+  it('delegates scoring to the pipeline when present', async () => {
+    const calls: Array<{ contactId: string; signal: unknown }> = [];
+    const mockPipeline = {
+      incrementalUpdate: async (id: string, signal: unknown) => {
+        calls.push({ contactId: id, signal });
+      },
+    };
+
+    const ctx = makeCtx({
+      contactService,
+      confidencePipeline: mockPipeline as SkillContext['confidencePipeline'],
+      input: { channel: 'email', identifier: 'dave@example.com', displayName: 'Dave', messageTimestamp: TIMESTAMP_A },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.contactId).toBe(contactId);
+    expect(calls[0]!.signal).toEqual({ type: 'message_seen' });
+  });
+
+  it('does not update lastSeenAt directly when pipeline is present', async () => {
+    const mockPipeline = {
+      incrementalUpdate: async () => { /* no-op — does not write lastSeenAt */ },
+    };
+
+    const ctx = makeCtx({
+      contactService,
+      confidencePipeline: mockPipeline as SkillContext['confidencePipeline'],
+      input: { channel: 'email', identifier: 'dave@example.com', displayName: 'Dave', messageTimestamp: TIMESTAMP_A },
+    });
+
+    await handler.execute(ctx);
+
+    // The mock pipeline is a no-op — lastSeenAt should remain null because the
+    // direct update path is skipped when the pipeline is present.
+    const contact = await contactService.getContact(contactId);
+    expect(contact!.lastSeenAt).toBeNull();
+  });
+});
+
 describe('ContactRegisterHandler — bus event emission', () => {
   let handler: ContactRegisterHandler;
   let contactService: ContactService;

--- a/skills/contact-register/handler.test.ts
+++ b/skills/contact-register/handler.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import pino from 'pino';
+import { ContactRegisterHandler } from './handler.js';
+import { ContactService } from '../../src/contacts/contact-service.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+const silentLog = pino({ level: 'silent' });
+
+function makeCtx(overrides: Partial<SkillContext> = {}): SkillContext {
+  return {
+    input: {},
+    secret: () => 'unused',
+    log: silentLog,
+    ...overrides,
+  } as unknown as SkillContext;
+}
+
+const TIMESTAMP_A = '2026-05-08T10:00:00.000Z';
+const TIMESTAMP_B = '2026-05-08T11:00:00.000Z'; // one hour later
+const TIMESTAMP_OLD = '2026-05-07T08:00:00.000Z'; // yesterday
+
+describe('ContactRegisterHandler — input validation', () => {
+  let handler: ContactRegisterHandler;
+  let contactService: ContactService;
+
+  beforeEach(() => {
+    handler = new ContactRegisterHandler();
+    contactService = ContactService.createInMemory();
+  });
+
+  it('returns error when channel is missing', async () => {
+    const ctx = makeCtx({
+      contactService,
+      input: { identifier: 'alice@example.com', displayName: 'Alice', messageTimestamp: TIMESTAMP_A },
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/channel/);
+  });
+
+  it('returns error when identifier is missing', async () => {
+    const ctx = makeCtx({
+      contactService,
+      input: { channel: 'email', displayName: 'Alice', messageTimestamp: TIMESTAMP_A },
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/identifier/);
+  });
+
+  it('returns error when displayName is missing', async () => {
+    const ctx = makeCtx({
+      contactService,
+      input: { channel: 'email', identifier: 'alice@example.com', messageTimestamp: TIMESTAMP_A },
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/displayName/);
+  });
+
+  it('returns error when messageTimestamp is missing', async () => {
+    const ctx = makeCtx({
+      contactService,
+      input: { channel: 'email', identifier: 'alice@example.com', displayName: 'Alice' },
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/messageTimestamp/);
+  });
+
+  it('returns error when messageTimestamp is not a valid date', async () => {
+    const ctx = makeCtx({
+      contactService,
+      input: { channel: 'email', identifier: 'alice@example.com', displayName: 'Alice', messageTimestamp: 'not-a-date' },
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/ISO 8601/);
+  });
+
+  it('returns error when direction is invalid', async () => {
+    const ctx = makeCtx({
+      contactService,
+      input: { channel: 'email', identifier: 'alice@example.com', displayName: 'Alice', messageTimestamp: TIMESTAMP_A, direction: 'sideways' },
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/direction/);
+  });
+
+  it('returns error when contactService is unavailable', async () => {
+    const ctx = makeCtx({
+      input: { channel: 'email', identifier: 'alice@example.com', displayName: 'Alice', messageTimestamp: TIMESTAMP_A },
+    });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect((result as { success: false; error: string }).error).toMatch(/contactService/);
+  });
+});
+
+describe('ContactRegisterHandler — known contact resolution', () => {
+  let handler: ContactRegisterHandler;
+  let contactService: ContactService;
+
+  beforeEach(async () => {
+    handler = new ContactRegisterHandler();
+    contactService = ContactService.createInMemory();
+
+    // Seed a known confirmed contact with an email identity
+    const contact = await contactService.createContact({
+      displayName: 'Alice Nguyen',
+      role: 'Head of Product',
+      status: 'confirmed',
+      source: 'ceo_stated',
+    });
+    await contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: 'alice@example.com',
+      source: 'email_participant',
+    });
+  });
+
+  it('resolves an existing contact and returns it', async () => {
+    const ctx = makeCtx({
+      contactService,
+      input: { channel: 'email', identifier: 'alice@example.com', displayName: 'Alice', messageTimestamp: TIMESTAMP_A },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.display_name).toBe('Alice Nguyen');
+    expect(data.status).toBe('confirmed');
+    expect(data.created).toBe(false);
+    expect(typeof data.contact_id).toBe('string');
+  });
+
+  it('does not create a duplicate contact for a known identifier', async () => {
+    const ctx = makeCtx({
+      contactService,
+      input: { channel: 'email', identifier: 'alice@example.com', displayName: 'Alice', messageTimestamp: TIMESTAMP_A },
+    });
+
+    await handler.execute(ctx);
+
+    const allContacts = await contactService.listContacts();
+    expect(allContacts).toHaveLength(1);
+  });
+});
+
+describe('ContactRegisterHandler — unknown contact creation', () => {
+  let handler: ContactRegisterHandler;
+  let contactService: ContactService;
+
+  beforeEach(() => {
+    handler = new ContactRegisterHandler();
+    contactService = ContactService.createInMemory();
+  });
+
+  it('creates a provisional contact for an unknown email address', async () => {
+    const ctx = makeCtx({
+      contactService,
+      input: { channel: 'email', identifier: 'newperson@example.com', displayName: 'New Person', messageTimestamp: TIMESTAMP_A },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.status).toBe('provisional');
+    expect(data.display_name).toBe('New Person');
+    expect(data.created).toBe(true);
+  });
+
+  it('links the identifier to the new contact so future calls resolve it', async () => {
+    const ctx = makeCtx({
+      contactService,
+      input: { channel: 'email', identifier: 'newperson@example.com', displayName: 'New Person', messageTimestamp: TIMESTAMP_A },
+    });
+
+    const firstResult = await handler.execute(ctx);
+    expect(firstResult.success).toBe(true);
+    const firstData = (firstResult as { success: true; data: Record<string, unknown> }).data;
+    const firstId = firstData.contact_id as string;
+
+    // Second call with same identifier should resolve, not create
+    const secondResult = await handler.execute(ctx);
+    expect(secondResult.success).toBe(true);
+    const secondData = (secondResult as { success: true; data: Record<string, unknown> }).data;
+    expect(secondData.contact_id).toBe(firstId);
+    expect(secondData.created).toBe(false);
+  });
+
+  it('stores the contact with source agent_called on the identity', async () => {
+    const ctx = makeCtx({
+      contactService,
+      input: { channel: 'email', identifier: 'newperson@example.com', displayName: 'New Person', messageTimestamp: TIMESTAMP_A },
+    });
+
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+
+    const withIdentities = await contactService.getContactWithIdentities(data.contact_id as string);
+    expect(withIdentities).toBeDefined();
+    const identity = withIdentities!.identities.find(i => i.channel === 'email');
+    expect(identity).toBeDefined();
+    expect(identity!.source).toBe('agent_called');
+  });
+});
+
+describe('ContactRegisterHandler — last_seen_at idempotency (pipeline absent)', () => {
+  let handler: ContactRegisterHandler;
+  let contactService: ContactService;
+
+  beforeEach(async () => {
+    handler = new ContactRegisterHandler();
+    contactService = ContactService.createInMemory();
+
+    // Seed a known contact
+    const contact = await contactService.createContact({
+      displayName: 'Bob Smith',
+      status: 'confirmed',
+      source: 'ceo_stated',
+    });
+    await contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: 'bob@example.com',
+      source: 'email_participant',
+    });
+  });
+
+  it('updates last_seen_at when messageTimestamp is newer than current value', async () => {
+    // First call — sets last_seen_at to TIMESTAMP_A
+    const ctx = makeCtx({
+      contactService,
+      input: { channel: 'email', identifier: 'bob@example.com', displayName: 'Bob', messageTimestamp: TIMESTAMP_A },
+    });
+    await handler.execute(ctx);
+
+    // Second call — newer timestamp should advance last_seen_at
+    const ctx2 = makeCtx({
+      contactService,
+      input: { channel: 'email', identifier: 'bob@example.com', displayName: 'Bob', messageTimestamp: TIMESTAMP_B },
+    });
+    const result = await handler.execute(ctx2);
+    expect(result.success).toBe(true);
+
+    // Verify last_seen_at advanced
+    const resolved = await contactService.resolveByChannelIdentity('email', 'bob@example.com');
+    const contact = await contactService.getContact(resolved!.contactId);
+    expect(contact!.lastSeenAt).not.toBeNull();
+    expect(contact!.lastSeenAt!.toISOString()).toBe(TIMESTAMP_B);
+  });
+
+  it('does not roll back last_seen_at when messageTimestamp is older than current value', async () => {
+    // First call — sets last_seen_at to TIMESTAMP_B (the later time)
+    const ctx = makeCtx({
+      contactService,
+      input: { channel: 'email', identifier: 'bob@example.com', displayName: 'Bob', messageTimestamp: TIMESTAMP_B },
+    });
+    await handler.execute(ctx);
+
+    // Second call — older timestamp must NOT overwrite last_seen_at
+    const ctx2 = makeCtx({
+      contactService,
+      input: { channel: 'email', identifier: 'bob@example.com', displayName: 'Bob', messageTimestamp: TIMESTAMP_OLD },
+    });
+    const result = await handler.execute(ctx2);
+    expect(result.success).toBe(true);
+
+    const resolved = await contactService.resolveByChannelIdentity('email', 'bob@example.com');
+    const contact = await contactService.getContact(resolved!.contactId);
+    // last_seen_at should still be TIMESTAMP_B, not TIMESTAMP_OLD
+    expect(contact!.lastSeenAt!.toISOString()).toBe(TIMESTAMP_B);
+  });
+});
+
+describe('ContactRegisterHandler — bus event emission', () => {
+  let handler: ContactRegisterHandler;
+  let contactService: ContactService;
+
+  beforeEach(async () => {
+    handler = new ContactRegisterHandler();
+    contactService = ContactService.createInMemory();
+
+    const contact = await contactService.createContact({
+      displayName: 'Carol Diaz',
+      status: 'confirmed',
+      source: 'ceo_stated',
+    });
+    await contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: 'carol@example.com',
+      source: 'email_participant',
+    });
+  });
+
+  it('publishes a contact.resolved event with sourceLayer execution', async () => {
+    const publishedEvents: unknown[] = [];
+    const mockBus = {
+      // Two-arg signature matches EventBus.publish(layer, event) — enforced here so
+      // a missing layer arg fails the test rather than silently passing.
+      publish: async (_layer: string, event: unknown) => { publishedEvents.push(event); },
+    };
+
+    const ctx = makeCtx({
+      contactService,
+      bus: mockBus as SkillContext['bus'],
+      input: { channel: 'email', identifier: 'carol@example.com', displayName: 'Carol', messageTimestamp: TIMESTAMP_A },
+    });
+
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+
+    // Give the fire-and-forget publish a tick to complete
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(publishedEvents).toHaveLength(1);
+    const event = publishedEvents[0] as Record<string, unknown>;
+    expect(event.type).toBe('contact.resolved');
+    expect(event.sourceLayer).toBe('execution');
+  });
+
+  it('succeeds even when bus is not available', async () => {
+    const ctx = makeCtx({
+      contactService,
+      // No bus injected
+      input: { channel: 'email', identifier: 'carol@example.com', displayName: 'Carol', messageTimestamp: TIMESTAMP_A },
+    });
+
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+  });
+});

--- a/skills/contact-register/handler.ts
+++ b/skills/contact-register/handler.ts
@@ -1,0 +1,198 @@
+// handler.ts — contact-register skill implementation.
+//
+// Bridges agents that read channels directly (e.g. the ceo-inbox agent reading
+// Nylas without going through the dispatcher) into the contact system.
+//
+// The normal dispatcher pipeline resolves contacts, emits contact.resolved events,
+// and triggers confidence scoring automatically. Agents that bypass the dispatcher
+// get none of that — this skill provides the equivalent integration point.
+//
+// Per invocation:
+//   1. Resolve by channel identity (or create a provisional contact if unknown)
+//   2. Trigger a scoring delta via the confidence pipeline (or update last_seen_at
+//      directly when the pipeline is not wired)
+//   3. Emit a contact.resolved bus event for the audit trail
+//   4. Return the contact record for use in triage / classification
+//
+// Services used:
+//   - contactService (universal — always available)
+//   - confidencePipeline (capability: "confidencePipeline" — optional)
+//   - bus (capability: "bus" — optional; audit trail only, skill succeeds without it)
+
+import { randomUUID } from 'node:crypto';
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { createContactResolved } from '../../src/bus/events.js';
+
+export class ContactRegisterHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { channel, identifier, displayName, direction, messageTimestamp } = ctx.input as {
+      channel?: string;
+      identifier?: string;
+      displayName?: string;
+      direction?: string;
+      messageTimestamp?: string;
+    };
+
+    // -- Input validation --
+
+    if (!channel || typeof channel !== 'string') {
+      return { success: false, error: 'Missing required input: channel' };
+    }
+    if (!identifier || typeof identifier !== 'string') {
+      return { success: false, error: 'Missing required input: identifier' };
+    }
+    if (!displayName || typeof displayName !== 'string') {
+      return { success: false, error: 'Missing required input: displayName' };
+    }
+    if (!messageTimestamp || typeof messageTimestamp !== 'string') {
+      return { success: false, error: 'Missing required input: messageTimestamp' };
+    }
+
+    const parsedTimestamp = new Date(messageTimestamp);
+    if (isNaN(parsedTimestamp.getTime())) {
+      return { success: false, error: `Invalid messageTimestamp — must be a valid ISO 8601 date: ${messageTimestamp}` };
+    }
+
+    // Generous upper bounds — prevent oversized payloads from reaching the DB
+    if (channel.length > 50) {
+      return { success: false, error: 'channel must be 50 characters or fewer' };
+    }
+    if (identifier.length > 500) {
+      return { success: false, error: 'identifier must be 500 characters or fewer' };
+    }
+    if (displayName.length > 500) {
+      return { success: false, error: 'displayName must be 500 characters or fewer' };
+    }
+
+    const resolvedDirection = direction ?? 'inbound';
+    if (resolvedDirection !== 'inbound' && resolvedDirection !== 'outbound') {
+      return { success: false, error: `direction must be 'inbound' or 'outbound', got: ${resolvedDirection}` };
+    }
+
+    if (!ctx.contactService) {
+      // contactService is a universal service — this path indicates a misconfigured
+      // ExecutionLayer and should never happen in normal operation.
+      return {
+        success: false,
+        error: 'contact-register: contactService not available — check ExecutionLayer configuration',
+      };
+    }
+
+    // Redact the identifier from logs to avoid leaking PII (email addresses) into
+    // structured log output, which may be shipped to third-party log aggregators.
+    ctx.log.info(
+      { channel, direction: resolvedDirection, hasConfidencePipeline: !!ctx.confidencePipeline },
+      'contact-register: registering interaction',
+    );
+
+    try {
+      // -- Step 1: Resolve or create the contact --
+
+      let resolvedSender = await ctx.contactService.resolveByChannelIdentity(channel, identifier);
+      let created = false;
+
+      if (!resolvedSender) {
+        ctx.log.info({ channel }, 'contact-register: no existing contact — creating provisional');
+
+        const contact = await ctx.contactService.createContact({
+          displayName,
+          // Use the identifier (e.g. email address) as a fallback display name in
+          // case the displayName sanitizes to empty (prompt injection defense).
+          fallbackDisplayName: identifier,
+          status: 'provisional',
+          source: 'agent_called',
+        });
+
+        await ctx.contactService.linkIdentity({
+          contactId: contact.id,
+          channel,
+          channelIdentifier: identifier,
+          source: 'agent_called',
+        });
+
+        // Re-resolve to get the full ResolvedSender shape (verified flag, contactConfidence, etc.).
+        // Should always succeed immediately after creation+link.
+        resolvedSender = await ctx.contactService.resolveByChannelIdentity(channel, identifier);
+        if (!resolvedSender) {
+          // Should never happen — we just created the identity.
+          return { success: false, error: 'contact-register: failed to resolve contact after creation — possible DB inconsistency' };
+        }
+
+        created = true;
+      }
+
+      const contactId = resolvedSender.contactId;
+
+      // -- Step 2: Update scoring signal --
+
+      if (ctx.confidencePipeline) {
+        // The pipeline handles last_seen_at, inbound_message_count, and confidence
+        // atomically. Note: lastSeenAt is set to now(), not messageTimestamp, by the
+        // pipeline — for real-time triage this is close enough.
+        await ctx.confidencePipeline.incrementalUpdate(contactId, { type: 'message_seen' });
+      } else if (resolvedDirection === 'inbound') {
+        // Pipeline not wired — update last_seen_at directly using the message timestamp.
+        // Only advance forward: don't roll back if a later message is processed first.
+        //
+        // Note: updateScoringFields is normally called by ConfidencePipeline only,
+        // but we use it here as the fallback path when the pipeline is absent.
+        // We pass the current contactConfidence unchanged — we're only updating the timestamp.
+        const contact = await ctx.contactService.getContact(contactId);
+        if (contact) {
+          const shouldUpdate = !contact.lastSeenAt || parsedTimestamp > contact.lastSeenAt;
+          if (shouldUpdate) {
+            await ctx.contactService.updateScoringFields(contactId, {
+              contactConfidence: contact.contactConfidence,
+              lastSeenAt: parsedTimestamp,
+            });
+          }
+        }
+      }
+
+      // -- Step 3: Emit contact.resolved bus event (audit trail) --
+
+      if (ctx.bus) {
+        const event = createContactResolved({
+          contactId,
+          displayName: resolvedSender.displayName,
+          role: resolvedSender.role,
+          kgNodeId: resolvedSender.kgNodeId,
+          verificationStatus: resolvedSender.verified ? 'verified' : 'unverified',
+          channel,
+          channelIdentifier: identifier,
+          // Use the task event ID for causal chain tracing; fall back to a fresh UUID
+          // if unavailable (e.g. when called outside a standard agent.task context).
+          parentEventId: ctx.taskEventId ?? randomUUID(),
+          sourceLayer: 'execution',
+        });
+        // Fire-and-forget — a publish failure must not fail the registration itself.
+        ctx.bus.publish('execution', event).catch((err: unknown) => {
+          ctx.log.warn({ err, contactId }, 'contact-register: bus publish failed — audit event lost');
+        });
+      }
+
+      // -- Step 4: Return updated contact record --
+
+      // Refetch after scoring update so contact_confidence reflects the latest value.
+      // Falls back to the pre-update snapshot if the fetch fails (non-fatal).
+      const updatedContact = await ctx.contactService.getContact(contactId);
+
+      ctx.log.info({ contactId, created, channel }, 'contact-register: interaction registered');
+
+      return {
+        success: true,
+        data: {
+          contact_id: contactId,
+          display_name: resolvedSender.displayName,
+          status: updatedContact?.status ?? resolvedSender.status,
+          contact_confidence: updatedContact?.contactConfidence ?? resolvedSender.contactConfidence,
+          created,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, channel }, 'contact-register: failed to register contact interaction');
+      return { success: false, error: `contact-register: ${message}` };
+    }
+  }
+}

--- a/skills/contact-register/handler.ts
+++ b/skills/contact-register/handler.ts
@@ -103,22 +103,51 @@ export class ContactRegisterHandler implements SkillHandler {
           source: 'agent_called',
         });
 
-        await ctx.contactService.linkIdentity({
-          contactId: contact.id,
-          channel,
-          channelIdentifier: identifier,
-          source: 'agent_called',
-        });
+        // Link the identity, guarding against a concurrent call that may have created
+        // and linked the same identity between our resolveByChannelIdentity check above
+        // and now. If linkIdentity hits a unique-constraint violation (23505), the
+        // concurrent caller won — clean up our orphaned provisional contact, then
+        // re-resolve to get theirs.
+        let linked = false;
+        try {
+          await ctx.contactService.linkIdentity({
+            contactId: contact.id,
+            channel,
+            channelIdentifier: identifier,
+            source: 'agent_called',
+          });
+          linked = true;
+        } catch (linkErr) {
+          const pgCode = (linkErr as { code?: string }).code;
+          if (pgCode !== '23505') throw linkErr;
+
+          ctx.log.info(
+            { channel, orphanId: contact.id },
+            'contact-register: concurrent link conflict — cleaning up orphan and re-resolving',
+          );
+          // Best-effort orphan cleanup. Failure here is non-fatal — the orphaned
+          // provisional contact has no linked identity and will be unreachable via
+          // normal resolution, but it will leave a dangling row. Log as warn so it
+          // can be caught by a periodic cleanup sweep if needed.
+          try {
+            await ctx.contactService.deleteContact(contact.id);
+          } catch (deleteErr) {
+            ctx.log.warn(
+              { deleteErr, orphanId: contact.id },
+              'contact-register: could not clean up orphaned provisional contact',
+            );
+          }
+        }
 
         // Re-resolve to get the full ResolvedSender shape (verified flag, contactConfidence, etc.).
-        // Should always succeed immediately after creation+link.
         resolvedSender = await ctx.contactService.resolveByChannelIdentity(channel, identifier);
         if (!resolvedSender) {
-          // Should never happen — we just created the identity.
           return { success: false, error: 'contact-register: failed to resolve contact after creation — possible DB inconsistency' };
         }
 
-        created = true;
+        // created = true only when we won the race and linked the identity ourselves.
+        // If a concurrent call won, created = false (the contact already existed from our POV).
+        created = linked;
       }
 
       const contactId = resolvedSender.contactId;

--- a/skills/contact-register/skill.json
+++ b/skills/contact-register/skill.json
@@ -1,0 +1,25 @@
+{
+  "name": "contact-register",
+  "description": "Register a contact interaction from an agent that reads a channel directly, outside the normal dispatcher pipeline. Given a channel type and identifier (e.g. an email address), resolves the sender to a known contact — or creates a provisional one — then updates last_seen_at and triggers a confidence scoring delta. Emits a contact.resolved bus event for the audit trail. Use this once per sender during triage when processing messages that bypass handleInbound(). Returns the contact record.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "channel": "string (channel type, e.g. 'email')",
+    "identifier": "string (channel identifier, e.g. sender email address)",
+    "displayName": "string (sender's display name — used as the contact name if a new contact is created)",
+    "direction": "string? (message direction: 'inbound' | 'outbound'; defaults to 'inbound')",
+    "messageTimestamp": "string (ISO 8601 timestamp of the message)"
+  },
+  "outputs": {
+    "contact_id": "string",
+    "display_name": "string",
+    "status": "string (confirmed | provisional | blocked)",
+    "contact_confidence": "number (0.0–1.0)",
+    "created": "boolean (true if a new provisional contact was created)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000,
+  "capabilities": ["bus", "confidencePipeline"]
+}

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -517,12 +517,14 @@ export interface AgentDiscussEvent extends BaseEvent {
   payload: AgentDiscussPayload;
 }
 
-// Contact events — emitted by the dispatch layer during the contact resolution step.
+// Contact events — emitted during contact resolution. Normally fired by the dispatch
+// layer, but can also be emitted by the execution layer (e.g. contact-register skill
+// for agents that read channels directly without going through the dispatcher).
 // contact.resolved fires when a sender maps to a known contact; contact.unknown fires when no match is found.
 
 export interface ContactResolvedEvent extends BaseEvent {
   type: 'contact.resolved';
-  sourceLayer: 'dispatch';
+  sourceLayer: 'dispatch' | 'execution';
   payload: ContactResolvedPayload;
 }
 
@@ -905,15 +907,17 @@ export function createMemoryQuery(
 }
 
 export function createContactResolved(
-  // parentEventId is required — every resolution must trace back to the inbound event that triggered it.
-  payload: ContactResolvedPayload & { parentEventId: string },
+  // parentEventId is required — every resolution must trace back to the triggering event.
+  // sourceLayer defaults to 'dispatch' for the normal pipeline; pass 'execution' when
+  // emitting from a skill (e.g. contact-register for agents that bypass the dispatcher).
+  payload: ContactResolvedPayload & { parentEventId: string; sourceLayer?: 'dispatch' | 'execution' },
 ): ContactResolvedEvent {
-  const { parentEventId, ...rest } = payload;
+  const { parentEventId, sourceLayer = 'dispatch', ...rest } = payload;
   return {
     id: randomUUID(),
     timestamp: new Date(),
     type: 'contact.resolved',
-    sourceLayer: 'dispatch',
+    sourceLayer,
     payload: rest,
     parentEventId,
   };

--- a/src/bus/permissions.ts
+++ b/src/bus/permissions.ts
@@ -19,11 +19,14 @@ import type { Layer, EventType } from './events.js';
 //          system layer gets full access for audit logging and monitoring.
 // PII redaction (#249): dispatch layer publishes outbound.pii-redacted when PII is scrubbed
 //          from an outbound message; system layer gets full access for future audit subscribers.
+// contact-register skill (#485): execution layer publishes contact.resolved when an agent registers
+//          a contact interaction outside the dispatcher pipeline (e.g. ceo-inbox reading Nylas directly).
+//          The sourceLayer on the event is 'execution'; the publish permission here is what puts it on the wire.
 const publishAllowlist: Record<Layer, Set<EventType>> = {
   channel: new Set(['inbound.message']),
   dispatch: new Set(['agent.task', 'outbound.message', 'outbound.blocked', 'outbound.pii-redacted', 'outbound.notification', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'contact.duplicate_detected', 'contact.merged', 'conversation.checkpoint', 'human.decision', 'autonomy.send_blocked']),
   agent: new Set(['agent.response', 'agent.error', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'agent.discuss', 'llm.call']),
-  execution: new Set(['skill.result', 'secret.accessed', 'autonomy.skill_blocked']),
+  execution: new Set(['skill.result', 'secret.accessed', 'autonomy.skill_blocked', 'contact.resolved']),
   system: new Set(['inbound.message', 'agent.task', 'agent.response', 'agent.error', 'outbound.message', 'outbound.blocked', 'outbound.pii-redacted', 'outbound.notification', 'skill.invoke', 'skill.result', 'memory.store', 'memory.query', 'contact.resolved', 'contact.unknown', 'message.held', 'message.rejected', 'schedule.created', 'schedule.fired', 'schedule.suspended', 'schedule.recovered', 'schedule.drift_paused', 'config.change', 'contact.duplicate_detected', 'contact.merged', 'agent.discuss', 'conversation.checkpoint', 'llm.call', 'human.decision', 'secret.accessed', 'autonomy.skill_blocked', 'autonomy.send_blocked']),
 };
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -94,15 +94,15 @@ interface ContactServiceBackend {
 // Per spec: ceo_stated, email_participant, crm_import, calendar_attendee are auto-verified.
 // signal_participant is also auto-verified — Signal's phone-number identity is stronger than
 // email (no header spoofing), so we trust the source number at the same level as email_participant.
-// Only self_claimed starts unverified.
+// agent_called is auto-verified — the agent extracted the identifier mechanically from the channel
+// (e.g. an email sender address), not from LLM-generated content. Same trust level as email_participant.
+// Only self_claimed starts unverified and cannot be force-verified.
 const AUTO_VERIFIED_SOURCES: ReadonlySet<IdentitySource> = new Set([
   'ceo_stated',
   'email_participant',
   'signal_participant',
   'crm_import',
   'calendar_attendee',
-  // agent_called: the agent is responsible for sourcing the identifier (same
-  // trust level as email_participant — provenance is from the channel itself).
   'agent_called',
 ]);
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -101,6 +101,9 @@ const AUTO_VERIFIED_SOURCES: ReadonlySet<IdentitySource> = new Set([
   'signal_participant',
   'crm_import',
   'calendar_attendee',
+  // agent_called: the agent is responsible for sourcing the identifier (same
+  // trust level as email_participant — provenance is from the channel itself).
+  'agent_called',
 ]);
 
 /**

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -37,7 +37,11 @@ export type IdentitySource =
   | 'signal_participant'
   | 'crm_import'
   | 'calendar_attendee'
-  | 'self_claimed';
+  | 'self_claimed'
+  // Contact registered by an agent calling the contact-register skill directly,
+  // outside the normal dispatcher pipeline. Treated with the same trust as
+  // email_participant — the agent is responsible for sourcing the identifier.
+  | 'agent_called';
 
 // -- Contact status --
 // confirmed: CEO has verified this contact


### PR DESCRIPTION
## Summary

Closes #485.

Adds the `contact-register` skill — the integration point between agents that read channels directly (like the planned `ceo-inbox` agent) and the contact system. The normal dispatcher pipeline resolves contacts, emits `contact.resolved` bus events, and fires confidence scoring automatically. Agents that bypass `handleInbound()` get none of that; this skill fills that gap.

- **Resolves or creates**: looks up by channel identity; creates a provisional `agent_called` contact if unknown
- **Scoring**: calls `confidencePipeline.incrementalUpdate({ type: 'message_seen' })` when wired; falls back to a direct `last_seen_at` write (only-if-newer) when not
- **Audit trail**: emits `contact.resolved` with `sourceLayer: 'execution'` via the bus
- **Returns**: contact ID, display name, status, confidence, and a `created` flag

## Design note: `agent_called` source, not `email_ceo_inbox`

The issue spec suggested `source: 'email_ceo_inbox'` for provisional contacts. We used `'agent_called'` instead — a generic value that scales to any agent calling this skill, rather than one that requires updating `IdentitySource` every time a new agent is added.

## Supporting changes

| File | Change |
|---|---|
| `src/contacts/types.ts` | `IdentitySource` gets `'agent_called'` |
| `src/contacts/contact-service.ts` | `'agent_called'` added to `AUTO_VERIFIED_SOURCES` (same trust as `email_participant`) |
| `src/bus/events.ts` | `ContactResolvedEvent.sourceLayer` widened to `'dispatch' \| 'execution'`; `createContactResolved()` accepts optional `sourceLayer` (default `'dispatch'`) |
| `src/bus/permissions.ts` | `execution` layer may now publish `contact.resolved` |

## Pinning note

This skill is intentionally not pinned to any agent in this repo. Its primary consumer is the `ceo-inbox` agent in `curia-deploy` — pin it there when wiring up the triage loop.

## Test plan

- [x] 16 unit tests covering: input validation, known contact resolution (no duplicate created), unknown contact creation + identity linking, `last_seen_at` idempotency (older timestamp does not roll back), bus event shape (`sourceLayer: 'execution'`), bus-absent path
- [x] Startup schema validator passes (no unknown manifest fields)
- [x] Full test suite: same 2 pre-existing failures as `main`, no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced contact-register skill for direct channel-reading integrations to resolve or create contacts, update last-seen timestamps, and emit contact resolution events.
  * Enhanced contact handling with confidence scoring pipeline supporting incremental and full recompute updates.

* **Documentation**
  * Updated contact resolution event to support origination from execution layer with optional source layer parameter.
  * Added new identity source type for agent-registered contacts.

* **Tests**
  * Added comprehensive test coverage for contact registration, validation, and scoring workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->