### PR TITLE
fix: add intent_anchor to agent schedule schema

### DIFF
--- a/schemas/agent-config.schema.json
+++ b/schemas/agent-config.schema.json
@@ -62,7 +62,8 @@
           "cron": { "type": "string", "minLength": 1 },
           "task": { "type": "string", "minLength": 1 },
           "agent_id": { "type": "string" },
-          "expectedDurationSeconds": { "type": "number", "minimum": 0 }
+          "expectedDurationSeconds": { "type": "number", "minimum": 0 },
+          "intent_anchor": { "type": "string" }
         }
       }
     },

--- a/tests/unit/startup/fixtures/agents/valid/scheduled-with-intent-anchor.yaml
+++ b/tests/unit/startup/fixtures/agents/valid/scheduled-with-intent-anchor.yaml
@@ -1,0 +1,9 @@
+name: test-scheduled-agent
+description: A valid test agent with a scheduled task that includes intent_anchor
+model:
+  tier: standard
+system_prompt: You are a test agent.
+schedule:
+  - cron: "*/30 * * * *"
+    task: Check for new items to process.
+    intent_anchor: Scheduled processing of inbound items for triage.


### PR DESCRIPTION
## Summary

- Adds `intent_anchor` to the schedule item properties in `agent-config.schema.json`
- The schema had `additionalProperties: false` but was missing this field, which the TypeScript interface (`loader.ts`) and the new `security-triage` agent both use
- The startup validator rejected the config, crashing the app before the health check could respond — causing the production deploy failure

## Test plan

- [x] Added valid fixture (`scheduled-with-intent-anchor.yaml`) that includes `intent_anchor` in a schedule item
- [x] All 184 non-DB test files pass (2 pre-existing DB integration test failures unrelated)
- [ ] Merge, rebuild Docker image, and redeploy — container should pass health check