### PR TITLE
feat: add inspect-prompts script for eval harness prompt block snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/ tests/",
     "migrate": "tsx --env-file=.env node_modules/node-pg-migrate/bin/node-pg-migrate.js up --migrations-dir src/db/migrations --migration-file-language sql",
-    "smoke": "tsx --env-file=.env tests/smoke/cli.ts"
+    "smoke": "tsx --env-file=.env tests/smoke/cli.ts",
+    "inspect-prompts": "tsx --env-file=.env scripts/inspect-prompts.ts"
   },
   "license": "MIT",
   "dependencies": {

--- a/scripts/inspect-prompts.ts
+++ b/scripts/inspect-prompts.ts
@@ -16,11 +16,16 @@
 //   - After changing security.trust_thresholds in config/default.yaml
 //   - After adding or removing specialist agents (agents/*.yaml)
 //
+// Requires: DATABASE_URL in .env (or environment) pointing at a bootstrapped Curia instance.
+// "Bootstrapped" means Curia has been started at least once (office_identity_current and
+// executive_profile_current are populated). On a fresh empty DB the services would seed those
+// tables from YAML — the same thing Curia startup does — so the output would still be correct,
+// but running inspect-prompts before any Curia startup is not the intended use case.
+//
 // This script connects to the database directly — it does NOT require Curia to be running.
 // It initializes only the services it needs, so it is safe to run alongside a live instance.
 
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 import pg from 'pg';
 import { loadConfig } from '../src/config.js';
 import { loadAllAgentConfigs } from '../src/agents/loader.js';
@@ -31,22 +36,32 @@ import { compileSecurityContextBlock } from '../src/security/security-context.js
 import { EventBus } from '../src/bus/bus.js';
 import { createSilentLogger } from '../src/logger.js';
 
-const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const REPO_ROOT = resolve(import.meta.dirname, '..');
 const AGENTS_DIR = resolve(REPO_ROOT, 'agents');
 const CONFIG_DIR = resolve(REPO_ROOT, 'config');
 
 async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required. Add it to .env or set it in the environment.');
+  }
+
   const logger = createSilentLogger();
   // No-op bus — this script only reads; the services use the bus only when writing
   // (update/reload paths), which never happen here.
   const bus = new EventBus(logger);
 
   const config = loadConfig();
