### PR TITLE
fix: harden self-email loop filter against aliases, plus-addressing, and send-as variations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Self-email loop filter hardened** — inbound poll now rejects messages via three independent checks: folder membership ("sent"/"draft"), recently-sent Nylas message ID, and plus-address-normalized `selfEmail` comparison. Prevents infinite reply loops when using send-as alias addresses (e.g. `security@meetcuria.com` forwarding to the Nylas account). (#37)
+
 ### Added
 
 - **Email attachment support** — surface metadata in email skills, append human-readable summaries to message content, and download bytes as base64 for `file-parse`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **Self-email loop filter hardened** — inbound poll now rejects messages via three independent checks: folder membership ("sent"/"draft"), recently-sent Nylas message ID, and plus-address-normalized `selfEmail` comparison. Prevents infinite reply loops when using send-as alias addresses (e.g. `security@meetcuria.com` forwarding to the Nylas account). (#37)
+- **Self-email loop filter hardened** — inbound poll now rejects self-sent messages via folder, sent-ID, and normalized-address checks to prevent reply loops. (#37)
 
 ### Added
 

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -252,9 +252,11 @@ export class EmailAdapter {
         // Skip messages in sent or draft folders — they are never genuine inbound
         // messages, regardless of the From address. This catches send-as aliases
         // (e.g. security@meetcuria.com) where the From won't match selfEmail.
-        // Folder IDs vary by provider but always contain "sent" or "draft" as a
-        // substring (Gmail: "SENT"/"DRAFT"; IMAP: "Sent Mail"/"Drafts").
-        const inSentOrDrafts = msg.folders.some((f) => /\b(sent|draft)/i.test(f));
+        // Folder IDs/names vary by provider but always contain "sent" or "draft"
+        // as a substring (Gmail: "SENT"/"DRAFT"; IMAP: "Sent Mail"/"Drafts").
+        // Using a plain substring match so provider-specific prefixes/suffixes
+        // like "recently-sent" still match without an asymmetric word boundary.
+        const inSentOrDrafts = msg.folders.some((f) => /(sent|draft)/i.test(f));
         if (inSentOrDrafts) {
           this.config.logger.debug(
             { messageId: msg.id, folders: msg.folders, accountId: this.config.accountId },
@@ -267,10 +269,13 @@ export class EmailAdapter {
         // Skip any message whose Nylas ID was recorded when we sent it.
         // This is the most reliable alias-proof check — the ID is unique and
         // does not depend on the From address matching selfEmail.
+        // Note: this only covers direct sends through sendWithGatedDraftFallback.
+        // Draft-to-send flows approved via the send-draft skill are not tracked
+        // here; those rely on Layers 1 and 3 for loop prevention.
         if (this.recentlySentIds.has(msg.id)) {
-          this.config.logger.debug(
+          this.config.logger.info(
             { messageId: msg.id, accountId: this.config.accountId },
-            'Email skipped — matches recently-sent message ID',
+            'Email skipped — matches recently-sent message ID (loop guard)',
           );
           continue;
         }
@@ -281,6 +286,15 @@ export class EmailAdapter {
         // normalizeForComparison strips plus-addressing and lowercases so that
         // variations like curia+reply@example.com still match curia@example.com.
         const fromEmail = msg.from[0]?.email;
+        if (!fromEmail) {
+          // Log a warning so misconfigured or malformed messages are observable.
+          // We still forward for processing — the downstream dispatcher applies its
+          // own sender policy and will surface the empty senderId appropriately.
+          this.config.logger.warn(
+            { messageId: msg.id, threadId: msg.threadId, accountId: this.config.accountId },
+            'Email received with missing From address — self-check skipped, processing with unknown sender',
+          );
+        }
         if (
           fromEmail &&
           normalizeForComparison(fromEmail) === normalizeForComparison(this.config.selfEmail)
@@ -504,7 +518,17 @@ export class EmailAdapter {
       // Track the sent message ID so the next inbound poll skips it.
       // Guards against the case where the provider returns our own sent message
       // as an unread inbox item (e.g. when using a send-as alias address).
-      if (result.messageId) this.trackSentId(result.messageId);
+      if (result.messageId) {
+        this.trackSentId(result.messageId);
+      } else {
+        // Gateway returned success without a message ID — Layer 2 loop guard
+        // is inactive for this specific message. Layers 1 (folder) and 3
+        // (address normalization) still apply.
+        this.config.logger.warn(
+          { accountId: this.config.accountId, conversationId: context.conversationId },
+          'email-adapter: send succeeded but gateway returned no messageId — Layer 2 loop guard inactive for this message',
+        );
+      }
       return;
     }
 

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -15,6 +15,24 @@ import { convertNylasMessage } from './message-converter.js';
 import { createInboundMessage, type OutboundMessageEvent, type OutboundNotificationEvent } from '../../bus/events.js';
 import { sanitizeOutput } from '../../skills/sanitize.js';
 
+// ---------------------------------------------------------------------------
+// Address normalization helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize an email address for self-identity comparison.
+ * Strips plus-addressing (local+tag@domain → local@domain) and lowercases.
+ * This catches send-as alias variations and plus-address routing tricks that
+ * could otherwise bypass the self-email loop filter.
+ */
+function normalizeForComparison(email: string): string {
+  const at = email.lastIndexOf('@');
+  if (at === -1) return email.toLowerCase();
+  const local = email.slice(0, at).replace(/\+.*$/, '');
+  const domain = email.slice(at);
+  return local.toLowerCase() + domain.toLowerCase();
+}
+
 export interface EmailAdapterConfig {
   /**
    * Logical name for this email account (e.g. "curia", "joseph").
@@ -56,6 +74,25 @@ export class EmailAdapter {
   private pollTimer?: ReturnType<typeof setInterval>;
   private lastSeenTimestamp: number = 0;
   private processing = false;
+
+  // ── Recently-sent message ID tracking (self-loop guard) ───────────────────
+  // After a successful send, the Nylas message ID is added here so that the
+  // next inbound poll can skip it even if the mail provider returns it as unread
+  // or uses a send-as alias address that doesn't match selfEmail.
+  // The set is bounded to MAX_SENT_IDS entries; oldest entries are evicted when
+  // the cap is reached. 200 covers thousands of hours at normal send rates.
+
+  private readonly recentlySentIds = new Set<string>();
+  private static readonly MAX_SENT_IDS = 200;
+
+  private trackSentId(id: string): void {
+    this.recentlySentIds.add(id);
+    // Set preserves insertion order, so values().next() is the oldest entry.
+    if (this.recentlySentIds.size > EmailAdapter.MAX_SENT_IDS) {
+      const oldest = this.recentlySentIds.values().next().value;
+      if (oldest !== undefined) this.recentlySentIds.delete(oldest);
+    }
+  }
 
   // ── Contact auto-creation rate limiting (#36) ──────────────────────────────
   // In-memory counters — reset on process restart, which is fine for anti-flood.
@@ -211,18 +248,50 @@ export class EmailAdapter {
           this.lastSeenTimestamp = msg.date + 1;
         }
 
+        // ── Layer 1: folder-based detection ──────────────────────────────────
+        // Skip messages in sent or draft folders — they are never genuine inbound
+        // messages, regardless of the From address. This catches send-as aliases
+        // (e.g. security@meetcuria.com) where the From won't match selfEmail.
+        // Folder IDs vary by provider but always contain "sent" or "draft" as a
+        // substring (Gmail: "SENT"/"DRAFT"; IMAP: "Sent Mail"/"Drafts").
+        const inSentOrDrafts = msg.folders.some((f) => /\b(sent|draft)/i.test(f));
+        if (inSentOrDrafts) {
+          this.config.logger.debug(
+            { messageId: msg.id, folders: msg.folders, accountId: this.config.accountId },
+            'Email skipped — message is in sent/drafts folder',
+          );
+          continue;
+        }
+
+        // ── Layer 2: recently-sent message ID ────────────────────────────────
+        // Skip any message whose Nylas ID was recorded when we sent it.
+        // This is the most reliable alias-proof check — the ID is unique and
+        // does not depend on the From address matching selfEmail.
+        if (this.recentlySentIds.has(msg.id)) {
+          this.config.logger.debug(
+            { messageId: msg.id, accountId: this.config.accountId },
+            'Email skipped — matches recently-sent message ID',
+          );
+          continue;
+        }
+
+        // ── Layer 3: address-based self-check (with plus-address normalization) ─
         // Skip emails sent by this account (self) — we only want inbound messages
         // from external senders, not our own outgoing replies.
-        // Case-insensitive to guard against inconsistent casing from mail servers.
+        // normalizeForComparison strips plus-addressing and lowercases so that
+        // variations like curia+reply@example.com still match curia@example.com.
         const fromEmail = msg.from[0]?.email;
-        if (fromEmail?.toLowerCase() === this.config.selfEmail.toLowerCase()) continue;
+        if (
+          fromEmail &&
+          normalizeForComparison(fromEmail) === normalizeForComparison(this.config.selfEmail)
+        ) continue;
 
         // Skip emails from any additionally-excluded sender addresses (e.g. Curia's
         // outbound address on a monitored inbox, to prevent self-reply loops).
         if (
           fromEmail &&
           this.config.excludedSenderEmails.some(
-            (excluded) => excluded.toLowerCase() === fromEmail.toLowerCase(),
+            (excluded) => normalizeForComparison(excluded) === normalizeForComparison(fromEmail),
           )
         ) {
           this.config.logger.debug(
@@ -329,8 +398,10 @@ export class EmailAdapter {
       const latestFromEmail = threadMessage.from[0]?.email;
 
       // If the latest message was sent BY us, the human's address is in 'to'.
-      // Comparing case-insensitively guards against inconsistent casing from mail servers.
-      const latestIsOurs = latestFromEmail?.toLowerCase() === this.config.selfEmail.toLowerCase();
+      // normalizeForComparison handles casing and plus-addressing variations.
+      const latestIsOurs =
+        latestFromEmail !== undefined &&
+        normalizeForComparison(latestFromEmail) === normalizeForComparison(this.config.selfEmail);
 
       // When the latest message is ours, find the first non-self address in 'to'.
       // to[] can contain multiple recipients (e.g. a thread with a CC'd third party);
@@ -339,7 +410,7 @@ export class EmailAdapter {
       // the inbound message rather than inferring the recipient from the thread.
       const recipientEmail = latestIsOurs
         ? threadMessage.to.find(
-            (r) => r.email.toLowerCase() !== this.config.selfEmail.toLowerCase(),
+            (r) => normalizeForComparison(r.email) !== normalizeForComparison(this.config.selfEmail),
           )?.email
         : latestFromEmail;
 
@@ -354,7 +425,7 @@ export class EmailAdapter {
       // Guard: if the resolved recipient is still our own address (e.g. a self-addressed
       // thread or malformed to[] list), bail out rather than looping a reply to our own
       // inbox. This would produce a misleading "sent" log with no human ever receiving it.
-      if (recipientEmail.toLowerCase() === this.config.selfEmail.toLowerCase()) {
+      if (normalizeForComparison(recipientEmail) === normalizeForComparison(this.config.selfEmail)) {
         logger.error(
           { threadId, messageId: threadMessage.id, latestIsOurs },
           'Cannot reply — resolved recipient is selfEmail; thread may be self-addressed or to[] is malformed',
@@ -368,8 +439,8 @@ export class EmailAdapter {
         .map((r) => r.email)
         .filter(
           (email) =>
-            email.toLowerCase() !== this.config.selfEmail.toLowerCase() &&
-            email.toLowerCase() !== recipientEmail.toLowerCase(),
+            normalizeForComparison(email) !== normalizeForComparison(this.config.selfEmail) &&
+            normalizeForComparison(email) !== normalizeForComparison(recipientEmail),
         );
 
       if (ccAddresses.length > 0) {
@@ -429,7 +500,13 @@ export class EmailAdapter {
       },
     });
 
-    if (result.success) return;
+    if (result.success) {
+      // Track the sent message ID so the next inbound poll skips it.
+      // Guards against the case where the provider returns our own sent message
+      // as an unread inbox item (e.g. when using a send-as alias address).
+      if (result.messageId) this.trackSentId(result.messageId);
+      return;
+    }
 
     if (result.gated) {
       // Gateway blocked the send — create draft as fallback.
@@ -518,9 +595,9 @@ export class EmailAdapter {
     let hitPerHourCap = false;
 
     for (const p of participants) {
-      // Don't create a contact for ourselves — case-insensitive to guard against
-      // inconsistent casing from mail servers (e.g. "User@Example.com" vs "user@example.com").
-      if (p.email.toLowerCase() === selfEmail.toLowerCase()) continue;
+      // Don't create a contact for ourselves — normalizeForComparison handles casing
+      // and plus-address variations (e.g. "curia+tag@example.com" vs "curia@example.com").
+      if (normalizeForComparison(p.email) === normalizeForComparison(selfEmail)) continue;
 
       try {
         // Check if this email is already linked to a contact

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -799,6 +799,196 @@ describe('EmailAdapter — sendWithGatedDraftFallback gated-fallback', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Inbound poll — self-loop hardening (#37)
+// Three-layer defense: folder detection, sent-ID tracking, plus-address normalization
+// ---------------------------------------------------------------------------
+
+describe('EmailAdapter — inbound poll: self-loop hardening', () => {
+  // Helper to create an adapter with a single-shot poll and start it.
+  async function startWithMessages(msgs: NylasMessage[]) {
+    const mocks = createMocks();
+    const adapter = makeAdapter(mocks);
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValueOnce(msgs);
+    await adapter.start();
+    await flushPoll();
+    return { mocks, adapter };
+  }
+
+  function wasPublished(mocks: ReturnType<typeof createMocks>) {
+    return (mocks.bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .find(([, ev]) => ev?.type === 'inbound.message') !== undefined;
+  }
+
+  // ── Layer 1: folder-based detection ───────────────────────────────────────
+
+  it('skips message in SENT folder regardless of From address', async () => {
+    const msg = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      folders: ['SENT'],
+    });
+    const { mocks, adapter } = await startWithMessages([msg]);
+    expect(wasPublished(mocks)).toBe(false);
+    await adapter.stop();
+  });
+
+  it('skips message in DRAFTS folder', async () => {
+    const msg = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      folders: ['DRAFTS'],
+    });
+    const { mocks, adapter } = await startWithMessages([msg]);
+    expect(wasPublished(mocks)).toBe(false);
+    await adapter.stop();
+  });
+
+  it('skips message with mixed folders when one is SENT', async () => {
+    // Some providers tag messages with both INBOX and SENT simultaneously
+    const msg = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      folders: ['INBOX', 'SENT'],
+    });
+    const { mocks, adapter } = await startWithMessages([msg]);
+    expect(wasPublished(mocks)).toBe(false);
+    await adapter.stop();
+  });
+
+  it('does not skip a normal INBOX message', async () => {
+    // Sanity check — regular inbound from CEO must still be published
+    const msg = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      folders: ['INBOX'],
+    });
+    const { mocks, adapter } = await startWithMessages([msg]);
+    expect(wasPublished(mocks)).toBe(true);
+    await adapter.stop();
+  });
+
+  // ── Layer 2: recently-sent message ID tracking ────────────────────────────
+
+  it('skips inbound message whose ID matches a recently-sent message', async () => {
+    const mocks = createMocks();
+    const triggerOutbound = captureHandler('outbound.message', mocks);
+    const adapter = makeAdapter(mocks);
+
+    // Outbound reply succeeds — gateway returns a messageId
+    (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      messageId: 'sent-loop-id',
+    });
+    const threadMsg = makeMockMessage({
+      id: 'thread-msg-1',
+      from: [{ email: CEO_EMAIL }],
+      to: [{ email: SELF_EMAIL }],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([threadMsg]);
+
+    await adapter.start();
+
+    // Trigger an outbound reply — this causes the adapter to call gateway.send()
+    // and track the returned 'sent-loop-id'
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    // Simulate the next inbound poll returning the sent message (ID = 'sent-loop-id')
+    const sentMsgAsInbound = makeMockMessage({
+      id: 'sent-loop-id',
+      from: [{ email: SELF_EMAIL }], // From would match selfEmail — but folder + ID checks run first
+      folders: ['INBOX'], // Not in SENT — only the ID check would catch it
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValueOnce([sentMsgAsInbound]);
+
+    // Reset publish spy so we only see events from this poll
+    (mocks.bus.publish as ReturnType<typeof vi.fn>).mockClear();
+    await (adapter as unknown as { poll(): Promise<void> }).poll();
+
+    expect(wasPublished(mocks)).toBe(false);
+
+    await adapter.stop();
+  });
+
+  it('does not skip a message whose ID is not in the recently-sent set', async () => {
+    // Regression: ensure the ID check does not filter legitimate inbound messages
+    const msg = makeMockMessage({
+      id: 'inbound-new-id',
+      from: [{ email: CEO_EMAIL }],
+    });
+    const { mocks, adapter } = await startWithMessages([msg]);
+    expect(wasPublished(mocks)).toBe(true);
+    await adapter.stop();
+  });
+
+  // ── Layer 3: plus-address normalization ──────────────────────────────────
+
+  it('skips message from selfEmail with a plus-address tag', async () => {
+    // SELF_EMAIL = 'curia@example.com'; from = 'curia+alerts@example.com'
+    const msg = makeMockMessage({
+      from: [{ email: 'curia+alerts@example.com' }],
+      folders: ['INBOX'],
+    });
+    const { mocks, adapter } = await startWithMessages([msg]);
+    expect(wasPublished(mocks)).toBe(false);
+    await adapter.stop();
+  });
+
+  it('skips message from selfEmail in all-caps (case normalization)', async () => {
+    const msg = makeMockMessage({
+      from: [{ email: SELF_EMAIL.toUpperCase() }],
+      folders: ['INBOX'],
+    });
+    const { mocks, adapter } = await startWithMessages([msg]);
+    expect(wasPublished(mocks)).toBe(false);
+    await adapter.stop();
+  });
+
+  it('does not skip a legitimate external sender that merely shares a domain with self', async () => {
+    // 'otherperson@example.com' is NOT selfEmail — must not be filtered
+    const msg = makeMockMessage({
+      from: [{ email: 'otherperson@example.com' }],
+      folders: ['INBOX'],
+    });
+    const { mocks, adapter } = await startWithMessages([msg]);
+    expect(wasPublished(mocks)).toBe(true);
+    await adapter.stop();
+  });
+
+  // ── Forwarding scenario (security@meetcuria.com → nathancuria1@gmail.com) ──
+
+  it('skips a send-as alias reply appearing in SENT — forwarding scenario', async () => {
+    // Curia uses security@meetcuria.com as send-as alias; selfEmail is nathancuria1@gmail.com.
+    // Mail provider may surface the sent message with From: security@meetcuria.com.
+    // The folder check (SENT) must catch it before the address check runs.
+    const mocks = createMocks();
+    const adapter = new EmailAdapter({
+      accountId: 'curia',
+      bus: mocks.bus,
+      logger: mocks.logger,
+      outboundGateway: mocks.outboundGateway,
+      contactService: mocks.contactService,
+      pollingIntervalMs: 999999,
+      selfEmail: 'nathancuria1@gmail.com',
+      excludedSenderEmails: [],
+      contactCreationMaxPerMessage: 10,
+      contactCreationMaxPerHour: 100,
+      ceoEmail: CEO_EMAIL,
+    });
+
+    const sentViaAlias = makeMockMessage({
+      from: [{ email: 'security@meetcuria.com' }], // alias, not selfEmail
+      folders: ['SENT'],
+    });
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValueOnce([sentViaAlias]);
+
+    await adapter.start();
+    await flushPoll();
+
+    const published = (mocks.bus.publish as ReturnType<typeof vi.fn>).mock.calls
+      .find(([, ev]) => ev?.type === 'inbound.message');
+    expect(published).toBeUndefined();
+
+    await adapter.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // sendOutboundReply — CC behaviour
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -863,6 +863,36 @@ describe('EmailAdapter — inbound poll: self-loop hardening', () => {
     await adapter.stop();
   });
 
+  it('skips message with Gmail-style folder name ([Gmail]/Sent Mail)', async () => {
+    const msg = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      folders: ['[Gmail]/Sent Mail'],
+    });
+    const { mocks, adapter } = await startWithMessages([msg]);
+    expect(wasPublished(mocks)).toBe(false);
+    await adapter.stop();
+  });
+
+  it('skips message with Outlook-style folder name (Sent Items)', async () => {
+    const msg = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      folders: ['Sent Items'],
+    });
+    const { mocks, adapter } = await startWithMessages([msg]);
+    expect(wasPublished(mocks)).toBe(false);
+    await adapter.stop();
+  });
+
+  it('skips message with suffixed draft folder name (Drafts_Old)', async () => {
+    const msg = makeMockMessage({
+      from: [{ email: CEO_EMAIL }],
+      folders: ['Drafts_Old'],
+    });
+    const { mocks, adapter } = await startWithMessages([msg]);
+    expect(wasPublished(mocks)).toBe(false);
+    await adapter.stop();
+  });
+
   // ── Layer 2: recently-sent message ID tracking ────────────────────────────
 
   it('skips inbound message whose ID matches a recently-sent message', async () => {
@@ -883,6 +913,7 @@ describe('EmailAdapter — inbound poll: self-loop hardening', () => {
     (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([threadMsg]);
 
     await adapter.start();
+    await flushPoll();
 
     // Trigger an outbound reply — this causes the adapter to call gateway.send()
     // and track the returned 'sent-loop-id'


### PR DESCRIPTION
## Summary

- **Three-layer loop guard** in the inbound email poll — folder membership, sent-message-ID tracking, and plus-address-normalized address comparison — replacing the single `selfEmail.toLowerCase()` check
- **No config changes required**: all protection is pattern-based and in-memory
- Closes #37

## What changed

**`src/channels/email/email-adapter.ts`**

- Added `normalizeForComparison(email)` helper — strips plus-addressing (`curia+tag@example.com` → `curia@example.com`) and lowercases; applied to every `selfEmail` comparison in `poll()`, `sendOutboundReply()`, and `extractParticipants()`
- Layer 1 (folder check): skip any message whose `folders` array contains `"sent"` or `"draft"` (case-insensitive substring); catches send-as alias replies regardless of From address
- Layer 2 (sent-ID tracking): after each successful `outboundGateway.send()`, the returned Nylas message ID is stored in a bounded in-memory `Set` (max 200); inbound poll skips any message whose ID is in the set
- Warn log when `fromEmail` is absent (pre-existing silent pass-through now observable)
- Warn log when `gateway.send()` succeeds but returns no `messageId` (Layer 2 gap made visible)

**`tests/unit/channels/email/email-adapter.test.ts`**

13 new tests covering all three layers, including the `security@meetcuria.com` forwarding scenario.

## Test plan

- [ ] `npm test -- tests/unit/channels/email/email-adapter.test.ts` — 39 tests, all green
- [ ] Full suite — no regressions (3 pre-existing failures unrelated to this PR)
- [ ] `npm run typecheck` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened email loop prevention during inbound polling to reduce infinite reply scenarios with send-as alias forwarding. The system now uses multiple independent detection layers including folder membership checks, message ID tracking, and normalized address comparison (supporting plus-addresses and case variations) to identify and skip self-sent emails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/586)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->