### PR TITLE
fix: config-store retrieve falls back to properties.key when label doesn't match

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+allowBuilds:
+  esbuild: set this to true or false
 # Explicitly declare pnpm v11 default: prevent transitive (indirect) dependencies
 # from being resolved via exotic sources (git repos, direct tarball URLs).
 # Note: this does NOT restrict direct dependencies listed in package.json,

--- a/skills/config-store/handler.test.ts
+++ b/skills/config-store/handler.test.ts
@@ -236,6 +236,28 @@ describe('ConfigStoreHandler', () => {
     }
   });
 
+  it('retrieves fact by properties.key when label does not match (label/key mismatch)', async () => {
+    // Regression test for #660: fact stored with label='sheet_id.2025' but properties.key='sheet_id.2026'
+    const handler = new ConfigStoreHandler();
+    const mem = makeEntityMemory({
+      findEntities: vi.fn().mockResolvedValue([{ id: 'anchor-1' }]),
+      getFacts: vi.fn().mockResolvedValue([
+        { id: 'f1', label: 'sheet_id.2025', properties: { key: 'sheet_id.2026', value: 'abc123', namespace: 'expense_tracker' } },
+      ]),
+    });
+    const ctx = makeCtx(mem, { action: 'retrieve', namespace: 'expense_tracker', key: 'sheet_id.2026' });
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { found: boolean; key: string; value: string };
+      expect(data.found).toBe(true);
+      expect(data.key).toBe('sheet_id.2026');
+      expect(data.value).toBe('abc123');
+    }
+  });
+
   it('returns found:false when namespace does not exist (single-key retrieve)', async () => {
     // findEntities returns [] — namespace anchor doesn't exist yet
     const handler = new ConfigStoreHandler();

--- a/skills/config-store/handler.ts
+++ b/skills/config-store/handler.ts
@@ -142,7 +142,8 @@ export class ConfigStoreHandler implements SkillHandler {
       const facts = allFacts.flat();
 
       if (key) {
-        const fact = facts.find((f) => f.label === key);
+        const fact = facts.find((f) => f.label === key)
+                  ?? facts.find((f) => (f.properties.key as string | undefined) === key);
         if (!fact) {
           return { success: true, data: { found: false, key } };
         }


### PR DESCRIPTION
## **User description**
## Summary

Closes #660

`config-store retrieve` now finds facts by `properties.key` when `label` doesn't match, making the single-key retrieve path consistent with the list-all path.

## Problem

During a production incident (2026-05-22), the expense-tracker agent's config entries had labels like `sheet_id.2025`, `folder_id.2025`, etc. while their `properties.key` correctly read `sheet_id.2026`. Every `retrieve("sheet_id.2026")` returned `found: false`, causing the agent to treat missing config as first-time setup and create blank spreadsheets on every run.

## Root Cause

```ts
// handler.ts retrieve() line 145
const fact = facts.find((f) => f.label === key);  // label-only match
```

The list-all path correctly falls back to `properties.key`:
```ts
key: (f.properties.key as string | undefined) ?? f.label,  // property-first
```

The single-key retrieve path didn't.

## Solution

Added fallback to `properties.key` in the single-key retrieve path:

```ts
const fact = facts.find((f) => f.label === key)
          ?? facts.find((f) => (f.properties.key as string | undefined) === key);
```

This makes both paths consistent and makes retrieve robust against label/key drift.

## Testing

- ✅ All 22 existing tests pass
- ✅ Added regression test for label/key mismatch scenario
- ✅ Test verifies `retrieve('sheet_id.2026')` returns `found: true` when fact has `label='sheet_id.2025'` but `properties.key='sheet_id.2026'`

## Acceptance Criteria

- [x] `retrieve(key)` returns `found: true` when a fact has `properties.key === key` even if `label !== key`
- [x] Existing tests pass; new test covers the label/key mismatch case
- [x] List-all (`retrieve` with namespace only) behaviour unchanged


___

## **CodeAnt-AI Description**
**Fix config lookup when the stored label does not match the requested key**

### What Changed
- `config-store retrieve` now finds a saved value even when its displayed label is different from the requested key, as long as the stored key matches
- This keeps single-item lookup consistent with the list view and prevents config from being treated as missing in label/key mismatch cases
- Added a regression test that covers the mismatch scenario and confirms the correct value is returned

### Impact
`✅ Fewer missing-config resets`
`✅ Fewer duplicate setup runs`
`✅ More reliable config retrieval`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
