### PR TITLE
fix: config-store retrieve fallback + store surfaces rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **`email-list` unread filter with search** — when both `search` and `unread_only: true` are passed, `is:unread` is now embedded into the search string so the filter is preserved. Previously the Nylas v3 API silently dropped `unread_only` whenever `search` was also set, causing all messages (including already-processed ones) to be returned.
-
+- **`config-store` retrieve label/key fallback** — `retrieve` now finds facts by `properties.key` when the node label doesn't match, making it resilient to label/key drift (e.g. year-rollover mismatch). (#660)
+- **`config-store` store surfaces rejection** — `store` now returns `stored: false` and an `action` field when `storeFact` rejects or rate-limits the write, instead of unconditionally reporting `stored: true`. (#661)
 - **OpenRouter truncation warning** — `OpenRouterProvider` now logs at `warn` level when `finish_reason === 'length'` so truncated responses are visible in production logs instead of silently passing as complete.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **`email-list` unread filter with search** — when both `search` and `unread_only: true` are passed, `is:unread` is now embedded into the search string so the filter is preserved. Previously the Nylas v3 API silently dropped `unread_only` whenever `search` was also set, causing all messages (including already-processed ones) to be returned.
-- **`config-store` retrieve label/key fallback** — `retrieve` now finds facts by `properties.key` when the node label doesn't match, making it resilient to label/key drift (e.g. year-rollover mismatch). (#660)
-- **`config-store` store surfaces rejection** — `store` now returns `stored: false` and an `action` field when `storeFact` rejects or rate-limits the write, instead of unconditionally reporting `stored: true`. (#661)
+- **`config-store` retrieve fallback** — `retrieve` falls back to `properties.key` when the node label mismatches. (#660)
+- **`config-store` rejection visibility** — `store` returns `stored: false` with `action` when `storeFact` rejects the write. (#661)
 - **OpenRouter truncation warning** — `OpenRouterProvider` now logs at `warn` level when `finish_reason === 'length'` so truncated responses are visible in production logs instead of silently passing as complete.
 
 ### Added

--- a/skills/config-store/handler.test.ts
+++ b/skills/config-store/handler.test.ts
@@ -13,7 +13,7 @@ function makeEntityMemory(overrides: Record<string, unknown> = {}) {
   return {
     findEntities: vi.fn().mockResolvedValue([]),
     createEntity: vi.fn().mockResolvedValue({ entity: { id: 'node-1' }, created: true }),
-    storeFact: vi.fn().mockResolvedValue({ stored: true, nodeId: 'fact-1' }),
+    storeFact: vi.fn().mockResolvedValue({ stored: true, action: 'created', nodeId: 'fact-1' }),
     getFacts: vi.fn().mockResolvedValue([]),
     ...overrides,
   };
@@ -115,8 +115,9 @@ describe('ConfigStoreHandler', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      const data = result.data as { stored: boolean; namespace: string; key: string };
+      const data = result.data as { stored: boolean; action: string; namespace: string; key: string };
       expect(data.stored).toBe(true);
+      expect(data.action).toBe('created');
       expect(data.namespace).toBe('writing_config');
       expect(data.key).toBe('writing_guide_url');
     }

--- a/skills/config-store/handler.test.ts
+++ b/skills/config-store/handler.test.ts
@@ -162,6 +162,30 @@ describe('ConfigStoreHandler', () => {
     expect(mem.storeFact.mock.calls[0][0].entityNodeId).toBe('anchor-existing');
   });
 
+  it('surfaces stored:false and action when storeFact rejects the write', async () => {
+    // Regression: storeFact previously returned stored:true unconditionally, masking
+    // cases where the entity-memory validator silently rejected or rate-limited the write.
+    const handler = new ConfigStoreHandler();
+    const mem = makeEntityMemory({
+      findEntities: vi.fn()
+        .mockResolvedValueOnce([{ id: 'anchor-existing' }])
+        .mockResolvedValueOnce([{ id: 'index-existing' }]),
+      storeFact: vi.fn().mockResolvedValue({ stored: false, action: 'auto_rejected' }),
+    });
+    const ctx = makeCtx(mem, { action: 'store', namespace: 'travel', key: 'aeroplan', value: 'AC123456' });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { stored: boolean; action: string; namespace: string; key: string };
+      expect(data.stored).toBe(false);
+      expect(data.action).toBe('auto_rejected');
+      expect(data.namespace).toBe('travel');
+      expect(data.key).toBe('aeroplan');
+    }
+  });
+
   it('skips namespace registration when namespace is already in the meta-index', async () => {
     const handler = new ConfigStoreHandler();
     const mem = makeEntityMemory({
@@ -213,6 +237,33 @@ describe('ConfigStoreHandler', () => {
       expect(data.found).toBe(true);
       expect(data.key).toBe('writing_guide_url');
       expect(data.value).toBe('https://docs.example.com');
+    }
+  });
+
+  it('returns found:true via properties.key fallback when label does not match (label/key mismatch)', async () => {
+    // Regression: a fact stored with label "sheet_id.2025" but properties.key "sheet_id.2026"
+    // must be discoverable when retrieve("sheet_id.2026") is called.
+    const handler = new ConfigStoreHandler();
+    const mem = makeEntityMemory({
+      findEntities: vi.fn().mockResolvedValue([{ id: 'anchor-1' }]),
+      getFacts: vi.fn().mockResolvedValue([
+        {
+          id: 'f1',
+          label: 'sheet_id.2025',  // wrong label from year-rollover bug
+          properties: { key: 'sheet_id.2026', value: 'real-sheet-id', namespace: 't2125' },
+        },
+      ]),
+    });
+    const ctx = makeCtx(mem, { action: 'retrieve', namespace: 't2125', key: 'sheet_id.2026' });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { found: boolean; key: string; value: string };
+      expect(data.found).toBe(true);
+      expect(data.key).toBe('sheet_id.2026');
+      expect(data.value).toBe('real-sheet-id');
     }
   });
 

--- a/skills/config-store/handler.test.ts
+++ b/skills/config-store/handler.test.ts
@@ -185,6 +185,10 @@ describe('ConfigStoreHandler', () => {
       expect(data.namespace).toBe('travel');
       expect(data.key).toBe('aeroplan');
     }
+    // storeFact called only once (the value write) — namespace registration must be
+    // skipped when the value write was rejected, otherwise list_namespaces would
+    // advertise a namespace with no stored config values (phantom namespace).
+    expect(mem.storeFact).toHaveBeenCalledTimes(1);
   });
 
   it('skips namespace registration when namespace is already in the meta-index', async () => {

--- a/skills/config-store/handler.ts
+++ b/skills/config-store/handler.ts
@@ -69,11 +69,14 @@ export class ConfigStoreHandler implements SkillHandler {
     }
 
     // Phase 1: write the value fact. If this fails, nothing was stored — return error.
+    // Declared before try so the return at the end of the method can reference them
+    // even though they are assigned inside the try block.
     let anchor: { id: string };
+    let storeResult: { stored: boolean; action: string };
     try {
       anchor = await this.findOrCreateAnchor(ctx, namespace);
 
-      await ctx.entityMemory!.storeFact({
+      storeResult = await ctx.entityMemory!.storeFact({
         entityNodeId: anchor.id,
         label: key,
         properties: { key, value, namespace },
@@ -83,7 +86,17 @@ export class ConfigStoreHandler implements SkillHandler {
         source: 'skill:config-store',
       });
 
-      ctx.log.info({ namespace, key }, 'Stored config value');
+      if (!storeResult.stored) {
+        // The entity-memory validator rejected or rate-limited this write (e.g. an existing
+        // fact with equal or higher confidence blocked the update). The agent must know the
+        // write did not land so it can react — previously this was silently swallowed.
+        ctx.log.warn(
+          { namespace, key, action: storeResult.action },
+          'Config value not written — storeFact rejected the write',
+        );
+      } else {
+        ctx.log.info({ namespace, key, action: storeResult.action }, 'Stored config value');
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       ctx.log.error({ err, namespace, key }, 'Failed to store config value');
@@ -103,7 +116,7 @@ export class ConfigStoreHandler implements SkillHandler {
       // Still return success: the value IS stored. The meta-index is a projection.
     }
 
-    return { success: true, data: { stored: true, namespace, key } };
+    return { success: true, data: { stored: storeResult.stored, action: storeResult.action, namespace, key } };
   }
 
   private async retrieve(ctx: SkillContext): Promise<SkillResult> {
@@ -142,7 +155,12 @@ export class ConfigStoreHandler implements SkillHandler {
       const facts = allFacts.flat();
 
       if (key) {
-        const fact = facts.find((f) => f.label === key);
+        // Primary match: label. Fallback: properties.key, which may differ from the label
+        // if a fact was stored with a mismatched label (e.g. a year-rollover bug that wrote
+        // label="sheet_id.2025" but properties.key="sheet_id.2026"). The fallback makes
+        // retrieve resilient to that class of data corruption.
+        const fact = facts.find((f) => f.label === key)
+          ?? facts.find((f) => (f.properties.key as string | undefined) === key);
         if (!fact) {
           return { success: true, data: { found: false, key } };
         }

--- a/skills/config-store/handler.ts
+++ b/skills/config-store/handler.ts
@@ -103,17 +103,24 @@ export class ConfigStoreHandler implements SkillHandler {
       return { success: false, error: `Failed to store: ${message}` };
     }
 
-    // Phase 2: register the namespace in the meta-index (best-effort).
-    // The value fact is already committed. A failure here leaves list_namespaces
-    // stale but does not affect retrieve — data is accessible by namespace anchor label.
-    try {
-      await this.registerNamespace(ctx, namespace);
-    } catch (err) {
-      ctx.log.error(
-        { err, namespace, key },
-        'Config value stored but meta-index registration failed — list_namespaces may not include this namespace',
+    // Phase 2: register the namespace in the meta-index (best-effort), but only
+    // when the value write was actually accepted. Registering on rejection would
+    // leave list_namespaces advertising a namespace with no stored config values.
+    if (storeResult.stored) {
+      try {
+        await this.registerNamespace(ctx, namespace);
+      } catch (err) {
+        ctx.log.error(
+          { err, namespace, key },
+          'Config value stored but meta-index registration failed — list_namespaces may not include this namespace',
+        );
+        // Still return success: the value IS stored. The meta-index is a projection.
+      }
+    } else {
+      ctx.log.debug(
+        { namespace, key, action: storeResult.action },
+        'Skipping namespace registration — value write was not accepted',
       );
-      // Still return success: the value IS stored. The meta-index is a projection.
     }
 
     return { success: true, data: { stored: storeResult.stored, action: storeResult.action, namespace, key } };


### PR DESCRIPTION
## **User description**
## Summary

Two bugs in `skills/config-store/handler.ts` found during the 2026-05-22 expense-tracker incident.

- **`retrieve` label/key fallback** — when a label-exact match fails, fall back to matching on `properties.key`. Fixes silent data loss when a fact's label drifts from its stored key (e.g. year-rollover mismatch writing `label="sheet_id.2025"` for `key="sheet_id.2026"`). The existing namespace-level retrieve already used `properties.key`-first; this brings single-key retrieve into line.
- **`store` surfaces rejection** — `store` now captures the `storeFact` return value and returns `stored: false` + `action` when the entity-memory validator rejects or rate-limits the write. Previously `storeFact` was always reported as `stored: true` regardless of outcome.

Closes #660, #661

## Test plan

- [ ] All 23 unit tests pass (`npm test -- skills/config-store/handler.test.ts`)
- [ ] New test: `retrieve` with label/key mismatch returns `found: true` via `properties.key` fallback
- [ ] New test: `store` with `storeFact` returning `auto_rejected` returns `stored: false, action: 'auto_rejected'`
- [ ] Default `storeFact` mock updated to include `action: 'created'` to match real `StoreFactResult` shape


___

## **CodeAnt-AI Description**
Fix config-store lookups and write results

### What Changed
- Retrieving a saved config now falls back to the stored key when the item label does not match, so records with label/key drift can still be found
- Saving a config now returns whether the write was accepted, including the rejection reason when the write is blocked or rate-limited
- Store success responses now include the action that occurred, instead of always reporting a successful write

### Impact
`✅ Fewer missing config values`
`✅ Clearer write rejection results`
`✅ Less silent data loss`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Config store retrieval now uses a fallback mechanism to locate values when internal label keys don't match stored entries.
  * Config store write operations now accurately report success or failure status, returning action details when writes are rejected or rate-limited.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/663?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->