### PR TITLE
chore: release v0.28.0 — "Thufir Hawat"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,28 +13,40 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+---
+
+## [0.28.0] — 2026-05-14 — "Thufir Hawat"
+
+> **Thufir Hawat** *(Dune, 1965, Frank Herbert)* — the Mentat Master of Assassins for House Atreides. A human computer who weighs every variable, tracks every cost, and routes intelligence through strict chains of command. His value is knowing exactly where resources are spent and what each capability costs — and never allocating more than the mission requires.
+
 ### Added
 
-- **LLM token tracking** — every successful Anthropic API call now publishes a structured `llm.call` bus event with full model provenance, token counts (including prompt-cache breakdown), estimated cost, latency, and SHA-256 content fingerprints. Events land in `audit_log` via the existing audit logger, enabling per-agent attribution and data-driven context budgeting. (closes #326, prerequisite for #24)
-- **Context budget** — token-aware context assembly with per-tier budgeting and automatic estimation. Publishes `context.budget` events after each LLM call with per-tier token estimates, utilization percentage, and which tiers were dropped — preventing silent context-window overflow on large conversations. (#24)
+- **LLM token tracking** — every Anthropic API call publishes a structured `llm.call` bus event with token counts, prompt-cache breakdown, estimated cost, and content fingerprints — enabling per-agent attribution. (closes #326)
+- **Context budget** — token-aware context assembly with per-tier budgeting, automatic estimation, and `context.budget` events that flag which tiers were dropped. (#24)
 
 ### Changed
 
 - **Model routing** — agents declare `model.tier` instead of a specific model; operator maps tiers centrally (ADR-014). (#260)
-- **Cache token fields** — `LLMUsage` and `LlmCallPayload` extended with `cacheCreationInputTokens` and `cacheReadInputTokens` (previously silently dropped from the Anthropic API response). `providerRequestId` comment corrected to reflect response body id (`msg_xxx`).
+- **Cache token fields** — `LLMUsage` and `LlmCallPayload` extended with `cacheCreationInputTokens` and `cacheReadInputTokens`, previously silently dropped.
 - **`security.trust_thresholds` config** — action thresholds moved from hardcoded coordinator text to config; startup fails if missing or malformed.
-- **Compiled security context block** — four security sections extracted from `coordinator.yaml` into a runtime-injected `${security_context_block}`, always present regardless of coordinator customization.
+- **Compiled security context block** — four security sections extracted from `coordinator.yaml` into a runtime-injected `${security_context_block}`, always present.
 
 ### Fixed
 
-- **`TaskOriginator` through delegation boundaries** — originator now propagates through scheduler, delegate, and bullpen (including the poll-fallback path) so `isPrincipalOriginated()` works correctly. (closes #504)
-- **Declarative job drift detection** — declarative (YAML-defined) scheduled jobs now support `intent_anchor`, enabling drift detection. Previously ignored at upsert time, causing the drift detector to silently skip all YAML jobs. (closes #416)
-- **Google Workspace tools** — doc creation, editing, formatting, sharing, and Drive tools now reliably available to the coordinator without manual discovery. (#497)
+- **`TaskOriginator` through delegation boundaries** — originator now propagates through scheduler, delegate, and bullpen so `isPrincipalOriginated()` works correctly. (closes #504)
+- **Declarative job drift detection** — YAML-defined scheduled jobs now support `intent_anchor`, enabling drift detection previously silently skipped. (closes #416)
+- **Google Workspace tools** — doc creation, editing, formatting, sharing, and Drive tools reliably available without manual discovery. (#497)
 - **`extract-facts`** — programming errors in the per-fact loop now re-throw instead of being silently swallowed. (#493)
 
 ### Removed
 
 - **`trust_policy` config key** — dead config removed; replaced by `security.trust_thresholds`.
+
+---
+
+*count before you speak —*
+*the right mind for every task;*
+*cost writes its ledger.*
 
 ---
 
@@ -689,7 +701,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Bootstrap orchestrator** — `src/index.ts` wires all layers in dependency order
 - Architecture specs 00–08, contributor docs (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
 
-[Unreleased]: https://github.com/josephfung/curia/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/josephfung/curia/compare/v0.28.0...HEAD
+[0.28.0]: https://github.com/josephfung/curia/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/josephfung/curia/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/josephfung/curia/compare/v0.25.1...v0.26.0
 [0.25.1]: https://github.com/josephfung/curia/compare/v0.25.0...v0.25.1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.27.0-blueviolet" alt="Version: 0.27.0" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.28.0-blueviolet" alt="Version: 0.28.0" /></a>
   <img src="https://img.shields.io/badge/status-pre--alpha-orange" alt="Status: Pre-Alpha" />
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License: MIT" />
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node >= 22" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "packageManager": "pnpm@11.0.8",


### PR DESCRIPTION
> **Thufir Hawat** *(Dune, 1965, Frank Herbert)* — the Mentat Master of Assassins for House Atreides. A human computer who weighs every variable, tracks every cost, and routes intelligence through strict chains of command. His value is knowing exactly where resources are spent and what each capability costs — and never allocating more than the mission requires.

## [0.28.0] — 2026-05-14 — "Thufir Hawat"

### Added

- **LLM token tracking** — every Anthropic API call publishes a structured `llm.call` bus event with token counts, prompt-cache breakdown, estimated cost, and content fingerprints — enabling per-agent attribution. (closes #326)
- **Context budget** — token-aware context assembly with per-tier budgeting, automatic estimation, and `context.budget` events that flag which tiers were dropped. (#24)

### Changed

- **Model routing** — agents declare `model.tier` instead of a specific model; operator maps tiers centrally (ADR-014). (#260)
- **Cache token fields** — `LLMUsage` and `LlmCallPayload` extended with `cacheCreationInputTokens` and `cacheReadInputTokens`, previously silently dropped.
- **`security.trust_thresholds` config** — action thresholds moved from hardcoded coordinator text to config; startup fails if missing or malformed.
- **Compiled security context block** — four security sections extracted from `coordinator.yaml` into a runtime-injected `${security_context_block}`, always present.

### Fixed

- **`TaskOriginator` through delegation boundaries** — originator now propagates through scheduler, delegate, and bullpen so `isPrincipalOriginated()` works correctly. (closes #504)
- **Declarative job drift detection** — YAML-defined scheduled jobs now support `intent_anchor`, enabling drift detection previously silently skipped. (closes #416)
- **Google Workspace tools** — doc creation, editing, formatting, sharing, and Drive tools reliably available without manual discovery. (#497)
- **`extract-facts`** — programming errors in the per-fact loop now re-throw instead of being silently swallowed. (#493)

### Removed

- **`trust_policy` config key** — dead config removed; replaced by `security.trust_thresholds`.

---

*count before you speak —*
*the right mind for every task;*
*cost writes its ledger.*