### PR TITLE
fix: use relative date in decay-warnings-list test

### DIFF
--- a/skills/decay-warnings-list/handler.test.ts
+++ b/skills/decay-warnings-list/handler.test.ts
@@ -13,7 +13,9 @@ function makeCtx(warnings: unknown[]): SkillContext {
   } as unknown as SkillContext;
 }
 
-const warnedAt = new Date('2026-05-10T14:00:00.000Z');  // 2 days before 2026-05-12
+// Compute warnedAt relative to now so daysRemaining stays within the 7-day window
+// regardless of when the test runs.  2 days ago → ~5 days remaining.
+const warnedAt = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
 
 describe('DecayWarningsListHandler', () => {
   it('returns warned nodes sorted oldest-first with daysRemaining', async () => {


### PR DESCRIPTION
## Summary

- The `decay-warnings-list` handler test hardcoded `warnedAt` to `2026-05-10`. Once the 7-day hold-back window elapsed (May 17), `daysRemaining` clamped to 0 and the `toBeGreaterThan(0)` assertion started failing on every CI run.
- Changed `warnedAt` to be computed as 2 days before "now", so `daysRemaining` is always ~5 regardless of when the test runs.
- This is the sole cause of CI failure on all 5 open dependabot PRs (#625, #626, #627, #628, #629).

## Test plan

- [x] `vitest run skills/decay-warnings-list/handler.test.ts` — all 3 tests pass
- [x] Full test suite — no regressions (3 pre-existing failures in unrelated files: autonomy-routes, autonomy-service-pagination, smoke/loader)