### PR TITLE
fix: make loadDeclarativeJobs idempotent on cron changes and YAML removals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Declarative job cleanup** — `loadDeclarativeJobs` now automatically cancels stale `scheduled_jobs` rows when a cron expression changes or a schedule entry is removed from YAML, eliminating the need for one-off migrations. (#640)
 - **`ceo-inbox-list`** — normalize `DRAFTS` folder alias to `DRAFT` for Gmail API compatibility; the digest agent was failing on every run with "Invalid label: DRAFTS".
 - **`NylasClient.listMessages`** — suppress conflicting filter params when `searchQueryNative` is set, matching the guard already in `CeoNylasClient`; fixes HTTP 400 errors in security-triage's email-list calls.
 - **Provider registry routing** — WorkingMemory, DriftDetector, AutonomyScoringPass, and ExecutionLayer now resolve their LLM provider from `providerRegistry`, not the hardwired Anthropic singleton. (#646)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **Declarative job cleanup** — `loadDeclarativeJobs` now automatically cancels stale `scheduled_jobs` rows when a cron expression changes or a schedule entry is removed from YAML, eliminating the need for one-off migrations. (#640)
+- **Declarative job cleanup** — auto-cancels stale YAML schedules after cron changes or removals. (#640)
 - **`ceo-inbox-list`** — normalize `DRAFTS` folder alias to `DRAFT` for Gmail API compatibility; the digest agent was failing on every run with "Invalid label: DRAFTS".
 - **`NylasClient.listMessages`** — suppress conflicting filter params when `searchQueryNative` is set, matching the guard already in `CeoNylasClient`; fixes HTTP 400 errors in security-triage's email-list calls.
 - **Provider registry routing** — WorkingMemory, DriftDetector, AutonomyScoringPass, and ExecutionLayer now resolve their LLM provider from `providerRegistry`, not the hardwired Anthropic singleton. (#646)

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -550,6 +550,64 @@ export class SchedulerService {
   }
 
   /**
+   * Cancel stale declarative (system-created) jobs that are no longer declared in YAML.
+   *
+   * After all upsertDeclarativeJob() calls complete, the caller passes the full set of
+   * (agent_id, cron_expr, task_payload::text) tuples that were successfully upserted.
+   * Any system-created rows in 'pending' or 'failed' status whose triple is NOT in that
+   * set are stale — their cron changed, or the entry was removed from YAML entirely.
+   *
+   * Running and suspended jobs are left alone: running jobs are handled by the watchdog,
+   * and suspended jobs may have been paused intentionally by an operator.
+   *
+   * Returns the number of rows cancelled.
+   */
+  async cancelStaleDeclarativeJobs(
+    liveTuples: Array<{ agentId: string; cronExpr: string; taskPayload: string }>,
+  ): Promise<number> {
+    // Build a parameterized exclusion clause. Each live tuple becomes a
+    // (agent_id, cron_expr, task_payload::text) triple in a VALUES list so
+    // the NOT IN check is a single set operation — no per-tuple subqueries.
+    //
+    // When there are zero live tuples, every system row is stale (all schedules
+    // were removed). The empty exclusion clause correctly targets all system rows.
+    const valuePlaceholders: string[] = [];
+    const params: unknown[] = [];
+    let idx = 1;
+    for (const tuple of liveTuples) {
+      valuePlaceholders.push(`($${idx}, $${idx + 1}, $${idx + 2})`);
+      params.push(tuple.agentId, tuple.cronExpr, tuple.taskPayload);
+      idx += 3;
+    }
+
+    // When liveTuples is non-empty, exclude the live set. When empty, no exclusion
+    // is needed — the UPDATE targets all system rows with pending/failed status.
+    const exclusionClause = valuePlaceholders.length > 0
+      ? `AND (agent_id, cron_expr, task_payload::text) NOT IN (VALUES ${valuePlaceholders.join(', ')})`
+      : '';
+
+    const sql = `
+      UPDATE scheduled_jobs
+         SET status = 'cancelled'
+       WHERE created_by = 'system'
+         AND status IN ('pending', 'failed')
+         ${exclusionClause}
+      RETURNING id, agent_id, cron_expr, task_payload
+    `;
+
+    const { rows } = await this.pool.query(sql, params);
+
+    for (const row of rows as Array<{ id: string; agent_id: string; cron_expr: string; task_payload: unknown }>) {
+      this.logger.info(
+        { jobId: row.id, agentId: row.agent_id, cronExpr: row.cron_expr, action: 'cancelled' },
+        'Stale declarative job cancelled — schedule entry changed or removed from YAML',
+      );
+    }
+
+    return rows.length;
+  }
+
+  /**
    * Complete a job run.
    * - On success: if recurring (has cron_expr), advance next_run_at and reset failures;
    *   if one-shot, mark as completed.

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -604,6 +604,11 @@ export class SchedulerService {
       );
     }
 
+    // TODO: if declarative schedules ever use intent_anchor, cancelling the scheduled_jobs row
+    // here leaves the linked agent_tasks row orphaned (scheduled_job_id becomes NULL). At that
+    // point this method should also cancel any agent_tasks rows whose scheduled_job_id was
+    // just cleared — mirror the cleanup in cancelJob(). No declarative schedules use
+    // intent_anchor today, so this is safe to defer.
     return rows.length;
   }
 

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -575,7 +575,14 @@ export class SchedulerService {
     const params: unknown[] = [];
     let idx = 1;
     for (const tuple of liveTuples) {
-      valuePlaceholders.push(`($${idx}, $${idx + 1}, $${idx + 2})`);
+      // Cast the payload parameter to ::jsonb::text so PostgreSQL normalizes it
+      // (sorts object keys, strips whitespace) before comparing. This ensures
+      // both sides of the NOT IN check go through the same JSONB serializer —
+      // matching how the unique index (task_payload::text) is computed. Without
+      // the cast, a multi-key payload could diverge between JS JSON.stringify
+      // key order and PostgreSQL's canonical key order, silently failing to
+      // shield a live job from cancellation.
+      valuePlaceholders.push(`($${idx}, $${idx + 1}, $${idx + 2}::jsonb::text)`);
       params.push(tuple.agentId, tuple.cronExpr, tuple.taskPayload);
       idx += 3;
     }

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -602,8 +602,8 @@ export class Scheduler {
       }
     } catch (err) {
       this.logger.error(
-        { err },
-        'Failed to cancel stale declarative jobs — stale rows may continue firing until next restart',
+        { err, liveTupleCount: liveTuples.length },
+        'Failed to cancel stale declarative jobs — resolve the error above and restart to trigger cleanup',
       );
     }
   }

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -512,8 +512,11 @@ export class Scheduler {
    */
   async loadDeclarativeJobs(agentConfigs: AgentYamlConfig[]): Promise<void> {
     const knownAgents = new Set(agentConfigs.map(config => config.name));
-    // Collect all (source → target) schedule edges for cycle detection after upserts.
+    // Collect all (source -> target) schedule edges for cycle detection after upserts.
     const edges: Array<{ source: string; target: string }> = [];
+    // Collect the (agent_id, cron_expr, task_payload) tuples that were successfully upserted.
+    // Used after the loop to cancel stale system rows no longer in the YAML config.
+    const liveTuples: Array<{ agentId: string; cronExpr: string; taskPayload: string }> = [];
 
     for (const config of agentConfigs) {
       if (!config.schedule || config.schedule.length === 0) {
@@ -543,6 +546,13 @@ export class Scheduler {
           // Only record the edge after a successful upsert — a failed upsert means
           // the job doesn't exist in the DB, so it shouldn't influence cycle detection.
           edges.push({ source: config.name, target: targetAgentId });
+          // Only track successfully upserted tuples in the live set — a failed upsert
+          // means the job isn't reliably in the DB, so it must not shield a stale row.
+          liveTuples.push({
+            agentId: targetAgentId,
+            cronExpr: schedule.cron,
+            taskPayload: JSON.stringify({ task: schedule.task }),
+          });
           this.logger.info(
             { agentId: targetAgentId, sourceAgent: config.name, cron: schedule.cron, task: schedule.task, jobId },
             'Declarative job upserted',
@@ -576,6 +586,25 @@ export class Scheduler {
           'Declarative schedule cycle detected — agents target each other; this will cause infinite task loops',
         );
       }
+    }
+
+    // Cancel system-created rows whose (agent_id, cron_expr, task_payload) triple is no longer
+    // declared in any agent YAML. This handles both cron expression changes (old row becomes
+    // stale when the new cron conflicts on the unique index) and removed schedule entries
+    // (row has no corresponding YAML declaration at all).
+    try {
+      const cancelledCount = await this.schedulerService.cancelStaleDeclarativeJobs(liveTuples);
+      if (cancelledCount > 0) {
+        this.logger.info(
+          { cancelledCount },
+          'stale declarative jobs cancelled — schedule entries changed or removed from YAML',
+        );
+      }
+    } catch (err) {
+      this.logger.error(
+        { err },
+        'Failed to cancel stale declarative jobs — stale rows may continue firing until next restart',
+      );
     }
   }
 

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -514,9 +514,11 @@ export class Scheduler {
     const knownAgents = new Set(agentConfigs.map(config => config.name));
     // Collect all (source -> target) schedule edges for cycle detection after upserts.
     const edges: Array<{ source: string; target: string }> = [];
-    // Collect the (agent_id, cron_expr, task_payload) tuples that were successfully upserted.
-    // Used after the loop to cancel stale system rows no longer in the YAML config.
-    const liveTuples: Array<{ agentId: string; cronExpr: string; taskPayload: string }> = [];
+    // Collect (agent_id, cron_expr, task_payload) tuples for every YAML-declared schedule that
+    // passes the knownAgents guard. Used to shield existing DB rows from stale-job cleanup.
+    // Populated BEFORE the upsert attempt so that a transient upsert failure cannot cause a
+    // still-declared job's existing DB row to be misclassified as stale and cancelled.
+    const declaredTuples: Array<{ agentId: string; cronExpr: string; taskPayload: string }> = [];
 
     for (const config of agentConfigs) {
       if (!config.schedule || config.schedule.length === 0) {
@@ -538,6 +540,16 @@ export class Scheduler {
           continue;
         }
 
+        // Track this declaration before attempting the upsert — a YAML declaration
+        // protects its DB row from stale-job cleanup regardless of upsert outcome.
+        // (A transient DB error during the upsert must not cause a still-declared
+        // job's existing pending row to be cancelled on this startup pass.)
+        declaredTuples.push({
+          agentId: targetAgentId,
+          cronExpr: schedule.cron,
+          taskPayload: JSON.stringify({ task: schedule.task }),
+        });
+
         try {
           const jobId = await this.schedulerService.upsertDeclarativeJob(
             targetAgentId,
@@ -546,13 +558,6 @@ export class Scheduler {
           // Only record the edge after a successful upsert — a failed upsert means
           // the job doesn't exist in the DB, so it shouldn't influence cycle detection.
           edges.push({ source: config.name, target: targetAgentId });
-          // Only track successfully upserted tuples in the live set — a failed upsert
-          // means the job isn't reliably in the DB, so it must not shield a stale row.
-          liveTuples.push({
-            agentId: targetAgentId,
-            cronExpr: schedule.cron,
-            taskPayload: JSON.stringify({ task: schedule.task }),
-          });
           this.logger.info(
             { agentId: targetAgentId, sourceAgent: config.name, cron: schedule.cron, task: schedule.task, jobId },
             'Declarative job upserted',
@@ -593,7 +598,7 @@ export class Scheduler {
     // stale when the new cron conflicts on the unique index) and removed schedule entries
     // (row has no corresponding YAML declaration at all).
     try {
-      const cancelledCount = await this.schedulerService.cancelStaleDeclarativeJobs(liveTuples);
+      const cancelledCount = await this.schedulerService.cancelStaleDeclarativeJobs(declaredTuples);
       if (cancelledCount > 0) {
         this.logger.info(
           { cancelledCount },
@@ -602,7 +607,7 @@ export class Scheduler {
       }
     } catch (err) {
       this.logger.error(
-        { err, liveTupleCount: liveTuples.length },
+        { err, declaredTupleCount: declaredTuples.length },
         'Failed to cancel stale declarative jobs — resolve the error above and restart to trigger cleanup',
       );
     }

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -816,7 +816,7 @@ describe('SchedulerService', () => {
       const count = await svc.cancelStaleDeclarativeJobs(liveTuples);
 
       expect(count).toBe(2);
-      const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
+      const [sql] = pool.query.mock.calls[0] as [string, unknown[]];
       // Must only target pending/failed system jobs
       expect(sql).toContain("created_by = 'system'");
       expect(sql).toContain("status IN ('pending', 'failed')");
@@ -859,7 +859,7 @@ describe('SchedulerService', () => {
 
       await svc.cancelStaleDeclarativeJobs(liveTuples);
 
-      const [_sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
+      const [, params] = pool.query.mock.calls[0] as [string, unknown[]];
       // All six values from the two tuples should appear in the params array
       expect(params).toContain('agent-a');
       expect(params).toContain('0 8 * * *');

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -799,6 +799,77 @@ describe('SchedulerService', () => {
     });
   });
 
+  describe('cancelStaleDeclarativeJobs', () => {
+    it('cancels stale system jobs not in the live set', async () => {
+      // The query returns two stale rows that were cancelled
+      pool.query.mockResolvedValueOnce({
+        rows: [
+          { id: 'stale-1', agent_id: 'coordinator', cron_expr: '*/30 * * * *', task_payload: '{"task":"old-cron"}' },
+          { id: 'stale-2', agent_id: 'scout', cron_expr: '0 9 * * 1', task_payload: '{"task":"removed-task"}' },
+        ],
+      });
+
+      const liveTuples = [
+        { agentId: 'coordinator', cronExpr: '*/30 6-17 * * *', taskPayload: '{"task":"old-cron"}' },
+      ];
+
+      const count = await svc.cancelStaleDeclarativeJobs(liveTuples);
+
+      expect(count).toBe(2);
+      const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
+      // Must only target pending/failed system jobs
+      expect(sql).toContain("created_by = 'system'");
+      expect(sql).toContain("status IN ('pending', 'failed')");
+      expect(sql).toContain("'cancelled'");
+    });
+
+    it('returns 0 and still issues the query when liveTuples is empty (all system rows are stale)', async () => {
+      // When there are no declarative jobs at all, we still need to cancel any
+      // leftover system rows from a previous config that had schedules.
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      const count = await svc.cancelStaleDeclarativeJobs([]);
+
+      expect(count).toBe(0);
+      // Query is still issued — an empty live set means ALL system rows are stale
+      expect(pool.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not touch running or suspended jobs', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      await svc.cancelStaleDeclarativeJobs([
+        { agentId: 'coordinator', cronExpr: '0 9 * * *', taskPayload: '{"task":"brief"}' },
+      ]);
+
+      const [sql] = pool.query.mock.calls[0] as [string];
+      // The WHERE clause must restrict to pending/failed only
+      expect(sql).toContain("status IN ('pending', 'failed')");
+      expect(sql).not.toContain("'running'");
+      expect(sql).not.toContain("'suspended'");
+    });
+
+    it('passes live tuples as parameterized exclusion values', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [] });
+
+      const liveTuples = [
+        { agentId: 'agent-a', cronExpr: '0 8 * * *', taskPayload: '{"task":"t1"}' },
+        { agentId: 'agent-b', cronExpr: '0 9 * * 1', taskPayload: '{"task":"t2"}' },
+      ];
+
+      await svc.cancelStaleDeclarativeJobs(liveTuples);
+
+      const [_sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
+      // All six values from the two tuples should appear in the params array
+      expect(params).toContain('agent-a');
+      expect(params).toContain('0 8 * * *');
+      expect(params).toContain('{"task":"t1"}');
+      expect(params).toContain('agent-b');
+      expect(params).toContain('0 9 * * 1');
+      expect(params).toContain('{"task":"t2"}');
+    });
+  });
+
   // -- updateJob --
 
   describe('updateJob', () => {

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -29,6 +29,7 @@ function mockSchedulerService() {
   return {
     completeJobRun: vi.fn(),
     upsertDeclarativeJob: vi.fn(),
+    cancelStaleDeclarativeJobs: vi.fn(),
     getJob: vi.fn(),
     nextRunFromCron: vi.fn(),
     recoverStuckJob: vi.fn(),
@@ -1017,6 +1018,189 @@ describe('Scheduler', () => {
           task: 'weekly digest',
           intent_anchor: 'Produce a weekly summary of key business metrics',
         },
+      );
+    });
+
+    it('calls cancelStaleDeclarativeJobs with the live tuple set after all upserts', async () => {
+      schedulerService.upsertDeclarativeJob.mockResolvedValue('job-1');
+      schedulerService.cancelStaleDeclarativeJobs.mockResolvedValue(0);
+
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'coordinator',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Coord.',
+          schedule: [
+            { cron: '0 9 * * 1', task: 'weekly-standup' },
+            { cron: '0 8 * * *', task: 'daily-brief' },
+          ],
+        },
+      ];
+
+      await scheduler.loadDeclarativeJobs(configs);
+
+      expect(schedulerService.cancelStaleDeclarativeJobs).toHaveBeenCalledTimes(1);
+      const [liveTuples] = schedulerService.cancelStaleDeclarativeJobs.mock.calls[0] as [
+        Array<{ agentId: string; cronExpr: string; taskPayload: string }>,
+      ];
+      expect(liveTuples).toHaveLength(2);
+      expect(liveTuples).toContainEqual({
+        agentId: 'coordinator',
+        cronExpr: '0 9 * * 1',
+        taskPayload: JSON.stringify({ task: 'weekly-standup' }),
+      });
+      expect(liveTuples).toContainEqual({
+        agentId: 'coordinator',
+        cronExpr: '0 8 * * *',
+        taskPayload: JSON.stringify({ task: 'daily-brief' }),
+      });
+    });
+
+    it('excludes failed upserts from the live tuple set', async () => {
+      schedulerService.upsertDeclarativeJob
+        .mockRejectedValueOnce(new Error('db error'))
+        .mockResolvedValueOnce('job-ok');
+      schedulerService.cancelStaleDeclarativeJobs.mockResolvedValue(0);
+
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'agent-x',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'test',
+          schedule: [
+            { cron: '0 1 * * *', task: 'fail-task' },
+            { cron: '0 2 * * *', task: 'ok-task' },
+          ],
+        },
+      ];
+
+      await scheduler.loadDeclarativeJobs(configs);
+
+      const [liveTuples] = schedulerService.cancelStaleDeclarativeJobs.mock.calls[0] as [
+        Array<{ agentId: string; cronExpr: string; taskPayload: string }>,
+      ];
+      // Only the successful upsert should be in the live set
+      expect(liveTuples).toHaveLength(1);
+      expect(liveTuples[0]).toEqual({
+        agentId: 'agent-x',
+        cronExpr: '0 2 * * *',
+        taskPayload: JSON.stringify({ task: 'ok-task' }),
+      });
+    });
+
+    it('uses targetAgentId (not source config.name) in the live tuple', async () => {
+      schedulerService.upsertDeclarativeJob.mockResolvedValue('job-1');
+      schedulerService.cancelStaleDeclarativeJobs.mockResolvedValue(0);
+
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'writing-scout',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Scout.',
+          schedule: [
+            { cron: '30 8 * * 2', task: 'Run the writing scout', agent_id: 'coordinator' },
+          ],
+        },
+        {
+          name: 'coordinator',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Coord.',
+        },
+      ];
+
+      await scheduler.loadDeclarativeJobs(configs);
+
+      const [liveTuples] = schedulerService.cancelStaleDeclarativeJobs.mock.calls[0] as [
+        Array<{ agentId: string; cronExpr: string; taskPayload: string }>,
+      ];
+      // The live tuple must use 'coordinator' (the targetAgentId), not 'writing-scout'
+      expect(liveTuples).toEqual([
+        {
+          agentId: 'coordinator',
+          cronExpr: '30 8 * * 2',
+          taskPayload: JSON.stringify({ task: 'Run the writing scout' }),
+        },
+      ]);
+    });
+
+    it('calls cancelStaleDeclarativeJobs with empty array when no configs have schedules', async () => {
+      schedulerService.cancelStaleDeclarativeJobs.mockResolvedValue(0);
+
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'no-schedule',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'No schedule.',
+        },
+      ];
+
+      await scheduler.loadDeclarativeJobs(configs);
+
+      expect(schedulerService.cancelStaleDeclarativeJobs).toHaveBeenCalledWith([]);
+    });
+
+    it('logs the count of cancelled stale jobs at info level', async () => {
+      schedulerService.upsertDeclarativeJob.mockResolvedValue('job-1');
+      schedulerService.cancelStaleDeclarativeJobs.mockResolvedValue(3);
+
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'coordinator',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Coord.',
+          schedule: [{ cron: '0 9 * * *', task: 'brief' }],
+        },
+      ];
+
+      await scheduler.loadDeclarativeJobs(configs);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ cancelledCount: 3 }),
+        expect.stringContaining('stale declarative jobs cancelled'),
+      );
+    });
+
+    it('does not log cancellation message when count is 0 (fresh install / no stale rows)', async () => {
+      schedulerService.upsertDeclarativeJob.mockResolvedValue('job-1');
+      schedulerService.cancelStaleDeclarativeJobs.mockResolvedValue(0);
+
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'coordinator',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Coord.',
+          schedule: [{ cron: '0 9 * * *', task: 'brief' }],
+        },
+      ];
+
+      await scheduler.loadDeclarativeJobs(configs);
+
+      // The only info log should be the upsert confirmation, not a "0 stale jobs" message
+      const infoCalls = logger.info.mock.calls as Array<[Record<string, unknown>, string]>;
+      const staleLogs = infoCalls.filter(([, msg]) =>
+        typeof msg === 'string' && msg.includes('stale'),
+      );
+      expect(staleLogs).toHaveLength(0);
+    });
+
+    it('logs and continues if cancelStaleDeclarativeJobs throws', async () => {
+      schedulerService.upsertDeclarativeJob.mockResolvedValue('job-1');
+      schedulerService.cancelStaleDeclarativeJobs.mockRejectedValue(new Error('cleanup query failed'));
+
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'coordinator',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Coord.',
+          schedule: [{ cron: '0 9 * * *', task: 'brief' }],
+        },
+      ];
+
+      // Should not throw — startup must not abort for a cleanup failure
+      await expect(scheduler.loadDeclarativeJobs(configs)).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.any(Error) }),
+        expect.stringContaining('Failed to cancel stale declarative jobs'),
       );
     });
   });

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -1021,7 +1021,7 @@ describe('Scheduler', () => {
       );
     });
 
