### PR TITLE
fix: revert ceo-inbox model tier from fast to standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`ceo-inbox` model tier** — reverted from `fast` (Haiku) to `standard` (Sonnet); Haiku produced incorrect Unix timestamps in Step 6 high-water-mark saves, causing `last_processed_at` to drift ~40 days into the future and blinding inbox triage.
 - **`email-list` unread filter with search** — when both `search` and `unread_only: true` are passed, `is:unread` is now embedded into the search string so the filter is preserved. Previously the Nylas v3 API silently dropped `unread_only` whenever `search` was also set, causing all messages (including already-processed ones) to be returned.
 - **`config-store` retrieve fallback** — `retrieve` falls back to `properties.key` when the node label mismatches. (#660)
 - **`config-store` rejection visibility** — `store` returns `stored: false` with `action` when `storeFact` rejects the write. (#661)

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -8,7 +8,7 @@ description: >
   escalates urgent items via Signal and the bullpen.
 
 model:
-  tier: fast  # trial: rule-based triage; CEO reviews reply drafts before send — watch draft quality
+  tier: standard  # reverted from fast — Haiku botched Unix timestamp arithmetic, causing last_processed_at to drift ~40 days into the future and blinding inbox triage
 
 inject_specialists: true
 


### PR DESCRIPTION
## **User description**
## Summary

- Reverts ceo-inbox agent from `fast` (Haiku) back to `standard` (Sonnet)
- Haiku cannot reliably compute Unix timestamps — it was saving `last_processed_at` values ~40 days in the future, causing every triage run to find 0 messages
- Production KG has been manually patched (reset `last_processed_at` to correct current timestamp)

## Context

The `fast` tier trial (#648) downgraded ceo-inbox to Haiku. Step 6 of the triage prompt tells the agent to "use the current time" when saving the high-water mark. Haiku's date arithmetic produced timestamps around July 2026 instead of May 2026. Each 15-minute run reinforced the drift, creating a self-healing-proof failure loop.

## Test plan

- [ ] Verify the next scheduled ceo-inbox run (within 15 min of deploy) processes real unread messages
- [ ] Confirm `last_processed_at` stays close to the actual current time after each run
- [ ] Spot-check draft quality on NEEDS DRAFT emails — Sonnet should produce higher-quality drafts than Haiku was


___

## **CodeAnt-AI Description**
**Restore reliable CEO inbox triage**

### What Changed
- The CEO inbox agent now runs on the standard model again instead of the faster trial model.
- This fixes incorrect time calculations that were pushing the saved “last processed” time far into the future and causing inbox triage to skip unread messages.
- The changelog now records this rollback as a fixed issue.

### Impact
`✅ Fewer missed inbox messages`
`✅ Reliable 15-minute triage runs`
`✅ Correct inbox processing timestamps`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
