### PR TITLE
fix: loop-based HTML sanitization to prevent nested-substitution bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **OpenRouter provider** — optional multi-model routing for Gemini Flash, DeepSeek V3, and GPT-4o via `OPENROUTER_API_KEY`. (#379)
 
+### Security
+
+- **HTML sanitizers** — replaced single-pass regex replacements with loop-based stripping in `html-to-text`, `file-parse`, and `held-messages-list` to prevent nested-substitution bypass (CodeQL `js/incomplete-multi-character-sanitization`, 6 alerts). (#591)
+
 ### Fixed
 
 - **`ceo-inbox-list`** — normalize `DRAFTS` folder alias to `DRAFT` for Gmail API compatibility; the digest agent was failing on every run with "Invalid label: DRAFTS".

--- a/skills/file-parse/handler.test.ts
+++ b/skills/file-parse/handler.test.ts
@@ -279,6 +279,50 @@ describe('FileParseHandler', () => {
       }
     });
 
+    // ── Security: js/incomplete-multi-character-sanitization ─────────────────
+    // A single-pass replace of <script…>…</script> can be bypassed: the g flag
+    // finds all non-overlapping matches left-to-right in the original string.
+    // Input <scri<script>X</script>pt>…<scri<script>Y</script>pt> has two
+    // matches (<script>X</script> and <script>Y</script>); removing both
+    // simultaneously leaves <scri + pt> = <script> and the content unstripped.
+    // The loop approach catches this by re-running until the string stabilizes.
+
+    it('strips <script> tags reconstructed by nested-substitution bypass', async () => {
+      const payload =
+        '<scri<script>X</script>pt>alert("xss")</scri<script>Y</script>pt>';
+      const content = Buffer.from(payload).toString('base64');
+      const handler = new FileParseHandler();
+      const result = await handler.execute(makeCtx({
+        content_base64: content,
+        mime_type: 'text/html',
+        extract_as: 'raw',
+      }, makeLlmProvider('{}')));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { raw_text: string };
+        expect(data.raw_text).not.toContain('<script');
+        expect(data.raw_text).not.toContain('alert("xss")');
+      }
+    });
+
+    it('strips <style> tags reconstructed by nested-substitution bypass', async () => {
+      const payload =
+        '<sty<style>X</style>le>body{color:red}</sty<style>Y</style>le>';
+      const content = Buffer.from(payload).toString('base64');
+      const handler = new FileParseHandler();
+      const result = await handler.execute(makeCtx({
+        content_base64: content,
+        mime_type: 'text/html',
+        extract_as: 'raw',
+      }, makeLlmProvider('{}')));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { raw_text: string };
+        expect(data.raw_text).not.toContain('<style');
+        expect(data.raw_text).not.toContain('body{color:red}');
+      }
+    });
+
     // ── Security: js/double-escaping ──────────────────────────────────────────
 
     it('does not double-decode &amp;lt; into a literal < in HTML text', async () => {

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -312,25 +312,38 @@ export class FileParseHandler implements SkillHandler {
 
 /** Strip HTML tags and decode common entities. Lightweight, no dependency. */
 function stripHtmlTags(html: string): string {
-  // nosemgrep: js/incomplete-multi-character-sanitization — incomplete tags caught by /<[a-zA-Z][^>]{0,500}/g below
-  return html
-    // Strip <script> and <style> blocks including their content.
-    // \s* before the closing > handles whitespace-padded closing tags like </script >
-    // which the original pattern (</script>) did not match (js/bad-tag-filter).
-    // nosemgrep: js/bad-tag-filter — \s* handles whitespace before >; attribute-bearing closing tags like </script bar> are invalid HTML
-    .replace(/<script[^>]*>[\s\S]*?<\/script\s*>/gi, '')
-    .replace(/<style[^>]*>[\s\S]*?<\/style\s*>/gi, '')
-    // Strip all complete HTML tags (< ... >).
-    .replace(/<[^>]+>/g, ' ')
-    // Strip incomplete tags — bare <tagname without a closing > cannot be caught by
-    // <[^>]+> above (which requires >). This prevents <script fragments from leaking
-    // into the extracted text. {0,500} caps match length to prevent stripping large
-    // text bodies on inputs with a lone < far from any > (js/incomplete-multi-character-sanitization).
-    .replace(/<[a-zA-Z][^>]{0,500}/g, ' ')
-    // Decode HTML entities.
-    // Order matters: &amp; must be decoded LAST to prevent double-decoding.
-    // Decoding &amp; first turns &amp;lt; into &lt;, which then decodes to <,
-    // smuggling a literal < through (js/double-escaping).
+  let text = html;
+
+  // Strip <script> and <style> blocks including their content. Loop until the
+  // string stops changing to prevent nested-substitution bypass: a crafted
+  // input like <scri<script>X</script>pt>…<scri<script>Y</script>pt> causes the
+  // g-flag replace to strip both inner blocks simultaneously, leaving the outer
+  // fragments to merge into <script>…</script>. A second pass catches that.
+  // \s* before the closing > handles whitespace-padded tags like </script >.
+  for (let prev = ''; prev !== text; ) {
+    prev = text;
+    text = text.replace(/<script[^>]*>[\s\S]*?<\/script\s*>/gi, '');
+    text = text.replace(/<style[^>]*>[\s\S]*?<\/style\s*>/gi, '');
+  }
+
+  // Strip all complete HTML tags (< ... >).
+  text = text.replace(/<[^>]+>/g, ' ');
+
+  // Strip incomplete tags — bare <tagname without a closing > cannot be caught
+  // by <[^>]+> above (which requires >). Loop until stable: stripping a complete
+  // inner tag can expose a bare <script fragment from a nested pattern.
+  // {0,500} caps match length to prevent consuming large text bodies on inputs
+  // with a lone < far from any >.
+  for (let prev = ''; prev !== text; ) {
+    prev = text;
+    text = text.replace(/<[a-zA-Z][^>]{0,500}/g, ' ');
+  }
+
+  // Decode HTML entities.
+  // Order matters: &amp; must be decoded LAST to prevent double-decoding.
+  // Decoding &amp; first turns &amp;lt; into &lt;, which then decodes to <,
+  // smuggling a literal < through (js/double-escaping).
+  return text
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')

--- a/skills/held-messages-list/handler.test.ts
+++ b/skills/held-messages-list/handler.test.ts
@@ -58,6 +58,27 @@ describe('HeldMessagesListHandler', () => {
     expect(messages[0].preview).toContain('Hello');
   });
 
+  it('strips <script> fragments reconstructed by nested-substitution bypass', async () => {
+    // Removing the inner <a> complete tag from <sc<a>ript exposes an incomplete
+    // <script fragment. The loop re-runs until no tag fragments remain.
+    const svc = HeldMessageService.createInMemory();
+    await svc.hold({
+      channel: 'email',
+      senderId: 'attacker@example.com',
+      conversationId: 'conv-nested-tag',
+      content: 'Message <sc<a>ript body text',
+      subject: 'Nested tag test',
+      metadata: {},
+    });
+    const handler = new HeldMessagesListHandler();
+    const result = await handler.execute(makeCtx(svc));
+
+    expect(result.success).toBe(true);
+    const messages = (result as { success: true; data: { messages: Array<{ preview: string }> } }).data.messages;
+    expect(messages[0].preview).not.toContain('<');
+    expect(messages[0].preview).toContain('Message');
+  });
+
   it('strips HTML tags from the preview', async () => {
     const svc = HeldMessageService.createInMemory();
     await svc.hold({

--- a/skills/held-messages-list/handler.ts
+++ b/skills/held-messages-list/handler.ts
@@ -20,6 +20,9 @@ import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 
 // Strip HTML tags for plaintext extraction.
 // Not a full DOM parser — good enough for preview purposes.
+// Note: this function strips tags but not block content, so <script>payload</script>
+// will leave "payload" in the output. The threat model here is LLM context
+// injection, not XSS rendering; a separate issue tracks adding block stripping.
 function stripHtml(content: string): string {
   // Loop until stable: stripping a complete inner tag (e.g. <a> from <sc<a>ript)
   // can expose an incomplete <script fragment. Re-running catches what each pass

--- a/skills/held-messages-list/handler.ts
+++ b/skills/held-messages-list/handler.ts
@@ -4,9 +4,10 @@
 // Optionally filters by channel. Returns a summary with sender, subject,
 // plaintext preview (500 chars), totalLength, and timestamp for each message.
 //
-// preview is stripped of HTML tags before slicing — two regex passes (complete tags
-// then incomplete tag fragments), not a full DOM parser. Good enough for preview
-// extraction; the coordinator LLM reads this to infer the nature of the request.
+// preview is stripped of HTML tags before slicing — loop-based regex (complete tags
+// then incomplete tag fragments, repeated until stable), not a full DOM parser.
+// Good enough for preview extraction; the coordinator LLM reads this to infer the
+// nature of the request.
 //
 // totalLength is the character count of the full plaintext body. When preview
 // is short relative to totalLength, the coordinator qualifies its assessment
@@ -20,16 +21,18 @@ import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 // Strip HTML tags for plaintext extraction.
 // Not a full DOM parser — good enough for preview purposes.
 function stripHtml(content: string): string {
-  // nosemgrep: js/incomplete-multi-character-sanitization — incomplete tags caught by /<[a-zA-Z][^>]{0,500}/g below;
-  // output goes to LLM context, not rendered in a browser, so XSS injection is not the threat model
-  return content
-    // Strip complete tags (< ... >).
-    .replace(/<[^>]+>/g, '')
-    // Strip incomplete tags — bare <tagname without a closing > is not caught by <[^>]+>
-    // (which requires >). This prevents <script fragments from leaking into the preview
-    // and reaching the LLM context. {0,500} caps match length to prevent stripping large
-    // text bodies on inputs with a lone < far from any > (js/incomplete-multi-character-sanitization).
-    .replace(/<[a-zA-Z][^>]{0,500}/g, '');
+  // Loop until stable: stripping a complete inner tag (e.g. <a> from <sc<a>ript)
+  // can expose an incomplete <script fragment. Re-running catches what each pass
+  // reveals. {0,500} caps the incomplete-tag match to prevent consuming large
+  // bodies on inputs with a lone < far from any >.
+  let result = content;
+  for (let prev = ''; prev !== result; ) {
+    prev = result;
+    result = result
+      .replace(/<[^>]+>/g, '')               // complete tags
+      .replace(/<[a-zA-Z][^>]{0,500}/g, ''); // incomplete tags
+  }
+  return result;
 }
 
 export class HeldMessagesListHandler implements SkillHandler {

--- a/src/channels/email/html-to-text.test.ts
+++ b/src/channels/email/html-to-text.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { htmlToText } from './html-to-text.js';
+
+describe('htmlToText', () => {
+  it('returns empty string for null/undefined input', () => {
+    expect(htmlToText(null)).toBe('');
+    expect(htmlToText(undefined)).toBe('');
+    expect(htmlToText('')).toBe('');
+  });
+
+  it('strips <script> blocks and their content', () => {
+    expect(htmlToText('<p>Hello</p><script>evil()</script><p>World</p>')).toBe('Hello\nWorld');
+  });
+
+  it('strips <style> blocks and their content', () => {
+    expect(htmlToText('<style>body{color:red}</style><p>Hello</p>')).toBe('Hello');
+  });
+
+  it('strips <script> blocks with whitespace-padded closing tags (</script >)', () => {
+    expect(htmlToText('<p>Safe</p><script>evil()</script ><p>After</p>')).toBe('Safe\nAfter');
+  });
+
+  // ── Security: js/incomplete-multi-character-sanitization ─────────────────────
+  // A single-pass replace of <script…>…</script> can be bypassed by splitting the
+  // opening tag across nested inner <script> elements. The g flag replaces all
+  // non-overlapping matches in the original string left-to-right; two inner blocks
+  // get removed simultaneously, leaving the outer fragments to merge into <script>.
+  //
+  // Example:
+  //   <scri<script>X</script>pt>…<scri<script>Y</script>pt>
+  //   pass 1: removes <script>X</script> and <script>Y</script>
+  //   result: <script>…</script>  ← bypass succeeded in single-pass approach
+  //   loop:   removes <script>…</script> in the next iteration → safe
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  it('strips <script> tags reconstructed by nested-substitution bypass', () => {
+    // Split <script> across two inner <script> blocks so a single .replace() pass
+    // removes the inner blocks and leaves the outer <script>…</script> intact.
+    const payload =
+      '<scri<script>X</script>pt>alert("xss")</scri<script>Y</script>pt>';
+    const result = htmlToText(payload);
+    expect(result).not.toContain('<script');
+    expect(result).not.toContain('alert("xss")');
+  });
+
+  it('strips <style> tags reconstructed by nested-substitution bypass', () => {
+    const payload =
+      '<sty<style>X</style>le>body{color:red}</sty<style>Y</style>le>';
+    const result = htmlToText(payload);
+    expect(result).not.toContain('<style');
+    expect(result).not.toContain('body{color:red}');
+  });
+
+  it('strips deeply nested <script> reconstruction attempts', () => {
+    // Three levels of nesting — each loop iteration peels one layer.
+    const payload =
+      '<scri<scri<script>A</script>pt>B</scri<script>C</script>pt>pt>evil()</scri<script>D</script>pt>';
+    const result = htmlToText(payload);
+    expect(result).not.toContain('<script');
+    expect(result).not.toContain('evil()');
+  });
+
+  it('converts <br> to newlines', () => {
+    expect(htmlToText('Line1<br>Line2<br/>Line3')).toBe('Line1\nLine2\nLine3');
+  });
+
+  it('converts block-level closing tags to newlines', () => {
+    expect(htmlToText('<p>First</p><p>Second</p>')).toBe('First\nSecond');
+  });
+
+  it('decodes common HTML entities (preserving order — &amp; last)', () => {
+    expect(htmlToText('&lt;tag&gt; &amp; &quot;quote&quot; &#39;apos&#39; &nbsp;space')).toBe(
+      '<tag> & "quote" \'apos\' space',
+    );
+  });
+
+  it('does not double-decode &amp;lt; into a literal <', () => {
+    // If &amp; is decoded before &lt;, &amp;lt; → &lt; → <, smuggling a literal <.
+    // Correct order: &lt; first, then &amp; last.
+    expect(htmlToText('&amp;lt;')).toBe('&lt;');
+  });
+
+  it('collapses runs of whitespace', () => {
+    expect(htmlToText('<p>Hello   World</p>')).toBe('Hello World');
+  });
+
+  it('returns the plain-text content of a realistic email body', () => {
+    const html = `
+      <html><body>
+        <style>.hide{display:none}</style>
+        <h1>Invoice #123</h1>
+        <p>Dear Customer,</p>
+        <p>Your invoice for <strong>$50.00</strong> is attached.</p>
+        <script>track()</script>
+        <p>Thanks!</p>
+      </body></html>
+    `;
+    const result = htmlToText(html);
+    expect(result).toContain('Invoice #123');
+    expect(result).toContain('Dear Customer');
+    expect(result).toContain('$50.00');
+    expect(result).toContain('Thanks!');
+    expect(result).not.toContain('track()');
+    expect(result).not.toContain('.hide');
+    expect(result).not.toContain('<script');
+    expect(result).not.toContain('<style');
+  });
+});

--- a/src/channels/email/html-to-text.ts
+++ b/src/channels/email/html-to-text.ts
@@ -8,13 +8,17 @@ export function htmlToText(html: string | undefined | null): string {
 
   let text = html;
 
-  // Remove <style> and <script> blocks entirely (content + tags).
-  // \s* before the closing > handles whitespace-padded closing tags like </script >
-  // which the original pattern (</script>) did not match (js/bad-tag-filter).
-  // nosemgrep: js/incomplete-multi-character-sanitization — incomplete tags (<tag without >) caught on line below
-  text = text.replace(/<style[^>]*>[\s\S]*?<\/style\s*>/gi, '');
-  // nosemgrep: js/incomplete-multi-character-sanitization, js/bad-tag-filter — \s* handles whitespace before >; incomplete tags caught below
-  text = text.replace(/<script[^>]*>[\s\S]*?<\/script\s*>/gi, '');
+  // Remove <style> and <script> blocks entirely (content + tags). Loop until
+  // the string stops changing to prevent nested-substitution bypass: a crafted
+  // input like <scri<script>X</script>pt>…<scri<script>Y</script>pt> causes the
+  // g-flag replace to strip both inner blocks simultaneously, leaving the outer
+  // fragments to merge into <script>…</script>. A second pass catches that.
+  // \s* before the closing > handles whitespace-padded tags like </script >.
+  for (let prev = ''; prev !== text; ) {
+    prev = text;
+    text = text.replace(/<style[^>]*>[\s\S]*?<\/style\s*>/gi, '');
+    text = text.replace(/<script[^>]*>[\s\S]*?<\/script\s*>/gi, '');
+  }
 
   // Convert <br> variants to newlines
   text = text.replace(/<br\s*\/?>/gi, '\n');
@@ -25,16 +29,18 @@ export function htmlToText(html: string | undefined | null): string {
   // Convert <hr> to a separator
   text = text.replace(/<hr\s*\/?>/gi, '\n---\n');
 
-  // Strip all remaining complete HTML tags
-  // nosemgrep: js/incomplete-multi-character-sanitization — incomplete tags (no closing >) caught by the strip on the next line
+  // Strip all remaining complete HTML tags.
   text = text.replace(/<[^>]+>/g, '');
 
-  // Strip incomplete tags — bare <tagname without a closing > is not caught by <[^>]+>
-  // above (which requires >). Entity decoding happens below, so any < remaining at this
-  // point must be from an incomplete tag in the original HTML source.
-  // {0,500} caps match length to prevent stripping large text bodies if the input
-  // happens to contain a lone < far from any > (js/incomplete-multi-character-sanitization).
-  text = text.replace(/<[a-zA-Z][^>]{0,500}/g, '');
+  // Strip incomplete tags — bare <tagname without a closing > is not caught by
+  // <[^>]+> above (which requires >). Loop until stable: stripping a complete
+  // inner tag (above) can expose a bare <script fragment from a nested pattern,
+  // so we re-run until no tag fragments remain. {0,500} caps match length to
+  // prevent consuming large text bodies on inputs with a lone < far from any >.
+  for (let prev = ''; prev !== text; ) {
+    prev = text;
+    text = text.replace(/<[a-zA-Z][^>]{0,500}/g, '');
+  }
 
   // Decode common HTML entities.
   // Order matters: &amp; must be decoded LAST to prevent double-decoding.


### PR DESCRIPTION
## Summary

- Replaces all single-pass `.replace()` calls in the three affected HTML sanitizers with idempotent stability loops (`for (let prev = ''; prev !== text; )`)
- A crafted input like `<scri<script>X</script>pt>…<scri<script>Y</script>pt>` causes the `g`-flag replace to strip both inner blocks simultaneously, leaving the outer fragments to merge into `<script>…</script>`; looping until the string stabilizes prevents this
- Removes all 6 `nosemgrep: js/incomplete-multi-character-sanitization` suppressions — the underlying vulnerability is fixed, not suppressed
- Adds `src/channels/email/html-to-text.test.ts` (new) covering the bypass vectors plus full `htmlToText` behaviour
- Adds nested-bypass test cases to `file-parse` and `held-messages-list` test suites

Closes #591

## Files changed

| File | Change |
|------|--------|
| `src/channels/email/html-to-text.ts` | Block strippers + incomplete-tag stripper now loop until stable |
| `src/channels/email/html-to-text.test.ts` | **New** — 13 tests covering bypass, entities, realistic email |
| `skills/file-parse/handler.ts` | `stripHtmlTags()` refactored from chained returns to loop-based imperative |
| `skills/file-parse/handler.test.ts` | Added `<script>` and `<style>` nested-bypass test cases |
| `skills/held-messages-list/handler.ts` | `stripHtml()` refactored to loop; threat-model comment restored |
| `skills/held-messages-list/handler.test.ts` | Added nested-bypass test case |
| `CHANGELOG.md` | Security entry under `[Unreleased]` |

## Pre-existing gap (out of scope, flagged for follow-up)

`held-messages-list/handler.ts`'s `stripHtml()` strips HTML *tags* but not block *content* — `<script>payload</script>` leaves `payload` visible to the coordinator LLM. This predates this PR. A follow-up issue should add block-content stripping for LLM prompt-injection hardening.

## Test plan

- [x] All 49 existing + new tests pass
- [x] The 3 bypass-specific tests fail on `origin/main` and pass on this branch (TDD red→green confirmed)
- [x] No `nosemgrep` suppressions remain in the three modified files