### PR TITLE
fix: local-timezone timestamps on calendar write-path + strengthen toLocalIso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Coordinator inbox delegation** — CEO inbox queries now delegate seamlessly to the ceo-inbox specialist instead of explaining the multi-agent architecture.
 
+### Fixed
+
+- **`calendar-create-event` / `calendar-update-event`** — confirmation timestamps now returned in the user's local timezone instead of UTC, matching the format used by the read-path handlers since #368. (#369)
+
 ### Security
 
 - **Gitleaks secret scanning** — CI now runs Gitleaks on every PR and push to `main`, blocking merge if secrets are detected. (#560)

--- a/skills/calendar-check-conflicts/handler.ts
+++ b/skills/calendar-check-conflicts/handler.ts
@@ -59,20 +59,11 @@ export class CalendarCheckConflictsHandler implements SkillHandler {
         for (const slot of result.timeSlots) {
           // Check overlap: busy slot overlaps the proposed range
           if (slot.startTime < proposedEndTs && slot.endTime > proposedStartTs) {
-            // Guard non-finite and non-positive values the same way calendar-list-events does.
-            if (!Number.isFinite(slot.startTime) || slot.startTime <= 0 || !Number.isFinite(slot.endTime) || slot.endTime <= 0) {
-              ctx.log.warn({ calendarId: result.email, startTime: slot.startTime, endTime: slot.endTime }, 'calendar-check-conflicts: suspicious slot timestamp — skipping');
-              continue;
-            }
-            // Format timestamps in the user's local timezone so the LLM reads correct
-            // wall-clock times. Falls back to UTC Z-suffix when timezone is not configured.
-            conflicts.push({
-              calendarId: result.email,
-              contactName,
-              startTime: tz ? toLocalIso(slot.startTime, tz) : new Date(slot.startTime * 1000).toISOString(),
-              endTime: tz ? toLocalIso(slot.endTime, tz) : new Date(slot.endTime * 1000).toISOString(),
-              status: slot.status,
-            });
+            const startTime = toLocalIso(slot.startTime, tz);
+            const endTime = toLocalIso(slot.endTime, tz);
+            // Skip corrupt slots — a conflict entry with no timestamps is not actionable.
+            if (startTime === null || endTime === null) continue;
+            conflicts.push({ calendarId: result.email, contactName, startTime, endTime, status: slot.status });
           }
         }
       }

--- a/skills/calendar-create-event/handler.ts
+++ b/skills/calendar-create-event/handler.ts
@@ -69,44 +69,18 @@ export class CalendarCreateEventHandler implements SkillHandler {
 
       const event = await ctx.nylasCalendarClient.createEvent(calendarId, eventData);
       ctx.log.info({ calendarId, eventId: event.id }, 'Created calendar event');
-      // Format timestamps in the user's local timezone so the confirmation matches what
-      // calendar-list-events returns. Falls back to UTC Z-suffix when timezone is not configured.
-      // Defensive fallback on bad timezone: the event was already written — a misconfigured
-      // ctx.timezone must not falsely report failure.
+      // Format timestamps in the user's local timezone so the confirmation matches
+      // what calendar-list-events returns. toLocalIso handles null/invalid values internally.
       const tz = ctx.timezone;
-      const toIso = (unix: number | null, field: string): string | null => {
-        if (unix === null) return null;
-        if (!Number.isFinite(unix) || unix <= 0) {
-          ctx.log.warn({ eventId: event.id, field, value: unix }, `calendar-create-event: suspicious ${field} value — omitting`);
-          return null;
-        }
-        if (tz) {
-          try {
-            return toLocalIso(unix, tz);
-          } catch {
-            ctx.log.warn({ tz }, 'calendar-create-event: invalid timezone — falling back to UTC');
-            return new Date(unix * 1000).toISOString();
-          }
-        }
-        return new Date(unix * 1000).toISOString();
-      };
-      let displayTimezone: string | null = null;
-      if (tz) {
-        try {
-          displayTimezone = formatDisplayTimezone(tz, new Date());
-        } catch {
-          ctx.log.warn({ tz }, 'calendar-create-event: invalid timezone for displayTimezone');
-        }
-      }
       return {
         success: true,
         data: {
           event: {
             ...event,
-            startTime: toIso(event.startTime, 'startTime'),
-            endTime: toIso(event.endTime, 'endTime'),
+            startTime: toLocalIso(event.startTime, tz),
+            endTime: toLocalIso(event.endTime, tz),
           },
-          displayTimezone,
+          displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : null,
         },
       };
     } catch (err) {

--- a/skills/calendar-create-event/handler.ts
+++ b/skills/calendar-create-event/handler.ts
@@ -6,6 +6,7 @@
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { CreateEventInput } from '../../src/channels/calendar/nylas-calendar-client.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 
 export class CalendarCreateEventHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -68,17 +69,44 @@ export class CalendarCreateEventHandler implements SkillHandler {
 
       const event = await ctx.nylasCalendarClient.createEvent(calendarId, eventData);
       ctx.log.info({ calendarId, eventId: event.id }, 'Created calendar event');
-      // Format timestamps as UTC ISO strings — LLMs can't reliably convert raw Unix seconds.
+      // Format timestamps in the user's local timezone so the confirmation matches what
+      // calendar-list-events returns. Falls back to UTC Z-suffix when timezone is not configured.
+      // Defensive fallback on bad timezone: the event was already written — a misconfigured
+      // ctx.timezone must not falsely report failure.
+      const tz = ctx.timezone;
+      const toIso = (unix: number | null, field: string): string | null => {
+        if (unix === null) return null;
+        if (!Number.isFinite(unix) || unix <= 0) {
+          ctx.log.warn({ eventId: event.id, field, value: unix }, `calendar-create-event: suspicious ${field} value — omitting`);
+          return null;
+        }
+        if (tz) {
+          try {
+            return toLocalIso(unix, tz);
+          } catch {
+            ctx.log.warn({ tz }, 'calendar-create-event: invalid timezone — falling back to UTC');
+            return new Date(unix * 1000).toISOString();
+          }
+        }
+        return new Date(unix * 1000).toISOString();
+      };
+      let displayTimezone: string | null = null;
+      if (tz) {
+        try {
+          displayTimezone = formatDisplayTimezone(tz, new Date());
+        } catch {
+          ctx.log.warn({ tz }, 'calendar-create-event: invalid timezone for displayTimezone');
+        }
+      }
       return {
         success: true,
         data: {
           event: {
             ...event,
-            startTime: event.startTime !== null && Number.isFinite(event.startTime) && event.startTime > 0
-              ? new Date(event.startTime * 1000).toISOString() : null,
-            endTime: event.endTime !== null && Number.isFinite(event.endTime) && event.endTime > 0
-              ? new Date(event.endTime * 1000).toISOString() : null,
+            startTime: toIso(event.startTime, 'startTime'),
+            endTime: toIso(event.endTime, 'endTime'),
           },
+          displayTimezone,
         },
       };
     } catch (err) {

--- a/skills/calendar-find-free-time/handler.ts
+++ b/skills/calendar-find-free-time/handler.ts
@@ -82,20 +82,10 @@ export class CalendarFindFreeTimeHandler implements SkillHandler {
         ? freeWindows.filter((w) => w.end - w.start >= minSeconds)
         : freeWindows;
 
-      // Format timestamps in the user's local timezone so the LLM reads correct
-      // wall-clock times. Falls back to UTC Z-suffix when timezone is not configured.
-      // Guard non-finite and non-positive values the same way calendar-list-events does.
       const tz = ctx.timezone;
-      const formatTs = (unix: number, field: string): string | null => {
-        if (!Number.isFinite(unix) || unix <= 0) {
-          ctx.log.warn({ value: unix, field }, 'calendar-find-free-time: suspicious timestamp — omitting');
-          return null;
-        }
-        return tz ? toLocalIso(unix, tz) : new Date(unix * 1000).toISOString();
-      };
       const freeWindowsFormatted = filtered.map((w) => ({
-        start: formatTs(w.start, 'start'),
-        end: formatTs(w.end, 'end'),
+        start: toLocalIso(w.start, tz),
+        end: toLocalIso(w.end, tz),
       }));
 
       ctx.log.info({ calendarCount: calendarIds.length, freeWindowCount: freeWindowsFormatted.length }, 'Found free time');

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -122,27 +122,14 @@ export class CalendarListEventsHandler implements SkillHandler {
       }
 
       // Format events for LLM consumption.
-      // Nylas returns timed event timestamps as Unix seconds. Convert to the user's
-      // local timezone so the wall-clock digits in the ISO string match local time.
-      // The LLM reads these digits directly — it cannot reliably do UTC conversion.
-      // Falls back to UTC Z-suffix when timezone is not configured (defensive).
-      //
-      // Guard non-finite and non-positive values: Unix 0 is never a real calendar
-      // event time, and passing "1970-01-01T00:00:00Z" to the LLM would be silently
-      // wrong. Log and null-out rather than propagate corrupted data.
+      // toLocalIso converts Unix seconds to the user's local timezone so the LLM reads
+      // correct wall-clock times. Falls back to UTC when timezone is not configured,
+      // and returns null for null/invalid timestamp values.
       const tz = ctx.timezone;
-      const toIso = (unix: number | null, field: string, eventId: string): string | null => {
-        if (unix === null) return null;
-        if (!Number.isFinite(unix) || unix <= 0) {
-          ctx.log.warn({ eventId, field, value: unix }, `calendar-list-events: suspicious ${field} value — omitting`);
-          return null;
-        }
-        return tz ? toLocalIso(unix, tz) : new Date(unix * 1000).toISOString();
-      };
       const formattedEvents = events.map((evt) => ({
         ...evt,
-        startTime: toIso(evt.startTime, 'startTime', evt.id),
-        endTime: toIso(evt.endTime, 'endTime', evt.id),
+        startTime: toLocalIso(evt.startTime, tz),
+        endTime: toLocalIso(evt.endTime, tz),
       }));
 
       ctx.log.info({ calendarIds, count: formattedEvents.length, failedCalendarIds }, 'Listed events');

--- a/skills/calendar-update-event/handler.ts
+++ b/skills/calendar-update-event/handler.ts
@@ -4,6 +4,7 @@
 // Checks the read-only flag before attempting the update.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 
 export class CalendarUpdateEventHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -64,17 +65,44 @@ export class CalendarUpdateEventHandler implements SkillHandler {
 
       const event = await ctx.nylasCalendarClient.updateEvent(calendarId, eventId, changes);
       ctx.log.info({ calendarId, eventId }, 'Updated calendar event');
-      // Format timestamps as UTC ISO strings — LLMs can't reliably convert raw Unix seconds.
+      // Format timestamps in the user's local timezone so the confirmation matches what
+      // calendar-list-events returns. Falls back to UTC Z-suffix when timezone is not configured.
+      // Defensive fallback on bad timezone: the event was already written — a misconfigured
+      // ctx.timezone must not falsely report failure.
+      const tz = ctx.timezone;
+      const toIso = (unix: number | null, field: string): string | null => {
+        if (unix === null) return null;
+        if (!Number.isFinite(unix) || unix <= 0) {
+          ctx.log.warn({ eventId, field, value: unix }, `calendar-update-event: suspicious ${field} value — omitting`);
+          return null;
+        }
+        if (tz) {
+          try {
+            return toLocalIso(unix, tz);
+          } catch {
+            ctx.log.warn({ tz }, 'calendar-update-event: invalid timezone — falling back to UTC');
+            return new Date(unix * 1000).toISOString();
+          }
+        }
+        return new Date(unix * 1000).toISOString();
+      };
+      let displayTimezone: string | null = null;
+      if (tz) {
+        try {
+          displayTimezone = formatDisplayTimezone(tz, new Date());
+        } catch {
+          ctx.log.warn({ tz }, 'calendar-update-event: invalid timezone for displayTimezone');
+        }
+      }
       return {
         success: true,
         data: {
           event: {
             ...event,
-            startTime: event.startTime !== null && Number.isFinite(event.startTime) && event.startTime > 0
-              ? new Date(event.startTime * 1000).toISOString() : null,
-            endTime: event.endTime !== null && Number.isFinite(event.endTime) && event.endTime > 0
-              ? new Date(event.endTime * 1000).toISOString() : null,
+            startTime: toIso(event.startTime, 'startTime'),
+            endTime: toIso(event.endTime, 'endTime'),
           },
+          displayTimezone,
         },
       };
     } catch (err) {

--- a/skills/calendar-update-event/handler.ts
+++ b/skills/calendar-update-event/handler.ts
@@ -65,44 +65,18 @@ export class CalendarUpdateEventHandler implements SkillHandler {
 
       const event = await ctx.nylasCalendarClient.updateEvent(calendarId, eventId, changes);
       ctx.log.info({ calendarId, eventId }, 'Updated calendar event');
-      // Format timestamps in the user's local timezone so the confirmation matches what
-      // calendar-list-events returns. Falls back to UTC Z-suffix when timezone is not configured.
-      // Defensive fallback on bad timezone: the event was already written — a misconfigured
-      // ctx.timezone must not falsely report failure.
+      // Format timestamps in the user's local timezone so the confirmation matches
+      // what calendar-list-events returns. toLocalIso handles null/invalid values internally.
       const tz = ctx.timezone;
-      const toIso = (unix: number | null, field: string): string | null => {
-        if (unix === null) return null;
-        if (!Number.isFinite(unix) || unix <= 0) {
-          ctx.log.warn({ eventId, field, value: unix }, `calendar-update-event: suspicious ${field} value — omitting`);
-          return null;
-        }
-        if (tz) {
-          try {
-            return toLocalIso(unix, tz);
-          } catch {
-            ctx.log.warn({ tz }, 'calendar-update-event: invalid timezone — falling back to UTC');
-            return new Date(unix * 1000).toISOString();
-          }
-        }
-        return new Date(unix * 1000).toISOString();
-      };
-      let displayTimezone: string | null = null;
-      if (tz) {
-        try {
-          displayTimezone = formatDisplayTimezone(tz, new Date());
-        } catch {
-          ctx.log.warn({ tz }, 'calendar-update-event: invalid timezone for displayTimezone');
-        }
-      }
       return {
         success: true,
         data: {
           event: {
             ...event,
-            startTime: toIso(event.startTime, 'startTime'),
-            endTime: toIso(event.endTime, 'endTime'),
+            startTime: toLocalIso(event.startTime, tz),
+            endTime: toLocalIso(event.endTime, tz),
           },
-          displayTimezone,
+          displayTimezone: tz ? formatDisplayTimezone(tz, new Date()) : null,
         },
       };
     } catch (err) {

--- a/skills/decay-warnings-list/handler.ts
+++ b/skills/decay-warnings-list/handler.ts
@@ -40,7 +40,7 @@ export class DecayWarningsListHandler implements SkillHandler {
           sensitivity: w.sensitivity,
           edgeCount: w.edgeCount,
           reason: w.reason,
-          warnedAt: toLocalIso(Math.floor(warnedAtMs / 1000), tz ?? 'UTC'),
+          warnedAt: toLocalIso(Math.floor(warnedAtMs / 1000), tz),
           daysRemaining,
         };
       });

--- a/skills/held-messages-list/handler.ts
+++ b/skills/held-messages-list/handler.ts
@@ -46,7 +46,7 @@ export class HeldMessagesListHandler implements SkillHandler {
           subject: m.subject,
           preview: plaintext.slice(0, 500),
           totalLength: plaintext.length,
-          receivedAt: tz ? toLocalIso(unixSeconds, tz) : m.createdAt.toISOString(),
+          receivedAt: toLocalIso(unixSeconds, tz),
         };
       });
 

--- a/skills/list-pending-actions/handler.ts
+++ b/skills/list-pending-actions/handler.ts
@@ -30,10 +30,8 @@ export class ListPendingActionsHandler implements SkillHandler {
         short_ref: row.shortRef,
         description: row.description,
         skill_name: row.skillName,
-        created_at: tz ? toLocalIso(Math.floor(row.createdAt.getTime() / 1000), tz) : row.createdAt.toISOString(),
-        expires_at: row.expiresAt
-          ? (tz ? toLocalIso(Math.floor(row.expiresAt.getTime() / 1000), tz) : row.expiresAt.toISOString())
-          : null,
+        created_at: toLocalIso(Math.floor(row.createdAt.getTime() / 1000), tz),
+        expires_at: row.expiresAt ? toLocalIso(Math.floor(row.expiresAt.getTime() / 1000), tz) : null,
       }));
 
       if (pending.length === 0) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -698,6 +698,15 @@ export function loadConfig(): Config {
     throw new Error(`NYLAS_POLL_INTERVAL_MS must be a number >= 1000, got: ${process.env.NYLAS_POLL_INTERVAL_MS}`);
   }
 
