### PR TITLE
feat: date-resolve skill + coordinator scheduling behavior

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -13,6 +13,12 @@ system_prompt: |
   user can confirm you understood correctly.
   The current date, time, and timezone are injected at the top of each turn.
 
+  IMPORTANT: You are unreliable at day-of-week arithmetic — all LLMs are. When
+  you need to state a day-of-week for a specific date (or vice versa), call
+  date-resolve to verify. Never write "Monday May 19" without confirming that
+  May 19 is actually a Monday. Getting a date wrong in an email is embarrassing
+  and creates scheduling confusion.
+
   ## Your Identity
   Your contact ID is ${agent_contact_id}. Use this when "you" or "your" clearly refers
   to you as the agent (e.g. "what's your calendar look like?"). This is the ONLY contact
@@ -408,6 +414,27 @@ system_prompt: |
   calendar I don't recognize yet — [name]. Who does this belong to?" Then
   register it with the correct contact based on their answer.
 
+  ## Scheduling Behavior
+  When negotiating meeting times — whether replying to an email, composing a
+  new message, or responding on the CLI:
+
+  1. **Be specific.** Always propose a concrete date AND time (e.g. "Monday
+     May 18 at 10:30 AM"). Never say "before 2pm" or "in the morning" — pick
+     a slot. If someone asks you to suggest times, suggest times — don't offer
+     to suggest times later.
+
+  2. **Offer alternatives.** Propose a primary time and one backup on a
+     different day. Two options reduces round-trips without overwhelming.
+
+  3. **Respect constraints.** If the other party said "Monday/Wednesday/Friday
+     before 2pm", only propose times within those bounds.
+
+  4. **Verify dates.** Call date-resolve to confirm every date + day-of-week
+     pair before writing it.
+
+  5. **Defaults.** 30-minute meetings unless context suggests otherwise. Prefer
+     mid-morning (9:30-11:30 AM) when no time preference is stated.
+
   ${executive_voice_block}
 
   ## Account Identity for Tool Calls
@@ -557,6 +584,7 @@ pinned_skills:
   - calendar-delete-event
   - calendar-find-free-time
   - calendar-check-conflicts
+  - date-resolve
   - get-autonomy
   - set-autonomy
   - query-relationships

--- a/skills/date-resolve/handler.test.ts
+++ b/skills/date-resolve/handler.test.ts
@@ -3,7 +3,7 @@
 // Tests for the date-resolve skill. All tests are pure computation —
 // no mocks, no external services.
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { DateResolveHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 import { DateTime, Settings } from 'luxon';

--- a/skills/date-resolve/handler.test.ts
+++ b/skills/date-resolve/handler.test.ts
@@ -287,4 +287,25 @@ describe('DateResolveHandler', () => {
       expect(data).not.toHaveProperty('expected_day');
     }
   });
+
+  it('includes displayTimezone when timezone is set', async () => {
+    const result = await handler.execute(makeCtx({ date: '2026-05-19' }, 'America/Toronto'));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as Record<string, unknown>;
+      expect(typeof data.displayTimezone).toBe('string');
+      expect(data.displayTimezone).toMatch(/UTC/);
+    }
+  });
+
+  it('sets displayTimezone to null when timezone is not configured', async () => {
+    const ctx = makeCtx({ date: '2026-05-19' });
+    (ctx as Record<string, unknown>).timezone = undefined;
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as Record<string, unknown>;
+      expect(data.displayTimezone).toBeNull();
+    }
+  });
 });

