### PR TITLE
chore: normalize implementation status tables across spec docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **Spec docs** — normalized Implementation Status tables across all 17 specs: replaced vague status labels with item-by-item counts, stripped explanatory suffixes and issue numbers from "Done" entries, standardized section headings, added spec 17 (Meeting Debrief) to the master index in `00-overview.md`
+
 ### Removed
 
 - **`file-reader` and `file-writer` skills** removed from spec scope (spec 03, 06). General-purpose filesystem access from LLM-driven agents is an unacceptable prompt-injection vector on a single-tenant VPS. Email attachments are handled in-memory via Nylas SDK; agent-created documents should use the knowledge graph.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
-- **Spec docs** — normalized Implementation Status tables across all 17 specs: replaced vague status labels with item-by-item counts, stripped explanatory suffixes and issue numbers from "Done" entries, standardized section headings, added spec 17 (Meeting Debrief) to the master index in `00-overview.md`
+- **Spec docs** — updated spec documentation to match implementation status
 
 ### Removed
 

--- a/docs/specs/00-overview.md
+++ b/docs/specs/00-overview.md
@@ -8,22 +8,23 @@
 | # | Document | Scope | Status |
 |---|----------|-------|--------|
 | 00 | This file | Architecture, layers, bus, message flow, design principles | ✅ Implemented |
-| 01 | [Memory System](01-memory-system.md) | Knowledge graph, entity memory, working memory, Bullpen, embeddings | ✅ Implemented |
-| 02 | [Agent System](02-agent-system.md) | Agent definition, lifecycle, state, execution modes, LLM providers | ✅ Implemented |
-| 03 | [Skills & Execution](03-skills-and-execution.md) | Local skills, MCP, discovery, secrets, permissions | Partial — concurrency limits and streaming buffer caps not yet built |
-| 04 | [Channels](04-channels.md) | Adapter interface, CLI, HTTP, Signal, Email channels, message normalization | ✅ Implemented |
-| 05 | [Error Recovery](05-error-recovery.md) | Error budgets, state continuity, pattern detection, failure model | ✅ Implemented |
-| 06 | [Audit & Security](06-audit-and-security.md) | Audit log, redaction, tool sanitization, intent drift, security | Partial — only bulk export gates remaining |
-| 07 | [Scheduler](07-scheduler.md) | Job model, cron, one-shot, persistent tasks, burst execution | ✅ Implemented |
-| 08 | [Operations](08-operations.md) | Config, deployment, health checks, logging, project structure | Partial - config validation & onboarding planned |
-| 09 | [Contacts & Identity](09-contacts-and-identity.md) | Contact resolution, identity verification, unknown sender policy, authorization, channel identity linking | ✅ Implemented |
-| 10 | [Audit Log Hardening](10-audit-log-hardening.md) | Structured audit fields, LLM provenance, tamper evidence, source attribution, HITL records | Planned |
-| 11 | [Entity Context Enrichment](11-entity-context-enrichment.md) | Entity model, KG-backed sender/entity profiles, context assembly, agent self-identity, skill convention for entity-scoped operations | Partial - Phase 1 done, Phase 2 and 3 pending  |
-| 12 | [Knowledge Graph Web Explorer](12-knowledge-graph-web-explorer.md) | Knowledge graph browser, relationship visualization, entity memory viewer | ✅ Implemented |
-| 13 | [Office Identity](13-office-identity.md) | Persona config, voice settings, runtime identity injection | ✅ Implemented |
-| 14 | [Autonomy Engine](14-autonomy-engine.md) | Global score, autonomy bands, skill action_risk, per-task prompt injection, CEO controls | Partial — Phase 1 & 2 implemented; Phase 3 (automatic score adjustment) planned |
-| 15 | [Outbound Safety](15-outbound-safety.md) | Content filter, display name sanitization, caller verification, LLM-as-judge gateway | Partial — deterministic rules done; LLM-as-judge planned |
-| 16 | [Smoke Test Framework](16-smoke-test-framework.md) | Chat-based test cases, LLM-as-judge evaluation, HTML reports | ✅ Implemented |
+| 01 | [Memory System](01-memory-system.md) | Knowledge graph, entity memory, working memory, Bullpen, embeddings | ✅ 12 of 12 Done |
+| 02 | [Agent System](02-agent-system.md) | Agent definition, lifecycle, state, execution modes, LLM providers | 16 of 22 Done |
+| 03 | [Skills & Execution](03-skills-and-execution.md) | Local skills, MCP, discovery, secrets, permissions | 17 of 22 Done |
+| 04 | [Channels](04-channels.md) | Adapter interface, CLI, HTTP, Signal, Email channels, message normalization | 8 of 15 Done |
+| 05 | [Error Recovery](05-error-recovery.md) | Error budgets, state continuity, pattern detection, failure model | 10 of 18 Done |
+| 06 | [Audit & Security](06-audit-and-security.md) | Audit log, redaction, tool sanitization, intent drift, security | 20 of 22 Done |
+| 07 | [Scheduler](07-scheduler.md) | Job model, cron, one-shot, persistent tasks, burst execution | 16 of 17 Done |
+| 08 | [Operations](08-operations.md) | Config, deployment, health checks, logging, project structure | 10 of 11 Done |
+| 09 | [Contacts & Identity](09-contacts-and-identity.md) | Contact resolution, identity verification, unknown sender policy, authorization, channel identity linking | 10 of 15 Done |
+| 10 | [Audit Log Hardening](10-audit-log-hardening.md) | Structured audit fields, LLM provenance, tamper evidence, source attribution, HITL records | 2 of 17 Done |
+| 11 | [Entity Context Enrichment](11-entity-context-enrichment.md) | Entity model, KG-backed sender/entity profiles, context assembly, agent self-identity, skill convention for entity-scoped operations | 11 of 18 Done |
+| 12 | [Knowledge Graph Web Explorer](12-knowledge-graph-web-explorer.md) | Knowledge graph browser, relationship visualization, entity memory viewer | ✅ 5 of 5 Done |
+| 13 | [Office Identity](13-office-identity.md) | Persona config, voice settings, runtime identity injection | ✅ 10 of 10 Done |
+| 14 | [Autonomy Engine](14-autonomy-engine.md) | Global score, autonomy bands, skill action_risk, per-task prompt injection, CEO controls | ✅ 9 of 9 Done |
+| 15 | [Outbound Safety](15-outbound-safety.md) | Content filter, display name sanitization, caller verification, LLM-as-judge gateway | 6 of 13 Done |
+| 16 | [Smoke Test Framework](16-smoke-test-framework.md) | Chat-based test cases, LLM-as-judge evaluation, HTML reports | 8 of 18 Done |
+| 17 | [Meeting Debrief](17-meeting-debrief.md) | Proactive debrief agent, conversation claims, detection pipeline, follow-up execution | 1 of 21 Done |
 
 ---
 

