### PR TITLE
fix: use createRequire for pdf-parse CJS import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **file-parse skill** — fixed ESM import of `pdf-parse` (CJS-only package) using `createRequire`, which caused the skill to fail to load in production
+
 ### Added
 
 - **file-parse skill** — general-purpose document parser that extracts structured data from CSV, PDF, HTML, and image files. CSV is parsed deterministically (no LLM, confidence 1.0); images use Claude vision; PDFs and HTML use text extraction with optional LLM structuring. Supports `extract_as` hint for `receipt`, `bank_statement`, and `invoice` schemas. Reusable by any agent.

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -6,9 +6,14 @@
 // - PDF: pdf-parse text extraction, then optional LLM structuring
 // - HTML: tag stripping, then optional LLM structuring
 
+import { createRequire } from 'node:module';
 import Anthropic from '@anthropic-ai/sdk';
-import pdfParse from 'pdf-parse';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+// pdf-parse is CJS-only and doesn't provide a default ESM export.
+// Use createRequire to load it reliably under Node ESM + tsx.
+const require = createRequire(import.meta.url);
+const pdfParse = require('pdf-parse') as typeof import('pdf-parse');
 import { parseCsv } from './csv.js';
 import { getExtractionPrompt, type ExtractAs } from './prompts.js';
 


### PR DESCRIPTION
## Summary

- `pdf-parse` is CJS-only and doesn't provide a default ESM export
- `import pdfParse from 'pdf-parse'` fails at runtime under Node ESM + tsx with "does not provide an export named 'default'"
- Switch to `createRequire` for reliable CJS interop
- All 20 existing file-parse tests pass

## Test plan

- [x] `vitest run skills/file-parse/handler.test.ts` — all 20 tests pass
- [ ] Deploy to production and verify `file-parse` skill loads without error