### PR TITLE
fix: pass ALLOWED_FILE_DIRS to workspace-mcp for TempFileStore access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Attachment Drive uploads blocked by file allowlist** — workspace-mcp's `validate_file_path` rejects `file://` URLs outside its own storage dir; `ALLOWED_FILE_DIRS=/run/curia-tempfiles` now passed to the subprocess so `create_drive_file` can read TempFileStore files.
 - **Attachment Drive uploads unreachable** — `create_drive_file` was not pinned to the coordinator, so the agent couldn't upload downloaded attachments to Drive and reported a "sandboxed temp directory" error instead. Now pinned with prompt guidance to use `temp_file_url` via `fileUrl`.
 - **Email attachment Drive uploads corrupted** — `create_drive_file` was receiving the base64 string via `content` and encoding it as UTF-8 text, producing Drive files containing ASCII base64 rather than decoded binary bytes. Downloads now write raw bytes to a secure noexec tmpfs store (`TempFileStore`) and return a `file://` URL; the agent passes this as `fileUrl` to upload binary-correctly. Both `ceo-inbox-download-attachment` and `email-download-attachment` return the new `temp_file_url` field alongside `content_base64`. (#622, #624)
 - **`held-messages-process`** — identify action with `existing_contact_id` now promotes the contact to `confirmed` before replaying; previously provisional contacts caused the replayed message to be re-held immediately by the dispatcher.

--- a/config/skills.yaml
+++ b/config/skills.yaml
@@ -69,6 +69,11 @@ servers:
     env:
       GOOGLE_OAUTH_CLIENT_ID: ""
       GOOGLE_OAUTH_CLIENT_SECRET: ""
+      # Allow the workspace-mcp subprocess to read files from the TempFileStore
+      # directory. Without this, create_drive_file rejects file:// URLs pointing
+      # to /run/curia-tempfiles/ because validate_file_path only allows reads
+      # from its own STORAGE_DIR by default.
+      ALLOWED_FILE_DIRS: "/run/curia-tempfiles"
     # Bind the Google Workspace user email at the tool layer so agents never see
     # or reason about it. Resolved from CURIA_GOOGLE_EMAIL env var at startup.
     # This replaces the system prompt injection approach (#387) which was fragile


### PR DESCRIPTION
## Summary

- workspace-mcp's `validate_file_path` has an allowlist of directories from which `file://` URLs can be read — defaulting to its own managed storage dir only
- `/run/curia-tempfiles` (where TempFileStore writes) was not in the allowlist, so `create_drive_file` rejected every `temp_file_url` with a path validation error
- The agents saw the rejection and fell back to passing `content_base64` via the `content` param, producing corrupted Drive files (base64 text instead of binary)
- Fix: add `ALLOWED_FILE_DIRS=/run/curia-tempfiles` to the workspace-mcp subprocess env in `config/skills.yaml`

This is the missing piece from #631 — the agent prompt and skill pinning were correct, but the MCP subprocess couldn't actually read the temp files.

## Test plan

- [ ] Deploy and send Curia an email with a PDF receipt asking to save it to Drive
- [ ] Verify `create_drive_file` uses `fileUrl` (check workspace-mcp logs for "Reading local file" message)
- [ ] Verify the uploaded file on Drive is valid binary PDF, not base64 text