### PR TITLE
fix: alias propagation gaps — atomic addAlias, mergeEntities union, search alias path (closes #536)

### DIFF
--- a/docs/superpowers/plans/2026-05-15-alias-propagation-gaps.md
+++ b/docs/superpowers/plans/2026-05-15-alias-propagation-gaps.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Write failing tests for `KnowledgeGraphStore.addAlias`
+## Task 1: Write failing tests for `KnowledgeGraphStore.addAlias`
 
 **Files:**
 - Modify: `src/memory/knowledge-graph.upsert.test.ts`
@@ -79,7 +79,7 @@ Expected: FAIL — `store.addAlias is not a function` (or equivalent TypeError).
 
 ---
 
-### Task 2: Implement `addAlias` in the backend interface, both backends, and the store
+## Task 2: Implement `addAlias` in the backend interface, both backends, and the store
 
 **Files:**
 - Modify: `src/memory/knowledge-graph.ts`
@@ -161,7 +161,7 @@ git -C /Users/josephfung/Projects/worktrees/curia-alias-propagation commit -m "f
 
 ---
 
-### Task 3: Update `entity-memory.addAlias` to use `store.addAlias`
+## Task 3: Update `entity-memory.addAlias` to use `store.addAlias`
 
 **Files:**
 - Modify: `src/memory/entity-memory.ts`
@@ -228,7 +228,7 @@ git -C /Users/josephfung/Projects/worktrees/curia-alias-propagation commit -m "f
 
 ---
 
-### Task 4: Write failing tests for `mergeEntities` alias union
+## Task 4: Write failing tests for `mergeEntities` alias union
 
 **Files:**
 - Modify: `src/memory/entity-memory.resolve-or-create.test.ts`
@@ -344,7 +344,7 @@ Expected: the four new `mergeEntities — alias consolidation` tests FAIL (secon
 
 ---
 
-### Task 5: Implement alias union in `mergeEntities`
+## Task 5: Implement alias union in `mergeEntities`
 
 **Files:**
 - Modify: `src/memory/entity-memory.ts`
@@ -398,7 +398,7 @@ git -C /Users/josephfung/Projects/worktrees/curia-alias-propagation commit -m "f
 
 ---
 
-### Task 6: Write failing tests for two-path `EntityMemory.search`
+## Task 6: Write failing tests for two-path `EntityMemory.search`
 
 **Files:**
 - Modify: `src/memory/entity-memory.resolve-or-create.test.ts`
@@ -513,7 +513,7 @@ Expected: the five new `EntityMemory.search — alias exact-match path` tests FA
 
 ---
 
-### Task 7: Implement two-path `EntityMemory.search`
+## Task 7: Implement two-path `EntityMemory.search`
 
 **Files:**
 - Modify: `src/memory/entity-memory.ts`

--- a/docs/superpowers/plans/2026-05-15-alias-propagation-gaps.md
+++ b/docs/superpowers/plans/2026-05-15-alias-propagation-gaps.md
@@ -1,0 +1,624 @@
+# Alias Propagation Gaps Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three alias propagation gaps in the knowledge graph: make `addAlias` atomic at the DB level, have `mergeEntities` union aliases from both nodes, and add an exact alias-match path to `EntityMemory.search`.
+
+**Architecture:** All changes live in `src/memory/` — specifically `knowledge-graph.ts` (backend interface + both implementations + store pass-through) and `entity-memory.ts` (`addAlias`, `mergeEntities`, `search`). No changes are needed to the `memory-query` skill handler — the improved `search()` is transparent to callers.
+
+**Tech Stack:** TypeScript ESM, Vitest, Postgres (pgvector), in-memory backend for tests.
+
+---
+
+### Task 1: Write failing tests for `KnowledgeGraphStore.addAlias`
+
+**Files:**
+- Modify: `src/memory/knowledge-graph.upsert.test.ts`
+
+- [ ] **Step 1: Add the failing test suite to `knowledge-graph.upsert.test.ts`**
+
+Append this block at the end of the file (after existing `describe` blocks):
+
+```typescript
+describe('KnowledgeGraphStore.addAlias', () => {
+  it('returns true and appends alias when alias is new', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+
+    const added = await store.addAlias(node.id, 'al');
+
+    expect(added).toBe(true);
+    const updated = await store.getNode(node.id);
+    expect(updated!.aliases).toEqual(['al']);
+  });
+
+  it('returns false and does not duplicate when alias already exists', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    await store.addAlias(node.id, 'al');
+
+    const added = await store.addAlias(node.id, 'al');
+
+    expect(added).toBe(false);
+    const updated = await store.getNode(node.id);
+    expect(updated!.aliases).toEqual(['al']); // still exactly one copy
+  });
+
+  it('returns false when alias cap (10) is reached', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    for (let i = 0; i < 10; i++) {
+      await store.addAlias(node.id, `alias-${i}`);
+    }
+
+    const added = await store.addAlias(node.id, 'one-more');
+
+    expect(added).toBe(false);
+    const updated = await store.getNode(node.id);
+    expect(updated!.aliases).toHaveLength(10);
+    expect(updated!.aliases).not.toContain('one-more');
+  });
+
+  it('returns false for an unknown nodeId', async () => {
+    const store = makeStore();
+
+    const added = await store.addAlias('does-not-exist', 'some-alias');
+
+    expect(added).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+```bash
+npx --prefix /Users/josephfung/Projects/worktrees/curia-alias-propagation vitest run src/memory/knowledge-graph.upsert.test.ts
+```
+
+Expected: FAIL — `store.addAlias is not a function` (or equivalent TypeError).
+
+---
+
+### Task 2: Implement `addAlias` in the backend interface, both backends, and the store
+
+**Files:**
+- Modify: `src/memory/knowledge-graph.ts`
+
+- [ ] **Step 1: Add `addAlias` to the `KnowledgeGraphBackend` interface**
+
+In `src/memory/knowledge-graph.ts`, find the `KnowledgeGraphBackend` interface (starts around line 70). After the `findNodesByLabel` line, insert:
+
+```typescript
+  /** Atomically append an alias to a node's aliases array.
+   *  Returns true if the alias was appended, false if skipped
+   *  (already present, cap reached, or node not found). */
+  addAlias(nodeId: string, alias: string): Promise<boolean>;
+```
+
+- [ ] **Step 2: Implement `PostgresBackend.addAlias`**
+
+In `src/memory/knowledge-graph.ts`, find `PostgresBackend.findNodesByLabel` (around line 523). After its closing brace, add:
+
+```typescript
+  async addAlias(nodeId: string, alias: string): Promise<boolean> {
+    // Single atomic UPDATE: predicate enforces dedup and cap at the DB level.
+    // No SELECT needed — rowCount tells us whether the guard passed.
+    const result = await this.pool.query(
+      `UPDATE kg_nodes
+       SET aliases = array_append(aliases, $2)
+       WHERE id = $1
+         AND archived_at IS NULL
+         AND NOT ($2 = ANY(aliases))
+         AND cardinality(aliases) < 10`,
+      [nodeId, alias],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+```
+
+- [ ] **Step 3: Implement `InMemoryBackend.addAlias`**
+
+In `src/memory/knowledge-graph.ts`, find `InMemoryBackend.findNodesByLabel` (around line 979). After its closing brace, add:
+
+```typescript
+  async addAlias(nodeId: string, alias: string): Promise<boolean> {
+    // JS is single-threaded so no true race exists, but this mirrors the
+    // Postgres predicate semantics so in-memory tests are reliable proxies.
+    const node = this.nodes.get(nodeId);
+    if (!node || this.archivedNodes.has(nodeId)) return false;
+    if (node.aliases.includes(alias)) return false;
+    if (node.aliases.length >= 10) return false;
+    this.nodes.set(nodeId, { ...node, aliases: [...node.aliases, alias] });
+    return true;
+  }
+```
+
+- [ ] **Step 4: Add `addAlias` pass-through to `KnowledgeGraphStore`**
+
+In `src/memory/knowledge-graph.ts`, find `KnowledgeGraphStore.findNodesByLabel` (around line 283). After its closing brace, add:
+
+```typescript
+  /** Atomically append an alias — see KnowledgeGraphBackend.addAlias for semantics. */
+  addAlias(nodeId: string, alias: string): Promise<boolean> {
+    return this.backend.addAlias(nodeId, alias);
+  }
+```
+
+- [ ] **Step 5: Run the store tests to verify they pass**
+
+```bash
+npx --prefix /Users/josephfung/Projects/worktrees/curia-alias-propagation vitest run src/memory/knowledge-graph.upsert.test.ts
+```
+
+Expected: all tests PASS, including the four new `KnowledgeGraphStore.addAlias` tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-alias-propagation add src/memory/knowledge-graph.ts src/memory/knowledge-graph.upsert.test.ts
+git -C /Users/josephfung/Projects/worktrees/curia-alias-propagation commit -m "feat: add atomic addAlias to KnowledgeGraphBackend interface and both backends"
+```
+
+---
+
+### Task 3: Update `entity-memory.addAlias` to use `store.addAlias`
+
+**Files:**
+- Modify: `src/memory/entity-memory.ts`
+
+- [ ] **Step 1: Replace the body of `entity-memory.addAlias`**
+
+In `src/memory/entity-memory.ts`, find `async addAlias` (around line 417). Replace its body with:
+
+```typescript
+  async addAlias(nodeId: string, alias: string): Promise<void> {
+    // Non-throwing contract: alias learning must never block fact storage.
+    try {
+      const lowerAlias = alias.toLowerCase();
+
+      // Reading the node here serves two purposes: canonical-label check (the
+      // backend predicate cannot cover this since the label is not in the aliases
+      // array) and cap-warning logging. The actual dedup+cap guard is atomic in
+      // the backend, so this read is for logging only — not for correctness.
+      const node = await this.store.getNode(nodeId);
+      if (!node) {
+        this.logger.warn({ nodeId, alias }, 'addAlias: entity node not found');
+        return;
+      }
+
+      // Skip if alias matches the canonical label (backend predicate won't catch this)
+      if (node.label.toLowerCase() === lowerAlias) {
+        return;
+      }
+
+      // Log before delegating so the warning appears even if the backend silently rejects.
+      if (node.aliases.length >= MAX_ALIASES_PER_ENTITY) {
+        this.logger.warn(
+          { nodeId, alias, count: node.aliases.length, max: MAX_ALIASES_PER_ENTITY },
+          'addAlias: alias cap reached — skipping',
+        );
+        return;
+      }
+
+      await this.store.addAlias(nodeId, lowerAlias);
+    } catch (err) {
+      this.logger.warn(
+        { nodeId, alias, error: err instanceof Error ? err.message : String(err) },
+        'addAlias: unexpected error — skipping',
+      );
+      // Best-effort: do not rethrow
+    }
+  }
+```
+
+- [ ] **Step 2: Run the existing `addAlias` tests to verify nothing broke**
+
+```bash
+npx --prefix /Users/josephfung/Projects/worktrees/curia-alias-propagation vitest run src/memory/entity-memory.resolve-or-create.test.ts
+```
+
+Expected: all tests PASS (including the existing `EntityMemory.addAlias` describe block).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-alias-propagation add src/memory/entity-memory.ts
+git -C /Users/josephfung/Projects/worktrees/curia-alias-propagation commit -m "fix: make addAlias atomic by delegating dedup+cap guard to the backend predicate"
+```
+
+---
+
+### Task 4: Write failing tests for `mergeEntities` alias union
+
+**Files:**
+- Modify: `src/memory/entity-memory.resolve-or-create.test.ts`
+
+- [ ] **Step 1: Append the failing test suite**
+
+At the end of `src/memory/entity-memory.resolve-or-create.test.ts`, append:
+
+```typescript
+describe('EntityMemory.mergeEntities — alias consolidation', () => {
+  it('unions secondary aliases into primary on merge', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity: primary } = await mem.createEntity({
+      type: 'person', label: 'Jane Doe', properties: {}, source: 'test',
+    });
+    const { entity: secondary } = await mem.createEntity({
+      type: 'person', label: 'Jane', properties: {}, source: 'test',
+    });
+    await mem.addAlias(primary.id, 'jane-doe');
+    await mem.addAlias(secondary.id, 'jane');
+    await mem.addAlias(secondary.id, 'j-doe');
+
+    await mem.mergeEntities(primary.id, secondary.id);
+
+    const surviving = await store.getNode(primary.id);
+    expect(surviving!.aliases).toContain('jane-doe');  // primary's own alias
+    expect(surviving!.aliases).toContain('jane');       // from secondary
+    expect(surviving!.aliases).toContain('j-doe');      // from secondary
+    // No duplicates
+    expect(new Set(surviving!.aliases).size).toBe(surviving!.aliases.length);
+  });
+
+  it('deduplicates aliases that appear on both nodes', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity: primary } = await mem.createEntity({
+      type: 'person', label: 'Jane Doe', properties: {}, source: 'test',
+    });
+    const { entity: secondary } = await mem.createEntity({
+      type: 'person', label: 'Jane', properties: {}, source: 'test',
+    });
+    await mem.addAlias(primary.id, 'shared-alias');
+    await mem.addAlias(secondary.id, 'shared-alias');
+    await mem.addAlias(secondary.id, 'extra');
+
+    await mem.mergeEntities(primary.id, secondary.id);
+
+    const surviving = await store.getNode(primary.id);
+    const count = surviving!.aliases.filter(a => a === 'shared-alias').length;
+    expect(count).toBe(1);
+    expect(surviving!.aliases).toContain('extra');
+  });
+
+  it('caps the alias union at MAX_ALIASES_PER_ENTITY and preserves primary aliases first', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity: primary } = await mem.createEntity({
+      type: 'person', label: 'Primary', properties: {}, source: 'test',
+    });
+    const { entity: secondary } = await mem.createEntity({
+      type: 'person', label: 'Secondary', properties: {}, source: 'test',
+    });
+
+    // Fill primary with 8 aliases
+    for (let i = 0; i < 8; i++) {
+      await mem.addAlias(primary.id, `primary-alias-${i}`);
+    }
+    // Give secondary 5 aliases (only 2 can fit into the cap of 10)
+    for (let i = 0; i < 5; i++) {
+      await mem.addAlias(secondary.id, `secondary-alias-${i}`);
+    }
+
+    await mem.mergeEntities(primary.id, secondary.id);
+
+    const surviving = await store.getNode(primary.id);
+    expect(surviving!.aliases).toHaveLength(10);
+    // All 8 primary aliases are preserved
+    for (let i = 0; i < 8; i++) {
+      expect(surviving!.aliases).toContain(`primary-alias-${i}`);
+    }
+    // The first 2 secondary aliases fit; the last 3 are dropped
+    expect(surviving!.aliases).toContain('secondary-alias-0');
+    expect(surviving!.aliases).toContain('secondary-alias-1');
+    expect(surviving!.aliases).not.toContain('secondary-alias-2');
+    expect(surviving!.aliases).not.toContain('secondary-alias-3');
+    expect(surviving!.aliases).not.toContain('secondary-alias-4');
+  });
+
+  it('leaves primary aliases unchanged when secondary has no aliases', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity: primary } = await mem.createEntity({
+      type: 'person', label: 'Primary', properties: {}, source: 'test',
+    });
+    const { entity: secondary } = await mem.createEntity({
+      type: 'person', label: 'Secondary', properties: {}, source: 'test',
+    });
+    await mem.addAlias(primary.id, 'p-alias');
+    // secondary has no aliases
+
+    await mem.mergeEntities(primary.id, secondary.id);
+
+    const surviving = await store.getNode(primary.id);
+    expect(surviving!.aliases).toEqual(['p-alias']);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm they fail**
+
+```bash
+npx --prefix /Users/josephfung/Projects/worktrees/curia-alias-propagation vitest run src/memory/entity-memory.resolve-or-create.test.ts
+```
+
+Expected: the four new `mergeEntities — alias consolidation` tests FAIL (secondary aliases are currently lost after merge).
+
+---
+
+### Task 5: Implement alias union in `mergeEntities`
+
+**Files:**
+- Modify: `src/memory/entity-memory.ts`
+
+- [ ] **Step 1: Add alias union step inside `mergeEntities`**
+
+In `src/memory/entity-memory.ts`, find the `mergeEntities` method (around line 795). Locate the line that updates the primary node with merged properties:
+
+```typescript
+    // Update primary node with the merged property set
+    await this.store.updateNode(primaryId, { properties: mergedProperties });
+```
+
+Immediately after that line, before the comment `// Move facts:`, insert the alias union block:
+
+```typescript
+    // Union secondary's aliases into primary.
+    // Primary's aliases take priority: secondary extras are dropped if combined > cap.
+    const newAliases = secondaryNode.aliases.filter(
+      a => !primaryNode.aliases.includes(a),
+    );
+    const combined = [...primaryNode.aliases, ...newAliases];
+    const capped = combined.slice(0, MAX_ALIASES_PER_ENTITY);
+
+    if (capped.length < combined.length) {
+      this.logger.warn(
+        { primaryId, secondaryId, dropped: combined.slice(MAX_ALIASES_PER_ENTITY) },
+        'mergeEntities: alias cap reached — dropping excess secondary aliases',
+      );
+    }
+
+    if (capped.length > primaryNode.aliases.length) {
+      await this.store.updateNode(primaryId, { aliases: capped });
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+```bash
+npx --prefix /Users/josephfung/Projects/worktrees/curia-alias-propagation vitest run src/memory/entity-memory.resolve-or-create.test.ts
+```
+
+Expected: all tests PASS, including the four new `mergeEntities — alias consolidation` tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-alias-propagation add src/memory/entity-memory.ts
+git -C /Users/josephfung/Projects/worktrees/curia-alias-propagation commit -m "feat: mergeEntities now unions aliases from both nodes (deduplicated, capped)"
+```
+
+---
+
+### Task 6: Write failing tests for two-path `EntityMemory.search`
+
+**Files:**
+- Modify: `src/memory/entity-memory.resolve-or-create.test.ts`
+
+- [ ] **Step 1: Confirm no new imports are needed**
+
+`KnowledgeGraphStore`, `EmbeddingService`, `EntityMemory`, `MemoryValidator`, and `createSilentLogger` are already imported at the top of the file. The test code below uses string literals (`'internal'`, `'restricted'`) rather than the `SENSITIVITY_LEVELS` constant, so no additional imports are needed.
+
+- [ ] **Step 2: Append the failing test suite**
+
+At the end of `src/memory/entity-memory.resolve-or-create.test.ts`, append:
+
+```typescript
+describe('EntityMemory.search — alias exact-match path', () => {
+  it('surfaces a node via its stored alias with score 1.0', async () => {
+    const { mem } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+    // The fake embedding for 'darlise' is completely different from 'Darlise Restaurant',
+    // so this node won't appear via vector search alone.
+    await mem.addAlias(entity.id, 'darlise');
+
+    const results = await mem.search('darlise');
+
+    expect(results.length).toBeGreaterThan(0);
+    const match = results.find(r => r.node.id === entity.id);
+    expect(match).toBeDefined();
+    expect(match!.score).toBe(1.0);
+  });
+
+  it('returns an alias-matched node exactly once even when vector search also finds it', async () => {
+    const { mem } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+    // Alias matches the canonical label (lower-cased) — findNodesByLabel and
+    // semanticSearch will both return this node.
+    await mem.addAlias(entity.id, 'darlise restaurant');
+
+    const results = await mem.search('darlise restaurant');
+
+    const matches = results.filter(r => r.node.id === entity.id);
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.score).toBe(1.0);
+  });
+
+  it('excludes alias-matched nodes that do not match the type filter', async () => {
+    const { mem } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+    await mem.addAlias(entity.id, 'darlise');
+
+    // Search for type: 'person' — the organization node should not appear
+    const results = await mem.search('darlise', { type: 'person' });
+
+    expect(results.every(r => r.node.id !== entity.id)).toBe(true);
+  });
+
+  it('excludes alias-matched nodes above the sensitivity ceiling', async () => {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    const mem = new EntityMemory(store, validator, embeddingService, createSilentLogger());
+
+    // Create a restricted node directly via the store to set sensitivity
+    const restrictedNode = await store.createNode({
+      type: 'person',
+      label: 'Private Person',
+      properties: {},
+      source: 'test',
+      sensitivity: 'restricted',
+    });
+    // Add alias directly via store (bypasses entity-memory.addAlias canonical-label check,
+    // which is fine — we just need the alias in the array for this test)
+    await store.addAlias(restrictedNode.id, 'private');
+
+    // Search with ceiling of 'internal' — 'restricted' is above that
+    const results = await mem.search('private', { maxSensitivity: 'internal' });
+
+    expect(results.every(r => r.node.id !== restrictedNode.id)).toBe(true);
+  });
+
+  it('alias-matched nodes appear before lower-scoring vector results', async () => {
+    const { mem } = makeEntityMemory();
+    // Create two nodes: one with an exact alias match, one that may appear via embedding
+    const { entity: aliasNode } = await mem.createEntity({
+      type: 'person', label: 'Completely Unrelated Label XYZ', properties: {}, source: 'test',
+    });
+    await mem.addAlias(aliasNode.id, 'searchterm');
+
+    await mem.createEntity({
+      type: 'person', label: 'searchterm adjacent', properties: {}, source: 'test',
+    });
+
+    const results = await mem.search('searchterm', { limit: 10 });
+
+    expect(results[0]!.node.id).toBe(aliasNode.id);
+    expect(results[0]!.score).toBe(1.0);
+  });
+});
+```
+
+- [ ] **Step 3: Run to confirm they fail**
+
+```bash
+npx --prefix /Users/josephfung/Projects/worktrees/curia-alias-propagation vitest run src/memory/entity-memory.resolve-or-create.test.ts
+```
+
+Expected: the five new `EntityMemory.search — alias exact-match path` tests FAIL (current implementation only does vector search, never returns score 1.0 for alias matches).
+
+---
+
+### Task 7: Implement two-path `EntityMemory.search`
+
+**Files:**
+- Modify: `src/memory/entity-memory.ts`
+
+- [ ] **Step 1: Check the import at the top of entity-memory.ts**
+
+Confirm that `SENSITIVITY_LEVELS` is imported. Search for it at the top of the file. If it is not imported (it comes from `'./types.js'`), add it to the import block that already pulls other types from `'./types.js'`:
+
+```typescript
+import type {
+  KgNode,
+  KgEdge,
+  NodeType,
+  EdgeType,
+  Sensitivity,
+  StoreFactOptions,
+  SearchResult,
+} from './types.js';
+import { SENSITIVITY_LEVELS } from './types.js';
+```
+
+Note: it may already be a `type` import — in that case add a separate value import for `SENSITIVITY_LEVELS`.
+
+- [ ] **Step 2: Replace `EntityMemory.search` with the two-path implementation**
+
+In `src/memory/entity-memory.ts`, find `async search(` (around line 949). Replace the entire method:
+
+```typescript
+  /**
+   * Search across all nodes using two complementary paths:
+   *
+   * Path 1 — exact alias/label match (GIN-indexed, no embedding cost):
+   *   Calls findNodesByLabel(query) which checks both canonical label and aliases.
+   *   Matched nodes receive score 1.0 and are returned first.
+   *
+   * Path 2 — vector semantic search (existing behaviour):
+   *   Embeds the query and finds nodes by cosine similarity.
+   *   Nodes already returned by Path 1 are deduplicated.
+   *
+   * The two paths run concurrently. Results are truncated to `limit` after merging.
+   */
+  async search(
+    query: string,
+    options?: { limit?: number; type?: NodeType; maxSensitivity?: Sensitivity },
+  ): Promise<SearchResult[]> {
+    const limit = options?.limit ?? 10;
+
+    // Pre-compute sensitivity ceiling rank for in-process filter on alias results.
+    // This mirrors the check inside KnowledgeGraphStore.semanticSearch.
+    const maxSensitivityRank =
+      options?.maxSensitivity !== undefined
+        ? SENSITIVITY_LEVELS.indexOf(options.maxSensitivity)
+        : undefined;
+
+    // Run both paths concurrently — they are independent queries.
+    const [labelMatches, vectorResults] = await Promise.all([
+      this.store.findNodesByLabel(query),
+      this.store.semanticSearch(query, options),
+    ]);
+
+    // Path 1: filter alias matches in-process (findNodesByLabel has no filter params).
+    const aliasMatchIds = new Set<string>();
+    const aliasResults: SearchResult[] = [];
+    for (const node of labelMatches) {
+      if (options?.type && node.type !== options.type) continue;
+      if (maxSensitivityRank !== undefined) {
+        const nodeRank = SENSITIVITY_LEVELS.indexOf(node.sensitivity);
+        // Exclude nodes with unrecognized sensitivity or above the ceiling.
+        if (nodeRank === -1 || nodeRank > maxSensitivityRank) continue;
+      }
+      aliasMatchIds.add(node.id);
+      aliasResults.push({ node, score: 1.0, edges: [] });
+    }
+
+    // Merge: alias results first, then vector results (dedup by node id).
+    const merged: SearchResult[] = [...aliasResults];
+    for (const r of vectorResults) {
+      if (!aliasMatchIds.has(r.node.id)) {
+        merged.push(r);
+      }
+    }
+
+    return merged.slice(0, limit);
+  }
+```
+
+- [ ] **Step 3: Run the tests to verify they all pass**
+
+```bash
+npx --prefix /Users/josephfung/Projects/worktrees/curia-alias-propagation vitest run src/memory/entity-memory.resolve-or-create.test.ts
+```
+
+Expected: all tests PASS, including the five new `EntityMemory.search — alias exact-match path` tests.
+
+- [ ] **Step 4: Run the full test suite to catch any regressions**
+
+```bash
+npm --prefix /Users/josephfung/Projects/worktrees/curia-alias-propagation test
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-alias-propagation add src/memory/entity-memory.ts
+git -C /Users/josephfung/Projects/worktrees/curia-alias-propagation commit -m "feat: EntityMemory.search now checks aliases before vector search (issue #536)"
+```

