### PR TITLE
feat: add email folder management and read-state skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **`email-label`** — apply Gmail labels to messages in any configured email account, creating labels that don't yet exist.
+- **`email-mark-read`** — mark messages as read in any configured email account.
+
 ---
 
 ## [0.28.0] — 2026-05-14 — "Thufir Hawat"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **`email-label`** — apply Gmail labels to messages in any configured email account, creating labels that don't yet exist.
+- **`email-list-folders`** — list all folders and labels in an email account.
+- **`email-create-folder`** — create a new folder or label in an email account.
 - **`email-mark-read`** — mark messages as read in any configured email account.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **`email-label`** — apply Gmail labels to messages in any configured email account, creating labels that don't yet exist.
-- **`email-list-folders`** — list all folders and labels in an email account.
-- **`email-create-folder`** — create a new folder or label in an email account.
-- **`email-mark-read`** — mark messages as read in any configured email account.
+- **Email folder management skills** — `email-label`, `email-list-folders`, `email-create-folder`, and `email-mark-read` expose Nylas folder and read-state operations as general-purpose skills.
 
 ---
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -492,6 +492,8 @@ pinned_skills:
   - email-list
   - email-get
   - email-draft-save
+  - email-label
+  - email-mark-read
   - send-draft
   - signal-send
   - held-messages-list

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -493,6 +493,8 @@ pinned_skills:
   - email-get
   - email-draft-save
   - email-label
+  - email-list-folders
+  - email-create-folder
   - email-mark-read
   - send-draft
   - signal-send

--- a/skills/email-create-folder/handler.ts
+++ b/skills/email-create-folder/handler.ts
@@ -1,0 +1,46 @@
+// handler.ts — email-create-folder skill implementation.
+//
+// Creates a new folder/label in an email account via OutboundGateway.
+// For Gmail, this creates a user-defined label.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class EmailCreateFolderHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { name: rawName, account } = ctx.input as {
+      name?: string;
+      account?: string;
+    };
+
+    const name = typeof rawName === 'string' ? rawName.trim() : undefined;
+
+    if (!name) {
+      return { success: false, error: 'Missing required input: name (string)' };
+    }
+
+    if (!ctx.outboundGateway) {
+      return {
+        success: false,
+        error: 'email-create-folder requires outboundGateway (capabilities: ["outboundGateway"])',
+      };
+    }
+
+    const trimmedAccount = typeof account === 'string' ? account.trim() : '';
+    const accountId = trimmedAccount.length > 0 ? trimmedAccount : undefined;
+
+    ctx.log.info({ name, accountId }, 'Creating email folder');
+
+    try {
+      const folder = await ctx.outboundGateway.createEmailFolder(name, accountId);
+
+      ctx.log.info({ folderId: folder.id, name: folder.name, accountId }, 'Email folder created');
+      return {
+        success: true,
+        data: { id: folder.id, name: folder.name },
+      };
+    } catch (err) {
+      ctx.log.error({ err, name, accountId }, 'email-create-folder: failed to create folder');
+      return { success: false, error: 'Failed to create folder' };
+    }
+  }
+}

--- a/skills/email-create-folder/skill.json
+++ b/skills/email-create-folder/skill.json
@@ -1,0 +1,21 @@
+{
+  "name": "email-create-folder",
+  "description": "Create a new folder or label in an email account. For Gmail, creates a user-defined label. Returns the folder ID and name. Idempotent — if a label with the same name already exists in Gmail, the provider may return it or error depending on the backend.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "name": "string (the folder/label name to create, e.g. 'SECURITY')",
+    "account": "string? (named account, e.g. 'curia'; defaults to the primary account if omitted)"
+  },
+  "outputs": {
+    "id": "string (Nylas folder ID)",
+    "name": "string (folder name as created)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": [
+    "outboundGateway"
+  ]
+}

--- a/skills/email-label/handler.ts
+++ b/skills/email-label/handler.ts
@@ -1,0 +1,72 @@
+// handler.ts — email-label skill implementation.
+//
+// Applies one or more labels (Gmail folders) to an email message via the
+// OutboundGateway. Creates labels that don't yet exist. Preserves all
+// existing labels on the message (merge, not replace).
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class EmailLabelHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const input =
+      ctx.input && typeof ctx.input === 'object' ? (ctx.input as Record<string, unknown>) : {};
+
+    const rawMessageId = input.message_id;
+    const messageId = typeof rawMessageId === 'string' ? rawMessageId.trim() : undefined;
+
+    if (!messageId) {
+      return { success: false, error: 'Missing required input: message_id (string)' };
+    }
+
+    const labels = Array.isArray(input.labels)
+      ? input.labels
+          .filter((l): l is string => typeof l === 'string' && l.trim().length > 0)
+          .map((l) => l.trim())
+      : [];
+
+    if (labels.length === 0) {
+      return { success: false, error: 'labels array is required and must contain at least one label' };
+    }
+
+    if (!ctx.outboundGateway) {
+      return {
+        success: false,
+        error: 'email-label requires outboundGateway (capabilities: ["outboundGateway"])',
+      };
+    }
+
+    const account = input.account;
+    const trimmedAccount = typeof account === 'string' ? account.trim() : '';
+    const accountId = trimmedAccount.length > 0 ? trimmedAccount : undefined;
+
+    ctx.log.info({ messageId, labels, accountId }, 'Applying labels to email');
+
+    let result: { success: boolean; applied: string[]; created: string[]; folders: string[]; error?: string };
+    try {
+      result = await ctx.outboundGateway.labelEmailMessage(messageId, labels, accountId);
+    } catch (err) {
+      ctx.log.error({ err, messageId, labels, accountId }, 'email-label: unexpected error from gateway');
+      return { success: false, error: 'Label operation failed' };
+    }
+
+    if (!result.success) {
+      ctx.log.error({ messageId, labels, accountId, error: result.error }, 'Failed to apply labels');
+      return { success: false, error: result.error ?? 'Label operation failed' };
+    }
+
+    ctx.log.info(
+      { messageId, applied: result.applied, created: result.created, accountId },
+      'Labels applied successfully',
+    );
+
+    return {
+      success: true,
+      data: {
+        message_id: messageId,
+        applied: result.applied,
+        created: result.created,
+        folders: result.folders,
+      },
+    };
+  }
+}

