### PR TITLE
refactor(executive): extract validateProfile and compileWritingVoiceBlock as exported pure functions

### DIFF
--- a/src/executive/service.ts
+++ b/src/executive/service.ts
@@ -130,7 +130,7 @@ export class ExecutiveProfileService {
    * upsert all happen inside a single transaction.
    */
   async update(config: ExecutiveProfile, changedBy: string, note?: string): Promise<void> {
-    this.validateProfile(config);
+    validateProfile(config);
 
     // Snapshot the previous config before writing — used for the diff summary.
     const previousConfig = this.cached;
@@ -267,66 +267,10 @@ export class ExecutiveProfileService {
 
   /**
    * Compiles the writing voice config into a system prompt block.
-   *
-   * The executiveName parameter comes from the contact system — the executive's
-   * identity lives there, not in this profile. This avoids storing the name in
-   * two places and keeps the profile purely about style/preferences.
-   *
-   * Output order:
-   *   1. Header with executive name and context instruction
-   *   2. Tone guidance (free-form descriptors + formality band)
-   *   3. Writing patterns (ordered list)
-   *   4. Vocabulary (prefer / avoid)
-   *   5. Sign-off
+   * Delegates to the exported pure function — see compileWritingVoiceBlock() below.
    */
   compileWritingVoiceBlock(executiveName: string): string {
-    const profile = this.get();
-    const voice = profile.writingVoice;
-    const lines: string[] = [];
-
-    lines.push('## Executive Writing Voice');
-    lines.push('');
-    lines.push(`When drafting emails or content under ${executiveName}'s name, follow this voice guidance.`);
-    lines.push('This is NOT your (the assistant\'s) voice — this is the executive\'s voice.');
-    lines.push('');
-
-    // 1. Tone
-    if (voice.tone.length > 0) {
-      const tonePhrase = voice.tone.join(' and ');
-      lines.push('**Tone:**');
-      lines.push(`Write in a tone that is ${tonePhrase}.`);
-      lines.push(formalityGuidance(voice.formality));
-      lines.push('');
-    }
-
-    // 2. Writing patterns
-    if (voice.patterns.length > 0) {
-      lines.push('**Writing patterns (follow these closely):**');
-      for (const pattern of voice.patterns) {
-        lines.push(`- ${pattern}`);
-      }
-      lines.push('');
-    }
-
-    // 3. Vocabulary
-    if (voice.vocabulary.prefer.length > 0 || voice.vocabulary.avoid.length > 0) {
-      lines.push('**Vocabulary:**');
-      if (voice.vocabulary.prefer.length > 0) {
-        lines.push(`Prefer: ${voice.vocabulary.prefer.join(', ')}`);
-      }
-      if (voice.vocabulary.avoid.length > 0) {
-        lines.push(`Avoid: ${voice.vocabulary.avoid.join(', ')}`);
-      }
-      lines.push('');
-    }
-
-    // 4. Sign-off
-    if (voice.signOff) {
-      lines.push('**Sign-off:**');
-      lines.push(`End emails with: ${voice.signOff}`);
-    }
-
-    return lines.join('\n');
+    return compileWritingVoiceBlock(this.get(), executiveName);
   }
 
   /**
@@ -418,47 +362,6 @@ export class ExecutiveProfileService {
     };
   }
 
-  /** Validate that the profile config is well-formed before persisting. */
-  private validateProfile(config: ExecutiveProfile): void {
-    // Guard nested fields before dereferencing — API payloads are not guaranteed
-    // to match the TypeScript shape at runtime.
-    if (!config.writingVoice) {
-      throw new Error('Executive profile requires writingVoice');
-    }
-    const voice = config.writingVoice;
-
-    if (!Array.isArray(voice.tone) || !voice.tone.every(item => typeof item === 'string')) {
-      throw new Error('writingVoice.tone must be an array of strings');
-    }
-    if (voice.tone.length > 3) {
-      throw new Error(`writingVoice.tone may contain at most 3 descriptors; got ${voice.tone.length}`);
-    }
-    // Tone values are free-form strings — no predefined set validation.
-    // The executive's voice is personal and should not be artificially constrained.
-
-    if (!Number.isInteger(voice.formality) || voice.formality < 0 || voice.formality > 100) {
-      throw new Error(`writingVoice.formality must be an integer between 0 and 100; got ${voice.formality}`);
-    }
-
-    if (!Array.isArray(voice.patterns) || !voice.patterns.every(item => typeof item === 'string')) {
-      throw new Error('writingVoice.patterns must be an array of strings');
-    }
-
-    if (
-      !voice.vocabulary ||
-      !Array.isArray(voice.vocabulary.prefer) ||
-      !voice.vocabulary.prefer.every(item => typeof item === 'string') ||
-      !Array.isArray(voice.vocabulary.avoid) ||
-      !voice.vocabulary.avoid.every(item => typeof item === 'string')
-    ) {
-      throw new Error('writingVoice.vocabulary must have prefer and avoid string arrays');
-    }
-
-    if (typeof voice.signOff !== 'string') {
-      throw new Error('writingVoice.signOff must be a string');
-    }
-  }
-
   /** Start watching the config file for changes. Writes a new DB version on change. */
   private startFileWatcher(): void {
     this.watcher = chokidar.watch(this.configFilePath, {
@@ -496,4 +399,114 @@ export class ExecutiveProfileService {
 
     this.logger.debug({ path: this.configFilePath }, 'Executive profile file watcher started');
   }
+}
+
+// -- Exported pure functions --
+// These are extracted from the class so they can be unit-tested without a DB pool.
+
+/**
+ * Validates that an ExecutiveProfile config is well-formed.
+ * Throws a descriptive error if any field fails validation.
+ *
+ * Guard nested fields before dereferencing — API payloads are not guaranteed
+ * to match the TypeScript shape at runtime.
+ */
+export function validateProfile(config: ExecutiveProfile): void {
+  if (!config.writingVoice) {
+    throw new Error('Executive profile requires writingVoice');
+  }
+  const voice = config.writingVoice;
+
+  if (!Array.isArray(voice.tone) || !voice.tone.every(item => typeof item === 'string')) {
+    throw new Error('writingVoice.tone must be an array of strings');
+  }
+  if (voice.tone.length > 3) {
+    throw new Error(`writingVoice.tone may contain at most 3 descriptors; got ${voice.tone.length}`);
+  }
+  // Tone values are free-form strings — no predefined set validation.
+  // The executive's voice is personal and should not be artificially constrained.
+
+  if (!Number.isInteger(voice.formality) || voice.formality < 0 || voice.formality > 100) {
+    throw new Error(`writingVoice.formality must be an integer between 0 and 100; got ${voice.formality}`);
+  }
+
+  if (!Array.isArray(voice.patterns) || !voice.patterns.every(item => typeof item === 'string')) {
+    throw new Error('writingVoice.patterns must be an array of strings');
+  }
+
+  if (
+    !voice.vocabulary ||
+    !Array.isArray(voice.vocabulary.prefer) ||
+    !voice.vocabulary.prefer.every(item => typeof item === 'string') ||
+    !Array.isArray(voice.vocabulary.avoid) ||
+    !voice.vocabulary.avoid.every(item => typeof item === 'string')
+  ) {
+    throw new Error('writingVoice.vocabulary must have prefer and avoid string arrays');
+  }
+
+  if (typeof voice.signOff !== 'string') {
+    throw new Error('writingVoice.signOff must be a string');
+  }
+}
+
+/**
+ * Compiles a writing voice config into a system prompt block.
+ *
+ * The executiveName comes from the contact system — the executive's identity
+ * lives there, not in the profile, to avoid storing the name in two places.
+ *
+ * Output order:
+ *   1. Header with executive name and context instruction
+ *   2. Tone guidance (free-form descriptors + formality band)
+ *   3. Writing patterns (ordered list)
+ *   4. Vocabulary (prefer / avoid)
+ *   5. Sign-off
+ */
+export function compileWritingVoiceBlock(profile: ExecutiveProfile, executiveName: string): string {
+  const voice = profile.writingVoice;
+  const lines: string[] = [];
+
+  lines.push('## Executive Writing Voice');
+  lines.push('');
+  lines.push(`When drafting emails or content under ${executiveName}'s name, follow this voice guidance.`);
+  lines.push('This is NOT your (the assistant\'s) voice — this is the executive\'s voice.');
+  lines.push('');
+
+  // 1. Tone
+  if (voice.tone.length > 0) {
+    const tonePhrase = voice.tone.join(' and ');
+    lines.push('**Tone:**');
+    lines.push(`Write in a tone that is ${tonePhrase}.`);
+    lines.push(formalityGuidance(voice.formality));
+    lines.push('');
+  }
+
+  // 2. Writing patterns
+  if (voice.patterns.length > 0) {
+    lines.push('**Writing patterns (follow these closely):**');
+    for (const pattern of voice.patterns) {
+      lines.push(`- ${pattern}`);
+    }
+    lines.push('');
+  }
+
+  // 3. Vocabulary
+  if (voice.vocabulary.prefer.length > 0 || voice.vocabulary.avoid.length > 0) {
+    lines.push('**Vocabulary:**');
+    if (voice.vocabulary.prefer.length > 0) {
+      lines.push(`Prefer: ${voice.vocabulary.prefer.join(', ')}`);
+    }
+    if (voice.vocabulary.avoid.length > 0) {
+      lines.push(`Avoid: ${voice.vocabulary.avoid.join(', ')}`);
+    }
+    lines.push('');
+  }
+
+  // 4. Sign-off
+  if (voice.signOff) {
+    lines.push('**Sign-off:**');
+    lines.push(`End emails with: ${voice.signOff}`);
+  }
+
+  return lines.join('\n');
 }

--- a/tests/unit/executive/service.test.ts
+++ b/tests/unit/executive/service.test.ts
@@ -1,6 +1,7 @@
 // Tests for ExecutiveProfileService — validation, YAML mapping, and prompt compilation.
 //
-// These are unit tests that exercise the service's public methods without a database.
+// These are unit tests that exercise the service's pure-function exports directly,
+// without needing a database or a full service instance.
 // The service's DB lifecycle (initialize, update, reload, history) follows the same
 // pattern as OfficeIdentityService and is covered by integration tests.
 
@@ -9,6 +10,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import yaml from 'js-yaml';
 import type { ExecutiveProfile } from '../../../src/executive/types.js';
+import { validateProfile, compileWritingVoiceBlock } from '../../../src/executive/service.js';
 
 describe('Executive profile YAML schema', () => {
   it('loads the default config/executive-profile.yaml', () => {
@@ -47,100 +49,91 @@ describe('Executive profile YAML schema', () => {
   });
 });
 
-describe('ExecutiveProfile validation', () => {
-  // Since validateProfile is private, we test via the type shape and
-  // known constraints that the compiler relies on.
+describe('validateProfile', () => {
+  const validProfile: ExecutiveProfile = {
+    writingVoice: {
+      tone: ['direct', 'warm'],
+      formality: 50,
+      patterns: ['Short sentences.'],
+      vocabulary: { prefer: ['folks'], avoid: ['synergy'] },
+      signOff: '-- Joseph',
+    },
+  };
 
-  it('rejects formality outside 0-100', () => {
-    const badProfile: ExecutiveProfile = {
-      writingVoice: {
-        tone: ['direct'],
-        formality: 150,
-        patterns: ['Short sentences'],
-        vocabulary: { prefer: [], avoid: [] },
-        signOff: '',
-      },
-    };
-
-    // Formality must be 0-100
-    expect(badProfile.writingVoice.formality).toBeGreaterThan(100);
+  it('accepts a valid profile without throwing', () => {
+    expect(() => validateProfile(validProfile)).not.toThrow();
   });
 
-  it('allows up to 3 tone descriptors', () => {
-    const profile: ExecutiveProfile = {
-      writingVoice: {
-        tone: ['direct', 'warm', 'confident'],
-        formality: 50,
-        patterns: [],
-        vocabulary: { prefer: [], avoid: [] },
-        signOff: '',
-      },
+  it('rejects a profile missing writingVoice', () => {
+    expect(() => validateProfile({} as ExecutiveProfile)).toThrow('Executive profile requires writingVoice');
+  });
+
+  it('rejects formality outside 0-100', () => {
+    const bad: ExecutiveProfile = {
+      writingVoice: { ...validProfile.writingVoice, formality: 150 },
     };
-    expect(profile.writingVoice.tone).toHaveLength(3);
+    expect(() => validateProfile(bad)).toThrow(
+      'writingVoice.formality must be an integer between 0 and 100',
+    );
+  });
+
+  it('rejects non-integer formality', () => {
+    const bad: ExecutiveProfile = {
+      writingVoice: { ...validProfile.writingVoice, formality: 50.5 },
+    };
+    expect(() => validateProfile(bad)).toThrow(
+      'writingVoice.formality must be an integer between 0 and 100',
+    );
+  });
+
+  it('accepts exactly 3 tone descriptors', () => {
+    const profile: ExecutiveProfile = {
+      writingVoice: { ...validProfile.writingVoice, tone: ['direct', 'warm', 'confident'] },
+    };
+    expect(() => validateProfile(profile)).not.toThrow();
+  });
+
+  it('rejects more than 3 tone descriptors', () => {
+    const bad: ExecutiveProfile = {
+      writingVoice: { ...validProfile.writingVoice, tone: ['a', 'b', 'c', 'd'] },
+    };
+    expect(() => validateProfile(bad)).toThrow(
+      'writingVoice.tone may contain at most 3 descriptors',
+    );
+  });
+
+  it('rejects non-string tone entries', () => {
+    const bad = {
+      writingVoice: { ...validProfile.writingVoice, tone: [1, 2] },
+    } as unknown as ExecutiveProfile;
+    expect(() => validateProfile(bad)).toThrow('writingVoice.tone must be an array of strings');
+  });
+
+  it('rejects non-string patterns entries', () => {
+    const bad = {
+      writingVoice: { ...validProfile.writingVoice, patterns: [42] },
+    } as unknown as ExecutiveProfile;
+    expect(() => validateProfile(bad)).toThrow('writingVoice.patterns must be an array of strings');
+  });
+
+  it('rejects missing vocabulary', () => {
+    const bad = {
+      writingVoice: { ...validProfile.writingVoice, vocabulary: null },
+    } as unknown as ExecutiveProfile;
+    expect(() => validateProfile(bad)).toThrow(
+      'writingVoice.vocabulary must have prefer and avoid string arrays',
+    );
+  });
+
+  it('rejects non-string signOff', () => {
+    const bad = {
+      writingVoice: { ...validProfile.writingVoice, signOff: 42 },
+    } as unknown as ExecutiveProfile;
+    expect(() => validateProfile(bad)).toThrow('writingVoice.signOff must be a string');
   });
 });
 
-describe('compileWritingVoiceBlock output', () => {
-  // We test the compiled output format by importing the service and using a
-  // helper that bypasses initialization. Since compileWritingVoiceBlock just
-  // reads from the cached profile, we can test the output format directly.
-
-  // We can't construct the full service without a pool, so we test the
-  // compilation logic via a standalone implementation that mirrors the service.
-  // This is intentionally duplicated from the service to keep the test
-  // independent of DB setup.
-
-  function compileWritingVoiceBlock(profile: ExecutiveProfile, executiveName: string): string {
-    const voice = profile.writingVoice;
-    const lines: string[] = [];
-
-    lines.push('## Executive Writing Voice');
-    lines.push('');
-    lines.push(`When drafting emails or content under ${executiveName}'s name, follow this voice guidance.`);
-    lines.push('This is NOT your (the assistant\'s) voice — this is the executive\'s voice.');
-    lines.push('');
-
-    if (voice.tone.length > 0) {
-      const tonePhrase = voice.tone.join(' and ');
-      lines.push('**Tone:**');
-      lines.push(`Write in a tone that is ${tonePhrase}.`);
-      // formality guidance
-      let formalityText: string;
-      if (voice.formality <= 25) formalityText = 'Keep the register casual — like a Slack message to a colleague.';
-      else if (voice.formality <= 50) formalityText = 'Write conversationally but with structure — like a thoughtful email to a peer.';
-      else if (voice.formality <= 75) formalityText = 'Professional and composed — like a well-crafted business email.';
-      else formalityText = 'Formal and precise — like a board communication or investor letter.';
-      lines.push(formalityText);
-      lines.push('');
-    }
-
-    if (voice.patterns.length > 0) {
-      lines.push('**Writing patterns (follow these closely):**');
-      for (const pattern of voice.patterns) {
-        lines.push(`- ${pattern}`);
-      }
-      lines.push('');
-    }
-
-    if (voice.vocabulary.prefer.length > 0 || voice.vocabulary.avoid.length > 0) {
-      lines.push('**Vocabulary:**');
-      if (voice.vocabulary.prefer.length > 0) {
-        lines.push(`Prefer: ${voice.vocabulary.prefer.join(', ')}`);
-      }
-      if (voice.vocabulary.avoid.length > 0) {
-        lines.push(`Avoid: ${voice.vocabulary.avoid.join(', ')}`);
-      }
-      lines.push('');
-    }
-
-    if (voice.signOff) {
-      lines.push('**Sign-off:**');
-      lines.push(`End emails with: ${voice.signOff}`);
-    }
-
-    return lines.join('\n');
-  }
-
+describe('compileWritingVoiceBlock', () => {
   const testProfile: ExecutiveProfile = {
     writingVoice: {
       tone: ['direct', 'warm'],


### PR DESCRIPTION
## Summary

- Extracts `validateProfile` from a private instance method to an exported module-level pure function; `update()` calls it directly (private wrapper removed)
- Extracts `compileWritingVoiceBlock` to an exported pure function with signature `(profile: ExecutiveProfile, executiveName: string): string`; the instance method delegates to it
- Updates `tests/unit/executive/service.test.ts` to import and call the real production functions, replacing an inline duplicate and passive type assertions with actual behavioural tests — 25 tests now (was 17)

No behaviour change to the service itself. All existing tests continue to pass.

Closes #382.

## Test plan

- [x] `npm test tests/unit/executive/service.test.ts` — 25 passed
- [x] Full `npm test` — same pass/fail as main (2 pre-existing autonomy failures requiring DATABASE_URL)
- [x] `npm run typecheck` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Tests**
- Enhanced unit test coverage for executive profile validation scenarios, including comprehensive checks for required fields, data type validation, and acceptable value ranges for all configuration parameters.

**Chores**
- Refactored internal code structure and improved testability of profile validation and writing voice configuration features to ensure better code quality, reliability, and future maintainability across the platform.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/507)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->