### PR TITLE
fix: embed is:unread in search string when unread_only is set with search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`email-list` unread filter with search** — when both `search` and `unread_only: true` are passed, `is:unread` is now embedded into the search string so the filter is preserved. Previously the Nylas v3 API silently dropped `unread_only` whenever `search` was also set, causing all messages (including already-processed ones) to be returned.
+
 - **OpenRouter truncation warning** — `OpenRouterProvider` now logs at `warn` level when `finish_reason === 'length'` so truncated responses are visible in production logs instead of silently passing as complete.
 
 ### Added

--- a/skills/email-list/handler.test.ts
+++ b/skills/email-list/handler.test.ts
@@ -120,6 +120,45 @@ describe('EmailListHandler — standard message fields', () => {
   });
 });
 
+describe('EmailListHandler — unread_only with search', () => {
+  it('embeds is:unread into the search string when both search and unread_only are provided', async () => {
+    const gateway = makeMockGateway();
+    const handler = new EmailListHandler();
+    await handler.execute(makeCtx({
+      outboundGateway: gateway,
+      input: { search: 'to:security@example.com', unread_only: true },
+    }));
+    const opts = (gateway!.listEmailMessages as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    // unread_only should be embedded in the search string, not passed as a separate filter
+    expect(opts.searchQueryNative).toBe('to:security@example.com is:unread');
+    expect(opts.unread).toBeUndefined();
+  });
+
+  it('does not add is:unread when unread_only is false', async () => {
+    const gateway = makeMockGateway();
+    const handler = new EmailListHandler();
+    await handler.execute(makeCtx({
+      outboundGateway: gateway,
+      input: { search: 'to:security@example.com', unread_only: false },
+    }));
+    const opts = (gateway!.listEmailMessages as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(opts.searchQueryNative).toBe('to:security@example.com');
+    expect(opts.unread).toBeUndefined();
+  });
+
+  it('uses native unread filter (not search string) when search is not set', async () => {
+    const gateway = makeMockGateway();
+    const handler = new EmailListHandler();
+    await handler.execute(makeCtx({
+      outboundGateway: gateway,
+      input: { unread_only: true },
+    }));
+    const opts = (gateway!.listEmailMessages as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(opts.unread).toBe(true);
+    expect(opts.searchQueryNative).toBeUndefined();
+  });
+});
+
 describe('EmailListHandler — error handling', () => {
   it('returns error when gateway throws', async () => {
     const gateway = {

--- a/skills/email-list/handler.ts
+++ b/skills/email-list/handler.ts
@@ -33,10 +33,20 @@ export class EmailListHandler implements SkillHandler {
 
     const options: ListMessagesOptions = {};
     if (typeof folder === 'string' && folder.trim()) options.folders = [folder.trim()];
-    if (unread_only === true) options.unread = true;
     if (typeof from === 'string' && from.trim()) options.from = from.trim();
     if (typeof subject === 'string' && subject.trim()) options.subject = subject.trim();
-    if (typeof search === 'string' && search.trim()) options.searchQueryNative = search.trim();
+
+    const rawSearch = typeof search === 'string' && search.trim() ? search.trim() : undefined;
+    if (rawSearch !== undefined) {
+      // Nylas v3: search_query_native cannot be combined with unread, folders, receivedAfter,
+      // from, or subject — they are silently dropped (see NylasClient.listMessages). For the
+      // unread filter specifically, embed Gmail's `is:unread` operator directly into the search
+      // string so it is preserved despite the Nylas limitation.
+      const effectiveSearch = unread_only === true ? `${rawSearch} is:unread` : rawSearch;
+      options.searchQueryNative = effectiveSearch;
+    } else {
+      if (unread_only === true) options.unread = true;
+    }
     // Coerce to a positive integer before forwarding — LLMs occasionally emit floats
     // (e.g. 12.7) and Nylas expects an int. Non-finite or non-positive values fall back
     // to DEFAULT_LIMIT.

--- a/skills/email-list/handler.ts
+++ b/skills/email-list/handler.ts
@@ -40,8 +40,15 @@ export class EmailListHandler implements SkillHandler {
     if (rawSearch !== undefined) {
       // Nylas v3: search_query_native cannot be combined with unread, folders, receivedAfter,
       // from, or subject — they are silently dropped (see NylasClient.listMessages). For the
-      // unread filter specifically, embed Gmail's `is:unread` operator directly into the search
-      // string so it is preserved despite the Nylas limitation.
+      // unread filter specifically, embed the provider-native unread operator directly into
+      // the search string so it is preserved despite the Nylas limitation.
+      //
+      // NOTE: `is:unread` is Gmail-specific syntax. Curia currently operates Gmail-only
+      // accounts, so this is correct. If a non-Gmail provider is ever configured (e.g.
+      // Outlook KQL uses `isRead:false`), the embedding here will need to be gated on
+      // account provider type — which will require threading provider metadata through
+      // OutboundGateway into the skill context.
+      // TODO: make unread embedding provider-aware when multi-provider support is added.
       const effectiveSearch = unread_only === true ? `${rawSearch} is:unread` : rawSearch;
       options.searchQueryNative = effectiveSearch;
     } else {

--- a/skills/email-list/handler.ts
+++ b/skills/email-list/handler.ts
@@ -48,7 +48,7 @@ export class EmailListHandler implements SkillHandler {
       // Outlook KQL uses `isRead:false`), the embedding here will need to be gated on
       // account provider type — which will require threading provider metadata through
       // OutboundGateway into the skill context.
-      // TODO: make unread embedding provider-aware when multi-provider support is added.
+      // TODO(#662): make unread embedding provider-aware when multi-provider support is added.
       const effectiveSearch = unread_only === true ? `${rawSearch} is:unread` : rawSearch;
       options.searchQueryNative = effectiveSearch;
     } else {


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause**: Nylas v3 silently drops the `unread` filter when `searchQueryNative` is also set (documented in `NylasClient.listMessages`). Callers passing both `search` and `unread_only: true` were unknowingly getting all messages matching the search, not just unread ones.
- **Fix**: When both `search` and `unread_only: true` are provided, embed Gmail's `is:unread` operator directly into the search string so it is preserved through the Nylas API call.
- **Tests**: Three new unit tests verify the embedding behavior, the no-op case (`unread_only: false`), and the fallback path when `search` is absent.

Closes #N/A — no issue filed; this was discovered via production incident where the security-triage agent sent duplicate replies because it could not filter unread-only messages when using a Gmail search string.

## Test plan

- [ ] `npm --prefix worktrees/curia-fix-email-list-unread test skills/email-list/handler.test.ts` — all 9 tests pass
- [ ] Verify no existing tests broken


___

## **CodeAnt-AI Description**
**Keep unread email filters working when search is also used**

### What Changed
- When a search query and `unread_only: true` are both provided, the unread filter is now included in the search itself so only unread messages are returned
- If `unread_only` is false, the search query is sent unchanged
- If there is no search query, unread messages are still filtered normally
- Added tests to cover all three cases

### Impact
`✅ Fewer duplicate replies`
`✅ Correct unread-only search results`
`✅ Safer email triage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