--- a/skills/email-label/skill.json
+++ b/skills/email-label/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "email-label",
+  "description": "Apply one or more labels to an email message. Resolves label names to Gmail folder IDs, creating any labels that do not yet exist. Preserves existing labels on the message.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "message_id": "string (Nylas message ID to label)",
+    "labels": "string[] (label names to apply, e.g. ['SECURITY', 'URGENT'])",
+    "account": "string? (named account, e.g. 'curia'; defaults to the primary account if omitted)"
+  },
+  "outputs": {
+    "message_id": "string",
+    "applied": "string[] (labels successfully applied)",
+    "created": "string[] (labels that were newly created)",
+    "folders": "string[] (full folder list after update)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 30000,
+  "capabilities": [
+    "outboundGateway"
+  ]
+}

--- a/skills/email-list-folders/handler.ts
+++ b/skills/email-list-folders/handler.ts
@@ -1,0 +1,37 @@
+// handler.ts — email-list-folders skill implementation.
+//
+// Lists all folders/labels in an email account via OutboundGateway.
+// Read-only operation — no side effects.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class EmailListFoldersHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.outboundGateway) {
+      return {
+        success: false,
+        error: 'email-list-folders requires outboundGateway (capabilities: ["outboundGateway"])',
+      };
+    }
+
+    const { account } = ctx.input as { account?: string };
+    const trimmedAccount = typeof account === 'string' ? account.trim() : '';
+    const accountId = trimmedAccount.length > 0 ? trimmedAccount : undefined;
+
+    ctx.log.info({ accountId }, 'Listing email folders');
+
+    try {
+      const folders = await ctx.outboundGateway.listEmailFolders(accountId);
+      return {
+        success: true,
+        data: {
+          folders: folders.map((f) => ({ id: f.id, name: f.name })),
+          count: folders.length,
+        },
+      };
+    } catch (err) {
+      ctx.log.error({ err, accountId }, 'email-list-folders: failed to list folders');
+      return { success: false, error: 'Failed to list folders' };
+    }
+  }
+}

--- a/skills/email-list-folders/skill.json
+++ b/skills/email-list-folders/skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "email-list-folders",
+  "description": "List all folders and labels in an email account. For Gmail, returns both system folders (INBOX, SENT, DRAFTS, etc.) and user-created labels. Useful for checking whether a label exists before applying it.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "account": "string? (named account, e.g. 'curia'; defaults to the primary account if omitted)"
+  },
+  "outputs": {
+    "folders": "object[] (each with id and name)",
+    "count": "number"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": [
+    "outboundGateway"
+  ]
+}

--- a/skills/email-mark-read/handler.ts
+++ b/skills/email-mark-read/handler.ts
@@ -1,0 +1,48 @@
+// handler.ts — email-mark-read skill implementation.
+//
+// Marks an email as read via the OutboundGateway. Used after triage or
+// processing to prevent re-processing on subsequent polling runs.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+
+export class EmailMarkReadHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { message_id: rawMessageId, account } = ctx.input as {
+      message_id?: string;
+      account?: string;
+    };
+
+    const messageId = typeof rawMessageId === 'string' ? rawMessageId.trim() : undefined;
+
+    if (!messageId) {
+      return { success: false, error: 'Missing required input: message_id (string)' };
+    }
+
+    if (!ctx.outboundGateway) {
+      return {
+        success: false,
+        error: 'email-mark-read requires outboundGateway (capabilities: ["outboundGateway"])',
+      };
+    }
+
+    const trimmedAccount = typeof account === 'string' ? account.trim() : '';
+    const accountId = trimmedAccount.length > 0 ? trimmedAccount : undefined;
+
+    ctx.log.info({ messageId, accountId }, 'Marking email as read');
+
+    let result: { success: boolean; error?: string };
+    try {
+      result = await ctx.outboundGateway.markEmailAsRead(messageId, accountId);
+    } catch (err) {
+      ctx.log.error({ err, messageId, accountId }, 'email-mark-read: unexpected error from gateway');
+      return { success: false, error: 'Mark as read failed' };
+    }
+
+    if (!result.success) {
+      ctx.log.error({ messageId, accountId, error: result.error }, 'Failed to mark email as read');
+      return { success: false, error: result.error ?? 'Mark as read failed' };
+    }
+
+    return { success: true, data: { marked_read: true } };
+  }
+}