--- a/docs/superpowers/specs/2026-05-15-alias-propagation-gaps-design.md
+++ b/docs/superpowers/specs/2026-05-15-alias-propagation-gaps-design.md
@@ -1,0 +1,237 @@
+# Design: Alias Propagation Gaps (issue #536)
+
+**Date:** 2026-05-15  
+**Branch:** `fix/alias-propagation-536`  
+**Status:** Approved
+
+## Context
+
+PR #534 (fuzzy entity resolution, issue #467) implemented alias-learning and
+embedding-based fallback for `resolveOrCreate()`. Three follow-up gaps were
+identified:
+
+1. `addAlias` has a race condition — dedup and cap enforcement are not atomic.
+2. `mergeEntities` drops the absorbed node's aliases instead of unioning them.
+3. `memory-query` ignores the `aliases` column; exact alias matches are missed.
+
+(Item 2 from the original issue — `updateNode` alias-aware collision check — was
+confirmed already addressed by the `findNodesByLabel` alias-aware SQL added in
+PR #534. No work needed.)
+
+---
+
+## Item 1: Atomic alias dedup in `addAlias`
+
+### Problem
+
+`entity-memory.addAlias` reads `node.aliases`, checks for duplicates, then calls
+`store.updateNode` with the appended array. Two concurrent callers (e.g. parallel
+`memory-store` invocations on the same entity) can both pass the in-process check
+and both write, producing duplicate alias entries.
+
+### Design
+
+Add `addAlias(nodeId: string, alias: string): Promise<boolean>` to the
+`KnowledgeGraphBackend` interface. Returns `true` if the alias was appended,
+`false` if it was skipped (duplicate, cap reached, or node not found).
+
+**`PostgresBackend.addAlias`** — single atomic UPDATE with a predicate that
+enforces both dedup and cap:
+
+```sql
+UPDATE kg_nodes
+SET aliases = array_append(aliases, $2)
+WHERE id = $1
+  AND archived_at IS NULL
+  AND NOT ($2 = ANY(aliases))
+  AND cardinality(aliases) < 10
+```
+
+Returns `rowCount > 0`. No SELECT required — the predicate is the guard.
+
+**`InMemoryBackend.addAlias`** — synchronous read-guard (JS is single-threaded
+so no true race, but mirrors Postgres semantics for test parity):
+
+```typescript
+const node = this.nodes.get(nodeId);
+if (!node || this.archivedNodes.has(nodeId)) return false;
+if (node.aliases.includes(alias)) return false;
+if (node.aliases.length >= MAX_ALIASES_PER_ENTITY) return false;
+this.nodes.set(nodeId, { ...node, aliases: [...node.aliases, alias] });
+return true;
+```
+
+**`KnowledgeGraphStore.addAlias`** — thin pass-through to the backend.
+
+**`entity-memory.addAlias`** — still calls `getNode`, but only for two cheap
+in-process purposes:
+1. Canonical-label check: skip if the alias matches the node's canonical label
+   (the SQL predicate cannot cover this because the canonical label is not stored
+   in the `aliases` array).
+2. Cap-warning log: if `node.aliases.length >= MAX_ALIASES_PER_ENTITY`, log
+   `warn` and return early (the predicate would also reject it, but logging
+   requires knowing why).
+
+After those checks, call `this.store.addAlias(nodeId, lowerAlias)`. The
+predicate in the backend handles dedup and cap atomically — the in-process read
+is for logging only, not for correctness. Even if the node's alias array changes
+between the `getNode` read and the `store.addAlias` write (e.g. another process
+fills the cap), the predicate rejects the write safely.
+
+Non-throwing contract is preserved — the outer `try/catch` remains.
+
+### Files changed
+
+- `src/memory/knowledge-graph.ts` — backend interface + both implementations + store pass-through
+- `src/memory/entity-memory.ts` — `addAlias` simplified
+
+---
+
+## Item 3: `mergeEntities` alias consolidation
+
+### Problem
+
+`mergeEntities(primaryId, secondaryId)` migrates scalar properties, facts, and
+relationship edges from the secondary node to the primary node, then deletes the
+secondary. It does not touch `aliases`, so the secondary node's learned aliases
+are permanently lost.
+
+### Design
+
+After the primary-property update (existing line that calls `store.updateNode`
+with `mergedProperties`) and before Phase 2 (edge re-pointing), insert an alias
+union step:
+
+```typescript
+// Union secondary's aliases into primary.
+// Primary's aliases take priority: secondary extras are dropped if combined > cap.
+const newAliases = secondaryNode.aliases.filter(
+  a => !primaryNode.aliases.includes(a),
+);
+const combined = [...primaryNode.aliases, ...newAliases];
+const capped = combined.slice(0, MAX_ALIASES_PER_ENTITY);
+
+if (capped.length < combined.length) {
+  this.logger.warn(
+    { primaryId, secondaryId, dropped: combined.slice(MAX_ALIASES_PER_ENTITY) },
+    'mergeEntities: alias cap reached — dropping excess secondary aliases',
+  );
+}
+
+if (capped.length > primaryNode.aliases.length) {
+  await this.store.updateNode(primaryId, { aliases: capped });
+}
+```
+
+This uses `store.updateNode` (full array replacement) rather than the new
+`store.addAlias` because we are doing a bulk union — one write is preferable to
+N individual calls.
+
+**Survivorship rule:** Primary's aliases take priority. Secondary's aliases fill
+remaining slots (up to cap 10), in their original order. Any secondary aliases
+that don't fit are logged as warnings and dropped.
+
+### Files changed
+
+- `src/memory/entity-memory.ts` — `mergeEntities` alias union step
+
+---
+
+## Item 4: Alias exact-match path in `memory-query`
+
+### Problem
+
+`EntityMemory.search()` delegates entirely to `KnowledgeGraphStore.semanticSearch()`,
+which embeds the query and runs a vector similarity query. The `aliases` column is
+never consulted. A query for "Darlise" will not reliably surface a node whose
+canonical label is "Darlise Restaurant" but which has the alias `"darlise"` stored,
+unless the embeddings happen to be close enough.
+
+Once aliases are learned via `resolveOrCreate()`, an exact alias lookup is both
+cheaper and more reliable than relying on embedding proximity.
+
+### Design
+
+`EntityMemory.search()` becomes a two-path lookup with in-process merge:
+
+**Path 1 — exact alias/label match** (cheap, GIN-indexed, no embedding):
+- Call `this.store.findNodesByLabel(query)`.
+- Filter results in-process for `type` and `maxSensitivity` (same logic as vector
+  path, since `findNodesByLabel` does not accept these filters).
+- Assign score `1.0` to all alias-matched nodes.
+
+**Path 2 — vector semantic search** (existing behaviour):
+- Call `this.store.semanticSearch(query, options)` unchanged.
+
+**Concurrency:** Both paths are independent — run them concurrently via
+`Promise.all([this.store.findNodesByLabel(query), this.store.semanticSearch(query, options)])`.
+
+**Merge:**
+- Start with all alias-matched results (score `1.0`).
+- Append vector results, skipping any node ID already present from Path 1.
+- Truncate to `limit`.
+
+This ensures alias-matched nodes always appear first. A node that matches both
+an alias and the embedding query will appear once, with score `1.0`.
+
+The `memory-query` skill handler (`skills/memory-query/handler.ts`) requires no
+changes — it calls `ctx.entityMemory.search()` and the new behaviour is
+transparent.
+
+### Sensitivity filter in-process
+
+`findNodesByLabel` returns all matched nodes regardless of sensitivity. The
+sensitivity ceiling filter is applied in the merge loop:
+
+```typescript
+const maxRank = options?.maxSensitivity
+  ? SENSITIVITY_LEVELS.indexOf(options.maxSensitivity)
+  : undefined;
+// ...
+for (const node of labelMatches) {
+  if (options?.type && node.type !== options.type) continue;
+  if (maxRank !== undefined) {
+    const nodeRank = SENSITIVITY_LEVELS.indexOf(node.sensitivity);
+    if (nodeRank === -1 || nodeRank > maxRank) continue;
+  }
+  aliasMatchIds.add(node.id);
+  aliasResults.push({ node, score: 1.0, edges: [] });
+}
+```
+
+### Files changed
+
+- `src/memory/entity-memory.ts` — `search()` two-path lookup
+
+---
+
+## Testing
+
+### Item 1 tests (`entity-memory.resolve-or-create.test.ts` or new file)
+
+- Call `addAlias` twice with the same alias on the same node; assert the aliases
+  array contains the alias exactly once.
+- Call `addAlias` 10 times with distinct aliases; assert array length stays at
+  `MAX_ALIASES_PER_ENTITY` after the cap is reached.
+- Call `addAlias` with an alias that matches the canonical label; assert it is skipped.
+- In-memory backend: verify `addAlias` returns `false` on dup/cap, `true` on success.
+
+### Item 3 tests (`entity-memory.edges.test.ts` or new file)
+
+- `mergeEntities` where both nodes have aliases: assert the surviving node holds
+  the union (deduped).
+- `mergeEntities` where combined aliases exceed 10: assert capped at 10, warning
+  logged, primary's aliases preserved in full.
+- `mergeEntities` where secondary has no aliases: assert no change to primary's
+  aliases.
+
+### Item 4 tests (`entity-memory.resolve-or-create.test.ts` or new file)
+
+- `EntityMemory.search` where query matches a stored alias exactly; assert the
+  alias-matched node is in results with score `1.0`.
+- `EntityMemory.search` where query matches both an alias and a high-scoring
+  embedding result for the same node; assert the node appears once with score `1.0`.
+- `EntityMemory.search` with `max_sensitivity` filter; assert alias-matched nodes
+  above the ceiling are excluded.
+- `EntityMemory.search` with `type` filter; assert alias-matched nodes of wrong
+  type are excluded.

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -643,3 +643,108 @@ describe('EntityMemory.mergeEntities — alias consolidation', () => {
     expect(surviving!.aliases).toEqual(['p-alias']);
   });
 });
