### PR TITLE
chore: release v0.26.0 — In the Record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,31 +13,39 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+---
+
+## [0.26.0] — 2026-05-10 — "In the Record"
+
 ### Added
-- **Non-threaded channel context bridging** — dispatch layer writes outbound context memos to working memory on non-threaded channels (Signal, CLI, HTTP) and injects them as a preamble when the user replies, so the coordinator knows what it last said. Coordinator prompt gains a channel-agnostic clarification gate for reply-shaped messages without context (#431)
-- **Contact confidence scoring pipeline** — `contact_confidence` is now updated on each qualifying event (inbound/outbound message, CEO trust grant, verified identity pairing). Supports incremental and full-recompute modes with convergence guarantee (spec 06, #460)
-- **`contact-register` skill** — integration point for agents that read channels directly (e.g. the ceo-inbox agent) rather than through the dispatcher. Resolves or creates contacts, updates `last_seen_at`, triggers a confidence scoring delta, and emits a `contact.resolved` bus event (#485)
-- **MCP `fixed_inputs`** — MCP server entries in `skills.yaml` now support a `fixed_inputs` field that binds constant parameter values at the tool layer. Values are resolved from env vars or literals at startup, stripped from tool schemas (invisible to agents), and merged into every `callTool` invocation (#432)
-- **Thread-participants block** injected into LLM context for all inbound email tasks, showing From / To / CC with self displayed as "you"
+
+- **Contact confidence scoring pipeline** — `contact_confidence` is now updated on each qualifying event (inbound message, outbound message, CEO trust grant, verified identity pairing) rather than being set by fiat. Supports incremental updates per event and full-recompute on demand with a convergence guarantee. Replaces the `setTrustLevel('high')` band-aid in the outbound gateway. (spec 06, #460)
+- **`contact-register` skill** — agents that read channels directly (e.g. the ceo-inbox agent) can now call this skill to resolve or create a contact, update `last_seen_at`, trigger a confidence delta, and emit a `contact.resolved` bus event. (#485)
+- **MCP `fixed_inputs`** — MCP server entries in `skills.yaml` now accept a `fixed_inputs` map that binds constant parameter values at startup. Values are resolved from env vars or literals, stripped from tool schemas (invisible to agents), and merged into every `callTool` invocation. Useful for per-server identity data (e.g. which Google Workspace account to use) without polluting the agent's input space. (#432)
+- **Non-threaded channel context bridging** — the dispatch layer writes outbound context memos to working memory after each response on non-threaded channels (Signal, CLI, HTTP) and injects them as a preamble when the user replies. Eliminates "what are you referring to?" on Signal follow-ups. The coordinator gains a channel-agnostic clarification gate for reply-shaped messages without context. (#431)
+- **Thread-participants block** — inbound email tasks now include a structured From / To / CC block in LLM context, with Curia's own address shown as "you", giving the coordinator unambiguous context on CC'd threads.
 
 ### Changed
-- **Bullpen context refresh in tool-use loop** — `AgentRuntime` now re-fetches pending Bullpen threads before every `chatWithRetry` call, not just once at task start. Replies and closures that occur mid-task are visible to the model on the next loop iteration (#213)
-- **`contact.resolved` bus event** — `sourceLayer` widened from `'dispatch'` to `'dispatch' | 'execution'`; `createContactResolved()` factory accepts an optional `sourceLayer` parameter (defaults to `'dispatch'` for backward compatibility). This is a public API surface change.
-- **`IdentitySource`** — new value `'agent_called'` for contacts registered by agents outside the normal dispatcher pipeline
-- **Outbound gateway** — removed `setTrustLevel('high')` band-aid; outbound sends now trigger the confidence scoring pipeline instead, giving contacts a real `contact_confidence` value
-- **Smoke tests** — renamed three `email-triage-*` test cases to `email-prioritization-*` following the CEO inbox redesign; updated the `email-triage` tag to `email-prioritization` in each
-- **ADR-017** — added a note that observation mode has been removed since this ADR was written (v0.25.x, CEO inbox redesign)
-- **email-reply skill** now defaults to reply-all; pass `cc: ""` to reply to sender only, or a comma-separated list to override recipients explicitly
-- **sendOutboundReply** (implicit reply path) now includes CC recipients from the thread message by default, filtering self and the primary To recipient
-- **SkillContext** gains `selfEmail?: string` field (public API surface — skills can use this to filter self from CC lists)
+
+- **`email-reply` defaults to reply-all** — pass `cc: ""` to reply to sender only, or a comma-separated list to override recipients explicitly. `sendOutboundReply` (implicit reply path) now includes CC recipients by default, filtering self and the primary To recipient. `SkillContext` gains `selfEmail?: string` so skills can filter Curia's own address from CC lists. *(Public API surface change.)*
+- **Bullpen context refresh** — `AgentRuntime` re-fetches pending Bullpen threads before every `chatWithRetry` call, not just at task start. Replies and closures that arrive mid-task are visible to the model on the next iteration. (#213)
+- **`contact.resolved` bus event** — `sourceLayer` widened from `'dispatch'` to `'dispatch' | 'execution'`; `createContactResolved()` factory accepts an optional `sourceLayer` parameter (defaults to `'dispatch'`). `IdentitySource` gains new value `'agent_called'`. *(Public API surface changes.)*
+- **Google Workspace identity** — removed the `channel_accounts.google_workspace` config block and `googleWorkspaceAccounts` system-prompt injection; account identity now supplied via `fixed_inputs` on the MCP server config entry. (#432)
 
 ### Fixed
-- **Trust floor confirmed-contact exemption** — confirmed contacts with `contact_confidence=0` and no `trust_level` override are no longer incorrectly held by the trust floor; the floor now exempts contacts with `status='confirmed'` since they have passed explicit CEO approval.
-- **extract-facts rate-limit handling** — the per-fact loop now breaks immediately when `storeFact` returns `action:'rate_limited'`, logs at `error` level, and counts the fact as `failed`; previously all rate-limited facts were silently collapsed into the warn log alongside contradictions with no aggregate signal.
-- **extract-facts catch scope** — `subject` and `attribute` are now declared before the per-fact `try` block so the `catch` block can always reference them; previously a `ReferenceError` could mask the original error if an exception fired before those `const` declarations ran.
+
+- **Trust floor confirmed-contact exemption** — confirmed contacts with `contact_confidence=0` and no explicit `trust_level` override are no longer incorrectly held by the trust floor; the floor exempts all contacts with `status='confirmed'`.
+- **`extract-facts` reliability** — rate-limited facts now break the per-fact loop immediately and log at `error` level instead of silently collapsing into the contradiction warn log; variable declarations moved before the try block so the catch can always reference `subject` and `attribute`. (#470)
 
 ### Removed
-- **Google Workspace prompt injection** — removed the `googleWorkspaceAccounts` system prompt injection block, the `channel_accounts.google_workspace` config schema, and all related types/wiring. Google Workspace account identity is now handled via `fixed_inputs` on the MCP server config (#432)
+
+- **Google Workspace prompt injection** — `googleWorkspaceAccounts` system prompt block, `channel_accounts.google_workspace` config schema, and all related types. Account identity moves to `fixed_inputs`. (#432)
+
+---
+
+*each exchange is logged —*
+*confidence built from the count;*
+*the record holds true.*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.25.1-blueviolet" alt="Version: 0.25.1" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.26.0-blueviolet" alt="Version: 0.26.0" /></a>
   <img src="https://img.shields.io/badge/status-pre--alpha-orange" alt="Status: Pre-Alpha" />
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License: MIT" />
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node >= 22" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "packageManager": "pnpm@11.0.8",


### PR DESCRIPTION
## v0.26.0 — "In the Record"

### Added

- **Contact confidence scoring pipeline** — `contact_confidence` is now updated on each qualifying event (inbound message, outbound message, CEO trust grant, verified identity pairing) rather than being set by fiat. Supports incremental updates per event and full-recompute on demand with a convergence guarantee. Replaces the `setTrustLevel('high')` band-aid in the outbound gateway. (spec 06, #460)
- **`contact-register` skill** — agents that read channels directly (e.g. the ceo-inbox agent) can now call this skill to resolve or create a contact, update `last_seen_at`, trigger a confidence delta, and emit a `contact.resolved` bus event. (#485)
- **MCP `fixed_inputs`** — MCP server entries in `skills.yaml` now accept a `fixed_inputs` map that binds constant parameter values at startup. Values are resolved from env vars or literals, stripped from tool schemas (invisible to agents), and merged into every `callTool` invocation. Useful for per-server identity data (e.g. which Google Workspace account to use) without polluting the agent's input space. (#432)
- **Non-threaded channel context bridging** — the dispatch layer writes outbound context memos to working memory after each response on non-threaded channels (Signal, CLI, HTTP) and injects them as a preamble when the user replies. Eliminates "what are you referring to?" on Signal follow-ups. The coordinator gains a channel-agnostic clarification gate for reply-shaped messages without context. (#431)
- **Thread-participants block** — inbound email tasks now include a structured From / To / CC block in LLM context, with Curia's own address shown as "you", giving the coordinator unambiguous context on CC'd threads.

### Changed

- **`email-reply` defaults to reply-all** — pass `cc: ""` to reply to sender only, or a comma-separated list to override recipients explicitly. `sendOutboundReply` (implicit reply path) now includes CC recipients by default, filtering self and the primary To recipient. `SkillContext` gains `selfEmail?: string` so skills can filter Curia's own address from CC lists. *(Public API surface change.)*
- **Bullpen context refresh** — `AgentRuntime` re-fetches pending Bullpen threads before every `chatWithRetry` call, not just at task start. Replies and closures that arrive mid-task are visible to the model on the next iteration. (#213)
- **`contact.resolved` bus event** — `sourceLayer` widened from `'dispatch'` to `'dispatch' | 'execution'`; `createContactResolved()` factory accepts an optional `sourceLayer` parameter (defaults to `'dispatch'`). `IdentitySource` gains new value `'agent_called'`. *(Public API surface changes.)*
- **Google Workspace identity** — removed the `channel_accounts.google_workspace` config block and `googleWorkspaceAccounts` system-prompt injection; account identity now supplied via `fixed_inputs` on the MCP server config entry. (#432)

### Fixed

- **Trust floor confirmed-contact exemption** — confirmed contacts with `contact_confidence=0` and no explicit `trust_level` override are no longer incorrectly held by the trust floor; the floor exempts all contacts with `status='confirmed'`.
- **`extract-facts` reliability** — rate-limited facts now break the per-fact loop immediately and log at `error` level instead of silently collapsing into the contradiction warn log; variable declarations moved before the try block so the catch can always reference `subject` and `attribute`. (#470)

### Removed

- **Google Workspace prompt injection** — `googleWorkspaceAccounts` system prompt block, `channel_accounts.google_workspace` config schema, and all related types. Account identity moves to `fixed_inputs`. (#432)

---

*each exchange is logged —*
*confidence built from the count;*
*the record holds true.*