--- a/skills/email-mark-read/skill.json
+++ b/skills/email-mark-read/skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "email-mark-read",
+  "description": "Mark an email message as read. Call after processing a message to prevent re-processing on subsequent triage runs.",
+  "version": "1.0.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "message_id": "string (Nylas message ID to mark as read)",
+    "account": "string? (named account, e.g. 'curia'; defaults to the primary account if omitted)"
+  },
+  "outputs": {
+    "marked_read": "boolean — true when the message was successfully marked as read"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 10000,
+  "capabilities": [
+    "outboundGateway"
+  ]
+}

--- a/src/channels/email/nylas-client.ts
+++ b/src/channels/email/nylas-client.ts
@@ -13,10 +13,12 @@
 import NylasDefault from 'nylas';
 import type {
   Message as NylasSdkMessage,
+  Folder as NylasSdkFolder,
   ListMessagesQueryParams,
   NylasResponse,
   NylasListResponse,
   SendMessageRequest,
+  CreateFolderRequest,
   MessageFields,
   Draft as NylasDraft,
   CreateDraftRequest,
@@ -68,6 +70,16 @@ interface NylasLike {
       draftId: string;
     }): Promise<NylasResponse<NylasSdkMessage>>;
   };
+  folders: {
+    list(params: {
+      identifier: string;
+    }): Promise<NylasListResponse<NylasSdkFolder>>;
+
+    create(params: {
+      identifier: string;
+      requestBody: CreateFolderRequest;
+    }): Promise<NylasResponse<NylasSdkFolder>>;
+  };
 }
 
 /**
@@ -100,6 +112,15 @@ export interface NylasMessage {
    * Used by the email adapter to extract Authentication-Results for SPF/DKIM/DMARC validation.
    */
   headers?: Array<{ name: string; value: string }>;
+}
+
+/**
+ * Simplified folder/label shape — normalized from the Nylas SDK's Folder type.
+ * Used by skills that need to list, create, or reference email folders.
+ */
+export interface NylasFolder {
+  id: string;
+  name: string;
 }
 
 export interface SendEmailOptions {
@@ -366,6 +387,86 @@ export class NylasClient {
       this.log.info({ messageId, updatedFolders: currentFolders }, 'message archived successfully');
     } catch (err) {
       this.log.error({ err, grantId: this.grantId, messageId }, 'Nylas messages.update failed during archive');
+      throw err;
+    }
+  }
+
+  /**
+   * Mark a message as read by setting its unread flag to false.
+   */
+  async markAsRead(messageId: string): Promise<void> {
+    this.log.debug({ messageId }, 'marking message as read');
+
+    try {
+      await this.nylas.messages.update({
+        identifier: this.grantId,
+        messageId,
+        requestBody: { unread: false },
+      });
+      this.log.info({ messageId }, 'message marked as read');
+    } catch (err) {
+      this.log.error({ err, grantId: this.grantId, messageId }, 'Nylas markAsRead failed');
+      throw err;
+    }
+  }
+
+  /**
+   * List all folders/labels in the email account.
+   * For Gmail, this returns both system folders (INBOX, SENT, etc.) and user-created labels.
+   */
+  async listFolders(): Promise<NylasFolder[]> {
+    this.log.debug('listing folders');
+
+    try {
+      const response = await this.nylas.folders.list({
+        identifier: this.grantId,
+      });
+      return response.data.map((f) => ({ id: f.id, name: f.name }));
+    } catch (err) {
+      this.log.error({ err, grantId: this.grantId }, 'Nylas listFolders failed');
+      throw err;
+    }
+  }
+
+  /**
+   * Create a new folder/label. For Gmail, this creates a user label.
+   */
+  async createFolder(name: string): Promise<NylasFolder> {
+    this.log.debug({ name }, 'creating folder');
+
+    try {
+      const response = await this.nylas.folders.create({
+        identifier: this.grantId,
+        requestBody: { name },
+      });
+      this.log.info({ folderId: response.data.id, name }, 'folder created');
+      return { id: response.data.id, name: response.data.name };
+    } catch (err) {
+      this.log.error({ err, grantId: this.grantId, name }, 'Nylas createFolder failed');
+      throw err;
+    }
+  }
+
+  /**
+   * Replace a message's folder list with the given folder IDs.
+   *
+   * This is a low-level operation — callers are responsible for preserving
+   * existing folders they want to keep. See OutboundGateway.labelEmailMessage()
+   * for the higher-level label-resolution-and-merge workflow.
+   */
+  async updateMessageFolders(messageId: string, folders: string[]): Promise<NylasMessage> {
+    this.log.debug({ messageId, folders }, 'updating message folders');
+
+    try {
+      const response = await this.nylas.messages.update({
+        identifier: this.grantId,
+        messageId,
+        requestBody: { folders },
+      });
+      this.log.info({ messageId, folders }, 'message folders updated');
+      return this.normalizeMessage(response.data);
+    } catch (err) {
+      this.log.error({ err, grantId: this.grantId, messageId }, 'Nylas updateMessageFolders failed');
       throw err;
     }
   }

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -1312,6 +1312,34 @@ export class OutboundGateway {
   }
 
   /**
+   * List all folders/labels in an email account.
+   * For Gmail, returns both system folders (INBOX, SENT, etc.) and user-created labels.
+   */
+  async listEmailFolders(
+    accountId?: string,
+  ): Promise<NylasFolder[]> {
+    const client = this.getNylasClient(accountId);
+    if (!client) {
+      throw new Error(`outbound-gateway: listEmailFolders called but no email client configured for account: ${accountId ?? 'primary'}`);
+    }
+    return client.listFolders();
+  }
+
+  /**
+   * Create a new folder/label in an email account. For Gmail, creates a user label.
+   */
+  async createEmailFolder(
+    name: string,
+    accountId?: string,
+  ): Promise<NylasFolder> {
+    const client = this.getNylasClient(accountId);
+    if (!client) {
+      throw new Error(`outbound-gateway: createEmailFolder called but no email client configured for account: ${accountId ?? 'primary'}`);
+    }
+    return client.createFolder(name);
+  }
+
+  /**
    * Mark an email message as read.
    */
   async markEmailAsRead(

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -1359,6 +1359,12 @@ export class OutboundGateway {
       };
     }
 
