### PR TITLE
fix(autonomy): populate deciderId/deciderChannel in human.decision audit events

### DIFF
--- a/skills/approve-action/handler.test.ts
+++ b/skills/approve-action/handler.test.ts
@@ -40,11 +40,9 @@ function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
       originator: {
         contactId: 'ceo-1',
         systemRole: 'principal' as const,
-        channel: 'cli',
+        channel: 'email',
         initiatedAt: new Date().toISOString(),
       },
-      senderId: 'ceo-1',
-      channelId: 'cli',
     },
     taskEventId: 'task-1',
     caller: { contactId: 'ceo-1', role: 'ceo', channel: 'cli' },
@@ -119,11 +117,13 @@ describe('ApproveActionHandler', () => {
     expect(childRow.parentActionId).toBe(10);
     expect(childRow.outcome).toBe('success');
 
-    // Verify audit event
+    // Verify audit event — deciderId and deciderChannel must come from originator, not 'unknown'
     expect(bus.publish).toHaveBeenCalledOnce();
     const event = (bus.publish as ReturnType<typeof vi.fn>).mock.calls[0]![1];
     expect(event.type).toBe('human.decision');
     expect(event.payload.decision).toBe('approve');
+    expect(event.payload.deciderId).toBe('ceo-1');
+    expect(event.payload.deciderChannel).toBe('email');
 
     // Verify return
     expect(result.success).toBe(true);
@@ -187,6 +187,34 @@ describe('ApproveActionHandler', () => {
     // No child row or audit event either
     expect(repo.insert).not.toHaveBeenCalled();
     expect(bus.publish).not.toHaveBeenCalled();
+  });
+
+  it('skips human.decision and logs error when originator contact/channel is absent', async () => {
+    // Originator passes isPrincipalOriginated but lacks contactId/channel — dispatch-layer bug.
+    // The skill should still succeed (approval happened) but must not publish a counterfeit
+    // audit row with deciderId: 'unknown'. Instead it logs an error and skips the event.
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const execLayer = makeMockExecutionLayer();
+    const mockLog = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const handler = new ApproveActionHandler();
+
+    const result = await handler.execute(makeCtx({
+      log: mockLog,
+      taskMetadata: {
+        // systemRole = 'principal' passes isPrincipalOriginated but contactId/channel are absent
+        originator: { systemRole: 'principal' as const, initiatedAt: new Date().toISOString() },
+      },
+      actionLogRepo: repo,
+      bus,
+      executionLayer: execLayer,
+    }));
+
+    expect(result.success).toBe(true);
+    // No audit row published — fake IDs are worse than a missing row
+    expect(bus.publish).not.toHaveBeenCalled();
+    // Error is surfaced so the dispatch-layer bug is visible in alerting
+    expect(mockLog.error).toHaveBeenCalled();
   });
 
   it('returns error when row has null payload', async () => {

--- a/skills/approve-action/handler.ts
+++ b/skills/approve-action/handler.ts
@@ -11,6 +11,7 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { createHumanDecision } from '../../src/bus/events.js';
 import { isPrincipalOriginated } from '../../src/contacts/principal.js';
+import type { TaskOriginator } from '../../src/contacts/types.js';
 
 export class ApproveActionHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -92,10 +93,22 @@ export class ApproveActionHandler implements SkillHandler {
       }
 
       // Step 4: Publish human.decision audit event (best-effort).
-      // Skip if taskEventId is absent — an empty parentEventId breaks event lineage.
-      if (ctx.taskEventId) {
-        const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
-        const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
+      //
+      // originator is stamped by the dispatcher on every task and carries the contactId
+      // and channel of whoever initiated the task chain. Must be present if we passed the
+      // principal-origin check above — if missing, that indicates a dispatch-layer bug.
+      // Log loudly but don't publish a fake audit row with placeholder IDs, as a
+      // counterfeit audit trail is worse than a missing one. See ADR-017.
+      const originator = ctx.taskMetadata?.originator as TaskOriginator | undefined;
+      const senderId = originator?.contactId;
+      const channelId = originator?.channel;
+
+      if (!senderId || !channelId || !ctx.taskEventId) {
+        ctx.log.error(
+          { senderId, channelId, taskEventId: ctx.taskEventId },
+          'approve-action: audit metadata incomplete — originator/taskEventId should always be present when task is principal-originated. This indicates a dispatch-layer bug.',
+        );
+      } else {
         try {
           await ctx.bus.publish(
             'dispatch',
@@ -115,8 +128,6 @@ export class ApproveActionHandler implements SkillHandler {
         } catch (err) {
           ctx.log.error({ err, rowId: row.id }, 'approve-action: failed to publish human.decision event');
         }
-      } else {
-        ctx.log.warn({ rowId: row.id }, 'approve-action: no taskEventId — skipping human.decision audit event');
       }
 
       ctx.log.info(

--- a/skills/deny-action/handler.test.ts
+++ b/skills/deny-action/handler.test.ts
@@ -39,11 +39,9 @@ function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
       originator: {
         contactId: 'ceo-1',
         systemRole: 'principal' as const,
-        channel: 'cli',
+        channel: 'email',
         initiatedAt: new Date().toISOString(),
       },
-      senderId: 'ceo-1',
-      channelId: 'cli',
     },
     taskEventId: 'task-1',
     ...overrides,
@@ -96,6 +94,28 @@ describe('DenyActionHandler', () => {
     const event = (bus.publish as ReturnType<typeof vi.fn>).mock.calls[0]![1];
     expect(event.type).toBe('human.decision');
     expect(event.payload.decision).toBe('deny');
+    expect(event.payload.deciderId).toBe('ceo-1');
+    expect(event.payload.deciderChannel).toBe('email');
+  });
+
+  it('skips human.decision and logs error when originator contact/channel is absent', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const mockLog = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const handler = new DenyActionHandler();
+
+    const result = await handler.execute(makeCtx({
+      log: mockLog,
+      taskMetadata: {
+        originator: { systemRole: 'principal' as const, initiatedAt: new Date().toISOString() },
+      },
+      actionLogRepo: repo,
+      bus,
+    }));
+
+    expect(result.success).toBe(true);
+    expect(bus.publish).not.toHaveBeenCalled();
+    expect(mockLog.error).toHaveBeenCalled();
   });
 
   it('returns error when resolveRow returns false (concurrent resolve)', async () => {

--- a/skills/deny-action/handler.ts
+++ b/skills/deny-action/handler.ts
@@ -9,6 +9,7 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { createHumanDecision } from '../../src/bus/events.js';
 import { isPrincipalOriginated } from '../../src/contacts/principal.js';
+import type { TaskOriginator } from '../../src/contacts/types.js';
 
 export class DenyActionHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -43,10 +44,22 @@ export class DenyActionHandler implements SkillHandler {
       }
 
       // Publish human.decision audit event (best-effort).
-      // Skip if taskEventId is absent — an empty parentEventId breaks event lineage.
-      if (ctx.taskEventId) {
-        const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
-        const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
+      //
+      // originator is stamped by the dispatcher on every task and carries the contactId
+      // and channel of whoever initiated the task chain. Must be present if we passed the
+      // principal-origin check above — if missing, that indicates a dispatch-layer bug.
+      // Log loudly but don't publish a fake audit row with placeholder IDs, as a
+      // counterfeit audit trail is worse than a missing one. See ADR-017.
+      const originator = ctx.taskMetadata?.originator as TaskOriginator | undefined;
+      const senderId = originator?.contactId;
+      const channelId = originator?.channel;
+
+      if (!senderId || !channelId || !ctx.taskEventId) {
+        ctx.log.error(
+          { senderId, channelId, taskEventId: ctx.taskEventId },
+          'deny-action: audit metadata incomplete — originator/taskEventId should always be present when task is principal-originated. This indicates a dispatch-layer bug.',
+        );
+      } else {
         try {
           await ctx.bus.publish(
             'dispatch',
@@ -66,8 +79,6 @@ export class DenyActionHandler implements SkillHandler {
         } catch (err) {
           ctx.log.error({ err, rowId: row.id }, 'deny-action: failed to publish human.decision event');
         }
-      } else {
-        ctx.log.warn({ rowId: row.id }, 'deny-action: no taskEventId — skipping human.decision audit event');
       }
 
       ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'deny-action: request denied');

--- a/skills/dismiss-action/handler.test.ts
+++ b/skills/dismiss-action/handler.test.ts
@@ -39,11 +39,9 @@ function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
       originator: {
         contactId: 'ceo-1',
         systemRole: 'principal' as const,
-        channel: 'cli',
+        channel: 'email',
         initiatedAt: new Date().toISOString(),
       },
-      senderId: 'ceo-1',
-      channelId: 'cli',
     },
     taskEventId: 'task-1',
     ...overrides,
@@ -104,6 +102,28 @@ describe('DismissActionHandler', () => {
     const event = (bus.publish as ReturnType<typeof vi.fn>).mock.calls[0]![1];
     expect(event.type).toBe('human.decision');
     expect(event.payload.decision).toBe('dismiss');
+    expect(event.payload.deciderId).toBe('ceo-1');
+    expect(event.payload.deciderChannel).toBe('email');
+  });
+
+  it('skips human.decision and logs error when originator contact/channel is absent', async () => {
+    const repo = makeMockRepo();
+    const bus = makeMockBus();
+    const mockLog = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const handler = new DismissActionHandler();
+
+    const result = await handler.execute(makeCtx({
+      log: mockLog,
+      taskMetadata: {
+        originator: { systemRole: 'principal' as const, initiatedAt: new Date().toISOString() },
+      },
+      actionLogRepo: repo,
+      bus,
+    }));
+
+    expect(result.success).toBe(true);
+    expect(bus.publish).not.toHaveBeenCalled();
+    expect(mockLog.error).toHaveBeenCalled();
   });
 
   it('returns error when resolveRow returns false (concurrent resolve)', async () => {

--- a/skills/dismiss-action/handler.ts
+++ b/skills/dismiss-action/handler.ts
@@ -8,6 +8,7 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { createHumanDecision } from '../../src/bus/events.js';
 import { isPrincipalOriginated } from '../../src/contacts/principal.js';
+import type { TaskOriginator } from '../../src/contacts/types.js';
 
 export class DismissActionHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -42,10 +43,22 @@ export class DismissActionHandler implements SkillHandler {
       }
 
       // Publish human.decision audit event (best-effort).
-      // Skip if taskEventId is absent — an empty parentEventId breaks event lineage.
-      if (ctx.taskEventId) {
-        const senderId = typeof ctx.taskMetadata?.senderId === 'string' ? ctx.taskMetadata.senderId : 'unknown';
-        const channelId = typeof ctx.taskMetadata?.channelId === 'string' ? ctx.taskMetadata.channelId : 'unknown';
+      //
+      // originator is stamped by the dispatcher on every task and carries the contactId
+      // and channel of whoever initiated the task chain. Must be present if we passed the
+      // principal-origin check above — if missing, that indicates a dispatch-layer bug.
+      // Log loudly but don't publish a fake audit row with placeholder IDs, as a
+      // counterfeit audit trail is worse than a missing one. See ADR-017.
+      const originator = ctx.taskMetadata?.originator as TaskOriginator | undefined;
+      const senderId = originator?.contactId;
+      const channelId = originator?.channel;
+
+      if (!senderId || !channelId || !ctx.taskEventId) {
+        ctx.log.error(
+          { senderId, channelId, taskEventId: ctx.taskEventId },
+          'dismiss-action: audit metadata incomplete — originator/taskEventId should always be present when task is principal-originated. This indicates a dispatch-layer bug.',
+        );
+      } else {
         try {
           await ctx.bus.publish(
             'dispatch',
@@ -65,8 +78,6 @@ export class DismissActionHandler implements SkillHandler {
         } catch (err) {
           ctx.log.error({ err, rowId: row.id }, 'dismiss-action: failed to publish human.decision event');
         }
-      } else {
-        ctx.log.warn({ rowId: row.id }, 'dismiss-action: no taskEventId — skipping human.decision audit event');
       }
 
       ctx.log.info({ rowId: row.id, shortRef: row.shortRef }, 'dismiss-action: request dismissed');


### PR DESCRIPTION
## **User description**
## Summary

Fixes #602.

- `approve-action`, `deny-action`, and `dismiss-action` were reading `ctx.taskMetadata.senderId` / `.channelId` — fields that don't exist on task metadata — so every `human.decision` audit event emitted `deciderId: "unknown"` and `deciderChannel: "unknown"`
- Fix reads from `ctx.taskMetadata.originator` (`TaskOriginator`) instead, matching the correct pattern already used in `send-draft`
- When `originator` fields are absent (dispatch-layer bug), the event is skipped entirely rather than publishing fake IDs — consistent with ADR-017

## Test plan

- [ ] All three handler test suites pass (25/25 tests)
- [ ] Existing happy-path tests updated to assert `deciderId` = `'ceo-1'` and `deciderChannel` = `'email'` (proves the bug is fixed — old code would have produced `'unknown'`)
- [ ] New test in each suite: missing originator → `bus.publish` not called + `log.error` called
- [ ] Full suite: 2544 tests pass, 2 pre-existing DB integration failures (require `DATABASE_URL`, unrelated)


___

## **CodeAnt-AI Description**
**Fix human decision audit events so they show the real decider**

### What Changed
- Human decision audit events now use the task originator’s contact and channel, so approve, deny, and dismiss actions no longer publish `unknown` values
- If the originator details are missing, the action still completes but the audit event is skipped and an error is logged instead of recording fake IDs
- Test coverage now checks both the correct decider details and the missing-originator case for all three actions

### Impact
`✅ Clearer audit trails`
`✅ Fewer misleading decision records`
`✅ Safer handling of missing task metadata`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved audit event tracking to ensure decision events consistently include complete originator metadata from task sources.
  * Enhanced validation and error handling when required audit information is missing across approval, denial, and dismissal handlers, preventing incomplete event publications while providing clearer diagnostic logging for troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->