### PR TITLE
feat: publish llm.call bus events after every Anthropic API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **LLM token tracking** — every successful Anthropic API call now publishes a structured `llm.call` bus event (spec 10) with full model provenance, token counts (including prompt-cache breakdown), estimated cost, latency, and SHA-256 content fingerprints. Events land in `audit_log` automatically via the existing audit logger, enabling per-agent attribution and data-driven context budgeting (closes #326, prerequisite for #24).
+
+### Changed
+
+- **`LLMUsage`** extended with `cacheCreationInputTokens` and `cacheReadInputTokens` fields (previously silently dropped from the Anthropic API response).
+- **`LlmCallPayload`** extended with `cacheCreationInputTokens` and `cacheReadInputTokens` fields; `providerRequestId` comment corrected to reflect response body id (`msg_xxx`), not the HTTP header.
+
 ### Fixed
 
 - **Google Workspace tools** pinned to coordinator — doc creation, editing, formatting, sharing, and drive tools are now always available without requiring `skill-registry` discovery (see #497).

--- a/docs/wip/2026-05-12-llm-token-tracking.md
+++ b/docs/wip/2026-05-12-llm-token-tracking.md
@@ -1,0 +1,238 @@
+# Implementation Plan: Per-Call LLM Token Tracking (Issue #326)
+
+**Branch:** `feat/llm-token-tracking`
+**Date:** 2026-05-12
+**Issue:** josephfung/curia#326
+
+---
+
+## Goal
+
+Wire the existing (but never-called) `createLlmCall` factory so that a structured `llm.call` bus event is published after every Anthropic API call. This lands in `audit_log` automatically via the existing audit logger, providing per-agent token attribution as the baseline for data-driven context budgeting (#24).
+
+Simultaneously:
+- Capture cache tokens (`cache_creation_input_tokens`, `cache_read_input_tokens`) which are currently silently dropped
+- Populate the full `LlmCallPayload` spec including `estimatedCostUsd`, `latencyMs`, `providerRequestId`, `promptHash`, `responseHash`
+
+No new DB table is needed — the `audit_log` (JSONB) plus enriched structured log lines are sufficient.
+
+---
+
+## Architecture Decision
+
+**Approach: Enrich `LLMResponse` with call provenance**
+
+Three fields are only available inside `AnthropicProvider.chat()` but needed by the runtime for event publishing:
+- `requestedModel` — the model string resolved at the start of `chat()`
+- `actualModel` — from `response.model` in the API response body
+- `providerRequestId` — from `response.id` (the `msg_xxx` identifier Anthropic shows in their console)
+
+Solution: add a new `LLMCallProvenance` interface to `provider.ts` and attach it as a required `provenance` field on the `text` and `tool_use` response variants. The runtime then uses this plus its own context (timing, agentId, conversationId, bus) to build and publish the event.
+
+Rejected alternatives:
+- **Separate return type** (`LLMChatResult`): large blast radius — every `response.type`, `response.usage`, `response.content` read in `runtime.ts` would need updating.
+- **Callback pattern** (`onCallComplete`): provider fires a callback from inside `chat()`, violating the layer boundary (provider would implicitly participate in bus publishing).
+
+---
+
+## Step-by-Step Plan
+
+### Step 1 — Extend `LLMUsage` and add `LLMCallProvenance` in `provider.ts`
+
+File: `src/agents/llm/provider.ts`
+
+Changes:
+1. Add cache fields to `LLMUsage`:
+   ```ts
+   export interface LLMUsage {
+     inputTokens: number;
+     outputTokens: number;
+     cacheCreationInputTokens: number;  // 0 when not applicable
+     cacheReadInputTokens: number;       // 0 when not applicable
+   }
+   ```
+2. Add new interface:
+   ```ts
+   /** Provider-level metadata returned alongside every successful LLM response. */
+   export interface LLMCallProvenance {
+     requestedModel: string;   // model string passed to the provider (requested by caller)
+     actualModel: string;      // model that actually ran (from API response body)
+     providerRequestId: string; // Anthropic: response.id (msg_xxx); used for support correlation
+   }
+   ```
+3. Add `provenance: LLMCallProvenance` to the `text` and `tool_use` variants in `LLMResponse`:
+   ```ts
+   export type LLMResponse =
+     | { type: 'text'; content: string; usage: LLMUsage; provenance: LLMCallProvenance }
+     | { type: 'tool_use'; toolCalls: ToolCall[]; content?: string; usage: LLMUsage; provenance: LLMCallProvenance }
+     | { type: 'error'; error: AgentError; usage?: LLMUsage };
+   ```
+   Error paths don't include provenance — when the API fails (timeout, network error), there's no response body to extract these from.
+
+**Why cache fields are `number` not `number | null`:** The `LlmCallPayload` spec defines them as `number`. Zero is semantically correct for non-caching calls — no tokens were served from cache.
+
+---
+
+### Step 2 — Populate provenance and cache tokens in `anthropic.ts`
+
+File: `src/agents/llm/anthropic.ts`
+
+Changes:
+1. After the successful API response (`const response = await this.client.messages.create(...)`), build provenance:
+   ```ts
+   const provenance: LLMCallProvenance = {
+     requestedModel: model,            // local const resolved at top of chat()
+     actualModel: response.model,      // from response body
+     providerRequestId: response.id,   // msg_xxx identifier
+   };
+   ```
+2. Extend the `LLMUsage` construction (current lines 157–160) to include cache fields:
+   ```ts
+   const usage: LLMUsage = {
+     inputTokens: response.usage.input_tokens,
+     outputTokens: response.usage.output_tokens,
+     cacheCreationInputTokens: response.usage.cache_creation_input_tokens ?? 0,
+     cacheReadInputTokens: response.usage.cache_read_input_tokens ?? 0,
+   };
+   ```
+3. Enrich the existing debug log (lines 147–155) to include cache fields:
+   ```ts
+   this.logger.debug(
+     {
+       model,
+       inputTokens: response.usage.input_tokens,
+       outputTokens: response.usage.output_tokens,
+       cacheCreationTokens: response.usage.cache_creation_input_tokens ?? 0,
+       cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
+       stopReason: response.stop_reason,
+     },
+     'Anthropic API call completed',
+   );
+   ```
+4. Add `provenance` to both return paths:
+   - `tool_use` return: add `provenance` field
+   - `text` return: add `provenance` field
+   - `error` catch path: unchanged (no provenance)
+
+---
+
+### Step 3 — Create `src/agents/llm/pricing.ts`
+
+New file: `src/agents/llm/pricing.ts`
+
+Responsibilities:
+- Define per-model pricing ($ per million tokens)
+- Export `estimateCostUsd(actualModel: string, usage: LLMUsage): number`
+
+Pricing data (as of 2026-05):
+```
+claude-opus-4-6:    $15.00/$75.00/$18.75/$1.50 per MTok (in/out/cache-create/cache-read)
+claude-sonnet-4-6:  $3.00/$15.00/$3.75/$0.30 per MTok
+claude-haiku-4-5:   $0.80/$4.00/$1.00/$0.08 per MTok
+```
+
+Lookup is by prefix-match on `actualModel` (handles minor version suffixes gracefully). Falls back to `claude-sonnet-4-6` pricing with a `warn` log when the model is unrecognized — never silently returns 0.
+
+`estimateCostUsd` takes `LLMUsage` (which now has all four token fields) and returns a single `number` (full float precision, not rounded — callers round for display).
+
+---
+
+### Step 4 — Wire event publishing in `runtime.ts`
+
+File: `src/agents/runtime.ts`
+
+This is the core wiring step. All changes are inside `chatWithRetry()`.
+
+Imports to add at top of file:
+```ts
+import { createHash } from 'node:crypto';
+import { createLlmCall } from '../bus/events.js';
+import { estimateCostUsd } from './llm/pricing.js';
+```
+
+In `chatWithRetry()`:
+
+1. Add timing before the first `provider.chat()` call:
+   ```ts
+   const callStartMs = Date.now();
+   const response = await provider.chat(params);
+   const latencyMs = Date.now() - callStartMs;
+   ```
+
+2. Add a `publishLlmCallEvent` helper inline (or as a private method) that takes `(response, params, latencyMs, taskEvent)` and:
+   - Returns early if `response.type === 'error'` (no provenance available)
+   - Computes `promptHash` = SHA-256 of `JSON.stringify({ messages: params.messages, tools: params.tools ?? [] })`
+   - Computes `responseHash`:
+     - `text`: SHA-256 of `response.content`
+     - `tool_use`: SHA-256 of `JSON.stringify(response.toolCalls)`
+   - Calls `estimateCostUsd(response.provenance.actualModel, response.usage)`
+   - Calls `createLlmCall({ agentId, conversationId: taskEvent.payload.conversationId, ...response.provenance, ...token fields, estimatedCostUsd, latencyMs, promptHash, responseHash, parentEventId: taskEvent.id })`
+   - `await bus.publish('agent', event)`
+
+3. Call the helper after the initial `provider.chat()` call succeeds (before returning).
+
+4. Also call it in the retry loop after each successful retry attempt.
+
+5. `bus` and `agentId` are destructured from `this.config` at the top of `chatWithRetry()`:
+   ```ts
+   const { agentId, bus, logger } = this.config;
+   ```
+   (Currently only `agentId` and `logger` are destructured here.)
+
+**Note on error paths:** Failed attempts (responses of type `error`) do not emit `llm.call` events. A `// TODO: emit llm.call for error paths when spec 10 cost-on-failure policy is settled` comment marks the gap.
+
+**Note on retry timing:** Each retry attempt resets `callStartMs` and measures its own `latencyMs`. The published event reflects the latency of the successful attempt, not the total time including wait periods.
+
+---
+
+### Step 5 — Tests
+
+#### `src/agents/llm/anthropic.test.ts`
+
+Additions:
+- Extend mock API responses to include `id: 'msg_test_123'`, `model: 'claude-sonnet-4-6'`, and `usage.cache_creation_input_tokens: null`, `usage.cache_read_input_tokens: null`
+- Add assertions on `result.provenance.actualModel`, `result.provenance.requestedModel`, `result.provenance.providerRequestId` for both `text` and `tool_use` response paths
+- Add assertion that `result.usage.cacheCreationInputTokens === 0` when API returns `null`
+- Add a test case where cache tokens are non-zero (e.g., `cache_creation_input_tokens: 1500`)
+
+#### New `src/agents/llm/pricing.test.ts`
+
+- `estimateCostUsd('claude-sonnet-4-6', { inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 })` → expected value
+- `estimateCostUsd('claude-opus-4-6', ...)` → expected value
+- `estimateCostUsd('claude-haiku-4-5-20251001', ...)` → matches haiku pricing (prefix match)
+- `estimateCostUsd('unknown-model-xyz', ...)` → falls back to sonnet pricing, verify no crash
+
+---
+
+## Files Modified/Created
+
+| File | Type | Description |
+|------|------|-------------|
+| `src/agents/llm/provider.ts` | Modified | Add `LLMCallProvenance`, extend `LLMUsage`, add `provenance` to response types |
+| `src/agents/llm/anthropic.ts` | Modified | Populate cache tokens, build provenance, enrich debug log |
+| `src/agents/llm/pricing.ts` | **New** | `ANTHROPIC_PRICING` map + `estimateCostUsd()` function |
+| `src/agents/runtime.ts` | Modified | Timing, hash computation, `llm.call` event publishing in `chatWithRetry()` |
+| `src/agents/llm/anthropic.test.ts` | Modified | Extend mocks to include new fields, add provenance assertions |
+| `src/agents/llm/pricing.test.ts` | **New** | Unit tests for `estimateCostUsd` |
+
+No DB migrations needed. No new bus event types or permission entries needed (`llm.call` is already in the agent layer's publish allowlist at `permissions.ts:30`).
+
+---
+
+## Acceptance Criteria
+
+(From issue #326 + design decisions above)
+
+- [ ] Every successful Anthropic API call (initial, tool-use continuation, recovery) publishes a `llm.call` bus event with a complete `LlmCallPayload`
+- [ ] `inputTokens`, `outputTokens`, `cacheCreationInputTokens`, `cacheReadInputTokens` are all populated correctly (cache fields default to 0 when not applicable)
+- [ ] `provider` field is `'anthropic'` (from `AnthropicProvider.id`)
+- [ ] `requestedModel` and `actualModel` are populated from the provider; they may differ if Anthropic aliases the model
+- [ ] `providerRequestId` is the `msg_xxx` body identifier from the API response
+- [ ] `estimatedCostUsd` reflects all four token types weighted by model pricing
+- [ ] `latencyMs` measures only the actual API call time, not retry wait periods
+- [ ] `promptHash` and `responseHash` are stable SHA-256 hex digests
+- [ ] `parentEventId` traces back to the `agent.task` event that triggered the LLM call
+- [ ] Failed API calls (type `'error'`) do not publish an event (TODO comment left for spec 10)
+- [ ] Existing debug log at `'Anthropic API call completed'` is enriched with cache token fields
+- [ ] All existing tests pass
+- [ ] New tests pass: provenance fields on text/tool_use paths, cache token zero-default, pricing function correctness

--- a/src/agents/llm/anthropic.test.ts
+++ b/src/agents/llm/anthropic.test.ts
@@ -21,10 +21,84 @@ vi.mock('@anthropic-ai/sdk', () => ({
 }));
 
 // A valid text-only Anthropic API response. Used as the default mock return.
+// Includes id, model, and cache token fields to match the full Anthropic SDK shape.
 const makeTextResponse = () => ({
+  id: 'msg_test_123',
+  model: 'claude-sonnet-4-6',
   content: [{ type: 'text', text: 'hello' }],
-  usage: { input_tokens: 10, output_tokens: 5 },
+  usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: null, cache_read_input_tokens: null },
   stop_reason: 'end_turn',
+});
+
+describe('AnthropicProvider — provenance and cache tokens', () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+    mockCreate.mockResolvedValue(makeTextResponse());
+  });
+
+  it('returns provenance with requestedModel, actualModel, and providerRequestId on text response', async () => {
+    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const result = await provider.chat({
+      messages: [{ role: 'user', content: 'Hello' }],
+      options: { model: 'claude-opus-4-6' },
+    });
+
+    expect(result.type).toBe('text');
+    if (result.type !== 'text') return;
+    expect(result.provenance.requestedModel).toBe('claude-opus-4-6');
+    expect(result.provenance.actualModel).toBe('claude-sonnet-4-6'); // from mock response.model
+    expect(result.provenance.providerRequestId).toBe('msg_test_123');
+  });
+
+  it('returns provenance on tool_use response', async () => {
+    mockCreate.mockResolvedValue({
+      id: 'msg_tool_456',
+      model: 'claude-sonnet-4-6',
+      content: [{ type: 'tool_use', id: 'tu_1', name: 'search', input: { query: 'test' } }],
+      usage: { input_tokens: 20, output_tokens: 10, cache_creation_input_tokens: null, cache_read_input_tokens: null },
+      stop_reason: 'tool_use',
+    });
+
+    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const result = await provider.chat({
+      messages: [{ role: 'user', content: 'Search something' }],
+      tools: [{ name: 'search', description: 'Search', input_schema: { type: 'object' as const, properties: {} } }],
+    });
+
+    expect(result.type).toBe('tool_use');
+    if (result.type !== 'tool_use') return;
+    expect(result.provenance.requestedModel).toBe('claude-sonnet-4-6'); // default model
+    expect(result.provenance.actualModel).toBe('claude-sonnet-4-6');
+    expect(result.provenance.providerRequestId).toBe('msg_tool_456');
+  });
+
+  it('defaults cache token fields to 0 when API returns null', async () => {
+    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const result = await provider.chat({ messages: [{ role: 'user', content: 'Hi' }] });
+
+    expect(result.type).toBe('text');
+    if (result.type !== 'text') return;
+    expect(result.usage.cacheCreationInputTokens).toBe(0);
+    expect(result.usage.cacheReadInputTokens).toBe(0);
+  });
+
+  it('captures non-zero cache tokens from the API response', async () => {
+    mockCreate.mockResolvedValue({
+      id: 'msg_cache_789',
+      model: 'claude-sonnet-4-6',
+      content: [{ type: 'text', text: 'cached' }],
+      usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 1500, cache_read_input_tokens: 300 },
+      stop_reason: 'end_turn',
+    });
+
+    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const result = await provider.chat({ messages: [{ role: 'user', content: 'Hi' }] });
+
+    expect(result.type).toBe('text');
+    if (result.type !== 'text') return;
+    expect(result.usage.cacheCreationInputTokens).toBe(1500);
+    expect(result.usage.cacheReadInputTokens).toBe(300);
+  });
 });
 
 describe('AnthropicProvider — prompt caching', () => {

--- a/src/agents/llm/anthropic.ts
+++ b/src/agents/llm/anthropic.ts
@@ -14,7 +14,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import type { MessageParam, ToolUseBlock, TextBlock, TextBlockParam, ToolResultBlockParam } from '@anthropic-ai/sdk/resources/messages/messages.js';
-import type { LLMProvider, LLMResponse, LLMUsage, Message, ToolCall, ToolDefinition, ToolResult } from './provider.js';
+import type { LLMProvider, LLMResponse, LLMUsage, LLMCallProvenance, Message, ToolCall, ToolDefinition, ToolResult } from './provider.js';
 import type { Logger } from '../../logger.js';
 import { classifyError } from '../../errors/classify.js';
 
@@ -149,6 +149,8 @@ export class AnthropicProvider implements LLMProvider {
           model,
           inputTokens: response.usage.input_tokens,
           outputTokens: response.usage.output_tokens,
+          cacheCreationTokens: response.usage.cache_creation_input_tokens ?? 0,
+          cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
           stopReason: response.stop_reason,
         },
         'Anthropic API call completed',
@@ -157,6 +159,16 @@ export class AnthropicProvider implements LLMProvider {
       const usage: LLMUsage = {
         inputTokens: response.usage.input_tokens,
         outputTokens: response.usage.output_tokens,
+        cacheCreationInputTokens: response.usage.cache_creation_input_tokens ?? 0,
+        cacheReadInputTokens: response.usage.cache_read_input_tokens ?? 0,
+      };
+
+      // Provenance captures what model was requested vs. what actually ran, plus the
+      // Anthropic response ID for cross-referencing with Anthropic's own audit console.
+      const provenance: LLMCallProvenance = {
+        requestedModel: model,
+        actualModel: response.model,
+        providerRequestId: response.id,
       };
 
       // Use type guard functions for narrowing — avoids casting and is safer
@@ -184,6 +196,7 @@ export class AnthropicProvider implements LLMProvider {
           toolCalls,
           content: textBlock?.text,
           usage,
+          provenance,
         };
       }
 
@@ -204,6 +217,7 @@ export class AnthropicProvider implements LLMProvider {
         type: 'text',
         content,
         usage,
+        provenance,
       };
     } catch (err) {
       this.logger.error({ err, model }, 'Anthropic API call failed');

--- a/src/agents/llm/pricing.test.ts
+++ b/src/agents/llm/pricing.test.ts
@@ -1,0 +1,72 @@
+// pricing.test.ts — unit tests for estimateCostUsd.
+//
+// Verifies correct pricing for each supported model, prefix-match for versioned
+// model names, and the unknown-model fallback to sonnet pricing.
+
+import { describe, it, expect, vi } from 'vitest';
+import { estimateCostUsd } from './pricing.js';
+import type { LLMUsage } from './provider.js';
+
+// A usage object with known token counts for easy manual cost verification.
+const makeUsage = (overrides: Partial<LLMUsage> = {}): LLMUsage => ({
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheCreationInputTokens: 0,
+  cacheReadInputTokens: 0,
+  ...overrides,
+});
+
+describe('estimateCostUsd', () => {
+  it('calculates cost correctly for claude-sonnet-4-6', () => {
+    // 1000 input @ $3/MTok + 500 output @ $15/MTok + 200 cache-create @ $3.75/MTok + 100 cache-read @ $0.30/MTok
+    // = 0.003 + 0.0075 + 0.00075 + 0.00003 = 0.01128
+    const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 });
+    const cost = estimateCostUsd('claude-sonnet-4-6', usage);
+    expect(cost).toBeCloseTo(0.01128, 8);
+  });
+
+  it('calculates cost correctly for claude-opus-4-6', () => {
+    // 1000 input @ $15/MTok + 500 output @ $75/MTok + 200 cache-create @ $18.75/MTok + 100 cache-read @ $1.50/MTok
+    // = 0.015 + 0.0375 + 0.00375 + 0.00015 = 0.0564
+    const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 });
+    const cost = estimateCostUsd('claude-opus-4-6', usage);
+    expect(cost).toBeCloseTo(0.0564, 8);
+  });
+
+  it('calculates cost correctly for claude-haiku-4-5', () => {
+    // 1000 input @ $0.80/MTok + 500 output @ $4.00/MTok + 200 cache-create @ $1.00/MTok + 100 cache-read @ $0.08/MTok
+    // = 0.0008 + 0.002 + 0.0002 + 0.000008 = 0.003008
+    const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 });
+    const cost = estimateCostUsd('claude-haiku-4-5', usage);
+    expect(cost).toBeCloseTo(0.003008, 8);
+  });
+
+  it('matches haiku pricing by prefix for versioned model names', () => {
+    // 'claude-haiku-4-5-20251001' starts with 'claude-haiku-4-5' — should match haiku pricing
+    const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 });
+    const versionedCost = estimateCostUsd('claude-haiku-4-5-20251001', usage);
+    const baseCost = estimateCostUsd('claude-haiku-4-5', usage);
+    expect(versionedCost).toBe(baseCost);
+  });
+
+  it('falls back to sonnet pricing for unrecognised models without crashing', () => {
+    const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 });
+    const fallbackCost = estimateCostUsd('unknown-model-xyz', usage);
+    const sonnetCost = estimateCostUsd('claude-sonnet-4-6', usage);
+    expect(fallbackCost).toBe(sonnetCost);
+  });
+
+  it('logs a warning for unrecognised models', () => {
+    const warnFn = vi.fn();
+    const mockLogger = { warn: warnFn } as never;
+    const usage = makeUsage({ inputTokens: 100 });
+    estimateCostUsd('mystery-model', usage, mockLogger);
+    expect(warnFn).toHaveBeenCalledOnce();
+    expect(warnFn.mock.calls[0]![0]).toMatchObject({ actualModel: 'mystery-model', fallback: 'claude-sonnet-4-6' });
+  });
+
+  it('returns 0 when all token counts are 0', () => {
+    const cost = estimateCostUsd('claude-sonnet-4-6', makeUsage());
+    expect(cost).toBe(0);
+  });
+});

