### PR TITLE
fix: omit content_base64 when temp_file_url is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Attachment download output truncation** — `content_base64` (~214KB for a 160KB image) was listed first in the skill result, causing the output sanitizer to truncate the JSON and destroy `temp_file_url`. Now omitted when `temp_file_url` is available; included only as a fallback when temp storage is down.
 - **Attachment Drive uploads blocked by file allowlist** — workspace-mcp's `validate_file_path` rejects `file://` URLs outside its own storage dir; `ALLOWED_FILE_DIRS=/run/curia-tempfiles` now passed to the subprocess so `create_drive_file` can read TempFileStore files.
 - **Attachment Drive uploads unreachable** — `create_drive_file` was not pinned to the coordinator, so the agent couldn't upload downloaded attachments to Drive and reported a "sandboxed temp directory" error instead. Now pinned with prompt guidance to use `temp_file_url` via `fileUrl`.
 - **Email attachment Drive uploads corrupted** — `create_drive_file` was receiving the base64 string via `content` and encoding it as UTF-8 text, producing Drive files containing ASCII base64 rather than decoded binary bytes. Downloads now write raw bytes to a secure noexec tmpfs store (`TempFileStore`) and return a `file://` URL; the agent passes this as `fileUrl` to upload binary-correctly. Both `ceo-inbox-download-attachment` and `email-download-attachment` return the new `temp_file_url` field alongside `content_base64`. (#622, #624)

--- a/skills/ceo-inbox-download-attachment/handler.ts
+++ b/skills/ceo-inbox-download-attachment/handler.ts
@@ -106,14 +106,21 @@ export class CeoInboxDownloadAttachmentHandler implements SkillHandler {
       }
     }
 
+    // When temp_file_url is available, omit content_base64 to avoid blowing the
+    // skill output size limit. A 160KB image produces ~214KB of base64 which
+    // exceeds the ~200K truncation threshold, destroying the JSON and hiding
+    // temp_file_url from the agent. The temp file has the raw bytes for both
+    // Drive uploads (via fileUrl) and file-parse (via content_base64 on a
+    // re-download if needed). When temp storage is unavailable, content_base64
+    // is the only way to access the file so it must be included.
     return {
       success: true,
       data: {
-        content_base64: buffer.toString('base64'),
         temp_file_url: tempFileUrl,
         filename: attachment.filename,
         content_type: attachment.contentType,
         size: buffer.length,
+        ...(tempFileUrl ? {} : { content_base64: buffer.toString('base64') }),
       },
     };
   }

--- a/skills/ceo-inbox-download-attachment/skill.json
+++ b/skills/ceo-inbox-download-attachment/skill.json
@@ -9,8 +9,8 @@
     "message_id": "string (Nylas message ID the attachment belongs to)"
   },
   "outputs": {
-    "content_base64": "string (base64-encoded file content, ready to pass to file-parse)",
     "temp_file_url": "string | undefined (file:// URL of the downloaded bytes on disk — for binary-safe Drive uploads, pass this as create_drive_file's fileUrl param and use the `filename` field as the file_name param to preserve the original attachment name)",
+    "content_base64": "string | undefined (base64-encoded file content — only included when temp_file_url is unavailable, to avoid exceeding the skill output size limit)",
     "filename": "string (original attachment filename)",
     "content_type": "string (MIME type, e.g. 'application/pdf')",
     "size": "number (actual byte count after download)"

--- a/skills/email-download-attachment/handler.ts
+++ b/skills/email-download-attachment/handler.ts
@@ -113,14 +113,21 @@ export class EmailDownloadAttachmentHandler implements SkillHandler {
       }
     }
 
+    // When temp_file_url is available, omit content_base64 to avoid blowing the
+    // skill output size limit. A 160KB image produces ~214KB of base64 which
+    // exceeds the ~200K truncation threshold, destroying the JSON and hiding
+    // temp_file_url from the agent. The temp file has the raw bytes for both
+    // Drive uploads (via fileUrl) and file-parse (via content_base64 on a
+    // re-download if needed). When temp storage is unavailable, content_base64
+    // is the only way to access the file so it must be included.
     return {
       success: true,
       data: {
-        content_base64: buffer.toString('base64'),
         temp_file_url: tempFileUrl,
         filename: attachment.filename,
         content_type: attachment.contentType,
         size: buffer.length,
+        ...(tempFileUrl ? {} : { content_base64: buffer.toString('base64') }),
       },
     };
   }

--- a/skills/email-download-attachment/skill.json
+++ b/skills/email-download-attachment/skill.json
@@ -10,8 +10,8 @@
     "account": "string? (named account to read from, as configured in channel_accounts.email. Defaults to the primary account.)"
   },
   "outputs": {
-    "content_base64": "string (base64-encoded file content, ready to pass to file-parse)",
     "temp_file_url": "string | undefined (file:// URL of the downloaded bytes on disk — for binary-safe Drive uploads, pass this as create_drive_file's fileUrl param and use the `filename` field as the file_name param to preserve the original attachment name)",
+    "content_base64": "string | undefined (base64-encoded file content — only included when temp_file_url is unavailable, to avoid exceeding the skill output size limit)",
     "filename": "string (original attachment filename)",
     "content_type": "string (MIME type, e.g. 'application/pdf')",
     "size": "number (actual byte count after download)"


### PR DESCRIPTION
## Summary

- `content_base64` was listed first in the download skill result JSON — for files >~150KB, the base64 encoding (~214KB) exceeded the ~200K skill output truncation limit
- The truncated JSON failed to parse, destroying `temp_file_url` and all other fields after `content_base64`
- Agents never saw `temp_file_url` and fell back to passing the truncated base64 via `content`, producing corrupted Drive files
- Fix: omit `content_base64` entirely when `temp_file_url` is available — the temp file has the raw bytes for Drive uploads; `content_base64` is only included as a fallback when temp storage is down
- Both `email-download-attachment` and `ceo-inbox-download-attachment` updated
- Skill.json output docs updated to reflect `content_base64` is now conditional

Follow-up to #631 and #634.

## Test plan

- [x] All 21 handler tests pass for both download skills
- [ ] Deploy and email Curia a >150KB attachment asking to save to Drive
- [ ] Verify `temp_file_url` is present in the skill result (not truncated)
- [ ] Verify the uploaded Drive file is valid binary, not base64 text

### Follow-up

- Update `file-parse` to accept `temp_file_url` as an alternative to `content_base64` so parsing works without a separate download call