### PR TITLE
feat(memory): resolveOrCreate logs warning on single-match type mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Entity resolution:** `resolveOrCreate` now logs a warning when a single label match has a different type than the caller's hint, improving observability without changing resolution behaviour ([#474](https://github.com/josephfung/curia/issues/474))
 - **Principal identity consolidation** — replaced fragmented CEO identity (env var config, `role` column, `OutboundGatewayConfig` flat fields) with a database-driven `system_role` column on the `contacts` table. One contact holds `system_role='principal'`, one holds `system_role='agent'`. Enforced by partial unique indexes.
 - **TaskOriginator on every task** — replaced `ceoInitiated: boolean` with a `TaskOriginator` object stamped by the dispatcher on every task, carrying `contactId`, `systemRole`, `channel`, and `initiatedAt`. CEO-authorization checks now use `isPrincipalOriginated(taskMetadata)`. Originator context survives task delegation, resolving the autonomy gate bug for scheduled CEO-authorized actions.
 

--- a/docs/wip/2026-05-11-resolve-or-create-type-hint-design.md
+++ b/docs/wip/2026-05-11-resolve-or-create-type-hint-design.md
@@ -1,0 +1,87 @@
+# resolveOrCreate: Single-Match Type Hint Handling
+
+**Issue:** [#474](https://github.com/josephfung/curia/issues/474)
+**Date:** 2026-05-11
+
+## Problem
+
+`EntityMemory.resolveOrCreate()` uses a three-outcome resolution strategy:
+
+- **0 matches** — auto-create with the caller's type
+- **1 match** — return `{ kind: 'found', node }` unconditionally
+- **2+ matches** — prefer a type-matching node; return `ambiguous` if none matches
+
+The 1-match path returns any label match without checking whether the node's
+type matches the caller's type hint. This is inconsistent with the 2+ case,
+which explicitly prefers type-matching nodes.
+
+If a caller requests `resolveOrCreate({ label: 'Acme', type: 'organization' })`
+and the only match is a `person` node, the method silently returns it.
+
+## Decision
+
+**Keep current behaviour; add observability.**
+
+Cross-type name collisions are rare in practice. Changing the return kind (to
+`ambiguous` or `created`) would disrupt callers for a case that almost always
+represents the same real-world entity under a different type label.
+
+Both callers already handle `ambiguous` gracefully, but returning it for a
+1-match case would add unnecessary round-trips (`memory-store`) or silent
+auto-picks (`extract-facts` takes `candidates[0]`) for what is usually a false
+alarm.
+
+## Design
+
+### Change 1: Warning log on type mismatch (entity-memory.ts)
+
+In the `matches.length === 1` branch, add a type-mismatch check before
+returning. When the single match's type differs from the caller's hint, log a
+warning with structured fields:
+
+```typescript
+if (matches.length === 1) {
+  const node = matches[0]!;
+  // Single-match returns 'found' even when the type doesn't match the caller's
+  // hint. This is intentional: a lone label match almost always represents the
+  // same real-world entity under a different type classification. The 2+ path
+  // uses type as a tiebreaker because multiple nodes genuinely share a name;
+  // with one match there is nothing to disambiguate. We log a warning so
+  // operators can spot patterns that suggest genuinely distinct entities.
+  if (node.type !== options.type) {
+    this.logger.warn(
+      { label: options.label, expectedType: options.type, actualType: node.type, nodeId: node.id },
+      'resolveOrCreate: single match type differs from caller hint',
+    );
+  }
+  return { kind: 'found', node };
+}
+```
+
+### Change 2: Test for 1-match type mismatch (entity-memory.resolve-or-create.test.ts)
+
+Add one test to the existing suite:
+
+- Create a `person` node with label `"Acme"`
+- Call `resolveOrCreate({ label: 'Acme', type: 'organization', source: 'test' })`
+- Assert `result.kind === 'found'`
+- Assert `result.node.type === 'person'` (the existing node, not a new one)
+
+This locks in the intentional behaviour and prevents future regressions.
+
+## What does NOT change
+
+- **Return type:** No new `kind` values, no type changes
+- **Callers:** `memory-store` and `extract-facts` are untouched
+- **Spec:** `docs/specs/01-memory-system.md` does not prescribe this behaviour
+  and needs no update
+
+## Acceptance criteria mapping
+
+From the issue:
+
+- [x] `resolveOrCreate` documents the exact behaviour when 1 match exists and
+  its type differs — covered by the inline code comment (Change 1)
+- [x] At least one test covers the "1 match, type mismatch" scenario — Change 2
+- [x] If behaviour is changed, all callers updated — behaviour is NOT changed,
+  so no caller updates needed

--- a/docs/wip/2026-05-11-resolve-or-create-type-hint.md
+++ b/docs/wip/2026-05-11-resolve-or-create-type-hint.md
@@ -1,0 +1,142 @@
+# resolveOrCreate Type Hint Handling — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a warning log and test coverage for the single-match type-mismatch edge case in `EntityMemory.resolveOrCreate()`.
+
+**Architecture:** No structural changes. One method gets a type check + log call in its existing 1-match branch. One test is added to the existing test file.
+
+**Tech Stack:** TypeScript, pino (Logger), Vitest
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `src/memory/entity-memory.ts:287-289` | Add type-mismatch warning log + comment in the 1-match branch |
+| Modify | `src/memory/entity-memory.resolve-or-create.test.ts:100` | Add test for 1-match type-mismatch scenario |
+
+---
+
+### Task 1: Test the type-mismatch behaviour
+
+**Files:**
+- Modify: `src/memory/entity-memory.resolve-or-create.test.ts` (insert after line 100, before the closing of the `resolveOrCreate` describe block)
+
+- [ ] **Step 1: Write the failing test**
+
+Insert this test after the "returns ambiguous when 2+ labels match" test (after line 100), inside the existing `describe('EntityMemory.resolveOrCreate', ...)` block:
+
+```typescript
+  it('returns found (with existing type) when 1 match exists but type differs from caller hint', async () => {
+    const { mem } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'person', label: 'Acme', properties: {}, source: 'test',
+    });
+
+    const result = await mem.resolveOrCreate({
+      label: 'Acme',
+      type: 'organization',  // differs from the existing 'person' node
+      source: 'test',
+    });
+
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') throw new Error('narrowing');
+    expect(result.node.id).toBe(entity.id);
+    expect(result.node.type).toBe('person');  // returns the existing node as-is
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it passes (current behaviour already returns `found`)**
+
+Run: `npm --prefix /path/to/worktree run test -- src/memory/entity-memory.resolve-or-create.test.ts`
+
+Expected: PASS — the current code already returns `found` for a single match regardless of type. This test locks in that behaviour.
+
+- [ ] **Step 3: Commit the test**
+
+```bash
+git add src/memory/entity-memory.resolve-or-create.test.ts
+git commit -m "test(memory): cover 1-match type-mismatch in resolveOrCreate (#474)"
+```
+
+---
+
+### Task 2: Add the warning log
+
+**Files:**
+- Modify: `src/memory/entity-memory.ts:287-289`
+
+- [ ] **Step 1: Replace the 1-match branch**
+
+In `src/memory/entity-memory.ts`, replace lines 287-289:
+
+```typescript
+    if (matches.length === 1) {
+      return { kind: 'found', node: matches[0]! };
+    }
+```
+
+with:
+
+```typescript
+    if (matches.length === 1) {
+      const node = matches[0]!;
+      // Single-match returns 'found' even when the type doesn't match the caller's
+      // hint. This is intentional: a lone label match almost always represents the
+      // same real-world entity under a different type classification. The 2+ path
+      // uses type as a tiebreaker because multiple nodes genuinely share a name;
+      // with one match there is nothing to disambiguate. We log a warning so
+      // operators can spot patterns that suggest genuinely distinct entities.
+      // See: https://github.com/josephfung/curia/issues/474
+      if (node.type !== options.type) {
+        this.logger.warn(
+          { label: options.label, expectedType: options.type, actualType: node.type, nodeId: node.id },
+          'resolveOrCreate: single match type differs from caller hint',
+        );
+      }
+      return { kind: 'found', node };
+    }
+```
+
+- [ ] **Step 2: Run the full test file to verify nothing broke**
+
+Run: `npm --prefix /path/to/worktree run test -- src/memory/entity-memory.resolve-or-create.test.ts`
+
+Expected: All 7 tests pass (the 6 existing + the 1 added in Task 1).
+
+- [ ] **Step 3: Commit the implementation**
+
+```bash
+git add src/memory/entity-memory.ts
+git commit -m "feat(memory): log warning on resolveOrCreate single-match type mismatch (#474)"
+```
+
+---
+
+### Task 3: Update CHANGELOG and final verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add changelog entry**
+
+Under `## [Unreleased]`, in the **Changed** section (create it if it doesn't exist), add:
+
+```markdown
+- **Entity resolution:** `resolveOrCreate` now logs a warning when a single label match has a different type than the caller's hint, improving observability without changing resolution behaviour ([#474](https://github.com/josephfung/curia/issues/474))
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npm --prefix /path/to/worktree test`
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit the changelog**
+
+```bash
+git add CHANGELOG.md
+git commit -m "chore: changelog entry for resolveOrCreate type hint warning (#474)"
+```

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -99,6 +99,24 @@ describe('EntityMemory.resolveOrCreate', () => {
     expect(result.candidates).toHaveLength(2);
   });
 
+  it('returns found (with existing type) when 1 match exists but type differs from caller hint', async () => {
+    const { mem } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'person', label: 'Acme', properties: {}, source: 'test',
+    });
+
+    const result = await mem.resolveOrCreate({
+      label: 'Acme',
+      type: 'organization',  // differs from the existing 'person' node
+      source: 'test',
+    });
+
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') throw new Error('narrowing');
+    expect(result.node.id).toBe(entity.id);
+    expect(result.node.type).toBe('person');  // returns the existing node as-is
+  });
+
   it('uses the caller-supplied confidence when auto-creating', async () => {
     const { mem } = makeEntityMemory();
     const result = await mem.resolveOrCreate({

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -285,7 +285,21 @@ export class EntityMemory {
     }
 
     if (matches.length === 1) {
-      return { kind: 'found', node: matches[0]! };
+      const node = matches[0]!;
+      // Single-match returns 'found' even when the type doesn't match the caller's
+      // hint. This is intentional: a lone label match almost always represents the
+      // same real-world entity under a different type classification. The 2+ path
+      // uses type as a tiebreaker because multiple nodes genuinely share a name;
+      // with one match there is nothing to disambiguate. We log a warning so
+      // operators can spot patterns that suggest genuinely distinct entities.
+      // See: https://github.com/josephfung/curia/issues/474
+      if (node.type !== options.type) {
+        this.logger.warn(
+          { label: options.label, expectedType: options.type, actualType: node.type, nodeId: node.id },
+          'resolveOrCreate: single match type differs from caller hint',
+        );
+      }
+      return { kind: 'found', node };
     }
 
     // 2+ matches — prefer a node whose type matches the caller's expected type.


### PR DESCRIPTION
## Summary

- **Adds a warning log** when `resolveOrCreate` finds exactly one label match whose type differs from the caller's type hint, improving observability without changing resolution behaviour
- **Adds a test** covering the 1-match type-mismatch scenario, locking in the intentional `found` return
- **Documents the design rationale** in an inline comment explaining why the 1-match path doesn't use type as a filter (unlike the 2+ path)

Closes #474

## Test plan

- [x] New test: 1-match type-mismatch returns `found` with existing node's type
- [x] All 9 `resolveOrCreate` + `storeFact` tests pass
- [x] Full suite: 2052 tests pass (2 pre-existing DB-dependent failures unrelated)