### PR TITLE
fix: route Google Workspace URLs through workspace skills (#496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Startup readiness checks** — system refuses inbound messages if no principal contact exists (`system_role='principal'`). Extensible `ReadinessCheck` interface for future setup validation.
 - **Research-analyst memory access** — pinned `memory-query` and `memory-store` to the research-analyst agent with domain-specific recall and storage guidance. Stored context about known entities now informs research; important findings about CEO-relevant entities are persisted to the knowledge graph.
 
+### Fixed
+
+- **Google Workspace URL routing** — coordinator now uses workspace skills for Google Docs/Drive URLs instead of falling back to web-browser. Research-analyst reports correctly when it cannot access a Workspace URL. Coordinator delegates to specialists more reliably via injected specialist list.
+
 ### Removed
 
 - **`knowledge-company-overview`, `knowledge-meeting-links`, `knowledge-travel-preferences`, `knowledge-loyalty-programs` skills** — replaced by `config-store` with namespaces `company`, `meeting_links`, `travel_preferences`, and `loyalty_programs`. The coordinator prompt now carries explicit namespace guidance.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -387,20 +387,6 @@ system_prompt: |
   fresh anchor. Do not treat it as an update to the existing job.
 
 
-  ## Research
-  You can search the web and fetch pages to answer questions and do research.
-  - For simple lookups ("find a restaurant", "what is X"), one search is enough.
-  - For research tasks, run multiple targeted searches before forming a conclusion —
-    each query should explore a different angle of the topic.
-  - When a search result looks important, use web-fetch to read the full article
-    before summarising it. Snippets can mislead.
-  - Use web-browser when a page requires JavaScript to render its content, when you
-    need to log in, fill out a form, or interact with a site that has no API.
-    web-fetch is faster — prefer it for static pages. web-browser is the fallback
-    for anything that needs a real browser.
-  - Cite your sources naturally ("according to [source]...") rather than listing URLs
-    at the end.
-
   ## Email
 
   You have your own email account (Curia's account). All email skills operate on your account.
@@ -522,9 +508,19 @@ system_prompt: |
 
   ## Your Team
   You have specialist agents you can delegate to using the "delegate" tool.
+
+  ${available_specialists}
+
   When a request requires specialized expertise, delegate to the right specialist.
   Always synthesize their response into your own voice — the user should never
   know multiple agents were involved.
+
+  When the CEO or a message provides a Google Workspace URL (docs.google.com,
+  drive.google.com, sheets.google.com), use the appropriate workspace skill to
+  access it — get_doc_as_markdown or get_doc_content for Google Docs,
+  get_drive_file_content for Drive files. Extract the document ID from the URL
+  and pass it to the skill. Never use web-browser or web-fetch for these URLs —
+  those tools have no Google credentials and will only return a login page.
 
   ### Delegation acknowledgment on synchronous channels
   When delegating a task that will take significant time (essay polishing, research,
@@ -582,6 +578,9 @@ pinned_skills:
   - web-browser
   - web-search
   - delegate
+  - get_doc_content
+  - get_doc_as_markdown
+  - get_drive_file_content
   - executive-profile-get
   - executive-profile-update
   - contact-create

--- a/agents/research-analyst.yaml
+++ b/agents/research-analyst.yaml
@@ -17,9 +17,14 @@ system_prompt: |
   2. Once you have identified a specific source that looks important, use web-fetch for
      targeted follow-up on known URLs only (never broad exploration). Always set a
      bounded max_length (e.g., 10000 chars) and fetch at most 3–4 pages per task.
+     Never use web-fetch on Google Workspace URLs (docs.google.com, drive.google.com,
+     sheets.google.com) — these require authenticated access and will return a login
+     page. If the task requires reading a Google Doc, report that you cannot access it
+     and recommend the coordinator delegate to a specialist with Google Workspace skills.
   3. Synthesize all findings into a clear, concise summary.
   4. Highlight key takeaways and any concerns.
-  5. Note your sources when possible.
+  5. Cite your sources naturally ("according to [source]...") rather than listing URLs
+     at the end.
 
   ## Memory
 


### PR DESCRIPTION
## Summary

- Removes the `## Research` section from coordinator.yaml — those heuristics belong in the research-analyst
- Injects `${available_specialists}` into coordinator so it sees its specialists at runtime and routes correctly
- Pins `get_doc_content`, `get_doc_as_markdown`, `get_drive_file_content` to the coordinator; adds explicit guidance to use workspace skills for Google Workspace URLs instead of web-browser or web-fetch
- Adds guidance to research-analyst to surface the gap when it receives a Google Workspace URL it can't access

Closes #496

## Test plan
- [ ] Given a `docs.google.com` URL in conversation, coordinator calls `get_doc_content` or `get_doc_as_markdown` without prompting
- [ ] Coordinator no longer calls `web-browser` for any Google Workspace URL
- [ ] Research-analyst reports it cannot access a Google Workspace URL and recommends a specialist