### PR TITLE
feat: secure TempFileStore for binary attachment handoff to Google Drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Email attachment Drive uploads corrupted** — `create_drive_file` was receiving the base64 string via `content` and encoding it as UTF-8 text, producing Drive files containing ASCII base64 rather than decoded binary bytes. Downloads now write raw bytes to a secure noexec tmpfs store (`TempFileStore`) and return a `file://` URL; the agent passes this as `fileUrl` to upload binary-correctly. Both `ceo-inbox-download-attachment` and `email-download-attachment` return the new `temp_file_url` field alongside `content_base64`. (#622, #624)
 - **`held-messages-process`** — identify action with `existing_contact_id` now promotes the contact to `confirmed` before replaying; previously provisional contacts caused the replayed message to be re-held immediately by the dispatcher.
 - **`ceo-inbox-search`** — uses `search_query_native` instead of `q` (Nylas v3); suppresses incompatible filter params when a search query is active.
 - **`ceo-inbox` ACTIONABLE archive** — added step 4h action checklist so ACTIONABLE emails reliably get archived after specialist handoff; rewrote ambiguous classification note.
@@ -28,6 +29,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **`TempFileStore` platform capability** — new capability-gated service (`tempFileStore`) that writes binary buffers to a noexec RAM-only tmpfs mount and returns `file://` URLs; skills declare it in their manifest to receive `ctx.writeTempFile()`. TTL sweep (5 min) and startup purge ensure files never linger. (#624)
 - **`ceo-inbox` agent and 9 skills** — moved from `curia-deploy/custom/` into curia core; now covered by curia's CI and type-checked against real types. (#592)
 - **Email attachment support** — surface metadata in email skills, append human-readable summaries to message content, and download bytes as base64 for `file-parse`.
 - **Email folder management skills** — `email-label`, `email-list-folders`, `email-create-folder`, and `email-mark-read` expose Nylas folder and read-state operations as general-purpose skills.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       # Without this volume, re-authentication is required on every container restart.
       # See docs/dev/google-drive.md for first-time OAuth setup.
       - google_workspace_tokens:/root/.google_workspace_mcp
+    tmpfs:
+      - /run/curia-tempfiles:size=50M,noexec,nosuid,nodev,mode=0700
 
 volumes:
   pgdata:

--- a/skills/ceo-inbox-download-attachment/handler.ts
+++ b/skills/ceo-inbox-download-attachment/handler.ts
@@ -11,8 +11,7 @@
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { CeoNylasClient } from '../_shared/ceo-nylas-client.js';
-
-const MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
+import { MAX_TEMP_FILE_BYTES } from '../../src/skills/temp-file-store.js';
 
 export class CeoInboxDownloadAttachmentHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -52,7 +51,7 @@ export class CeoInboxDownloadAttachmentHandler implements SkillHandler {
       };
     }
 
-    if (attachment.size > MAX_DOWNLOAD_BYTES) {
+    if (attachment.size > MAX_TEMP_FILE_BYTES) {
       const sizeMB = (attachment.size / (1024 * 1024)).toFixed(1);
       return {
         success: false,
@@ -81,7 +80,7 @@ export class CeoInboxDownloadAttachmentHandler implements SkillHandler {
     }
 
     // Post-download size check — catches cases where the declared size was 0 (missing) or incorrect.
-    if (buffer.length > MAX_DOWNLOAD_BYTES) {
+    if (buffer.length > MAX_TEMP_FILE_BYTES) {
       const sizeMB = (buffer.length / (1024 * 1024)).toFixed(1);
       ctx.log.warn(
         { attachmentId, messageId, actualBytes: buffer.length, declaredSize: attachment.size },
@@ -93,10 +92,25 @@ export class CeoInboxDownloadAttachmentHandler implements SkillHandler {
       };
     }
 
+    // Write to temp storage so the agent can pass a file:// URL to Drive upload.
+    // The workspace-mcp create_drive_file tool reads raw bytes from disk via
+    // fileUrl, avoiding the base64 corruption that occurs via the content param.
+    let tempFileUrl: string | undefined;
+    if (ctx.writeTempFile) {
+      try {
+        tempFileUrl = await ctx.writeTempFile(buffer, attachment.filename);
+      } catch (err) {
+        // Non-fatal — the agent can still use content_base64 for parsing.
+        // Log the failure so operators know temp storage is degraded.
+        ctx.log.warn({ err, filename: attachment.filename }, 'ceo-inbox-download-attachment: writeTempFile failed');
+      }
+    }
+
     return {
       success: true,
       data: {
         content_base64: buffer.toString('base64'),
+        temp_file_url: tempFileUrl,
         filename: attachment.filename,
         content_type: attachment.contentType,
         size: buffer.length,

--- a/skills/ceo-inbox-download-attachment/skill.json
+++ b/skills/ceo-inbox-download-attachment/skill.json
@@ -10,7 +10,7 @@
   },
   "outputs": {
     "content_base64": "string (base64-encoded file content, ready to pass to file-parse)",
-    "temp_file_url": "string | undefined (file:// URL pointing to the downloaded bytes on disk — pass to create_drive_file fileUrl param for binary-safe uploads to Google Drive)",
+    "temp_file_url": "string | undefined (file:// URL of the downloaded bytes on disk — for binary-safe Drive uploads, pass this as create_drive_file's fileUrl param and use the `filename` field as the file_name param to preserve the original attachment name)",
     "filename": "string (original attachment filename)",
     "content_type": "string (MIME type, e.g. 'application/pdf')",
     "size": "number (actual byte count after download)"

--- a/skills/ceo-inbox-download-attachment/skill.json
+++ b/skills/ceo-inbox-download-attachment/skill.json
@@ -3,7 +3,7 @@
   "description": "Download an email attachment from the CEO's personal inbox by its Nylas attachment ID. Returns base64-encoded file content ready to pass directly to file-parse. Use ceo-inbox-read first to find attachment IDs. Enforces a 10 MB size limit.",
   "version": "0.1.0",
   "sensitivity": "normal",
-  "action_risk": "none",
+  "action_risk": "low",
   "inputs": {
     "attachment_id": "string (Nylas attachment ID from ceo-inbox-read's attachments array)",
     "message_id": "string (Nylas message ID the attachment belongs to)"

--- a/skills/ceo-inbox-download-attachment/skill.json
+++ b/skills/ceo-inbox-download-attachment/skill.json
@@ -10,6 +10,7 @@
   },
   "outputs": {
     "content_base64": "string (base64-encoded file content, ready to pass to file-parse)",
+    "temp_file_url": "string | undefined (file:// URL pointing to the downloaded bytes on disk — pass to create_drive_file fileUrl param for binary-safe uploads to Google Drive)",
     "filename": "string (original attachment filename)",
     "content_type": "string (MIME type, e.g. 'application/pdf')",
     "size": "number (actual byte count after download)"
@@ -17,5 +18,5 @@
   "permissions": [],
   "secrets": ["nylas_api_key", "ceo_nylas_grant_id"],
   "timeout": 30000,
-  "capabilities": []
+  "capabilities": ["tempFileStore"]
 }

--- a/skills/email-download-attachment/handler.ts
+++ b/skills/email-download-attachment/handler.ts
@@ -10,8 +10,7 @@
 //   4. Return base64-encoded content plus metadata.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
-
-const MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
+import { MAX_TEMP_FILE_BYTES } from '../../src/skills/temp-file-store.js';
 
 export class EmailDownloadAttachmentHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -60,7 +59,7 @@ export class EmailDownloadAttachmentHandler implements SkillHandler {
       };
     }
 
-    if (attachment.size > MAX_DOWNLOAD_BYTES) {
+    if (attachment.size > MAX_TEMP_FILE_BYTES) {
       const sizeMB = (attachment.size / (1024 * 1024)).toFixed(1);
       return {
         success: false,
@@ -88,7 +87,7 @@ export class EmailDownloadAttachmentHandler implements SkillHandler {
 
     // Post-download size check — catches cases where the declared size was 0 (missing from API)
     // or where the actual content was larger than declared.
-    if (buffer.length > MAX_DOWNLOAD_BYTES) {
+    if (buffer.length > MAX_TEMP_FILE_BYTES) {
       const sizeMB = (buffer.length / (1024 * 1024)).toFixed(1);
       ctx.log.warn(
         { attachmentId, messageId, actualBytes: buffer.length, declaredSize: attachment.size },
@@ -100,10 +99,25 @@ export class EmailDownloadAttachmentHandler implements SkillHandler {
       };
     }
 
+    // Write to temp storage so the agent can pass a file:// URL to Drive upload.
+    // The workspace-mcp create_drive_file tool reads raw bytes from disk via
+    // fileUrl, avoiding the base64 corruption that occurs via the content param.
+    let tempFileUrl: string | undefined;
+    if (ctx.writeTempFile) {
+      try {
+        tempFileUrl = await ctx.writeTempFile(buffer, attachment.filename);
+      } catch (err) {
+        // Non-fatal — the agent can still use content_base64 for parsing.
+        // Log the failure so operators know temp storage is degraded.
+        ctx.log.warn({ err, filename: attachment.filename }, 'email-download-attachment: writeTempFile failed');
+      }
+    }
+
     return {
       success: true,
       data: {
         content_base64: buffer.toString('base64'),
+        temp_file_url: tempFileUrl,
         filename: attachment.filename,
         content_type: attachment.contentType,
         size: buffer.length,

--- a/skills/email-download-attachment/skill.json
+++ b/skills/email-download-attachment/skill.json
@@ -11,7 +11,7 @@
   },
   "outputs": {
     "content_base64": "string (base64-encoded file content, ready to pass to file-parse)",
-    "temp_file_url": "string | undefined (file:// URL pointing to the downloaded bytes on disk — pass to create_drive_file fileUrl param for binary-safe uploads to Google Drive)",
+    "temp_file_url": "string | undefined (file:// URL of the downloaded bytes on disk — for binary-safe Drive uploads, pass this as create_drive_file's fileUrl param and use the `filename` field as the file_name param to preserve the original attachment name)",
     "filename": "string (original attachment filename)",
     "content_type": "string (MIME type, e.g. 'application/pdf')",
     "size": "number (actual byte count after download)"

--- a/skills/email-download-attachment/skill.json
+++ b/skills/email-download-attachment/skill.json
@@ -11,6 +11,7 @@
   },
   "outputs": {
     "content_base64": "string (base64-encoded file content, ready to pass to file-parse)",
+    "temp_file_url": "string | undefined (file:// URL pointing to the downloaded bytes on disk — pass to create_drive_file fileUrl param for binary-safe uploads to Google Drive)",
     "filename": "string (original attachment filename)",
     "content_type": "string (MIME type, e.g. 'application/pdf')",
     "size": "number (actual byte count after download)"
@@ -18,5 +19,5 @@
   "permissions": [],
   "secrets": [],
   "timeout": 30000,
-  "capabilities": ["outboundGateway"]
+  "capabilities": ["outboundGateway", "tempFileStore"]
 }

--- a/skills/email-download-attachment/skill.json
+++ b/skills/email-download-attachment/skill.json
@@ -3,7 +3,7 @@
   "description": "Download an email attachment by its Nylas attachment ID and return the file content as base64. Use email-get first to get the attachment ID. Pass the returned content_base64 and content_type directly to file-parse for processing. Enforces a 10 MB size limit.",
   "version": "1.0.0",
   "sensitivity": "normal",
-  "action_risk": "none",
+  "action_risk": "low",
   "inputs": {
     "attachment_id": "string (Nylas attachment ID from email-get's attachments array)",
     "message_id": "string (Nylas message ID the attachment belongs to)",

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ import type { AgentPersona } from './skills/types.js';
 import type { ConfigChangeEvent } from './bus/events.js';
 import { BullpenService } from './memory/bullpen.js';
 import { BullpenDispatcher } from './dispatch/bullpen-dispatcher.js';
+import { TempFileStore } from './skills/temp-file-store.js';
 import { ConversationCheckpointProcessor } from './checkpoint/processor.js';
 import { runStartupValidation } from './startup/validator.js';
 import { runReadinessChecks } from './startup/readiness.js';
@@ -1012,11 +1013,17 @@ async function main(): Promise<void> {
     actionLogRepo, outboundGateway, logger, config.ceoPrimaryEmail || undefined,
   );
 
+  // Temp file store — secure tmpfs-backed storage for binary attachment handoff.
+  // Skills declaring 'tempFileStore' capability get ctx.writeTempFile().
+  // See docs/specs/2026-05-16-temp-attachment-store-design.md for security model.
+  const tempFileStore = new TempFileStore();
+  await tempFileStore.init(logger);
+
   // Execution layer — services wired here are injected per-skill based on their
   // capability-gated declarations. outboundGateway gives email skills their send path.
   // entityContextAssembler enables entity_enrichment pre-enrichment and the
   // entity-context skill. agentContactId enables entity_enrichment default='agent'.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, actionLogRepo, confidencePipeline, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, actionLogRepo, confidencePipeline, tempFileStore, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete
@@ -1398,6 +1405,12 @@ async function main(): Promise<void> {
       dispatcher.close();
     } catch (err) {
       logger.error({ err }, 'Error clearing checkpoint timers during shutdown');
+    }
+    // Purge temp files and stop the sweep timer before exit.
+    try {
+      await tempFileStore.shutdown();
+    } catch (err) {
+      logger.error({ err }, 'Error shutting down temp file store during shutdown');
     }
     try {
       await pool.end();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1016,8 +1016,16 @@ async function main(): Promise<void> {
   // Temp file store — secure tmpfs-backed storage for binary attachment handoff.
   // Skills declaring 'tempFileStore' capability get ctx.writeTempFile().
   // See docs/specs/2026-05-16-temp-attachment-store-design.md for security model.
-  const tempFileStore = new TempFileStore();
-  await tempFileStore.init(logger);
+  // Non-fatal: if the tmpfs mount is unavailable and the fallback dir can't be
+  // created, we log and continue without this capability rather than aborting startup.
+  let tempFileStore: TempFileStore | undefined;
+  try {
+    tempFileStore = new TempFileStore();
+    await tempFileStore.init(logger);
+  } catch (err) {
+    logger.error({ err }, 'Temp file store init failed — continuing without tempFileStore capability');
+    tempFileStore = undefined;
+  }
 
   // Execution layer — services wired here are injected per-skill based on their
   // capability-gated declarations. outboundGateway gives email skills their send path.
@@ -1407,10 +1415,12 @@ async function main(): Promise<void> {
       logger.error({ err }, 'Error clearing checkpoint timers during shutdown');
     }
     // Purge temp files and stop the sweep timer before exit.
-    try {
-      await tempFileStore.shutdown();
-    } catch (err) {
-      logger.error({ err }, 'Error shutting down temp file store during shutdown');
+    if (tempFileStore) {
+      try {
+        await tempFileStore.shutdown();
+      } catch (err) {
+        logger.error({ err }, 'Error shutting down temp file store during shutdown');
+      }
     }
     try {
       await pool.end();

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, vi } from 'vitest';
 import pino from 'pino';
 import { SkillRegistry } from './registry.js';
 import { ExecutionLayer } from './execution.js';
+import { TempFileStore } from './temp-file-store.js';
 import type { SkillHandler, SkillManifest, SkillResult, SkillContext } from './types.js';
 import type { EventBus } from '../bus/bus.js';
 import type { OutboundGateway } from './outbound-gateway.js';
@@ -286,6 +287,56 @@ describe('capability-gated service injection', () => {
     }
     // Handler should NOT have been called — fail-closed
     expect(handler.execute).not.toHaveBeenCalled();
+  });
+
+  it('injects writeTempFile for skills declaring tempFileStore capability', async () => {
+    // Use a temp dir under /tmp so TempFileStore.init() can create it without
+    // needing the production /run/curia-tempfiles mount to be present.
+    const tempFileStore = new TempFileStore({
+      dir: `/tmp/curia-test-tempfiles-${Date.now()}`,
+      sweepIntervalMs: 0, // Disable auto-sweep so the test doesn't leave timers running
+    });
+    await tempFileStore.init();
+
+    const registry = new SkillRegistry();
+    let capturedCtx: SkillContext | undefined;
+    const handler: SkillHandler = {
+      execute: vi.fn(async (ctx): Promise<SkillResult> => {
+        capturedCtx = ctx;
+        return { success: true, data: 'ok' };
+      }),
+    };
+    registry.register(makeCapManifest('upload-attachment', ['tempFileStore']), handler);
+
+    const layer = new ExecutionLayer(registry, logger, { tempFileStore });
+
+    await layer.invoke('upload-attachment', {});
+
+    // writeTempFile should be injected as a callable closure — not the raw store
+    expect(typeof capturedCtx?.writeTempFile).toBe('function');
+
+    await tempFileStore.shutdown();
+  });
+
+  it('does NOT inject writeTempFile for skills without tempFileStore capability', async () => {
+    const registry = new SkillRegistry();
+    let capturedCtx: SkillContext | undefined;
+    const handler: SkillHandler = {
+      execute: vi.fn(async (ctx): Promise<SkillResult> => {
+        capturedCtx = ctx;
+        return { success: true, data: 'ok' };
+      }),
+    };
+    // Register with empty capabilities — no tempFileStore declared
+    registry.register(makeCapManifest('search-docs', []), handler);
+
+    // ExecutionLayer constructed WITHOUT tempFileStore wired
+    const layer = new ExecutionLayer(registry, logger);
+
+    await layer.invoke('search-docs', {});
+
+    // writeTempFile must be absent — undeclared capabilities must not leak into ctx
+    expect(capturedCtx?.writeTempFile).toBeUndefined();
   });
 });
 

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -319,6 +319,14 @@ describe('capability-gated service injection', () => {
   });
 
   it('does NOT inject writeTempFile for skills without tempFileStore capability', async () => {
+    // Wire a real TempFileStore into the layer but register the skill WITHOUT the capability.
+    // This proves the gate is enforced — not just that nothing was wired.
+    const gatingStore = new TempFileStore({
+      dir: `/tmp/curia-test-tempfiles-gate-${Date.now()}`,
+      sweepIntervalMs: 0,
+    });
+    await gatingStore.init();
+
     const registry = new SkillRegistry();
     let capturedCtx: SkillContext | undefined;
     const handler: SkillHandler = {
@@ -330,13 +338,15 @@ describe('capability-gated service injection', () => {
     // Register with empty capabilities — no tempFileStore declared
     registry.register(makeCapManifest('search-docs', []), handler);
 
-    // ExecutionLayer constructed WITHOUT tempFileStore wired
-    const layer = new ExecutionLayer(registry, logger);
+    // ExecutionLayer HAS tempFileStore, but skill did not declare the capability
+    const layer = new ExecutionLayer(registry, logger, { tempFileStore: gatingStore });
 
     await layer.invoke('search-docs', {});
 
     // writeTempFile must be absent — undeclared capabilities must not leak into ctx
     expect(capturedCtx?.writeTempFile).toBeUndefined();
+
+    await gatingStore.shutdown();
   });
 });
 

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -39,6 +39,7 @@ import { AutonomyService } from '../autonomy/autonomy-service.js';
 import type { AutonomyConfig } from '../autonomy/autonomy-service.js';
 import type { BrowserService } from '../browser/browser-service.js';
 import type { ApprovalTriggerService } from '../autonomy/approval-trigger.js';
+import { TempFileStore } from './temp-file-store.js';
 
 // Default max output length — used when no value is configured in default.yaml.
 // Skills returning more than this will have their output truncated before it
@@ -80,6 +81,7 @@ export class ExecutionLayer {
   private approvalTrigger?: ApprovalTriggerService;
   private actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
   private confidencePipeline?: import('../contacts/confidence-pipeline.js').ConfidencePipeline;
+  private tempFileStore?: TempFileStore;
   /** The agent's own contactId — injected into ctx.agentContactId for entity_enrichment default='agent' */
   private agentContactId?: string;
   /** IANA timezone name used for normalizing offset-less timestamp inputs from the LLM. */
@@ -107,6 +109,7 @@ export class ExecutionLayer {
     approvalTrigger?: ApprovalTriggerService;
     actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
     confidencePipeline?: import('../contacts/confidence-pipeline.js').ConfidencePipeline;
+    tempFileStore?: TempFileStore;
     agentContactId?: string;
     timezone?: string;
     selfEmail?: string;
@@ -131,6 +134,7 @@ export class ExecutionLayer {
     this.approvalTrigger = options?.approvalTrigger;
     this.actionLogRepo = options?.actionLogRepo;
     this.confidencePipeline = options?.confidencePipeline;
+    this.tempFileStore = options?.tempFileStore;
     this.agentContactId = options?.agentContactId;
     this.timezone = options?.timezone ?? 'UTC';
     this.selfEmail = options?.selfEmail;
@@ -504,6 +508,9 @@ export class ExecutionLayer {
       executiveProfileService: this.executiveProfileService,
       actionLogRepo: this.actionLogRepo,
       confidencePipeline: this.confidencePipeline,
+      // tempFileStore is handled as a special case in the injection loop (writeTempFile closure).
+      // Listed here so the missing-cap guard knows it's configured when this.tempFileStore is set.
+      tempFileStore: this.tempFileStore,
       // executionLayer injects `this` so approve-action can re-invoke blocked skills
       // with humanApproved: true (see ADR-018). Only approve-action should declare this.
       executionLayer: this,
@@ -568,6 +575,13 @@ export class ExecutionLayer {
           this.registry.search(query)
             .filter(s => s.manifest.name !== 'skill-registry')
             .map(s => ({ name: s.manifest.name, description: s.manifest.description }));
+      } else if (cap === 'tempFileStore') {
+        // Inject writeTempFile as a bound closure rather than the raw store.
+        // Skills get a focused write method, not full store access (no delete/sweep).
+        if (this.tempFileStore) {
+          ctx.writeTempFile = (buffer: Buffer, filename: string) =>
+            this.tempFileStore!.write(buffer, filename);
+        }
       } else {
         (ctx as unknown as Record<string, unknown>)[cap] = capabilityServices[cap];
       }

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -28,7 +28,7 @@ export const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
   'bus', 'agentRegistry', 'outboundGateway', 'heldMessages',
   'schedulerService', 'entityMemory', 'nylasCalendarClient',
   'autonomyService', 'executiveProfileService', 'browserService', 'bullpenService', 'skillSearch',
-  'actionLogRepo', 'executionLayer', 'confidencePipeline',
+  'actionLogRepo', 'executionLayer', 'confidencePipeline', 'tempFileStore',
 ]);
 
 /**

--- a/src/skills/temp-file-store.test.ts
+++ b/src/skills/temp-file-store.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { TempFileStore, MAX_TEMP_FILE_BYTES } from './temp-file-store.js';
+
+describe('TempFileStore', () => {
+  let store: TempFileStore;
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'curia-tempfile-test-'));
+    store = new TempFileStore({ dir: testDir, sweepIntervalMs: 0 }); // sweepIntervalMs=0 disables auto-sweep in tests
+    await store.init(); // no logger in tests — suppresses the "not tmpfs" warning
+  });
+
+  afterEach(async () => {
+    await store.shutdown();
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('MAX_TEMP_FILE_BYTES', () => {
+    it('exports a 10 MB constant', () => {
+      expect(MAX_TEMP_FILE_BYTES).toBe(10 * 1024 * 1024);
+    });
+  });
+
+  describe('write()', () => {
+    it('writes buffer and returns a file:// URL', async () => {
+      const content = Buffer.from('hello world');
+      const url = await store.write(content, 'test.txt');
+
+      expect(url).toMatch(/^file:\/\//);
+      const filePath = url.replace('file://', '');
+      const written = await fs.readFile(filePath);
+      expect(written).toEqual(content);
+    });
+
+    it('preserves binary content exactly', async () => {
+      // Random binary bytes (not valid UTF-8)
+      const content = Buffer.from([0x00, 0x01, 0xFF, 0xFE, 0x89, 0x50, 0x4E, 0x47]);
+      const url = await store.write(content, 'binary.bin');
+
+      const filePath = url.replace('file://', '');
+      const written = await fs.readFile(filePath);
+      expect(written).toEqual(content);
+    });
+
+    it('generates unique filenames with UUID prefix', async () => {
+      const urls = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        urls.add(await store.write(Buffer.from('x'), 'same.pdf'));
+      }
+      expect(urls.size).toBe(100);
+    });
+
+    it('sanitizes the extension from the original filename', async () => {
+      const url = await store.write(Buffer.from('x'), 'receipt.pdf');
+      expect(url).toMatch(/\.pdf$/);
+    });
+
+    it('strips path traversal from filename', async () => {
+      const url = await store.write(Buffer.from('x'), '../../etc/passwd');
+      const filePath = url.replace('file://', '');
+      expect(filePath.startsWith(testDir)).toBe(true);
+      expect(filePath).not.toContain('..');
+    });
+
+    it('strips null bytes from filename', async () => {
+      const url = await store.write(Buffer.from('x'), 'file\x00.pdf');
+      const filePath = url.replace('file://', '');
+      expect(filePath).not.toContain('\x00');
+    });
+
+    it('falls back to .bin for filenames without extension', async () => {
+      const url = await store.write(Buffer.from('x'), 'noext');
+      expect(url).toMatch(/\.bin$/);
+    });
+
+    it('truncates excessively long extensions', async () => {
+      const url = await store.write(Buffer.from('x'), 'file.' + 'a'.repeat(50));
+      const filePath = url.replace('file://', '');
+      const ext = path.extname(filePath);
+      expect(ext.length).toBeLessThanOrEqual(11); // dot + 10 chars
+    });
+
+    it('rejects buffers exceeding MAX_TEMP_FILE_BYTES', async () => {
+      const oversized = Buffer.alloc(MAX_TEMP_FILE_BYTES + 1);
+      await expect(store.write(oversized, 'big.pdf')).rejects.toThrow(/size/i);
+    });
+
+    it('accepts buffers exactly at MAX_TEMP_FILE_BYTES', async () => {
+      const maxSize = Buffer.alloc(MAX_TEMP_FILE_BYTES);
+      const url = await store.write(maxSize, 'max.pdf');
+      expect(url).toMatch(/^file:\/\//);
+    });
+  });
+
+  describe('delete()', () => {
+    it('removes the file at the given URL', async () => {
+      const url = await store.write(Buffer.from('delete me'), 'del.txt');
+      await store.delete(url);
+
+      const filePath = url.replace('file://', '');
+      await expect(fs.access(filePath)).rejects.toThrow();
+    });
+
+    it('is idempotent — does not throw for missing files', async () => {
+      await expect(store.delete('file:///nonexistent/path.txt')).resolves.not.toThrow();
+    });
+  });
+
+  describe('sweep()', () => {
+    it('removes files older than maxAgeMs', async () => {
+      const url = await store.write(Buffer.from('old'), 'old.txt');
+      const filePath = url.replace('file://', '');
+
+      // Backdate the file's mtime
+      const pastTime = new Date(Date.now() - 600_000); // 10 min ago
+      await fs.utimes(filePath, pastTime, pastTime);
+
+      const removed = await store.sweep(300_000); // 5 min threshold
+      expect(removed).toBe(1);
+      await expect(fs.access(filePath)).rejects.toThrow();
+    });
+
+    it('preserves files newer than maxAgeMs', async () => {
+      const url = await store.write(Buffer.from('recent'), 'new.txt');
+      const filePath = url.replace('file://', '');
+
+      const removed = await store.sweep(300_000);
+      expect(removed).toBe(0);
+      await expect(fs.access(filePath)).resolves.not.toThrow();
+    });
+  });
+
+  describe('shutdown()', () => {
+    it('removes all files in the directory', async () => {
+      await store.write(Buffer.from('a'), 'a.txt');
+      await store.write(Buffer.from('b'), 'b.txt');
+
+      await store.shutdown();
+
+      const remaining = await fs.readdir(testDir);
+      expect(remaining).toHaveLength(0);
+    });
+  });
+});

--- a/src/skills/temp-file-store.test.ts
+++ b/src/skills/temp-file-store.test.ts
@@ -106,7 +106,10 @@ describe('TempFileStore', () => {
     });
 
     it('is idempotent — does not throw for missing files', async () => {
-      await expect(store.delete('file:///nonexistent/path.txt')).resolves.not.toThrow();
+      // Write a file to get a valid URL pattern, then try to delete a non-existent file
+      // using the same store directory but a bogus UUID filename
+      const fakeUrl = `file://${testDir}/00000000-0000-0000-0000-000000000000.bin`;
+      await expect(store.delete(fakeUrl)).resolves.not.toThrow();
     });
   });
 

--- a/src/skills/temp-file-store.ts
+++ b/src/skills/temp-file-store.ts
@@ -32,6 +32,7 @@ export class TempFileStore {
   private readonly maxBytes: number;
   private readonly ttlMs: number;
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  private logger?: { warn(obj: Record<string, unknown>, msg: string): void };
 
   constructor(options?: TempFileStoreOptions) {
     this.dir = options?.dir
@@ -56,6 +57,7 @@ export class TempFileStore {
    * and purges any stale files from a previous run.
    */
   async init(logger?: { warn(obj: Record<string, unknown>, msg: string): void }): Promise<void> {
+    this.logger = logger;
     // Check if the directory already exists (pre-mounted tmpfs in production)
     let preExists = true;
     try {
@@ -76,7 +78,7 @@ export class TempFileStore {
     }
 
     // Startup purge — clean slate after unclean shutdown
-    await this.purgeAll();
+    await this.purgeAll(logger);
   }
 
   /** Write binary content. Returns a file:// URL. Throws if size exceeds limit. */
@@ -100,8 +102,13 @@ export class TempFileStore {
   /** Delete a previously written file by its URL. Idempotent. */
   async delete(fileUrl: string): Promise<void> {
     const filePath = fileUrl.replace('file://', '');
+    const resolved = path.resolve(filePath);
+    // Refuse to delete files outside the store directory — prevents path traversal.
+    if (!resolved.startsWith(this.dir + path.sep) && resolved !== this.dir) {
+      throw new Error(`Refusing to delete file outside temp store: ${resolved}`);
+    }
     try {
-      await fs.unlink(filePath);
+      await fs.unlink(resolved);
     } catch (err) {
       // Idempotent — already deleted or never existed
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
@@ -116,8 +123,11 @@ export class TempFileStore {
     let entries: string[];
     try {
       entries = await fs.readdir(this.dir);
-    } catch {
-      return 0; // Directory doesn't exist yet
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 0; // Not initialized yet
+      // Any other error (EACCES, EIO, ENOTDIR) means cleanup is broken — log it.
+      this.logger?.warn({ err, dir: this.dir }, 'TempFileStore.sweep: readdir failed — sweep skipped, files may accumulate');
+      return 0;
     }
 
     for (const entry of entries) {
@@ -128,8 +138,11 @@ export class TempFileStore {
           await fs.unlink(filePath);
           removed++;
         }
-      } catch {
-        // File disappeared between readdir and stat — benign race
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          // ENOENT = benign race (file deleted between readdir and stat). Anything else is unexpected.
+          this.logger?.warn({ err, filePath }, 'TempFileStore.sweep: could not stat/unlink file');
+        }
       }
     }
     return removed;
@@ -141,22 +154,28 @@ export class TempFileStore {
       clearInterval(this.sweepTimer);
       this.sweepTimer = null;
     }
-    await this.purgeAll();
+    await this.purgeAll(this.logger);
   }
 
   /** Remove all files in the store directory. */
-  private async purgeAll(): Promise<void> {
+  private async purgeAll(logger?: { warn(obj: Record<string, unknown>, msg: string): void }): Promise<void> {
     let entries: string[];
     try {
       entries = await fs.readdir(this.dir);
-    } catch {
-      return; // Directory doesn't exist
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        logger?.warn({ err, dir: this.dir }, 'TempFileStore.purgeAll: readdir failed — purge skipped, stale files may persist');
+      }
+      return; // ENOENT = directory doesn't exist, nothing to purge
     }
     for (const entry of entries) {
       try {
         await fs.unlink(path.join(this.dir, entry));
-      } catch {
-        // Best-effort cleanup
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          // ENOENT = already gone, truly benign. Anything else is worth surfacing.
+          logger?.warn({ err, entry, dir: this.dir }, 'TempFileStore.purgeAll: could not unlink — file may persist');
+        }
       }
     }
   }

--- a/src/skills/temp-file-store.ts
+++ b/src/skills/temp-file-store.ts
@@ -8,7 +8,6 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import os from 'node:os';
 import crypto from 'node:crypto';
 
 /**

--- a/src/skills/temp-file-store.ts
+++ b/src/skills/temp-file-store.ts
@@ -1,0 +1,191 @@
+// temp-file-store.ts — Secure temporary file storage for binary content.
+//
+// Writes buffers to a noexec tmpfs mount and returns file:// URLs that MCP
+// tools (e.g. create_drive_file) can read directly. Files are cleaned up via
+// TTL sweep and startup purge.
+//
+// Security: see docs/specs/2026-05-16-temp-attachment-store-design.md
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+
+/**
+ * Centralized per-file size limit. Exported so upstream skills can reference it
+ * for pre-download validation rather than re-declaring their own constants.
+ */
+export const MAX_TEMP_FILE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+export interface TempFileStoreOptions {
+  /** Directory for temp files. Defaults to CURIA_TEMPFILE_DIR env or /run/curia-tempfiles. */
+  dir?: string;
+  /** Max file size in bytes. Defaults to CURIA_TEMPFILE_MAX_BYTES env or MAX_TEMP_FILE_BYTES. */
+  maxBytes?: number;
+  /** TTL in ms before sweep removes files. Defaults to CURIA_TEMPFILE_TTL_MS env or 300000. */
+  ttlMs?: number;
+  /** Sweep interval in ms. 0 disables auto-sweep (for tests). Defaults to 60000. */
+  sweepIntervalMs?: number;
+}
+
+export class TempFileStore {
+  readonly dir: string;
+  private readonly maxBytes: number;
+  private readonly ttlMs: number;
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(options?: TempFileStoreOptions) {
+    this.dir = options?.dir
+      ?? process.env.CURIA_TEMPFILE_DIR
+      ?? '/run/curia-tempfiles';
+    this.maxBytes = options?.maxBytes
+      ?? (process.env.CURIA_TEMPFILE_MAX_BYTES ? parseInt(process.env.CURIA_TEMPFILE_MAX_BYTES, 10) : MAX_TEMP_FILE_BYTES);
+    this.ttlMs = options?.ttlMs
+      ?? (process.env.CURIA_TEMPFILE_TTL_MS ? parseInt(process.env.CURIA_TEMPFILE_TTL_MS, 10) : 300_000);
+
+    const sweepIntervalMs = options?.sweepIntervalMs ?? 60_000;
+    if (sweepIntervalMs > 0) {
+      this.sweepTimer = setInterval(() => { void this.sweep(this.ttlMs); }, sweepIntervalMs);
+      // Allow the process to exit without waiting for the timer
+      this.sweepTimer.unref();
+    }
+  }
+
+  /**
+   * Initialize the store directory. Call once at startup.
+   * Creates the directory if it doesn't exist (local dev fallback)
+   * and purges any stale files from a previous run.
+   */
+  async init(logger?: { warn(obj: Record<string, unknown>, msg: string): void }): Promise<void> {
+    // Check if the directory already exists (pre-mounted tmpfs in production)
+    let preExists = true;
+    try {
+      await fs.access(this.dir);
+    } catch {
+      preExists = false;
+    }
+
+    if (!preExists) {
+      // Local dev or misconfigured deploy — create as regular directory.
+      // Warn that this lacks tmpfs security properties (noexec, RAM-only).
+      logger?.warn(
+        { dir: this.dir },
+        'TempFileStore: directory does not exist as a pre-mounted tmpfs — creating as regular directory. ' +
+        'In production, mount a tmpfs at this path (see docker-compose.yml).',
+      );
+      await fs.mkdir(this.dir, { mode: 0o700, recursive: true });
+    }
+
+    // Startup purge — clean slate after unclean shutdown
+    await this.purgeAll();
+  }
+
+  /** Write binary content. Returns a file:// URL. Throws if size exceeds limit. */
+  async write(buffer: Buffer, originalFilename: string): Promise<string> {
+    if (buffer.length > this.maxBytes) {
+      const sizeMB = (buffer.length / (1024 * 1024)).toFixed(1);
+      const limitMB = (this.maxBytes / (1024 * 1024)).toFixed(0);
+      throw new Error(
+        `Temp file size ${sizeMB} MB exceeds the ${limitMB} MB limit`,
+      );
+    }
+
+    const ext = this.sanitizeExtension(originalFilename);
+    const filename = `${crypto.randomUUID()}${ext}`;
+    const filePath = path.join(this.dir, filename);
+
+    await fs.writeFile(filePath, buffer, { mode: 0o600 });
+    return `file://${filePath}`;
+  }
+
+  /** Delete a previously written file by its URL. Idempotent. */
+  async delete(fileUrl: string): Promise<void> {
+    const filePath = fileUrl.replace('file://', '');
+    try {
+      await fs.unlink(filePath);
+    } catch (err) {
+      // Idempotent — already deleted or never existed
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+  }
+
+  /** Remove all files older than maxAgeMs. Returns count of removed files. */
+  async sweep(maxAgeMs: number): Promise<number> {
+    const cutoff = Date.now() - maxAgeMs;
+    let removed = 0;
+
+    let entries: string[];
+    try {
+      entries = await fs.readdir(this.dir);
+    } catch {
+      return 0; // Directory doesn't exist yet
+    }
+
+    for (const entry of entries) {
+      const filePath = path.join(this.dir, entry);
+      try {
+        const stat = await fs.stat(filePath);
+        if (stat.mtimeMs < cutoff) {
+          await fs.unlink(filePath);
+          removed++;
+        }
+      } catch {
+        // File disappeared between readdir and stat — benign race
+      }
+    }
+    return removed;
+  }
+
+  /** Shut down: clear all files, stop sweep timer. */
+  async shutdown(): Promise<void> {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+    await this.purgeAll();
+  }
+
+  /** Remove all files in the store directory. */
+  private async purgeAll(): Promise<void> {
+    let entries: string[];
+    try {
+      entries = await fs.readdir(this.dir);
+    } catch {
+      return; // Directory doesn't exist
+    }
+    for (const entry of entries) {
+      try {
+        await fs.unlink(path.join(this.dir, entry));
+      } catch {
+        // Best-effort cleanup
+      }
+    }
+  }
+
+  /**
+   * Extract and sanitize the file extension from an original filename.
+   * Strips path separators, null bytes, limits length. Falls back to '.bin'.
+   */
+  private sanitizeExtension(originalFilename: string): string {
+    // Strip path components — only the basename matters
+    const basename = path.basename(originalFilename);
+    // Remove null bytes
+    const clean = basename.replace(/\0/g, '');
+    // Extract extension
+    let ext = path.extname(clean).toLowerCase();
+
+    if (!ext || ext === '.') {
+      return '.bin';
+    }
+
+    // Keep only alphanumeric chars and dot in the extension
+    ext = ext.replace(/[^a-z0-9.]/g, '');
+
+    // Limit to dot + 10 chars
+    if (ext.length > 11) {
+      ext = ext.slice(0, 11);
+    }
+
+    return ext;
+  }
+}

--- a/src/skills/temp-file-store.ts
+++ b/src/skills/temp-file-store.ts
@@ -35,13 +35,24 @@ export class TempFileStore {
   private logger?: { warn(obj: Record<string, unknown>, msg: string): void };
 
   constructor(options?: TempFileStoreOptions) {
-    this.dir = options?.dir
+    // path.resolve() ensures boundary checks work even if a relative dir is passed.
+    this.dir = path.resolve(
+      options?.dir
       ?? process.env.CURIA_TEMPFILE_DIR
-      ?? '/run/curia-tempfiles';
+      ?? '/run/curia-tempfiles',
+    );
+
+    // parseInt can return NaN for malformed env vars — fall back to compiled defaults.
+    const parsePositiveInt = (raw: string | undefined, fallback: number): number => {
+      if (!raw) return fallback;
+      const parsed = Number.parseInt(raw, 10);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+    };
+
     this.maxBytes = options?.maxBytes
-      ?? (process.env.CURIA_TEMPFILE_MAX_BYTES ? parseInt(process.env.CURIA_TEMPFILE_MAX_BYTES, 10) : MAX_TEMP_FILE_BYTES);
+      ?? parsePositiveInt(process.env.CURIA_TEMPFILE_MAX_BYTES, MAX_TEMP_FILE_BYTES);
     this.ttlMs = options?.ttlMs
-      ?? (process.env.CURIA_TEMPFILE_TTL_MS ? parseInt(process.env.CURIA_TEMPFILE_TTL_MS, 10) : 300_000);
+      ?? parsePositiveInt(process.env.CURIA_TEMPFILE_TTL_MS, 300_000);
 
     const sweepIntervalMs = options?.sweepIntervalMs ?? 60_000;
     if (sweepIntervalMs > 0) {
@@ -62,8 +73,15 @@ export class TempFileStore {
     let preExists = true;
     try {
       await fs.access(this.dir);
-    } catch {
-      preExists = false;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        preExists = false;
+      } else {
+        // EACCES, EIO, or other unexpected error — surface it rather than silently
+        // treating the directory as "missing" and attempting to create it.
+        logger?.warn({ err, dir: this.dir }, 'TempFileStore.init: access check failed');
+        throw err;
+      }
     }
 
     if (!preExists) {

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -57,7 +57,7 @@ export interface SkillManifest {
    *  Valid capabilities: bus, agentRegistry, outboundGateway, heldMessages,
    *  schedulerService, entityMemory, nylasCalendarClient, autonomyService,
    *  executiveProfileService, browserService, bullpenService, skillSearch,
-   *  actionLogRepo, executionLayer, confidencePipeline.
+   *  actionLogRepo, executionLayer, confidencePipeline, tempFileStore.
    *
    *  Services NOT listed here (contactService, entityContextAssembler, agentPersona)
    *  are universal — available to every skill without declaration. */

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -201,6 +201,11 @@ export interface SkillContext {
    *  Allows re-invocation of skills with humanApproved bypass. Only approve-action (#428)
    *  should declare this capability; it is sensitivity: "elevated" (CEO-only). */
   executionLayer?: import('./execution.js').ExecutionLayer;
+  /** Temp file store — available to skills declaring 'tempFileStore' in capabilities.
+   *  Writes binary buffers to a secure tmpfs mount and returns file:// URLs for
+   *  MCP tools that accept file paths. Used by email download skills to hand off
+   *  attachment bytes to Google Drive uploads without corruption. */
+  writeTempFile?(buffer: Buffer, filename: string): Promise<string>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a platform-level `TempFileStore` service that writes attachment bytes to a noexec tmpfs mount and returns `file://` URLs
- Email download skills (`ceo-inbox-download-attachment`, `email-download-attachment`) now return `temp_file_url` alongside `content_base64`
- The agent can pass `temp_file_url` to `create_drive_file(fileUrl=...)` to upload binary bytes correctly — fixing corrupted Drive files that contained base64 ASCII text instead of decoded PDF/image bytes
- Capability-gated: only skills declaring `tempFileStore` in their manifest get `ctx.writeTempFile()`

## Root Cause Fixed

`workspace-mcp`'s `create_drive_file` does `content.encode("utf-8")` on the base64 string, uploading ASCII text rather than decoded binary. The tool does handle binary correctly when given a `fileUrl` pointing to a local file — this PR provides that file path via secure tmpfs storage.

## Security Model

| Control | Threat mitigated |
|---------|-----------------|
| tmpfs (RAM-only, 50MB cap) | Disk persistence, memory exhaustion |
| noexec, nosuid, nodev | Execution of uploaded content, privilege escalation |
| mode 0700 | Other processes reading files |
| 10MB per-file cap | Single large file DoS |
| Random UUIDs | Path enumeration |
| Permission-gated capability | Arbitrary skills writing to disk |
| Source trust (Nylas only) | Agent controlling byte content |
| TTL sweep (5 min) + startup purge | Minimizes exposure window |
| Path validation in `delete()` | Path traversal attacks |

## Test Plan

- [ ] 50 unit + integration tests pass (`src/skills/temp-file-store.test.ts` + `src/skills/execution.test.ts`)
- [ ] Type check clean
- [ ] Manual: download a PDF email attachment, upload to Drive via `create_drive_file(fileUrl=...)`, confirm the Drive file opens correctly (not corrupted base64 text)

Fixes #622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed corrupted email attachment uploads to Drive by replacing UTF-8 encoded base64 handling with binary-safe temporary file storage.

* **New Features**
  * Added TempFileStore capability for secure temporary file handling with automatic TTL-based cleanup.
  * Attachment download responses now include temporary file URLs alongside base64 content for improved upload workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->