### PR TITLE
fix: bypass autonomy gates A and B for principal-originated tasks

### DIFF
--- a/docs/superpowers/plans/2026-05-15-principal-bypass-autonomy-gate.md
+++ b/docs/superpowers/plans/2026-05-15-principal-bypass-autonomy-gate.md
@@ -1,0 +1,231 @@
+# Principal Bypass for Autonomy Gates A and B — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a task is originated by the principal (CEO), skip autonomy Gates A and B so that direct CEO instructions are never blocked by the autonomy score.
+
+**Architecture:** Single edit to `src/skills/execution.ts` — wrap the existing Gate A and Gate B logic in an `else` branch gated by `isPrincipalOriginated()`. The helper is already imported. No schema changes, no new files.
+
+**Tech Stack:** TypeScript, Vitest
+
+**Worktree:** `/Users/josephfung/Projects/curia-principal-bypass` (branch `fix/principal-bypass-autonomy-gate`)
+
+---
+
+### Task 1: Write the three failing tests
+
+**Files:**
+- Modify: `src/skills/execution.test.ts` — add three cases to the existing `'autonomy gates'` describe block (after the last `it(...)` in that block, before the closing `}`).
+
+- [ ] **Step 1.1: Add the three test cases**
+
+Open `src/skills/execution.test.ts`. The `'autonomy gates'` describe block ends just before the `// ---------------------------------------------------------------------------` comment for `humanApproved bypass tests` (around line 543). Add these three `it(...)` blocks inside the `'autonomy gates'` describe, immediately before its closing `});`:
+
+```ts
+  it('skips gates A and B when task is principal-originated (Gate B territory)', async () => {
+    const registry = new SkillRegistry();
+    const handler = makeHandler('ok');
+    // calendar-create-event uses action_risk: 'high' → requires score 80. Score 74 would normally block.
+    registry.register(makeRiskyManifest('calendar-create-event', 'high'), handler);
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(74),
+    });
+
+    const result = await layer.invoke('calendar-create-event', {}, undefined, {
+      taskMetadata: {
+        originator: {
+          contactId: 'ceo-contact-id',
+          systemRole: 'principal' as const,
+          channel: 'email',
+          initiatedAt: new Date().toISOString(),
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(handler.execute).toHaveBeenCalledOnce();
+  });
+
+  it('skips gates A and B when task is principal-originated (Gate A territory)', async () => {
+    const registry = new SkillRegistry();
+    const handler = makeHandler('ok');
+    // score 50 triggers Gate A (< 60 blocks all non-none) — principal should still pass
+    registry.register(makeRiskyManifest('send-email', 'low'), handler);
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(50),
+    });
+
+    const result = await layer.invoke('send-email', {}, undefined, {
+      taskMetadata: {
+        originator: {
+          contactId: 'ceo-contact-id',
+          systemRole: 'principal' as const,
+          channel: 'email',
+          initiatedAt: new Date().toISOString(),
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(handler.execute).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT bypass gates for agent-originated tasks', async () => {
+    const registry = new SkillRegistry();
+    const handler = makeHandler('should not run');
+    registry.register(makeRiskyManifest('calendar-create-event', 'high'), handler); // requires 80
+
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(74), // below 80 — should block non-principal
+      bus: mockBus,
+    });
+
+    const result = await layer.invoke('calendar-create-event', {}, undefined, {
+      taskMetadata: {
+        originator: {
+          contactId: 'agent-contact-id',
+          systemRole: 'agent' as const,
+          channel: 'internal',
+          initiatedAt: new Date().toISOString(),
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(handler.execute).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 1.2: Run the new tests to confirm they fail**
+
+```bash
+npm --prefix /Users/josephfung/Projects/curia-principal-bypass test -- --reporter=verbose src/skills/execution.test.ts 2>&1 | tail -30
+```
+
+Expected: the two `'skips gates'` tests FAIL with `expected false to be true` (gate fires instead of bypassing). The `'does NOT bypass'` test should PASS (it exercises existing behaviour).
+
+---
+
+### Task 2: Implement the principal bypass
+
+**Files:**
+- Modify: `src/skills/execution.ts` — wrap Gates A and B in an `else` branch
+
+- [ ] **Step 2.1: Replace the gate block**
+
+In `src/skills/execution.ts`, find this exact block (currently starting around line 346):
+
+```ts
+      if (autonomyConfig !== null) {
+        const currentScore = autonomyConfig.score;
+
+        // Gate A: Full restriction — score < 60 blocks all non-read skills.
+        // action_risk: 'none' is exempt (reads, retrieval, summarisation).
+        if (currentScore < 60 && manifest.action_risk !== 'none') {
+```
+
+Replace the entire `if (autonomyConfig !== null) { ... }` block with this:
+
+```ts
+      if (autonomyConfig !== null) {
+        const currentScore = autonomyConfig.score;
+
+        // Principal bypass — if the task was originated by the principal (CEO), skip gates A and B.
+        // The autonomy gate governs *autonomous* behavior; a direct CEO instruction overrides it
+        // by intent. Log at info so bypasses are visible in production.
+        if (isPrincipalOriginated(options?.taskMetadata)) {
+          skillLogger.info(
+            { skillName, currentScore },
+            'autonomy gate: skipped — task originated by principal',
+          );
+        } else {
+          // Gate A: Full restriction — score < 60 blocks all non-read skills.
+          // action_risk: 'none' is exempt (reads, retrieval, summarisation).
+          if (currentScore < 60 && manifest.action_risk !== 'none') {
+            skillLogger.info(
+              { skillName, currentScore, actionRisk: manifest.action_risk },
+              'autonomy gate: skill blocked — agent is in restricted mode (score < 60)',
+            );
+            if (this.bus) {
+              this.bus.publish('execution', createAutonomySkillBlocked({
+                skillName,
+                actionRisk: manifest.action_risk,
+                currentScore,
+                requiredScore: 60,
+                agentId: options?.agentId,
+                taskEventId: options?.taskEventId,
+              })).catch((err) => {
+                skillLogger.warn({ err, skillName }, 'autonomy gate: failed to publish autonomy.skill_blocked event');
+              });
+            }
+            // Note: `input` here is post-timestamp-normalization (mutated in-place above).
+            // The stored payload in autonomy_action_log will contain normalized timestamps,
+            // which is correct — re-normalization on approve-action re-invocation is a no-op.
+            const gateAError = await this.buildGateError(
+              skillName, input, currentScore, 60, manifest.action_risk, options, skillLogger,
+            );
+            return {
+              success: false,
+              error: this.wrapSkillError(gateAError),
+            };
+          }
+
+          // Gate B: Per-skill action_risk threshold.
+          const requiredScore = AutonomyService.minScoreForActionRisk(manifest.action_risk);
+          if (currentScore < requiredScore) {
+            skillLogger.info(
+              { skillName, currentScore, requiredScore, actionRisk: manifest.action_risk },
+              'autonomy gate: skill blocked — score below action_risk threshold',
+            );
+            if (this.bus) {
+              this.bus.publish('execution', createAutonomySkillBlocked({
+                skillName,
+                actionRisk: manifest.action_risk,
+                currentScore,
+                requiredScore,
+                agentId: options?.agentId,
+                taskEventId: options?.taskEventId,
+              })).catch((err) => {
+                skillLogger.warn({ err, skillName }, 'autonomy gate: failed to publish autonomy.skill_blocked event');
+              });
+            }
+            // Note: same post-normalization `input` as Gate A — see comment above.
+            const gateBError = await this.buildGateError(
+              skillName, input, currentScore, requiredScore, manifest.action_risk, options, skillLogger,
+            );
+            return {
+              success: false,
+              error: this.wrapSkillError(gateBError),
+            };
+          }
+        }
+      } else {
+```
+
+> **Tip:** The closing `} else {` at the end connects to the existing `autonomyConfig is null — pre-migration or empty table. Fail-open.` warn block — do not change that part.
+
+- [ ] **Step 2.2: Run the three new tests — all should now pass**
+
+```bash
+npm --prefix /Users/josephfung/Projects/curia-principal-bypass test -- --reporter=verbose src/skills/execution.test.ts 2>&1 | tail -30
+```
+
+Expected: all three new tests PASS.
+
+- [ ] **Step 2.3: Run the full test suite — no regressions**
+
+```bash
+npm --prefix /Users/josephfung/Projects/curia-principal-bypass test 2>&1 | tail -20
+```
+
+Expected: all tests pass. If any fail, fix before continuing.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/curia-principal-bypass add src/skills/execution.ts src/skills/execution.test.ts
+git -C /Users/josephfung/Projects/curia-principal-bypass commit -m "fix: bypass autonomy gates A and B for principal-originated tasks"
+```

--- a/docs/superpowers/specs/2026-05-15-principal-bypass-autonomy-gate-design.md
+++ b/docs/superpowers/specs/2026-05-15-principal-bypass-autonomy-gate-design.md
@@ -1,0 +1,103 @@
+# Principal Bypass for Autonomy Gates A and B
+
+**Date:** 2026-05-15
+**Status:** Approved
+**Discovered via:** approval request `39afde15` (2026-05-15)
+**Branch:** fix/principal-bypass-autonomy-gate
+
+---
+
+## Problem
+
+The autonomy gate in `src/skills/execution.ts` blocks skill invocations based solely on the
+numeric autonomy score, with no consideration for who originated the task. When the CEO
+directly instructs Curia to take an action (e.g. via email), the gate fires and generates an
+approval request — requiring the CEO to approve their own explicit instruction. This is
+friction without benefit.
+
+The recent principal identity work (`2499a48`) added an `isPrincipalOriginated()` check to
+the **elevated-skill gate** (for `sensitivity: 'elevated'` skills), but did not extend the
+same bypass to the **autonomy score gates** (Gate A and Gate B). This was an oversight.
+
+**Root cause confirmed from production:**
+- Autonomy score: 74 | `calendar-create-event` requires 80 (`action_risk: 'high'`)
+- Task `1f101d86` was principal-originated (CEO email) → Gate B fired → approval request `39afde15` sent
+
+---
+
+## Design
+
+### Scope
+
+Single file edit: `src/skills/execution.ts`. No schema changes, no new types, no new files.
+
+`isPrincipalOriginated` is already imported at line 24. No new imports needed.
+
+### Change
+
+Within the autonomy gate block (currently lines 336–412), after reading `autonomyConfig` and
+confirming it is non-null, add a principal-originated check **before** Gate A and Gate B. If
+the check passes, log at `info` level and fall through to skill execution. Otherwise, proceed
+to the existing gate logic unchanged.
+
+```ts
+// Principal bypass — if the task was originated by the principal (CEO), skip gates A and B.
+// The autonomy gate governs *autonomous* behavior; a direct CEO instruction overrides it by intent.
+// Log at info level so bypasses are visible in production logs.
+if (isPrincipalOriginated(options?.taskMetadata)) {
+  skillLogger.info(
+    { skillName, currentScore },
+    'autonomy gate: skipped — task originated by principal',
+  );
+  // fall through to skill execution
+} else {
+  // Gate A: Full restriction — score < 60 blocks all non-read skills.
+  // ...existing Gate A logic...
+
+  // Gate B: Per-skill action_risk threshold.
+  // ...existing Gate B logic...
+}
+```
+
+### Why not reuse `humanApproved`
+
+`humanApproved` is set exclusively by `approve-action` to re-execute a previously blocked
+skill after explicit CEO approval. Reusing it here would blur the semantics — principal
+origination is a task-level signal established at dispatch time, not a post-hoc re-execution
+flag. Keeping them separate makes each signal's meaning clear and avoids coupling the two
+code paths.
+
+### Logging
+
+Log at `info` with `skillName` and `currentScore` when the bypass fires. This makes principal
+bypasses searchable in production (`"autonomy gate: skipped"`) and provides the same
+traceability as the `humanApproved` log at line 322.
+
+No bus event is emitted for the bypass (there is no `autonomy.skill_bypassed` event type).
+The existing `skill.invoke` event provides sufficient audit coverage.
+
+---
+
+## Test Plan
+
+Additions to `src/skills/execution.test.ts`:
+
+1. **Principal bypass — Gate B territory:**
+   Task metadata has `originator.systemRole === 'principal'`, autonomy score is 74,
+   skill has `action_risk: 'high'` (requires 80). Skill should run successfully.
+
+2. **Principal bypass — Gate A territory:**
+   Same originator metadata, autonomy score is 50 (below Gate A threshold of 60),
+   skill has `action_risk: 'low'`. Skill should run successfully.
+
+3. **Regression — non-principal still gated:**
+   Task metadata has no originator (or `systemRole !== 'principal'`), same low score.
+   Skill should be blocked by the gate (return `{ success: false }`).
+
+---
+
+## Out of Scope
+
+- Changes to `approve-action` or the `humanApproved` flag
+- Changes to the elevated-skill gate (already uses `isPrincipalOriginated`)
+- Any schema or bus event changes

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -540,6 +540,88 @@ describe('autonomy gates', () => {
 
     expect(result.success).toBe(true);
   });
+
+  it('skips gates A and B when task is principal-originated (Gate B territory)', async () => {
+    const registry = new SkillRegistry();
+    const handler = makeHandler('ok');
+    // calendar-create-event uses action_risk: 'high' → requires score 80. Score 74 would normally block.
+    registry.register(makeRiskyManifest('calendar-create-event', 'high'), handler);
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(74),
+    });
+
+    const result = await layer.invoke('calendar-create-event', {}, undefined, {
+      taskMetadata: {
+        originator: {
+          contactId: 'ceo-contact-id',
+          systemRole: 'principal' as const,
+          channel: 'email',
+          initiatedAt: new Date().toISOString(),
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(handler.execute).toHaveBeenCalledOnce();
+  });
+
+  it('skips gates A and B when task is principal-originated (Gate A territory)', async () => {
+    const registry = new SkillRegistry();
+    const handler = makeHandler('ok');
+    // score 50 triggers Gate A (< 60 blocks all non-none) and Gate B (50 < 70 threshold for medium) —
+    // principal should bypass both
+    registry.register(makeRiskyManifest('send-email', 'medium'), handler);
+
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(50),
+    });
+
+    const result = await layer.invoke('send-email', {}, undefined, {
+      taskMetadata: {
+        originator: {
+          contactId: 'ceo-contact-id',
+          systemRole: 'principal' as const,
+          channel: 'email',
+          initiatedAt: new Date().toISOString(),
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(handler.execute).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT bypass gates for agent-originated tasks', async () => {
+    const registry = new SkillRegistry();
+    const handler = makeHandler('should not run');
+    registry.register(makeRiskyManifest('calendar-create-event', 'high'), handler); // requires 80
+
+    const mockBus = { publish: vi.fn().mockResolvedValue(undefined) } as unknown as EventBus;
+    const layer = new ExecutionLayer(registry, logger, {
+      autonomyService: makeAutonomyService(74), // below 80 — should block non-principal
+      bus: mockBus,
+    });
+
+    const result = await layer.invoke('calendar-create-event', {}, undefined, {
+      taskMetadata: {
+        originator: {
+          contactId: 'agent-contact-id',
+          systemRole: 'agent' as const,
+          channel: 'internal',
+          initiatedAt: new Date().toISOString(),
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // Gate B fired — error should reference the autonomy score and the required threshold (80)
+      expect(result.error).toContain('autonomy');
+      expect(result.error).toContain('80');
+    }
+    expect(handler.execute).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -351,7 +351,7 @@ export class ExecutionLayer {
         // by intent. Log at info so bypasses are visible in production.
         if (isPrincipalOriginated(options?.taskMetadata)) {
           skillLogger.info(
-            { skillName, currentScore },
+            { skillName, currentScore, agentId: options?.agentId, taskEventId: options?.taskEventId },
             'autonomy gate: skipped — task originated by principal',
           );
         } else {
@@ -386,6 +386,8 @@ export class ExecutionLayer {
             };
           }
 
+          // action_risk: 'none' skills fall through Gate A above and reach Gate B.
+          // minScoreForActionRisk('none') returns 0, so Gate B is always a no-op for reads.
           // Gate B: Per-skill action_risk threshold.
           const requiredScore = AutonomyService.minScoreForActionRisk(manifest.action_risk);
           if (currentScore < requiredScore) {

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -346,64 +346,74 @@ export class ExecutionLayer {
       if (autonomyConfig !== null) {
         const currentScore = autonomyConfig.score;
 
-        // Gate A: Full restriction — score < 60 blocks all non-read skills.
-        // action_risk: 'none' is exempt (reads, retrieval, summarisation).
-        if (currentScore < 60 && manifest.action_risk !== 'none') {
+        // Principal bypass — if the task was originated by the principal (CEO), skip gates A and B.
+        // The autonomy gate governs *autonomous* behavior; a direct CEO instruction overrides it
+        // by intent. Log at info so bypasses are visible in production.
+        if (isPrincipalOriginated(options?.taskMetadata)) {
           skillLogger.info(
-            { skillName, currentScore, actionRisk: manifest.action_risk },
-            'autonomy gate: skill blocked — agent is in restricted mode (score < 60)',
+            { skillName, currentScore },
+            'autonomy gate: skipped — task originated by principal',
           );
-          if (this.bus) {
-            this.bus.publish('execution', createAutonomySkillBlocked({
-              skillName,
-              actionRisk: manifest.action_risk,
-              currentScore,
-              requiredScore: 60,
-              agentId: options?.agentId,
-              taskEventId: options?.taskEventId,
-            })).catch((err) => {
-              skillLogger.warn({ err, skillName }, 'autonomy gate: failed to publish autonomy.skill_blocked event');
-            });
+        } else {
+          // Gate A: Full restriction — score < 60 blocks all non-read skills.
+          // action_risk: 'none' is exempt (reads, retrieval, summarisation).
+          if (currentScore < 60 && manifest.action_risk !== 'none') {
+            skillLogger.info(
+              { skillName, currentScore, actionRisk: manifest.action_risk },
+              'autonomy gate: skill blocked — agent is in restricted mode (score < 60)',
+            );
+            if (this.bus) {
+              this.bus.publish('execution', createAutonomySkillBlocked({
+                skillName,
+                actionRisk: manifest.action_risk,
+                currentScore,
+                requiredScore: 60,
+                agentId: options?.agentId,
+                taskEventId: options?.taskEventId,
+              })).catch((err) => {
+                skillLogger.warn({ err, skillName }, 'autonomy gate: failed to publish autonomy.skill_blocked event');
+              });
+            }
+            // Note: `input` here is post-timestamp-normalization (mutated in-place above).
+            // The stored payload in autonomy_action_log will contain normalized timestamps,
+            // which is correct — re-normalization on approve-action re-invocation is a no-op.
+            const gateAError = await this.buildGateError(
+              skillName, input, currentScore, 60, manifest.action_risk, options, skillLogger,
+            );
+            return {
+              success: false,
+              error: this.wrapSkillError(gateAError),
+            };
           }
-          // Note: `input` here is post-timestamp-normalization (mutated in-place above).
-          // The stored payload in autonomy_action_log will contain normalized timestamps,
-          // which is correct — re-normalization on approve-action re-invocation is a no-op.
-          const gateAError = await this.buildGateError(
-            skillName, input, currentScore, 60, manifest.action_risk, options, skillLogger,
-          );
-          return {
-            success: false,
-            error: this.wrapSkillError(gateAError),
-          };
-        }
 
-        // Gate B: Per-skill action_risk threshold.
-        const requiredScore = AutonomyService.minScoreForActionRisk(manifest.action_risk);
-        if (currentScore < requiredScore) {
-          skillLogger.info(
-            { skillName, currentScore, requiredScore, actionRisk: manifest.action_risk },
-            'autonomy gate: skill blocked — score below action_risk threshold',
-          );
-          if (this.bus) {
-            this.bus.publish('execution', createAutonomySkillBlocked({
-              skillName,
-              actionRisk: manifest.action_risk,
-              currentScore,
-              requiredScore,
-              agentId: options?.agentId,
-              taskEventId: options?.taskEventId,
-            })).catch((err) => {
-              skillLogger.warn({ err, skillName }, 'autonomy gate: failed to publish autonomy.skill_blocked event');
-            });
+          // Gate B: Per-skill action_risk threshold.
+          const requiredScore = AutonomyService.minScoreForActionRisk(manifest.action_risk);
+          if (currentScore < requiredScore) {
+            skillLogger.info(
+              { skillName, currentScore, requiredScore, actionRisk: manifest.action_risk },
+              'autonomy gate: skill blocked — score below action_risk threshold',
+            );
+            if (this.bus) {
+              this.bus.publish('execution', createAutonomySkillBlocked({
+                skillName,
+                actionRisk: manifest.action_risk,
+                currentScore,
+                requiredScore,
+                agentId: options?.agentId,
+                taskEventId: options?.taskEventId,
+              })).catch((err) => {
+                skillLogger.warn({ err, skillName }, 'autonomy gate: failed to publish autonomy.skill_blocked event');
+              });
+            }
+            // Note: same post-normalization `input` as Gate A — see comment above.
+            const gateBError = await this.buildGateError(
+              skillName, input, currentScore, requiredScore, manifest.action_risk, options, skillLogger,
+            );
+            return {
+              success: false,
+              error: this.wrapSkillError(gateBError),
+            };
           }
-          // Note: same post-normalization `input` as Gate A — see comment above.
-          const gateBError = await this.buildGateError(
-            skillName, input, currentScore, requiredScore, manifest.action_risk, options, skillLogger,
-          );
-          return {
-            success: false,
-            error: this.wrapSkillError(gateBError),
-          };
         }
       } else {
         // autonomyConfig is null — pre-migration or empty table. Fail-open.


### PR DESCRIPTION
## Summary

- Wraps Gate A and Gate B in an `else` branch under `isPrincipalOriginated(options?.taskMetadata)` in `src/skills/execution.ts` — direct CEO instructions now skip the autonomy score gate
- Logs at `info` level when bypass fires, including `skillName`, `currentScore`, `agentId`, and `taskEventId` for production observability
- Adds three tests covering Gate B bypass (score 74 / `action_risk: high`), Gate A bypass (score 50), and regression (agent-originated task still blocked)

## Root cause

Production autonomy score: 74. `calendar-create-event` has `action_risk: 'high'` requiring score 80. Gate B fired on CEO-originated task `1f101d86` (ref `39afde15`). The principal identity work (`2499a48`) added `isPrincipalOriginated()` to the elevated-skill gate but not to Gates A and B — an oversight now corrected.

## Design notes

- `isPrincipalOriginated` is already imported at line 24 and used by the elevated-skill gate — no new trust assumptions
- No bus event emitted for the bypass (deliberate — no `autonomy.skill_bypassed` type exists; the existing `skill.invoke` event provides sufficient audit coverage per design doc)
- `humanApproved` is not reused — semantically distinct (re-execution flag set post-hoc by `approve-action`, not a task-level origination signal)

## Test plan

- [ ] All 3 new tests pass: `skips gates A and B when task is principal-originated (Gate B territory)`, `(Gate A territory)`, `does NOT bypass gates for agent-originated tasks`
- [ ] Full test suite passes with no new failures
- [ ] Verify in production: next CEO-originated `calendar-create-event` completes without triggering an approval request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Principal-originated tasks now bypass autonomy gates A and B without score restrictions.
  * Added info logging when autonomy gates are bypassed for principal-originated requests.

* **Tests**
  * Added three new test cases covering principal-originated bypass scenarios and agent-originated regression testing.

* **Documentation**
  * Added implementation plan and design specification for principal bypass feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/605)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->