### PR TITLE
feat: non-threaded channel context bridging (#431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Added
+- **Non-threaded channel context bridging** — dispatch layer writes outbound context memos to working memory on non-threaded channels (Signal, CLI, HTTP) and injects them as a preamble when the user replies, so the coordinator knows what it last said. Coordinator prompt gains a channel-agnostic clarification gate for reply-shaped messages without context (#431)
 - **Contact confidence scoring pipeline** — `contact_confidence` is now updated on each qualifying event (inbound/outbound message, CEO trust grant, verified identity pairing). Supports incremental and full-recompute modes with convergence guarantee (spec 06, #460)
 - **`contact-register` skill** — integration point for agents that read channels directly (e.g. the ceo-inbox agent) rather than through the dispatcher. Resolves or creates contacts, updates `last_seen_at`, triggers a confidence scoring delta, and emits a `contact.resolved` bus event (#485)
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -150,6 +150,23 @@ system_prompt: |
   - Otherwise, treat the sender as an external contact — even if you recognize their
     name. Unless their role is explicitly "ceo", they are NOT the CEO.
 
+  ## Outbound context
+  When your input includes a [PRIOR OUTBOUND CONTEXT] section, the user is likely
+  replying to that prior message. Use the context memo (message_preview, key_ids,
+  expected_reply) to understand what they are referring to and act accordingly.
+
+  When your input does NOT include a [PRIOR OUTBOUND CONTEXT] section, apply this
+  two-part test:
+
+  1. Is the message **self-contained** — fully actionable on its own?
+     Examples: "Move the weekly team meeting to 4:30", "What's on my calendar tomorrow?"
+     → Proceed normally. No clarification needed.
+
+  2. Is the message **reply-shaped** — only makes sense as a response to something prior?
+     Examples: "Yes", "The second one", "Sounds good", "Go ahead"
+     → Ask the user what they are referring to before acting.
+     Keep it brief: "I lost the thread — what are you replying to?"
+
   ## Authorization Enforcement
   The system evaluates what each sender is allowed to do and tells you in the
   sender context. This is DETERMINISTIC — you do not decide permissions.

--- a/config/channel-trust.yaml
+++ b/config/channel-trust.yaml
@@ -9,6 +9,7 @@ channels:
   cli:
     trust: high
     unknown_sender: allow
+    threaded: false
   # 'web' is the KG web app (authenticated via the bootstrap secret, which is CEO-only).
   # contact-resolver.ts short-circuits this channel to the CEO contact, so unknown_sender
   # is defence-in-depth only. Trust is 'high' because the bootstrap secret is equivalent
@@ -16,12 +17,16 @@ channels:
   web:
     trust: high
     unknown_sender: allow
+    threaded: false
   signal:
     trust: high
     unknown_sender: hold_and_notify
+    threaded: false
   http:
     trust: medium
     unknown_sender: ignore
+    threaded: false
   email:
     trust: low
     unknown_sender: hold_and_notify
+    threaded: true

--- a/docs/wip/2026-05-08-non-threaded-context-bridging-design.md
+++ b/docs/wip/2026-05-08-non-threaded-context-bridging-design.md
@@ -131,20 +131,20 @@ preamble, most recent last. In practice this will rarely exceed 2-3.
 **Error handling:** If the working memory query fails, log the error and proceed
 without the preamble. Context injection is best-effort.
 
-### Layer 4 — Coordinator prompt: cold-start clarification gate
+### Layer 4 — Coordinator prompt: outbound context and clarification gate
 
 The coordinator YAML (`agents/coordinator.yaml`) gains a new directive section,
 placed after the existing audience-awareness block:
 
 ```
-## Non-threaded channel context
+## Outbound context
 
 When your input includes a [PRIOR OUTBOUND CONTEXT] section, the user is likely
 replying to that prior message. Use the context memo (message_preview, key_ids,
 expected_reply) to understand what they are referring to and act accordingly.
 
-When your input does NOT include a [PRIOR OUTBOUND CONTEXT] section and you are
-on a non-threaded channel (Signal, SMS), apply this two-part test:
+When your input does NOT include a [PRIOR OUTBOUND CONTEXT] section, apply this
+two-part test:
 
 1. Is the message **self-contained** — fully actionable on its own?
    Examples: "Move the weekly team meeting to 4:30", "What's on my calendar tomorrow?"
@@ -159,12 +159,11 @@ on a non-threaded channel (Signal, SMS), apply this two-part test:
 This is a soft LLM directive — the coordinator uses judgment. "Yes, cancel it" is
 reply-shaped (cancel what?). "Yes, cancel the 3pm meeting" is self-contained.
 
-No changes to threaded channels. Email threading already carries context.
-
-**Channel identification:** The coordinator already receives `channelId` in the task
-payload. The prompt lists non-threaded channels explicitly (Signal, SMS, CLI). Adding
-a new non-threaded channel requires updating this list — but adding a channel already
-requires prompt updates for audience-awareness, so this is not incremental work.
+The gate is **channel-agnostic** — it applies universally. On threaded channels like
+email, it rarely fires because the email body carries thread context (quoted text,
+subject line). On non-threaded channels, it fires more often because there is no
+structural threading. This avoids hardcoding channel lists in the prompt and handles
+cross-channel scenarios (e.g., user receives a Signal notification, replies via email).
 
 ## What is NOT in scope
 
@@ -197,8 +196,8 @@ requires prompt updates for audience-awareness, so this is not incremental work.
 - [ ] Dispatch layer reads the most recent outbound context memo(s) (within 24h TTL)
       and injects them when routing an inbound message from a non-threaded channel.
 - [ ] If no recent memo exists, the inbound message passes through without a preamble.
-- [ ] Coordinator prompt reflects the two-condition clarification gate (no preamble AND
-      reply-shaped → ask; no preamble AND self-contained → proceed).
+- [ ] Coordinator prompt reflects the channel-agnostic clarification gate (no preamble
+      AND reply-shaped → ask; no preamble AND self-contained → proceed).
 - [ ] Integration test: simulate scheduler-sends-Signal → user-replies flow; verify
       coordinator context contains the outbound memo.
 - [ ] Integration test: cold-start self-contained message proceeds without clarification.

--- a/docs/wip/2026-05-08-non-threaded-context-bridging-design.md
+++ b/docs/wip/2026-05-08-non-threaded-context-bridging-design.md
@@ -14,7 +14,7 @@ Real failure: the scheduler sent a Signal notification about held Google Docs co
 emails but wrote no context into Signal working memory. When the CEO replied, the
 coordinator searched the wrong inbox because it had no record of what it had just told him.
 
-## Solution: Three Layers
+## Solution
 
 ### Layer 1 — Channel threading declaration
 
@@ -160,6 +160,11 @@ This is a soft LLM directive — the coordinator uses judgment. "Yes, cancel it"
 reply-shaped (cancel what?). "Yes, cancel the 3pm meeting" is self-contained.
 
 No changes to threaded channels. Email threading already carries context.
+
+**Channel identification:** The coordinator already receives `channelId` in the task
+payload. The prompt lists non-threaded channels explicitly (Signal, SMS, CLI). Adding
+a new non-threaded channel requires updating this list — but adding a channel already
+requires prompt updates for audience-awareness, so this is not incremental work.
 
 ## What is NOT in scope
 

--- a/docs/wip/2026-05-08-non-threaded-context-bridging-design.md
+++ b/docs/wip/2026-05-08-non-threaded-context-bridging-design.md
@@ -1,0 +1,200 @@
+# Non-Threaded Channel Context Bridging — Design Spec
+
+**Issue:** [#431](https://github.com/josephfung/curia/issues/431)
+**Date:** 2026-05-08
+
+## Problem
+
+Non-threaded channels (Signal, SMS, CLI) have no structural link between outbound
+and inbound messages. When Curia sends a proactive notification on Signal and the
+CEO replies, the coordinator's new conversation context has no knowledge of what the
+CEO is responding to.
+
+Real failure: the scheduler sent a Signal notification about held Google Docs comment
+emails but wrote no context into Signal working memory. When the CEO replied, the
+coordinator searched the wrong inbox because it had no record of what it had just told him.
+
+## Solution: Three Layers
+
+### Layer 1 — Channel threading declaration
+
+`ChannelPolicyConfig` gains a `threaded: boolean` field:
+
+```typescript
+export interface ChannelPolicyConfig {
+  trust: TrustLevel;
+  unknownSender: UnknownSenderPolicy;
+  threaded: boolean;
+}
+```
+
+`channel-trust.yaml` declares per channel:
+
+```yaml
+channels:
+  cli:
+    trust: high
+    unknown_sender: allow
+    threaded: false
+  web:
+    trust: high
+    unknown_sender: allow
+    threaded: false
+  signal:
+    trust: high
+    unknown_sender: hold_and_notify
+    threaded: false
+  http:
+    trust: medium
+    unknown_sender: ignore
+    threaded: false
+  email:
+    trust: low
+    unknown_sender: hold_and_notify
+    threaded: true
+```
+
+The config loader defaults `threaded` to `false` when absent (backwards compat with
+legacy flat-string configs).
+
+### Layer 2 — Outbound context memo (dispatch layer writes)
+
+**Trigger:** `handleAgentResponse` in `dispatcher.ts`, after publishing the
+`outbound.message` event.
+
+**Condition:** The target channel's policy has `threaded: false`.
+
+**Action:** Write a system-role turn to working memory for the tuple
+`(conversationId, 'coordinator')`:
+
+```
+[OUTBOUND CONTEXT — 2026-05-08T14:23:00-04:00]
+source_conversation: signal:+14155552671
+message_preview: You have 3 held Google Docs comment emails from notifications-noreply@google.com. Woul…
+task_type: coordinator-response
+key_ids: task:evt-abc123
+expected_reply: User may reply with instructions about the held messages
+```
+
+Fields:
+- **Timestamp:** ISO 8601, local timezone.
+- **source_conversation:** The `conversationId` from the routing table.
+- **message_preview:** First 200 chars of the outbound content, truncated with `…`.
+- **task_type:** `coordinator-response` (could be refined later as agent metadata grows).
+- **key_ids:** The `taskEventId` from the outbound message, prefixed with `task:`.
+- **expected_reply:** Brief hint about what the user might say next. Derived from the
+  outbound content — if the message asks a question or presents options, note that.
+  For now, a generic "User may reply to this message" is acceptable; the LLM can
+  infer intent from `message_preview`.
+
+**Dependencies:** `DispatcherConfig` gains a `workingMemory?: WorkingMemory` field.
+
+**Error handling:** Best-effort. Memo write failure is logged but does not block
+outbound delivery. Same pattern as checkpoint scheduling.
+
+### Layer 3 — Inbound context injection (dispatch layer reads)
+
+**Trigger:** `handleInbound` in `dispatcher.ts`, before creating the `agent.task` event.
+
+**Condition:** The inbound channel's policy has `threaded: false`.
+
+**Action:**
+1. Call `workingMemory.getHistory(conversationId, 'coordinator')`.
+2. Filter system-role turns whose content starts with `[OUTBOUND CONTEXT — `.
+3. Filter to those within the 24-hour TTL (parse the ISO timestamp from the prefix).
+4. If memos are found, prepend a preamble to the task content:
+
+```
+[PRIOR OUTBOUND CONTEXT — this is what you last sent on this channel]
+---
+[OUTBOUND CONTEXT — 2026-05-08T14:23:00-04:00]
+source_conversation: signal:+14155552671
+message_preview: You have 3 held Google Docs comment emails…
+task_type: coordinator-response
+key_ids: task:evt-abc123
+expected_reply: User may reply with instructions about the held messages
+---
+
+{original inbound content}
+```
+
+5. If no memos are found within the TTL, pass the content through unchanged — no
+   metadata tag, no preamble.
+
+**TTL:** 24 hours, configurable via `DispatcherConfig.contextMemoTtlMs`
+(default `86_400_000`). This is a query-time filter, not a hard delete. Old memos
+remain in working memory and are subject to the normal summarization lifecycle.
+
+**Multiple memos:** If several memos exist within the TTL, all are included in the
+preamble, most recent last. In practice this will rarely exceed 2-3.
+
+**Error handling:** If the working memory query fails, log the error and proceed
+without the preamble. Context injection is best-effort.
+
+### Layer 4 — Coordinator prompt: cold-start clarification gate
+
+The coordinator YAML (`agents/coordinator.yaml`) gains a new directive section,
+placed after the existing audience-awareness block:
+
+```
+## Non-threaded channel context
+
+When your input includes a [PRIOR OUTBOUND CONTEXT] section, the user is likely
+replying to that prior message. Use the context memo (message_preview, key_ids,
+expected_reply) to understand what they are referring to and act accordingly.
+
+When your input does NOT include a [PRIOR OUTBOUND CONTEXT] section and you are
+on a non-threaded channel (Signal, SMS), apply this two-part test:
+
+1. Is the message **self-contained** — fully actionable on its own?
+   Examples: "Move the weekly team meeting to 4:30", "What's on my calendar tomorrow?"
+   → Proceed normally. No clarification needed.
+
+2. Is the message **reply-shaped** — only makes sense as a response to something prior?
+   Examples: "Yes", "The second one", "Sounds good", "Go ahead", "Which one should I pick?"
+   → Ask the user what they are referring to before acting.
+   Keep it brief: "I lost the thread — what are you replying to?"
+```
+
+This is a soft LLM directive — the coordinator uses judgment. "Yes, cancel it" is
+reply-shaped (cancel what?). "Yes, cancel the 3pm meeting" is self-contained.
+
+No changes to threaded channels. Email threading already carries context.
+
+## What is NOT in scope
+
+- Threaded channels (email) — no changes needed.
+- Retroactive context reconstruction — if working memory has been checkpointed past
+  the relevant outbound message, that is a separate memory decay problem.
+- `expected_reply` intelligence — for now, a generic hint is acceptable. LLM-powered
+  analysis of outbound content to generate smarter `expected_reply` values is a
+  future enhancement.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `src/contacts/types.ts` | Add `threaded: boolean` to `ChannelPolicyConfig` |
+| `config/channel-trust.yaml` | Add `threaded` field to each channel |
+| `src/contacts/config-loader.ts` | Parse `threaded` from YAML, default `false` |
+| `src/dispatch/dispatcher.ts` | Add `workingMemory` to config; outbound memo write in `handleAgentResponse`; inbound injection in `handleInbound` |
+| `agents/coordinator.yaml` | Add non-threaded channel context directive |
+| Tests (new) | Integration tests for the three acceptance scenarios |
+
+## Acceptance criteria
+
+- [ ] `ChannelPolicyConfig` has a `threaded: boolean` field; Signal (and any future
+      non-threaded adapters) declare `threaded: false`; email declares `threaded: true`.
+- [ ] Dispatch layer writes an outbound context memo to channel working memory for
+      every message routed to a `threaded: false` channel.
+- [ ] Context memos are structured (not freeform text) and include: timestamp, source
+      conversation ID, message preview, task type, and key IDs.
+- [ ] Dispatch layer reads the most recent outbound context memo(s) (within 24h TTL)
+      and injects them when routing an inbound message from a non-threaded channel.
+- [ ] If no recent memo exists, the inbound message passes through without a preamble.
+- [ ] Coordinator prompt reflects the two-condition clarification gate (no preamble AND
+      reply-shaped → ask; no preamble AND self-contained → proceed).
+- [ ] Integration test: simulate scheduler-sends-Signal → user-replies flow; verify
+      coordinator context contains the outbound memo.
+- [ ] Integration test: cold-start self-contained message proceeds without clarification.
+- [ ] Integration test: cold-start reply-shaped message triggers clarification.

--- a/docs/wip/2026-05-08-non-threaded-context-bridging.md
+++ b/docs/wip/2026-05-08-non-threaded-context-bridging.md
@@ -1,0 +1,1047 @@
+# Non-Threaded Channel Context Bridging — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bridge context between outbound and inbound messages on non-threaded channels (Signal, SMS, CLI) so the coordinator knows what the user is replying to.
+
+**Architecture:** The dispatch layer writes structured "outbound context memos" to working memory whenever it routes an outbound message to a non-threaded channel. On inbound, it reads recent memos and prepends them to the coordinator's task content. The coordinator prompt gets a channel-agnostic clarification gate for reply-shaped messages without context.
+
+**Tech Stack:** TypeScript (ESM), Vitest, YAML config, pino logging
+
+**Spec:** `docs/wip/2026-05-08-non-threaded-context-bridging-design.md`
+**Issue:** [#431](https://github.com/josephfung/curia/issues/431)
+**Worktree:** `/Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging` (branch `feat/non-threaded-context-bridging`)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/contacts/types.ts` | Modify | Add `threaded: boolean` to `ChannelPolicyConfig` |
+| `config/channel-trust.yaml` | Modify | Add `threaded` field to each channel entry |
+| `src/contacts/config-loader.ts` | Modify | Parse `threaded` from YAML, default `false` |
+| `src/dispatch/context-memo.ts` | Create | Pure functions: `formatOutboundMemo()`, `extractRecentMemos()`, `buildContextPreamble()` |
+| `src/dispatch/dispatcher.ts` | Modify | Wire `workingMemory`, call memo functions in `handleAgentResponse` and `handleInbound` |
+| `src/index.ts` | Modify | Pass `memory` to `Dispatcher` config |
+| `agents/coordinator.yaml` | Modify | Add outbound context / clarification gate directive |
+| `tests/unit/dispatch/context-memo.test.ts` | Create | Unit tests for memo formatting and extraction |
+| `tests/unit/dispatch/dispatcher-context-bridging.test.ts` | Create | Integration tests for the full inbound/outbound flow |
+
+---
+
+### Task 1: Add `threaded` to `ChannelPolicyConfig` and config loader
+
+**Files:**
+- Modify: `src/contacts/types.ts:203-206`
+- Modify: `config/channel-trust.yaml`
+- Modify: `src/contacts/config-loader.ts:77-104`
+- Test: `tests/unit/contacts/config-loader.test.ts` (if it exists, otherwise inline verification)
+
+- [ ] **Step 1: Add `threaded` field to the interface**
+
+In `src/contacts/types.ts`, add `threaded` to `ChannelPolicyConfig`:
+
+```typescript
+export interface ChannelPolicyConfig {
+  trust: TrustLevel;
+  unknownSender: UnknownSenderPolicy;
+  /** Whether this channel structurally links replies to their parent messages.
+   *  Email is threaded (subject + in-reply-to headers); Signal/SMS/CLI are not.
+   *  The dispatch layer uses this to decide whether to write/read outbound context memos. */
+  threaded: boolean;
+}
+```
+
+- [ ] **Step 2: Update `channel-trust.yaml`**
+
+Add `threaded` to every channel entry in `config/channel-trust.yaml`:
+
+```yaml
+channels:
+  cli:
+    trust: high
+    unknown_sender: allow
+    threaded: false
+  web:
+    trust: high
+    unknown_sender: allow
+    threaded: false
+  signal:
+    trust: high
+    unknown_sender: hold_and_notify
+    threaded: false
+  http:
+    trust: medium
+    unknown_sender: ignore
+    threaded: false
+  email:
+    trust: low
+    unknown_sender: hold_and_notify
+    threaded: true
+```
+
+- [ ] **Step 3: Update config loader to parse `threaded`**
+
+In `src/contacts/config-loader.ts`, update the type assertion on line 77 to include `threaded`:
+
+```typescript
+const trustTyped = trustRaw as { channels: Record<string, string | { trust: string; unknown_sender: string; threaded?: boolean }> };
+```
+
+In the legacy flat-string branch (line 92), add `threaded: false`:
+
+```typescript
+channelPolicies[channel] = { trust, unknownSender: 'allow', threaded: false };
+```
+
+In the object branch (line 103), parse `threaded` with a default:
+
+```typescript
+const threaded = (config as { threaded?: boolean }).threaded ?? false;
+channelPolicies[channel] = { trust, unknownSender, threaded };
+```
+
+- [ ] **Step 4: Run the build to verify types compile**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging run build`
+
+Expected: Clean build. Any existing code that constructs `ChannelPolicyConfig` objects (like test helpers) will fail to compile — fix those by adding `threaded: false` (or `true` for email) to each construction site.
+
+- [ ] **Step 5: Fix any compilation errors in tests**
+
+Search for `ChannelPolicyConfig` or `channelPolicies:` in test files and add the `threaded` field to each inline object. For example, in `tests/unit/dispatch/dispatcher.test.ts` line 128:
+
+```typescript
+// Before:
+channelPolicies: { http: { trust: 'low', unknownSender: 'ignore' } },
+// After:
+channelPolicies: { http: { trust: 'low', unknownSender: 'ignore', threaded: false } },
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging test`
+
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging add src/contacts/types.ts config/channel-trust.yaml src/contacts/config-loader.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging commit -m "feat: add threaded field to ChannelPolicyConfig (#431)"
+```
+
+Stage and commit any test files that needed `threaded` added too.
+
+---
+
+### Task 2: Create `context-memo.ts` — pure functions for memo formatting and extraction
+
+**Files:**
+- Create: `src/dispatch/context-memo.ts`
+- Create: `tests/unit/dispatch/context-memo.test.ts`
+
+This task creates the memo logic as pure functions with no dependencies on the bus or working memory — easy to test in isolation.
+
+- [ ] **Step 1: Write failing tests for `formatOutboundMemo()`**
+
+Create `tests/unit/dispatch/context-memo.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { formatOutboundMemo, extractRecentMemos, buildContextPreamble, OUTBOUND_MEMO_PREFIX } from '../../../src/dispatch/context-memo.js';
+
+describe('formatOutboundMemo', () => {
+  it('produces a structured memo with all fields', () => {
+    const memo = formatOutboundMemo({
+      conversationId: 'signal:+14155552671',
+      content: 'You have 3 held emails. Want me to process them?',
+      taskEventId: 'evt-abc123',
+    });
+
+    expect(memo).toContain(OUTBOUND_MEMO_PREFIX);
+    expect(memo).toContain('source_conversation: signal:+14155552671');
+    expect(memo).toContain('message_preview: You have 3 held emails. Want me to process them?');
+    expect(memo).toContain('task_type: coordinator-response');
+    expect(memo).toContain('key_ids: task:evt-abc123');
+    expect(memo).toContain('expected_reply: User may reply to this message');
+  });
+
+  it('truncates message_preview at 200 chars with ellipsis', () => {
+    const longContent = 'A'.repeat(250);
+    const memo = formatOutboundMemo({
+      conversationId: 'signal:+14155552671',
+      content: longContent,
+      taskEventId: 'evt-1',
+    });
+
+    const previewLine = memo.split('\n').find(l => l.startsWith('message_preview:'));
+    // "message_preview: " is 17 chars, then 200 chars of 'A', then '…'
+    expect(previewLine).toBe(`message_preview: ${'A'.repeat(200)}…`);
+  });
+
+  it('does not add ellipsis when content fits within 200 chars', () => {
+    const shortContent = 'Hello there';
+    const memo = formatOutboundMemo({
+      conversationId: 'signal:+14155552671',
+      content: shortContent,
+      taskEventId: 'evt-1',
+    });
+
+    const previewLine = memo.split('\n').find(l => l.startsWith('message_preview:'));
+    expect(previewLine).toBe('message_preview: Hello there');
+  });
+
+  it('omits key_ids line when taskEventId is undefined', () => {
+    const memo = formatOutboundMemo({
+      conversationId: 'signal:+14155552671',
+      content: 'Hello',
+      taskEventId: undefined,
+    });
+
+    expect(memo).not.toContain('key_ids:');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging test tests/unit/dispatch/context-memo.test.ts`
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `formatOutboundMemo()`**
+
+Create `src/dispatch/context-memo.ts`:
+
+```typescript
+// src/dispatch/context-memo.ts
+//
+// Pure functions for outbound context memos on non-threaded channels.
+// The dispatch layer writes memos to working memory on outbound and reads them
+// on inbound. These functions format, parse, and assemble memo content without
+// any dependency on the bus, database, or working memory service.
+//
+// See docs/wip/2026-05-08-non-threaded-context-bridging-design.md
+
+import type { ConversationTurn } from '../memory/working-memory.js';
+
+/** Prefix that identifies outbound context memos in working memory turns. */
+export const OUTBOUND_MEMO_PREFIX = '[OUTBOUND CONTEXT — ';
+
+const MAX_PREVIEW_LENGTH = 200;
+
+interface FormatMemoInput {
+  conversationId: string;
+  content: string;
+  taskEventId: string | undefined;
+}
+
+/**
+ * Format an outbound context memo as a structured text string.
+ * Written to working memory as a system-role turn so the coordinator
+ * can see what it last sent on a non-threaded channel.
+ */
+export function formatOutboundMemo(input: FormatMemoInput): string {
+  const timestamp = new Date().toISOString();
+  const preview = input.content.length > MAX_PREVIEW_LENGTH
+    ? input.content.slice(0, MAX_PREVIEW_LENGTH) + '…'
+    : input.content;
+
+  const lines = [
+    `${OUTBOUND_MEMO_PREFIX}${timestamp}]`,
+    `source_conversation: ${input.conversationId}`,
+    `message_preview: ${preview}`,
+    `task_type: coordinator-response`,
+  ];
+
+  if (input.taskEventId) {
+    lines.push(`key_ids: task:${input.taskEventId}`);
+  }
+
+  lines.push('expected_reply: User may reply to this message');
+
+  return lines.join('\n');
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging test tests/unit/dispatch/context-memo.test.ts`
+
+Expected: All `formatOutboundMemo` tests PASS.
+
+- [ ] **Step 5: Write failing tests for `extractRecentMemos()`**
+
+Append to `tests/unit/dispatch/context-memo.test.ts`:
+
+```typescript
+describe('extractRecentMemos', () => {
+  function makeTurn(content: string): ConversationTurn {
+    return { role: 'system', content };
+  }
+
+  it('extracts memos from system turns matching the prefix', () => {
+    const recentMemo = `${OUTBOUND_MEMO_PREFIX}${new Date().toISOString()}]\nsource_conversation: signal:+1\nmessage_preview: hello\ntask_type: coordinator-response\nexpected_reply: User may reply to this message`;
+    const turns: ConversationTurn[] = [
+      { role: 'user', content: 'Hi' },
+      makeTurn(recentMemo),
+      { role: 'assistant', content: 'Hello!' },
+    ];
+
+    const result = extractRecentMemos(turns, 86_400_000);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(recentMemo);
+  });
+
+  it('excludes memos older than the TTL', () => {
+    const oldDate = new Date(Date.now() - 2 * 86_400_000).toISOString(); // 2 days ago
+    const oldMemo = `${OUTBOUND_MEMO_PREFIX}${oldDate}]\nsource_conversation: signal:+1\nmessage_preview: old\ntask_type: coordinator-response\nexpected_reply: User may reply to this message`;
+    const turns: ConversationTurn[] = [makeTurn(oldMemo)];
+
+    const result = extractRecentMemos(turns, 86_400_000);
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes non-system turns and system turns without the memo prefix', () => {
+    const turns: ConversationTurn[] = [
+      { role: 'user', content: `${OUTBOUND_MEMO_PREFIX}fake` },
+      { role: 'system', content: '[Conversation summary]\nSome summary text' },
+    ];
+
+    const result = extractRecentMemos(turns, 86_400_000);
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns multiple memos in chronological order', () => {
+    const t1 = new Date(Date.now() - 3600_000).toISOString(); // 1 hour ago
+    const t2 = new Date().toISOString(); // now
+    const memo1 = `${OUTBOUND_MEMO_PREFIX}${t1}]\nmessage_preview: first`;
+    const memo2 = `${OUTBOUND_MEMO_PREFIX}${t2}]\nmessage_preview: second`;
+    const turns: ConversationTurn[] = [makeTurn(memo1), makeTurn(memo2)];
+
+    const result = extractRecentMemos(turns, 86_400_000);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toContain('first');
+    expect(result[1]).toContain('second');
+  });
+});
+```
+
+- [ ] **Step 6: Implement `extractRecentMemos()`**
+
+Append to `src/dispatch/context-memo.ts`:
+
+```typescript
+/**
+ * Extract outbound context memos from a working memory turn history.
+ * Filters to system-role turns with the memo prefix whose embedded
+ * timestamp is within the TTL window.
+ *
+ * Returns memos in the same order they appear in `turns` (chronological,
+ * since working memory returns oldest-first).
+ */
+export function extractRecentMemos(
+  turns: ConversationTurn[],
+  ttlMs: number,
+): string[] {
+  const cutoff = Date.now() - ttlMs;
+
+  return turns.filter((turn) => {
+    if (turn.role !== 'system') return false;
+    if (!turn.content.startsWith(OUTBOUND_MEMO_PREFIX)) return false;
+
+    // Parse timestamp from the prefix line: [OUTBOUND CONTEXT — <ISO timestamp>]
+    const closingBracket = turn.content.indexOf(']');
+    if (closingBracket === -1) return false;
+    const timestamp = turn.content.slice(OUTBOUND_MEMO_PREFIX.length, closingBracket);
+    const memoTime = new Date(timestamp).getTime();
+    if (isNaN(memoTime)) return false;
+
+    return memoTime >= cutoff;
+  }).map(turn => turn.content);
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging test tests/unit/dispatch/context-memo.test.ts`
+
+Expected: All tests PASS.
+
+- [ ] **Step 8: Write failing tests for `buildContextPreamble()`**
+
+Append to `tests/unit/dispatch/context-memo.test.ts`:
+
+```typescript
+describe('buildContextPreamble', () => {
+  it('wraps memos in preamble header and separator, then appends original content', () => {
+    const memos = ['[OUTBOUND CONTEXT — 2026-05-08T14:00:00Z]\nmessage_preview: hello'];
+    const result = buildContextPreamble(memos, 'User says hi');
+
+    expect(result).toContain('[PRIOR OUTBOUND CONTEXT — this is what you last sent on this channel]');
+    expect(result).toContain('message_preview: hello');
+    expect(result).toContain('User says hi');
+    // Memo block is separated from user content by ---
+    expect(result).toContain('---');
+  });
+
+  it('includes multiple memos separated by ---', () => {
+    const memos = [
+      '[OUTBOUND CONTEXT — 2026-05-08T14:00:00Z]\nmessage_preview: first',
+      '[OUTBOUND CONTEXT — 2026-05-08T15:00:00Z]\nmessage_preview: second',
+    ];
+    const result = buildContextPreamble(memos, 'Reply');
+
+    // Both memos present
+    expect(result).toContain('message_preview: first');
+    expect(result).toContain('message_preview: second');
+  });
+
+  it('returns null when memos array is empty', () => {
+    const result = buildContextPreamble([], 'Hello');
+    expect(result).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 9: Implement `buildContextPreamble()`**
+
+Append to `src/dispatch/context-memo.ts`:
+
+```typescript
+/**
+ * Build the context preamble that the dispatcher prepends to inbound task content.
+ * Returns null if no memos are provided (caller should use original content as-is).
+ */
+export function buildContextPreamble(
+  memos: string[],
+  originalContent: string,
+): string | null {
+  if (memos.length === 0) return null;
+
+  const memoBlock = memos.map(m => `---\n${m}\n---`).join('\n');
+
+  return [
+    '[PRIOR OUTBOUND CONTEXT — this is what you last sent on this channel]',
+    memoBlock,
+    '',
+    originalContent,
+  ].join('\n');
+}
+```
+
+- [ ] **Step 10: Run all context-memo tests**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging test tests/unit/dispatch/context-memo.test.ts`
+
+Expected: All tests PASS.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging add src/dispatch/context-memo.ts tests/unit/dispatch/context-memo.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging commit -m "feat: add context-memo pure functions for outbound memo format/extract/preamble (#431)"
+```
+
+---
+
+### Task 3: Wire outbound memo write into `handleAgentResponse`
+
+**Files:**
+- Modify: `src/dispatch/dispatcher.ts:41-147` (config + constructor) and `811-850` (handleAgentResponse)
+- Test: `tests/unit/dispatch/dispatcher-context-bridging.test.ts` (new)
+
+- [ ] **Step 1: Write failing test for outbound memo write**
+
+Create `tests/unit/dispatch/dispatcher-context-bridging.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
+import { EventBus } from '../../../src/bus/bus.js';
+import { AgentRuntime } from '../../../src/agents/runtime.js';
+import { WorkingMemory } from '../../../src/memory/working-memory.js';
+import { createInboundMessage, type OutboundMessageEvent, type AgentTaskEvent } from '../../../src/bus/events.js';
+import type { LLMProvider } from '../../../src/agents/llm/provider.js';
+import { createLogger } from '../../../src/logger.js';
+import { OUTBOUND_MEMO_PREFIX } from '../../../src/dispatch/context-memo.js';
+
+function setupTestBus() {
+  const logger = createLogger('error');
+  const bus = new EventBus(logger);
+  const memory = WorkingMemory.createInMemory();
+
+  const mockProvider: LLMProvider = {
+    id: 'mock',
+    chat: vi.fn().mockResolvedValue({
+      type: 'text' as const,
+      content: 'Response from Coordinator',
+      usage: { inputTokens: 10, outputTokens: 5 },
+    }),
+  };
+
+  const coordinator = new AgentRuntime({
+    agentId: 'coordinator',
+    systemPrompt: 'You are a helpful assistant.',
+    provider: mockProvider,
+    bus,
+    logger,
+  });
+  coordinator.register();
+
+  return { bus, logger, memory, mockProvider };
+}
+
+describe('Dispatcher context bridging — outbound memo', () => {
+  it('writes an outbound context memo to working memory for non-threaded channels', async () => {
+    const { bus, logger, memory } = setupTestBus();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      workingMemory: memory,
+      channelPolicies: { signal: { trust: 'high', unknownSender: 'hold_and_notify', threaded: false } },
+    });
+    dispatcher.register();
+
+    // Capture outbound to confirm the message was sent
+    const outbound: OutboundMessageEvent[] = [];
+    bus.subscribe('outbound.message', 'channel', (event) => {
+      outbound.push(event as OutboundMessageEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'signal:+14155552671',
+      channelId: 'signal',
+      senderId: '+14155552671',
+      content: 'Hello',
+    });
+    await bus.publish('channel', event);
+
+    // Verify outbound was sent
+    expect(outbound).toHaveLength(1);
+
+    // Verify memo was written to working memory
+    const history = await memory.getHistory('signal:+14155552671', 'coordinator');
+    const memoTurns = history.filter(t => t.role === 'system' && t.content.startsWith(OUTBOUND_MEMO_PREFIX));
+    expect(memoTurns).toHaveLength(1);
+    expect(memoTurns[0].content).toContain('message_preview: Response from Coordinator');
+    expect(memoTurns[0].content).toContain('source_conversation: signal:+14155552671');
+  });
+
+  it('does NOT write a memo for threaded channels', async () => {
+    const { bus, logger, memory } = setupTestBus();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      workingMemory: memory,
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify', threaded: true } },
+    });
+    dispatcher.register();
+
+    const outbound: OutboundMessageEvent[] = [];
+    bus.subscribe('outbound.message', 'channel', (event) => {
+      outbound.push(event as OutboundMessageEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'email:alice@example.com',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Hello',
+    });
+    await bus.publish('channel', event);
+
+    expect(outbound).toHaveLength(1);
+
+    const history = await memory.getHistory('email:alice@example.com', 'coordinator');
+    const memoTurns = history.filter(t => t.role === 'system' && t.content.startsWith(OUTBOUND_MEMO_PREFIX));
+    expect(memoTurns).toHaveLength(0);
+  });
+
+  it('does NOT write a memo when workingMemory is not configured', async () => {
+    const { bus, logger } = setupTestBus();
+
+    // No workingMemory passed — memo writing should be silently skipped
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      channelPolicies: { signal: { trust: 'high', unknownSender: 'hold_and_notify', threaded: false } },
+    });
+    dispatcher.register();
+
+    const outbound: OutboundMessageEvent[] = [];
+    bus.subscribe('outbound.message', 'channel', (event) => {
+      outbound.push(event as OutboundMessageEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'signal:+14155552671',
+      channelId: 'signal',
+      senderId: '+14155552671',
+      content: 'Hello',
+    });
+
+    // Should not throw — just skip memo write
+    await bus.publish('channel', event);
+    expect(outbound).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging test tests/unit/dispatch/dispatcher-context-bridging.test.ts`
+
+Expected: FAIL — `workingMemory` is not a valid property of `DispatcherConfig`.
+
+- [ ] **Step 3: Add `workingMemory` to `DispatcherConfig` and constructor**
+
+In `src/dispatch/dispatcher.ts`, add the import at the top:
+
+```typescript
+import type { WorkingMemory } from '../memory/working-memory.js';
+import { formatOutboundMemo } from './context-memo.js';
+```
+
+Add to `DispatcherConfig` (after `confidencePipeline`):
+
+```typescript
+  /** Working memory — used to write outbound context memos on non-threaded channels
+   *  and read them back for inbound context injection. When omitted, context
+   *  bridging is disabled (e.g. in unit tests that don't exercise it). */
+  workingMemory?: WorkingMemory;
+  /** TTL for outbound context memos in milliseconds. Memos older than this are
+   *  excluded from inbound injection. Default: 86400000 (24 hours). */
+  contextMemoTtlMs?: number;
+```
+
+Add private fields to the `Dispatcher` class:
+
+```typescript
+  private workingMemory?: WorkingMemory;
+  private contextMemoTtlMs: number;
+```
+
+In the constructor, assign them:
+
+```typescript
+    this.workingMemory = config.workingMemory;
+    this.contextMemoTtlMs = config.contextMemoTtlMs ?? 86_400_000;
+```
+
+- [ ] **Step 4: Add outbound memo write to `handleAgentResponse`**
+
+In `handleAgentResponse`, after `await this.bus.publish('dispatch', outbound);` and before `this.scheduleCheckpoint(...)`, add:
+
+```typescript
+    // Write an outbound context memo to working memory for non-threaded channels.
+    // When the user replies, the inbound handler reads these memos and prepends
+    // them to the coordinator's task content so it knows what it last said.
+    // Best-effort: failure is logged but does not block outbound delivery.
+    const channelPolicy = this.channelPolicies?.[routing.channelId];
+    if (this.workingMemory && channelPolicy && !channelPolicy.threaded) {
+      try {
+        const memo = formatOutboundMemo({
+          conversationId: routing.conversationId,
+          content: event.payload.content,
+          taskEventId: event.parentEventId ?? undefined,
+        });
+        await this.workingMemory.addTurn(routing.conversationId, 'coordinator', {
+          role: 'system',
+          content: memo,
+        });
+        this.logger.debug(
+          { channelId: routing.channelId, conversationId: routing.conversationId },
+          'Outbound context memo written to working memory',
+        );
+      } catch (err) {
+        this.logger.warn(
+          { err, channelId: routing.channelId, conversationId: routing.conversationId },
+          'Failed to write outbound context memo — context bridging degraded for this message',
+        );
+      }
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging test tests/unit/dispatch/dispatcher-context-bridging.test.ts`
+
+Expected: All 3 tests PASS.
+
+- [ ] **Step 6: Run the full test suite to check for regressions**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging test`
+
+Expected: All tests PASS. Existing dispatcher tests should be unaffected since they don't pass `workingMemory`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging add src/dispatch/dispatcher.ts tests/unit/dispatch/dispatcher-context-bridging.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging commit -m "feat: write outbound context memos for non-threaded channels (#431)"
+```
+
+---
+
+### Task 4: Wire inbound context injection into `handleInbound`
+
+**Files:**
+- Modify: `src/dispatch/dispatcher.ts:176-798` (handleInbound, before task creation)
+- Test: `tests/unit/dispatch/dispatcher-context-bridging.test.ts` (append)
+
+- [ ] **Step 1: Write failing test for inbound context injection**
+
+Append to `tests/unit/dispatch/dispatcher-context-bridging.test.ts`:
+
+```typescript
+describe('Dispatcher context bridging — inbound injection', () => {
+  it('prepends outbound context preamble to task content when memos exist', async () => {
+    const { bus, logger, memory } = setupTestBus();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      workingMemory: memory,
+      channelPolicies: { signal: { trust: 'high', unknownSender: 'allow', threaded: false } },
+    });
+    dispatcher.register();
+
+    // Pre-seed working memory with an outbound context memo
+    const memoContent = `${OUTBOUND_MEMO_PREFIX}${new Date().toISOString()}]\nsource_conversation: signal:+14155552671\nmessage_preview: You have 3 held emails\ntask_type: coordinator-response\nexpected_reply: User may reply to this message`;
+    await memory.addTurn('signal:+14155552671', 'coordinator', {
+      role: 'system',
+      content: memoContent,
+    });
+
+    // Capture the agent.task to inspect the content
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (event) => {
+      tasks.push(event as AgentTaskEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'signal:+14155552671',
+      channelId: 'signal',
+      senderId: '+14155552671',
+      content: 'Yes, process them',
+    });
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].payload.content).toContain('[PRIOR OUTBOUND CONTEXT');
+    expect(tasks[0].payload.content).toContain('You have 3 held emails');
+    expect(tasks[0].payload.content).toContain('Yes, process them');
+  });
+
+  it('does NOT inject preamble when no memos exist', async () => {
+    const { bus, logger, memory } = setupTestBus();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      workingMemory: memory,
+      channelPolicies: { signal: { trust: 'high', unknownSender: 'allow', threaded: false } },
+    });
+    dispatcher.register();
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (event) => {
+      tasks.push(event as AgentTaskEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'signal:+14155552671',
+      channelId: 'signal',
+      senderId: '+14155552671',
+      content: 'Hello there',
+    });
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].payload.content).toBe('Hello there');
+    expect(tasks[0].payload.content).not.toContain('[PRIOR OUTBOUND CONTEXT');
+  });
+
+  it('does NOT inject preamble for threaded channels even if memos exist', async () => {
+    const { bus, logger, memory } = setupTestBus();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      workingMemory: memory,
+      channelPolicies: { email: { trust: 'low', unknownSender: 'allow', threaded: true } },
+    });
+    dispatcher.register();
+
+    // Pre-seed a memo (shouldn't happen in practice but tests the guard)
+    await memory.addTurn('email:alice@example.com', 'coordinator', {
+      role: 'system',
+      content: `${OUTBOUND_MEMO_PREFIX}${new Date().toISOString()}]\nmessage_preview: hello`,
+    });
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (event) => {
+      tasks.push(event as AgentTaskEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'email:alice@example.com',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Reply to thread',
+    });
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].payload.content).not.toContain('[PRIOR OUTBOUND CONTEXT');
+  });
+
+  it('excludes memos older than TTL', async () => {
+    const { bus, logger, memory } = setupTestBus();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      workingMemory: memory,
+      channelPolicies: { signal: { trust: 'high', unknownSender: 'allow', threaded: false } },
+      contextMemoTtlMs: 1000, // 1 second TTL for testing
+    });
+    dispatcher.register();
+
+    // Pre-seed with a memo timestamped 2 seconds ago (outside TTL)
+    const oldDate = new Date(Date.now() - 2000).toISOString();
+    await memory.addTurn('signal:+14155552671', 'coordinator', {
+      role: 'system',
+      content: `${OUTBOUND_MEMO_PREFIX}${oldDate}]\nmessage_preview: old message\ntask_type: coordinator-response\nexpected_reply: User may reply`,
+    });
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (event) => {
+      tasks.push(event as AgentTaskEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'signal:+14155552671',
+      channelId: 'signal',
+      senderId: '+14155552671',
+      content: 'Hello',
+    });
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].payload.content).toBe('Hello');
+    expect(tasks[0].payload.content).not.toContain('[PRIOR OUTBOUND CONTEXT');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging test tests/unit/dispatch/dispatcher-context-bridging.test.ts`
+
+Expected: FAIL — the new inbound injection tests fail because the dispatcher doesn't inject the preamble yet.
+
+- [ ] **Step 3: Add inbound context injection to `handleInbound`**
+
+In `src/dispatch/dispatcher.ts`, add the import for the extraction/preamble functions:
+
+```typescript
+import { formatOutboundMemo, extractRecentMemos, buildContextPreamble } from './context-memo.js';
+```
+
+(Replace the existing `import { formatOutboundMemo }` from Task 3.)
+
+In `handleInbound`, find the line that sets `taskContent` (look for `let taskContent = payload.content;` or the equivalent — this is the variable that becomes the `agent.task` content). **Before** any existing content modifications (like the CC preamble), add the context injection block:
+
+```typescript
+    // Inbound context injection for non-threaded channels.
+    // Read recent outbound context memos from working memory and prepend them
+    // to the task content so the coordinator knows what it last sent.
+    // Best-effort: failure is logged but does not block message routing.
+    const inboundPolicy = this.channelPolicies?.[payload.channelId];
+    if (this.workingMemory && inboundPolicy && !inboundPolicy.threaded) {
+      try {
+        const history = await this.workingMemory.getHistory(
+          payload.conversationId, 'coordinator',
+        );
+        const recentMemos = extractRecentMemos(history, this.contextMemoTtlMs);
+        const preamble = buildContextPreamble(recentMemos, taskContent);
+        if (preamble !== null) {
+          taskContent = preamble;
+          this.logger.debug(
+            { channelId: payload.channelId, conversationId: payload.conversationId, memoCount: recentMemos.length },
+            'Injected outbound context preamble into task content',
+          );
+        }
+      } catch (err) {
+        this.logger.warn(
+          { err, channelId: payload.channelId, conversationId: payload.conversationId },
+          'Failed to read outbound context memos — proceeding without context injection',
+        );
+      }
+    }
+```
+
+**Placement:** This must go after `let taskContent` is assigned from `payload.content` (or equivalent), and before the `createAgentTask()` call. The exact location depends on where `taskContent` is first assigned — look for the variable declaration in `handleInbound`. Place the injection block right after it, before any other content transformations (CC preamble, injection scanner, etc.). The context preamble should be the outermost wrapper so other preambles (like CC) stack on top of the user content inside it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging test tests/unit/dispatch/dispatcher-context-bridging.test.ts`
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging test`
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging add src/dispatch/dispatcher.ts tests/unit/dispatch/dispatcher-context-bridging.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging commit -m "feat: inject outbound context memos into inbound tasks for non-threaded channels (#431)"
+```
+
+---
+
+### Task 5: Wire `workingMemory` into bootstrap and update coordinator prompt
+
+**Files:**
+- Modify: `src/index.ts:1100-1115` (Dispatcher construction)
+- Modify: `agents/coordinator.yaml:152` (after Audience Awareness, before Authorization Enforcement)
+
+- [ ] **Step 1: Pass `memory` to Dispatcher in `index.ts`**
+
+In `src/index.ts`, find the `new Dispatcher({` call (around line 1100). Add `workingMemory: memory,` to the config object:
+
+```typescript
+  const dispatcher = new Dispatcher({
+    bus,
+    logger,
+    contactResolver,
+    contactService,
+    heldMessages,
+    channelPolicies: authConfig?.channelPolicies,
+    injectionScanner,
+    rateLimiter,
+    pool,
+    conversationCheckpointDebounceMs: yamlConfig.dispatch?.conversationCheckpointDebounceMs,
+    trustScorerWeights,
+    trustScoreFloor,
+    maxMessageBytes: yamlConfig.channels?.max_message_bytes ?? 102_400,
+    confidencePipeline,
+    workingMemory: memory,
+  });
+```
+
+The `memory` variable is already in scope (created around line 226).
+
+- [ ] **Step 2: Add outbound context directive to coordinator prompt**
+
+In `agents/coordinator.yaml`, insert the following block after the "Audience Awareness" section (after line 152, before "## Authorization Enforcement"):
+
+```yaml
+
+  ## Outbound context
+  When your input includes a [PRIOR OUTBOUND CONTEXT] section, the user is likely
+  replying to that prior message. Use the context memo (message_preview, key_ids,
+  expected_reply) to understand what they are referring to and act accordingly.
+
+  When your input does NOT include a [PRIOR OUTBOUND CONTEXT] section, apply this
+  two-part test:
+
+  1. Is the message **self-contained** — fully actionable on its own?
+     Examples: "Move the weekly team meeting to 4:30", "What's on my calendar tomorrow?"
+     → Proceed normally. No clarification needed.
+
+  2. Is the message **reply-shaped** — only makes sense as a response to something prior?
+     Examples: "Yes", "The second one", "Sounds good", "Go ahead"
+     → Ask the user what they are referring to before acting.
+     Keep it brief: "I lost the thread — what are you replying to?"
+
+```
+
+- [ ] **Step 3: Run the build**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging run build`
+
+Expected: Clean build.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging test`
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging add src/index.ts agents/coordinator.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging commit -m "feat: wire context bridging into bootstrap and add coordinator clarification gate (#431)"
+```
+
+---
+
+### Task 6: Update CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add changelog entry under `## [Unreleased]`**
+
+Add under the appropriate section (create `### Added` if it doesn't exist under Unreleased):
+
+```markdown
+### Added
+- **Non-threaded channel context bridging** — dispatch layer writes outbound context memos to working memory on non-threaded channels (Signal, CLI, HTTP) and injects them as a preamble when the user replies, so the coordinator knows what it last said. Coordinator prompt gains a channel-agnostic clarification gate for reply-shaped messages without context (#431).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging commit -m "docs: add changelog entry for non-threaded context bridging (#431)"
+```
+
+---
+
+### Task 7: Final verification
+
+- [ ] **Step 1: Run the full build**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging run build`
+
+Expected: Clean build, no errors.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging test`
+
+Expected: All tests PASS, including the new context-memo and dispatcher-context-bridging tests.
+
+- [ ] **Step 3: Review all changes on the branch**
+
+Run: `git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-context-bridging diff main...HEAD --stat`
+
+Verify the file list matches the plan's file map. No unexpected files should be changed.
+
+- [ ] **Step 4: Verify acceptance criteria**
+
+Walk through each criterion from the spec:
+
+1. `ChannelPolicyConfig` has `threaded: boolean` — check `src/contacts/types.ts`
+2. `channel-trust.yaml` declares threaded per channel — check the YAML
+3. Dispatcher writes outbound memos for `threaded: false` — confirmed by tests
+4. Memos are structured (timestamp, source_conversation, preview, task_type, key_ids) — confirmed by `formatOutboundMemo` tests
+5. Dispatcher reads memos within TTL and injects preamble — confirmed by tests
+6. No preamble when no memos exist — confirmed by tests
+7. Coordinator prompt has channel-agnostic clarification gate — check `coordinator.yaml`
+8. Integration test: outbound-then-reply flow — `dispatcher-context-bridging.test.ts` first test
+9. Integration test: cold-start self-contained — second test (no preamble, content passes through unchanged)
+10. Integration test: cold-start reply-shaped — covered by coordinator prompt (LLM behavior, not unit-testable)

--- a/src/contacts/config-loader.ts
+++ b/src/contacts/config-loader.ts
@@ -99,7 +99,11 @@ export function loadAuthConfig(configDir: string): AuthConfig {
       if (!['allow', 'hold_and_notify', 'ignore'].includes(unknownSender)) {
         throw new Error(`Invalid unknown_sender policy '${unknownSender}' for channel '${channel}'`);
       }
-      const threaded = (config as { threaded?: boolean }).threaded ?? false;
+      const rawThreaded = (config as { threaded?: unknown }).threaded;
+      if (rawThreaded !== undefined && typeof rawThreaded !== 'boolean') {
+        throw new Error(`Invalid threaded flag '${String(rawThreaded)}' for channel '${channel}'`);
+      }
+      const threaded = rawThreaded ?? false;
       channelTrust[channel] = trust;
       channelPolicies[channel] = { trust, unknownSender, threaded };
     }

--- a/src/contacts/config-loader.ts
+++ b/src/contacts/config-loader.ts
@@ -74,7 +74,7 @@ export function loadAuthConfig(configDir: string): AuthConfig {
     throw new Error("Missing or invalid 'channels' section in channel-trust.yaml");
   }
   // Accept either flat strings (legacy) or objects with trust + unknown_sender fields
-  const trustTyped = trustRaw as { channels: Record<string, string | { trust: string; unknown_sender: string }> };
+  const trustTyped = trustRaw as { channels: Record<string, string | { trust: string; unknown_sender: string; threaded?: boolean }> };
 
   const channelTrust: Record<string, TrustLevel> = {};
   const channelPolicies: Record<string, ChannelPolicyConfig> = {};
@@ -89,7 +89,7 @@ export function loadAuthConfig(configDir: string): AuthConfig {
       channelTrust[channel] = trust;
       // Default to 'allow' for legacy configs — silently holding messages would be
       // a surprising behavior change for deployments using the old flat-string format.
-      channelPolicies[channel] = { trust, unknownSender: 'allow' };
+      channelPolicies[channel] = { trust, unknownSender: 'allow', threaded: false };
     } else {
       const trust = (config as { trust: string }).trust as TrustLevel;
       if (!['high', 'medium', 'low'].includes(trust)) {
@@ -99,8 +99,9 @@ export function loadAuthConfig(configDir: string): AuthConfig {
       if (!['allow', 'hold_and_notify', 'ignore'].includes(unknownSender)) {
         throw new Error(`Invalid unknown_sender policy '${unknownSender}' for channel '${channel}'`);
       }
+      const threaded = (config as { threaded?: boolean }).threaded ?? false;
       channelTrust[channel] = trust;
-      channelPolicies[channel] = { trust, unknownSender };
+      channelPolicies[channel] = { trust, unknownSender, threaded };
     }
   }
 

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -203,6 +203,10 @@ export interface HeldMessage {
 export interface ChannelPolicyConfig {
   trust: TrustLevel;
   unknownSender: UnknownSenderPolicy;
+  /** Whether this channel structurally links replies to their parent messages.
+   *  Email is threaded (subject + in-reply-to headers); Signal/SMS/CLI are not.
+   *  The dispatch layer uses this to decide whether to write/read outbound context memos. */
+  threaded: boolean;
 }
 
 // -- Calendar registry types --

--- a/src/dispatch/context-memo.ts
+++ b/src/dispatch/context-memo.ts
@@ -1,0 +1,97 @@
+// src/dispatch/context-memo.ts
+//
+// Pure functions for outbound context memos on non-threaded channels.
+// The dispatch layer writes memos to working memory on outbound and reads them
+// on inbound. These functions format, parse, and assemble memo content without
+// any dependency on the bus, database, or working memory service.
+//
+// See docs/wip/2026-05-08-non-threaded-context-bridging-design.md
+
+import type { ConversationTurn } from '../memory/working-memory.js';
+
+/** Prefix that identifies outbound context memos in working memory turns. */
+export const OUTBOUND_MEMO_PREFIX = '[OUTBOUND CONTEXT — ';
+
+const MAX_PREVIEW_LENGTH = 200;
+
+interface FormatMemoInput {
+  conversationId: string;
+  content: string;
+  taskEventId: string | undefined;
+}
+
+/**
+ * Format an outbound context memo as a structured text string.
+ * Written to working memory as a system-role turn so the coordinator
+ * can see what it last sent on a non-threaded channel.
+ */
+export function formatOutboundMemo(input: FormatMemoInput): string {
+  const timestamp = new Date().toISOString();
+  const preview = input.content.length > MAX_PREVIEW_LENGTH
+    ? input.content.slice(0, MAX_PREVIEW_LENGTH) + '…'
+    : input.content;
+
+  const lines = [
+    `${OUTBOUND_MEMO_PREFIX}${timestamp}]`,
+    `source_conversation: ${input.conversationId}`,
+    `message_preview: ${preview}`,
+    `task_type: coordinator-response`,
+  ];
+
+  if (input.taskEventId) {
+    lines.push(`key_ids: task:${input.taskEventId}`);
+  }
+
+  lines.push('expected_reply: User may reply to this message');
+
+  return lines.join('\n');
+}
+
+/**
+ * Extract outbound context memos from a working memory turn history.
+ * Filters to system-role turns with the memo prefix whose embedded
+ * timestamp is within the TTL window.
+ *
+ * Returns memos in the same order they appear in `turns` (chronological,
+ * since working memory returns oldest-first).
+ */
+export function extractRecentMemos(
+  turns: ConversationTurn[],
+  ttlMs: number,
+): string[] {
+  const cutoff = Date.now() - ttlMs;
+
+  return turns.filter((turn) => {
+    if (turn.role !== 'system') return false;
+    if (!turn.content.startsWith(OUTBOUND_MEMO_PREFIX)) return false;
+
+    // Parse timestamp from the prefix line: [OUTBOUND CONTEXT — <ISO timestamp>]
+    const closingBracket = turn.content.indexOf(']');
+    if (closingBracket === -1) return false;
+    const timestamp = turn.content.slice(OUTBOUND_MEMO_PREFIX.length, closingBracket);
+    const memoTime = new Date(timestamp).getTime();
+    if (isNaN(memoTime)) return false;
+
+    return memoTime >= cutoff;
+  }).map(turn => turn.content);
+}
+
+/**
+ * Build the context preamble that the dispatcher prepends to inbound task content.
+ * Returns null if no memos are provided (caller should use original content as-is).
+ */
+export function buildContextPreamble(
+  memos: string[],
+  originalContent: string,
+): string | null {
+  if (memos.length === 0) return null;
+
+  const memoBlock = memos.map(m => `---\n${m}\n---`).join('\n');
+
+  return [
+    '[PRIOR OUTBOUND CONTEXT — this is what you last sent on this channel]',
+    memoBlock,
+    '',
+    originalContent,
+  ].join('\n');
+}

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -11,6 +11,8 @@ import type { RateLimiter } from './rate-limiter.js';
 import type { DbPool } from '../db/connection.js';
 import { computeTrustScore, DEFAULT_TRUST_WEIGHTS } from './trust-scorer.js';
 import type { TrustScorerWeights } from './trust-scorer.js';
+import type { WorkingMemory } from '../memory/working-memory.js';
+import { formatOutboundMemo, extractRecentMemos, buildContextPreamble } from './context-memo.js';
 
 /** Redact a channel identifier (email address or phone number) for safe log output. */
 function redactSenderId(value: string): string {
@@ -73,6 +75,13 @@ export interface DispatcherConfig {
   /** Contact confidence scoring pipeline. When provided, fires message_seen on
    *  every resolved inbound sender. When absent, scoring is disabled. */
   confidencePipeline?: import('../contacts/confidence-pipeline.js').ConfidencePipeline;
+  /** Working memory — used to write outbound context memos on non-threaded channels
+   *  and read them back for inbound context injection. When omitted, context
+   *  bridging is disabled (e.g. in unit tests that don't exercise it). */
+  workingMemory?: WorkingMemory;
+  /** TTL for outbound context memos in milliseconds. Memos older than this are
+   *  excluded from inbound injection. Default: 86400000 (24 hours). */
+  contextMemoTtlMs?: number;
 }
 
 /**
@@ -119,6 +128,8 @@ export class Dispatcher {
   private conversationCheckpointDebounceMs: number;
   private maxMessageBytes: number;
   private confidencePipeline?: import('../contacts/confidence-pipeline.js').ConfidencePipeline;
+  private workingMemory?: WorkingMemory;
+  private contextMemoTtlMs: number;
 
   constructor(config: DispatcherConfig) {
     this.bus = config.bus;
@@ -135,6 +146,8 @@ export class Dispatcher {
     this.trustScoreFloor = config.trustScoreFloor ?? 0.2;
     this.maxMessageBytes = config.maxMessageBytes ?? 102_400;
     this.confidencePipeline = config.confidencePipeline;
+    this.workingMemory = config.workingMemory;
+    this.contextMemoTtlMs = config.contextMemoTtlMs ?? 86_400_000;
 
     // Warn if the trust floor is active but no held-message service was provided — the floor
     // silently becomes a no-op in that case, which is a security-relevant degradation.
@@ -542,6 +555,33 @@ export class Dispatcher {
     let taskContent = payload.content;
     let injectionMetadata: Record<string, unknown> | undefined;
 
+    // Inbound context injection for non-threaded channels.
+    // Read recent outbound context memos from working memory and prepend them
+    // to the task content so the coordinator knows what it last sent.
+    // Best-effort: failure is logged but does not block message routing.
+    const inboundPolicy = this.channelPolicies?.[payload.channelId];
+    if (this.workingMemory && inboundPolicy && !inboundPolicy.threaded) {
+      try {
+        const history = await this.workingMemory.getHistory(
+          payload.conversationId, 'coordinator',
+        );
+        const recentMemos = extractRecentMemos(history, this.contextMemoTtlMs);
+        const preamble = buildContextPreamble(recentMemos, taskContent);
+        if (preamble !== null) {
+          taskContent = preamble;
+          this.logger.debug(
+            { channelId: payload.channelId, conversationId: payload.conversationId, memoCount: recentMemos.length },
+            'Injected outbound context preamble into task content',
+          );
+        }
+      } catch (err) {
+        this.logger.warn(
+          { err, channelId: payload.channelId, conversationId: payload.conversationId },
+          'Failed to read outbound context memos — proceeding without context injection',
+        );
+      }
+    }
+
     if (this.injectionScanner) {
       try {
         const scan = this.injectionScanner.scan(payload.content);
@@ -843,6 +883,34 @@ export class Dispatcher {
       taskEventId: event.parentEventId ?? undefined,
     });
     await this.bus.publish('dispatch', outbound);
+
+    // Write an outbound context memo to working memory for non-threaded channels.
+    // When the user replies, the inbound handler reads these memos and prepends
+    // them to the coordinator's task content so it knows what it last said.
+    // Best-effort: failure is logged but does not block outbound delivery.
+    const channelPolicy = this.channelPolicies?.[routing.channelId];
+    if (this.workingMemory && channelPolicy && !channelPolicy.threaded) {
+      try {
+        const memo = formatOutboundMemo({
+          conversationId: routing.conversationId,
+          content: event.payload.content,
+          taskEventId: event.parentEventId ?? undefined,
+        });
+        await this.workingMemory.addTurn(routing.conversationId, 'coordinator', {
+          role: 'system',
+          content: memo,
+        });
+        this.logger.debug(
+          { channelId: routing.channelId, conversationId: routing.conversationId },
+          'Outbound context memo written to working memory',
+        );
+      } catch (err) {
+        this.logger.warn(
+          { err, channelId: routing.channelId, conversationId: routing.conversationId },
+          'Failed to write outbound context memo — context bridging degraded for this message',
+        );
+      }
+    }
 
     // Schedule a checkpoint for this conversation — resets the debounce timer if
     // already running, so only fires after a full window of inactivity.

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -555,33 +555,6 @@ export class Dispatcher {
     let taskContent = payload.content;
     let injectionMetadata: Record<string, unknown> | undefined;
 
-    // Inbound context injection for non-threaded channels.
-    // Read recent outbound context memos from working memory and prepend them
-    // to the task content so the coordinator knows what it last sent.
-    // Best-effort: failure is logged but does not block message routing.
-    const inboundPolicy = this.channelPolicies?.[payload.channelId];
-    if (this.workingMemory && inboundPolicy && !inboundPolicy.threaded) {
-      try {
-        const history = await this.workingMemory.getHistory(
-          payload.conversationId, 'coordinator',
-        );
-        const recentMemos = extractRecentMemos(history, this.contextMemoTtlMs);
-        const preamble = buildContextPreamble(recentMemos, taskContent);
-        if (preamble !== null) {
-          taskContent = preamble;
-          this.logger.debug(
-            { channelId: payload.channelId, conversationId: payload.conversationId, memoCount: recentMemos.length },
-            'Injected outbound context preamble into task content',
-          );
-        }
-      } catch (err) {
-        this.logger.warn(
-          { err, channelId: payload.channelId, conversationId: payload.conversationId },
-          'Failed to read outbound context memos — proceeding without context injection',
-        );
-      }
-    }
-
     if (this.injectionScanner) {
       try {
         const scan = this.injectionScanner.scan(payload.content);
@@ -612,6 +585,33 @@ export class Dispatcher {
         this.logger.error(
           { err: scanErr, channelId: payload.channelId, senderId: payload.senderId },
           'Inbound scanner threw unexpectedly — forwarding raw content to coordinator (Layer 2 defense still active)',
+        );
+      }
+    }
+
+    // Inbound context injection for non-threaded channels.
+    // Placed AFTER the injection scanner so the preamble (system-generated content)
+    // wraps the already-sanitized user content and is not itself scanned or overwritten.
+    // Best-effort: failure is logged but does not block message routing.
+    const inboundPolicy = this.channelPolicies?.[payload.channelId];
+    if (this.workingMemory && inboundPolicy && !inboundPolicy.threaded) {
+      try {
+        const history = await this.workingMemory.getHistory(
+          payload.conversationId, 'coordinator',
+        );
+        const recentMemos = extractRecentMemos(history, this.contextMemoTtlMs);
+        const preamble = buildContextPreamble(recentMemos, taskContent);
+        if (preamble !== null) {
+          taskContent = preamble;
+          this.logger.debug(
+            { channelId: payload.channelId, conversationId: payload.conversationId, memoCount: recentMemos.length },
+            'Injected outbound context preamble into task content',
+          );
+        }
+      } catch (err) {
+        this.logger.warn(
+          { err, channelId: payload.channelId, conversationId: payload.conversationId },
+          'Failed to read outbound context memos — proceeding without context injection',
         );
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1112,6 +1112,7 @@ async function main(): Promise<void> {
     trustScoreFloor,
     maxMessageBytes: yamlConfig.channels?.max_message_bytes ?? 102_400,
     confidencePipeline,
+    workingMemory: memory,
   });
   dispatcher.register();
 

--- a/tests/integration/http-api.test.ts
+++ b/tests/integration/http-api.test.ts
@@ -149,7 +149,7 @@ describe('HTTP API — unknown_sender: ignore policy', () => {
       bus,
       logger,
       contactResolver: mockResolver,
-      channelPolicies: { http: { trust: 'low', unknownSender: 'ignore' } },
+      channelPolicies: { http: { trust: 'low', unknownSender: 'ignore', threaded: false } },
     });
     dispatcher.register();
 
@@ -394,7 +394,7 @@ describe('Trust scoring — unknown sender via HTTP', () => {
       bus,
       logger,
       contactResolver: mockResolver,
-      channelPolicies: { http: { trust: 'medium', unknownSender: 'allow' } },
+      channelPolicies: { http: { trust: 'medium', unknownSender: 'allow', threaded: false } },
     });
     dispatcher.register();
 

--- a/tests/integration/vertical-slice.test.ts
+++ b/tests/integration/vertical-slice.test.ts
@@ -139,7 +139,7 @@ describe('Vertical Slice: Unknown sender email → hold_and_notify', () => {
       logger,
       contactResolver: mockResolver,
       heldMessages,
-      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify' } },
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify', threaded: true } },
     });
     dispatcher.register();
 

--- a/tests/unit/dispatch/context-memo.test.ts
+++ b/tests/unit/dispatch/context-memo.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { formatOutboundMemo, extractRecentMemos, buildContextPreamble, OUTBOUND_MEMO_PREFIX } from '../../../src/dispatch/context-memo.js';
+import type { ConversationTurn } from '../../../src/memory/working-memory.js';
+
+describe('formatOutboundMemo', () => {
+  it('produces a structured memo with all fields', () => {
+    const memo = formatOutboundMemo({
+      conversationId: 'signal:+14155552671',
+      content: 'You have 3 held emails. Want me to process them?',
+      taskEventId: 'evt-abc123',
+    });
+
+    expect(memo).toContain(OUTBOUND_MEMO_PREFIX);
+    expect(memo).toContain('source_conversation: signal:+14155552671');
+    expect(memo).toContain('message_preview: You have 3 held emails. Want me to process them?');
+    expect(memo).toContain('task_type: coordinator-response');
+    expect(memo).toContain('key_ids: task:evt-abc123');
+    expect(memo).toContain('expected_reply: User may reply to this message');
+  });
+
+  it('truncates message_preview at 200 chars with ellipsis', () => {
+    const longContent = 'A'.repeat(250);
+    const memo = formatOutboundMemo({
+      conversationId: 'signal:+14155552671',
+      content: longContent,
+      taskEventId: 'evt-1',
+    });
+
+    const previewLine = memo.split('\n').find(l => l.startsWith('message_preview:'));
+    expect(previewLine).toBe(`message_preview: ${'A'.repeat(200)}…`);
+  });
+
+  it('does not add ellipsis when content fits within 200 chars', () => {
+    const shortContent = 'Hello there';
+    const memo = formatOutboundMemo({
+      conversationId: 'signal:+14155552671',
+      content: shortContent,
+      taskEventId: 'evt-1',
+    });
+
+    const previewLine = memo.split('\n').find(l => l.startsWith('message_preview:'));
+    expect(previewLine).toBe('message_preview: Hello there');
+  });
+
+  it('omits key_ids line when taskEventId is undefined', () => {
+    const memo = formatOutboundMemo({
+      conversationId: 'signal:+14155552671',
+      content: 'Hello',
+      taskEventId: undefined,
+    });
+
+    expect(memo).not.toContain('key_ids:');
+  });
+});
+
+describe('extractRecentMemos', () => {
+  function makeTurn(content: string): ConversationTurn {
+    return { role: 'system', content };
+  }
+
+  it('extracts memos from system turns matching the prefix', () => {
+    const recentMemo = `${OUTBOUND_MEMO_PREFIX}${new Date().toISOString()}]\nsource_conversation: signal:+1\nmessage_preview: hello\ntask_type: coordinator-response\nexpected_reply: User may reply to this message`;
+    const turns: ConversationTurn[] = [
+      { role: 'user', content: 'Hi' },
+      makeTurn(recentMemo),
+      { role: 'assistant', content: 'Hello!' },
+    ];
+
+    const result = extractRecentMemos(turns, 86_400_000);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(recentMemo);
+  });
+
+  it('excludes memos older than the TTL', () => {
+    const oldDate = new Date(Date.now() - 2 * 86_400_000).toISOString();
+    const oldMemo = `${OUTBOUND_MEMO_PREFIX}${oldDate}]\nsource_conversation: signal:+1\nmessage_preview: old\ntask_type: coordinator-response\nexpected_reply: User may reply to this message`;
+    const turns: ConversationTurn[] = [makeTurn(oldMemo)];
+
+    const result = extractRecentMemos(turns, 86_400_000);
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes non-system turns and system turns without the memo prefix', () => {
+    const turns: ConversationTurn[] = [
+      { role: 'user', content: `${OUTBOUND_MEMO_PREFIX}fake` },
+      { role: 'system', content: '[Conversation summary]\nSome summary text' },
+    ];
+
+    const result = extractRecentMemos(turns, 86_400_000);
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns multiple memos in chronological order', () => {
+    const t1 = new Date(Date.now() - 3600_000).toISOString();
+    const t2 = new Date().toISOString();
+    const memo1 = `${OUTBOUND_MEMO_PREFIX}${t1}]\nmessage_preview: first`;
+    const memo2 = `${OUTBOUND_MEMO_PREFIX}${t2}]\nmessage_preview: second`;
+    const turns: ConversationTurn[] = [makeTurn(memo1), makeTurn(memo2)];
+
+    const result = extractRecentMemos(turns, 86_400_000);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toContain('first');
+    expect(result[1]).toContain('second');
+  });
+});
+
+describe('buildContextPreamble', () => {
+  it('wraps memos in preamble header and separator, then appends original content', () => {
+    const memos = ['[OUTBOUND CONTEXT — 2026-05-08T14:00:00Z]\nmessage_preview: hello'];
+    const result = buildContextPreamble(memos, 'User says hi');
+
+    expect(result).toContain('[PRIOR OUTBOUND CONTEXT — this is what you last sent on this channel]');
+    expect(result).toContain('message_preview: hello');
+    expect(result).toContain('User says hi');
+    expect(result).toContain('---');
+  });
+
+  it('includes multiple memos separated by ---', () => {
+    const memos = [
+      '[OUTBOUND CONTEXT — 2026-05-08T14:00:00Z]\nmessage_preview: first',
+      '[OUTBOUND CONTEXT — 2026-05-08T15:00:00Z]\nmessage_preview: second',
+    ];
+    const result = buildContextPreamble(memos, 'Reply');
+
+    expect(result).toContain('message_preview: first');
+    expect(result).toContain('message_preview: second');
+  });
+
+  it('returns null when memos array is empty', () => {
+    const result = buildContextPreamble([], 'Hello');
+    expect(result).toBeNull();
+  });
+});

--- a/tests/unit/dispatch/dispatcher-context-bridging.test.ts
+++ b/tests/unit/dispatch/dispatcher-context-bridging.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
+import { EventBus } from '../../../src/bus/bus.js';
+import { AgentRuntime } from '../../../src/agents/runtime.js';
+import { WorkingMemory } from '../../../src/memory/working-memory.js';
+import { createInboundMessage, type OutboundMessageEvent, type AgentTaskEvent } from '../../../src/bus/events.js';
+import type { LLMProvider } from '../../../src/agents/llm/provider.js';
+import { createLogger } from '../../../src/logger.js';
+import { OUTBOUND_MEMO_PREFIX } from '../../../src/dispatch/context-memo.js';
+
+function setupTestBus() {
+  const logger = createLogger('error');
+  const bus = new EventBus(logger);
+  const memory = WorkingMemory.createInMemory();
+
+  const mockProvider: LLMProvider = {
+    id: 'mock',
+    chat: vi.fn().mockResolvedValue({
+      type: 'text' as const,
+      content: 'Response from Coordinator',
+      usage: { inputTokens: 10, outputTokens: 5 },
+    }),
+  };
+
+  const coordinator = new AgentRuntime({
+    agentId: 'coordinator',
+    systemPrompt: 'You are a helpful assistant.',
+    provider: mockProvider,
+    bus,
+    logger,
+  });
+  coordinator.register();
+
+  return { bus, logger, memory, mockProvider };
+}
+
+describe('Dispatcher context bridging — outbound memo', () => {
+  it('writes an outbound context memo to working memory for non-threaded channels', async () => {
+    const { bus, logger, memory } = setupTestBus();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      workingMemory: memory,
+      channelPolicies: { signal: { trust: 'high', unknownSender: 'hold_and_notify', threaded: false } },
+    });
+    dispatcher.register();
+
+    const outbound: OutboundMessageEvent[] = [];
+    bus.subscribe('outbound.message', 'channel', (event) => {
+      outbound.push(event as OutboundMessageEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'signal:+14155552671',
+      channelId: 'signal',
+      senderId: '+14155552671',
+      content: 'Hello',
+    });
+    await bus.publish('channel', event);
+
+    expect(outbound).toHaveLength(1);
+
+    const history = await memory.getHistory('signal:+14155552671', 'coordinator');
+    const memoTurns = history.filter(t => t.role === 'system' && t.content.startsWith(OUTBOUND_MEMO_PREFIX));
+    expect(memoTurns).toHaveLength(1);
+    expect(memoTurns[0].content).toContain('message_preview: Response from Coordinator');
+    expect(memoTurns[0].content).toContain('source_conversation: signal:+14155552671');
+  });
+
+  it('does NOT write a memo for threaded channels', async () => {
+    const { bus, logger, memory } = setupTestBus();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      workingMemory: memory,
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify', threaded: true } },
+    });
+    dispatcher.register();
+
+    const outbound: OutboundMessageEvent[] = [];
+    bus.subscribe('outbound.message', 'channel', (event) => {
+      outbound.push(event as OutboundMessageEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'email:alice@example.com',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Hello',
+    });
+    await bus.publish('channel', event);
+
+    expect(outbound).toHaveLength(1);
+
+    const history = await memory.getHistory('email:alice@example.com', 'coordinator');
+    const memoTurns = history.filter(t => t.role === 'system' && t.content.startsWith(OUTBOUND_MEMO_PREFIX));
+    expect(memoTurns).toHaveLength(0);
+  });
+
+  it('does NOT write a memo when workingMemory is not configured', async () => {
+    const { bus, logger } = setupTestBus();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      channelPolicies: { signal: { trust: 'high', unknownSender: 'hold_and_notify', threaded: false } },
+    });
+    dispatcher.register();
+
+    const outbound: OutboundMessageEvent[] = [];
+    bus.subscribe('outbound.message', 'channel', (event) => {
+      outbound.push(event as OutboundMessageEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'signal:+14155552671',
+      channelId: 'signal',
+      senderId: '+14155552671',
+      content: 'Hello',
+    });
+
+    await bus.publish('channel', event);
+    expect(outbound).toHaveLength(1);
+  });
+});
+
+describe('Dispatcher context bridging — inbound injection', () => {
+  it('prepends outbound context preamble to task content when memos exist', async () => {
+    const { bus, logger, memory } = setupTestBus();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      workingMemory: memory,
+      channelPolicies: { signal: { trust: 'high', unknownSender: 'allow', threaded: false } },
+    });
+    dispatcher.register();
+
+    const memoContent = `${OUTBOUND_MEMO_PREFIX}${new Date().toISOString()}]\nsource_conversation: signal:+14155552671\nmessage_preview: You have 3 held emails\ntask_type: coordinator-response\nexpected_reply: User may reply to this message`;
+    await memory.addTurn('signal:+14155552671', 'coordinator', {
+      role: 'system',
+      content: memoContent,
+    });
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (event) => {
+      tasks.push(event as AgentTaskEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'signal:+14155552671',
+      channelId: 'signal',
+      senderId: '+14155552671',
+      content: 'Yes, process them',
+    });
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].payload.content).toContain('[PRIOR OUTBOUND CONTEXT');
+    expect(tasks[0].payload.content).toContain('You have 3 held emails');
+    expect(tasks[0].payload.content).toContain('Yes, process them');
+  });
+
+  it('does NOT inject preamble when no memos exist', async () => {
+    const { bus, logger, memory } = setupTestBus();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      workingMemory: memory,
+      channelPolicies: { signal: { trust: 'high', unknownSender: 'allow', threaded: false } },
+    });
+    dispatcher.register();
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (event) => {
+      tasks.push(event as AgentTaskEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'signal:+14155552671',
+      channelId: 'signal',
+      senderId: '+14155552671',
+      content: 'Hello there',
+    });
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].payload.content).toBe('Hello there');
+    expect(tasks[0].payload.content).not.toContain('[PRIOR OUTBOUND CONTEXT');
+  });
+
+  it('does NOT inject preamble for threaded channels even if memos exist', async () => {
+    const { bus, logger, memory } = setupTestBus();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      workingMemory: memory,
+      channelPolicies: { email: { trust: 'low', unknownSender: 'allow', threaded: true } },
+    });
+    dispatcher.register();
+
+    await memory.addTurn('email:alice@example.com', 'coordinator', {
+      role: 'system',
+      content: `${OUTBOUND_MEMO_PREFIX}${new Date().toISOString()}]\nmessage_preview: hello`,
+    });
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (event) => {
+      tasks.push(event as AgentTaskEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'email:alice@example.com',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Reply to thread',
+    });
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].payload.content).not.toContain('[PRIOR OUTBOUND CONTEXT');
+  });
+
+  it('excludes memos older than TTL', async () => {
+    const { bus, logger, memory } = setupTestBus();
+
+    const dispatcher = new Dispatcher({
+      bus,
+      logger,
+      workingMemory: memory,
+      channelPolicies: { signal: { trust: 'high', unknownSender: 'allow', threaded: false } },
+      contextMemoTtlMs: 1000,
+    });
+    dispatcher.register();
+
+    const oldDate = new Date(Date.now() - 2000).toISOString();
+    await memory.addTurn('signal:+14155552671', 'coordinator', {
+      role: 'system',
+      content: `${OUTBOUND_MEMO_PREFIX}${oldDate}]\nmessage_preview: old message\ntask_type: coordinator-response\nexpected_reply: User may reply`,
+    });
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (event) => {
+      tasks.push(event as AgentTaskEvent);
+    });
+
+    const event = createInboundMessage({
+      conversationId: 'signal:+14155552671',
+      channelId: 'signal',
+      senderId: '+14155552671',
+      content: 'Hello',
+    });
+    await bus.publish('channel', event);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].payload.content).toBe('Hello');
+    expect(tasks[0].payload.content).not.toContain('[PRIOR OUTBOUND CONTEXT');
+  });
+});

--- a/tests/unit/dispatch/dispatcher-context-bridging.test.ts
+++ b/tests/unit/dispatch/dispatcher-context-bridging.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Dispatcher } from '../../../src/dispatch/dispatcher.js';
 import { EventBus } from '../../../src/bus/bus.js';
 import { AgentRuntime } from '../../../src/agents/runtime.js';

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -125,7 +125,7 @@ describe('Dispatcher unknown_sender: ignore policy', () => {
       bus,
       logger,
       contactResolver: mockResolver,
-      channelPolicies: { http: { trust: 'low', unknownSender: 'ignore' } },
+      channelPolicies: { http: { trust: 'low', unknownSender: 'ignore', threaded: false } },
     });
     dispatcher.register();
 
@@ -226,7 +226,7 @@ describe('Dispatcher unknown_sender: ignore policy', () => {
       bus,
       logger,
       contactResolver: mockResolver,
-      channelPolicies: { http: { trust: 'low', unknownSender: 'allow' } },
+      channelPolicies: { http: { trust: 'low', unknownSender: 'allow', threaded: false } },
     });
     dispatcher.register();
 
@@ -287,7 +287,7 @@ describe('Dispatcher — messageTrustScore', () => {
       bus,
       logger,
       contactResolver: resolver,
-      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify' } },
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify', threaded: true } },
     });
     dispatcher.register();
 
@@ -314,7 +314,7 @@ describe('Dispatcher — messageTrustScore', () => {
       bus,
       logger,
       contactResolver: resolver,
-      channelPolicies: { email: { trust: 'low', unknownSender: 'allow' } },
+      channelPolicies: { email: { trust: 'low', unknownSender: 'allow', threaded: true } },
     });
     dispatcher.register();
 
@@ -348,7 +348,7 @@ describe('Dispatcher — messageTrustScore', () => {
       logger,
       contactResolver: resolver,
       heldMessages,
-      channelPolicies: { email: { trust: 'low', unknownSender: 'allow' } },
+      channelPolicies: { email: { trust: 'low', unknownSender: 'allow', threaded: true } },
       trustScoreFloor: 0.2,
     });
     dispatcher.register();
@@ -407,7 +407,7 @@ describe('Dispatcher — messageTrustScore', () => {
       logger,
       contactResolver: resolver,
       heldMessages,
-      channelPolicies: { email: { trust: 'low', unknownSender: 'allow' } },
+      channelPolicies: { email: { trust: 'low', unknownSender: 'allow', threaded: true } },
       trustScoreFloor: 0.2,
     });
     dispatcher.register();
@@ -452,7 +452,7 @@ describe('Dispatcher — messageTrustScore', () => {
       logger,
       contactResolver: resolver,
       heldMessages,
-      channelPolicies: { http: { trust: 'medium', unknownSender: 'ignore' } },
+      channelPolicies: { http: { trust: 'medium', unknownSender: 'ignore', threaded: false } },
       trustScoreFloor: 0.5,
     });
     dispatcher.register();
@@ -486,7 +486,7 @@ describe('Dispatcher — messageTrustScore', () => {
       logger,
       contactResolver: resolver,
       heldMessages,
-      channelPolicies: { email: { trust: 'low', unknownSender: 'allow' } },
+      channelPolicies: { email: { trust: 'low', unknownSender: 'allow', threaded: true } },
       trustScoreFloor: 0.2,
     });
     dispatcher.register();
@@ -520,7 +520,7 @@ describe('Dispatcher — contact.unknown event payload', () => {
       logger,
       contactResolver: resolver,
       heldMessages,
-      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify' } },
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify', threaded: true } },
     });
     dispatcher.register();
 
@@ -551,7 +551,7 @@ describe('Dispatcher — contact.unknown event payload', () => {
       bus,
       logger,
       contactResolver: resolver,
-      channelPolicies: { http: { trust: 'medium', unknownSender: 'ignore' } },
+      channelPolicies: { http: { trust: 'medium', unknownSender: 'ignore', threaded: false } },
     });
     dispatcher.register();
 
@@ -1232,7 +1232,7 @@ describe('Dispatcher thread-originated trust bypass', () => {
       contactResolver: resolver,
       contactService,
       heldMessages,
-      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify' } },
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify', threaded: true } },
       pool: pool as unknown as DbPool,
       // No trustScoreFloor override — the threadTrusted flag now bypasses the floor for
       // thread-trusted messages, so this test exercises production behaviour.
@@ -1273,7 +1273,7 @@ describe('Dispatcher thread-originated trust bypass', () => {
       contactResolver: resolver,
       contactService,
       heldMessages,
-      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify' } },
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify', threaded: true } },
       pool: pool as unknown as DbPool,
     });
     dispatcher.register();
@@ -1307,7 +1307,7 @@ describe('Dispatcher thread-originated trust bypass', () => {
       contactResolver: resolver,
       contactService,
       heldMessages,
-      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify' } },
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify', threaded: true } },
       pool: pool as unknown as DbPool,
       // No trustScoreFloor override — threadTrusted flag bypasses it for this message.
     });
@@ -1354,7 +1354,7 @@ describe('Dispatcher thread-originated trust bypass', () => {
       contactResolver: resolver,
       contactService,
       heldMessages,
-      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify' } },
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify', threaded: true } },
       // pool intentionally omitted
     });
     dispatcher.register();
@@ -1390,7 +1390,7 @@ describe('Dispatcher thread-originated trust bypass', () => {
       contactResolver: resolver,
       contactService,
       heldMessages,
-      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify' } },
+      channelPolicies: { email: { trust: 'low', unknownSender: 'hold_and_notify', threaded: true } },
       pool: pool as unknown as DbPool,
     });
     dispatcher.register();


### PR DESCRIPTION
## Summary

- **Outbound context memos** — dispatch layer writes structured context memos to working memory whenever it routes a message to a non-threaded channel (`threaded: false`), so the coordinator knows what it last said
- **Inbound context injection** — dispatch layer reads recent memos (24h TTL) and prepends them as a `[PRIOR OUTBOUND CONTEXT]` preamble to the coordinator's task content when a reply arrives on a non-threaded channel
- **Clarification gate** — coordinator prompt gains a channel-agnostic two-part test: self-contained messages proceed normally; reply-shaped messages without context get "I lost the thread — what are you replying to?"
- **`ChannelPolicyConfig.threaded`** — new boolean field parsed from `channel-trust.yaml`; email is `true`, everything else is `false`

Closes #431

## Test plan

- [ ] `context-memo.test.ts` — 11 unit tests for memo formatting, extraction with TTL, and preamble assembly
- [ ] `dispatcher-context-bridging.test.ts` — 7 integration tests covering outbound memo write (non-threaded, threaded, no memory), inbound injection (with memos, without memos, threaded channel, TTL expiry)
- [ ] Full test suite passes (1995 tests, 2 pre-existing DB-dependent failures unrelated)
- [ ] Build clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Non-threaded channels (Signal, CLI, HTTP) now maintain conversation context automatically. Previous messages are injected when users reply, enabling the coordinator to recognize message continuity without native threading support.

* **Tests**
  * Added unit tests covering context bridging functionality on non-threaded channels.

* **Documentation**
  * Added design specifications and implementation guidance for context bridging across communication channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->