--- a/src/agents/llm/pricing.ts
+++ b/src/agents/llm/pricing.ts
@@ -1,0 +1,92 @@
+// pricing.ts — Anthropic model pricing for LLM call cost estimation.
+//
+// estimateCostUsd() is called by the runtime after every successful provider.chat()
+// to populate estimatedCostUsd in the llm.call bus event. Full float precision is
+// returned — callers round for display.
+//
+// Pricing is matched by prefix so that minor version suffixes (e.g.
+// 'claude-haiku-4-5-20251001') fall through to the correct base entry.
+// Unrecognised models fall back to sonnet pricing with a warn log rather than
+// silently returning 0 — a silent zero would make cost dashboards misleading.
+//
+// Rates as of 2026-05 (USD per million tokens):
+//   Model            Input    Output   CacheCreate   CacheRead
+//   claude-opus-4-6  $15.00   $75.00   $18.75        $1.50
+//   claude-sonnet-4-6 $3.00   $15.00   $3.75         $0.30
+//   claude-haiku-4-5  $0.80    $4.00    $1.00         $0.08
+
+import type { Logger } from '../../logger.js';
+import type { LLMUsage } from './provider.js';
+
+interface ModelPricing {
+  /** USD per million input tokens */
+  inputPerMToken: number;
+  /** USD per million output tokens */
+  outputPerMToken: number;
+  /** USD per million cache-creation tokens (written to prompt cache) */
+  cacheCreationPerMToken: number;
+  /** USD per million cache-read tokens (served from prompt cache) */
+  cacheReadPerMToken: number;
+}
+
+// Keyed by model name prefix. Longer prefixes take precedence over shorter ones
+// because we sort entries by key length descending before matching.
+const ANTHROPIC_PRICING: Record<string, ModelPricing> = {
+  'claude-opus-4-6': {
+    inputPerMToken: 15.00,
+    outputPerMToken: 75.00,
+    cacheCreationPerMToken: 18.75,
+    cacheReadPerMToken: 1.50,
+  },
+  'claude-sonnet-4-6': {
+    inputPerMToken: 3.00,
+    outputPerMToken: 15.00,
+    cacheCreationPerMToken: 3.75,
+    cacheReadPerMToken: 0.30,
+  },
+  'claude-haiku-4-5': {
+    inputPerMToken: 0.80,
+    outputPerMToken: 4.00,
+    cacheCreationPerMToken: 1.00,
+    cacheReadPerMToken: 0.08,
+  },
+};
+
+// Pre-sort by key length descending so the first prefix match is always the
+// most specific one (e.g. 'claude-sonnet-4-6' beats 'claude-sonnet').
+const SORTED_PRICING_ENTRIES = Object.entries(ANTHROPIC_PRICING)
+  .sort(([a], [b]) => b.length - a.length);
+
+const FALLBACK_MODEL = 'claude-sonnet-4-6';
+
+/**
+ * Estimate the cost in USD for a single LLM API call.
+ *
+ * Matches `actualModel` against known prefixes (longest match wins).
+ * Falls back to claude-sonnet-4-6 pricing for unrecognised models, logging a
+ * warning — this makes unknown-model costs visible rather than silently zero.
+ *
+ * @param actualModel  The model that ran, from the API response body.
+ * @param usage        Token counts, including all four Anthropic token categories.
+ * @param logger       Optional logger; warn is emitted for unrecognised models.
+ */
+export function estimateCostUsd(actualModel: string, usage: LLMUsage, logger?: Logger): number {
+  const entry = SORTED_PRICING_ENTRIES.find(([prefix]) => actualModel.startsWith(prefix));
+
+  let pricing: ModelPricing;
+  if (entry) {
+    pricing = entry[1];
+  } else {
+    logger?.warn({ actualModel, fallback: FALLBACK_MODEL }, 'Unrecognised model — using fallback pricing for cost estimate');
+    pricing = ANTHROPIC_PRICING[FALLBACK_MODEL]!;
+  }
+
+  // Divide by 1_000_000 to convert from per-million-token rate to per-token rate.
+  return (
+    (usage.inputTokens * pricing.inputPerMToken +
+     usage.outputTokens * pricing.outputPerMToken +
+     usage.cacheCreationInputTokens * pricing.cacheCreationPerMToken +
+     usage.cacheReadInputTokens * pricing.cacheReadPerMToken) /
+    1_000_000
+  );
+}

