### PR TITLE
fix: store intent_anchor for declarative jobs so drift detection fires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **LLM token tracking** — every successful Anthropic API call now publishes a structured `llm.call` bus event (spec 10) with full model provenance, token counts (including prompt-cache breakdown), estimated cost, latency, and SHA-256 content fingerprints. Events land in `audit_log` automatically via the existing audit logger, enabling per-agent attribution and data-driven context budgeting (closes #326, prerequisite for #24).
 
+### Fixed
+
+- **Declarative job drift detection** — `upsertDeclarativeJob()` now accepts `intent_anchor` from YAML schedule blocks and creates the linked `agent_tasks` row so the drift detector fires for those jobs. Previously `agent_task_id` was always `null` for declarative jobs, silently bypassing drift detection (closes #416). Spec 07 updated to document `intent_anchor` as a valid schedule field.
+
 ### Changed
 
 - **`LLMUsage`** extended with `cacheCreationInputTokens` and `cacheReadInputTokens` fields (previously silently dropped from the Anthropic API response).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **LLM token tracking** — every successful Anthropic API call now publishes a structured `llm.call` bus event (spec 10) with full model provenance, token counts (including prompt-cache breakdown), estimated cost, latency, and SHA-256 content fingerprints. Events land in `audit_log` automatically via the existing audit logger, enabling per-agent attribution and data-driven context budgeting (closes #326, prerequisite for #24).
 
-### Fixed
-
-- **Declarative job drift detection** — `upsertDeclarativeJob()` now accepts `intent_anchor` from YAML schedule blocks and creates the linked `agent_tasks` row so the drift detector fires for those jobs. Previously `agent_task_id` was always `null` for declarative jobs, silently bypassing drift detection (closes #416). Spec 07 updated to document `intent_anchor` as a valid schedule field.
-
 ### Changed
 
 - **`LLMUsage`** extended with `cacheCreationInputTokens` and `cacheReadInputTokens` fields (previously silently dropped from the Anthropic API response).
@@ -29,6 +25,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Declarative job drift detection** — declarative (YAML-defined) scheduled jobs now support `intent_anchor`, enabling drift detection. Previously ignored at upsert time, causing the drift detector to silently skip all YAML jobs (closes #416).
 - **Google Workspace tools** pinned to coordinator — doc creation, editing, formatting, sharing, and drive tools are now always available without requiring `skill-registry` discovery (see #497).
 - **`extract-facts`** — programming errors in the per-fact loop now re-throw instead of silently incrementing `failed`. (#493)
 

--- a/docs/specs/07-scheduler.md
+++ b/docs/specs/07-scheduler.md
@@ -166,11 +166,18 @@ Agents are not required to call `scheduler-report`. Stateless jobs (e.g. a daily
 schedule:
   - cron: "0 9 * * 1"
     task: "Generate weekly expense summary"
+    intent_anchor: "Produce a one-page summary of all expenses incurred during the previous week"
   - cron: "0 */4 * * *"
     task: "Check inbox for new receipts"
 ```
 
 These are created at startup from the agent's YAML config.
+
+#### `intent_anchor` (optional)
+
+When `intent_anchor` is set on a declarative schedule entry, the scheduler creates a linked `agent_tasks` row at startup. This enables drift detection for the job — exactly the same mechanism used by runtime-created jobs with `intent_anchor`. The anchor should express the stable original goal of the recurring task in plain language.
+
+Without `intent_anchor`, the job runs normally but the drift detector never fires for it (the `agentTaskId` and `intentAnchor` fields remain `null` on the job row). Jobs without an `intent_anchor` are unaffected by this field's addition.
 
 ### From Agents at Runtime (via skill)
 

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -42,6 +42,9 @@ export interface AgentYamlConfig {
     agent_id?: string;             // target agent for this job (defaults to config.name if omitted)
     /** Expected wall-clock duration in seconds. Drives stuck-job recovery timeout. */
     expectedDurationSeconds?: number;
+    /** When set, creates a linked agent_tasks row that enables drift detection for this job.
+     *  Should express the stable original goal of the recurring task in plain language. */
+    intent_anchor?: string;
   }>;
   /** Expected wall-clock duration for delegate calls targeting this agent, in seconds.
    *  When set, the runtime injects timeout_ms = expected_duration_seconds * 1000 into

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -429,10 +429,14 @@ export class SchedulerService {
    * scheduled_jobs_declarative_uq (agent_id, cron_expr, task_payload::text WHERE created_by = 'system').
    * Note: ON CONFLICT ON CONSTRAINT only works with named CONSTRAINTS, not named indexes —
    * so we use the column-based syntax here to match the CREATE UNIQUE INDEX definition.
+   *
+   * When schedule.intent_anchor is present, also creates a linked agent_tasks row so the
+   * drift detector can fire for this job. The INSERT is guarded by WHERE NOT EXISTS to
+   * preserve the existing agent_task row (and its accumulated progress) across restarts.
    */
   async upsertDeclarativeJob(
     agentId: string,
-    schedule: { cron: string; task: string; expectedDurationSeconds?: number },
+    schedule: { cron: string; task: string; expectedDurationSeconds?: number; intent_anchor?: string },
   ): Promise<string> {
     const taskPayload = { task: schedule.task };
     const nextRunAt = this.nextRunFromCron(schedule.cron);
@@ -487,7 +491,27 @@ export class SchedulerService {
     ];
 
     const { rows } = await this.pool.query(sql, params);
-    return (rows[0] as { id: string }).id;
+    const jobId = (rows[0] as { id: string }).id;
+
+    // If intent_anchor is set, create a linked agent_tasks row so the drift detector can
+    // fire for this job — same pattern as createJob(). The WHERE NOT EXISTS guard ensures
+    // this is a no-op on restart (preserving accumulated progress in the existing row).
+    if (schedule.intent_anchor) {
+      const taskSql = `
+        INSERT INTO agent_tasks (agent_id, intent_anchor, status, error_budget, scheduled_job_id)
+        SELECT $1, $2, $3, $4, $5
+        WHERE NOT EXISTS (SELECT 1 FROM agent_tasks WHERE scheduled_job_id = $5)
+      `;
+      await this.pool.query(taskSql, [
+        agentId,
+        schedule.intent_anchor,
+        'active',
+        JSON.stringify({}),
+        jobId,
+      ]);
+    }
+
+    return jobId;
   }
 
   /**

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -502,13 +502,34 @@ export class SchedulerService {
         SELECT $1, $2, $3, $4, $5
         WHERE NOT EXISTS (SELECT 1 FROM agent_tasks WHERE scheduled_job_id = $5)
       `;
-      await this.pool.query(taskSql, [
-        agentId,
-        schedule.intent_anchor,
-        'active',
-        JSON.stringify({}),
-        jobId,
-      ]);
+      let taskResult: { rowCount: number | null };
+      try {
+        taskResult = await this.pool.query(taskSql, [
+          agentId,
+          schedule.intent_anchor,
+          'active',
+          JSON.stringify({}),
+          jobId,
+        ]);
+      } catch (err) {
+        // Re-throw so loadDeclarativeJobs treats the whole upsert as failed.
+        // The scheduled_jobs row was already written, but without the agent_tasks
+        // link the drift detector cannot fire — running silently in a degraded state
+        // is worse than a loud failure that prompts operator attention.
+        this.logger.error(
+          { err, agentId, jobId, intentAnchor: schedule.intent_anchor },
+          'upsertDeclarativeJob: failed to create agent_tasks row — job will run without drift detection until this is resolved',
+        );
+        throw err;
+      }
+      // rowCount === 0 means the WHERE NOT EXISTS guard fired — an existing row was preserved.
+      const anchorCreated = (taskResult.rowCount ?? 0) > 0;
+      this.logger.info(
+        { agentId, jobId, intentAnchor: schedule.intent_anchor, anchorCreated },
+        anchorCreated
+          ? 'upsertDeclarativeJob: agent_tasks row created for intent_anchor (drift detection enabled)'
+          : 'upsertDeclarativeJob: agent_tasks row already exists — skipped (restart idempotency)',
+      );
     }
 
     return jobId;

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -738,9 +738,9 @@ describe('SchedulerService', () => {
     });
 
     it('creates an agent_tasks row when intent_anchor is provided', async () => {
-      // First query: the scheduled_jobs upsert; second query: the agent_tasks INSERT.
+      // First query: the scheduled_jobs upsert; second query: the agent_tasks INSERT (row created).
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-anchor' }] });
-      pool.query.mockResolvedValueOnce({ rows: [] });
+      pool.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
       await svc.upsertDeclarativeJob('coordinator', {
         cron: '0 9 * * 1',
@@ -758,6 +758,32 @@ describe('SchedulerService', () => {
       expect(taskParams).toContain('Produce a weekly summary of key business metrics');
       expect(taskParams).toContain('active');
       expect(taskParams).toContain('job-anchor');
+
+      // Logs at info level confirming the anchor was created.
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: 'coordinator', jobId: 'job-anchor', anchorCreated: true }),
+        expect.stringContaining('drift detection enabled'),
+      );
+    });
+
+    it('is idempotent on restart — skips agent_tasks INSERT when row already exists', async () => {
+      // rowCount: 0 means WHERE NOT EXISTS fired — the existing row was preserved.
+      pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-anchor-2' }] });
+      pool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await svc.upsertDeclarativeJob('coordinator', {
+        cron: '0 9 * * 1',
+        task: 'weekly digest',
+        intent_anchor: 'Produce a weekly summary of key business metrics',
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(2);
+
+      // Logs at info level confirming the existing row was preserved.
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: 'coordinator', jobId: 'job-anchor-2', anchorCreated: false }),
+        expect.stringContaining('restart idempotency'),
+      );
     });
 
     it('does not create an agent_tasks row when intent_anchor is absent', async () => {

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -736,6 +736,41 @@ describe('SchedulerService', () => {
         expect(params[params.length - 1]).toBeNull();
       }
     });
+
+    it('creates an agent_tasks row when intent_anchor is provided', async () => {
+      // First query: the scheduled_jobs upsert; second query: the agent_tasks INSERT.
+      pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-anchor' }] });
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      await svc.upsertDeclarativeJob('coordinator', {
+        cron: '0 9 * * 1',
+        task: 'weekly digest',
+        intent_anchor: 'Produce a weekly summary of key business metrics',
+      });
+
+      expect(pool.query).toHaveBeenCalledTimes(2);
+
+      // Second call must be the agent_tasks INSERT with WHERE NOT EXISTS guard.
+      const [taskSql, taskParams] = pool.query.mock.calls[1] as [string, unknown[]];
+      expect(taskSql).toContain('INSERT INTO agent_tasks');
+      expect(taskSql).toContain('WHERE NOT EXISTS');
+      expect(taskParams).toContain('coordinator');
+      expect(taskParams).toContain('Produce a weekly summary of key business metrics');
+      expect(taskParams).toContain('active');
+      expect(taskParams).toContain('job-anchor');
+    });
+
+    it('does not create an agent_tasks row when intent_anchor is absent', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-no-anchor' }] });
+
+      await svc.upsertDeclarativeJob('coordinator', {
+        cron: '0 9 * * 1',
+        task: 'weekly standup',
+      });
+
+      // Only the scheduled_jobs upsert — no second query.
+      expect(pool.query).toHaveBeenCalledTimes(1);
+    });
   });
 
   // -- updateJob --

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -957,6 +957,36 @@ describe('Scheduler', () => {
       // Second one succeeded
       expect(logger.info).toHaveBeenCalled();
     });
+
+    it('passes intent_anchor from YAML schedule entry through to upsertDeclarativeJob', async () => {
+      schedulerService.upsertDeclarativeJob.mockResolvedValue('job-anchor-1');
+
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'coordinator',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Coord.',
+          schedule: [
+            {
+              cron: '0 9 * * 1',
+              task: 'weekly digest',
+              intent_anchor: 'Produce a weekly summary of key business metrics',
+            },
+          ],
+        },
+      ];
+
+      await scheduler.loadDeclarativeJobs(configs);
+
+      expect(schedulerService.upsertDeclarativeJob).toHaveBeenCalledWith(
+        'coordinator',
+        {
+          cron: '0 9 * * 1',
+          task: 'weekly digest',
+          intent_anchor: 'Produce a weekly summary of key business metrics',
+        },
+      );
+    });
   });
 
   // -- recoverStuckJobs --


### PR DESCRIPTION
## Summary

- `upsertDeclarativeJob()` now accepts `intent_anchor` from YAML schedule blocks and creates a linked `agent_tasks` row, enabling the drift detector to fire for declarative jobs
- Uses a `WHERE NOT EXISTS` guard so the INSERT is idempotent across restarts (preserves existing row and accumulated progress)
- `AgentYamlConfig.schedule` type updated with the new optional field
- Spec 07 updated to document `intent_anchor` as a valid declarative schedule field

Closes #416

## Test plan

- [x] `upsertDeclarativeJob` creates `agent_tasks` row when `intent_anchor` is provided (rowCount > 0 path)
- [x] `upsertDeclarativeJob` is a no-op on restart when `agent_tasks` row already exists (rowCount = 0 path)
- [x] `upsertDeclarativeJob` does not create `agent_tasks` row when `intent_anchor` is absent (no regression)
- [x] `loadDeclarativeJobs` passes `intent_anchor` through to `upsertDeclarativeJob`
- [x] All existing unit tests pass