--- a/docs/specs/00-overview.md
+++ b/docs/specs/00-overview.md
@@ -10,7 +10,7 @@
 | 00 | This file | Architecture, layers, bus, message flow, design principles | ✅ Implemented |
 | 01 | [Memory System](01-memory-system.md) | Knowledge graph, entity memory, working memory, Bullpen, embeddings | ✅ 12 of 12 Done |
 | 02 | [Agent System](02-agent-system.md) | Agent definition, lifecycle, state, execution modes, LLM providers | 16 of 22 Done |
-| 03 | [Skills & Execution](03-skills-and-execution.md) | Local skills, MCP, discovery, secrets, permissions | 17 of 22 Done |
+| 03 | [Skills & Execution](03-skills-and-execution.md) | Local skills, MCP, discovery, secrets, permissions | 17 of 20 Done |
 | 04 | [Channels](04-channels.md) | Adapter interface, CLI, HTTP, Signal, Email channels, message normalization | 8 of 15 Done |
 | 05 | [Error Recovery](05-error-recovery.md) | Error budgets, state continuity, pattern detection, failure model | 10 of 18 Done |
 | 06 | [Audit & Security](06-audit-and-security.md) | Audit log, redaction, tool sanitization, intent drift, security | 20 of 22 Done |

--- a/docs/specs/04-channels.md
+++ b/docs/specs/04-channels.md
@@ -138,8 +138,8 @@ Each adapter implements reconnection with exponential backoff:
 | Item | Status |
 |---|---|
 | `ChannelAdapter` interface (`start`, `stop`, `send`) | Partial — no shared TypeScript interface; each adapter implements the pattern independently |
-| `InboundMessage` type | Done — defined as `InboundMessagePayload` in `src/bus/events.ts` |
-| `OutboundMessage` type | Done — defined as `OutboundMessagePayload` in `src/bus/events.ts` |
+| `InboundMessage` type | Done |
+| `OutboundMessage` type | Done |
 | CLI channel adapter | Done |
 | Email channel adapter (Nylas API, polling, participant extraction) | Done |
 | Signal channel adapter (signal-cli JSON-RPC subprocess) | Done |

--- a/docs/specs/06-audit-and-security.md
+++ b/docs/specs/06-audit-and-security.md
@@ -338,31 +338,31 @@ Even if all preventive layers fail, the audit trail enables full post-incident f
 
 ---
 
-## Security Completion Status
+## Implementation Status
 
 These are non-negotiable for launch.
 
 | Item | Status |
 |---|---|
