### PR TITLE
chore: schedule periodic cleanup for outbound_context expired/released rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **`context-bridge-release`** — new coordinator skill to release outbound context entries when conversations complete. (#615)
 - **`outbound_context` table** — dedicated Postgres table replaces working-memory memos for outbound context tracking. (#615)
+- **Outbound context cleanup** — scheduler now purges expired and released `outbound_context` rows at startup and daily; count is logged at info level. (#679)
 
 ### Changed
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1059,7 +1059,14 @@ async function main(): Promise<void> {
   const dreamEngine = new DreamEngine(pool, bus, logger, decayConfig, scoringPass);
   logger.info({ decayConfig }, 'DreamEngine configured');
 
-  const scheduler = new Scheduler({ pool, bus, logger, schedulerService, driftDetector, dreamEngine });
+  // Outbound context bridge — delegation-aware context registry for
+  // specialist-initiated outbound. Requires pool (Postgres).
+  // Constructed here (before Scheduler) so the scheduler can run startup + daily cleanup.
+  const outboundContextService = pool
+    ? new OutboundContextService(pool, logger)
+    : undefined;
+
+  const scheduler = new Scheduler({ pool, bus, logger, schedulerService, driftDetector, dreamEngine, outboundContextService });
 
   // SuspensionNotifier — emails the CEO when a scheduled job is auto-suspended.
   // Bypasses the LLM pipeline: notifies even when Anthropic is the thing that's down.
@@ -1142,12 +1149,6 @@ async function main(): Promise<void> {
   }
   const infraLlmRouter = new LLMProviderRouter(modelRegistry, providerRegistry);
   const infraLlmService = new InfraLlmService(infraLlmRouter, modelRouter, bus, logger, modelRegistry);
-
-  // Outbound context bridge — delegation-aware context registry for
-  // specialist-initiated outbound. Requires pool (Postgres).
-  const outboundContextService = pool
-    ? new OutboundContextService(pool, logger)
-    : undefined;
 
   // Execution layer — services wired here are injected per-skill based on their
   // capability-gated declarations. outboundGateway gives email skills their send path.

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -15,12 +15,16 @@ import type { AgentResponseEvent, AgentErrorEvent } from '../bus/events.js';
 import type { DriftDetector } from './drift-detector.js';
 import type { DreamEngine } from '../memory/dream-engine.js';
 import type { JobRow } from './scheduler-service.js';
+import type { OutboundContextService } from '../dispatch/outbound-context.js';
 
 // Poll every 30 seconds for due jobs.
 export const POLL_INTERVAL_MS = 30_000;
 
 // Watchdog runs every 5 minutes to detect jobs stuck mid-run.
 export const WATCHDOG_INTERVAL_MS = 5 * 60 * 1000;
+
+// Outbound context cleanup runs daily to purge expired and released rows.
+export const OUTBOUND_CONTEXT_CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 // Default assumed duration for a job with no explicit expectedDurationSeconds.
 const DEFAULT_EXPECTED_DURATION_SECONDS = 600; // 10 minutes
@@ -83,6 +87,8 @@ export interface SchedulerConfig {
   driftDetector?: DriftDetector;
   /** Dream engine for background KG maintenance. When absent, no background decay runs. */
   dreamEngine?: DreamEngine;
+  /** Outbound context service — when present, expired/released rows are purged daily and at startup. */
+  outboundContextService?: OutboundContextService;
 }
 
 export class Scheduler {
@@ -92,8 +98,10 @@ export class Scheduler {
   private schedulerService: SchedulerService;
   private driftDetector?: DriftDetector;
   private dreamEngine?: DreamEngine;
+  private outboundContextService?: OutboundContextService;
   private intervalHandle: ReturnType<typeof setInterval> | null = null;
   private watchdogHandle: ReturnType<typeof setInterval> | null = null;
+  private cleanupHandle: ReturnType<typeof setInterval> | null = null;
 
   // Maps the agent.task event ID back to the job ID so we can match
   // agent.response / agent.error events to the originating scheduled job.
@@ -110,6 +118,7 @@ export class Scheduler {
     this.schedulerService = config.schedulerService;
     this.driftDetector = config.driftDetector;
     this.dreamEngine = config.dreamEngine;
+    this.outboundContextService = config.outboundContextService;
   }
 
   /**
@@ -163,6 +172,16 @@ export class Scheduler {
       this.dreamEngine.start();
     }
 
+    // Outbound context cleanup — purge expired and released rows.
+    // Run once at startup to clear any rows that expired while the service was down,
+    // then schedule the interval for ongoing daily maintenance.
+    if (this.outboundContextService) {
+      this.runOutboundContextCleanup();
+      this.cleanupHandle = setInterval(() => {
+        this.runOutboundContextCleanup();
+      }, OUTBOUND_CONTEXT_CLEANUP_INTERVAL_MS);
+    }
+
     this.logger.info({ intervalMs: POLL_INTERVAL_MS }, 'Scheduler started');
   }
 
@@ -178,10 +197,26 @@ export class Scheduler {
       clearInterval(this.watchdogHandle);
       this.watchdogHandle = null;
     }
+    if (this.cleanupHandle) {
+      clearInterval(this.cleanupHandle);
+      this.cleanupHandle = null;
+    }
     if (this.dreamEngine) {
       this.dreamEngine.stop();
     }
     this.logger.info('Scheduler stopped');
+  }
+
+  /**
+   * Delete expired and released outbound context rows and log the result.
+   * Called at startup and then on the daily interval via cleanupHandle.
+   */
+  private runOutboundContextCleanup(): void {
+    this.outboundContextService!.cleanupExpired().then((deletedCount) => {
+      this.logger.info({ deletedCount }, 'Outbound context cleanup complete');
+    }).catch((err) => {
+      this.logger.error({ err }, 'Unhandled error in outbound context cleanup');
+    });
   }
 
   /**

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -16,6 +16,7 @@ import type { DriftDetector } from './drift-detector.js';
 import type { DreamEngine } from '../memory/dream-engine.js';
 import type { JobRow } from './scheduler-service.js';
 import type { OutboundContextService } from '../dispatch/outbound-context.js';
+import { classifyError } from '../errors/classify.js';
 
 // Poll every 30 seconds for due jobs.
 export const POLL_INTERVAL_MS = 30_000;
@@ -221,7 +222,8 @@ export class Scheduler {
         this.logger.info({ deletedCount }, 'Outbound context cleanup complete');
       })
       .catch((err: unknown) => {
-        this.logger.error({ err, service: 'outboundContext' }, 'Outbound context cleanup failed');
+        const agentErr = classifyError(err, 'outbound-context-cleanup');
+        this.logger.error({ err: agentErr, service: 'outboundContext' }, 'Outbound context cleanup failed');
       });
   }
 

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -210,13 +210,19 @@ export class Scheduler {
   /**
    * Delete expired and released outbound context rows and log the result.
    * Called at startup and then on the daily interval via cleanupHandle.
+   *
+   * The explicit guard prevents a synchronous throw from escaping the Promise
+   * chain in case the method is ever called outside its guarded call sites.
    */
   private runOutboundContextCleanup(): void {
-    this.outboundContextService!.cleanupExpired().then((deletedCount) => {
-      this.logger.info({ deletedCount }, 'Outbound context cleanup complete');
-    }).catch((err) => {
-      this.logger.error({ err }, 'Unhandled error in outbound context cleanup');
-    });
+    if (!this.outboundContextService) return;
+    this.outboundContextService.cleanupExpired()
+      .then((deletedCount) => {
+        this.logger.info({ deletedCount }, 'Outbound context cleanup complete');
+      })
+      .catch((err: unknown) => {
+        this.logger.error({ err }, 'Outbound context cleanup failed');
+      });
   }
 
   /**

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -221,7 +221,7 @@ export class Scheduler {
         this.logger.info({ deletedCount }, 'Outbound context cleanup complete');
       })
       .catch((err: unknown) => {
-        this.logger.error({ err }, 'Outbound context cleanup failed');
+        this.logger.error({ err, service: 'outboundContext' }, 'Outbound context cleanup failed');
       });
   }
 


### PR DESCRIPTION
## **User description**
## Summary

Closes #679

- Wire `OutboundContextService.cleanupExpired()` into the `Scheduler` so stale `outbound_context` rows are automatically pruned.
- Runs once at startup (to catch rows that expired while the service was down) and daily thereafter via a `setInterval` in `Scheduler.start()`.
- Count is logged at `info` level; errors are logged at `error` level with `service: 'outboundContext'`.
- No new dependencies. Follows the existing watchdog/dream-engine pattern in `Scheduler`.

**Why `setInterval` instead of the declarative YAML approach:** `cleanupExpired()` is a pure SQL `DELETE` with no agent reasoning required. The YAML/scheduler-job approach is appropriate for agent-driven tasks (like the contact auto-promotion sweep); infrastructure-level maintenance belongs alongside the watchdog and dream engine in `Scheduler.start()`.

## Changes

- `src/scheduler/scheduler.ts` — add `OUTBOUND_CONTEXT_CLEANUP_INTERVAL_MS`, `outboundContextService?` to `SchedulerConfig`/`Scheduler`, `cleanupHandle` field, startup call + daily interval in `start()`, `clearInterval` in `stop()`, `runOutboundContextCleanup()` private method
- `src/index.ts` — move `outboundContextService` construction before `new Scheduler(...)` (it only needs `pool` + `logger`, both available earlier); pass it into `Scheduler` config
- `CHANGELOG.md` — entry under Added

## Test plan

- [ ] Typecheck passes (`pnpm run typecheck`)
- [ ] Existing outbound-context unit tests pass (14/14)
- [ ] Confirm log line `Outbound context cleanup complete` appears at startup with `deletedCount` field
- [ ] Confirm `cleanupHandle` is cleared when `scheduler.stop()` is called (no interval leak on graceful shutdown)


___

## **CodeAnt-AI Description**
**Automatically clean up expired outbound context rows**

### What Changed
- Expired and released outbound context rows are now removed automatically when the app starts and then once a day
- Successful cleanup is logged with the number of rows removed
- Cleanup failures are logged with a clear service name so they are easier to spot

### Impact
`✅ Fewer stale outbound context rows`
`✅ Cleaner startup recovery after downtime`
`✅ Easier cleanup error tracking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The scheduler now automatically purges expired and released outbound context data at application startup and every 24 hours thereafter, with the count of removed rows logged at the information level for operational visibility.

* **Refactor**
  * Service initialization order optimised during startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->