### PR TITLE
chore: remove file-reader and file-writer skills from spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Removed
+
+- **`file-reader` and `file-writer` skills** removed from spec scope (spec 03, 06). General-purpose filesystem access from LLM-driven agents is an unacceptable prompt-injection vector on a single-tenant VPS. Email attachments are handled in-memory via Nylas SDK; agent-created documents should use the knowledge graph.
+
 ### Added
 
 - **Calendar Specialist agent** (`agents/calendar.yaml`) — new specialist that owns the full calendar domain: scheduling intelligence, free/busy queries, conflict resolution, event CRUD, and scheduling-related email composition. The coordinator delegates scheduling intent in natural language; the specialist resolves entities, finds available time, creates events, and composes meeting request/reschedule/cancellation email text. Includes preference-sensitive scheduling (queries memory for stored CEO preferences), multi-party timezone-aware slot finding, and conflict escalation patterns. (#499)

--- a/docs/specs/03-skills-and-execution.md
+++ b/docs/specs/03-skills-and-execution.md
@@ -185,7 +185,7 @@ The framework ships with these skills (in `skills/` as part of core):
 - `template-doc-request` — structured document request template (scheduling templates retired; calendar specialist composes scheduling email text directly)
 - `image-generate` — generate an image from a text prompt via DALL-E 3; returns a temporary CDN URL (~1hr TTL)
 
-**Not yet built:** `file-reader`, `file-writer`
+> **Removed from scope:** `file-reader` and `file-writer` were originally planned but removed after security review. General-purpose filesystem access from LLM-driven agents on a single-tenant VPS creates an unacceptable prompt-injection-to-file-exfiltration attack vector. Email attachments (the primary use case) are handled in-memory via the Nylas SDK's streaming/buffer APIs. Agent-created documents should use the knowledge graph. If a narrowly-scoped filesystem need arises later, build a purpose-specific skill rather than a general reader/writer.
 
 ---
 
@@ -227,5 +227,3 @@ These are not bundled but documented as recommended integrations:
 | Built-in skill: `image-generate` (DALL-E 3 image generation) | Done |
 | Built-in skill: `memory-query` (freeform KG search) | Done |
 | Built-in skill: `memory-store` (write-with-validation) | Done |
-| Built-in skill: `file-reader` | Not Done |
-| Built-in skill: `file-writer` | Not Done |

--- a/docs/specs/06-audit-and-security.md
+++ b/docs/specs/06-audit-and-security.md
@@ -308,7 +308,7 @@ Default sensitivity for new data is `internal`. Financial data defaults to `conf
 
 ### Bulk Export Controls
 
-Skills that export data (file-writer, Google Drive MCP, email-send with attachments) enforce:
+Skills that export data (Google Drive MCP, email-send with attachments) enforce:
 
 1. **Item count threshold** — exporting more than 10 items tagged `confidential` or higher in a single invocation triggers a human approval gate
 2. **Destination allowlisting** — external destinations (Drive folder IDs, email addresses, URLs) can be allowlisted in config. Unknown destinations trigger approval: "You're asking me to send financial data to a destination I haven't seen before. Can you confirm?"


### PR DESCRIPTION
## Summary

- Removes `file-reader` and `file-writer` from the skills spec (03) and audit spec (06) after security review
- General-purpose filesystem access from LLM-driven agents on a single-tenant VPS creates an unacceptable prompt-injection-to-file-exfiltration attack vector
- Email attachments (the primary use case) are handled in-memory via Nylas SDK streaming/buffer APIs; agent-created documents should use the knowledge graph

## Test plan

- [ ] Confirm spec 03 no longer lists file-reader/file-writer as planned or in the implementation status table
- [ ] Confirm spec 06 bulk export controls no longer reference file-writer
- [ ] Confirm CHANGELOG has a Removed entry under [Unreleased]