### PR TITLE
fix: pin create_drive_file and add attachment-to-Drive prompt guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **Attachment Drive uploads unreachable** — `create_drive_file` was not pinned to the coordinator, so the agent couldn't upload downloaded attachments to Drive and reported a "sandboxed temp directory" error instead. Now pinned with prompt guidance to use `temp_file_url` via `fileUrl`; ceo-inbox step 4d updated to delegate Drive uploads via bullpen.
+- **Attachment Drive uploads unreachable** — `create_drive_file` was not pinned to the coordinator, so the agent couldn't upload downloaded attachments to Drive and reported a "sandboxed temp directory" error instead. Now pinned with prompt guidance to use `temp_file_url` via `fileUrl`.
 - **Email attachment Drive uploads corrupted** — `create_drive_file` was receiving the base64 string via `content` and encoding it as UTF-8 text, producing Drive files containing ASCII base64 rather than decoded binary bytes. Downloads now write raw bytes to a secure noexec tmpfs store (`TempFileStore`) and return a `file://` URL; the agent passes this as `fileUrl` to upload binary-correctly. Both `ceo-inbox-download-attachment` and `email-download-attachment` return the new `temp_file_url` field alongside `content_base64`. (#622, #624)
 - **`held-messages-process`** — identify action with `existing_contact_id` now promotes the contact to `confirmed` before replaying; previously provisional contacts caused the replayed message to be re-held immediately by the dispatcher.
 - **`ceo-inbox-search`** — uses `search_query_native` instead of `q` (Nylas v3); suppresses incompatible filter params when a search query is active.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
-### Fixed
-
-- **Attachment Drive uploads unreachable** — `create_drive_file` was not pinned to the coordinator, so the agent couldn't upload downloaded attachments to Drive and reported a "sandboxed temp directory" error instead. Now pinned with prompt guidance to use `temp_file_url` via `fileUrl`; ceo-inbox step 4d updated to delegate Drive uploads via bullpen.
-
 ### Changed
 
 - **Spec 07 (Scheduler)** — corrected suspension notification description: `SuspensionNotifier` emails the CEO directly via `OutboundGateway.sendNotification()`, bypassing the LLM pipeline; added `RecoveryNotifier` for watchdog-recovered stuck jobs.
@@ -30,6 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Attachment Drive uploads unreachable** — `create_drive_file` was not pinned to the coordinator, so the agent couldn't upload downloaded attachments to Drive and reported a "sandboxed temp directory" error instead. Now pinned with prompt guidance to use `temp_file_url` via `fileUrl`; ceo-inbox step 4d updated to delegate Drive uploads via bullpen.
 - **Email attachment Drive uploads corrupted** — `create_drive_file` was receiving the base64 string via `content` and encoding it as UTF-8 text, producing Drive files containing ASCII base64 rather than decoded binary bytes. Downloads now write raw bytes to a secure noexec tmpfs store (`TempFileStore`) and return a `file://` URL; the agent passes this as `fileUrl` to upload binary-correctly. Both `ceo-inbox-download-attachment` and `email-download-attachment` return the new `temp_file_url` field alongside `content_base64`. (#622, #624)
 - **`held-messages-process`** — identify action with `existing_contact_id` now promotes the contact to `confirmed` before replaying; previously provisional contacts caused the replayed message to be re-held immediately by the dispatcher.
 - **`ceo-inbox-search`** — uses `search_query_native` instead of `q` (Nylas v3); suppresses incompatible filter params when a search query is active.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Attachment Drive uploads unreachable** — `create_drive_file` was not pinned to the coordinator, so the agent couldn't upload downloaded attachments to Drive and reported a "sandboxed temp directory" error instead. Now pinned with prompt guidance to use `temp_file_url` via `fileUrl`; ceo-inbox step 4d updated to delegate Drive uploads via bullpen.
+
 ### Changed
 
 - **Spec 07 (Scheduler)** — corrected suspension notification description: `SuspensionNotifier` emails the CEO directly via `OutboundGateway.sendNotification()`, bypassing the LLM pipeline; added `RecoveryNotifier` for watchdog-recovered stuck jobs.

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -240,6 +240,13 @@ system_prompt: |
   `id`. Then pass `content_base64` and `content_type` to `file-parse` for
   structured extraction (e.g. `extract_as: "receipt"` for invoices).
 
+  **Drive uploads:** If the attachment should be saved to Google Drive (e.g. a
+  receipt, invoice, or document the CEO asked to file), classify as ACTIONABLE
+  and open a bullpen thread mentioning the coordinator. In the handoff summary,
+  include the `temp_file_url`, `filename`, and `content_type` from the download
+  result so the coordinator can upload via create_drive_file. Do NOT attempt to
+  upload to Drive yourself — you do not have Drive skills.
+
   ### 4e. Classify into one of five categories
 
   Evaluate in priority order:

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -240,17 +240,6 @@ system_prompt: |
   `id`. Then pass `content_base64` and `content_type` to `file-parse` for
   structured extraction (e.g. `extract_as: "receipt"` for invoices).
 
-  **Drive uploads:** If the attachment should be saved to Google Drive (e.g. a
-  receipt, invoice, or document the CEO asked to file), classify as ACTIONABLE
-  and open a bullpen thread mentioning the coordinator. If `temp_file_url` is
-  present in the download result, include it in the handoff along with
-  `filename` and `content_type` so the coordinator can upload via
-  create_drive_file. If `temp_file_url` is missing or undefined, tell the
-  coordinator that the temp file was unavailable — the coordinator should
-  inform the CEO that the attachment cannot be uploaded to Drive at this time
-  and suggest downloading and uploading it manually. Do NOT attempt to upload
-  to Drive yourself — you do not have Drive skills.
-
   ### 4e. Classify into one of five categories
 
   Evaluate in priority order:

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -242,10 +242,14 @@ system_prompt: |
 
   **Drive uploads:** If the attachment should be saved to Google Drive (e.g. a
   receipt, invoice, or document the CEO asked to file), classify as ACTIONABLE
-  and open a bullpen thread mentioning the coordinator. In the handoff summary,
-  include the `temp_file_url`, `filename`, and `content_type` from the download
-  result so the coordinator can upload via create_drive_file. Do NOT attempt to
-  upload to Drive yourself — you do not have Drive skills.
+  and open a bullpen thread mentioning the coordinator. If `temp_file_url` is
+  present in the download result, include it in the handoff along with
+  `filename` and `content_type` so the coordinator can upload via
+  create_drive_file. If `temp_file_url` is missing or undefined, tell the
+  coordinator that the temp file was unavailable — the coordinator should
+  inform the CEO that the attachment cannot be uploaded to Drive at this time
+  and suggest downloading and uploading it manually. Do NOT attempt to upload
+  to Drive yourself — you do not have Drive skills.
 
   ### 4e. Classify into one of five categories
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -403,6 +403,20 @@ system_prompt: |
   skill-registry have any Drive skills, the Google Drive integration is likely
   down — tell the CEO it appears to be temporarily unavailable.
 
+  **Uploading attachments to Drive:** When you download an email attachment
+  (via email-download-attachment or when the ceo-inbox specialist hands off an
+  attachment), the result includes a `temp_file_url` field — a `file://` URL
+  pointing to the raw bytes on disk. To upload the file to Google Drive, call
+  create_drive_file with:
+  - `fileUrl`: the `temp_file_url` value (e.g. `file:///run/curia-tempfiles/...`)
+  - `file_name`: the original `filename` from the download result
+  - `mime_type`: the `content_type` from the download result
+  - `folder_id`: the target Drive folder (or omit for root)
+
+  Do NOT pass `content_base64` as the `content` parameter — that produces a
+  corrupted file containing raw base64 text instead of binary data. Always use
+  `fileUrl` for binary file uploads.
+
   ### Delegation acknowledgment on synchronous channels
   When delegating a task that will take significant time (essay polishing, research,
   multi-step workflows) and the message arrived via a synchronous channel (cli, http,
@@ -481,6 +495,7 @@ pinned_skills:
   - get_drive_file_content
   - list_drive_items
   - list_docs_in_folder
+  - create_drive_file
   - create_drive_folder
   - copy_drive_file
   - manage_drive_access

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -405,7 +405,7 @@ system_prompt: |
 
   **Uploading attachments to Drive:** When you download an email attachment
   (via email-download-attachment or when the ceo-inbox specialist hands off an
-  attachment), the result includes a `temp_file_url` field — a `file://` URL
+  attachment), the result may include a `temp_file_url` field — a `file://` URL
   pointing to the raw bytes on disk. To upload the file to Google Drive, call
   create_drive_file with:
   - `fileUrl`: the `temp_file_url` value (e.g. `file:///run/curia-tempfiles/...`)
@@ -416,6 +416,20 @@ system_prompt: |
   Do NOT pass `content_base64` as the `content` parameter — that produces a
   corrupted file containing raw base64 text instead of binary data. Always use
   `fileUrl` for binary file uploads.
+
+  If `temp_file_url` is missing or undefined, the temp file store was
+  unavailable. Do NOT attempt to upload — inform the CEO the attachment could
+  not be saved to Drive and suggest they download and upload it manually.
+
+  **Timing:** Temp files have a limited lifespan (a few minutes). If
+  create_drive_file fails with a file-not-found error on the `temp_file_url`,
+  the temp file has expired. Tell the CEO the upload window expired and ask
+  them to re-send or forward the email so the attachment can be re-downloaded.
+  Do NOT retry the upload without a fresh download — the temp file cannot be
+  regenerated from the coordinator.
+
+  If create_drive_file fails for other reasons (quota, auth, permissions),
+  tell the CEO the upload failed and include the error. Do NOT claim success.
 
   ### Delegation acknowledgment on synchronous channels
   When delegating a task that will take significant time (essay polishing, research,


### PR DESCRIPTION
## Summary

- Pin `create_drive_file` to coordinator's Drive skills — it was available from workspace-mcp (core tier) but never pinned, causing the "sandboxed temp directory" error when the LLM tried to upload downloaded attachments
- Add coordinator prompt guidance for using `temp_file_url` → `fileUrl` parameter, with explicit warnings against the base64 `content` param (corruption bug)
- Handle edge cases: `temp_file_url` undefined (temp store unavailable), TTL expiry (file-not-found after a few minutes), and `create_drive_file` execution failures

Note: ceo-inbox does not need changes — receipt attachments are classified as ACTIONABLE and delegated to T2125-expense-tracker via bullpen, which already has both `ceo-inbox-download-attachment` and `create_drive_file` pinned.

## Test plan

- [x] Agent loader tests pass (8/8) — YAML is valid and parseable
- [ ] Deploy and send Curia an email with an attached receipt asking to save it to Drive
- [ ] Verify the coordinator calls `create_drive_file` with `fileUrl` (not `content`)
- [ ] Verify the file appears correctly on Google Drive (not corrupted base64 text)

### Follow-up items (out of scope)

- Add `temp_file_warning` field to download skill results when `writeTempFile` fails
- Add test coverage for the `writeTempFile` success/failure paths in both download handler test files
- T2125-expense-tracker in curia-deploy may need similar `temp_file_url` → `fileUrl` guidance in its receipt ingestion protocol