### PR TITLE
chore: release v0.30.0 — "Kaylee Frye"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,51 +13,50 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
-### Added
+## [0.30.0] — 2026-05-22 — "Kaylee Frye"
 
-- **`contact-register` auto-promotion** — provisional contacts promoted to confirmed on Curia outbound, CEO email, or calendar signals; returns `promoted` and `promotion_signal`. (#633)
-- **Contacts agent daily sweep** — 8 AM cron reconciles provisional contacts against CEO Sent folder and calendar. (#633)
-- **Contacts agent pinned skills** — `ceo-inbox-list` and `contact-register` added. (#633)
-
-### Changed
-
-- **`ceo-inbox-list` message shape** — messages now include `to` and `cc` recipient arrays. (#633)
-- **Agent tier downgrades** — contacts, calendar, research-analyst, and ceo-inbox moved from `standard` to `fast` tier. (#648)
-
-### Fixed
-
-- **`ceo-inbox` model tier** — reverted from `fast` (Haiku) to `standard` (Sonnet); Haiku produced incorrect Unix timestamps in Step 6 high-water-mark saves, causing `last_processed_at` to drift ~40 days into the future and blinding inbox triage.
-- **`email-list` unread filter with search** — when both `search` and `unread_only: true` are passed, `is:unread` is now embedded into the search string so the filter is preserved. Previously the Nylas v3 API silently dropped `unread_only` whenever `search` was also set, causing all messages (including already-processed ones) to be returned.
-- **`config-store` retrieve fallback** — `retrieve` falls back to `properties.key` when the node label mismatches. (#660)
-- **`config-store` rejection visibility** — `store` returns `stored: false` with `action` when `storeFact` rejects the write. (#661)
-- **OpenRouter truncation warning** — `OpenRouterProvider` now logs at `warn` level when `finish_reason === 'length'` so truncated responses are visible in production logs instead of silently passing as complete.
+> **Kaylee Frye** *(Firefly, 2002, Joss Whedon)* — Serenity's mechanic, who keeps a ship flying on spare parts, intuition, and a refusal to waste anything. She routes around problems, trusts the parts she knows, and gets more out of less than anyone thought possible. This release adds multi-model routing to stretch every dollar, downgrades agents to cheaper tiers where they don't need the power, and tightens security without adding overhead.
 
 ### Added
 
 - **OpenRouter provider** — optional multi-model routing for Gemini Flash, DeepSeek V3, and GPT-4o via `OPENROUTER_API_KEY`. (#379)
-- **`contact-list`** — new `status` and `limit` filter parameters for direct DB-level filtering; eliminates entity-context timeout for status queries. (#644)
-
-### Security
-
-- **HTML sanitizers** — replaced single-pass regex replacements with loop-based stripping in `html-to-text`, `file-parse`, and `held-messages-list` to prevent nested-substitution bypass (CodeQL `js/incomplete-multi-character-sanitization`, 6 alerts). (#591)
-
-### Fixed
-
-- **Declarative job cleanup** — auto-cancels stale YAML schedules after cron changes or removals. (#640)
-- **`ceo-inbox-list`** — normalize `DRAFTS` folder alias to `DRAFT` for Gmail API compatibility; the digest agent was failing on every run with "Invalid label: DRAFTS".
-- **`NylasClient.listMessages`** — suppress conflicting filter params when `searchQueryNative` is set, matching the guard already in `CeoNylasClient`; fixes HTTP 400 errors in security-triage's email-list calls.
-- **Provider registry routing** — WorkingMemory, DriftDetector, AutonomyScoringPass, and ExecutionLayer now resolve their LLM provider from `providerRegistry`, not the hardwired Anthropic singleton. (#646)
-
-### Security
-
-- **Non-root container** — production image runs as non-root `curia` user; resolves Semgrep alert #48 (`dockerfile.security.missing-user`). (#607)
+- **Model registry** — centralised pricing, context windows, and capabilities in `ModelRegistry`; cost estimation and token tracking delegate to registry data instead of hardcoded values. (#556)
+- **Contact auto-promotion** — provisional contacts promoted to confirmed automatically when Curia sends them a message, the CEO has emailed them, or the CEO accepted a calendar event with them; daily 8 AM sweep reconciles. (#633)
+- **`contact-list` filters** — new `status` and `limit` parameters for direct DB-level filtering; eliminates entity-context timeout on status queries. (#644)
+- **`allowed_callers` enforcement** — skills can restrict invocation to named agents via `allowed_callers` in `skill.json`; validated at startup, enforced before autonomy gates. (#618)
+- **`infraLlm` capability** — constrained LLM access (`classify` and `extract` only) for infrastructure skills, replacing raw SDK usage with telemetry-emitting `LLMProvider` calls. (#637)
+- **Trivy scanning** — filesystem scan (npm deps + secrets) on every PR; Docker image scan weekly. (#563)
 
 ### Changed
 
-- **Time context injection** — extended from coordinator-only to all agents; specialists now receive the `## Current Date & Time` block on every task turn, enabling reliable time-sensitive reasoning in scheduled agents.
-- **Model registry** — centralised pricing, context windows, and capabilities in `ModelRegistry`. (#556)
-- **`model_routing` config** — removed tier `provider`; renamed `autonomy_scoring.model` to `model_tier`.
-- **Skill LLM abstraction** — migrated `extract-facts`, `extract-relationships`, `file-parse` to `LLMProvider` via SkillContext; LLM calls now emit telemetry. (#556)
+- **`model_routing` config** — removed tier `provider` field; renamed `autonomy_scoring.model` to `model_tier`. Provider is now inferred from the model registry. *(Public API surface change.)*
+- **Agent tier downgrades** — contacts, calendar, and research-analyst moved from `standard` to `fast` tier for cost savings. (#648)
+- **Time context injection** — extended from coordinator-only to all agents; specialists now receive date and time on every task turn. (#55)
+- **Skill LLM abstraction** — `extract-facts`, `extract-relationships`, `file-parse` migrated from raw Anthropic SDK to `LLMProvider` via SkillContext. (#556)
+
+### Fixed
+
+- **`ceo-inbox` model tier** — reverted from `fast` to `standard`; Haiku produced incorrect Unix timestamps that blinded inbox triage.
+- **`email-list` unread filter** — `is:unread` now embedded in search string when both `search` and `unread_only` are set; Nylas v3 was silently dropping the filter.
+- **`config-store`** — `retrieve` falls back to `properties.key` on label mismatch (#660); `store` surfaces rejection status instead of reporting success (#661).
+- **Declarative job cleanup** — `loadDeclarativeJobs` auto-cancels stale YAML schedules after cron changes or removals. (#640)
+- **`ceo-inbox-list`** — normalize `DRAFTS` folder alias to `DRAFT` for Gmail API compatibility.
+- **`NylasClient.listMessages`** — suppress conflicting params when `searchQueryNative` is set; fixes HTTP 400 errors. (#646)
+- **Provider registry routing** — shared LLM consumers (WorkingMemory, DriftDetector, AutonomyScoringPass, ExecutionLayer) now resolve from `providerRegistry`, not the Anthropic singleton. (#646)
+
+### Security
+
+- **HTML sanitizers** — loop-based stripping replaces single-pass regex in `html-to-text`, `file-parse`, and `held-messages-list`; resolves 6 CodeQL alerts. (#591)
+- **Non-root container** — production image runs as `curia` user. (#607)
+- **Branch protection** — `main` requires PR review and passing status checks. (#567)
+
+---
+
+*spare parts, new roads —*
+*the engine hums on less now;*
+*trust what you can see.*
+
+---
 
 ## [0.29.0] — 2026-05-19 — "Naomi Nagata"
 
@@ -790,7 +789,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Bootstrap orchestrator** — `src/index.ts` wires all layers in dependency order
 - Architecture specs 00–08, contributor docs (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
 
-[Unreleased]: https://github.com/josephfung/curia/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/josephfung/curia/compare/v0.30.0...HEAD
+[0.30.0]: https://github.com/josephfung/curia/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/josephfung/curia/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/josephfung/curia/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/josephfung/curia/compare/v0.26.0...v0.27.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.29.0-blueviolet" alt="Version: 0.29.0" /></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/badge/version-0.30.0-blueviolet" alt="Version: 0.30.0" /></a>
   <img src="https://img.shields.io/badge/status-pre--alpha-orange" alt="Status: Pre-Alpha" />
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License: MIT" />
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node >= 22" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curia",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "The AI executive staff your C-Suite will use and your Board will trust",
   "type": "module",
   "packageManager": "pnpm@11.0.8",


### PR DESCRIPTION
## **User description**
> **Kaylee Frye** *(Firefly, 2002, Joss Whedon)* — Serenity's mechanic, who keeps a ship flying on spare parts, intuition, and a refusal to waste anything. She routes around problems, trusts the parts she knows, and gets more out of less than anyone thought possible. This release adds multi-model routing to stretch every dollar, downgrades agents to cheaper tiers where they don't need the power, and tightens security without adding overhead.

### Added

- **OpenRouter provider** — optional multi-model routing for Gemini Flash, DeepSeek V3, and GPT-4o via `OPENROUTER_API_KEY`. (#379)
- **Model registry** — centralised pricing, context windows, and capabilities in `ModelRegistry`; cost estimation and token tracking delegate to registry data instead of hardcoded values. (#556)
- **Contact auto-promotion** — provisional contacts promoted to confirmed automatically when Curia sends them a message, the CEO has emailed them, or the CEO accepted a calendar event with them; daily 8 AM sweep reconciles. (#633)
- **`contact-list` filters** — new `status` and `limit` parameters for direct DB-level filtering; eliminates entity-context timeout on status queries. (#644)
- **`allowed_callers` enforcement** — skills can restrict invocation to named agents via `allowed_callers` in `skill.json`; validated at startup, enforced before autonomy gates. (#618)
- **`infraLlm` capability** — constrained LLM access (`classify` and `extract` only) for infrastructure skills, replacing raw SDK usage with telemetry-emitting `LLMProvider` calls. (#637)
- **Trivy scanning** — filesystem scan (npm deps + secrets) on every PR; Docker image scan weekly. (#563)

### Changed

- **`model_routing` config** — removed tier `provider` field; renamed `autonomy_scoring.model` to `model_tier`. Provider is now inferred from the model registry. *(Public API surface change.)*
- **Agent tier downgrades** — contacts, calendar, and research-analyst moved from `standard` to `fast` tier for cost savings. (#648)
- **Time context injection** — extended from coordinator-only to all agents; specialists now receive date and time on every task turn. (#55)
- **Skill LLM abstraction** — `extract-facts`, `extract-relationships`, `file-parse` migrated from raw Anthropic SDK to `LLMProvider` via SkillContext. (#556)

### Fixed

- **`ceo-inbox` model tier** — reverted from `fast` to `standard`; Haiku produced incorrect Unix timestamps that blinded inbox triage.
- **`email-list` unread filter** — `is:unread` now embedded in search string when both `search` and `unread_only` are set; Nylas v3 was silently dropping the filter.
- **`config-store`** — `retrieve` falls back to `properties.key` on label mismatch (#660); `store` surfaces rejection status instead of reporting success (#661).
- **Declarative job cleanup** — `loadDeclarativeJobs` auto-cancels stale YAML schedules after cron changes or removals. (#640)
- **`ceo-inbox-list`** — normalize `DRAFTS` folder alias to `DRAFT` for Gmail API compatibility.
- **`NylasClient.listMessages`** — suppress conflicting params when `searchQueryNative` is set; fixes HTTP 400 errors. (#646)
- **Provider registry routing** — shared LLM consumers now resolve from `providerRegistry`, not the Anthropic singleton. (#646)

### Security

- **HTML sanitizers** — loop-based stripping replaces single-pass regex; resolves 6 CodeQL alerts. (#591)
- **Non-root container** — production image runs as `curia` user. (#607)
- **Branch protection** — `main` requires PR review and passing status checks. (#567)

---

*spare parts, new roads —*
*the engine hums on less now;*
*trust what you can see.*


___

## **CodeAnt-AI Description**
**Release v0.30.0 — “Kaylee Frye”**

### What Changed
- Bumped the project to version 0.30.0 and updated the release badge in the README.
- Published the 0.30.0 changelog with the main user-facing changes: multi-model routing, automatic contact promotion, new contact filtering, agent access limits, and safer LLM access for infrastructure skills.
- Documented the main fixes and security updates, including the restored inbox model tier, preserved unread filtering in email search, clearer config-store results, stale job cleanup, and HTML sanitization hardening.

### Impact
`✅ Clearer release tracking`
`✅ Easier upgrade review`
`✅ Visible security and reliability improvements`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