+  // Validate IANA timezone before any consumer sees it — bad config should fail at
+  // startup, not silently produce wrong timestamps at runtime.
+  const timezone = process.env.TIMEZONE ?? 'America/Toronto';
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: timezone });
+  } catch {
+    throw new Error(`Invalid TIMEZONE configuration: "${timezone}" is not a recognized IANA timezone`);
+  }
+
   return {
     databaseUrl,
     anthropicApiKey: process.env.ANTHROPIC_API_KEY,
@@ -707,7 +716,7 @@ export function loadConfig(): Config {
     apiToken: process.env.API_TOKEN,
     webAppBootstrapSecret: process.env.WEB_APP_BOOTSTRAP_SECRET,
     appOrigin: process.env.APP_ORIGIN || undefined,
-    timezone: process.env.TIMEZONE ?? 'America/Toronto',
+    timezone,
     nylasApiKey: process.env.NYLAS_API_KEY,
     nylasGrantId: process.env.NYLAS_GRANT_ID,
     nylasPollingIntervalMs,

--- a/src/time/timestamp.ts
+++ b/src/time/timestamp.ts
@@ -76,16 +76,23 @@ export function normalizeTimestamp(iso: string, defaultZone: string): string {
  * Convert Unix seconds to an ISO 8601 string in the given IANA timezone,
  * with the local UTC offset baked in.
  *
+ * Returns null for null, non-finite, or non-positive inputs — these are never
+ * valid event timestamps (Unix 0 = 1970, negatives = before epoch).
+ *
+ * When timezone is omitted, falls back to a UTC Z-suffix string via new Date().
+ *
  * Example: toLocalIso(1775489400, 'America/Toronto') → "2026-04-06T11:30:00.000-04:00"
  *
  * This is the output-side complement to normalizeTimestamp() (which handles inputs).
  * The wall-clock digits in the returned string match the user's local time, so LLMs
  * read them correctly without needing to perform timezone arithmetic.
  *
- * @param unixSeconds  Unix epoch seconds (as returned by Nylas calendar API)
- * @param timezone     IANA timezone name (e.g. "America/Toronto")
+ * @param unixSeconds  Unix epoch seconds (as returned by Nylas calendar API), or null
+ * @param timezone     IANA timezone name (e.g. "America/Toronto"), or undefined for UTC
  */
-export function toLocalIso(unixSeconds: number, timezone: string): string {
+export function toLocalIso(unixSeconds: number | null, timezone?: string): string | null {
+  if (unixSeconds === null || !Number.isFinite(unixSeconds) || unixSeconds <= 0) return null;
+  if (!timezone) return new Date(unixSeconds * 1000).toISOString();
   const dt = DateTime.fromSeconds(unixSeconds, { zone: timezone });
   if (!dt.isValid) {
     throw new Error(`toLocalIso: invalid timezone "${timezone}" (${dt.invalidReason ?? 'unknown reason'})`);

--- a/tests/unit/time/timestamp.test.ts
+++ b/tests/unit/time/timestamp.test.ts
@@ -26,6 +26,25 @@ describe('toLocalIso', () => {
   it('throws on invalid timezone', () => {
     expect(() => toLocalIso(1775489400, 'Not/A/Zone')).toThrow('invalid timezone');
   });
+
+  it('returns null for null input', () => {
+    expect(toLocalIso(null, 'America/Toronto')).toBeNull();
+  });
+
+  it('returns null for non-finite input', () => {
+    expect(toLocalIso(NaN, 'America/Toronto')).toBeNull();
+    expect(toLocalIso(Infinity, 'America/Toronto')).toBeNull();
+  });
+
+  it('returns null for non-positive input', () => {
+    expect(toLocalIso(0, 'America/Toronto')).toBeNull();
+    expect(toLocalIso(-1, 'America/Toronto')).toBeNull();
+  });
+
+  it('falls back to UTC when timezone is omitted', () => {
+    // 1775489400 = 2026-04-06T15:30:00Z
+    expect(toLocalIso(1775489400)).toBe('2026-04-06T15:30:00.000Z');
+  });
 });
 
 describe('formatDisplayTimezone', () => {


### PR DESCRIPTION
## Summary

Closes #369

**Bug fix:** `calendar-create-event` and `calendar-update-event` were returning confirmation timestamps in UTC (e.g. `3:30 PM Z`) while `calendar-list-events` showed the same event in local time (e.g. `11:30 AM EDT`) after #368. The LLM would relay inconsistent times to the user.

**Refactor:** Rather than adding per-handler wrappers, we strengthened `toLocalIso` so it handles edge cases once, centrally:

- `toLocalIso` now accepts `number | null` and returns `string | null` — null, non-finite, and non-positive inputs return null instead of requiring callers to guard
- When timezone is omitted (undefined), it falls back to a UTC Z-suffix string instead of requiring callers to write `tz ? toLocalIso(x, tz) : x.toISOString()`
- Removed local `toIso`/`formatTs` wrapper functions from all 6 callers (`calendar-list-events`, `calendar-find-free-time`, `calendar-check-conflicts`, `list-pending-actions`, `held-messages-list`, `decay-warnings-list`)

**Startup validation:** `TIMEZONE` env var is now validated via `Intl.DateTimeFormat` in `config.ts` at boot — a misconfigured timezone fails fast instead of producing wrong timestamps at runtime.

## Test plan

- [ ] Create an event via `calendar-create-event` — confirm `startTime`/`endTime` use local-timezone offset (e.g. `-04:00`) not `Z`
- [ ] Update an event via `calendar-update-event` — same check
- [ ] `displayTimezone` present in both responses (e.g. `"EDT (UTC-04:00)"`)
- [ ] Wall-clock times in create/update confirmation match `calendar-list-events` for the same event
- [ ] Set `TIMEZONE=Not/A/Zone` — server refuses to start with a clear error message
- [ ] Unit tests pass: `vitest run tests/unit/time/timestamp.test.ts`