### PR TITLE
chore: upgrade CodeQL Action v3 → v4 and opt in to Node.js 24

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   actions: read
 
+env:
+  # Opt in to Node.js 24 runtime before it becomes the forced default on 2026-06-02.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analyze:
     name: Analyze
@@ -25,16 +29,16 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Gitleaks secret scanning** — CI now runs Gitleaks on every PR and push to `main`, blocking merge if secrets are detected. (#560)
 - **CodeQL static analysis** — weekly scheduled code scanning for JS/TS security vulnerabilities. (#561)
+- **CodeQL Action v4 + Node.js 24** — bumped all three `codeql-action` steps to `@v4` and opted in to the Node.js 24 runner ahead of the June 2026 forced migration. (#582)
 
 ---
 


### PR DESCRIPTION
## Summary

- Bumped all three `github/codeql-action/*` steps from `@v3` to `@v4` — v3 is deprecated and stops working in December 2026
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` workflow-level env var to opt in to the Node.js 24 runner ahead of the forced migration on 2026-06-02

Closes #582

## Test plan

- [ ] Trigger the CodeQL workflow via `workflow_dispatch` and confirm it runs clean with no deprecation warnings
- [ ] Confirm all three analysis steps (init, autobuild, analyze) complete successfully