### PR TITLE
fix: promote contact to confirmed on identify with existing_contact_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`held-messages-process`** — identify action with `existing_contact_id` now promotes the contact to `confirmed` before replaying; previously provisional contacts caused the replayed message to be re-held immediately by the dispatcher.
 - **`ceo-inbox-search`** — uses `search_query_native` instead of `q` (Nylas v3); suppresses incompatible filter params when a search query is active.
 - **`ceo-inbox` ACTIONABLE archive** — added step 4h action checklist so ACTIONABLE emails reliably get archived after specialist handoff; rewrote ambiguous classification note.
 - **Self-email loop filter hardened** — inbound poll now rejects self-sent messages via folder, sent-ID, and normalized-address checks to prevent reply loops. (#37)

--- a/skills/held-messages-process/handler.test.ts
+++ b/skills/held-messages-process/handler.test.ts
@@ -66,7 +66,7 @@ describe('HeldMessagesProcessHandler — identify with existing_contact_id', () 
     expect(setStatusOrder).toBeLessThan(busPublishOrder);
   });
 
-  it('still succeeds when setStatus fails (non-fatal)', async () => {
+  it('fails the operation when setStatus throws (avoids re-hold loop)', async () => {
     const ctx = makeCtx();
     (ctx.contactService.setStatus as ReturnType<typeof vi.fn>).mockRejectedValue(
       new Error('DB connection timeout'),
@@ -74,11 +74,12 @@ describe('HeldMessagesProcessHandler — identify with existing_contact_id', () 
     const handler = new HeldMessagesProcessHandler();
     const result = await handler.execute(ctx);
 
-    expect(result.success).toBe(true);
-    expect(ctx.log.warn).toHaveBeenCalled();
-    // Replay and markProcessed should still proceed
-    expect(ctx.bus!.publish).toHaveBeenCalled();
-    expect(ctx.heldMessages!.markProcessed).toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toMatch(/re-hold loop/);
+    expect(ctx.log.error).toHaveBeenCalled();
+    // Replay must NOT fire — replaying with a provisional contact would re-hold
+    expect(ctx.bus!.publish).not.toHaveBeenCalled();
+    expect(ctx.heldMessages!.markProcessed).not.toHaveBeenCalled();
   });
 
   it('does not call setStatus for the new-contact path (already confirmed at creation)', async () => {

--- a/skills/held-messages-process/handler.test.ts
+++ b/skills/held-messages-process/handler.test.ts
@@ -1,0 +1,99 @@
+// handler.test.ts — unit tests for held-messages-process skill.
+//
+// Focused on the identify-with-existing-contact path: verifying that the handler
+// promotes provisional contacts to 'confirmed' before replaying. Without this
+// promotion, the dispatcher re-holds the replayed message because it treats
+// provisional senders the same as unknown senders.
+
+import { describe, it, expect, vi } from 'vitest';
+import { HeldMessagesProcessHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+const HELD_MSG = {
+  id: 'held-1',
+  channel: 'email',
+  senderId: 'notify@x.com',
+  conversationId: 'email:notify@x.com',
+  content: 'Your account has been suspended',
+  subject: 'Account suspended',
+  status: 'pending' as const,
+  metadata: {},
+  createdAt: new Date(),
+};
+
+function makeCtx(inputOverrides?: Record<string, unknown>): SkillContext {
+  return {
+    input: {
+      held_message_id: 'held-1',
+      action: 'identify',
+      existing_contact_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      ...inputOverrides,
+    },
+    heldMessages: {
+      getById: vi.fn().mockResolvedValue(HELD_MSG),
+      markProcessed: vi.fn().mockResolvedValue(true),
+      discard: vi.fn().mockResolvedValue(true),
+    },
+    bus: {
+      publish: vi.fn().mockResolvedValue(undefined),
+    },
+    contactService: {
+      linkIdentity: vi.fn().mockResolvedValue(undefined),
+      setStatus: vi.fn().mockResolvedValue({ id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', status: 'confirmed' }),
+      setTrustLevel: vi.fn().mockResolvedValue(undefined),
+      createContact: vi.fn(),
+      resolveByChannelIdentity: vi.fn(),
+      deleteContact: vi.fn(),
+    },
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  } as unknown as SkillContext;
+}
+
+describe('HeldMessagesProcessHandler — identify with existing_contact_id', () => {
+  it('promotes the contact to confirmed status before replaying', async () => {
+    const ctx = makeCtx();
+    const handler = new HeldMessagesProcessHandler();
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(ctx.contactService.setStatus).toHaveBeenCalledWith(
+      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      'confirmed',
+    );
+    // setStatus must be called BEFORE bus.publish (replay) to avoid re-hold
+    const setStatusOrder = (ctx.contactService.setStatus as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+    const busPublishOrder = (ctx.bus!.publish as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0];
+    expect(setStatusOrder).toBeLessThan(busPublishOrder);
+  });
+
+  it('still succeeds when setStatus fails (non-fatal)', async () => {
+    const ctx = makeCtx();
+    (ctx.contactService.setStatus as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('DB connection timeout'),
+    );
+    const handler = new HeldMessagesProcessHandler();
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect(ctx.log.warn).toHaveBeenCalled();
+    // Replay and markProcessed should still proceed
+    expect(ctx.bus!.publish).toHaveBeenCalled();
+    expect(ctx.heldMessages!.markProcessed).toHaveBeenCalled();
+  });
+
+  it('does not call setStatus for the new-contact path (already confirmed at creation)', async () => {
+    const ctx = makeCtx({
+      existing_contact_id: undefined,
+      contact_name: 'X Notifications',
+    });
+    (ctx.contactService.createContact as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 'new-contact-id',
+    });
+    const handler = new HeldMessagesProcessHandler();
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    // setStatus should NOT be called — createContact already uses status: 'confirmed'
+    expect(ctx.contactService.setStatus).not.toHaveBeenCalled();
+  });
+});

--- a/skills/held-messages-process/handler.ts
+++ b/skills/held-messages-process/handler.ts
@@ -288,6 +288,27 @@ export class HeldMessagesProcessHandler implements SkillHandler {
         }
       }
 
+      // Promote to 'confirmed' so the dispatcher doesn't treat the contact as
+      // an unknown sender when the replay event goes through. The existing_contact_id
+      // path links the identity to a pre-existing contact that may still be
+      // provisional (auto-created by a channel adapter). Without this promotion,
+      // the replayed message gets re-held immediately — the dispatcher treats
+      // provisional senders the same as unknown senders for hold policy.
+      // The new-contact path doesn't need this — createContact already uses
+      // status: 'confirmed'.
+      // Failure is non-fatal: the identity is linked and the message will be
+      // marked processed regardless.
+      if (existing_contact_id) {
+        try {
+          await ctx.contactService.setStatus(contactId, 'confirmed');
+        } catch (err) {
+          ctx.log.warn(
+            { err, contactId },
+            'held-messages-process: setStatus failed — replayed message may be re-held if contact is still provisional',
+          );
+        }
+      }
+
       // Set trust_level = 'high' so subsequent messages from this sender score
       // above the trust floor. contactConfidence starts at 0 for new contacts
       // (enriched later via KG), so without this override the dispatcher's

--- a/skills/held-messages-process/handler.ts
+++ b/skills/held-messages-process/handler.ts
@@ -296,16 +296,22 @@ export class HeldMessagesProcessHandler implements SkillHandler {
       // provisional senders the same as unknown senders for hold policy.
       // The new-contact path doesn't need this — createContact already uses
       // status: 'confirmed'.
-      // Failure is non-fatal: the identity is linked and the message will be
-      // marked processed regardless.
+      // This IS fatal for the replay: if setStatus fails, the replayed message
+      // will be re-held by the dispatcher, creating an infinite hold loop. Fail
+      // the operation so the message stays in the held queue (retryable) rather
+      // than silently re-entering the hold cycle.
       if (existing_contact_id) {
         try {
           await ctx.contactService.setStatus(contactId, 'confirmed');
         } catch (err) {
-          ctx.log.warn(
-            { err, contactId },
-            'held-messages-process: setStatus failed — replayed message may be re-held if contact is still provisional',
+          ctx.log.error(
+            { err, contactId, heldMessageId: held_message_id },
+            'held-messages-process: setStatus failed — cannot replay safely; contact is still provisional and dispatcher would re-hold',
           );
+          return {
+            success: false,
+            error: 'Failed to promote contact to confirmed status — the message was not replayed to avoid a re-hold loop. Please retry.',
+          };
         }
       }
 

--- a/tests/unit/skills/held-messages-process.test.ts
+++ b/tests/unit/skills/held-messages-process.test.ts
@@ -77,6 +77,7 @@ describe('HeldMessagesProcessHandler — identify action', () => {
     const contactService = {
       linkIdentity: vi.fn().mockResolvedValue({ id: 'identity-1' }),
       resolveByChannelIdentity: vi.fn(),
+      setStatus: vi.fn().mockResolvedValue({ id: CONTACT_ID, status: 'confirmed' }),
       setTrustLevel: vi.fn().mockResolvedValue({ id: CONTACT_ID, trustLevel: 'high' }),
     };
     const bus = makeBus();
@@ -92,6 +93,7 @@ describe('HeldMessagesProcessHandler — identify action', () => {
       channel: 'email',
       channelIdentifier: 'donna@example.com',
     }));
+    expect(contactService.setStatus).toHaveBeenCalledWith(CONTACT_ID, 'confirmed');
     expect(contactService.setTrustLevel).toHaveBeenCalledWith(CONTACT_ID, 'high');
     expect(bus.publish).toHaveBeenCalledOnce();
     expect(heldMessages.markProcessed).toHaveBeenCalledWith(HELD_MSG_ID, CONTACT_ID);
@@ -121,6 +123,7 @@ describe('HeldMessagesProcessHandler — identify action', () => {
         status: 'confirmed',
         trustLevel: null,
       }),
+      setStatus: vi.fn().mockResolvedValue({ id: CONTACT_ID, status: 'confirmed' }),
       setTrustLevel: vi.fn().mockResolvedValue({ id: CONTACT_ID, trustLevel: 'high' }),
     };
     const bus = makeBus();
@@ -232,6 +235,7 @@ describe('HeldMessagesProcessHandler — identify action', () => {
     const contactService = {
       linkIdentity: vi.fn().mockResolvedValue({ id: 'identity-1' }),
       resolveByChannelIdentity: vi.fn(),
+      setStatus: vi.fn().mockResolvedValue({ id: CONTACT_ID, status: 'confirmed' }),
       setTrustLevel: vi.fn().mockResolvedValue({ id: CONTACT_ID, trustLevel: 'high' }),
     };
     const bus = makeBus();
@@ -258,6 +262,7 @@ describe('HeldMessagesProcessHandler — identify action', () => {
     const contactService = {
       linkIdentity: vi.fn().mockResolvedValue({ id: 'identity-1' }),
       resolveByChannelIdentity: vi.fn(),
+      setStatus: vi.fn().mockResolvedValue({ id: CONTACT_ID, status: 'confirmed' }),
       setTrustLevel: vi.fn().mockRejectedValue(new Error('DB connection lost')),
     };
     const bus = makeBus();


### PR DESCRIPTION
## Summary

- **held-messages-process identify action** now calls `setStatus(contactId, 'confirmed')` when using `existing_contact_id`, before replaying the message through the dispatcher
- Without this, provisional contacts (auto-created by channel adapters) cause the dispatcher to immediately re-hold the replayed message — the CEO sees the same held messages resurface the next day
- If `setStatus` fails, the handler now returns `success: false` instead of replaying into a re-hold loop

**Root cause:** The dispatcher treats provisional senders identically to unknown senders for hold policy (`dispatcher.ts:294`). The identify handler linked identities and set trust level but never promoted `status` from `provisional` to `confirmed`. The bus delivers replay events synchronously, so the dispatcher processed the replay within the same `bus.publish` call — finding a provisional contact and holding it again.

**Production data fix applied:** The 3 stuck held messages have been discarded and the 3 affected contacts (X, Cloudflare x2) promoted to `confirmed`.

## Test plan

- [x] New unit test: `setStatus` called with correct args before `bus.publish` (ordering verified via `invocationCallOrder`)
- [x] New unit test: handler returns `success: false` when `setStatus` throws (no replay, no markProcessed)
- [x] New unit test: `setStatus` NOT called on new-contact path (already `confirmed` at creation)
- [x] Full test suite passes (3 pre-existing failures in unrelated files)
- [x] Production held_messages table verified: 0 pending rows after data fix