### PR TITLE
fix: seamless CEO inbox delegation from coordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Email folder management skills** — `email-label`, `email-list-folders`, `email-create-folder`, and `email-mark-read` expose Nylas folder and read-state operations as general-purpose skills.
 
+### Changed
+
+- **Coordinator inbox delegation** — CEO inbox queries now delegate seamlessly to the ceo-inbox specialist instead of explaining the multi-agent architecture.
+
 ### Security
 
 - **Gitleaks secret scanning** — CI now runs Gitleaks on every PR and push to `main`, blocking merge if secrets are detected. (#560)

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -363,12 +363,10 @@ system_prompt: |
   0. **CC'd email (`[OWNER CC —]` context):** The email came to YOUR inbox —
      reply using `email-reply` (no account selection needed; it uses your
      account automatically).
-  1. If the CEO asks you to draft, read, or archive emails in THEIR inbox,
-     use the CEO's account name — not yours. "Draft this from me",
-     "check my email", "draft an email for me to send", "save a draft
-     for me to review" all mean the CEO's account. The CEO does not want
-     drafts appearing in Curia's outbox — they want them in their own
-     drafts folder so they can review and send.
+  1. **CEO's inbox** — any request to read, draft, archive, or otherwise
+     act on the CEO's email: delegate to the ceo-inbox specialist per the
+     section above. Do not use email-list/email-get/email-draft-save/
+     email-archive with the CEO's account directly.
   2. If operating on your own inbox (Curia's messages, Curia's drafts),
      use your own account or omit the param.
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -330,11 +330,13 @@ system_prompt: |
   compose an email." Use the contact IDs from the <resolved_entities> block for
   addressing. Only ask the CEO for contact details as a last resort.
 
-  ## Inbox Disambiguation
-  When the CEO says "my inbox" or "my email", they mean the CEO's personal inbox,
-  which is monitored by a separate specialist agent (not you). If asked to check
-  or act on the CEO's inbox, explain that inbox monitoring runs automatically.
-  "Your inbox" or "Curia's inbox" refers to your own email account.
+  ## CEO Inbox Requests
+  When the CEO says "my inbox", "my email", or asks about a specific email they
+  received, they mean the CEO's personal inbox — not yours. Delegate to the
+  ceo-inbox specialist with the specific request and present the result in your
+  own voice.
+  "Your inbox" or "Curia's inbox" refers to your own email account — use your
+  own email skills for those.
 
   ${executive_voice_block}
 


### PR DESCRIPTION
## Summary

- Replaced the \"Inbox Disambiguation\" section in the coordinator prompt, which told the coordinator to *explain* that inbox monitoring runs on a separate schedule, with a \"CEO Inbox Requests\" section that delegates directly to the ceo-inbox specialist and presents the result in the coordinator's own voice
- Removed the stale Account Identity exception that told the coordinator to use email-draft-save with the CEO's account for drafting — this predates the ceo-inbox specialist and conflicted with the new delegation instruction; all CEO inbox operations now route through the specialist

## Test plan

- [ ] Ask \"Can you see the XYZ email in my inbox?\" — Curia should pull it up directly without mentioning a separate agent or schedule
- [ ] Ask \"Check my inbox\" — same seamless delegation behavior
- [ ] Ask \"Draft an email for me to send to Jim\" — should delegate to ceo-inbox specialist (not attempt email-draft-save with CEO's account directly)
- [ ] Ask Curia to check its own inbox — should use its own email skills as before