### PR TITLE
chore: release v0.27.0 — "Gerty"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,43 +13,47 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+---
+
+## [0.27.0] — 2026-05-12 — "Gerty"
+
+> **Gerty** *(Moon, 2009, dir. Duncan Jones)* — the AI station manager aboard Sarang lunar base. Unobtrusive, precise, deeply loyal. Remembers everything, knows the identity of everyone under its care, and manages complex operations without fanfare. When things get uncertain, Gerty resolves them quietly. Nothing important gets forgotten.
+
 ### Added
 
-- **Fuzzy entity resolution** — `resolveOrCreate()` now falls back to embedding-based semantic search when exact label match fails, preventing duplicate KG nodes from name variants like "Darlise" / "Darlise Restaurant". Confirmed matches are stored as aliases for instant future resolution. New `addAlias()` method on `EntityMemory`; `memory-store` handler learns aliases after disambiguation and auto-resolve. New migration `038_add_kg_node_aliases.sql` adds `aliases TEXT[]` column with GIN index. (#467)
-- **Decay warnings (#280):** DreamEngine now flags important KG nodes before archiving — high-sensitivity (`confidential`/`restricted`) or high-connectivity (top 5th percentile by edge count, floor 5) nodes get a 7-day hold-back window instead of silent archival. The coordinator proactively surfaces re-confirmation nudges to the CEO; confirming resets the decay clock, dismissing archives immediately.
-- **`decay-warnings-list` skill:** Lists KG nodes currently in the warned state with `daysRemaining` until auto-archive.
-- **`memory-confirm` skill:** Records the CEO's confirm or dismiss decision on a warned node.
-- **`memory.decay_warning` bus event:** Emitted by DreamEngine for each newly warned node (audit trail).
-- **Calendar Specialist agent** (`agents/calendar.yaml`) — new specialist that owns the full calendar domain: scheduling intelligence, free/busy queries, conflict resolution, event CRUD, and scheduling-related email composition. The coordinator delegates scheduling intent in natural language; the specialist resolves entities, finds available time, creates events, and composes meeting request/reschedule/cancellation email text. Includes preference-sensitive scheduling (queries memory for stored CEO preferences), multi-party timezone-aware slot finding, and conflict escalation patterns. (#499)
-- **General pronoun-resolution rule** — coordinator now resolves possessive pronouns ("my calendar", "your schedule") to explicit entity identities before delegating to any specialist, replacing the calendar-specific disambiguation section.
-- **file-parse skill** — general-purpose document parser that extracts structured data from CSV, PDF, HTML, and image files. CSV is parsed deterministically (no LLM, confidence 1.0); images use Claude vision; PDFs and HTML use text extraction with optional LLM structuring. Supports `extract_as` hint for `receipt`, `bank_statement`, and `invoice` schemas. Reusable by any agent.
-- **Identity status** — contact channel identities now carry a `status` field (`active`/`defunct`/`bounced`), orthogonal to `verified`. contact-lookup surfaces status alongside each identity. context-for-email prefers active identities and includes `identity_status` in the recipient context. New `contact-set-identity-status` skill (pinned to contacts agent) for manual updates. Contacts specialist warns the coordinator when non-active identities are about to be suggested. (#377)
-- **Contact Specialist agent** (`agents/contacts.yaml`) — new specialist that owns the full contact domain: briefings, CRUD, deduplication, relationship management, and entity resolution for people and organizations. The coordinator delegates contact intelligence via a "brief me" natural-language pattern; the specialist returns enriched context and resolved contact IDs in a `<resolved_entities>` XML block. Weekly dedup scan migrated from the coordinator's scheduler to the contact specialist's `schedule:` entry. (#498)
-- **Startup readiness checks** — system refuses inbound messages if no principal contact exists (`system_role='principal'`). Extensible `ReadinessCheck` interface for future setup validation.
-- **Research-analyst memory access** — pinned `memory-query` and `memory-store` to the research-analyst agent with domain-specific recall and storage guidance. Stored context about known entities now informs research; important findings about CEO-relevant entities are persisted to the knowledge graph.
+- **Contact Specialist agent** — new dedicated agent for all contact-domain work: briefings, CRUD, deduplication, and entity resolution. The coordinator now delegates rather than handles contact tasks directly. (#498)
+- **Calendar Specialist agent** — new dedicated agent for all scheduling work: finding time, resolving conflicts, creating events, and drafting scheduling emails. Multi-party, timezone-aware, preference-sensitive. (#499)
+- **Fuzzy entity resolution** — the knowledge graph now resolves near-matches by semantic similarity, preventing duplicate nodes from name variants ("Darlise" / "Darlise Restaurant"). Confirmed matches are stored as aliases for instant future resolution. (#467)
+- **Decay warnings** — important KG nodes are flagged before archival rather than silently deleted. High-sensitivity or highly-connected nodes enter a 7-day hold-back window; the coordinator nudges the CEO to confirm before anything is lost. (#280)
+- **`file-parse` skill** — parses CSV, PDF, HTML, and images into structured data. CSV is deterministic; images use vision; PDFs and HTML use text extraction with optional LLM structuring.
+- **Identity status** — channel identities now carry an `active`/`defunct`/`bounced` status, separate from `verified`. Outbound routing and contact lookup both prefer active identities. (#377)
+- **Startup readiness gate** — Curia refuses inbound messages until a principal contact is configured.
+- **Research-analyst memory** — the research analyst can now read from and write to the knowledge graph; important findings about known entities persist across sessions.
 
 ### Changed
 
-- **Spec docs** — updated spec documentation to match implementation status
-- **Coordinator prompt reduced** — removed Calendar Disambiguation, Scheduling Behavior, and calendar account identity exception sections (~40 lines). Removed 8 calendar skills and 3 template skills from coordinator's pinned_skills. Net reduction: ~35 lines of prompt text and 11 pinned skills.
-- **Contradiction auto-resolution** (spec 01): `validateContradiction` now auto-rejects incoming facts with lower confidence than the existing contradicting fact, and auto-resolves (updates in place) when the incoming confidence is higher, preserving the old value in a `properties.previous_values` audit trail. Equal-confidence contradictions continue to escalate to human review unchanged.
-- **Coordinator contact domain cleanup** — removed ~165 lines of contact-domain prompt guidance (Contact Awareness, Contact Lookup Best Practices, Contact Deduplication, Relationship Management, entity resolution quick reference) and 15 contact skills from the coordinator's `pinned_skills`. Replaced with an 8-line delegation note. (#498)
-- **Entity resolution:** `resolveOrCreate` now logs a warning when a single label match has a different type than the caller's hint, improving observability without changing resolution behaviour ([#474](https://github.com/josephfung/curia/issues/474))
-- **Principal identity consolidation** — replaced fragmented CEO identity (env var config, `role` column, `OutboundGatewayConfig` flat fields) with a database-driven `system_role` column on the `contacts` table. One contact holds `system_role='principal'`, one holds `system_role='agent'`. Enforced by partial unique indexes.
-- **TaskOriginator on every task** — replaced `ceoInitiated: boolean` with a `TaskOriginator` object stamped by the dispatcher on every task, carrying `contactId`, `systemRole`, `channel`, and `initiatedAt`. CEO-authorization checks now use `isPrincipalOriginated(taskMetadata)`. Originator context survives task delegation, resolving the autonomy gate bug for scheduled CEO-authorized actions.
+- **Specialists absorb their domains** — the coordinator sheds ~200 lines of prompt text and 26 pinned skills as Contact and Calendar specialists take full ownership of their areas.
+- **Contradiction auto-resolution** — conflicting facts are now resolved automatically by confidence: lower-confidence incoming facts are rejected; higher-confidence ones update in place with the prior value preserved in an audit trail. Equal-confidence contradictions still escalate for human review.
+- **Principal identity is database-driven** — CEO identity is now `system_role='principal'` on the contacts table instead of env vars and config fields. *(Public API change: `TaskOriginator` replaces `ceoInitiated: boolean`; use `isPrincipalOriginated()`.)*
+- **`config-store` replaces knowledge-* skills** — `knowledge-company-overview`, `knowledge-meeting-links`, `knowledge-travel-preferences`, `knowledge-loyalty-programs` replaced by `config-store` with equivalent namespaces.
 
 ### Fixed
 
-- **file-parse skill** — fixed ESM import of `pdf-parse` (CJS-only package) using `createRequire`, which caused the skill to fail to load in production
-- **Coordinator: Google Drive sharing** — pinned Drive management skills (search, list, share, permissions) to the coordinator and added prompt guidance for Drive management and capability discovery, fixing a bug where the coordinator claimed it couldn't share Drive files despite the skills being registered
-- **Google Workspace URL routing** — coordinator now uses workspace skills for Google Docs/Drive URLs instead of falling back to web-browser. Research-analyst reports correctly when it cannot access a Workspace URL. Coordinator delegates to specialists more reliably via injected specialist list.
-- **Entity-context email resolution** — `resolveKgNodeId` now resolves email addresses via `contact_channel_identities` before attempting UUID-based queries, fixing missing KG context in CC flows and ceo-inbox triage for known contacts ([#461](https://github.com/josephfung/curia/issues/461))
+- **`file-parse`** — ESM import of the CJS-only `pdf-parse` package now works; the skill was failing silently in production.
+- **Google Drive sharing** — the coordinator correctly surfaces Drive management skills instead of claiming it cannot share files.
+- **Entity-context email resolution** — known contacts referenced by email address in CC'd threads now receive full KG context. (#461)
 
 ### Removed
 
-- **`file-reader` and `file-writer` skills** removed from spec scope (spec 03, 06). General-purpose filesystem access from LLM-driven agents is an unacceptable prompt-injection vector on a single-tenant VPS. Email attachments are handled in-memory via Nylas SDK; agent-created documents should use the knowledge graph.
-- **Template scheduling skills** — `template-meeting-request`, `template-reschedule`, and `template-cancel` deleted. The calendar specialist composes scheduling email text directly with full scheduling context, producing better results than parameterized templates.
-- **`knowledge-company-overview`, `knowledge-meeting-links`, `knowledge-travel-preferences`, `knowledge-loyalty-programs` skills** — replaced by `config-store` with namespaces `company`, `meeting_links`, `travel_preferences`, and `loyalty_programs`. The coordinator prompt now carries explicit namespace guidance.
+- **`file-reader` and `file-writer` skills** — general filesystem access from LLM agents is a prompt-injection risk; removed from spec scope.
+- **Template scheduling skills** — `template-meeting-request`, `template-reschedule`, and `template-cancel` deleted; the Calendar Specialist composes scheduling emails directly.
+- **`knowledge-*` static skills** — see `config-store` above.
+
+---
+
+*know your own domain —*
+*names blur into the known shape;*
+*memory holds true.*
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ Open `CHANGELOG.md` and review all entries under `## [Unreleased]`. Read for the
 
 **2. Name the release and determine the version bump**
 
-Pick a short, evocative release name that captures the dominant theme (e.g. "Memory Stabilization", "Autonomy Foundations", "Signal Clarity"). Keep it dignified — not whimsical, not corporate.
+Name each release after a sci-fi character whose nature embodies the dominant theme of the changes. Choose characters that readers are likely to know; draw from a broad canon (films, novels, games — not just one franchise). The fit should be genuinely tight, not forced. If no character fits well, defer to a short evocative phrase.
 
 Use the bump table above to determine the version bump. If the unreleased batch mixes types, the highest applicable bump wins (any minor → minor; all patches → patch).
 
@@ -205,7 +205,11 @@ Use the bump table above to determine the version bump. If the unreleased batch 
 
 - Create a new heading immediately after `## [Unreleased]`:
   ```
-  ## [X.Y.Z] — YYYY-MM-DD — "Release Name"
+  ## [X.Y.Z] — YYYY-MM-DD — "Character Name"
+  ```
+- Immediately below the heading, add a blockquote with the character's name, source (work + year + creator), and a brief statement about who they are and why the fit is apt:
+  ```
+  > **Character Name** *(Work, Year, creator)* — one or two sentences: who they are, what defines them, and why this release embodies that.
   ```
 - Move all `[Unreleased]` bullets under it. Leave `## [Unreleased]` in place above it, empty, ready for the next batch.
 - Condense and group the bullets — aim for clarity over completeness. Merge related entries, cut implementation detail, and make it readable to someone who uses Curia but didn't write the code. The CHANGELOG is a reader document, not a commit log.
@@ -222,8 +226,8 @@ Write a haiku thematically aligned with the release — drawn from the changes, 
 **6. Open a release PR**
 
 - Branch: `chore/release-X.Y.Z`
-- PR title: `chore: release vX.Y.Z — Release Name`
-- PR body: the new CHANGELOG section, followed by the haiku
+- PR title: `chore: release vX.Y.Z — "Character Name"`
+- PR body: the character blockquote, followed by the new CHANGELOG section, followed by the haiku
 - No other code changes — this PR is the release commit only
 - Watch CI; wait for merge before proceeding
 
@@ -237,16 +241,18 @@ git -C /path/to/repo fetch origin main
 git -C /path/to/repo show origin/main:CHANGELOG.md | grep "X.Y.Z"
 
 # Tag origin/main directly — no checkout or pull needed
-git -C /path/to/repo tag -a vX.Y.Z -m "vX.Y.Z — Release Name" origin/main
+git -C /path/to/repo tag -a vX.Y.Z -m "vX.Y.Z — Character Name" origin/main
 git -C /path/to/repo push origin vX.Y.Z
 ```
 
-Then write the release notes (rewrite the CHANGELOG bullets into natural, friendly prose — past tense, as if narrating what changed; prioritize what a user of Curia would care about; close with a horizontal rule and the haiku) and create the GitHub release:
+Then write the release notes (open with the character blockquote; rewrite the CHANGELOG bullets into natural, friendly prose — past tense, as if narrating what changed; prioritize what a user of Curia would care about; close with a horizontal rule and the haiku) and create the GitHub release:
 
 ```bash
 gh release create vX.Y.Z \
-  --title 'vX.Y.Z — "Release Name"' \
+  --title 'vX.Y.Z — "Character Name"' \
   --notes "$(cat <<'EOF'
+[character blockquote here]
+
 [release prose here]
 
 ---

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.26.0-blueviolet" alt="Version: 0.26.0" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.27.0-blueviolet" alt="Version: 0.27.0" /></a>
   <img src="https://img.shields.io/badge/status-pre--alpha-orange" alt="Status: Pre-Alpha" />
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License: MIT" />
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node >= 22" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "packageManager": "pnpm@11.0.8",


### PR DESCRIPTION
> **Gerty** *(Moon, 2009, dir. Duncan Jones)* — the AI station manager aboard Sarang lunar base. Unobtrusive, precise, deeply loyal. Remembers everything, knows the identity of everyone under its care, and manages complex operations without fanfare. When things get uncertain, Gerty resolves them quietly. Nothing important gets forgotten.

## [0.27.0] — 2026-05-12 — "Gerty"

### Added

- **Contact Specialist agent** (`agents/contacts.yaml`) — new specialist that owns the full contact domain: briefings, CRUD, deduplication, relationship management, and entity resolution. The coordinator delegates contact intelligence via a "brief me" natural-language pattern; the specialist returns enriched context and resolved contact IDs in a `<resolved_entities>` XML block. (#498)
- **Calendar Specialist agent** (`agents/calendar.yaml`) — new specialist that owns the full calendar domain: scheduling intelligence, free/busy queries, conflict resolution, event CRUD, and scheduling-related email composition. Preference-sensitive, multi-party timezone-aware, with conflict escalation patterns. (#499)
- **Fuzzy entity resolution** — `resolveOrCreate()` falls back to embedding-based semantic search when exact label match fails, preventing duplicate KG nodes from name variants. Confirmed matches stored as aliases. New `addAlias()` method; migration `038` adds `aliases TEXT[]` with GIN index. (#467)
- **Decay warnings** — DreamEngine flags important KG nodes before archiving. High-sensitivity or high-connectivity nodes receive a 7-day hold-back window. New `decay-warnings-list` and `memory-confirm` skills; new `memory.decay_warning` bus event. (#280)
- **`file-parse` skill** — document parser for CSV (deterministic), PDF, HTML, and image files. Supports `extract_as` schemas for receipts, bank statements, and invoices.
- **Identity status** — contact channel identities now carry `active`/`defunct`/`bounced` status. `contact-lookup`, `context-for-email`, and new `contact-set-identity-status` skill all updated. (#377)
- **Startup readiness checks** — system refuses inbound messages if no principal contact exists.
- **Research-analyst memory access** — `memory-query` and `memory-store` pinned to the research-analyst agent.

### Changed

- **Contradiction auto-resolution** (spec 01) — `validateContradiction` now auto-rejects lower-confidence incoming facts and auto-resolves higher-confidence ones with a `previous_values` audit trail.
- **Principal identity consolidation** — replaced fragmented CEO identity with a database-driven `system_role` column on `contacts`. *(Public API surface change: `TaskOriginator` replaces `ceoInitiated: boolean`; use `isPrincipalOriginated(taskMetadata)`.)*
- **Coordinator prompt reduced** — ~200 lines and 26 pinned skills removed as Contact and Calendar specialists take ownership of their domains.
- **`config-store` replaces knowledge-* skills** — `knowledge-company-overview`, `knowledge-meeting-links`, `knowledge-travel-preferences`, `knowledge-loyalty-programs` replaced by `config-store` with equivalent namespaces.
- **Release naming convention** — releases are now named after sci-fi characters whose nature embodies the dominant theme. `CLAUDE.md` updated with the full convention, including the character blockquote format.

### Fixed

- **`file-parse` skill** — ESM import of `pdf-parse` (CJS-only) fixed via `createRequire`.
- **Coordinator: Google Drive sharing** — Drive management skills pinned; capability-discovery guidance added.
- **Google Workspace URL routing** — coordinator now uses workspace skills for Google Docs/Drive URLs.
- **Entity-context email resolution** — `resolveKgNodeId` resolves email addresses via `contact_channel_identities` before UUID lookup. (#461)

### Removed

- **`file-reader` and `file-writer` skills** — removed from spec scope; prompt-injection risk.
- **Template scheduling skills** — `template-meeting-request`, `template-reschedule`, `template-cancel` deleted.

---

*know your own domain —*
*names blur into the known shape;*
*memory holds true.*