--- a/skills/date-resolve/handler.test.ts
+++ b/skills/date-resolve/handler.test.ts
@@ -1,0 +1,290 @@
+// skills/date-resolve/handler.test.ts
+//
+// Tests for the date-resolve skill. All tests are pure computation —
+// no mocks, no external services.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DateResolveHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import { DateTime, Settings } from 'luxon';
+import pino from 'pino';
+
+function makeCtx(input: Record<string, unknown>, timezone = 'America/Toronto'): SkillContext {
+  return {
+    input,
+    timezone,
+    log: pino({ level: 'silent' }),
+  } as unknown as SkillContext;
+}
+
+const handler = new DateResolveHandler();
+
+describe('DateResolveHandler', () => {
+  // ── Input validation ─────────────────────────────────────────────────────
+
+  it('returns error when neither date nor relative is provided', async () => {
+    const result = await handler.execute(makeCtx({}));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/date.*relative/i);
+  });
+
+  it('returns error for unparseable date', async () => {
+    const result = await handler.execute(makeCtx({ date: 'not-a-date' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/could not parse/i);
+  });
+
+  it('returns error for unrecognized relative expression', async () => {
+    const result = await handler.execute(makeCtx({ relative: 'sometime next week maybe' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/could not resolve/i);
+  });
+
+  it('returns error for invalid expected_day name', async () => {
+    const result = await handler.execute(makeCtx({ date: '2026-05-19', expected_day: 'Funday' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/unrecognized day/i);
+  });
+
+  // ── Date lookup (absolute date → day-of-week) ───────────────────────────
+
+  it('resolves ISO date to correct day-of-week', async () => {
+    const result = await handler.execute(makeCtx({ date: '2026-05-19' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        date: '2026-05-19',
+        day_of_week: 'Tuesday',
+        formatted: 'Tuesday, May 19, 2026',
+      });
+    }
+  });
+
+  it('resolves natural date format "May 19, 2026"', async () => {
+    const result = await handler.execute(makeCtx({ date: 'May 19, 2026' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        date: '2026-05-19',
+        day_of_week: 'Tuesday',
+      });
+    }
+  });
+
+  it('resolves natural date without comma "May 19 2026"', async () => {
+    const result = await handler.execute(makeCtx({ date: 'May 19 2026' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({ date: '2026-05-19', day_of_week: 'Tuesday' });
+    }
+  });
+
+  it('resolves abbreviated month "May 7, 2026"', async () => {
+    // May 7, 2026 is a Thursday (the date from the real incident)
+    const result = await handler.execute(makeCtx({ date: 'May 7, 2026' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        date: '2026-05-07',
+        day_of_week: 'Thursday',
+        formatted: 'Thursday, May 7, 2026',
+      });
+    }
+  });
+
+  it('resolves US slash format "05/19/2026"', async () => {
+    const result = await handler.execute(makeCtx({ date: '05/19/2026' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({ date: '2026-05-19', day_of_week: 'Tuesday' });
+    }
+  });
+
+  // ── Verification mode ────────────────────────────────────────────────────
+
+  it('verifies correct date + day-of-week pairing', async () => {
+    const result = await handler.execute(makeCtx({ date: '2026-05-19', expected_day: 'Tuesday' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        correct: true,
+        expected_day: 'Tuesday',
+        day_of_week: 'Tuesday',
+      });
+    }
+  });
+
+  it('catches incorrect date + day-of-week pairing', async () => {
+    // This is the exact error from the May 7 incident: "Monday May 19"
+    const result = await handler.execute(makeCtx({ date: '2026-05-19', expected_day: 'Monday' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({
+        correct: false,
+        expected_day: 'Monday',
+        day_of_week: 'Tuesday',
+      });
+    }
+  });
+
+  it('handles case-insensitive expected_day', async () => {
+    const result = await handler.execute(makeCtx({ date: '2026-05-19', expected_day: 'tuesday' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({ correct: true, expected_day: 'Tuesday' });
+    }
+  });
+
+  // ── Relative date resolution ─────────────────────────────────────────────
+
+  describe('relative expressions (anchored to Thu May 7, 2026)', () => {
+    // Compute the fixed timestamp once outside the mock to avoid infinite recursion
+    // (Settings.now → DateTime.fromISO → Settings.now → …)
+    const fixedMs = DateTime.fromISO('2026-05-07T12:00:00', { zone: 'America/Toronto' }).toMillis();
+
+    beforeEach(() => {
+      Settings.now = () => fixedMs;
+    });
+
+    afterEach(() => {
+      Settings.now = () => Date.now();
+    });
+
+    it('"next Monday" → Monday May 11, 2026', async () => {
+      const result = await handler.execute(makeCtx({ relative: 'next Monday' }));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toMatchObject({
+          date: '2026-05-11',
+          day_of_week: 'Monday',
+          formatted: 'Monday, May 11, 2026',
+        });
+      }
+    });
+
+    it('"next Thursday" → Thursday May 14 (not today)', async () => {
+      // "next Thursday" when today is Thursday should go to next week
+      const result = await handler.execute(makeCtx({ relative: 'next Thursday' }));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toMatchObject({ date: '2026-05-14', day_of_week: 'Thursday' });
+      }
+    });
+
+    it('"this Monday" → Monday May 4 (earlier this week)', async () => {
+      // May 7 is Thursday → Monday of this ISO week is May 4
+      const result = await handler.execute(makeCtx({ relative: 'this Monday' }));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toMatchObject({ date: '2026-05-04', day_of_week: 'Monday' });
+      }
+    });
+
+    it('"this Friday" → Friday May 8 (tomorrow)', async () => {
+      const result = await handler.execute(makeCtx({ relative: 'this Friday' }));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toMatchObject({ date: '2026-05-08', day_of_week: 'Friday' });
+      }
+    });
+
+    it('"Monday of the week of May 18" → Monday May 18', async () => {
+      const result = await handler.execute(makeCtx({ relative: 'Monday of the week of May 18, 2026' }));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toMatchObject({ date: '2026-05-18', day_of_week: 'Monday' });
+      }
+    });
+
+    it('"Wednesday of the week of May 18" → Wednesday May 20', async () => {
+      const result = await handler.execute(makeCtx({ relative: 'Wednesday of the week of May 18, 2026' }));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toMatchObject({ date: '2026-05-20', day_of_week: 'Wednesday' });
+      }
+    });
+
+    it('"Friday of the week of May 18" → Friday May 22', async () => {
+      const result = await handler.execute(makeCtx({ relative: 'Friday of the week of May 18, 2026' }));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toMatchObject({ date: '2026-05-22', day_of_week: 'Friday' });
+      }
+    });
+
+    it('"Monday after May 15" → Monday May 18', async () => {
+      const result = await handler.execute(makeCtx({ relative: 'Monday after May 15, 2026' }));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toMatchObject({ date: '2026-05-18', day_of_week: 'Monday' });
+      }
+    });
+
+    it('"Friday after May 15" → Friday May 22 (May 15 is a Friday, so skip to next)', async () => {
+      const result = await handler.execute(makeCtx({ relative: 'Friday after May 15, 2026' }));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toMatchObject({ date: '2026-05-22', day_of_week: 'Friday' });
+      }
+    });
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────────────
+
+  it('handles month boundary (May 31 → June 1)', async () => {
+    const result = await handler.execute(makeCtx({ date: '2026-05-31' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({ date: '2026-05-31', day_of_week: 'Sunday' });
+    }
+
+    const next = await handler.execute(makeCtx({ date: '2026-06-01' }));
+    expect(next.success).toBe(true);
+    if (next.success) {
+      expect(next.data).toMatchObject({ date: '2026-06-01', day_of_week: 'Monday' });
+    }
+  });
+
+  it('handles year boundary (Dec 31, 2026 → Jan 1, 2027)', async () => {
+    const dec31 = await handler.execute(makeCtx({ date: '2026-12-31' }));
+    expect(dec31.success).toBe(true);
+    if (dec31.success) {
+      expect(dec31.data).toMatchObject({ date: '2026-12-31', day_of_week: 'Thursday' });
+    }
+
+    const jan1 = await handler.execute(makeCtx({ date: '2027-01-01' }));
+    expect(jan1.success).toBe(true);
+    if (jan1.success) {
+      expect(jan1.data).toMatchObject({ date: '2027-01-01', day_of_week: 'Friday' });
+    }
+  });
+
+  it('handles leap year (Feb 29, 2028)', async () => {
+    const result = await handler.execute(makeCtx({ date: '2028-02-29' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject({ date: '2028-02-29', day_of_week: 'Tuesday' });
+    }
+  });
+
+  it('falls back to UTC when timezone is not set', async () => {
+    const ctx = makeCtx({ date: '2026-05-19' });
+    (ctx as Record<string, unknown>).timezone = undefined;
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Day-of-week should still be correct — dates don't change with timezone
+      expect(result.data).toMatchObject({ date: '2026-05-19', day_of_week: 'Tuesday' });
+    }
+  });
+
+  it('does not include correct/expected_day when expected_day is not provided', async () => {
+    const result = await handler.execute(makeCtx({ date: '2026-05-19' }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as Record<string, unknown>;
+      expect(data).not.toHaveProperty('correct');
+      expect(data).not.toHaveProperty('expected_day');
+    }
+  });
+});

--- a/skills/date-resolve/handler.ts
+++ b/skills/date-resolve/handler.ts
@@ -7,7 +7,7 @@
 //
 // Pure computation using luxon. No external services, no side effects.
 
-import { DateTime, Info } from 'luxon';
+import { DateTime } from 'luxon';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 
 /** Canonical day names for matching against user input. */

--- a/skills/date-resolve/handler.ts
+++ b/skills/date-resolve/handler.ts
@@ -1,0 +1,170 @@
+// skills/date-resolve/handler.ts
+//
+// Deterministic date resolution and verification. LLMs are unreliable at
+// day-of-week arithmetic — this skill provides a tool they can call to
+// verify date + day-of-week pairings or resolve relative expressions
+// ("next Monday", "this Friday") to absolute dates.
+//
+// Pure computation using luxon. No external services, no side effects.
+
+import { DateTime, Info } from 'luxon';
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+/** Canonical day names for matching against user input. */
+const DAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'] as const;
+type DayName = (typeof DAY_NAMES)[number];
+
+/** Map lowercase day name to luxon weekday number (1=Monday … 7=Sunday). */
+const DAY_TO_WEEKDAY: Record<string, number> = {};
+for (let i = 0; i < DAY_NAMES.length; i++) {
+  DAY_TO_WEEKDAY[DAY_NAMES[i].toLowerCase()] = i + 1;
+}
+
+/**
+ * Try to parse a date string in various formats. Returns a valid DateTime or null.
+ * Supports:
+ *   - ISO: "2026-05-19"
+ *   - Natural: "May 19, 2026" / "May 19 2026"
+ *   - US-ish: "05/19/2026"
+ */
+function parseDate(raw: string, timezone: string): DateTime | null {
+  const trimmed = raw.trim();
+
+  // ISO date (yyyy-MM-dd)
+  const iso = DateTime.fromISO(trimmed, { zone: timezone });
+  if (iso.isValid) return iso.startOf('day');
+
+  // "May 19, 2026" or "May 19 2026"
+  for (const fmt of ['MMMM d, yyyy', 'MMMM d yyyy', 'MMM d, yyyy', 'MMM d yyyy']) {
+    const dt = DateTime.fromFormat(trimmed, fmt, { zone: timezone });
+    if (dt.isValid) return dt.startOf('day');
+  }
+
+  // "05/19/2026"
+  const slashed = DateTime.fromFormat(trimmed, 'MM/dd/yyyy', { zone: timezone });
+  if (slashed.isValid) return slashed.startOf('day');
+
+  return null;
+}
+
+/**
+ * Resolve a relative date expression to an absolute date.
+ *
+ * Supported patterns:
+ *   - "next Monday", "next Friday"          → the coming occurrence (never today)
+ *   - "this Monday", "this Friday"          → this week's occurrence (may be today or past)
+ *   - "Monday of the week of May 18"        → the Monday of the week containing May 18
+ *   - "Monday after May 15"                 → the first Monday strictly after May 15
+ */
+function resolveRelative(raw: string, now: DateTime, timezone: string): DateTime | null {
+  const lower = raw.trim().toLowerCase();
+
+  // "next <day>" — the soonest future occurrence, never today
+  const nextMatch = lower.match(/^next\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/);
+  if (nextMatch) {
+    const targetWeekday = DAY_TO_WEEKDAY[nextMatch[1]];
+    const daysAhead = ((targetWeekday - now.weekday + 7) % 7) || 7;
+    return now.plus({ days: daysAhead }).startOf('day');
+  }
+
+  // "this <day>" — this week's occurrence (ISO week: Mon=1)
+  const thisMatch = lower.match(/^this\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/);
+  if (thisMatch) {
+    const targetWeekday = DAY_TO_WEEKDAY[thisMatch[1]];
+    const diff = targetWeekday - now.weekday;
+    return now.plus({ days: diff }).startOf('day');
+  }
+
+  // "<day> of the week of <date>" — find the ISO week containing <date>, return the requested day
+  const weekOfMatch = lower.match(
+    /^(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\s+of\s+the\s+week\s+of\s+(.+)$/,
+  );
+  if (weekOfMatch) {
+    const targetWeekday = DAY_TO_WEEKDAY[weekOfMatch[1]];
+    const anchor = parseDate(weekOfMatch[2], timezone);
+    if (!anchor) return null;
+    // Find Monday of the anchor's week, then jump to target day
+    const monday = anchor.startOf('week'); // luxon ISO: Monday
+    return monday.plus({ days: targetWeekday - 1 }).startOf('day');
+  }
+
+  // "<day> after <date>" — the first occurrence of <day> strictly after <date>
+  const afterMatch = lower.match(
+    /^(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\s+after\s+(.+)$/,
+  );
+  if (afterMatch) {
+    const targetWeekday = DAY_TO_WEEKDAY[afterMatch[1]];
+    const anchor = parseDate(afterMatch[2], timezone);
+    if (!anchor) return null;
+    const daysAhead = ((targetWeekday - anchor.weekday + 7) % 7) || 7;
+    return anchor.plus({ days: daysAhead }).startOf('day');
+  }
+
+  return null;
+}
+
+/** Normalize a day-of-week string to canonical form ("monday" → "Monday"). */
+function canonicalDay(input: string): DayName | null {
+  const lower = input.trim().toLowerCase();
+  for (const name of DAY_NAMES) {
+    if (name.toLowerCase() === lower) return name;
+  }
+  return null;
+}
+
+export class DateResolveHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const input = (ctx.input ?? {}) as Record<string, unknown>;
+    const dateInput = typeof input.date === 'string' ? input.date.trim() : '';
+    const relativeInput = typeof input.relative === 'string' ? input.relative.trim() : '';
+    const expectedDayInput = typeof input.expected_day === 'string' ? input.expected_day.trim() : '';
+
+    if (!dateInput && !relativeInput) {
+      return { success: false, error: "Provide either 'date' (e.g. '2026-05-19') or 'relative' (e.g. 'next Monday')" };
+    }
+
+    const timezone = ctx.timezone ?? 'UTC';
+    const now = DateTime.now().setZone(timezone);
+
+    let resolved: DateTime | null = null;
+
+    if (dateInput) {
+      resolved = parseDate(dateInput, timezone);
+      if (!resolved) {
+        return { success: false, error: `Could not parse date: "${dateInput}". Use ISO (2026-05-19) or natural (May 19, 2026) format.` };
+      }
+    } else {
+      resolved = resolveRelative(relativeInput, now, timezone);
+      if (!resolved) {
+        return {
+          success: false,
+          error: `Could not resolve relative expression: "${relativeInput}". Supported: "next Monday", "this Friday", "Monday of the week of May 18", "Monday after May 15".`,
+        };
+      }
+    }
+
+    const dayOfWeek = resolved.toFormat('cccc'); // e.g. "Tuesday"
+    const isoDate = resolved.toFormat('yyyy-MM-dd'); // e.g. "2026-05-19"
+    const formatted = resolved.toFormat('cccc, MMMM d, yyyy'); // e.g. "Tuesday, May 19, 2026"
+
+    const result: Record<string, unknown> = {
+      date: isoDate,
+      day_of_week: dayOfWeek,
+      formatted,
+    };
+
+    // Verification mode: check expected day-of-week
+    if (expectedDayInput) {
+      const canonical = canonicalDay(expectedDayInput);
+      if (!canonical) {
+        return { success: false, error: `Unrecognized day name: "${expectedDayInput}". Use full English day names (Monday, Tuesday, etc.)` };
+      }
+      result.expected_day = canonical;
+      result.correct = dayOfWeek === canonical;
+    }
+
+    ctx.log.info({ date: isoDate, dayOfWeek, relative: relativeInput || undefined }, 'date-resolve: resolved');
+
+    return { success: true, data: result };
+  }
+}

--- a/skills/date-resolve/handler.ts
+++ b/skills/date-resolve/handler.ts
@@ -9,6 +9,7 @@
 
 import { DateTime } from 'luxon';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { formatDisplayTimezone } from '../../src/time/timestamp.js';
 
 /** Canonical day names for matching against user input. */
 const DAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'] as const;
@@ -151,6 +152,9 @@ export class DateResolveHandler implements SkillHandler {
       date: isoDate,
       day_of_week: dayOfWeek,
       formatted,
+      // Included so the LLM can label timezone context in its response,
+      // consistent with other skills that return formatted date/time output.
+      displayTimezone: ctx.timezone ? formatDisplayTimezone(ctx.timezone, new Date()) : null,
     };
 
     // Verification mode: check expected day-of-week

--- a/skills/date-resolve/skill.json
+++ b/skills/date-resolve/skill.json
@@ -1,0 +1,23 @@
+{
+  "name": "date-resolve",
+  "description": "Verify or resolve dates deterministically. Use this any time you need to state a day-of-week for a specific date, resolve a relative date expression ('next Monday', 'this Friday'), or verify a date + day-of-week pairing. LLMs are unreliable at day-of-week arithmetic — always call this skill instead of computing dates yourself.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "date": "string? (ISO date like '2026-05-19', or natural format like 'May 19, 2026')",
+    "relative": "string? (relative expression like 'next Monday', 'this Friday', 'Monday of the week of May 18')",
+    "expected_day": "string? (day-of-week to verify against the resolved date, e.g. 'Monday')"
+  },
+  "outputs": {
+    "date": "string (ISO date, e.g. '2026-05-19')",
+    "day_of_week": "string (full day name, e.g. 'Tuesday')",
+    "formatted": "string (human-readable, e.g. 'Tuesday, May 19, 2026')",
+    "correct": "boolean? (present only when expected_day is provided — true if day_of_week matches)",
+    "expected_day": "string? (echoed back when provided)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 5000,
+  "capabilities": []
+}

--- a/skills/date-resolve/skill.json
+++ b/skills/date-resolve/skill.json
@@ -14,7 +14,8 @@
     "day_of_week": "string (full day name, e.g. 'Tuesday')",
     "formatted": "string (human-readable, e.g. 'Tuesday, May 19, 2026')",
     "correct": "boolean? (present only when expected_day is provided — true if day_of_week matches)",
-    "expected_day": "string? (echoed back when provided)"
+    "expected_day": "string? (echoed back when provided)",
+    "displayTimezone": "string? (human-readable timezone label, e.g. 'EDT (UTC-04:00)', or null if timezone not configured)"
   },
   "permissions": [],
   "secrets": [],


### PR DESCRIPTION
## Summary

- New `date-resolve` skill: deterministic date verification for agents. Call it before writing any date + day-of-week pair — LLMs can't do this arithmetic reliably (the May 7 incident, and my own error during investigation, both prove this)
- `coordinator.yaml`: added explicit warning to call `date-resolve` for date verification, new `## Scheduling Behavior` section (be specific, offer alternatives, verify dates), pinned the skill

## What this fixes

On May 7, ceo-inbox drafted "Monday May 19" for a scheduling reply — May 19 is a Tuesday. The root cause is LLM day-of-week arithmetic failure, which is universal across all models. The fix is a tool rather than a calendar grid: on-demand, zero context waste, handles any date range.

## Test plan

- [ ] `date-resolve` handler tests: 26 passing (`npm test -- --run skills/date-resolve`)
- [ ] Full test suite: 170 files passing (2 pre-existing DB integration failures unrelated to this change)
- [ ] Manual: trigger a scheduling email in the coordinator and verify it calls `date-resolve` before proposing times

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced coordinator scheduling with explicit date verification requirements
  * Introduced `date-resolve` skill for parsing dates and validating day-of-week pairings; supports absolute dates (multiple formats) and relative expressions

* **Tests**
  * Added comprehensive test coverage for date resolution, including edge cases for month/year boundaries and timezone handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/505)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->