### PR TITLE
docs: fix migration number and conversation ID format in spec 17

### DIFF
--- a/docs/specs/17-meeting-debrief.md
+++ b/docs/specs/17-meeting-debrief.md
@@ -86,7 +86,7 @@ The agent's `agent_tasks.progress` JSON field tracks:
   "pendingDebriefs": {
     "nylas_event_abc": {
       "promptedAt": "2026-04-28T14:05:00Z",
-      "conversationId": "signal:ceo:xyz",
+      "conversationId": "signal:+15550001111",
       "reminderJobId": "job_123",
       "meetingTitle": "Strategy sync with Meridian",
       "attendees": ["sarah@meridian.com", "david@meridian.com"],

--- a/docs/wip/2026-04-28-meeting-debrief.md
+++ b/docs/wip/2026-04-28-meeting-debrief.md
@@ -74,12 +74,12 @@ CREATE INDEX idx_conversation_claims_agent
 - [ ] **Step 2: Verify migration number is unique**
 
 Run: `ls src/db/migrations/ | sort`
-Expected: No duplicate `029` prefix. If one exists (from a concurrent branch), renumber to the next available slot.
+Expected: No duplicate `042` prefix. If one exists (from a concurrent branch), renumber to the next available slot.
 
 - [ ] **Step 3: Commit**
 
 ```bash
-git add src/db/migrations/029_create_conversation_claims.sql
+git add src/db/migrations/042_create_conversation_claims.sql
 git commit -m "feat: add conversation_claims migration (ADR-017)"
 ```
 
@@ -988,5 +988,10 @@ const isExternal = (email: string) =>
   !internalDomains.some(d => email.toLowerCase().endsWith(`@${d}`));
 ```
 
-### Conversation ID for Signal
-Signal conversation IDs follow the pattern `signal:<phone>:<thread>`. The agent must use this exact ID when claiming the conversation.
+### Conversation IDs by channel
+Each channel adapter generates a stable `conversationId` that groups related messages:
+- **Signal 1:1:** `signal:<E.164 phone>` (e.g., `signal:+15550001111`) — all messages from the same phone share one ID
+- **Signal group:** `signal:group=<base64 groupId>` — stable per group
+- **Email:** `email:<threadId>` — stable per email thread
+
+The debrief agent claims the conversation ID returned by the outbound gateway after sending the prompt. For Signal 1:1 (the typical debrief channel), this means claiming `signal:<ceo-phone>`, and all subsequent 1:1 messages from the CEO will route to the claiming agent.


### PR DESCRIPTION
## Summary

Fixes two documentation inaccuracies in the spec 17 (meeting debrief) docs before implementation begins.

**Migration number:** The plan referenced migration prefix `029`, but the latest on main is `041`. Updated to `042`.

**Conversation ID format:** The spec and plan documented Signal conversation IDs as `signal:<phone>:<thread>`, but the actual Signal adapter produces `signal:<phone>` for 1:1 and `signal:group=<base64>` for groups. There is no `:<thread>` component — Signal doesn't have explicit thread IDs. Updated the spec example JSON and the plan's implementer notes to match reality. The claims model works correctly with the actual format (all 1:1 messages from the same phone share one conversation ID).

## Test plan

- [ ] Verify no other references to `029` or `signal:<phone>:<thread>` remain in the docs
- [ ] Confirm migration 042 prefix is still available at implementation time (rebase hazard)