+
+describe('EntityMemory.search — alias exact-match path', () => {
+  it('surfaces a node via its stored alias with score 1.0', async () => {
+    const { mem } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+    // The fake embedding for 'darlise' is completely different from 'Darlise Restaurant',
+    // so this node won't appear via vector search alone.
+    await mem.addAlias(entity.id, 'darlise');
+
+    const results = await mem.search('darlise');
+
+    expect(results.length).toBeGreaterThan(0);
+    const match = results.find(r => r.node.id === entity.id);
+    expect(match).toBeDefined();
+    expect(match!.score).toBe(1.0);
+  });
+
+  it('returns an alias-matched node exactly once even when vector search also finds it', async () => {
+    const { mem } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+    // Alias matches the canonical label (lower-cased) — findNodesByLabel and
+    // semanticSearch will both return this node.
+    await mem.addAlias(entity.id, 'darlise restaurant');
+
+    const results = await mem.search('darlise restaurant');
+
+    const matches = results.filter(r => r.node.id === entity.id);
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.score).toBe(1.0);
+  });
+
+  it('excludes alias-matched nodes that do not match the type filter', async () => {
+    const { mem } = makeEntityMemory();
+    const { entity } = await mem.createEntity({
+      type: 'organization', label: 'Darlise Restaurant', properties: {}, source: 'test',
+    });
+    await mem.addAlias(entity.id, 'darlise');
+
+    // Search for type: 'person' — the organization node should not appear
+    const results = await mem.search('darlise', { type: 'person' });
+
+    expect(results.every(r => r.node.id !== entity.id)).toBe(true);
+  });
+
+  it('excludes alias-matched nodes above the sensitivity ceiling', async () => {
+    const embeddingService = EmbeddingService.createForTesting();
+    const store = KnowledgeGraphStore.createInMemory(embeddingService);
+    const validator = new MemoryValidator(store, embeddingService);
+    const mem = new EntityMemory(store, validator, embeddingService, createSilentLogger());
+
+    // Create a restricted node directly via the store to set sensitivity
+    const restrictedNode = await store.createNode({
+      type: 'person',
+      label: 'Private Person',
+      properties: {},
+      source: 'test',
+      sensitivity: 'restricted',
+    });
+    // Add alias directly via store (EntityMemory.addAlias silently skips aliases
+    // matching the canonical label; here we bypass that to set up the test alias)
+    await store.addAlias(restrictedNode.id, 'private');
+
+    // Create an internal node with the same alias — this one should appear
+    const internalNode = await store.createNode({
+      type: 'person',
+      label: 'Internal Person',
+      properties: {},
+      source: 'test',
+      sensitivity: 'internal',
+    });
+    await store.addAlias(internalNode.id, 'private');
+
+    // Search with ceiling of 'internal' — 'restricted' is above that
+    const results = await mem.search('private', { maxSensitivity: 'internal' });
+
+    // Restricted node must not appear
+    expect(results.every(r => r.node.id !== restrictedNode.id)).toBe(true);
+    // Internal node must appear (positive assertion: filter allows valid nodes through)
+    expect(results.some(r => r.node.id === internalNode.id)).toBe(true);
+  });
+
+  it('alias-matched nodes appear before lower-scoring vector results', async () => {
+    const { mem } = makeEntityMemory();
+    // Create two nodes: one with an exact alias match, one that may appear via embedding
+    const { entity: aliasNode } = await mem.createEntity({
+      type: 'person', label: 'Completely Unrelated Label XYZ', properties: {}, source: 'test',
+    });
+    await mem.addAlias(aliasNode.id, 'searchterm');
+
+    await mem.createEntity({
+      type: 'person', label: 'searchterm adjacent', properties: {}, source: 'test',
+    });
+
+    const results = await mem.search('searchterm', { limit: 10 });
+
+    expect(results[0]!.node.id).toBe(aliasNode.id);
+    expect(results[0]!.score).toBe(1.0);
+    // Verify the secondary node (non-alias-matched) also appears via vector search
+    expect(results.some(r => r.node.label === 'searchterm adjacent')).toBe(true);
+  });
+});

