### PR TITLE
fix: malformed-fact warn log exposes PII via raw fact object — extract-facts (#494)

### DIFF
--- a/skills/extract-facts/handler.test.ts
+++ b/skills/extract-facts/handler.test.ts
@@ -270,6 +270,40 @@ describe('ExtractFactsHandler', () => {
     expect(result).toEqual({ success: false, error: "Cannot read properties of undefined (reading 'id')" });
   });
 
+  it('malformed-fact warn logs only structural metadata — not the raw fact object (PII guard)', async () => {
+    const entityMemory = makeEntityMemory();
+    // fact.value is null — triggers the malformed guard on line 183
+    const facts = JSON.stringify([
+      { subject: 'Jane Doe', subjectType: 'person', attribute: 'home_city', value: null, confidence: 0.9, decayClass: 'slow_decay' },
+    ]);
+    const anthropic = makeMockAnthropicClient(['yes', facts]);
+    const handler = new ExtractFactsHandler(anthropic as never);
+
+    // Build a real logger and spy on warn so we can inspect what was logged.
+    const log = pino({ level: 'silent' });
+    const warnSpy = vi.spyOn(log, 'warn');
+    const ctx = makeCtx(entityMemory, { text: 'Jane Doe lives in Toronto.', source: 'test' });
+    (ctx as Record<string, unknown>).log = log;
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { stored: 0, skipped: false, failed: 1 } });
+
+    // Find the malformed-fact warn call by its message
+    const malformedCall = warnSpy.mock.calls.find(
+      (args) => typeof args[args.length - 1] === 'string' && (args[args.length - 1] as string).includes('skipping malformed fact'),
+    );
+    expect(malformedCall).toBeDefined();
+
+    const loggedData = malformedCall![0] as Record<string, unknown>;
+    // Raw fact must not be present — it contains PII (subject name, value strings)
+    expect(loggedData).not.toHaveProperty('fact');
+    // Structural metadata must be present instead
+    expect(loggedData).toHaveProperty('subjectType', 'string');   // typeof 'Jane Doe'
+    expect(loggedData).toHaveProperty('attributeType', 'string'); // typeof 'home_city'
+    expect(loggedData).toHaveProperty('valueType', 'object');     // typeof null
+  });
+
   it('catch block is safe when storeFact throws — failed incremented, no ReferenceError', async () => {
     const entityMemory = makeEntityMemory();
     const facts = JSON.stringify([

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -182,7 +182,15 @@ ${text}`,
             !attribute ||
             typeof fact.value !== 'string' || !fact.value.trim()
           ) {
-            ctx.log.warn({ fact }, 'extract-facts: skipping malformed fact');
+            ctx.log.warn(
+              {
+                // Log only field types — never the raw values (subject/attribute/value may contain PII).
+                subjectType: typeof fact?.subject,
+                attributeType: typeof fact?.attribute,
+                valueType: typeof fact?.value,
+              },
+              'extract-facts: skipping malformed fact',
+            );
             failed++;
             continue;
           }


### PR DESCRIPTION
## Summary

- Replaces `ctx.log.warn({ fact }, ...)` with `ctx.log.warn({ subjectType, attributeType, valueType }, ...)` in the malformed-fact guard inside `skills/extract-facts/handler.ts`
- The old code serialised the entire `ExtractedFact` object — including `subject` (person/org name) and `value` (address, dietary restriction, etc.) — into structured logs
- The new code logs only `typeof` each field, which is sufficient to diagnose why the LLM output was malformed without exposing any actual content

## Test plan

- [x] Added a regression test (`handler.test.ts`) that spies on `ctx.log.warn`, triggers the malformed guard by supplying a fact with `value: null`, and asserts `fact` is absent from the logged object while `subjectType`/`attributeType`/`valueType` are present with correct `typeof` values
- [x] All 13 existing tests pass
- [x] Verified test failed before the fix and passes after

Fixes #494