### PR TITLE
fix: ceo-inbox-search Nylas v3 param + ACTIONABLE archive prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`ceo-inbox-search`** — uses `search_query_native` instead of `q` (Nylas v3); suppresses incompatible filter params when a search query is active.
+- **`ceo-inbox` ACTIONABLE archive** — added step 4h action checklist so ACTIONABLE emails reliably get archived after specialist handoff; rewrote ambiguous classification note.
 - **Self-email loop filter hardened** — inbound poll now rejects self-sent messages via folder, sent-ID, and normalized-address checks to prevent reply loops. (#37)
 
 ### Added

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -400,9 +400,10 @@ system_prompt: |
     Do NOT archive.
   - **ACTIONABLE**: Open a bullpen thread mentioning the capable specialist
     with a clear handoff summary. Call ceo-inbox-archive with the message_id.
-  - **NEEDS DRAFT**: Call ceo-inbox-draft-reply (using the drafting rules in
-    step 4e — voice profile, scheduling rules, etc.). Call ceo-inbox-archive
-    with the message_id.
+  - **NEEDS DRAFT**: Execute the full NEEDS DRAFT procedure from step 4e
+    (read full message, check for prior replies, memory-query for context,
+    evaluate LEAVE FOR CEO guard conditions, then draft using voice profile
+    and scheduling rules). Call ceo-inbox-archive with the message_id.
   - **LEAVE FOR CEO**: No action. Do not archive, draft, or notify.
   - **NOISE**: Call ceo-inbox-archive with the message_id.
 

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -254,9 +254,13 @@ system_prompt: |
     - Check the available specialists below to understand what the team can do.
     - Open a bullpen thread mentioning the capable specialist with a clear
       handoff summary.
-    - Do NOT use ACTIONABLE for archive (that is NOISE) or drafting (that
-      is NEEDS DRAFT). ACTIONABLE is for tasks requiring a specialist.
-    - Call ceo-inbox-archive with the message_id.
+    - Classification note: if the only action needed is to discard the email,
+      classify as NOISE instead. If a human reply is needed, classify as NEEDS
+      DRAFT instead. ACTIONABLE is specifically for delegating a task to a
+      specialist agent.
+    - Note: ACTIONABLE emails ARE archived after the specialist is notified
+      (see step 4h). Archiving is a side-effect of processing, not a reason
+      to choose a different classification.
 
   **NEEDS DRAFT** — a reply is warranted and the CEO should review before
   sending:
@@ -323,8 +327,10 @@ system_prompt: |
     - Call ceo-inbox-archive with the message_id.
 
   **Important:** After choosing a classification above, do NOT execute the
-  associated actions yet. Proceed to step 4g to evaluate standing rules
-  before executing any action — rules may change your classification.
+  associated actions yet. Proceed through steps 4f and 4g to evaluate
+  standing rules before executing any action — rules may change your
+  classification. You will execute all actions in step 4h, after rules
+  have been evaluated.
 
   ### 4f. When in doubt
 
@@ -382,6 +388,26 @@ system_prompt: |
   ceo-inbox-label calls were made, merge the applied lists.
   If ceo-inbox-label succeeds, add to the per-message output:
     Labels: <comma-separated list of all labels applied>
+
+  ### 4h. Execute final actions
+
+  Now execute the primary actions for this message's FINAL classification
+  (after any overrides from step 4g). This is the authoritative action
+  checklist — every action for every classification is listed here:
+
+  - **URGENT**: Open a bullpen thread mentioning the coordinator (sender,
+    subject, one-sentence summary, deadline/ask). Send a Signal alert.
+    Do NOT archive.
+  - **ACTIONABLE**: Open a bullpen thread mentioning the capable specialist
+    with a clear handoff summary. Call ceo-inbox-archive with the message_id.
+  - **NEEDS DRAFT**: Call ceo-inbox-draft-reply (using the drafting rules in
+    step 4e — voice profile, scheduling rules, etc.). Call ceo-inbox-archive
+    with the message_id.
+  - **LEAVE FOR CEO**: No action. Do not archive, draft, or notify.
+  - **NOISE**: Call ceo-inbox-archive with the message_id.
+
+  If any skill call fails, log the error in the Response Format and continue.
+  Do not abort the run for a single action failure.
 
   ## Step 5: Mark as read (optional)
 

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -110,10 +110,16 @@ export class CeoNylasClient {
   async listMessages(options: ListMessagesOptions = {}): Promise<NylasMessageSummary[]> {
     const params = new URLSearchParams();
     if (options.limit !== undefined) params.set('limit', String(options.limit));
-    if (options.folder) params.set('in', options.folder);
-    if (options.unread !== undefined) params.set('unread', String(options.unread));
-    if (options.query) params.set('q', options.query);
-    if (options.receivedAfter !== undefined) params.set('received_after', String(options.receivedAfter));
+    if (options.query) {
+      // Nylas v3: search_query_native cannot be combined with any other filter
+      // param except limit and page_token — sending in/unread/received_after
+      // alongside it returns HTTP 400 "invalid_request_error".
+      params.set('search_query_native', options.query);
+    } else {
+      if (options.folder) params.set('in', options.folder);
+      if (options.unread !== undefined) params.set('unread', String(options.unread));
+      if (options.receivedAfter !== undefined) params.set('received_after', String(options.receivedAfter));
+    }
 
     const url = `${this.baseUrl}/messages?${params}`;
     const data = await this.request<NylasApiMessage[]>('GET', url, 'listMessages');

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -114,6 +114,12 @@ export class CeoNylasClient {
       // Nylas v3: search_query_native cannot be combined with any other filter
       // param except limit and page_token — sending in/unread/received_after
       // alongside it returns HTTP 400 "invalid_request_error".
+      if (options.folder || options.unread !== undefined || options.receivedAfter !== undefined) {
+        this.log.warn(
+          { suppressedOptions: { folder: options.folder, unread: options.unread, receivedAfter: options.receivedAfter } },
+          'nylas: listMessages — folder/unread/receivedAfter ignored because search_query_native is set (Nylas v3 limitation)',
+        );
+      }
       params.set('search_query_native', options.query);
     } else {
       if (options.folder) params.set('in', options.folder);

--- a/skills/ceo-inbox-search/handler.test.ts
+++ b/skills/ceo-inbox-search/handler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CeoInboxSearchHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 
@@ -47,6 +47,10 @@ describe('CeoInboxSearchHandler — query parameter', () => {
 
   beforeEach(() => {
     handler = new CeoInboxSearchHandler();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('uses search_query_native instead of q', async () => {

--- a/skills/ceo-inbox-search/handler.test.ts
+++ b/skills/ceo-inbox-search/handler.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CeoInboxSearchHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeCtx(
+  input: Record<string, unknown>,
+  opts: { selfEmail?: string } = {},
+): SkillContext {
+  return {
+    input,
+    secret(name: string) {
+      if (name === 'nylas_api_key') return 'test-key';
+      if (name === 'ceo_nylas_grant_id') return 'test-grant';
+      if (name === 'nylas_self_email') {
+        if (opts.selfEmail) return opts.selfEmail;
+        throw new Error('not set');
+      }
+      throw new Error(`unknown secret: ${name}`);
+    },
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  };
+}
+
+function mockFetchReturning(messages: unknown[] = []) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: messages }),
+  } as unknown as Response);
+}
+
+function extractQueryParam(fetchMock: ReturnType<typeof vi.fn>, param: string): string | null {
+  const url = new URL(fetchMock.mock.calls[0][0] as string);
+  return url.searchParams.get(param);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('CeoInboxSearchHandler — query parameter', () => {
+  let handler: CeoInboxSearchHandler;
+
+  beforeEach(() => {
+    handler = new CeoInboxSearchHandler();
+  });
+
+  it('uses search_query_native instead of q', async () => {
+    const ctx = makeCtx({ query: 'Tim Hortons receipt' });
+    const fetchSpy = mockFetchReturning();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await handler.execute(ctx);
+
+    // Nylas v3 requires search_query_native — the old q parameter is rejected with HTTP 400
+    expect(extractQueryParam(fetchSpy, 'search_query_native')).toBe('Tim Hortons receipt');
+    expect(extractQueryParam(fetchSpy, 'q')).toBeNull();
+  });
+
+  it('does not send other filter params when search_query_native is set', async () => {
+    // Nylas v3 rejects any param other than limit/page_token alongside search_query_native
+    const ctx = makeCtx({ query: 'expense report' });
+    const fetchSpy = mockFetchReturning();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await handler.execute(ctx);
+
+    expect(extractQueryParam(fetchSpy, 'unread')).toBeNull();
+    expect(extractQueryParam(fetchSpy, 'in')).toBeNull();
+    expect(extractQueryParam(fetchSpy, 'received_after')).toBeNull();
+  });
+
+  it('returns error when query is missing', async () => {
+    const ctx = makeCtx({});
+    const result = await handler.execute(ctx);
+    expect(result).toMatchObject({ success: false, error: expect.any(String) });
+  });
+
+  it('returns error when query is empty string', async () => {
+    const ctx = makeCtx({ query: '   ' });
+    const result = await handler.execute(ctx);
+    expect(result).toMatchObject({ success: false, error: expect.any(String) });
+  });
+
+  it('respects the limit parameter', async () => {
+    const ctx = makeCtx({ query: 'invoice', limit: 5 });
+    const fetchSpy = mockFetchReturning();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await handler.execute(ctx);
+
+    expect(extractQueryParam(fetchSpy, 'limit')).toBe('5');
+  });
+
+  it('filters out messages from the Curia self email', async () => {
+    const curiaEmail = 'curia@example.com';
+    const ctx = makeCtx({ query: 'test' }, { selfEmail: curiaEmail });
+    const fetchSpy = mockFetchReturning([
+      { id: '1', from: [{ email: curiaEmail, name: 'Curia' }], thread_id: '1', subject: '', snippet: '', date: 0, unread: false, folders: [] },
+      { id: '2', from: [{ email: 'someone@example.com', name: 'Someone' }], thread_id: '2', subject: '', snippet: '', date: 0, unread: false, folders: [] },
+    ]);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { messages: unknown[]; count: number };
+      expect(data.count).toBe(1);
+      expect(data.messages).toHaveLength(1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **`ceo-inbox-search` HTTP 400 on every run** — was sending `q` (Nylas v2); now sends `search_query_native` (Nylas v3). Other filter params (`in`, `unread`, `received_after`) are suppressed when a search query is active since Nylas v3 rejects them alongside `search_query_native`; a warning is logged if any are present. This was causing `T2125-expense-tracker` to hit its error budget and get suspended.
- **ACTIONABLE emails not archived after triage** — two prompt defects in `agents/ceo-inbox.yaml`: (1) no execution step after rule evaluation meant the deferred archive was silently dropped; fixed by adding explicit step 4h. (2) "Do NOT use ACTIONABLE for archive" was ambiguous and read as forbidding archive; reworded to clarify it's a classification note only.

## Test plan

- [ ] `skills/ceo-inbox-search/handler.test.ts` — new tests confirm `search_query_native` is sent, `q` is absent, other params suppressed, limit respected, self-email filtered
- [ ] All 870 skill unit tests pass
- [ ] `T2125-expense-tracker` job is already unsuspended in prod; verify it processes successfully after deploy
- [ ] Monitor next ceo-inbox triage run — ACTIONABLE emails should appear in the archive skill invocations in the audit log