--- a/src/memory/entity-memory.resolve-or-create.test.ts
+++ b/src/memory/entity-memory.resolve-or-create.test.ts
@@ -545,3 +545,101 @@ describe('EntityMemory.findEntities — alias awareness', () => {
     expect(results).toHaveLength(0);
   });
 });
+
+describe('EntityMemory.mergeEntities — alias consolidation', () => {
+  it('unions secondary aliases into primary on merge', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity: primary } = await mem.createEntity({
+      type: 'person', label: 'Jane Doe', properties: {}, source: 'test',
+    });
+    // Use a label that does not conflict with the aliases we intend to add:
+    // addAlias() silently skips aliases that match the canonical label (case-insensitive),
+    // so 'Jane Smith' lets us test 'jane' as a stored alias.
+    const { entity: secondary } = await mem.createEntity({
+      type: 'person', label: 'Jane Smith', properties: {}, source: 'test',
+    });
+    await mem.addAlias(primary.id, 'jane-doe');
+    await mem.addAlias(secondary.id, 'jane');
+    await mem.addAlias(secondary.id, 'j-doe');
+
+    await mem.mergeEntities(primary.id, secondary.id);
+
+    const surviving = await store.getNode(primary.id);
+    expect(surviving!.aliases).toContain('jane-doe');  // primary's own alias
+    expect(surviving!.aliases).toContain('jane');       // from secondary
+    expect(surviving!.aliases).toContain('j-doe');      // from secondary
+    // No duplicates
+    expect(new Set(surviving!.aliases).size).toBe(surviving!.aliases.length);
+  });
+
+  it('deduplicates aliases that appear on both nodes', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity: primary } = await mem.createEntity({
+      type: 'person', label: 'Jane Doe', properties: {}, source: 'test',
+    });
+    const { entity: secondary } = await mem.createEntity({
+      type: 'person', label: 'Jane', properties: {}, source: 'test',
+    });
+    await mem.addAlias(primary.id, 'shared-alias');
+    await mem.addAlias(secondary.id, 'shared-alias');
+    await mem.addAlias(secondary.id, 'extra');
+
+    await mem.mergeEntities(primary.id, secondary.id);
+
+    const surviving = await store.getNode(primary.id);
+    const count = surviving!.aliases.filter(a => a === 'shared-alias').length;
+    expect(count).toBe(1);
+    expect(surviving!.aliases).toContain('extra');
+  });
+
+  it('caps the alias union at MAX_ALIASES_PER_ENTITY and preserves primary aliases first', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity: primary } = await mem.createEntity({
+      type: 'person', label: 'Primary', properties: {}, source: 'test',
+    });
+    const { entity: secondary } = await mem.createEntity({
+      type: 'person', label: 'Secondary', properties: {}, source: 'test',
+    });
+
+    // Fill primary with 8 aliases
+    for (let i = 0; i < 8; i++) {
+      await mem.addAlias(primary.id, `primary-alias-${i}`);
+    }
+    // Give secondary 5 aliases (only 2 can fit into the cap of 10)
+    for (let i = 0; i < 5; i++) {
+      await mem.addAlias(secondary.id, `secondary-alias-${i}`);
+    }
+
+    await mem.mergeEntities(primary.id, secondary.id);
+
+    const surviving = await store.getNode(primary.id);
+    expect(surviving!.aliases).toHaveLength(10);
+    // All 8 primary aliases are preserved
+    for (let i = 0; i < 8; i++) {
+      expect(surviving!.aliases).toContain(`primary-alias-${i}`);
+    }
+    // The first 2 secondary aliases fit; the last 3 are dropped
+    expect(surviving!.aliases).toContain('secondary-alias-0');
+    expect(surviving!.aliases).toContain('secondary-alias-1');
+    expect(surviving!.aliases).not.toContain('secondary-alias-2');
+    expect(surviving!.aliases).not.toContain('secondary-alias-3');
+    expect(surviving!.aliases).not.toContain('secondary-alias-4');
+  });
+
+  it('leaves primary aliases unchanged when secondary has no aliases', async () => {
+    const { mem, store } = makeEntityMemory();
+    const { entity: primary } = await mem.createEntity({
+      type: 'person', label: 'Primary', properties: {}, source: 'test',
+    });
+    const { entity: secondary } = await mem.createEntity({
+      type: 'person', label: 'Secondary', properties: {}, source: 'test',
+    });
+    await mem.addAlias(primary.id, 'p-alias');
+    // secondary has no aliases
+
+    await mem.mergeEntities(primary.id, secondary.id);
+
+    const surviving = await store.getNode(primary.id);
+    expect(surviving!.aliases).toEqual(['p-alias']);
+  });
+});

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -17,6 +17,7 @@ import type {
   StoreFactOptions,
   SearchResult,
 } from './types.js';
