### PR TITLE
fix(security): pin qs to >=6.15.2 to close CVE-2026-8723

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+
+- **`qs`** — pinned transitive dependency to `>=6.15.2` via pnpm override, closing CVE-2026-8723 (DoS via crash in `qs.stringify` with null/undefined in comma-format arrays).
+
 ### Fixed
 
 - **`ceo-inbox-update-folders`** — added empty-folders guard matching `ceo-inbox-label`: falls back to the computed folder list when Nylas omits `folders` from the PUT response. (#596)

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "overrides": {
       "hono": ">=4.12.18",
       "fast-uri": ">=3.1.2",
-      "vite": ">=8.0.5"
+      "vite": ">=8.0.5",
+      "qs": ">=6.15.2"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2152,8 +2152,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -3389,7 +3389,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -3758,7 +3758,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -4394,7 +4394,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
## **User description**
## Summary

- Adds `"qs": ">=6.15.2"` to `pnpm.overrides` in `package.json`
- Regenerates `pnpm-lock.yaml` so all 4 transitive dependency chains now resolve `qs@6.15.2`
- Closes Dependabot alerts #35 and #33

**Affected chains:** `express` (via `@modelcontextprotocol/sdk`), `body-parser` (via `express`), `fast-querystring` (via `fastify`), `express` (via `openredaction`)

**Vulnerability:** CVE-2026-8723 — `qs.stringify` throws a synchronous `TypeError` (remotely triggerable DoS) when called with `arrayFormat: 'comma'` + `encodeValuesOnly: true` on arrays containing `null` or `undefined`. The throw is unhandled and crashes the process.

## Test plan

- [x] `npm run test` — 2,544 tests pass; 2 pre-existing integration test failures (require `DATABASE_URL`, unrelated to this change)
- [x] `npm ls qs` confirms all consumers resolve `qs@6.15.2`
- [x] Code reviewer and silent-failure-hunter agents: no issues found


___

## **CodeAnt-AI Description**
**Pin `qs` to a fixed version to prevent a crash-based denial of service**

### What Changed
- Forces all bundled `qs` dependencies to use version `6.15.2` or newer
- Updates the lockfile so affected request-parsing paths no longer resolve the vulnerable `qs@6.15.1`
- Records the security fix in the changelog

### Impact
`✅ Fewer crash-triggered outages`
`✅ Safer request parsing`
`✅ Reduced exposure to CVE-2026-8723`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