-    it('calls cancelStaleDeclarativeJobs with the live tuple set after all upserts', async () => {
+    it('calls cancelStaleDeclarativeJobs with all declared tuples after upserts', async () => {
       schedulerService.upsertDeclarativeJob.mockResolvedValue('job-1');
       schedulerService.cancelStaleDeclarativeJobs.mockResolvedValue(0);
 
@@ -1040,23 +1040,26 @@ describe('Scheduler', () => {
       await scheduler.loadDeclarativeJobs(configs);
 
       expect(schedulerService.cancelStaleDeclarativeJobs).toHaveBeenCalledTimes(1);
-      const [liveTuples] = schedulerService.cancelStaleDeclarativeJobs.mock.calls[0] as [
+      const [declaredTuples] = schedulerService.cancelStaleDeclarativeJobs.mock.calls[0] as [
         Array<{ agentId: string; cronExpr: string; taskPayload: string }>,
       ];
-      expect(liveTuples).toHaveLength(2);
-      expect(liveTuples).toContainEqual({
+      expect(declaredTuples).toHaveLength(2);
+      expect(declaredTuples).toContainEqual({
         agentId: 'coordinator',
         cronExpr: '0 9 * * 1',
         taskPayload: JSON.stringify({ task: 'weekly-standup' }),
       });
-      expect(liveTuples).toContainEqual({
+      expect(declaredTuples).toContainEqual({
         agentId: 'coordinator',
         cronExpr: '0 8 * * *',
         taskPayload: JSON.stringify({ task: 'daily-brief' }),
       });
     });
 
-    it('excludes failed upserts from the live tuple set', async () => {
+    it('includes declared tuples in cleanup set even when upsert fails', async () => {
+      // A transient upsert failure must not cause a still-declared job's existing
+      // DB row to be cancelled. Tuples are tracked before the upsert attempt, so
+      // a failure leaves the tuple in the declared set to shield the existing row.
       schedulerService.upsertDeclarativeJob
         .mockRejectedValueOnce(new Error('db error'))
         .mockResolvedValueOnce('job-ok');
@@ -1076,19 +1079,24 @@ describe('Scheduler', () => {
 
       await scheduler.loadDeclarativeJobs(configs);
 
-      const [liveTuples] = schedulerService.cancelStaleDeclarativeJobs.mock.calls[0] as [
+      const [declaredTuples] = schedulerService.cancelStaleDeclarativeJobs.mock.calls[0] as [
         Array<{ agentId: string; cronExpr: string; taskPayload: string }>,
       ];
-      // Only the successful upsert should be in the live set
-      expect(liveTuples).toHaveLength(1);
-      expect(liveTuples[0]).toEqual({
+      // Both tuples — including the one whose upsert failed — must be in the declared set
+      expect(declaredTuples).toHaveLength(2);
+      expect(declaredTuples).toContainEqual({
+        agentId: 'agent-x',
+        cronExpr: '0 1 * * *',
+        taskPayload: JSON.stringify({ task: 'fail-task' }),
+      });
+      expect(declaredTuples).toContainEqual({
         agentId: 'agent-x',
         cronExpr: '0 2 * * *',
         taskPayload: JSON.stringify({ task: 'ok-task' }),
       });
     });
 
-    it('uses targetAgentId (not source config.name) in the live tuple', async () => {
+    it('uses targetAgentId (not source config.name) in the declared tuple', async () => {
       schedulerService.upsertDeclarativeJob.mockResolvedValue('job-1');
       schedulerService.cancelStaleDeclarativeJobs.mockResolvedValue(0);
 
@@ -1110,11 +1118,11 @@ describe('Scheduler', () => {
 
       await scheduler.loadDeclarativeJobs(configs);
 
-      const [liveTuples] = schedulerService.cancelStaleDeclarativeJobs.mock.calls[0] as [
+      const [declaredTuples] = schedulerService.cancelStaleDeclarativeJobs.mock.calls[0] as [
         Array<{ agentId: string; cronExpr: string; taskPayload: string }>,
       ];
-      // The live tuple must use 'coordinator' (the targetAgentId), not 'writing-scout'
-      expect(liveTuples).toEqual([
+      // The declared tuple must use 'coordinator' (the targetAgentId), not 'writing-scout'
+      expect(declaredTuples).toEqual([
         {
           agentId: 'coordinator',
           cronExpr: '30 8 * * 2',


### PR DESCRIPTION
## **User description**
## Summary

- Adds `cancelStaleDeclarativeJobs()` to `SchedulerService` — cancels `created_by = 'system'` rows in `pending/failed` status whose `(agent_id, cron_expr, task_payload)` triple is no longer in the live YAML config
- Wires the cleanup into `loadDeclarativeJobs` after all upserts complete, using `::jsonb::text` casting so PostgreSQL normalizes both sides of the exclusion comparison identically
- Covers both failure modes from #640: cron expression changes (new row conflicts on unique index, old row stays pending) and removed schedule entries (no corresponding YAML at all)
- Jobs in `running` or `suspended` status are never touched; `created_by != 'system'` rows (conversation-created, API-created) are never affected

Closes #640

## Test Plan

- [ ] 11 new unit tests added (4 in `scheduler-service.test.ts`, 7 in `scheduler.test.ts`); all 127 scheduler tests pass
- [ ] Edge cases covered: failed upserts excluded from live set, cross-agent `targetAgentId` used (not `config.name`), empty live set calls cleanup with `[]`, cleanup failure logs and does not abort startup
- [ ] Fresh-install behavior unchanged (cleanup finds nothing to cancel, count = 0, no log noise)


___

## **CodeAnt-AI Description**
Prevent stale scheduled jobs from staying active after YAML changes

### What Changed
- After loading schedules from YAML, the app now removes old system-created jobs that no longer match any current schedule
- This covers both changed cron timing and schedules removed from YAML entirely
- Only pending and failed jobs are cancelled; running and suspended jobs are left alone
- If cleanup fails, startup continues and the error is logged instead of stopping the scheduler

### Impact
`✅ Fewer duplicate scheduled jobs after config changes`
`✅ Fewer leftover jobs after removing a schedule`
`✅ Safer scheduler startup when cleanup hits an error`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Fixed**
  * Declarative jobs now automatically cancel stale scheduled jobs when cron expressions change or when schedule entries are removed from YAML, eliminating the need for manual migrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->