+    // Declared outside try so partial progress is reported on failure.
+    // If label creation succeeds (commits server-side) but a later step fails,
+    // the caller still sees which labels were created as a side effect.
+    const created: string[] = [];
+    const resolvedIds: string[] = [];
+
     try {
       // Step 1: List existing folders to build a name → ID lookup
       const existingFolders = await client.listFolders();
@@ -1367,9 +1373,6 @@ export class OutboundGateway {
       );
 
       // Step 2: Resolve each label to a folder ID, creating if needed
-      const created: string[] = [];
-      const resolvedIds: string[] = [];
-
       for (const label of labels) {
         const key = label.toUpperCase();
         let folder = foldersByName.get(key);
@@ -1406,8 +1409,8 @@ export class OutboundGateway {
 
       return { success: true, applied: labels, created, folders: finalFolders };
     } catch (err) {
-      this.log.error({ err, messageId, labels, accountId }, 'outbound-gateway: labelEmailMessage failed');
-      return { success: false, applied: [], created: [], folders: [], error: 'Label operation failed' };
+      this.log.error({ err, messageId, labels, accountId, created }, 'outbound-gateway: labelEmailMessage failed');
+      return { success: false, applied: [], created, folders: [], error: 'Label operation failed' };
     }
   }
 

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -20,7 +20,7 @@
 //   run for all channels before dispatch.
 
 import { randomUUID } from 'node:crypto';
-import type { NylasClient, NylasMessage, ListMessagesOptions, SendEmailOptions } from '../channels/email/nylas-client.js';
+import type { NylasClient, NylasMessage, NylasFolder, ListMessagesOptions, SendEmailOptions } from '../channels/email/nylas-client.js';
 import type { SignalRpcClient } from '../channels/signal/signal-rpc-client.js';
 import type { ContactService } from '../contacts/contact-service.js';
 import type { TrustLevel, ChannelIdentity } from '../contacts/types.js';
@@ -1308,6 +1308,106 @@ export class OutboundGateway {
     } catch (err) {
       this.log.error({ err, messageId, accountId }, 'outbound-gateway: archiveEmailMessage failed');
       return { success: false, error: 'Archive failed' };
+    }
+  }
+
+  /**
+   * Mark an email message as read.
+   */
+  async markEmailAsRead(
+    messageId: string,
+    accountId?: string,
+  ): Promise<{ success: boolean; error?: string }> {
+    const client = this.getNylasClient(accountId);
+    if (!client) {
+      return {
+        success: false,
+        error: `No email client configured for account: ${accountId ?? 'primary'}`,
+      };
+    }
+
+    try {
+      await client.markAsRead(messageId);
+      this.log.info({ messageId, accountId }, 'outbound-gateway: message marked as read');
+      return { success: true };
+    } catch (err) {
+      this.log.error({ err, messageId, accountId }, 'outbound-gateway: markEmailAsRead failed');
+      return { success: false, error: 'Mark as read failed' };
+    }
+  }
+
+  /**
+   * Apply one or more labels to an email message. Resolves label names to Gmail
+   * folder IDs, creating any labels that don't yet exist. Preserves existing
+   * folders on the message (merge, not replace).
+   *
+   * @returns Applied and created label names, or an error.
+   */
+  async labelEmailMessage(
+    messageId: string,
+    labels: string[],
+    accountId?: string,
+  ): Promise<{ success: boolean; applied: string[]; created: string[]; folders: string[]; error?: string }> {
+    const client = this.getNylasClient(accountId);
+    if (!client) {
+      return {
+        success: false,
+        applied: [],
+        created: [],
+        folders: [],
+        error: `No email client configured for account: ${accountId ?? 'primary'}`,
+      };
+    }
+
+    try {
+      // Step 1: List existing folders to build a name → ID lookup
+      const existingFolders = await client.listFolders();
+      const foldersByName = new Map<string, NylasFolder>(
+        existingFolders.map((f) => [f.name.toUpperCase(), f]),
+      );
+
+      // Step 2: Resolve each label to a folder ID, creating if needed
+      const created: string[] = [];
+      const resolvedIds: string[] = [];
+
+      for (const label of labels) {
+        const key = label.toUpperCase();
+        let folder = foldersByName.get(key);
+
+        if (!folder) {
+          this.log.info({ label, accountId }, 'outbound-gateway: creating new label');
+          folder = await client.createFolder(label);
+          foldersByName.set(key, folder);
+          created.push(label);
+        }
+
+        resolvedIds.push(folder.id);
+      }
+
+      // Step 3: Read current message folders
+      const msg = await client.getMessage(messageId);
+      const currentFolders = new Set(msg.folders);
+
+      // Step 4: Merge — add new folder IDs without removing existing ones
+      for (const id of resolvedIds) {
+        currentFolders.add(id);
+      }
+
+      const mergedFolders = [...currentFolders];
+
+      // Step 5: Write back the merged folder set
+      const result = await client.updateMessageFolders(messageId, mergedFolders);
+      const finalFolders = result.folders.length > 0 ? result.folders : mergedFolders;
+
+      this.log.info(
+        { messageId, applied: labels, created, accountId },
+        'outbound-gateway: labels applied',
+      );
+
+      return { success: true, applied: labels, created, folders: finalFolders };
+    } catch (err) {
+      this.log.error({ err, messageId, labels, accountId }, 'outbound-gateway: labelEmailMessage failed');
+      return { success: false, applied: [], created: [], folders: [], error: 'Label operation failed' };
     }
   }
 

