### PR TITLE
chore: add concurrency groups and paths-ignore to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - '.github/**/*.md'
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: secret-scan-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Closes #575

## Summary

- **Concurrency groups** on both `ci.yml` and `secret-scan.yml`: cancels in-progress runs when a PR branch is updated, but preserves all runs on `main` pushes (rapid back-to-back merges won't cancel each other)
- **`paths-ignore`** on `ci.yml` only: skips CI entirely for doc-only PRs (`*.md`, `docs/**`, `.github/**/*.md`)
- **`secret-scan.yml`** intentionally has no `paths-ignore` — secrets can be committed in any file type
- **Branch protection migrated to a repository ruleset** (done via API, not part of this PR): rulesets treat skipped checks as passing, so doc-only PRs satisfy the required `ci` check and can merge normally

## Concurrency group design

Uses `github.head_ref || github.ref` as the group key so PR runs are grouped by branch name, and `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` to preserve all post-merge runs on main.

## Test plan

- [ ] Push a second commit to a PR — confirm the first CI run is cancelled
- [ ] Open a PR that only changes `.md` files — confirm CI is skipped and the PR can still merge
- [ ] Merge two PRs in quick succession — confirm both CI runs complete on main
- [ ] Confirm secret-scan runs on doc-only PRs (no paths-ignore)