--- a/src/agents/llm/provider.ts
+++ b/src/agents/llm/provider.ts
@@ -44,6 +44,23 @@ export interface Message {
 export interface LLMUsage {
   inputTokens: number;
   outputTokens: number;
+  /** Tokens written to the prompt cache on this call. 0 when not applicable. */
+  cacheCreationInputTokens: number;
+  /** Tokens served from the prompt cache on this call. 0 when not applicable. */
+  cacheReadInputTokens: number;
+}
+
+/**
+ * Provider-level metadata returned alongside every successful LLM response.
+ * Only available on successful calls — error responses carry no API body to extract these from.
+ */
+export interface LLMCallProvenance {
+  /** Model string passed to the provider (what the caller requested). */
+  requestedModel: string;
+  /** Model that actually ran, from the API response body (may differ if provider aliases). */
+  actualModel: string;
+  /** Anthropic: response.id (msg_xxx) — shown in Anthropic's console for support correlation. */
+  providerRequestId: string;
 }
 
 // Import and re-export ToolDefinition from the canonical location in skills/types.ts
@@ -72,9 +89,11 @@ export interface ToolResult {
 // Discriminated union — agents switch on response.type to decide what to do.
 // 'error' is a first-class value (not a thrown exception) so callers can handle
 // partial failures gracefully without try/catch boilerplate throughout the agent.
+// Successful variants carry provenance — the runtime uses it to publish llm.call events.
+// Error paths omit provenance: when the API fails there is no response body to extract from.
 export type LLMResponse =
-  | { type: 'text'; content: string; usage: LLMUsage }
-  | { type: 'tool_use'; toolCalls: ToolCall[]; content?: string; usage: LLMUsage }
+  | { type: 'text'; content: string; usage: LLMUsage; provenance: LLMCallProvenance }
+  | { type: 'tool_use'; toolCalls: ToolCall[]; content?: string; usage: LLMUsage; provenance: LLMCallProvenance }
   | { type: 'error'; error: AgentError; usage?: LLMUsage };
 
 export interface LLMProvider {

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1,6 +1,8 @@
 import type { LLMProvider, LLMResponse, Message, ToolDefinition, ContentBlock, ToolUseContent, ToolResultContent, TextContent } from './llm/provider.js';
 import type { EventBus } from '../bus/bus.js';
-import { createAgentResponse, createAgentError, createSkillInvoke, createSkillResult, type AgentTaskEvent } from '../bus/events.js';
+import { createAgentResponse, createAgentError, createSkillInvoke, createSkillResult, createLlmCall, type AgentTaskEvent } from '../bus/events.js';
+import { createHash } from 'node:crypto';
+import { estimateCostUsd } from './llm/pricing.js';
 import type { Logger } from '../logger.js';
 import type { WorkingMemory } from '../memory/working-memory.js';
 import type { EntityMemory } from '../memory/entity-memory.js';
@@ -862,12 +864,56 @@ export class AgentRuntime {
     budget: ErrorBudget,
     taskEvent: AgentTaskEvent,
   ): Promise<LLMResponse | null> {
-    const { agentId, logger } = this.config;
+    const { agentId, bus, logger } = this.config;
 
+    // Helper: publish a llm.call event for a successful provider response.
+    // Called after every successful provider.chat() — initial call and each retry.
+    // Error responses are skipped: there is no API body to extract provenance from.
+    // TODO: emit llm.call for error paths when spec 10 cost-on-failure policy is settled.
+    const publishLlmCallEvent = async (
+      response: LLMResponse,
+      callLatencyMs: number,
+    ): Promise<void> => {
+      if (response.type === 'error') return;
+
+      // SHA-256 of the prompt input — stable fingerprint for deduplication and diffing.
+      // Includes messages and tools since both affect what the model sees.
+      const promptHash = createHash('sha256')
+        .update(JSON.stringify({ messages: params.messages, tools: params.tools ?? [] }))
+        .digest('hex');
+
+      // SHA-256 of the response output — fingerprint for the model's actual reply.
+      const responseHash = createHash('sha256')
+        .update(response.type === 'text' ? response.content : JSON.stringify(response.toolCalls))
+        .digest('hex');
+
+      const event = createLlmCall({
+        agentId,
+        conversationId: taskEvent.payload.conversationId,
+        requestedModel: response.provenance.requestedModel,
+        actualModel: response.provenance.actualModel,
+        provider: provider.id,
+        providerRequestId: response.provenance.providerRequestId,
+        inputTokens: response.usage.inputTokens,
+        outputTokens: response.usage.outputTokens,
+        cacheCreationInputTokens: response.usage.cacheCreationInputTokens,
+        cacheReadInputTokens: response.usage.cacheReadInputTokens,
+        estimatedCostUsd: estimateCostUsd(response.provenance.actualModel, response.usage, logger),
+        latencyMs: callLatencyMs,
+        promptHash,
+        responseHash,
+        parentEventId: taskEvent.id,
+      });
+      await bus.publish('agent', event);
+    };
+
+    const callStartMs = Date.now();
     const response = await provider.chat(params);
+    const latencyMs = Date.now() - callStartMs;
     if (response.type !== 'error') {
-      // LLM call succeeded — reset consecutive error counter
+      // LLM call succeeded — reset consecutive error counter and publish telemetry
       budget.consecutiveErrors = 0;
+      await publishLlmCallEvent(response, latencyMs);
       return response;
     }
 
@@ -903,10 +949,13 @@ export class AgentRuntime {
 
       await new Promise(resolve => setTimeout(resolve, backoffMs));
 
+      const retryStartMs = Date.now();
       const retryResponse = await provider.chat(params);
+      const retryLatencyMs = Date.now() - retryStartMs;
       if (retryResponse.type !== 'error') {
-        // Retry succeeded — reset consecutive error counter
+        // Retry succeeded — reset consecutive error counter and publish telemetry
         budget.consecutiveErrors = 0;
+        await publishLlmCallEvent(retryResponse, retryLatencyMs);
         return retryResponse;
       }
 

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -870,41 +870,51 @@ export class AgentRuntime {
     // Called after every successful provider.chat() — initial call and each retry.
     // Error responses are skipped: there is no API body to extract provenance from.
     // TODO: emit llm.call for error paths when spec 10 cost-on-failure policy is settled.
+    //
+    // The entire helper is wrapped in try-catch because llm.call is telemetry — any
+    // failure here (audit DB write error from the bus onEvent hook, JSON.stringify on a
+    // circular tool input, etc.) must not abort a valid agent response. A token tracking
+    // gap is acceptable; losing the user's answer is not.
     const publishLlmCallEvent = async (
       response: LLMResponse,
       callLatencyMs: number,
     ): Promise<void> => {
       if (response.type === 'error') return;
+      try {
+        // SHA-256 of the prompt input — stable fingerprint for deduplication and diffing.
+        // Includes messages and tools since both affect what the model sees.
+        const promptHash = createHash('sha256')
+          .update(JSON.stringify({ messages: params.messages, tools: params.tools ?? [] }))
+          .digest('hex');
 
-      // SHA-256 of the prompt input — stable fingerprint for deduplication and diffing.
-      // Includes messages and tools since both affect what the model sees.
-      const promptHash = createHash('sha256')
-        .update(JSON.stringify({ messages: params.messages, tools: params.tools ?? [] }))
-        .digest('hex');
+        // SHA-256 of the response output — fingerprint for the model's actual reply.
+        const responseHash = createHash('sha256')
+          .update(response.type === 'text' ? response.content : JSON.stringify(response.toolCalls))
+          .digest('hex');
 
-      // SHA-256 of the response output — fingerprint for the model's actual reply.
-      const responseHash = createHash('sha256')
-        .update(response.type === 'text' ? response.content : JSON.stringify(response.toolCalls))
-        .digest('hex');
-
-      const event = createLlmCall({
-        agentId,
-        conversationId: taskEvent.payload.conversationId,
-        requestedModel: response.provenance.requestedModel,
-        actualModel: response.provenance.actualModel,
-        provider: provider.id,
-        providerRequestId: response.provenance.providerRequestId,
-        inputTokens: response.usage.inputTokens,
-        outputTokens: response.usage.outputTokens,
-        cacheCreationInputTokens: response.usage.cacheCreationInputTokens,
-        cacheReadInputTokens: response.usage.cacheReadInputTokens,
-        estimatedCostUsd: estimateCostUsd(response.provenance.actualModel, response.usage, logger),
-        latencyMs: callLatencyMs,
-        promptHash,
-        responseHash,
-        parentEventId: taskEvent.id,
-      });
-      await bus.publish('agent', event);
+        const event = createLlmCall({
+          agentId,
+          conversationId: taskEvent.payload.conversationId,
+          requestedModel: response.provenance.requestedModel,
+          actualModel: response.provenance.actualModel,
+          provider: provider.id,
+          providerRequestId: response.provenance.providerRequestId,
+          inputTokens: response.usage.inputTokens,
+          outputTokens: response.usage.outputTokens,
+          cacheCreationInputTokens: response.usage.cacheCreationInputTokens,
+          cacheReadInputTokens: response.usage.cacheReadInputTokens,
+          estimatedCostUsd: estimateCostUsd(response.provenance.actualModel, response.usage, logger),
+          latencyMs: callLatencyMs,
+          promptHash,
+          responseHash,
+          parentEventId: taskEvent.id,
+        });
+        await bus.publish('agent', event);
+      } catch (err) {
+        // Telemetry failure must not abort the agent task. Log at error so the gap
+        // is visible in production, but allow chatWithRetry to return the response.
+        logger.error({ err, agentId, eventId: taskEvent.id }, 'Failed to publish llm.call telemetry event — token tracking gap');
+      }
     };
 
     const callStartMs = Date.now();

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -363,11 +363,15 @@ interface LlmCallPayload {
   // Token accounting
   inputTokens: number;
   outputTokens: number;
-  estimatedCostUsd: number;     // computed from provider pricing at call time
+  /** Tokens written to the prompt cache on this call. 0 when not applicable. */
+  cacheCreationInputTokens: number;
+  /** Tokens served from the prompt cache on this call. 0 when not applicable. */
+  cacheReadInputTokens: number;
+  estimatedCostUsd: number;     // computed from all four token types at call time
   // Timing
   latencyMs: number;
   // Upstream correlation — enables cross-referencing with the provider's own audit logs
-  providerRequestId: string;    // Anthropic: x-request-id header; OpenAI: x-request-id header
+  providerRequestId: string;    // Anthropic: response.id (msg_xxx body field); OpenAI: response.id
   // Content fingerprints — SHA-256 of full prompt/response (not raw content;
   // full prompts/responses go in llm_call_archive, see spec 10)
   promptHash: string;

--- a/tests/integration/conversation-memory.test.ts
+++ b/tests/integration/conversation-memory.test.ts
@@ -5,6 +5,7 @@ import { AgentRuntime } from '../../src/agents/runtime.js';
 import { WorkingMemory } from '../../src/memory/working-memory.js';
 import { createInboundMessage, type OutboundMessageEvent } from '../../src/bus/events.js';
 import type { LLMProvider } from '../../src/agents/llm/provider.js';
+const MOCK_PROVENANCE = { requestedModel: 'mock-model', actualModel: 'mock-model', providerRequestId: 'msg_mock_000' } as const;
 import { createLogger } from '../../src/logger.js';
 
 describe('Multi-turn conversation with working memory', () => {
@@ -24,7 +25,8 @@ describe('Multi-turn conversation with working memory', () => {
         return Promise.resolve({
           type: 'text' as const,
           content: `Response ${callCount}`,
-          usage: { inputTokens: 10, outputTokens: 5 },
+          usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         });
       }),
     };
@@ -90,7 +92,8 @@ describe('Multi-turn conversation with working memory', () => {
       chat: vi.fn().mockResolvedValue({
         type: 'text' as const,
         content: 'Reply',
-        usage: { inputTokens: 10, outputTokens: 5 },
+        usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       }),
     };
 

--- a/tests/integration/http-api.test.ts
+++ b/tests/integration/http-api.test.ts
@@ -10,6 +10,7 @@ import { agentRoutes } from '../../src/channels/http/routes/agents.js';
 import { Dispatcher } from '../../src/dispatch/dispatcher.js';
 import { validateBearerToken } from '../../src/channels/http/auth.js';
 import type { LLMProvider } from '../../src/agents/llm/provider.js';
+const MOCK_PROVENANCE = { requestedModel: 'mock-model', actualModel: 'mock-model', providerRequestId: 'msg_mock_000' } as const;
 import type { ContactResolver } from '../../src/contacts/contact-resolver.js';
 import type { InboundSenderContext } from '../../src/contacts/types.js';
 import type { AgentTaskEvent } from '../../src/bus/events.js';
@@ -35,7 +36,8 @@ describe('HTTP API integration', () => {
     chat: async () => ({
       type: 'text' as const,
       content: 'Hello from the HTTP API!',
-      usage: { inputTokens: 10, outputTokens: 5 },
+      usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+      provenance: MOCK_PROVENANCE,
     }),
   };
 
@@ -206,7 +208,8 @@ describe('HTTP API — bearer token authentication', () => {
       chat: async () => ({
         type: 'text' as const,
         content: 'auth test response',
-        usage: { inputTokens: 1, outputTokens: 1 },
+        usage: { inputTokens: 1, outputTokens: 1, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       }),
     };
 
@@ -361,7 +364,8 @@ describe('Trust scoring — unknown sender via HTTP', () => {
     chat: async () => ({
       type: 'text' as const,
       content: 'Trust test response',
-      usage: { inputTokens: 5, outputTokens: 3 },
+      usage: { inputTokens: 5, outputTokens: 3, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+      provenance: MOCK_PROVENANCE,
     }),
   };
 

--- a/tests/integration/multi-agent-delegation.test.ts
+++ b/tests/integration/multi-agent-delegation.test.ts
@@ -6,6 +6,7 @@ import { SkillRegistry } from '../../src/skills/registry.js';
 import { ExecutionLayer } from '../../src/skills/execution.js';
 import { DelegateHandler } from '../../skills/delegate/handler.js';
 import type { LLMProvider, Message, ContentBlock } from '../../src/agents/llm/provider.js';
+const MOCK_PROVENANCE = { requestedModel: 'mock-model', actualModel: 'mock-model', providerRequestId: 'msg_mock_000' } as const;
 import type { SkillManifest } from '../../src/skills/types.js';
 import { createAgentTask } from '../../src/bus/events.js';
 import pino from 'pino';
@@ -54,7 +55,8 @@ describe('Multi-agent delegation integration', () => {
               name: 'delegate',
               input: { agent: 'research-analyst', task: 'Research the latest AI trends', conversation_id: 'test-conv' },
             }],
-            usage: { inputTokens: 100, outputTokens: 50 },
+            usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
           };
         }
         // After getting delegation result, synthesize
@@ -64,7 +66,8 @@ describe('Multi-agent delegation integration', () => {
         return {
           type: 'text' as const,
           content: `Based on my research team's findings${hasToolResult ? ' (delegation successful)' : ''}: AI is advancing rapidly.`,
-          usage: { inputTokens: 200, outputTokens: 60 },
+          usage: { inputTokens: 200, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         };
       },
     };
@@ -78,7 +81,8 @@ describe('Multi-agent delegation integration', () => {
         return {
           type: 'text' as const,
           content: 'Key AI trends: LLMs are becoming multimodal, agents are emerging as a paradigm.',
-          usage: { inputTokens: 50, outputTokens: 30 },
+          usage: { inputTokens: 50, outputTokens: 30, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         };
       },
     };

--- a/tests/integration/skill-invocation.test.ts
+++ b/tests/integration/skill-invocation.test.ts
@@ -4,6 +4,7 @@ import { AgentRuntime } from '../../src/agents/runtime.js';
 import { SkillRegistry } from '../../src/skills/registry.js';
 import { ExecutionLayer } from '../../src/skills/execution.js';
 import type { LLMProvider, Message, ContentBlock } from '../../src/agents/llm/provider.js';
+const MOCK_PROVENANCE = { requestedModel: 'mock-model', actualModel: 'mock-model', providerRequestId: 'msg_mock_000' } as const;
 import type { SkillManifest, SkillHandler, SkillContext } from '../../src/skills/types.js';
 import { createAgentTask } from '../../src/bus/events.js';
 import pino from 'pino';
@@ -51,7 +52,8 @@ describe('Skill invocation integration', () => {
           return {
             type: 'tool_use' as const,
             toolCalls: [{ id: 'call-1', name: 'echo', input: { message: 'Hello from integration test' } }],
-            usage: { inputTokens: 50, outputTokens: 20 },
+            usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
           };
         }
         // On the second call, check if tool results were passed as content blocks
@@ -62,7 +64,8 @@ describe('Skill invocation integration', () => {
         return {
           type: 'text' as const,
           content: `The echo skill responded. Tool results were provided: ${hasToolResults ? 'yes' : 'no'}`,
-          usage: { inputTokens: 100, outputTokens: 30 },
+          usage: { inputTokens: 100, outputTokens: 30, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         };
       },
     };
@@ -138,7 +141,8 @@ describe('Skill invocation integration', () => {
           return {
             type: 'tool_use' as const,
             toolCalls: [{ id: 'call-1', name: 'fail-skill', input: {} }],
-            usage: { inputTokens: 50, outputTokens: 20 },
+            usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
           };
         }
         // Check if any tool_result block in messages has is_error set
@@ -150,7 +154,8 @@ describe('Skill invocation integration', () => {
         return {
           type: 'text' as const,
           content: `Handled the failure: ${hasError ? 'got error' : 'no error'}`,
-          usage: { inputTokens: 100, outputTokens: 30 },
+          usage: { inputTokens: 100, outputTokens: 30, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         };
       },
     };

--- a/tests/integration/vertical-slice.test.ts
+++ b/tests/integration/vertical-slice.test.ts
@@ -4,6 +4,7 @@ import { Dispatcher } from '../../src/dispatch/dispatcher.js';
 import { AgentRuntime } from '../../src/agents/runtime.js';
 import { createInboundMessage, type OutboundMessageEvent, type ContactUnknownEvent, type MessageHeldEvent, type AgentTaskEvent } from '../../src/bus/events.js';
 import type { LLMProvider } from '../../src/agents/llm/provider.js';
+const MOCK_PROVENANCE = { requestedModel: 'mock-model', actualModel: 'mock-model', providerRequestId: 'msg_mock_000' } as const;
 import { createLogger } from '../../src/logger.js';
 import type { ContactResolver } from '../../src/contacts/contact-resolver.js';
 import { HeldMessageService } from '../../src/contacts/held-messages.js';
@@ -28,7 +29,8 @@ describe('Vertical Slice: CLI → Dispatch → Coordinator → Response', () => 
       chat: vi.fn().mockResolvedValue({
         type: 'text' as const,
         content: 'Hello! How can I help you today?',
-        usage: { inputTokens: 20, outputTokens: 10 },
+        usage: { inputTokens: 20, outputTokens: 10, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       }),
     };
 
@@ -85,15 +87,17 @@ describe('Vertical Slice: CLI → Dispatch → Coordinator → Response', () => 
     expect(outbound[0]?.payload.channelId).toBe('cli');
     expect(outbound[0]?.payload.conversationId).toBe('cli:local:default');
 
-    // -- Assert the complete 4-event audit trail --
+    // -- Assert the complete 5-event audit trail --
     // This sequence is the spec-mandated message flow from 00-overview.md.
     // The order is guaranteed because the bus awaits each publish before returning.
-    expect(auditLog).toHaveLength(4);
+    // llm.call is published inside agent task processing (between agent.task and agent.response).
+    expect(auditLog).toHaveLength(5);
     expect(auditLog.map((e) => e.type)).toEqual([
       'inbound.message',  // 1. Channel publishes user input
       'agent.task',       // 2. Dispatcher converts inbound.message to a task for the coordinator
-      'agent.response',   // 3. Coordinator publishes the LLM result
-      'outbound.message', // 4. Dispatcher converts agent.response back to a channel message
+      'llm.call',         // 3. Runtime publishes LLM provenance after the API call (spec 10)
+      'agent.response',   // 4. Coordinator publishes the LLM result
+      'outbound.message', // 5. Dispatcher converts agent.response back to a channel message
     ]);
 
     // -- Assert the causal chain is intact --

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -8,13 +8,22 @@ import { createLogger } from '../../../src/logger.js';
 import { WorkingMemory } from '../../../src/memory/working-memory.js';
 import type { AgentError } from '../../../src/errors/types.js';
 
+// Minimal provenance block for mock LLM responses — satisfies the required field
+// without tying tests to specific model names.
+const MOCK_PROVENANCE = {
+  requestedModel: 'mock-model',
+  actualModel: 'mock-model',
+  providerRequestId: 'msg_mock_000',
+} as const;
+
 function createMockProvider(response: string): LLMProvider {
   return {
     id: 'mock',
     chat: vi.fn().mockResolvedValue({
       type: 'text' as const,
       content: response,
-      usage: { inputTokens: 10, outputTokens: 5 },
+      usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+      provenance: MOCK_PROVENANCE,
     }),
   };
 }
@@ -403,13 +412,15 @@ function createToolUseProvider(toolCallName: string, toolCallInput: Record<strin
         return {
           type: 'tool_use' as const,
           toolCalls: [{ id: 'call-1', name: toolCallName, input: toolCallInput }],
-          usage: { inputTokens: 100, outputTokens: 50 },
+          usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         };
       }
       return {
         type: 'text' as const,
         content: `Tool result was processed. Call count: ${callCount}`,
-        usage: { inputTokens: 200, outputTokens: 60 },
+        usage: { inputTokens: 200, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       };
     },
   };
@@ -528,14 +539,16 @@ describe('AgentRuntime tool-use loop', () => {
           return {
             type: 'tool_use' as const,
             toolCalls: [{ id: 'call-extract-1', name: 'extract-relationships', input: { text: 'Hello', source: 'test' } }],
-            usage: { inputTokens: 100, outputTokens: 20 },
+            usage: { inputTokens: 100, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
           };
         }
         // Second call: LLM returns end_turn with empty content array
         return {
           type: 'text' as const,
           content: '',
-          usage: { inputTokens: 150, outputTokens: 0 },
+          usage: { inputTokens: 150, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         };
       }),
     };
@@ -592,13 +605,15 @@ describe('AgentRuntime tool-use loop', () => {
           return {
             type: 'tool_use' as const,
             toolCalls: [{ id: 'call-extract-2', name: 'extract-relationships', input: { text: 'Hello', source: 'test' } }],
-            usage: { inputTokens: 100, outputTokens: 20 },
+            usage: { inputTokens: 100, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
           };
         }
         return {
           type: 'text' as const,
           content: '\n',
-          usage: { inputTokens: 150, outputTokens: 1 },
+          usage: { inputTokens: 150, outputTokens: 1, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         };
       }),
     };
@@ -651,7 +666,8 @@ describe('AgentRuntime tool-use loop', () => {
         type: 'tool_use' as const,
         toolCalls: [{ id: `call-${callId++}`, name: 'web-fetch', input: { url: 'https://example.com' } }],
         content: 'Still trying...',
-        usage: { inputTokens: 50, outputTokens: 20 },
+        usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       }),
     };
 
@@ -717,7 +733,8 @@ describe('AgentRuntime error budget', () => {
       chat: vi.fn(async () => ({
         type: 'tool_use' as const,
         toolCalls: [{ id: `call-${callId++}`, name: 'web-fetch', input: {} }],
-        usage: { inputTokens: 50, outputTokens: 20 },
+        usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       })),
     };
 
@@ -779,7 +796,8 @@ describe('AgentRuntime error budget', () => {
           { id: `call-${callId++}`, name: 'web-fetch', input: {} },
           { id: `call-${callId++}`, name: 'web-fetch', input: {} },
         ],
-        usage: { inputTokens: 50, outputTokens: 20 },
+        usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       })),
     };
 
@@ -844,13 +862,15 @@ describe('AgentRuntime error budget', () => {
           return {
             type: 'tool_use' as const,
             toolCalls: [{ id: `call-${callId++}`, name: 'web-fetch', input: {} }],
-            usage: { inputTokens: 50, outputTokens: 20 },
+            usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
           };
         }
         return {
           type: 'text' as const,
           content: 'Done!',
-          usage: { inputTokens: 50, outputTokens: 20 },
+          usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         };
       }),
     };
@@ -913,7 +933,8 @@ describe('AgentRuntime error budget', () => {
       chat: vi.fn(async () => ({
         type: 'tool_use' as const,
         toolCalls: [{ id: `call-${callId++}`, name: 'web-fetch', input: {} }],
-        usage: { inputTokens: 50, outputTokens: 20 },
+        usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       })),
     };
 
@@ -974,13 +995,15 @@ describe('AgentRuntime structured error injection', () => {
           return {
             type: 'tool_use' as const,
             toolCalls: [{ id: 'call-err-1', name: 'email-send', input: { to: 'test@example.com' } }],
-            usage: { inputTokens: 50, outputTokens: 20 },
+            usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
           };
         }
         return {
           type: 'text' as const,
           content: 'I see the error, let me try differently.',
-          usage: { inputTokens: 100, outputTokens: 30 },
+          usage: { inputTokens: 100, outputTokens: 30, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         };
       }),
     };
@@ -1085,7 +1108,8 @@ describe('AgentRuntime chatWithRetry', () => {
         return {
           type: 'text' as const,
           content: 'Success after retry!',
-          usage: { inputTokens: 50, outputTokens: 20 },
+          usage: { inputTokens: 50, outputTokens: 20, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         };
       }),
     };
@@ -1192,7 +1216,7 @@ describe('AgentRuntime chatWithRetry', () => {
         id: 'mock',
         chat: vi.fn(async ({ messages }) => {
           capturedMessages = messages;
-          return { type: 'text' as const, content: 'OK', usage: { inputTokens: 10, outputTokens: 2 } };
+          return { type: 'text' as const, content: 'OK', usage: { inputTokens: 10, outputTokens: 2, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 }, provenance: MOCK_PROVENANCE };
         }),
       };
 
@@ -1254,7 +1278,7 @@ describe('AgentRuntime chatWithRetry', () => {
         id: 'mock',
         chat: vi.fn(async ({ messages }) => {
           capturedMessages = messages;
-          return { type: 'text' as const, content: 'OK', usage: { inputTokens: 10, outputTokens: 2 } };
+          return { type: 'text' as const, content: 'OK', usage: { inputTokens: 10, outputTokens: 2, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 }, provenance: MOCK_PROVENANCE };
         }),
       };
 
@@ -1322,7 +1346,7 @@ describe('AgentRuntime chatWithRetry', () => {
         id: 'mock',
         chat: vi.fn(async ({ messages }) => {
           capturedMessages = messages;
-          return { type: 'text' as const, content: 'OK', usage: { inputTokens: 10, outputTokens: 2 } };
+          return { type: 'text' as const, content: 'OK', usage: { inputTokens: 10, outputTokens: 2, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 }, provenance: MOCK_PROVENANCE };
         }),
       };
 
@@ -1374,10 +1398,11 @@ describe('AgentRuntime chatWithRetry', () => {
             return {
               type: 'tool_use' as const,
               toolCalls: [{ id: 'call-delegate', name: 'delegate', input: { agent: 'essay-editor', task: 'polish essay' } }],
-              usage: { inputTokens: 100, outputTokens: 50 },
+              usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
             };
           }
-          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60 } };
+          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 }, provenance: MOCK_PROVENANCE };
         }),
       };
 
@@ -1434,10 +1459,11 @@ describe('AgentRuntime chatWithRetry', () => {
             return {
               type: 'tool_use' as const,
               toolCalls: [{ id: 'call-delegate-2', name: 'delegate', input: { agent: 'essay-editor', task: 'polish', timeout_ms: 30000 } }],
-              usage: { inputTokens: 100, outputTokens: 50 },
+              usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
             };
           }
-          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60 } };
+          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 }, provenance: MOCK_PROVENANCE };
         }),
       };
 
@@ -1496,10 +1522,11 @@ describe('AgentRuntime chatWithRetry', () => {
             return {
               type: 'tool_use' as const,
               toolCalls: [{ id: 'call-delegate-sched', name: 'delegate', input: { agent: 'essay-editor', task: 'polish essay' } }],
-              usage: { inputTokens: 100, outputTokens: 50 },
+              usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
             };
           }
-          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60 } };
+          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 }, provenance: MOCK_PROVENANCE };
         }),
       };
 
