### PR TITLE
chore: add Gitleaks secret scanning to CI

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,21 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history for diff-aware scanning
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+[extend]
+useDefault = true
+
+[allowlist]
+# Exclude test fixtures, generated files, and documentation
+paths = [
+  '''tests/''',
+  '''pnpm-lock\.yaml''',
+  '''dist/''',
+  '''docs/''',
+]
+regexes = [
+  # Postgres connection strings pointing at localhost (test/dev configs, CI, .env.example)
+  '''postgres://[^@]*@localhost''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,12 +2,13 @@
 useDefault = true
 
 [allowlist]
-# Exclude test fixtures, generated files, and documentation
+# Exclude test fixtures and generated files.
+# tests/ excluded because test configs routinely contain placeholder credentials
+# that trigger false positives. dist/ and docs/ are NOT excluded — dist is
+# gitignored (never scanned), and docs should be scanned for accidental leaks.
 paths = [
   '''tests/''',
   '''pnpm-lock\.yaml''',
-  '''dist/''',
-  '''docs/''',
 ]
 regexes = [
   # Postgres connection strings pointing at localhost (test/dev configs, CI, .env.example)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Email folder management skills** — `email-label`, `email-list-folders`, `email-create-folder`, and `email-mark-read` expose Nylas folder and read-state operations as general-purpose skills.
 
+### Security
+
+- **Gitleaks secret scanning** — CI now runs Gitleaks on every PR and push to `main`, blocking merge if secrets are detected. (#560)
+
 ---
 
 ## [0.28.0] — 2026-05-14 — "Thufir Hawat"


### PR DESCRIPTION
## Summary

Closes #560

- Add `.gitleaks.toml` with default rules and targeted allowlist for test fixtures and localhost Postgres connection strings
- Add dedicated `secret-scan.yml` workflow that runs Gitleaks on every PR and push to `main`
- Runs in CE mode (no license key needed — repo is public), scanning the PR diff for secrets

## Test plan

- [ ] Verify `Secret Scan` workflow runs on this PR and passes (no false positives)
- [ ] Confirm branch protection can be configured to require the `gitleaks` check
- [ ] Verify that intentionally adding a fake secret pattern to a test branch triggers a failure