### PR TITLE
feat: smart auto-promotion for provisional contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **`contact-register` auto-promotion** — provisional contacts are now promoted to confirmed automatically when any of three engagement signals fire: Curia has sent them email (`curia_outbound`, self-contained DB check), the CEO emailed them from their personal inbox (`ceo_has_sent` input), or the CEO attended a calendar event with them (`calendar_accepted` input). Blocked contacts are never promoted; confirmed contacts are a no-op. Returns `promoted` and `promotion_signal` in the response. (#633)
+- **Contacts agent daily sweep** — new 8 AM cron scans provisional contacts against the CEO's Sent folder and calendar; promotes matching contacts via `contact-register`. `ceo-inbox-list` and `contact-register` added to contacts agent pinned skills. (#633)
+
+### Changed
+
+- **`ceo-inbox-list` message shape** — messages now include `to` and `cc` participant arrays; previously only `from` was exposed. Sent folder sweeps no longer require per-message `getMessage` calls. (#633)
+
 ### Changed
 
 - **Agent tier downgrades** — contacts, calendar, research-analyst, and ceo-inbox moved from `standard` to `fast` tier. (#648)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,13 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **`contact-register` auto-promotion** — provisional contacts are now promoted to confirmed automatically when any of three engagement signals fire: Curia has sent them email (`curia_outbound`, self-contained DB check), the CEO emailed them from their personal inbox (`ceo_has_sent` input), or the CEO attended a calendar event with them (`calendar_accepted` input). Blocked contacts are never promoted; confirmed contacts are a no-op. Returns `promoted` and `promotion_signal` in the response. (#633)
-- **Contacts agent daily sweep** — new 8 AM cron scans provisional contacts against the CEO's Sent folder and calendar; promotes matching contacts via `contact-register`. `ceo-inbox-list` and `contact-register` added to contacts agent pinned skills. (#633)
+- **`contact-register` auto-promotion** — provisional contacts promoted to confirmed on Curia outbound, CEO email, or calendar signals; returns `promoted` and `promotion_signal`. (#633)
+- **Contacts agent daily sweep** — 8 AM cron reconciles provisional contacts against CEO Sent folder and calendar. (#633)
+- **Contacts agent pinned skills** — `ceo-inbox-list` and `contact-register` added. (#633)
 
 ### Changed
 
-- **`ceo-inbox-list` message shape** — messages now include `to` and `cc` participant arrays; previously only `from` was exposed. Sent folder sweeps no longer require per-message `getMessage` calls. (#633)
-
-### Changed
-
+- **`ceo-inbox-list` message shape** — messages now include `to` and `cc` recipient arrays. (#633)
 - **Agent tier downgrades** — contacts, calendar, research-analyst, and ceo-inbox moved from `standard` to `fast` tier. (#648)
 
 ### Fixed

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -250,6 +250,9 @@ schedule:
       2. Call ceo-inbox-list with folder: "SENT", unread_only: false,
          received_after_hours: 2160 (90 days), limit: 50. Collect all email addresses
          from the "to" and "cc" arrays across all returned messages. Deduplicate into a set.
+         Note: ceo-inbox-list is capped at 50 messages per call by the skill definition.
+         For high-volume inboxes this may miss older provisional contacts.
+         @TODO: add pagination support to ceo-inbox-list to scan beyond 50 messages.
 
       3. Call calendar-list-events with a wide date range: timeMin 90 days ago,
          timeMax 90 days from now. Collect all attendee email addresses from

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -248,8 +248,8 @@ schedule:
          If the count is zero, exit and report that no provisional contacts need promotion.
 
       2. Call ceo-inbox-list with folder: "SENT", unread_only: false,
-         received_after_hours: 2160 (90 days). Collect all email addresses from the
-         "to" and "cc" arrays across all returned messages. Deduplicate into a set.
+         received_after_hours: 2160 (90 days), limit: 50. Collect all email addresses
+         from the "to" and "cc" arrays across all returned messages. Deduplicate into a set.
 
       3. Call calendar-list-events with a wide date range: timeMin 90 days ago,
          timeMax 90 days from now. Collect all attendee email addresses from
@@ -261,9 +261,11 @@ schedule:
          - Check whether their email appears in the Sent folder set (step 2) or
            the calendar attendee set (step 3).
          - If found in Sent folder: call contact-register with channel: "email",
-           identifier: their email, displayName: their display name,
+           identifier: their email address, displayName: their display name,
            messageTimestamp: the current ISO 8601 time, ceo_has_sent: true.
-         - If found in calendar only: call contact-register with calendar_accepted: true.
+         - If found in calendar only (not in Sent folder): call contact-register with
+           channel: "email", identifier: their email address, displayName: their display
+           name, messageTimestamp: the current ISO 8601 time, calendar_accepted: true.
          - contact-register automatically checks the curia_outbound signal for every call.
 
       5. Report a clear summary: how many provisional contacts were checked, how many

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -224,8 +224,49 @@ pinned_skills:
   # Calendar — read-only, used for meeting history enrichment in briefings only.
   # Calendar specialist owns the domain; contacts keeps this read-only pin for briefing enrichment.
   - calendar-list-events
+  # Promotion sweep — access to CEO Sent folder and contact-register for daily sweep.
+  # ceo-inbox-list is intentionally scoped here: contacts only uses it read-only (folder: SENT)
+  # to collect recipient email addresses; it never reads inbox triage state or writes messages.
+  - ceo-inbox-list
+  - contact-register
 
 schedule:
   - cron: "0 9 * * 1"   # Mondays at 9 AM
     task: "Run your weekly contacts dedup scan — find probable and certain duplicate contact pairs, present them to the CEO for review one pair at a time, and merge confirmed pairs."
     expectedDurationSeconds: 300
+
+  - cron: "0 8 * * *"   # Daily at 8 AM
+    task: >
+      Run the provisional contact promotion sweep. Your goal is to auto-promote provisional
+      contacts to confirmed based on engagement signals from the CEO's Sent folder and calendar.
+      The curia_outbound signal (Curia itself has emailed this contact) fires automatically
+      inside contact-register — no explicit check needed for it.
+
+      Steps:
+
+      1. Call contact-list with status: "provisional" to get all provisional contacts.
+         If the count is zero, exit and report that no provisional contacts need promotion.
+
+      2. Call ceo-inbox-list with folder: "SENT", unread_only: false,
+         received_after_hours: 2160 (90 days). Collect all email addresses from the
+         "to" and "cc" arrays across all returned messages. Deduplicate into a set.
+
+      3. Call calendar-list-events with a wide date range: timeMin 90 days ago,
+         timeMax 90 days from now. Collect all attendee email addresses from
+         non-cancelled events. Deduplicate into a set.
+
+      4. For each provisional contact from step 1:
+         - Use contact-lookup (by: "name") to get their channel identities (email addresses).
+         - If a contact has no email identity, skip them.
+         - Check whether their email appears in the Sent folder set (step 2) or
+           the calendar attendee set (step 3).
+         - If found in Sent folder: call contact-register with channel: "email",
+           identifier: their email, displayName: their display name,
+           messageTimestamp: the current ISO 8601 time, ceo_has_sent: true.
+         - If found in calendar only: call contact-register with calendar_accepted: true.
+         - contact-register automatically checks the curia_outbound signal for every call.
+
+      5. Report a clear summary: how many provisional contacts were checked, how many
+         were promoted, which signal triggered each promotion (curia_outbound,
+         ceo_has_sent, or calendar_accepted), and how many provisional contacts remain.
+    expectedDurationSeconds: 180

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -17,6 +17,11 @@ export interface NylasMessageSummary {
   threadId: string;
   subject: string;
   from: NylasParticipant[];
+  // to and cc are included in list responses by the Nylas v3 API. Needed by
+  // the Sent folder sweep (issue #633) so the contacts agent can collect recipient
+  // addresses without a separate getMessage() call per message.
+  to: NylasParticipant[];
+  cc: NylasParticipant[];
   snippet: string;
   date: number;
   unread: boolean;
@@ -25,8 +30,7 @@ export interface NylasMessageSummary {
 }
 
 export interface NylasMessageFull extends NylasMessageSummary {
-  to: NylasParticipant[];
-  cc: NylasParticipant[];
+  // to and cc are inherited from NylasMessageSummary
   bcc: NylasParticipant[];
   body: string;
   labels: string[];
@@ -381,6 +385,10 @@ function normalizeMessageSummary(msg: NylasApiMessage): NylasMessageSummary {
     threadId: msg.thread_id ?? '',
     subject: msg.subject ?? '',
     from: (msg.from ?? []).map(normParticipant),
+    // Nylas v3 list responses include to and cc. Expose them in the summary so
+    // Sent-folder sweeps can collect recipient addresses without per-message reads.
+    to: (msg.to ?? []).map(normParticipant),
+    cc: (msg.cc ?? []).map(normParticipant),
     snippet: msg.snippet ?? '',
     date: msg.date ?? 0,
     unread: msg.unread ?? false,
@@ -392,8 +400,7 @@ function normalizeMessageSummary(msg: NylasApiMessage): NylasMessageSummary {
 function normalizeMessageFull(msg: NylasApiMessage): NylasMessageFull {
   return {
     ...normalizeMessageSummary(msg),
-    to: (msg.to ?? []).map(normParticipant),
-    cc: (msg.cc ?? []).map(normParticipant),
+    // to and cc come from normalizeMessageSummary; only bcc is full-message-only.
     bcc: (msg.bcc ?? []).map(normParticipant),
     body: msg.body ?? '',
     labels: msg.labels ?? msg.folders ?? [],

--- a/skills/ceo-inbox-list/skill.json
+++ b/skills/ceo-inbox-list/skill.json
@@ -1,18 +1,18 @@
 {
   "name": "ceo-inbox-list",
   "description": "List recent messages from the CEO's personal email inbox. Intended for use by the ceo-inbox agent — accesses the CEO's personal email, do not call from other agents.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
     "limit": "number? (max messages to return, 1–50, default 20)",
-    "folder": "string? (Gmail folder/label to list, default 'INBOX')",
+    "folder": "string? (Gmail folder/label to list, default 'INBOX'; use 'SENT' for the Sent folder)",
     "unread_only": "boolean? (if true, only return unread messages, default true)",
     "received_after_hours": "number? (only return messages received in the last N hours, e.g. 24 for last day; ignored if received_after_timestamp is set)",
     "received_after_timestamp": "number? (unix timestamp in seconds — only return messages received after this time; takes precedence over received_after_hours)"
   },
   "outputs": {
-    "messages": "array of { id, threadId, from, subject, date, snippet, unread, folders, attachments: [{ id, filename, contentType, size }] }",
+    "messages": "array of { id, threadId, from, to, cc, subject, date, snippet, unread, folders, attachments: [{ id, filename, contentType, size }] }",
     "count": "number of messages returned"
   },
   "permissions": [],

--- a/skills/contact-register/handler.test.ts
+++ b/skills/contact-register/handler.test.ts
@@ -402,3 +402,226 @@ describe('ContactRegisterHandler — bus event emission', () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe('ContactRegisterHandler — auto-promotion signals', () => {
+  let handler: ContactRegisterHandler;
+  let contactService: ContactService;
+  let provisionalId: string;
+
+  beforeEach(async () => {
+    handler = new ContactRegisterHandler();
+    contactService = ContactService.createInMemory();
+
+    // Seed a provisional contact — the subject of all promotion tests
+    const contact = await contactService.createContact({
+      displayName: 'Eve Provisional',
+      status: 'provisional',
+      source: 'agent_called',
+    });
+    provisionalId = contact.id;
+    await contactService.linkIdentity({
+      contactId: contact.id,
+      channel: 'email',
+      channelIdentifier: 'eve@example.com',
+      source: 'agent_called',
+    });
+  });
+
+  it('promotes a provisional contact when curia_outbound signal fires (outboundMessageCount > 0)', async () => {
+    // Simulate Curia having sent an outbound message to this contact
+    await contactService.updateScoringFields(provisionalId, {
+      outboundMessageCountDelta: 1,
+      contactConfidence: 0.5,
+    });
+
+    const ctx = makeCtx({
+      contactService,
+      input: {
+        channel: 'email',
+        identifier: 'eve@example.com',
+        displayName: 'Eve',
+        messageTimestamp: TIMESTAMP_A,
+        // No agent-asserted signals — curia_outbound fires from DB alone
+      },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.status).toBe('confirmed');
+    expect(data.promoted).toBe(true);
+    expect(data.promotion_signal).toBe('curia_outbound');
+  });
+
+  it('promotes a provisional contact when ceo_has_sent is true', async () => {
+    const ctx = makeCtx({
+      contactService,
+      input: {
+        channel: 'email',
+        identifier: 'eve@example.com',
+        displayName: 'Eve',
+        messageTimestamp: TIMESTAMP_A,
+        ceo_has_sent: true,
+      },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.status).toBe('confirmed');
+    expect(data.promoted).toBe(true);
+    expect(data.promotion_signal).toBe('ceo_has_sent');
+  });
+
+  it('promotes a provisional contact when calendar_accepted is true', async () => {
+    const ctx = makeCtx({
+      contactService,
+      input: {
+        channel: 'email',
+        identifier: 'eve@example.com',
+        displayName: 'Eve',
+        messageTimestamp: TIMESTAMP_A,
+        calendar_accepted: true,
+      },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.status).toBe('confirmed');
+    expect(data.promoted).toBe(true);
+    expect(data.promotion_signal).toBe('calendar_accepted');
+  });
+
+  it('prefers curia_outbound over ceo_has_sent when both signals are present', async () => {
+    await contactService.updateScoringFields(provisionalId, {
+      outboundMessageCountDelta: 2,
+      contactConfidence: 0.6,
+    });
+
+    const ctx = makeCtx({
+      contactService,
+      input: {
+        channel: 'email',
+        identifier: 'eve@example.com',
+        displayName: 'Eve',
+        messageTimestamp: TIMESTAMP_A,
+        ceo_has_sent: true,
+      },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.promoted).toBe(true);
+    // curia_outbound takes priority (checked first)
+    expect(data.promotion_signal).toBe('curia_outbound');
+  });
+
+  it('does not promote a blocked contact regardless of signals', async () => {
+    // Block the contact
+    await contactService.setStatus(provisionalId, 'blocked');
+
+    const ctx = makeCtx({
+      contactService,
+      input: {
+        channel: 'email',
+        identifier: 'eve@example.com',
+        displayName: 'Eve',
+        messageTimestamp: TIMESTAMP_A,
+        ceo_has_sent: true,
+        calendar_accepted: true,
+      },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.status).toBe('blocked');
+    expect(data.promoted).toBe(false);
+    expect(data.promotion_signal).toBeUndefined();
+  });
+
+  it('is a no-op for already-confirmed contacts (no status change, no error)', async () => {
+    // Seed a separate confirmed contact
+    const confirmed = await contactService.createContact({
+      displayName: 'Frank Confirmed',
+      status: 'confirmed',
+      source: 'ceo_stated',
+    });
+    await contactService.linkIdentity({
+      contactId: confirmed.id,
+      channel: 'email',
+      channelIdentifier: 'frank@example.com',
+      source: 'ceo_stated',
+    });
+
+    const ctx = makeCtx({
+      contactService,
+      input: {
+        channel: 'email',
+        identifier: 'frank@example.com',
+        displayName: 'Frank',
+        messageTimestamp: TIMESTAMP_A,
+        ceo_has_sent: true,
+      },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.status).toBe('confirmed');
+    expect(data.promoted).toBe(false);
+    expect(data.promotion_signal).toBeUndefined();
+  });
+
+  it('returns promoted: false when no signal fires for a provisional contact', async () => {
+    // No outbound count, no ceo_has_sent, no calendar_accepted
+    const ctx = makeCtx({
+      contactService,
+      input: {
+        channel: 'email',
+        identifier: 'eve@example.com',
+        displayName: 'Eve',
+        messageTimestamp: TIMESTAMP_A,
+      },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.status).toBe('provisional');
+    expect(data.promoted).toBe(false);
+    expect(data.promotion_signal).toBeUndefined();
+  });
+
+  it('promotes a newly-created provisional contact when ceo_has_sent fires on first registration', async () => {
+    // The contact does not exist yet — contact-register creates and immediately promotes it
+    const ctx = makeCtx({
+      contactService,
+      input: {
+        channel: 'email',
+        identifier: 'newceo@example.com',
+        displayName: 'New CEO Contact',
+        messageTimestamp: TIMESTAMP_A,
+        ceo_has_sent: true,
+      },
+    });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    const data = (result as { success: true; data: Record<string, unknown> }).data;
+    expect(data.created).toBe(true);
+    expect(data.status).toBe('confirmed');
+    expect(data.promoted).toBe(true);
+    expect(data.promotion_signal).toBe('ceo_has_sent');
+  });
+});

--- a/skills/contact-register/handler.ts
+++ b/skills/contact-register/handler.ts
@@ -208,31 +208,55 @@ export class ContactRegisterHandler implements SkillHandler {
       //      no caller input required.
       //   2. ceo_has_sent — caller asserts the CEO personally emailed this address.
       //   3. calendar_accepted — caller asserts the CEO attended an event with them.
+      //
+      // Important: resolvedSender.status is a snapshot from Step 1. Fetch the contact
+      // fresh from the DB so a concurrent call that blocked/confirmed the contact between
+      // Step 1 and now is respected — this prevents undoing a deliberate block.
 
       let promoted = false;
       let promotionSignal: string | null = null;
 
       if (resolvedSender.status === 'provisional') {
-        // Fetch the full contact record to read outbound_message_count.
-        // This fetch is needed even when the pipeline is present, because the pipeline
-        // does not update outbound_message_count for inbound registrations.
+        // Fetch the full contact record to read outbound_message_count and get the
+        // authoritative current status. This guards against TOCTOU: if a concurrent
+        // call changed the status to blocked/confirmed since Step 1, we bail out.
         const contactForPromotion = await ctx.contactService.getContact(contactId);
 
-        if (contactForPromotion) {
+        if (!contactForPromotion) {
+          // Contact was resolved moments ago but is no longer retrievable — possible
+          // concurrent deletion (e.g. admin operation). Log and skip promotion safely.
+          ctx.log.warn(
+            { contactId, channel },
+            'contact-register: getContact returned undefined during promotion check — skipping promotion',
+          );
+        } else if (contactForPromotion.status !== 'provisional') {
+          // Status changed since Step 1 (concurrent block or promotion). Respect
+          // the current DB state and skip our own promotion attempt.
+          ctx.log.info(
+            { contactId, currentStatus: contactForPromotion.status },
+            'contact-register: contact status changed since Step 1 — skipping promotion',
+          );
+        } else {
+          // Contact is still provisional — evaluate signals.
+          let decidedSignal: string | null = null;
+
           if (contactForPromotion.outboundMessageCount > 0) {
             // Curia has previously sent a message to this contact — strong signal.
-            promotionSignal = 'curia_outbound';
+            decidedSignal = 'curia_outbound';
           } else if (ceo_has_sent === true) {
             // Calling agent asserts the CEO sent from their personal inbox.
-            promotionSignal = 'ceo_has_sent';
+            decidedSignal = 'ceo_has_sent';
           } else if (calendar_accepted === true) {
             // Calling agent asserts the CEO has a shared accepted calendar event.
-            promotionSignal = 'calendar_accepted';
+            decidedSignal = 'calendar_accepted';
           }
 
-          if (promotionSignal) {
+          if (decidedSignal) {
+            // Assign promotionSignal only after the DB write succeeds so the two
+            // fields remain consistent: promotionSignal !== null ↔ promoted === true.
             await ctx.contactService.setStatus(contactId, 'confirmed');
             promoted = true;
+            promotionSignal = decidedSignal;
             ctx.log.info(
               { contactId, promotionSignal },
               'contact-register: auto-promoted provisional contact to confirmed',
@@ -267,7 +291,15 @@ export class ContactRegisterHandler implements SkillHandler {
 
       // Refetch after scoring update and any promotion so status/confidence reflect
       // the latest values. Falls back to the pre-update snapshot if the fetch fails.
+      // Log a warning when the refetch fails after a promotion so callers can
+      // detect the stale-status edge case (promoted: true but status: 'provisional').
       const updatedContact = await ctx.contactService.getContact(contactId);
+      if (!updatedContact && promoted) {
+        ctx.log.warn(
+          { contactId, promotionSignal, channel },
+          'contact-register: getContact returned undefined after promotion — status in response reflects pre-promotion snapshot',
+        );
+      }
 
       ctx.log.info({ contactId, created, promoted, channel }, 'contact-register: interaction registered');
 

--- a/skills/contact-register/handler.ts
+++ b/skills/contact-register/handler.ts
@@ -11,8 +11,17 @@
 //   1. Resolve by channel identity (or create a provisional contact if unknown)
 //   2. Trigger a scoring delta via the confidence pipeline (or update last_seen_at
 //      directly when the pipeline is not wired)
+//   2b. Auto-promote provisional contacts when any engagement signal fires:
+//       - curia_outbound: contact has outbound_message_count > 0 in the DB
+//       - ceo_has_sent: calling agent asserts the CEO sent email to this address
+//       - calendar_accepted: calling agent asserts the CEO attended an event with them
 //   3. Emit a contact.resolved bus event for the audit trail
 //   4. Return the contact record for use in triage / classification
+//
+// Promotion rules:
+//   - Blocked contacts are never promoted regardless of signals.
+//   - Already-confirmed contacts are a no-op (signals are not evaluated).
+//   - Only provisional contacts are checked and eligible for promotion.
 //
 // Services used:
 //   - contactService (universal — always available)
@@ -25,12 +34,22 @@ import { createContactResolved } from '../../src/bus/events.js';
 
 export class ContactRegisterHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const { channel, identifier, displayName, direction, messageTimestamp } = ctx.input as {
+    const {
+      channel,
+      identifier,
+      displayName,
+      direction,
+      messageTimestamp,
+      ceo_has_sent,
+      calendar_accepted,
+    } = ctx.input as {
       channel?: string;
       identifier?: string;
       displayName?: string;
       direction?: string;
       messageTimestamp?: string;
+      ceo_has_sent?: boolean;
+      calendar_accepted?: boolean;
     };
 
     // -- Input validation --
@@ -178,6 +197,50 @@ export class ContactRegisterHandler implements SkillHandler {
         }
       }
 
+      // -- Step 2b: Auto-promote provisional contacts --
+      //
+      // Check three engagement signals. Any single signal is sufficient to promote
+      // provisional → confirmed. Blocked contacts are never promoted. Already-confirmed
+      // contacts skip this block entirely (no status change, no extra DB reads).
+      //
+      // Signal priority (first match wins for the returned promotion_signal):
+      //   1. curia_outbound — Curia has already emailed this person; DB-sourced,
+      //      no caller input required.
+      //   2. ceo_has_sent — caller asserts the CEO personally emailed this address.
+      //   3. calendar_accepted — caller asserts the CEO attended an event with them.
+
+      let promoted = false;
+      let promotionSignal: string | null = null;
+
+      if (resolvedSender.status === 'provisional') {
+        // Fetch the full contact record to read outbound_message_count.
+        // This fetch is needed even when the pipeline is present, because the pipeline
+        // does not update outbound_message_count for inbound registrations.
+        const contactForPromotion = await ctx.contactService.getContact(contactId);
+
+        if (contactForPromotion) {
+          if (contactForPromotion.outboundMessageCount > 0) {
+            // Curia has previously sent a message to this contact — strong signal.
+            promotionSignal = 'curia_outbound';
+          } else if (ceo_has_sent === true) {
+            // Calling agent asserts the CEO sent from their personal inbox.
+            promotionSignal = 'ceo_has_sent';
+          } else if (calendar_accepted === true) {
+            // Calling agent asserts the CEO has a shared accepted calendar event.
+            promotionSignal = 'calendar_accepted';
+          }
+
+          if (promotionSignal) {
+            await ctx.contactService.setStatus(contactId, 'confirmed');
+            promoted = true;
+            ctx.log.info(
+              { contactId, promotionSignal },
+              'contact-register: auto-promoted provisional contact to confirmed',
+            );
+          }
+        }
+      }
+
       // -- Step 3: Emit contact.resolved bus event (audit trail) --
 
       if (ctx.bus) {
@@ -202,11 +265,11 @@ export class ContactRegisterHandler implements SkillHandler {
 
       // -- Step 4: Return updated contact record --
 
-      // Refetch after scoring update so contact_confidence reflects the latest value.
-      // Falls back to the pre-update snapshot if the fetch fails (non-fatal).
+      // Refetch after scoring update and any promotion so status/confidence reflect
+      // the latest values. Falls back to the pre-update snapshot if the fetch fails.
       const updatedContact = await ctx.contactService.getContact(contactId);
 
-      ctx.log.info({ contactId, created, channel }, 'contact-register: interaction registered');
+      ctx.log.info({ contactId, created, promoted, channel }, 'contact-register: interaction registered');
 
       return {
         success: true,
@@ -216,6 +279,8 @@ export class ContactRegisterHandler implements SkillHandler {
           status: updatedContact?.status ?? resolvedSender.status,
           contact_confidence: updatedContact?.contactConfidence ?? resolvedSender.contactConfidence,
           created,
+          promoted,
+          ...(promotionSignal !== null ? { promotion_signal: promotionSignal } : {}),
         },
       };
     } catch (err) {

--- a/skills/contact-register/handler.ts
+++ b/skills/contact-register/handler.ts
@@ -252,15 +252,25 @@ export class ContactRegisterHandler implements SkillHandler {
           }
 
           if (decidedSignal) {
-            // Assign promotionSignal only after the DB write succeeds so the two
-            // fields remain consistent: promotionSignal !== null ↔ promoted === true.
-            await ctx.contactService.setStatus(contactId, 'confirmed');
-            promoted = true;
-            promotionSignal = decidedSignal;
-            ctx.log.info(
-              { contactId, promotionSignal },
-              'contact-register: auto-promoted provisional contact to confirmed',
-            );
+            // promoteToConfirmed is a conditional UPDATE (WHERE status = 'provisional').
+            // If a concurrent admin block landed between our getContact check above and
+            // this write, the row won't match and wasPromoted returns false — so we
+            // never undo a deliberate block. promotionSignal is set only on success
+            // so that promotionSignal !== null ↔ promoted === true always holds.
+            const wasPromoted = await ctx.contactService.promoteToConfirmed(contactId);
+            if (wasPromoted) {
+              promoted = true;
+              promotionSignal = decidedSignal;
+              ctx.log.info(
+                { contactId, promotionSignal },
+                'contact-register: auto-promoted provisional contact to confirmed',
+              );
+            } else {
+              ctx.log.info(
+                { contactId },
+                'contact-register: promotion aborted — contact status changed concurrently',
+              );
+            }
           }
         }
       }

--- a/skills/contact-register/skill.json
+++ b/skills/contact-register/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "contact-register",
-  "description": "Register a contact interaction from an agent that reads a channel directly, outside the normal dispatcher pipeline. Given a channel type and identifier (e.g. an email address), resolves the sender to a known contact — or creates a provisional one — then updates last_seen_at and triggers a confidence scoring delta. Emits a contact.resolved bus event for the audit trail. Use this once per sender during triage when processing messages that bypass handleInbound(). Returns the contact record.",
-  "version": "1.0.0",
+  "description": "Register a contact interaction from an agent that reads a channel directly, outside the normal dispatcher pipeline. Given a channel type and identifier (e.g. an email address), resolves the sender to a known contact — or creates a provisional one — then updates last_seen_at and triggers a confidence scoring delta. Automatically promotes provisional contacts to confirmed when engagement signals fire: Curia has sent outbound email to this contact (self-contained DB check), the CEO has sent email to them (ceo_has_sent), or the CEO attended a calendar event with them (calendar_accepted). Blocked contacts are never promoted; confirmed contacts are a no-op. Emits a contact.resolved bus event for the audit trail. Use this once per sender during triage when processing messages that bypass handleInbound(). Returns the contact record.",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
@@ -9,14 +9,18 @@
     "identifier": "string (channel identifier, e.g. sender email address)",
     "displayName": "string (sender's display name — used as the contact name if a new contact is created)",
     "direction": "string? (message direction: 'inbound' | 'outbound'; defaults to 'inbound')",
-    "messageTimestamp": "string (ISO 8601 timestamp of the message)"
+    "messageTimestamp": "string (ISO 8601 timestamp of the message)",
+    "ceo_has_sent": "boolean? (when true, asserts the CEO has sent email to this address from their personal inbox — promotes provisional contact to confirmed)",
+    "calendar_accepted": "boolean? (when true, asserts the CEO has an accepted calendar event with this person — promotes provisional contact to confirmed)"
   },
   "outputs": {
     "contact_id": "string",
     "display_name": "string",
     "status": "string (confirmed | provisional | blocked)",
     "contact_confidence": "number (0.0–1.0)",
-    "created": "boolean (true if a new provisional contact was created)"
+    "created": "boolean (true if a new provisional contact was created)",
+    "promoted": "boolean (true if the contact was auto-promoted from provisional to confirmed)",
+    "promotion_signal": "string? (present when promoted=true: 'curia_outbound' | 'ceo_has_sent' | 'calendar_accepted')"
   },
   "permissions": [],
   "secrets": [],

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -52,6 +52,15 @@ interface ContactServiceBackend {
   resolveByChannelIdentity(channel: string, channelIdentifier: string): Promise<ResolvedSender | null>;
   unlinkIdentity(identityId: string): Promise<boolean>;
   setIdentityStatus(identityId: string, status: IdentityStatus): Promise<ChannelIdentity>;
+
+  /**
+   * Atomically promote a contact from provisional → confirmed only if the contact's
+   * current status is still 'provisional' at write time. Returns true if the row was
+   * updated, false if the contact was not provisional (concurrent block or already
+   * confirmed) — callers should treat false as "promotion did not happen".
+   */
+  promoteToConfirmed(contactId: string): Promise<boolean>;
+
   getAuthOverrides(contactId: string): Promise<Array<{ permission: string; granted: boolean }>>;
   createAuthOverride(override: AuthOverride): Promise<void>;
   revokeAuthOverride(contactId: string, permission: string): Promise<boolean>;
@@ -540,6 +549,17 @@ export class ContactService {
     };
 
     return this.updateStoredContact(updated);
+  }
+
+  /**
+   * Atomically promote a contact from provisional → confirmed.
+   * Returns true if the promotion happened, false if the contact was not provisional
+   * at write time (concurrent block or already confirmed). This is the preferred
+   * method for auto-promotion: it prevents TOCTOU races where a concurrent admin
+   * block could be silently overwritten by an unconditional setStatus call.
+   */
+  async promoteToConfirmed(contactId: string): Promise<boolean> {
+    return this.backend.promoteToConfirmed(contactId);
   }
 
   /** Remove a channel identity by its ID. Returns true if found and removed, false if not found. */
@@ -1132,6 +1152,17 @@ class PostgresContactBackend implements ContactServiceBackend {
     return (result.rowCount ?? 0) > 0;
   }
 
+  async promoteToConfirmed(contactId: string): Promise<boolean> {
+    // Atomic conditional update — only flips to confirmed when status is STILL
+    // 'provisional' at DB write time. Guards against concurrent blocks between
+    // the caller's last getContact check and this write (TOCTOU mitigation).
+    const result = await this.pool.query(
+      `UPDATE contacts SET status = 'confirmed', updated_at = now() WHERE id = $1 AND status = 'provisional'`,
+      [contactId],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
   async setIdentityStatus(identityId: string, status: IdentityStatus): Promise<ChannelIdentity> {
     this.logger.debug({ identityId, status }, 'contacts: updating identity status');
     const result = await this.pool.query<{
@@ -1550,6 +1581,15 @@ class InMemoryContactBackend implements ContactServiceBackend {
       lastSeenAt: updates.lastSeenAt ?? contact.lastSeenAt,
       updatedAt: new Date(),
     });
+  }
+
+  async promoteToConfirmed(contactId: string): Promise<boolean> {
+    // JS is single-threaded, so check-and-set here is effectively atomic for tests.
+    // The same conditional-update semantics as the Postgres implementation apply.
+    const contact = this.contacts.get(contactId);
+    if (!contact || contact.status !== 'provisional') return false;
+    this.contacts.set(contactId, { ...contact, status: 'confirmed', updatedAt: new Date() });
+    return true;
   }
 
   async createIdentity(identity: ChannelIdentity): Promise<void> {


### PR DESCRIPTION
## **User description**
Closes #633

## Summary

- **`contact-register` now auto-promotes provisional contacts** when any of three engagement signals fire — Curia has emailed them (`curia_outbound`, self-contained DB check), the CEO emailed them from their personal inbox (`ceo_has_sent` input), or the CEO attended a calendar event with them (`calendar_accepted` input). Blocked contacts are never promoted; confirmed contacts are a no-op. Returns `promoted: bool` and `promotion_signal` in the response.
- **`ceo-inbox-list` messages now include `to` and `cc`** participant arrays. Previously only `from` was exposed; the Sent-folder sweep needs recipient addresses without per-message `getMessage()` calls.
- **Contacts agent has a new daily 8 AM promotional sweep** that lists provisional contacts, checks the CEO's Sent folder and calendar for engagement signals, and promotes matches via `contact-register`. `ceo-inbox-list` and `contact-register` are now pinned to the contacts agent.

## Acceptance criteria coverage

- [x] `contact-register` checks `outbound_message_count > 0` on resolved provisional contacts and auto-promotes without any new input
- [x] `contact-register` accepts optional `ceo_has_sent` boolean — promotes provisional contact when true
- [x] `contact-register` accepts optional `calendar_accepted` boolean — promotes provisional contact when true
- [x] `contact-register` returns `promoted: true` and `promotion_signal` in response data when a promotion occurs
- [x] `contact-register` does not promote blocked contacts regardless of signals
- [x] `contact-register` is a no-op for already-confirmed contacts (no error, no status change)
- [x] `ceo-inbox-list` output includes `to` and `cc` arrays on each message
- [x] Contacts agent has a daily scheduled sweep that lists provisional contacts, checks Sent folder + calendar, and promotes matches via `contact-register`
- [x] `ceo-inbox-list` is pinned to the contacts agent
- [x] Unit tests cover all three promotion signals, blocked-contact guard, and already-confirmed no-op (8 new tests, 26 total in the file)

## Test plan

- [x] All 26 `contact-register` handler tests pass (18 existing + 8 new promotion tests)
- [x] Full test suite: 2528 tests pass, 0 new failures (2 pre-existing DB integration failures require `DATABASE_URL`)
- [x] TypeScript: clean `tsc --noEmit`
- [ ] Dry-run validation: trigger the contacts agent via delegated mode to review sweep promotions before scheduled runs go live (manual — requires prod access)


___

## **CodeAnt-AI Description**
**Auto-promote provisional contacts from real engagement signals**

### What Changed
- Provisional contacts are now promoted to confirmed automatically when Curia has already emailed them, the CEO has emailed them, or the CEO has an accepted calendar event with them.
- Blocked contacts stay blocked, and already-confirmed contacts are left unchanged.
- The contact registration response now includes whether a promotion happened and which signal triggered it.
- CEO Sent-folder messages now expose recipient lists, so the contacts sweep can find matching contacts without extra message lookups.
- The contacts agent now runs a daily 8 AM sweep to check provisional contacts against the CEO’s Sent folder and calendar, then promotes matches through contact registration.

### Impact
`✅ Fewer manual contact reviews`
`✅ Faster promotion of warm contacts`
`✅ Less missed follow-up for CEO-sent replies`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Provisional contacts now auto-promote to confirmed status based on outbound email activity, CEO inbox interactions, or calendar event attendance.
  * Daily 8 AM automated sweep reconciles provisional contacts against CEO's sent emails and calendar events.
  * Message payloads now include recipient and CC participant arrays for improved contact tracking.

* **Chores**
  * Multiple agent services optimized to faster processing tier.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->