### PR TITLE
fix(deps): upgrade fast-uri 3.1.0 → 3.1.2 via pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   },
   "pnpm": {
     "overrides": {
-      "hono": ">=4.12.18"
+      "hono": ">=4.12.18",
+      "fast-uri": ">=3.1.2"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1221,8 +1221,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
@@ -2442,7 +2442,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
 
   '@fastify/cookie@11.0.2':
     dependencies:
@@ -2956,7 +2956,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3327,7 +3327,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -3339,7 +3339,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastify-plugin@5.1.0: {}
 


### PR DESCRIPTION
## Summary

- Adds `"fast-uri": ">=3.1.2"` to the existing `pnpm.overrides` section, closing 2 high-severity Dependabot alerts
- `fast-uri` is a transitive dep of `ajv`, `@fastify/ajv-compiler`, and `fast-json-stringify` — all runtime components of the fastify server

## Security alerts resolved

| # | Severity | CVE | Summary |
|---|----------|-----|---------|
| #23 | high | CVE-2026-6321 | Path traversal via percent-encoded dot segments — encoded paths like `/public/%2e%2e/admin` normalized to `/admin`, bypassing path policy checks |
| #28 | high | CVE-2026-6322 | Host confusion via percent-encoded authority delimiters — `http://trusted.com%40evil.com/` normalized to `http://trusted.com@evil.com/`, bypassing allowlist checks |

## Test plan

- [x] `pnpm test` passes (2121 tests; 2 pre-existing DB integration test failures unrelated to this change)
- [x] `pnpm-lock.yaml` confirms `fast-uri@3.1.2` resolved throughout (all 5 occurrences)
- [x] All three transitive consumers (`ajv@8.20.0`, `@fastify/ajv-compiler@4.0.5`, `fast-json-stringify@6.3.0`) updated cleanly