-| Bus layer enforcement tested (channel cannot publish `skill.invoke`) | Done (#187) |
-| Audit log append-only verified (no UPDATE or DELETE code paths) and DB-level trigger enforcement | Done (#248) |
+| Bus layer enforcement tested (channel cannot publish `skill.invoke`) | Done |
+| Audit log append-only verified (no UPDATE or DELETE code paths) and DB-level trigger enforcement | Done |
 | Secret values never appear in logs, audit, or LLM context | Not Done |
 | Tool output sanitization active for all skill results | Done |
 | Inbound message sanitization active (injection pattern detection) | Done |
-| Error strings scrubbed before LLM injection | Done (#250) |
-| Agent config validation blocks malformed YAML at startup | Done (#263) |
+| Error strings scrubbed before LLM injection | Done |
+| Agent config validation blocks malformed YAML at startup | Done |
 | HTTP API channel requires token authentication | Done |
-| Rate limiting active at dispatch layer | Done (#198) |
-| Intent drift detection pauses tasks (not just logs) | Done (#199) |
-| Email channel exposes provider-level SPF/DKIM/DMARC validation via Nylas message metadata | Done (#195) |
-| Anti-injection system prompt hardening and architectural containment (Layers 2 & 3) | Done (#194) |
+| Rate limiting active at dispatch layer | Done |
+| Intent drift detection pauses tasks (not just logs) | Done |
+| Email channel exposes provider-level SPF/DKIM/DMARC validation via Nylas message metadata | Done |
+| Anti-injection system prompt hardening and architectural containment (Layers 2 & 3) | Done |
 | Migration 020 adds `contact_confidence`, `trust_level`, `last_seen_at` columns to existing `contacts` table | Done |
 | All `agent.task` events carry `messageTrustScore` (computed float); `trustLevel` and `contactConfidence` are inputs only, not propagated to bus events | Done |
 | Unknown sender lookup targets `contact_channel_identities (channel, channel_identifier)` | Done |
 | Unknown sender routing configured in `config/channel-trust.yaml` using `allow` / `hold_and_notify` / `ignore` | Done |
-| `contact.unknown` event includes `routingDecision` field so audit trail is self-contained without downstream correlation | Done (#254) |
-| Unknown sender → `hold_and_notify` path covered by integration test (in-memory `HeldMessageService`, verifies score, event payload, and store write) | Done (#254) |
+| `contact.unknown` event includes `routingDecision` field so audit trail is self-contained without downstream correlation | Done |
+| Unknown sender → `hold_and_notify` path covered by integration test (in-memory `HeldMessageService`, verifies score, event payload, and store write) | Done |
 | Trust score floor: messages below `security.trust_score_floor` (default 0.2) trigger `hold_and_notify` regardless of per-channel policy | Done |
 | Trust-gated action thresholds use `messageTrustScore` numeric values, enforced via Coordinator system prompt | Done |
-| Data sensitivity tags on knowledge graph entities | Done (#200) |
+| Data sensitivity tags on knowledge graph entities | Done |
 | Bulk export gates active for confidential+ data | Not Done |

--- a/docs/specs/10-audit-log-hardening.md
+++ b/docs/specs/10-audit-log-hardening.md
@@ -422,13 +422,13 @@ This spec is designed to be implemented incrementally. Each phase is independent
 
 ---
 
-## Implementation Completion Status
+## Implementation Status
 
 | Item | Status |
 |---|---|
 | Migration: structured columns on `audit_log` (`action`, `outcome`, `target_type`, `target_id`, `initiator_type`, `initiator_id`) | Not Done |
 | Field extraction logic in `AuditLogger.log()` | Not Done |
-| `llm.call` event type added to `events.ts` | Done (#187) |
+| `llm.call` event type added to `events.ts` | Done |
 | LLM providers emit `llm.call` events with provenance fields | Not Done |
 | `llm_call_archive` table created and populated | Not Done |
 | Redaction applied to prompt/response archive writes | Not Done |

--- a/docs/specs/17-meeting-debrief.md
+++ b/docs/specs/17-meeting-debrief.md
@@ -348,7 +348,7 @@ These are out of scope for this feature but identified during design:
 
 ---
 
-## 12. Implementation Status
+## Implementation Status
 
 | Number | Item | Status |
 |---|---|---|


### PR DESCRIPTION
## Summary

- Replace vague status labels in the master index (`00-overview.md`) with precise "X of Y Done" counts for all 17 specs; apply ✅ only where 100% complete
- Strip explanatory suffixes and issue numbers from "Done" entries in specs 04, 06, and 10
- Standardize section heading to `## Implementation Status` in specs 06, 10, and 17
- Add spec 17 (Meeting Debrief) to the master index — was missing entirely

## Test plan

- [ ] Verify each count in `00-overview.md` matches the item count in the corresponding spec's Implementation Status table
- [ ] Confirm ✅ is only present on specs where every item is Done (01, 12, 13, 14)
- [ ] Confirm no "Done — ..." or "Done (#NNN)" suffixes remain in any spec
- [ ] Confirm all specs use `## Implementation Status` as the section heading