### PR TITLE
chore: add Semgrep CE scanning (#562)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,49 @@
+name: Semgrep
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 7 * * 3'  # Weekly, Wednesday — staggered from CodeQL (06:00)
+
+permissions:
+  contents: read
+  security-events: write  # required for SARIF upload
+
+jobs:
+  semgrep:
+    name: Semgrep Scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run Semgrep
+        # continue-on-error so Semgrep's issue-found exit code (1) doesn't
+        # halt the job before we can upload the SARIF results
+        continue-on-error: true
+        run: |
+          semgrep \
+            --config p/typescript \
+            --config p/nodejs \
+            --config p/owasp-top-ten \
+            --config p/command-injection \
+            --config p/secrets \
+            --metrics=off \
+            --sarif \
+            --output semgrep.sarif \
+            --exclude 'node_modules/**' \
+            --exclude 'dist/**' \
+            --exclude 'pnpm-lock.yaml' \
+            --exclude 'tests/**/*.snap'
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: semgrep.sarif
+        # Upload even when Semgrep finds issues so alerts appear in Security tab
+        if: always()

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+pnpm-lock.yaml
+# Snapshot files contain intentional patterns that would trigger false positives
+**/*.snap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
+- **Semgrep CE scanning** — adds pattern-based SAST on every PR and weekly schedule; covers TypeScript, Node.js OWASP Top 10, command injection, and secrets rulesets; SARIF results surface in the Security tab. (#562)
 - **Per-route rate limiting** — all 24 CodeQL `js/missing-rate-limiting` alerts resolved; auth/authorization endpoints (identity, autonomy, executive) capped at 10 req/min per IP, KG explorer and health endpoints at 60 req/min. (#580)
 
 ### Fixed


### PR DESCRIPTION
## Summary

Closes #562

- Adds `.github/workflows/semgrep.yml` — Semgrep CE SAST scanning on every PR, push to `main`, and weekly schedule (Wed 07:00 UTC, staggered 1 hour from CodeQL)
- Adds `.semgrepignore` — excludes `node_modules/`, `dist/`, `pnpm-lock.yaml`, and snapshot files
- SARIF results upload to the GitHub Security tab via `upload-sarif@v4`

**Rulesets:** `p/typescript`, `p/nodejs`, `p/owasp-top-ten`, `p/command-injection`, `p/secrets`

**Explicitly excluded (per issue):** `p/ai` (high false-positive rate), `p/semgrep-misconfigurations` (noisy), `p/eslint-plugin-security` (overlaps with `p/nodejs`)

**Implementation notes vs. original issue spec:**
- `SEMGREP_RULES: ""` replaced with `--metrics=off` flag — the env var would silently override `--config` flags and disable all rules
- `upload-sarif@v4` (not `@v3`) — consistent with `codeql.yml`
- `continue-on-error: true` on scan step — Semgrep exits 1 when it finds issues; this prevents the job from halting before SARIF is uploaded
- `tests/` removed from `.semgrepignore` — too broad; snapshots are already covered by `**/*.snap`

## Test plan

- [ ] Merge and verify the workflow appears in the Actions tab
- [ ] Confirm SARIF results appear in Security → Code scanning alerts after first run
- [ ] Review initial findings and add `# nosemgrep:` suppressions for confirmed false positives (step 3 from issue — post-merge triage)