### PR TITLE
feat: thread TaskOriginator through scheduler, delegate, and bullpen (#504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`TaskOriginator` through delegation boundaries** — scheduled jobs, delegated specialist tasks, and bullpen-spawned tasks now carry the `TaskOriginator` from the task that created them, so `isPrincipalOriginated()` returns correctly and the elevated-skill gate no longer blocks principal-authorized deferred or delegated actions (closes #504). `AgentDiscussPayload` gains an optional `originator` field (backwards-compatible bus API change).
 - **Declarative job drift detection** — declarative (YAML-defined) scheduled jobs now support `intent_anchor`, enabling drift detection. Previously ignored at upsert time, causing the drift detector to silently skip all YAML jobs (closes #416).
 - **Google Workspace tools** pinned to coordinator — doc creation, editing, formatting, sharing, and drive tools are now always available without requiring `skill-registry` discovery (see #497).
 - **`extract-facts`** — programming errors in the per-fact loop now re-throw instead of silently incrementing `failed`. (#493)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`TaskOriginator` through delegation boundaries** — scheduled jobs, delegated specialist tasks, and bullpen-spawned tasks now carry the `TaskOriginator` from the task that created them, so `isPrincipalOriginated()` returns correctly and the elevated-skill gate no longer blocks principal-authorized deferred or delegated actions (closes #504). `AgentDiscussPayload` gains an optional `originator` field (backwards-compatible bus API change).
+- **`TaskOriginator` through delegation boundaries** — originator now propagates through the scheduler, delegate skill, and bullpen so `isPrincipalOriginated()` returns correctly for deferred and delegated principal-authorized work (closes #504).
 - **Declarative job drift detection** — declarative (YAML-defined) scheduled jobs now support `intent_anchor`, enabling drift detection. Previously ignored at upsert time, causing the drift detector to silently skip all YAML jobs (closes #416).
 - **Google Workspace tools** pinned to coordinator — doc creation, editing, formatting, sharing, and drive tools are now always available without requiring `skill-registry` discovery (see #497).
 - **`extract-facts`** — programming errors in the per-fact loop now re-throw instead of silently incrementing `failed`. (#493)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`TaskOriginator` through delegation boundaries** — originator now propagates through the scheduler, delegate skill, and bullpen so `isPrincipalOriginated()` returns correctly for deferred and delegated principal-authorized work (closes #504).
+- **`TaskOriginator` through delegation boundaries** — originator now propagates through scheduler, delegate, and bullpen so `isPrincipalOriginated()` works correctly (closes #504).
 - **Declarative job drift detection** — declarative (YAML-defined) scheduled jobs now support `intent_anchor`, enabling drift detection. Previously ignored at upsert time, causing the drift detector to silently skip all YAML jobs (closes #416).
 - **Google Workspace tools** pinned to coordinator — doc creation, editing, formatting, sharing, and drive tools are now always available without requiring `skill-registry` discovery (see #497).
 - **`extract-facts`** — programming errors in the per-fact loop now re-throw instead of silently incrementing `failed`. (#493)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`TaskOriginator` through delegation boundaries** — originator now propagates through scheduler, delegate, and bullpen so `isPrincipalOriginated()` works correctly (closes #504).
+- **`TaskOriginator` through delegation boundaries** — originator now propagates through scheduler, delegate, and bullpen (including the poll-fallback path) so `isPrincipalOriginated()` works correctly (closes #504).
 - **Declarative job drift detection** — declarative (YAML-defined) scheduled jobs now support `intent_anchor`, enabling drift detection. Previously ignored at upsert time, causing the drift detector to silently skip all YAML jobs (closes #416).
 - **Google Workspace tools** pinned to coordinator — doc creation, editing, formatting, sharing, and drive tools are now always available without requiring `skill-registry` discovery (see #497).
 - **`extract-facts`** — programming errors in the per-fact loop now re-throw instead of silently incrementing `failed`. (#493)

--- a/skills/bullpen/handler.ts
+++ b/skills/bullpen/handler.ts
@@ -64,12 +64,18 @@ export class BullpenHandler implements SkillHandler {
             ? (rawMentioned as string[]).map(m => m.trim()).filter(m => m.length > 0 && cleanParticipants.includes(m))
             : cleanParticipants;
 
+          // Capture originator before openThread so we can pass it both to the thread
+          // record (for poll-fallback rehydration) and to the agent.discuss event payload.
+          const originator = ctx.taskMetadata?.originator as TaskOriginator | undefined;
+
           const { thread, message } = await ctx.bullpenService.openThread(
-            topic, ctx.agentId, cleanParticipants, content, mentionedAgentIds,
+            topic, ctx.agentId, cleanParticipants, content, mentionedAgentIds, originator,
           );
 
           // Publish is best-effort — thread is already persisted. If publish fails,
           // agents will still see the thread via pending-thread context injection.
+          // The originator is also stored on the thread row, so BullpenDispatcher can
+          // rehydrate it from DB when processing poll-fallback replies.
           try {
             await ctx.bus.publish('agent', createAgentDiscuss({
               threadId: thread.id,
@@ -82,20 +88,13 @@ export class BullpenHandler implements SkillHandler {
               // Forward the parent task's originator so BullpenDispatcher can stamp it
               // on the reply tasks it creates for each participant. This ensures
               // isPrincipalOriginated() returns correctly for CEO-authorized bullpen work.
-              originator: ctx.taskMetadata?.originator as TaskOriginator | undefined,
+              originator,
               parentEventId: ctx.taskEventId,
             }));
           } catch (publishErr) {
             ctx.log.error(
-              {
-                err: publishErr,
-                threadId: thread.id,
-                // If an originator was present, it is now lost — participant tasks created
-                // via the poll fallback will have no originator and isPrincipalOriginated()
-                // will return false. TODO: fix by storing originator on bullpen_threads (#558).
-                originatorLost: !!ctx.taskMetadata?.originator,
-              },
-              'Bullpen: thread created but discuss event publish failed — agents will see it on next poll',
+              { err: publishErr, threadId: thread.id, originatorRole: originator?.systemRole ?? 'none' },
+              'Bullpen: thread created but discuss event publish failed — agents will see it on next poll (originator preserved in thread row)',
             );
           }
 
@@ -146,11 +145,7 @@ export class BullpenHandler implements SkillHandler {
             }));
           } catch (publishErr) {
             ctx.log.error(
-              {
-                err: publishErr,
-                threadId,
-                originatorLost: !!ctx.taskMetadata?.originator,
-              },
+              { err: publishErr, threadId },
               'Bullpen: reply posted but discuss event publish failed — agents will see it on next poll',
             );
           }

--- a/skills/bullpen/handler.ts
+++ b/skills/bullpen/handler.ts
@@ -13,6 +13,7 @@
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { createAgentDiscuss } from '../../src/bus/events.js';
+import type { TaskOriginator } from '../../src/contacts/types.js';
 
 export class BullpenHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -78,6 +79,10 @@ export class BullpenHandler implements SkillHandler {
               participants: thread.participants,
               mentionedAgentIds,
               content,
+              // Forward the parent task's originator so BullpenDispatcher can stamp it
+              // on the reply tasks it creates for each participant. This ensures
+              // isPrincipalOriginated() returns correctly for CEO-authorized bullpen work.
+              originator: ctx.taskMetadata?.originator as TaskOriginator | undefined,
               parentEventId: ctx.taskEventId,
             }));
           } catch (publishErr) {
@@ -127,6 +132,9 @@ export class BullpenHandler implements SkillHandler {
               participants: existing.thread.participants,
               mentionedAgentIds,
               content,
+              // Forward the parent task's originator so BullpenDispatcher can stamp it
+              // on the reply tasks it creates for each participant.
+              originator: ctx.taskMetadata?.originator as TaskOriginator | undefined,
               parentEventId: ctx.taskEventId,
             }));
           } catch (publishErr) {

--- a/skills/bullpen/handler.ts
+++ b/skills/bullpen/handler.ts
@@ -87,7 +87,14 @@ export class BullpenHandler implements SkillHandler {
             }));
           } catch (publishErr) {
             ctx.log.error(
-              { err: publishErr, threadId: thread.id },
+              {
+                err: publishErr,
+                threadId: thread.id,
+                // If an originator was present, it is now lost — participant tasks created
+                // via the poll fallback will have no originator and isPrincipalOriginated()
+                // will return false. TODO: fix by storing originator on bullpen_threads (#558).
+                originatorLost: !!ctx.taskMetadata?.originator,
+              },
               'Bullpen: thread created but discuss event publish failed — agents will see it on next poll',
             );
           }
@@ -139,7 +146,11 @@ export class BullpenHandler implements SkillHandler {
             }));
           } catch (publishErr) {
             ctx.log.error(
-              { err: publishErr, threadId },
+              {
+                err: publishErr,
+                threadId,
+                originatorLost: !!ctx.taskMetadata?.originator,
+              },
               'Bullpen: reply posted but discuss event publish failed — agents will see it on next poll',
             );
           }

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -90,12 +90,20 @@ export class DelegateHandler implements SkillHandler {
     // to the Coordinator's skill.invoke event, but SkillContext doesn't currently
     // carry the invoking event's ID. TODO: Add invokeEventId to SkillContext so
     // capability-gated skills can maintain the full audit causal chain.
+    //
+    // Forward the parent task's originator so the specialist inherits the original
+    // TaskOriginator. Without this, a CEO-initiated task delegated to a specialist
+    // would lose its originator at the delegation boundary and isPrincipalOriginated()
+    // would return false for all skill calls inside the specialist's turn.
     const taskEvent = createAgentTask({
       agentId: agent,
       conversationId,
       channelId: 'internal',
       senderId: 'coordinator',
       content: task,
+      metadata: ctx.taskMetadata?.originator
+        ? { originator: ctx.taskMetadata.originator }
+        : undefined,
       parentEventId: `delegate-${randomUUID()}`,
     });
 

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -101,6 +101,9 @@ export class DelegateHandler implements SkillHandler {
       channelId: 'internal',
       senderId: 'coordinator',
       content: task,
+      // Forward only the originator field, not the full taskMetadata. Other metadata fields
+      // (e.g. future billing context, routing hints) are coordinator-internal and should
+      // not propagate transitively down the delegation chain unless explicitly designed to.
       metadata: ctx.taskMetadata?.originator
         ? { originator: ctx.taskMetadata.originator }
         : undefined,

--- a/skills/scheduler-create/handler.ts
+++ b/skills/scheduler-create/handler.ts
@@ -63,7 +63,7 @@ export class SchedulerCreateHandler implements SkillHandler {
         originator,
       });
 
-      ctx.log.info({ jobId: result.jobId, agentId }, 'Scheduled job created via skill');
+      ctx.log.info({ jobId: result.jobId, agentId, originatorRole: originator?.systemRole ?? 'none' }, 'Scheduled job created via skill');
 
       return { success: true, data: result };
     } catch (err) {

--- a/skills/scheduler-create/handler.ts
+++ b/skills/scheduler-create/handler.ts
@@ -5,6 +5,7 @@
 // When intent_anchor is provided, a persistent agent_task is linked to the job.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { TaskOriginator } from '../../src/contacts/types.js';
 
 export class SchedulerCreateHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -40,6 +41,12 @@ export class SchedulerCreateHandler implements SkillHandler {
 
     const agentId = agent_id ?? 'coordinator';
 
+    // Propagate the task originator from the parent task to the scheduled job so
+    // isPrincipalOriginated() returns correctly when the job fires. Without this,
+    // "email my mother tomorrow at 10am" would be blocked by the elevated-skill gate
+    // at fire time because the scheduler task would have no originator.
+    const originator = ctx.taskMetadata?.originator as TaskOriginator | undefined;
+
     try {
       const result = await ctx.schedulerService.createJob({
         agentId,
@@ -53,6 +60,7 @@ export class SchedulerCreateHandler implements SkillHandler {
         // run_at is already normalized to UTC by the execution layer, so timezone only affects cron jobs.
         // Normalize to undefined if blank so createJob() falls back to the service default.
         timezone: typeof timezone === 'string' && timezone.trim() !== '' ? timezone.trim() : undefined,
+        originator,
       });
 
       ctx.log.info({ jobId: result.jobId, agentId }, 'Scheduled job created via skill');

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -194,6 +194,10 @@ interface AgentDiscussPayload {
   participants: string[];      // all thread participants
   mentionedAgentIds: string[]; // subset that get reply-expected tasks (empty = broadcast)
   content: string;
+  /** TaskOriginator of the task that published this discuss event. Forwarded by
+   *  BullpenDispatcher into the resulting agent.task metadata so that skills invoked
+   *  during bullpen work can pass the elevated-skill gate for principal-authorized tasks. */
+  originator?: import('../contacts/types.js').TaskOriginator;
 }
 
 // Contact event payloads — emitted by the dispatch layer during contact resolution (Contacts Phase A).

--- a/src/db/migrations/040_add_scheduled_jobs_originator.sql
+++ b/src/db/migrations/040_add_scheduled_jobs_originator.sql
@@ -1,0 +1,14 @@
+-- 040_add_scheduled_jobs_originator.sql
+--
+-- Add originator to scheduled_jobs so TaskOriginator is preserved across the
+-- gap between when a schedule entry is created and when the job fires.
+--
+-- NULL for declarative (YAML-defined, system-created) jobs and for any jobs
+-- created before this migration. isPrincipalOriginated() returns false for
+-- null originators, preserving the existing conservative-default behaviour.
+--
+-- See: github.com/josephfung/curia/issues/504
+
+ALTER TABLE scheduled_jobs ADD COLUMN originator JSONB;
+
+-- Rollback: ALTER TABLE scheduled_jobs DROP COLUMN originator;

--- a/src/db/migrations/041_add_bullpen_threads_originator.sql
+++ b/src/db/migrations/041_add_bullpen_threads_originator.sql
@@ -1,0 +1,5 @@
+-- Up Migration
+
+ALTER TABLE bullpen_threads ADD COLUMN originator JSONB;
+
+-- Rollback: ALTER TABLE bullpen_threads DROP COLUMN originator;

--- a/src/dispatch/bullpen-dispatcher.ts
+++ b/src/dispatch/bullpen-dispatcher.ts
@@ -53,6 +53,12 @@ export class BullpenDispatcher {
 
     const { topic, participants } = threadRecord.thread;
 
+    // Prefer the originator from the discuss event (fast path — already in memory).
+    // Fall back to the originator stored on the thread at creation time: this covers
+    // the poll-fallback path where the original agent.discuss publish failed, so the
+    // reply event has no originator but the thread row still holds the CEO's identity.
+    const effectiveOriginator = event.payload.originator ?? threadRecord.thread.originator ?? undefined;
+
     // Create one agent.task per participant, excluding the sender.
     // Mentioned agents get a reply-expected prompt; others get an FYI.
     const otherParticipants = participants.filter((id) => id !== senderAgentId);
@@ -77,10 +83,10 @@ export class BullpenDispatcher {
             taskOrigin: 'bullpen',
             threadId,
             mentioned: isMentioned,
-            // Propagate the originator from the discuss event so the receiving agent's
-            // task carries the original TaskOriginator. Without this, a specialist agent
-            // involved in a CEO-authorized bullpen thread cannot invoke elevated skills.
-            ...(event.payload.originator ? { originator: event.payload.originator } : {}),
+            // Propagate the originator so the receiving agent's task carries the original
+            // TaskOriginator. Without this, a specialist agent involved in a CEO-authorized
+            // bullpen thread cannot invoke elevated skills.
+            ...(effectiveOriginator ? { originator: effectiveOriginator } : {}),
           },
           parentEventId: event.id,
         });

--- a/src/dispatch/bullpen-dispatcher.ts
+++ b/src/dispatch/bullpen-dispatcher.ts
@@ -77,6 +77,10 @@ export class BullpenDispatcher {
             taskOrigin: 'bullpen',
             threadId,
             mentioned: isMentioned,
+            // Propagate the originator from the discuss event so the receiving agent's
+            // task carries the original TaskOriginator. Without this, a specialist agent
+            // involved in a CEO-authorized bullpen thread cannot invoke elevated skills.
+            ...(event.payload.originator ? { originator: event.payload.originator } : {}),
           },
           parentEventId: event.id,
         });

--- a/src/memory/bullpen.ts
+++ b/src/memory/bullpen.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import type { Pool } from 'pg';
 import type { Logger } from '../logger.js';
+import type { TaskOriginator } from '../contacts/types.js';
 
 // -- Public types --
 
@@ -13,6 +14,10 @@ export interface BullpenThread {
   messageCount: number;
   lastMessageAt: Date | null;
   createdAt: Date;
+  // Stored at thread-creation time so the poll-fallback path (when the initial
+  // agent.discuss publish fails) can rehydrate the originator when dispatching
+  // participant tasks. null for threads opened without an authenticated originator.
+  originator: TaskOriginator | null;
 }
 
 export interface BullpenMessage {
@@ -124,9 +129,9 @@ class PostgresBullpenBackend implements BullpenBackend {
     try {
       await client.query('BEGIN');
       await client.query(
-        `INSERT INTO bullpen_threads (id, topic, creator_agent_id, participants, status, message_count, last_message_at, created_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-        [thread.id, thread.topic, thread.creatorAgentId, thread.participants, thread.status, thread.messageCount, thread.lastMessageAt, thread.createdAt],
+        `INSERT INTO bullpen_threads (id, topic, creator_agent_id, participants, status, message_count, last_message_at, created_at, originator)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+        [thread.id, thread.topic, thread.creatorAgentId, thread.participants, thread.status, thread.messageCount, thread.lastMessageAt, thread.createdAt, thread.originator ? JSON.stringify(thread.originator) : null],
       );
       await client.query(
         `INSERT INTO bullpen_messages (id, thread_id, sender_type, sender_id, content, mentioned_agent_ids, created_at)
@@ -188,8 +193,9 @@ class PostgresBullpenBackend implements BullpenBackend {
     const threadRes = await this.pool.query<{
       id: string; topic: string; creator_agent_id: string; participants: string[];
       status: string; message_count: number; last_message_at: Date | null; created_at: Date;
+      originator: Record<string, unknown> | null;
     }>(
-      `SELECT id, topic, creator_agent_id, participants, status, message_count, last_message_at, created_at
+      `SELECT id, topic, creator_agent_id, participants, status, message_count, last_message_at, created_at, originator
        FROM bullpen_threads WHERE id = $1`,
       [threadId],
     );
@@ -199,6 +205,7 @@ class PostgresBullpenBackend implements BullpenBackend {
       id: row.id, topic: row.topic, creatorAgentId: row.creator_agent_id,
       participants: row.participants, status: row.status as 'open' | 'closed',
       messageCount: row.message_count, lastMessageAt: row.last_message_at, createdAt: row.created_at,
+      originator: row.originator as TaskOriginator | null,
     };
 
     const msgRes = await this.pool.query<{
@@ -283,6 +290,7 @@ export class BullpenService {
     participants: string[],
     initialContent: string,
     mentionedAgentIds: string[],
+    originator?: TaskOriginator,
   ): Promise<{ thread: BullpenThread; message: BullpenMessage }> {
     // Normalize: always include the creator, deduplicate, preserve order.
     const normalizedParticipants = [...new Set([creatorAgentId, ...participants])];
@@ -290,6 +298,9 @@ export class BullpenService {
     const thread: BullpenThread = {
       id: randomUUID(), topic, creatorAgentId, participants: normalizedParticipants,
       status: 'open', messageCount: 1, lastMessageAt: now, createdAt: now,
+      // Persist originator so BullpenDispatcher can rehydrate it on the poll-fallback
+      // path if the initial agent.discuss event publish fails.
+      originator: originator ?? null,
     };
     const message: BullpenMessage = {
       id: randomUUID(), threadId: thread.id, senderType: 'agent',

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -4,6 +4,7 @@ import type { Pool } from 'pg';
 import type { EventBus } from '../bus/bus.js';
 import type { Logger } from '../logger.js';
 import { createScheduleCreated } from '../bus/events.js';
+import type { TaskOriginator } from '../contacts/types.js';
 
 // -- Public types --
 
@@ -21,6 +22,11 @@ export interface CreateJobParams {
    *  long-running jobs and to compute the watchdog recovery threshold. Must be a positive
    *  finite integer; non-integer, zero, negative, and non-finite values are rejected. */
   expectedDurationSeconds?: number;
+  /** Who originally initiated the task chain that created this schedule entry.
+   *  Preserved in the DB so fireJob() can stamp it on the resulting agent.task,
+   *  allowing isPrincipalOriginated() to return true for principal-authorized scheduled work.
+   *  Null for declarative (YAML-defined) jobs and jobs created before migration 040. */
+  originator?: TaskOriginator;
 }
 
 export interface CreateJobResult {
@@ -53,6 +59,9 @@ export interface JobRow {
   lastRunOutcome: 'completed' | 'failed' | 'timed_out' | null;
   lastRunSummary: string | null;
   lastRunContext: Record<string, unknown> | null;
+  /** TaskOriginator stored at schedule-creation time. Null for declarative jobs and
+   *  jobs created before migration 040. Stamped on the resulting agent.task by fireJob(). */
+  originator: TaskOriginator | null;
 }
 
 export interface ListJobsFilters {
@@ -84,6 +93,7 @@ interface DbJobRow {
   last_run_outcome: 'completed' | 'failed' | 'timed_out' | null;
   last_run_summary: string | null;   // agent-written summary; null until first scheduler-report call
   last_run_context: Record<string, unknown> | null; // opaque agent context; null until first scheduler-report call
+  originator: Record<string, unknown> | null; // JSONB — cast to TaskOriginator when mapping
 }
 
 // Threshold for auto-suspending jobs after consecutive failures.
@@ -182,9 +192,11 @@ export class SchedulerService {
     // for one-shot jobs use runAt directly (already UTC from timestamp normalization).
     const nextRunAt = cronExpr ? this.nextRunFromCron(cronExpr, jobTimezone) : runAt!;
 
+    // originator is always written — null for non-principal-initiated jobs. Always including
+    // it (rather than conditionally) keeps the SQL simpler and matches the nullable column.
     const insertSql = `
-      INSERT INTO scheduled_jobs (agent_id, cron_expr, run_at, task_payload, status, next_run_at, created_by, timezone${hasExpectedDuration ? ', expected_duration_seconds' : ''})
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8${hasExpectedDuration ? ', $9' : ''})
+      INSERT INTO scheduled_jobs (agent_id, cron_expr, run_at, task_payload, status, next_run_at, created_by, timezone, originator${hasExpectedDuration ? ', expected_duration_seconds' : ''})
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9${hasExpectedDuration ? ', $10' : ''})
       RETURNING id
     `;
     const insertParams: unknown[] = [
@@ -196,6 +208,8 @@ export class SchedulerService {
       nextRunAt,
       createdBy,
       jobTimezone,
+      // Serialize as JSON string for pg JSONB — null when no originator was provided.
+      params.originator ? JSON.stringify(params.originator) : null,
     ];
     if (hasExpectedDuration) {
       insertParams.push(rawDuration);
@@ -759,5 +773,7 @@ function mapJobRow(row: DbJobRow): JobRow {
     lastRunOutcome: row.last_run_outcome,
     lastRunSummary: row.last_run_summary,
     lastRunContext: row.last_run_context,
+    // pg returns JSONB columns as plain JS objects — cast to the typed interface.
+    originator: row.originator as TaskOriginator | null,
   };
 }

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -231,6 +231,8 @@ export class Scheduler {
           lastRunOutcome: row.last_run_outcome ?? null,
           lastRunSummary: row.last_run_summary ?? null,
           lastRunContext: row.last_run_context ?? null,
+          // pg returns JSONB as a plain object; null for pre-040 rows and declarative jobs.
+          originator: row.originator ?? null,
         };
         try {
           await this.fireJob(job);
@@ -319,6 +321,10 @@ export class Scheduler {
     const runId = randomUUID();
 
     // Publish agent.task so the coordinator picks up the work.
+    // Restore the TaskOriginator stored at schedule-creation time so the autonomy gate
+    // can correctly identify principal-authorized scheduled actions (e.g. "email my
+    // mother tomorrow at 10am"). Without this, the scheduler task fires with no originator
+    // and isPrincipalOriginated() returns false, blocking elevated skills.
     const taskEvent = createAgentTask({
       agentId: job.agentId,
       conversationId: `scheduler:${job.id}:${runId}`,
@@ -331,6 +337,8 @@ export class Scheduler {
       // Pass the duration hint so the runtime can widen the delegate timeout for
       // long-running scheduled tasks. null (no explicit duration) becomes undefined.
       expectedDurationSeconds: job.expectedDurationSeconds ?? undefined,
+      // Thread the stored originator through — null (declarative / pre-040 jobs) becomes undefined.
+      metadata: job.originator ? { originator: job.originator } : undefined,
       parentEventId: firedEvent.id,
     });
     // Track the mapping BEFORE publishing — bus.publish() awaits all handlers

--- a/tests/unit/dispatch/bullpen-dispatcher.test.ts
+++ b/tests/unit/dispatch/bullpen-dispatcher.test.ts
@@ -121,7 +121,7 @@ describe('BullpenDispatcher', () => {
     expect(task?.payload.metadata?.originator).toEqual(originator);
   });
 
-  it('omits originator from task metadata when discuss event has none', async () => {
+  it('omits originator from task metadata when discuss event has none and thread has none', async () => {
     const { thread } = await bullpenService.openThread(
       'No originator', 'coordinator', ['coordinator', 'agent-b'], 'Hi', [],
     );
@@ -136,6 +136,63 @@ describe('BullpenDispatcher', () => {
       { payload: { metadata: Record<string, unknown> } };
     // originator key should be absent — not present as undefined
     expect(task?.payload.metadata).not.toHaveProperty('originator');
+  });
+
+  it('uses thread stored originator as fallback when discuss event carries none', async () => {
+    // Simulate the poll-fallback path: the original agent.discuss publish failed
+    // so the event has no originator, but the thread was opened with one and it
+    // is stored on bullpen_threads.
+    const originator = {
+      contactId: 'ceo-contact-id',
+      systemRole: 'principal' as const,
+      channel: 'email',
+      initiatedAt: '2026-05-01T10:00:00.000Z',
+    };
+    const { thread } = await bullpenService.openThread(
+      'Fallback test', 'coordinator', ['coordinator', 'agent-b'], 'Hi', ['agent-b'],
+      originator,
+    );
+    // Event has no originator (simulates a reply on the poll-fallback path)
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-1', topic: 'Fallback test',
+      senderAgentId: 'coordinator', participants: ['coordinator', 'agent-b'],
+      mentionedAgentIds: ['agent-b'], content: 'Hi', parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    const task = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .find(([_l, e]) => (e as { type: string }).type === 'agent.task')?.[1] as
+      { payload: { metadata: Record<string, unknown> } };
+    expect(task?.payload.metadata?.originator).toEqual(originator);
+  });
+
+  it('event originator takes precedence over thread stored originator', async () => {
+    const threadOriginator = {
+      contactId: 'original-contact-id',
+      systemRole: 'principal' as const,
+      channel: 'email',
+      initiatedAt: '2026-05-01T10:00:00.000Z',
+    };
+    const eventOriginator = {
+      contactId: 'override-contact-id',
+      systemRole: 'principal' as const,
+      channel: 'email',
+      initiatedAt: '2026-05-02T12:00:00.000Z',
+    };
+    const { thread } = await bullpenService.openThread(
+      'Precedence test', 'coordinator', ['coordinator', 'agent-b'], 'Hi', ['agent-b'],
+      threadOriginator,
+    );
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-1', topic: 'Precedence test',
+      senderAgentId: 'coordinator', participants: ['coordinator', 'agent-b'],
+      mentionedAgentIds: ['agent-b'], content: 'Hi', originator: eventOriginator,
+      parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    const task = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .find(([_l, e]) => (e as { type: string }).type === 'agent.task')?.[1] as
+      { payload: { metadata: Record<string, unknown> } };
+    expect(task?.payload.metadata?.originator).toEqual(eventOriginator);
   });
 
   it('skips task creation when thread message_count >= 100', async () => {

--- a/tests/unit/dispatch/bullpen-dispatcher.test.ts
+++ b/tests/unit/dispatch/bullpen-dispatcher.test.ts
@@ -99,6 +99,45 @@ describe('BullpenDispatcher', () => {
     expect(cTask?.payload.metadata?.mentioned).toBe(false);
   });
 
+  it('forwards originator from discuss event to task metadata', async () => {
+    const { thread } = await bullpenService.openThread(
+      'Originator test', 'coordinator', ['coordinator', 'agent-b'], 'Hi', ['agent-b'],
+    );
+    const originator = {
+      contactId: 'ceo-contact-id',
+      systemRole: 'principal' as const,
+      channel: 'email',
+      initiatedAt: '2026-05-01T10:00:00.000Z',
+    };
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-1', topic: 'Originator test',
+      senderAgentId: 'coordinator', participants: ['coordinator', 'agent-b'],
+      mentionedAgentIds: ['agent-b'], content: 'Hi', originator, parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    const task = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .find(([_l, e]) => (e as { type: string }).type === 'agent.task')?.[1] as
+      { payload: { metadata: Record<string, unknown> } };
+    expect(task?.payload.metadata?.originator).toEqual(originator);
+  });
+
+  it('omits originator from task metadata when discuss event has none', async () => {
+    const { thread } = await bullpenService.openThread(
+      'No originator', 'coordinator', ['coordinator', 'agent-b'], 'Hi', [],
+    );
+    const event = createAgentDiscuss({
+      threadId: thread.id, messageId: 'msg-1', topic: 'No originator',
+      senderAgentId: 'coordinator', participants: ['coordinator', 'agent-b'],
+      mentionedAgentIds: ['agent-b'], content: 'Hi', parentEventId: 'task-1',
+    });
+    await bus._trigger('agent.discuss', event);
+    const task = (bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .find(([_l, e]) => (e as { type: string }).type === 'agent.task')?.[1] as
+      { payload: { metadata: Record<string, unknown> } };
+    // originator key should be absent — not present as undefined
+    expect(task?.payload.metadata).not.toHaveProperty('originator');
+  });
+
   it('skips task creation when thread message_count >= 100', async () => {
     const { thread } = await bullpenService.openThread(
       'Cap test', 'coordinator', ['coordinator', 'agent-b'], 'Start', [],

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -406,6 +406,38 @@ describe('Scheduler', () => {
     });
   });
 
+  // -- originator propagation --
+
+  describe('originator propagation', () => {
+    it('stamps originator from stored job row onto the fired agent.task', async () => {
+      const originator = {
+        contactId: 'ceo-contact-id',
+        systemRole: 'principal',
+        channel: 'email',
+        initiatedAt: '2026-05-01T10:00:00.000Z',
+      };
+      const row = fakeDbRow({ originator });
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] }); // claim
+
+      await scheduler.pollDueJobs();
+
+      const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { metadata?: Record<string, unknown> } }];
+      expect(taskEvent.payload.metadata?.originator).toEqual(originator);
+    });
+
+    it('omits metadata from fired agent.task when job has no originator', async () => {
+      const row = fakeDbRow({ originator: null });
+      pool.query.mockResolvedValueOnce({ rows: [row] });
+      pool.query.mockResolvedValueOnce({ rowCount: 1, rows: [] }); // claim
+
+      await scheduler.pollDueJobs();
+
+      const [, taskEvent] = bus.publish.mock.calls[1] as [string, { payload: { metadata?: Record<string, unknown> } }];
+      expect(taskEvent.payload.metadata).toBeUndefined();
+    });
+  });
+
   // -- completion tracking --
 
   describe('handleCompletion (via bus subscribers)', () => {

--- a/tests/unit/skills/delegate.test.ts
+++ b/tests/unit/skills/delegate.test.ts
@@ -192,4 +192,69 @@ describe('DelegateHandler', () => {
       expect(data.response).toContain('research findings');
     }
   });
+
+  it('forwards originator from taskMetadata into the specialist task metadata', async () => {
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main' });
+    agentRegistry.register('research-analyst', { role: 'specialist', description: 'Research' });
+    const bus = new EventBus(logger);
+
+    const originator = {
+      contactId: 'ceo-contact-id',
+      systemRole: 'principal' as const,
+      channel: 'email',
+      initiatedAt: '2026-05-01T10:00:00.000Z',
+    };
+
+    let capturedMetadata: Record<string, unknown> | undefined;
+    bus.subscribe('agent.task', 'agent', async (event) => {
+      if (event.type === 'agent.task' && event.payload.agentId === 'research-analyst') {
+        capturedMetadata = event.payload.metadata as Record<string, unknown> | undefined;
+        const { createAgentResponse } = await import('../../../src/bus/events.js');
+        await bus.publish('agent', createAgentResponse({
+          agentId: 'research-analyst',
+          conversationId: event.payload.conversationId,
+          content: 'Done',
+          parentEventId: event.id,
+        }));
+      }
+    });
+
+    const result = await handler.execute(makeCtx(
+      { agent: 'research-analyst', task: 'Research AI trends' },
+      { bus, agentRegistry, taskMetadata: { originator } },
+    ));
+
+    expect(result.success).toBe(true);
+    expect(capturedMetadata?.originator).toEqual(originator);
+  });
+
+  it('sets metadata to undefined on specialist task when no originator in parent', async () => {
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main' });
+    agentRegistry.register('research-analyst', { role: 'specialist', description: 'Research' });
+    const bus = new EventBus(logger);
+
+    let capturedMetadata: Record<string, unknown> | undefined = { sentinel: true };
+    bus.subscribe('agent.task', 'agent', async (event) => {
+      if (event.type === 'agent.task' && event.payload.agentId === 'research-analyst') {
+        capturedMetadata = event.payload.metadata as Record<string, unknown> | undefined;
+        const { createAgentResponse } = await import('../../../src/bus/events.js');
+        await bus.publish('agent', createAgentResponse({
+          agentId: 'research-analyst',
+          conversationId: event.payload.conversationId,
+          content: 'Done',
+          parentEventId: event.id,
+        }));
+      }
+    });
+
+    await handler.execute(makeCtx(
+      { agent: 'research-analyst', task: 'Research AI trends' },
+      { bus, agentRegistry },
+    ));
+
+    // No originator in parent task → specialist task should have no metadata
+    expect(capturedMetadata).toBeUndefined();
+  });
 });

--- a/tests/unit/skills/scheduler-create.test.ts
+++ b/tests/unit/skills/scheduler-create.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { SchedulerCreateHandler } from '../../../skills/scheduler-create/handler.js';
 import type { SkillContext } from '../../../src/skills/types.js';
+import type { TaskOriginator } from '../../../src/contacts/types.js';
 
 import pino from 'pino';
 
@@ -79,6 +80,7 @@ describe('SchedulerCreateHandler', () => {
       createdBy: 'coordinator',
       intentAnchor: undefined,
       errorBudget: undefined,
+      originator: undefined,
     });
   });
 
@@ -105,6 +107,7 @@ describe('SchedulerCreateHandler', () => {
       createdBy: 'research-analyst',
       intentAnchor: undefined,
       errorBudget: undefined,
+      originator: undefined,
     });
   });
 
@@ -140,6 +143,7 @@ describe('SchedulerCreateHandler', () => {
       createdBy: 'coordinator',
       intentAnchor: 'weekly-report-v1',
       errorBudget: { maxRetries: 3 },
+      originator: undefined,
     });
   });
 
@@ -159,5 +163,53 @@ describe('SchedulerCreateHandler', () => {
     if (!result.success) {
       expect(result.error).toContain('DB connection lost');
     }
+  });
+
+  it('passes originator from taskMetadata to createJob', async () => {
+    const originator: TaskOriginator = {
+      contactId: 'ceo-contact-id',
+      systemRole: 'principal',
+      channel: 'email',
+      initiatedAt: '2026-05-01T10:00:00.000Z',
+    };
+    const createResult = { jobId: 'job-4' };
+    const schedulerService = {
+      createJob: vi.fn().mockResolvedValue(createResult),
+      listJobs: vi.fn(),
+      cancelJob: vi.fn(),
+    };
+
+    const result = await handler.execute(makeCtx(
+      { task: 'birthday email', run_at: '2026-05-14T10:00:00Z' },
+      {
+        schedulerService: schedulerService as never,
+        taskMetadata: { originator },
+      },
+    ));
+
+    expect(result.success).toBe(true);
+    expect(schedulerService.createJob).toHaveBeenCalledWith(
+      expect.objectContaining({ originator }),
+    );
+  });
+
+  it('passes originator: undefined when taskMetadata has no originator', async () => {
+    const createResult = { jobId: 'job-5' };
+    const schedulerService = {
+      createJob: vi.fn().mockResolvedValue(createResult),
+      listJobs: vi.fn(),
+      cancelJob: vi.fn(),
+    };
+
+    await handler.execute(makeCtx(
+      { task: 'no-originator job', cron_expr: '0 9 * * *' },
+      {
+        schedulerService: schedulerService as never,
+        taskMetadata: { someOtherField: 'value' },
+      },
+    ));
+
+    const call = schedulerService.createJob.mock.calls[0]?.[0] as { originator?: unknown };
+    expect(call?.originator).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Closes #504

- **Scheduler** — `originator` stored as `JSONB` on `scheduled_jobs` at creation time (migration `040`); restored onto the fired `agent.task` metadata so `isPrincipalOriginated()` works correctly at fire time
- **Delegate skill** — forwards `ctx.taskMetadata.originator` into the specialist's `agent.task` metadata so the originator survives the coordinator→specialist boundary
- **Bullpen** — adds an optional `originator` field to `AgentDiscussPayload`; both `post` and `reply` actions forward it from `ctx.taskMetadata`; `BullpenDispatcher` stamps it on the per-participant `agent.task` events it spawns

Scheduler notification tasks (drift-pause, suspension) are intentionally excluded — those are system alerts, not user-initiated work. Declarative YAML-defined jobs keep `null` originator for now (tracked separately).

Also adds a TODO comment referencing #558 (store originator on `bullpen_threads`) so the poll-path fallback can eventually recover the originator too.

## Files changed

| File | Change |
|------|--------|
| `src/db/migrations/040_add_scheduled_jobs_originator.sql` | New migration — nullable JSONB originator column |
| `src/scheduler/scheduler-service.ts` | CreateJobParams / JobRow / mapJobRow / createJob INSERT all gain originator |
| `src/scheduler/scheduler.ts` | pollDueJobs inline mapping + fireJob — restore originator onto fired task metadata |
| `skills/scheduler-create/handler.ts` | Capture originator from ctx.taskMetadata and pass to createJob |
| `skills/delegate/handler.ts` | Forward originator into specialist task metadata |
| `src/bus/events.ts` | AgentDiscussPayload gains optional originator field |
| `skills/bullpen/handler.ts` | Both post and reply actions forward originator; originatorLost flag on publish-failure logs |
| `src/dispatch/bullpen-dispatcher.ts` | Stamp originator on per-participant task events |
| Tests | 8 new unit tests across scheduler, delegate, bullpen-dispatcher, scheduler-create |
| `CHANGELOG.md` | Entry under Fixed |

## Test plan

- [x] scheduler-create: originator passed to createJob; no originator when none in parent
- [x] delegate: originator in specialist task metadata; metadata undefined when no originator
- [x] bullpen-dispatcher: originator forwarded to participant tasks; omitted when absent
- [x] scheduler: originator stamped on fired task; metadata undefined when job has no originator
- [x] All 71 affected unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected task originator propagation across scheduling, delegation, and bullpen flows so principal-authorized work is preserved for deferred, delegated and poll-fallback scenarios (fixes authorization tracking).

* **Chores**
  * Added persistence and schema support for storing originator data and extended tests to cover propagation and fallback behaviours.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/559)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->