### PR TITLE
chore: add pnpm-workspace.yaml with blockExoticSubdeps

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,12 @@
+# Explicitly declare pnpm v11 default: prevent transitive (indirect) dependencies
+# from being resolved via exotic sources (git repos, direct tarball URLs).
+# Note: this does NOT restrict direct dependencies listed in package.json,
+# and file: references are not considered exotic by pnpm.
+# We declare this explicitly so the policy is visible and survives future
+# pnpm default changes.
+blockExoticSubdeps: true
+
+# If a dependency needs to run postinstall scripts (e.g. native addons),
+# explicitly allow it here. Currently no packages require this.
+#   allowBuilds:
+#     some-package: true


### PR DESCRIPTION
## Summary

- Introduces `pnpm-workspace.yaml` to make the pnpm v11 security default explicit
- `blockExoticSubdeps: true` prevents transitive dependencies from resolving via git repos or direct tarball URLs (this is already the v11 default; we declare it to make the policy visible and resilient to future default changes)
- Documents the `allowBuilds` pattern for native addon postinstall scripts — commented out since no packages currently require it (zero `requiresBuild` entries in lockfile)

## What this does NOT cover

- Direct dependencies in `package.json` can still reference exotic sources — `blockExoticSubdeps` only restricts transitive deps
- `file:` references are not considered exotic by pnpm and are unaffected

## Test plan

- [ ] Run `pnpm install` in the repo root — should complete without errors
- [ ] Verify `pnpm-workspace.yaml` is picked up: `pnpm config get blockExoticSubdeps` should return `true`