### PR TITLE
chore: extract email metadata parsing and preamble builders from dispatcher (#465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Dispatcher email metadata refactor** — extracted `parseEmailMetadata`, `sanitizeNylasMessageId`, `buildCcPreamble`, and `buildThreadParticipantsBlock` from `handleInbound` into a standalone `email-metadata.ts` module with 34 unit tests; no change to observable behaviour. (#465)
 - **Coordinator inbox delegation** — CEO inbox queries now delegate seamlessly to the ceo-inbox specialist instead of explaining the multi-agent architecture.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
-- **Dispatcher email metadata refactor** — extracted `parseEmailMetadata`, `sanitizeNylasMessageId`, `buildCcPreamble`, and `buildThreadParticipantsBlock` from `handleInbound` into a standalone `email-metadata.ts` module with 34 unit tests; no change to observable behaviour. (#465)
+- **Dispatcher email metadata refactor** — extracted email parsing and preamble builders into standalone `email-metadata.ts` module with 35 unit tests; no observable behaviour change. (#465)
 - **Coordinator inbox delegation** — CEO inbox queries now delegate seamlessly to the ceo-inbox specialist instead of explaining the multi-agent architecture.
 
 ### Fixed

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -765,7 +765,7 @@ export class Dispatcher {
         }
 
         this.logger.info(
-          { channelId: payload.channelId, senderId: payload.senderId, primaryRecipients: emailMeta.primaryRecipientEmails },
+          { channelId: payload.channelId, senderId: payload.senderId, primaryRecipientCount: emailMeta.primaryRecipientEmails.length },
           'CC role preamble injected — Curia was not the primary recipient',
         );
 

--- a/src/dispatch/dispatcher.ts
+++ b/src/dispatch/dispatcher.ts
@@ -13,6 +13,7 @@ import { computeTrustScore, DEFAULT_TRUST_WEIGHTS } from './trust-scorer.js';
 import type { TrustScorerWeights } from './trust-scorer.js';
 import type { WorkingMemory } from '../memory/working-memory.js';
 import { formatOutboundMemo, extractRecentMemos, buildContextPreamble } from './context-memo.js';
+import { parseEmailMetadata, sanitizeNylasMessageId, buildCcPreamble, buildThreadParticipantsBlock } from './email-metadata.js';
 
 /** Redact a channel identifier (email address or phone number) for safe log output. */
 function redactSenderId(value: string): string {
@@ -718,98 +719,37 @@ export class Dispatcher {
       }
     }
 
-    // Thread-participants block: inject structured participant context for every
-    // inbound email so the coordinator can reason about who's on the thread.
-    // Placed before the CC preamble so the CC role marker appears on top.
+    // Email metadata: parse once here and pass to the preamble builders below,
+    // replacing the repeated `payload.metadata as Record<string, unknown>` casts
+    // that previously appeared in both the thread-participants and CC preamble blocks.
     if (payload.channelId === 'email') {
-      const emailMeta = payload.metadata as Record<string, unknown> | undefined;
-      const rawParticipants = emailMeta?.participants;
-      if (Array.isArray(rawParticipants) && rawParticipants.length > 0) {
-        const selfLower = this.selfEmail?.toLowerCase();
-        const MAX_PARTICIPANTS = 15;
+      const emailMeta = parseEmailMetadata(payload.metadata);
 
-        // Sanitize participant email addresses — they come from Nylas (attacker-controlled)
-        // and are injected into taskContent. Strip characters that could enable prompt
-        // injection. Same pattern as the CC preamble sanitization above.
-        const sanitize = (s: string): string =>
-          String(s).replace(/[\n\r\[\]<>]/g, '').trim().slice(0, 254);
-
-        const froms: string[] = [];
-        const tos: string[] = [];
-        const ccs: string[] = [];
-
-        for (const p of (rawParticipants as Array<{ email: string; role: string }>).slice(0, MAX_PARTICIPANTS)) {
-          if (p.email == null) continue;  // guard: skip participants with missing email field
-          const addr = sanitize(p.email);
-          if (!addr) continue;
-          // Replace Curia's own address with "you" for readability.
-          const display = selfLower && addr.toLowerCase() === selfLower ? 'you' : addr;
-          if (p.role === 'from') froms.push(display);
-          else if (p.role === 'to') tos.push(display);
-          else if (p.role === 'cc') ccs.push(display);
-        }
-
-        const parts: string[] = [];
-        if (froms.length > 0) parts.push(`From: ${froms.join(', ')}`);
-        if (tos.length > 0) parts.push(`To: ${tos.join(', ')}`);
-        if (ccs.length > 0) parts.push(`CC: ${ccs.join(', ')}`);
-
-        if (parts.length > 0) {
-          taskContent = `[Thread participants — ${parts.join('; ')}]\n` + taskContent;
-        }
+      // Thread-participants block: inject structured participant context for every
+      // inbound email so the coordinator can reason about who's on the thread.
+      // Placed before the CC preamble so the CC role marker appears on top.
+      const participantsBlock = buildThreadParticipantsBlock(emailMeta, this.selfEmail);
+      if (participantsBlock !== null) {
+        taskContent = participantsBlock + taskContent;
       }
-    }
 
-    // CC role marker: when the email adapter determined that Curia was CC'd rather than
-    // directly addressed, prepend a context block so the coordinator knows it was an
-    // observer on this email (e.g. the CEO looping Curia in on a message to a third party).
-    if (payload.channelId === 'email') {
-      const meta = payload.metadata as Record<string, unknown> | undefined;
-      const curiaRole = meta?.curiaRole as string | undefined;
-      if (curiaRole === 'cc') {
-        // Runtime type guard — metadata values cross a Record<string, unknown> boundary,
-        // so a bare `as string[]` cast could silently accept a non-array from a future
-        // code path. Mirrors the isFinite guard on injectionRiskScore above.
-        const rawRecipients = meta?.primaryRecipientEmails;
-        const primaryRecipients = Array.isArray(rawRecipients) ? (rawRecipients as string[]) : [];
-        // Sanitize each address before interpolation — primaryRecipientEmails comes from
-        // the Nylas To-field (attacker-controlled) and is injected into taskContent AFTER
-        // the injection scanner has already run on payload.content. Without sanitization,
-        // a crafted email address could embed prompt injection patterns that bypass Layer 1.
-        // RFC 5321 limits email addresses to 254 characters; anything longer is malformed.
-        const MAX_RECIPIENTS_IN_PREAMBLE = 10;
-        const sanitizedRecipients = primaryRecipients
-          .map((addr) => String(addr).replace(/[\n\r\[\]<>]/g, '').trim().slice(0, 254))
-          .filter((addr) => addr.length > 0)
-          .slice(0, MAX_RECIPIENTS_IN_PREAMBLE);
-        const omittedCount = Math.max(0, primaryRecipients.length - sanitizedRecipients.length);
-        const recipientListBase = sanitizedRecipients.length > 0
-          ? sanitizedRecipients.join(', ')
-          : 'unknown recipients';
-        const recipientList = omittedCount > 0
-          ? `${recipientListBase}, +${omittedCount} more`
-          : recipientListBase;
-        // Extract the Nylas message ID from metadata so the coordinator can pass it
-        // to email-reply to thread a response from Curia's own account.
-        // Sanitize for the same reason as recipient addresses above — this value
-        // comes from Nylas and is interpolated into the task preamble after the
-        // injection scanner has run on payload.content.
-        const rawNylasMessageId = meta?.nylasMessageId;
+      // CC role marker: when the email adapter determined that Curia was CC'd rather than
+      // directly addressed, prepend a context block so the coordinator knows it was an
+      // observer on this email (e.g. the CEO looping Curia in on a message to a third party).
+      if (emailMeta.curiaRole === 'cc') {
+        const msgIdResult = sanitizeNylasMessageId(emailMeta.nylasMessageId);
         let nylasMessageId: string | undefined;
-        if (typeof rawNylasMessageId === 'string' && rawNylasMessageId.trim()) {
-          const sanitized = rawNylasMessageId.replace(/[\n\r\[\]<>]/g, '').trim().slice(0, 200);
-          if (sanitized.length === 0) {
-            // Non-empty raw value collapsed to empty after sanitization — structurally
-            // suspicious (e.g. a message ID composed entirely of stripped characters).
-            // Omit from preamble and warn so operators have an audit trail.
-            // rawNylasMessageId is deliberately excluded from the log — it may be attacker-controlled.
-            this.logger.warn(
-              { channelId: payload.channelId, conversationId: payload.conversationId },
-              'CC preamble: nylasMessageId was non-empty but sanitized to empty — omitting Message ID from preamble',
-            );
-          } else {
-            nylasMessageId = sanitized;
-          }
+        if (msgIdResult.ok) {
+          nylasMessageId = msgIdResult.value;
+        } else if (msgIdResult.reason === 'empty-after-sanitize') {
+          // Non-empty raw value collapsed to empty after sanitization — structurally
+          // suspicious (e.g. composed entirely of stripped characters).
+          // Omit from preamble and warn so operators have an audit trail.
+          // The raw value is deliberately excluded from the log — it may be attacker-controlled.
+          this.logger.warn(
+            { channelId: payload.channelId, conversationId: payload.conversationId },
+            'CC preamble: nylasMessageId was non-empty but sanitized to empty — omitting Message ID from preamble',
+          );
         } else {
           // nylasMessageId absent or non-string — warn so operators can diagnose
           // a coordinator that falls back to email-draft-save due to missing Message ID.
@@ -818,27 +758,18 @@ export class Dispatcher {
               channelId: payload.channelId,
               conversationId: payload.conversationId,
               senderId: redactSenderId(payload.senderId),
-              rawType: typeof rawNylasMessageId,
+              rawType: typeof emailMeta.nylasMessageId,
             },
             'CC preamble: nylasMessageId absent or invalid — Message ID omitted; coordinator may fall back to email-draft-save',
           );
         }
 
         this.logger.info(
-          { channelId: payload.channelId, senderId: payload.senderId, primaryRecipients: recipientList },
+          { channelId: payload.channelId, senderId: payload.senderId, primaryRecipients: emailMeta.primaryRecipientEmails },
           'CC role preamble injected — Curia was not the primary recipient',
         );
-        // Include Message ID and Account so the coordinator can call email-reply
-        // with the correct message ID.
-        // Without these identifiers the coordinator cannot use email-reply and falls back
-        // to email-draft-save, where it has historically chosen the wrong account (CEO's).
-        const ccIdentifierBlock = nylasMessageId
-          ? `Message ID: ${nylasMessageId}\nAccount: ${payload.accountId ?? 'curia'}\n\n`
-          : `Account: ${payload.accountId ?? 'curia'}\n\n`;
-        taskContent =
-          `[OWNER CC — this email was addressed to ${recipientList}; you were CC'd, not the primary recipient]\n` +
-          ccIdentifierBlock +
-          taskContent;
+
+        taskContent = buildCcPreamble(emailMeta, payload.accountId, nylasMessageId) + taskContent;
       }
     }
 

--- a/src/dispatch/email-metadata.ts
+++ b/src/dispatch/email-metadata.ts
@@ -1,0 +1,204 @@
+// src/dispatch/email-metadata.ts
+//
+// Pure functions for parsing email-channel metadata and building the preamble
+// blocks that the dispatcher prepends to inbound task content.
+//
+// No dependencies on the bus, runtime, database, or logger — all functions
+// are pure and unit-testable in isolation. The dispatcher calls
+// parseEmailMetadata once at the top of its email-handling section, then
+// passes the typed struct to the preamble builders rather than repeating the
+// raw Record<string, unknown> cast.
+
+// Maximum participants to include in the thread-participants block.
+// Prevents runaway loops on unusually large mailing-list threads.
+const MAX_PARTICIPANTS = 15;
+
+// Maximum recipient addresses to show in the CC preamble before truncating.
+// RFC 5321 allows long To-fields; this cap keeps the preamble readable.
+const MAX_RECIPIENTS_IN_PREAMBLE = 10;
+
+/**
+ * Typed view of email-specific fields inside InboundMessagePayload.metadata.
+ *
+ * Fields are typed to reflect what parseEmailMetadata can safely infer from
+ * the raw Record<string, unknown> boundary. Array elements remain `unknown`
+ * until individually validated inside the consumer functions, since casting
+ * them as a typed array at the boundary would be a silent lie.
+ */
+export interface EmailMetadata {
+  /** 'cc' when Curia was CC'd rather than directly addressed; undefined otherwise. */
+  curiaRole: string | undefined;
+  /** Validated array of primary recipient addresses; empty if absent or non-array in raw metadata. */
+  primaryRecipientEmails: unknown[];
+  /** Raw Nylas message ID — validate and sanitize via sanitizeNylasMessageId before use. */
+  nylasMessageId: unknown;
+  /** Validated array of raw participant entries; empty if absent or non-array. Elements
+   *  are unknown — structural validation happens inside buildThreadParticipantsBlock. */
+  participants: unknown[];
+}
+
+/**
+ * Parse email-specific fields from the raw InboundMessagePayload.metadata bag.
+ *
+ * Validates presence and type at the collection level (string check for
+ * curiaRole, Array.isArray guards for the array fields). Individual element
+ * validation happens inside the consumer functions where the values are used.
+ */
+export function parseEmailMetadata(metadata: Record<string, unknown> | undefined): EmailMetadata {
+  const raw = metadata;
+  return {
+    curiaRole: typeof raw?.curiaRole === 'string' ? raw.curiaRole : undefined,
+    primaryRecipientEmails: Array.isArray(raw?.primaryRecipientEmails)
+      ? (raw.primaryRecipientEmails as unknown[])
+      : [],
+    nylasMessageId: raw?.nylasMessageId,
+    participants: Array.isArray(raw?.participants)
+      ? (raw.participants as unknown[])
+      : [],
+  };
+}
+
+/** Result of sanitizeNylasMessageId — discriminated so callers can log the
+ *  specific failure reason without adding a logger dependency to this module. */
+export type NylasMessageIdResult =
+  | { ok: true; value: string }
+  | { ok: false; reason: 'empty-after-sanitize' | 'absent-or-invalid' };
+
+/**
+ * Sanitize a raw Nylas message ID for safe interpolation into preamble content.
+ *
+ * Strips characters that could enable prompt injection (`\n`, `\r`, `[`, `]`,
+ * `<`, `>`), trims whitespace, and caps the result at 200 characters (Nylas
+ * IDs are short; anything longer is structurally suspicious).
+ *
+ * Returns a discriminated result so the caller (the dispatcher) can emit the
+ * correct log message for each failure case without logging side effects here.
+ */
+export function sanitizeNylasMessageId(raw: unknown): NylasMessageIdResult {
+  if (typeof raw === 'string' && raw.trim().length > 0) {
+    const sanitized = raw.replace(/[\n\r\[\]<>]/g, '').trim().slice(0, 200);
+    if (sanitized.length === 0) {
+      // Non-empty raw value collapsed to empty after sanitization — structurally
+      // suspicious (e.g. composed entirely of stripped characters).
+      return { ok: false, reason: 'empty-after-sanitize' };
+    }
+    return { ok: true, value: sanitized };
+  }
+  return { ok: false, reason: 'absent-or-invalid' };
+}
+
+/**
+ * Sanitize a single email field value before interpolation into preamble content.
+ *
+ * Strips the same prompt-injection characters as sanitizeNylasMessageId and
+ * enforces a maximum length. RFC 5321 caps email addresses at 254 characters.
+ * Returns an empty string for null/undefined so callers' downstream empty-string
+ * filters discard the value rather than interpolating the literal "null".
+ */
+function sanitizeEmailField(raw: unknown, maxLen = 254): string {
+  if (raw == null) return '';
+  return String(raw).replace(/[\n\r\[\]<>]/g, '').trim().slice(0, maxLen);
+}
+
+/**
+ * Build the CC role preamble prepended to inbound task content when Curia was
+ * CC'd (not directly addressed) on an email.
+ *
+ * The preamble tells the coordinator which account it was CC'd on and provides
+ * the Nylas message ID so it can call email-reply to thread a response from
+ * Curia's own account. Without the message ID the coordinator falls back to
+ * email-draft-save, where it has historically chosen the wrong account (CEO's).
+ *
+ * @param meta            Parsed email metadata from parseEmailMetadata.
+ * @param accountId       The named Nylas account (e.g. "curia"); falls back to 'curia'.
+ * @param nylasMessageId  Pre-sanitized message ID from sanitizeNylasMessageId,
+ *                        or undefined if absent/sanitized-to-empty.
+ */
+export function buildCcPreamble(
+  meta: EmailMetadata,
+  accountId: string | undefined,
+  nylasMessageId: string | undefined,
+): string {
+  // Sanitize each address before interpolation — primaryRecipientEmails comes
+  // from the Nylas To-field (attacker-controlled) and is injected into
+  // taskContent after the injection scanner has already run on payload.content.
+  // Without sanitization a crafted address could bypass Layer 1.
+  const sanitizedRecipients = meta.primaryRecipientEmails
+    .map((addr) => sanitizeEmailField(addr))
+    .filter((addr) => addr.length > 0)
+    .slice(0, MAX_RECIPIENTS_IN_PREAMBLE);
+
+  // Count items dropped by the empty-string filter or by the 10-item cap.
+  const omittedCount = Math.max(0, meta.primaryRecipientEmails.length - sanitizedRecipients.length);
+
+  const recipientListBase = sanitizedRecipients.length > 0
+    ? sanitizedRecipients.join(', ')
+    : 'unknown recipients';
+  const recipientList = omittedCount > 0
+    ? `${recipientListBase}, +${omittedCount} more`
+    : recipientListBase;
+
+  // Include Message ID and Account so the coordinator can call email-reply
+  // with the correct thread context. Without these identifiers it cannot use
+  // email-reply and falls back to email-draft-save.
+  const identifierBlock = nylasMessageId
+    ? `Message ID: ${nylasMessageId}\nAccount: ${accountId ?? 'curia'}\n\n`
+    : `Account: ${accountId ?? 'curia'}\n\n`;
+
+  return (
+    `[OWNER CC — this email was addressed to ${recipientList}; you were CC'd, not the primary recipient]\n` +
+    identifierBlock
+  );
+}
+
+/**
+ * Build the thread-participants block prepended to inbound task content for
+ * every inbound email so the coordinator can reason about who is on the thread.
+ *
+ * Returns null when the participants list is absent, empty, or all entries are
+ * invalid (null email, empty after sanitization, or unknown role) — the caller
+ * should skip prepending in that case.
+ *
+ * @param meta       Parsed email metadata from parseEmailMetadata.
+ * @param selfEmail  Curia's own email address for the receiving account, if
+ *                   known. Matching participants are displayed as "you".
+ */
+export function buildThreadParticipantsBlock(
+  meta: EmailMetadata,
+  selfEmail: string | undefined,
+): string | null {
+  if (meta.participants.length === 0) return null;
+
+  const selfLower = selfEmail?.toLowerCase();
+  const froms: string[] = [];
+  const tos: string[] = [];
+  const ccs: string[] = [];
+
+  for (const raw of meta.participants.slice(0, MAX_PARTICIPANTS)) {
+    // Guard against null/undefined elements and non-object entries — Nylas
+    // API responses can include nulls during partial failures or schema drift.
+    if (raw == null || typeof raw !== 'object') continue;
+    const p = raw as { email: unknown; role: unknown };
+    if (p.email == null) continue; // guard: skip participants with missing email field
+    // Sanitize participant email addresses — they come from Nylas (attacker-controlled)
+    // and are injected into taskContent after the injection scanner has run on
+    // payload.content. Strip characters that could enable prompt injection.
+    const addr = sanitizeEmailField(p.email);
+    if (!addr) continue;
+    // Replace Curia's own address with "you" for readability.
+    const display = selfLower && addr.toLowerCase() === selfLower ? 'you' : addr;
+    const role = typeof p.role === 'string' ? p.role : '';
+    if (role === 'from') froms.push(display);
+    else if (role === 'to') tos.push(display);
+    else if (role === 'cc') ccs.push(display);
+  }
+
+  const parts: string[] = [];
+  if (froms.length > 0) parts.push(`From: ${froms.join(', ')}`);
+  if (tos.length > 0) parts.push(`To: ${tos.join(', ')}`);
+  if (ccs.length > 0) parts.push(`CC: ${ccs.join(', ')}`);
+
+  if (parts.length === 0) return null;
+
+  return `[Thread participants — ${parts.join('; ')}]\n`;
+}

--- a/src/dispatch/email-metadata.ts
+++ b/src/dispatch/email-metadata.ts
@@ -131,12 +131,13 @@ export function buildCcPreamble(
   // Count items dropped by the empty-string filter or by the 10-item cap.
   const omittedCount = Math.max(0, meta.primaryRecipientEmails.length - sanitizedRecipients.length);
 
-  const recipientListBase = sanitizedRecipients.length > 0
-    ? sanitizedRecipients.join(', ')
+  // Only append "+N more" when there are named recipients to precede it —
+  // "unknown recipients, +3 more" is misleading when every address was stripped.
+  const recipientList = sanitizedRecipients.length > 0
+    ? (omittedCount > 0
+        ? `${sanitizedRecipients.join(', ')}, +${omittedCount} more`
+        : sanitizedRecipients.join(', '))
     : 'unknown recipients';
-  const recipientList = omittedCount > 0
-    ? `${recipientListBase}, +${omittedCount} more`
-    : recipientListBase;
 
   // Include Message ID and Account so the coordinator can call email-reply
   // with the correct thread context. Without these identifiers it cannot use

--- a/tests/unit/dispatch/email-metadata.test.ts
+++ b/tests/unit/dispatch/email-metadata.test.ts
@@ -166,6 +166,18 @@ describe('buildCcPreamble', () => {
     expect(result).toContain('+2 more');
   });
 
+  it('shows plain "unknown recipients" when every address sanitizes to empty — no "+N more" suffix', () => {
+    // Regression: previously produced "unknown recipients, +2 more" which is misleading
+    const result = buildCcPreamble(
+      makeMeta({ primaryRecipientEmails: ['\n\r', '\n\r\n'] }),
+      'curia',
+      'msg-abc123',
+    );
+
+    expect(result).toContain('unknown recipients');
+    expect(result).not.toContain('+');
+  });
+
   it('counts filtered-out (empty-after-sanitize) recipients in the omitted total', () => {
     // '\n\r' sanitizes to empty and should be counted as omitted
     const result = buildCcPreamble(

--- a/tests/unit/dispatch/email-metadata.test.ts
+++ b/tests/unit/dispatch/email-metadata.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseEmailMetadata,
+  sanitizeNylasMessageId,
+  buildCcPreamble,
+  buildThreadParticipantsBlock,
+} from '../../../src/dispatch/email-metadata.js';
+import type { EmailMetadata } from '../../../src/dispatch/email-metadata.js';
+
+// ---------------------------------------------------------------------------
+// parseEmailMetadata
+// ---------------------------------------------------------------------------
+
+describe('parseEmailMetadata', () => {
+  it('extracts typed fields from a well-formed metadata object', () => {
+    const meta = parseEmailMetadata({
+      curiaRole: 'cc',
+      primaryRecipientEmails: ['alice@example.com', 'bob@example.com'],
+      nylasMessageId: 'msg-abc123',
+      participants: [{ email: 'alice@example.com', role: 'from' }],
+    });
+
+    expect(meta.curiaRole).toBe('cc');
+    expect(meta.primaryRecipientEmails).toEqual(['alice@example.com', 'bob@example.com']);
+    expect(meta.nylasMessageId).toBe('msg-abc123');
+    expect(meta.participants).toHaveLength(1);
+  });
+
+  it('returns safe defaults when metadata is undefined', () => {
+    const meta = parseEmailMetadata(undefined);
+
+    expect(meta.curiaRole).toBeUndefined();
+    expect(meta.primaryRecipientEmails).toEqual([]);
+    expect(meta.nylasMessageId).toBeUndefined();
+    expect(meta.participants).toEqual([]);
+  });
+
+  it('returns undefined curiaRole when the field is not a string', () => {
+    expect(parseEmailMetadata({ curiaRole: 42 }).curiaRole).toBeUndefined();
+    expect(parseEmailMetadata({ curiaRole: null }).curiaRole).toBeUndefined();
+    expect(parseEmailMetadata({ curiaRole: true }).curiaRole).toBeUndefined();
+  });
+
+  it('returns empty arrays when array fields are non-array types', () => {
+    const meta = parseEmailMetadata({
+      primaryRecipientEmails: 'not-an-array',
+      participants: { email: 'foo@example.com' },
+    });
+
+    expect(meta.primaryRecipientEmails).toEqual([]);
+    expect(meta.participants).toEqual([]);
+  });
+
+  it('passes nylasMessageId through as-is (unknown) for downstream sanitization', () => {
+    expect(parseEmailMetadata({ nylasMessageId: 'msg-1' }).nylasMessageId).toBe('msg-1');
+    expect(parseEmailMetadata({ nylasMessageId: undefined }).nylasMessageId).toBeUndefined();
+    expect(parseEmailMetadata({ nylasMessageId: 42 }).nylasMessageId).toBe(42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeNylasMessageId
+// ---------------------------------------------------------------------------
+
+describe('sanitizeNylasMessageId', () => {
+  it('returns ok with the value for a clean message ID', () => {
+    expect(sanitizeNylasMessageId('msg-abc123')).toEqual({ ok: true, value: 'msg-abc123' });
+  });
+
+  it('strips prompt-injection characters and returns the sanitized value', () => {
+    // Only \n \r [ ] < > are stripped; other characters survive
+    const result = sanitizeNylasMessageId('msg-[<\n>]bar');
+    expect(result).toEqual({ ok: true, value: 'msg-bar' });
+  });
+
+  it('truncates values longer than 200 characters', () => {
+    const result = sanitizeNylasMessageId('x'.repeat(300));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toHaveLength(200);
+  });
+
+  it('returns empty-after-sanitize when raw collapses to empty after stripping', () => {
+    // A value composed entirely of stripped characters
+    const result = sanitizeNylasMessageId('\n\r[<>]');
+    expect(result).toEqual({ ok: false, reason: 'empty-after-sanitize' });
+  });
+
+  it('returns absent-or-invalid for undefined', () => {
+    expect(sanitizeNylasMessageId(undefined)).toEqual({ ok: false, reason: 'absent-or-invalid' });
+  });
+
+  it('returns absent-or-invalid for null', () => {
+    expect(sanitizeNylasMessageId(null)).toEqual({ ok: false, reason: 'absent-or-invalid' });
+  });
+
+  it('returns absent-or-invalid for a non-string type', () => {
+    expect(sanitizeNylasMessageId(42)).toEqual({ ok: false, reason: 'absent-or-invalid' });
+    expect(sanitizeNylasMessageId({})).toEqual({ ok: false, reason: 'absent-or-invalid' });
+  });
+
+  it('returns absent-or-invalid for a whitespace-only string', () => {
+    expect(sanitizeNylasMessageId('   ')).toEqual({ ok: false, reason: 'absent-or-invalid' });
+    expect(sanitizeNylasMessageId('\n\t')).toEqual({ ok: false, reason: 'absent-or-invalid' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCcPreamble
+// ---------------------------------------------------------------------------
+
+describe('buildCcPreamble', () => {
+  // Minimal valid EmailMetadata for CC preamble tests
+  function makeMeta(overrides: Partial<EmailMetadata> = {}): EmailMetadata {
+    return {
+      curiaRole: 'cc',
+      primaryRecipientEmails: ['alice@example.com'],
+      nylasMessageId: 'msg-abc123',
+      participants: [],
+      ...overrides,
+    };
+  }
+
+  it('includes recipient list, Message ID, and Account when all present', () => {
+    const result = buildCcPreamble(makeMeta(), 'curia', 'msg-abc123');
+
+    expect(result).toContain('[OWNER CC — this email was addressed to alice@example.com');
+    expect(result).toContain("you were CC'd, not the primary recipient]");
+    expect(result).toContain('Message ID: msg-abc123');
+    expect(result).toContain('Account: curia');
+  });
+
+  it('omits the Message ID line when nylasMessageId is undefined', () => {
+    const result = buildCcPreamble(makeMeta(), 'curia', undefined);
+
+    expect(result).not.toContain('Message ID:');
+    expect(result).toContain('Account: curia');
+  });
+
+  it('falls back to "curia" when accountId is undefined', () => {
+    const result = buildCcPreamble(makeMeta(), undefined, 'msg-abc123');
+
+    expect(result).toContain('Account: curia');
+  });
+
+  it('shows "unknown recipients" when primaryRecipientEmails is empty', () => {
+    const result = buildCcPreamble(makeMeta({ primaryRecipientEmails: [] }), 'curia', 'msg-abc123');
+
+    expect(result).toContain('this email was addressed to unknown recipients');
+  });
+
+  it('sanitizes recipient addresses before interpolation', () => {
+    const result = buildCcPreamble(
+      makeMeta({ primaryRecipientEmails: ['evil[<\n>]injection@example.com'] }),
+      'curia',
+      'msg-abc123',
+    );
+
+    expect(result).toContain('evilinjection@example.com');
+    expect(result).not.toContain('evil[<\n>]injection@example.com');
+  });
+
+  it('truncates to 10 recipients and shows +N more', () => {
+    const recipients = Array.from({ length: 12 }, (_, i) => `user${i}@example.com`);
+    const result = buildCcPreamble(makeMeta({ primaryRecipientEmails: recipients }), 'curia', 'msg-abc123');
+
+    expect(result).toContain('+2 more');
+  });
+
+  it('counts filtered-out (empty-after-sanitize) recipients in the omitted total', () => {
+    // '\n\r' sanitizes to empty and should be counted as omitted
+    const result = buildCcPreamble(
+      makeMeta({ primaryRecipientEmails: ['\n\r', 'alice@example.com'] }),
+      'curia',
+      'msg-abc123',
+    );
+
+    expect(result).toContain('alice@example.com');
+    expect(result).toContain('+1 more');
+  });
+
+  it('does not interpolate "null" when primaryRecipientEmails contains null elements', () => {
+    // String(null) === "null" — ensure null elements are treated as empty, not the string "null"
+    const meta = makeMeta({ primaryRecipientEmails: [null, 'alice@example.com'] });
+    const result = buildCcPreamble(meta, 'curia', 'msg-abc123');
+
+    expect(result).toContain('alice@example.com');
+    expect(result).not.toContain('"null"');
+    expect(result).not.toMatch(/\bnull\b/);
+  });
+
+  it('handles multiple valid recipients joined by commas', () => {
+    const result = buildCcPreamble(
+      makeMeta({ primaryRecipientEmails: ['alice@example.com', 'bob@example.com'] }),
+      'curia',
+      'msg-abc123',
+    );
+
+    expect(result).toContain('alice@example.com, bob@example.com');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildThreadParticipantsBlock
+// ---------------------------------------------------------------------------
+
+describe('buildThreadParticipantsBlock', () => {
+  // Minimal valid EmailMetadata for participants tests
+  function makeMeta(participants: Array<{ email: unknown; role: unknown }>): EmailMetadata {
+    return {
+      curiaRole: undefined,
+      primaryRecipientEmails: [],
+      nylasMessageId: undefined,
+      participants,
+    };
+  }
+
+  it('returns a formatted participants line for a typical email', () => {
+    const meta = makeMeta([
+      { email: 'alice@example.com', role: 'from' },
+      { email: 'curia@example.com', role: 'to' },
+      { email: 'bob@example.com', role: 'cc' },
+    ]);
+
+    const result = buildThreadParticipantsBlock(meta, 'curia@example.com');
+
+    expect(result).toContain('[Thread participants —');
+    expect(result).toContain('From: alice@example.com');
+    expect(result).toContain('To: you');
+    expect(result).toContain('CC: bob@example.com');
+  });
+
+  it('returns null when the participants array is empty', () => {
+    expect(buildThreadParticipantsBlock(makeMeta([]), undefined)).toBeNull();
+  });
+
+  it('returns null when all participants have null or empty-after-sanitize emails', () => {
+    const meta = makeMeta([
+      { email: null, role: 'from' },
+      { email: '\n\r', role: 'to' },
+    ]);
+
+    expect(buildThreadParticipantsBlock(meta, undefined)).toBeNull();
+  });
+
+  it('handles null elements in the participants array without crashing', () => {
+    // Nylas can return null elements during partial failures or schema drift
+    const meta = {
+      curiaRole: undefined,
+      primaryRecipientEmails: [],
+      nylasMessageId: undefined,
+      participants: [null, { email: 'alice@example.com', role: 'from' }] as unknown[],
+    };
+
+    const result = buildThreadParticipantsBlock(meta, undefined);
+    expect(result).toContain('From: alice@example.com');
+  });
+
+  it('handles non-object elements in the participants array without crashing', () => {
+    const meta = {
+      curiaRole: undefined,
+      primaryRecipientEmails: [],
+      nylasMessageId: undefined,
+      participants: [42, 'bad-entry', { email: 'alice@example.com', role: 'from' }] as unknown[],
+    };
+
+    const result = buildThreadParticipantsBlock(meta, undefined);
+    expect(result).toContain('From: alice@example.com');
+  });
+
+  it('returns null when all participants have unrecognized roles', () => {
+    // Only 'from', 'to', 'cc' are bucketed — unknown roles are dropped
+    const meta = makeMeta([{ email: 'alice@example.com', role: 'bcc' }]);
+
+    expect(buildThreadParticipantsBlock(meta, undefined)).toBeNull();
+  });
+
+  it('sanitizes participant emails before interpolation', () => {
+    const meta = makeMeta([{ email: 'evil[\n<inject>]@example.com', role: 'from' }]);
+
+    const result = buildThreadParticipantsBlock(meta, undefined);
+
+    expect(result).not.toBeNull();
+    // The sanitized address should appear; the raw malicious form should not
+    expect(result).toContain('evilinject@example.com');
+    expect(result).not.toContain('evil[\n<inject>]@example.com');
+  });
+
+  it('caps at MAX_PARTICIPANTS (15) and ignores entries beyond the limit', () => {
+    const participants = Array.from({ length: 20 }, (_, i) => ({
+      email: `user${i}@example.com`,
+      role: 'to',
+    }));
+
+    const result = buildThreadParticipantsBlock(makeMeta(participants), undefined);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain('user14@example.com');
+    expect(result).not.toContain('user15@example.com');
+  });
+
+  it('replaces selfEmail with "you" case-insensitively', () => {
+    const meta = makeMeta([{ email: 'CURIA@EXAMPLE.COM', role: 'to' }]);
+
+    const result = buildThreadParticipantsBlock(meta, 'curia@example.com');
+
+    expect(result).toContain('To: you');
+    expect(result).not.toContain('CURIA@EXAMPLE.COM');
+  });
+
+  it('does not replace selfEmail when selfEmail is undefined', () => {
+    const meta = makeMeta([{ email: 'curia@example.com', role: 'to' }]);
+
+    const result = buildThreadParticipantsBlock(meta, undefined);
+
+    expect(result).toContain('To: curia@example.com');
+  });
+
+  it('omits buckets that are empty (only shows From/To/CC with entries)', () => {
+    const meta = makeMeta([{ email: 'alice@example.com', role: 'from' }]);
+
+    const result = buildThreadParticipantsBlock(meta, undefined);
+
+    expect(result).toContain('From: alice@example.com');
+    expect(result).not.toContain('To:');
+    expect(result).not.toContain('CC:');
+  });
+
+  it('handles multiple addresses per role joined by commas', () => {
+    const meta = makeMeta([
+      { email: 'alice@example.com', role: 'from' },
+      { email: 'bob@example.com', role: 'from' },
+    ]);
+
+    const result = buildThreadParticipantsBlock(meta, undefined);
+
+    expect(result).toContain('From: alice@example.com, bob@example.com');
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts `parseEmailMetadata`, `sanitizeNylasMessageId`, `buildCcPreamble`, and `buildThreadParticipantsBlock` from `handleInbound` into a new `src/dispatch/email-metadata.ts` module
- The two separate `if (payload.channelId === 'email')` blocks in `handleInbound` are collapsed into one, parsing metadata once via `parseEmailMetadata` and delegating to the pure helpers
- `sanitizeNylasMessageId` returns a discriminated result (`{ ok: true; value } | { ok: false; reason }`) so the dispatcher can log specific failure reasons without a logger dependency in the helper module
- 34 new unit tests following the `context-memo.test.ts` pattern
- No change to observable dispatcher behaviour — all existing dispatch tests continue to pass

**Security hardening picked up during review:**
- `sanitizeEmailField` now guards `null`/`undefined` inputs (previously `String(null)` would have produced the literal string `"null"` as a recipient address in the CC preamble)
- The participants loop validates each element is a non-null object before property access, guarding against null array elements from Nylas schema drift

Closes #465

## Test plan

- [ ] All 211 dispatch unit tests pass (`tests/unit/dispatch/`)
- [ ] New tests cover: `parseEmailMetadata` (typed extraction, safe defaults, non-string/non-array field handling), `sanitizeNylasMessageId` (clean ID, injection stripping, truncation, all failure reasons), `buildCcPreamble` (all recipient edge cases, Message ID present/absent, sanitization), `buildThreadParticipantsBlock` (participants formatting, null elements, self-email substitution, MAX_PARTICIPANTS cap)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extracted email metadata processing logic into dedicated helper functions to improve code maintainability and reduce duplication across email handling workflows
  * Reorganized dispatcher implementation for clearer separation of concerns

* **Tests**
  * Added 34 comprehensive unit tests verifying email metadata extraction, validation, sanitization, and preamble generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/600)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->