+import { SENSITIVITY_LEVELS } from './types.js';
 
 export interface EdgeResult {
   edge: KgEdge;
@@ -958,16 +959,60 @@ export class EntityMemory {
   }
 
   /**
-   * Semantic search across all nodes in the knowledge graph.
-   * Embeds the query string and finds the most similar nodes by cosine similarity.
+   * Search across all nodes using two complementary paths:
    *
-   * Returns SearchResult[] sorted by score descending (most similar first).
+   * Path 1 — exact alias/label match (GIN-indexed, no embedding cost):
+   *   Calls findNodesByLabel(query) which checks both canonical label and aliases.
+   *   Matched nodes receive score 1.0 and are returned first.
+   *
+   * Path 2 — vector semantic search (existing behaviour):
+   *   Embeds the query and finds nodes by cosine similarity.
+   *   Nodes already returned by Path 1 are deduplicated.
+   *
+   * The two paths run concurrently. Results are truncated to `limit` after merging.
    */
   async search(
     query: string,
     options?: { limit?: number; type?: NodeType; maxSensitivity?: Sensitivity },
   ): Promise<SearchResult[]> {
-    return this.store.semanticSearch(query, options);
+    const limit = options?.limit ?? 10;
+
+    // Pre-compute sensitivity ceiling rank for in-process filter on alias results.
+    // This mirrors the check inside KnowledgeGraphStore.semanticSearch.
+    const maxSensitivityRank =
+      options?.maxSensitivity !== undefined
+        ? SENSITIVITY_LEVELS.indexOf(options.maxSensitivity)
+        : undefined;
+
+    // Run both paths concurrently — they are independent queries.
+    const [labelMatches, vectorResults] = await Promise.all([
+      this.store.findNodesByLabel(query),
+      this.store.semanticSearch(query, options),
+    ]);
+
+    // Path 1: filter alias matches in-process (findNodesByLabel has no filter params).
+    const aliasMatchIds = new Set<string>();
+    const aliasResults: SearchResult[] = [];
+    for (const node of labelMatches) {
+      if (options?.type && node.type !== options.type) continue;
+      if (maxSensitivityRank !== undefined) {
+        const nodeRank = SENSITIVITY_LEVELS.indexOf(node.sensitivity);
+        // Exclude nodes with unrecognized sensitivity or above the ceiling.
+        if (nodeRank === -1 || nodeRank > maxSensitivityRank) continue;
+      }
+      aliasMatchIds.add(node.id);
+      aliasResults.push({ node, score: 1.0, edges: [] });
+    }
+
+    // Merge: alias results first, then vector results (dedup by node id).
+    const merged: SearchResult[] = [...aliasResults];
+    for (const r of vectorResults) {
+      if (!aliasMatchIds.has(r.node.id)) {
+        merged.push(r);
+      }
+    }
+
+    return merged.slice(0, limit);
   }
 
   /** List KG nodes flagged for CEO re-confirmation by the decay warning pass. */

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -415,27 +415,26 @@ export class EntityMemory {
    * block fact storage.
    */
   async addAlias(nodeId: string, alias: string): Promise<void> {
-    // Entire method is wrapped so no DB or network error can violate the non-throwing contract.
+    // Non-throwing contract: alias learning must never block fact storage.
     try {
       const lowerAlias = alias.toLowerCase();
 
+      // Reading the node here serves two purposes: canonical-label check (the
+      // backend predicate cannot cover this since the label is not in the aliases
+      // array) and cap-warning logging. The actual dedup+cap guard is atomic in
+      // the backend, so this read is for logging only — not for correctness.
       const node = await this.store.getNode(nodeId);
       if (!node) {
         this.logger.warn({ nodeId, alias }, 'addAlias: entity node not found');
         return;
       }
 
-      // Skip if alias matches canonical label
+      // Skip if alias matches the canonical label (backend predicate won't catch this)
       if (node.label.toLowerCase() === lowerAlias) {
         return;
       }
 
-      // Skip if alias already exists
-      if (node.aliases.includes(lowerAlias)) {
-        return;
-      }
-
-      // Skip if at cap
+      // Log before delegating so the warning appears even if the backend silently rejects.
       if (node.aliases.length >= MAX_ALIASES_PER_ENTITY) {
         this.logger.warn(
           { nodeId, alias, count: node.aliases.length, max: MAX_ALIASES_PER_ENTITY },
@@ -444,8 +443,7 @@ export class EntityMemory {
         return;
       }
 
-      const updatedAliases = [...node.aliases, lowerAlias];
-      await this.store.updateNode(nodeId, { aliases: updatedAliases });
+      await this.store.addAlias(nodeId, lowerAlias);
     } catch (err) {
       this.logger.warn(
         { nodeId, alias, error: err instanceof Error ? err.message : String(err) },

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -970,6 +970,10 @@ export class EntityMemory {
    *   Nodes already returned by Path 1 are deduplicated.
    *
    * The two paths run concurrently. Results are truncated to `limit` after merging.
+   *
+   * Note: the final result count may be less than `limit` when alias matches overlap
+   * with the top vector results. This is a known trade-off of the concurrent design —
+   * the vector path is capped at `limit` upfront and overlap nodes are deduped out.
    */
   async search(
     query: string,
@@ -983,6 +987,15 @@ export class EntityMemory {
       options?.maxSensitivity !== undefined
         ? SENSITIVITY_LEVELS.indexOf(options.maxSensitivity)
         : undefined;
+
+    // Guard: reject unrecognized maxSensitivity values early.
+    // The vector path (semanticSearch) throws on unknown values; we must match
+    // that behavior so both paths fail consistently instead of diverging.
+    if (maxSensitivityRank === -1) {
+      throw new Error(
+        `Unknown maxSensitivity: "${options!.maxSensitivity}". Valid values: ${SENSITIVITY_LEVELS.join(', ')}`,
+      );
+    }
 
     // Run both paths concurrently — they are independent queries.
     const [labelMatches, vectorResults] = await Promise.all([

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -822,6 +822,25 @@ export class EntityMemory {
     // Update primary node with the merged property set
     await this.store.updateNode(primaryId, { properties: mergedProperties });
 
+    // Union secondary's aliases into primary.
+    // Primary's aliases take priority: secondary extras are dropped if combined > cap.
+    const newAliases = secondaryNode.aliases.filter(
+      a => !primaryNode.aliases.includes(a),
+    );
+    const combined = [...primaryNode.aliases, ...newAliases];
+    const capped = combined.slice(0, MAX_ALIASES_PER_ENTITY);
+
+    if (capped.length < combined.length) {
+      this.logger.warn(
+        { primaryId, secondaryId, dropped: combined.slice(MAX_ALIASES_PER_ENTITY) },
+        'mergeEntities: alias cap reached — dropping excess secondary aliases',
+      );
+    }
+
+    if (capped.length > primaryNode.aliases.length) {
+      await this.store.updateNode(primaryId, { aliases: capped });
+    }
+
     // Move facts: fetch secondary's facts and re-store them on primary.
     // getFacts() is more efficient than query() here — it returns only fact nodes
     // without resolving relationship edges, which we don't need for the merge.

--- a/src/memory/entity-memory.ts
+++ b/src/memory/entity-memory.ts
@@ -444,7 +444,15 @@ export class EntityMemory {
         return;
       }
 
-      await this.store.addAlias(nodeId, lowerAlias);
+      const added = await this.store.addAlias(nodeId, lowerAlias);
+      if (!added) {
+        // Backend rejected — likely a dedup or cap race between our pre-flight read and this write.
+        // The backend's atomic predicate handled it correctly; this is just for observability.
+        this.logger.debug(
+          { nodeId, alias: lowerAlias },
+          'addAlias: backend rejected (dedup or cap race)',
+        );
+      }
     } catch (err) {
       this.logger.warn(
         { nodeId, alias, error: err instanceof Error ? err.message : String(err) },

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -78,6 +78,10 @@ interface KnowledgeGraphBackend {
   archiveEdge(id: string): Promise<void>;
   findNodesByType(type: NodeType): Promise<KgNode[]>;
   findNodesByLabel(label: string): Promise<KgNode[]>;
+  /** Atomically append an alias to a node's aliases array.
+   *  Returns true if the alias was appended, false if skipped
+   *  (already present, cap reached, or node not found). */
+  addAlias(nodeId: string, alias: string): Promise<boolean>;
   createEdge(edge: KgEdge): Promise<void>;
   getEdgesForNode(nodeId: string): Promise<KgEdge[]>;
   deleteEdge(id: string): Promise<void>;
@@ -283,6 +287,11 @@ export class KnowledgeGraphStore {
   /** Find nodes by label (case-insensitive exact match) */
   async findNodesByLabel(label: string): Promise<KgNode[]> {
     return this.backend.findNodesByLabel(label);
+  }
+
+  /** Atomically append an alias — see KnowledgeGraphBackend.addAlias for semantics. */
+  addAlias(nodeId: string, alias: string): Promise<boolean> {
+    return this.backend.addAlias(nodeId, alias);
   }
 
   /** Create an edge between two nodes */
@@ -532,6 +541,21 @@ class PostgresBackend implements KnowledgeGraphBackend {
       [label],
     );
     return result.rows.map(pgRowToNode);
+  }
+
+  async addAlias(nodeId: string, alias: string): Promise<boolean> {
+    // Single atomic UPDATE: predicate enforces dedup and cap at the DB level.
+    // No SELECT needed — rowCount tells us whether the guard passed.
+    const result = await this.pool.query(
+      `UPDATE kg_nodes
+       SET aliases = array_append(aliases, $2)
+       WHERE id = $1
+         AND archived_at IS NULL
+         AND NOT ($2 = ANY(aliases))
+         AND cardinality(aliases) < 10`,
+      [nodeId, alias],
+    );
+    return (result.rowCount ?? 0) > 0;
   }
 
   async createEdge(edge: KgEdge): Promise<void> {
@@ -988,6 +1012,17 @@ class InMemoryBackend implements KnowledgeGraphBackend {
       }
     }
     return results;
+  }
+
+  async addAlias(nodeId: string, alias: string): Promise<boolean> {
+    // JS is single-threaded so no true race exists, but this mirrors the
+    // Postgres predicate semantics so in-memory tests are reliable proxies.
+    const node = this.nodes.get(nodeId);
+    if (!node || this.archivedNodes.has(nodeId)) return false;
+    if (node.aliases.includes(alias)) return false;
+    if (node.aliases.length >= 10) return false;
+    this.nodes.set(nodeId, { ...node, aliases: [...node.aliases, alias] });
+    return true;
   }
 
   async createEdge(edge: KgEdge): Promise<void> {

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -290,7 +290,7 @@ export class KnowledgeGraphStore {
   }
 
   /** Atomically append an alias — see KnowledgeGraphBackend.addAlias for semantics. */
-  addAlias(nodeId: string, alias: string): Promise<boolean> {
+  async addAlias(nodeId: string, alias: string): Promise<boolean> {
     return this.backend.addAlias(nodeId, alias);
   }
 

--- a/src/memory/knowledge-graph.ts
+++ b/src/memory/knowledge-graph.ts
@@ -552,7 +552,7 @@ class PostgresBackend implements KnowledgeGraphBackend {
        WHERE id = $1
          AND archived_at IS NULL
          AND NOT ($2 = ANY(aliases))
-         AND cardinality(aliases) < 10`,
+         AND cardinality(aliases) < 10`,  /* must match MAX_ALIASES_PER_ENTITY */
       [nodeId, alias],
     );
     return (result.rowCount ?? 0) > 0;
@@ -1020,7 +1020,7 @@ class InMemoryBackend implements KnowledgeGraphBackend {
     const node = this.nodes.get(nodeId);
     if (!node || this.archivedNodes.has(nodeId)) return false;
     if (node.aliases.includes(alias)) return false;
-    if (node.aliases.length >= 10) return false;
+    if (node.aliases.length >= 10) return false; // must match MAX_ALIASES_PER_ENTITY
     this.nodes.set(nodeId, { ...node, aliases: [...node.aliases, alias] });
     return true;
   }

--- a/src/memory/knowledge-graph.upsert.test.ts
+++ b/src/memory/knowledge-graph.upsert.test.ts
@@ -197,4 +197,14 @@ describe('KnowledgeGraphStore.addAlias', () => {
 
     expect(added).toBe(false);
   });
+
+  it('returns false for an archived node', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    await store.archiveNode(node.id);
+
+    const added = await store.addAlias(node.id, 'al');
+
+    expect(added).toBe(false);
+  });
 });

--- a/src/memory/knowledge-graph.upsert.test.ts
+++ b/src/memory/knowledge-graph.upsert.test.ts
@@ -150,3 +150,51 @@ describe('KnowledgeGraphStore sensitivity defaults', () => {
     expect(node.sensitivity).toBe('restricted');
   });
 });
+
+describe('KnowledgeGraphStore.addAlias', () => {
+  it('returns true and appends alias when alias is new', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+
+    const added = await store.addAlias(node.id, 'al');
+
+    expect(added).toBe(true);
+    const updated = await store.getNode(node.id);
+    expect(updated!.aliases).toEqual(['al']);
+  });
+
+  it('returns false and does not duplicate when alias already exists', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    await store.addAlias(node.id, 'al');
+
+    const added = await store.addAlias(node.id, 'al');
+
+    expect(added).toBe(false);
+    const updated = await store.getNode(node.id);
+    expect(updated!.aliases).toEqual(['al']); // still exactly one copy
+  });
+
+  it('returns false when alias cap (10) is reached', async () => {
+    const store = makeStore();
+    const node = await store.createNode({ type: 'person', label: 'Alice', properties: {}, source: 'test' });
+    for (let i = 0; i < 10; i++) {
+      await store.addAlias(node.id, `alias-${i}`);
+    }
+
+    const added = await store.addAlias(node.id, 'one-more');
+
+    expect(added).toBe(false);
+    const updated = await store.getNode(node.id);
+    expect(updated!.aliases).toHaveLength(10);
+    expect(updated!.aliases).not.toContain('one-more');
+  });
+
+  it('returns false for an unknown nodeId', async () => {
+    const store = makeStore();
+
+    const added = await store.addAlias('does-not-exist', 'some-alias');
+
+    expect(added).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **`addAlias` is now atomic at the DB level** — replaced the read-check-write race condition with a single Postgres `UPDATE ... WHERE NOT ($2 = ANY(aliases)) AND cardinality(aliases) < 10`. Both `PostgresBackend` and `InMemoryBackend` implement the new `KnowledgeGraphBackend.addAlias` interface; `EntityMemory.addAlias` retains its `getNode` pre-flight only for canonical-label checking and cap-warning logging.
- **`mergeEntities` now unions aliases from both nodes** — secondary's aliases are merged into primary after the property merge, deduped, capped at `MAX_ALIASES_PER_ENTITY` (primary's aliases take priority), and any overflow is logged as a warning.
- **`EntityMemory.search` now checks aliases before vector search** — `findNodesByLabel(query)` and `semanticSearch(query, options)` run concurrently via `Promise.all`. Alias/label-exact-matched nodes receive score `1.0` and appear first; vector results are appended with deduplication. Type and sensitivity filters are applied in-process on alias results (since `findNodesByLabel` accepts no filter params).

## Test Plan

- [ ] `npx vitest run src/memory/knowledge-graph.upsert.test.ts` — 5 new `KnowledgeGraphStore.addAlias` tests (new alias, duplicate, cap, unknown nodeId, archived node)
- [ ] `npx vitest run src/memory/entity-memory.resolve-or-create.test.ts` — 4 new `mergeEntities — alias consolidation` tests + 5 new `EntityMemory.search — alias exact-match path` tests
- [ ] `npm test` — full suite (2389 passing, 60 skipped; 2 skipped integration tests require `DATABASE_URL`)

Closes #536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added alias management to the knowledge graph, allowing aliases to be added to entities with deduplication and cap enforcement.
  * Enhanced entity merging to consolidate secondary aliases into primary entities while preserving primary aliases first.
  * Improved search functionality to include exact alias and label matching alongside vector-based results, prioritizing alias matches.

* **Documentation**
  * Added design specification and implementation plan for alias propagation improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->