@@ -1558,10 +1585,11 @@ describe('AgentRuntime chatWithRetry', () => {
             return {
               type: 'tool_use' as const,
               toolCalls: [{ id: 'call-delegate-3', name: 'delegate', input: { agent: 'research-analyst', task: 'research' } }],
-              usage: { inputTokens: 100, outputTokens: 50 },
+              usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
             };
           }
-          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60 } };
+          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 }, provenance: MOCK_PROVENANCE };
         }),
       };
 
@@ -1616,10 +1644,11 @@ describe('AgentRuntime chatWithRetry', () => {
               type: 'tool_use' as const,
               // LLM uses @-mention style — runtime should strip the '@'
               toolCalls: [{ id: 'call-delegate-at', name: 'delegate', input: { agent: '@essay-editor', task: 'polish essay' } }],
-              usage: { inputTokens: 100, outputTokens: 50 },
+              usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
             };
           }
-          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60 } };
+          return { type: 'text' as const, content: 'Done', usage: { inputTokens: 200, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 }, provenance: MOCK_PROVENANCE };
         }),
       };
 
@@ -1692,14 +1721,16 @@ describe('AgentRuntime Bullpen context refresh', () => {
           return {
             type: 'tool_use' as const,
             toolCalls: [{ id: 'call-bp-1', name: 'web-fetch', input: { url: 'https://example.com' } }],
-            usage: { inputTokens: 100, outputTokens: 50 },
+            usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
           };
         }
         // Second call: LLM returns text (exit tool-use loop)
         return {
           type: 'text' as const,
           content: 'All done.',
-          usage: { inputTokens: 200, outputTokens: 60 },
+          usage: { inputTokens: 200, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         };
       }),
     };
