### PR TITLE
fix(ceo-inbox-draft-reply): fail on missing sender instead of using unknown placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **`ceo-inbox-update-folders`** — added empty-folders guard matching `ceo-inbox-label`: falls back to the computed folder list when Nylas omits `folders` from the PUT response. (#596)
+- **`ceo-inbox-draft-reply`** — empty `from` now returns `{ success: false }` with an error log instead of silently creating a draft addressed to `unknown`. (#598)
 
 ## [0.30.0] — 2026-05-22 — "Kaylee Frye"
 

--- a/skills/ceo-inbox-draft-reply/handler.test.ts
+++ b/skills/ceo-inbox-draft-reply/handler.test.ts
@@ -342,4 +342,39 @@ describe('CeoInboxDraftReplyHandler', () => {
     // Confirm fetch was never called
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  it('Case 8: Empty from — returns { success: false } with error-level log', async () => {
+    // Message exists but has no sender (from: [])
+    const messageResponse = buildNylasMessage({
+      from: [],
+      to: [{ email: 'ceo@example.com' }],
+      cc: [],
+    });
+
+    mockFetch.mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('/messages/msg-001')) {
+        return new Response(JSON.stringify(messageResponse), { status: 200 });
+      }
+      // Draft creation must NOT be called — throw if it is
+      throw new Error(`Unexpected fetch (draft must not be created): ${urlStr}`);
+    });
+
+    const ctx = buildCtx();
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('no sender address');
+    }
+
+    // An error-level log must have been emitted
+    expect(ctx.log.error).toHaveBeenCalled();
+
+    // The drafts endpoint must NOT have been called
+    const draftCall = mockFetch.mock.calls.find(
+      (call) => String(call[0]).includes('/drafts'),
+    );
+    expect(draftCall).toBeUndefined();
+  });
 });

--- a/skills/ceo-inbox-draft-reply/handler.ts
+++ b/skills/ceo-inbox-draft-reply/handler.ts
@@ -41,10 +41,18 @@ export class CeoInboxDraftReplyHandler implements SkillHandler {
       // Reply-all: original sender → to, original to + cc (minus self) → cc.
       const original = await client.getMessage(replyToMessageId);
 
+      // Guard: without a sender we have no valid To address — fail rather than
+      // silently creating a draft addressed to the placeholder 'unknown'.
+      if (original.from.length === 0) {
+        ctx.log.error(
+          { replyToMessageId },
+          'ceo-inbox-draft-reply: original message has no sender address; cannot create reply draft',
+        );
+        return { success: false, error: 'Original message has no sender address; cannot create a reply draft' };
+      }
+
       // To: the original sender
-      const to: NylasParticipant[] = original.from.length > 0
-        ? original.from
-        : [{ email: 'unknown' }];
+      const to: NylasParticipant[] = original.from;
 
       // CC: everyone from original to + cc, minus the CEO's own address
       // and minus the original sender (already in "to")


### PR DESCRIPTION
## **User description**
## Summary

Closes #598

- When `original.from` is empty, returns `{ success: false, error: 'Original message has no sender address; cannot create a reply draft' }` with an error-level log
- Removes the `{ email: 'unknown' }` fallback that caused Nylas to silently accept a non-sendable draft
- Adds unit test Case 8 covering the no-sender path (asserts: `success` is false, error contains `'no sender address'`, error log fired, drafts endpoint never called)

## Test plan

- [ ] `pnpm test` passes — all 8 `ceo-inbox-draft-reply` cases green
- [ ] No other test files affected


___

## **CodeAnt-AI Description**
**Fail fast when a reply draft has no sender**

### What Changed
- Reply drafts now stop with an error when the original message has no sender instead of using `unknown`
- The app logs this as an error and returns a clear message saying the reply draft cannot be created
- Added test coverage for the no-sender case to confirm no draft is created

### Impact
`✅ Fewer non-sendable reply drafts`
`✅ Clearer reply failure messages`
`✅ Safer inbox automation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
