### PR TITLE
feat: extend time context injection to all agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **Time context injection** — extended from coordinator-only to all agents; specialists now receive the `## Current Date & Time` block on every task turn, enabling reliable time-sensitive reasoning in scheduled agents.
+
 ## [0.29.0] — 2026-05-19 — "Naomi Nagata"
 
 > **Naomi Nagata** *(The Expanse, 2011, James S.A. Corey)* — chief engineer of the Rocinante: she keeps disparate systems integrated, monitors ship health, and is always the first to notice when something is about to break. This release consolidates the CEO inbox into core, adds self-monitoring alerts for broken and stuck jobs, and hardens the engineering foundation with security scanning and proper binary file handling.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1137,10 +1137,11 @@ async function main(): Promise<void> {
       // Use role (same predicate as interpolateRuntimeContext above) so both
       // branches stay in sync if the coordinator YAML is ever reconfigured.
       autonomyService: agentConfig.role === 'coordinator' ? autonomyService : undefined,
-      // The coordinator gets per-turn time block injection so the date/timezone are
-      // always current. Specialist agents don't need this — they work with
-      // structured data, not user-facing time references.
-      timezone: agentConfig.role === 'coordinator' ? config.timezone : undefined,
+      // All agents receive per-turn time block injection so the current date/time
+      // and timezone are always accurate. Specialists need this too — scheduled
+      // agents in particular make time-sensitive decisions (backoff gates, date
+      // comparisons) that require a reliable "now".
+      timezone: config.timezone,
       // The coordinator gets per-turn identity block injection via officeIdentityService.
       // This replaces the ${office_identity_block} placeholder in the system prompt on
       // every task, so identity hot-reloads (file watcher or API PUT) take effect on the

--- a/src/time/time-context.ts
+++ b/src/time/time-context.ts
@@ -1,8 +1,9 @@
 // time-context.ts — helpers for injecting current date/time into agent system prompts.
 //
 // Called once per task turn (not at bootstrap) so the date never goes stale.
-// The coordinator's runtime appends formatTimeContextBlock() to the system prompt
-// on every processTask() call — mirroring the autonomy block pattern.
+// All agent runtimes append formatTimeContextBlock() to the system prompt on every
+// processTask() call — mirroring the autonomy block pattern. Specialists need this
+// too: scheduled agents make time-sensitive decisions that require a reliable "now".
 
 import { DateTime } from 'luxon';
 


### PR DESCRIPTION
## Summary

Removes the `role === 'coordinator'` guard on `timezone` in `index.ts`, so all agents — not just the coordinator — receive the `## Current Date & Time` block appended to their system prompt on every task turn.

The original assumption ("specialists work with structured data, not user-facing time references") broke in practice: scheduled specialist agents like `T2125-expense-tracker` make time-sensitive decisions (backoff gate comparisons, ISO timestamp writes) that require a reliable injected "now". Without this, those agents fall back on training-cutoff approximations.

Companion to curia-deploy#55 (T2125 dark period + idle backoff).

## Test plan

- [ ] Spot-check a specialist agent task in the audit log — confirm the system prompt includes `## Current Date & Time` with the correct local time
- [ ] Coordinator behaviour unchanged — still receives the block as before
- [ ] No performance regression (block is ~4 lines; token impact is negligible)