@@ -1814,13 +1845,15 @@ describe('AgentRuntime Bullpen context refresh', () => {
           return {
             type: 'tool_use' as const,
             toolCalls: [{ id: 'call-bp-2', name: 'web-fetch', input: {} }],
-            usage: { inputTokens: 100, outputTokens: 50 },
+            usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
           };
         }
         return {
           type: 'text' as const,
           content: 'Done.',
-          usage: { inputTokens: 200, outputTokens: 60 },
+          usage: { inputTokens: 200, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         };
       }),
     };
@@ -1905,13 +1938,15 @@ describe('AgentRuntime Bullpen context refresh', () => {
           return {
             type: 'tool_use' as const,
             toolCalls: [{ id: 'call-bp-3', name: 'web-fetch', input: {} }],
-            usage: { inputTokens: 100, outputTokens: 50 },
+            usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
           };
         }
         return {
           type: 'text' as const,
           content: 'Done.',
-          usage: { inputTokens: 200, outputTokens: 60 },
+          usage: { inputTokens: 200, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
         };
       }),
     };

--- a/tests/unit/dispatch/dispatcher-context-bridging.test.ts
+++ b/tests/unit/dispatch/dispatcher-context-bridging.test.ts
@@ -13,12 +13,14 @@ function setupTestBus() {
   const bus = new EventBus(logger);
   const memory = WorkingMemory.createInMemory();
 
+  const MOCK_PROVENANCE = { requestedModel: 'mock-model', actualModel: 'mock-model', providerRequestId: 'msg_mock_000' } as const;
   const mockProvider: LLMProvider = {
     id: 'mock',
     chat: vi.fn().mockResolvedValue({
       type: 'text' as const,
       content: 'Response from Coordinator',
-      usage: { inputTokens: 10, outputTokens: 5 },
+      usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+      provenance: MOCK_PROVENANCE,
     }),
   };
 

--- a/tests/unit/dispatch/dispatcher.test.ts
+++ b/tests/unit/dispatch/dispatcher.test.ts
@@ -11,6 +11,9 @@ import type { InboundSenderContext, ContactStatus, TrustLevel, TaskOriginator } 
 import { HeldMessageService } from '../../../src/contacts/held-messages.js';
 import { createLogger } from '../../../src/logger.js';
 
+// Minimal provenance block for all mock LLM responses — satisfies the required field.
+const MOCK_PROVENANCE = { requestedModel: 'mock-model', actualModel: 'mock-model', providerRequestId: 'msg_mock_000' } as const;
+
 // -- Test helpers --
 
 /**
@@ -67,7 +70,8 @@ describe('Dispatcher', () => {
       chat: vi.fn().mockResolvedValue({
         type: 'text' as const,
         content: 'Response from Coordinator',
-        usage: { inputTokens: 10, outputTokens: 5 },
+        usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       }),
     };
 
@@ -210,7 +214,8 @@ describe('Dispatcher unknown_sender: ignore policy', () => {
       chat: vi.fn().mockResolvedValue({
         type: 'text' as const,
         content: 'OK',
-        usage: { inputTokens: 1, outputTokens: 1 },
+        usage: { inputTokens: 1, outputTokens: 1, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       }),
     };
 
@@ -386,7 +391,8 @@ describe('Dispatcher — messageTrustScore', () => {
       chat: vi.fn().mockResolvedValue({
         type: 'text' as const,
         content: 'OK',
-        usage: { inputTokens: 1, outputTokens: 1 },
+        usage: { inputTokens: 1, outputTokens: 1, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       }),
     };
     const coordinator = new AgentRuntime({
@@ -583,7 +589,8 @@ describe('Dispatcher — contact.unknown event payload', () => {
       chat: vi.fn().mockResolvedValue({
         type: 'text' as const,
         content: 'OK',
-        usage: { inputTokens: 1, outputTokens: 1 },
+        usage: { inputTokens: 1, outputTokens: 1, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       }),
     };
     const coordinator = new AgentRuntime({
@@ -669,7 +676,8 @@ describe('Dispatcher — rate limiting', () => {
       chat: vi.fn().mockResolvedValue({
         type: 'text' as const,
         content: 'OK',
-        usage: { inputTokens: 1, outputTokens: 1 },
+        usage: { inputTokens: 1, outputTokens: 1, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       }),
     };
     const coordinator = new AgentRuntime({
@@ -1070,7 +1078,8 @@ describe('Dispatcher message size limit', () => {
       chat: vi.fn().mockResolvedValue({
         type: 'text' as const,
         content: 'ok',
-        usage: { inputTokens: 1, outputTokens: 1 },
+        usage: { inputTokens: 1, outputTokens: 1, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       }),
     };
     const coordinator = new AgentRuntime({
@@ -1420,7 +1429,8 @@ describe('Dispatcher thread-originated trust bypass', () => {
       chat: vi.fn().mockResolvedValue({
         type: 'text' as const,
         content: 'Reply from Coordinator',
-        usage: { inputTokens: 10, outputTokens: 5 },
+        usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        provenance: MOCK_PROVENANCE,
       }),
     };
     const coordinator = new AgentRuntime({


### PR DESCRIPTION
## Summary

- Wires the previously-unused `createLlmCall()` factory so a structured `llm.call` bus event is published after every successful Anthropic API call (initial call, tool-use continuations, and retries)
- Captures prompt-cache token breakdown (`cacheCreationInputTokens`, `cacheReadInputTokens`) that was previously silently dropped from the API response
- Adds `estimateCostUsd()` in new `src/agents/llm/pricing.ts` covering all four Anthropic token types (input, output, cache-create, cache-read) for opus/sonnet/haiku with prefix matching for versioned model names
- Events land in `audit_log` automatically via the existing audit logger — no new DB table needed
- `publishLlmCallEvent` is guarded with try-catch so a telemetry failure (audit DB write error, `JSON.stringify` on a circular tool input) never aborts a valid agent response

Closes #326

## Architecture

The key design choice is enriching `LLMResponse` with a required `provenance: LLMCallProvenance` field on the `text` and `tool_use` variants. This lets `AnthropicProvider` surface `requestedModel`, `actualModel`, and `providerRequestId` (the `msg_xxx` body ID) to the runtime layer, which is the only place that has the bus, timing, and `conversationId` needed to publish the event.

See `docs/wip/2026-05-12-llm-token-tracking.md` for the full design rationale.

## Files Changed

| File | Type |
|------|------|
| `src/agents/llm/provider.ts` | Modified — `LLMCallProvenance` interface, extended `LLMUsage`, `provenance` on response variants |
| `src/agents/llm/anthropic.ts` | Modified — cache tokens, provenance, enriched debug log |
| `src/agents/llm/pricing.ts` | **New** — `ANTHROPIC_PRICING` + `estimateCostUsd()` |
| `src/agents/runtime.ts` | Modified — timing, SHA-256 hashes, `llm.call` publishing in `chatWithRetry()` |
| `src/bus/events.ts` | Modified — cache token fields on `LlmCallPayload`, corrected comment |
| `src/agents/llm/anthropic.test.ts` | Modified — provenance + cache token assertions |
| `src/agents/llm/pricing.test.ts` | **New** — unit tests for `estimateCostUsd` |
| `tests/**` | Modified — `MOCK_PROVENANCE` + cache fields added to all mock LLM responses |

## Test plan

- [ ] `npm test` passes (2123 passing; only pre-existing DB-guard failures excluded)
- [ ] `src/agents/llm/pricing.test.ts` — all 7 pricing unit tests pass including prefix match, fallback, zero-cost
- [ ] `src/agents/llm/anthropic.test.ts` — 4 new tests: provenance on text/tool_use paths, cache zero-default, non-zero cache tokens
- [ ] `tests/integration/vertical-slice.test.ts` — audit trail asserts 5 events (`llm.call` now included between `agent.task` and `agent.response`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Enhanced LLM token tracking now captures cache metrics alongside standard usage data for complete visibility into API consumption
  * Automated cost estimation for all API calls to support financial tracking and budget management
  * Expanded call provenance tracking with request correlation IDs to enable comprehensive audit logging

* **Tests**
  * Updated test suites to validate new token tracking, cost estimation, and provenance functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/549)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->