-  const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+  const pool = new pg.Pool({ connectionString: databaseUrl });
+
+  // Declared outside try so the finally block can call stop() on each service.
+  // initialize() starts chokidar file watchers; without stop() the process hangs.
+  let identityService: OfficeIdentityService | null = null;
+  let profileService: ExecutiveProfileService | null = null;
 
   try {
     // ── Identity block ─────────────────────────────────────────────────────────
-    const identityService = new OfficeIdentityService(
+    identityService = new OfficeIdentityService(
       pool,
       logger,
       bus,
@@ -55,7 +70,7 @@ async function main(): Promise<void> {
     await identityService.initialize();
 
     // ── Executive voice block ──────────────────────────────────────────────────
-    const profileService = new ExecutiveProfileService(
+    profileService = new ExecutiveProfileService(
       pool,
       logger,
       bus,
@@ -85,15 +100,16 @@ async function main(): Promise<void> {
     // as that would create the record if absent and produce unwanted side effects
     // in a read-only inspection script.
     const agentResult = await pool.query<{ id: string }>(
-      `SELECT id FROM contacts WHERE system_role = 'agent' LIMIT 1`,
+      // ORDER BY id ASC ensures a deterministic result if multiple rows exist.
+      `SELECT id FROM contacts WHERE system_role = 'agent' ORDER BY id ASC LIMIT 1`,
     );
     const agentContactId = agentResult.rows[0]?.id ?? '';
     if (!agentContactId) {
       // Non-fatal: Curia may not have been bootstrapped yet. The eval harness
-      // doesn't use ${agent_contact_id} for routing tests; leave it empty.
+      // doesn't use agent_contact_id for routing tests; leave it empty.
       process.stderr.write(
         'Warning: no agent contact found (system_role=agent). Has Curia been started at least once?\n' +
-        '         ${agent_contact_id} will be empty in the output.\n',
+        '         agent_contact_id will be empty in the output.\n',
       );
     }
 
@@ -147,6 +163,10 @@ async function main(): Promise<void> {
     // which can confuse downstream JSON parsers when appended to.
     process.stdout.write(JSON.stringify(output, null, 2) + '\n');
   } finally {
+    // Stop file watchers before closing the pool — initialize() starts chokidar
+    // watchers and without stop() the Node event loop stays alive indefinitely.
+    await identityService?.stop();
+    await profileService?.stop();
     await pool.end();
   }
 }

--- a/scripts/inspect-prompts.ts
+++ b/scripts/inspect-prompts.ts
@@ -1,0 +1,157 @@
+// scripts/inspect-prompts.ts
+// Prints the resolved system prompt injection blocks as JSON to stdout.
+//
+// Usage:
+//   pnpm inspect-prompts
+//   (expands to: tsx --env-file=.env scripts/inspect-prompts.ts)
+//
+// On the server: pnpm --prefix /opt/curia tsx --env-file=.env scripts/inspect-prompts.ts
+//
+// Pipe the output into curia-deploy to update the eval harness mock blocks:
+//   pnpm inspect-prompts > /path/to/curia-deploy/tests/eval/prompt-blocks.json
+//
+// When to re-run:
+//   - After editing config/office-identity.yaml or applying identity changes via the API
+//   - After editing config/executive-profile.yaml or applying profile changes via the API
+//   - After changing security.trust_thresholds in config/default.yaml
+//   - After adding or removing specialist agents (agents/*.yaml)
+//
+// This script connects to the database directly — it does NOT require Curia to be running.
+// It initializes only the services it needs, so it is safe to run alongside a live instance.
+
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+import { loadConfig } from '../src/config.js';
+import { loadAllAgentConfigs } from '../src/agents/loader.js';
+import { AgentRegistry } from '../src/agents/agent-registry.js';
+import { OfficeIdentityService } from '../src/identity/service.js';
+import { ExecutiveProfileService, compileWritingVoiceBlock } from '../src/executive/service.js';
+import { compileSecurityContextBlock } from '../src/security/security-context.js';
+import { EventBus } from '../src/bus/bus.js';
+import { createSilentLogger } from '../src/logger.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const AGENTS_DIR = resolve(REPO_ROOT, 'agents');
+const CONFIG_DIR = resolve(REPO_ROOT, 'config');
+
+async function main(): Promise<void> {
+  const logger = createSilentLogger();
+  // No-op bus — this script only reads; the services use the bus only when writing
+  // (update/reload paths), which never happen here.
+  const bus = new EventBus(logger);
+
+  const config = loadConfig();
+  const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+
+  try {
+    // ── Identity block ─────────────────────────────────────────────────────────
+    const identityService = new OfficeIdentityService(
+      pool,
+      logger,
+      bus,
+      resolve(CONFIG_DIR, 'office-identity.yaml'),
+    );
+    await identityService.initialize();
+
+    // ── Executive voice block ──────────────────────────────────────────────────
+    const profileService = new ExecutiveProfileService(
+      pool,
+      logger,
+      bus,
+      resolve(CONFIG_DIR, 'executive-profile.yaml'),
+    );
+    await profileService.initialize();
+
+    // Look up the CEO's display name the same way index.ts does.
+    // Falls back to 'the executive' if CEO_PRIMARY_EMAIL is unset or the contact
+    // doesn't exist yet (first-run case before ceo-bootstrap has run).
+    let executiveDisplayName = 'the executive';
+    if (config.ceoPrimaryEmail) {
+      const nameResult = await pool.query<{ display_name: string }>(
+        `SELECT c.display_name
+         FROM contacts c
+         JOIN contact_channel_identities ci ON ci.contact_id = c.id
+         WHERE ci.channel = 'email' AND ci.channel_identifier = $1`,
+        [config.ceoPrimaryEmail],
+      );
+      if (nameResult.rows[0]?.display_name) {
+        executiveDisplayName = nameResult.rows[0].display_name;
+      }
+    }
+
+    // ── Agent contact ID ───────────────────────────────────────────────────────
+    // Read the existing agent contact — do NOT call bootstrapAgentIdentity here,
+    // as that would create the record if absent and produce unwanted side effects
+    // in a read-only inspection script.
+    const agentResult = await pool.query<{ id: string }>(
+      `SELECT id FROM contacts WHERE system_role = 'agent' LIMIT 1`,
+    );
+    const agentContactId = agentResult.rows[0]?.id ?? '';
+    if (!agentContactId) {
+      // Non-fatal: Curia may not have been bootstrapped yet. The eval harness
+      // doesn't use ${agent_contact_id} for routing tests; leave it empty.
+      process.stderr.write(
+        'Warning: no agent contact found (system_role=agent). Has Curia been started at least once?\n' +
+        '         ${agent_contact_id} will be empty in the output.\n',
+      );
+    }
+
+    // ── Available specialists ──────────────────────────────────────────────────
+    // Mirror the two-pass registration in index.ts: load all agent configs, then
+    // register non-coordinator agents so specialistSummary() produces the correct
+    // @name: description lines.
+    const agentConfigs = loadAllAgentConfigs(AGENTS_DIR);
+    const registry = new AgentRegistry();
+    for (const cfg of agentConfigs) {
+      if (cfg.role !== 'coordinator') {
+        registry.register(cfg.name, {
+          role: cfg.role ?? 'specialist',
+          description: cfg.description ?? cfg.name,
+        });
+      }
+    }
+
+    // ── Security context block ─────────────────────────────────────────────────
+    // Read from config the same way index.ts does. The defaults here match
+    // Curia's hardcoded fallbacks so the output is correct even without a
+    // config/default.yaml override.
+    const rawThresholds = config.security?.trust_thresholds;
+    const thresholds = {
+      information_query: rawThresholds?.information_query ?? 0.30,
+      scheduling:        rawThresholds?.scheduling        ?? 0.50,
+      data_export:       rawThresholds?.data_export       ?? 0.60,
+      financial:         rawThresholds?.financial         ?? 0.70,
+    };
+    const securityContextBlock = compileSecurityContextBlock(thresholds);
+
+    // ── Output ─────────────────────────────────────────────────────────────────
+    const output = {
+      _note: [
+        'Generated by: pnpm inspect-prompts (scripts/inspect-prompts.ts).',
+        'Re-run after changing: office-identity.yaml, executive-profile.yaml,',
+        'security trust_thresholds, or agents/*.yaml.',
+        'Paste into: tests/eval/prompt-blocks.json in curia-deploy.',
+      ].join(' '),
+      coordinator: {
+        office_identity_block:   identityService.compileSystemPromptBlock(),
+        security_context_block:  securityContextBlock,
+        executive_voice_block:   compileWritingVoiceBlock(profileService.get(), executiveDisplayName),
+        agent_contact_id:        agentContactId,
+        available_specialists:   registry.specialistSummary(),
+      },
+    };
+
+    // Write to stdout — caller can pipe to a file.
+    // Use process.stdout.write to avoid the trailing newline console.log adds,
+    // which can confuse downstream JSON parsers when appended to.
+    process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`inspect-prompts: fatal error\n${String(err)}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## **User description**
## Summary

- Adds `scripts/inspect-prompts.ts` — a self-contained CLI that connects to the DB, initializes `OfficeIdentityService` and `ExecutiveProfileService`, builds the agent registry, and prints all coordinator system prompt injection blocks as JSON
- Adds `pnpm inspect-prompts` npm script

## Motivation

The eval harness in curia-deploy runs agent system prompts through LLMs to test routing and behavior. The coordinator's prompt contains `${...}` placeholders (`${available_specialists}`, `${office_identity_block}`, etc.) that are normally resolved at runtime by the Curia server. Without resolution, coordinator routing scenarios fail because the model doesn't know its specialist roster.

This script generates a `prompt-blocks.json` snapshot file (gitignored, instance-specific) that the eval harness uses to substitute those placeholders before each eval run.

## Usage

```bash
# Requires .env with DATABASE_URL (and other config vars)
pnpm inspect-prompts > /path/to/curia-deploy/tests/eval/prompt-blocks.json
```

Re-run after changing: `config/office-identity.yaml`, `config/executive-profile.yaml`, `security.trust_thresholds`, or `agents/*.yaml`.

## Design notes

- Self-initializing: does not require Curia to be running
- Read-only: does not call `bootstrapAgentIdentity` (no side effects)
- Uses `createSilentLogger()` and a no-op `EventBus` (no log noise, no event emission)
- Gracefully warns if agent contact not found (pre-bootstrap case)

## Test plan

- [ ] Verify the script runs locally: `pnpm inspect-prompts`
- [ ] Confirm JSON output includes all 5 blocks for `coordinator`
- [ ] Pipe output to `prompt-blocks.json` in curia-deploy and re-run coordinator routing eval scenarios — expect meaningful scores instead of 25%


___

## **CodeAnt-AI Description**
**Add a prompt snapshot script for eval harness setup**

### What Changed
- Adds a command that prints the current coordinator prompt blocks as JSON so they can be saved and reused by the eval harness
- Includes the office identity, security guidance, executive voice, agent contact ID, and specialist list in the generated output
- Uses the current database and config values, while warning if no agent contact exists yet instead of creating one
- Adds a package script so the snapshot can be generated with a single command

### Impact
`✅ More reliable coordinator eval runs`
`✅ Fewer prompt placeholder issues in snapshots`
`✅ Easier refresh of eval prompt data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smoke testing script enabling automated quality assurance checks and validation workflows
  * Introduced configuration inspection utility for generating test data and system verification

* **Chores**
  * Expanded npm script configuration with new testing and inspection command-line tools
  * Enhanced development infrastructure to support improved testing and operational workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->