### PR TITLE
fix: empty-folders guard in ceo-inbox-update-folders (#596)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ceo-inbox-update-folders`** — added empty-folders guard matching `ceo-inbox-label`: falls back to the computed folder list when Nylas omits `folders` from the PUT response. (#596)
+
 ## [0.30.0] — 2026-05-22 — "Kaylee Frye"
 
 > **Kaylee Frye** *(Firefly, 2002, Joss Whedon)* — Serenity's mechanic, who keeps a ship flying on spare parts, intuition, and a refusal to waste anything. She routes around problems, trusts the parts she knows, and gets more out of less than anyone thought possible. This release adds multi-model routing to stretch every dollar, downgrades agents to cheaper tiers where they don't need the power, and tightens security without adding overhead.

--- a/skills/ceo-inbox-update-folders/handler.ts
+++ b/skills/ceo-inbox-update-folders/handler.ts
@@ -50,8 +50,15 @@ export class CeoInboxUpdateFoldersHandler implements SkillHandler {
 
       const result = await client.updateMessageFolders(messageId, updatedFolders);
 
+      // Nylas sometimes omits the folders field from the PUT response (implementation-defined).
+      // Fall back to the folder list we computed locally to avoid returning [] to the agent.
+      if (result.folders.length === 0) {
+        ctx.log.warn({ messageId }, 'ceo-inbox-update-folders: Nylas returned empty folders on write — using computed folder list');
+      }
+      const finalFolders = result.folders.length > 0 ? result.folders : updatedFolders;
+
       ctx.log.info(
-        { messageId, folders: result.folders },
+        { messageId, folders: finalFolders },
         'ceo-inbox-update-folders: updated successfully',
       );
 
@@ -59,7 +66,7 @@ export class CeoInboxUpdateFoldersHandler implements SkillHandler {
         success: true,
         data: {
           message_id: messageId,
-          folders: result.folders,
+          folders: finalFolders,
         },
       };
     } catch (err) {

--- a/skills/ceo-inbox-update-folders/handler.ts
+++ b/skills/ceo-inbox-update-folders/handler.ts
@@ -52,8 +52,10 @@ export class CeoInboxUpdateFoldersHandler implements SkillHandler {
 
       // Nylas sometimes omits the folders field from the PUT response (implementation-defined).
       // Fall back to the folder list we computed locally to avoid returning [] to the agent.
+      // @TODO: A 200 with empty folders could also be a silent no-op write, which is
+      // indistinguishable from the "field omitted from echo" case without a read-after-write.
       if (result.folders.length === 0) {
-        ctx.log.warn({ messageId }, 'ceo-inbox-update-folders: Nylas returned empty folders on write — using computed folder list');
+        ctx.log.warn({ messageId, nylasResult: result }, 'ceo-inbox-update-folders: Nylas returned empty folders on write — using computed folder list');
       }
       const finalFolders = result.folders.length > 0 ? result.folders : updatedFolders;
 

--- a/tests/unit/skills/ceo-inbox-update-folders.test.ts
+++ b/tests/unit/skills/ceo-inbox-update-folders.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import pino from 'pino';
+import type { SkillContext } from '../../../src/skills/types.js';
+import { CeoInboxUpdateFoldersHandler } from '../../../skills/ceo-inbox-update-folders/handler.js';
+
+const logger = pino({ level: 'silent' });
+
+// CeoNylasClient uses global fetch — spy on it rather than mocking the constructor.
+// This avoids ESM constructor-mock complications and follows the ceo-nylas-client.test.ts pattern.
+
+function makeCtx(input: Record<string, unknown>): SkillContext {
+  return {
+    input,
+    secret: (key: string) => `fake-${key}`,
+    log: logger,
+  } as unknown as SkillContext;
+}
+
+/** Build a successful Nylas JSON envelope response. */
+function nylasOk(data: unknown): Response {
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** Build a minimal Nylas message object (only fields the handler cares about). */
+function nylasMsg(id: string, folders: string[]) {
+  return { id, thread_id: 'thread-1', subject: 'Test', from: [], to: [], cc: [], snippet: '', date: 0, unread: false, folders };
+}
+
+describe('CeoInboxUpdateFoldersHandler', () => {
+  const handler = new CeoInboxUpdateFoldersHandler();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Input validation ──────────────────────────────────────────────────────
+
+  it('returns failure when message_id is missing', async () => {
+    const result = await handler.execute(makeCtx({ add_folders: ['INBOX'] }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('message_id');
+  });
+
+  it('returns failure when both add_folders and remove_folders are empty', async () => {
+    const result = await handler.execute(makeCtx({ message_id: 'msg-1' }));
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('at least one');
+  });
+
+  // ── Normal path ───────────────────────────────────────────────────────────
+
+  it('returns the folders from the Nylas response when non-empty', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      // First call: getMessage → current folders are INBOX, SENT
+      .mockResolvedValueOnce(nylasOk(nylasMsg('msg-1', ['INBOX', 'SENT'])))
+      // Second call: updateMessageFolders → Nylas confirms new folder set
+      .mockResolvedValueOnce(nylasOk(nylasMsg('msg-1', ['INBOX', 'SENT', 'IMPORTANT'])));
+
+    const result = await handler.execute(
+      makeCtx({ message_id: 'msg-1', add_folders: ['IMPORTANT'] }),
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { folders: string[] };
+      expect(data.folders).toEqual(['INBOX', 'SENT', 'IMPORTANT']);
+    }
+  });
+
+  it('removes the specified folder from the current set', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(nylasOk(nylasMsg('msg-1', ['INBOX', 'SPAM'])))
+      .mockResolvedValueOnce(nylasOk(nylasMsg('msg-1', ['INBOX'])));
+
+    const result = await handler.execute(
+      makeCtx({ message_id: 'msg-1', remove_folders: ['SPAM'] }),
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { folders: string[] };
+      expect(data.folders).toEqual(['INBOX']);
+    }
+  });
+
+  // ── Empty-folders guard (the bug fixed by issue #596) ────────────────────
+
+  it('falls back to the computed folder list when Nylas returns empty folders', async () => {
+    // Nylas omits the folders field — CeoNylasClient normalises it to [] via `data.folders ?? []`.
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(nylasOk(nylasMsg('msg-1', ['INBOX'])))
+      // Nylas PUT response with folders omitted — normalises to []
+      .mockResolvedValueOnce(nylasOk({ id: 'msg-1' }));
+
+    const result = await handler.execute(
+      makeCtx({ message_id: 'msg-1', add_folders: ['IMPORTANT'] }),
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { folders: string[] };
+      // Must return the computed set (INBOX + IMPORTANT), not the empty Nylas response.
+      expect(data.folders).toEqual(['INBOX', 'IMPORTANT']);
+    }
+  });
+
+  it('does not duplicate a folder that is already present', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(nylasOk(nylasMsg('msg-1', ['INBOX', 'IMPORTANT'])))
+      .mockResolvedValueOnce(nylasOk(nylasMsg('msg-1', ['INBOX', 'IMPORTANT'])));
+
+    const result = await handler.execute(
+      makeCtx({ message_id: 'msg-1', add_folders: ['IMPORTANT'] }),
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { folders: string[] };
+      expect(data.folders).toEqual(['INBOX', 'IMPORTANT']);
+    }
+  });
+
+  // ── Error handling ────────────────────────────────────────────────────────
+
+  it('returns failure when getMessage throws', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('Nylas 404'));
+
+    const result = await handler.execute(
+      makeCtx({ message_id: 'msg-missing', add_folders: ['INBOX'] }),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('Failed to update');
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- **`ceo-inbox-update-folders`** now guards against Nylas omitting `folders` from its PUT response, matching the existing pattern in `ceo-inbox-label` (lines 82–85)
- Falls back to the locally-computed folder list and logs a `warn` with the raw Nylas result
- Adds a `@TODO` comment flagging the silent no-op write ambiguity for future follow-up
- Adds the first unit test suite for this handler (7 tests covering input validation, normal paths, the guard, and error handling)

Closes #596

## Test plan

- [ ] All 7 unit tests in `tests/unit/skills/ceo-inbox-update-folders.test.ts` pass
- [ ] Full test suite passes (2540 tests; 2 pre-existing failures in `autonomy-service-pagination.test.ts` are unrelated and exist on main)


___

## **CodeAnt-AI Description**
**Keep message folder updates from coming back empty when Nylas omits them**

### What Changed
- When Nylas does not return a folder list after updating a message, the handler now keeps the folder list it calculated instead of returning an empty result
- The update flow now logs a warning with the raw API response when this fallback is used
- Added unit tests that cover missing input, add/remove folder updates, duplicate folder handling, the empty-response fallback, and update failures
- Documented the fix in the changelog

### Impact
`✅ Fewer empty folder results after message updates`
`✅ Clearer warnings when the API response is incomplete`
`✅ More reliable folder update behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