--- a/tests/unit/channels/email/nylas-client-label-read.test.ts
+++ b/tests/unit/channels/email/nylas-client-label-read.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockMessages, mockFolders } = vi.hoisted(() => {
+  const mockMessages = {
+    list: vi.fn(),
+    find: vi.fn(),
+    send: vi.fn(),
+    update: vi.fn(),
+  };
+  const mockFolders = {
+    list: vi.fn(),
+    create: vi.fn(),
+  };
+  return { mockMessages, mockFolders };
+});
+
+vi.mock('nylas', () => {
+  class MockNylas {
+    messages = mockMessages;
+    drafts = { create: vi.fn() };
+    folders = mockFolders;
+  }
+  return { default: MockNylas };
+});
+
+import { NylasClient } from '../../../../src/channels/email/nylas-client.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function mockMsg(overrides: { folders?: string[]; unread?: boolean } = {}) {
+  return {
+    id: 'msg-1',
+    threadId: 'thread-1',
+    subject: 'Test subject',
+    from: [{ name: 'Sender', email: 'sender@example.com' }],
+    to: [{ email: 'ceo@example.com' }],
+    cc: [],
+    bcc: [],
+    body: 'Body text',
+    snippet: 'Body text',
+    date: 1744000000,
+    unread: overrides.unread ?? true,
+    starred: false,
+    folders: overrides.folders ?? ['INBOX'],
+    headers: undefined,
+  };
+}
+
+describe('NylasClient.markAsRead', () => {
+  let client: NylasClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new NylasClient('test-api-key', 'test-grant-id', logger);
+  });
+
+  it('calls messages.update with unread: false', async () => {
+    mockMessages.update.mockResolvedValue({ data: mockMsg({ unread: false }) });
+
+    await client.markAsRead('msg-1');
+
+    expect(mockMessages.update).toHaveBeenCalledWith({
+      identifier: 'test-grant-id',
+      messageId: 'msg-1',
+      requestBody: { unread: false },
+    });
+  });
+
+  it('throws if the Nylas update call fails', async () => {
+    mockMessages.update.mockRejectedValue(new Error('Nylas API 500'));
+
+    await expect(client.markAsRead('msg-1')).rejects.toThrow('Nylas API 500');
+  });
+});
+
+describe('NylasClient.listFolders', () => {
+  let client: NylasClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new NylasClient('test-api-key', 'test-grant-id', logger);
+  });
+
+  it('returns normalized folder objects', async () => {
+    mockFolders.list.mockResolvedValue({
+      data: [
+        { id: 'folder-1', name: 'INBOX', object: 'folder', grantId: 'test-grant-id' },
+        { id: 'folder-2', name: 'SECURITY', object: 'folder', grantId: 'test-grant-id' },
+      ],
+    });
+
+    const folders = await client.listFolders();
+
+    expect(folders).toEqual([
+      { id: 'folder-1', name: 'INBOX' },
+      { id: 'folder-2', name: 'SECURITY' },
+    ]);
+    expect(mockFolders.list).toHaveBeenCalledWith({
+      identifier: 'test-grant-id',
+    });
+  });
+
+  it('throws if the Nylas API call fails', async () => {
+    mockFolders.list.mockRejectedValue(new Error('Nylas API 403'));
+
+    await expect(client.listFolders()).rejects.toThrow('Nylas API 403');
+  });
+});
+
+describe('NylasClient.createFolder', () => {
+  let client: NylasClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new NylasClient('test-api-key', 'test-grant-id', logger);
+  });
+
+  it('creates a folder and returns the normalized result', async () => {
+    mockFolders.create.mockResolvedValue({
+      data: { id: 'folder-new', name: 'SECURITY', object: 'folder', grantId: 'test-grant-id' },
+    });
+
+    const folder = await client.createFolder('SECURITY');
+
+    expect(folder).toEqual({ id: 'folder-new', name: 'SECURITY' });
+    expect(mockFolders.create).toHaveBeenCalledWith({
+      identifier: 'test-grant-id',
+      requestBody: { name: 'SECURITY' },
+    });
+  });
+
+  it('throws if the Nylas API call fails', async () => {
+    mockFolders.create.mockRejectedValue(new Error('Nylas API 409'));
+
+    await expect(client.createFolder('DUPLICATE')).rejects.toThrow('Nylas API 409');
+  });
+});
+
+describe('NylasClient.updateMessageFolders', () => {
+  let client: NylasClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new NylasClient('test-api-key', 'test-grant-id', logger);
+  });
+
+  it('updates the message folder list and returns normalized message', async () => {
+    const updatedFolders = ['INBOX', 'folder-security'];
+    mockMessages.update.mockResolvedValue({ data: mockMsg({ folders: updatedFolders }) });
+
+    const result = await client.updateMessageFolders('msg-1', updatedFolders);
+
+    expect(result.folders).toEqual(updatedFolders);
+    expect(mockMessages.update).toHaveBeenCalledWith({
+      identifier: 'test-grant-id',
+      messageId: 'msg-1',
+      requestBody: { folders: updatedFolders },
+    });
+  });
+
+  it('throws if the Nylas update call fails', async () => {
+    mockMessages.update.mockRejectedValue(new Error('Nylas API 500'));
+
+    await expect(client.updateMessageFolders('msg-1', ['INBOX'])).rejects.toThrow('Nylas API 500');
+  });
+});

