### PR TITLE
chore: add CodeQL static analysis workflow

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+name: "Curia CodeQL config"
+
+paths-ignore:
+  - dist
+  - node_modules

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,7 @@
 name: CodeQL
 
 on:
+  workflow_dispatch:
   schedule:
     # Weekly full scan — Wednesday 6am UTC (off-peak)
     - cron: '0 6 * * 3'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  schedule:
+    # Weekly full scan — Wednesday 6am UTC (off-peak)
+    - cron: '0 6 * * 3'
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Security
 
 - **Gitleaks secret scanning** — CI now runs Gitleaks on every PR and push to `main`, blocking merge if secrets are detected. (#560)
+- **CodeQL static analysis** — weekly scheduled code scanning for JS/TS security vulnerabilities. (#561)
 
 ---
 


### PR DESCRIPTION
## Summary

Add weekly scheduled CodeQL static analysis for JavaScript/TypeScript code scanning. Runs every Wednesday at 6am UTC using the `security-extended` query suite. Findings appear in the Security tab (alert-only — not a required status check).

Schedule-only by design to conserve GitHub Actions minutes (~50 PRs/week). PR-level gating can be added later with `paths-ignore` once the baseline is triaged and budget allows (see #575).

Closes #561

## Changes

- Add `.github/workflows/codeql.yml` — weekly scheduled CodeQL scan
- Add `.github/codeql/codeql-config.yml` — excludes `dist/` and `node_modules/` from analysis
- Update `CHANGELOG.md` under [Unreleased] > Security

## Test plan

- [ ] Merge PR, confirm workflow appears in Actions tab
- [ ] After next Wednesday 6am UTC: confirm scheduled run completes
- [ ] Check Security > Code scanning alerts for initial findings
- [ ] Triage baseline: true positives get follow-up issues, false positives get suppressed
- [ ] Confirm CodeQL is NOT a required status check (alert-only mode)