### PR TITLE
docs: update specs 07 and 14 for v0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **Spec 07 (Scheduler)** — corrected suspension notification description: `SuspensionNotifier` emails the CEO directly via `OutboundGateway.sendNotification()`, bypassing the LLM pipeline; added `RecoveryNotifier` for watchdog-recovered stuck jobs.
+- **Spec 14 (Autonomy Engine)** — documented principal bypass: CEO-originated tasks skip Gates A and B; added to Phase 2 gates table and implementation status.
+
 ### Security
 
 - **Semgrep CE scanning** — adds pattern-based SAST on every PR and weekly schedule; covers TypeScript, Node.js OWASP Top 10, command injection, and secrets rulesets; SARIF results surface in the Security tab. (#562)

--- a/docs/specs/07-scheduler.md
+++ b/docs/specs/07-scheduler.md
@@ -10,7 +10,9 @@ Built into the main process, backed by Postgres. Handles both user-defined recur
 
 **Shared service:** `SchedulerService` handles all job CRUD — consumed by scheduler loop, agent skills, and HTTP API routes.
 
-**Suspension notifications:** Routed through the coordinator as synthetic `agent.task` events — no dedicated notification subsystem.
+**Suspension notifications:** Sent via `SuspensionNotifier` — a system-layer bus subscriber that emails the CEO directly through `OutboundGateway.sendNotification()`. This path intentionally bypasses the LLM pipeline: the most common cause of job suspension is the Anthropic API being down, so any notification routed through the coordinator would fail in exactly that scenario.
+
+**Stuck-job recovery notifications:** Sent via `RecoveryNotifier` — same design as `SuspensionNotifier`, subscribes to `schedule.recovered`. Fires only for the reset-to-pending case (watchdog recovered a stuck job without suspending it); when a recovery leads to suspension, `SuspensionNotifier` handles the CEO email instead.
 
 ---
 
@@ -216,7 +218,8 @@ Four skills available to agents:
 
 - All job executions are audit-logged (start, success, failure, suspension)
 - The health endpoint does not yet include scheduler stats (active jobs, suspended jobs, next due time) — see Implementation Status below
-- Suspended jobs generate a user notification via the configured alert channel
+- Suspended jobs trigger a `SuspensionNotifier` direct email to the CEO (bypasses LLM — see Overview above)
+- Watchdog-recovered stuck jobs trigger a `RecoveryNotifier` direct email to the CEO
 
 ---
 
@@ -238,6 +241,7 @@ Four skills available to agents:
 | HTTP API routes (`POST/GET/PATCH/DELETE /api/jobs`) | Done |
 | Prior run context injection (structured system message prepended to task) | Done |
 | Timezone handling (per-job tz passed to `cron-parser`) | Done |
-| Suspension notifications (via Coordinator as synthetic `agent.task`) | Done |
-| Audit logging (`schedule.fired`, `schedule.suspended` events) | Done |
+| `SuspensionNotifier` — direct CEO email on suspension (bypasses LLM via `OutboundGateway.sendNotification`) | Done |
+| `RecoveryNotifier` — direct CEO email when watchdog resets a stuck job to pending | Done |
+| Audit logging (`schedule.fired`, `schedule.suspended`, `schedule.recovered` events) | Done |
 | Health endpoint: scheduler stats (active jobs, suspended jobs, next due) | Not Done |

--- a/docs/specs/14-autonomy-engine.md
+++ b/docs/specs/14-autonomy-engine.md
@@ -212,6 +212,14 @@ Phase 2 enforces three hard gates:
 
 The `OutboundGateway` (see [15-outbound-safety.md](15-outbound-safety.md)) is already the natural choke point — adding an autonomy check there requires no architectural change.
 
+### Principal bypass
+
+When a task is **principal-originated** (initiated by a direct CEO message, as determined by `isPrincipalOriginated(taskMetadata)`), both Gate A and Gate B are skipped. The autonomy gate governs *autonomous* behavior; an explicit CEO instruction is its own authorization and must not be blocked by the score the CEO themselves set.
+
+Implementation: the execution layer calls `isPrincipalOriginated()` before evaluating autonomy gates. If the task traces back to a principal message, the gates are logged but not enforced. Bypasses are written to the audit log at `info` level for operator visibility.
+
+Scope: principal bypass applies to Gates A and B only. The elevated-skill gate (`sensitivity: 'elevated'`) is **not** bypassed — elevated skills have their own stricter access control that requires principal origination regardless of autonomy score.
+
 ---
 
 ## Implementation Status
@@ -226,6 +234,7 @@ The `OutboundGateway` (see [15-outbound-safety.md](15-outbound-safety.md)) is al
 | `action_risk` field required on all skill manifests, validated at startup | Done |
 | Phase 2: hard execution gates (block skill when score < `action_risk` floor) | Done |
 | Phase 2: `OutboundGateway` autonomy check (score < 70 → block direct send, drafts unaffected) | Done |
+| Phase 2: principal bypass — skip Gates A and B for CEO-originated tasks (`isPrincipalOriginated`) | Done |
 | Phase 3: automatic score adjustment (Competence/Commitment/Compatibility formula) | Done |
 
 ---


### PR DESCRIPTION
## Summary

- **Spec 07 (Scheduler)** — corrected suspension notification description: `SuspensionNotifier` emails the CEO directly via `OutboundGateway.sendNotification()`, bypassing LLM. Prior description said "via Coordinator as synthetic agent.task" which was the original design but was never implemented. Added `RecoveryNotifier` for watchdog-recovered stuck jobs. Updated implementation status table.
- **Spec 14 (Autonomy Engine)** — documented principal bypass in Phase 2 gates section: CEO-originated tasks skip Gates A and B via `isPrincipalOriginated()`. Added to implementation status table.

## Test plan

- [ ] Verify spec 07 suspension notification description matches `src/scheduler/suspension-notifier.ts`
- [ ] Verify RecoveryNotifier description matches `src/scheduler/recovery-notifier.ts`
- [ ] Verify principal bypass description matches `src/skills/execution.ts` gate logic
- [ ] Verify implementation status tables are accurate