--- a/tests/unit/skills/email-create-folder.test.ts
+++ b/tests/unit/skills/email-create-folder.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EmailCreateFolderHandler } from '../../../skills/email-create-folder/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  return { input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
+}
+
+describe('EmailCreateFolderHandler', () => {
+  const handler = new EmailCreateFolderHandler();
+
+  it('returns failure when name is missing', async () => {
+    const result = await handler.execute(makeCtx({}));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('name');
+  });
+
+  it('returns failure when name is not a string', async () => {
+    const result = await handler.execute(makeCtx({ name: 42 }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('name');
+  });
+
+  it('returns failure when name is empty after trimming', async () => {
+    const result = await handler.execute(makeCtx({ name: '   ' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('name');
+  });
+
+  it('returns failure when outboundGateway is not configured', async () => {
+    const result = await handler.execute(makeCtx({ name: 'SECURITY' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('outboundGateway');
+  });
+
+  it('creates a folder successfully', async () => {
+    const gateway = {
+      createEmailFolder: vi.fn().mockResolvedValue({ id: 'folder-new', name: 'SECURITY' }),
+    };
+    const result = await handler.execute(
+      makeCtx({ name: 'SECURITY' }, { outboundGateway: gateway as never }),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { id: string; name: string };
+      expect(data.id).toBe('folder-new');
+      expect(data.name).toBe('SECURITY');
+    }
+    expect(gateway.createEmailFolder).toHaveBeenCalledWith('SECURITY', undefined);
+  });
+
+  it('passes accountId when account is provided', async () => {
+    const gateway = {
+      createEmailFolder: vi.fn().mockResolvedValue({ id: 'f1', name: 'TEST' }),
+    };
+    await handler.execute(
+      makeCtx({ name: 'TEST', account: 'curia' }, { outboundGateway: gateway as never }),
+    );
+    expect(gateway.createEmailFolder).toHaveBeenCalledWith('TEST', 'curia');
+  });
+
+  it('trims whitespace from name', async () => {
+    const gateway = {
+      createEmailFolder: vi.fn().mockResolvedValue({ id: 'f1', name: 'SECURITY' }),
+    };
+    await handler.execute(
+      makeCtx({ name: '  SECURITY  ' }, { outboundGateway: gateway as never }),
+    );
+    expect(gateway.createEmailFolder).toHaveBeenCalledWith('SECURITY', undefined);
+  });
+
+  it('returns failure when gateway throws', async () => {
+    const gateway = {
+      createEmailFolder: vi.fn().mockRejectedValue(new Error('Nylas 409')),
+    };
+    const result = await handler.execute(
+      makeCtx({ name: 'SECURITY' }, { outboundGateway: gateway as never }),
+    );
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/skills/email-label.test.ts
+++ b/tests/unit/skills/email-label.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EmailLabelHandler } from '../../../skills/email-label/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  return { input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
+}
+
+describe('EmailLabelHandler', () => {
+  const handler = new EmailLabelHandler();
+
+  it('returns failure when message_id is missing', async () => {
+    const result = await handler.execute(makeCtx({ labels: ['SECURITY'] }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('message_id');
+  });
+
+  it('returns failure when labels array is empty', async () => {
+    const result = await handler.execute(makeCtx({ message_id: 'msg-1', labels: [] }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('labels');
+  });
+
+  it('returns failure when labels is not an array', async () => {
+    const result = await handler.execute(makeCtx({ message_id: 'msg-1', labels: 'SECURITY' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('labels');
+  });
+
+  it('filters out non-string and empty labels', async () => {
+    const result = await handler.execute(makeCtx({ message_id: 'msg-1', labels: [42, '', '  '] }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('labels');
+  });
+
+  it('returns failure when outboundGateway is not configured', async () => {
+    const result = await handler.execute(makeCtx({ message_id: 'msg-1', labels: ['SECURITY'] }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('outboundGateway');
+  });
+
+  it('applies labels successfully', async () => {
+    const gateway = {
+      labelEmailMessage: vi.fn().mockResolvedValue({
+        success: true,
+        applied: ['SECURITY'],
+        created: [],
+        folders: ['INBOX', 'folder-security-id'],
+      }),
+    };
+    const result = await handler.execute(
+      makeCtx({ message_id: 'msg-1', labels: ['SECURITY'] }, { outboundGateway: gateway as never }),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { message_id: string; applied: string[]; created: string[]; folders: string[] };
+      expect(data.message_id).toBe('msg-1');
+      expect(data.applied).toEqual(['SECURITY']);
+      expect(data.created).toEqual([]);
+    }
+    expect(gateway.labelEmailMessage).toHaveBeenCalledWith('msg-1', ['SECURITY'], undefined);
+  });
+
+  it('passes accountId when account is provided', async () => {
+    const gateway = {
+      labelEmailMessage: vi.fn().mockResolvedValue({
+        success: true,
+        applied: ['SECURITY'],
+        created: ['SECURITY'],
+        folders: ['INBOX', 'folder-security-id'],
+      }),
+    };
+    const result = await handler.execute(
+      makeCtx(
+        { message_id: 'msg-1', labels: ['SECURITY'], account: 'curia' },
+        { outboundGateway: gateway as never },
+      ),
+    );
+    expect(result.success).toBe(true);
+    expect(gateway.labelEmailMessage).toHaveBeenCalledWith('msg-1', ['SECURITY'], 'curia');
+  });
+
+  it('returns failure when gateway returns an error', async () => {
+    const gateway = {
+      labelEmailMessage: vi.fn().mockResolvedValue({
+        success: false,
+        applied: [],
+        created: [],
+        folders: [],
+        error: 'Nylas API error',
+      }),
+    };
+    const result = await handler.execute(
+      makeCtx({ message_id: 'msg-1', labels: ['SECURITY'] }, { outboundGateway: gateway as never }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Nylas API error');
+  });
+
+  it('returns failure when gateway throws', async () => {
+    const gateway = {
+      labelEmailMessage: vi.fn().mockRejectedValue(new Error('Unexpected')),
+    };
+    const result = await handler.execute(
+      makeCtx({ message_id: 'msg-1', labels: ['SECURITY'] }, { outboundGateway: gateway as never }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('trims whitespace from message_id and labels', async () => {
+    const gateway = {
+      labelEmailMessage: vi.fn().mockResolvedValue({
+        success: true,
+        applied: ['SECURITY'],
+        created: [],
+        folders: ['folder-id'],
+      }),
+    };
+    const result = await handler.execute(
+      makeCtx(
+        { message_id: '  msg-1  ', labels: ['  SECURITY  '] },
+        { outboundGateway: gateway as never },
+      ),
+    );
+    expect(result.success).toBe(true);
+    expect(gateway.labelEmailMessage).toHaveBeenCalledWith('msg-1', ['SECURITY'], undefined);
+  });
+});

--- a/tests/unit/skills/email-list-folders.test.ts
+++ b/tests/unit/skills/email-list-folders.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EmailListFoldersHandler } from '../../../skills/email-list-folders/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  return { input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
+}
+
+describe('EmailListFoldersHandler', () => {
+  const handler = new EmailListFoldersHandler();
+
+  it('returns failure when outboundGateway is not configured', async () => {
+    const result = await handler.execute(makeCtx({}));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('outboundGateway');
+  });
+
+  it('lists folders successfully', async () => {
+    const gateway = {
+      listEmailFolders: vi.fn().mockResolvedValue([
+        { id: 'f1', name: 'INBOX' },
+        { id: 'f2', name: 'SECURITY' },
+      ]),
+    };
+    const result = await handler.execute(
+      makeCtx({}, { outboundGateway: gateway as never }),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { folders: Array<{ id: string; name: string }>; count: number };
+      expect(data.count).toBe(2);
+      expect(data.folders).toEqual([
+        { id: 'f1', name: 'INBOX' },
+        { id: 'f2', name: 'SECURITY' },
+      ]);
+    }
+    expect(gateway.listEmailFolders).toHaveBeenCalledWith(undefined);
+  });
+
+  it('passes accountId when account is provided', async () => {
+    const gateway = { listEmailFolders: vi.fn().mockResolvedValue([]) };
+    await handler.execute(
+      makeCtx({ account: 'curia' }, { outboundGateway: gateway as never }),
+    );
+    expect(gateway.listEmailFolders).toHaveBeenCalledWith('curia');
+  });
+
+  it('passes undefined accountId when account is empty string', async () => {
+    const gateway = { listEmailFolders: vi.fn().mockResolvedValue([]) };
+    await handler.execute(
+      makeCtx({ account: '' }, { outboundGateway: gateway as never }),
+    );
+    expect(gateway.listEmailFolders).toHaveBeenCalledWith(undefined);
+  });
+
+  it('returns failure when gateway throws', async () => {
+    const gateway = { listEmailFolders: vi.fn().mockRejectedValue(new Error('Nylas 500')) };
+    const result = await handler.execute(
+      makeCtx({}, { outboundGateway: gateway as never }),
+    );
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/skills/email-mark-read.test.ts
+++ b/tests/unit/skills/email-mark-read.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EmailMarkReadHandler } from '../../../skills/email-mark-read/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(input: Record<string, unknown>, overrides?: Partial<SkillContext>): SkillContext {
+  return { input, secret: () => { throw new Error('no secrets'); }, log: logger, ...overrides };
+}
+
+describe('EmailMarkReadHandler', () => {
+  const handler = new EmailMarkReadHandler();
+
+  it('returns failure when message_id is missing', async () => {
+    const result = await handler.execute(makeCtx({}));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('message_id');
+  });
+
+  it('returns failure when message_id is not a string', async () => {
+    const result = await handler.execute(makeCtx({ message_id: 42 }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('message_id');
+  });
+
+  it('returns failure when outboundGateway is not configured', async () => {
+    const result = await handler.execute(makeCtx({ message_id: 'msg-1' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('outboundGateway');
+  });
+
+  it('marks as read successfully and returns { marked_read: true }', async () => {
+    const gateway = { markEmailAsRead: vi.fn().mockResolvedValue({ success: true }) };
+    const result = await handler.execute(
+      makeCtx({ message_id: 'msg-1', account: 'curia' }, { outboundGateway: gateway as never }),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) expect((result.data as { marked_read: boolean }).marked_read).toBe(true);
+    expect(gateway.markEmailAsRead).toHaveBeenCalledWith('msg-1', 'curia');
+  });
+
+  it('passes undefined accountId when account is absent', async () => {
+    const gateway = { markEmailAsRead: vi.fn().mockResolvedValue({ success: true }) };
+    const result = await handler.execute(
+      makeCtx({ message_id: 'msg-1' }, { outboundGateway: gateway as never }),
+    );
+    expect(result.success).toBe(true);
+    expect(gateway.markEmailAsRead).toHaveBeenCalledWith('msg-1', undefined);
+  });
+
+  it('passes undefined accountId when account is empty string', async () => {
+    const gateway = { markEmailAsRead: vi.fn().mockResolvedValue({ success: true }) };
+    const result = await handler.execute(
+      makeCtx({ message_id: 'msg-1', account: '' }, { outboundGateway: gateway as never }),
+    );
+    expect(result.success).toBe(true);
+    expect(gateway.markEmailAsRead).toHaveBeenCalledWith('msg-1', undefined);
+  });
+
+  it('returns failure when gateway returns an error', async () => {
+    const gateway = {
+      markEmailAsRead: vi.fn().mockResolvedValue({ success: false, error: 'Nylas 503' }),
+    };
+    const result = await handler.execute(
+      makeCtx({ message_id: 'msg-1' }, { outboundGateway: gateway as never }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Nylas 503');
+  });
+
+  it('returns failure when gateway throws', async () => {
+    const gateway = {
+      markEmailAsRead: vi.fn().mockRejectedValue(new Error('Unexpected')),
+    };
+    const result = await handler.execute(
+      makeCtx({ message_id: 'msg-1' }, { outboundGateway: gateway as never }),
+    );
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `markAsRead()`, `listFolders()`, `createFolder()`, `updateMessageFolders()` to NylasClient
- Add `markEmailAsRead()` and `labelEmailMessage()` to OutboundGateway — the latter orchestrates the full label-resolution-and-merge workflow
- Add **`email-label`** skill — applies Gmail labels to messages, creating labels that don't exist
- Add **`email-mark-read`** skill — marks messages as read in any configured account
- Pin both skills to the coordinator agent
- Unit tests for all new code (NylasClient methods + skill handlers)

These are general-purpose email management skills needed by the upcoming security-triage agent (josephfung/curia-deploy#47) but useful for any agent that needs to organize email.

## Test plan

- [x] 26 new unit tests pass (NylasClient: markAsRead, listFolders, createFolder, updateMessageFolders; skill handlers: validation, success, error paths)
- [x] All existing tests continue to pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Integration test: apply a label to a real email via the Nylas API