### PR TITLE
fix: coordinator can't share Google Drive files despite skills being registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **file-parse skill** — fixed ESM import of `pdf-parse` (CJS-only package) using `createRequire`, which caused the skill to fail to load in production
+- **Coordinator: Google Drive sharing** — pinned Drive management skills (search, list, share, permissions) to the coordinator and added prompt guidance for Drive management and capability discovery, fixing a bug where the coordinator claimed it couldn't share Drive files despite the skills being registered
 
 ### Added
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -462,7 +462,9 @@ system_prompt: |
   folder, find something on Drive, or change who has access, use the appropriate
   Drive skill (search_drive_files, list_drive_items, manage_drive_access,
   set_drive_file_permissions). If you don't have the right skill pinned, search
-  for it with skill-registry before saying you can't.
+  for it with skill-registry before saying you can't. If neither your tools nor
+  skill-registry have any Drive skills, the Google Drive integration is likely
+  down — tell the CEO it appears to be temporarily unavailable.
 
   ### Delegation acknowledgment on synchronous channels
   When delegating a task that will take significant time (essay polishing, research,

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -446,12 +446,23 @@ system_prompt: |
   Always synthesize their response into your own voice — the user should never
   know multiple agents were involved.
 
-  When the CEO or a message provides a Google Workspace URL (docs.google.com,
-  drive.google.com, sheets.google.com), use the appropriate workspace skill to
-  access it — get_doc_as_markdown or get_doc_content for Google Docs,
-  get_drive_file_content for Drive files. Extract the document ID from the URL
-  and pass it to the skill. Never use web-browser or web-fetch for these URLs —
-  those tools have no Google credentials and will only return a login page.
+  ## Google Workspace
+  You have access to Google Drive, Docs, and Sheets through your workspace skills.
+
+  **Reading content:** When the CEO or a message provides a Google Workspace URL
+  (docs.google.com, drive.google.com, sheets.google.com), use the appropriate
+  workspace skill to access it — get_doc_as_markdown or get_doc_content for
+  Google Docs, get_drive_file_content for Drive files. Extract the document ID
+  from the URL and pass it to the skill. Never use web-browser or web-fetch for
+  these URLs — those tools have no Google credentials and will only return a
+  login page.
+
+  **Drive management:** You can also search for files, browse folders, and manage
+  sharing permissions on Google Drive. If the CEO asks you to share a file or
+  folder, find something on Drive, or change who has access, use the appropriate
+  Drive skill (search_drive_files, list_drive_items, manage_drive_access,
+  set_drive_file_permissions). If you don't have the right skill pinned, search
+  for it with skill-registry before saying you can't.
 
   ### Delegation acknowledgment on synchronous channels
   When delegating a task that will take significant time (essay polishing, research,
@@ -497,6 +508,12 @@ system_prompt: |
   - If the CEO's intent is ambiguous and multiple requests are pending,
     show the list and ask which one they mean
 
+  ## Capability Discovery
+  Your pinned skills are not everything you can do. Before telling the CEO you
+  lack a capability, search for it with skill-registry — additional skills from
+  external integrations (Google Workspace, etc.) may be available but not pinned.
+  Only say "I can't do that" after a search comes back empty.
+
   ## Guidelines
   - For casual messages, respond naturally and warmly
   - Handle tasks within your capability directly
@@ -511,6 +528,10 @@ pinned_skills:
   - get_doc_content
   - get_doc_as_markdown
   - get_drive_file_content
+  - search_drive_files
+  - list_drive_items
+  - manage_drive_access
+  - set_drive_file_permissions
   - executive-profile-get
   - executive-profile-update
   - email-send


### PR DESCRIPTION
## Summary

- Pin Drive management skills (`search_drive_files`, `list_drive_items`, `manage_drive_access`, `set_drive_file_permissions`) to the coordinator — the minimum set for Drive navigation and sharing
- Expand the Google Workspace prompt section to cover Drive management (sharing, permissions, folder browsing), not just reading documents
- Add a "Capability Discovery" guardrail: search `skill-registry` before saying "I can't do that" — prevents the same class of bug for any future MCP tool that's registered but not pinned
- Add degraded-state guidance so the coordinator tells the CEO "Drive integration appears temporarily unavailable" instead of a confusing "I can't do that" when the MCP server is down

**Root cause:** The coordinator only had read-only Google Workspace tools pinned (`get_doc_content`, `get_doc_as_markdown`, `get_drive_file_content`). When asked to share a Drive folder, it claimed no sharing skills existed — even though `manage_drive_access` and `set_drive_file_permissions` were registered in the global skill registry by the `workspace-mcp` server. The prompt also only described reading, and there was no guidance to use `skill-registry` before declining.

**Production conversation:** `kg-web-6f9663eb-f489-4ccb-b1f4-4017071da265`

## Test plan

- [ ] Typecheck passes (confirmed locally)
- [ ] All 2103 unit tests pass (confirmed locally)
- [ ] Agent loader and startup validator tests pass (confirmed locally — 32/32)
- [ ] Deploy to staging and ask coordinator to "share the Taxes folder with joseph@josephfung.ca as an editor" — should use `manage_drive_access` or `set_drive_file_permissions`
- [ ] Verify `skill-registry` fallback: ask coordinator for an obscure Drive operation not in pinned skills — should search skill-registry before declining
- [ ] Verify degraded state: stop the workspace-mcp server and ask for a Drive operation — should say "Drive integration appears temporarily unavailable"