### PR TITLE
fix: resolve email addresses in entity-context via contact_channel_identities (#461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Principal identity consolidation** — replaced fragmented CEO identity (env var config, `role` column, `OutboundGatewayConfig` flat fields) with a database-driven `system_role` column on the `contacts` table. One contact holds `system_role='principal'`, one holds `system_role='agent'`. Enforced by partial unique indexes.
 - **TaskOriginator on every task** — replaced `ceoInitiated: boolean` with a `TaskOriginator` object stamped by the dispatcher on every task, carrying `contactId`, `systemRole`, `channel`, and `initiatedAt`. CEO-authorization checks now use `isPrincipalOriginated(taskMetadata)`. Originator context survives task delegation, resolving the autonomy gate bug for scheduled CEO-authorized actions.
 
+### Fixed
+
+- **Entity-context email resolution** — `resolveKgNodeId` now resolves email addresses via `contact_channel_identities` before attempting UUID-based queries, fixing missing KG context in CC flows and ceo-inbox triage for known contacts ([#461](https://github.com/josephfung/curia/issues/461))
+
 ---
 
 ## [0.26.0] — 2026-05-10 — "In the Record"

--- a/docs/wip/2026-05-11-entity-context-email-resolve-design.md
+++ b/docs/wip/2026-05-11-entity-context-email-resolve-design.md
@@ -1,0 +1,101 @@
+# Entity-Context Email Address Resolution — Design
+
+**Issue:** [#461](https://github.com/josephfung/curia/issues/461)
+**Date:** 2026-05-11
+
+## Problem
+
+`resolveKgNodeId()` in `src/entity-context/assembler.ts` only handles UUID inputs
+(contact IDs and KG node IDs). When an email address is passed — which happens in
+CC flows (coordinator) and CEO inbox triage (ceo-inbox agent) — PostgreSQL throws
+error `22P02` (invalid text representation for UUID). The catch block logs a warning
+and returns `undefined`, so no KG context is assembled for that entity.
+
+Two code paths are affected:
+
+1. **CC flow**: The dispatcher injects a `[OWNER CC —]` preamble containing raw
+   primary recipient email addresses. The coordinator extracts these and passes them
+   to entity-context — the email is the only identifier available.
+2. **CEO-inbox triage**: The ceo-inbox agent prompt (line 145) instructs the LLM to
+   "call entity-context on the sender's email address."
+
+## Design
+
+### Code change: `resolveKgNodeId()` in assembler.ts
+
+Add email address detection before the existing UUID-based queries:
+
+1. Check if `id` contains `@` with non-whitespace on both sides (simple email pattern).
+2. If yes, query `contact_channel_identities JOIN contacts` to resolve:
+   email → contact.id → contact.kg_node_id.
+3. If the email resolves to a contact with a kg_node_id, return it.
+4. If the email resolves to a contact without a kg_node_id, log debug and return
+   undefined (matches existing contact-without-kg-node behavior).
+5. If the email doesn't match any contact, return undefined (genuinely unknown).
+6. Existing UUID queries become an `else` branch — unchanged for non-email inputs.
+
+Resolution query:
+
+```sql
+SELECT c.id, c.kg_node_id
+FROM contact_channel_identities cci
+JOIN contacts c ON c.id = cci.contact_id
+WHERE cci.channel = 'email' AND LOWER(cci.channel_identifier) = LOWER($1)
+```
+
+Case-insensitive match per RFC 5321. This eliminates the `22P02` error path for
+email addresses since they never reach a UUID column.
+
+The `22P02` catch block remains for other non-UUID strings (LLM hallucinations like
+`'primary-user'`).
+
+### Prompt clarification: ceo-inbox.yaml (curia-deploy)
+
+Line 145 currently says:
+
+> Call entity-context on the sender's email address.
+
+Update to:
+
+> Call entity-context with contactIds set to the sender's email address.
+
+Guides the LLM toward the correct input parameter. The code fix handles resolution
+regardless, but the prompt should be semantically accurate.
+
+### Cache interaction
+
+No changes. The cache keys are entity/contact UUIDs. Email lookups resolve to UUIDs
+before caching applies. If the same email is passed twice within the TTL, the email
+resolution query runs again (cheap SELECT), then hits the UUID-keyed cache for the
+full assembly. Adding email-as-cache-key is not worth the invalidation complexity.
+
+### Error handling
+
+No new error paths. The email query is a simple SELECT JOIN. If it fails (DB error),
+the existing catch block propagates it. No new catch blocks needed.
+
+## Testing
+
+- `resolveKgNodeId` with a registered email address → returns correct kg_node_id
+- `resolveKgNodeId` with a registered email that has no kg_node_id → returns undefined
+- `resolveKgNodeId` with an unregistered email → returns undefined
+- Existing UUID paths still work unchanged (regression)
+- `assembleMany` with mixed email + UUID inputs → resolves both correctly
+
+## Acceptance Criteria (from issue)
+
+- [x] When entity-context receives an email address, it resolves to a contact UUID
+  via the identity index before calling UUID-based queries
+- [x] No `non-UUID id passed to resolveKgNodeId` warning for registered contacts
+- [x] KG context (facts, relationships, history) correctly assembled for primary
+  recipient in CC flows
+- [x] Unregistered addresses still degrade gracefully with the unresolved path
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/entity-context/assembler.ts` | Add email detection + resolution in `resolveKgNodeId()` |
+| `src/entity-context/assembler.test.ts` (new or existing) | Unit tests for email resolution |
+| `curia-deploy: custom/agents/ceo-inbox.yaml` | Prompt clarification (line 145) |
+| `CHANGELOG.md` | Entry under `## [Unreleased]` |

--- a/docs/wip/2026-05-11-entity-context-email-resolve.md
+++ b/docs/wip/2026-05-11-entity-context-email-resolve.md
@@ -1,0 +1,331 @@
+# Entity-Context Email Address Resolution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `resolveKgNodeId()` in `EntityContextAssembler` resolve email addresses to contact UUIDs via `contact_channel_identities`, so CC flows and ceo-inbox triage get KG context for known contacts instead of "unresolved."
+
+**Architecture:** Add an email-detection branch at the top of `resolveKgNodeId()`. When the input contains `@`, query `contact_channel_identities JOIN contacts` to resolve email → contact.id → kg_node_id. Existing UUID paths are unchanged (wrapped in an `else` branch). One prompt clarification in curia-deploy's ceo-inbox agent.
+
+**Tech Stack:** TypeScript, PostgreSQL, Vitest (unit tests with mock pool)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/entity-context/assembler.ts` | Modify (lines 254-305) | Add email detection + resolution in `resolveKgNodeId()` |
+| `tests/unit/entity-context/assembler.test.ts` | Modify (append new describe block) | Tests for email resolution path |
+| `CHANGELOG.md` | Modify (line 14, under `## [Unreleased]`) | Add `### Fixed` entry |
+
+The ceo-inbox.yaml prompt clarification is in curia-deploy (separate repo). It will be noted in the PR description but not included in this PR.
+
+---
+
+### Task 1: Write failing tests for email resolution
+
+**Files:**
+- Modify: `tests/unit/entity-context/assembler.test.ts`
+
+The existing tests use `makeSequentialPool()` to return canned DB responses in order. The email resolution path adds one new query before the existing UUID-based queries. Tests need to account for this new query position.
+
+- [ ] **Step 1: Add test fixtures at the top of the file**
+
+Add these fixtures after the existing `relationshipRow` fixture (after line 81):
+
+```typescript
+// -- Channel identity fixture for email resolution --
+const channelIdentityRow = {
+  contact_id: 'contact-1',
+  kg_node_id: 'node-1',
+};
+```
+
+- [ ] **Step 2: Write the test for a registered email that resolves to a KG node**
+
+Add a new `describe` block after the existing `describe('fact value extraction', ...)` block (after line 344):
+
+```typescript
+describe('resolveKgNodeId — email address resolution', () => {
+  it('resolves a registered email address to a KG node via contact_channel_identities', async () => {
+    // Query order for email path:
+    // 1. resolveKgNodeId: email → contact_channel_identities JOIN contacts → contact_id + kg_node_id
+    // 2. getKgNode
+    // 3. getFacts
+    // 4. getContactByKgNodeId
+    // 5. getConnectedAccounts
+    // 6. getRelationships
+    const pool = makeSequentialPool([
+      { rows: [channelIdentityRow] },   // email resolution: found
+      { rows: [personNodeRow] },         // getKgNode
+      { rows: [timezoneFactRow] },       // getFacts
+      { rows: [contactRow] },            // getContactByKgNodeId
+      { rows: [calendarRow] },           // getConnectedAccounts
+      { rows: [relationshipRow] },       // getRelationships
+    ]);
+
+    const assembler = new EntityContextAssembler(pool, logger);
+    const ctx = await assembler.assembleOne('jenna@example.com');
+
+    expect(ctx).toBeDefined();
+    expect(ctx!.entityId).toBe('node-1');
+    expect(ctx!.entityType).toBe('person');
+    expect(ctx!.label).toBe('Jenna Smith');
+    expect(ctx!.contact).toEqual({
+      contactId: 'contact-1',
+      displayName: 'Jenna Smith',
+      role: null,
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Write the test for a registered email with no KG node**
+
+Add inside the same `describe` block:
+
+```typescript
+  it('returns undefined when email resolves to a contact with no KG node', async () => {
+    const pool = makeSequentialPool([
+      { rows: [{ contact_id: 'contact-1', kg_node_id: null }] }, // email found, no KG node
+    ]);
+
+    const assembler = new EntityContextAssembler(pool, logger);
+    const ctx = await assembler.assembleOne('jenna@example.com');
+    expect(ctx).toBeUndefined();
+  });
+```
+
+- [ ] **Step 4: Write the test for an unregistered email**
+
+Add inside the same `describe` block:
+
+```typescript
+  it('returns undefined for an unregistered email address', async () => {
+    const pool = makeSequentialPool([
+      { rows: [] }, // email not found in contact_channel_identities
+    ]);
+
+    const assembler = new EntityContextAssembler(pool, logger);
+    const ctx = await assembler.assembleOne('stranger@unknown.com');
+    expect(ctx).toBeUndefined();
+  });
+```
+
+- [ ] **Step 5: Write the test for assembleMany with mixed email + UUID inputs**
+
+Add inside the same `describe` block:
+
+```typescript
+  it('assembleMany resolves a mix of email addresses and contact UUIDs', async () => {
+    // putInCache stores under all aliases: inputId ('jenna@example.com'),
+    // entityId ('node-1'), and contactId ('contact-1'). So the second
+    // lookup for 'contact-1' is a cache hit — no extra DB queries needed.
+    const pool = makeSequentialPool([
+      // First ID: email address — full resolution + assembly
+      { rows: [channelIdentityRow] },    // email resolution
+      { rows: [personNodeRow] },          // getKgNode
+      { rows: [] },                       // getFacts
+      { rows: [contactRow] },             // getContactByKgNodeId
+      { rows: [] },                       // getConnectedAccounts
+      { rows: [] },                       // getRelationships
+      // Second ID 'contact-1': cache hit, no DB queries
+    ]);
+
+    const assembler = new EntityContextAssembler(pool, logger);
+    const { entities, unresolved } = await assembler.assembleMany([
+      'jenna@example.com',
+      'contact-1',
+    ]);
+
+    expect(entities).toHaveLength(2);
+    expect(unresolved).toHaveLength(0);
+    expect(entities[0].entityId).toBe('node-1');
+    // Second entity served from cache — same underlying contact
+    expect(entities[1].entityId).toBe('node-1');
+  });
+```
+
+- [ ] **Step 6: Run the tests to verify they fail**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-email-resolve test -- tests/unit/entity-context/assembler.test.ts`
+
+Expected: All four new tests FAIL. The email address `'jenna@example.com'` goes through the UUID path, hits the sequential pool in the wrong order, and throws `Unexpected query call` or returns the wrong result.
+
+- [ ] **Step 7: Commit the failing tests**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-email-resolve add tests/unit/entity-context/assembler.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-email-resolve commit -m "test: add failing tests for email address resolution in resolveKgNodeId (#461)"
+```
+
+---
+
+### Task 2: Implement email resolution in resolveKgNodeId()
+
+**Files:**
+- Modify: `src/entity-context/assembler.ts` (lines 254-305)
+
+- [ ] **Step 1: Update the JSDoc comment on resolveKgNodeId**
+
+Replace lines 254-257:
+
+```typescript
+  /**
+   * Resolve an input ID to a KG node ID.
+   * Tries contacts.id first, then kg_nodes.id directly.
+   */
+```
+
+With:
+
+```typescript
+  /**
+   * Resolve an input ID to a KG node ID.
+   *
+   * Resolution priority:
+   *   1. Email address → contact_channel_identities → contacts.kg_node_id
+   *   2. Contact UUID → contacts.kg_node_id
+   *   3. KG node UUID → kg_nodes.id directly
+   *
+   * Email detection uses a simple @ check. This handles the common case where
+   * LLMs pass raw email addresses from CC preambles or inbox triage rather than
+   * resolving to a contact UUID first.
+   */
+```
+
+- [ ] **Step 2: Add email detection and resolution branch**
+
+Replace the body of `resolveKgNodeId` (lines 258-305) with:
+
+```typescript
+  private async resolveKgNodeId(id: string): Promise<string | undefined> {
+    // Email address detection: if the input contains '@' with non-whitespace on
+    // both sides, resolve via contact_channel_identities instead of UUID columns.
+    // This handles CC flows and ceo-inbox triage where the LLM passes a raw email.
+    if (/^\S+@\S+$/.test(id)) {
+      const emailResult = await this.pool.query<{ contact_id: string; kg_node_id: string | null }>(
+        `SELECT c.id AS contact_id, c.kg_node_id
+         FROM contact_channel_identities cci
+         JOIN contacts c ON c.id = cci.contact_id
+         WHERE cci.channel = 'email' AND LOWER(cci.channel_identifier) = LOWER($1)`,
+        [id],
+      );
+      if (emailResult.rows.length > 0) {
+        const row = emailResult.rows[0];
+        const kgNodeId = row?.kg_node_id;
+        if (!kgNodeId) {
+          this.logger.debug({ email: id, contactId: row?.contact_id }, 'entity-context: email resolved to contact with no linked KG node');
+          return undefined;
+        }
+        return kgNodeId;
+      }
+      // Email not found in contact_channel_identities — genuinely unknown contact
+      return undefined;
+    }
+
+    try {
+      // Try as a contact ID first
+      const contactResult = await this.pool.query<{ kg_node_id: string | null }>(
+        'SELECT kg_node_id FROM contacts WHERE id = $1',
+        [id],
+      );
+      if (contactResult.rows.length > 0) {
+        const row = contactResult.rows[0];
+        const kgNodeId = row?.kg_node_id;
+        // Contact found but has no linked KG node — return undefined (unresolved)
+        if (!kgNodeId) {
+          this.logger.debug({ contactId: id }, 'entity-context: contact has no linked KG node');
+          return undefined;
+        }
+        return kgNodeId;
+      }
+
+      // Try as a KG node ID directly
+      const nodeResult = await this.pool.query<{ id: string }>(
+        'SELECT id FROM kg_nodes WHERE id = $1',
+        [id],
+      );
+      if (nodeResult.rows.length > 0) {
+        return nodeResult.rows[0]?.id;
+      }
+
+      return undefined;
+    } catch (err) {
+      // PostgreSQL error 22P02 = invalid_text_representation: the ID is not a valid UUID.
+      // This happens when the LLM passes a hallucinated or synthetic string (e.g.
+      // 'joseph-fung-contact-id', 'primary-user') to a UUID column. Treat as unresolved
+      // rather than letting the error bubble up and surface to the caller.
+      if (
+        err !== null &&
+        typeof err === 'object' &&
+        'code' in err &&
+        (err as { code: string }).code === '22P02'
+      ) {
+        // Warn rather than debug: after the contact-resolver fix ships, this path should be
+        // unreachable in production. If it fires, something upstream is still leaking a
+        // synthetic/hallucinated ID and operators need a searchable signal to trace it.
+        this.logger.warn({ id }, 'entity-context: non-UUID id passed to resolveKgNodeId — treating as unresolved');
+        return undefined;
+      }
+      throw err;
+    }
+  }
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-email-resolve test -- tests/unit/entity-context/assembler.test.ts`
+
+Expected: All tests pass — both the new email resolution tests and the existing UUID-path tests.
+
+- [ ] **Step 4: Commit the implementation**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-email-resolve add src/entity-context/assembler.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-email-resolve commit -m "fix: resolve email addresses in entity-context via contact_channel_identities (#461)"
+```
+
+---
+
+### Task 3: Update CHANGELOG and run full test suite
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add a Fixed section to the changelog**
+
+Under `## [Unreleased]`, after the existing `### Changed` section (after line 28, before the `---` separator), add:
+
+```markdown
+### Fixed
+
+- **Entity-context email resolution** — `resolveKgNodeId` now resolves email addresses via `contact_channel_identities` before attempting UUID-based queries, fixing missing KG context in CC flows and ceo-inbox triage for known contacts ([#461](https://github.com/josephfung/curia/issues/461))
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-email-resolve test`
+
+Expected: All tests pass. No regressions.
+
+- [ ] **Step 3: Commit the changelog**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-email-resolve add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-email-resolve commit -m "chore: changelog entry for entity-context email resolution (#461)"
+```
+
+---
+
+## Follow-up (separate PR in curia-deploy)
+
+Update `custom/agents/ceo-inbox.yaml` line 145 from:
+
+> Call entity-context on the sender's email address.
+
+To:
+
+> Call entity-context with contactIds set to the sender's email address.
+
+This is a prompt clarification — the code fix in this PR makes it work either way, but the prompt should guide the LLM toward the correct input parameter.

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -253,9 +253,41 @@ export class EntityContextAssembler {
 
   /**
    * Resolve an input ID to a KG node ID.
-   * Tries contacts.id first, then kg_nodes.id directly.
+   *
+   * Resolution priority:
+   *   1. Email address → contact_channel_identities → contacts.kg_node_id
+   *   2. Contact UUID → contacts.kg_node_id
+   *   3. KG node UUID → kg_nodes.id directly
+   *
+   * Email detection uses a simple @ check. This handles the common case where
+   * LLMs pass raw email addresses from CC preambles or inbox triage rather than
+   * resolving to a contact UUID first.
    */
   private async resolveKgNodeId(id: string): Promise<string | undefined> {
+    // Email address detection: if the input contains '@' with non-whitespace on
+    // both sides, resolve via contact_channel_identities instead of UUID columns.
+    // This handles CC flows and ceo-inbox triage where the LLM passes a raw email.
+    if (/^\S+@\S+$/.test(id)) {
+      const emailResult = await this.pool.query<{ contact_id: string; kg_node_id: string | null }>(
+        `SELECT c.id AS contact_id, c.kg_node_id
+         FROM contact_channel_identities cci
+         JOIN contacts c ON c.id = cci.contact_id
+         WHERE cci.channel = 'email' AND LOWER(cci.channel_identifier) = LOWER($1)`,
+        [id],
+      );
+      if (emailResult.rows.length > 0) {
+        const row = emailResult.rows[0];
+        const kgNodeId = row?.kg_node_id;
+        if (!kgNodeId) {
+          this.logger.debug({ email: id, contactId: row?.contact_id }, 'entity-context: email resolved to contact with no linked KG node');
+          return undefined;
+        }
+        return kgNodeId;
+      }
+      // Email not found in contact_channel_identities — genuinely unknown contact
+      return undefined;
+    }
+
     try {
       // Try as a contact ID first
       const contactResult = await this.pool.query<{ kg_node_id: string | null }>(

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -264,33 +264,34 @@ export class EntityContextAssembler {
    * resolving to a contact UUID first.
    */
   private async resolveKgNodeId(id: string): Promise<string | undefined> {
-    // Email address detection: if the input looks like an email address (local-part @
-    // domain with at least one dot), resolve via contact_channel_identities instead of
-    // UUID columns. This handles CC flows and ceo-inbox triage where the LLM passes a
-    // raw email rather than a contact UUID.
-    if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(id)) {
-      const emailResult = await this.pool.query<{ contact_id: string; kg_node_id: string | null }>(
-        `SELECT c.id AS contact_id, c.kg_node_id
-         FROM contact_channel_identities cci
-         JOIN contacts c ON c.id = cci.contact_id
-         WHERE cci.channel = 'email' AND LOWER(cci.channel_identifier) = LOWER($1)`,
-        [id],
-      );
-      if (emailResult.rows.length > 0) {
-        const row = emailResult.rows[0];
-        const kgNodeId = row?.kg_node_id;
-        if (!kgNodeId) {
-          this.logger.debug({ email: id, contactId: row?.contact_id }, 'entity-context: email resolved to contact with no linked KG node');
-          return undefined;
-        }
-        return kgNodeId;
-      }
-      // Email not found in contact_channel_identities — unregistered contact
-      this.logger.debug({ email: id }, 'entity-context: email not found in contact_channel_identities — treating as unresolved');
-      return undefined;
-    }
-
     try {
+      // Email address detection: if the input looks like an email address (local-part @
+      // domain with at least one dot), resolve via contact_channel_identities instead of
+      // UUID columns. This handles CC flows and ceo-inbox triage where the LLM passes a
+      // raw email rather than a contact UUID.
+      if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(id)) {
+        const emailResult = await this.pool.query<{ contact_id: string; kg_node_id: string | null }>(
+          `SELECT c.id AS contact_id, c.kg_node_id
+           FROM contact_channel_identities cci
+           JOIN contacts c ON c.id = cci.contact_id
+           WHERE cci.channel = 'email' AND LOWER(cci.channel_identifier) = LOWER($1)`,
+          [id],
+        );
+        if (emailResult.rows.length > 0) {
+          const row = emailResult.rows[0];
+          const kgNodeId = row?.kg_node_id;
+          if (!kgNodeId) {
+            // Use inputKind rather than the raw email — 'email' is on the pino redact list.
+            this.logger.debug({ inputKind: 'email', contactId: row?.contact_id }, 'entity-context: email resolved to contact with no linked KG node');
+            return undefined;
+          }
+          return kgNodeId;
+        }
+        // Email not found in contact_channel_identities — unregistered contact
+        this.logger.debug({ inputKind: 'email' }, 'entity-context: email not found in contact_channel_identities — treating as unresolved');
+        return undefined;
+      }
+
       // Try as a contact ID first
       const contactResult = await this.pool.query<{ kg_node_id: string | null }>(
         'SELECT kg_node_id FROM contacts WHERE id = $1',

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -264,10 +264,11 @@ export class EntityContextAssembler {
    * resolving to a contact UUID first.
    */
   private async resolveKgNodeId(id: string): Promise<string | undefined> {
-    // Email address detection: if the input contains '@' with non-whitespace on
-    // both sides, resolve via contact_channel_identities instead of UUID columns.
-    // This handles CC flows and ceo-inbox triage where the LLM passes a raw email.
-    if (/^\S+@\S+$/.test(id)) {
+    // Email address detection: if the input looks like an email address (local-part @
+    // domain with at least one dot), resolve via contact_channel_identities instead of
+    // UUID columns. This handles CC flows and ceo-inbox triage where the LLM passes a
+    // raw email rather than a contact UUID.
+    if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(id)) {
       const emailResult = await this.pool.query<{ contact_id: string; kg_node_id: string | null }>(
         `SELECT c.id AS contact_id, c.kg_node_id
          FROM contact_channel_identities cci
@@ -284,7 +285,8 @@ export class EntityContextAssembler {
         }
         return kgNodeId;
       }
-      // Email not found in contact_channel_identities — genuinely unknown contact
+      // Email not found in contact_channel_identities — unregistered contact
+      this.logger.debug({ email: id }, 'entity-context: email not found in contact_channel_identities — treating as unresolved');
       return undefined;
     }
 

--- a/tests/unit/entity-context/assembler.test.ts
+++ b/tests/unit/entity-context/assembler.test.ts
@@ -429,6 +429,31 @@ describe('EntityContextAssembler', () => {
       expect(entities[1].entityId).toBe('node-1');
     });
 
+    it('resolves a mixed-case email address to the same KG node (case-insensitive)', async () => {
+      // Exercises the LOWER() match in the contact_channel_identities query.
+      const pool = makeSequentialPool([
+        { rows: [channelIdentityRow] },   // email resolution: found (case-insensitive match)
+        { rows: [personNodeRow] },         // getKgNode
+        { rows: [timezoneFactRow] },       // getFacts
+        { rows: [contactRow] },            // getContactByKgNodeId
+        { rows: [calendarRow] },           // getConnectedAccounts
+        { rows: [relationshipRow] },       // getRelationships
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const ctx = await assembler.assembleOne('Jenna@Example.com');
+
+      expect(ctx).toBeDefined();
+      expect(ctx!.entityId).toBe('node-1');
+      expect(ctx!.entityType).toBe('person');
+      expect(ctx!.label).toBe('Jenna Smith');
+      expect(ctx!.contact).toEqual({
+        contactId: 'contact-1',
+        displayName: 'Jenna Smith',
+        role: null,
+      });
+    });
+
     it('propagates DB errors from the email query path out of assembleOne', async () => {
       const pool = makeMockPool();
       const dbError = new Error('Connection reset by peer');

--- a/tests/unit/entity-context/assembler.test.ts
+++ b/tests/unit/entity-context/assembler.test.ts
@@ -428,5 +428,24 @@ describe('EntityContextAssembler', () => {
       // Second entity served from cache — same underlying contact
       expect(entities[1].entityId).toBe('node-1');
     });
+
+    it('propagates DB errors from the email query path out of assembleOne', async () => {
+      const pool = makeMockPool();
+      const dbError = new Error('Connection reset by peer');
+      vi.mocked(pool.query).mockRejectedValueOnce(dbError);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      await expect(assembler.assembleOne('jenna@example.com')).rejects.toThrow('Connection reset by peer');
+    });
+
+    it('treats email DB errors as unresolved in assembleMany', async () => {
+      const pool = makeMockPool();
+      vi.mocked(pool.query).mockRejectedValueOnce(new Error('pool timeout'));
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities, unresolved } = await assembler.assembleMany(['jenna@example.com']);
+      expect(entities).toHaveLength(0);
+      expect(unresolved).toEqual(['jenna@example.com']);
+    });
   });
 });

--- a/tests/unit/entity-context/assembler.test.ts
+++ b/tests/unit/entity-context/assembler.test.ts
@@ -80,6 +80,12 @@ const relationshipRow = {
   related_type: 'organization',
 };
 
+// -- Channel identity fixture for email resolution --
+const channelIdentityRow = {
+  contact_id: 'contact-1',
+  kg_node_id: 'node-1',
+};
+
 describe('EntityContextAssembler', () => {
   describe('assembleOne — person entity via contact ID', () => {
     it('assembles a full EntityContext for a person with facts and calendars', async () => {
@@ -340,6 +346,87 @@ describe('EntityContextAssembler', () => {
       const assembler = new EntityContextAssembler(pool, logger);
       const ctx = await assembler.assembleOne('contact-1');
       expect(ctx!.facts[0].category).toBe('unknown');
+    });
+  });
+
+  describe('resolveKgNodeId — email address resolution', () => {
+    it('resolves a registered email address to a KG node via contact_channel_identities', async () => {
+      // Query order for email path:
+      // 1. resolveKgNodeId: email → contact_channel_identities JOIN contacts → contact_id + kg_node_id
+      // 2. getKgNode
+      // 3. getFacts
+      // 4. getContactByKgNodeId
+      // 5. getConnectedAccounts
+      // 6. getRelationships
+      const pool = makeSequentialPool([
+        { rows: [channelIdentityRow] },   // email resolution: found
+        { rows: [personNodeRow] },         // getKgNode
+        { rows: [timezoneFactRow] },       // getFacts
+        { rows: [contactRow] },            // getContactByKgNodeId
+        { rows: [calendarRow] },           // getConnectedAccounts
+        { rows: [relationshipRow] },       // getRelationships
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const ctx = await assembler.assembleOne('jenna@example.com');
+
+      expect(ctx).toBeDefined();
+      expect(ctx!.entityId).toBe('node-1');
+      expect(ctx!.entityType).toBe('person');
+      expect(ctx!.label).toBe('Jenna Smith');
+      expect(ctx!.contact).toEqual({
+        contactId: 'contact-1',
+        displayName: 'Jenna Smith',
+        role: null,
+      });
+    });
+
+    it('returns undefined when email resolves to a contact with no KG node', async () => {
+      const pool = makeSequentialPool([
+        { rows: [{ contact_id: 'contact-1', kg_node_id: null }] }, // email found, no KG node
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const ctx = await assembler.assembleOne('jenna@example.com');
+      expect(ctx).toBeUndefined();
+    });
+
+    it('returns undefined for an unregistered email address', async () => {
+      const pool = makeSequentialPool([
+        { rows: [] }, // email not found in contact_channel_identities
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const ctx = await assembler.assembleOne('stranger@unknown.com');
+      expect(ctx).toBeUndefined();
+    });
+
+    it('assembleMany resolves a mix of email addresses and contact UUIDs', async () => {
+      // putInCache stores under all aliases: inputId ('jenna@example.com'),
+      // entityId ('node-1'), and contactId ('contact-1'). So the second
+      // lookup for 'contact-1' is a cache hit — no extra DB queries needed.
+      const pool = makeSequentialPool([
+        // First ID: email address — full resolution + assembly
+        { rows: [channelIdentityRow] },    // email resolution
+        { rows: [personNodeRow] },          // getKgNode
+        { rows: [] },                       // getFacts
+        { rows: [contactRow] },             // getContactByKgNodeId
+        { rows: [] },                       // getConnectedAccounts
+        { rows: [] },                       // getRelationships
+        // Second ID 'contact-1': cache hit, no DB queries
+      ]);
+
+      const assembler = new EntityContextAssembler(pool, logger);
+      const { entities, unresolved } = await assembler.assembleMany([
+        'jenna@example.com',
+        'contact-1',
+      ]);
+
+      expect(entities).toHaveLength(2);
+      expect(unresolved).toHaveLength(0);
+      expect(entities[0].entityId).toBe('node-1');
+      // Second entity served from cache — same underlying contact
+      expect(entities[1].entityId).toBe('node-1');
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause:** `resolveKgNodeId()` passed all inputs directly to UUID-typed columns (`contacts.id`, `kg_nodes.id`). Email addresses from CC preambles and ceo-inbox triage triggered PostgreSQL `22P02` errors, causing the entity to be treated as unresolved with no KG context.
- **Fix:** Added an email detection branch (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`) at the top of `resolveKgNodeId()` — inside the existing `try/catch` — that resolves via `contact_channel_identities JOIN contacts` with case-insensitive matching before touching UUID columns.
- **Tests:** 4 new unit tests covering registered email→KG node, email→contact with no KG node, unregistered email, mixed email+UUID batch with cache validation, and 2 DB error propagation tests.

Fixes #461. Follow-up: prompt clarification in curia-deploy (`ceo-inbox.yaml` line 145) to say `contactIds` instead of "sender's email address" — the code fix handles either, but the prompt should be accurate.

## Test Plan

- [x] `npm test -- tests/unit/entity-context/assembler.test.ts` — 17/17 pass
- [x] `npm test` — 2056/2056 pass (2 pre-existing integration tests skip without `DATABASE_URL`)
- [x] Email path sits inside `try/catch` — DB errors propagate consistently with UUID path
- [x] `inputKind: 'email'` used in debug logs instead of `email: id` (which is on the pino redact list)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed knowledge graph context resolution to support email address inputs, enabling proper contact identification for CC flows and CEO inbox triage workflows for known contacts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/522)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->