### PR TITLE
feat(contact-list): add status and limit filter parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`contact-list`** — accepts optional `status` and `limit` parameters; contacts agent can now query provisional contacts directly instead of timing out on entity-context enumeration. (#644)
 - **`ceo-inbox-list`** — normalize `DRAFTS` folder alias to `DRAFT` for Gmail API compatibility; the digest agent was failing on every run with "Invalid label: DRAFTS".
 - **`NylasClient.listMessages`** — suppress conflicting filter params when `searchQueryNative` is set, matching the guard already in `CeoNylasClient`; fixes HTTP 400 errors in security-triage's email-list calls.
 - **Provider registry routing** — WorkingMemory, DriftDetector, AutonomyScoringPass, and ExecutionLayer now resolve their LLM provider from `providerRegistry`, not the hardwired Anthropic singleton. (#646)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **OpenRouter provider** — optional multi-model routing for Gemini Flash, DeepSeek V3, and GPT-4o via `OPENROUTER_API_KEY`. (#379)
+- **`contact-list`** — new `status` and `limit` filter parameters for direct DB-level filtering; eliminates entity-context timeout for status queries. (#644)
 
 ### Security
 
@@ -23,7 +24,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`contact-list`** — accepts optional `status` and `limit` parameters; contacts agent can now query provisional contacts directly instead of timing out on entity-context enumeration. (#644)
 - **`ceo-inbox-list`** — normalize `DRAFTS` folder alias to `DRAFT` for Gmail API compatibility; the digest agent was failing on every run with "Invalid label: DRAFTS".
 - **`NylasClient.listMessages`** — suppress conflicting filter params when `searchQueryNative` is set, matching the guard already in `CeoNylasClient`; fixes HTTP 400 errors in security-triage's email-list calls.
 - **Provider registry routing** — WorkingMemory, DriftDetector, AutonomyScoringPass, and ExecutionLayer now resolve their LLM provider from `providerRegistry`, not the hardwired Anthropic singleton. (#646)

--- a/docs/wip/2026-05-21-contact-list-filters-design.md
+++ b/docs/wip/2026-05-21-contact-list-filters-design.md
@@ -1,0 +1,130 @@
+# Design: contact-list status filter and result limit
+
+**Issue:** [#644](https://github.com/josephfung/curia/issues/644)
+**Date:** 2026-05-21
+
+## Problem
+
+The contacts agent times out when asked to list provisional contacts. With 156+
+contacts and no status filter, the agent falls back to enumerating all contacts
+via entity-context batched calls (~15 round trips with LLM reasoning), taking
+3–5 minutes. The coordinator's 90-second delegate timeout fires first, producing
+a misleading "system was unresponsive" message.
+
+Even without the timeout, presenting 40+ provisional contacts in a chat message
+is not actionable for a CEO.
+
+## Solution
+
+Add `status` and `limit` parameters to the `contact-list` skill. The contacts
+agent can then resolve "list provisional contacts" in a single fast DB query:
+
+```
+contact-list({ status: "provisional", limit: 10 })
+```
+
+No entity-context enumeration, no timeout, no retry.
+
+## Changes
+
+### 1. Skill manifest (`skills/contact-list/skill.json`)
+
+Add two optional inputs and update the description:
+
+| Input    | Type      | Default | Validation                                    |
+|----------|-----------|---------|-----------------------------------------------|
+| `role`   | `string?` | null   | Existing — max 200 characters                 |
+| `status` | `string?` | null   | Must be `confirmed`, `provisional`, or `blocked` |
+| `limit`  | `number?` | null   | Must be a positive integer; null = no limit   |
+
+Description changes from "List all contacts, optionally filtered by role" to
+"List contacts, optionally filtered by role or status, with optional result limit."
+
+### 2. ContactServiceBackend interface (`src/contacts/contact-service.ts`)
+
+Update the `listContacts` signature on the interface:
+
+```typescript
+listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]>;
+```
+
+### 3. PostgresContactBackend
+
+Build a dynamic query from the filters:
+
+```sql
+-- No filters (existing behavior)
+SELECT ... FROM contacts ORDER BY created_at ASC
+
+-- Status only
+SELECT ... FROM contacts WHERE status = $1 ORDER BY created_at ASC
+
+-- Status + limit
+SELECT ... FROM contacts WHERE status = $1 ORDER BY created_at ASC LIMIT $2
+
+-- Limit only
+SELECT ... FROM contacts ORDER BY created_at ASC LIMIT $1
+```
+
+Sort order stays `ORDER BY created_at ASC` — no behavior change from the
+current implementation.
+
+The `idx_contacts_status` index already exists (migration 006), so no new
+migration is needed.
+
+### 4. InMemoryContactBackend
+
+Apply the same filter and limit logic in memory: filter by status if provided,
+sort by `createdAt` ascending (existing behavior), then slice to limit.
+
+### 5. ContactService public API
+
+Update the public `listContacts` method to pass through filters:
+
+```typescript
+async listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]> {
+  return this.backend.listContacts(filters);
+}
+```
+
+### 6. contact-list handler (`skills/contact-list/handler.ts`)
+
+- Extract `status` and `limit` from `ctx.input`
+- Validate `status` is one of the allowed values (if provided)
+- Validate `limit` is a positive integer (if provided)
+- When `role` is provided, use the existing `findContactByRole()` path (no
+  change — role and status are independent filters; combining them is not
+  needed for this use case)
+- When `status` or `limit` is provided (without role), call
+  `listContacts({ status, limit })`
+- When neither role, status, nor limit is provided, call `listContacts()`
+  (existing behavior)
+
+### 7. Tests
+
+- Status filter returns only matching contacts
+- Limit caps results
+- Status + limit combined
+- No filters returns all contacts (existing behavior preserved)
+- Invalid status value rejected
+- Invalid limit value rejected (zero, negative, non-integer)
+- Role filter still works independently (no regression)
+
+## What this does NOT change
+
+- **No agent prompt changes.** The contacts agent will naturally use the new
+  parameters once they appear in the skill manifest.
+- **No scheduled job changes in code.** The runtime-created scheduler job will
+  be updated operationally to use `contact-list({ status: "provisional", limit: 10 })`.
+- **No entity-context changes.** With a limit of 10, entity-context batch
+  performance is acceptable (~70 queries, sub-second). Batch optimization is
+  deferred until a real workload demands it.
+- **No migration needed.** `idx_contacts_status` already exists.
+- **No sort order change.** `ORDER BY created_at ASC` is preserved.
+
+## Acceptance criteria (from issue #644)
+
+- [ ] `contact-list` accepts optional `status` (`provisional`, `confirmed`, `blocked`) and filters at DB layer
+- [ ] `contact-list` accepts optional `limit` (positive integer, null = no limit)
+- [ ] The contacts agent uses `contact-list({ status: "provisional" })` rather than enumerating all contacts — verified by the scheduled job completing within 30 seconds
+- [ ] The misleading "system was unresponsive" message no longer appears

--- a/docs/wip/2026-05-21-contact-list-filters.md
+++ b/docs/wip/2026-05-21-contact-list-filters.md
@@ -1,0 +1,566 @@
+# contact-list Status Filter & Limit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `status` and `limit` parameters to the `contact-list` skill so the contacts agent can query provisional contacts directly instead of enumerating all contacts through entity-context.
+
+**Architecture:** Extend the existing `ContactServiceBackend` interface with optional filters on `listContacts()`. Both Postgres and InMemory backends implement the filters. The skill handler validates and passes them through.
+
+**Tech Stack:** TypeScript (ESM), PostgreSQL, Vitest
+
+**Spec:** `docs/wip/2026-05-21-contact-list-filters-design.md`
+**Issue:** [#644](https://github.com/josephfung/curia/issues/644)
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `src/contacts/contact-service.ts:42-48` | `ContactServiceBackend` interface — add filters to `listContacts` |
+| Modify | `src/contacts/contact-service.ts:314-317` | `ContactService.listContacts()` — pass through filters |
+| Modify | `src/contacts/contact-service.ts:952-974` | `PostgresContactBackend.listContacts()` — dynamic WHERE/LIMIT |
+| Modify | `src/contacts/contact-service.ts:1486-1488` | `InMemoryContactBackend.listContacts()` — filter/limit in memory |
+| Modify | `skills/contact-list/skill.json` | Add `status` and `limit` inputs, update description |
+| Modify | `skills/contact-list/handler.ts` | Validate new inputs, route to `listContacts(filters)` |
+| Create | `skills/contact-list/handler.test.ts` | Unit tests for handler with all filter combinations |
+
+---
+
+### Task 1: Add filters to ContactServiceBackend interface and implementations
+
+**Files:**
+- Modify: `src/contacts/contact-service.ts:48` (interface)
+- Modify: `src/contacts/contact-service.ts:314-317` (public API)
+- Modify: `src/contacts/contact-service.ts:952-974` (Postgres backend)
+- Modify: `src/contacts/contact-service.ts:1486-1488` (InMemory backend)
+
+- [ ] **Step 1: Update the `ContactServiceBackend` interface**
+
+In `src/contacts/contact-service.ts`, change line 48 from:
+
+```typescript
+listContacts(): Promise<Contact[]>;
+```
+
+to:
+
+```typescript
+listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]>;
+```
+
+`ContactStatus` is already imported in this file from `./types.js`.
+
+- [ ] **Step 2: Update the `ContactService` public method**
+
+In `src/contacts/contact-service.ts`, replace lines 314–317:
+
+```typescript
+  /** List all contacts. */
+  async listContacts(): Promise<Contact[]> {
+    return this.backend.listContacts();
+  }
+```
+
+with:
+
+```typescript
+  /** List contacts, optionally filtered by status and/or capped by limit. */
+  async listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]> {
+    return this.backend.listContacts(filters);
+  }
+```
+
+- [ ] **Step 3: Update `PostgresContactBackend.listContacts()`**
+
+In `src/contacts/contact-service.ts`, replace the `listContacts()` method (lines 952–974) with:
+
+```typescript
+  async listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]> {
+    const cols = 'id, kg_node_id, display_name, role, system_role, status, contact_confidence, trust_level, last_seen_at, inbound_message_count, outbound_message_count, notes, created_at, updated_at';
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (filters?.status) {
+      params.push(filters.status);
+      conditions.push(`status = $${params.length}`);
+    }
+
+    const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
+    let sql = `SELECT ${cols} FROM contacts${where} ORDER BY created_at ASC`;
+
+    if (filters?.limit != null) {
+      params.push(filters.limit);
+      sql += ` LIMIT $${params.length}`;
+    }
+
+    const result = await this.pool.query<{
+      id: string;
+      kg_node_id: string | null;
+      display_name: string;
+      role: string | null;
+      system_role: string | null;
+      status: string;
+      contact_confidence: string;
+      trust_level: string | null;
+      last_seen_at: Date | null;
+      inbound_message_count: string;
+      outbound_message_count: string;
+      notes: string | null;
+      created_at: Date;
+      updated_at: Date;
+    }>(sql, params);
+
+    return result.rows.map((row) => this.rowToContact(row));
+  }
+```
+
+Note: The `conditions` array pattern supports future filters without restructuring. Only `status` is added now — YAGNI for anything else.
+
+- [ ] **Step 4: Update `InMemoryContactBackend.listContacts()`**
+
+In `src/contacts/contact-service.ts`, replace the `listContacts()` method (lines 1486–1488) with:
+
+```typescript
+  async listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]> {
+    let results = [...this.contacts.values()];
+
+    if (filters?.status) {
+      results = results.filter((c) => c.status === filters.status);
+    }
+
+    // Sort by createdAt ascending to match Postgres ORDER BY created_at ASC
+    results.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+
+    if (filters?.limit != null) {
+      results = results.slice(0, filters.limit);
+    }
+
+    return results;
+  }
+```
+
+- [ ] **Step 5: Verify the project compiles**
+
+Run: `npx --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-contact-list-filters tsc --noEmit`
+
+Expected: no type errors. If there are callers of `listContacts()` that pass no arguments, they're still valid because the parameter is optional.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-contact-list-filters add src/contacts/contact-service.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-contact-list-filters commit -m "feat(contacts): add status and limit filters to listContacts backend"
+```
+
+---
+
+### Task 2: Update skill manifest and handler
+
+**Files:**
+- Modify: `skills/contact-list/skill.json`
+- Modify: `skills/contact-list/handler.ts`
+
+- [ ] **Step 1: Update the skill manifest**
+
+Replace the contents of `skills/contact-list/skill.json` with:
+
+```json
+{
+  "name": "contact-list",
+  "description": "List contacts, optionally filtered by role or status, with optional result limit.",
+  "version": "1.1.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "role": "string?",
+    "status": "string? (confirmed | provisional | blocked)",
+    "limit": "number?"
+  },
+  "outputs": {
+    "contacts": "array",
+    "count": "number"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 15000
+}
+```
+
+Changes: description updated, version bumped to 1.1.0, `status` and `limit` inputs added.
+
+- [ ] **Step 2: Update the handler**
+
+Replace the contents of `skills/contact-list/handler.ts` with:
+
+```typescript
+// handler.ts — contact-list skill implementation.
+//
+// Lists contacts, optionally filtered by role or status, with optional result limit.
+// Returns an array of contact summaries.
+//
+// This skill uses contactService, which is a universal service.
+
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { ContactStatus } from '../../src/contacts/types.js';
+
+const VALID_STATUSES: readonly string[] = ['confirmed', 'provisional', 'blocked'];
+
+export class ContactListHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    const { role, status, limit } = ctx.input as {
+      role?: string;
+      status?: string;
+      limit?: number;
+    };
+
+    // Input validation
+    if (role && typeof role === 'string' && role.length > 200) {
+      return { success: false, error: 'Role must be 200 characters or fewer' };
+    }
+
+    if (status != null && !VALID_STATUSES.includes(status)) {
+      return { success: false, error: `Invalid status: "${status}". Must be one of: ${VALID_STATUSES.join(', ')}` };
+    }
+
+    if (limit != null) {
+      if (typeof limit !== 'number' || !Number.isInteger(limit) || limit < 1) {
+        return { success: false, error: 'Limit must be a positive integer' };
+      }
+    }
+
+    // contactService is a universal service — always injected by ExecutionLayer
+    if (!ctx.contactService) {
+      return {
+        success: false,
+        error: 'contact-list: contactService not available — this is a universal service, check ExecutionLayer configuration.',
+      };
+    }
+
+    ctx.log.info({ role: role ?? '(all)', status: status ?? '(all)', limit: limit ?? '(none)' }, 'Listing contacts');
+
+    try {
+      // Role filter uses the dedicated findContactByRole path (no change from existing behavior)
+      const contacts = role && typeof role === 'string'
+        ? await ctx.contactService.findContactByRole(role)
+        : await ctx.contactService.listContacts({
+            status: status as ContactStatus | undefined,
+            limit,
+          });
+
+      return {
+        success: true,
+        data: {
+          contacts: contacts.map((c) => ({
+            contact_id: c.id,
+            display_name: c.displayName,
+            role: c.role,
+            status: c.status,
+            kg_node_id: c.kgNodeId,
+          })),
+          count: contacts.length,
+        },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, role, status, limit }, 'Failed to list contacts');
+      return { success: false, error: `Failed to list contacts: ${message}` };
+    }
+  }
+}
+```
+
+Key changes from the original:
+- Imports `ContactStatus` type for the cast
+- Validates `status` against the allowed enum values
+- Validates `limit` is a positive integer
+- Passes `{ status, limit }` to `listContacts()` when `role` is not provided
+- Adds `status` to the output payload per contact (was missing before — useful for the agent to see)
+- Logs the new parameters
+
+- [ ] **Step 3: Verify the project compiles**
+
+Run: `npx --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-contact-list-filters tsc --noEmit`
+
+Expected: no type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-contact-list-filters add skills/contact-list/skill.json skills/contact-list/handler.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-contact-list-filters commit -m "feat(contact-list): add status and limit parameters to skill"
+```
+
+---
+
+### Task 3: Write tests
+
+**Files:**
+- Create: `skills/contact-list/handler.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `skills/contact-list/handler.test.ts`:
+
+```typescript
+// handler.test.ts — tests for contact-list skill.
+// Covers: no filters, status filter, limit, status+limit, role (existing),
+// invalid status, invalid limit.
+import { describe, it, expect, vi } from 'vitest';
+import { ContactListHandler } from './handler.js';
+import type { SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { Contact } from '../../src/contacts/types.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+// Factory for minimal Contact objects — only fields the handler reads
+function makeContact(overrides: Partial<Contact> & { id: string; displayName: string }): Contact {
+  return {
+    kgNodeId: null,
+    role: null,
+    systemRole: null,
+    status: 'confirmed',
+    contactConfidence: 0.5,
+    trustLevel: null,
+    lastSeenAt: null,
+    inboundMessageCount: 0,
+    outboundMessageCount: 0,
+    notes: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    ...overrides,
+  };
+}
+
+const alice = makeContact({ id: 'a1', displayName: 'Alice', status: 'confirmed', createdAt: new Date('2026-01-01') });
+const bob = makeContact({ id: 'b2', displayName: 'Bob', status: 'provisional', createdAt: new Date('2026-02-01') });
+const carol = makeContact({ id: 'c3', displayName: 'Carol', status: 'provisional', createdAt: new Date('2026-03-01') });
+const dave = makeContact({ id: 'd4', displayName: 'Dave', status: 'blocked', createdAt: new Date('2026-04-01') });
+
+const allContacts = [alice, bob, carol, dave];
+
+function makeCtx(input: Record<string, unknown> = {}, contacts: Contact[] = allContacts): SkillContext {
+  return {
+    input,
+    log: createSilentLogger(),
+    contactService: {
+      listContacts: vi.fn().mockImplementation((filters?: { status?: string; limit?: number }) => {
+        let results = [...contacts];
+        if (filters?.status) {
+          results = results.filter((c) => c.status === filters.status);
+        }
+        // Sort ascending by createdAt to match real backend
+        results.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+        if (filters?.limit != null) {
+          results = results.slice(0, filters.limit);
+        }
+        return Promise.resolve(results);
+      }),
+      findContactByRole: vi.fn().mockResolvedValue([]),
+    },
+  } as unknown as SkillContext;
+}
+
+/** Extract contacts array from a successful result. */
+function getContacts(result: SkillResult): Array<{ contact_id: string; display_name: string; status: string }> {
+  if (!result.success) throw new Error(`Expected success, got: ${result.error}`);
+  return (result.data as { contacts: Array<{ contact_id: string; display_name: string; status: string }> }).contacts;
+}
+
+describe('ContactListHandler', () => {
+  const handler = new ContactListHandler();
+
+  // --- No filters (existing behavior) ---
+
+  it('returns all contacts when no filters provided', async () => {
+    const ctx = makeCtx();
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(getContacts(result)).toHaveLength(4);
+    expect(ctx.contactService!.listContacts).toHaveBeenCalledWith({
+      status: undefined,
+      limit: undefined,
+    });
+  });
+
+  // --- Status filter ---
+
+  it('filters by status=provisional', async () => {
+    const ctx = makeCtx({ status: 'provisional' });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const contacts = getContacts(result);
+    expect(contacts).toHaveLength(2);
+    expect(contacts.every((c) => c.status === 'provisional')).toBe(true);
+  });
+
+  it('filters by status=confirmed', async () => {
+    const ctx = makeCtx({ status: 'confirmed' });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const contacts = getContacts(result);
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].display_name).toBe('Alice');
+  });
+
+  it('filters by status=blocked', async () => {
+    const ctx = makeCtx({ status: 'blocked' });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const contacts = getContacts(result);
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].display_name).toBe('Dave');
+  });
+
+  // --- Limit ---
+
+  it('caps results with limit', async () => {
+    const ctx = makeCtx({ limit: 2 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(getContacts(result)).toHaveLength(2);
+  });
+
+  it('returns all contacts when limit exceeds total', async () => {
+    const ctx = makeCtx({ limit: 100 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(getContacts(result)).toHaveLength(4);
+  });
+
+  // --- Status + limit combined ---
+
+  it('filters by status and caps with limit', async () => {
+    const ctx = makeCtx({ status: 'provisional', limit: 1 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const contacts = getContacts(result);
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].status).toBe('provisional');
+  });
+
+  // --- Role filter (existing behavior, regression check) ---
+
+  it('uses findContactByRole when role is provided', async () => {
+    const cfo = makeContact({ id: 'r1', displayName: 'CFO Person', role: 'CFO' });
+    const ctx = makeCtx({ role: 'CFO' }, allContacts);
+    (ctx.contactService!.findContactByRole as ReturnType<typeof vi.fn>).mockResolvedValue([cfo]);
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(getContacts(result)).toHaveLength(1);
+    expect(getContacts(result)[0].display_name).toBe('CFO Person');
+    // Should NOT have called listContacts
+    expect(ctx.contactService!.listContacts).not.toHaveBeenCalled();
+  });
+
+  // --- Validation ---
+
+  it('rejects invalid status value', async () => {
+    const ctx = makeCtx({ status: 'invalid' });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid status');
+  });
+
+  it('rejects limit of zero', async () => {
+    const ctx = makeCtx({ limit: 0 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('positive integer');
+  });
+
+  it('rejects negative limit', async () => {
+    const ctx = makeCtx({ limit: -5 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('positive integer');
+  });
+
+  it('rejects non-integer limit', async () => {
+    const ctx = makeCtx({ limit: 2.5 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('positive integer');
+  });
+
+  it('rejects role exceeding 200 characters', async () => {
+    const ctx = makeCtx({ role: 'x'.repeat(201) });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('200 characters');
+  });
+
+  // --- Output shape ---
+
+  it('includes status field in each contact output', async () => {
+    const ctx = makeCtx();
+    const result = await handler.execute(ctx);
+    const contacts = getContacts(result);
+    expect(contacts[0]).toHaveProperty('status');
+    expect(contacts[0].status).toBe('confirmed');
+  });
+
+  // --- Error handling ---
+
+  it('returns error when contactService throws', async () => {
+    const ctx = makeCtx();
+    (ctx.contactService!.listContacts as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB down'));
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('DB down');
+  });
+
+  it('returns error when contactService is missing', async () => {
+    const ctx = {
+      input: {},
+      log: createSilentLogger(),
+      contactService: undefined,
+    } as unknown as SkillContext;
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('contactService not available');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `npx --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-contact-list-filters vitest run skills/contact-list/handler.test.ts`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-contact-list-filters add skills/contact-list/handler.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-contact-list-filters commit -m "test(contact-list): add handler tests for status, limit, and validation"
+```
+
+---
+
+### Task 4: Update CHANGELOG and run full test suite
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add CHANGELOG entry**
+
+Add the following under `## [Unreleased]` in the appropriate section (create `### Fixed` if it doesn't exist under Unreleased, or add to existing):
+
+```markdown
+### Fixed
+
+- **`contact-list`** — accepts optional `status` and `limit` parameters; contacts agent can now query provisional contacts directly instead of enumerating all contacts through entity-context. (#644)
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npx --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-contact-list-filters vitest run`
+
+Expected: all tests pass, including the new `handler.test.ts` and all existing tests (no regressions).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-contact-list-filters add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-contact-list-filters commit -m "docs: add changelog entry for contact-list filters (#644)"
+```

--- a/skills/contact-list/handler.test.ts
+++ b/skills/contact-list/handler.test.ts
@@ -1,0 +1,217 @@
+// handler.test.ts — tests for contact-list skill.
+// Covers: no filters, status filter, limit, status+limit, role (existing),
+// invalid status, invalid limit.
+import { describe, it, expect, vi } from 'vitest';
+import { ContactListHandler } from './handler.js';
+import type { SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { Contact } from '../../src/contacts/types.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+// Factory for minimal Contact objects — only fields the handler reads
+function makeContact(overrides: Partial<Contact> & { id: string; displayName: string }): Contact {
+  return {
+    kgNodeId: null,
+    role: null,
+    systemRole: null,
+    status: 'confirmed',
+    contactConfidence: 0.5,
+    trustLevel: null,
+    lastSeenAt: null,
+    inboundMessageCount: 0,
+    outboundMessageCount: 0,
+    notes: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    ...overrides,
+  };
+}
+
+const alice = makeContact({ id: 'a1', displayName: 'Alice', status: 'confirmed', createdAt: new Date('2026-01-01') });
+const bob = makeContact({ id: 'b2', displayName: 'Bob', status: 'provisional', createdAt: new Date('2026-02-01') });
+const carol = makeContact({ id: 'c3', displayName: 'Carol', status: 'provisional', createdAt: new Date('2026-03-01') });
+const dave = makeContact({ id: 'd4', displayName: 'Dave', status: 'blocked', createdAt: new Date('2026-04-01') });
+
+const allContacts = [alice, bob, carol, dave];
+
+function makeCtx(input: Record<string, unknown> = {}, contacts: Contact[] = allContacts): SkillContext {
+  return {
+    input,
+    log: createSilentLogger(),
+    contactService: {
+      listContacts: vi.fn().mockImplementation((filters?: { status?: string; limit?: number }) => {
+        let results = [...contacts];
+        if (filters?.status) {
+          results = results.filter((c) => c.status === filters.status);
+        }
+        // Sort ascending by createdAt to match real backend
+        results.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+        if (filters?.limit != null) {
+          results = results.slice(0, filters.limit);
+        }
+        return Promise.resolve(results);
+      }),
+      findContactByRole: vi.fn().mockResolvedValue([]),
+    },
+  } as unknown as SkillContext;
+}
+
+/** Extract contacts array from a successful result. */
+function getContacts(result: SkillResult): Array<{ contact_id: string; display_name: string; status: string }> {
+  if (!result.success) throw new Error(`Expected success, got: ${result.error}`);
+  return (result.data as { contacts: Array<{ contact_id: string; display_name: string; status: string }> }).contacts;
+}
+
+describe('ContactListHandler', () => {
+  const handler = new ContactListHandler();
+
+  // --- No filters (existing behavior) ---
+
+  it('returns all contacts when no filters provided', async () => {
+    const ctx = makeCtx();
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(getContacts(result)).toHaveLength(4);
+    expect(ctx.contactService!.listContacts).toHaveBeenCalledWith({
+      status: undefined,
+      limit: undefined,
+    });
+  });
+
+  // --- Status filter ---
+
+  it('filters by status=provisional', async () => {
+    const ctx = makeCtx({ status: 'provisional' });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const contacts = getContacts(result);
+    expect(contacts).toHaveLength(2);
+    expect(contacts.every((c) => c.status === 'provisional')).toBe(true);
+  });
+
+  it('filters by status=confirmed', async () => {
+    const ctx = makeCtx({ status: 'confirmed' });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const contacts = getContacts(result);
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].display_name).toBe('Alice');
+  });
+
+  it('filters by status=blocked', async () => {
+    const ctx = makeCtx({ status: 'blocked' });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const contacts = getContacts(result);
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].display_name).toBe('Dave');
+  });
+
+  // --- Limit ---
+
+  it('caps results with limit', async () => {
+    const ctx = makeCtx({ limit: 2 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(getContacts(result)).toHaveLength(2);
+  });
+
+  it('returns all contacts when limit exceeds total', async () => {
+    const ctx = makeCtx({ limit: 100 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(getContacts(result)).toHaveLength(4);
+  });
+
+  // --- Status + limit combined ---
+
+  it('filters by status and caps with limit', async () => {
+    const ctx = makeCtx({ status: 'provisional', limit: 1 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    const contacts = getContacts(result);
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].status).toBe('provisional');
+  });
+
+  // --- Role filter (existing behavior, regression check) ---
+
+  it('uses findContactByRole when role is provided', async () => {
+    const cfo = makeContact({ id: 'r1', displayName: 'CFO Person', role: 'CFO' });
+    const ctx = makeCtx({ role: 'CFO' }, allContacts);
+    (ctx.contactService!.findContactByRole as ReturnType<typeof vi.fn>).mockResolvedValue([cfo]);
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+    expect(getContacts(result)).toHaveLength(1);
+    expect(getContacts(result)[0].display_name).toBe('CFO Person');
+    // Should NOT have called listContacts
+    expect(ctx.contactService!.listContacts).not.toHaveBeenCalled();
+  });
+
+  // --- Validation ---
+
+  it('rejects invalid status value', async () => {
+    const ctx = makeCtx({ status: 'invalid' });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid status');
+  });
+
+  it('rejects limit of zero', async () => {
+    const ctx = makeCtx({ limit: 0 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('positive integer');
+  });
+
+  it('rejects negative limit', async () => {
+    const ctx = makeCtx({ limit: -5 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('positive integer');
+  });
+
+  it('rejects non-integer limit', async () => {
+    const ctx = makeCtx({ limit: 2.5 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('positive integer');
+  });
+
+  it('rejects role exceeding 200 characters', async () => {
+    const ctx = makeCtx({ role: 'x'.repeat(201) });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('200 characters');
+  });
+
+  // --- Output shape ---
+
+  it('includes status field in each contact output', async () => {
+    const ctx = makeCtx();
+    const result = await handler.execute(ctx);
+    const contacts = getContacts(result);
+    expect(contacts[0]).toHaveProperty('status');
+    expect(contacts[0].status).toBe('confirmed');
+  });
+
+  // --- Error handling ---
+
+  it('returns error when contactService throws', async () => {
+    const ctx = makeCtx();
+    (ctx.contactService!.listContacts as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB down'));
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('DB down');
+  });
+
+  it('returns error when contactService is missing', async () => {
+    const ctx = {
+      input: {},
+      log: createSilentLogger(),
+      contactService: undefined,
+    } as unknown as SkillContext;
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('contactService not available');
+  });
+});

--- a/skills/contact-list/handler.test.ts
+++ b/skills/contact-list/handler.test.ts
@@ -184,6 +184,20 @@ describe('ContactListHandler', () => {
     expect(result.error).toContain('200 characters');
   });
 
+  it('rejects combining role with status', async () => {
+    const ctx = makeCtx({ role: 'CFO', status: 'provisional' });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Cannot combine role');
+  });
+
+  it('rejects combining role with limit', async () => {
+    const ctx = makeCtx({ role: 'CFO', limit: 5 });
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Cannot combine role');
+  });
+
   // --- Output shape ---
 
   it('includes status field in each contact output', async () => {

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -1,21 +1,36 @@
 // handler.ts — contact-list skill implementation.
 //
-// Lists all contacts, optionally filtered by role.
+// Lists contacts, optionally filtered by role or status, with optional result limit.
 // Returns an array of contact summaries.
 //
 // This skill uses contactService, which is a universal service.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { ContactStatus } from '../../src/contacts/types.js';
+
+const VALID_STATUSES: readonly string[] = ['confirmed', 'provisional', 'blocked'];
 
 export class ContactListHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const { role } = ctx.input as {
+    const { role, status, limit } = ctx.input as {
       role?: string;
+      status?: string;
+      limit?: number;
     };
 
-    // Input length limit — prevent oversized payloads reaching the DB
+    // Input validation
     if (role && typeof role === 'string' && role.length > 200) {
       return { success: false, error: 'Role must be 200 characters or fewer' };
+    }
+
+    if (status != null && !VALID_STATUSES.includes(status)) {
+      return { success: false, error: `Invalid status: "${status}". Must be one of: ${VALID_STATUSES.join(', ')}` };
+    }
+
+    if (limit != null) {
+      if (typeof limit !== 'number' || !Number.isInteger(limit) || limit < 1) {
+        return { success: false, error: 'Limit must be a positive integer' };
+      }
     }
 
     // contactService is a universal service — always injected by ExecutionLayer
@@ -26,12 +41,16 @@ export class ContactListHandler implements SkillHandler {
       };
     }
 
-    ctx.log.info({ role: role ?? '(all)' }, 'Listing contacts');
+    ctx.log.info({ role: role ?? '(all)', status: status ?? '(all)', limit: limit ?? '(none)' }, 'Listing contacts');
 
     try {
+      // Role filter uses the dedicated findContactByRole path (no change from existing behavior)
       const contacts = role && typeof role === 'string'
         ? await ctx.contactService.findContactByRole(role)
-        : await ctx.contactService.listContacts();
+        : await ctx.contactService.listContacts({
+            status: status as ContactStatus | undefined,
+            limit,
+          });
 
       return {
         success: true,
@@ -40,6 +59,7 @@ export class ContactListHandler implements SkillHandler {
             contact_id: c.id,
             display_name: c.displayName,
             role: c.role,
+            status: c.status,
             kg_node_id: c.kgNodeId,
           })),
           count: contacts.length,
@@ -47,7 +67,7 @@ export class ContactListHandler implements SkillHandler {
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err, role }, 'Failed to list contacts');
+      ctx.log.error({ err, role, status, limit }, 'Failed to list contacts');
       return { success: false, error: `Failed to list contacts: ${message}` };
     }
   }

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -33,6 +33,12 @@ export class ContactListHandler implements SkillHandler {
       }
     }
 
+    // Role uses a separate query path that doesn't support status/limit — reject the combination
+    // rather than silently dropping filters.
+    if (role && typeof role === 'string' && (status != null || limit != null)) {
+      return { success: false, error: 'Cannot combine role filter with status or limit. Use role alone, or status/limit without role.' };
+    }
+
     // contactService is a universal service — always injected by ExecutionLayer
     if (!ctx.contactService) {
       return {

--- a/skills/contact-list/handler.ts
+++ b/skills/contact-list/handler.ts
@@ -8,7 +8,7 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { ContactStatus } from '../../src/contacts/types.js';
 
-const VALID_STATUSES: readonly string[] = ['confirmed', 'provisional', 'blocked'];
+const VALID_STATUSES: readonly ContactStatus[] = ['confirmed', 'provisional', 'blocked'];
 
 export class ContactListHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {

--- a/skills/contact-list/skill.json
+++ b/skills/contact-list/skill.json
@@ -1,11 +1,13 @@
 {
   "name": "contact-list",
-  "description": "List all contacts, optionally filtered by role.",
-  "version": "1.0.0",
+  "description": "List contacts, optionally filtered by role or status, with optional result limit.",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
-    "role": "string?"
+    "role": "string?",
+    "status": "string? (confirmed | provisional | blocked)",
+    "limit": "number?"
   },
   "outputs": {
     "contacts": "array",

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -954,7 +954,7 @@ class PostgresContactBackend implements ContactServiceBackend {
     const conditions: string[] = [];
     const params: unknown[] = [];
 
-    if (filters?.status) {
+    if (filters?.status != null) {
       params.push(filters.status);
       conditions.push(`status = $${params.length}`);
     }
@@ -1500,7 +1500,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
   async listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]> {
     let results = [...this.contacts.values()];
 
-    if (filters?.status) {
+    if (filters?.status != null) {
       results = results.filter((c) => c.status === filters.status);
     }
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -45,7 +45,7 @@ interface ContactServiceBackend {
   findContactByName(name: string): Promise<Contact[]>;
   findContactByRole(role: string): Promise<Contact[]>;
   findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null>;
-  listContacts(): Promise<Contact[]>;
+  listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]>;
   updateContact(contact: Contact): Promise<void>;
   createIdentity(identity: ChannelIdentity): Promise<void>;
   getIdentitiesForContact(contactId: string): Promise<ChannelIdentity[]>;
@@ -311,9 +311,9 @@ export class ContactService {
     return this.backend.findContactBySystemRole(systemRole);
   }
 
-  /** List all contacts. */
-  async listContacts(): Promise<Contact[]> {
-    return this.backend.listContacts();
+  /** List contacts, optionally filtered by status and/or capped by limit. */
+  async listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]> {
+    return this.backend.listContacts(filters);
   }
 
   /**
@@ -949,7 +949,24 @@ class PostgresContactBackend implements ContactServiceBackend {
     return this.rowToContact(row);
   }
 
-  async listContacts(): Promise<Contact[]> {
+  async listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]> {
+    const cols = 'id, kg_node_id, display_name, role, system_role, status, contact_confidence, trust_level, last_seen_at, inbound_message_count, outbound_message_count, notes, created_at, updated_at';
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (filters?.status) {
+      params.push(filters.status);
+      conditions.push(`status = $${params.length}`);
+    }
+
+    const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
+    let sql = `SELECT ${cols} FROM contacts${where} ORDER BY created_at ASC`;
+
+    if (filters?.limit != null) {
+      params.push(filters.limit);
+      sql += ` LIMIT $${params.length}`;
+    }
+
     const result = await this.pool.query<{
       id: string;
       kg_node_id: string | null;
@@ -960,15 +977,12 @@ class PostgresContactBackend implements ContactServiceBackend {
       contact_confidence: string;
       trust_level: string | null;
       last_seen_at: Date | null;
-      inbound_message_count: string;  // INT returned as string by node-pg
+      inbound_message_count: string;
       outbound_message_count: string;
       notes: string | null;
       created_at: Date;
       updated_at: Date;
-    }>(
-      `SELECT id, kg_node_id, display_name, role, system_role, status, contact_confidence, trust_level, last_seen_at, inbound_message_count, outbound_message_count, notes, created_at, updated_at
-       FROM contacts ORDER BY created_at ASC`,
-    );
+    }>(sql, params);
 
     return result.rows.map((row) => this.rowToContact(row));
   }
@@ -1483,8 +1497,21 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return null;
   }
 
-  async listContacts(): Promise<Contact[]> {
-    return [...this.contacts.values()];
+  async listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]> {
+    let results = [...this.contacts.values()];
+
+    if (filters?.status) {
+      results = results.filter((c) => c.status === filters.status);
+    }
+
+    // Sort by createdAt ascending to match Postgres ORDER BY created_at ASC
+    results.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+
+    if (filters?.limit != null) {
+      results = results.slice(0, filters.limit);
+    }
+
+    return results;
   }
 
   async updateContact(contact: Contact): Promise<void> {


### PR DESCRIPTION
## **User description**
## Summary

Closes #644

- Add `status` (confirmed/provisional/blocked) and `limit` (positive integer) optional parameters to the `contact-list` skill
- Extend `ContactServiceBackend.listContacts()` with filter support across Postgres and InMemory backends
- Validate inputs and reject invalid combinations (role + status/limit cannot be combined)
- 18 unit tests covering all filter combinations, validation, error handling, and regression

## Test plan

- [x] `tsc --noEmit` passes (0 errors)
- [x] 18/18 handler tests pass
- [x] Full worktree test suite: 202 test files pass, 0 regressions (3 pre-existing failures in unrelated smoke loader)
- [ ] Deploy and verify the contacts agent uses `contact-list({ status: "provisional", limit: 10 })` for the scheduled provisional check
- [ ] Verify the scheduled job completes within 30 seconds
- [ ] Update runtime scheduler job to use the new parameters


___

## **CodeAnt-AI Description**
**Add status and limit filters to contact-list**

### What Changed
- `contact-list` now accepts optional `status` and `limit` inputs, so users can list only confirmed, provisional, or blocked contacts and cap the number returned
- Results now include each contact’s status, and the output stays sorted by oldest contact first
- Invalid status values, bad limits, and mixing role with status/limit are now rejected with clear errors instead of being ignored

### Impact
`✅ Faster provisional contact lookups`
`✅ Fewer contacts-agent timeouts`
`✅ Clearer input validation errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact-list skill now supports optional `status` filtering (confirmed, provisional, blocked) and result limiting to prevent timeouts when querying contacts.

* **Documentation**
  * Added design and implementation guides for contact-list filtering capabilities.

* **Tests**
  * Added comprehensive test coverage for status filtering, result limiting, validation, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->