### PR TITLE
fix(runtime): separate uninitialized executive service guard from voice-block compile catch

### DIFF
--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -17,7 +17,7 @@ import { DEFAULT_ERROR_BUDGET, type AgentError, type ErrorBudget } from '../erro
 import { AutonomyService } from '../autonomy/autonomy-service.js';
 import { formatTimeContextBlock } from '../time/time-context.js';
 import type { OfficeIdentityService } from '../identity/service.js';
-import type { ExecutiveProfileService } from '../executive/service.js';
+import { compileWritingVoiceBlock, type ExecutiveProfileService } from '../executive/service.js';
 import { formatBullpenContext, type BullpenService } from '../memory/bullpen.js';
 import type { AgentRegistry } from './agent-registry.js';
 
@@ -242,10 +242,13 @@ export class AgentRuntime {
     // The executive's display name comes from the contact system (not the profile)
     // so that identity data has a single source of truth.
     if (executiveProfileService) {
+      // get() throws only when initialize() was never awaited — this is a startup
+      // programming error and should fail loudly, not be swallowed.
+      const executiveProfile = executiveProfileService.get();
       try {
         effectiveSystemPrompt = effectiveSystemPrompt.replace(
           '${executive_voice_block}',
-          executiveProfileService.compileWritingVoiceBlock(executiveDisplayName ?? 'the executive'),
+          compileWritingVoiceBlock(executiveProfile, executiveDisplayName ?? 'the executive'),
         );
       } catch (err) {
         logger.error({ err, agentId }, 'Failed to compile executive voice block — ${executive_voice_block} placeholder left in prompt');

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -7,6 +7,7 @@ import type { ExecutionLayer } from '../../../src/skills/execution.js';
 import { createLogger } from '../../../src/logger.js';
 import { WorkingMemory } from '../../../src/memory/working-memory.js';
 import type { AgentError } from '../../../src/errors/types.js';
+import type { ExecutiveProfile } from '../../../src/executive/types.js';
 
 // Minimal provenance block for mock LLM responses — satisfies the required field
 // without tying tests to specific model names.
@@ -119,6 +120,77 @@ describe('AgentRuntime', () => {
     // Error responses must be flagged so consumers (e.g. delegate skill) know not
     // to treat the fallback message as a real result.
     expect(responses[0]?.payload.isError).toBe(true);
+  });
+
+  it('fails task when executiveProfileService is provided but not initialized', async () => {
+    const provider = createMockProvider('This should not be called');
+    const logger = createLogger('error');
+    const runtime = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'Header ${executive_voice_block} Footer',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executiveProfileService: {
+        get: vi.fn(() => {
+          throw new Error('ExecutiveProfileService not initialized — call initialize() before get()');
+        }),
+      } as unknown as import('../../../src/executive/service.js').ExecutiveProfileService,
+      executiveDisplayName: 'Joseph',
+    });
+    runtime.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-exec-uninitialized',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'hello',
+      parentEventId: 'parent-exec-uninitialized',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(provider.chat).not.toHaveBeenCalled();
+    expect(responses).toHaveLength(1);
+    expect(responses[0]?.payload.isError).toBe(true);
+    expect(responses[0]?.payload.content).toContain('unexpected error occurred');
+  });
+
+  it('logs and continues when executive voice block compilation throws', async () => {
+    const provider = createMockProvider('Hello with fallback prompt');
+    const logger = createLogger('error');
+    const loggerErrorSpy = vi.spyOn(logger, 'error');
+    const executiveProfile = {} as ExecutiveProfile;
+    const runtime = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'Header ${executive_voice_block} Footer',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executiveProfileService: {
+        get: vi.fn(() => executiveProfile),
+      } as unknown as import('../../../src/executive/service.js').ExecutiveProfileService,
+      executiveDisplayName: 'Joseph',
+    });
+    runtime.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-exec-compile-throws',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'hello',
+      parentEventId: 'parent-exec-compile-throws',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(provider.chat).toHaveBeenCalledTimes(1);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error), agentId: 'coordinator' }),
+      'Failed to compile executive voice block — ${executive_voice_block} placeholder left in prompt',
+    );
   });
 
   it('includes conversation history in LLM context', async () => {


### PR DESCRIPTION
### Motivation
- Prevent a startup wiring error from being silently swallowed when compiling the `${executive_voice_block}` placeholder so uninitialized service usage surfaces as a task failure. 
- Allow prompt compilation errors to be handled gracefully while still signaling operator-visible errors in the logs.

### Description
- Call `executiveProfileService.get()` outside the `try/catch` so an uninitialized `ExecutiveProfileService` throws and fails the task instead of being swallowed. 
- Use the exported pure `compileWritingVoiceBlock(profile, executiveName)` function directly instead of the instance method indirection. 
- Narrow the `try/catch` to wrap only the compilation call so only compilation errors are logged and the task continues. 
- Add unit tests in `tests/unit/agents/runtime.test.ts` covering the uninitialized-service → task failure path and the compilation-throws → log-and-continue path.

### Testing
- Attempted to run `pnpm vitest run tests/unit/agents/runtime.test.ts` but the environment-level `pnpm` install step failed due to the local build approval policy (`ERR_PNPM_IGNORED_BUILDS`).
- Ran `./node_modules/.bin/vitest run tests/unit/agents/runtime.test.ts` and the file passed: `1 passed (1)` test file, `39 passed (39)` individual tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a077188f10083239234bbbd4bf7f37a)