### PR TITLE
fix: run production container as non-root curia user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+
+- **Non-root container** — production Docker image now runs as a dedicated `curia` system user instead of root, closing Semgrep alert #48 (`dockerfile.security.missing-user`). (#607)
+
 ### Changed
 
 - **Time context injection** — extended from coordinator-only to all agents; specialists now receive the `## Current Date & Time` block on every task turn, enabling reliable time-sensitive reasoning in scheduled agents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
-- **Non-root container** — production Docker image now runs as a dedicated `curia` system user instead of root, closing Semgrep alert #48 (`dockerfile.security.missing-user`). (#607)
+- **Non-root container** — production image runs as non-root `curia` user; resolves Semgrep alert #48 (`dockerfile.security.missing-user`). (#607)
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,11 @@ COPY --from=ghcr.io/astral-sh/uv:0.6.3 /uv /uvx /usr/local/bin/
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root system user/group for the runtime process.
-# --system: no login shell, UID/GID in the system range.
-# --no-create-home: no home directory needed; /app is the working dir.
-RUN groupadd --system curia && useradd --system --gid curia --no-create-home curia
+# UIDs/GIDs are pinned (not dynamic) so docker-compose tmpfs uid= options
+# and any external tooling can reference a stable, known value.
+# --no-create-home: HOME=/tmp is set below; no home dir on disk is needed.
+RUN groupadd --system --gid 1001 curia \
+ && useradd --system --uid 1001 --gid 1001 --no-create-home curia
 
 WORKDIR /app
 
@@ -63,6 +65,13 @@ COPY src/ ./src/
 # /usr/local/bin/uvx, and /usr/bin/curl are world-executable (no chown needed).
 RUN chown -R curia:curia /app
 
+# Pre-create the tmpfs mount point so Docker's runtime tmpfs mount inherits
+# curia ownership. Without this, Docker mounts the tmpfs as root:root with
+# mode=0700, making it inaccessible to the curia user at runtime.
+RUN mkdir -p /run/curia-tempfiles \
+ && chown curia:curia /run/curia-tempfiles \
+ && chmod 0700 /run/curia-tempfiles
+
 EXPOSE 3000
 
 # Health check matches the Fastify /api/health route
@@ -70,9 +79,14 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD curl -f http://localhost:3000/api/health || exit 1
 
 # Drop to non-root before starting the process.
-# HOME=/tmp gives tools (e.g. tsx's disk cache) a writable location;
-# system users created with --no-create-home otherwise have HOME=/ (read-only).
-ENV HOME=/tmp
+# HOME=/tmp: --no-create-home leaves /etc/passwd pointing at /home/curia (which
+# does not exist on disk). Tools like tsx and uv write cache files to $HOME; with
+# a missing home they would get ENOENT. /tmp is world-writable and always exists.
+# USER and LOGNAME are not set automatically by Docker when using exec-form CMD
+# (no shell login), so we set them explicitly for MCP subprocess environments.
+ENV HOME=/tmp \
+    USER=curia \
+    LOGNAME=curia
 USER curia
 
 # tsx handles dynamic .ts skill imports with ESM .js→.ts extension resolution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,12 @@ RUN mkdir -p /run/curia-tempfiles \
  && chown curia:curia /run/curia-tempfiles \
  && chmod 0700 /run/curia-tempfiles
 
+# Pre-create the OAuth token directory for workspace-mcp. Without this,
+# Docker's copy-up creates the directory as root when the named volume is
+# first mounted, making it unwritable by the curia user at runtime.
+RUN mkdir -p /tmp/.google_workspace_mcp \
+ && chown curia:curia /tmp/.google_workspace_mcp
+
 EXPOSE 3000
 
 # Health check matches the Fastify /api/health route

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,11 @@ COPY --from=ghcr.io/astral-sh/uv:0.6.3 /uv /uvx /usr/local/bin/
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
+# Create a non-root system user/group for the runtime process.
+# --system: no login shell, UID/GID in the system range.
+# --no-create-home: no home directory needed; /app is the working dir.
+RUN groupadd --system curia && useradd --system --gid curia --no-create-home curia
+
 WORKDIR /app
 
 RUN corepack enable
@@ -53,11 +58,22 @@ COPY skills/ ./skills/
 COPY config/ ./config/
 COPY src/ ./src/
 
+# node_modules were installed as root above, so we chown the entire /app tree
+# to the non-root user before dropping privileges. /usr/local/bin/uv,
+# /usr/local/bin/uvx, and /usr/bin/curl are world-executable (no chown needed).
+RUN chown -R curia:curia /app
+
 EXPOSE 3000
 
 # Health check matches the Fastify /api/health route
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD curl -f http://localhost:3000/api/health || exit 1
+
+# Drop to non-root before starting the process.
+# HOME=/tmp gives tools (e.g. tsx's disk cache) a writable location;
+# system users created with --no-create-home otherwise have HOME=/ (read-only).
+ENV HOME=/tmp
+USER curia
 
 # tsx handles dynamic .ts skill imports with ESM .js→.ts extension resolution.
 # The compiled dist/index.js is the entrypoint, but it dynamically imports

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,9 +55,13 @@ services:
       # Tokens are written here on first OAuth login and auto-refreshed thereafter.
       # Without this volume, re-authentication is required on every container restart.
       # See docs/dev/google-drive.md for first-time OAuth setup.
-      - google_workspace_tokens:/root/.google_workspace_mcp
+      # Path matches $HOME/.google_workspace_mcp; HOME=/tmp is set in the Dockerfile.
+      - google_workspace_tokens:/tmp/.google_workspace_mcp
     tmpfs:
-      - /run/curia-tempfiles:size=50M,noexec,nosuid,nodev,mode=0700
+      # uid/gid match the pinned curia UID/GID (1001) in the Dockerfile.
+      # Without these options the tmpfs is mounted root:root with mode=0700,
+      # which is inaccessible to the non-root curia runtime user.
+      - /run/curia-tempfiles:size=50M,noexec,nosuid,nodev,mode=0700,uid=1001,gid=1001
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary

Closes #607

- Adds a dedicated `curia` system user/group (UID/GID 1001, pinned for stability) in the production stage
- `chown -R curia:curia /app` transfers ownership of node_modules and all app files installed as root
- Pre-creates `/run/curia-tempfiles` with `curia` ownership so Docker's tmpfs mount is accessible at runtime
- Sets `ENV HOME=/tmp USER=curia LOGNAME=curia` before `USER curia` to give tools a writable home and MCP subprocesses correct env vars
- Updates `docker-compose.yml`: moves `google_workspace_tokens` volume mount from `/root/.google_workspace_mcp` → `/tmp/.google_workspace_mcp` (matches new `$HOME`); adds `uid=1001,gid=1001` to the tmpfs options so the mount isn't root-owned

## Test plan

- [ ] Build the image: `docker build -t curia-test .`
- [ ] Verify runtime user: `docker run --rm curia-test whoami` → should print `curia`
- [ ] Verify health check passes when started with `docker compose up`
- [ ] Verify `whoami` inside a running container returns `curia`
- [ ] Confirm Semgrep alert #48 (`dockerfile.security.missing-user`) is resolved on next scan
- [ ] On first start after deploy: confirm Google Workspace OAuth flow completes and tokens persist across restart (volume now at `/tmp/.google_workspace_mcp`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Production Docker image now runs as a dedicated non-root system user, improving security posture and reducing potential attack surface.

* **Infrastructure**
  * Updated Docker runtime configuration and volume mappings to properly support non-root operation with correct file permissions and home directory handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->