### PR TITLE
fix: per-route rate limits — resolve 24 CodeQL missing-rate-limiting alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+
+- **Per-route rate limiting** — all 24 CodeQL `js/missing-rate-limiting` alerts resolved; auth/authorization endpoints (identity, autonomy, executive) capped at 10 req/min per IP, KG explorer and health endpoints at 60 req/min. (#580)
+
 ### Fixed
 
 - **Self-email loop filter hardened** — inbound poll now rejects self-sent messages via folder, sent-ID, and normalized-address checks to prevent reply loops. (#37)

--- a/src/channels/http/routes/autonomy.ts
+++ b/src/channels/http/routes/autonomy.ts
@@ -33,9 +33,14 @@ export async function autonomyRoutes(
     return assertSecret(request, reply, webAppBootstrapSecret, sessions);
   }
 
+  // Stricter per-route rate limit for all autonomy endpoints: 10 req/min per IP.
+  // These routes check credentials on every call — a brute-force target that
+  // needs tighter throttling than the global 200/min baseline.
+  const AUTH_RATE = { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } };
+
   // -- GET /api/autonomy — return current autonomy config --
 
-  app.get('/api/autonomy', async (request, reply) => {
+  app.get('/api/autonomy', AUTH_RATE, async (request, reply) => {
     if (!requireAuth(request, reply)) return;
 
     try {
@@ -64,7 +69,7 @@ export async function autonomyRoutes(
 
   // -- PUT /api/autonomy — set the autonomy score --
 
-  app.put('/api/autonomy', async (request, reply) => {
+  app.put('/api/autonomy', AUTH_RATE, async (request, reply) => {
     if (!requireAuth(request, reply)) return;
 
     const body = request.body as { score?: unknown; reason?: unknown } | null;
@@ -106,7 +111,7 @@ export async function autonomyRoutes(
 
   // -- GET /api/autonomy/history — paginated history of score changes --
 
-  app.get('/api/autonomy/history', async (request, reply) => {
+  app.get('/api/autonomy/history', AUTH_RATE, async (request, reply) => {
     if (!requireAuth(request, reply)) return;
 
     // Parse query params with safe defaults. Clamp limit to max 50 to prevent

--- a/src/channels/http/routes/executive.ts
+++ b/src/channels/http/routes/executive.ts
@@ -30,9 +30,14 @@ export async function executiveRoutes(
     return assertSecret(request, reply, webAppBootstrapSecret, sessions);
   }
 
+  // Stricter per-route rate limit for all executive endpoints: 10 req/min per IP.
+  // These routes check credentials on every call — a brute-force target that
+  // needs tighter throttling than the global 200/min baseline.
+  const AUTH_RATE = { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } };
+
   // -- GET /api/executive — return current executive profile --
 
-  app.get('/api/executive', async (request, reply) => {
+  app.get('/api/executive', AUTH_RATE, async (request, reply) => {
     if (!requireAuth(request, reply)) return;
 
     try {
@@ -46,7 +51,7 @@ export async function executiveRoutes(
 
   // -- PUT /api/executive — save a new version and trigger hot reload --
 
-  app.put('/api/executive', async (request, reply) => {
+  app.put('/api/executive', AUTH_RATE, async (request, reply) => {
     if (!requireAuth(request, reply)) return;
 
     const body = request.body as {
@@ -81,7 +86,7 @@ export async function executiveRoutes(
 
   // -- GET /api/executive/history — return all versions, newest first --
 
-  app.get('/api/executive/history', async (request, reply) => {
+  app.get('/api/executive/history', AUTH_RATE, async (request, reply) => {
     if (!requireAuth(request, reply)) return;
 
     try {
@@ -95,7 +100,7 @@ export async function executiveRoutes(
 
   // -- POST /api/executive/reload — force a reload from DB --
 
-  app.post('/api/executive/reload', async (request, reply) => {
+  app.post('/api/executive/reload', AUTH_RATE, async (request, reply) => {
     if (!requireAuth(request, reply)) return;
 
     try {

--- a/src/channels/http/routes/health.ts
+++ b/src/channels/http/routes/health.ts
@@ -22,7 +22,10 @@ export async function healthRoutes(
   const { pool, logger, agentNames, skillNames } = options;
   const startTime = Date.now();
 
-  app.get('/api/health', async (_request, reply) => {
+  // Permissive rate limit: 60 req/min per IP — allows monitoring tools to probe every
+  // second while still preventing denial-of-service from rogue scanners. This is well
+  // above the expected load from any real health-check fleet.
+  app.get('/api/health', { config: { rateLimit: { max: 60, timeWindow: '1 minute' } } }, async (_request, reply) => {
     let dbStatus = 'connected';
 
     try {

--- a/src/channels/http/routes/identity.ts
+++ b/src/channels/http/routes/identity.ts
@@ -37,9 +37,14 @@ export async function identityRoutes(
     return assertSecret(request, reply, webAppBootstrapSecret, sessions);
   }
 
+  // Stricter per-route rate limit for all identity endpoints: 10 req/min per IP.
+  // These routes check credentials on every call — a brute-force target that
+  // needs tighter throttling than the global 200/min baseline.
+  const AUTH_RATE = { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } };
+
   // -- GET /api/identity — return current identity config --
 
-  app.get('/api/identity', async (request, reply) => {
+  app.get('/api/identity', AUTH_RATE, async (request, reply) => {
     if (!requireAuth(request, reply)) return;
 
     try {
@@ -65,7 +70,7 @@ export async function identityRoutes(
 
   // -- PUT /api/identity — save a new version and trigger hot reload --
 
-  app.put('/api/identity', async (request, reply) => {
+  app.put('/api/identity', AUTH_RATE, async (request, reply) => {
     if (!requireAuth(request, reply)) return;
 
     const body = request.body as {
@@ -109,7 +114,7 @@ export async function identityRoutes(
 
   // -- GET /api/identity/history — return all versions, newest first --
 
-  app.get('/api/identity/history', async (request, reply) => {
+  app.get('/api/identity/history', AUTH_RATE, async (request, reply) => {
     if (!requireAuth(request, reply)) return;
 
     try {
@@ -125,7 +130,7 @@ export async function identityRoutes(
   // Used by the wizard after saving, to ensure the latest DB version is reflected
   // in the in-memory cache before the next coordinator turn.
 
-  app.post('/api/identity/reload', async (request, reply) => {
+  app.post('/api/identity/reload', AUTH_RATE, async (request, reply) => {
     if (!requireAuth(request, reply)) return;
 
     try {

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -3836,7 +3836,18 @@ export async function knowledgeGraphRoutes(
     return reply.status(200).send({ ok: true });
   });
 
-  app.get('/assets/cytoscape.min.js', async (_request, reply) => {
+  // Per-route rate limits for KG handlers (CodeQL js/missing-rate-limiting).
+  // Two tiers, both well above normal usage:
+  //   ASSET_RATE — static JS bundles served with immutable Cache-Control;
+  //               browsers only fetch once, so 60/min is a generous ceiling
+  //               against scanners without affecting real users.
+  //   KG_RATE    — KG explorer and task/contact API endpoints; 60/min per IP
+  //               allows rapid interactive browsing while blocking DoS-level
+  //               query floods against the database.
+  const ASSET_RATE = { config: { rateLimit: { max: 60, timeWindow: '1 minute' } } };
+  const KG_RATE = { config: { rateLimit: { max: 60, timeWindow: '1 minute' } } };
+
+  app.get('/assets/cytoscape.min.js', ASSET_RATE, async (_request, reply) => {
     // Use createRequire so Node's module resolution finds cytoscape relative to
     // this source file, not relative to the compiled bundle output path.
     // The URL-relative approach (new URL('../../../../node_modules/...')) breaks
@@ -3855,7 +3866,7 @@ export async function knowledgeGraphRoutes(
 
   // cytoscape-fcose layout extension — requires layout-base and cose-base as UMD globals.
   // All three are served as self-hosted assets using the same createRequire pattern as cytoscape.
-  app.get('/assets/layout-base.js', async (_request, reply) => {
+  app.get('/assets/layout-base.js', ASSET_RATE, async (_request, reply) => {
     const require = createRequire(import.meta.url);
     const source = await readFile(require.resolve('layout-base/layout-base.js'), 'utf8');
     reply
@@ -3864,7 +3875,7 @@ export async function knowledgeGraphRoutes(
       .send(source);
   });
 
-  app.get('/assets/cose-base.js', async (_request, reply) => {
+  app.get('/assets/cose-base.js', ASSET_RATE, async (_request, reply) => {
     const require = createRequire(import.meta.url);
     const source = await readFile(require.resolve('cose-base/cose-base.js'), 'utf8');
     reply
@@ -3873,7 +3884,7 @@ export async function knowledgeGraphRoutes(
       .send(source);
   });
 
-  app.get('/assets/cytoscape-fcose.js', async (_request, reply) => {
+  app.get('/assets/cytoscape-fcose.js', ASSET_RATE, async (_request, reply) => {
     const require = createRequire(import.meta.url);
     const source = await readFile(require.resolve('cytoscape-fcose/cytoscape-fcose.js'), 'utf8');
     reply
@@ -3882,7 +3893,7 @@ export async function knowledgeGraphRoutes(
       .send(source);
   });
 
-  app.get('/api/kg/nodes', async (request, reply) => {
+  app.get('/api/kg/nodes', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
 
     const query = request.query as {
@@ -3925,7 +3936,7 @@ export async function knowledgeGraphRoutes(
     });
   });
 
-  app.get('/api/kg/graph', async (request, reply) => {
+  app.get('/api/kg/graph', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
 
     const query = request.query as {
@@ -4054,7 +4065,7 @@ export async function knowledgeGraphRoutes(
     };
   }
 
-  app.get('/api/kg/tasks', async (request, reply) => {
+  app.get('/api/kg/tasks', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const result = await pool.query(
       `SELECT id, agent_id, intent_anchor, status, progress, error_budget, conversation_id, scheduled_job_id, created_at, updated_at
@@ -4080,7 +4091,7 @@ export async function knowledgeGraphRoutes(
     });
   });
 
-  app.post('/api/kg/tasks', async (request, reply) => {
+  app.post('/api/kg/tasks', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const body = request.body as {
       agentId?: unknown;
@@ -4155,7 +4166,7 @@ export async function knowledgeGraphRoutes(
     });
   });
 
-  app.patch('/api/kg/tasks/:id', async (request, reply) => {
+  app.patch('/api/kg/tasks/:id', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const { id } = request.params as { id: string };
     if (!UUID_RE.test(id)) {
@@ -4268,7 +4279,7 @@ export async function knowledgeGraphRoutes(
     });
   });
 
-  app.delete('/api/kg/tasks/:id', async (request, reply) => {
+  app.delete('/api/kg/tasks/:id', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const { id } = request.params as { id: string };
     if (!UUID_RE.test(id)) {
@@ -4281,7 +4292,7 @@ export async function knowledgeGraphRoutes(
     return reply.status(204).send();
   });
 
-  app.get('/api/kg/contacts', async (request, reply) => {
+  app.get('/api/kg/contacts', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const contacts = await contactService.listContacts();
     return reply.send({
@@ -4298,7 +4309,7 @@ export async function knowledgeGraphRoutes(
     });
   });
 
-  app.post('/api/kg/contacts', async (request, reply) => {
+  app.post('/api/kg/contacts', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const body = request.body as {
       displayName?: unknown;
@@ -4347,7 +4358,7 @@ export async function knowledgeGraphRoutes(
     });
   });
 
-  app.patch('/api/kg/contacts/:id', async (request, reply) => {
+  app.patch('/api/kg/contacts/:id', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const { id } = request.params as { id: string };
     const body = request.body as {
@@ -4421,7 +4432,7 @@ export async function knowledgeGraphRoutes(
     });
   });
 
-  app.delete('/api/kg/contacts/:id', async (request, reply) => {
+  app.delete('/api/kg/contacts/:id', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const { id } = request.params as { id: string };
     const contact = await contactService.getContact(id);


### PR DESCRIPTION
## Summary

- **Auth endpoints** (identity, autonomy, executive — 11 handlers): 10 req/min per IP, matching the existing `POST /auth` brute-force protection pattern
- **KG explorer + static assets + health** (13 handlers): 60 req/min per IP — permissive for interactive browsing and monitoring probes
- `@fastify/rate-limit` was already globally registered at 200/min; this PR wires the per-route `config.rateLimit` overrides that were mentioned in a TODO comment since the plugin was first added

Closes #580

## Files changed

| File | Handlers | Limit |
|------|----------|-------|
| `src/channels/http/routes/identity.ts` | GET, PUT, GET /history, POST /reload | 10/min |
| `src/channels/http/routes/autonomy.ts` | GET, PUT, GET /history | 10/min |
| `src/channels/http/routes/executive.ts` | GET, PUT, GET /history, POST /reload | 10/min |
| `src/channels/http/routes/health.ts` | GET /api/health | 60/min |
| `src/channels/http/routes/kg.ts` | 4 static assets + 10 API handlers | 60/min |

## Pre-existing — out of scope

Two follow-up issues surfaced during review but are pre-existing and unrelated to the CodeQL alerts:
- No `errorResponseBuilder` on the rate-limit plugin (store errors would produce unlogged 500s)
- No `allowList` for internal callers sharing an IP with end-users (deployment-topology concern)

## Test plan

- [ ] CI typecheck passes
- [ ] Confirm all 24 CodeQL `js/missing-rate-limiting` alerts are resolved in the next scan
- [ ] Verify 429 is returned after 10 rapid requests to `/api/identity` or `/api/autonomy`
- [ ] Verify `/api/health` still responds normally for monitoring probes