### PR TITLE
feat: better email etiquette — reply-all default, thread-participant context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Contact confidence scoring pipeline** — `contact_confidence` is now updated on each qualifying event (inbound/outbound message, CEO trust grant, verified identity pairing). Supports incremental and full-recompute modes with convergence guarantee (spec 06, #460)
 - **`contact-register` skill** — integration point for agents that read channels directly (e.g. the ceo-inbox agent) rather than through the dispatcher. Resolves or creates contacts, updates `last_seen_at`, triggers a confidence scoring delta, and emits a `contact.resolved` bus event (#485)
 - **MCP `fixed_inputs`** — MCP server entries in `skills.yaml` now support a `fixed_inputs` field that binds constant parameter values at the tool layer. Values are resolved from env vars or literals at startup, stripped from tool schemas (invisible to agents), and merged into every `callTool` invocation (#432)
+- **Thread-participants block** injected into LLM context for all inbound email tasks, showing From / To / CC with self displayed as "you"
 
 ### Changed
 - **Bullpen context refresh in tool-use loop** — `AgentRuntime` now re-fetches pending Bullpen threads before every `chatWithRetry` call, not just once at task start. Replies and closures that occur mid-task are visible to the model on the next loop iteration (#213)
@@ -26,6 +27,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Outbound gateway** — removed `setTrustLevel('high')` band-aid; outbound sends now trigger the confidence scoring pipeline instead, giving contacts a real `contact_confidence` value
 - **Smoke tests** — renamed three `email-triage-*` test cases to `email-prioritization-*` following the CEO inbox redesign; updated the `email-triage` tag to `email-prioritization` in each
 - **ADR-017** — added a note that observation mode has been removed since this ADR was written (v0.25.x, CEO inbox redesign)
+- **email-reply skill** now defaults to reply-all; pass `cc: ""` to reply to sender only, or a comma-separated list to override recipients explicitly
+- **sendOutboundReply** (implicit reply path) now includes CC recipients from the thread message by default, filtering self and the primary To recipient
+- **SkillContext** gains `selfEmail?: string` field (public API surface — skills can use this to filter self from CC lists)
 
 ### Fixed
 - **Trust floor confirmed-contact exemption** — confirmed contacts with `contact_confidence=0` and no `trust_level` override are no longer incorrectly held by the trust floor; the floor now exempts contacts with `status='confirmed'` since they have passed explicit CEO approval.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -367,6 +367,21 @@ system_prompt: |
 
   Keep email responses concise and professional.
 
+  ### To / CC etiquette
+  The `[Thread participants]` block at the top of each email task shows who is on this
+  message (From / To / CC). It reflects the current message's headers only, not the
+  full thread history.
+
+  **Default: reply-all.** When replying to an email with CC recipients, keep them on
+  the thread unless there is a specific reason not to (e.g. the conversation has become
+  private, or the CEO explicitly asks you to reply directly).
+
+  To reply to the sender only, call `email-reply` with `cc: ""` (empty string). Omitting
+  `cc` entirely triggers automatic reply-all — this is the right default for most replies.
+
+  Use judgment on who belongs on the thread: removing a CC requires a reason; adding
+  someone new to CC should be intentional.
+
   ### Before composing any email
   Before drafting or sending any email, resolve ALL recipients and CC contacts
   using contact-lookup. If a contact is not found by name, search email-list and

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -5,6 +5,12 @@
 // This handler focuses on thread resolution (fetching the original message
 // to extract the sender address and subject line).
 //
+// CC behaviour (three modes):
+//   - cc absent (undefined): reply-all — auto-populate from original.to[] + original.cc[],
+//     excluding the primary To recipient and ctx.selfEmail (Curia's own address).
+//   - cc === "": reply to sender only — no CC recipients.
+//   - cc is a non-empty string: parse comma-separated addresses explicitly.
+//
 // sensitivity: "elevated" — enforced by the gateway's security pipeline.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
@@ -13,9 +19,10 @@ const MAX_BODY_LENGTH = 50000;
 
 export class EmailReplyHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const { reply_to_message_id: replyToMessageId, body } = ctx.input as {
+    const { reply_to_message_id: replyToMessageId, body, cc: ccInput } = ctx.input as {
       reply_to_message_id?: string;
       body?: string;
+      cc?: string;
     };
 
     if (!replyToMessageId || typeof replyToMessageId !== 'string') {
@@ -52,12 +59,60 @@ export class EmailReplyHandler implements SkillHandler {
       const baseSubject = original.subject.replace(/^Re:\s*/i, '');
       const replySubject = `Re: ${baseSubject}`;
 
+      // Resolve CC addresses based on the three input modes.
+      let ccAddresses: string[] | undefined;
+
+      if (ccInput === undefined) {
+        // Reply-all mode: collect all addresses from the original To and CC fields,
+        // excluding the primary To recipient (already in To) and Curia's own address
+        // (must never CC itself). Use a lowercase Set for case-insensitive deduplication.
+        const excluded = new Set<string>();
+        excluded.add(originalFrom.toLowerCase());
+        if (ctx.selfEmail) {
+          excluded.add(ctx.selfEmail.toLowerCase());
+        }
+
+        const candidates = [
+          ...(original.to ?? []),
+          ...(original.cc ?? []),
+        ];
+
+        const resolved = candidates
+          .map((p) => p.email)
+          .filter((addr): addr is string => !!addr)
+          .filter((addr) => !excluded.has(addr.toLowerCase()));
+
+        // Deduplicate while preserving first-seen order.
+        const seen = new Set<string>();
+        ccAddresses = resolved.filter((addr) => {
+          const key = addr.toLowerCase();
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+
+        // Treat an empty resolved list the same as no CC (don't pass an empty array).
+        if (ccAddresses.length === 0) ccAddresses = undefined;
+      } else if (ccInput === '') {
+        // Explicit reply-to-sender-only: omit CC entirely.
+        ccAddresses = undefined;
+      } else {
+        // Explicit CC list: parse comma-separated addresses, trim, and drop empties.
+        ccAddresses = ccInput
+          .split(',')
+          .map((addr) => addr.trim())
+          .filter((addr) => addr.length > 0);
+
+        if (ccAddresses.length === 0) ccAddresses = undefined;
+      }
+
       const result = await ctx.outboundGateway.send({
         channel: 'email',
         to: originalFrom,
         subject: replySubject,
         body,
         replyToMessageId,
+        ...(ccAddresses ? { cc: ccAddresses } : {}),
       });
 
       if (!result.success) {
@@ -65,7 +120,7 @@ export class EmailReplyHandler implements SkillHandler {
       }
 
       ctx.log.info(
-        { messageId: result.messageId, to: originalFrom, subject: replySubject },
+        { messageId: result.messageId, to: originalFrom, subject: replySubject, cc: ccAddresses },
         'Email reply sent successfully',
       );
 
@@ -75,6 +130,8 @@ export class EmailReplyHandler implements SkillHandler {
           message_id: result.messageId,
           to: originalFrom,
           subject: replySubject,
+          // Return the CC list that was used; empty string when none.
+          cc: ccAddresses?.join(', ') ?? '',
         },
       };
     } catch (err) {

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -70,6 +70,8 @@ export class EmailReplyHandler implements SkillHandler {
         excluded.add(originalFrom.toLowerCase());
         if (ctx.selfEmail) {
           excluded.add(ctx.selfEmail.toLowerCase());
+        } else {
+          ctx.log.warn({ replyToMessageId }, 'email-reply: selfEmail not configured — Curia may CC itself in reply-all');
         }
 
         const candidates = [

--- a/skills/email-reply/skill.json
+++ b/skills/email-reply/skill.json
@@ -1,17 +1,19 @@
 {
   "name": "email-reply",
-  "description": "Reply to an existing email thread. Provide the Nylas message ID to reply to and the reply body. The reply will be threaded correctly and sent to the original sender.",
-  "version": "1.0.0",
+  "description": "Reply to an existing email thread. By default, replies to all participants (reply-all). Pass cc as empty string to reply to sender only, or as a comma-separated list to explicitly set recipients. Provide the Nylas message ID to reply to and the reply body.",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {
     "reply_to_message_id": "string",
-    "body": "string"
+    "body": "string",
+    "cc": "string? (comma-separated — omit for reply-all default, empty string to reply to sender only)"
   },
   "outputs": {
     "message_id": "string",
     "to": "string",
-    "subject": "string"
+    "subject": "string",
+    "cc": "string"
   },
   "permissions": [],
   "secrets": [],

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -362,10 +362,20 @@ export class EmailAdapter {
         return;
       }
 
-      // Reply-all: include CC recipients from the thread message, excluding self.
+      // Reply-all: include CC recipients from the thread message, excluding self and the
+      // primary To recipient — in rare thread shapes the To recipient may appear in the
+      // CC list of the fetched message, which would produce duplicate addressing.
       const ccAddresses = threadMessage.cc
         .map((r) => r.email)
-        .filter((email) => email.toLowerCase() !== this.config.selfEmail.toLowerCase());
+        .filter(
+          (email) =>
+            email.toLowerCase() !== this.config.selfEmail.toLowerCase() &&
+            email.toLowerCase() !== recipientEmail.toLowerCase(),
+        );
+
+      if (ccAddresses.length > 0) {
+        logger.debug({ ccAddresses, count: ccAddresses.length }, 'sendOutboundReply: reply-all including CC recipients');
+      }
 
       // Strip any existing "Re:" prefix before prepending our own to avoid
       // "Re: Re: Re: ..." chains when replying to already-replied threads.

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -362,6 +362,11 @@ export class EmailAdapter {
         return;
       }
 
+      // Reply-all: include CC recipients from the thread message, excluding self.
+      const ccAddresses = threadMessage.cc
+        .map((r) => r.email)
+        .filter((email) => email.toLowerCase() !== this.config.selfEmail.toLowerCase());
+
       // Strip any existing "Re:" prefix before prepending our own to avoid
       // "Re: Re: Re: ..." chains when replying to already-replied threads.
       const baseSubject = threadMessage.subject.replace(/^Re:\s*/i, '');
@@ -373,6 +378,7 @@ export class EmailAdapter {
         subject: `Re: ${baseSubject}`,
         body: outbound.payload.content,
         replyToMessageId: threadMessage.id,
+        ...(ccAddresses.length > 0 ? { cc: ccAddresses } : {}),
       };
 
       await this.sendWithGatedDraftFallback(sendRequest, {

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -362,10 +362,9 @@ export class EmailAdapter {
         return;
       }
 
-      // Reply-all: include CC recipients from the thread message, excluding self and the
-      // primary To recipient — in rare thread shapes the To recipient may appear in the
-      // CC list of the fetched message, which would produce duplicate addressing.
-      const ccAddresses = threadMessage.cc
+      // Reply-all: include To and CC recipients from the thread message, excluding self and the primary recipient.
+      // Both to[] and cc[] are candidates — mirrors the email-reply skill's reply-all logic.
+      const ccAddresses = [...(threadMessage.to ?? []), ...(threadMessage.cc ?? [])]
         .map((r) => r.email)
         .filter(
           (email) =>

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -173,16 +173,6 @@ export class Dispatcher {
     this.checkpointTimers.clear();
   }
 
-  /**
-   * Curia's own email address, used in PR1-D to substitute "you" for Curia's
-   * address in thread-participants blocks. Exposed as a getter so downstream
-   * components (e.g. thread-participants formatter) can read it from the Dispatcher
-   * without needing their own copy of the config.
-   */
-  getSelfEmail(): string | undefined {
-    return this.selfEmail;
-  }
-
   register(): void {
     // inbound.message → agent.task
     this.bus.subscribe('inbound.message', 'dispatch', async (event) => {
@@ -724,6 +714,47 @@ export class Dispatcher {
         }
         // Always return if the hold succeeded — a publish failure is not a reason to forward to the coordinator.
         if (held) return;
+      }
+    }
+
+    // Thread-participants block: inject structured participant context for every
+    // inbound email so the coordinator can reason about who's on the thread.
+    // Placed before the CC preamble so the CC role marker appears on top.
+    if (payload.channelId === 'email') {
+      const emailMeta = payload.metadata as Record<string, unknown> | undefined;
+      const rawParticipants = emailMeta?.participants;
+      if (Array.isArray(rawParticipants) && rawParticipants.length > 0) {
+        const selfLower = this.selfEmail?.toLowerCase();
+        const MAX_PARTICIPANTS = 15;
+
+        // Sanitize participant email addresses — they come from Nylas (attacker-controlled)
+        // and are injected into taskContent. Strip characters that could enable prompt
+        // injection. Same pattern as the CC preamble sanitization above.
+        const sanitize = (s: string): string =>
+          String(s).replace(/[\n\r\[\]<>]/g, '').trim().slice(0, 254);
+
+        const froms: string[] = [];
+        const tos: string[] = [];
+        const ccs: string[] = [];
+
+        for (const p of (rawParticipants as Array<{ email: string; role: string }>).slice(0, MAX_PARTICIPANTS)) {
+          const addr = sanitize(p.email);
+          if (!addr) continue;
+          // Replace Curia's own address with "you" for readability.
+          const display = selfLower && addr.toLowerCase() === selfLower ? 'you' : addr;
+          if (p.role === 'from') froms.push(display);
+          else if (p.role === 'to') tos.push(display);
+          else if (p.role === 'cc') ccs.push(display);
+        }
+
+        const parts: string[] = [];
+        if (froms.length > 0) parts.push(`From: ${froms.join(', ')}`);
+        if (tos.length > 0) parts.push(`To: ${tos.join(', ')}`);
+        if (ccs.length > 0) parts.push(`CC: ${ccs.join(', ')}`);
+
+        if (parts.length > 0) {
+          taskContent = `[Thread participants — ${parts.join('; ')}]\n` + taskContent;
+        }
       }
     }
 

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -82,6 +82,9 @@ export interface DispatcherConfig {
   /** TTL for outbound context memos in milliseconds. Memos older than this are
    *  excluded from inbound injection. Default: 86400000 (24 hours). */
   contextMemoTtlMs?: number;
+  /** Curia's own email address — used to substitute "you" for Curia's address
+   *  in thread-participants blocks (PR1-D). */
+  selfEmail?: string;
 }
 
 /**
@@ -130,6 +133,8 @@ export class Dispatcher {
   private confidencePipeline?: import('../contacts/confidence-pipeline.js').ConfidencePipeline;
   private workingMemory?: WorkingMemory;
   private contextMemoTtlMs: number;
+  /** Curia's own email address — used in thread-participants substitution (PR1-D). */
+  private selfEmail?: string;
 
   constructor(config: DispatcherConfig) {
     this.bus = config.bus;
@@ -148,6 +153,7 @@ export class Dispatcher {
     this.confidencePipeline = config.confidencePipeline;
     this.workingMemory = config.workingMemory;
     this.contextMemoTtlMs = config.contextMemoTtlMs ?? 86_400_000;
+    this.selfEmail = config.selfEmail;
 
     // Warn if the trust floor is active but no held-message service was provided — the floor
     // silently becomes a no-op in that case, which is a security-relevant degradation.
@@ -165,6 +171,16 @@ export class Dispatcher {
       clearTimeout(timer);
     }
     this.checkpointTimers.clear();
+  }
+
+  /**
+   * Curia's own email address, used in PR1-D to substitute "you" for Curia's
+   * address in thread-participants blocks. Exposed as a getter so downstream
+   * components (e.g. thread-participants formatter) can read it from the Dispatcher
+   * without needing their own copy of the config.
+   */
+  getSelfEmail(): string | undefined {
+    return this.selfEmail;
   }
 
   register(): void {

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -738,6 +738,7 @@ export class Dispatcher {
         const ccs: string[] = [];
 
         for (const p of (rawParticipants as Array<{ email: string; role: string }>).slice(0, MAX_PARTICIPANTS)) {
+          if (p.email == null) continue;  // guard: skip participants with missing email field
           const addr = sanitize(p.email);
           if (!addr) continue;
           // Replace Curia's own address with "you" for readability.

--- a/src/index.ts
+++ b/src/index.ts
@@ -858,7 +858,7 @@ async function main(): Promise<void> {
   // capability-gated declarations. outboundGateway gives email skills their send path.
   // entityContextAssembler enables entity_enrichment pre-enrichment and the
   // entity-context skill. agentContactId enables entity_enrichment default='agent'.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, actionLogRepo, confidencePipeline, timezone: config.timezone, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, actionLogRepo, confidencePipeline, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete
@@ -1104,6 +1104,7 @@ async function main(): Promise<void> {
     maxMessageBytes: yamlConfig.channels?.max_message_bytes ?? 102_400,
     confidencePipeline,
     workingMemory: memory,
+    selfEmail: resolvedEmailAccounts[0]?.selfEmail,
   });
   dispatcher.register();
 

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -83,6 +83,8 @@ export class ExecutionLayer {
   private agentContactId?: string;
   /** IANA timezone name used for normalizing offset-less timestamp inputs from the LLM. */
   private timezone: string;
+  /** Curia's own email address — used by email skills to filter self from CC lists. */
+  private selfEmail?: string;
   /** Max character length for sanitized skill output before truncation. */
   private skillOutputMaxLength: number;
 
@@ -106,6 +108,7 @@ export class ExecutionLayer {
     confidencePipeline?: import('../contacts/confidence-pipeline.js').ConfidencePipeline;
     agentContactId?: string;
     timezone?: string;
+    selfEmail?: string;
     skillOutputMaxLength?: number;
   }) {
     this.registry = registry;
@@ -129,6 +132,7 @@ export class ExecutionLayer {
     this.confidencePipeline = options?.confidencePipeline;
     this.agentContactId = options?.agentContactId;
     this.timezone = options?.timezone ?? 'UTC';
+    this.selfEmail = options?.selfEmail;
     this.skillOutputMaxLength = options?.skillOutputMaxLength ?? DEFAULT_SKILL_OUTPUT_MAX_LENGTH;
   }
 
@@ -462,6 +466,8 @@ export class ExecutionLayer {
       // Expose the configured timezone so skills can format output timestamps
       // in the user's local time. See toLocalIso() in src/time/timestamp.ts.
       timezone: this.timezone,
+      // Expose Curia's own email address so email skills can filter self from CC lists.
+      selfEmail: this.selfEmail,
     };
 
     // Capability-gated service injection.

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -191,6 +191,8 @@ export interface SkillContext {
    *  Populated from the global config timezone. Skills returning timestamps for display
    *  should use toLocalIso() with this value rather than returning raw UTC strings. */
   timezone?: string;
+  /** Curia's own email address — used by email skills to filter self from CC lists. */
+  selfEmail?: string;
   /** Action log repo — available to skills declaring 'actionLogRepo' in capabilities.
    *  Provides read/write access to the autonomy_action_log table for approval lifecycle
    *  management. Used by approve-action, deny-action, dismiss-action, list-pending-actions. */

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -864,6 +864,7 @@ describe('EmailAdapter — sendOutboundReply CC', () => {
   });
 
   it('omits CC field from send when CC list is empty after filtering', async () => {
+    // to[] only contains selfEmail (filtered out), cc[] is empty — no CC should be set.
     const threadMessage = makeMockMessage({
       from: [{ email: CEO_EMAIL }],
       to: [{ email: SELF_EMAIL }],
@@ -875,5 +876,23 @@ describe('EmailAdapter — sendOutboundReply CC', () => {
 
     const sendArg = (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(sendArg.cc).toBeUndefined();
+  });
+
+  it('includes To recipients in reply-all CC', async () => {
+    // Thread message has an extra address in to[] that is neither the primary recipient
+    // nor selfEmail — it should appear in the outbound CC (reply-all behaviour).
+    const threadMessage = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      to: [{ email: 'extra@example.com' }],
+      cc: [],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([threadMessage]);
+
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    expect(mocks.outboundGateway.send).toHaveBeenCalledWith(
+      expect.objectContaining({ cc: ['extra@example.com'] }),
+      expect.any(Object),
+    );
   });
 });

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -796,3 +796,84 @@ describe('EmailAdapter — sendWithGatedDraftFallback gated-fallback', () => {
   });
 
 });
+
+// ---------------------------------------------------------------------------
+// sendOutboundReply — CC behaviour
+// ---------------------------------------------------------------------------
+
+describe('EmailAdapter — sendOutboundReply CC', () => {
+  let mocks: ReturnType<typeof createMocks>;
+  let adapter: EmailAdapter;
+  let triggerOutbound: (event: BusEvent) => Promise<void>;
+
+  beforeEach(() => {
+    mocks = createMocks();
+    triggerOutbound = captureHandler('outbound.message', mocks);
+    adapter = makeAdapter(mocks);
+    void adapter.start();
+  });
+
+  it('includes CC recipients from the thread message in the send call', async () => {
+    const threadMessage = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      to: [{ email: SELF_EMAIL }],
+      cc: [{ email: 'cc@example.com', name: 'CC Person' }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([threadMessage]);
+
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    expect(mocks.outboundGateway.send).toHaveBeenCalledWith(
+      expect.objectContaining({ cc: ['cc@example.com'] }),
+      expect.any(Object),
+    );
+  });
+
+  it('filters selfEmail from CC recipients', async () => {
+    // Thread message has self in CC — must be excluded from outbound reply CC
+    const threadMessage = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      to: [{ email: SELF_EMAIL }],
+      cc: [{ email: SELF_EMAIL, name: 'Curia' }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([threadMessage]);
+
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    // send() should not receive a cc property (empty CC list is omitted)
+    const sendArg = (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sendArg.cc).toBeUndefined();
+  });
+
+  it('filters the primary To recipient from CC recipients', async () => {
+    // Thread message has the primary recipient (CEO_EMAIL) also in CC.
+    // This can happen in thread shapes where a participant appears in both To and CC
+    // of the fetched message. The adapter must not double-address the recipient.
+    const threadMessage = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      to: [{ email: SELF_EMAIL }],
+      cc: [{ email: CEO_EMAIL, name: 'CEO' }, { email: 'other@example.com' }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([threadMessage]);
+
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    // CEO_EMAIL is the primary To recipient — it must NOT appear in CC
+    const sendArg = (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sendArg.cc).toEqual(['other@example.com']);
+  });
+
+  it('omits CC field from send when CC list is empty after filtering', async () => {
+    const threadMessage = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      to: [{ email: SELF_EMAIL }],
+      cc: [], // no CC at all
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([threadMessage]);
+
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    const sendArg = (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sendArg.cc).toBeUndefined();
+  });
+});

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -1588,3 +1588,157 @@ describe('ceoInitiated metadata stamping', () => {
   });
 
 });
+
+// ---------------------------------------------------------------------------
+// Thread-participants block injection (PR1-D)
+// ---------------------------------------------------------------------------
+
+describe('Dispatcher — thread-participants block', () => {
+  it('injects [Thread participants] line for email with participants metadata', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'email:thread-participants-1',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Can we meet tomorrow?',
+      metadata: {
+        participants: [
+          { email: 'alice@example.com', role: 'from' },
+          { email: 'bob@example.com', role: 'to' },
+          { email: 'carol@example.com', role: 'cc' },
+        ],
+      },
+    }));
+
+    expect(tasks).toHaveLength(1);
+    const content = tasks[0]!.payload.content;
+    expect(content).toMatch(/^\[Thread participants — From: alice@example\.com; To: bob@example\.com; CC: carol@example\.com\]/);
+    expect(content).toContain('Can we meet tomorrow?');
+  });
+
+  it('substitutes selfEmail with "you" in the participants block', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+
+    const dispatcher = new Dispatcher({ bus, logger, selfEmail: 'curia@example.com' });
+    dispatcher.register();
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'email:thread-participants-self',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Looping you in.',
+      metadata: {
+        participants: [
+          { email: 'alice@example.com', role: 'from' },
+          { email: 'curia@example.com', role: 'to' },
+          { email: 'bob@example.com', role: 'cc' },
+        ],
+      },
+    }));
+
+    expect(tasks).toHaveLength(1);
+    const content = tasks[0]!.payload.content;
+    // Curia's own address replaced with "you"
+    expect(content).toContain('To: you');
+    expect(content).not.toContain('curia@example.com');
+  });
+
+  it('sanitizes participant emails containing newlines and angle brackets', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'email:thread-participants-sanitize',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'Hello',
+      metadata: {
+        participants: [
+          { email: 'alice@example.com', role: 'from' },
+          { email: 'evil\n@inject<>ed.com', role: 'to' },
+        ],
+      },
+    }));
+
+    expect(tasks).toHaveLength(1);
+    const content = tasks[0]!.payload.content;
+    // Newlines and angle brackets stripped
+    expect(content).not.toContain('\n@');
+    expect(content).not.toContain('<');
+    expect(content).not.toContain('>');
+    expect(content).toContain('To: evil@injected.com');
+  });
+
+  it('does not inject [Thread participants] when participants array is empty', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'email:thread-participants-empty',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'No participants.',
+      metadata: {
+        participants: [],
+      },
+    }));
+
+    expect(tasks).toHaveLength(1);
+    const content = tasks[0]!.payload.content;
+    expect(content).not.toContain('[Thread participants');
+    expect(content).toBe('No participants.');
+  });
+
+  it('does not inject [Thread participants] for non-email channels', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const tasks: AgentTaskEvent[] = [];
+    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'signal:conv-participants',
+      channelId: 'signal',
+      senderId: '+15551234567',
+      content: 'Signal message.',
+      metadata: {
+        participants: [
+          { email: 'alice@example.com', role: 'from' },
+          { email: 'bob@example.com', role: 'to' },
+        ],
+      },
+    }));
+
+    expect(tasks).toHaveLength(1);
+    const content = tasks[0]!.payload.content;
+    expect(content).not.toContain('[Thread participants');
+    expect(content).toBe('Signal message.');
+  });
+});

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -1594,13 +1594,18 @@ describe('ceoInitiated metadata stamping', () => {
 // ---------------------------------------------------------------------------
 
 describe('Dispatcher — thread-participants block', () => {
-  it('injects [Thread participants] line for email with participants metadata', async () => {
-    const logger = createLogger('error');
-    const bus = new EventBus(logger);
+  let logger: ReturnType<typeof createLogger>;
+  let bus: EventBus;
+  let tasks: AgentTaskEvent[];
 
-    const tasks: AgentTaskEvent[] = [];
+  beforeEach(() => {
+    logger = createLogger('error');
+    bus = new EventBus(logger);
+    tasks = [];
     bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
+  });
 
+  it('injects [Thread participants] line for email with participants metadata', async () => {
     const dispatcher = new Dispatcher({ bus, logger });
     dispatcher.register();
 
@@ -1625,12 +1630,6 @@ describe('Dispatcher — thread-participants block', () => {
   });
 
   it('substitutes selfEmail with "you" in the participants block', async () => {
-    const logger = createLogger('error');
-    const bus = new EventBus(logger);
-
-    const tasks: AgentTaskEvent[] = [];
-    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
-
     const dispatcher = new Dispatcher({ bus, logger, selfEmail: 'curia@example.com' });
     dispatcher.register();
 
@@ -1656,12 +1655,6 @@ describe('Dispatcher — thread-participants block', () => {
   });
 
   it('sanitizes participant emails containing newlines and angle brackets', async () => {
-    const logger = createLogger('error');
-    const bus = new EventBus(logger);
-
-    const tasks: AgentTaskEvent[] = [];
-    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
-
     const dispatcher = new Dispatcher({ bus, logger });
     dispatcher.register();
 
@@ -1688,12 +1681,6 @@ describe('Dispatcher — thread-participants block', () => {
   });
 
   it('does not inject [Thread participants] when participants array is empty', async () => {
-    const logger = createLogger('error');
-    const bus = new EventBus(logger);
-
-    const tasks: AgentTaskEvent[] = [];
-    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
-
     const dispatcher = new Dispatcher({ bus, logger });
     dispatcher.register();
 
@@ -1713,13 +1700,25 @@ describe('Dispatcher — thread-participants block', () => {
     expect(content).toBe('No participants.');
   });
 
+  it('does not inject [Thread participants] when metadata.participants is absent', async () => {
+    const dispatcher = new Dispatcher({ bus, logger });
+    dispatcher.register();
+
+    await bus.publish('channel', createInboundMessage({
+      conversationId: 'email:thread-participants-absent',
+      channelId: 'email',
+      senderId: 'alice@example.com',
+      content: 'No participants key at all.',
+      metadata: { someOtherField: true },
+    }));
+
+    expect(tasks).toHaveLength(1);
+    const content = tasks[0]!.payload.content;
+    expect(content).not.toContain('[Thread participants');
+    expect(content).toBe('No participants key at all.');
+  });
+
   it('does not inject [Thread participants] for non-email channels', async () => {
-    const logger = createLogger('error');
-    const bus = new EventBus(logger);
-
-    const tasks: AgentTaskEvent[] = [];
-    bus.subscribe('agent.task', 'agent', (e) => tasks.push(e as AgentTaskEvent));
-
     const dispatcher = new Dispatcher({ bus, logger });
     dispatcher.register();
 

--- a/tests/unit/skills/email-reply.test.ts
+++ b/tests/unit/skills/email-reply.test.ts
@@ -115,3 +115,132 @@ describe('EmailReplyHandler', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// CC modes — reply-all, reply-to-sender, explicit CC list
+// ---------------------------------------------------------------------------
+
+describe('EmailReplyHandler — CC modes', () => {
+  const handler = new EmailReplyHandler();
+
+  /** Extended makeCtx that supports selfEmail for CC filtering. */
+  function makeCtxWithSelf(
+    input: Record<string, unknown>,
+    gateway: Partial<{
+      getEmailMessage: (...args: unknown[]) => unknown;
+      send: (...args: unknown[]) => unknown;
+    }>,
+    selfEmail?: string,
+  ): SkillContext {
+    return {
+      input,
+      secret: () => { throw new Error('no secrets'); },
+      log: logger,
+      outboundGateway: gateway as never,
+      taskMetadata: {},
+      selfEmail,
+    } as SkillContext;
+  }
+
+  it('cc absent (undefined) — auto-populates from original to/cc, excluding primary To and selfEmail', async () => {
+    const gateway = {
+      getEmailMessage: vi.fn().mockResolvedValue({
+        from: [{ email: 'sender@example.com' }],
+        to: [{ email: 'curia@example.com' }, { email: 'bob@example.com' }],
+        cc: [{ email: 'carol@example.com' }],
+        subject: 'Group thread',
+      }),
+      send: vi.fn().mockResolvedValue({ success: true, messageId: 'sent-cc-1' }),
+    };
+
+    // cc is NOT in the input — triggers reply-all mode
+    const result = await handler.execute(
+      makeCtxWithSelf(
+        { reply_to_message_id: 'msg-group', body: 'Sounds good' },
+        gateway,
+        'curia@example.com',
+      ),
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { cc: string };
+      // sender@example.com is excluded (primary To recipient), curia@example.com is excluded (selfEmail)
+      // bob@example.com and carol@example.com remain
+      expect(data.cc).toBe('bob@example.com, carol@example.com');
+    }
+
+    // Verify the send call received the CC array
+    expect(gateway.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cc: ['bob@example.com', 'carol@example.com'],
+      }),
+    );
+  });
+
+  it('cc === "" — reply to sender only, no CC', async () => {
+    const gateway = {
+      getEmailMessage: vi.fn().mockResolvedValue({
+        from: [{ email: 'sender@example.com' }],
+        to: [{ email: 'curia@example.com' }, { email: 'bob@example.com' }],
+        cc: [{ email: 'carol@example.com' }],
+        subject: 'Group thread',
+      }),
+      send: vi.fn().mockResolvedValue({ success: true, messageId: 'sent-cc-2' }),
+    };
+
+    // cc is explicitly empty string — reply to sender only
+    const result = await handler.execute(
+      makeCtxWithSelf(
+        { reply_to_message_id: 'msg-group', body: 'Private reply', cc: '' },
+        gateway,
+        'curia@example.com',
+      ),
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { cc: string };
+      expect(data.cc).toBe('');
+    }
+
+    // Verify the send call does NOT include a cc property
+    const sendArg = (gateway.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sendArg).not.toHaveProperty('cc');
+  });
+
+  it('cc is explicit comma-separated list — used as-is', async () => {
+    const gateway = {
+      getEmailMessage: vi.fn().mockResolvedValue({
+        from: [{ email: 'sender@example.com' }],
+        to: [{ email: 'curia@example.com' }],
+        cc: [],
+        subject: 'Forwarded',
+      }),
+      send: vi.fn().mockResolvedValue({ success: true, messageId: 'sent-cc-3' }),
+    };
+
+    // Explicit CC list overrides all auto-population logic
+    const result = await handler.execute(
+      makeCtxWithSelf(
+        { reply_to_message_id: 'msg-fwd', body: 'Adding you both', cc: 'a@example.com,b@example.com' },
+        gateway,
+        'curia@example.com',
+      ),
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { cc: string };
+      // join(', ') produces a space after each comma
+      expect(data.cc).toBe('a@example.com, b@example.com');
+    }
+
+    // Verify the send call received the explicit CC array
+    expect(gateway.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cc: ['a@example.com', 'b@example.com'],
+      }),
+    );
+  });
+});

--- a/tests/unit/skills/email-reply.test.ts
+++ b/tests/unit/skills/email-reply.test.ts
@@ -12,6 +12,7 @@ function makeCtx(
     send: (...args: unknown[]) => unknown;
   }>,
   taskMetadata?: Record<string, unknown>,
+  opts?: { selfEmail?: string },
 ): SkillContext {
   return {
     input,
@@ -19,7 +20,8 @@ function makeCtx(
     log: logger,
     outboundGateway: gateway as never,
     taskMetadata,
-  };
+    ...(opts?.selfEmail ? { selfEmail: opts.selfEmail } : {}),
+  } as SkillContext;
 }
 
 describe('EmailReplyHandler', () => {
@@ -123,7 +125,7 @@ describe('EmailReplyHandler', () => {
 describe('EmailReplyHandler — CC modes', () => {
   const handler = new EmailReplyHandler();
 
-  /** Extended makeCtx that supports selfEmail for CC filtering. */
+  /** Delegates to makeCtx with selfEmail support. */
   function makeCtxWithSelf(
     input: Record<string, unknown>,
     gateway: Partial<{
@@ -132,14 +134,7 @@ describe('EmailReplyHandler — CC modes', () => {
     }>,
     selfEmail?: string,
   ): SkillContext {
-    return {
-      input,
-      secret: () => { throw new Error('no secrets'); },
-      log: logger,
-      outboundGateway: gateway as never,
-      taskMetadata: {},
-      selfEmail,
-    } as SkillContext;
+    return makeCtx(input, gateway, {}, { selfEmail });
   }
 
   it('cc absent (undefined) — auto-populates from original to/cc, excluding primary To and selfEmail', async () => {
@@ -164,7 +159,10 @@ describe('EmailReplyHandler — CC modes', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { cc: string };
+      const data = result.data as { message_id: string; to: string; subject: string; cc: string };
+      expect(data.message_id).toBe('sent-cc-1');
+      expect(data.to).toBe('sender@example.com');
+      expect(data.subject).toBe('Re: Group thread');
       // sender@example.com is excluded (primary To recipient), curia@example.com is excluded (selfEmail)
       // bob@example.com and carol@example.com remain
       expect(data.cc).toBe('bob@example.com, carol@example.com');
@@ -200,7 +198,10 @@ describe('EmailReplyHandler — CC modes', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { cc: string };
+      const data = result.data as { message_id: string; to: string; subject: string; cc: string };
+      expect(data.message_id).toBe('sent-cc-2');
+      expect(data.to).toBe('sender@example.com');
+      expect(data.subject).toBe('Re: Group thread');
       expect(data.cc).toBe('');
     }
 
@@ -231,7 +232,10 @@ describe('EmailReplyHandler — CC modes', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { cc: string };
+      const data = result.data as { message_id: string; to: string; subject: string; cc: string };
+      expect(data.message_id).toBe('sent-cc-3');
+      expect(data.to).toBe('sender@example.com');
+      expect(data.subject).toBe('Re: Forwarded');
       // join(', ') produces a space after each comma
       expect(data.cc).toBe('a@example.com, b@example.com');
     }


### PR DESCRIPTION
## Summary

Closes #125.

Curia previously sent all email replies to the sender only — no CC awareness, no visibility into who else was on a thread. This PR fixes both: the coordinator now sees who's on every thread, and both reply paths default to reply-all with proper self-filtering.

### What changed

- **`email-reply` skill** — new optional `cc` input with three modes:
  - Omit `cc` (default): auto-populates CC from original `to[]` + `cc[]`, filtering Curia's own address and the primary To recipient
  - `cc: ""`: reply to sender only
  - `cc: "a@,b@"`: explicit comma-separated override
  - `skill.json` version bumped `1.0.0 → 1.1.0`

- **`sendOutboundReply`** (implicit reply path in `email-adapter.ts`) — now collects CC from `threadMessage.to[]` and `threadMessage.cc[]`, filtering self and the primary To recipient. Both arrays null-coalesced for safety.

- **Thread-participants block** — injected at the top of every inbound email task in the dispatcher: `[Thread participants — From: x; To: y; CC: z]`. Curia's own address shows as "you". Participant emails are sanitized (strips `\n\r[]<>`) and capped at 15 entries. Null-guarded against missing `email` fields.

- **`SkillContext`** — gains `selfEmail?: string` (public API surface). Threaded through `ExecutionLayer` and `src/index.ts`.

- **Coordinator prompt** — new `### To / CC etiquette` subsection documenting the `[Thread participants]` block, reply-all as default, and how to use `cc: ""` for sender-only replies.

### Test plan

- [x] `email-reply` handler: 3 new CC-mode cases (auto reply-all, sender-only, explicit list)
- [x] Dispatcher: 6 new thread-participants cases (happy path, selfEmail substitution, sanitization, empty array, absent metadata, non-email channel)
- [x] `sendOutboundReply`: 5 new cases (CC included, selfEmail filtered, recipientEmail filtered, To recipients included in reply-all, empty CC omitted)
- [x] `npm test` — 2013 passing (2 pre-existing DB-only integration tests require `DATABASE_URL`)
- [x] `npm run typecheck` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Thread participants now displayed in email context showing From/To/CC with self identified as "you"
  * email-reply skill now defaults to reply-all mode; use `cc: ""` for sender-only replies or provide comma-separated list to specify custom recipients

* **Documentation**
  * Updated CHANGELOG and email-reply skill descriptions with new recipient handling details

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/501)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->