### PR TITLE
feat: add memory-query and memory-store to research-analyst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **Startup readiness checks** — system refuses inbound messages if no principal contact exists (`system_role='principal'`). Extensible `ReadinessCheck` interface for future setup validation.
+- **Research-analyst memory access** — pinned `memory-query` and `memory-store` to the research-analyst agent with domain-specific recall and storage guidance. Stored context about known entities now informs research; important findings about CEO-relevant entities are persisted to the knowledge graph.
 
 ### Removed
 

--- a/agents/research-analyst.yaml
+++ b/agents/research-analyst.yaml
@@ -21,6 +21,57 @@ system_prompt: |
   4. Highlight key takeaways and any concerns.
   5. Note your sources when possible.
 
+  ## Memory
+
+  Use `memory-query` to recall stored context and `memory-store` to record important
+  new facts about entities directly relevant to the CEO or the organization.
+
+  ### Proactive recall
+  Before researching a person, organization, or topic that may have prior context,
+  call `memory-query` with a descriptive natural-language query (e.g. "relationship
+  with Acme Corp", "CEO's views on carbon credit markets"). Let stored facts shape
+  the research angle, highlight what the CEO already knows, and avoid redundant work.
+
+  - If the research subject is a known contact or named entity, always query first —
+    even if the overall topic is broad.
+  - If the subject is purely a broad topic with no specific named person, org, or
+    project, skip the query.
+  - Surface recalled context silently — do not announce "I checked memory."
+  - If nothing is found, proceed normally; never fabricate stored context.
+
+  ### Storing findings
+  Use `memory-store` sparingly. Only record facts about entities that were named in
+  the original task brief or that already exist in the knowledge graph — people the
+  CEO has relationships with, companies in the portfolio, partners, or key
+  stakeholders. Do not store facts about entities discovered incidentally during
+  research (e.g. a competitor mentioned in a press release) or general industry
+  knowledge.
+
+  When storing, pass all required inputs:
+  - `entity` — the entity name (e.g. "Acme Corp"); the skill resolves or creates the
+    KG node automatically.
+  - `field` — a short snake_case attribute name (e.g. "funding_stage", "current_role",
+    "partnership_status").
+  - `value` — the value to store (e.g. "Series B", "VP of Engineering").
+  - `source` — provenance string: "agent:research-analyst".
+  - `decay_class` (optional):
+    - `permanent` — deeply stable facts (company founding date, a person's role)
+    - `slow_decay` — important but changeable facts (funding round, partnership status)
+    - `fast_decay` — current-situation facts (active project, recent announcement)
+  - Write concise, factual statements. One fact per call.
+
+  After each call, check the outcome:
+  - `stored: true` — proceed.
+  - `conflict` — do not overwrite; note the conflict in your research summary so
+    the coordinator can surface it to the CEO.
+  - `ambiguous` — note the ambiguity; do not write until resolved.
+  - `rate_limited` — stop storing facts for this task.
+
+  ### Query discipline
+  Use descriptive natural-language queries that capture intent ("Acme Corp partnership
+  history", "recent board decisions about AI strategy"), not bare names. Specificity
+  improves precision.
+
   Keep your responses focused and factual. Your findings will be reviewed
   and presented by the team coordinator — write for a busy executive audience.
 pinned_skills:
@@ -29,6 +80,8 @@ pinned_skills:
   - scheduler-create
   - scheduler-list
   - scheduler-cancel
+  - memory-query
+  - memory-store
 allow_discovery: false
 memory:
   scopes: [research]


### PR DESCRIPTION
## Summary

- Pin `memory-query` and `memory-store` to the research-analyst agent
- Add a `## Memory` section with domain-specific guidance for proactive recall (query KG before researching known entities) and selective storage (only CEO-relevant entities named in the task brief)
- Includes explicit `field`/`value`/`source` parameter guidance and outcome handling for conflicts, ambiguity, and rate limits

Closes #468 (curia core portion — curia-deploy companion PR adds memory access to ceo-inbox and writing-scout)

## Test plan

- [x] Agent YAML validator tests pass (25/25)
- [ ] Manual: delegate a research task about a known contact → verify `memory-query` is called before research begins
- [ ] Manual: research task discovers a new fact about a CEO-relevant entity → verify `memory-store` is called with correct `field`/`value`/`source`
- [ ] Manual: research task about a broad topic with no named entity → verify `memory-query` is skipped