### PR TITLE
feat: fuzzy entity resolution for non-contact KG nodes (#467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Fuzzy entity resolution** — `resolveOrCreate()` now falls back to embedding-based semantic search when exact label match fails, preventing duplicate KG nodes from name variants like "Darlise" / "Darlise Restaurant". Confirmed matches are stored as aliases for instant future resolution. New `addAlias()` method on `EntityMemory`; `memory-store` handler learns aliases after disambiguation and auto-resolve. New migration `038_add_kg_node_aliases.sql` adds `aliases TEXT[]` column with GIN index. (#467)
+
 - **Calendar Specialist agent** (`agents/calendar.yaml`) — new specialist that owns the full calendar domain: scheduling intelligence, free/busy queries, conflict resolution, event CRUD, and scheduling-related email composition. The coordinator delegates scheduling intent in natural language; the specialist resolves entities, finds available time, creates events, and composes meeting request/reschedule/cancellation email text. Includes preference-sensitive scheduling (queries memory for stored CEO preferences), multi-party timezone-aware slot finding, and conflict escalation patterns. (#499)
 - **General pronoun-resolution rule** — coordinator now resolves possessive pronouns ("my calendar", "your schedule") to explicit entity identities before delegating to any specialist, replacing the calendar-specific disambiguation section.
 

--- a/docs/wip/2026-05-12-fuzzy-entity-resolve-design.md
+++ b/docs/wip/2026-05-12-fuzzy-entity-resolve-design.md
@@ -1,0 +1,168 @@
+# Fuzzy Entity Resolution for Non-Contact KG Nodes
+
+**Issue:** [#467](https://github.com/josephfung/curia/issues/467)
+**Date:** 2026-05-12
+
+## Problem
+
+`resolveOrCreate()` resolves non-contact entities by exact case-insensitive label
+match only (`WHERE lower(label) = lower($1)`). When the CEO refers to the same
+entity by slightly different names — "Darlise", "Darlise Restaurant", "the
+Darlise place" — each variant silently creates a separate KG node. Facts fragment
+across the graph, and `memory-query` recall degrades over time.
+
+Contacts don't have this problem because the coordinator resolves them via
+`contact-lookup → kg_node_id` before calling `memory-store`, bypassing label
+matching entirely.
+
+## Solution
+
+Three layered changes to `resolveOrCreate()` and its surroundings:
+
+1. **Migration: `aliases` column** — a `TEXT[]` array on `kg_nodes` that stores
+   confirmed name variants, capped at 10 per entity.
+2. **Embedding fallback** — when exact match (label + aliases) fails, embed the
+   input and vector-search entity nodes using a two-tier similarity threshold.
+3. **Alias learning** — when the coordinator confirms a disambiguation, store the
+   variant as an alias so future lookups resolve instantly via exact match.
+
+## Resolution Flow (New)
+
+```
+Input label
+    │
+    ├─ Exact match on lower(label) OR lower($1) = ANY(aliases)?
+    │   └─ yes → existing found/ambiguous logic (unchanged)
+    │
+    ├─ no → embed the label, vector search non-fact non-archived entity nodes
+    │   │
+    │   ├─ best candidate ≥ 0.90 cosine similarity → { kind: 'found', node }
+    │   ├─ any candidates 0.75–0.90 → { kind: 'ambiguous', candidates }
+    │   └─ nothing ≥ 0.75 → create new entity (reuse the computed embedding)
+    │
+    └─ done
+```
+
+### Exact-match phase (step 1)
+
+`findNodesByLabel()` gains alias awareness. The SQL becomes:
+
+```sql
+SELECT * FROM kg_nodes
+WHERE (lower(label) = lower($1) OR lower($1) = ANY(aliases))
+  AND archived_at IS NULL
+```
+
+The `aliases` column stores pre-lowercased strings, so the `ANY(aliases)` check
+compares `lower(input)` against stored values directly. A GIN index on the array
+supports efficient containment queries.
+
+This phase is unchanged in semantics — it returns all matching nodes, and the
+existing 0/1/2+ branching in `resolveOrCreate()` handles the result the same way.
+
+### Embedding fallback (step 2)
+
+When exact match returns 0 results, `resolveOrCreate()`:
+
+1. Embeds the input label via `embeddingService.embed(label)`.
+2. Runs a vector search against non-fact, non-archived entity nodes using the
+   existing pgvector HNSW index.
+3. Applies the two-tier threshold to partition results:
+   - **≥ 0.90** (auto-resolve threshold): high confidence that this is the same
+     entity. Returns `{ kind: 'found', node }` for the best match.
+   - **0.75–0.90** (ambiguity zone): plausible but uncertain. Returns
+     `{ kind: 'ambiguous', candidates }` with ranked results.
+   - **< 0.75**: no plausible match. Falls through to entity creation, reusing
+     the embedding vector already computed (avoids a redundant API call).
+
+The vector search filters to `type != 'fact'` and `archived_at IS NULL` but does
+**not** filter by the caller's type hint. This is consistent with the existing
+single-match behavior where a lone label match returns 'found' even when the type
+differs (see issue #474). The type hint participates only as a tiebreaker when
+multiple candidates exceed the auto-resolve threshold, consistent with the existing
+2+ match logic.
+
+### Alias learning (step 3)
+
+When `memory-store` receives an `ambiguous` result and the coordinator confirms
+which entity the CEO meant, the handler calls:
+
+```typescript
+await ctx.entityMemory.addAlias(confirmedNodeId, originalInputLabel);
+```
+
+`addAlias()`:
+- Lowercases the alias.
+- Checks the current alias count; rejects if >= 10 (logs a warning, does not
+  throw — the fact storage still proceeds, we just don't learn the alias).
+- Appends to the `aliases` array on the node via
+  `UPDATE kg_nodes SET aliases = array_append(aliases, $2) WHERE id = $1`.
+
+On subsequent calls with the same variant, exact match finds it via the alias
+in step 1 — no embedding call needed.
+
+### Auto-resolve alias learning
+
+When the embedding fallback auto-resolves (≥ 0.90), the system also stores the
+input label as an alias on the matched node. This prevents the same high-confidence
+match from requiring an embedding call on every future occurrence.
+
+## Thresholds
+
+| Constant | Value | Rationale |
+|----------|-------|-----------|
+| `FUZZY_RESOLVE_THRESHOLD` | 0.90 | Entity labels are short phrases; 0.90 is high enough to avoid false matches but lower than the 0.92 fact dedup threshold (fact labels like "location: Toronto" carry more semantic signal than bare entity names) |
+| `FUZZY_AMBIGUITY_FLOOR` | 0.75 | Below this, names are too different to be plausible variants of the same entity |
+| `MAX_ALIASES_PER_ENTITY` | 10 | Guardrail against degenerate alias accumulation; real entities rarely have more than 3-4 name variants |
+
+These are defined as named constants in `entity-memory.ts`, easy to tune later.
+
+## Performance
+
+The embedding API call in the fallback path is not new overhead — `upsertNode()`
+already calls `embeddingService.embed(label)` on every entity creation. The
+fallback simply moves this call earlier in the flow (before the create/match
+decision) and adds one indexed vector search query against the HNSW index.
+
+On the happy path (exact match on label or alias), there is zero added cost —
+no embedding call, no vector search.
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Exact label match | 1 DB query | 1 DB query (same, now includes alias check) |
+| Alias match (learned) | N/A (would create duplicate) | 1 DB query (alias hit in exact-match phase) |
+| Fuzzy match (first time) | 1 DB query + 1 embed (creates duplicate) | 1 DB query + 1 embed + 1 vector search (correct match) |
+| No match → create | 1 DB query + 1 embed | 1 DB query + 1 embed + 1 vector search (confirms no near-match) |
+
+## Migration
+
+Migration `037_add_kg_node_aliases.sql`:
+
+```sql
+ALTER TABLE kg_nodes ADD COLUMN aliases TEXT[] NOT NULL DEFAULT '{}';
+CREATE INDEX idx_kg_nodes_aliases ON kg_nodes USING GIN (aliases);
+```
+
+The `aliases` array stores pre-lowercased strings. The GIN index supports
+`lower($1) = ANY(aliases)` containment queries efficiently.
+
+## Scope
+
+### In scope (this issue)
+
+- Migration adding `aliases TEXT[]` column + GIN index
+- `findNodesByLabel()` gains alias awareness in both Postgres and in-memory backends
+- `resolveOrCreate()` gains embedding fallback with two-tier threshold
+- `addAlias()` method on `EntityMemory` with cap enforcement
+- `memory-store` handler calls `addAlias()` after disambiguation confirmation
+  and after auto-resolve
+- Unit tests for all new behavior
+- Integration test for the full resolve → disambiguate → alias → re-resolve cycle
+
+### Out of scope (follow-up issues)
+
+- `updateNode()` label-collision check using aliases
+- `memory-query` semantic search surfacing alias matches
+- `mergeEntities()` consolidating aliases from both nodes
+- Other callers of `findNodesByLabel()` (e.g. extract-facts)
+- Backfill: detecting and merging existing duplicate nodes in production

--- a/docs/wip/2026-05-12-fuzzy-entity-resolve-design.md
+++ b/docs/wip/2026-05-12-fuzzy-entity-resolve-design.md
@@ -136,7 +136,7 @@ no embedding call, no vector search.
 
 ## Migration
 
-Migration `037_add_kg_node_aliases.sql`:
+Migration `038_add_kg_node_aliases.sql`:
 
 ```sql
 ALTER TABLE kg_nodes ADD COLUMN aliases TEXT[] NOT NULL DEFAULT '{}';

--- a/docs/wip/2026-05-12-fuzzy-entity-resolve.md
+++ b/docs/wip/2026-05-12-fuzzy-entity-resolve.md
@@ -1,0 +1,905 @@
+# Fuzzy Entity Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace exact-match-only entity resolution with embedding-based fuzzy matching and alias learning, so name variants like "Darlise" / "Darlise Restaurant" resolve to the same KG node instead of creating duplicates.
+
+**Architecture:** `resolveOrCreate()` gains a two-phase lookup: exact match (label + aliases) first, then embedding-based vector search as a fallback. Confirmed matches store aliases for instant future resolution. A new `aliases TEXT[]` column on `kg_nodes` provides the storage.
+
+**Tech Stack:** PostgreSQL (GIN index on TEXT[]), pgvector (HNSW index for cosine similarity), Vitest
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Create | `src/db/migrations/038_add_kg_node_aliases.sql` | Add `aliases` column + GIN index |
+| Modify | `src/memory/types.ts` | Add `aliases` field to `KgNode` interface |
+| Modify | `src/memory/knowledge-graph.ts:666-711` | Update `PgNodeRow`, `pgRowToNode`, `findNodesByLabel` (Postgres + in-memory) |
+| Modify | `src/memory/entity-memory.ts:77-90,110-119,273-313` | Add `addAlias()`, update constructor to keep `embeddingService`, add fuzzy fallback to `resolveOrCreate()`, new constants |
+| Modify | `skills/memory-store/handler.ts:136-156` | Call `addAlias()` on disambiguation confirmation and auto-resolve |
+| Create | `src/memory/entity-memory.resolve-or-create.test.ts` (extend) | Tests for fuzzy resolution and alias learning |
+
+---
+
+## Task 1: Migration — add `aliases` column
+
+**Files:**
+- Create: `src/db/migrations/038_add_kg_node_aliases.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+```sql
+-- 038_add_kg_node_aliases.sql
+--
+-- Adds an aliases column to kg_nodes for fuzzy entity resolution (#467).
+-- Stores lowercased name variants so exact-match resolution catches
+-- previously-confirmed name variants without an embedding call.
+--
+-- The GIN index supports efficient ANY() containment queries on the array.
+
+ALTER TABLE kg_nodes ADD COLUMN aliases TEXT[] NOT NULL DEFAULT '{}';
+
+CREATE INDEX idx_kg_nodes_aliases ON kg_nodes USING GIN (aliases);
+```
+
+- [ ] **Step 2: Verify migration numbering**
+
+Run: `ls src/db/migrations/ | sort | tail -5`
+
+Expected: `038_add_kg_node_aliases.sql` is the latest and there are no duplicates. If another migration 038 exists from the parallel session, renumber to 039.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/db/migrations/038_add_kg_node_aliases.sql
+git commit -m "feat: add aliases column to kg_nodes for fuzzy entity resolution"
+```
+
+---
+
+## Task 2: Add `aliases` to KgNode type and row converter
+
+**Files:**
+- Modify: `src/memory/types.ts:64-74`
+- Modify: `src/memory/knowledge-graph.ts:666-711`
+
+- [ ] **Step 1: Write the failing test — aliases field exists on KgNode**
+
+Add to the bottom of `src/memory/entity-memory.resolve-or-create.test.ts`:
+
+```typescript
+describe('KgNode aliases field', () => {
+  it('newly created entity nodes have an empty aliases array', async () => {
+    const { mem } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Acme Corp', properties: {}, source: 'test',
+    });
+
+    expect(entity.aliases).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx --prefix /path/to/worktree vitest run src/memory/entity-memory.resolve-or-create.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: FAIL — `entity.aliases` is undefined because the field doesn't exist on `KgNode` yet.
+
+- [ ] **Step 3: Add `aliases` to the `KgNode` interface in `src/memory/types.ts`**
+
+In `src/memory/types.ts`, add the `aliases` field to the `KgNode` interface after `sensitivity`:
+
+```typescript
+  // Confirmed name variants for fuzzy entity resolution (#467).
+  // Stored as lowercased strings; exact-match resolution checks aliases
+  // alongside the canonical label. Capped at MAX_ALIASES_PER_ENTITY (10).
+  aliases: string[];
+```
+
+- [ ] **Step 4: Add `aliases` to `PgNodeRow` in `src/memory/knowledge-graph.ts`**
+
+In `src/memory/knowledge-graph.ts`, add to the `PgNodeRow` interface (after `archived_at`):
+
+```typescript
+  aliases: string[];
+```
+
+- [ ] **Step 5: Update `pgRowToNode` to include aliases**
+
+In `src/memory/knowledge-graph.ts`, update the `pgRowToNode` function to include aliases in the returned object (after `sensitivity`):
+
+```typescript
+    aliases: row.aliases ?? [],
+```
+
+- [ ] **Step 6: Update `createNode` to include aliases in the INSERT**
+
+In `KnowledgeGraphStore.createNode()` (line ~122), add `aliases: []` to the `KgNode` object being constructed:
+
+```typescript
+    const node: KgNode = {
+      id: createNodeId(),
+      type: options.type,
+      label: options.label,
+      properties: { ...options.properties },
+      embedding,
+      temporal: {
+        createdAt: now,
+        lastConfirmedAt: now,
+        confidence: options.confidence ?? 0.7,
+        decayClass: options.decayClass ?? 'slow_decay',
+        source: options.source,
+      },
+      sensitivity: options.sensitivity ?? 'internal',
+      aliases: [],
+    };
+```
+
+- [ ] **Step 7: Update `upsertNode` in `KnowledgeGraphStore` to include aliases**
+
+In `KnowledgeGraphStore.upsertNode()` (line ~160), add `aliases: []` to the `KgNode` object being constructed (same pattern as `createNode`).
+
+- [ ] **Step 8: Update `InMemoryBackend.upsertNode` to preserve aliases on merge**
+
+In `InMemoryBackend.upsertNode()` (line ~765), when constructing the `updated` node for the existing-match path, preserve the existing aliases:
+
+```typescript
+      const updated: KgNode = {
+        ...existing,
+        temporal: {
+          ...existing.temporal,
+          confidence: Math.max(existing.temporal.confidence, node.temporal.confidence),
+          lastConfirmedAt: node.temporal.lastConfirmedAt,
+        },
+      };
+```
+
+No change needed here — the spread of `...existing` already preserves `aliases`. But the newly constructed node in the `node.type === 'fact'` fast path and the no-match insert path need `aliases: []` added. Since `KgNode` now requires `aliases`, the in-memory backend's `createNode` already receives it from the store layer. Verify this compiles.
+
+- [ ] **Step 9: Run test to verify it passes**
+
+Run: `npx --prefix /path/to/worktree vitest run src/memory/entity-memory.resolve-or-create.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: PASS — all existing tests still pass, and the new test confirms `aliases` is `[]`.
+
+- [ ] **Step 10: Run full test suite to check nothing broke**
+
+Run: `npx --prefix /path/to/worktree vitest run src/memory/ --reporter=verbose 2>&1 | tail -30`
+
+Expected: All tests pass. If any fail, fix compilation issues where `KgNode` objects are constructed without `aliases`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/memory/types.ts src/memory/knowledge-graph.ts src/memory/entity-memory.resolve-or-create.test.ts
+git commit -m "feat: add aliases field to KgNode type and row converter"
+```
+
+---
+
+## Task 3: Alias-aware `findNodesByLabel`
+
+**Files:**
+- Modify: `src/memory/knowledge-graph.ts:472-480` (Postgres backend)
+- Modify: `src/memory/knowledge-graph.ts:843-852` (in-memory backend)
+- Test: `src/memory/entity-memory.resolve-or-create.test.ts`
+
+- [ ] **Step 1: Write the failing test — findNodesByLabel matches aliases**
+
+Add to `src/memory/entity-memory.resolve-or-create.test.ts`, inside a new describe block:
+
+```typescript
+describe('EntityMemory.findEntities — alias awareness', () => {
+  it('finds an entity by alias when the canonical label does not match', async () => {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    const mem = new EntityMemory(store, validator, embeddingService, createSilentLogger());
+
+    // Create a node and manually set an alias on it via the store
+    const node = await store.createNode({
+      type: 'organization',
+      label: 'Darlise Restaurant',
+      properties: {},
+      source: 'test',
+    });
+    // Simulate a learned alias by updating the node's aliases directly
+    const withAlias: KgNode = { ...node, aliases: ['darlise'] };
+    await store.updateNode(node.id, withAlias);
+
+    const results = await mem.findEntities('Darlise');
+    expect(results).toHaveLength(1);
+    expect(results[0]!.id).toBe(node.id);
+  });
+
+  it('does not match archived nodes via alias', async () => {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    const mem = new EntityMemory(store, validator, embeddingService, createSilentLogger());
+
+    const node = await store.createNode({
+      type: 'organization',
+      label: 'Darlise Restaurant',
+      properties: {},
+      source: 'test',
+    });
+    const withAlias: KgNode = { ...node, aliases: ['darlise'] };
+    await store.updateNode(node.id, withAlias);
+    await store.archiveNode(node.id);
+
+    const results = await mem.findEntities('Darlise');
+    expect(results).toHaveLength(0);
+  });
+});
+```
+
+You will also need to import `KgNode` from `./types.js` at the top of the test file.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx --prefix /path/to/worktree vitest run src/memory/entity-memory.resolve-or-create.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: FAIL — `findEntities('Darlise')` returns 0 results because the current implementation only checks label, not aliases.
+
+- [ ] **Step 3: Update Postgres `findNodesByLabel` to check aliases**
+
+In `src/memory/knowledge-graph.ts`, update the `PostgresBackend.findNodesByLabel` method (line ~472):
+
+```typescript
+  async findNodesByLabel(label: string): Promise<KgNode[]> {
+    // Case-insensitive match on canonical label OR any stored alias.
+    // Aliases are stored pre-lowercased, so lower($1) matches directly.
+    // The btree index on lower(label) handles the first condition;
+    // the GIN index on aliases handles the second.
+    const result = await this.pool.query<PgNodeRow>(
+      `SELECT * FROM kg_nodes
+       WHERE (lower(label) = lower($1) OR lower($1) = ANY(aliases))
+         AND archived_at IS NULL`,
+      [label],
+    );
+    return result.rows.map(pgRowToNode);
+  }
+```
+
+- [ ] **Step 4: Update in-memory `findNodesByLabel` to check aliases**
+
+In `src/memory/knowledge-graph.ts`, update `InMemoryBackend.findNodesByLabel` (line ~843):
+
+```typescript
+  async findNodesByLabel(label: string): Promise<KgNode[]> {
+    const lowerLabel = label.toLowerCase();
+    const results: KgNode[] = [];
+    for (const node of this.nodes.values()) {
+      if (this.archivedNodes.has(node.id)) continue;
+      const labelMatch = node.label.toLowerCase() === lowerLabel;
+      const aliasMatch = node.aliases.some(a => a === lowerLabel);
+      if (labelMatch || aliasMatch) {
+        results.push(node);
+      }
+    }
+    return results;
+  }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx --prefix /path/to/worktree vitest run src/memory/entity-memory.resolve-or-create.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: PASS — both new tests and all existing tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/memory/knowledge-graph.ts src/memory/entity-memory.resolve-or-create.test.ts
+git commit -m "feat: findNodesByLabel checks aliases for fuzzy entity resolution"
+```
+
+---
+
+## Task 4: `addAlias()` method on EntityMemory
+
+**Files:**
+- Modify: `src/memory/entity-memory.ts`
+- Modify: `src/memory/knowledge-graph.ts` (store-level `addAlias` or `updateNode`)
+- Test: `src/memory/entity-memory.resolve-or-create.test.ts`
+
+- [ ] **Step 1: Write the failing tests for addAlias**
+
+Add to `src/memory/entity-memory.resolve-or-create.test.ts`:
+
+```typescript
+describe('EntityMemory.addAlias', () => {
+  it('appends a lowercased alias to the entity node', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+
+    await mem.addAlias(entity.id, 'Darlise');
+
+    const updated = await store.getNode(entity.id);
+    expect(updated!.aliases).toEqual(['darlise']);
+  });
+
+  it('does not add duplicate aliases', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+
+    await mem.addAlias(entity.id, 'Darlise');
+    await mem.addAlias(entity.id, 'DARLISE'); // same after lowering
+
+    const updated = await store.getNode(entity.id);
+    expect(updated!.aliases).toEqual(['darlise']);
+  });
+
+  it('does not add an alias that matches the canonical label', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+
+    await mem.addAlias(entity.id, 'Darlise Restaurant');
+
+    const updated = await store.getNode(entity.id);
+    expect(updated!.aliases).toEqual([]);
+  });
+
+  it('rejects when alias count reaches MAX_ALIASES_PER_ENTITY', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+
+    // Fill up to the cap (10)
+    for (let i = 0; i < 10; i++) {
+      await mem.addAlias(entity.id, `alias-${i}`);
+    }
+
+    const updated = await store.getNode(entity.id);
+    expect(updated!.aliases).toHaveLength(10);
+
+    // 11th alias should be silently rejected
+    await mem.addAlias(entity.id, 'one-too-many');
+    const afterReject = await store.getNode(entity.id);
+    expect(afterReject!.aliases).toHaveLength(10);
+    expect(afterReject!.aliases).not.toContain('one-too-many');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx --prefix /path/to/worktree vitest run src/memory/entity-memory.resolve-or-create.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: FAIL — `mem.addAlias` does not exist.
+
+- [ ] **Step 3: Add the constant and method to EntityMemory**
+
+In `src/memory/entity-memory.ts`, add the constant near the top of the file (after the `FACT_TYPE` constant on line ~94):
+
+```typescript
+/** Maximum aliases per entity node. Guardrail against degenerate alias accumulation;
+ *  real entities rarely have more than 3-4 name variants. */
+export const MAX_ALIASES_PER_ENTITY = 10;
+```
+
+Then add the `addAlias` method to the `EntityMemory` class (after `resolveOrCreate`, around line 313):
+
+```typescript
+  /**
+   * Store a confirmed name variant as an alias on an entity node.
+   *
+   * Lowercases the alias before storing. Silently skips if:
+   * - The alias matches the canonical label (case-insensitive)
+   * - The alias already exists in the aliases array
+   * - The entity has reached MAX_ALIASES_PER_ENTITY (10)
+   * - The entity node does not exist
+   *
+   * Does not throw — alias learning is best-effort and should never
+   * block fact storage.
+   */
+  async addAlias(nodeId: string, alias: string): Promise<void> {
+    const lowerAlias = alias.toLowerCase();
+
+    const node = await this.store.getNode(nodeId);
+    if (!node) {
+      this.logger.warn({ nodeId, alias }, 'addAlias: entity node not found');
+      return;
+    }
+
+    // Skip if alias matches canonical label
+    if (node.label.toLowerCase() === lowerAlias) {
+      return;
+    }
+
+    // Skip if alias already exists
+    if (node.aliases.includes(lowerAlias)) {
+      return;
+    }
+
+    // Skip if at cap
+    if (node.aliases.length >= MAX_ALIASES_PER_ENTITY) {
+      this.logger.warn(
+        { nodeId, alias, count: node.aliases.length, max: MAX_ALIASES_PER_ENTITY },
+        'addAlias: alias cap reached — skipping',
+      );
+      return;
+    }
+
+    const updatedAliases = [...node.aliases, lowerAlias];
+    await this.store.updateNode(nodeId, { ...node, aliases: updatedAliases });
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx --prefix /path/to/worktree vitest run src/memory/entity-memory.resolve-or-create.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: PASS — all four addAlias tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/memory/entity-memory.ts src/memory/entity-memory.resolve-or-create.test.ts
+git commit -m "feat: addAlias method on EntityMemory with cap enforcement"
+```
+
+---
+
+## Task 5: Embedding fallback in `resolveOrCreate()`
+
+**Files:**
+- Modify: `src/memory/entity-memory.ts:110-119,273-313`
+- Test: `src/memory/entity-memory.resolve-or-create.test.ts`
+
+This is the core change. `resolveOrCreate()` needs access to the `store.semanticSearch()` method (which handles embedding + vector search internally). It already has `this.store`.
+
+- [ ] **Step 1: Write failing tests for fuzzy resolution**
+
+Add to `src/memory/entity-memory.resolve-or-create.test.ts`:
+
+```typescript
+describe('EntityMemory.resolveOrCreate — fuzzy fallback', () => {
+  it('returns found via embedding when label is a close variant of an existing entity', async () => {
+    const { mem } = makeEntityMemory();
+    // Create a node with one name
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+
+    // Resolve with a variant — exact match will miss, fuzzy fallback should find it.
+    // Note: with the fake embedding backend, similarity depends on string hash proximity.
+    // We test the *mechanism* (fallback fires and returns found), not the threshold tuning.
+    const result = await mem.resolveOrCreate({
+      label: 'Darlise Restaurant',  // exact match — this should still hit the exact path
+      type: 'organization',
+      source: 'test',
+    });
+
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') throw new Error('narrowing');
+    expect(result.node.id).toBe(entity.id);
+  });
+
+  it('creates a new entity when no fuzzy match exceeds the ambiguity floor', async () => {
+    const { mem } = makeEntityMemory();
+    // Create an entity with a completely unrelated name
+    await mem.createEntity({
+      type: 'organization', label: 'Acme Corp', properties: {}, source: 'test',
+    });
+
+    // Resolve with a totally different name — should create, not match
+    const result = await mem.resolveOrCreate({
+      label: 'Zephyr Dynamics',
+      type: 'organization',
+      source: 'test',
+    });
+
+    expect(result.kind).toBe('created');
+  });
+
+  it('stores an alias on auto-resolve so the next call uses exact match', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+
+    // Manually set up a scenario where fuzzy match would fire and auto-resolve:
+    // Add an alias directly so the second resolveOrCreate hits exact match.
+    await mem.addAlias(entity.id, 'darlise');
+
+    const result = await mem.resolveOrCreate({
+      label: 'Darlise',
+      type: 'organization',
+      source: 'test',
+    });
+
+    // Should find via alias — no fuzzy fallback needed
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') throw new Error('narrowing');
+    expect(result.node.id).toBe(entity.id);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify initial state**
+
+Run: `npx --prefix /path/to/worktree vitest run src/memory/entity-memory.resolve-or-create.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: The "alias exact match" test should already pass (from Task 3 work). The others may pass or fail depending on whether the fake embedding backend produces close enough vectors. Note the test results — they establish which paths need the fuzzy fallback vs which already work.
+
+- [ ] **Step 3: Add threshold constants to `entity-memory.ts`**
+
+Add near the top of `src/memory/entity-memory.ts`, after `MAX_ALIASES_PER_ENTITY`:
+
+```typescript
+/** Cosine similarity threshold for auto-resolving a fuzzy entity match.
+ *  At or above this, the match is confident enough to return 'found' without
+ *  asking the CEO. Lower than the 0.92 fact dedup threshold because entity
+ *  labels are shorter phrases with less semantic signal. */
+export const FUZZY_RESOLVE_THRESHOLD = 0.90;
+
+/** Cosine similarity floor for surfacing ambiguous fuzzy candidates.
+ *  Below this, names are too different to be plausible variants. */
+export const FUZZY_AMBIGUITY_FLOOR = 0.75;
+
+/** Max candidates to retrieve from semantic search during fuzzy resolution.
+ *  Kept small — we only need the top few potential matches. */
+const FUZZY_SEARCH_LIMIT = 5;
+```
+
+- [ ] **Step 4: Update `resolveOrCreate` with the fuzzy fallback**
+
+Replace the body of `resolveOrCreate()` in `src/memory/entity-memory.ts` (lines 273-313):
+
+```typescript
+  async resolveOrCreate(options: ResolveOrCreateOptions): Promise<ResolveOrCreateResult> {
+    // Phase 1: exact match on canonical label + aliases
+    const matches = await this.store.findNodesByLabel(options.label);
+
+    if (matches.length === 1) {
+      const node = matches[0]!;
+      if (node.type !== options.type) {
+        this.logger.warn(
+          { label: options.label, expectedType: options.type, actualType: node.type, nodeId: node.id },
+          'resolveOrCreate: single match type differs from caller hint',
+        );
+      }
+      return { kind: 'found', node };
+    }
+
+    if (matches.length > 1) {
+      const typeMatch = matches.find(n => n.type === options.type);
+      if (typeMatch) {
+        return { kind: 'found', node: typeMatch };
+      }
+      return { kind: 'ambiguous', candidates: matches };
+    }
+
+    // Phase 2: no exact match — try embedding-based fuzzy resolution.
+    // semanticSearch() embeds the query and returns results sorted by score desc.
+    // Filter to non-fact entity nodes only.
+    const fuzzyResults = await this.store.semanticSearch(options.label, {
+      limit: FUZZY_SEARCH_LIMIT,
+    });
+
+    // Filter out fact nodes — we only want entity nodes
+    const entityCandidates = fuzzyResults.filter(r => r.node.type !== 'fact');
+
+    // Partition candidates by threshold
+    const autoResolve = entityCandidates.filter(r => r.score >= FUZZY_RESOLVE_THRESHOLD);
+    const ambiguous = entityCandidates.filter(
+      r => r.score >= FUZZY_AMBIGUITY_FLOOR && r.score < FUZZY_RESOLVE_THRESHOLD,
+    );
+
+    if (autoResolve.length > 0) {
+      // Pick the best match; use type as tiebreaker if multiple exceed the threshold
+      const typeMatch = autoResolve.find(r => r.node.type === options.type);
+      const best = typeMatch ?? autoResolve[0]!;
+
+      if (best.node.type !== options.type) {
+        this.logger.warn(
+          { label: options.label, expectedType: options.type, actualType: best.node.type, nodeId: best.node.id },
+          'resolveOrCreate: fuzzy auto-resolve type differs from caller hint',
+        );
+      }
+
+      // Learn the alias so future lookups resolve via exact match
+      await this.addAlias(best.node.id, options.label);
+
+      return { kind: 'found', node: best.node };
+    }
+
+    if (ambiguous.length > 0) {
+      return { kind: 'ambiguous', candidates: ambiguous.map(r => r.node) };
+    }
+
+    // Phase 3: no match at all — create a new entity
+    const { entity } = await this.createEntity({
+      type: options.type,
+      label: options.label,
+      properties: {},
+      source: options.source,
+      confidence: options.confidence ?? 0.6,
+    });
+    return { kind: 'created', node: entity };
+  }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx --prefix /path/to/worktree vitest run src/memory/entity-memory.resolve-or-create.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: All tests pass. The "alias exact match" test hits Phase 1. The "creates when no fuzzy match" test hits Phase 3. The exact-match tests from Task 2 are unchanged.
+
+**Note about the fake embedding backend:** The `FakeEmbeddingBackend` produces deterministic vectors using a hash-based LCG. Cosine similarity between "Darlise Restaurant" and "Darlise" may or may not exceed 0.90 with fake embeddings. If the auto-resolve test fails because the fake similarity is too low, that's expected — the test is validating the mechanism, not the threshold. Adjust the test to use a name pair whose fake-embedding similarity lands above 0.90, or test the auto-resolve path more directly (see Task 6).
+
+- [ ] **Step 6: Run the full memory test suite**
+
+Run: `npx --prefix /path/to/worktree vitest run src/memory/ --reporter=verbose 2>&1 | tail -30`
+
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/memory/entity-memory.ts src/memory/entity-memory.resolve-or-create.test.ts
+git commit -m "feat: embedding-based fuzzy fallback in resolveOrCreate"
+```
+
+---
+
+## Task 6: Targeted fuzzy-path tests with controlled similarity
+
+The fake embedding backend makes it hard to test threshold behavior directly. This task adds tests that exercise the fuzzy path by injecting known embeddings, bypassing the fake backend's hash-based vectors.
+
+**Files:**
+- Modify: `src/memory/entity-memory.resolve-or-create.test.ts`
+
+- [ ] **Step 1: Write tests that exercise the fuzzy auto-resolve and ambiguity paths**
+
+These tests create entities with known embeddings and then call `resolveOrCreate` with labels that will produce different embeddings — but we can control the outcome by directly manipulating node embeddings in the in-memory store.
+
+Add to `src/memory/entity-memory.resolve-or-create.test.ts`:
+
+```typescript
+import { FUZZY_RESOLVE_THRESHOLD, FUZZY_AMBIGUITY_FLOOR } from './entity-memory.js';
+
+describe('EntityMemory.resolveOrCreate — fuzzy threshold behavior', () => {
+  it('auto-resolves and learns alias when fuzzy score >= FUZZY_RESOLVE_THRESHOLD', async () => {
+    // This test validates the mechanism by checking that:
+    // 1. When exact match misses, semantic search is called
+    // 2. A high-scoring result returns 'found'
+    // 3. An alias is learned
+    //
+    // With the fake embedding backend, we rely on the deterministic hash to produce
+    // consistent results. The key assertion is that resolveOrCreate does NOT create
+    // a duplicate when a semantically similar entity exists.
+    const { mem, store } = makeEntityMemory();
+
+    // Create entity — this embeds the label via the fake backend
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Acme Corp', properties: {}, source: 'test',
+    });
+
+    // Use the exact same label — this will hit exact match (Phase 1), which is fine.
+    // The real fuzzy path test requires labels that miss exact match but produce
+    // high similarity. With fake embeddings, case variations hit exact match via
+    // lower() comparison. Instead, test the alias-learning side effect:
+    // after an alias is learned, subsequent calls hit exact match.
+    await mem.addAlias(entity.id, 'acme');
+
+    const result = await mem.resolveOrCreate({
+      label: 'acme',
+      type: 'organization',
+      source: 'test',
+    });
+
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') throw new Error('narrowing');
+    expect(result.node.id).toBe(entity.id);
+  });
+
+  it('returns ambiguous when fuzzy candidates are in the uncertain zone', async () => {
+    // With the fake embedding backend, it's hard to engineer exact similarity scores.
+    // This test verifies the structural behavior: when 0 exact matches exist and
+    // semantic search returns results, the threshold logic partitions them correctly.
+    // We verify this indirectly: if resolveOrCreate returns 'created', it means
+    // no fuzzy candidate exceeded the ambiguity floor.
+    const { mem } = makeEntityMemory();
+
+    // Two completely unrelated entities
+    await mem.createEntity({
+      type: 'organization', label: 'Alpha Industries', properties: {}, source: 'test',
+    });
+    await mem.createEntity({
+      type: 'organization', label: 'Beta Systems', properties: {}, source: 'test',
+    });
+
+    // This label is unrelated to both — should create, not match
+    const result = await mem.resolveOrCreate({
+      label: 'Gamma Innovations',
+      type: 'organization',
+      source: 'test',
+    });
+
+    expect(result.kind).toBe('created');
+  });
+
+  it('exports threshold constants for external validation', () => {
+    expect(FUZZY_RESOLVE_THRESHOLD).toBe(0.90);
+    expect(FUZZY_AMBIGUITY_FLOOR).toBe(0.75);
+    expect(FUZZY_RESOLVE_THRESHOLD).toBeGreaterThan(FUZZY_AMBIGUITY_FLOOR);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npx --prefix /path/to/worktree vitest run src/memory/entity-memory.resolve-or-create.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: All pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/memory/entity-memory.resolve-or-create.test.ts
+git commit -m "test: add fuzzy resolution threshold and alias learning tests"
+```
+
+---
+
+## Task 7: Wire `addAlias` into memory-store handler
+
+**Files:**
+- Modify: `skills/memory-store/handler.ts:136-156`
+
+The memory-store handler needs to call `addAlias()` in two scenarios:
+
+1. **After disambiguation confirmation**: When the coordinator re-calls memory-store with a UUID (the confirmed entity), the original name variant that triggered ambiguity should be stored as an alias. However, the handler doesn't currently receive the original name — the coordinator re-submits with the UUID as `entity`. This means alias learning from disambiguation must happen at the **coordinator level** (the coordinator passes the original label alongside the confirmed UUID).
+
+2. **Simpler path**: The `resolveOrCreate` fuzzy auto-resolve path (Task 5) already calls `addAlias` automatically. The disambiguation path needs the coordinator to re-call with the confirmed UUID **plus** the original name. We can add an optional `alias_for` input parameter to the skill.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `skills/memory-store/handler.test.ts` addition (or add to the existing test file if it exists). First, check if a test file exists:
+
+Run: `ls skills/memory-store/handler.test.ts 2>/dev/null` from the worktree.
+
+If it exists, add to it. If not, note that testing the handler requires a SkillContext mock. For now, test the alias-learning indirectly: the `resolveOrCreate` fuzzy path already calls `addAlias`, so the end-to-end path is covered. The `alias_for` parameter is a new input field.
+
+Add the `alias_for` parameter support to the handler. In `skills/memory-store/handler.ts`, add to the destructured input (after `entity_type`):
+
+```typescript
+      alias_for?: string;
+```
+
+- [ ] **Step 2: Add alias_for handling after entity resolution**
+
+In `skills/memory-store/handler.ts`, after the UUID resolution path (line ~135) and the resolveOrCreate path, add alias learning when `alias_for` is provided:
+
+After line 155 (`entityNode = resolved.node;`), add:
+
+```typescript
+        // Learn alias when the coordinator confirms a disambiguation.
+        // alias_for carries the original name variant that the CEO used;
+        // resolveOrCreate's fuzzy auto-resolve path learns aliases automatically,
+        // but the disambiguation path needs explicit alias learning because the
+        // coordinator re-submits with a UUID, not the original name.
+        if (alias_for && typeof alias_for === 'string' && resolved.kind === 'found') {
+          await ctx.entityMemory.addAlias(entityNode.id, alias_for);
+        }
+```
+
+Also add alias learning in the UUID path — when the coordinator re-calls with a confirmed UUID after disambiguation, `alias_for` carries the original name:
+
+After line 135 (`entityNode = byId;`), add:
+
+```typescript
+        // Learn alias from disambiguation: coordinator confirmed this UUID
+        // for the original name variant carried in alias_for.
+        if (alias_for && typeof alias_for === 'string') {
+          await ctx.entityMemory.addAlias(entityNode.id, alias_for);
+        }
+```
+
+- [ ] **Step 3: Run memory-store tests (if they exist)**
+
+Run: `npx --prefix /path/to/worktree vitest run skills/memory-store/ --reporter=verbose 2>&1 | tail -20`
+
+Expected: All existing tests pass. If no test file exists, the command reports 0 tests — that's fine.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `npx --prefix /path/to/worktree vitest run --reporter=verbose 2>&1 | tail -30`
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/memory-store/handler.ts
+git commit -m "feat: memory-store learns aliases on disambiguation via alias_for param"
+```
+
+---
+
+## Task 8: Update skill manifest and changelog
+
+**Files:**
+- Modify: `skills/memory-store/skill.json` (add `alias_for` to input schema)
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update skill.json input schema**
+
+Open `skills/memory-store/skill.json` and add the `alias_for` parameter to the `input_schema.properties`:
+
+```json
+    "alias_for": {
+      "type": "string",
+      "description": "Original name variant to store as an alias on the resolved entity. Used after disambiguation: when the CEO confirms which entity they meant, pass the original name here so future lookups resolve instantly. Ignored when entity is a plain name (resolveOrCreate learns aliases automatically)."
+    }
+```
+
+Do NOT add it to `required` — it is optional.
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Add under `## [Unreleased]`, in the **Added** section (create the section if needed):
+
+```markdown
+### Added
+
+- **Fuzzy entity resolution** — `resolveOrCreate()` now falls back to embedding-based semantic search when exact label match fails, preventing duplicate KG nodes from name variants like "Darlise" / "Darlise Restaurant". Confirmed matches are stored as aliases for instant future resolution. (#467)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/memory-store/skill.json CHANGELOG.md
+git commit -m "feat: add alias_for to memory-store manifest, update changelog"
+```
+
+---
+
+## Task 9: Final verification
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `npx --prefix /path/to/worktree vitest run --reporter=verbose 2>&1 | tail -40`
+
+Expected: All tests pass. Zero failures.
+
+- [ ] **Step 2: Check for TypeScript compilation errors**
+
+Run: `npx --prefix /path/to/worktree tsc --noEmit 2>&1 | tail -20`
+
+Expected: No errors. If there are errors, they are likely `KgNode` construction sites that are missing the `aliases` field — fix them.
+
+- [ ] **Step 3: Verify migration numbering (rebase hazard)**
+
+Run: `ls src/db/migrations/ | sort` from the worktree.
+
+Expected: Every prefix is unique. `038_add_kg_node_aliases.sql` has no collision. If another branch landed a 038 migration, renumber to 039.
+
+- [ ] **Step 4: Review all changes**
+
+Run: `git -C /path/to/worktree diff main --stat`
+
+Review the file list. Confirm:
+- No changes to files outside the scope (no drive-by refactoring)
+- Migration, types, knowledge-graph, entity-memory, handler, skill.json, changelog, tests — nothing else
+
+- [ ] **Step 5: Commit any remaining fixes**
+
+If any compilation or test fixes were needed, commit them:
+
+```bash
+git commit -m "fix: address compilation issues from aliases field addition"
+```

--- a/skills/memory-store/handler.ts
+++ b/skills/memory-store/handler.ts
@@ -160,11 +160,12 @@ export class MemoryStoreHandler implements SkillHandler {
         }
 
         entityNode = resolved.node;
-        // Learn alias when the coordinator confirms a disambiguation.
-        // alias_for carries the original name variant that the CEO used;
-        // resolveOrCreate's fuzzy auto-resolve path learns aliases automatically,
-        // but the disambiguation path needs explicit alias learning because the
-        // coordinator re-submits with a UUID, not the original name.
+        // Learn alias when the coordinator confirms a disambiguation by re-submitting
+        // the canonical entity name (not a UUID) alongside the original name variant.
+        // alias_for = original variant (e.g. "the Darlise place"); entity = confirmed
+        // canonical name (e.g. "Darlise Restaurant"). resolveOrCreate's auto-resolve
+        // path already adds options.label as an alias, but alias_for is a different
+        // string — the variant the CEO actually said — so it needs explicit learning here.
         if (alias_for && typeof alias_for === 'string' && resolved.kind === 'found') {
           await ctx.entityMemory.addAlias(entityNode.id, alias_for);
         }

--- a/skills/memory-store/handler.ts
+++ b/skills/memory-store/handler.ts
@@ -39,6 +39,7 @@ export class MemoryStoreHandler implements SkillHandler {
       sensitivity,
       sensitivity_category,
       entity_type,
+      alias_for,
     } = ctx.input as {
       entity?: string;
       field?: string;
@@ -49,6 +50,7 @@ export class MemoryStoreHandler implements SkillHandler {
       sensitivity?: string;
       sensitivity_category?: string;
       entity_type?: string;
+      alias_for?: string;
     };
 
     // --- Input validation ---
@@ -133,6 +135,11 @@ export class MemoryStoreHandler implements SkillHandler {
           };
         }
         entityNode = byId;
+        // Learn alias from disambiguation: coordinator confirmed this UUID
+        // for the original name variant carried in alias_for.
+        if (alias_for && typeof alias_for === 'string') {
+          await ctx.entityMemory.addAlias(entityNode.id, alias_for);
+        }
       } else {
         const resolved = await ctx.entityMemory.resolveOrCreate({
           label: entity,
@@ -153,6 +160,14 @@ export class MemoryStoreHandler implements SkillHandler {
         }
 
         entityNode = resolved.node;
+        // Learn alias when the coordinator confirms a disambiguation.
+        // alias_for carries the original name variant that the CEO used;
+        // resolveOrCreate's fuzzy auto-resolve path learns aliases automatically,
+        // but the disambiguation path needs explicit alias learning because the
+        // coordinator re-submits with a UUID, not the original name.
+        if (alias_for && typeof alias_for === 'string' && resolved.kind === 'found') {
+          await ctx.entityMemory.addAlias(entityNode.id, alias_for);
+        }
       }
 
       // --- Fact storage ---

--- a/skills/memory-store/skill.json
+++ b/skills/memory-store/skill.json
@@ -13,7 +13,8 @@
     "decay_class": "string? (one of: permanent, slow_decay, fast_decay; defaults to slow_decay)",
     "sensitivity": "string? (one of: public, internal, confidential, restricted; when omitted the engine auto-classifies from content and defaults to internal)",
     "sensitivity_category": "string? (optional category hint for the auto-classifier, e.g. 'financial'; only used when sensitivity is omitted)",
-    "entity_type": "string? (optional node type hint for auto-creation when the entity does not exist yet — one of: person, organization, project, decision, event, concept; defaults to 'concept'; has no effect if the entity already exists or if entity is a node ID)"
+    "entity_type": "string? (optional node type hint for auto-creation when the entity does not exist yet — one of: person, organization, project, decision, event, concept; defaults to 'concept'; has no effect if the entity already exists or if entity is a node ID)",
+    "alias_for": "string? (original name variant the CEO used, supplied when re-submitting after disambiguation — e.g. 'Darlise' when the confirmed entity is 'Darlise Restaurant'. The handler stores this as an alias on the confirmed entity so future calls with the same variant resolve instantly via exact match rather than embedding search)"
   },
   "outputs": {
     "stored": "boolean — true when the fact was persisted (created or updated)",

--- a/src/db/migrations/038_add_kg_node_aliases.sql
+++ b/src/db/migrations/038_add_kg_node_aliases.sql
@@ -1,0 +1,11 @@
+-- 038_add_kg_node_aliases.sql
+--
+-- Adds an aliases column to kg_nodes for fuzzy entity resolution (#467).
+-- Stores lowercased name variants so exact-match resolution catches
+-- previously-confirmed name variants without an embedding call.
+--
+-- The GIN index supports efficient ANY() containment queries on the array.
+
+ALTER TABLE kg_nodes ADD COLUMN aliases TEXT[] NOT NULL DEFAULT '{}';
+
+CREATE INDEX idx_kg_nodes_aliases ON kg_nodes USING GIN (aliases);

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -9,7 +9,6 @@ import { EmbeddingService } from './embedding.js';
 import { EntityMemory, FUZZY_RESOLVE_THRESHOLD, FUZZY_AMBIGUITY_FLOOR, MAX_ALIASES_PER_ENTITY } from './entity-memory.js';
 import { MemoryValidator, MAX_WRITES_PER_AGENT_TASK } from './validation.js';
 import { createSilentLogger } from '../logger.js';
-import type { KgNode } from './types.js';
 
 function makeEntityMemory() {
   const embeddingService = EmbeddingService.createForTesting();
@@ -520,8 +519,7 @@ describe('EntityMemory.findEntities — alias awareness', () => {
       source: 'test',
     });
     // Simulate a learned alias by updating the node's aliases directly
-    const withAlias: KgNode = { ...node, aliases: ['darlise'] };
-    await store.updateNode(node.id, withAlias);
+    await store.updateNode(node.id, { aliases: ['darlise'] });
 
     const results = await mem.findEntities('Darlise');
     expect(results).toHaveLength(1);
@@ -540,8 +538,7 @@ describe('EntityMemory.findEntities — alias awareness', () => {
       properties: {},
       source: 'test',
     });
-    const withAlias: KgNode = { ...node, aliases: ['darlise'] };
-    await store.updateNode(node.id, withAlias);
+    await store.updateNode(node.id, { aliases: ['darlise'] });
     await store.archiveNode(node.id);
 
     const results = await mem.findEntities('Darlise');

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import { KnowledgeGraphStore } from './knowledge-graph.js';
 import { EmbeddingService } from './embedding.js';
-import { EntityMemory } from './entity-memory.js';
+import { EntityMemory, FUZZY_RESOLVE_THRESHOLD, FUZZY_AMBIGUITY_FLOOR, MAX_ALIASES_PER_ENTITY } from './entity-memory.js';
 import { MemoryValidator, MAX_WRITES_PER_AGENT_TASK } from './validation.js';
 import { createSilentLogger } from '../logger.js';
 import type { KgNode } from './types.js';
@@ -339,6 +339,53 @@ describe('EntityMemory.addAlias', () => {
     const afterReject = await store.getNode(entity.id);
     expect(afterReject!.aliases).toHaveLength(10);
     expect(afterReject!.aliases).not.toContain('one-too-many');
+  });
+});
+
+describe('EntityMemory.resolveOrCreate — fuzzy fallback', () => {
+  it('creates a new entity when no fuzzy match exceeds the ambiguity floor', async () => {
+    const { mem } = makeEntityMemory();
+    // Create an entity with a completely unrelated name
+    await mem.createEntity({
+      type: 'organization', label: 'Alpha Industries', properties: {}, source: 'test',
+    });
+    await mem.createEntity({
+      type: 'organization', label: 'Beta Systems', properties: {}, source: 'test',
+    });
+
+    // This label is unrelated — should create, not match
+    const result = await mem.resolveOrCreate({
+      label: 'Gamma Innovations',
+      type: 'organization',
+      source: 'test',
+    });
+
+    expect(result.kind).toBe('created');
+  });
+
+  it('finds via alias so no fuzzy fallback is needed', async () => {
+    const { mem } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+
+    await mem.addAlias(entity.id, 'darlise');
+
+    const result = await mem.resolveOrCreate({
+      label: 'Darlise',
+      type: 'organization',
+      source: 'test',
+    });
+
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') throw new Error('narrowing');
+    expect(result.node.id).toBe(entity.id);
+  });
+
+  it('exports threshold constants with correct relative ordering', () => {
+    expect(FUZZY_RESOLVE_THRESHOLD).toBe(0.90);
+    expect(FUZZY_AMBIGUITY_FLOOR).toBe(0.75);
+    expect(FUZZY_RESOLVE_THRESHOLD).toBeGreaterThan(FUZZY_AMBIGUITY_FLOOR);
   });
 });
 

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -478,6 +478,12 @@ describe('EntityMemory.resolveOrCreate — fuzzy auto-resolve end-to-end', () =>
       return i === 0 ? scaled + norm * Math.sqrt(1 - 0.82 * 0.82) : scaled;
     });
 
+    // Verify the perturbation math lands in the ambiguous zone [0.75, 0.90)
+    // before proceeding — this makes the test self-validating.
+    const actualSimilarity = EmbeddingService.cosineSimilarity(queryEmbedding, perturbedEmbedding);
+    expect(actualSimilarity).toBeGreaterThanOrEqual(FUZZY_AMBIGUITY_FLOOR);
+    expect(actualSimilarity).toBeLessThan(FUZZY_RESOLVE_THRESHOLD);
+
     await store.createNode({
       type: 'organization',
       label: 'Another Restaurant',

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -282,6 +282,66 @@ describe('EntityMemory.storeFact — updated action codes', () => {
   });
 });
 
+describe('EntityMemory.addAlias', () => {
+  it('appends a lowercased alias to the entity node', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+
+    await mem.addAlias(entity.id, 'Darlise');
+
+    const updated = await store.getNode(entity.id);
+    expect(updated!.aliases).toEqual(['darlise']);
+  });
+
+  it('does not add duplicate aliases', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+
+    await mem.addAlias(entity.id, 'Darlise');
+    await mem.addAlias(entity.id, 'DARLISE'); // same after lowering
+
+    const updated = await store.getNode(entity.id);
+    expect(updated!.aliases).toEqual(['darlise']);
+  });
+
+  it('does not add an alias that matches the canonical label', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+
+    await mem.addAlias(entity.id, 'Darlise Restaurant');
+
+    const updated = await store.getNode(entity.id);
+    expect(updated!.aliases).toEqual([]);
+  });
+
+  it('rejects when alias count reaches MAX_ALIASES_PER_ENTITY', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+
+    // Fill up to the cap (10)
+    for (let i = 0; i < 10; i++) {
+      await mem.addAlias(entity.id, `alias-${i}`);
+    }
+
+    const updated = await store.getNode(entity.id);
+    expect(updated!.aliases).toHaveLength(10);
+
+    // 11th alias should be silently rejected
+    await mem.addAlias(entity.id, 'one-too-many');
+    const afterReject = await store.getNode(entity.id);
+    expect(afterReject!.aliases).toHaveLength(10);
+    expect(afterReject!.aliases).not.toContain('one-too-many');
+  });
+});
+
 describe('EntityMemory.findEntities — alias awareness', () => {
   it('finds an entity by alias when the canonical label does not match', async () => {
     const embeddingService = EmbeddingService.createForTesting();

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -9,6 +9,7 @@ import { EmbeddingService } from './embedding.js';
 import { EntityMemory } from './entity-memory.js';
 import { MemoryValidator, MAX_WRITES_PER_AGENT_TASK } from './validation.js';
 import { createSilentLogger } from '../logger.js';
+import type { KgNode } from './types.js';
 
 function makeEntityMemory() {
   const embeddingService = EmbeddingService.createForTesting();
@@ -278,5 +279,49 @@ describe('EntityMemory.storeFact — updated action codes', () => {
 
     expect(result.stored).toBe(false);
     expect(result.action).toBe('rate_limited');
+  });
+});
+
+describe('EntityMemory.findEntities — alias awareness', () => {
+  it('finds an entity by alias when the canonical label does not match', async () => {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    const mem = new EntityMemory(store, validator, embeddingService, createSilentLogger());
+
+    // Create a node and manually set an alias on it via the store
+    const node = await store.createNode({
+      type: 'organization',
+      label: 'Darlise Restaurant',
+      properties: {},
+      source: 'test',
+    });
+    // Simulate a learned alias by updating the node's aliases directly
+    const withAlias: KgNode = { ...node, aliases: ['darlise'] };
+    await store.updateNode(node.id, withAlias);
+
+    const results = await mem.findEntities('Darlise');
+    expect(results).toHaveLength(1);
+    expect(results[0]!.id).toBe(node.id);
+  });
+
+  it('does not match archived nodes via alias', async () => {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    const mem = new EntityMemory(store, validator, embeddingService, createSilentLogger());
+
+    const node = await store.createNode({
+      type: 'organization',
+      label: 'Darlise Restaurant',
+      properties: {},
+      source: 'test',
+    });
+    const withAlias: KgNode = { ...node, aliases: ['darlise'] };
+    await store.updateNode(node.id, withAlias);
+    await store.archiveNode(node.id);
+
+    const results = await mem.findEntities('Darlise');
+    expect(results).toHaveLength(0);
   });
 });

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -326,18 +326,18 @@ describe('EntityMemory.addAlias', () => {
       type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
     });
 
-    // Fill up to the cap (10)
-    for (let i = 0; i < 10; i++) {
+    // Fill up to the cap
+    for (let i = 0; i < MAX_ALIASES_PER_ENTITY; i++) {
       await mem.addAlias(entity.id, `alias-${i}`);
     }
 
     const updated = await store.getNode(entity.id);
-    expect(updated!.aliases).toHaveLength(10);
+    expect(updated!.aliases).toHaveLength(MAX_ALIASES_PER_ENTITY);
 
-    // 11th alias should be silently rejected
+    // One more alias should be silently rejected
     await mem.addAlias(entity.id, 'one-too-many');
     const afterReject = await store.getNode(entity.id);
-    expect(afterReject!.aliases).toHaveLength(10);
+    expect(afterReject!.aliases).toHaveLength(MAX_ALIASES_PER_ENTITY);
     expect(afterReject!.aliases).not.toContain('one-too-many');
   });
 });

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -232,6 +232,17 @@ describe('EntityMemory.storeFact — contradiction auto-resolution', () => {
   });
 });
 
+describe('KgNode aliases field', () => {
+  it('newly created entity nodes have an empty aliases array', async () => {
+    const { mem } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Acme Corp', properties: {}, source: 'test',
+    });
+
+    expect(entity.aliases).toEqual([]);
+  });
+});
+
 describe('EntityMemory.storeFact — updated action codes', () => {
   it('returns action:entity_not_found when entity node does not exist', async () => {
     const { mem } = makeEntityMemory();

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -389,6 +389,116 @@ describe('EntityMemory.resolveOrCreate — fuzzy fallback', () => {
   });
 });
 
+describe('EntityMemory.resolveOrCreate — fuzzy auto-resolve end-to-end', () => {
+  it('auto-resolves via fuzzy match when embedding similarity >= FUZZY_RESOLVE_THRESHOLD', async () => {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    const mem = new EntityMemory(store, validator, embeddingService, createSilentLogger());
+
+    // Pre-compute the embedding for the query label we will use
+    const queryLabel = 'Darlise';
+    const queryEmbedding = await embeddingService.embed(queryLabel);
+
+    // Create a node whose embedding matches the query exactly (cosine similarity = 1.0)
+    // but whose canonical label is different — so Phase 1 (exact match) will miss
+    // and Phase 2 (fuzzy) will fire.
+    const node = await store.createNode({
+      type: 'organization',
+      label: 'Darlise Restaurant',
+      properties: {},
+      source: 'test',
+      embedding: queryEmbedding,  // identical vector → similarity 1.0
+    });
+
+    const result = await mem.resolveOrCreate({
+      label: queryLabel,
+      type: 'organization',
+      source: 'test',
+    });
+
+    // Phase 2 fires: similarity = 1.0 ≥ 0.90 → auto-resolve
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') throw new Error('narrowing');
+    expect(result.node.id).toBe(node.id);
+
+    // Alias is learned as a side effect of auto-resolve
+    const refreshed = await store.getNode(node.id);
+    expect(refreshed!.aliases).toContain(queryLabel.toLowerCase());
+  });
+
+  it('does not create a duplicate when a fuzzy match auto-resolves', async () => {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    const mem = new EntityMemory(store, validator, embeddingService, createSilentLogger());
+
+    const queryLabel = 'the Darlise place';
+    const queryEmbedding = await embeddingService.embed(queryLabel);
+
+    await store.createNode({
+      type: 'organization',
+      label: 'Darlise Restaurant',
+      properties: {},
+      source: 'test',
+      embedding: queryEmbedding,
+    });
+
+    // Resolve once — should auto-resolve, not create
+    const result = await mem.resolveOrCreate({
+      label: queryLabel,
+      type: 'organization',
+      source: 'test',
+    });
+
+    expect(result.kind).toBe('found');
+
+    // Only one organization node should exist — no duplicate created
+    const allOrgs = await store.findNodesByType('organization');
+    expect(allOrgs).toHaveLength(1);
+  });
+
+  it('returns ambiguous when best score is in the uncertain zone (0.75-0.90)', async () => {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    const mem = new EntityMemory(store, validator, embeddingService, createSilentLogger());
+
+    const queryLabel = 'Restaurant X';
+    const queryEmbedding = await embeddingService.embed(queryLabel);
+
+    // Build a vector that is 0.82 similar to the query embedding (in the ambiguous zone).
+    // We do this by computing a weighted blend: blend = 0.82 * query + sqrt(1 - 0.82^2) * perp
+    // where perp is orthogonal to query, giving exact cosine(blend, query) = 0.82.
+    // For a simpler approximation: scale query and add a small orthogonal component.
+    const norm = Math.sqrt(queryEmbedding.reduce((s, v) => s + v * v, 0));
+    // Create a perturbed vector: keep 82% of the direction, add 18% noise on first dim
+    const perturbedEmbedding = queryEmbedding.map((v, i) => {
+      const scaled = v * 0.82;
+      return i === 0 ? scaled + norm * Math.sqrt(1 - 0.82 * 0.82) : scaled;
+    });
+
+    await store.createNode({
+      type: 'organization',
+      label: 'Another Restaurant',
+      properties: {},
+      source: 'test',
+      embedding: perturbedEmbedding,
+    });
+
+    const result = await mem.resolveOrCreate({
+      label: queryLabel,
+      type: 'organization',
+      source: 'test',
+    });
+
+    // Should be ambiguous (0.75 ≤ score < 0.90), not found and not created
+    expect(result.kind).toBe('ambiguous');
+    if (result.kind !== 'ambiguous') throw new Error('narrowing');
+    expect(result.candidates).toHaveLength(1);
+  });
+});
+
 describe('EntityMemory.findEntities — alias awareness', () => {
   it('finds an entity by alias when the canonical label does not match', async () => {
     const embeddingService = EmbeddingService.createForTesting();

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -97,6 +97,20 @@ const FACT_TYPE: NodeType = 'fact';
  *  real entities rarely have more than 3-4 name variants. */
 export const MAX_ALIASES_PER_ENTITY = 10;
 
+/** Cosine similarity threshold for auto-resolving a fuzzy entity match.
+ *  At or above this, the match is confident enough to return 'found' without
+ *  asking the CEO. Lower than the 0.92 fact dedup threshold because entity
+ *  labels are shorter phrases with less semantic signal. */
+export const FUZZY_RESOLVE_THRESHOLD = 0.90;
+
+/** Cosine similarity floor for surfacing ambiguous fuzzy candidates.
+ *  Below this, names are too different to be plausible variants. */
+export const FUZZY_AMBIGUITY_FLOOR = 0.75;
+
+/** Max candidates to retrieve from semantic search during fuzzy resolution.
+ *  Kept small — we only need the top few potential matches. */
+const FUZZY_SEARCH_LIMIT = 5;
+
 /**
  * EntityMemory: the high-level query layer that agents interact with.
  *
@@ -275,18 +289,8 @@ export class EntityMemory {
    * extract-facts takes candidates[0] to avoid stalling a batch job.
    */
   async resolveOrCreate(options: ResolveOrCreateOptions): Promise<ResolveOrCreateResult> {
+    // Phase 1: exact match on canonical label + aliases
     const matches = await this.store.findNodesByLabel(options.label);
-
-    if (matches.length === 0) {
-      const { entity } = await this.createEntity({
-        type: options.type,
-        label: options.label,
-        properties: {},
-        source: options.source,
-        confidence: options.confidence ?? 0.6,
-      });
-      return { kind: 'created', node: entity };
-    }
 
     if (matches.length === 1) {
       const node = matches[0]!;
@@ -306,14 +310,64 @@ export class EntityMemory {
       return { kind: 'found', node };
     }
 
-    // 2+ matches — prefer a node whose type matches the caller's expected type.
-    const typeMatch = matches.find(n => n.type === options.type);
-    if (typeMatch) {
-      return { kind: 'found', node: typeMatch };
+    if (matches.length > 1) {
+      // 2+ matches — prefer a node whose type matches the caller's expected type.
+      const typeMatch = matches.find(n => n.type === options.type);
+      if (typeMatch) {
+        return { kind: 'found', node: typeMatch };
+      }
+      // No type match — caller must ask the user to pick one.
+      return { kind: 'ambiguous', candidates: matches };
     }
 
-    // No type match — caller must ask the user to pick one.
-    return { kind: 'ambiguous', candidates: matches };
+    // Phase 2: no exact match — try embedding-based fuzzy resolution.
+    // semanticSearch() embeds the query and returns results sorted by score desc.
+    // Does not filter by type — consistent with single-match behavior above (which
+    // also returns 'found' across types). Type is only used as a tiebreaker.
+    const fuzzyResults = await this.store.semanticSearch(options.label, {
+      limit: FUZZY_SEARCH_LIMIT,
+    });
+
+    // Filter out fact nodes — we only want entity nodes for disambiguation
+    const entityCandidates = fuzzyResults.filter(r => r.node.type !== 'fact');
+
+    // Partition candidates by threshold
+    const autoResolve = entityCandidates.filter(r => r.score >= FUZZY_RESOLVE_THRESHOLD);
+    const ambiguous = entityCandidates.filter(
+      r => r.score >= FUZZY_AMBIGUITY_FLOOR && r.score < FUZZY_RESOLVE_THRESHOLD,
+    );
+
+    if (autoResolve.length > 0) {
+      // Pick the best match; use type as tiebreaker if multiple exceed the threshold
+      const typeMatch = autoResolve.find(r => r.node.type === options.type);
+      const best = typeMatch ?? autoResolve[0]!;
+
+      if (best.node.type !== options.type) {
+        this.logger.warn(
+          { label: options.label, expectedType: options.type, actualType: best.node.type, nodeId: best.node.id },
+          'resolveOrCreate: fuzzy auto-resolve type differs from caller hint',
+        );
+      }
+
+      // Learn the alias so future lookups resolve via exact match
+      await this.addAlias(best.node.id, options.label);
+
+      return { kind: 'found', node: best.node };
+    }
+
+    if (ambiguous.length > 0) {
+      return { kind: 'ambiguous', candidates: ambiguous.map(r => r.node) };
+    }
+
+    // Phase 3: no match at all — create a new entity
+    const { entity } = await this.createEntity({
+      type: options.type,
+      label: options.label,
+      properties: {},
+      source: options.source,
+      confidence: options.confidence ?? 0.6,
+    });
+    return { kind: 'created', node: entity };
   }
 
   /**

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -278,10 +278,15 @@ export class EntityMemory {
    * Find or create an entity node by label.
    *
    * Resolution logic (in order):
-   *   0 matches → create via createEntity(), return { kind: 'created', node }
-   *   1 match   → return { kind: 'found', node }
-   *   2+ matches, one has the expected type → return { kind: 'found', node: typeMatch }
-   *   2+ matches, no type match → return { kind: 'ambiguous', candidates }
+   *   1 exact match  → return { kind: 'found', node }
+   *   2+ exact matches, one has the expected type → return { kind: 'found', node: typeMatch }
+   *   2+ exact matches, no type match → return { kind: 'ambiguous', candidates }
+   *   0 exact matches, fuzzy score ≥ 0.90 → auto-resolve, learn alias, return { kind: 'found', node }
+   *   0 exact matches, fuzzy score 0.75–0.90 → return { kind: 'ambiguous', candidates }
+   *   0 exact matches, fuzzy score < 0.75 → create via createEntity(), return { kind: 'created', node }
+   *
+   * Three phases: (1) exact label match via findNodesByLabel, (2) embedding-based fuzzy
+   * resolution when exact match finds nothing, (3) create if no plausible candidate exists.
    *
    * This is the shared primitive used by both memory-store (agent-directed writes)
    * and extract-facts (background batch extraction). Callers handle 'ambiguous'
@@ -329,7 +334,7 @@ export class EntityMemory {
     });
 
     // Filter out fact nodes — we only want entity nodes for disambiguation
-    const entityCandidates = fuzzyResults.filter(r => r.node.type !== 'fact');
+    const entityCandidates = fuzzyResults.filter(r => r.node.type !== FACT_TYPE);
 
     // Partition candidates by threshold
     const autoResolve = entityCandidates.filter(r => r.score >= FUZZY_RESOLVE_THRESHOLD);
@@ -352,7 +357,10 @@ export class EntityMemory {
       // Learn the alias so future lookups resolve via exact match
       await this.addAlias(best.node.id, options.label);
 
-      return { kind: 'found', node: best.node };
+      // Re-fetch so the returned node reflects the newly learned alias.
+      // addAlias is best-effort — if re-fetch fails, fall back to the pre-alias snapshot.
+      const refreshed = await this.store.getNode(best.node.id);
+      return { kind: 'found', node: refreshed ?? best.node };
     }
 
     if (ambiguous.length > 0) {

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -93,6 +93,10 @@ export type ResolveOrCreateResult =
 // Per types.ts, 'fact' is the only node type that carries atomic facts about entities.
 const FACT_TYPE: NodeType = 'fact';
 
+/** Maximum aliases per entity node. Guardrail against degenerate alias accumulation;
+ *  real entities rarely have more than 3-4 name variants. */
+export const MAX_ALIASES_PER_ENTITY = 10;
+
 /**
  * EntityMemory: the high-level query layer that agents interact with.
  *
@@ -310,6 +314,50 @@ export class EntityMemory {
 
     // No type match — caller must ask the user to pick one.
     return { kind: 'ambiguous', candidates: matches };
+  }
+
+  /**
+   * Store a confirmed name variant as an alias on an entity node.
+   *
+   * Lowercases the alias before storing. Silently skips if:
+   * - The alias matches the canonical label (case-insensitive)
+   * - The alias already exists in the aliases array
+   * - The entity has reached MAX_ALIASES_PER_ENTITY (10)
+   * - The entity node does not exist
+   *
+   * Does not throw — alias learning is best-effort and should never
+   * block fact storage.
+   */
+  async addAlias(nodeId: string, alias: string): Promise<void> {
+    const lowerAlias = alias.toLowerCase();
+
+    const node = await this.store.getNode(nodeId);
+    if (!node) {
+      this.logger.warn({ nodeId, alias }, 'addAlias: entity node not found');
+      return;
+    }
+
+    // Skip if alias matches canonical label
+    if (node.label.toLowerCase() === lowerAlias) {
+      return;
+    }
+
+    // Skip if alias already exists
+    if (node.aliases.includes(lowerAlias)) {
+      return;
+    }
+
+    // Skip if at cap
+    if (node.aliases.length >= MAX_ALIASES_PER_ENTITY) {
+      this.logger.warn(
+        { nodeId, alias, count: node.aliases.length, max: MAX_ALIASES_PER_ENTITY },
+        'addAlias: alias cap reached — skipping',
+      );
+      return;
+    }
+
+    const updatedAliases = [...node.aliases, lowerAlias];
+    await this.store.updateNode(nodeId, { aliases: updatedAliases });
   }
 
   /**

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -329,42 +329,66 @@ export class EntityMemory {
     // semanticSearch() embeds the query and returns results sorted by score desc.
     // Does not filter by type — consistent with single-match behavior above (which
     // also returns 'found' across types). Type is only used as a tiebreaker.
-    const fuzzyResults = await this.store.semanticSearch(options.label, {
-      limit: FUZZY_SEARCH_LIMIT,
-    });
+    //
+    // The entire phase is wrapped so that embedding API failures or transient DB
+    // errors fall through gracefully to Phase 3 (entity creation). This preserves
+    // the pre-PR behavior as the degraded-mode path — fact storage must not block
+    // on embedding service availability.
+    try {
+      const fuzzyResults = await this.store.semanticSearch(options.label, {
+        limit: FUZZY_SEARCH_LIMIT,
+      });
 
-    // Filter out fact nodes — we only want entity nodes for disambiguation
-    const entityCandidates = fuzzyResults.filter(r => r.node.type !== FACT_TYPE);
+      // Filter out fact nodes — we only want entity nodes for disambiguation
+      const entityCandidates = fuzzyResults.filter(r => r.node.type !== FACT_TYPE);
 
-    // Partition candidates by threshold
-    const autoResolve = entityCandidates.filter(r => r.score >= FUZZY_RESOLVE_THRESHOLD);
-    const ambiguous = entityCandidates.filter(
-      r => r.score >= FUZZY_AMBIGUITY_FLOOR && r.score < FUZZY_RESOLVE_THRESHOLD,
-    );
+      // Partition candidates by threshold
+      const autoResolve = entityCandidates.filter(r => r.score >= FUZZY_RESOLVE_THRESHOLD);
+      const ambiguous = entityCandidates.filter(
+        r => r.score >= FUZZY_AMBIGUITY_FLOOR && r.score < FUZZY_RESOLVE_THRESHOLD,
+      );
 
-    if (autoResolve.length > 0) {
-      // Pick the best match; use type as tiebreaker if multiple exceed the threshold
-      const typeMatch = autoResolve.find(r => r.node.type === options.type);
-      const best = typeMatch ?? autoResolve[0]!;
+      if (autoResolve.length > 0) {
+        // Pick the best match; use type as tiebreaker if multiple exceed the threshold
+        const typeMatch = autoResolve.find(r => r.node.type === options.type);
+        const best = typeMatch ?? autoResolve[0]!;
 
-      if (best.node.type !== options.type) {
-        this.logger.warn(
-          { label: options.label, expectedType: options.type, actualType: best.node.type, nodeId: best.node.id },
-          'resolveOrCreate: fuzzy auto-resolve type differs from caller hint',
-        );
+        if (best.node.type !== options.type) {
+          this.logger.warn(
+            { label: options.label, expectedType: options.type, actualType: best.node.type, nodeId: best.node.id },
+            'resolveOrCreate: fuzzy auto-resolve type differs from caller hint',
+          );
+        }
+
+        // Learn the alias so future lookups resolve via exact match.
+        // addAlias is best-effort — never throws.
+        await this.addAlias(best.node.id, options.label);
+
+        // Re-fetch so the returned node reflects the newly learned alias.
+        // Falls back to the pre-alias snapshot on getNode failure (best-effort).
+        let refreshed: KgNode | undefined;
+        try {
+          refreshed = await this.store.getNode(best.node.id) ?? undefined;
+        } catch (err) {
+          this.logger.warn(
+            { nodeId: best.node.id, error: err instanceof Error ? err.message : String(err) },
+            'resolveOrCreate: failed to re-fetch node after alias learning — returning pre-alias snapshot',
+          );
+        }
+        return { kind: 'found', node: refreshed ?? best.node };
       }
 
-      // Learn the alias so future lookups resolve via exact match
-      await this.addAlias(best.node.id, options.label);
-
-      // Re-fetch so the returned node reflects the newly learned alias.
-      // addAlias is best-effort — if re-fetch fails, fall back to the pre-alias snapshot.
-      const refreshed = await this.store.getNode(best.node.id);
-      return { kind: 'found', node: refreshed ?? best.node };
-    }
-
-    if (ambiguous.length > 0) {
-      return { kind: 'ambiguous', candidates: ambiguous.map(r => r.node) };
+      if (ambiguous.length > 0) {
+        return { kind: 'ambiguous', candidates: ambiguous.map(r => r.node) };
+      }
+    } catch (err) {
+      this.logger.warn(
+        { label: options.label, error: err instanceof Error ? err.message : String(err) },
+        'resolveOrCreate: fuzzy semantic search failed — falling back to entity creation',
+      );
+      // Fall through to Phase 3 intentionally: fact storage must not block on
+      // embedding API availability. The entity will be created as a new node,
+      // which is the same behavior as before this fuzzy-resolution feature.
     }
 
     // Phase 3: no match at all — create a new entity
@@ -391,40 +415,41 @@ export class EntityMemory {
    * block fact storage.
    */
   async addAlias(nodeId: string, alias: string): Promise<void> {
-    const lowerAlias = alias.toLowerCase();
-
-    const node = await this.store.getNode(nodeId);
-    if (!node) {
-      this.logger.warn({ nodeId, alias }, 'addAlias: entity node not found');
-      return;
-    }
-
-    // Skip if alias matches canonical label
-    if (node.label.toLowerCase() === lowerAlias) {
-      return;
-    }
-
-    // Skip if alias already exists
-    if (node.aliases.includes(lowerAlias)) {
-      return;
-    }
-
-    // Skip if at cap
-    if (node.aliases.length >= MAX_ALIASES_PER_ENTITY) {
-      this.logger.warn(
-        { nodeId, alias, count: node.aliases.length, max: MAX_ALIASES_PER_ENTITY },
-        'addAlias: alias cap reached — skipping',
-      );
-      return;
-    }
-
-    const updatedAliases = [...node.aliases, lowerAlias];
+    // Entire method is wrapped so no DB or network error can violate the non-throwing contract.
     try {
+      const lowerAlias = alias.toLowerCase();
+
+      const node = await this.store.getNode(nodeId);
+      if (!node) {
+        this.logger.warn({ nodeId, alias }, 'addAlias: entity node not found');
+        return;
+      }
+
+      // Skip if alias matches canonical label
+      if (node.label.toLowerCase() === lowerAlias) {
+        return;
+      }
+
+      // Skip if alias already exists
+      if (node.aliases.includes(lowerAlias)) {
+        return;
+      }
+
+      // Skip if at cap
+      if (node.aliases.length >= MAX_ALIASES_PER_ENTITY) {
+        this.logger.warn(
+          { nodeId, alias, count: node.aliases.length, max: MAX_ALIASES_PER_ENTITY },
+          'addAlias: alias cap reached — skipping',
+        );
+        return;
+      }
+
+      const updatedAliases = [...node.aliases, lowerAlias];
       await this.store.updateNode(nodeId, { aliases: updatedAliases });
     } catch (err) {
       this.logger.warn(
         { nodeId, alias, error: err instanceof Error ? err.message : String(err) },
-        'addAlias: failed to persist aliases — skipping',
+        'addAlias: unexpected error — skipping',
       );
       // Best-effort: do not rethrow
     }

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -357,7 +357,15 @@ export class EntityMemory {
     }
 
     const updatedAliases = [...node.aliases, lowerAlias];
-    await this.store.updateNode(nodeId, { aliases: updatedAliases });
+    try {
+      await this.store.updateNode(nodeId, { aliases: updatedAliases });
+    } catch (err) {
+      this.logger.warn(
+        { nodeId, alias, error: err instanceof Error ? err.message : String(err) },
+        'addAlias: failed to persist aliases — skipping',
+      );
+      // Best-effort: do not rethrow
+    }
   }
 
   /**

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -198,6 +198,8 @@ export class KnowledgeGraphStore {
       properties?: Record<string, unknown>;
       sensitivity?: Sensitivity;
       confidence?: number; // allows auto_resolved to raise stored confidence
+      /** Replaces the full aliases array when provided (e.g. after alias learning). */
+      aliases?: string[];
     },
   ): Promise<KgNode> {
     const existing = await this.backend.getNode(id);
@@ -212,6 +214,7 @@ export class KnowledgeGraphStore {
       label: updates.label ?? existing.label,
       properties: updates.properties ?? existing.properties,
       sensitivity: updates.sensitivity ?? existing.sensitivity,
+      aliases: updates.aliases ?? existing.aliases,
       // Re-embed if the label changed, otherwise keep existing embedding
       embedding: labelChanged
         ? await this.embeddingService.embed(updates.label!)
@@ -472,10 +475,14 @@ class PostgresBackend implements KnowledgeGraphBackend {
   }
 
   async findNodesByLabel(label: string): Promise<KgNode[]> {
-    // Case-insensitive exact match using lower() to leverage the idx_kg_nodes_label index.
-    // ILIKE would require a pg_trgm index; lower() = lower() uses the btree on lower(label).
+    // Case-insensitive match on canonical label OR any stored alias.
+    // Aliases are stored pre-lowercased, so lower($1) matches directly.
+    // The btree index on lower(label) handles the first condition;
+    // the GIN index on aliases handles the second.
     const result = await this.pool.query<PgNodeRow>(
-      'SELECT * FROM kg_nodes WHERE lower(label) = lower($1) AND archived_at IS NULL',
+      `SELECT * FROM kg_nodes
+       WHERE (lower(label) = lower($1) OR lower($1) = ANY(aliases))
+         AND archived_at IS NULL`,
       [label],
     );
     return result.rows.map(pgRowToNode);
@@ -848,7 +855,10 @@ class InMemoryBackend implements KnowledgeGraphBackend {
     const lowerLabel = label.toLowerCase();
     const results: KgNode[] = [];
     for (const node of this.nodes.values()) {
-      if (node.label.toLowerCase() === lowerLabel && !this.archivedNodes.has(node.id)) {
+      if (this.archivedNodes.has(node.id)) continue;
+      const labelMatch = node.label.toLowerCase() === lowerLabel;
+      const aliasMatch = node.aliases.some(a => a === lowerLabel);
+      if (labelMatch || aliasMatch) {
         results.push(node);
       }
     }

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -360,8 +360,8 @@ class PostgresBackend implements KnowledgeGraphBackend {
     this.logger.debug({ nodeId: node.id, type: node.type, sensitivity: node.sensitivity }, 'kg: creating node');
     const embeddingStr = node.embedding ? `[${node.embedding.join(',')}]` : null;
     await this.pool.query(
-      `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity)
-       VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $10, $11)`,
+      `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity, aliases)
+       VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $10, $11, $12)`,
       [
         node.id,
         node.type,
@@ -374,6 +374,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
         node.temporal.createdAt,
         node.temporal.lastConfirmedAt,
         node.sensitivity,
+        node.aliases,
       ],
     );
   }
@@ -382,8 +383,8 @@ class PostgresBackend implements KnowledgeGraphBackend {
     this.logger.debug({ type: node.type, label: node.label }, 'kg: upserting node');
     const embeddingStr = node.embedding ? `[${node.embedding.join(',')}]` : null;
     const result = await this.pool.query<PgNodeRow & { is_new: boolean }>(
-      `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity)
-       VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $9, $10)
+      `INSERT INTO kg_nodes (id, type, label, properties, embedding, confidence, decay_class, source, created_at, last_confirmed_at, sensitivity, aliases)
+       VALUES ($1, $2, $3, $4, $5::vector, $6, $7, $8, $9, $9, $10, $11)
        ON CONFLICT (lower(label), type) WHERE type != 'fact' AND archived_at IS NULL
        DO UPDATE SET
          confidence = GREATEST(kg_nodes.confidence, EXCLUDED.confidence),
@@ -400,6 +401,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
         node.temporal.source,
         node.temporal.createdAt,
         node.sensitivity,
+        node.aliases,
       ],
     );
     const row = result.rows[0];

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -432,14 +432,15 @@ class PostgresBackend implements KnowledgeGraphBackend {
     // via KnowledgeGraphStore.updateNode() are durably persisted to the DB.
     await this.pool.query(
       `UPDATE kg_nodes
-       SET label = $1, properties = $2, embedding = $3::vector, last_confirmed_at = $4, confidence = $5, aliases = $6
-       WHERE id = $7`,
+       SET label = $1, properties = $2, embedding = $3::vector, last_confirmed_at = $4, confidence = $5, sensitivity = $6, aliases = $7
+       WHERE id = $8`,
       [
         node.label,
         JSON.stringify(node.properties),
         embeddingStr,
         node.temporal.lastConfirmedAt,
         node.temporal.confidence,
+        node.sensitivity,
         node.aliases,
         id,
       ],
@@ -484,7 +485,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
     // the GIN index on aliases handles the second.
     const result = await this.pool.query<PgNodeRow>(
       `SELECT * FROM kg_nodes
-       WHERE (lower(label) = lower($1) OR lower($1) = ANY(aliases))
+       WHERE (lower(label) = lower($1) OR aliases @> ARRAY[lower($1)])
          AND archived_at IS NULL`,
       [label],
     );

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -430,14 +430,15 @@ class PostgresBackend implements KnowledgeGraphBackend {
     // via KnowledgeGraphStore.updateNode() are durably persisted to the DB.
     await this.pool.query(
       `UPDATE kg_nodes
-       SET label = $1, properties = $2, embedding = $3::vector, last_confirmed_at = $4, confidence = $5
-       WHERE id = $6`,
+       SET label = $1, properties = $2, embedding = $3::vector, last_confirmed_at = $4, confidence = $5, aliases = $6
+       WHERE id = $7`,
       [
         node.label,
         JSON.stringify(node.properties),
         embeddingStr,
         node.temporal.lastConfirmedAt,
         node.temporal.confidence,
+        node.aliases,
         id,
       ],
     );

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -139,6 +139,7 @@ export class KnowledgeGraphStore {
         source: options.source,
       },
       sensitivity: options.sensitivity ?? 'internal',
+      aliases: [],
     };
 
     await this.backend.createNode(node);
@@ -175,6 +176,7 @@ export class KnowledgeGraphStore {
         source: options.source,
       },
       sensitivity: options.sensitivity ?? 'internal',
+      aliases: [],
     };
 
     return this.backend.upsertNode(node);
@@ -676,6 +678,7 @@ interface PgNodeRow {
   last_confirmed_at: Date;
   sensitivity: string;
   archived_at: Date | null;
+  aliases: string[];
 }
 
 interface PgEdgeRow {
@@ -707,6 +710,7 @@ function pgRowToNode(row: PgNodeRow): KgNode {
       source: row.source,
     },
     sensitivity: (row.sensitivity as Sensitivity) ?? 'internal',
+    aliases: row.aliases ?? [],
   };
 }
 

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -71,6 +71,10 @@ export interface KgNode {
   // Sensitivity classification assigned at creation time (#200).
   // Immutable after creation — changing sensitivity requires a manual data migration.
   sensitivity: Sensitivity;
+  // Confirmed name variants for fuzzy entity resolution (#467).
+  // Stored as lowercased strings; exact-match resolution checks aliases
+  // alongside the canonical label. Capped at MAX_ALIASES_PER_ENTITY (10).
+  aliases: string[];
 }
 
 // -- Knowledge Graph Edge --


### PR DESCRIPTION
## Summary

Closes #467

- **Migration `038_add_kg_node_aliases.sql`** — adds `aliases TEXT[] NOT NULL DEFAULT '{}'` column and GIN index to `kg_nodes` for efficient `ANY()` containment queries
- **`findNodesByLabel()` alias-aware** — both Postgres and in-memory backends now check `lower($1) = ANY(aliases)` alongside the canonical label, so confirmed variants resolve via fast exact match
- **`resolveOrCreate()` three-phase design** — exact match → embedding-based fuzzy fallback (≥0.90 auto-resolve, 0.75–0.90 ambiguous) → entity creation; fuzzy phase is wrapped in try/catch so embedding API flakiness falls through to creation without blocking fact storage
- **`addAlias()` method** — best-effort (never throws); entire body wrapped in try/catch; enforces `MAX_ALIASES_PER_ENTITY = 10` cap; stores lowercased strings
- **Alias learning** — auto-resolve writes the input label as an alias so future calls hit exact match; disambiguation confirmation via `alias_for` parameter on `memory-store` handler writes the original variant as an alias on the confirmed entity
- **`memory-store` handler** — accepts optional `alias_for` string; calls `addAlias` after UUID-confirmed and name-confirmed disambiguation

## Constants

| Constant | Value | Rationale |
|---|---|---|
| `FUZZY_RESOLVE_THRESHOLD` | 0.90 | High confidence auto-resolve; below 0.92 fact-dedup threshold |
| `FUZZY_AMBIGUITY_FLOOR` | 0.75 | Below this, names are too different to be plausible variants |
| `MAX_ALIASES_PER_ENTITY` | 10 | Guardrail against unbounded alias accumulation |

## Test plan

- [ ] All 24 new unit tests pass (`src/memory/entity-memory.resolve-or-create.test.ts`)
- [ ] Full test suite: `npm test` — only 2 pre-existing DATABASE_URL failures (autonomy integration tests requiring live DB)
- [ ] TypeScript: `npm run typecheck` — clean
- [ ] Migration prefix 038 is unique (`ls src/db/migrations/ | sort` — 037 is taken by a parallel branch)
- [ ] End-to-end: apply migration against a dev DB, call `memory-store` twice with a name variant, verify second call resolves via alias match (no embedding call) using DB query `SELECT aliases FROM kg_nodes WHERE id = '<id>'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fuzzy entity resolution now prevents duplicate knowledge graph nodes when entity names have slight variations, using semantic similarity matching as a fallback when exact matches fail
  * Aliases are automatically learned and stored for entities, enabling faster and more reliable resolution of name variations in future interactions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/534)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->