### PR TITLE
feat: consolidate model metadata into ModelRegistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 
 - **Time context injection** — extended from coordinator-only to all agents; specialists now receive the `## Current Date & Time` block on every task turn, enabling reliable time-sensitive reasoning in scheduled agents.
-- **Model registry** — consolidated scattered model metadata (pricing, context windows, capabilities) into a single `ModelRegistry` in `src/agents/llm/model-registry.ts`. (#556)
-- **`model_routing` config** — tier definitions no longer include `provider` (resolved from registry); `autonomy_scoring.model` renamed to `.model_tier`.
-- **`extract-facts`, `extract-relationships`, `file-parse`** — migrated from raw Anthropic SDK to shared `LLMProvider` via SkillContext capabilities; LLM calls now appear in cost telemetry. (#556)
+- **Model registry** — centralised pricing, context windows, and capabilities in `ModelRegistry`. (#556)
+- **`model_routing` config** — removed tier `provider`; renamed `autonomy_scoring.model` to `model_tier`.
+- **Skill LLM abstraction** — migrated `extract-facts`, `extract-relationships`, `file-parse` to `LLMProvider` via SkillContext; LLM calls now emit telemetry. (#556)
 
 ## [0.29.0] — 2026-05-19 — "Naomi Nagata"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 
 - **Time context injection** — extended from coordinator-only to all agents; specialists now receive the `## Current Date & Time` block on every task turn, enabling reliable time-sensitive reasoning in scheduled agents.
-- **`extract-facts`** — migrated from raw Anthropic SDK to shared `LLMProvider` + `ModelRouter`; LLM calls now go through telemetry/cost tracking infrastructure.
+- **Model registry** — consolidated scattered model metadata (pricing, context windows, capabilities) into a single `ModelRegistry` in `src/agents/llm/model-registry.ts`. (#556)
+- **`model_routing` config** — tier definitions no longer include `provider` (resolved from registry); `autonomy_scoring.model` renamed to `.model_tier`.
+- **`extract-facts`, `extract-relationships`, `file-parse`** — migrated from raw Anthropic SDK to shared `LLMProvider` via SkillContext capabilities; LLM calls now appear in cost telemetry. (#556)
 
 ## [0.29.0] — 2026-05-19 — "Naomi Nagata"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 
 - **Time context injection** — extended from coordinator-only to all agents; specialists now receive the `## Current Date & Time` block on every task turn, enabling reliable time-sensitive reasoning in scheduled agents.
+- **`extract-facts`** — migrated from raw Anthropic SDK to shared `LLMProvider` + `ModelRouter`; LLM calls now go through telemetry/cost tracking infrastructure.
 
 ## [0.29.0] — 2026-05-19 — "Naomi Nagata"
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,17 +1,14 @@
 # Capability-tier model routing (ADR-014).
 # Agents declare a tier (fast | standard | powerful) — this config maps each
-# tier to a concrete provider + model. Change these values to upgrade all
-# agents of a tier in one place, or route tiers through different providers.
+# tier to a concrete model. The provider is resolved from the model registry.
+# Change these values to upgrade all agents of a tier in one place.
 model_routing:
   tiers:
     fast:
-      provider: anthropic
       model: claude-haiku-4-5
     standard:
-      provider: anthropic
       model: claude-sonnet-4-6
     powerful:
-      provider: anthropic
       model: claude-opus-4-6
   default_tier: standard
 
@@ -270,7 +267,7 @@ dreaming:
   # autonomy score ±5 via a delta formula.
   autonomy_scoring:
     intervalMs: 86400000          # daily (same cadence as decay)
-    model: "claude-haiku-4-5"     # cheaper model for the LLM judge
+    model_tier: fast              # tier for the LLM judge (resolved via ModelRouter)
     batchSize: 50                 # max rows scored per pass
     minScoredActions: 30          # minimum before any adjustment fires
     halfLifeDays: 30              # time-decay half-life for weighting

--- a/docs/wip/2026-05-19-model-registry-design.md
+++ b/docs/wip/2026-05-19-model-registry-design.md
@@ -39,8 +39,8 @@ Single source of truth for model metadata. Defines the following types and expor
 interface ModelPricing {
   inputPerMToken: number;
   outputPerMToken: number;
-  cacheCreationPerMToken: number;
-  cacheReadPerMToken: number;
+  cacheCreationPerMToken?: number;  // undefined = model doesn't support caching
+  cacheReadPerMToken?: number;      // undefined = model doesn't support caching
 }
 
 interface ModelMetadata {
@@ -96,8 +96,9 @@ model_routing:
 Changes from current config:
 - **`provider` field removed from tier config.** Provider is a property of the model in the
   registry, not declared per-tier. Eliminates the possibility of a provider/model mismatch.
-- **`autonomy_scoring.model` becomes `autonomy_scoring.tier: fast`.** Resolved through
-  `ModelRouter` like everything else.
+- **`autonomy_scoring.model` becomes `autonomy_scoring.model_tier: fast`.** Resolved through
+  `ModelRouter` like everything else. Named `model_tier` (not just `tier`) for clarity in
+  a config file that also defines tier mappings elsewhere.
 
 ### Consumer migration
 
@@ -125,13 +126,16 @@ validation TODO gets the data structure it needs but enforcement is deferred to 
 `providerRegistry.get('anthropic')` to
 `providerRegistry.get(modelRegistry.getProvider(resolvedModel))`.
 
-**Skill handlers (`extract-facts`, `extract-relationships`, `file-parse`)** — these currently
-construct their own raw `Anthropic` SDK clients via `ctx.secret('ANTHROPIC_API_KEY')` and
-hardcode model IDs. The migration uses Curia's existing SkillContext capability system:
+**Skill handlers (`extract-facts`, `extract-relationships`, `file-parse`)** — these three
+infrastructure skills currently construct their own raw `Anthropic` SDK clients via
+`ctx.secret('ANTHROPIC_API_KEY')` and hardcode model IDs. The migration uses Curia's existing
+SkillContext capability system:
 
 1. Add `llmProvider` and `modelRouter` as new capabilities in the `SkillContext` interface
    and the `capabilities` allowlist in the skill manifest schema.
-2. Each skill's `skill.json` declares `"capabilities": ["llmProvider", "modelRouter"]`.
+2. Only these three infrastructure skills' `skill.json` files declare
+   `"capabilities": ["llmProvider", "modelRouter"]`. No other skills need or should
+   request these capabilities.
 3. The execution layer injects the shared `LLMProvider` instance and `ModelRouter` into
    `SkillContext` at invocation time (same pattern as `bus`, `agentRegistry`, etc.).
 4. Handlers replace `new Anthropic()` + hardcoded model IDs with:
@@ -147,10 +151,16 @@ This brings all three skills' LLM calls into the telemetry/cost-tracking path (t
 bypass `llm.call` bus events entirely).
 
 Note: `llmProvider` and `modelRouter` are new additions to the SkillContext public API surface.
-This is a backwards-compatible addition (new optional properties).
+This is a backwards-compatible addition (new optional properties). However, exposing direct
+LLM access through the skill capability system is a pragmatic choice, not an ideal one —
+any skill author could declare these capabilities and get unsandboxed LLM access. A follow-up
+issue will explore redesigning these three infrastructure skills to eliminate the need for
+`llmProvider` and `modelRouter` on the SkillContext surface (e.g., promoting them out of the
+skill system, or providing a more constrained LLM access pattern). See the follow-up issue
+linked in the Out of Scope section.
 
-**`autonomy/scoring-pass.ts`** — stops accepting a model string. Receives a tier (from config)
-and resolves via `ModelRouter`.
+**`autonomy/scoring-pass.ts`** — stops accepting a model string. Receives a `model_tier`
+(from config) and resolves via `ModelRouter`.
 
 **`memory/working-memory.ts` and `scheduler/drift-detector.ts`** — currently call
 `provider.chat()` with no model override. They get an explicit tier config (defaulting to
@@ -198,6 +208,10 @@ model IDs (`claude-haiku-4-5-20251001`) to resolve without being listed explicit
   but no other changes to their logic.
 - **`maxOutputTokens` per-model tuning** — field exists in `ModelMetadata`, all models start
   at 4096. Per-model tuning is a future concern.
+- **Redesigning infrastructure skill LLM access (#637)** — the `llmProvider` and `modelRouter`
+  SkillContext capabilities are a pragmatic stopgap. #637 will explore better patterns
+  (e.g., promoting these skills out of the skill system, or a constrained LLM access layer)
+  to avoid exposing direct LLM access on the public skill API surface.
 
 ## Files affected
 
@@ -212,8 +226,8 @@ model IDs (`claude-haiku-4-5-20251001`) to resolve without being listed explicit
 - `src/agents/llm/anthropic.ts` — remove hardcoded model fallback, use registry for `maxOutputTokens`
 - `src/agents/runtime.ts` — switch to registry-backed lookups, provider resolution via registry
 - `src/index.ts` — new startup wiring, validation chain, autonomy scoring tier config
-- `src/config.ts` — update `YamlConfig` types (`TierConfig` without `provider`, `autonomy_scoring.tier` replacing `.model`)
-- `config/default.yaml` — simplify tier config, change `autonomy_scoring.model` to `.tier`
+- `src/config.ts` — update `YamlConfig` types (`TierConfig` without `provider`, `autonomy_scoring.model_tier` replacing `.model`)
+- `config/default.yaml` — simplify tier config, change `autonomy_scoring.model` to `.model_tier`
 - `src/skills/types.ts` — add `llmProvider` and `modelRouter` optional properties to `SkillContext`
 - `src/skills/execution-layer.ts` (or equivalent) — inject `llmProvider` and `modelRouter` into context for capable skills
 - `skills/extract-facts/handler.ts` — remove raw SDK client, use `ctx.llmProvider` + `ctx.modelRouter`

--- a/docs/wip/2026-05-19-model-registry-design.md
+++ b/docs/wip/2026-05-19-model-registry-design.md
@@ -1,0 +1,227 @@
+# Model Registry Consolidation
+
+**Issue:** [#556](https://github.com/josephfung/curia/issues/556)
+**Related:** [#379](https://github.com/josephfung/curia/issues/379) (OpenRouter multi-model support)
+**Date:** 2026-05-19
+
+## Problem
+
+Model metadata is scattered across five independent locations:
+
+| Location | What it stores |
+|----------|---------------|
+| `src/agents/llm/pricing.ts` | Per-model token costs (input, output, cache creation, cache read) |
+| `src/agents/llm/token-estimator.ts` | Context window sizes, `DEFAULT_MODEL_NAME` constant |
+| `config/default.yaml` → `model_routing.tiers` | Tier-to-model mapping with redundant `provider` field |
+| `config/default.yaml` → `autonomy_scoring.model` | Hardcoded model ID outside the tier system |
+| `src/agents/llm/anthropic.ts` line 109 | Hardcoded sonnet fallback |
+
+Additionally, three skill handlers (`extract-facts`, `extract-relationships`, `file-parse`)
+construct their own raw `Anthropic` SDK clients with hardcoded model IDs, bypassing the
+`LLMProvider` abstraction and cost telemetry entirely.
+
+The same three model IDs (`claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`) appear
+independently in each location. A model rename requires touching all of them. There is no
+cross-check that pricing and context window maps cover the same models.
+
+## Decision
+
+### Separation of concerns
+
+- **TypeScript registry** = what models Curia officially supports (developer concern, compile-time safety)
+- **YAML config** = which models this deployment uses for which tiers (operator concern, runtime config)
+
+### New module: `src/agents/llm/model-registry.ts`
+
+Single source of truth for model metadata. Defines the following types and exports:
+
+```typescript
+interface ModelPricing {
+  inputPerMToken: number;
+  outputPerMToken: number;
+  cacheCreationPerMToken: number;
+  cacheReadPerMToken: number;
+}
+
+interface ModelMetadata {
+  provider: string;              // 'anthropic', 'openrouter', etc.
+  contextWindow: number;         // max tokens
+  pricing: ModelPricing;
+  capabilities: string[];        // 'vision', 'reasoning', 'coding', etc.
+  maxOutputTokens?: number;      // default 4096 if unset
+}
+```
+
+The `MODEL_REGISTRY` constant is a `Record<string, ModelMetadata>` keyed by base model name
+prefix. It contains the three current Anthropic models. Entries are pre-sorted by key length
+descending at module level to preserve the existing prefix-match strategy (longer, more specific
+prefixes win — so `claude-haiku-4-5-20251001` matches `claude-haiku-4-5`).
+
+The `ModelRegistry` class wraps lookup methods:
+
+- `getModel(modelId: string): ModelMetadata | undefined` — prefix-match lookup
+- `getContextWindow(modelId: string): number` — replaces `token-estimator.ts`'s function
+- `getPricing(modelId: string): ModelPricing | undefined` — replaces `pricing.ts`'s internal lookup
+- `getProvider(modelId: string): string | undefined` — resolves provider from model name
+- `isKnownModel(modelId: string): boolean` — replaces `isKnownContextWindowModel()`
+
+Instantiated once at startup, passed to consumers via constructor injection.
+
+### Capabilities schema
+
+The registry includes a `capabilities` string array per model, populated with what is true
+today (e.g., all Anthropic models get `vision`, none get `image_generation`). The capability
+vocabulary follows ADR-014: `vision`, `large_context`, `reasoning`, `coding`, `audio`,
+`image_generation`.
+
+The `needs`-based validation in `ModelRouter.resolve()` is **not** implemented in this issue —
+the data structure is ready for #379 to wire up enforcement. The existing TODO stays.
+
+### YAML config changes
+
+`config/default.yaml` `model_routing` section simplifies:
+
+```yaml
+model_routing:
+  tiers:
+    fast:
+      model: claude-haiku-4-5
+    standard:
+      model: claude-sonnet-4-6
+    powerful:
+      model: claude-opus-4-6
+  default_tier: standard
+```
+
+Changes from current config:
+- **`provider` field removed from tier config.** Provider is a property of the model in the
+  registry, not declared per-tier. Eliminates the possibility of a provider/model mismatch.
+- **`autonomy_scoring.model` becomes `autonomy_scoring.tier: fast`.** Resolved through
+  `ModelRouter` like everything else.
+
+### Consumer migration
+
+**`pricing.ts`** — `ANTHROPIC_PRICING` constant and prefix-match logic deleted.
+`estimateCostUsd()` is rewritten to look up pricing from a `ModelRegistry` instance. The
+registry is injected at module level (the function is constructed with a registry reference
+at startup), not passed per-call — so the call signature for callers (`estimateCostUsd(model,
+usage, logger)`) stays the same.
+
+**`token-estimator.ts`** — `CONTEXT_WINDOWS`, `getContextWindow()`,
+`isKnownContextWindowModel()`, and `DEFAULT_MODEL_NAME` all deleted. Callers switch to
+`modelRegistry.getContextWindow(modelId)`. The `DEFAULT_MODEL_NAME` concept goes away — the
+default is `modelRouter.resolve()` with no tier argument (uses `default_tier` from config).
+
+**`anthropic.ts`** — hardcoded `'claude-sonnet-4-6'` fallback on line 109 removed. Model is
+always passed explicitly by the runtime (which already does this). Hardcoded `maxTokens: 4096`
+becomes `modelRegistry.getModel(model)?.maxOutputTokens ?? 4096`.
+
+**`model-router.ts`** — `TierConfig` drops the `provider` field. `resolve()` returns
+`{ model, tier }` and the runtime looks up the provider from the registry. The `needs`
+validation TODO gets the data structure it needs but enforcement is deferred to #379.
+
+**`runtime.ts`** — minimal changes. Already calls `getContextWindow()` and
+`estimateCostUsd()` — those get backed by the registry. Provider lookup changes from
+`providerRegistry.get('anthropic')` to
+`providerRegistry.get(modelRegistry.getProvider(resolvedModel))`.
+
+**Skill handlers (`extract-facts`, `extract-relationships`, `file-parse`)** — these currently
+construct their own raw `Anthropic` SDK clients via `ctx.secret('ANTHROPIC_API_KEY')` and
+hardcode model IDs. The migration uses Curia's existing SkillContext capability system:
+
+1. Add `llmProvider` and `modelRouter` as new capabilities in the `SkillContext` interface
+   and the `capabilities` allowlist in the skill manifest schema.
+2. Each skill's `skill.json` declares `"capabilities": ["llmProvider", "modelRouter"]`.
+3. The execution layer injects the shared `LLMProvider` instance and `ModelRouter` into
+   `SkillContext` at invocation time (same pattern as `bus`, `agentRegistry`, etc.).
+4. Handlers replace `new Anthropic()` + hardcoded model IDs with:
+   ```typescript
+   const classifierModel = ctx.modelRouter!.resolve('fast').model;
+   const extractionModel = ctx.modelRouter!.resolve('standard').model;
+   const response = await ctx.llmProvider!.chat({ model: classifierModel, messages: [...] });
+   ```
+5. The `@anthropic-ai/sdk` import and `CLASSIFIER_MODEL` / `EXTRACTION_MODEL` constants
+   are removed from each handler.
+
+This brings all three skills' LLM calls into the telemetry/cost-tracking path (they currently
+bypass `llm.call` bus events entirely).
+
+Note: `llmProvider` and `modelRouter` are new additions to the SkillContext public API surface.
+This is a backwards-compatible addition (new optional properties).
+
+**`autonomy/scoring-pass.ts`** — stops accepting a model string. Receives a tier (from config)
+and resolves via `ModelRouter`.
+
+**`memory/working-memory.ts` and `scheduler/drift-detector.ts`** — currently call
+`provider.chat()` with no model override. They get an explicit tier config (defaulting to
+`standard`) so the model is intentional rather than an implicit provider default.
+
+### Startup wiring and validation
+
+In `src/index.ts`, the startup sequence becomes:
+
+1. **Instantiate `ModelRegistry`** — `new ModelRegistry(logger)`. Static TypeScript data,
+   no config needed.
+2. **Instantiate `ModelRouter`** — `new ModelRouter(yamlConfig.model_routing, modelRegistry, logger)`.
+   At construction, validates every tier's `model` exists in the registry. Unknown model →
+   fail-fast.
+3. **Build `providerRegistry`** — `Map<string, LLMProvider>` keyed by provider IDs from the
+   registry (currently just `'anthropic'`). When #379 lands, `'openrouter'` gets a second entry.
+4. **Validate completeness** — after building the provider registry, check that every provider
+   referenced by any model in the registry has a corresponding entry in `providerRegistry`.
+   Catches the case where a model declares `provider: 'openrouter'` but the API key is missing
+   or the provider isn't instantiated.
+5. **Resolve agents** — same loop. `modelRouter.resolve(tier, needs)` → `{ model, tier }`.
+   Runtime looks up provider via `modelRegistry.getProvider(model)` → `providerRegistry.get(id)`.
+
+Validation order: registry (static) → router (tiers against registry) → provider registry
+(providers instantiated) → agent resolution (needs against capabilities, deferred to #379).
+
+### Prefix-match strategy
+
+The existing prefix-matching behavior from `pricing.ts` and `token-estimator.ts` is preserved.
+Registry keys are base model names (`claude-haiku-4-5`). Lookups use `startsWith` matching,
+with entries pre-sorted by key length descending so longer prefixes win. This allows versioned
+model IDs (`claude-haiku-4-5-20251001`) to resolve without being listed explicitly.
+
+## Out of scope
+
+- **`needs` enforcement in `ModelRouter.resolve()`** — registry provides capabilities data,
+  but warning/failing on unmet needs is deferred to #379.
+- **OpenRouter models in the registry** — no entries until #379 adds the provider. Schema
+  supports `provider: 'openrouter'` from day one.
+- **OpenAI direct usages** (DALL-E image generation, text-embedding-3-small for knowledge
+  graph, GPT-4o smoke test judge) — different API surfaces, not part of the
+  `LLMProvider.chat()` path. These stay as-is.
+- **Skill handler logic changes beyond model migration** — `extract-facts`,
+  `extract-relationships`, and `file-parse` get migrated to shared provider and tier routing
+  but no other changes to their logic.
+- **`maxOutputTokens` per-model tuning** — field exists in `ModelMetadata`, all models start
+  at 4096. Per-model tuning is a future concern.
+
+## Files affected
+
+### New files
+- `src/agents/llm/model-registry.ts` — registry module, types, and class
+- `src/agents/llm/model-registry.test.ts` — unit tests
+
+### Modified files
+- `src/agents/llm/pricing.ts` — delete `ANTHROPIC_PRICING`, rewrite `estimateCostUsd()` to use registry
+- `src/agents/llm/token-estimator.ts` — delete `CONTEXT_WINDOWS`, `getContextWindow()`, `isKnownContextWindowModel()`, `DEFAULT_MODEL_NAME`
+- `src/agents/llm/model-router.ts` — drop `provider` from `TierConfig`, accept `ModelRegistry` in constructor
+- `src/agents/llm/anthropic.ts` — remove hardcoded model fallback, use registry for `maxOutputTokens`
+- `src/agents/runtime.ts` — switch to registry-backed lookups, provider resolution via registry
+- `src/index.ts` — new startup wiring, validation chain, autonomy scoring tier config
+- `src/config.ts` — update `YamlConfig` types (`TierConfig` without `provider`, `autonomy_scoring.tier` replacing `.model`)
+- `config/default.yaml` — simplify tier config, change `autonomy_scoring.model` to `.tier`
+- `src/skills/types.ts` — add `llmProvider` and `modelRouter` optional properties to `SkillContext`
+- `src/skills/execution-layer.ts` (or equivalent) — inject `llmProvider` and `modelRouter` into context for capable skills
+- `skills/extract-facts/handler.ts` — remove raw SDK client, use `ctx.llmProvider` + `ctx.modelRouter`
+- `skills/extract-facts/skill.json` — add `capabilities: ["llmProvider", "modelRouter"]`
+- `skills/extract-relationships/handler.ts` — same migration
+- `skills/extract-relationships/skill.json` — add capabilities
+- `skills/file-parse/handler.ts` — same migration
+- `skills/file-parse/skill.json` — add capabilities
+- `src/autonomy/scoring-pass.ts` — accept tier instead of model string
+- `src/memory/working-memory.ts` — add explicit tier/model config
+- `src/scheduler/drift-detector.ts` — add explicit tier/model config

--- a/docs/wip/2026-05-19-model-registry.md
+++ b/docs/wip/2026-05-19-model-registry.md
@@ -1,0 +1,1647 @@
+# Model Registry Consolidation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate scattered model metadata (pricing, context windows, capabilities) into a single TypeScript registry, and migrate all consumers to use it.
+
+**Architecture:** A new `ModelRegistry` class in `src/agents/llm/model-registry.ts` becomes the single source of truth. `pricing.ts` and `token-estimator.ts` shed their model-specific data. `ModelRouter` drops its redundant `provider` field and validates tiers against the registry. Three infrastructure skill handlers are migrated from raw Anthropic SDK clients to the shared `LLMProvider` via SkillContext capabilities.
+
+**Tech Stack:** TypeScript, Vitest, YAML config
+
+**Spec:** `docs/wip/2026-05-19-model-registry-design.md`
+
+---
+
+## File Map
+
+### New files
+| File | Responsibility |
+|------|---------------|
+| `src/agents/llm/model-registry.ts` | ModelMetadata types, MODEL_REGISTRY data, ModelRegistry class |
+| `src/agents/llm/model-registry.test.ts` | Unit tests for ModelRegistry |
+
+### Modified files
+| File | What changes |
+|------|-------------|
+| `src/agents/llm/pricing.ts` | Delete ANTHROPIC_PRICING; estimateCostUsd delegates to registry |
+| `src/agents/llm/pricing.test.ts` | Update to inject registry |
+| `src/agents/llm/token-estimator.ts` | Delete CONTEXT_WINDOWS, getContextWindow, isKnownContextWindowModel, DEFAULT_MODEL_NAME |
+| `src/agents/llm/model-router.ts` | TierConfig drops provider; constructor accepts ModelRegistry; ResolvedModel drops provider |
+| `src/agents/llm/model-router.test.ts` | Update config shape and assertions |
+| `src/agents/llm/anthropic.ts` | Remove hardcoded model fallback; accept ModelRegistry for maxOutputTokens |
+| `src/agents/runtime.ts` | Use registry for context window + cost; resolve provider via registry |
+| `src/index.ts` | New startup wiring: registry → router → provider registry → validation |
+| `src/config.ts` | TierConfig without provider; autonomy_scoring.model_tier replacing .model |
+| `config/default.yaml` | Simplify tier config (drop provider); change autonomy_scoring.model to .model_tier |
+| `src/skills/types.ts` | Add llmProvider and modelRouter to SkillContext |
+| `src/skills/loader.ts` | Add llmProvider and modelRouter to VALID_CAPABILITIES |
+| `src/skills/execution.ts` | Inject llmProvider and modelRouter for capable skills |
+| `skills/extract-facts/handler.ts` | Use ctx.llmProvider + ctx.modelRouter instead of raw SDK |
+| `skills/extract-facts/skill.json` | Add capabilities |
+| `skills/extract-relationships/handler.ts` | Same migration |
+| `skills/extract-relationships/skill.json` | Add capabilities |
+| `skills/file-parse/handler.ts` | Same migration |
+| `skills/file-parse/skill.json` | Add capabilities |
+| `src/autonomy/scoring-pass.ts` | Accept model_tier instead of model string |
+| `src/memory/working-memory.ts` | Add model to SummarizationConfig; pass to provider.chat |
+| `src/scheduler/drift-detector.ts` | Accept model string; pass to provider.chat |
+
+---
+
+## Task 1: Create ModelRegistry module with tests (TDD)
+
+**Files:**
+- Create: `src/agents/llm/model-registry.ts`
+- Create: `src/agents/llm/model-registry.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+```typescript
+// src/agents/llm/model-registry.test.ts
+import { describe, it, expect } from 'vitest';
+import { ModelRegistry } from './model-registry.js';
+import { createSilentLogger } from '../../logger.js';
+
+describe('ModelRegistry', () => {
+  const registry = new ModelRegistry(createSilentLogger());
+
+  describe('getModel', () => {
+    it('returns metadata for an exact model name', () => {
+      const meta = registry.getModel('claude-sonnet-4-6');
+      expect(meta).toBeDefined();
+      expect(meta!.provider).toBe('anthropic');
+      expect(meta!.contextWindow).toBe(200_000);
+      expect(meta!.pricing.inputPerMToken).toBe(3.0);
+    });
+
+    it('matches versioned model names by prefix', () => {
+      const meta = registry.getModel('claude-haiku-4-5-20251001');
+      expect(meta).toBeDefined();
+      expect(meta!.provider).toBe('anthropic');
+      expect(meta!.pricing.inputPerMToken).toBe(0.80);
+    });
+
+    it('returns undefined for unknown models', () => {
+      expect(registry.getModel('unknown-model')).toBeUndefined();
+    });
+
+    it('prefers longer prefix matches', () => {
+      // 'claude-sonnet-4-6' should not match 'claude-opus-4-6'
+      const meta = registry.getModel('claude-sonnet-4-6-preview');
+      expect(meta).toBeDefined();
+      expect(meta!.pricing.inputPerMToken).toBe(3.0); // sonnet pricing, not opus
+    });
+  });
+
+  describe('getContextWindow', () => {
+    it('returns context window for a known model', () => {
+      expect(registry.getContextWindow('claude-opus-4-6')).toBe(200_000);
+    });
+
+    it('returns context window for a versioned model name', () => {
+      expect(registry.getContextWindow('claude-haiku-4-5-20251001')).toBe(200_000);
+    });
+
+    it('returns 0 for unknown models', () => {
+      expect(registry.getContextWindow('unknown-model')).toBe(0);
+    });
+  });
+
+  describe('getPricing', () => {
+    it('returns pricing for a known model', () => {
+      const pricing = registry.getPricing('claude-haiku-4-5');
+      expect(pricing).toBeDefined();
+      expect(pricing!.inputPerMToken).toBe(0.80);
+      expect(pricing!.outputPerMToken).toBe(4.00);
+      expect(pricing!.cacheCreationPerMToken).toBe(1.00);
+      expect(pricing!.cacheReadPerMToken).toBe(0.08);
+    });
+
+    it('returns undefined for unknown models', () => {
+      expect(registry.getPricing('unknown-model')).toBeUndefined();
+    });
+  });
+
+  describe('getProvider', () => {
+    it('returns provider for a known model', () => {
+      expect(registry.getProvider('claude-sonnet-4-6')).toBe('anthropic');
+    });
+
+    it('returns undefined for unknown models', () => {
+      expect(registry.getProvider('unknown-model')).toBeUndefined();
+    });
+  });
+
+  describe('isKnownModel', () => {
+    it('returns true for exact match', () => {
+      expect(registry.isKnownModel('claude-sonnet-4-6')).toBe(true);
+    });
+
+    it('returns true for prefix match', () => {
+      expect(registry.isKnownModel('claude-haiku-4-5-20251001')).toBe(true);
+    });
+
+    it('returns false for unknown models', () => {
+      expect(registry.isKnownModel('unknown-model')).toBe(false);
+    });
+  });
+
+  describe('all three Anthropic models are registered', () => {
+    it.each([
+      'claude-opus-4-6',
+      'claude-sonnet-4-6',
+      'claude-haiku-4-5',
+    ])('%s is registered with provider, pricing, contextWindow, and capabilities', (model) => {
+      const meta = registry.getModel(model);
+      expect(meta).toBeDefined();
+      expect(meta!.provider).toBe('anthropic');
+      expect(meta!.contextWindow).toBeGreaterThan(0);
+      expect(meta!.pricing.inputPerMToken).toBeGreaterThan(0);
+      expect(meta!.pricing.outputPerMToken).toBeGreaterThan(0);
+      expect(meta!.capabilities).toContain('vision');
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx --prefix /path/to/worktree vitest run src/agents/llm/model-registry.test.ts`
+Expected: FAIL — `model-registry.js` does not exist yet.
+
+- [ ] **Step 3: Write the ModelRegistry module**
+
+```typescript
+// src/agents/llm/model-registry.ts — single source of truth for model metadata.
+//
+// The TypeScript registry defines what models Curia officially supports (pricing,
+// context windows, capabilities). Deployment-specific config (which tier maps to
+// which model) stays in config/default.yaml.
+//
+// Lookup uses prefix matching: 'claude-haiku-4-5-20251001' matches 'claude-haiku-4-5'.
+// Entries are pre-sorted by key length descending so longer prefixes win.
+
+import type { Logger } from '../../logger.js';
+
+export interface ModelPricing {
+  /** USD per million input tokens */
+  inputPerMToken: number;
+  /** USD per million output tokens */
+  outputPerMToken: number;
+  /** USD per million cache-creation tokens. undefined = model doesn't support caching. */
+  cacheCreationPerMToken?: number;
+  /** USD per million cache-read tokens. undefined = model doesn't support caching. */
+  cacheReadPerMToken?: number;
+}
+
+export interface ModelMetadata {
+  /** Provider identifier ('anthropic', 'openrouter', etc.) */
+  provider: string;
+  /** Maximum context window in tokens */
+  contextWindow: number;
+  /** Token pricing rates */
+  pricing: ModelPricing;
+  /** Model capabilities per ADR-014 vocabulary */
+  capabilities: string[];
+  /** Maximum output tokens per call. Default 4096 if unset. */
+  maxOutputTokens?: number;
+}
+
+// Keyed by model name prefix. When #379 lands, OpenRouter models are added here
+// with provider: 'openrouter'.
+const MODEL_REGISTRY: Record<string, ModelMetadata> = {
+  'claude-opus-4-6': {
+    provider: 'anthropic',
+    contextWindow: 200_000,
+    pricing: {
+      inputPerMToken: 15.00,
+      outputPerMToken: 75.00,
+      cacheCreationPerMToken: 18.75,
+      cacheReadPerMToken: 1.50,
+    },
+    capabilities: ['vision', 'reasoning', 'coding', 'large_context'],
+  },
+  'claude-sonnet-4-6': {
+    provider: 'anthropic',
+    contextWindow: 200_000,
+    pricing: {
+      inputPerMToken: 3.00,
+      outputPerMToken: 15.00,
+      cacheCreationPerMToken: 3.75,
+      cacheReadPerMToken: 0.30,
+    },
+    capabilities: ['vision', 'reasoning', 'coding'],
+  },
+  'claude-haiku-4-5': {
+    provider: 'anthropic',
+    contextWindow: 200_000,
+    pricing: {
+      inputPerMToken: 0.80,
+      outputPerMToken: 4.00,
+      cacheCreationPerMToken: 1.00,
+      cacheReadPerMToken: 0.08,
+    },
+    capabilities: ['vision', 'coding'],
+  },
+};
+
+// Pre-sorted entries for prefix matching — longest prefix wins.
+const SORTED_ENTRIES = Object.entries(MODEL_REGISTRY)
+  .sort(([a], [b]) => b.length - a.length);
+
+/**
+ * Provides typed lookups against the static model registry.
+ *
+ * All lookups use prefix matching: 'claude-haiku-4-5-20251001' resolves to
+ * the 'claude-haiku-4-5' entry. Entries are sorted by key length descending
+ * so longer prefixes take priority.
+ */
+export class ModelRegistry {
+  private readonly logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  /** Look up full metadata for a model. Returns undefined if no prefix matches. */
+  getModel(modelId: string): ModelMetadata | undefined {
+    const entry = SORTED_ENTRIES.find(([prefix]) => modelId.startsWith(prefix));
+    return entry ? entry[1] : undefined;
+  }
+
+  /** Returns context window size in tokens. Returns 0 for unknown models. */
+  getContextWindow(modelId: string): number {
+    return this.getModel(modelId)?.contextWindow ?? 0;
+  }
+
+  /** Returns pricing for the model. Returns undefined for unknown models. */
+  getPricing(modelId: string): ModelPricing | undefined {
+    return this.getModel(modelId)?.pricing;
+  }
+
+  /** Returns the provider identifier for a model. Returns undefined for unknown models. */
+  getProvider(modelId: string): string | undefined {
+    return this.getModel(modelId)?.provider;
+  }
+
+  /** Returns true if the model is in the registry (prefix match). */
+  isKnownModel(modelId: string): boolean {
+    return this.getModel(modelId) !== undefined;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx --prefix /path/to/worktree vitest run src/agents/llm/model-registry.test.ts`
+Expected: All 13 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /path/to/worktree add src/agents/llm/model-registry.ts src/agents/llm/model-registry.test.ts
+git -C /path/to/worktree commit -m "feat: add ModelRegistry with types, data, and prefix-match lookups"
+```
+
+---
+
+## Task 2: Update ModelRouter — drop provider from TierConfig
+
+**Files:**
+- Modify: `src/agents/llm/model-router.ts`
+- Modify: `src/agents/llm/model-router.test.ts`
+
+- [ ] **Step 1: Update the test file first**
+
+Replace the full contents of `src/agents/llm/model-router.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { ModelRouter, type ModelRoutingConfig } from './model-router.js';
+import { ModelRegistry } from './model-registry.js';
+import { createSilentLogger } from '../../logger.js';
+
+const logger = createSilentLogger();
+const registry = new ModelRegistry(logger);
+
+const defaultConfig: ModelRoutingConfig = {
+  tiers: {
+    fast: { model: 'claude-haiku-4-5' },
+    standard: { model: 'claude-sonnet-4-6' },
+    powerful: { model: 'claude-opus-4-6' },
+  },
+  default_tier: 'standard',
+};
+
+describe('ModelRouter', () => {
+  it('resolves fast tier to the configured model', () => {
+    const router = new ModelRouter(defaultConfig, registry, logger);
+    const result = router.resolve('fast');
+    expect(result).toEqual({ model: 'claude-haiku-4-5', tier: 'fast' });
+  });
+
+  it('resolves standard tier to the configured model', () => {
+    const router = new ModelRouter(defaultConfig, registry, logger);
+    const result = router.resolve('standard');
+    expect(result).toEqual({ model: 'claude-sonnet-4-6', tier: 'standard' });
+  });
+
+  it('resolves powerful tier to the configured model', () => {
+    const router = new ModelRouter(defaultConfig, registry, logger);
+    const result = router.resolve('powerful');
+    expect(result).toEqual({ model: 'claude-opus-4-6', tier: 'powerful' });
+  });
+
+  it('throws on unknown tier', () => {
+    const router = new ModelRouter(defaultConfig, registry, logger);
+    expect(() => router.resolve('ultra')).toThrow('Unknown model tier');
+  });
+
+  it('passes needs through without validation', () => {
+    const router = new ModelRouter(defaultConfig, registry, logger);
+    const result = router.resolve('standard', ['vision', 'large_context']);
+    expect(result.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('falls back to default_tier when tier is omitted', () => {
+    const router = new ModelRouter(defaultConfig, registry, logger);
+    const result = router.resolve(undefined);
+    expect(result).toEqual({ model: 'claude-sonnet-4-6', tier: 'standard' });
+  });
+
+  it('throws at construction if a tier config is missing', () => {
+    const config: ModelRoutingConfig = {
+      tiers: {
+        fast: { model: 'claude-haiku-4-5' },
+        standard: { model: 'claude-sonnet-4-6' },
+        // @ts-expect-error — intentionally omitting powerful to test validation
+        powerful: undefined,
+      },
+      default_tier: 'standard',
+    };
+    expect(() => new ModelRouter(config, registry, logger)).toThrow('model_routing.tiers.powerful');
+  });
+
+  it('throws at construction if a tier has empty model', () => {
+    const config: ModelRoutingConfig = {
+      tiers: {
+        fast: { model: 'claude-haiku-4-5' },
+        standard: { model: '' },
+        powerful: { model: 'claude-opus-4-6' },
+      },
+      default_tier: 'standard',
+    };
+    expect(() => new ModelRouter(config, registry, logger)).toThrow('model_routing.tiers.standard');
+  });
+
+  it('throws at construction if a tier references an unknown model', () => {
+    const config: ModelRoutingConfig = {
+      tiers: {
+        fast: { model: 'claude-haiku-4-5' },
+        standard: { model: 'unknown-model-xyz' },
+        powerful: { model: 'claude-opus-4-6' },
+      },
+      default_tier: 'standard',
+    };
+    expect(() => new ModelRouter(config, registry, logger)).toThrow('not found in the model registry');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx --prefix /path/to/worktree vitest run src/agents/llm/model-router.test.ts`
+Expected: FAIL — ModelRouter constructor signature changed, ResolvedModel shape changed.
+
+- [ ] **Step 3: Update model-router.ts**
+
+Replace the full contents of `src/agents/llm/model-router.ts`:
+
+```typescript
+// model-router.ts — resolves capability tiers to concrete models.
+//
+// Agents declare a tier (fast | standard | powerful) in their YAML config.
+// The operator maps tiers to models in config/default.yaml. This class
+// performs the lookup at startup so the runtime knows which model to use.
+// The provider is resolved from the model registry — not declared per-tier.
+//
+// Capability needs (vision, large_context, etc.) are accepted but not
+// validated in this version — they are documentary-only, logged at debug
+// level for observability. Validation deferred to #379.
+
+import type { Logger } from '../../logger.js';
+import type { ModelRegistry } from './model-registry.js';
+
+export type Tier = 'fast' | 'standard' | 'powerful';
+
+export interface TierConfig {
+  model: string;
+}
+
+export interface ModelRoutingConfig {
+  tiers: Record<Tier, TierConfig>;
+  default_tier: Tier;
+}
+
+export interface ResolvedModel {
+  model: string;
+  tier: Tier;
+}
+
+const VALID_TIERS: ReadonlySet<string> = new Set<string>(['fast', 'standard', 'powerful']);
+
+export class ModelRouter {
+  private readonly config: ModelRoutingConfig;
+  private readonly logger: Logger;
+
+  constructor(config: ModelRoutingConfig, registry: ModelRegistry, logger: Logger) {
+    // Eagerly validate all tier configs at construction time so misconfigurations
+    // are caught at startup, not when a specific tier is first resolved.
+    for (const tier of ['fast', 'standard', 'powerful'] as const) {
+      const tc = config.tiers[tier];
+      if (!tc || !tc.model) {
+        throw new Error(
+          `model_routing.tiers.${tier} must have a non-empty "model" field`,
+        );
+      }
+      // Validate that the model exists in the registry — fail-fast on unknown models.
+      if (!registry.isKnownModel(tc.model)) {
+        throw new Error(
+          `model_routing.tiers.${tier}: model "${tc.model}" not found in the model registry`,
+        );
+      }
+    }
+    if (!VALID_TIERS.has(config.default_tier)) {
+      throw new Error(
+        `model_routing.default_tier must be one of ${[...VALID_TIERS].join(', ')}, got: "${config.default_tier}"`,
+      );
+    }
+    this.config = config;
+    this.logger = logger;
+  }
+
+  /**
+   * Resolve a tier (and optional needs) to a concrete model.
+   *
+   * Falls back to `default_tier` from config when tier is omitted.
+   * Throws if the resolved tier is unknown.
+   * `needs` is accepted but not validated; logged at debug level.
+   */
+  resolve(tier?: string, needs?: string[]): ResolvedModel {
+    const effectiveTier = tier ?? this.config.default_tier;
+    if (!VALID_TIERS.has(effectiveTier)) {
+      throw new Error(`Unknown model tier "${effectiveTier}". Valid tiers: ${[...VALID_TIERS].join(', ')}`);
+    }
+
+    const tierConfig = this.config.tiers[effectiveTier as Tier];
+
+    if (needs && needs.length > 0) {
+      // TODO: validate that the resolved model supports the declared needs
+      // when capability validation is implemented (#379).
+      this.logger.debug({ tier: effectiveTier, needs, model: tierConfig.model }, 'Model tier resolved (needs not validated)');
+    } else {
+      this.logger.debug({ tier: effectiveTier, model: tierConfig.model }, 'Model tier resolved');
+    }
+
+    return {
+      model: tierConfig.model,
+      tier: effectiveTier as Tier,
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx --prefix /path/to/worktree vitest run src/agents/llm/model-router.test.ts`
+Expected: All 9 tests PASS (the old "non-anthropic provider" test is replaced by "unknown model" test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /path/to/worktree add src/agents/llm/model-router.ts src/agents/llm/model-router.test.ts
+git -C /path/to/worktree commit -m "feat: ModelRouter drops provider from TierConfig, validates models against registry"
+```
+
+---
+
+## Task 3: Migrate pricing.ts to use ModelRegistry
+
+**Files:**
+- Modify: `src/agents/llm/pricing.ts`
+- Modify: `src/agents/llm/pricing.test.ts`
+
+- [ ] **Step 1: Update pricing.test.ts to inject registry**
+
+Replace the full contents of `src/agents/llm/pricing.test.ts`:
+
+```typescript
+// pricing.test.ts — unit tests for estimateCostUsd.
+//
+// Verifies correct pricing for each supported model, prefix-match for versioned
+// model names, and the unknown-model fallback to sonnet pricing.
+
+import { describe, it, expect, vi } from 'vitest';
+import { createEstimateCostUsd } from './pricing.js';
+import { ModelRegistry } from './model-registry.js';
+import { createSilentLogger } from '../../logger.js';
+import type { LLMUsage } from './provider.js';
+
+const registry = new ModelRegistry(createSilentLogger());
+const estimateCostUsd = createEstimateCostUsd(registry);
+
+// A usage object with known token counts for easy manual cost verification.
+const makeUsage = (overrides: Partial<LLMUsage> = {}): LLMUsage => ({
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheCreationInputTokens: 0,
+  cacheReadInputTokens: 0,
+  ...overrides,
+});
+
+describe('estimateCostUsd', () => {
+  it('calculates cost correctly for claude-sonnet-4-6', () => {
+    // 1000 input @ $3/MTok + 500 output @ $15/MTok + 200 cache-create @ $3.75/MTok + 100 cache-read @ $0.30/MTok
+    // = 0.003 + 0.0075 + 0.00075 + 0.00003 = 0.01128
+    const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 });
+    const cost = estimateCostUsd('claude-sonnet-4-6', usage);
+    expect(cost).toBeCloseTo(0.01128, 8);
+  });
+
+  it('calculates cost correctly for claude-opus-4-6', () => {
+    const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 });
+    const cost = estimateCostUsd('claude-opus-4-6', usage);
+    expect(cost).toBeCloseTo(0.0564, 8);
+  });
+
+  it('calculates cost correctly for claude-haiku-4-5', () => {
+    const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 });
+    const cost = estimateCostUsd('claude-haiku-4-5', usage);
+    expect(cost).toBeCloseTo(0.003008, 8);
+  });
+
+  it('matches haiku pricing by prefix for versioned model names', () => {
+    const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 });
+    const versionedCost = estimateCostUsd('claude-haiku-4-5-20251001', usage);
+    const baseCost = estimateCostUsd('claude-haiku-4-5', usage);
+    expect(versionedCost).toBe(baseCost);
+  });
+
+  it('falls back to sonnet pricing for unrecognised models without crashing', () => {
+    const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 });
+    const fallbackCost = estimateCostUsd('unknown-model-xyz', usage);
+    const sonnetCost = estimateCostUsd('claude-sonnet-4-6', usage);
+    expect(fallbackCost).toBe(sonnetCost);
+  });
+
+  it('logs a warning for unrecognised models', () => {
+    const warnFn = vi.fn();
+    const mockLogger = { warn: warnFn } as never;
+    const usage = makeUsage({ inputTokens: 100 });
+    estimateCostUsd('mystery-model', usage, mockLogger);
+    expect(warnFn).toHaveBeenCalledOnce();
+    expect(warnFn.mock.calls[0]![0]).toMatchObject({ actualModel: 'mystery-model', fallback: 'claude-sonnet-4-6' });
+  });
+
+  it('returns 0 when all token counts are 0', () => {
+    const cost = estimateCostUsd('claude-sonnet-4-6', makeUsage());
+    expect(cost).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx --prefix /path/to/worktree vitest run src/agents/llm/pricing.test.ts`
+Expected: FAIL — `createEstimateCostUsd` does not exist.
+
+- [ ] **Step 3: Rewrite pricing.ts**
+
+Replace the full contents of `src/agents/llm/pricing.ts`:
+
+```typescript
+// pricing.ts — LLM call cost estimation backed by the model registry.
+//
+// createEstimateCostUsd() returns a closure pre-wired with a ModelRegistry
+// instance. The closure's signature is the same as the old estimateCostUsd()
+// so callers don't change.
+//
+// Unrecognised models fall back to the default tier's model pricing with a
+// warn log — a silent zero would make cost dashboards misleading.
+
+import type { Logger } from '../../logger.js';
+import type { LLMUsage } from './provider.js';
+import type { ModelRegistry, ModelPricing } from './model-registry.js';
+
+const FALLBACK_MODEL = 'claude-sonnet-4-6';
+
+/**
+ * Creates an estimateCostUsd function backed by the given model registry.
+ * Call once at startup; use the returned function for all cost estimation.
+ */
+export function createEstimateCostUsd(
+  registry: ModelRegistry,
+): (actualModel: string, usage: LLMUsage, logger?: Logger) => number {
+  return (actualModel: string, usage: LLMUsage, logger?: Logger): number => {
+    let pricing: ModelPricing | undefined = registry.getPricing(actualModel);
+
+    if (!pricing) {
+      logger?.warn({ actualModel, fallback: FALLBACK_MODEL }, 'Unrecognised model — using fallback pricing for cost estimate');
+      pricing = registry.getPricing(FALLBACK_MODEL);
+      if (!pricing) {
+        // Registry doesn't even have the fallback — return 0 to avoid crashing.
+        logger?.warn({ actualModel, fallback: FALLBACK_MODEL }, 'Fallback model also missing from registry — returning $0 cost');
+        return 0;
+      }
+    }
+
+    // Divide by 1_000_000 to convert from per-million-token rate to per-token rate.
+    // Cache fields default to 0 when the model doesn't support caching.
+    return (
+      (usage.inputTokens * pricing.inputPerMToken +
+       usage.outputTokens * pricing.outputPerMToken +
+       usage.cacheCreationInputTokens * (pricing.cacheCreationPerMToken ?? 0) +
+       usage.cacheReadInputTokens * (pricing.cacheReadPerMToken ?? 0)) /
+      1_000_000
+    );
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx --prefix /path/to/worktree vitest run src/agents/llm/pricing.test.ts`
+Expected: All 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /path/to/worktree add src/agents/llm/pricing.ts src/agents/llm/pricing.test.ts
+git -C /path/to/worktree commit -m "refactor: pricing.ts delegates to ModelRegistry via createEstimateCostUsd"
+```
+
+---
+
+## Task 4: Migrate token-estimator.ts — remove model metadata
+
+**Files:**
+- Modify: `src/agents/llm/token-estimator.ts`
+
+- [ ] **Step 1: Remove model-specific exports from token-estimator.ts**
+
+Delete lines 80–116 (everything from the `-- Context window map --` comment through `DEFAULT_MODEL_NAME`). Keep `estimateTokens`, `estimateMessagesTokens`, and `DEFAULT_SAFETY_MARGIN`. The file should end with:
+
+```typescript
+/** Safety margin (5%) subtracted from the context window before budgeting. */
+export const DEFAULT_SAFETY_MARGIN = 0.05;
+```
+
+Specifically remove: `CONTEXT_WINDOWS`, `SORTED_WINDOW_ENTRIES`, `FALLBACK_WINDOW_MODEL`, `getContextWindow()`, `isKnownContextWindowModel()`, and `DEFAULT_MODEL_NAME`.
+
+- [ ] **Step 2: Run full test suite to see what breaks**
+
+Run: `npx --prefix /path/to/worktree vitest run src/agents/llm/ 2>&1 | tail -30`
+Expected: model-registry and pricing tests pass; any tests importing `getContextWindow` or `DEFAULT_MODEL_NAME` from `token-estimator.js` will fail. These will be fixed in later tasks when updating runtime.ts and index.ts.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add src/agents/llm/token-estimator.ts
+git -C /path/to/worktree commit -m "refactor: remove model metadata from token-estimator.ts (moved to ModelRegistry)"
+```
+
+---
+
+## Task 5: Update config.ts and config/default.yaml
+
+**Files:**
+- Modify: `src/config.ts`
+- Modify: `config/default.yaml`
+
+- [ ] **Step 1: Update the YAML config — remove provider from tiers, change autonomy_scoring.model to .model_tier**
+
+In `config/default.yaml`, replace the `model_routing` section (lines 0–15) with:
+
+```yaml
+# Capability-tier model routing (ADR-014).
+# Agents declare a tier (fast | standard | powerful) — this config maps each
+# tier to a concrete model. The provider is resolved from the model registry.
+# Change these values to upgrade all agents of a tier in one place.
+model_routing:
+  tiers:
+    fast:
+      model: claude-haiku-4-5
+    standard:
+      model: claude-sonnet-4-6
+    powerful:
+      model: claude-opus-4-6
+  default_tier: standard
+```
+
+And in the `autonomy_scoring` section (~line 271–279), change:
+```yaml
+    model: "claude-haiku-4-5"     # cheaper model for the LLM judge
+```
+to:
+```yaml
+    model_tier: fast              # tier for the LLM judge (resolved via ModelRouter)
+```
+
+- [ ] **Step 2: Update the YamlConfig type in config.ts**
+
+In `src/config.ts`, find the `model_routing` type (around line 242–249) and replace:
+
+```typescript
+  model_routing?: {
+    tiers: {
+      fast: { provider: string; model: string };
+      standard: { provider: string; model: string };
+      powerful: { provider: string; model: string };
+    };
+    default_tier: 'fast' | 'standard' | 'powerful';
+  };
+```
+
+with:
+
+```typescript
+  model_routing?: {
+    tiers: {
+      fast: { model: string };
+      standard: { model: string };
+      powerful: { model: string };
+    };
+    default_tier: 'fast' | 'standard' | 'powerful';
+  };
+```
+
+- [ ] **Step 3: Update autonomy_scoring validation in config.ts**
+
+Find the validation block for `autonomy_scoring.model` (~line 559) and replace:
+
+```typescript
+      if (autonomyScoring.model !== undefined && (typeof autonomyScoring.model !== 'string' || autonomyScoring.model.trim().length === 0)) {
+        throw new Error(`dreaming.autonomy_scoring.model must be a non-empty string, got: ${String(autonomyScoring.model)}`);
+      }
+```
+
+with:
+
+```typescript
+      if (autonomyScoring.model_tier !== undefined && (typeof autonomyScoring.model_tier !== 'string' || autonomyScoring.model_tier.trim().length === 0)) {
+        throw new Error(`dreaming.autonomy_scoring.model_tier must be a non-empty string, got: ${String(autonomyScoring.model_tier)}`);
+      }
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /path/to/worktree add config/default.yaml src/config.ts
+git -C /path/to/worktree commit -m "refactor: drop provider from tier config, rename autonomy_scoring.model to .model_tier"
+```
+
+---
+
+## Task 6: Update index.ts — new startup wiring
+
+**Files:**
+- Modify: `src/index.ts`
+
+This task updates the bootstrap orchestrator to use the new registry and updated types. Note: this task has multiple sub-changes across `index.ts`.
+
+- [ ] **Step 1: Add ModelRegistry import and instantiation**
+
+Near the top of `src/index.ts`, add the import:
+
+```typescript
+import { ModelRegistry } from './agents/llm/model-registry.js';
+```
+
+Then, right before the `modelRouter` construction (~line 277), add:
+
+```typescript
+  const modelRegistry = new ModelRegistry(logger);
+```
+
+- [ ] **Step 2: Update ModelRouter construction**
+
+Change the ModelRouter construction (~line 282) from:
+
+```typescript
+  const modelRouter = new ModelRouter(modelRoutingConfig, logger);
+```
+
+to:
+
+```typescript
+  const modelRouter = new ModelRouter(modelRoutingConfig, modelRegistry, logger);
+```
+
+- [ ] **Step 3: Update provider registry to resolve from model registry**
+
+The existing `providerRegistry` construction (~line 283) stays the same:
+
+```typescript
+  const providerRegistry = new Map<string, LLMProvider>([
+    ['anthropic', llmProvider],
+  ]);
+```
+
+But after it, add a validation step that ensures every provider referenced by registry models is available:
+
+```typescript
+  // Validate that every provider referenced by a model in the registry has
+  // an entry in providerRegistry. Fail-fast if an operator adds a model
+  // requiring a provider that isn't instantiated.
+  for (const [modelId, meta] of Object.entries(modelRegistry.getAllModels())) {
+    if (!providerRegistry.has(meta.provider)) {
+      logger.warn(
+        { model: modelId, provider: meta.provider },
+        'Model in registry references a provider that is not registered — model will be unusable',
+      );
+    }
+  }
+```
+
+This requires adding a `getAllModels()` method to `ModelRegistry`. Add it:
+
+```typescript
+  /** Returns all registered models. Used for startup validation only. */
+  getAllModels(): Readonly<Record<string, ModelMetadata>> {
+    return MODEL_REGISTRY;
+  }
+```
+
+And add a test for it in `model-registry.test.ts`:
+
+```typescript
+  describe('getAllModels', () => {
+    it('returns all registered models', () => {
+      const all = registry.getAllModels();
+      expect(Object.keys(all)).toContain('claude-sonnet-4-6');
+      expect(Object.keys(all)).toContain('claude-haiku-4-5');
+      expect(Object.keys(all)).toContain('claude-opus-4-6');
+    });
+  });
+```
+
+- [ ] **Step 4: Create estimateCostUsd closure**
+
+Add the import at the top of `index.ts`:
+
+```typescript
+import { createEstimateCostUsd } from './agents/llm/pricing.js';
+```
+
+After the ModelRegistry is instantiated, create the cost function:
+
+```typescript
+  const estimateCostUsd = createEstimateCostUsd(modelRegistry);
+```
+
+Then pass `estimateCostUsd` to wherever `AgentRuntime` is constructed (or make it available in the scope where `publishLlmCallEvent` is defined in runtime.ts — this will be addressed in Task 7).
+
+- [ ] **Step 5: Update working memory summarization config**
+
+Change the working memory construction (~lines 291–298) to pass the resolved model:
+
+```typescript
+  const summarizationCfg = yamlConfig.workingMemory?.summarization;
+  const summarizationModel = modelRouter.resolve('standard').model;
+  const memory = WorkingMemory.createWithPostgres(pool, logger, summarizationCfg
+    ? {
+        threshold: summarizationCfg.threshold ?? 20,
+        keepWindow: summarizationCfg.keepWindow ?? 10,
+        provider: llmProvider,
+        model: summarizationModel,
+      }
+    : undefined,
+  );
+```
+
+- [ ] **Step 6: Update autonomy scoring config**
+
+Change the scoring pass config (~line 952–954) from:
+
+```typescript
+  const scoringPassConfig: ScoringPassConfig = {
+    intervalMs: yamlConfig.dreaming?.autonomy_scoring?.intervalMs ?? 86_400_000,
+    model: yamlConfig.dreaming?.autonomy_scoring?.model ?? 'claude-haiku-4-5',
+```
+
+to:
+
+```typescript
+  const scoringModelTier = yamlConfig.dreaming?.autonomy_scoring?.model_tier ?? 'fast';
+  const scoringModel = modelRouter.resolve(scoringModelTier).model;
+  const scoringPassConfig: ScoringPassConfig = {
+    intervalMs: yamlConfig.dreaming?.autonomy_scoring?.intervalMs ?? 86_400_000,
+    model: scoringModel,
+```
+
+- [ ] **Step 7: Update agent bootstrap — resolve provider from registry**
+
+Change the agent bootstrap loop (~lines 1115–1121) from:
+
+```typescript
+    const resolved = modelRouter.resolve(agentConfig.model.tier, agentConfig.model.needs);
+    const agentProvider = providerRegistry.get(resolved.provider);
+    if (!agentProvider) {
+      logger.fatal({ provider: resolved.provider, agent: agentConfig.name, tier: resolved.tier },
+        'No provider registered for tier-resolved provider name');
+      process.exit(1);
+    }
+```
+
+to:
+
+```typescript
+    const resolved = modelRouter.resolve(agentConfig.model.tier, agentConfig.model.needs);
+    const resolvedProvider = modelRegistry.getProvider(resolved.model);
+    if (!resolvedProvider) {
+      logger.fatal({ model: resolved.model, agent: agentConfig.name, tier: resolved.tier },
+        'Model not found in registry — cannot resolve provider');
+      process.exit(1);
+    }
+    const agentProvider = providerRegistry.get(resolvedProvider);
+    if (!agentProvider) {
+      logger.fatal({ provider: resolvedProvider, agent: agentConfig.name, tier: resolved.tier },
+        'No provider registered for model\'s provider');
+      process.exit(1);
+    }
+```
+
+- [ ] **Step 8: Remove old imports**
+
+Remove any remaining imports of `getContextWindow`, `isKnownContextWindowModel`, `DEFAULT_MODEL_NAME` from `token-estimator.js`, and `estimateCostUsd` from `pricing.js` (replaced by `createEstimateCostUsd`).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git -C /path/to/worktree add src/index.ts src/agents/llm/model-registry.ts src/agents/llm/model-registry.test.ts
+git -C /path/to/worktree commit -m "feat: wire ModelRegistry into startup — registry, router, provider validation"
+```
+
+---
+
+## Task 7: Update runtime.ts — registry-backed lookups
+
+**Files:**
+- Modify: `src/agents/runtime.ts`
+
+- [ ] **Step 1: Update context budget setup**
+
+Find the context budget block (~lines 326–333). Change:
+
+```typescript
+    const modelName = this.config.resolvedModel ?? this.config.modelName ?? DEFAULT_MODEL_NAME;
+    const contextWindow = getContextWindow(modelName);
+    if (!isKnownContextWindowModel(modelName)) {
+      logger.warn(
+        { agentId, modelName, fallbackWindow: contextWindow },
+        'Model not in context window map — using fallback; budget may be incorrect. Add this model to token-estimator.ts',
+      );
+    }
+```
+
+to:
+
+```typescript
+    const modelName = this.config.resolvedModel ?? this.config.modelName;
+    if (!modelName) {
+      throw new Error(`Agent ${agentId} has no resolvedModel or modelName — cannot create context budget`);
+    }
+    const contextWindow = this.config.modelRegistry.getContextWindow(modelName);
+    if (!this.config.modelRegistry.isKnownModel(modelName)) {
+      logger.warn(
+        { agentId, modelName },
+        'Model not in model registry — context budget will use 0 window. Add this model to model-registry.ts',
+      );
+    }
+```
+
+This requires `modelRegistry` on the `AgentRuntime` config. Add it to whatever config interface `AgentRuntime` uses (likely a `config` object passed to the constructor). The exact interface name will be visible in the file — add `modelRegistry: ModelRegistry` to it.
+
+- [ ] **Step 2: Update estimateCostUsd usage**
+
+The `estimateCostUsd` call on ~line 1038 currently imports the function directly. Change the runtime to accept it as a config parameter:
+
+Add `estimateCostUsd: (actualModel: string, usage: LLMUsage, logger?: Logger) => number` to the config interface, and update the call from:
+
+```typescript
+          estimatedCostUsd: estimateCostUsd(response.provenance.actualModel, response.usage, logger),
+```
+
+to:
+
+```typescript
+          estimatedCostUsd: this.config.estimateCostUsd(response.provenance.actualModel, response.usage, logger),
+```
+
+- [ ] **Step 3: Remove old imports**
+
+Remove imports of `getContextWindow`, `isKnownContextWindowModel`, `DEFAULT_MODEL_NAME` from `token-estimator.js`, and the direct import of `estimateCostUsd` from `pricing.js`.
+
+Add import:
+
+```typescript
+import type { ModelRegistry } from './llm/model-registry.js';
+```
+
+- [ ] **Step 4: Update AgentRuntime construction in index.ts**
+
+In `src/index.ts`, pass the new config to `AgentRuntime`:
+
+```typescript
+    const agent = new AgentRuntime({
+      // ... existing fields ...
+      modelRegistry,
+      estimateCostUsd,
+    });
+```
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `npx --prefix /path/to/worktree vitest run 2>&1 | tail -40`
+Expected: model-registry, pricing, and model-router tests pass. Some integration tests may need updates if they construct `AgentRuntime` directly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /path/to/worktree add src/agents/runtime.ts src/index.ts
+git -C /path/to/worktree commit -m "refactor: runtime.ts uses ModelRegistry for context window and cost estimation"
+```
+
+---
+
+## Task 8: Update anthropic.ts — remove hardcoded fallback, use registry for maxOutputTokens
+
+**Files:**
+- Modify: `src/agents/llm/anthropic.ts`
+
+- [ ] **Step 1: Accept ModelRegistry in constructor**
+
+Add a `modelRegistry` parameter to `AnthropicProvider`'s constructor and store it as a private field:
+
+```typescript
+import type { ModelRegistry } from './model-registry.js';
+
+// In the class:
+  private readonly modelRegistry: ModelRegistry;
+
+  constructor(apiKey: string, logger: Logger, modelRegistry: ModelRegistry) {
+    // ... existing init ...
+    this.modelRegistry = modelRegistry;
+  }
+```
+
+- [ ] **Step 2: Remove the hardcoded model fallback**
+
+Find ~line 108–109:
+
+```typescript
+    const optionsModel = typeof options?.model === 'string' ? options.model : undefined;
+    const model = modelOverride ?? optionsModel ?? 'claude-sonnet-4-6';
+```
+
+Replace with:
+
+```typescript
+    const optionsModel = typeof options?.model === 'string' ? options.model : undefined;
+    const model = modelOverride ?? optionsModel;
+    if (!model) {
+      throw new Error('AnthropicProvider.chat() requires a model — no model was provided and no default is configured');
+    }
+```
+
+This is safe because the runtime always passes `model: this.config.resolvedModel` explicitly (~line 1053).
+
+- [ ] **Step 3: Use registry for max_tokens**
+
+Find the hardcoded `max_tokens: 4096` (~line 114) and replace with:
+
+```typescript
+        max_tokens: this.modelRegistry.getModel(model)?.maxOutputTokens ?? 4096,
+```
+
+- [ ] **Step 4: Update AnthropicProvider construction in index.ts**
+
+Change:
+
+```typescript
+  const llmProvider = new AnthropicProvider(config.anthropicApiKey, logger);
+```
+
+to:
+
+```typescript
+  const llmProvider = new AnthropicProvider(config.anthropicApiKey, logger, modelRegistry);
+```
+
+Note: the `ModelRegistry` must be instantiated before `AnthropicProvider` in the startup sequence.
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx --prefix /path/to/worktree vitest run src/agents/ 2>&1 | tail -30`
+Expected: PASS. Any test that relied on the implicit default will now need to pass a model explicitly. Tests constructing `AnthropicProvider` will need to pass a `ModelRegistry` instance.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /path/to/worktree add src/agents/llm/anthropic.ts src/index.ts
+git -C /path/to/worktree commit -m "refactor: AnthropicProvider uses registry for maxOutputTokens, removes hardcoded fallback"
+```
+
+---
+
+## Task 9: Add llmProvider and modelRouter to SkillContext
+
+**Files:**
+- Modify: `src/skills/types.ts`
+- Modify: `src/skills/loader.ts`
+- Modify: `src/skills/execution.ts`
+
+- [ ] **Step 1: Add capabilities to VALID_CAPABILITIES in loader.ts**
+
+In `src/skills/loader.ts`, find the `VALID_CAPABILITIES` set (~line 27–32) and add `'llmProvider'` and `'modelRouter'`:
+
+```typescript
+export const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
+  'bus', 'agentRegistry', 'outboundGateway', 'heldMessages',
+  'schedulerService', 'entityMemory', 'nylasCalendarClient',
+  'autonomyService', 'executiveProfileService', 'browserService', 'bullpenService', 'skillSearch',
+  'actionLogRepo', 'executionLayer', 'confidencePipeline', 'tempFileStore',
+  'llmProvider', 'modelRouter',
+]);
+```
+
+- [ ] **Step 2: Add properties to SkillContext in types.ts**
+
+In `src/skills/types.ts`, within the `SkillContext` interface, add after the existing capability-gated properties (before the closing `}`):
+
+```typescript
+  /** LLM provider — available to skills declaring 'llmProvider' in capabilities.
+   *  Grants direct LLM access — use only for infrastructure skills (extract-facts,
+   *  extract-relationships, file-parse). See #637 for planned redesign. */
+  llmProvider?: import('../agents/llm/provider.js').LLMProvider;
+  /** Model router — available to skills declaring 'modelRouter' in capabilities.
+   *  Resolves tier names to model strings. See #637 for planned redesign. */
+  modelRouter?: import('../agents/llm/model-router.js').ModelRouter;
+```
+
+- [ ] **Step 3: Wire injection in execution.ts**
+
+In `src/skills/execution.ts`, find the `capabilityServices` map (~line 497). The `ExecutionLayer` class needs to receive `llmProvider` and `modelRouter` in its constructor. Add them as constructor parameters and add to the capability map:
+
+```typescript
+      llmProvider: this.llmProvider,
+      modelRouter: this.modelRouter,
+```
+
+Also update the `ExecutionLayer` constructor to accept and store these:
+
+```typescript
+  private readonly llmProvider?: LLMProvider;
+  private readonly modelRouter?: ModelRouter;
+```
+
+And in the constructor:
+
+```typescript
+  constructor(opts: {
+    // ... existing opts ...
+    llmProvider?: LLMProvider;
+    modelRouter?: ModelRouter;
+  }) {
+    // ... existing assignments ...
+    this.llmProvider = opts.llmProvider;
+    this.modelRouter = opts.modelRouter;
+  }
+```
+
+- [ ] **Step 4: Update ExecutionLayer construction in index.ts**
+
+In `src/index.ts`, where the `ExecutionLayer` is constructed, pass the new dependencies:
+
+```typescript
+  const executionLayer = new ExecutionLayer({
+    // ... existing params ...
+    llmProvider,
+    modelRouter,
+  });
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx --prefix /path/to/worktree vitest run src/skills/ 2>&1 | tail -30`
+Expected: PASS. No existing skill declares these capabilities, so nothing breaks.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /path/to/worktree add src/skills/types.ts src/skills/loader.ts src/skills/execution.ts src/index.ts
+git -C /path/to/worktree commit -m "feat: add llmProvider and modelRouter as SkillContext capabilities"
+```
+
+---
+
+## Task 10: Migrate extract-facts handler
+
+**Files:**
+- Modify: `skills/extract-facts/handler.ts`
+- Modify: `skills/extract-facts/skill.json`
+- Modify: `skills/extract-facts/handler.test.ts` (if it has Anthropic SDK mocks)
+
+- [ ] **Step 1: Update skill.json — declare capabilities, remove ANTHROPIC_API_KEY secret**
+
+In `skills/extract-facts/skill.json`, change:
+
+```json
+  "secrets": ["ANTHROPIC_API_KEY"],
+  "timeout": 15000,
+  "capabilities": ["entityMemory"]
+```
+
+to:
+
+```json
+  "secrets": [],
+  "timeout": 15000,
+  "capabilities": ["entityMemory", "llmProvider", "modelRouter"]
+```
+
+- [ ] **Step 2: Rewrite handler imports and constructor**
+
+In `skills/extract-facts/handler.ts`:
+
+Remove:
+```typescript
+import Anthropic from '@anthropic-ai/sdk';
+```
+and the model constants:
+```typescript
+const CLASSIFIER_MODEL = 'claude-haiku-4-5-20251001';
+const EXTRACTION_MODEL = 'claude-sonnet-4-6';
+```
+
+Remove the constructor's Anthropic client parameter:
+```typescript
+  constructor(private readonly anthropicClient?: Anthropic) {}
+```
+Replace with a no-arg constructor (or remove the constructor entirely).
+
+- [ ] **Step 3: Update the classifier LLM call**
+
+Find the classifier call (uses `CLASSIFIER_MODEL` and the `Anthropic` client). Replace it with:
+
+```typescript
+    if (!ctx.llmProvider || !ctx.modelRouter) {
+      return { success: false, error: 'extract-facts requires llmProvider and modelRouter capabilities' };
+    }
+
+    const classifierModel = ctx.modelRouter.resolve('fast').model;
+    const extractionModel = ctx.modelRouter.resolve('standard').model;
+```
+
+Then replace each `this.anthropicClient.messages.create(...)` call with the equivalent `ctx.llmProvider.chat(...)` call. The Anthropic SDK returns `response.content[0].text`; `LLMProvider.chat()` returns `{ type: 'text', content: string }`. Adjust response handling accordingly.
+
+For the classifier call, replace:
+
+```typescript
+    const client = this.anthropicClient ?? new Anthropic({ apiKey: ctx.secret('ANTHROPIC_API_KEY') });
+    const classifyResponse = await client.messages.create({
+      model: CLASSIFIER_MODEL,
+      max_tokens: 10,
+      messages: [{ role: 'user', content: classifyPrompt }],
+    });
+```
+
+with:
+
+```typescript
+    const classifyResponse = await ctx.llmProvider.chat({
+      model: classifierModel,
+      messages: [{ role: 'user', content: classifyPrompt }],
+      options: { max_tokens: 10 },
+    });
+    if (classifyResponse.type === 'error') {
+      ctx.log.error({ error: classifyResponse.error }, 'extract-facts: classifier LLM call failed');
+      return { success: false, error: `Classifier LLM call failed: ${classifyResponse.error.message}` };
+    }
+```
+
+And adjust the response content extraction from `classifyResponse.content[0].text` to `classifyResponse.content` (since `LLMProvider.chat()` returns `{ type: 'text', content: string }`).
+
+- [ ] **Step 4: Update the extraction LLM call**
+
+Same pattern for the extraction call — replace `client.messages.create({ model: EXTRACTION_MODEL, ... })` with `ctx.llmProvider.chat({ model: extractionModel, ... })`. Adjust response handling.
+
+- [ ] **Step 5: Update tests**
+
+The handler tests likely mock the `Anthropic` client. Update them to mock `ctx.llmProvider` and `ctx.modelRouter` instead. The `modelRouter` mock returns `{ model: 'claude-haiku-4-5', tier: 'fast' }` for 'fast' and `{ model: 'claude-sonnet-4-6', tier: 'standard' }` for 'standard'.
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx --prefix /path/to/worktree vitest run skills/extract-facts/ 2>&1 | tail -30`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /path/to/worktree add skills/extract-facts/
+git -C /path/to/worktree commit -m "refactor: extract-facts uses shared LLMProvider + ModelRouter instead of raw SDK"
+```
+
+---
+
+## Task 11: Migrate extract-relationships handler
+
+**Files:**
+- Modify: `skills/extract-relationships/handler.ts`
+- Modify: `skills/extract-relationships/skill.json`
+- Modify: `skills/extract-relationships/handler.test.ts`
+
+Follow the same pattern as Task 10:
+
+- [ ] **Step 1: Update skill.json**
+
+Change:
+```json
+  "secrets": ["ANTHROPIC_API_KEY"],
+  "capabilities": ["entityMemory"]
+```
+to:
+```json
+  "secrets": [],
+  "capabilities": ["entityMemory", "llmProvider", "modelRouter"]
+```
+
+- [ ] **Step 2: Rewrite handler — remove Anthropic SDK import and model constants**
+
+Remove `import Anthropic from '@anthropic-ai/sdk'` and the `CLASSIFIER_MODEL` / `EXTRACTION_MODEL` constants. Remove the Anthropic client constructor parameter.
+
+- [ ] **Step 3: Update classifier and extraction LLM calls**
+
+Same pattern as Task 10 — resolve models from ctx.modelRouter, use ctx.llmProvider.chat(), handle response types.
+
+- [ ] **Step 4: Update tests**
+
+Mock `ctx.llmProvider` and `ctx.modelRouter` instead of the Anthropic client.
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx --prefix /path/to/worktree vitest run skills/extract-relationships/ 2>&1 | tail -30`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /path/to/worktree add skills/extract-relationships/
+git -C /path/to/worktree commit -m "refactor: extract-relationships uses shared LLMProvider + ModelRouter instead of raw SDK"
+```
+
+---
+
+## Task 12: Migrate file-parse handler
+
+**Files:**
+- Modify: `skills/file-parse/handler.ts`
+- Modify: `skills/file-parse/skill.json`
+- Modify: `skills/file-parse/handler.test.ts`
+
+- [ ] **Step 1: Update skill.json**
+
+Change:
+```json
+  "secrets": ["ANTHROPIC_API_KEY"],
+  "capabilities": []
+```
+to:
+```json
+  "secrets": [],
+  "capabilities": ["llmProvider", "modelRouter"]
+```
+
+- [ ] **Step 2: Rewrite handler — remove Anthropic SDK import and model constant**
+
+`file-parse` only has `EXTRACTION_MODEL = 'claude-sonnet-4-6'` (no classifier stage). Remove the import and constant. Remove the Anthropic client constructor parameter if present.
+
+- [ ] **Step 3: Update LLM calls**
+
+Replace each `client.messages.create({ model: EXTRACTION_MODEL, ... })` with `ctx.llmProvider.chat({ model: ctx.modelRouter.resolve('standard').model, ... })`. Note: `file-parse` uses the vision API for images — check that the `LLMProvider.chat()` interface supports image content blocks. If it doesn't, this may need an adjustment (pass the image as a content block in the messages array).
+
+- [ ] **Step 4: Update tests**
+
+Mock `ctx.llmProvider` and `ctx.modelRouter`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx --prefix /path/to/worktree vitest run skills/file-parse/ 2>&1 | tail -30`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /path/to/worktree add skills/file-parse/
+git -C /path/to/worktree commit -m "refactor: file-parse uses shared LLMProvider + ModelRouter instead of raw SDK"
+```
+
+---
+
+## Task 13: Update autonomy scoring-pass — tier instead of model
+
+**Files:**
+- Modify: `src/autonomy/scoring-pass.ts`
+
+- [ ] **Step 1: Update ScoringPassConfig**
+
+The `model` field stays as-is in `ScoringPassConfig` — it receives the resolved model string. The change is in `index.ts` (already done in Task 6 step 6), where the tier is resolved to a model before being passed. No changes needed to `scoring-pass.ts` itself beyond verifying the `model` field is still used correctly.
+
+Actually — re-reading the code, `scoring-pass.ts` passes the model via `options: { model: this.config.model }`. This works as-is because `index.ts` now resolves the tier to a model before constructing the config. Verify this is the case and move on.
+
+- [ ] **Step 2: Run tests**
+
+Run: `npx --prefix /path/to/worktree vitest run src/autonomy/ 2>&1 | tail -30`
+Expected: PASS (config shape unchanged — the model field still receives a string).
+
+- [ ] **Step 3: Commit (skip if no changes)**
+
+If no code changes were needed, skip the commit.
+
+---
+
+## Task 14: Update working-memory — add model to SummarizationConfig
+
+**Files:**
+- Modify: `src/memory/working-memory.ts`
+
+- [ ] **Step 1: Add model to SummarizationConfig**
+
+In `src/memory/working-memory.ts`, update the `SummarizationConfig` interface (~line 15–22):
+
+```typescript
+export interface SummarizationConfig {
+  threshold: number;
+  keepWindow: number;
+  provider: LLMProvider;
+  /** Resolved model string for the summarization call. */
+  model: string;
+}
+```
+
+- [ ] **Step 2: Pass model to provider.chat()**
+
+Find the `provider.chat()` call (~line 230):
+
+```typescript
+    const response = await provider.chat({
+      messages: [{ role: 'user', content: summaryPrompt }],
+    });
+```
+
+Change to:
+
+```typescript
+    const response = await provider.chat({
+      messages: [{ role: 'user', content: summaryPrompt }],
+      model: this.summarizationConfig.model,
+    });
+```
+
+The exact way `this.summarizationConfig` is accessed depends on how the class stores it — check the code. The summarization config is passed through `createWithPostgres`. Thread the model through to wherever `provider.chat()` is called.
+
+- [ ] **Step 3: Run tests**
+
+Run: `npx --prefix /path/to/worktree vitest run src/memory/ 2>&1 | tail -30`
+Expected: PASS (or tests may need the `model` field added to test fixtures).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /path/to/worktree add src/memory/working-memory.ts
+git -C /path/to/worktree commit -m "refactor: working-memory summarization passes explicit model to provider.chat()"
+```
+
+---
+
+## Task 15: Update drift-detector — add model config
+
+**Files:**
+- Modify: `src/scheduler/drift-detector.ts`
+
+- [ ] **Step 1: Add model to DriftDetector config**
+
+Find the `DriftDetector` class constructor. Add a `model` parameter (string) to whatever config it accepts. Store it as a private field.
+
+- [ ] **Step 2: Pass model to provider.chat()**
+
+Find the `provider.chat()` call (~line 86):
+
+```typescript
+      const response = await this.provider.chat({
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userLines.join('\n') },
+        ],
+        options: { max_tokens: 200, temperature: 0 },
+      });
+```
+
+Change to:
+
+```typescript
+      const response = await this.provider.chat({
+        model: this.model,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userLines.join('\n') },
+        ],
+        options: { max_tokens: 200, temperature: 0 },
+      });
+```
+
+- [ ] **Step 3: Update DriftDetector construction in index.ts**
+
+Pass the resolved model from `modelRouter.resolve('standard').model` (or whatever tier is appropriate — standard is a safe default for a quick LLM judge call):
+
+```typescript
+  const driftDetector = new DriftDetector({
+    // ... existing config ...
+    model: modelRouter.resolve('standard').model,
+  });
+```
+
+- [ ] **Step 4: Remove the TODO comment**
+
+Delete the TODO comment at ~lines 11–12:
+
+```typescript
+// TODO: When multi-model support is added, make the LLM provider here independently
+// configurable from the coordinator's provider (cheaper/faster model for this check).
+```
+
+Replace with:
+
+```typescript
+// Model is resolved from the standard tier at startup via ModelRouter.
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx --prefix /path/to/worktree vitest run src/scheduler/ 2>&1 | tail -30`
+Expected: PASS (tests may need the model field added to fixtures).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /path/to/worktree add src/scheduler/drift-detector.ts src/index.ts
+git -C /path/to/worktree commit -m "refactor: drift-detector passes explicit model to provider.chat()"
+```
+
+---
+
+## Task 16: Final validation and cleanup
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npx --prefix /path/to/worktree vitest run 2>&1 | tail -60`
+Expected: All tests PASS.
+
+- [ ] **Step 2: Run the TypeScript compiler**
+
+Run: `npx --prefix /path/to/worktree tsc --noEmit 2>&1 | tail -30`
+Expected: No type errors.
+
+- [ ] **Step 3: Verify no remaining hardcoded model IDs outside the registry**
+
+Search for stale model references:
+
+Run: `grep -rn "claude-haiku-4-5\|claude-sonnet-4-6\|claude-opus-4-6" /path/to/worktree/src/ /path/to/worktree/skills/ /path/to/worktree/config/ --include="*.ts" --include="*.yaml" --include="*.json" | grep -v node_modules | grep -v model-registry.ts | grep -v ".test.ts"`
+
+Expected: Only `config/default.yaml` (tier mappings) should reference model names. No `.ts` files outside of `model-registry.ts` and test files should contain hardcoded model IDs.
+
+- [ ] **Step 4: Verify no remaining imports of deleted exports**
+
+Search for stale imports:
+
+Run: `grep -rn "getContextWindow\|isKnownContextWindowModel\|DEFAULT_MODEL_NAME\|ANTHROPIC_PRICING" /path/to/worktree/src/ --include="*.ts" | grep -v ".test.ts" | grep -v token-estimator.ts`
+
+Expected: No results.
+
+- [ ] **Step 5: Update CHANGELOG.md**
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Changed
+- **Model registry** — consolidated scattered model metadata (pricing, context windows, capabilities) into a single `ModelRegistry` in `src/agents/llm/model-registry.ts`. (#556)
+- **`model_routing` config** — tier definitions no longer include `provider` (resolved from registry); `autonomy_scoring.model` renamed to `.model_tier`.
+- **`extract-facts`, `extract-relationships`, `file-parse`** — migrated from raw Anthropic SDK to shared `LLMProvider` via SkillContext capabilities; LLM calls now appear in cost telemetry. (#556)
+```
+
+- [ ] **Step 6: Commit changelog**
+
+```bash
+git -C /path/to/worktree add CHANGELOG.md
+git -C /path/to/worktree commit -m "docs: update CHANGELOG for model registry consolidation"
+```

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -175,7 +175,7 @@
           "additionalProperties": false,
           "properties": {
             "intervalMs": { "type": "integer", "minimum": 1 },
-            "model": { "type": "string", "minLength": 1 },
+            "model_tier": { "type": "string", "enum": ["fast", "standard", "powerful"] },
             "batchSize": { "type": "integer", "minimum": 1 },
             "minScoredActions": { "type": "integer", "minimum": 1 },
             "halfLifeDays": { "type": "number", "minimum": 1 },
@@ -277,11 +277,10 @@
   "definitions": {
     "tierConfig": {
       "type": "object",
-      "required": ["provider", "model"],
+      "required": ["model"],
       "additionalProperties": false,
       "properties": {
-        "provider": { "type": "string", "minLength": 1 },
-        "model":    { "type": "string", "minLength": 1 }
+        "model": { "type": "string", "minLength": 1 }
       }
     }
   }

--- a/skills/extract-facts/handler.test.ts
+++ b/skills/extract-facts/handler.test.ts
@@ -1,7 +1,7 @@
 // handler.test.ts — unit tests for extract-facts skill.
 //
-// Uses an in-memory KG backend (no Postgres) and a mock Anthropic client
-// injected via the handler constructor, so no real API calls are made.
+// Uses an in-memory KG backend (no Postgres) and mock llmProvider / modelRouter
+// injected via ctx, so no real API calls are made.
 
 import { describe, it, expect, vi } from 'vitest';
 import pino from 'pino';
@@ -22,27 +22,42 @@ function makeEntityMemory(): EntityMemory {
   return new EntityMemory(store, validator, embeddingService, createSilentLogger());
 }
 
-function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {
+// Creates mock llmProvider + modelRouter objects for injection into ctx.
+// responses: scripted sequence of text responses — first call is the classifier
+// gate, second call (if triggered) is extraction.
+function makeMocks(responses: string[]) {
+  let callIndex = 0;
+
+  const mockModelRouter = {
+    resolve: vi.fn().mockImplementation((tier: string) => ({
+      model: tier === 'fast' ? 'claude-haiku-4-5' : 'claude-sonnet-4-6',
+      tier,
+    })),
+  };
+
+  const mockLlmProvider = {
+    chat: vi.fn().mockImplementation(() => {
+      const content = responses[callIndex++] ?? 'no';
+      return Promise.resolve({ type: 'text', content });
+    }),
+  };
+
+  return { mockLlmProvider, mockModelRouter };
+}
+
+function makeCtx(
+  entityMemory: EntityMemory,
+  input: Record<string, unknown>,
+  mocks: ReturnType<typeof makeMocks>,
+): SkillContext {
   return {
     input,
     secret: () => 'test-api-key',
     log: pino({ level: 'silent' }),
     entityMemory,
+    llmProvider: mocks.mockLlmProvider,
+    modelRouter: mocks.mockModelRouter,
   } as unknown as SkillContext;
-}
-
-// Creates a mock Anthropic client that returns a scripted sequence of responses.
-// First call is the classifier gate; second call (if triggered) is extraction.
-function makeMockAnthropicClient(responses: string[]) {
-  let callIndex = 0;
-  return {
-    messages: {
-      create: vi.fn().mockImplementation(() => {
-        const text = responses[callIndex++] ?? 'no';
-        return Promise.resolve({ content: [{ type: 'text', text }] });
-      }),
-    },
-  };
 }
 
 // -- Tests --
@@ -50,18 +65,18 @@ function makeMockAnthropicClient(responses: string[]) {
 describe('ExtractFactsHandler', () => {
   it('returns skipped:true when classifier gate fires on unrelated text', async () => {
     const entityMemory = makeEntityMemory();
-    const anthropic = makeMockAnthropicClient(['no']);
-    const handler = new ExtractFactsHandler(anthropic as never);
+    const mocks = makeMocks(['no']);
+    const handler = new ExtractFactsHandler();
     const ctx = makeCtx(entityMemory, {
       text: 'Ada manages Project Orion and works closely with Bob.',
       source: 'test',
-    });
+    }, mocks);
 
     const result = await handler.execute(ctx);
 
     expect(result).toEqual({ success: true, data: { stored: 0, skipped: true, failed: 0 } });
     // Classifier was called; extraction was not
-    expect(anthropic.messages.create).toHaveBeenCalledTimes(1);
+    expect(mocks.mockLlmProvider.chat).toHaveBeenCalledTimes(1);
   });
 
   it('acceptance criterion: "Bob lives in Toronto" stores a location fact', async () => {
@@ -69,12 +84,12 @@ describe('ExtractFactsHandler', () => {
     const facts = JSON.stringify([
       { subject: 'Jane Doe', subjectType: 'person', attribute: 'home_city', value: 'Toronto', confidence: 0.9, decayClass: 'slow_decay' },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', facts]);
-    const handler = new ExtractFactsHandler(anthropic as never);
+    const mocks = makeMocks(['yes', facts]);
+    const handler = new ExtractFactsHandler();
     const ctx = makeCtx(entityMemory, {
       text: 'Bob lives in Toronto.',
       source: 'test',
-    });
+    }, mocks);
 
     const result = await handler.execute(ctx);
 
@@ -94,12 +109,12 @@ describe('ExtractFactsHandler', () => {
     const facts = JSON.stringify([
       { subject: 'Ada Lovelace', subjectType: 'person', attribute: 'current_location', value: 'London', confidence: 0.8, decayClass: 'fast_decay' },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', facts]);
-    const handler = new ExtractFactsHandler(anthropic as never);
+    const mocks = makeMocks(['yes', facts]);
+    const handler = new ExtractFactsHandler();
     const ctx = makeCtx(entityMemory, {
       text: 'Ada is currently in London this week.',
       source: 'test',
-    });
+    }, mocks);
 
     await handler.execute(ctx);
 
@@ -115,12 +130,12 @@ describe('ExtractFactsHandler', () => {
     const facts = JSON.stringify([
       { subject: 'Brand New Person', subjectType: 'person', attribute: 'role', value: 'engineer', confidence: 0.85, decayClass: 'slow_decay' },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', facts]);
-    const handler = new ExtractFactsHandler(anthropic as never);
+    const mocks = makeMocks(['yes', facts]);
+    const handler = new ExtractFactsHandler();
     const ctx = makeCtx(entityMemory, {
       text: 'Brand New Person is an engineer.',
       source: 'test',
-    });
+    }, mocks);
 
     await handler.execute(ctx);
 
@@ -136,12 +151,12 @@ describe('ExtractFactsHandler', () => {
     const facts = JSON.stringify([
       { subject: 'Jane Doe', subjectType: 'person', attribute: 'role', value: 'CEO', confidence: 0.9, decayClass: 'ultra_slow' },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', facts]);
-    const handler = new ExtractFactsHandler(anthropic as never);
+    const mocks = makeMocks(['yes', facts]);
+    const handler = new ExtractFactsHandler();
     const ctx = makeCtx(entityMemory, {
       text: 'Bob is the CEO.',
       source: 'test',
-    });
+    }, mocks);
 
     await handler.execute(ctx);
 
@@ -158,16 +173,16 @@ describe('ExtractFactsHandler', () => {
     ]);
 
     // First invocation — stores the fact
-    const anthropic1 = makeMockAnthropicClient(['yes', facts]);
-    const handler1 = new ExtractFactsHandler(anthropic1 as never);
-    const ctx1 = makeCtx(entityMemory, { text: 'Bob lives in Toronto.', source: 'test' });
+    const mocks1 = makeMocks(['yes', facts]);
+    const handler1 = new ExtractFactsHandler();
+    const ctx1 = makeCtx(entityMemory, { text: 'Bob lives in Toronto.', source: 'test' }, mocks1);
     const result1 = await handler1.execute(ctx1);
     expect(result1).toEqual({ success: true, data: { stored: 1, skipped: false, failed: 0 } });
 
     // Second invocation with semantically identical fact — storeFact deduplicates internally
-    const anthropic2 = makeMockAnthropicClient(['yes', facts]);
-    const handler2 = new ExtractFactsHandler(anthropic2 as never);
-    const ctx2 = makeCtx(entityMemory, { text: 'Bob lives in Toronto.', source: 'test' });
+    const mocks2 = makeMocks(['yes', facts]);
+    const handler2 = new ExtractFactsHandler();
+    const ctx2 = makeCtx(entityMemory, { text: 'Bob lives in Toronto.', source: 'test' }, mocks2);
     const result2 = await handler2.execute(ctx2);
     expect(result2).toEqual({ success: true, data: { stored: 1, skipped: false, failed: 0 } });
 
@@ -180,24 +195,24 @@ describe('ExtractFactsHandler', () => {
 
   it('returns error when text input is missing', async () => {
     const entityMemory = makeEntityMemory();
-    const anthropic = makeMockAnthropicClient([]);
-    const handler = new ExtractFactsHandler(anthropic as never);
-    const ctx = makeCtx(entityMemory, { source: 'test' });
+    const mocks = makeMocks([]);
+    const handler = new ExtractFactsHandler();
+    const ctx = makeCtx(entityMemory, { source: 'test' }, mocks);
 
     const result = await handler.execute(ctx);
 
     expect(result).toEqual({ success: false, error: 'Missing required input: text (string)' });
-    expect(anthropic.messages.create).not.toHaveBeenCalled();
+    expect(mocks.mockLlmProvider.chat).not.toHaveBeenCalled();
   });
 
   it('returns failure when extraction returns non-array — distinguishable from legitimate no-facts run', async () => {
     const entityMemory = makeEntityMemory();
-    const anthropic = makeMockAnthropicClient(['yes', 'null']);
-    const handler = new ExtractFactsHandler(anthropic as never);
+    const mocks = makeMocks(['yes', 'null']);
+    const handler = new ExtractFactsHandler();
     const ctx = makeCtx(entityMemory, {
       text: 'Bob lives in Toronto.',
       source: 'test',
-    });
+    }, mocks);
 
     const result = await handler.execute(ctx);
 
@@ -209,8 +224,8 @@ describe('ExtractFactsHandler', () => {
     const facts = JSON.stringify([
       { subject: 'Jane Doe', subjectType: 'person', attribute: 'home_city', value: 'Toronto', confidence: 0.9, decayClass: 'slow_decay' },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', facts]);
-    const handler = new ExtractFactsHandler(anthropic as never);
+    const mocks = makeMocks(['yes', facts]);
+    const handler = new ExtractFactsHandler();
 
     // Mock storeFact to return a conflict (contradicts an existing fact)
     const storeFact = vi.spyOn(entityMemory, 'storeFact').mockResolvedValueOnce({
@@ -219,7 +234,7 @@ describe('ExtractFactsHandler', () => {
       conflict: 'contradicts existing value: London',
     });
 
-    const ctx = makeCtx(entityMemory, { text: 'Bob lives in Toronto.', source: 'test' });
+    const ctx = makeCtx(entityMemory, { text: 'Bob lives in Toronto.', source: 'test' }, mocks);
     const result = await handler.execute(ctx);
 
     // conflict is a semantic outcome — not counted as failed
@@ -235,8 +250,8 @@ describe('ExtractFactsHandler', () => {
       { subject: 'Jane Doe', subjectType: 'person', attribute: 'job_title', value: 'CEO', confidence: 0.9, decayClass: 'slow_decay' },
       { subject: 'Jane Doe', subjectType: 'person', attribute: 'nationality', value: 'Canadian', confidence: 0.9, decayClass: 'permanent' },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', facts]);
-    const handler = new ExtractFactsHandler(anthropic as never);
+    const mocks = makeMocks(['yes', facts]);
+    const handler = new ExtractFactsHandler();
 
     const storeFact = vi.spyOn(entityMemory, 'storeFact')
       .mockResolvedValueOnce({ stored: true, action: 'created' })
@@ -244,7 +259,7 @@ describe('ExtractFactsHandler', () => {
     // No third mock — if the loop doesn't break, storeFact will be called a third time and
     // the test will fail because the spy has no more configured responses.
 
-    const ctx = makeCtx(entityMemory, { text: 'Jane Doe is the Canadian CEO based in Toronto.', source: 'test' });
+    const ctx = makeCtx(entityMemory, { text: 'Jane Doe is the Canadian CEO based in Toronto.', source: 'test' }, mocks);
     const result = await handler.execute(ctx);
 
     // first fact stored, rate-limit counted as failed, loop stopped before fact 3
@@ -257,14 +272,14 @@ describe('ExtractFactsHandler', () => {
     const facts = JSON.stringify([
       { subject: 'Jane Doe', subjectType: 'person', attribute: 'home_city', value: 'Toronto', confidence: 0.9, decayClass: 'slow_decay' },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', facts]);
-    const handler = new ExtractFactsHandler(anthropic as never);
+    const mocks = makeMocks(['yes', facts]);
+    const handler = new ExtractFactsHandler();
 
     // TypeError signals a programming bug — should escape the per-fact catch and
     // reach the outer catch, returning { success: false } instead of { failed: 1 }.
     vi.spyOn(entityMemory, 'storeFact').mockRejectedValueOnce(new TypeError("Cannot read properties of undefined (reading 'id')"));
 
-    const ctx = makeCtx(entityMemory, { text: 'Jane Doe lives in Toronto.', source: 'test' });
+    const ctx = makeCtx(entityMemory, { text: 'Jane Doe lives in Toronto.', source: 'test' }, mocks);
     const result = await handler.execute(ctx);
 
     expect(result).toEqual({ success: false, error: "Cannot read properties of undefined (reading 'id')" });
@@ -276,13 +291,13 @@ describe('ExtractFactsHandler', () => {
     const facts = JSON.stringify([
       { subject: 'Jane Doe', subjectType: 'person', attribute: 'home_city', value: null, confidence: 0.9, decayClass: 'slow_decay' },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', facts]);
-    const handler = new ExtractFactsHandler(anthropic as never);
+    const mocks = makeMocks(['yes', facts]);
+    const handler = new ExtractFactsHandler();
 
     // Build a real logger and spy on warn so we can inspect what was logged.
     const log = pino({ level: 'silent' });
     const warnSpy = vi.spyOn(log, 'warn');
-    const ctx = makeCtx(entityMemory, { text: 'Jane Doe lives in Toronto.', source: 'test' });
+    const ctx = makeCtx(entityMemory, { text: 'Jane Doe lives in Toronto.', source: 'test' }, mocks);
     (ctx as Record<string, unknown>).log = log;
 
     const result = await handler.execute(ctx);
@@ -309,13 +324,13 @@ describe('ExtractFactsHandler', () => {
     const facts = JSON.stringify([
       { subject: 'Jane Doe', subjectType: 'person', attribute: 'home_city', value: 'Toronto', confidence: 0.9, decayClass: 'slow_decay' },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', facts]);
-    const handler = new ExtractFactsHandler(anthropic as never);
+    const mocks = makeMocks(['yes', facts]);
+    const handler = new ExtractFactsHandler();
 
     // Simulate a DB outage — storeFact throws instead of returning a failure result.
     const storeFact = vi.spyOn(entityMemory, 'storeFact').mockRejectedValueOnce(new Error('DB connection lost'));
 
-    const ctx = makeCtx(entityMemory, { text: 'Jane Doe lives in Toronto.', source: 'test' });
+    const ctx = makeCtx(entityMemory, { text: 'Jane Doe lives in Toronto.', source: 'test' }, mocks);
     const result = await handler.execute(ctx);
 
     // The per-fact catch block must handle the error and increment failed.
@@ -324,5 +339,76 @@ describe('ExtractFactsHandler', () => {
     // distinguishes the two code paths.
     expect(result).toEqual({ success: true, data: { stored: 0, skipped: false, failed: 1 } });
     expect(storeFact).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns error when llmProvider capability is missing', async () => {
+    const entityMemory = makeEntityMemory();
+    const handler = new ExtractFactsHandler();
+    const ctx = {
+      input: { text: 'Bob lives in Toronto.', source: 'test' },
+      secret: () => 'test-api-key',
+      log: pino({ level: 'silent' }),
+      entityMemory,
+      // llmProvider intentionally omitted
+      modelRouter: { resolve: vi.fn() },
+    } as unknown as SkillContext;
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: false, error: 'extract-facts requires llmProvider and modelRouter capabilities' });
+  });
+
+  it('returns error when classifier LLM call fails', async () => {
+    const entityMemory = makeEntityMemory();
+    const { mockModelRouter } = makeMocks([]);
+    const mockLlmProvider = {
+      chat: vi.fn().mockResolvedValue({
+        type: 'error',
+        error: new Error('Rate limit exceeded'),
+      }),
+    };
+    const handler = new ExtractFactsHandler();
+    const ctx = {
+      input: { text: 'Bob lives in Toronto.', source: 'test' },
+      secret: () => 'test-api-key',
+      log: pino({ level: 'silent' }),
+      entityMemory,
+      llmProvider: mockLlmProvider,
+      modelRouter: mockModelRouter,
+    } as unknown as SkillContext;
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: false, error: 'Classifier LLM call failed: Rate limit exceeded' });
+  });
+
+  it('returns error when extraction LLM call fails', async () => {
+    const entityMemory = makeEntityMemory();
+    const { mockModelRouter } = makeMocks([]);
+    let callCount = 0;
+    const mockLlmProvider = {
+      chat: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // Classifier succeeds with 'yes'
+          return Promise.resolve({ type: 'text', content: 'yes' });
+        }
+        // Extraction fails
+        return Promise.resolve({ type: 'error', error: new Error('Context window exceeded') });
+      }),
+    };
+    const handler = new ExtractFactsHandler();
+    const ctx = {
+      input: { text: 'Bob lives in Toronto.', source: 'test' },
+      secret: () => 'test-api-key',
+      log: pino({ level: 'silent' }),
+      entityMemory,
+      llmProvider: mockLlmProvider,
+      modelRouter: mockModelRouter,
+    } as unknown as SkillContext;
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: false, error: 'Extraction LLM call failed: Context window exceeded' });
   });
 });

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -6,15 +6,13 @@
 //
 // Idempotent: storeFact() handles deduplication — reasserting the same fact
 // merges into or confirms the existing fact node rather than creating a duplicate.
+//
+// LLM calls go through the shared LLMProvider + ModelRouter rather than a raw
+// Anthropic client so all calls are tracked by the telemetry / cost infrastructure.
 
-import Anthropic from '@anthropic-ai/sdk';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { DECAY_CLASSES, NODE_TYPES } from '../../src/memory/types.js';
 import type { DecayClass, NodeType } from '../../src/memory/types.js';
-
-// Model constants — update here when model IDs rotate
-const CLASSIFIER_MODEL = 'claude-haiku-4-5-20251001';
-const EXTRACTION_MODEL = 'claude-sonnet-4-6';
 
 // Shape of each fact returned by the LLM extraction prompt.
 interface ExtractedFact {
@@ -33,11 +31,6 @@ const NODE_TYPES_LIST = NODE_TYPES.filter(t => t !== 'fact').join(', ');
 const DECAY_CLASSES_LIST = DECAY_CLASSES.join(', ');
 
 export class ExtractFactsHandler implements SkillHandler {
-  // Optional Anthropic client injection for testing.
-  // In production the skill registry instantiates with no args and the
-  // handler creates its own client from ctx.secret('ANTHROPIC_API_KEY').
-  constructor(private readonly anthropicClient?: Anthropic) {}
-
   async execute(ctx: SkillContext): Promise<SkillResult> {
     const { text, source } = ctx.input as { text?: string; source?: string };
 
@@ -55,33 +48,38 @@ export class ExtractFactsHandler implements SkillHandler {
       return { success: false, error: 'Entity memory not available — database not configured' };
     }
 
+    // Guard: llmProvider and modelRouter are required capabilities declared in skill.json.
+    // If either is missing the execution layer mis-configured this invocation.
+    if (!ctx.llmProvider || !ctx.modelRouter) {
+      return { success: false, error: 'extract-facts requires llmProvider and modelRouter capabilities' };
+    }
+
+    // Resolve tier names to concrete model strings at invocation time.
+    // Using the shared ModelRouter keeps model selection centralised — if the operator
+    // rotates a model, this skill picks up the new string automatically.
+    const classifierModel = ctx.modelRouter.resolve('fast').model;
+    const extractionModel = ctx.modelRouter.resolve('standard').model;
+
     try {
-      // Construct client inside the try so a missing/invalid secret returns { success: false }
-      // rather than throwing — skills must never throw (CLAUDE.md: "Skills return... never throw").
-      const client = this.anthropicClient ?? new Anthropic({ apiKey: ctx.secret('ANTHROPIC_API_KEY') });
       // -- Step 1: Classifier gate --
-      // Cheap haiku call — exits early on messages that carry no facts about a
+      // Cheap fast-tier call — exits early on messages that carry no facts about a
       // single entity (e.g. action requests, scheduling, relationship-only text).
-      const classifierResponse = await client.messages.create({
-        model: CLASSIFIER_MODEL,
-        max_tokens: 10,
+      const classifyResponse = await ctx.llmProvider.chat({
+        model: classifierModel,
         messages: [{
           role: 'user',
           content: `Does the following text assert an attribute, fact, or characteristic about a single entity (for example: a person, organisation, project, event, or other entity — such as where they are located, their role, their status, or their preferences)? Answer only 'yes' or 'no'.\n\n${text}`,
         }],
+        options: { max_tokens: 10 },
       });
 
-      const classifierTextBlock = classifierResponse.content.find(
-        (c): c is { type: 'text'; text: string } => c.type === 'text',
-      );
-      if (!classifierTextBlock) {
-        // Unexpected: the model returned no text block at all. Treat as an infrastructure
-        // error so the checkpoint processor logs a warning rather than silently advancing
-        // the watermark as if extraction succeeded.
-        ctx.log.warn({ textPreview: text.slice(0, 80) }, 'extract-facts: classifier returned no text block');
-        return { success: false, error: 'Classifier returned no text block' };
+      if (classifyResponse.type === 'error') {
+        ctx.log.error({ error: classifyResponse.error }, 'extract-facts: classifier LLM call failed');
+        return { success: false, error: `Classifier LLM call failed: ${classifyResponse.error.message}` };
       }
-      const classifierAnswer = classifierTextBlock.text.toLowerCase().trim();
+
+      // LLMProvider.chat() returns content as a plain string (not content[0].text).
+      const classifierAnswer = classifyResponse.content.toLowerCase().trim();
 
       if (!classifierAnswer.startsWith('yes')) {
         ctx.log.debug({ textPreview: text.slice(0, 80) }, 'extract-facts: classifier gate — no facts, skipping');
@@ -89,10 +87,9 @@ export class ExtractFactsHandler implements SkillHandler {
       }
 
       // -- Step 2: Extraction prompt --
-      // Sonnet call with the full vocabulary. Returns JSON array of facts.
-      const extractionResponse = await client.messages.create({
-        model: EXTRACTION_MODEL,
-        max_tokens: 1000,
+      // Standard-tier call with the full vocabulary. Returns JSON array of facts.
+      const extractionResponse = await ctx.llmProvider.chat({
+        model: extractionModel,
         messages: [{
           role: 'user',
           content: `Extract single-entity attribute facts from the text below. Return a JSON array of fact objects.
@@ -119,19 +116,16 @@ Format:
 Text:
 ${text}`,
         }],
+        options: { max_tokens: 1000 },
       });
 
-      const extractionTextBlock = extractionResponse.content.find(
-        (c): c is { type: 'text'; text: string } => c.type === 'text',
-      );
-      if (!extractionTextBlock) {
-        // Unexpected: model returned no text block — surface as failure so this
-        // is distinguishable from a genuine "no facts found" outcome.
-        ctx.log.warn('extract-facts: extraction returned no text block');
-        return { success: false, error: 'Extraction returned no text block' };
+      if (extractionResponse.type === 'error') {
+        ctx.log.error({ error: extractionResponse.error }, 'extract-facts: extraction LLM call failed');
+        return { success: false, error: `Extraction LLM call failed: ${extractionResponse.error.message}` };
       }
+
       // Strip optional markdown code fences the model may include despite instructions.
-      const rawText = extractionTextBlock.text.trim();
+      const rawText = extractionResponse.content.trim();
       const jsonText = rawText.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
 
       let facts: ExtractedFact[];
@@ -296,8 +290,9 @@ ${text}`,
       return { success: true, data: { stored, skipped: false, failed } };
     } catch (err) {
       // Two categories of errors reach here:
-      // 1. Anthropic SDK errors (rate limits, auth, timeouts, 5xx) from the classifier
-      //    and extraction calls.
+      // 1. LLMProvider errors (rate limits, auth, timeouts, 5xx) — these are returned as
+      //    { type: 'error' } values above, not thrown, so this catch only fires for
+      //    unexpected cases (e.g. provider implementation bug that throws instead of returning).
       // 2. Programming errors (TypeError, ReferenceError, RangeError, EvalError, URIError)
       //    re-thrown from the per-fact loop — indicate bugs in this handler, not infra issues.
       ctx.log.error({ err }, 'extract-facts: unexpected error');

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -51,6 +51,7 @@ export class ExtractFactsHandler implements SkillHandler {
     // Guard: llmProvider and modelRouter are required capabilities declared in skill.json.
     // If either is missing the execution layer mis-configured this invocation.
     if (!ctx.llmProvider || !ctx.modelRouter) {
+      ctx.log.error('extract-facts: llmProvider or modelRouter capability missing — execution layer misconfigured');
       return { success: false, error: 'extract-facts requires llmProvider and modelRouter capabilities' };
     }
 

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -55,13 +55,12 @@ export class ExtractFactsHandler implements SkillHandler {
       return { success: false, error: 'extract-facts requires llmProvider and modelRouter capabilities' };
     }
 
-    // Resolve tier names to concrete model strings at invocation time.
-    // Using the shared ModelRouter keeps model selection centralised — if the operator
-    // rotates a model, this skill picks up the new string automatically.
-    const classifierModel = ctx.modelRouter.resolve('fast').model;
-    const extractionModel = ctx.modelRouter.resolve('standard').model;
-
     try {
+      // Resolve tier names to concrete model strings at invocation time.
+      // Kept inside the try so a bad routing config (ModelRouter.resolve() throws)
+      // returns { success: false } instead of letting execute() throw.
+      const classifierModel = ctx.modelRouter.resolve('fast').model;
+      const extractionModel = ctx.modelRouter.resolve('standard').model;
       // -- Step 1: Classifier gate --
       // Cheap fast-tier call — exits early on messages that carry no facts about a
       // single entity (e.g. action requests, scheduling, relationship-only text).

--- a/skills/extract-facts/skill.json
+++ b/skills/extract-facts/skill.json
@@ -14,11 +14,11 @@
     "failed": "number (facts that could not be persisted due to errors)"
   },
   "permissions": [],
-  "secrets": [
-    "ANTHROPIC_API_KEY"
-  ],
+  "secrets": [],
   "timeout": 15000,
   "capabilities": [
-    "entityMemory"
+    "entityMemory",
+    "llmProvider",
+    "modelRouter"
   ]
 }

--- a/skills/extract-relationships/handler.test.ts
+++ b/skills/extract-relationships/handler.test.ts
@@ -1,7 +1,7 @@
 // handler.test.ts — unit tests for extract-relationships skill.
 //
-// Uses an in-memory KG backend (no Postgres) and a mock Anthropic client
-// injected via the handler constructor, so no real API calls are made.
+// Uses an in-memory KG backend (no Postgres) and a mock LLMProvider + ModelRouter
+// injected via the skill context, so no real API calls are made.
 
 import { describe, it, expect, vi } from 'vitest';
 import pino from 'pino';
@@ -22,27 +22,35 @@ function makeEntityMemory(): EntityMemory {
   return new EntityMemory(store, validator, embeddingService, createSilentLogger());
 }
 
-function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>): SkillContext {
+// Creates a mock ModelRouter that maps 'fast' → haiku and 'standard' → sonnet.
+const mockModelRouter = {
+  resolve: vi.fn().mockImplementation((tier: string) => ({
+    model: tier === 'fast' ? 'claude-haiku-4-5' : 'claude-sonnet-4-6',
+    tier,
+  })),
+};
+
+// Creates a mock LLMProvider that returns a scripted sequence of responses.
+// First call is the classifier gate; second call (if triggered) is extraction.
+function makeMockLlmProvider(responses: string[]) {
+  let callIndex = 0;
+  return {
+    chat: vi.fn().mockImplementation(() => {
+      const content = responses[callIndex++] ?? 'no';
+      return Promise.resolve({ type: 'text', content });
+    }),
+  };
+}
+
+function makeCtx(entityMemory: EntityMemory, input: Record<string, unknown>, llmProvider: ReturnType<typeof makeMockLlmProvider>): SkillContext {
   return {
     input,
     secret: () => 'test-api-key',
     log: pino({ level: 'silent' }),
     entityMemory,
+    llmProvider,
+    modelRouter: mockModelRouter,
   } as unknown as SkillContext;
-}
-
-// Creates a mock Anthropic client that returns a scripted sequence of responses.
-// First call is the classifier gate; second call (if triggered) is extraction.
-function makeMockAnthropicClient(responses: string[]) {
-  let callIndex = 0;
-  return {
-    messages: {
-      create: vi.fn().mockImplementation(() => {
-        const text = responses[callIndex++] ?? 'no';
-        return Promise.resolve({ content: [{ type: 'text', text }] });
-      }),
-    },
-  };
 }
 
 // -- Tests --
@@ -50,18 +58,18 @@ function makeMockAnthropicClient(responses: string[]) {
 describe('ExtractRelationshipsHandler', () => {
   it('returns skipped:true when classifier gate fires on unrelated text', async () => {
     const entityMemory = makeEntityMemory();
-    const anthropic = makeMockAnthropicClient(['no']);
-    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const llmProvider = makeMockLlmProvider(['no']);
+    const handler = new ExtractRelationshipsHandler();
     const ctx = makeCtx(entityMemory, {
       text: 'Please schedule a call with the engineering team for Thursday.',
       source: 'test',
-    });
+    }, llmProvider);
 
     const result = await handler.execute(ctx);
 
     expect(result).toEqual({ success: true, data: { extracted: 0, confirmed: 0, skipped: true } });
-    // Classifier was called; extraction was not (only 1 API call made)
-    expect(anthropic.messages.create).toHaveBeenCalledTimes(1);
+    // Classifier was called; extraction was not (only 1 LLM call made)
+    expect(llmProvider.chat).toHaveBeenCalledTimes(1);
   });
 
   it('extracts a single relationship and persists the edge', async () => {
@@ -69,12 +77,12 @@ describe('ExtractRelationshipsHandler', () => {
     const triple = JSON.stringify([
       { subject: 'Ada Lovelace', subjectType: 'person', predicate: 'manages', object: 'Project Orion', objectType: 'project', confidence: 0.9 },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', triple]);
-    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const llmProvider = makeMockLlmProvider(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler();
     const ctx = makeCtx(entityMemory, {
       text: 'Ada Lovelace is the lead on Project Orion.',
       source: 'test',
-    });
+    }, llmProvider);
 
     const result = await handler.execute(ctx);
 
@@ -98,15 +106,15 @@ describe('ExtractRelationshipsHandler', () => {
     ]);
 
     // First invocation — creates the edge
-    const anthropic1 = makeMockAnthropicClient(['yes', triple]);
-    const handler1 = new ExtractRelationshipsHandler(anthropic1 as never);
-    const ctx1 = makeCtx(entityMemory, { text: 'John Smith is Bob\'s wife.', source: 'test' });
+    const llmProvider1 = makeMockLlmProvider(['yes', triple]);
+    const handler1 = new ExtractRelationshipsHandler();
+    const ctx1 = makeCtx(entityMemory, { text: 'John Smith is Bob\'s wife.', source: 'test' }, llmProvider1);
     await handler1.execute(ctx1);
 
     // Second invocation with same text — should confirm, not duplicate
-    const anthropic2 = makeMockAnthropicClient(['yes', triple]);
-    const handler2 = new ExtractRelationshipsHandler(anthropic2 as never);
-    const ctx2 = makeCtx(entityMemory, { text: 'John Smith is Bob\'s wife.', source: 'test' });
+    const llmProvider2 = makeMockLlmProvider(['yes', triple]);
+    const handler2 = new ExtractRelationshipsHandler();
+    const ctx2 = makeCtx(entityMemory, { text: 'John Smith is Bob\'s wife.', source: 'test' }, llmProvider2);
     const result = await handler2.execute(ctx2);
 
     expect(result).toEqual({ success: true, data: { extracted: 0, confirmed: 1, failed: 0, skipped: false } });
@@ -126,12 +134,12 @@ describe('ExtractRelationshipsHandler', () => {
     const triple = JSON.stringify([
       { subject: 'New Person A', subjectType: 'person', predicate: 'collaborates_with', object: 'New Person B', objectType: 'person', confidence: 0.8 },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', triple]);
-    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const llmProvider = makeMockLlmProvider(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler();
     const ctx = makeCtx(entityMemory, {
       text: 'New Person A is collaborating with New Person B.',
       source: 'test',
-    });
+    }, llmProvider);
 
     await handler.execute(ctx);
 
@@ -150,12 +158,12 @@ describe('ExtractRelationshipsHandler', () => {
     const triple = JSON.stringify([
       { subject: 'John Smith', subjectType: 'person', predicate: 'spouse', object: 'Jane Doe', objectType: 'person', confidence: 0.95 },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', triple]);
-    const handler = new ExtractRelationshipsHandler(anthropic as never);
+    const llmProvider = makeMockLlmProvider(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler();
     const ctx = makeCtx(entityMemory, {
       text: 'John Smith is Bob\'s wife.',
       source: 'test',
-    });
+    }, llmProvider);
 
     const result = await handler.execute(ctx);
 
@@ -178,9 +186,9 @@ describe('ExtractRelationshipsHandler', () => {
     const triple = JSON.stringify([
       { subject: 'Alice', subjectType: 'person', predicate: 'knows_well', object: 'Bob', objectType: 'person', confidence: 0.7 },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', triple]);
-    const handler = new ExtractRelationshipsHandler(anthropic as never);
-    const ctx = makeCtx(entityMemory, { text: 'Alice knows Bob well.', source: 'test' });
+    const llmProvider = makeMockLlmProvider(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler();
+    const ctx = makeCtx(entityMemory, { text: 'Alice knows Bob well.', source: 'test' }, llmProvider);
 
     await handler.execute(ctx);
 

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -51,13 +51,12 @@ export class ExtractRelationshipsHandler implements SkillHandler {
       return { success: false, error: 'extract-relationships requires llmProvider and modelRouter capabilities' };
     }
 
-    // Resolve tier names to concrete model strings at invocation time.
-    // Using the shared ModelRouter keeps model selection centralised — if the operator
-    // rotates a model, this skill picks up the new string automatically.
-    const classifierModel = ctx.modelRouter.resolve('fast').model;
-    const extractionModel = ctx.modelRouter.resolve('standard').model;
-
     try {
+      // Resolve tier names to concrete model strings at invocation time.
+      // Kept inside the try so a bad routing config (ModelRouter.resolve() throws)
+      // returns { success: false } instead of letting execute() throw.
+      const classifierModel = ctx.modelRouter.resolve('fast').model;
+      const extractionModel = ctx.modelRouter.resolve('standard').model;
     // -- Step 1: Classifier gate --
     // Cheap fast-tier call — exits early on the majority of messages (scheduling,
     // email drafts, lookups) that contain no entity-to-entity relationships.

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -47,6 +47,7 @@ export class ExtractRelationshipsHandler implements SkillHandler {
     // Guard: llmProvider and modelRouter are required capabilities declared in skill.json.
     // If either is missing the execution layer mis-configured this invocation.
     if (!ctx.llmProvider || !ctx.modelRouter) {
+      ctx.log.error('extract-relationships: llmProvider or modelRouter capability missing — execution layer misconfigured');
       return { success: false, error: 'extract-relationships requires llmProvider and modelRouter capabilities' };
     }
 
@@ -71,7 +72,7 @@ export class ExtractRelationshipsHandler implements SkillHandler {
 
     if (classifierResponse.type === 'error') {
       ctx.log.error({ error: classifierResponse.error }, 'extract-relationships: classifier LLM call failed');
-      return { success: false, error: `LLM call failed: ${classifierResponse.error.message}` };
+      return { success: false, error: `Classifier LLM call failed: ${classifierResponse.error.message}` };
     }
 
     // LLMProvider.chat() returns content as a plain string (not content[0].text).

--- a/skills/extract-relationships/handler.ts
+++ b/skills/extract-relationships/handler.ts
@@ -6,15 +6,13 @@
 //
 // Idempotent: calling it twice with the same triple confirms the existing
 // edge rather than inserting a duplicate, and may raise its confidence.
+//
+// LLM calls go through the shared LLMProvider + ModelRouter rather than a raw
+// Anthropic client so all calls are tracked by the telemetry / cost infrastructure.
 
-import Anthropic from '@anthropic-ai/sdk';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { EDGE_TYPES, NODE_TYPES } from '../../src/memory/types.js';
 import type { EdgeType, NodeType } from '../../src/memory/types.js';
-
-// Model constants — update here when model IDs rotate
-const CLASSIFIER_MODEL = 'claude-haiku-4-5-20251001';
-const EXTRACTION_MODEL = 'claude-sonnet-4-6';
 
 // Shape of each triple returned by the LLM extraction prompt.
 interface ExtractedTriple {
@@ -30,11 +28,6 @@ const EDGE_TYPES_LIST = EDGE_TYPES.join(', ');
 const NODE_TYPES_LIST = NODE_TYPES.join(', ');
 
 export class ExtractRelationshipsHandler implements SkillHandler {
-  // Optional Anthropic client injection for testing.
-  // In production the skill registry instantiates with no args and the
-  // handler creates its own client from ctx.secret('ANTHROPIC_API_KEY').
-  constructor(private readonly anthropicClient?: Anthropic) {}
-
   async execute(ctx: SkillContext): Promise<SkillResult> {
     const { text, source } = ctx.input as { text?: string; source?: string };
 
@@ -51,29 +44,38 @@ export class ExtractRelationshipsHandler implements SkillHandler {
       return { success: false, error: 'Entity memory not available — database not configured' };
     }
 
-    const client = this.anthropicClient ?? new Anthropic({ apiKey: ctx.secret('ANTHROPIC_API_KEY') });
+    // Guard: llmProvider and modelRouter are required capabilities declared in skill.json.
+    // If either is missing the execution layer mis-configured this invocation.
+    if (!ctx.llmProvider || !ctx.modelRouter) {
+      return { success: false, error: 'extract-relationships requires llmProvider and modelRouter capabilities' };
+    }
+
+    // Resolve tier names to concrete model strings at invocation time.
+    // Using the shared ModelRouter keeps model selection centralised — if the operator
+    // rotates a model, this skill picks up the new string automatically.
+    const classifierModel = ctx.modelRouter.resolve('fast').model;
+    const extractionModel = ctx.modelRouter.resolve('standard').model;
 
     try {
     // -- Step 1: Classifier gate --
-    // Cheap haiku call — exits early on the majority of messages (scheduling,
+    // Cheap fast-tier call — exits early on the majority of messages (scheduling,
     // email drafts, lookups) that contain no entity-to-entity relationships.
-    const classifierResponse = await client.messages.create({
-      model: CLASSIFIER_MODEL,
-      max_tokens: 10,
+    const classifierResponse = await ctx.llmProvider.chat({
+      model: classifierModel,
       messages: [{
         role: 'user',
         content: `Does the following text assert a relationship or connection between two or more people or organisations? Answer only 'yes' or 'no'.\n\n${text}`,
       }],
+      options: { max_tokens: 10 },
     });
 
-    const classifierTextBlock = classifierResponse.content.find(
-      (c): c is { type: 'text'; text: string } => c.type === 'text',
-    );
-    if (!classifierTextBlock) {
-      ctx.log.warn({ textPreview: text.slice(0, 80) }, 'extract-relationships: classifier returned no text block, skipping');
-      return { success: true, data: { extracted: 0, confirmed: 0, skipped: true } };
+    if (classifierResponse.type === 'error') {
+      ctx.log.error({ error: classifierResponse.error }, 'extract-relationships: classifier LLM call failed');
+      return { success: false, error: `LLM call failed: ${classifierResponse.error.message}` };
     }
-    const classifierAnswer = classifierTextBlock.text.toLowerCase().trim();
+
+    // LLMProvider.chat() returns content as a plain string (not content[0].text).
+    const classifierAnswer = classifierResponse.content.toLowerCase().trim();
 
     if (!classifierAnswer.startsWith('yes')) {
       ctx.log.debug({ textPreview: text.slice(0, 80) }, 'extract-relationships: classifier gate — no relationships, skipping');
@@ -81,10 +83,9 @@ export class ExtractRelationshipsHandler implements SkillHandler {
     }
 
     // -- Step 2: Extraction prompt --
-    // Sonnet call with the full EDGE_TYPES vocabulary. Returns JSON triples.
-    const extractionResponse = await client.messages.create({
-      model: EXTRACTION_MODEL,
-      max_tokens: 1000,
+    // Standard-tier call with the full EDGE_TYPES vocabulary. Returns JSON triples.
+    const extractionResponse = await ctx.llmProvider.chat({
+      model: extractionModel,
       messages: [{
         role: 'user',
         content: `Extract entity-to-entity relationships from the text below. Return a JSON array of relationship triples.
@@ -105,18 +106,17 @@ Format:
 Text:
 ${text}`,
       }],
+      options: { max_tokens: 1000 },
     });
 
-    const extractionTextBlock = extractionResponse.content.find(
-      (c): c is { type: 'text'; text: string } => c.type === 'text',
-    );
-    if (!extractionTextBlock) {
-      ctx.log.warn('extract-relationships: extraction returned no text block, treating as empty');
-      return { success: true, data: { extracted: 0, confirmed: 0, skipped: false } };
+    if (extractionResponse.type === 'error') {
+      ctx.log.error({ error: extractionResponse.error }, 'extract-relationships: extraction LLM call failed');
+      return { success: false, error: `LLM call failed: ${extractionResponse.error.message}` };
     }
+
     // Strip optional markdown code fences the model may include despite instructions.
     // Case-insensitive to handle ```JSON as well as ```json.
-    const rawText = extractionTextBlock.text.trim();
+    const rawText = extractionResponse.content.trim();
     const jsonText = rawText.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
 
     let triples: ExtractedTriple[];
@@ -237,7 +237,8 @@ ${text}`,
     ctx.log.info({ extracted, confirmed, failed }, 'extract-relationships: complete');
     return { success: true, data: { extracted, confirmed, failed, skipped: false } };
     } catch (err) {
-      // Top-level catch for Anthropic API errors (rate limits, auth, timeouts, 5xx).
+      // Top-level catch for unexpected errors (e.g. provider implementation bugs that
+      // throw instead of returning { type: 'error' }).
       // Skills must never throw — return a failure result so the execution layer
       // can audit and surface the error to the caller.
       ctx.log.error({ err }, 'extract-relationships: unexpected error');

--- a/skills/extract-relationships/skill.json
+++ b/skills/extract-relationships/skill.json
@@ -14,11 +14,11 @@
     "skipped": "boolean (true if the classifier gate determined no relationships were present)"
   },
   "permissions": [],
-  "secrets": [
-    "ANTHROPIC_API_KEY"
-  ],
+  "secrets": [],
   "timeout": 15000,
   "capabilities": [
-    "entityMemory"
+    "entityMemory",
+    "llmProvider",
+    "modelRouter"
   ]
 }

--- a/skills/file-parse/handler.test.ts
+++ b/skills/file-parse/handler.test.ts
@@ -4,12 +4,42 @@ import { parseCsv } from './csv.js';
 import { FileParseHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 
-function makeCtx(input: Record<string, unknown>): SkillContext {
+// Minimal modelRouter stub that always resolves to 'claude-sonnet-4-6'
+const mockModelRouter = {
+  resolve: (_tier: string) => ({ model: 'claude-sonnet-4-6' }),
+};
+
+function makeCtx(
+  input: Record<string, unknown>,
+  llmProvider?: SkillContext['llmProvider'],
+): SkillContext {
   return {
     input,
     secret: () => 'test-api-key',
     log: pino({ level: 'silent' }),
+    llmProvider,
+    modelRouter: mockModelRouter,
   } as unknown as SkillContext;
+}
+
+/**
+ * Build a mock LLMProvider that returns a successful text response.
+ */
+function makeLlmProvider(responseText: string) {
+  const chat = vi.fn().mockResolvedValue({ type: 'text', content: responseText, usage: {}, provenance: {} });
+  return { id: 'mock', chat };
+}
+
+/**
+ * Build a mock LLMProvider that rejects (simulates an API error returned as
+ * a discriminated-union error value, not a thrown exception).
+ */
+function makeLlmProviderError(message: string) {
+  const chat = vi.fn().mockResolvedValue({
+    type: 'error',
+    error: { message, code: 'LLM_ERROR' },
+  });
+  return { id: 'mock', chat };
 }
 
 describe('parseCsv', () => {
@@ -52,17 +82,48 @@ describe('parseCsv', () => {
 });
 
 describe('FileParseHandler', () => {
+  describe('capability guard', () => {
+    it('returns error when llmProvider is missing', async () => {
+      const handler = new FileParseHandler();
+      // Pass no llmProvider so the guard fires
+      const ctx = {
+        input: { content_base64: Buffer.from('a,b\n1,2').toString('base64'), mime_type: 'text/csv' },
+        secret: () => 'test-api-key',
+        log: pino({ level: 'silent' }),
+        llmProvider: undefined,
+        modelRouter: mockModelRouter,
+      } as unknown as SkillContext;
+      const result = await handler.execute(ctx);
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/llmProvider/);
+    });
+
+    it('returns error when modelRouter is missing', async () => {
+      const handler = new FileParseHandler();
+      const ctx = {
+        input: { content_base64: Buffer.from('a,b\n1,2').toString('base64'), mime_type: 'text/csv' },
+        secret: () => 'test-api-key',
+        log: pino({ level: 'silent' }),
+        llmProvider: makeLlmProvider('{}'),
+        modelRouter: undefined,
+      } as unknown as SkillContext;
+      const result = await handler.execute(ctx);
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/modelRouter/);
+    });
+  });
+
   describe('input validation', () => {
     const handler = new FileParseHandler();
 
     it('rejects missing content_base64', async () => {
-      const result = await handler.execute(makeCtx({ mime_type: 'text/csv' }));
+      const result = await handler.execute(makeCtx({ mime_type: 'text/csv' }, makeLlmProvider('{}')));
       expect(result.success).toBe(false);
       if (!result.success) expect(result.error).toMatch(/content_base64/);
     });
 
     it('rejects missing mime_type', async () => {
-      const result = await handler.execute(makeCtx({ content_base64: 'abc' }));
+      const result = await handler.execute(makeCtx({ content_base64: 'abc' }, makeLlmProvider('{}')));
       expect(result.success).toBe(false);
       if (!result.success) expect(result.error).toMatch(/mime_type/);
     });
@@ -72,7 +133,7 @@ describe('FileParseHandler', () => {
       const result = await handler.execute(makeCtx({
         content_base64: content,
         mime_type: 'application/octet-stream',
-      }));
+      }, makeLlmProvider('{}')));
       expect(result.success).toBe(false);
       if (!result.success) expect(result.error).toMatch(/unsupported/i);
     });
@@ -85,7 +146,7 @@ describe('FileParseHandler', () => {
         content_base64: content,
         mime_type: 'text/csv',
         extract_as: '',
-      }));
+      }, makeLlmProvider('{}')));
       expect(result.success).toBe(false);
       if (!result.success) expect(result.error).toMatch(/extract_as/);
     });
@@ -99,7 +160,7 @@ describe('FileParseHandler', () => {
         content_base64: content,
         mime_type: 'text/csv',
         extract_as: 'purchase_order',
-      }));
+      }, makeLlmProvider('{}')));
       expect(result.success).toBe(true);
     });
   });
@@ -108,13 +169,16 @@ describe('FileParseHandler', () => {
     const handler = new FileParseHandler();
 
     it('parses CSV content without LLM call', async () => {
+      const llmProvider = makeLlmProvider('{}');
       const csv = 'date,vendor,amount\n2026-01-15,OpenAI,20.00';
       const content = Buffer.from(csv).toString('base64');
       const result = await handler.execute(makeCtx({
         content_base64: content,
         mime_type: 'text/csv',
-      }));
+      }, llmProvider));
       expect(result.success).toBe(true);
+      // CSV is deterministic — LLM should not be called
+      expect(llmProvider.chat).not.toHaveBeenCalled();
       if (result.success) {
         const data = result.data as { type: string; raw_text: string; structured: unknown; confidence: number };
         expect(data.type).toBe('csv');
@@ -131,7 +195,7 @@ describe('FileParseHandler', () => {
       const result = await handler.execute(makeCtx({
         content_base64: content,
         mime_type: 'text/csv',
-      }));
+      }, makeLlmProvider('{}')));
       expect(result.success).toBe(true);
       if (result.success) {
         const data = result.data as { raw_text: string };
@@ -141,53 +205,52 @@ describe('FileParseHandler', () => {
   });
 
   describe('image handling (vision)', () => {
-    it('calls Claude vision API for image/jpeg', async () => {
-      const mockCreate = vi.fn().mockResolvedValue({
-        content: [{ type: 'text', text: '{"vendor":"Starbucks","amount":5.75,"currency":"CAD","date":"2026-03-10","tax":0.75,"line_items":[]}' }],
-      });
-      const mockClient = { messages: { create: mockCreate } };
-      const handler = new FileParseHandler(mockClient as any);
+    it('calls LLMProvider.chat for image/jpeg with vision content', async () => {
+      const jsonText = '{"vendor":"Starbucks","amount":5.75,"currency":"CAD","date":"2026-03-10","tax":0.75,"line_items":[]}';
+      const llmProvider = makeLlmProvider(jsonText);
 
+      const handler = new FileParseHandler();
       const content = Buffer.from('fake-image-bytes').toString('base64');
       const result = await handler.execute(makeCtx({
         content_base64: content,
         mime_type: 'image/jpeg',
         extract_as: 'receipt',
-      }));
+      }, llmProvider));
 
       expect(result.success).toBe(true);
-      expect(mockCreate).toHaveBeenCalledOnce();
-      const callArgs = mockCreate.mock.calls[0][0];
+      expect(llmProvider.chat).toHaveBeenCalledOnce();
+
+      // Verify the message structure includes an image block
+      const callArgs = llmProvider.chat.mock.calls[0][0];
       const userMessage = callArgs.messages[0];
       expect(userMessage.content).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ type: 'image', source: expect.objectContaining({ type: 'base64' }) }),
         ]),
       );
+
       if (result.success) {
         const data = result.data as { structured: { vendor: string } };
         expect(data.structured.vendor).toBe('Starbucks');
       }
     });
 
-    it('normalizes image/jpg to image/jpeg for the Anthropic API', async () => {
+    it('normalizes image/jpg to image/jpeg in the vision call', async () => {
       // The Anthropic API only accepts image/jpeg, not the non-standard image/jpg alias.
-      // Verify the normalization happens before the API call.
-      const mockCreate = vi.fn().mockResolvedValue({
-        content: [{ type: 'text', text: '{"vendor":"Test","amount":1,"currency":"CAD","date":"2026-01-01","tax":null,"line_items":[]}' }],
-      });
-      const mockClient = { messages: { create: mockCreate } };
-      const handler = new FileParseHandler(mockClient as any);
+      // Verify the normalization happens before the LLMProvider call.
+      const jsonText = '{"vendor":"Test","amount":1,"currency":"CAD","date":"2026-01-01","tax":null,"line_items":[]}';
+      const llmProvider = makeLlmProvider(jsonText);
+      const handler = new FileParseHandler();
 
       const content = Buffer.from('fake-image-bytes').toString('base64');
       await handler.execute(makeCtx({
         content_base64: content,
         mime_type: 'image/jpg',
         extract_as: 'receipt',
-      }));
+      }, llmProvider));
 
-      expect(mockCreate).toHaveBeenCalledOnce();
-      const callArgs = mockCreate.mock.calls[0][0];
+      expect(llmProvider.chat).toHaveBeenCalledOnce();
+      const callArgs = llmProvider.chat.mock.calls[0][0];
       const imageBlock = callArgs.messages[0].content.find(
         (c: { type: string }) => c.type === 'image',
       );
@@ -206,7 +269,7 @@ describe('FileParseHandler', () => {
         content_base64: content,
         mime_type: 'text/html',
         extract_as: 'raw',
-      }));
+      }, makeLlmProvider('{}')));
       expect(result.success).toBe(true);
       if (result.success) {
         const data = result.data as { raw_text: string };
@@ -226,7 +289,7 @@ describe('FileParseHandler', () => {
         content_base64: content,
         mime_type: 'text/html',
         extract_as: 'raw',
-      }));
+      }, makeLlmProvider('{}')));
       expect(result.success).toBe(true);
       if (result.success) {
         const data = result.data as { raw_text: string };
@@ -237,7 +300,8 @@ describe('FileParseHandler', () => {
   });
 
   describe('HTML handling', () => {
-    it('extracts text from HTML and returns raw_text', async () => {
+    it('extracts text from HTML and returns raw_text (no LLM call for raw)', async () => {
+      const llmProvider = makeLlmProvider('{}');
       const html = '<html><body><h1>Invoice</h1><p>Amount: $50.00</p></body></html>';
       const content = Buffer.from(html).toString('base64');
       const handler = new FileParseHandler();
@@ -245,8 +309,10 @@ describe('FileParseHandler', () => {
         content_base64: content,
         mime_type: 'text/html',
         extract_as: 'raw',
-      }));
+      }, llmProvider));
       expect(result.success).toBe(true);
+      // extract_as: raw → no LLM call
+      expect(llmProvider.chat).not.toHaveBeenCalled();
       if (result.success) {
         const data = result.data as { type: string; raw_text: string };
         expect(data.type).toBe('html');
@@ -255,12 +321,10 @@ describe('FileParseHandler', () => {
       }
     });
 
-    it('uses LLM for structured extraction from HTML', async () => {
-      const mockCreate = vi.fn().mockResolvedValue({
-        content: [{ type: 'text', text: '{"vendor":"Acme","amount":50,"currency":"USD","date":"2026-01-01","tax":null,"line_items":[]}' }],
-      });
-      const mockClient = { messages: { create: mockCreate } };
-      const handler = new FileParseHandler(mockClient as any);
+    it('uses LLMProvider.chat for structured extraction from HTML', async () => {
+      const jsonText = '{"vendor":"Acme","amount":50,"currency":"USD","date":"2026-01-01","tax":null,"line_items":[]}';
+      const llmProvider = makeLlmProvider(jsonText);
+      const handler = new FileParseHandler();
 
       const html = '<html><body><p>Receipt from Acme: $50 USD</p></body></html>';
       const content = Buffer.from(html).toString('base64');
@@ -268,10 +332,10 @@ describe('FileParseHandler', () => {
         content_base64: content,
         mime_type: 'text/html',
         extract_as: 'receipt',
-      }));
+      }, llmProvider));
 
       expect(result.success).toBe(true);
-      expect(mockCreate).toHaveBeenCalledOnce();
+      expect(llmProvider.chat).toHaveBeenCalledOnce();
     });
   });
 
@@ -282,17 +346,16 @@ describe('FileParseHandler', () => {
       const result = await handler.execute(makeCtx({
         content_base64: content,
         mime_type: 'application/pdf',
-      }));
+      }, makeLlmProvider('{}')));
       expect(result.success).toBe(false);
       if (!result.success) expect(result.error).toMatch(/pdf/i);
     });
   });
 
   describe('LLM error handling', () => {
-    it('returns success: false when LLM call throws', async () => {
-      const mockCreate = vi.fn().mockRejectedValue(new Error('API rate limited'));
-      const mockClient = { messages: { create: mockCreate } };
-      const handler = new FileParseHandler(mockClient as any);
+    it('returns success: false when LLM call returns an error response', async () => {
+      const llmProvider = makeLlmProviderError('API rate limited');
+      const handler = new FileParseHandler();
 
       const html = '<p>receipt</p>';
       const content = Buffer.from(html).toString('base64');
@@ -300,18 +363,15 @@ describe('FileParseHandler', () => {
         content_base64: content,
         mime_type: 'text/html',
         extract_as: 'receipt',
-      }));
+      }, llmProvider));
 
       expect(result.success).toBe(false);
       if (!result.success) expect(result.error).toMatch(/extract/i);
     });
 
     it('returns low confidence when LLM returns unparseable JSON', async () => {
-      const mockCreate = vi.fn().mockResolvedValue({
-        content: [{ type: 'text', text: 'I cannot parse this document.' }],
-      });
-      const mockClient = { messages: { create: mockCreate } };
-      const handler = new FileParseHandler(mockClient as any);
+      const llmProvider = makeLlmProvider('I cannot parse this document.');
+      const handler = new FileParseHandler();
 
       const html = '<p>receipt</p>';
       const content = Buffer.from(html).toString('base64');
@@ -319,7 +379,7 @@ describe('FileParseHandler', () => {
         content_base64: content,
         mime_type: 'text/html',
         extract_as: 'receipt',
-      }));
+      }, llmProvider));
 
       expect(result.success).toBe(true);
       if (result.success) {

--- a/skills/file-parse/handler.test.ts
+++ b/skills/file-parse/handler.test.ts
@@ -4,9 +4,10 @@ import { parseCsv } from './csv.js';
 import { FileParseHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
 
-// Minimal modelRouter stub that always resolves to 'claude-sonnet-4-6'
+// Minimal modelRouter stub that always resolves to 'claude-sonnet-4-6'.
+// Returns the full ResolvedModel shape { model, tier } to match the runtime contract.
 const mockModelRouter = {
-  resolve: (_tier: string) => ({ model: 'claude-sonnet-4-6' }),
+  resolve: (_tier: string) => ({ model: 'claude-sonnet-4-6', tier: 'standard' as const }),
 };
 
 function makeCtx(

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -2,13 +2,16 @@
 //
 // General-purpose document parser. Dispatches by content type:
 // - CSV: deterministic parser (no LLM)
-// - Image: Claude vision API
+// - Image: LLMProvider vision (passes base64 image blocks)
 // - PDF: pdf-parse text extraction, then optional LLM structuring
 // - HTML: tag stripping, then optional LLM structuring
+//
+// All LLM calls go through the shared LLMProvider + ModelRouter so costs and
+// latency are tracked by the telemetry infrastructure.
 
 import { createRequire } from 'node:module';
-import Anthropic from '@anthropic-ai/sdk';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { Message } from '../../src/agents/llm/provider.js';
 
 // pdf-parse is CJS-only and doesn't provide a default ESM export.
 // Use createRequire to load it reliably under Node ESM + tsx.
@@ -16,8 +19,6 @@ const require = createRequire(import.meta.url);
 const pdfParse = require('pdf-parse') as typeof import('pdf-parse');
 import { parseCsv } from './csv.js';
 import { getExtractionPrompt, type ExtractAs } from './prompts.js';
-
-const EXTRACTION_MODEL = 'claude-sonnet-4-6';
 
 // MIME types we support, mapped to our internal content categories.
 const MIME_MAP: Record<string, 'csv' | 'pdf' | 'image' | 'html'> = {
@@ -35,10 +36,31 @@ const MIME_MAP: Record<string, 'csv' | 'pdf' | 'image' | 'html'> = {
 // 'raw' opts out of LLM extraction; any other non-empty string gets a generic prompt.
 // See prompts.ts — agents can define new document types without modifying this file.
 
-export class FileParseHandler implements SkillHandler {
-  constructor(private readonly anthropicClient?: Anthropic) {}
+/**
+ * Image content block for vision calls. The shared LLMProvider.Message interface
+ * uses ContentBlock for multi-content messages; image blocks are a superset used
+ * only in file-parse. We define it locally and cast as needed. The underlying
+ * Anthropic implementation accepts these shapes even though the interface doesn't
+ * formally declare them — tracked as a future provider.ts extension.
+ *
+ * @TODO Extend the ContentBlock union in src/agents/llm/provider.ts to include
+ * ImageContent natively so callers don't need local casts.
+ */
+interface ImageContent {
+  type: 'image';
+  source: {
+    type: 'base64';
+    media_type: 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif';
+    data: string;
+  };
+}
 
+export class FileParseHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.llmProvider || !ctx.modelRouter) {
+      return { success: false, error: 'file-parse requires llmProvider and modelRouter capabilities' };
+    }
+
     // --- Input validation ---
     const contentBase64 = typeof ctx.input.content_base64 === 'string'
       ? ctx.input.content_base64.trim() : '';
@@ -64,6 +86,9 @@ export class FileParseHandler implements SkillHandler {
       return { success: false, error: 'Invalid extract_as: value must be a non-empty string (e.g. receipt, bank_statement, invoice, raw, or a custom schema name)' };
     }
 
+    // Resolve the standard-tier model once for any LLM calls below.
+    const extractionModel = ctx.modelRouter.resolve('standard').model;
+
     try {
       const buffer = Buffer.from(contentBase64, 'base64');
 
@@ -71,11 +96,11 @@ export class FileParseHandler implements SkillHandler {
         case 'csv':
           return this.handleCsv(buffer);
         case 'image':
-          return await this.handleImage(ctx, contentBase64, mimeType, extractAs);
+          return await this.handleImage(ctx, extractionModel, contentBase64, mimeType, extractAs);
         case 'pdf':
-          return await this.handlePdf(ctx, buffer, extractAs);
+          return await this.handlePdf(ctx, extractionModel, buffer, extractAs);
         case 'html':
-          return await this.handleHtml(ctx, buffer, extractAs);
+          return await this.handleHtml(ctx, extractionModel, buffer, extractAs);
       }
     } catch (err) {
       ctx.log.error({ err, mimeType }, 'file-parse: unexpected error');
@@ -99,16 +124,16 @@ export class FileParseHandler implements SkillHandler {
     };
   }
 
-  // --- Image: Claude vision ---
+  // --- Image: LLMProvider vision ---
 
   private async handleImage(
     ctx: SkillContext,
+    extractionModel: string,
     contentBase64: string,
     mimeType: string,
     extractAs: ExtractAs,
   ): Promise<SkillResult> {
     const prompt = getExtractionPrompt(extractAs);
-    const client = this.anthropicClient ?? new Anthropic({ apiKey: ctx.secret('ANTHROPIC_API_KEY') });
 
     // For 'raw', ask for a plain text transcription of the image
     const textPrompt = prompt
@@ -117,47 +142,49 @@ export class FileParseHandler implements SkillHandler {
     // Normalize the non-standard image/jpg alias to the IANA-registered image/jpeg.
     // The Anthropic API only accepts the canonical MIME types; passing image/jpg would
     // produce an API error at runtime despite the TypeScript cast.
-    const normalizedMimeType = mimeType === 'image/jpg' ? 'image/jpeg' : mimeType;
+    const normalizedMimeType = (mimeType === 'image/jpg' ? 'image/jpeg' : mimeType) as ImageContent['source']['media_type'];
 
-    try {
-      const response = await client.messages.create({
-        model: EXTRACTION_MODEL,
-        max_tokens: 4000,
-        messages: [{
-          role: 'user',
-          content: [
-            {
-              type: 'image',
-              source: {
-                type: 'base64',
-                media_type: normalizedMimeType as 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif',
-                data: contentBase64,
-              },
-            },
-            { type: 'text', text: textPrompt },
-          ],
-        }],
-      });
+    // Image blocks are not yet in the shared ContentBlock union — cast via unknown.
+    // @TODO Remove this cast once ImageContent is added to provider.ts ContentBlock.
+    const imageMessage: Message = {
+      role: 'user',
+      content: [
+        {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: normalizedMimeType,
+            data: contentBase64,
+          },
+        } as unknown as ReturnType<typeof Object>,
+        { type: 'text', text: textPrompt },
+      ] as Message['content'],
+    };
 
-      const textBlock = response.content.find(
-        (c): c is { type: 'text'; text: string } => c.type === 'text',
-      );
-      if (!textBlock) {
-        ctx.log.warn('file-parse: vision API returned no text block');
-        return { success: true, data: { type: 'image', raw_text: '', structured: null, confidence: 0 } };
-      }
+    const response = await ctx.llmProvider!.chat({
+      model: extractionModel,
+      messages: [imageMessage],
+      options: { max_tokens: 4000 },
+    });
 
-      return this.buildResult(ctx, 'image', textBlock.text, extractAs, prompt !== null);
-    } catch (err) {
-      ctx.log.error({ err }, 'file-parse: Claude vision extraction failed');
+    if (response.type === 'error') {
+      ctx.log.error({ error: response.error }, 'file-parse: Claude vision extraction failed');
       return { success: false, error: 'Failed to extract content from image' };
     }
+
+    if (!response.content) {
+      ctx.log.warn('file-parse: vision API returned no text content');
+      return { success: true, data: { type: 'image', raw_text: '', structured: null, confidence: 0 } };
+    }
+
+    return this.buildResult(ctx, 'image', response.content, extractAs, prompt !== null);
   }
 
   // --- PDF: text extraction + optional LLM structuring ---
 
   private async handlePdf(
     ctx: SkillContext,
+    extractionModel: string,
     buffer: Buffer,
     extractAs: ExtractAs,
   ): Promise<SkillResult> {
@@ -188,13 +215,14 @@ export class FileParseHandler implements SkillHandler {
     }
 
     // Run LLM extraction on the text
-    return await this.extractStructured(ctx, 'pdf', rawText, extractAs);
+    return await this.extractStructured(ctx, extractionModel, 'pdf', rawText, extractAs);
   }
 
   // --- HTML: tag stripping + optional LLM structuring ---
 
   private async handleHtml(
     ctx: SkillContext,
+    extractionModel: string,
     buffer: Buffer,
     extractAs: ExtractAs,
   ): Promise<SkillResult> {
@@ -205,13 +233,14 @@ export class FileParseHandler implements SkillHandler {
       return { success: true, data: { type: 'html', raw_text: rawText, structured: null, confidence: 1.0 } };
     }
 
-    return await this.extractStructured(ctx, 'html', rawText, extractAs);
+    return await this.extractStructured(ctx, extractionModel, 'html', rawText, extractAs);
   }
 
   // --- Shared: LLM-based structured extraction from text ---
 
   private async extractStructured(
     ctx: SkillContext,
+    extractionModel: string,
     type: 'pdf' | 'html',
     rawText: string,
     extractAs: ExtractAs,
@@ -222,31 +251,26 @@ export class FileParseHandler implements SkillHandler {
       return { success: true, data: { type, raw_text: rawText, structured: null, confidence: 1.0 } };
     }
 
-    const client = this.anthropicClient ?? new Anthropic({ apiKey: ctx.secret('ANTHROPIC_API_KEY') });
+    const response = await ctx.llmProvider!.chat({
+      model: extractionModel,
+      messages: [{
+        role: 'user',
+        content: `${prompt}\n\nDocument text:\n${rawText}`,
+      }],
+      options: { max_tokens: 4000 },
+    });
 
-    try {
-      const response = await client.messages.create({
-        model: EXTRACTION_MODEL,
-        max_tokens: 4000,
-        messages: [{
-          role: 'user',
-          content: `${prompt}\n\nDocument text:\n${rawText}`,
-        }],
-      });
-
-      const textBlock = response.content.find(
-        (c): c is { type: 'text'; text: string } => c.type === 'text',
-      );
-      if (!textBlock) {
-        ctx.log.warn('file-parse: LLM extraction returned no text block');
-        return { success: true, data: { type, raw_text: rawText, structured: null, confidence: 0 } };
-      }
-
-      return this.buildResult(ctx, type, textBlock.text, extractAs, true, rawText);
-    } catch (err) {
-      ctx.log.error({ err, extractAs }, 'file-parse: LLM structured extraction failed');
+    if (response.type === 'error') {
+      ctx.log.error({ error: response.error, extractAs }, 'file-parse: LLM structured extraction failed');
       return { success: false, error: `Failed to extract structured data as ${extractAs}` };
     }
+
+    if (!response.content) {
+      ctx.log.warn('file-parse: LLM extraction returned no text content');
+      return { success: true, data: { type, raw_text: rawText, structured: null, confidence: 0 } };
+    }
+
+    return this.buildResult(ctx, type, response.content, extractAs, true, rawText);
   }
 
   // --- Result builder: parse LLM output into structured data ---

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -11,7 +11,7 @@
 
 import { createRequire } from 'node:module';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
-import type { Message } from '../../src/agents/llm/provider.js';
+import type { Message, ImageContent } from '../../src/agents/llm/provider.js';
 
 // pdf-parse is CJS-only and doesn't provide a default ESM export.
 // Use createRequire to load it reliably under Node ESM + tsx.
@@ -35,25 +35,6 @@ const MIME_MAP: Record<string, 'csv' | 'pdf' | 'image' | 'html'> = {
 // extract_as is open-ended: 'receipt', 'bank_statement', 'invoice' have tailored prompts;
 // 'raw' opts out of LLM extraction; any other non-empty string gets a generic prompt.
 // See prompts.ts — agents can define new document types without modifying this file.
-
-/**
- * Image content block for vision calls. The shared LLMProvider.Message interface
- * uses ContentBlock for multi-content messages; image blocks are a superset used
- * only in file-parse. We define it locally and cast as needed. The underlying
- * Anthropic implementation accepts these shapes even though the interface doesn't
- * formally declare them — tracked as a future provider.ts extension.
- *
- * @TODO Extend the ContentBlock union in src/agents/llm/provider.ts to include
- * ImageContent natively so callers don't need local casts.
- */
-interface ImageContent {
-  type: 'image';
-  source: {
-    type: 'base64';
-    media_type: 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif';
-    data: string;
-  };
-}
 
 export class FileParseHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -144,21 +125,17 @@ export class FileParseHandler implements SkillHandler {
     // produce an API error at runtime despite the TypeScript cast.
     const normalizedMimeType = (mimeType === 'image/jpg' ? 'image/jpeg' : mimeType) as ImageContent['source']['media_type'];
 
-    // Image blocks are not yet in the shared ContentBlock union — cast via unknown.
-    // @TODO Remove this cast once ImageContent is added to provider.ts ContentBlock.
+    const imageBlock: ImageContent = {
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: normalizedMimeType,
+        data: contentBase64,
+      },
+    };
     const imageMessage: Message = {
       role: 'user',
-      content: [
-        {
-          type: 'image',
-          source: {
-            type: 'base64',
-            media_type: normalizedMimeType,
-            data: contentBase64,
-          },
-        } as unknown as ReturnType<typeof Object>,
-        { type: 'text', text: textPrompt },
-      ] as Message['content'],
+      content: [imageBlock, { type: 'text', text: textPrompt }],
     };
 
     const response = await ctx.llmProvider!.chat({

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -11,7 +11,7 @@
 
 import { createRequire } from 'node:module';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
-import type { Message, ImageContent } from '../../src/agents/llm/provider.js';
+import type { LLMProvider, Message, ImageContent } from '../../src/agents/llm/provider.js';
 
 // pdf-parse is CJS-only and doesn't provide a default ESM export.
 // Use createRequire to load it reliably under Node ESM + tsx.
@@ -39,8 +39,11 @@ const MIME_MAP: Record<string, 'csv' | 'pdf' | 'image' | 'html'> = {
 export class FileParseHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     if (!ctx.llmProvider || !ctx.modelRouter) {
+      ctx.log.error('file-parse: llmProvider or modelRouter capability missing — execution layer misconfigured');
       return { success: false, error: 'file-parse requires llmProvider and modelRouter capabilities' };
     }
+    // Destructure after guard so TypeScript narrows the types; avoids ! assertions below.
+    const { llmProvider, modelRouter } = ctx;
 
     // --- Input validation ---
     const contentBase64 = typeof ctx.input.content_base64 === 'string'
@@ -68,7 +71,7 @@ export class FileParseHandler implements SkillHandler {
     }
 
     // Resolve the standard-tier model once for any LLM calls below.
-    const extractionModel = ctx.modelRouter.resolve('standard').model;
+    const extractionModel = modelRouter.resolve('standard').model;
 
     try {
       const buffer = Buffer.from(contentBase64, 'base64');
@@ -77,11 +80,11 @@ export class FileParseHandler implements SkillHandler {
         case 'csv':
           return this.handleCsv(buffer);
         case 'image':
-          return await this.handleImage(ctx, extractionModel, contentBase64, mimeType, extractAs);
+          return await this.handleImage(ctx, llmProvider, extractionModel, contentBase64, mimeType, extractAs);
         case 'pdf':
-          return await this.handlePdf(ctx, extractionModel, buffer, extractAs);
+          return await this.handlePdf(ctx, llmProvider, extractionModel, buffer, extractAs);
         case 'html':
-          return await this.handleHtml(ctx, extractionModel, buffer, extractAs);
+          return await this.handleHtml(ctx, llmProvider, extractionModel, buffer, extractAs);
       }
     } catch (err) {
       ctx.log.error({ err, mimeType }, 'file-parse: unexpected error');
@@ -109,6 +112,7 @@ export class FileParseHandler implements SkillHandler {
 
   private async handleImage(
     ctx: SkillContext,
+    llmProvider: LLMProvider,
     extractionModel: string,
     contentBase64: string,
     mimeType: string,
@@ -138,7 +142,7 @@ export class FileParseHandler implements SkillHandler {
       content: [imageBlock, { type: 'text', text: textPrompt }],
     };
 
-    const response = await ctx.llmProvider!.chat({
+    const response = await llmProvider.chat({
       model: extractionModel,
       messages: [imageMessage],
       options: { max_tokens: 4000 },
@@ -161,6 +165,7 @@ export class FileParseHandler implements SkillHandler {
 
   private async handlePdf(
     ctx: SkillContext,
+    llmProvider: LLMProvider,
     extractionModel: string,
     buffer: Buffer,
     extractAs: ExtractAs,
@@ -192,13 +197,14 @@ export class FileParseHandler implements SkillHandler {
     }
 
     // Run LLM extraction on the text
-    return await this.extractStructured(ctx, extractionModel, 'pdf', rawText, extractAs);
+    return await this.extractStructured(ctx, llmProvider, extractionModel, 'pdf', rawText, extractAs);
   }
 
   // --- HTML: tag stripping + optional LLM structuring ---
 
   private async handleHtml(
     ctx: SkillContext,
+    llmProvider: LLMProvider,
     extractionModel: string,
     buffer: Buffer,
     extractAs: ExtractAs,
@@ -210,13 +216,14 @@ export class FileParseHandler implements SkillHandler {
       return { success: true, data: { type: 'html', raw_text: rawText, structured: null, confidence: 1.0 } };
     }
 
-    return await this.extractStructured(ctx, extractionModel, 'html', rawText, extractAs);
+    return await this.extractStructured(ctx, llmProvider, extractionModel, 'html', rawText, extractAs);
   }
 
   // --- Shared: LLM-based structured extraction from text ---
 
   private async extractStructured(
     ctx: SkillContext,
+    llmProvider: LLMProvider,
     extractionModel: string,
     type: 'pdf' | 'html',
     rawText: string,
@@ -228,7 +235,7 @@ export class FileParseHandler implements SkillHandler {
       return { success: true, data: { type, raw_text: rawText, structured: null, confidence: 1.0 } };
     }
 
-    const response = await ctx.llmProvider!.chat({
+    const response = await llmProvider.chat({
       model: extractionModel,
       messages: [{
         role: 'user',
@@ -281,10 +288,10 @@ export class FileParseHandler implements SkillHandler {
           confidence: 0.85,
         },
       };
-    } catch {
+    } catch (err) {
       // LLM returned non-JSON — return with low confidence so the caller can surface
-      // this to the user for manual review. Log at debug so repeated occurrences are visible.
-      ctx.log.debug({ type, extractAs }, 'file-parse: LLM response was not valid JSON; returning low-confidence result');
+      // this to the user for manual review.
+      ctx.log.warn({ err, type, extractAs }, 'file-parse: LLM response was not valid JSON; returning low-confidence result');
       return {
         success: true,
         data: {

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -70,10 +70,12 @@ export class FileParseHandler implements SkillHandler {
       return { success: false, error: 'Invalid extract_as: value must be a non-empty string (e.g. receipt, bank_statement, invoice, raw, or a custom schema name)' };
     }
 
-    // Resolve the standard-tier model once for any LLM calls below.
-    const extractionModel = modelRouter.resolve('standard').model;
-
     try {
+      // Resolve the standard-tier model once for any LLM calls below.
+      // Kept inside the try so a bad routing config (ModelRouter.resolve() throws)
+      // returns { success: false } instead of letting execute() throw.
+      const extractionModel = modelRouter.resolve('standard').model;
+
       const buffer = Buffer.from(contentBase64, 'base64');
 
       switch (contentType) {
@@ -127,7 +129,10 @@ export class FileParseHandler implements SkillHandler {
     // Normalize the non-standard image/jpg alias to the IANA-registered image/jpeg.
     // The Anthropic API only accepts the canonical MIME types; passing image/jpg would
     // produce an API error at runtime despite the TypeScript cast.
-    const normalizedMimeType = (mimeType === 'image/jpg' ? 'image/jpeg' : mimeType) as ImageContent['source']['media_type'];
+    // Cast to the explicit base64 media_type union. After the discriminated union
+    // refactor on ImageContent.source, accessing ['media_type'] via a type path
+    // would require narrowing to the base64 variant first — the explicit union is cleaner.
+    const normalizedMimeType = (mimeType === 'image/jpg' ? 'image/jpeg' : mimeType) as 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif';
 
     const imageBlock: ImageContent = {
       type: 'image',

--- a/skills/file-parse/skill.json
+++ b/skills/file-parse/skill.json
@@ -3,7 +3,7 @@
   "description": "Parse a document (CSV, PDF, HTML, or image) and extract structured data. Accepts base64-encoded content and a MIME type. Optionally provide extract_as to get structured fields (receipt, bank_statement, invoice) instead of raw text. For CSV files, parsing is direct and deterministic. For images, PDFs, and HTML, uses Claude for text extraction and structuring. Returns a confidence score (0–1) for LLM-extracted results.",
   "version": "1.0.0",
   "sensitivity": "normal",
-  "action_risk": "none",
+  "action_risk": "medium",
   "inputs": {
     "content_base64": "string (base64-encoded file content)",
     "mime_type": "string (MIME type, e.g. 'text/csv', 'application/pdf', 'image/jpeg', 'text/html')",

--- a/skills/file-parse/skill.json
+++ b/skills/file-parse/skill.json
@@ -16,7 +16,7 @@
     "confidence": "number (0–1 confidence in the extraction; 1.0 for deterministic CSV parsing)"
   },
   "permissions": [],
-  "secrets": ["ANTHROPIC_API_KEY"],
+  "secrets": [],
   "timeout": 30000,
-  "capabilities": []
+  "capabilities": ["llmProvider", "modelRouter"]
 }

--- a/src/agents/llm/anthropic.test.ts
+++ b/src/agents/llm/anthropic.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AnthropicProvider } from './anthropic.js';
+import { ModelRegistry } from './model-registry.js';
 import { createSilentLogger } from '../../logger.js';
 
 // vi.mock is hoisted above variable declarations, so mockCreate must be
@@ -37,7 +38,7 @@ describe('AnthropicProvider — provenance and cache tokens', () => {
   });
 
   it('returns provenance with requestedModel, actualModel, and providerRequestId on text response', async () => {
-    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
     const result = await provider.chat({
       messages: [{ role: 'user', content: 'Hello' }],
       options: { model: 'claude-opus-4-6' },
@@ -59,22 +60,23 @@ describe('AnthropicProvider — provenance and cache tokens', () => {
       stop_reason: 'tool_use',
     });
 
-    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
     const result = await provider.chat({
       messages: [{ role: 'user', content: 'Search something' }],
+      model: 'claude-sonnet-4-6',
       tools: [{ name: 'search', description: 'Search', input_schema: { type: 'object' as const, properties: {} } }],
     });
 
     expect(result.type).toBe('tool_use');
     if (result.type !== 'tool_use') return;
-    expect(result.provenance.requestedModel).toBe('claude-sonnet-4-6'); // default model
+    expect(result.provenance.requestedModel).toBe('claude-sonnet-4-6');
     expect(result.provenance.actualModel).toBe('claude-sonnet-4-6');
     expect(result.provenance.providerRequestId).toBe('msg_tool_456');
   });
 
   it('defaults cache token fields to 0 when API returns null', async () => {
-    const provider = new AnthropicProvider('test-key', createSilentLogger());
-    const result = await provider.chat({ messages: [{ role: 'user', content: 'Hi' }] });
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
+    const result = await provider.chat({ messages: [{ role: 'user', content: 'Hi' }], model: 'claude-sonnet-4-6' });
 
     expect(result.type).toBe('text');
     if (result.type !== 'text') return;
@@ -91,8 +93,8 @@ describe('AnthropicProvider — provenance and cache tokens', () => {
       stop_reason: 'end_turn',
     });
 
-    const provider = new AnthropicProvider('test-key', createSilentLogger());
-    const result = await provider.chat({ messages: [{ role: 'user', content: 'Hi' }] });
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
+    const result = await provider.chat({ messages: [{ role: 'user', content: 'Hi' }], model: 'claude-sonnet-4-6' });
 
     expect(result.type).toBe('text');
     if (result.type !== 'text') return;
@@ -101,7 +103,7 @@ describe('AnthropicProvider — provenance and cache tokens', () => {
   });
 
   it('uses explicit model param over options.model', async () => {
-    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
     await provider.chat({
       messages: [{ role: 'user', content: 'Hello' }],
       model: 'claude-haiku-4-5',
@@ -113,7 +115,7 @@ describe('AnthropicProvider — provenance and cache tokens', () => {
   });
 
   it('falls back to options.model when model param is not provided', async () => {
-    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
     await provider.chat({
       messages: [{ role: 'user', content: 'Hello' }],
       options: { model: 'claude-opus-4-6' },
@@ -123,14 +125,16 @@ describe('AnthropicProvider — provenance and cache tokens', () => {
     expect(params.model).toBe('claude-opus-4-6');
   });
 
-  it('defaults to claude-sonnet-4-6 when neither model param nor options.model provided', async () => {
-    const provider = new AnthropicProvider('test-key', createSilentLogger());
-    await provider.chat({
-      messages: [{ role: 'user', content: 'Hello' }],
-    });
-
-    const params = mockCreate.mock.calls[0]![0];
-    expect(params.model).toBe('claude-sonnet-4-6');
+  it('throws when neither model param nor options.model is provided', async () => {
+    // The runtime always provides model via resolvedModel — a missing model indicates
+    // a bug at the call site. AnthropicProvider should fail loudly rather than silently
+    // falling back to a hardcoded default.
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
+    await expect(
+      provider.chat({
+        messages: [{ role: 'user', content: 'Hello' }],
+      }),
+    ).rejects.toThrow('AnthropicProvider.chat() requires a model');
   });
 });
 
@@ -141,8 +145,9 @@ describe('AnthropicProvider — prompt caching', () => {
   });
 
   it('passes system content as TextBlockParam[] with cache_control', async () => {
-    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
     await provider.chat({
+      model: 'claude-sonnet-4-6',
       messages: [
         { role: 'system', content: 'You are helpful.' },
         { role: 'user', content: 'Hello' },
@@ -156,8 +161,9 @@ describe('AnthropicProvider — prompt caching', () => {
   });
 
   it('omits system key entirely when no system messages', async () => {
-    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
     await provider.chat({
+      model: 'claude-sonnet-4-6',
       messages: [{ role: 'user', content: 'Hello' }],
     });
 
@@ -166,8 +172,9 @@ describe('AnthropicProvider — prompt caching', () => {
   });
 
   it('concatenates multiple system messages into one block with cache_control', async () => {
-    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
     await provider.chat({
+      model: 'claude-sonnet-4-6',
       messages: [
         { role: 'system', content: 'Part one.' },
         { role: 'system', content: 'Part two.' },
@@ -182,8 +189,9 @@ describe('AnthropicProvider — prompt caching', () => {
   });
 
   it('adds cache_control only to the last tool when multiple tools provided', async () => {
-    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
     await provider.chat({
+      model: 'claude-sonnet-4-6',
       messages: [{ role: 'user', content: 'Hello' }],
       tools: [
         { name: 'tool-a', description: 'First', input_schema: { type: 'object' as const, properties: {} } },
@@ -199,8 +207,9 @@ describe('AnthropicProvider — prompt caching', () => {
   });
 
   it('adds cache_control to the single tool when only one tool provided', async () => {
-    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
     await provider.chat({
+      model: 'claude-sonnet-4-6',
       messages: [{ role: 'user', content: 'Hello' }],
       tools: [
         { name: 'only-tool', description: 'The one', input_schema: { type: 'object' as const, properties: {} } },
@@ -212,8 +221,9 @@ describe('AnthropicProvider — prompt caching', () => {
   });
 
   it('omits tools key entirely when no tools provided', async () => {
-    const provider = new AnthropicProvider('test-key', createSilentLogger());
+    const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
     await provider.chat({
+      model: 'claude-sonnet-4-6',
       messages: [{ role: 'user', content: 'Hello' }],
     });
 

--- a/src/agents/llm/anthropic.test.ts
+++ b/src/agents/llm/anthropic.test.ts
@@ -125,16 +125,19 @@ describe('AnthropicProvider — provenance and cache tokens', () => {
     expect(params.model).toBe('claude-opus-4-6');
   });
 
-  it('throws when neither model param nor options.model is provided', async () => {
+  it('returns an error response when neither model param nor options.model is provided', async () => {
+    // The guard is inside the try block so the error is caught and returned as
+    // { type: 'error', ... } rather than thrown — preserving the LLMResponse contract.
     // The runtime always provides model via resolvedModel — a missing model indicates
-    // a bug at the call site. AnthropicProvider should fail loudly rather than silently
-    // falling back to a hardcoded default.
+    // a bug at the call site.
     const provider = new AnthropicProvider('test-key', createSilentLogger(), new ModelRegistry(createSilentLogger()));
-    await expect(
-      provider.chat({
-        messages: [{ role: 'user', content: 'Hello' }],
-      }),
-    ).rejects.toThrow('AnthropicProvider.chat() requires a model');
+    const result = await provider.chat({
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+    expect(result.type).toBe('error');
+    if (result.type === 'error') {
+      expect(result.error.message).toMatch('AnthropicProvider.chat() requires a model');
+    }
   });
 });
 

--- a/src/agents/llm/anthropic.ts
+++ b/src/agents/llm/anthropic.ts
@@ -17,15 +17,18 @@ import type { MessageParam, ToolUseBlock, TextBlock, TextBlockParam, ToolResultB
 import type { LLMProvider, LLMResponse, LLMUsage, LLMCallProvenance, Message, ToolCall, ToolDefinition, ToolResult } from './provider.js';
 import type { Logger } from '../../logger.js';
 import { classifyError } from '../../errors/classify.js';
+import type { ModelRegistry } from './model-registry.js';
 
 export class AnthropicProvider implements LLMProvider {
   id = 'anthropic';
   private client: Anthropic;
   private logger: Logger;
+  private readonly modelRegistry: ModelRegistry;
 
-  constructor(apiKey: string, logger: Logger) {
+  constructor(apiKey: string, logger: Logger, modelRegistry: ModelRegistry) {
     this.client = new Anthropic({ apiKey });
     this.logger = logger;
+    this.modelRegistry = modelRegistry;
   }
 
   async chat({
@@ -103,15 +106,20 @@ export class AnthropicProvider implements LLMProvider {
       conversationMessages.push({ role: 'user', content: toolResultBlocks });
     }
 
-    // Prefer the explicit model param; fall back to options.model for backward
-    // compatibility; default to sonnet if neither is provided.
+    // Prefer the explicit model param; fall back to options.model for backward compatibility.
+    // No default: the runtime always provides model via resolvedModel, so a missing model
+    // indicates a bug at the call site. Fail loudly rather than silently using a stale default.
     const optionsModel = typeof options?.model === 'string' ? options.model : undefined;
-    const model = modelOverride ?? optionsModel ?? 'claude-sonnet-4-6';
+    const model = modelOverride ?? optionsModel;
+    if (!model) {
+      throw new Error('AnthropicProvider.chat() requires a model — no model was provided and no default is configured');
+    }
 
     try {
       const createParams: Anthropic.Messages.MessageCreateParamsNonStreaming = {
         model,
-        max_tokens: 4096,
+        // Use per-model maxOutputTokens from the registry; fall back to 4096 for unknown models.
+        max_tokens: this.modelRegistry.getModel(model)?.maxOutputTokens ?? 4096,
         // Wrap the concatenated system string in a TextBlockParam array with a
         // cache_control breakpoint. This tells Anthropic to cache everything up
         // to this block, saving ~5K tokens of system prompt cost on repeat calls.

--- a/src/agents/llm/anthropic.ts
+++ b/src/agents/llm/anthropic.ts
@@ -91,7 +91,7 @@ export class AnthropicProvider implements LLMProvider {
             if (block.type === 'image') {
               // Pass image blocks through to the Anthropic SDK as-is — the shape
               // matches the SDK's ImageBlockParam structure directly.
-              return block as unknown as Parameters<typeof Object>[0];
+              return block as unknown as Anthropic.Messages.ImageBlockParam;
             }
             // TextContent
             return { type: 'text' as const, text: block.text };
@@ -116,11 +116,11 @@ export class AnthropicProvider implements LLMProvider {
     // indicates a bug at the call site. Fail loudly rather than silently using a stale default.
     const optionsModel = typeof options?.model === 'string' ? options.model : undefined;
     const model = modelOverride ?? optionsModel;
-    if (!model) {
-      throw new Error('AnthropicProvider.chat() requires a model — no model was provided and no default is configured');
-    }
 
     try {
+      if (!model) {
+        throw new Error('AnthropicProvider.chat() requires a model — no model was provided and no default is configured');
+      }
       const createParams: Anthropic.Messages.MessageCreateParamsNonStreaming = {
         model,
         // Use per-model maxOutputTokens from the registry; fall back to 4096 for unknown models.

--- a/src/agents/llm/anthropic.ts
+++ b/src/agents/llm/anthropic.ts
@@ -88,6 +88,11 @@ export class AnthropicProvider implements LLMProvider {
             if (block.type === 'tool_result') {
               return { type: 'tool_result' as const, tool_use_id: block.tool_use_id, content: block.content, is_error: block.is_error };
             }
+            if (block.type === 'image') {
+              // Pass image blocks through to the Anthropic SDK as-is — the shape
+              // matches the SDK's ImageBlockParam structure directly.
+              return block as unknown as Parameters<typeof Object>[0];
+            }
             // TextContent
             return { type: 'text' as const, text: block.text };
           }),

--- a/src/agents/llm/anthropic.ts
+++ b/src/agents/llm/anthropic.ts
@@ -121,10 +121,17 @@ export class AnthropicProvider implements LLMProvider {
       if (!model) {
         throw new Error('AnthropicProvider.chat() requires a model — no model was provided and no default is configured');
       }
+      // Per-model output cap from the registry. Fall back to 4096 for unknown models.
+      const modelMaxTokens = this.modelRegistry.getModel(model)?.maxOutputTokens ?? 4096;
+      // Honor the caller's max_tokens request, but never exceed the model's cap.
+      // Skills use low limits (e.g. 10 for a classifier gate) to stay cheap —
+      // silently ignoring those limits defeats the purpose of passing them.
+      const callerMaxTokens = typeof options?.max_tokens === 'number' && Number.isFinite(options.max_tokens)
+        ? Math.max(1, Math.floor(options.max_tokens as number))
+        : undefined;
       const createParams: Anthropic.Messages.MessageCreateParamsNonStreaming = {
         model,
-        // Use per-model maxOutputTokens from the registry; fall back to 4096 for unknown models.
-        max_tokens: this.modelRegistry.getModel(model)?.maxOutputTokens ?? 4096,
+        max_tokens: callerMaxTokens !== undefined ? Math.min(callerMaxTokens, modelMaxTokens) : modelMaxTokens,
         // Wrap the concatenated system string in a TextBlockParam array with a
         // cache_control breakpoint. This tells Anthropic to cache everything up
         // to this block, saving ~5K tokens of system prompt cost on repeat calls.

--- a/src/agents/llm/model-registry.test.ts
+++ b/src/agents/llm/model-registry.test.ts
@@ -86,6 +86,15 @@ describe('ModelRegistry', () => {
     });
   });
 
+  describe('getAllModels', () => {
+    it('returns all registered models', () => {
+      const all = registry.getAllModels();
+      expect(Object.keys(all)).toContain('claude-sonnet-4-6');
+      expect(Object.keys(all)).toContain('claude-haiku-4-5');
+      expect(Object.keys(all)).toContain('claude-opus-4-6');
+    });
+  });
+
   describe('all three Anthropic models are registered', () => {
     it.each([
       'claude-opus-4-6',

--- a/src/agents/llm/model-registry.test.ts
+++ b/src/agents/llm/model-registry.test.ts
@@ -43,7 +43,7 @@ describe('ModelRegistry', () => {
     });
 
     it('returns 0 for unknown models', () => {
-      expect(registry.getContextWindow('unknown-model')).toBe(0);
+      expect(registry.getContextWindow('unknown-model')).toBeUndefined();
     });
   });
 

--- a/src/agents/llm/model-registry.test.ts
+++ b/src/agents/llm/model-registry.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { ModelRegistry } from './model-registry.js';
+import { createSilentLogger } from '../../logger.js';
+
+describe('ModelRegistry', () => {
+  const registry = new ModelRegistry(createSilentLogger());
+
+  describe('getModel', () => {
+    it('returns metadata for an exact model name', () => {
+      const meta = registry.getModel('claude-sonnet-4-6');
+      expect(meta).toBeDefined();
+      expect(meta!.provider).toBe('anthropic');
+      expect(meta!.contextWindow).toBe(200_000);
+      expect(meta!.pricing.inputPerMToken).toBe(3.0);
+    });
+
+    it('matches versioned model names by prefix', () => {
+      const meta = registry.getModel('claude-haiku-4-5-20251001');
+      expect(meta).toBeDefined();
+      expect(meta!.provider).toBe('anthropic');
+      expect(meta!.pricing.inputPerMToken).toBe(0.80);
+    });
+
+    it('returns undefined for unknown models', () => {
+      expect(registry.getModel('unknown-model')).toBeUndefined();
+    });
+
+    it('prefers longer prefix matches', () => {
+      // 'claude-sonnet-4-6' should not match 'claude-opus-4-6'
+      const meta = registry.getModel('claude-sonnet-4-6-preview');
+      expect(meta).toBeDefined();
+      expect(meta!.pricing.inputPerMToken).toBe(3.0); // sonnet pricing, not opus
+    });
+  });
+
+  describe('getContextWindow', () => {
+    it('returns context window for a known model', () => {
+      expect(registry.getContextWindow('claude-opus-4-6')).toBe(200_000);
+    });
+
+    it('returns context window for a versioned model name', () => {
+      expect(registry.getContextWindow('claude-haiku-4-5-20251001')).toBe(200_000);
+    });
+
+    it('returns 0 for unknown models', () => {
+      expect(registry.getContextWindow('unknown-model')).toBe(0);
+    });
+  });
+
+  describe('getPricing', () => {
+    it('returns pricing for a known model', () => {
+      const pricing = registry.getPricing('claude-haiku-4-5');
+      expect(pricing).toBeDefined();
+      expect(pricing!.inputPerMToken).toBe(0.80);
+      expect(pricing!.outputPerMToken).toBe(4.00);
+      expect(pricing!.cacheCreationPerMToken).toBe(1.00);
+      expect(pricing!.cacheReadPerMToken).toBe(0.08);
+    });
+
+    it('returns undefined for unknown models', () => {
+      expect(registry.getPricing('unknown-model')).toBeUndefined();
+    });
+  });
+
+  describe('getProvider', () => {
+    it('returns provider for a known model', () => {
+      expect(registry.getProvider('claude-sonnet-4-6')).toBe('anthropic');
+    });
+
+    it('returns undefined for unknown models', () => {
+      expect(registry.getProvider('unknown-model')).toBeUndefined();
+    });
+  });
+
+  describe('isKnownModel', () => {
+    it('returns true for exact match', () => {
+      expect(registry.isKnownModel('claude-sonnet-4-6')).toBe(true);
+    });
+
+    it('returns true for prefix match', () => {
+      expect(registry.isKnownModel('claude-haiku-4-5-20251001')).toBe(true);
+    });
+
+    it('returns false for unknown models', () => {
+      expect(registry.isKnownModel('unknown-model')).toBe(false);
+    });
+  });
+
+  describe('all three Anthropic models are registered', () => {
+    it.each([
+      'claude-opus-4-6',
+      'claude-sonnet-4-6',
+      'claude-haiku-4-5',
+    ])('%s is registered with provider, pricing, contextWindow, and capabilities', (model) => {
+      const meta = registry.getModel(model);
+      expect(meta).toBeDefined();
+      expect(meta!.provider).toBe('anthropic');
+      expect(meta!.contextWindow).toBeGreaterThan(0);
+      expect(meta!.pricing.inputPerMToken).toBeGreaterThan(0);
+      expect(meta!.pricing.outputPerMToken).toBeGreaterThan(0);
+      expect(meta!.capabilities).toContain('vision');
+    });
+  });
+});

--- a/src/agents/llm/model-registry.ts
+++ b/src/agents/llm/model-registry.ts
@@ -83,7 +83,7 @@ const SORTED_ENTRIES = Object.entries(MODEL_REGISTRY)
  * so longer prefixes take priority.
  */
 export class ModelRegistry {
-  // Logger is stored for future debug/warn calls (e.g. unknown model warnings).
+  // Logger is used for debug/warn calls (e.g. unknown model warnings).
   private readonly logger: Logger;
 
   constructor(logger: Logger) {
@@ -93,6 +93,9 @@ export class ModelRegistry {
   /** Look up full metadata for a model. Returns undefined if no prefix matches. */
   getModel(modelId: string): ModelMetadata | undefined {
     const entry = SORTED_ENTRIES.find(([prefix]) => modelId.startsWith(prefix));
+    if (!entry) {
+      this.logger.debug({ modelId }, 'ModelRegistry: model not found in registry');
+    }
     return entry ? entry[1] : undefined;
   }
 
@@ -114,5 +117,10 @@ export class ModelRegistry {
   /** Returns true if the model is in the registry (prefix match). */
   isKnownModel(modelId: string): boolean {
     return this.getModel(modelId) !== undefined;
+  }
+
+  /** Returns all registered models. Used for startup validation only. */
+  getAllModels(): Readonly<Record<string, ModelMetadata>> {
+    return MODEL_REGISTRY;
   }
 }

--- a/src/agents/llm/model-registry.ts
+++ b/src/agents/llm/model-registry.ts
@@ -1,0 +1,118 @@
+// src/agents/llm/model-registry.ts — single source of truth for model metadata.
+//
+// The TypeScript registry defines what models Curia officially supports (pricing,
+// context windows, capabilities). Deployment-specific config (which tier maps to
+// which model) stays in config/default.yaml.
+//
+// Lookup uses prefix matching: 'claude-haiku-4-5-20251001' matches 'claude-haiku-4-5'.
+// Entries are pre-sorted by key length descending so longer prefixes win.
+
+import type { Logger } from '../../logger.js';
+
+export interface ModelPricing {
+  /** USD per million input tokens */
+  inputPerMToken: number;
+  /** USD per million output tokens */
+  outputPerMToken: number;
+  /** USD per million cache-creation tokens. undefined = model doesn't support caching. */
+  cacheCreationPerMToken?: number;
+  /** USD per million cache-read tokens. undefined = model doesn't support caching. */
+  cacheReadPerMToken?: number;
+}
+
+export interface ModelMetadata {
+  /** Provider identifier ('anthropic', 'openrouter', etc.) */
+  provider: string;
+  /** Maximum context window in tokens */
+  contextWindow: number;
+  /** Token pricing rates */
+  pricing: ModelPricing;
+  /** Model capabilities per ADR-014 vocabulary */
+  capabilities: string[];
+  /** Maximum output tokens per call. Default 4096 if unset. */
+  maxOutputTokens?: number;
+}
+
+// Keyed by model name prefix. When #379 lands, OpenRouter models are added here
+// with provider: 'openrouter'.
+const MODEL_REGISTRY: Record<string, ModelMetadata> = {
+  'claude-opus-4-6': {
+    provider: 'anthropic',
+    contextWindow: 200_000,
+    pricing: {
+      inputPerMToken: 15.00,
+      outputPerMToken: 75.00,
+      cacheCreationPerMToken: 18.75,
+      cacheReadPerMToken: 1.50,
+    },
+    capabilities: ['vision', 'reasoning', 'coding', 'large_context'],
+  },
+  'claude-sonnet-4-6': {
+    provider: 'anthropic',
+    contextWindow: 200_000,
+    pricing: {
+      inputPerMToken: 3.00,
+      outputPerMToken: 15.00,
+      cacheCreationPerMToken: 3.75,
+      cacheReadPerMToken: 0.30,
+    },
+    capabilities: ['vision', 'reasoning', 'coding'],
+  },
+  'claude-haiku-4-5': {
+    provider: 'anthropic',
+    contextWindow: 200_000,
+    pricing: {
+      inputPerMToken: 0.80,
+      outputPerMToken: 4.00,
+      cacheCreationPerMToken: 1.00,
+      cacheReadPerMToken: 0.08,
+    },
+    capabilities: ['vision', 'coding'],
+  },
+};
+
+// Pre-sorted entries for prefix matching — longest prefix wins.
+const SORTED_ENTRIES = Object.entries(MODEL_REGISTRY)
+  .sort(([a], [b]) => b.length - a.length);
+
+/**
+ * Provides typed lookups against the static model registry.
+ *
+ * All lookups use prefix matching: 'claude-haiku-4-5-20251001' resolves to
+ * the 'claude-haiku-4-5' entry. Entries are sorted by key length descending
+ * so longer prefixes take priority.
+ */
+export class ModelRegistry {
+  // Logger is stored for future debug/warn calls (e.g. unknown model warnings).
+  private readonly logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  /** Look up full metadata for a model. Returns undefined if no prefix matches. */
+  getModel(modelId: string): ModelMetadata | undefined {
+    const entry = SORTED_ENTRIES.find(([prefix]) => modelId.startsWith(prefix));
+    return entry ? entry[1] : undefined;
+  }
+
+  /** Returns context window size in tokens. Returns 0 for unknown models. */
+  getContextWindow(modelId: string): number {
+    return this.getModel(modelId)?.contextWindow ?? 0;
+  }
+
+  /** Returns pricing for the model. Returns undefined for unknown models. */
+  getPricing(modelId: string): ModelPricing | undefined {
+    return this.getModel(modelId)?.pricing;
+  }
+
+  /** Returns the provider identifier for a model. Returns undefined for unknown models. */
+  getProvider(modelId: string): string | undefined {
+    return this.getModel(modelId)?.provider;
+  }
+
+  /** Returns true if the model is in the registry (prefix match). */
+  isKnownModel(modelId: string): boolean {
+    return this.getModel(modelId) !== undefined;
+  }
+}

--- a/src/agents/llm/model-registry.ts
+++ b/src/agents/llm/model-registry.ts
@@ -35,6 +35,9 @@ export interface ModelMetadata {
 
 // Keyed by model name prefix. When #379 lands, OpenRouter models are added here
 // with provider: 'openrouter'.
+//
+// Each entry and its nested pricing/capabilities objects are frozen at module
+// load time so getModel()/getAllModels() callers cannot mutate registry state.
 const MODEL_REGISTRY: Record<string, ModelMetadata> = {
   'claude-opus-4-6': {
     provider: 'anthropic',
@@ -70,6 +73,13 @@ const MODEL_REGISTRY: Record<string, ModelMetadata> = {
     capabilities: ['vision', 'coding'],
   },
 };
+// Deep-freeze to prevent callers from mutating registry entries.
+for (const entry of Object.values(MODEL_REGISTRY)) {
+  Object.freeze(entry.pricing);
+  Object.freeze(entry.capabilities);
+  Object.freeze(entry);
+}
+Object.freeze(MODEL_REGISTRY);
 
 // Pre-sorted entries for prefix matching — longest prefix wins.
 const SORTED_ENTRIES = Object.entries(MODEL_REGISTRY)

--- a/src/agents/llm/model-registry.ts
+++ b/src/agents/llm/model-registry.ts
@@ -99,9 +99,9 @@ export class ModelRegistry {
     return entry ? entry[1] : undefined;
   }
 
-  /** Returns context window size in tokens. Returns 0 for unknown models. */
-  getContextWindow(modelId: string): number {
-    return this.getModel(modelId)?.contextWindow ?? 0;
+  /** Returns context window size in tokens. Returns undefined for unknown models. */
+  getContextWindow(modelId: string): number | undefined {
+    return this.getModel(modelId)?.contextWindow;
   }
 
   /** Returns pricing for the model. Returns undefined for unknown models. */

--- a/src/agents/llm/model-router.test.ts
+++ b/src/agents/llm/model-router.test.ts
@@ -1,88 +1,90 @@
 import { describe, it, expect } from 'vitest';
 import { ModelRouter, type ModelRoutingConfig } from './model-router.js';
+import { ModelRegistry } from './model-registry.js';
 import { createSilentLogger } from '../../logger.js';
+
+const logger = createSilentLogger();
+const registry = new ModelRegistry(logger);
 
 const defaultConfig: ModelRoutingConfig = {
   tiers: {
-    fast: { provider: 'anthropic', model: 'claude-haiku-4-5' },
-    standard: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
-    powerful: { provider: 'anthropic', model: 'claude-opus-4-6' },
+    fast: { model: 'claude-haiku-4-5' },
+    standard: { model: 'claude-sonnet-4-6' },
+    powerful: { model: 'claude-opus-4-6' },
   },
   default_tier: 'standard',
 };
 
 describe('ModelRouter', () => {
   it('resolves fast tier to the configured model', () => {
-    const router = new ModelRouter(defaultConfig, createSilentLogger());
+    const router = new ModelRouter(defaultConfig, registry, logger);
     const result = router.resolve('fast');
-    expect(result).toEqual({ provider: 'anthropic', model: 'claude-haiku-4-5', tier: 'fast' });
+    expect(result).toEqual({ model: 'claude-haiku-4-5', tier: 'fast' });
   });
 
   it('resolves standard tier to the configured model', () => {
-    const router = new ModelRouter(defaultConfig, createSilentLogger());
+    const router = new ModelRouter(defaultConfig, registry, logger);
     const result = router.resolve('standard');
-    expect(result).toEqual({ provider: 'anthropic', model: 'claude-sonnet-4-6', tier: 'standard' });
+    expect(result).toEqual({ model: 'claude-sonnet-4-6', tier: 'standard' });
   });
 
   it('resolves powerful tier to the configured model', () => {
-    const router = new ModelRouter(defaultConfig, createSilentLogger());
+    const router = new ModelRouter(defaultConfig, registry, logger);
     const result = router.resolve('powerful');
-    expect(result).toEqual({ provider: 'anthropic', model: 'claude-opus-4-6', tier: 'powerful' });
+    expect(result).toEqual({ model: 'claude-opus-4-6', tier: 'powerful' });
   });
 
   it('throws on unknown tier', () => {
-    const router = new ModelRouter(defaultConfig, createSilentLogger());
+    const router = new ModelRouter(defaultConfig, registry, logger);
     expect(() => router.resolve('ultra')).toThrow('Unknown model tier');
   });
 
   it('passes needs through without validation', () => {
-    const router = new ModelRouter(defaultConfig, createSilentLogger());
+    const router = new ModelRouter(defaultConfig, registry, logger);
     const result = router.resolve('standard', ['vision', 'large_context']);
     expect(result.model).toBe('claude-sonnet-4-6');
   });
 
   it('falls back to default_tier when tier is omitted', () => {
-    const router = new ModelRouter(defaultConfig, createSilentLogger());
+    const router = new ModelRouter(defaultConfig, registry, logger);
     const result = router.resolve(undefined);
-    expect(result).toEqual({ provider: 'anthropic', model: 'claude-sonnet-4-6', tier: 'standard' });
+    expect(result).toEqual({ model: 'claude-sonnet-4-6', tier: 'standard' });
   });
 
   it('throws at construction if a tier config is missing', () => {
     const config: ModelRoutingConfig = {
       tiers: {
-        fast: { provider: 'anthropic', model: 'claude-haiku-4-5' },
-        standard: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+        fast: { model: 'claude-haiku-4-5' },
+        standard: { model: 'claude-sonnet-4-6' },
         // @ts-expect-error — intentionally omitting powerful to test validation
         powerful: undefined,
       },
       default_tier: 'standard',
     };
-    expect(() => new ModelRouter(config, createSilentLogger())).toThrow('model_routing.tiers.powerful');
+    expect(() => new ModelRouter(config, registry, logger)).toThrow('model_routing.tiers.powerful');
   });
 
   it('throws at construction if a tier has empty model', () => {
     const config: ModelRoutingConfig = {
       tiers: {
-        fast: { provider: 'anthropic', model: 'claude-haiku-4-5' },
-        standard: { provider: 'anthropic', model: '' },
-        powerful: { provider: 'anthropic', model: 'claude-opus-4-6' },
+        fast: { model: 'claude-haiku-4-5' },
+        standard: { model: '' },
+        powerful: { model: 'claude-opus-4-6' },
       },
       default_tier: 'standard',
     };
-    expect(() => new ModelRouter(config, createSilentLogger())).toThrow('model_routing.tiers.standard');
+    expect(() => new ModelRouter(config, registry, logger)).toThrow('model_routing.tiers.standard');
   });
 
-  it('works with a non-anthropic provider in config', () => {
+  it('throws at construction if a tier references an unknown model', () => {
     const config: ModelRoutingConfig = {
       tiers: {
-        fast: { provider: 'openrouter', model: 'meta-llama/llama-3-8b' },
-        standard: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
-        powerful: { provider: 'anthropic', model: 'claude-opus-4-6' },
+        fast: { model: 'claude-haiku-4-5' },
+        standard: { model: 'unknown-model-xyz' },
+        powerful: { model: 'claude-opus-4-6' },
       },
       default_tier: 'standard',
     };
-    const router = new ModelRouter(config, createSilentLogger());
-    const result = router.resolve('fast');
-    expect(result).toEqual({ provider: 'openrouter', model: 'meta-llama/llama-3-8b', tier: 'fast' });
+    expect(() => new ModelRouter(config, registry, logger)).toThrow('not found in the model registry');
   });
 });

--- a/src/agents/llm/model-router.ts
+++ b/src/agents/llm/model-router.ts
@@ -1,20 +1,20 @@
-// model-router.ts — resolves capability tiers to concrete provider + model pairs.
+// model-router.ts — resolves capability tiers to concrete models.
 //
 // Agents declare a tier (fast | standard | powerful) in their YAML config.
 // The operator maps tiers to models in config/default.yaml. This class
 // performs the lookup at startup so the runtime knows which model to use.
+// The provider is resolved from the model registry — not declared per-tier.
 //
 // Capability needs (vision, large_context, etc.) are accepted but not
 // validated in this version — they are documentary-only, logged at debug
-// level for observability. Validation is deferred until multi-model
-// support lands (#379).
+// level for observability. Validation deferred to #379.
 
 import type { Logger } from '../../logger.js';
+import type { ModelRegistry } from './model-registry.js';
 
 export type Tier = 'fast' | 'standard' | 'powerful';
 
 export interface TierConfig {
-  provider: string;
   model: string;
 }
 
@@ -24,7 +24,6 @@ export interface ModelRoutingConfig {
 }
 
 export interface ResolvedModel {
-  provider: string;
   model: string;
   tier: Tier;
 }
@@ -35,14 +34,20 @@ export class ModelRouter {
   private readonly config: ModelRoutingConfig;
   private readonly logger: Logger;
 
-  constructor(config: ModelRoutingConfig, logger: Logger) {
+  constructor(config: ModelRoutingConfig, registry: ModelRegistry, logger: Logger) {
     // Eagerly validate all tier configs at construction time so misconfigurations
     // are caught at startup, not when a specific tier is first resolved.
     for (const tier of ['fast', 'standard', 'powerful'] as const) {
       const tc = config.tiers[tier];
-      if (!tc || !tc.provider || !tc.model) {
+      if (!tc || !tc.model) {
         throw new Error(
-          `model_routing.tiers.${tier} must have non-empty "provider" and "model" fields`,
+          `model_routing.tiers.${tier} must have a non-empty "model" field`,
+        );
+      }
+      // Validate that the model exists in the registry — fail-fast on unknown models.
+      if (!registry.isKnownModel(tc.model)) {
+        throw new Error(
+          `model_routing.tiers.${tier}: model "${tc.model}" not found in the model registry`,
         );
       }
     }
@@ -56,12 +61,11 @@ export class ModelRouter {
   }
 
   /**
-   * Resolve a tier (and optional needs) to a concrete provider + model.
+   * Resolve a tier (and optional needs) to a concrete model.
    *
    * Falls back to `default_tier` from config when tier is omitted.
-   * Throws if the resolved tier is unknown — this is a startup-fatal misconfiguration.
-   * `needs` is accepted but not validated; logged at debug level so operators
-   * can see what capabilities agents are requesting.
+   * Throws if the resolved tier is unknown.
+   * `needs` is accepted but not validated; logged at debug level.
    */
   resolve(tier?: string, needs?: string[]): ResolvedModel {
     const effectiveTier = tier ?? this.config.default_tier;
@@ -73,14 +77,13 @@ export class ModelRouter {
 
     if (needs && needs.length > 0) {
       // TODO: validate that the resolved model supports the declared needs
-      // when capability metadata is available (model registry consolidation).
+      // when capability validation is implemented (#379).
       this.logger.debug({ tier: effectiveTier, needs, model: tierConfig.model }, 'Model tier resolved (needs not validated)');
     } else {
       this.logger.debug({ tier: effectiveTier, model: tierConfig.model }, 'Model tier resolved');
     }
 
     return {
-      provider: tierConfig.provider,
       model: tierConfig.model,
       tier: effectiveTier as Tier,
     };

--- a/src/agents/llm/pricing.test.ts
+++ b/src/agents/llm/pricing.test.ts
@@ -4,8 +4,13 @@
 // model names, and the unknown-model fallback to sonnet pricing.
 
 import { describe, it, expect, vi } from 'vitest';
-import { estimateCostUsd } from './pricing.js';
+import { createEstimateCostUsd } from './pricing.js';
+import { ModelRegistry } from './model-registry.js';
+import { createSilentLogger } from '../../logger.js';
 import type { LLMUsage } from './provider.js';
+
+const registry = new ModelRegistry(createSilentLogger());
+const estimateCostUsd = createEstimateCostUsd(registry);
 
 // A usage object with known token counts for easy manual cost verification.
 const makeUsage = (overrides: Partial<LLMUsage> = {}): LLMUsage => ({
@@ -26,23 +31,18 @@ describe('estimateCostUsd', () => {
   });
 
   it('calculates cost correctly for claude-opus-4-6', () => {
-    // 1000 input @ $15/MTok + 500 output @ $75/MTok + 200 cache-create @ $18.75/MTok + 100 cache-read @ $1.50/MTok
-    // = 0.015 + 0.0375 + 0.00375 + 0.00015 = 0.0564
     const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 });
     const cost = estimateCostUsd('claude-opus-4-6', usage);
     expect(cost).toBeCloseTo(0.0564, 8);
   });
 
   it('calculates cost correctly for claude-haiku-4-5', () => {
-    // 1000 input @ $0.80/MTok + 500 output @ $4.00/MTok + 200 cache-create @ $1.00/MTok + 100 cache-read @ $0.08/MTok
-    // = 0.0008 + 0.002 + 0.0002 + 0.000008 = 0.003008
     const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 });
     const cost = estimateCostUsd('claude-haiku-4-5', usage);
     expect(cost).toBeCloseTo(0.003008, 8);
   });
 
   it('matches haiku pricing by prefix for versioned model names', () => {
-    // 'claude-haiku-4-5-20251001' starts with 'claude-haiku-4-5' — should match haiku pricing
     const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 200, cacheReadInputTokens: 100 });
     const versionedCost = estimateCostUsd('claude-haiku-4-5-20251001', usage);
     const baseCost = estimateCostUsd('claude-haiku-4-5', usage);

--- a/src/agents/llm/pricing.ts
+++ b/src/agents/llm/pricing.ts
@@ -1,92 +1,46 @@
-// pricing.ts — Anthropic model pricing for LLM call cost estimation.
+// pricing.ts — LLM call cost estimation backed by the model registry.
 //
-// estimateCostUsd() is called by the runtime after every successful provider.chat()
-// to populate estimatedCostUsd in the llm.call bus event. Full float precision is
-// returned — callers round for display.
+// createEstimateCostUsd() returns a closure pre-wired with a ModelRegistry
+// instance. The closure's signature is the same as the old estimateCostUsd()
+// so callers don't change.
 //
-// Pricing is matched by prefix so that minor version suffixes (e.g.
-// 'claude-haiku-4-5-20251001') fall through to the correct base entry.
-// Unrecognised models fall back to sonnet pricing with a warn log rather than
-// silently returning 0 — a silent zero would make cost dashboards misleading.
-//
-// Rates as of 2026-05 (USD per million tokens):
-//   Model            Input    Output   CacheCreate   CacheRead
-//   claude-opus-4-6  $15.00   $75.00   $18.75        $1.50
-//   claude-sonnet-4-6 $3.00   $15.00   $3.75         $0.30
-//   claude-haiku-4-5  $0.80    $4.00    $1.00         $0.08
+// Unrecognised models fall back to the default tier's model pricing with a
+// warn log — a silent zero would make cost dashboards misleading.
 
 import type { Logger } from '../../logger.js';
 import type { LLMUsage } from './provider.js';
-
-interface ModelPricing {
-  /** USD per million input tokens */
-  inputPerMToken: number;
-  /** USD per million output tokens */
-  outputPerMToken: number;
-  /** USD per million cache-creation tokens (written to prompt cache) */
-  cacheCreationPerMToken: number;
-  /** USD per million cache-read tokens (served from prompt cache) */
-  cacheReadPerMToken: number;
-}
-
-// Keyed by model name prefix. Longer prefixes take precedence over shorter ones
-// because we sort entries by key length descending before matching.
-const ANTHROPIC_PRICING: Record<string, ModelPricing> = {
-  'claude-opus-4-6': {
-    inputPerMToken: 15.00,
-    outputPerMToken: 75.00,
-    cacheCreationPerMToken: 18.75,
-    cacheReadPerMToken: 1.50,
-  },
-  'claude-sonnet-4-6': {
-    inputPerMToken: 3.00,
-    outputPerMToken: 15.00,
-    cacheCreationPerMToken: 3.75,
-    cacheReadPerMToken: 0.30,
-  },
-  'claude-haiku-4-5': {
-    inputPerMToken: 0.80,
-    outputPerMToken: 4.00,
-    cacheCreationPerMToken: 1.00,
-    cacheReadPerMToken: 0.08,
-  },
-};
-
-// Pre-sort by key length descending so the first prefix match is always the
-// most specific one (e.g. 'claude-sonnet-4-6' beats 'claude-sonnet').
-const SORTED_PRICING_ENTRIES = Object.entries(ANTHROPIC_PRICING)
-  .sort(([a], [b]) => b.length - a.length);
+import type { ModelRegistry, ModelPricing } from './model-registry.js';
 
 const FALLBACK_MODEL = 'claude-sonnet-4-6';
 
 /**
- * Estimate the cost in USD for a single LLM API call.
- *
- * Matches `actualModel` against known prefixes (longest match wins).
- * Falls back to claude-sonnet-4-6 pricing for unrecognised models, logging a
- * warning — this makes unknown-model costs visible rather than silently zero.
- *
- * @param actualModel  The model that ran, from the API response body.
- * @param usage        Token counts, including all four Anthropic token categories.
- * @param logger       Optional logger; warn is emitted for unrecognised models.
+ * Creates an estimateCostUsd function backed by the given model registry.
+ * Call once at startup; use the returned function for all cost estimation.
  */
-export function estimateCostUsd(actualModel: string, usage: LLMUsage, logger?: Logger): number {
-  const entry = SORTED_PRICING_ENTRIES.find(([prefix]) => actualModel.startsWith(prefix));
+export function createEstimateCostUsd(
+  registry: ModelRegistry,
+): (actualModel: string, usage: LLMUsage, logger?: Logger) => number {
+  return (actualModel: string, usage: LLMUsage, logger?: Logger): number => {
+    let pricing: ModelPricing | undefined = registry.getPricing(actualModel);
 
-  let pricing: ModelPricing;
-  if (entry) {
-    pricing = entry[1];
-  } else {
-    logger?.warn({ actualModel, fallback: FALLBACK_MODEL }, 'Unrecognised model — using fallback pricing for cost estimate');
-    pricing = ANTHROPIC_PRICING[FALLBACK_MODEL]!;
-  }
+    if (!pricing) {
+      logger?.warn({ actualModel, fallback: FALLBACK_MODEL }, 'Unrecognised model — using fallback pricing for cost estimate');
+      pricing = registry.getPricing(FALLBACK_MODEL);
+      if (!pricing) {
+        // Registry doesn't even have the fallback — return 0 to avoid crashing.
+        logger?.warn({ actualModel, fallback: FALLBACK_MODEL }, 'Fallback model also missing from registry — returning $0 cost');
+        return 0;
+      }
+    }
 
-  // Divide by 1_000_000 to convert from per-million-token rate to per-token rate.
-  return (
-    (usage.inputTokens * pricing.inputPerMToken +
-     usage.outputTokens * pricing.outputPerMToken +
-     usage.cacheCreationInputTokens * pricing.cacheCreationPerMToken +
-     usage.cacheReadInputTokens * pricing.cacheReadPerMToken) /
-    1_000_000
-  );
+    // Divide by 1_000_000 to convert from per-million-token rate to per-token rate.
+    // Cache fields default to 0 when the model doesn't support caching.
+    return (
+      (usage.inputTokens * pricing.inputPerMToken +
+       usage.outputTokens * pricing.outputPerMToken +
+       usage.cacheCreationInputTokens * (pricing.cacheCreationPerMToken ?? 0) +
+       usage.cacheReadInputTokens * (pricing.cacheReadPerMToken ?? 0)) /
+      1_000_000
+    );
+  };
 }

--- a/src/agents/llm/pricing.ts
+++ b/src/agents/llm/pricing.ts
@@ -11,26 +11,35 @@ import type { Logger } from '../../logger.js';
 import type { LLMUsage } from './provider.js';
 import type { ModelRegistry, ModelPricing } from './model-registry.js';
 
-const FALLBACK_MODEL = 'claude-sonnet-4-6';
+// Hard-coded last-resort fallback — only used when the caller doesn't pass a
+// fallbackModel and the registry lookup fails. Kept as a constant so the throw
+// message is informative about what to fix.
+const HARD_FALLBACK_MODEL = 'claude-sonnet-4-6';
 
 /**
  * Creates an estimateCostUsd function backed by the given model registry.
  * Call once at startup; use the returned function for all cost estimation.
+ *
+ * @param registry - the model registry to look up pricing from
+ * @param fallbackModel - model to use for cost estimates when actualModel is
+ *   not in the registry. Defaults to claude-sonnet-4-6 but callers should pass
+ *   their configured default tier model so estimates track operator routing.
  */
 export function createEstimateCostUsd(
   registry: ModelRegistry,
+  fallbackModel = HARD_FALLBACK_MODEL,
 ): (actualModel: string, usage: LLMUsage, logger?: Logger) => number {
   return (actualModel: string, usage: LLMUsage, logger?: Logger): number => {
     let pricing: ModelPricing | undefined = registry.getPricing(actualModel);
 
     if (!pricing) {
-      logger?.warn({ actualModel, fallback: FALLBACK_MODEL }, 'Unrecognised model — using fallback pricing for cost estimate');
-      pricing = registry.getPricing(FALLBACK_MODEL);
+      logger?.warn({ actualModel, fallback: fallbackModel }, 'Unrecognised model — using fallback pricing for cost estimate');
+      pricing = registry.getPricing(fallbackModel);
       if (!pricing) {
-        // The fallback model is hardcoded to a known registry entry. If it's missing,
-        // the registry was modified incorrectly — throw rather than silently returning $0
-        // which would corrupt all cost dashboards.
-        throw new Error(`Fallback pricing model '${FALLBACK_MODEL}' is not in the model registry — add it or update FALLBACK_MODEL`);
+        // The fallback model is not in the registry — the caller passed a model
+        // that isn't registered, or the default HARD_FALLBACK_MODEL was removed.
+        // Throw rather than silently returning $0, which corrupts cost dashboards.
+        throw new Error(`Fallback pricing model '${fallbackModel}' is not in the model registry — add it or update the fallback`);
       }
     }
 

--- a/src/agents/llm/pricing.ts
+++ b/src/agents/llm/pricing.ts
@@ -27,9 +27,10 @@ export function createEstimateCostUsd(
       logger?.warn({ actualModel, fallback: FALLBACK_MODEL }, 'Unrecognised model — using fallback pricing for cost estimate');
       pricing = registry.getPricing(FALLBACK_MODEL);
       if (!pricing) {
-        // Registry doesn't even have the fallback — return 0 to avoid crashing.
-        logger?.warn({ actualModel, fallback: FALLBACK_MODEL }, 'Fallback model also missing from registry — returning $0 cost');
-        return 0;
+        // The fallback model is hardcoded to a known registry entry. If it's missing,
+        // the registry was modified incorrectly — throw rather than silently returning $0
+        // which would corrupt all cost dashboards.
+        throw new Error(`Fallback pricing model '${FALLBACK_MODEL}' is not in the model registry — add it or update FALLBACK_MODEL`);
       }
     }
 

--- a/src/agents/llm/provider.ts
+++ b/src/agents/llm/provider.ts
@@ -33,7 +33,25 @@ export interface TextContent {
   text: string;
 }
 
-export type ContentBlock = TextContent | ToolUseContent | ToolResultContent;
+/**
+ * Image content block for vision calls (e.g. Anthropic's image input API).
+ * Supports both base64-encoded data and URL references; individual providers
+ * may only support a subset — pass only what the target model accepts.
+ */
+export interface ImageContent {
+  type: 'image';
+  source: {
+    type: 'base64' | 'url';
+    /** IANA media type for base64 sources (e.g. 'image/jpeg', 'image/png'). */
+    media_type?: 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif';
+    /** Base64-encoded image data. Required when source.type === 'base64'. */
+    data?: string;
+    /** Image URL. Required when source.type === 'url'. */
+    url?: string;
+  };
+}
+
+export type ContentBlock = TextContent | ToolUseContent | ToolResultContent | ImageContent;
 
 export interface Message {
   role: 'system' | 'user' | 'assistant';

--- a/src/agents/llm/provider.ts
+++ b/src/agents/llm/provider.ts
@@ -37,18 +37,26 @@ export interface TextContent {
  * Image content block for vision calls (e.g. Anthropic's image input API).
  * Supports both base64-encoded data and URL references; individual providers
  * may only support a subset — pass only what the target model accepts.
+ *
+ * source is a discriminated union so TypeScript enforces that base64 sources
+ * always include media_type and data, and URL sources always include url.
+ * Mixing optional fields (the old shape) allowed impossible states at compile time.
  */
 export interface ImageContent {
   type: 'image';
-  source: {
-    type: 'base64' | 'url';
-    /** IANA media type for base64 sources (e.g. 'image/jpeg', 'image/png'). */
-    media_type?: 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif';
-    /** Base64-encoded image data. Required when source.type === 'base64'. */
-    data?: string;
-    /** Image URL. Required when source.type === 'url'. */
-    url?: string;
-  };
+  source:
+    | {
+        type: 'base64';
+        /** IANA media type (e.g. 'image/jpeg', 'image/png'). */
+        media_type: 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif';
+        /** Base64-encoded image data. */
+        data: string;
+      }
+    | {
+        type: 'url';
+        /** Image URL. */
+        url: string;
+      };
 }
 
 export type ContentBlock = TextContent | ToolUseContent | ToolResultContent | ImageContent;

--- a/src/agents/llm/token-estimator.ts
+++ b/src/agents/llm/token-estimator.ts
@@ -43,13 +43,10 @@ export function estimateTokens(content: string | ContentBlock[]): number {
         totalChars += block.content.length;
         break;
       case 'image':
-        // Image blocks don't have a character representation; use a fixed
-        // estimate that accounts for base64 overhead without decoding the data.
-        // A base64 string's length ≈ 4/3 × raw bytes; we cap at a rough 500-token
-        // placeholder so context budgeting doesn't under-count large images.
-        totalChars += block.source.data
-          ? Math.ceil(block.source.data.length * 0.75) // revert base64 inflation
-          : block.source.url?.length ?? 50;
+        // Image tokens are billed by dimensions, not file size. Use a fixed
+        // ~500-token placeholder (1,750 chars at 3.5 chars/token) regardless of
+        // source type — estimating from base64 data length massively over-counts.
+        totalChars += 1_750;
         break;
       default: {
         // Exhaustiveness guard — if ContentBlock union is extended, this line

--- a/src/agents/llm/token-estimator.ts
+++ b/src/agents/llm/token-estimator.ts
@@ -42,6 +42,15 @@ export function estimateTokens(content: string | ContentBlock[]): number {
       case 'tool_result':
         totalChars += block.content.length;
         break;
+      case 'image':
+        // Image blocks don't have a character representation; use a fixed
+        // estimate that accounts for base64 overhead without decoding the data.
+        // A base64 string's length ≈ 4/3 × raw bytes; we cap at a rough 500-token
+        // placeholder so context budgeting doesn't under-count large images.
+        totalChars += block.source.data
+          ? Math.ceil(block.source.data.length * 0.75) // revert base64 inflation
+          : block.source.url?.length ?? 50;
+        break;
       default: {
         // Exhaustiveness guard — if ContentBlock union is extended, this line
         // becomes a compile error, prompting the developer to handle the new type.

--- a/src/agents/llm/token-estimator.ts
+++ b/src/agents/llm/token-estimator.ts
@@ -77,40 +77,5 @@ export function estimateMessagesTokens(messages: Message[]): number {
   return total;
 }
 
-// -- Context window map --
-// Maps model name prefixes to their advertised context window sizes (in tokens).
-// Sorted by descending key length so that more-specific prefixes match first
-// (e.g. "claude-haiku-4-5-20251001" matches "claude-haiku-4-5" before "claude").
-const CONTEXT_WINDOWS: Record<string, number> = {
-  'claude-opus-4-6': 200_000,
-  'claude-sonnet-4-6': 200_000,
-  'claude-haiku-4-5': 200_000,
-};
-
-const SORTED_WINDOW_ENTRIES = Object.entries(CONTEXT_WINDOWS)
-  .sort(([a], [b]) => b.length - a.length);
-
-const FALLBACK_WINDOW_MODEL = 'claude-sonnet-4-6';
-
-/**
- * Returns the context window size for the given model identifier.
- *
- * Matches by prefix so versioned model names (e.g. "claude-haiku-4-5-20251001")
- * resolve correctly. Falls back to the sonnet window for unrecognised models.
- */
-export function getContextWindow(model: string): number {
-  const entry = SORTED_WINDOW_ENTRIES.find(([prefix]) => model.startsWith(prefix));
-  return entry ? entry[1] : CONTEXT_WINDOWS[FALLBACK_WINDOW_MODEL]!;
-}
-
-/** Returns true if the model is in the known context window map (not using fallback). */
-export function isKnownContextWindowModel(model: string): boolean {
-  return SORTED_WINDOW_ENTRIES.some(([prefix]) => model.startsWith(prefix));
-}
-
 /** Safety margin (5%) subtracted from the context window before budgeting. */
 export const DEFAULT_SAFETY_MARGIN = 0.05;
-
-/** Default model used when agent YAML doesn't specify one. Kept alongside the
- *  context window map so the default and the lookup stay in lockstep. */
-export const DEFAULT_MODEL_NAME = 'claude-sonnet-4-6';

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1,10 +1,10 @@
-import type { LLMProvider, LLMResponse, Message, ToolDefinition, ContentBlock, ToolUseContent, ToolResultContent, TextContent } from './llm/provider.js';
+import type { LLMProvider, LLMResponse, LLMUsage, Message, ToolDefinition, ContentBlock, ToolUseContent, ToolResultContent, TextContent } from './llm/provider.js';
 import type { EventBus } from '../bus/bus.js';
 import { createAgentResponse, createAgentError, createSkillInvoke, createSkillResult, createLlmCall, createContextBudget, type AgentTaskEvent } from '../bus/events.js';
 import { ContextBudget } from './llm/context-budget.js';
-import { getContextWindow, DEFAULT_SAFETY_MARGIN, DEFAULT_MODEL_NAME, isKnownContextWindowModel } from './llm/token-estimator.js';
+import { DEFAULT_SAFETY_MARGIN } from './llm/token-estimator.js';
+import type { ModelRegistry } from './llm/model-registry.js';
 import { createHash } from 'node:crypto';
-import { estimateCostUsd } from './llm/pricing.js';
 import type { Logger } from '../logger.js';
 import type { WorkingMemory } from '../memory/working-memory.js';
 import type { EntityMemory } from '../memory/entity-memory.js';
@@ -90,6 +90,11 @@ export interface AgentConfig {
   bullpenService?: BullpenService;
   /** How far back to look for active threads, in minutes. Default: 60. */
   bullpenWindowMinutes?: number;
+  /** Model registry — used to look up context window sizes per model. */
+  modelRegistry: ModelRegistry;
+  /** Pre-wired cost estimation function — created at startup via createEstimateCostUsd()
+   *  and injected here so the runtime doesn't import pricing.ts directly. */
+  estimateCostUsd: (actualModel: string, usage: LLMUsage, logger?: Logger) => number;
   /** Compiled security context block — injected into the effective system prompt on every
    *  task. If the prompt contains ${security_context_block}, the placeholder is replaced at
    *  that position. If the placeholder is absent, the block is appended unconditionally as a
@@ -323,12 +328,15 @@ export class AgentRuntime {
     };
 
     // Create context budget for token-aware assembly.
-    const modelName = this.config.resolvedModel ?? this.config.modelName ?? DEFAULT_MODEL_NAME;
-    const contextWindow = getContextWindow(modelName);
-    if (!isKnownContextWindowModel(modelName)) {
+    const modelName = this.config.resolvedModel ?? this.config.modelName;
+    if (!modelName) {
+      throw new Error(`Agent ${agentId} has no resolvedModel or modelName — cannot create context budget`);
+    }
+    const contextWindow = this.config.modelRegistry.getContextWindow(modelName);
+    if (!this.config.modelRegistry.isKnownModel(modelName)) {
       logger.warn(
-        { agentId, modelName, fallbackWindow: contextWindow },
-        'Model not in context window map — using fallback; budget may be incorrect. Add this model to token-estimator.ts',
+        { agentId, modelName },
+        'Model not in model registry — context budget will use 0 window. Add this model to model-registry.ts',
       );
     }
     const ctxBudget = new ContextBudget({
@@ -1035,7 +1043,7 @@ export class AgentRuntime {
           outputTokens: response.usage.outputTokens,
           cacheCreationInputTokens: response.usage.cacheCreationInputTokens,
           cacheReadInputTokens: response.usage.cacheReadInputTokens,
-          estimatedCostUsd: estimateCostUsd(response.provenance.actualModel, response.usage, logger),
+          estimatedCostUsd: this.config.estimateCostUsd(response.provenance.actualModel, response.usage, logger),
           latencyMs: callLatencyMs,
           promptHash,
           responseHash,

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -27,8 +27,10 @@ export interface AgentConfig {
   provider: LLMProvider;
   /** The concrete model ID resolved from the agent's capability tier by the ModelRouter.
    *  Passed to provider.chat() on every call so a single provider instance can serve
-   *  multiple tiers. Set by bootstrap — always present for tier-routed agents. */
-  resolvedModel: string;
+   *  multiple tiers. Set by bootstrap — always present for tier-routed agents.
+   *  Optional for unit-test convenience; when omitted alongside modelName, the runtime
+   *  skips context-window lookup and uses a 200k-token default. */
+  resolvedModel?: string;
   bus: EventBus;
   logger: Logger;
   /** Optional working memory for conversation persistence across turns. */
@@ -90,11 +92,14 @@ export interface AgentConfig {
   bullpenService?: BullpenService;
   /** How far back to look for active threads, in minutes. Default: 60. */
   bullpenWindowMinutes?: number;
-  /** Model registry — used to look up context window sizes per model. */
-  modelRegistry: ModelRegistry;
+  /** Model registry — used to look up context window sizes per model.
+   *  Optional for test convenience; defaults to a no-op registry that returns 0
+   *  for all lookups (matches behaviour of an unknown model in the real registry). */
+  modelRegistry?: ModelRegistry;
   /** Pre-wired cost estimation function — created at startup via createEstimateCostUsd()
-   *  and injected here so the runtime doesn't import pricing.ts directly. */
-  estimateCostUsd: (actualModel: string, usage: LLMUsage, logger?: Logger) => number;
+   *  and injected here so the runtime doesn't import pricing.ts directly.
+   *  Optional for test convenience; defaults to a zero-cost no-op. */
+  estimateCostUsd?: (actualModel: string, usage: LLMUsage, logger?: Logger) => number;
   /** Compiled security context block — injected into the effective system prompt on every
    *  task. If the prompt contains ${security_context_block}, the placeholder is replaced at
    *  that position. If the placeholder is absent, the block is appended unconditionally as a
@@ -329,18 +334,21 @@ export class AgentRuntime {
 
     // Create context budget for token-aware assembly.
     const modelName = this.config.resolvedModel ?? this.config.modelName;
-    if (!modelName) {
-      throw new Error(`Agent ${agentId} has no resolvedModel or modelName — cannot create context budget`);
-    }
-    const contextWindow = this.config.modelRegistry.getContextWindow(modelName);
-    if (!this.config.modelRegistry.isKnownModel(modelName)) {
+    // When no model name is available (unit tests that omit resolvedModel/modelName),
+    // skip registry lookup and use the standard 200k Anthropic context window.
+    // In production both resolvedModel (set by ModelRouter) and the registry are always
+    // present; this fallback is exercised only by tests that don't wire the full stack.
+    const contextWindow = modelName
+      ? (this.config.modelRegistry?.getContextWindow(modelName) ?? 200_000)
+      : 200_000;
+    if (modelName && this.config.modelRegistry && !this.config.modelRegistry.isKnownModel(modelName)) {
       logger.warn(
         { agentId, modelName },
         'Model not in model registry — context budget will use 0 window. Add this model to model-registry.ts',
       );
     }
     const ctxBudget = new ContextBudget({
-      model: modelName,
+      model: modelName ?? 'unknown',
       contextWindow,
       responseReserve: this.config.contextBudget?.responseReserve ?? 8_192,
       safetyMargin: DEFAULT_SAFETY_MARGIN,
@@ -1043,7 +1051,8 @@ export class AgentRuntime {
           outputTokens: response.usage.outputTokens,
           cacheCreationInputTokens: response.usage.cacheCreationInputTokens,
           cacheReadInputTokens: response.usage.cacheReadInputTokens,
-          estimatedCostUsd: this.config.estimateCostUsd(response.provenance.actualModel, response.usage, logger),
+          // estimateCostUsd is optional; default to 0 when omitted (unit tests / unknown models).
+          estimatedCostUsd: this.config.estimateCostUsd?.(response.provenance.actualModel, response.usage, logger) ?? 0,
           latencyMs: callLatencyMs,
           promptHash,
           responseHash,
@@ -1058,7 +1067,7 @@ export class AgentRuntime {
     };
 
     const callStartMs = Date.now();
-    const response = await provider.chat({ ...params, model: this.config.resolvedModel });
+    const response = await provider.chat({ ...params, ...(this.config.resolvedModel !== undefined ? { model: this.config.resolvedModel } : {}) });
     const latencyMs = Date.now() - callStartMs;
     if (response.type !== 'error') {
       // LLM call succeeded — reset consecutive error counter and publish telemetry
@@ -1100,7 +1109,7 @@ export class AgentRuntime {
       await new Promise(resolve => setTimeout(resolve, backoffMs));
 
       const retryStartMs = Date.now();
-      const retryResponse = await provider.chat({ ...params, model: this.config.resolvedModel });
+      const retryResponse = await provider.chat({ ...params, ...(this.config.resolvedModel !== undefined ? { model: this.config.resolvedModel } : {}) });
       const retryLatencyMs = Date.now() - retryStartMs;
       if (retryResponse.type !== 'error') {
         // Retry succeeded — reset consecutive error counter and publish telemetry

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1066,8 +1066,11 @@ export class AgentRuntime {
       }
     };
 
+    // Prefer the explicitly resolved model; fall back to modelName so callers that
+    // set only modelName (e.g. unit tests) still reach the provider without error.
+    const modelForCall = this.config.resolvedModel ?? this.config.modelName;
     const callStartMs = Date.now();
-    const response = await provider.chat({ ...params, ...(this.config.resolvedModel !== undefined ? { model: this.config.resolvedModel } : {}) });
+    const response = await provider.chat({ ...params, ...(modelForCall !== undefined ? { model: modelForCall } : {}) });
     const latencyMs = Date.now() - callStartMs;
     if (response.type !== 'error') {
       // LLM call succeeded — reset consecutive error counter and publish telemetry
@@ -1109,7 +1112,7 @@ export class AgentRuntime {
       await new Promise(resolve => setTimeout(resolve, backoffMs));
 
       const retryStartMs = Date.now();
-      const retryResponse = await provider.chat({ ...params, ...(this.config.resolvedModel !== undefined ? { model: this.config.resolvedModel } : {}) });
+      const retryResponse = await provider.chat({ ...params, ...(modelForCall !== undefined ? { model: modelForCall } : {}) });
       const retryLatencyMs = Date.now() - retryStartMs;
       if (retryResponse.type !== 'error') {
         // Retry succeeded — reset consecutive error counter and publish telemetry

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -344,7 +344,7 @@ export class AgentRuntime {
     if (modelName && this.config.modelRegistry && !this.config.modelRegistry.isKnownModel(modelName)) {
       logger.warn(
         { agentId, modelName },
-        'Model not in model registry — context budget will use 0 window. Add this model to model-registry.ts',
+        'Model not in model registry — context budget using fallback window of 200,000 tokens. Add this model to model-registry.ts',
       );
     }
     const ctxBudget = new ContextBudget({

--- a/src/config.ts
+++ b/src/config.ts
@@ -553,6 +553,11 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       if (typeof autonomyScoring !== 'object' || autonomyScoring === null || Array.isArray(autonomyScoring)) {
         throw new Error('dreaming.autonomy_scoring must be a YAML mapping');
       }
+      // Reject the deprecated autonomy_scoring.model key so operators don't silently
+      // use a config key that is no longer read. The replacement is model_tier.
+      if ('model' in (autonomyScoring as object)) {
+        throw new Error('dreaming.autonomy_scoring.model is deprecated — use dreaming.autonomy_scoring.model_tier instead');
+      }
       if (autonomyScoring.intervalMs !== undefined && (!Number.isInteger(autonomyScoring.intervalMs) || autonomyScoring.intervalMs <= 0)) {
         throw new Error(`dreaming.autonomy_scoring.intervalMs must be a positive integer, got: ${autonomyScoring.intervalMs}`);
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -221,7 +221,7 @@ export interface YamlConfig {
     };
     autonomy_scoring?: {
       intervalMs?: number;
-      model?: string;
+      model_tier?: string;
       batchSize?: number;
       minScoredActions?: number;
       halfLifeDays?: number;
@@ -237,13 +237,13 @@ export interface YamlConfig {
     max_per_hour?: number;
   };
   /** Capability-tier model routing (ADR-014).
-   *  Maps tier names to provider + model pairs. Agents declare a tier
-   *  in their YAML; the operator controls which model each tier resolves to. */
+   *  Maps tier names to model names. Provider is resolved from the ModelRegistry.
+   *  Agents declare a tier in their YAML; the operator controls which model each tier resolves to. */
   model_routing?: {
     tiers: {
-      fast: { provider: string; model: string };
-      standard: { provider: string; model: string };
-      powerful: { provider: string; model: string };
+      fast: { model: string };
+      standard: { model: string };
+      powerful: { model: string };
     };
     default_tier: 'fast' | 'standard' | 'powerful';
   };
@@ -556,8 +556,8 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       if (autonomyScoring.intervalMs !== undefined && (!Number.isInteger(autonomyScoring.intervalMs) || autonomyScoring.intervalMs <= 0)) {
         throw new Error(`dreaming.autonomy_scoring.intervalMs must be a positive integer, got: ${autonomyScoring.intervalMs}`);
       }
-      if (autonomyScoring.model !== undefined && (typeof autonomyScoring.model !== 'string' || autonomyScoring.model.trim().length === 0)) {
-        throw new Error(`dreaming.autonomy_scoring.model must be a non-empty string, got: ${String(autonomyScoring.model)}`);
+      if (autonomyScoring.model_tier !== undefined && (typeof autonomyScoring.model_tier !== 'string' || autonomyScoring.model_tier.trim().length === 0)) {
+        throw new Error(`dreaming.autonomy_scoring.model_tier must be a non-empty string, got: ${String(autonomyScoring.model_tier)}`);
       }
       if (autonomyScoring.batchSize !== undefined && (!Number.isInteger(autonomyScoring.batchSize) || autonomyScoring.batchSize <= 0)) {
         throw new Error(`dreaming.autonomy_scoring.batchSize must be a positive integer, got: ${autonomyScoring.batchSize}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,7 +287,9 @@ async function main(): Promise<void> {
   // estimateCostUsd is a closure pre-wired with the model registry. Passed to
   // AgentRuntime as config (dependency injection) so the runtime stays testable
   // without importing pricing.ts directly.
-  const estimateCostUsd = createEstimateCostUsd(modelRegistry);
+  // Pass the configured standard tier model as the fallback so cost estimates
+  // for unrecognised models track operator routing rather than hardcoding Sonnet.
+  const estimateCostUsd = createEstimateCostUsd(modelRegistry, modelRoutingConfig.tiers.standard.model);
   const modelRouter = new ModelRouter(modelRoutingConfig, modelRegistry, logger);
   const providerRegistry = new Map<string, LLMProvider>([
     ['anthropic', llmProvider],

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,11 +282,10 @@ async function main(): Promise<void> {
     process.exit(1);
   }
   const modelRegistry = new ModelRegistry(logger);
-  // estimateCostUsd is created here and passed to AgentRuntime in Task 7.
-  // The 'void' suppresses the noUnusedLocals error until that wiring lands.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // estimateCostUsd is a closure pre-wired with the model registry. Passed to
+  // AgentRuntime as config (dependency injection) so the runtime stays testable
+  // without importing pricing.ts directly.
   const estimateCostUsd = createEstimateCostUsd(modelRegistry);
-  void estimateCostUsd;
   const modelRouter = new ModelRouter(modelRoutingConfig, modelRegistry, logger);
   const providerRegistry = new Map<string, LLMProvider>([
     ['anthropic', llmProvider],
@@ -1172,6 +1171,9 @@ async function main(): Promise<void> {
       executionLayer,
       pinnedSkills: agentPinnedSkills,
       skillToolDefs: agentToolDefs,
+      // Registry-backed context window lookups and cost estimation (DI so runtime is testable).
+      modelRegistry,
+      estimateCostUsd,
       // Only the coordinator receives the autonomy service — it's the only agent
       // that needs per-task autonomy prompt injection and the autonomy skills.
       // Use role (same predicate as interpolateRuntimeContext above) so both

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,14 +263,6 @@ async function main(): Promise<void> {
     executiveProfileService = undefined;
   }
 
-  // 5. LLM provider — hard fail early rather than discovering the missing
-  // key only when the first user message arrives.
-  if (!config.anthropicApiKey) {
-    logger.fatal('ANTHROPIC_API_KEY is required');
-    process.exit(1);
-  }
-  const llmProvider = new AnthropicProvider(config.anthropicApiKey, logger);
-
   // Capability-tier model routing (ADR-014).
   // The ModelRouter resolves tier declarations from agent YAML to concrete
   // provider + model pairs. The provider registry maps provider names to
@@ -282,6 +274,16 @@ async function main(): Promise<void> {
     process.exit(1);
   }
   const modelRegistry = new ModelRegistry(logger);
+
+  // 5. LLM provider — hard fail early rather than discovering the missing
+  // key only when the first user message arrives.
+  // modelRegistry must be instantiated first (above) — the provider uses it
+  // to look up maxOutputTokens per model rather than using a hardcoded constant.
+  if (!config.anthropicApiKey) {
+    logger.fatal('ANTHROPIC_API_KEY is required');
+    process.exit(1);
+  }
+  const llmProvider = new AnthropicProvider(config.anthropicApiKey, logger, modelRegistry);
   // estimateCostUsd is a closure pre-wired with the model registry. Passed to
   // AgentRuntime as config (dependency injection) so the runtime stays testable
   // without importing pricing.ts directly.

--- a/src/index.ts
+++ b/src/index.ts
@@ -941,8 +941,8 @@ async function main(): Promise<void> {
   // Build the drift detector if enabled in config. Requires the LLM provider
   // (already created above). If enabled but no provider is available, the config
   // is still valid — drift checks will simply never trigger.
-  //
-  // TODO: When multi-model support is added, make this provider independently configurable.
+  // The 'standard' tier is used for drift checks — they're concise JSON judgments
+  // that don't need the full flagship model.
   let driftDetector: DriftDetector | undefined;
   if (yamlConfig.intentDrift?.enabled !== false) {
     // Resolve effective drift config with defaults.
@@ -950,6 +950,7 @@ async function main(): Promise<void> {
       enabled: yamlConfig.intentDrift?.enabled ?? true,
       checkEveryNBursts: yamlConfig.intentDrift?.checkEveryNBursts ?? 1,
       minConfidenceToPause: yamlConfig.intentDrift?.minConfidenceToPause ?? 'high',
+      model: modelRouter.resolve('standard').model,
     };
     driftDetector = new DriftDetector(llmProvider, driftConfig, logger);
     logger.info({ driftConfig }, 'Intent drift detection enabled');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1063,7 +1063,7 @@ async function main(): Promise<void> {
   // capability-gated declarations. outboundGateway gives email skills their send path.
   // entityContextAssembler enables entity_enrichment pre-enrichment and the
   // entity-context skill. agentContactId enables entity_enrichment default='agent'.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, actionLogRepo, confidencePipeline, tempFileStore, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, actionLogRepo, confidencePipeline, tempFileStore, llmProvider, modelRouter, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,21 +311,19 @@ async function main(): Promise<void> {
   // llmProvider is already initialized above (step 5) so we can pass it directly.
   // If the config block is absent, summarization is disabled (no-op backend).
   const summarizationCfg = yamlConfig.workingMemory?.summarization;
-  // Resolve which model tier to use for summarization so the right model is passed
-  // when SummarizationConfig gains a model field (Task 14).
+  // Resolve which model tier to use for summarization. 'standard' is appropriate
+  // for summarization — it's a medium-complexity task that doesn't need the full
+  // flagship model but benefits from better instruction-following than a fast tier.
   const summarizationModel = modelRouter.resolve('standard').model;
   const memory = WorkingMemory.createWithPostgres(pool, logger, summarizationCfg
     ? {
         threshold: summarizationCfg.threshold ?? 20,
         keepWindow: summarizationCfg.keepWindow ?? 10,
         provider: llmProvider,
-        // TODO: model will be added in Task 14 once SummarizationConfig gains a model field.
-        // Use: model: summarizationModel
+        model: summarizationModel,
       }
     : undefined,
   );
-  // Suppress unused-variable warning until Task 14 wires it in.
-  void summarizationModel;
 
   // Entity memory — optional, requires OPENAI_API_KEY for embeddings.
   // If not configured, agents still work — they just don't have KG access.

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,8 @@ import { Dispatcher } from './dispatch/dispatcher.js';
 import { CliAdapter } from './channels/cli/cli-adapter.js';
 import { loadAllAgentConfigs, interpolateRuntimeContext } from './agents/loader.js';
 import { ModelRouter } from './agents/llm/model-router.js';
+import { ModelRegistry } from './agents/llm/model-registry.js';
+import { createEstimateCostUsd } from './agents/llm/pricing.js';
 import type { LLMProvider } from './agents/llm/provider.js';
 import { AgentRegistry } from './agents/agent-registry.js';
 import { WorkingMemory } from './memory/working-memory.js';
@@ -279,10 +281,28 @@ async function main(): Promise<void> {
     logger.fatal('model_routing config section is required in config/default.yaml');
     process.exit(1);
   }
-  const modelRouter = new ModelRouter(modelRoutingConfig, logger);
+  const modelRegistry = new ModelRegistry(logger);
+  // estimateCostUsd is created here and passed to AgentRuntime in Task 7.
+  // The 'void' suppresses the noUnusedLocals error until that wiring lands.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const estimateCostUsd = createEstimateCostUsd(modelRegistry);
+  void estimateCostUsd;
+  const modelRouter = new ModelRouter(modelRoutingConfig, modelRegistry, logger);
   const providerRegistry = new Map<string, LLMProvider>([
     ['anthropic', llmProvider],
   ]);
+
+  // Validate that every provider referenced by a model in the registry has
+  // an entry in providerRegistry. Fail-fast if an operator adds a model
+  // requiring a provider that isn't instantiated.
+  for (const [modelId, meta] of Object.entries(modelRegistry.getAllModels())) {
+    if (!providerRegistry.has(meta.provider)) {
+      logger.warn(
+        { model: modelId, provider: meta.provider },
+        'Model in registry references a provider that is not registered — model will be unusable',
+      );
+    }
+  }
 
   // Working memory — created after the pool is confirmed healthy so we know
   // the working_memory table is reachable before the first message arrives.
@@ -290,14 +310,21 @@ async function main(): Promise<void> {
   // llmProvider is already initialized above (step 5) so we can pass it directly.
   // If the config block is absent, summarization is disabled (no-op backend).
   const summarizationCfg = yamlConfig.workingMemory?.summarization;
+  // Resolve which model tier to use for summarization so the right model is passed
+  // when SummarizationConfig gains a model field (Task 14).
+  const summarizationModel = modelRouter.resolve('standard').model;
   const memory = WorkingMemory.createWithPostgres(pool, logger, summarizationCfg
     ? {
         threshold: summarizationCfg.threshold ?? 20,
         keepWindow: summarizationCfg.keepWindow ?? 10,
         provider: llmProvider,
+        // TODO: model will be added in Task 14 once SummarizationConfig gains a model field.
+        // Use: model: summarizationModel
       }
     : undefined,
   );
+  // Suppress unused-variable warning until Task 14 wires it in.
+  void summarizationModel;
 
   // Entity memory — optional, requires OPENAI_API_KEY for embeddings.
   // If not configured, agents still work — they just don't have KG access.
@@ -949,9 +976,13 @@ async function main(): Promise<void> {
   // Autonomy scoring pass — Phase 3 automatic score adjustment (issue #148).
   // Runs as a sibling DreamEngine pass alongside memory decay.
   // actionLogRepo is already instantiated above (before OutboundGateway) — reused here.
+  // Resolve model tier from config (defaults to 'fast' — the scoring pass is non-interactive
+  // and doesn't need a powerful model, so 'fast' is appropriate for cost efficiency).
+  const scoringModelTier = yamlConfig.dreaming?.autonomy_scoring?.model_tier ?? 'fast';
+  const scoringModel = modelRouter.resolve(scoringModelTier).model;
   const scoringPassConfig: ScoringPassConfig = {
     intervalMs: yamlConfig.dreaming?.autonomy_scoring?.intervalMs ?? 86_400_000,  // default: daily
-    model: yamlConfig.dreaming?.autonomy_scoring?.model ?? 'claude-haiku-4-5',
+    model: scoringModel,
     batchSize: yamlConfig.dreaming?.autonomy_scoring?.batchSize ?? 50,
     minScoredActions: yamlConfig.dreaming?.autonomy_scoring?.minScoredActions ?? 30,
     halfLifeDays: yamlConfig.dreaming?.autonomy_scoring?.halfLifeDays ?? 30,
@@ -1111,12 +1142,21 @@ async function main(): Promise<void> {
       }
     }
 
-    // Resolve this agent's capability tier to a concrete provider + model.
+    // Resolve this agent's capability tier to a concrete model, then look up
+    // the provider from the model registry. This decouples tier→model from
+    // model→provider: the registry is the single source of truth for which
+    // provider serves each model.
     const resolved = modelRouter.resolve(agentConfig.model.tier, agentConfig.model.needs);
-    const agentProvider = providerRegistry.get(resolved.provider);
+    const resolvedProvider = modelRegistry.getProvider(resolved.model);
+    if (!resolvedProvider) {
+      logger.fatal({ model: resolved.model, agent: agentConfig.name, tier: resolved.tier },
+        'Model not found in registry — cannot resolve provider');
+      process.exit(1);
+    }
+    const agentProvider = providerRegistry.get(resolvedProvider);
     if (!agentProvider) {
-      logger.fatal({ provider: resolved.provider, agent: agentConfig.name, tier: resolved.tier },
-        'No provider registered for tier-resolved provider name');
+      logger.fatal({ provider: resolvedProvider, agent: agentConfig.name, tier: resolved.tier },
+        `No provider registered for model's provider`);
       process.exit(1);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,10 +298,11 @@ async function main(): Promise<void> {
   // requiring a provider that isn't instantiated.
   for (const [modelId, meta] of Object.entries(modelRegistry.getAllModels())) {
     if (!providerRegistry.has(meta.provider)) {
-      logger.warn(
+      logger.fatal(
         { model: modelId, provider: meta.provider },
-        'Model in registry references a provider that is not registered — model will be unusable',
+        'Model in registry references a provider that is not registered — cannot start',
       );
+      process.exit(1);
     }
   }
 
@@ -979,7 +980,13 @@ async function main(): Promise<void> {
   // Resolve model tier from config (defaults to 'fast' — the scoring pass is non-interactive
   // and doesn't need a powerful model, so 'fast' is appropriate for cost efficiency).
   const scoringModelTier = yamlConfig.dreaming?.autonomy_scoring?.model_tier ?? 'fast';
-  const scoringModel = modelRouter.resolve(scoringModelTier).model;
+  let scoringModel: string;
+  try {
+    scoringModel = modelRouter.resolve(scoringModelTier).model;
+  } catch (err) {
+    logger.fatal({ scoringModelTier, err }, 'autonomy_scoring.model_tier references an unknown model tier — cannot start');
+    process.exit(1);
+  }
   const scoringPassConfig: ScoringPassConfig = {
     intervalMs: yamlConfig.dreaming?.autonomy_scoring?.intervalMs ?? 86_400_000,  // default: daily
     model: scoringModel,

--- a/src/memory/working-memory.ts
+++ b/src/memory/working-memory.ts
@@ -19,6 +19,8 @@ export interface SummarizationConfig {
   keepWindow: number;
   /** LLM provider used for the condensation call — same provider the agent uses. */
   provider: LLMProvider;
+  /** Model identifier to pass explicitly to provider.chat() for the summarization call. */
+  model: string;
 }
 
 interface StorageBackend {
@@ -154,7 +156,7 @@ class PostgresBackend implements StorageBackend {
     agentId: string,
     config: SummarizationConfig,
   ): Promise<void> {
-    const { threshold, keepWindow, provider } = config;
+    const { threshold, keepWindow, provider, model } = config;
 
     // Count active (non-archived) turns for this conversation+agent
     const countResult = await this.pool.query<{ count: string }>(
@@ -229,6 +231,7 @@ class PostgresBackend implements StorageBackend {
 
     const response = await provider.chat({
       messages: [{ role: 'user', content: summaryPrompt }],
+      model,
     });
 
     if (response.type === 'error') {

--- a/src/scheduler/drift-detector.ts
+++ b/src/scheduler/drift-detector.ts
@@ -8,8 +8,7 @@
 // Failure modes are all fail-open: any LLM error, timeout, or malformed response
 // is treated as "no drift" so the task continues. The failure is logged at warn.
 //
-// TODO: When multi-model support is added, make the LLM provider here independently
-// configurable from the coordinator's provider (cheaper/faster model for this check).
+// Model is resolved from the standard tier at startup via ModelRouter.
 
 import type { LLMProvider } from '../agents/llm/provider.js';
 import type { Logger } from '../logger.js';
@@ -28,6 +27,8 @@ export interface DriftConfig {
   checkEveryNBursts: number;
   /** Minimum LLM confidence required to trigger a pause. */
   minConfidenceToPause: DriftConfidence;
+  /** Model identifier passed explicitly to provider.chat() for each drift check call. */
+  model: string;
 }
 
 export interface DriftCheckParams {
@@ -88,6 +89,7 @@ export class DriftDetector {
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userLines.join('\n') },
         ],
+        model: this.config.model,
         options: { max_tokens: 200, temperature: 0 },
       });
 

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -48,6 +48,16 @@ import type { ModelRouter } from '../agents/llm/model-router.js';
 // reaches the LLM context window.
 const DEFAULT_SKILL_OUTPUT_MAX_LENGTH = 200_000;
 
+// Skills permitted to receive direct LLM infrastructure (llmProvider + modelRouter).
+// These are batch/background skills that run outside the agent runtime telemetry path.
+// Any other skill declaring these capabilities is misconfigured and must be rejected.
+// See #637 for the planned redesign of infrastructure skill LLM access.
+const LLM_INFRA_SKILL_ALLOWLIST: ReadonlySet<string> = new Set([
+  'extract-facts',
+  'extract-relationships',
+  'file-parse',
+]);
+
 /** Options passed to ExecutionLayer.invoke() by the agent runtime. */
 export interface InvokeOptions {
   taskEventId?: string;
@@ -544,6 +554,26 @@ export class ExecutionLayer {
         success: false,
         error: this.wrapSkillError(
           `Skill '${skillName}' declares capability 'executionLayer' but only 'approve-action' is permitted to use it`,
+        ),
+      };
+    }
+
+    // Hard-restrict llmProvider/modelRouter to infrastructure skills only.
+    // These grant direct LLM access outside the agent runtime — a rogue skill with
+    // these capabilities could make unbounded LLM calls without telemetry or rate limits.
+    // Only the three background skills explicitly designed for it are allowed.
+    if (
+      (caps.includes('llmProvider') || caps.includes('modelRouter')) &&
+      !LLM_INFRA_SKILL_ALLOWLIST.has(manifest.name)
+    ) {
+      skillLogger.error(
+        { skillName, manifestName: manifest.name },
+        'SECURITY: llmProvider/modelRouter capabilities are restricted to infrastructure skills — refusing to run skill',
+      );
+      return {
+        success: false,
+        error: this.wrapSkillError(
+          `Skill '${skillName}' declares restricted LLM infrastructure capabilities (llmProvider/modelRouter) — only extract-facts, extract-relationships, and file-parse are permitted`,
         ),
       };
     }

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -40,6 +40,8 @@ import type { AutonomyConfig } from '../autonomy/autonomy-service.js';
 import type { BrowserService } from '../browser/browser-service.js';
 import type { ApprovalTriggerService } from '../autonomy/approval-trigger.js';
 import { TempFileStore } from './temp-file-store.js';
+import type { LLMProvider } from '../agents/llm/provider.js';
+import type { ModelRouter } from '../agents/llm/model-router.js';
 
 // Default max output length — used when no value is configured in default.yaml.
 // Skills returning more than this will have their output truncated before it
@@ -82,6 +84,8 @@ export class ExecutionLayer {
   private actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
   private confidencePipeline?: import('../contacts/confidence-pipeline.js').ConfidencePipeline;
   private tempFileStore?: TempFileStore;
+  private readonly llmProvider?: LLMProvider;
+  private readonly modelRouter?: ModelRouter;
   /** The agent's own contactId — injected into ctx.agentContactId for entity_enrichment default='agent' */
   private agentContactId?: string;
   /** IANA timezone name used for normalizing offset-less timestamp inputs from the LLM. */
@@ -110,6 +114,8 @@ export class ExecutionLayer {
     actionLogRepo?: import('../autonomy/action-log-repo.js').ActionLogRepo;
     confidencePipeline?: import('../contacts/confidence-pipeline.js').ConfidencePipeline;
     tempFileStore?: TempFileStore;
+    llmProvider?: LLMProvider;
+    modelRouter?: ModelRouter;
     agentContactId?: string;
     timezone?: string;
     selfEmail?: string;
@@ -135,6 +141,8 @@ export class ExecutionLayer {
     this.actionLogRepo = options?.actionLogRepo;
     this.confidencePipeline = options?.confidencePipeline;
     this.tempFileStore = options?.tempFileStore;
+    this.llmProvider = options?.llmProvider;
+    this.modelRouter = options?.modelRouter;
     this.agentContactId = options?.agentContactId;
     this.timezone = options?.timezone ?? 'UTC';
     this.selfEmail = options?.selfEmail;
@@ -514,6 +522,11 @@ export class ExecutionLayer {
       // executionLayer injects `this` so approve-action can re-invoke blocked skills
       // with humanApproved: true (see ADR-018). Only approve-action should declare this.
       executionLayer: this,
+      // llmProvider and modelRouter are infrastructure-only capabilities for skills
+      // that need direct LLM access (extract-facts, extract-relationships, file-parse).
+      // See #637 for planned redesign of infrastructure skill LLM access.
+      llmProvider: this.llmProvider,
+      modelRouter: this.modelRouter,
     };
 
     // Hard-restrict executionLayer to approve-action only.

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -29,6 +29,7 @@ export const VALID_CAPABILITIES: ReadonlySet<string> = new Set([
   'schedulerService', 'entityMemory', 'nylasCalendarClient',
   'autonomyService', 'executiveProfileService', 'browserService', 'bullpenService', 'skillSearch',
   'actionLogRepo', 'executionLayer', 'confidencePipeline', 'tempFileStore',
+  'llmProvider', 'modelRouter',
 ]);
 
 /**

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -206,6 +206,13 @@ export interface SkillContext {
    *  MCP tools that accept file paths. Used by email download skills to hand off
    *  attachment bytes to Google Drive uploads without corruption. */
   writeTempFile?(buffer: Buffer, filename: string): Promise<string>;
+  /** LLM provider — available to skills declaring 'llmProvider' in capabilities.
+   *  Grants direct LLM access — use only for infrastructure skills (extract-facts,
+   *  extract-relationships, file-parse). See #637 for planned redesign. */
+  llmProvider?: import('../agents/llm/provider.js').LLMProvider;
+  /** Model router — available to skills declaring 'modelRouter' in capabilities.
+   *  Resolves tier names to model strings. See #637 for planned redesign. */
+  modelRouter?: import('../agents/llm/model-router.js').ModelRouter;
 }
 
 /**

--- a/tests/integration/extract-facts.test.ts
+++ b/tests/integration/extract-facts.test.ts
@@ -1,6 +1,6 @@
 // Integration test: extract-facts full round-trip.
 //
-// Uses real Postgres (DATABASE_URL must be set) and a mock Anthropic client
+// Uses real Postgres (DATABASE_URL must be set) and a mock LLMProvider
 // so no real LLM API calls are made. Tests that:
 // 1. The skill persists fact nodes to kg_nodes via real SQL
 // 2. EntityMemory.getFacts() reads those facts back
@@ -17,31 +17,49 @@ import { MemoryValidator } from '../../src/memory/validation.js';
 import { createSilentLogger } from '../../src/logger.js';
 import { ExtractFactsHandler } from '../../skills/extract-facts/handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
+import type { LLMProvider, LLMResponse } from '../../src/agents/llm/provider.js';
+import type { ModelRouter } from '../../src/agents/llm/model-router.js';
 
 const { Pool } = pg;
 
 const DATABASE_URL = process.env.DATABASE_URL;
 const describeIf = DATABASE_URL ? describe : describe.skip;
 
-function makeCtx(entityMemory: EntityMemory, text: string): SkillContext {
+// Builds a mock LLMProvider that returns sequential text responses.
+// Mirrors the old makeMockAnthropicClient but speaks the LLMProvider interface.
+function makeMockLLMProvider(responses: string[]): LLMProvider {
+  let callIndex = 0;
+  const chat = vi.fn().mockImplementation((): Promise<LLMResponse> => {
+    const content = responses[callIndex++] ?? 'no';
+    return Promise.resolve({
+      type: 'text' as const,
+      content,
+      usage: { inputTokens: 10, outputTokens: 10, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+      provenance: { requestedModel: 'claude-haiku-4-5', actualModel: 'claude-haiku-4-5', providerRequestId: 'test-req' },
+    });
+  });
+  return { chat } as unknown as LLMProvider;
+}
+
+// Minimal ModelRouter stub — returns fixed models for fast/standard tiers.
+function makeMockModelRouter(): ModelRouter {
+  return {
+    resolve: vi.fn().mockImplementation((tier: string) => {
+      const model = tier === 'fast' ? 'claude-haiku-4-5' : 'claude-sonnet-4-6';
+      return { model, tier };
+    }),
+  } as unknown as ModelRouter;
+}
+
+function makeCtx(entityMemory: EntityMemory, text: string, llmProvider: LLMProvider): SkillContext {
   return {
     input: { text, source: 'integration-test' },
     secret: () => 'test-api-key',
     log: pino({ level: 'silent' }),
     entityMemory,
+    llmProvider,
+    modelRouter: makeMockModelRouter(),
   } as unknown as SkillContext;
-}
-
-function makeMockAnthropicClient(responses: string[]) {
-  let callIndex = 0;
-  return {
-    messages: {
-      create: vi.fn().mockImplementation(() => {
-        const text = responses[callIndex++] ?? 'no';
-        return Promise.resolve({ content: [{ type: 'text', text }] });
-      }),
-    },
-  };
 }
 
 describeIf('extract-facts integration', () => {
@@ -79,9 +97,9 @@ describeIf('extract-facts integration', () => {
     const facts = JSON.stringify([
       { subject: 'Jane Doe', subjectType: 'person', attribute: 'home_city', value: 'Toronto', confidence: 0.9, decayClass: 'slow_decay' },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', facts]);
-    const handler = new ExtractFactsHandler(anthropic as never);
-    const ctx = makeCtx(entityMemory, 'Bob lives in Toronto.');
+    const llmProvider = makeMockLLMProvider(['yes', facts]);
+    const handler = new ExtractFactsHandler();
+    const ctx = makeCtx(entityMemory, 'Bob lives in Toronto.', llmProvider);
 
     const result = await handler.execute(ctx);
 
@@ -111,13 +129,13 @@ describeIf('extract-facts integration', () => {
       { subject: 'Idempotent Person', subjectType: 'person', attribute: 'role', value: 'engineer', confidence: 0.85, decayClass: 'slow_decay' },
     ]);
 
-    const anthropic1 = makeMockAnthropicClient(['yes', facts]);
-    const handler1 = new ExtractFactsHandler(anthropic1 as never);
-    await handler1.execute(makeCtx(entityMemory, 'Idempotent Person is an engineer.'));
+    const llmProvider1 = makeMockLLMProvider(['yes', facts]);
+    const handler1 = new ExtractFactsHandler();
+    await handler1.execute(makeCtx(entityMemory, 'Idempotent Person is an engineer.', llmProvider1));
 
-    const anthropic2 = makeMockAnthropicClient(['yes', facts]);
-    const handler2 = new ExtractFactsHandler(anthropic2 as never);
-    await handler2.execute(makeCtx(entityMemory, 'Idempotent Person is an engineer.'));
+    const llmProvider2 = makeMockLLMProvider(['yes', facts]);
+    const handler2 = new ExtractFactsHandler();
+    await handler2.execute(makeCtx(entityMemory, 'Idempotent Person is an engineer.', llmProvider2));
 
     const nodes = await entityMemory.findEntities('Idempotent Person');
     expect(nodes).toHaveLength(1);

--- a/tests/integration/extract-facts.test.ts
+++ b/tests/integration/extract-facts.test.ts
@@ -38,7 +38,8 @@ function makeMockLLMProvider(responses: string[]): LLMProvider {
       provenance: { requestedModel: 'claude-haiku-4-5', actualModel: 'claude-haiku-4-5', providerRequestId: 'test-req' },
     });
   });
-  return { chat } as unknown as LLMProvider;
+  // Include the required id field from the LLMProvider interface.
+  return { id: 'mock-llm-provider', chat };
 }
 
 // Minimal ModelRouter stub — returns fixed models for fast/standard tiers.

--- a/tests/integration/extract-relationships.test.ts
+++ b/tests/integration/extract-relationships.test.ts
@@ -39,7 +39,8 @@ function makeMockLLMProvider(responses: string[]): LLMProvider {
       provenance: { requestedModel: 'claude-haiku-4-5', actualModel: 'claude-haiku-4-5', providerRequestId: 'test-req' },
     });
   });
-  return { chat } as unknown as LLMProvider;
+  // Include the required id field from the LLMProvider interface.
+  return { id: 'mock-llm-provider', chat };
 }
 
 // Minimal ModelRouter stub — returns fixed models for fast/standard tiers.

--- a/tests/integration/extract-relationships.test.ts
+++ b/tests/integration/extract-relationships.test.ts
@@ -1,6 +1,6 @@
 // Integration test: extract-relationships full round-trip.
 //
-// Uses real Postgres (DATABASE_URL must be set) and a mock Anthropic client
+// Uses real Postgres (DATABASE_URL must be set) and a mock LLMProvider
 // so no real LLM API calls are made. Tests that:
 // 1. The skill persists edges to kg_edges via real SQL
 // 2. EntityContextAssembler reads those edges back on the next turn
@@ -18,31 +18,49 @@ import { createSilentLogger } from '../../src/logger.js';
 import { EntityContextAssembler } from '../../src/entity-context/assembler.js';
 import { ExtractRelationshipsHandler } from '../../skills/extract-relationships/handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
+import type { LLMProvider, LLMResponse } from '../../src/agents/llm/provider.js';
+import type { ModelRouter } from '../../src/agents/llm/model-router.js';
 
 const { Pool } = pg;
 
 const DATABASE_URL = process.env.DATABASE_URL;
 const describeIf = DATABASE_URL ? describe : describe.skip;
 
-function makeCtx(entityMemory: EntityMemory, text: string): SkillContext {
+// Builds a mock LLMProvider that returns sequential text responses.
+// Mirrors the old makeMockAnthropicClient but speaks the LLMProvider interface.
+function makeMockLLMProvider(responses: string[]): LLMProvider {
+  let callIndex = 0;
+  const chat = vi.fn().mockImplementation((): Promise<LLMResponse> => {
+    const content = responses[callIndex++] ?? 'no';
+    return Promise.resolve({
+      type: 'text' as const,
+      content,
+      usage: { inputTokens: 10, outputTokens: 10, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+      provenance: { requestedModel: 'claude-haiku-4-5', actualModel: 'claude-haiku-4-5', providerRequestId: 'test-req' },
+    });
+  });
+  return { chat } as unknown as LLMProvider;
+}
+
+// Minimal ModelRouter stub — returns fixed models for fast/standard tiers.
+function makeMockModelRouter(): ModelRouter {
+  return {
+    resolve: vi.fn().mockImplementation((tier: string) => {
+      const model = tier === 'fast' ? 'claude-haiku-4-5' : 'claude-sonnet-4-6';
+      return { model, tier };
+    }),
+  } as unknown as ModelRouter;
+}
+
+function makeCtx(entityMemory: EntityMemory, text: string, llmProvider: LLMProvider): SkillContext {
   return {
     input: { text, source: 'integration-test' },
     secret: () => 'test-api-key',
     log: pino({ level: 'silent' }),
     entityMemory,
+    llmProvider,
+    modelRouter: makeMockModelRouter(),
   } as unknown as SkillContext;
-}
-
-function makeMockAnthropicClient(responses: string[]) {
-  let callIndex = 0;
-  return {
-    messages: {
-      create: vi.fn().mockImplementation(() => {
-        const text = responses[callIndex++] ?? 'no';
-        return Promise.resolve({ content: [{ type: 'text', text }] });
-      }),
-    },
-  };
 }
 
 describeIf('extract-relationships integration', () => {
@@ -93,9 +111,9 @@ describeIf('extract-relationships integration', () => {
         confidence: 0.95,
       },
     ]);
-    const anthropic = makeMockAnthropicClient(['yes', triple]);
-    const handler = new ExtractRelationshipsHandler(anthropic as never);
-    const ctx = makeCtx(entityMemory, 'John Smith is Bob\'s wife.');
+    const llmProvider = makeMockLLMProvider(['yes', triple]);
+    const handler = new ExtractRelationshipsHandler();
+    const ctx = makeCtx(entityMemory, 'John Smith is Bob\'s wife.', llmProvider);
 
     const result = await handler.execute(ctx);
 
@@ -136,13 +154,13 @@ describeIf('extract-relationships integration', () => {
       },
     ]);
 
-    const anthropic1 = makeMockAnthropicClient(['yes', triple]);
-    const handler1 = new ExtractRelationshipsHandler(anthropic1 as never);
-    await handler1.execute(makeCtx(entityMemory, 'Person A reports to Person B.'));
+    const llmProvider1 = makeMockLLMProvider(['yes', triple]);
+    const handler1 = new ExtractRelationshipsHandler();
+    await handler1.execute(makeCtx(entityMemory, 'Person A reports to Person B.', llmProvider1));
 
-    const anthropic2 = makeMockAnthropicClient(['yes', triple]);
-    const handler2 = new ExtractRelationshipsHandler(anthropic2 as never);
-    const result2 = await handler2.execute(makeCtx(entityMemory, 'Person A reports to Person B.'));
+    const llmProvider2 = makeMockLLMProvider(['yes', triple]);
+    const handler2 = new ExtractRelationshipsHandler();
+    const result2 = await handler2.execute(makeCtx(entityMemory, 'Person A reports to Person B.', llmProvider2));
 
     expect(result2).toMatchObject({ success: true, data: { extracted: 0, confirmed: 1, skipped: false } });
 

--- a/tests/unit/agents/llm/token-estimator.test.ts
+++ b/tests/unit/agents/llm/token-estimator.test.ts
@@ -1,8 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import { estimateTokens } from '../../../../src/agents/llm/token-estimator.js';
-import { estimateMessagesTokens, getContextWindow, DEFAULT_SAFETY_MARGIN } from '../../../../src/agents/llm/token-estimator.js';
+import { estimateMessagesTokens, DEFAULT_SAFETY_MARGIN } from '../../../../src/agents/llm/token-estimator.js';
+import { ModelRegistry } from '../../../../src/agents/llm/model-registry.js';
 import type { ContentBlock } from '../../../../src/agents/llm/provider.js';
 import type { Message } from '../../../../src/agents/llm/provider.js';
+import type { Logger } from '../../../../src/logger.js';
+
+// Minimal logger stub for ModelRegistry construction in tests.
+const stubLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as Logger;
 
 describe('estimateTokens', () => {
   it('estimates tokens for a plain string', () => {
@@ -81,25 +91,32 @@ describe('estimateMessagesTokens', () => {
   });
 });
 
-describe('getContextWindow', () => {
+// getContextWindow is now a method on ModelRegistry (moved from token-estimator.ts
+// as part of the model registry consolidation). Tests use a stub logger.
+describe('ModelRegistry.getContextWindow', () => {
+  const registry = new ModelRegistry(stubLogger);
+
   it('returns 200_000 for claude-sonnet-4-6', () => {
-    expect(getContextWindow('claude-sonnet-4-6')).toBe(200_000);
+    expect(registry.getContextWindow('claude-sonnet-4-6')).toBe(200_000);
   });
 
   it('returns 200_000 for claude-opus-4-6', () => {
-    expect(getContextWindow('claude-opus-4-6')).toBe(200_000);
+    expect(registry.getContextWindow('claude-opus-4-6')).toBe(200_000);
   });
 
   it('returns 200_000 for claude-haiku-4-5', () => {
-    expect(getContextWindow('claude-haiku-4-5')).toBe(200_000);
+    expect(registry.getContextWindow('claude-haiku-4-5')).toBe(200_000);
   });
 
   it('matches versioned model names via prefix', () => {
-    expect(getContextWindow('claude-haiku-4-5-20251001')).toBe(200_000);
+    // 'claude-haiku-4-5-20251001' prefix-matches the 'claude-haiku-4-5' registry entry.
+    expect(registry.getContextWindow('claude-haiku-4-5-20251001')).toBe(200_000);
   });
 
-  it('falls back to sonnet window for unknown models', () => {
-    expect(getContextWindow('unknown-model-v1')).toBe(200_000);
+  it('returns 0 for unknown models (no match in registry)', () => {
+    // ModelRegistry returns 0 for unknown models and logs a warning.
+    // Callers (runtime.ts) check isKnownModel() and warn accordingly.
+    expect(registry.getContextWindow('unknown-model-v1')).toBe(0);
   });
 });
 

--- a/tests/unit/agents/llm/token-estimator.test.ts
+++ b/tests/unit/agents/llm/token-estimator.test.ts
@@ -113,10 +113,10 @@ describe('ModelRegistry.getContextWindow', () => {
     expect(registry.getContextWindow('claude-haiku-4-5-20251001')).toBe(200_000);
   });
 
-  it('returns 0 for unknown models (no match in registry)', () => {
-    // ModelRegistry returns 0 for unknown models and logs a warning.
-    // Callers (runtime.ts) check isKnownModel() and warn accordingly.
-    expect(registry.getContextWindow('unknown-model-v1')).toBe(0);
+  it('returns undefined for unknown models (no match in registry)', () => {
+    // ModelRegistry returns undefined for unknown models; callers apply their own fallback.
+    // runtime.ts uses ?? 200_000 and warns separately via isKnownModel().
+    expect(registry.getContextWindow('unknown-model-v1')).toBeUndefined();
   });
 });
 

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -2222,6 +2222,7 @@ describe('context budget', () => {
       agentId: 'coordinator',
       systemPrompt: 'You are a helpful assistant.',
       provider,
+      resolvedModel: 'mock-model',
       bus,
       logger,
       contextBudget: { responseReserve: 8192 },


### PR DESCRIPTION
## Summary

- **Model registry** — introduces `ModelRegistry` as the single source of truth for model metadata (pricing, context windows, capabilities), replacing duplicated data spread across `pricing.ts`, `token-estimator.ts`, `config/default.yaml`, and hardcoded fallbacks.
- **Config simplification** — tier configs drop the `provider` field (resolved from the registry); `autonomy_scoring.model` renamed to `model_tier`.
- **Skill migration** — `extract-facts`, `extract-relationships`, and `file-parse` drop raw Anthropic SDK clients in favour of `ctx.llmProvider` + `ctx.modelRouter` via SkillContext capabilities; their LLM calls now appear in cost telemetry.

Closes #556

## Test plan

- [ ] `npm run typecheck` — zero errors
- [ ] `npm test` — all existing tests pass (2435 passing, 2 pre-existing DB integration skips)
- [ ] `model-registry.test.ts` — prefix matching, unknown model lookups, data completeness
- [ ] `model-router.test.ts` — fail-fast on unknown model at construction, tier resolution
- [ ] `pricing.test.ts` — createEstimateCostUsd factory, cache pricing, unknown model fallback
- [ ] `extract-facts/handler.test.ts`, `extract-relationships/handler.test.ts`, `file-parse/handler.test.ts` — migrated skill handlers using mocked llmProvider/modelRouter
- [ ] Startup validation: ModelRouter constructor throws on unknown model; provider registry check fails-fast on missing provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced centralized Model Registry for unified model metadata management (pricing, context windows, capabilities).

* **Changed**
  * Configuration structure simplified: removed provider specifications from tier definitions; autonomy scoring now uses tier-based model selection.
  * LLM infrastructure skills migrated to shared provider infrastructure for improved cost tracking and telemetry visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->