### PR TITLE
fix: migration 042 — cancel stale T2125 declarative job after cron change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`T2125-expense-tracker` scheduler** — migration 042 cancels the stale `*/30 * * * *` declarative job row left behind when the enrichment cron was narrowed to the 6 am–6 pm window; without this, both expressions fire in parallel. (#623)
+
 ## [0.29.0] — 2026-05-19 — "Naomi Nagata"
 
 > **Naomi Nagata** *(The Expanse, 2011, James S.A. Corey)* — chief engineer of the Rocinante: she keeps disparate systems integrated, monitors ship health, and is always the first to notice when something is about to break. This release consolidates the CEO inbox into core, adds self-monitoring alerts for broken and stuck jobs, and hardens the engineering foundation with security scanning and proper binary file handling.

--- a/src/db/migrations/042_cancel_stale_t2125_enrichment_cron.sql
+++ b/src/db/migrations/042_cancel_stale_t2125_enrichment_cron.sql
@@ -1,0 +1,17 @@
+-- Cancel the stale T2125 enrichment cron row left behind by the dark-period change.
+--
+-- Background: upsertDeclarativeJob matches on (agent_id, cron_expr, task_payload::text).
+-- When the enrichment cron changed from */30 * * * * to */30 6-17 * * *, the old row
+-- was not updated — a new row was created. Without this migration the old all-day row
+-- would keep firing alongside the new time-windowed one.
+--
+-- This migration is idempotent: if the old row was already cancelled or never existed
+-- (e.g. on a fresh install), the UPDATE touches zero rows and succeeds.
+
+UPDATE scheduled_jobs
+   SET status     = 'cancelled',
+       updated_at = now()
+ WHERE agent_id   = 'T2125-expense-tracker'
+   AND cron_expr  = '*/30 * * * *'
+   AND created_by = 'system'
+   AND status IN ('pending', 'failed');

--- a/src/db/migrations/042_cancel_stale_t2125_enrichment_cron.sql
+++ b/src/db/migrations/042_cancel_stale_t2125_enrichment_cron.sql
@@ -9,9 +9,8 @@
 -- (e.g. on a fresh install), the UPDATE touches zero rows and succeeds.
 
 UPDATE scheduled_jobs
-   SET status     = 'cancelled',
-       updated_at = now()
- WHERE agent_id   = 'T2125-expense-tracker'
+   SET status = 'cancelled'
+ WHERE agent_id = 'T2125-expense-tracker'
    AND cron_expr  = '*/30 * * * *'
    AND created_by = 'system'
    AND status IN ('pending', 'failed');


### PR DESCRIPTION
## Summary

- Adds migration `042_cancel_stale_t2125_enrichment_cron.sql` to cancel the `*/30 * * * *` declarative job row for `T2125-expense-tracker` that was left in `pending` status when the enrichment cron was updated.

**Why this is needed:** `upsertDeclarativeJob` matches on `(agent_id, cron_expr, task_payload::text)`. Changing only `cron_expr` creates a new row rather than updating the old one. Without this migration both expressions fire in parallel indefinitely.

The migration is idempotent — if the old row was already cancelled or never existed (fresh install), the UPDATE touches zero rows and succeeds.

**Deploy order:** merge/apply this migration alongside or before the companion curia-deploy PR that changes the cron expression.

## Test plan

- [ ] Confirm migration applies cleanly on a DB with the old row present — `status` flips to `cancelled`, no error
- [ ] Confirm migration is a no-op on a fresh DB — zero rows affected, no error
- [ ] After both PRs are deployed: confirm only the `*/30 6-17 * * *` row is in `pending` status for `T2125-expense-tracker`