### PR TITLE
refactor(runtime): refresh Bullpen context on every tool-use loop iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **MCP `fixed_inputs`** — MCP server entries in `skills.yaml` now support a `fixed_inputs` field that binds constant parameter values at the tool layer. Values are resolved from env vars or literals at startup, stripped from tool schemas (invisible to agents), and merged into every `callTool` invocation (#432)
 
 ### Changed
+- **Bullpen context refresh in tool-use loop** — `AgentRuntime` now re-fetches pending Bullpen threads before every `chatWithRetry` call, not just once at task start. Replies and closures that occur mid-task are visible to the model on the next loop iteration (#213)
 - **`contact.resolved` bus event** — `sourceLayer` widened from `'dispatch'` to `'dispatch' | 'execution'`; `createContactResolved()` factory accepts an optional `sourceLayer` parameter (defaults to `'dispatch'` for backward compatibility). This is a public API surface change.
 - **`IdentitySource`** — new value `'agent_called'` for contacts registered by agents outside the normal dispatcher pipeline
 - **Outbound gateway** — removed `setTrustLevel('high')` band-aid; outbound sends now trigger the confidence scoring pipeline instead, giving contacts a real `contact_confidence` value

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -786,16 +786,6 @@ export class AgentRuntime {
   }
 
   /**
-   * Call the LLM provider with retry logic for transient failures.
-   *
-   * - Non-retryable errors: publish agent.error, send error response, return null
-   * - Retryable errors: backoff and retry up to 3 times, incrementing budget counters
-   * - AUTH_FAILURE counts double against the budget (it's a serious signal)
-   * - On success: reset consecutive error counter, return the response
-   * - If all retries exhausted: publish agent.error, send error response, return null
-   */
-
-  /**
    * Refresh the Bullpen pending-thread system message in the messages array.
    *
    * Called before every chatWithRetry invocation so the model sees current
@@ -834,9 +824,12 @@ export class AgentRuntime {
 
       if (pendingThreads.length > 0) {
         const bullpenBlock = formatBullpenContext(pendingThreads);
-        // Insert after sender context (if present) but before conversation history.
-        // bullpenInsertAt is 2 when sender context was injected, 1 otherwise.
-        messages.splice(bullpenInsertAt, 0, { role: 'system', content: bullpenBlock });
+        // If we removed a previous Bullpen message, re-insert at the same position
+        // so it stays adjacent to the surrounding context rather than jumping back to
+        // the top of a now-much-longer messages array. Only fall back to
+        // bullpenInsertAt on the initial injection (no prior message existed).
+        const insertAt = existingIdx !== -1 ? existingIdx : bullpenInsertAt;
+        messages.splice(insertAt, 0, { role: 'system', content: bullpenBlock });
       }
     } catch (err) {
       // A Bullpen lookup failure must not abort the task. Log and continue —
@@ -846,6 +839,15 @@ export class AgentRuntime {
     }
   }
 
+  /**
+   * Call the LLM provider with retry logic for transient failures.
+   *
+   * - Non-retryable errors: publish agent.error, send error response, return null
+   * - Retryable errors: backoff and retry up to 3 times, incrementing budget counters
+   * - AUTH_FAILURE counts double against the budget (it's a serious signal)
+   * - On success: reset consecutive error counter, return the response
+   * - If all retries exhausted: publish agent.error, send error response, return null
+   */
   private async chatWithRetry(
     provider: LLMProvider,
     params: { messages: Message[]; tools?: ToolDefinition[] },

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -817,25 +817,31 @@ export class AgentRuntime {
         this.config.bullpenWindowMinutes ?? 60,
       );
 
-      // Remove stale message first (if any)
+      // Build the replacement message BEFORE mutating the array, so that a
+      // formatBullpenContext failure preserves the stale message rather than
+      // leaving the array with the old message removed and no replacement.
+      const newBlock = pendingThreads.length > 0
+        ? formatBullpenContext(pendingThreads)
+        : null;
+
+      // Now atomically swap: remove stale, insert fresh.
       if (existingIdx !== -1) {
         messages.splice(existingIdx, 1);
       }
 
-      if (pendingThreads.length > 0) {
-        const bullpenBlock = formatBullpenContext(pendingThreads);
+      if (newBlock) {
         // If we removed a previous Bullpen message, re-insert at the same position
         // so it stays adjacent to the surrounding context rather than jumping back to
         // the top of a now-much-longer messages array. Only fall back to
         // bullpenInsertAt on the initial injection (no prior message existed).
         const insertAt = existingIdx !== -1 ? existingIdx : bullpenInsertAt;
-        messages.splice(insertAt, 0, { role: 'system', content: bullpenBlock });
+        messages.splice(insertAt, 0, { role: 'system', content: newBlock });
       }
     } catch (err) {
-      // A Bullpen lookup failure must not abort the task. Log and continue —
+      // A Bullpen refresh failure must not abort the task. Log and continue —
       // the agent will proceed with stale thread context (or none) rather than
       // failing entirely. The existing message (if any) is preserved.
-      logger.error({ err, agentId }, 'Failed to load Bullpen pending threads — proceeding without thread context');
+      logger.error({ err, agentId }, 'Bullpen context refresh failed — proceeding with stale thread context');
     }
   }
 

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -422,24 +422,9 @@ export class AgentRuntime {
     // Inject pending Bullpen threads as a system message so the agent is aware
     // of active inter-agent discussions. Inserted after sender context (if any),
     // before conversation history — matching spec context budget priority order.
-    if (this.config.bullpenService) {
-      try {
-        const pendingThreads = await this.config.bullpenService.getPendingThreadsForAgent(
-          agentId,
-          this.config.bullpenWindowMinutes ?? 60,
-        );
-        if (pendingThreads.length > 0) {
-          const bullpenBlock = formatBullpenContext(pendingThreads);
-          // Insert after sender context (if present) but before conversation history.
-          // bullpenInsertAt is 2 when sender context was injected, 1 otherwise.
-          messages.splice(bullpenInsertAt, 0, { role: 'system', content: bullpenBlock });
-        }
-      } catch (err) {
-        // A Bullpen lookup failure must not abort the task. Log and continue —
-        // the agent will proceed without thread context rather than failing entirely.
-        logger.error({ err, agentId }, 'Failed to load Bullpen pending threads — proceeding without thread context');
-      }
-    }
+    // Refreshed before every chatWithRetry call so the model sees current thread
+    // state, not a stale snapshot from the start of the task (#213).
+    await this.refreshBullpenContext(messages, bullpenInsertAt, agentId);
 
     logger.info({ agentId, conversationId, historyLength: history.length }, 'Agent processing task');
 
@@ -701,6 +686,10 @@ export class AgentRuntime {
       // a tool_use_id from the preceding assistant turn.
       messages.push({ role: 'user', content: toolResultBlocks });
 
+      // Refresh Bullpen context before the next LLM round so the model sees
+      // any new replies or closures that occurred during skill execution (#213).
+      await this.refreshBullpenContext(messages, bullpenInsertAt, agentId);
+
       // Continue the loop — the full conversation history is now in messages
       response = await this.chatWithRetry(provider, { messages, tools: workingToolDefs }, budget, taskEvent);
       if (!response) return; // chatWithRetry already published error events
@@ -805,6 +794,58 @@ export class AgentRuntime {
    * - On success: reset consecutive error counter, return the response
    * - If all retries exhausted: publish agent.error, send error response, return null
    */
+
+  /**
+   * Refresh the Bullpen pending-thread system message in the messages array.
+   *
+   * Called before every chatWithRetry invocation so the model sees current
+   * thread state, not a stale snapshot from the start of the task (#213).
+   *
+   * - Finds and removes any existing Bullpen system message (identified by
+   *   the `[Bullpen —` prefix produced by formatBullpenContext).
+   * - Fetches fresh pending threads and inserts a new system message.
+   * - On fetch failure: logs the error and leaves the existing message in
+   *   place (stale context is better than no context).
+   */
+  private async refreshBullpenContext(
+    messages: Message[],
+    bullpenInsertAt: number,
+    agentId: string,
+  ): Promise<void> {
+    if (!this.config.bullpenService) return;
+
+    const logger = this.config.logger;
+
+    // Find any existing Bullpen system message by its sentinel prefix.
+    const existingIdx = messages.findIndex(
+      m => m.role === 'system' && typeof m.content === 'string' && m.content.startsWith('[Bullpen'),
+    );
+
+    try {
+      const pendingThreads = await this.config.bullpenService.getPendingThreadsForAgent(
+        agentId,
+        this.config.bullpenWindowMinutes ?? 60,
+      );
+
+      // Remove stale message first (if any)
+      if (existingIdx !== -1) {
+        messages.splice(existingIdx, 1);
+      }
+
+      if (pendingThreads.length > 0) {
+        const bullpenBlock = formatBullpenContext(pendingThreads);
+        // Insert after sender context (if present) but before conversation history.
+        // bullpenInsertAt is 2 when sender context was injected, 1 otherwise.
+        messages.splice(bullpenInsertAt, 0, { role: 'system', content: bullpenBlock });
+      }
+    } catch (err) {
+      // A Bullpen lookup failure must not abort the task. Log and continue —
+      // the agent will proceed with stale thread context (or none) rather than
+      // failing entirely. The existing message (if any) is preserved.
+      logger.error({ err, agentId }, 'Failed to load Bullpen pending threads — proceeding without thread context');
+    }
+  }
+
   private async chatWithRetry(
     provider: LLMProvider,
     params: { messages: Message[]; tools?: ToolDefinition[] },

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -1664,3 +1664,317 @@ describe('AgentRuntime chatWithRetry', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Bullpen context refresh in tool-use loop (#213)
+// ---------------------------------------------------------------------------
+
+describe('AgentRuntime Bullpen context refresh', () => {
+  it('re-fetches pending threads before each chatWithRetry in the tool-use loop', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    // Track the messages array passed to each provider.chat() call so we can
+    // verify the Bullpen system message content changed between rounds.
+    const capturedMessageSnapshots: Array<Array<{ role: string; content: unknown }>> = [];
+
+    let chatCallCount = 0;
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn(async ({ messages }) => {
+        // Deep-copy the messages to capture the state at each call
+        capturedMessageSnapshots.push(
+          messages.map((m: { role: string; content: unknown }) => ({ role: m.role, content: m.content })),
+        );
+        chatCallCount++;
+        if (chatCallCount === 1) {
+          // First call: LLM requests a tool call
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{ id: 'call-bp-1', name: 'web-fetch', input: { url: 'https://example.com' } }],
+            usage: { inputTokens: 100, outputTokens: 50 },
+          };
+        }
+        // Second call: LLM returns text (exit tool-use loop)
+        return {
+          type: 'text' as const,
+          content: 'All done.',
+          usage: { inputTokens: 200, outputTokens: 60 },
+        };
+      }),
+    };
+
+    const mockExecution = {
+      invoke: vi.fn().mockResolvedValue({ success: true, data: 'fetched' }),
+    } as unknown as ExecutionLayer;
+
+    // Mock bullpenService: returns different threads on successive calls so we
+    // can verify the system message content actually changes.
+    let bullpenCallCount = 0;
+    const mockBullpenService = {
+      getPendingThreadsForAgent: vi.fn(async () => {
+        bullpenCallCount++;
+        if (bullpenCallCount === 1) {
+          return [{
+            threadId: 'thread-1',
+            topic: 'Sprint planning',
+            totalMessages: 1,
+            recentMessages: [{
+              senderAgentId: 'research-analyst',
+              content: 'Initial message',
+              mentionedAgentIds: ['coordinator'],
+              createdAt: new Date('2026-05-09T10:00:00Z'),
+            }],
+          }];
+        }
+        // Second call: thread has a new reply
+        return [{
+          threadId: 'thread-1',
+          topic: 'Sprint planning',
+          totalMessages: 2,
+          recentMessages: [
+            {
+              senderAgentId: 'research-analyst',
+              content: 'Initial message',
+              mentionedAgentIds: ['coordinator'],
+              createdAt: new Date('2026-05-09T10:00:00Z'),
+            },
+            {
+              senderAgentId: 'essay-editor',
+              content: 'Follow-up reply',
+              mentionedAgentIds: ['coordinator'],
+              createdAt: new Date('2026-05-09T10:01:00Z'),
+            },
+          ],
+        }];
+      }),
+    };
+
+    bus.subscribe('agent.response', 'dispatch', () => {});
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      skillToolDefs: [{ name: 'web-fetch', description: 'Fetch', input_schema: { type: 'object' as const, properties: {}, required: [] as string[] } }],
+      bullpenService: mockBullpenService as unknown as import('../../../src/memory/bullpen.js').BullpenService,
+    });
+    agent.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-bp-refresh',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Do something',
+      parentEventId: 'parent-bp-refresh',
+    });
+    await bus.publish('dispatch', task);
+
+    // bullpenService.getPendingThreadsForAgent must be called twice:
+    // once before the initial chatWithRetry, once before the loop chatWithRetry
+    expect(mockBullpenService.getPendingThreadsForAgent).toHaveBeenCalledTimes(2);
+
+    // Both chat calls should have included a Bullpen system message
+    expect(capturedMessageSnapshots).toHaveLength(2);
+
+    // First call: system messages should contain the initial thread state (1 message)
+    const firstSystemMsgs = capturedMessageSnapshots[0]!
+      .filter(m => m.role === 'system' && typeof m.content === 'string' && (m.content as string).includes('[Bullpen'));
+    expect(firstSystemMsgs).toHaveLength(1);
+    expect(firstSystemMsgs[0]!.content).toContain('1 total messages');
+    expect(firstSystemMsgs[0]!.content).not.toContain('Follow-up reply');
+
+    // Second call: system messages should contain the refreshed thread state (2 messages)
+    const secondSystemMsgs = capturedMessageSnapshots[1]!
+      .filter(m => m.role === 'system' && typeof m.content === 'string' && (m.content as string).includes('[Bullpen'));
+    expect(secondSystemMsgs).toHaveLength(1);
+    expect(secondSystemMsgs[1 - 1]!.content).toContain('2 total messages');
+    expect(secondSystemMsgs[0]!.content).toContain('Follow-up reply');
+  });
+
+  it('removes stale Bullpen message when no pending threads remain', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const capturedMessageSnapshots: Array<Array<{ role: string; content: unknown }>> = [];
+
+    let chatCallCount = 0;
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn(async ({ messages }) => {
+        capturedMessageSnapshots.push(
+          messages.map((m: { role: string; content: unknown }) => ({ role: m.role, content: m.content })),
+        );
+        chatCallCount++;
+        if (chatCallCount === 1) {
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{ id: 'call-bp-2', name: 'web-fetch', input: {} }],
+            usage: { inputTokens: 100, outputTokens: 50 },
+          };
+        }
+        return {
+          type: 'text' as const,
+          content: 'Done.',
+          usage: { inputTokens: 200, outputTokens: 60 },
+        };
+      }),
+    };
+
+    const mockExecution = {
+      invoke: vi.fn().mockResolvedValue({ success: true, data: 'ok' }),
+    } as unknown as ExecutionLayer;
+
+    let bullpenCallCount = 0;
+    const mockBullpenService = {
+      getPendingThreadsForAgent: vi.fn(async () => {
+        bullpenCallCount++;
+        if (bullpenCallCount === 1) {
+          // First call: one pending thread
+          return [{
+            threadId: 'thread-2',
+            topic: 'Design review',
+            totalMessages: 1,
+            recentMessages: [{
+              senderAgentId: 'research-analyst',
+              content: 'Review this',
+              mentionedAgentIds: ['coordinator'],
+              createdAt: new Date('2026-05-09T10:00:00Z'),
+            }],
+          }];
+        }
+        // Second call: thread was closed — no more pending threads
+        return [];
+      }),
+    };
+
+    bus.subscribe('agent.response', 'dispatch', () => {});
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      skillToolDefs: [{ name: 'web-fetch', description: 'Fetch', input_schema: { type: 'object' as const, properties: {}, required: [] as string[] } }],
+      bullpenService: mockBullpenService as unknown as import('../../../src/memory/bullpen.js').BullpenService,
+    });
+    agent.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-bp-remove',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Do something',
+      parentEventId: 'parent-bp-remove',
+    });
+    await bus.publish('dispatch', task);
+
+    // First call should have a Bullpen system message
+    const firstBullpenMsgs = capturedMessageSnapshots[0]!
+      .filter(m => m.role === 'system' && typeof m.content === 'string' && (m.content as string).includes('[Bullpen'));
+    expect(firstBullpenMsgs).toHaveLength(1);
+
+    // Second call: Bullpen message should be removed (no pending threads)
+    const secondBullpenMsgs = capturedMessageSnapshots[1]!
+      .filter(m => m.role === 'system' && typeof m.content === 'string' && (m.content as string).includes('[Bullpen'));
+    expect(secondBullpenMsgs).toHaveLength(0);
+  });
+
+  it('preserves existing Bullpen message when refresh fails', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const capturedMessageSnapshots: Array<Array<{ role: string; content: unknown }>> = [];
+
+    let chatCallCount = 0;
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn(async ({ messages }) => {
+        capturedMessageSnapshots.push(
+          messages.map((m: { role: string; content: unknown }) => ({ role: m.role, content: m.content })),
+        );
+        chatCallCount++;
+        if (chatCallCount === 1) {
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{ id: 'call-bp-3', name: 'web-fetch', input: {} }],
+            usage: { inputTokens: 100, outputTokens: 50 },
+          };
+        }
+        return {
+          type: 'text' as const,
+          content: 'Done.',
+          usage: { inputTokens: 200, outputTokens: 60 },
+        };
+      }),
+    };
+
+    const mockExecution = {
+      invoke: vi.fn().mockResolvedValue({ success: true, data: 'ok' }),
+    } as unknown as ExecutionLayer;
+
+    let bullpenCallCount = 0;
+    const mockBullpenService = {
+      getPendingThreadsForAgent: vi.fn(async () => {
+        bullpenCallCount++;
+        if (bullpenCallCount === 1) {
+          return [{
+            threadId: 'thread-3',
+            topic: 'Architecture review',
+            totalMessages: 1,
+            recentMessages: [{
+              senderAgentId: 'research-analyst',
+              content: 'Let us discuss',
+              mentionedAgentIds: ['coordinator'],
+              createdAt: new Date('2026-05-09T10:00:00Z'),
+            }],
+          }];
+        }
+        // Second call fails — refresh should preserve the stale message
+        throw new Error('DB connection lost');
+      }),
+    };
+
+    bus.subscribe('agent.response', 'dispatch', () => {});
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      skillToolDefs: [{ name: 'web-fetch', description: 'Fetch', input_schema: { type: 'object' as const, properties: {}, required: [] as string[] } }],
+      bullpenService: mockBullpenService as unknown as import('../../../src/memory/bullpen.js').BullpenService,
+    });
+    agent.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-bp-fail',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Do something',
+      parentEventId: 'parent-bp-fail',
+    });
+    await bus.publish('dispatch', task);
+
+    // Both calls should still have a Bullpen system message (stale one preserved on failure)
+    const firstBullpenMsgs = capturedMessageSnapshots[0]!
+      .filter(m => m.role === 'system' && typeof m.content === 'string' && (m.content as string).includes('[Bullpen'));
+    expect(firstBullpenMsgs).toHaveLength(1);
+
+    const secondBullpenMsgs = capturedMessageSnapshots[1]!
+      .filter(m => m.role === 'system' && typeof m.content === 'string' && (m.content as string).includes('[Bullpen'));
+    expect(secondBullpenMsgs).toHaveLength(1);
+    // Should still be the original content (stale, not updated)
+    expect(secondBullpenMsgs[0]!.content).toContain('Architecture review');
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `refreshBullpenContext()` private method on `AgentRuntime` that finds/removes the existing Bullpen system message by its `[Bullpen —` sentinel prefix, fetches fresh pending threads, and inserts the updated message
- Call it before both `chatWithRetry` invocations (initial + inside the tool-use loop) so the model sees current thread state, not a stale snapshot from task start
- On refresh failure, preserve the existing stale message (format before mutating the array)
- On refresh with no remaining threads, remove the stale message entirely

## Test plan
- [x] New test: re-fetches pending threads before each chatWithRetry in the tool-use loop (verifies `getPendingThreadsForAgent` called twice, system message content changes)
- [x] New test: removes stale Bullpen message when no pending threads remain
- [x] New test: preserves existing Bullpen message when refresh fails
- [x] All 33 runtime tests pass
- [x] Full test suite: 169 passed, 9 skipped (2 pre-existing DB-dependent failures unrelated to this change)

Closes #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents now detect and respond to inter-agent messages and thread updates continuously throughout task execution, providing real-time visibility into agent interactions rather than only initial state.

* **Tests**
  * Added comprehensive test suite verifying inter-agent message detection, removal when no pending threads exist, and graceful handling of refresh failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/495)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->