### PR TITLE
feat: downgrade contacts, calendar, research-analyst, ceo-inbox to fast tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Agent tier downgrades** — contacts, calendar, research-analyst, and ceo-inbox moved from `standard` to `fast` tier. (#648)
 
+### Fixed
+
+- **OpenRouter truncation warning** — `OpenRouterProvider` now logs at `warn` level when `finish_reason === 'length'` so truncated responses are visible in production logs instead of silently passing as complete.
+
 ### Added
 
 - **OpenRouter provider** — optional multi-model routing for Gemini Flash, DeepSeek V3, and GPT-4o via `OPENROUTER_API_KEY`. (#379)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **Agent tier downgrades** — contacts, calendar, research-analyst, and ceo-inbox moved from `standard` to `fast` tier. (#648)
+
 ### Added
 
 - **OpenRouter provider** — optional multi-model routing for Gemini Flash, DeepSeek V3, and GPT-4o via `OPENROUTER_API_KEY`. (#379)

--- a/agents/calendar.yaml
+++ b/agents/calendar.yaml
@@ -5,7 +5,7 @@ description: >
   event CRUD, and scheduling-related email composition for meeting requests,
   reschedules, and cancellations
 model:
-  tier: standard
+  tier: fast  # procedural scheduling + rule-based conflict resolution, no judgment calls
 allow_discovery: false
 system_prompt: |
   ## Role

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -8,7 +8,7 @@ description: >
   escalates urgent items via Signal and the bullpen.
 
 model:
-  tier: standard
+  tier: fast  # trial: rule-based triage; CEO reviews reply drafts before send — watch draft quality
 
 inject_specialists: true
 

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -4,7 +4,7 @@ description: >
   Contact domain specialist — briefings, CRUD, deduplication, relationship management,
   and memory entity resolution for people and organizations
 model:
-  tier: standard
+  tier: fast  # structured CRUD + briefings, no judgment calls, never user-facing
 allow_discovery: false
 system_prompt: |
   ## Role

--- a/agents/research-analyst.yaml
+++ b/agents/research-analyst.yaml
@@ -2,7 +2,7 @@ name: research-analyst
 role: specialist
 description: Conducts web research, summarizes findings, and provides analysis on topics the CEO asks about
 model:
-  tier: standard
+  tier: fast  # trial: search+synthesize workflow is well-defined; watch synthesis quality in prod
 system_prompt: |
   You are a research analyst working as part of an executive assistant team.
   Your role is to conduct thorough research and provide clear, actionable summaries.

--- a/src/agents/llm/openrouter.test.ts
+++ b/src/agents/llm/openrouter.test.ts
@@ -329,4 +329,57 @@ describe('OpenRouterProvider', () => {
     const params = mockCreate.mock.calls[0]![0];
     expect(params.model).toBe('deepseek/deepseek-chat-v3-0324');
   });
+
+  it('logs warn when finish_reason is "length" (response truncated by max_tokens cap)', async () => {
+    mockCreate.mockResolvedValue({
+      ...makeTextResponse(),
+      choices: [
+        {
+          index: 0,
+          finish_reason: 'length',  // model hit the output token cap
+          message: {
+            role: 'assistant' as const,
+            content: 'This response was cut off mid-',
+            tool_calls: undefined,
+            refusal: null,
+          },
+          logprobs: null,
+        },
+      ],
+    });
+
+    const logger = createSilentLogger();
+    const warnSpy = vi.spyOn(logger, 'warn');
+
+    const provider = new OpenRouterProvider('test-key', logger, new ModelRegistry(createSilentLogger()));
+    const result = await provider.chat({
+      messages: [{ role: 'user', content: 'Write a long essay' }],
+      model: 'google/gemini-2.0-flash-001',
+    });
+
+    // Response should still be returned as text — truncation doesn't cause an error
+    expect(result.type).toBe('text');
+    if (result.type !== 'text') return;
+    expect(result.content).toBe('This response was cut off mid-');
+
+    // Warn must fire with finish_reason and model in the log bindings
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const [bindings, message] = warnSpy.mock.calls[0]! as [Record<string, unknown>, string];
+    expect(bindings).toMatchObject({ model: 'google/gemini-2.0-flash-001', finishReason: 'length' });
+    expect(message).toMatch(/truncated/);
+  });
+
+  it('does not log warn for normal stop finish_reason', async () => {
+    const logger = createSilentLogger();
+    const warnSpy = vi.spyOn(logger, 'warn');
+
+    const provider = new OpenRouterProvider('test-key', logger, new ModelRegistry(createSilentLogger()));
+    await provider.chat({
+      messages: [{ role: 'user', content: 'Hello' }],
+      model: 'google/gemini-2.0-flash-001',
+    });
+
+    // No warn should fire for a clean stop
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/llm/openrouter.ts
+++ b/src/agents/llm/openrouter.ts
@@ -241,6 +241,20 @@ export class OpenRouterProvider implements LLMProvider {
         'OpenRouter API call completed',
       );
 
+      // Warn loudly when the model hit the max_tokens cap — the output is
+      // incomplete. Callers get back a partial response with no error flag, so
+      // without this warning there is no signal that truncation occurred.
+      if (choice.finish_reason === 'length') {
+        this.logger.warn(
+          {
+            model,
+            outputTokens: response.usage?.completion_tokens ?? 0,
+            finishReason: 'length',
+          },
+          'OpenRouter response truncated by max_tokens cap — output is incomplete. Consider increasing responseReserve or reducing input context.',
+        );
+      }
+
       // OpenRouter doesn't support Anthropic-style prompt caching.
       // Cache token fields are always 0.
       const usage: LLMUsage = {


### PR DESCRIPTION
## **User description**
## Summary

Switches four agents from `standard` to `fast` tier (Gemini Flash via OpenRouter). Closes #648.

- **contacts** — structural CRUD + briefings, no judgment calls, never user-facing → fast
- **calendar** — procedural scheduling, rule-based conflict resolution → fast
- **research-analyst** — well-defined search+synthesize workflow → fast (trial, watch synthesis quality)
- **ceo-inbox** — rule-based triage; CEO reviews reply drafts before send → fast (trial, watch draft quality)

The digest agent was already on fast tier (PR #60). coordinator, writing-scout, security-triage, T2125-expense-tracker, and essay-editor remain on standard — see issue #648 for rationale.

Also fixes a silent failure introduced by moving ceo-inbox to OpenRouter: `OpenRouterProvider.chat()` was silently returning truncated responses (finish_reason === 'length') as complete text with no log signal. A warn is now emitted so truncation events are visible in production log aggregators.

**Depends on curia-deploy PR #61** (standard/powerful tier remapping) to be deployed before the standard-tier agents' model changes take effect.

## Agents staying on standard (documented)

| Agent | Reason |
|---|---|
| coordinator | Hub for all delegation — persona, tone, trust decisions |
| writing-scout | Pattern recognition and taste; low tolerance for quality drops |
| security-triage | Threat assessment errors have real consequences |
| T2125-expense-tracker | Tax compliance, financial accuracy |
| essay-editor | 12-step creative workflow with published output |

## Production quality check required (post-merge)

Before closing #648:
- [ ] Spot-check 3-5 research-analyst outputs — confirm synthesis quality is acceptable on Gemini Flash
- [ ] Review 2 inbox triage cycles — confirm URGENT/ACTIONABLE classification is correct and draft reply quality is acceptable
- [ ] Monitor for `finish_reason: length` warnings in logs after ceo-inbox triage runs

## Test plan

- [ ] 2520 tests pass, 2 skipped (same pre-existing DB-required failures as main)
- [ ] 2 new tests in `openrouter.test.ts`: truncation warn fires on `finish_reason='length'`; no warn fires on `stop`
- [ ] Deploy and run quality spot-check (see above)


___

## **CodeAnt-AI Description**
Downgrade selected agents to the fast tier and warn when OpenRouter cuts off a response

### What Changed
- Contacts, calendar, research-analyst, and ceo-inbox now run on the fast tier instead of standard
- Research and scheduling tasks continue to work as before, but with lower-cost model settings
- When OpenRouter stops a reply because it hit the output limit, the system now logs a warning instead of treating the reply as complete
- Truncated replies still return to the caller, but operators now have a visible signal that the response was cut off

### Impact
`✅ Lower cost for routine agent work`
`✅ Faster contact, calendar, and inbox handling`
`✅ Clearer alerts when AI replies are cut off`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
