### PR TITLE
fix: re-throw programming errors from per-fact catch in extract-facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **Google Workspace tools** pinned to coordinator — doc creation, editing, formatting, sharing, and drive tools are now always available without requiring `skill-registry` discovery (see #497).
+- **`extract-facts` error handling** — per-fact catch block now re-throws `TypeError`/`ReferenceError`/`RangeError` instead of absorbing them into the `failed` counter; programming bugs propagate to the outer catch and return `{ success: false }` rather than hiding behind a misleading metric. (#493)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **Google Workspace tools** pinned to coordinator — doc creation, editing, formatting, sharing, and drive tools are now always available without requiring `skill-registry` discovery (see #497).
-- **`extract-facts` error handling** — per-fact catch block now re-throws `TypeError`/`ReferenceError`/`RangeError` instead of absorbing them into the `failed` counter; programming bugs propagate to the outer catch and return `{ success: false }` rather than hiding behind a misleading metric. (#493)
+- **`extract-facts`** — programming errors in the per-fact loop now re-throw instead of silently incrementing `failed`. (#493)
 
 ---
 

--- a/skills/extract-facts/handler.test.ts
+++ b/skills/extract-facts/handler.test.ts
@@ -252,6 +252,24 @@ describe('ExtractFactsHandler', () => {
     expect(storeFact).toHaveBeenCalledTimes(2);
   });
 
+  it('programming error (TypeError) in per-fact loop is re-thrown — returns { success: false }', async () => {
+    const entityMemory = makeEntityMemory();
+    const facts = JSON.stringify([
+      { subject: 'Jane Doe', subjectType: 'person', attribute: 'home_city', value: 'Toronto', confidence: 0.9, decayClass: 'slow_decay' },
+    ]);
+    const anthropic = makeMockAnthropicClient(['yes', facts]);
+    const handler = new ExtractFactsHandler(anthropic as never);
+
+    // TypeError signals a programming bug — should escape the per-fact catch and
+    // reach the outer catch, returning { success: false } instead of { failed: 1 }.
+    vi.spyOn(entityMemory, 'storeFact').mockRejectedValueOnce(new TypeError("Cannot read properties of undefined (reading 'id')"));
+
+    const ctx = makeCtx(entityMemory, { text: 'Jane Doe lives in Toronto.', source: 'test' });
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: false, error: "Cannot read properties of undefined (reading 'id')" });
+  });
+
   it('catch block is safe when storeFact throws — failed incremented, no ReferenceError', async () => {
     const entityMemory = makeEntityMemory();
     const facts = JSON.stringify([

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -266,7 +266,13 @@ ${text}`,
           // property access, invalid argument, unexpected resolveOrCreate return shape),
           // not transient infra failures. Absorbing them into `failed` hides regressions
           // behind a misleading metric; the outer catch will return { success: false }.
-          if (err instanceof TypeError || err instanceof ReferenceError || err instanceof RangeError) {
+          if (
+            err instanceof TypeError ||
+            err instanceof ReferenceError ||
+            err instanceof RangeError ||
+            err instanceof EvalError ||
+            err instanceof URIError
+          ) {
             ctx.log.error({ err, subject, attribute }, 'extract-facts: unexpected programming error in fact loop — re-throwing');
             throw err;
           }
@@ -281,7 +287,11 @@ ${text}`,
       ctx.log.info({ stored, failed }, 'extract-facts: complete');
       return { success: true, data: { stored, skipped: false, failed } };
     } catch (err) {
-      // Top-level catch for Anthropic API errors (rate limits, auth, timeouts, 5xx).
+      // Two categories of errors reach here:
+      // 1. Anthropic SDK errors (rate limits, auth, timeouts, 5xx) from the classifier
+      //    and extraction calls.
+      // 2. Programming errors (TypeError, ReferenceError, RangeError, EvalError, URIError)
+      //    re-thrown from the per-fact loop — indicate bugs in this handler, not infra issues.
       ctx.log.error({ err }, 'extract-facts: unexpected error');
       return { success: false, error: err instanceof Error ? err.message : String(err) };
     }

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -262,8 +262,16 @@ ${text}`,
             ctx.log.warn({ subject, attribute, conflict: result.conflict, action: result.action, source }, 'extract-facts: fact not stored');
           }
         } catch (err) {
-          // Log at error — persistence failures are infrastructure errors (DB outage,
-          // connection loss) that must surface in Sentry, not soft warnings.
+          // Re-throw programming errors — these indicate bugs in this handler (wrong
+          // property access, invalid argument, unexpected resolveOrCreate return shape),
+          // not transient infra failures. Absorbing them into `failed` hides regressions
+          // behind a misleading metric; the outer catch will return { success: false }.
+          if (err instanceof TypeError || err instanceof ReferenceError || err instanceof RangeError) {
+            ctx.log.error({ err, subject, attribute }, 'extract-facts: unexpected programming error in fact loop — re-throwing');
+            throw err;
+          }
+          // Infrastructure errors (DB outage, connection loss) — log at error so they
+          // surface in Sentry, then continue processing the remaining facts in the batch.
           // subject and attribute are always in scope here (declared before this try).
           ctx.log.error({ err, subject, attribute }, 'extract-facts: failed to persist fact, skipping');
           failed++;


### PR DESCRIPTION
## Summary

- Per-fact `catch (err)` block now re-throws `TypeError`, `ReferenceError`, `RangeError`, `EvalError`, and `URIError` instead of absorbing them into the `failed` counter
- Programming errors propagate to the outer catch and return `{ success: false }`, making regressions visible instead of hiding them behind a misleading metric
- Infrastructure errors (DB outage, connection loss) continue to increment `failed` and let the batch continue
- Outer catch comment updated to reflect its two distinct responsibilities

## Test plan

- [ ] New test: `TypeError` from `storeFact` → `{ success: false }` (not `{ failed: 1 }`)
- [ ] Existing test: `Error` (DB outage) from `storeFact` → `{ success: true, failed: 1 }` — unchanged
- [ ] All 12 tests pass

## Follow-up issues spotted (not touched — scope discipline)

- `resolveOrCreate`'s fuzzy-search catch block in `entity-memory.ts:384` has the same broad-catch problem and absorbs programming errors before they can reach the handler's re-throw guard
- Raw `fact` object is logged at `warn` level in the malformed-fact path (`handler.ts:185`) — inconsistent with the handler's stated PII discipline elsewhere

Closes #493