### PR TITLE
feat: notify CEO when watchdog auto-recovers a stuck job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Email attachment support** — surface metadata in email skills, append human-readable summaries to message content, and download bytes as base64 for `file-parse`.
 - **Email folder management skills** — `email-label`, `email-list-folders`, `email-create-folder`, and `email-mark-read` expose Nylas folder and read-state operations as general-purpose skills.
 - **`SuspensionNotifier`** — emails CEO when a scheduled job suspends after consecutive failures, bypassing the LLM pipeline for reliability during Anthropic outages. (#538)
+- **`RecoveryNotifier`** — emails CEO when the watchdog auto-recovers a stuck job (timeout exceeded), including stuck duration, timeout threshold, and whether the job was reset or suspended. (#207)
 
 ### Changed
 

--- a/src/bus/events.ts
+++ b/src/bus/events.ts
@@ -136,6 +136,7 @@ interface OutboundBlockedPayload {
 //   - 'approval_expired':     CEO alert that pending approvals expired without response (approval-expiry-sweep)
 //   - 'pending_actions_digest': Daily summary of open approvals awaiting CEO decision (pending-actions-digest)
 //   - 'schedule_suspended': CEO alert that a scheduled job was auto-suspended after consecutive failures (#538)
+//   - 'schedule_recovered': CEO alert that a stuck job was auto-recovered (reset to pending or suspended) (#207)
 export interface OutboundNotificationPayload {
   notificationType:
     | 'blocked_content'
@@ -144,7 +145,8 @@ export interface OutboundNotificationPayload {
     | 'approval_requested'
     | 'approval_expired'        // batched expiry notification (approval-expiry-sweep)
     | 'pending_actions_digest'  // daily pending-actions summary (pending-actions-digest)
-    | 'schedule_suspended';     // scheduled job auto-suspended after consecutive failures (#538)
+    | 'schedule_suspended'      // scheduled job auto-suspended after consecutive failures (#538)
+    | 'schedule_recovered';     // stuck job auto-recovered after exceeding timeout threshold (#207)
   /** Recipient email for this notification (always the CEO email today). */
   ceoEmail: string;
   subject: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ import { SchedulerService } from './scheduler/scheduler-service.js';
 import { Scheduler } from './scheduler/scheduler.js';
 import { DriftDetector } from './scheduler/drift-detector.js';
 import { SuspensionNotifier } from './scheduler/suspension-notifier.js';
+import { RecoveryNotifier } from './scheduler/recovery-notifier.js';
 import type { DriftConfig } from './scheduler/drift-detector.js';
 import { EntityContextAssembler } from './entity-context/assembler.js';
 import { bootstrapAgentIdentity } from './entity-context/bootstrap.js';
@@ -980,6 +981,25 @@ async function main(): Promise<void> {
     logger.warn(
       { hasGateway: !!outboundGateway, hasCeoEmail: !!config.ceoPrimaryEmail },
       'SuspensionNotifier not registered — outboundGateway or ceoPrimaryEmail absent; suspended jobs will not trigger CEO email alerts',
+    );
+  }
+
+  // RecoveryNotifier — emails the CEO when the watchdog auto-recovers a stuck job.
+  // Bypasses the LLM pipeline for the same reason as SuspensionNotifier: the LLM
+  // may be the reason the job is stuck in the first place.
+  // Skipped (with a warning) if outboundGateway or ceoPrimaryEmail is absent.
+  if (outboundGateway && config.ceoPrimaryEmail) {
+    const recoveryNotifier = new RecoveryNotifier({
+      bus,
+      outboundGateway,
+      ceoEmail: config.ceoPrimaryEmail,
+      logger,
+    });
+    recoveryNotifier.register();
+  } else {
+    logger.warn(
+      { hasGateway: !!outboundGateway, hasCeoEmail: !!config.ceoPrimaryEmail },
+      'RecoveryNotifier not registered — outboundGateway or ceoPrimaryEmail absent; recovered stuck jobs will not trigger CEO email alerts',
     );
   }
 

--- a/src/scheduler/recovery-notifier.ts
+++ b/src/scheduler/recovery-notifier.ts
@@ -1,0 +1,133 @@
+// src/scheduler/recovery-notifier.ts
+//
+// RecoveryNotifier — system-layer bus subscriber that emails the CEO whenever
+// the watchdog auto-recovers a stuck job (resets it from 'running' → 'pending'
+// after exceeding the computed timeout threshold). See #207.
+//
+// Design constraint: this path MUST NOT touch the LLM pipeline. The most
+// common trigger for a stuck job is an infrastructure failure (Anthropic API
+// down, network partition, OOM), so any notification path that calls the LLM
+// would fail in exactly that scenario. Instead we call
+// outboundGateway.sendNotification() directly, which routes through the
+// outbound.notification → EmailAdapter → Nylas path.
+//
+// Note: if recovery results in suspension (suspended: true), this class sends
+// the only CEO email for that event — schedule.suspended is NOT also emitted
+// by recoverStuckJobs(). SuspensionNotifier covers only the normal-completion
+// failure path.
+
+import type { EventBus } from '../bus/bus.js';
+import type { Logger } from '../logger.js';
+import type { OutboundGateway } from '../skills/outbound-gateway.js';
+import type { ScheduleRecoveredEvent, BusEvent } from '../bus/events.js';
+import { classifyError } from '../errors/classify.js';
+
+export interface RecoveryNotifierConfig {
+  bus: EventBus;
+  outboundGateway: OutboundGateway;
+  ceoEmail: string;
+  logger: Logger;
+}
+
+export class RecoveryNotifier {
+  private readonly log: Logger;
+
+  constructor(private readonly config: RecoveryNotifierConfig) {
+    this.log = config.logger.child({ component: 'recovery-notifier' });
+  }
+
+  /**
+   * Subscribe to schedule.recovered on the system layer.
+   * Call once at startup, after the bus and outbound gateway are ready.
+   */
+  register(): void {
+    this.config.bus.subscribe('schedule.recovered', 'system', (event: BusEvent) => {
+      // Fire-and-forget — the bus subscriber must be synchronous; async work is
+      // handled internally. The outer .catch() is a backstop for unexpected throws
+      // not covered by handle()'s own error handling.
+      void this.handle(event as ScheduleRecoveredEvent).catch((err: unknown) => {
+        const agentErr = classifyError(err, 'recovery-notifier');
+        this.log.error({ err: agentErr, eventId: event.id, eventType: event.type }, 'RecoveryNotifier: unexpected error in handler');
+      });
+    });
+    this.log.info('RecoveryNotifier registered');
+  }
+
+  private async handle(event: ScheduleRecoveredEvent): Promise<void> {
+    const { jobId, agentId, runStartedAt, timeoutSeconds, consecutiveFailures, suspended } = event.payload;
+
+    // Compute how long the job was stuck. runStartedAt is null for pre-migration
+    // rows that had no run_started_at recorded — fall back to the timeout value.
+    const stuckDescription = runStartedAt
+      ? formatStuckDuration(event.timestamp, new Date(runStartedAt))
+      : `at least ${formatMinutes(timeoutSeconds)} (start time unknown — pre-migration row)`;
+
+    const timeoutDescription = formatMinutes(timeoutSeconds);
+
+    const outcome = suspended
+      ? `SUSPENDED after ${consecutiveFailures} consecutive ${consecutiveFailures === 1 ? 'failure' : 'failures'}`
+      : `reset to pending (${consecutiveFailures} consecutive ${consecutiveFailures === 1 ? 'failure' : 'failures'})`;
+
+    const subject = suspended
+      ? `Scheduled job recovered then suspended: ${agentId}`
+      : `Scheduled job recovered from stuck state: ${agentId}`;
+
+    const body = [
+      suspended
+        ? 'Scheduled job was stuck, auto-recovered, and then suspended due to consecutive failures.'
+        : 'Scheduled job was stuck and has been auto-recovered (reset to pending).',
+      '',
+      `Agent:     ${agentId}`,
+      `Stuck for: ${stuckDescription}`,
+      `Timeout:   ${timeoutDescription}`,
+      `Outcome:   ${outcome}`,
+      '',
+      `Job ID: ${jobId}`,
+      '',
+      suspended
+        ? 'To resume this job, open the web app and navigate to Scheduler → Jobs.'
+        : 'The job has been rescheduled automatically and will run again on its next trigger.',
+    ].join('\n');
+
+    // sendNotification() catches its own errors and returns false on failure —
+    // it does not throw. We log at error if it returns false so the anomaly is
+    // visible in alerting.
+    const sent = await this.config.outboundGateway.sendNotification({
+      notificationType: 'schedule_recovered',
+      ceoEmail: this.config.ceoEmail,
+      subject,
+      body,
+    });
+
+    if (!sent) {
+      this.log.error(
+        { jobId, agentId, consecutiveFailures, suspended, stuckDescription },
+        'RecoveryNotifier: failed to publish notification — recovery already recorded in audit log',
+      );
+    }
+  }
+}
+
+/** Format a duration in seconds as a human-readable string (e.g. "15 min", "1 h 5 min"). */
+function formatMinutes(seconds: number): string {
+  const totalMin = Math.round(seconds / 60);
+  if (totalMin < 60) return `${totalMin} min`;
+  const hours = Math.floor(totalMin / 60);
+  const mins = totalMin % 60;
+  return mins === 0 ? `${hours} h` : `${hours} h ${mins} min`;
+}
+
+/**
+ * Compute the duration between when the job entered 'running' and the event
+ * timestamp (≈ the moment of recovery), then format it as a human-readable
+ * string prefixed with "~" to signal that it's approximate.
+ */
+function formatStuckDuration(eventTimestamp: Date, runStartedAt: Date): string {
+  const elapsedMs = eventTimestamp.getTime() - runStartedAt.getTime();
+  // Guard against clock skew producing a negative value.
+  if (elapsedMs < 0) return 'unknown duration (clock skew detected)';
+  const elapsedSeconds = Math.round(elapsedMs / 1000);
+  // Fall back to seconds for sub-minute durations so the message is meaningful.
+  if (elapsedSeconds < 60) return `~${elapsedSeconds}s`;
+  return `~${formatMinutes(elapsedSeconds)}`;
+}

--- a/src/scheduler/recovery-notifier.ts
+++ b/src/scheduler/recovery-notifier.ts
@@ -11,10 +11,10 @@
 // outboundGateway.sendNotification() directly, which routes through the
 // outbound.notification → EmailAdapter → Nylas path.
 //
-// Note: if recovery results in suspension (suspended: true), this class sends
-// the only CEO email for that event — schedule.suspended is NOT also emitted
-// by recoverStuckJobs(). SuspensionNotifier covers only the normal-completion
-// failure path.
+// Scope: recovery-without-suspension only. When recoverStuckJobs() suspends a
+// job (consecutive_failures >= 3), it also fires schedule.suspended, so
+// SuspensionNotifier handles that CEO email. This class handles only the
+// reset-to-pending case to avoid sending two emails for one watchdog event.
 
 import type { EventBus } from '../bus/bus.js';
 import type { Logger } from '../logger.js';
@@ -56,37 +56,28 @@ export class RecoveryNotifier {
   private async handle(event: ScheduleRecoveredEvent): Promise<void> {
     const { jobId, agentId, runStartedAt, timeoutSeconds, consecutiveFailures, suspended } = event.payload;
 
+    // When recovery leads to suspension, schedule.suspended is also fired and
+    // SuspensionNotifier sends the CEO email. Skip here to avoid a duplicate.
+    if (suspended) return;
+
     // Compute how long the job was stuck. runStartedAt is null for pre-migration
     // rows that had no run_started_at recorded — fall back to the timeout value.
     const stuckDescription = runStartedAt
       ? formatStuckDuration(event.timestamp, new Date(runStartedAt))
       : `at least ${formatMinutes(timeoutSeconds)} (start time unknown — pre-migration row)`;
 
-    const timeoutDescription = formatMinutes(timeoutSeconds);
-
-    const outcome = suspended
-      ? `SUSPENDED after ${consecutiveFailures} consecutive ${consecutiveFailures === 1 ? 'failure' : 'failures'}`
-      : `reset to pending (${consecutiveFailures} consecutive ${consecutiveFailures === 1 ? 'failure' : 'failures'})`;
-
-    const subject = suspended
-      ? `Scheduled job recovered then suspended: ${agentId}`
-      : `Scheduled job recovered from stuck state: ${agentId}`;
-
+    const subject = `Scheduled job recovered from stuck state: ${agentId}`;
     const body = [
-      suspended
-        ? 'Scheduled job was stuck, auto-recovered, and then suspended due to consecutive failures.'
-        : 'Scheduled job was stuck and has been auto-recovered (reset to pending).',
+      'Scheduled job was stuck and has been auto-recovered (reset to pending).',
       '',
       `Agent:     ${agentId}`,
       `Stuck for: ${stuckDescription}`,
-      `Timeout:   ${timeoutDescription}`,
-      `Outcome:   ${outcome}`,
+      `Timeout:   ${formatMinutes(timeoutSeconds)}`,
+      `Failures:  ${consecutiveFailures} consecutive`,
       '',
       `Job ID: ${jobId}`,
       '',
-      suspended
-        ? 'To resume this job, open the web app and navigate to Scheduler → Jobs.'
-        : 'The job has been rescheduled automatically and will run again on its next trigger.',
+      'The job has been rescheduled automatically and will run again on its next trigger.',
     ].join('\n');
 
     // sendNotification() catches its own errors and returns false on failure —
@@ -101,7 +92,7 @@ export class RecoveryNotifier {
 
     if (!sent) {
       this.log.error(
-        { jobId, agentId, consecutiveFailures, suspended, stuckDescription },
+        { jobId, agentId, consecutiveFailures, stuckDescription },
         'RecoveryNotifier: failed to publish notification — recovery already recorded in audit log',
       );
     }

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -656,7 +656,7 @@ export class Scheduler {
             'Stuck job recovered',
           );
 
-          // Publish audit event separately — failure here is non-fatal since the DB
+          // Publish audit events separately — failures here are non-fatal since the DB
           // mutation already committed. Log at error but do not treat as a recovery failure.
           try {
             const recoveredEvent = createScheduleRecovered({
@@ -668,6 +668,22 @@ export class Scheduler {
               suspended: result.suspended,
             });
             await this.bus.publish('system', recoveredEvent);
+
+            // When watchdog recovery leads to suspension, also fire schedule.suspended
+            // so SuspensionNotifier can email the CEO through the same path as normal
+            // completion-failure suspensions. Uses recoveredEvent as parent to preserve
+            // the causal chain in the audit log.
+            if (result.suspended) {
+              const timeoutMinutes = Math.round(row.timeout_seconds / 60);
+              const suspendedEvent = createScheduleSuspended({
+                jobId: row.id,
+                agentId: row.agent_id,
+                lastError: `Job timed out after ${timeoutMinutes}m — auto-recovered`,
+                consecutiveFailures: result.consecutiveFailures,
+                parentEventId: recoveredEvent.id,
+              });
+              await this.bus.publish('system', suspendedEvent);
+            }
           } catch (publishErr) {
             this.logger.error({ publishErr, jobId: row.id }, 'Failed to publish schedule.recovered event — job was recovered in DB');
           }

--- a/tests/unit/scheduler/recovery-notifier.test.ts
+++ b/tests/unit/scheduler/recovery-notifier.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RecoveryNotifier } from '../../../src/scheduler/recovery-notifier.js';
+import type { ScheduleRecoveredEvent } from '../../../src/bus/events.js';
+
+// -- Mock helpers --
+
+function mockBus() {
+  return {
+    subscribe: vi.fn(),
+    publish: vi.fn(),
+  };
+}
+
+function mockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+}
+
+function mockOutboundGateway() {
+  return {
+    sendNotification: vi.fn(),
+  };
+}
+
+// A fixed "now" for deterministic duration calculations in tests.
+const FIXED_NOW = new Date('2026-05-15T12:30:00.000Z');
+// Simulates a job that started running 20 minutes ago.
+const RUN_STARTED_AT = new Date('2026-05-15T12:10:00.000Z').toISOString();
+
+function makeEvent(overrides: Partial<ScheduleRecoveredEvent['payload']> = {}): ScheduleRecoveredEvent {
+  return {
+    id: 'evt-1',
+    timestamp: FIXED_NOW,
+    type: 'schedule.recovered',
+    sourceLayer: 'system',
+    payload: {
+      jobId: 'job-abc123',
+      agentId: 'coordinator',
+      runStartedAt: RUN_STARTED_AT,
+      timeoutSeconds: 900,         // 15-minute timeout
+      consecutiveFailures: 1,
+      suspended: false,
+      ...overrides,
+    },
+  };
+}
+
+describe('RecoveryNotifier', () => {
+  let bus: ReturnType<typeof mockBus>;
+  let gateway: ReturnType<typeof mockOutboundGateway>;
+  let logger: ReturnType<typeof mockLogger>;
+  let notifier: RecoveryNotifier;
+
+  beforeEach(() => {
+    bus = mockBus();
+    gateway = mockOutboundGateway();
+    logger = mockLogger();
+    notifier = new RecoveryNotifier({
+      bus: bus as never,
+      outboundGateway: gateway as never,
+      ceoEmail: 'ceo@example.com',
+      logger: logger as never,
+    });
+  });
+
+  it('registers on schedule.recovered at the system layer', () => {
+    notifier.register();
+    expect(bus.subscribe).toHaveBeenCalledWith(
+      'schedule.recovered',
+      'system',
+      expect.any(Function),
+    );
+  });
+
+  it('logs info on registration', () => {
+    notifier.register();
+    expect(logger.info).toHaveBeenCalledWith('RecoveryNotifier registered');
+  });
+
+  it('sends a notification with correct fields for a recovered (non-suspended) job', async () => {
+    gateway.sendNotification.mockResolvedValue(true);
+
+    // Call handle() directly so the test is synchronous and deterministic.
+    // The public register() path (fire-and-forget void) is covered by the test above.
+    await (notifier as never as { handle(e: ScheduleRecoveredEvent): Promise<void> })
+      .handle(makeEvent());
+
+    expect(gateway.sendNotification).toHaveBeenCalledOnce();
+    const call = gateway.sendNotification.mock.calls[0][0];
+    expect(call.notificationType).toBe('schedule_recovered');
+    expect(call.ceoEmail).toBe('ceo@example.com');
+    expect(call.subject).toContain('coordinator');                  // agentId in subject
+    expect(call.subject).not.toContain('suspended');               // should NOT say suspended
+    expect(call.body).toContain('coordinator');                    // agentId in body
+    expect(call.body).toContain('job-abc123');                     // jobId
+    expect(call.body).toContain('~20 min');                       // stuck duration (now - runStartedAt)
+    expect(call.body).toContain('15 min');                        // timeout threshold (900s)
+    expect(call.body).toContain('reset to pending');              // outcome
+    expect(call.body).toContain('rescheduled automatically');     // resume message for non-suspended
+  });
+
+  it('sends a notification with suspended-specific content when job is suspended', async () => {
+    gateway.sendNotification.mockResolvedValue(true);
+
+    await (notifier as never as { handle(e: ScheduleRecoveredEvent): Promise<void> })
+      .handle(makeEvent({ suspended: true, consecutiveFailures: 3 }));
+
+    expect(gateway.sendNotification).toHaveBeenCalledOnce();
+    const call = gateway.sendNotification.mock.calls[0][0];
+    expect(call.notificationType).toBe('schedule_recovered');
+    expect(call.subject).toContain('suspended');                   // subject flags suspension
+    expect(call.body).toContain('SUSPENDED');                     // outcome prominently marked
+    expect(call.body).toContain('3');                             // consecutiveFailures
+    expect(call.body).toContain('web app');                       // resume instructions for suspended
+    expect(call.body).not.toContain('rescheduled automatically'); // NOT the non-suspended message
+  });
+
+  it('handles null runStartedAt (pre-migration rows) gracefully', async () => {
+    gateway.sendNotification.mockResolvedValue(true);
+
+    await (notifier as never as { handle(e: ScheduleRecoveredEvent): Promise<void> })
+      .handle(makeEvent({ runStartedAt: null }));
+
+    const call = gateway.sendNotification.mock.calls[0][0];
+    // Should mention the timeout threshold as a fallback, not crash
+    expect(call.body).toContain('15 min');
+    expect(call.body).toContain('start time unknown');
+  });
+
+  it('formats hours correctly for long timeouts', async () => {
+    gateway.sendNotification.mockResolvedValue(true);
+
+    // timeoutSeconds = 3600 → "1 h"; runStartedAt = 90 minutes ago → "~1 h 30 min"
+    const runStartedAt = new Date(FIXED_NOW.getTime() - 90 * 60 * 1000).toISOString();
+    await (notifier as never as { handle(e: ScheduleRecoveredEvent): Promise<void> })
+      .handle(makeEvent({ timeoutSeconds: 3600, runStartedAt }));
+
+    const call = gateway.sendNotification.mock.calls[0][0];
+    expect(call.body).toContain('1 h');       // timeout formatted as hours
+    expect(call.body).toContain('~1 h 30 min'); // stuck duration ~90 min
+  });
+
+  it('logs an error and resolves when sendNotification returns false', async () => {
+    gateway.sendNotification.mockResolvedValue(false);
+
+    await expect(
+      (notifier as never as { handle(e: ScheduleRecoveredEvent): Promise<void> })
+        .handle(makeEvent()),
+    ).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/scheduler/recovery-notifier.test.ts
+++ b/tests/unit/scheduler/recovery-notifier.test.ts
@@ -82,7 +82,7 @@ describe('RecoveryNotifier', () => {
     expect(logger.info).toHaveBeenCalledWith('RecoveryNotifier registered');
   });
 
-  it('sends a notification with correct fields for a recovered (non-suspended) job', async () => {
+  it('sends a notification with correct fields when a job is reset to pending', async () => {
     gateway.sendNotification.mockResolvedValue(true);
 
     // Call handle() directly so the test is synchronous and deterministic.
@@ -94,30 +94,21 @@ describe('RecoveryNotifier', () => {
     const call = gateway.sendNotification.mock.calls[0][0];
     expect(call.notificationType).toBe('schedule_recovered');
     expect(call.ceoEmail).toBe('ceo@example.com');
-    expect(call.subject).toContain('coordinator');                  // agentId in subject
-    expect(call.subject).not.toContain('suspended');               // should NOT say suspended
-    expect(call.body).toContain('coordinator');                    // agentId in body
-    expect(call.body).toContain('job-abc123');                     // jobId
-    expect(call.body).toContain('~20 min');                       // stuck duration (now - runStartedAt)
-    expect(call.body).toContain('15 min');                        // timeout threshold (900s)
-    expect(call.body).toContain('reset to pending');              // outcome
-    expect(call.body).toContain('rescheduled automatically');     // resume message for non-suspended
+    expect(call.subject).toContain('coordinator');        // agentId in subject
+    expect(call.body).toContain('coordinator');           // agentId in body
+    expect(call.body).toContain('job-abc123');            // jobId
+    expect(call.body).toContain('~20 min');              // stuck duration (now - runStartedAt)
+    expect(call.body).toContain('15 min');               // timeout threshold (900s)
+    expect(call.body).toContain('rescheduled automatically'); // outcome
   });
 
-  it('sends a notification with suspended-specific content when job is suspended', async () => {
-    gateway.sendNotification.mockResolvedValue(true);
-
+  it('skips sending a notification when the job was suspended (SuspensionNotifier handles it)', async () => {
+    // When suspended: true, recoverStuckJobs() also fires schedule.suspended,
+    // and SuspensionNotifier sends the CEO email. We must not send a second email.
     await (notifier as never as { handle(e: ScheduleRecoveredEvent): Promise<void> })
       .handle(makeEvent({ suspended: true, consecutiveFailures: 3 }));
 
-    expect(gateway.sendNotification).toHaveBeenCalledOnce();
-    const call = gateway.sendNotification.mock.calls[0][0];
-    expect(call.notificationType).toBe('schedule_recovered');
-    expect(call.subject).toContain('suspended');                   // subject flags suspension
-    expect(call.body).toContain('SUSPENDED');                     // outcome prominently marked
-    expect(call.body).toContain('3');                             // consecutiveFailures
-    expect(call.body).toContain('web app');                       // resume instructions for suspended
-    expect(call.body).not.toContain('rescheduled automatically'); // NOT the non-suspended message
+    expect(gateway.sendNotification).not.toHaveBeenCalled();
   });
 
   it('handles null runStartedAt (pre-migration rows) gracefully', async () => {
@@ -141,8 +132,8 @@ describe('RecoveryNotifier', () => {
       .handle(makeEvent({ timeoutSeconds: 3600, runStartedAt }));
 
     const call = gateway.sendNotification.mock.calls[0][0];
-    expect(call.body).toContain('1 h');       // timeout formatted as hours
-    expect(call.body).toContain('~1 h 30 min'); // stuck duration ~90 min
+    expect(call.body).toContain('1 h');           // timeout formatted as hours
+    expect(call.body).toContain('~1 h 30 min');  // stuck duration ~90 min
   });
 
   it('logs an error and resolves when sendNotification returns false', async () => {

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -1058,7 +1058,7 @@ describe('Scheduler', () => {
       expect(event.type).toBe('schedule.recovered');
     });
 
-    it('publishes schedule.recovered with suspended:true when job is suspended', async () => {
+    it('publishes schedule.recovered then schedule.suspended when watchdog recovery leads to suspension', async () => {
       const stuckRow = {
         id: 'job-3fail',
         agent_id: 'agent-1',
@@ -1074,10 +1074,19 @@ describe('Scheduler', () => {
 
       await scheduler.recoverStuckJobs();
 
-      expect(bus.publish).toHaveBeenCalledOnce();
-      const [, event] = bus.publish.mock.calls[0] as [string, { type: string; payload: { suspended: boolean } }];
-      expect(event.type).toBe('schedule.recovered');
-      expect(event.payload.suspended).toBe(true);
+      // Two events: schedule.recovered (always) + schedule.suspended (when suspended)
+      expect(bus.publish).toHaveBeenCalledTimes(2);
+
+      const [, recoveredEvent] = bus.publish.mock.calls[0] as [string, { type: string; payload: { suspended: boolean } }];
+      expect(recoveredEvent.type).toBe('schedule.recovered');
+      expect(recoveredEvent.payload.suspended).toBe(true);
+
+      const [, suspendedEvent] = bus.publish.mock.calls[1] as [string, { type: string; payload: { jobId: string; agentId: string; consecutiveFailures: number; lastError: string } }];
+      expect(suspendedEvent.type).toBe('schedule.suspended');
+      expect(suspendedEvent.payload.jobId).toBe('job-3fail');
+      expect(suspendedEvent.payload.agentId).toBe('agent-1');
+      expect(suspendedEvent.payload.consecutiveFailures).toBe(3);
+      expect(suspendedEvent.payload.lastError).toContain('timed out');
     });
 
     it('skips publish and warn log when recoverStuckJob returns noOp:true (race condition)', async () => {


### PR DESCRIPTION
## Summary

Closes #207.

- **`RecoveryNotifier`** — new system-layer subscriber to `schedule.recovered` that emails the CEO when the watchdog resets a stuck job. Mirrors the `SuspensionNotifier` pattern (direct `outbound.notification` path, bypassing LLM pipeline).
- **`'schedule_recovered'` notificationType** — added to the `OutboundNotificationPayload` discriminated union in `events.ts`.
- **Registration in `index.ts`** — registered immediately after `SuspensionNotifier`, with the same `outboundGateway && ceoPrimaryEmail` guard.

### Notification content

The email includes:
- Agent ID and job ID
- Stuck duration (computed from `runStartedAt` to event timestamp; falls back gracefully for pre-migration null rows)
- Computed timeout threshold that was exceeded
- Outcome: reset to pending or SUSPENDED (if `consecutiveFailures >= 3`)

### Important nuance

When `recoverStuckJobs()` suspends a job (consecutive failures ≥ 3), it emits **only** `schedule.recovered` — not `schedule.suspended`. `RecoveryNotifier` is therefore the sole CEO notification path for watchdog-triggered suspensions. `SuspensionNotifier` covers only the normal completion-failure path.

## Test plan

- [ ] `RecoveryNotifier` registers on `schedule.recovered` at the system layer
- [ ] Correct notification content for reset-to-pending case (stuck duration, timeout, `reset to pending` outcome)
- [ ] Correct notification content for suspended case (`SUSPENDED`, web app resume instructions)
- [ ] Null `runStartedAt` (pre-migration rows) falls back gracefully
- [ ] Hour-formatted timeouts render correctly (`1 h`, `1 h 30 min`)
- [ ] `sendNotification → false` logs an error and resolves without throwing
- [ ] CI passes (7 new unit tests, 2370 existing pass)