### PR TITLE
feat: audit sensitive skills for allowed_callers restrictions

### DIFF
--- a/docs/dev/adding-a-skill.md
+++ b/docs/dev/adding-a-skill.md
@@ -114,13 +114,22 @@ A raw integer (0–100) may be used for precision when the named levels are too 
 Restricts which agents may invoke this skill. When set, only the named agents (and system-layer callers via `"system"`) can invoke the skill — all others are rejected with a structured failure. The caller gate runs after the elevated-skill gate but before score-based autonomy gates, so structurally forbidden callers are rejected without creating pointless approval requests.
 
 ```json
-"allowed_callers": ["contacts", "coordinator"]
+"allowed_callers": ["coordinator"]
 ```
 
 - Agent names are validated against the loaded agent registry at startup — unknown names cause a hard startup failure.
 - CEO-approved re-executions (`humanApproved: true`) bypass the caller gate.
 - Omit `allowed_callers` entirely (or set to `[]`) to allow any agent to invoke the skill — this is the default behavior.
 - The `skillSearch` closure also respects `allowed_callers`: skills whose caller list excludes the searching agent are filtered from discovery results (defense-in-depth).
+
+**When to use `allowed_callers`:**
+
+The right choice depends on whether the skill lives in the core repo or a deployment repo:
+
+- **Core skills** (`skills/` in curia): use `allowed_callers` only for **structural invariants** — restrictions that must hold across every deployment regardless of what custom agents exist. Examples: `["system"]` for infrastructure-only skills (extract-facts, extract-relationships), `["coordinator"]` for governance primitives (set-autonomy, approve-action, delegate). **Never reference deployment-specific agent names** in core skill manifests — the startup validator hard-fails on unknown names, and coupling core to a specific deployment's agents breaks other deployments.
+- **Custom/deploy skills** (`custom/skills/` in a deploy repo): **default to restricting** to the intended agent(s) unless the skill is designed for general use. Since the skill and its agents live in the same repo, referencing each other is safe. Restricting reduces discovery noise in the skill registry and documents the skill's intended consumer.
+
+For deployment-level access control of core skills, rely on the existing mechanisms instead: `pinned_skills` (agents only see skills they pin), `allow_discovery: false` (specialists can't discover unpinned skills), autonomy score gates, and sensitivity levels.
 
 #### `capabilities` (optional)
 
@@ -502,7 +511,7 @@ See [Adding an Agent — Using config-store](adding-an-agent.md#using-config-sto
 - [ ] `action_risk` is declared in `skill.json`
 - [ ] `sensitivity` matches whether the skill has external effects (remember: `"elevated"` = CEO-or-CLI-only gate)
 - [ ] `capabilities` declares only the privileged services actually used — omit if using only universal services
-- [ ] `allowed_callers` is set if the skill should only be invocable by specific agents (validated at startup)
+- [ ] `allowed_callers` is set appropriately: for core skills, only for structural invariants (coordinator-only governance, system-only infrastructure); for custom/deploy skills, default to restricting to the intended agent(s)
 - [ ] All optional inputs are suffixed with `?` in the manifest
 - [ ] Handler exports a **class** implementing `SkillHandler`, not a bare function
 - [ ] Handler never throws — all errors returned as `{ success: false, error }`

--- a/docs/dev/adding-an-agent.md
+++ b/docs/dev/adding-an-agent.md
@@ -150,6 +150,8 @@ Browse the `skills/` directory for available skills. As a heuristic:
 - Don't pin skills that are rarely needed — use `allow_discovery: true` instead so they're available on demand without cluttering the tool list
 - The Coordinator should pin a broad set since it handles all inbound routing
 
+**`allowed_callers` and custom skills:** If a custom skill in your deploy repo has `allowed_callers` set and your new agent needs to use it, add your agent's name to that skill's `allowed_callers` list. This only applies to custom skills in the same deploy repo — core skills should never restrict by deployment-specific agent name. See [Adding a Skill — `allowed_callers`](adding-a-skill.md#allowed_callers-optional) for the full pattern.
+
 Current built-in skills include (see `skills/` for the full list):
 
 | Category | Skills |

--- a/skills/approve-action/skill.json
+++ b/skills/approve-action/skill.json
@@ -13,5 +13,6 @@
   "permissions": [],
   "secrets": [],
   "timeout": 60000,
-  "capabilities": ["bus", "actionLogRepo", "executionLayer"]
+  "capabilities": ["bus", "actionLogRepo", "executionLayer"],
+  "allowed_callers": ["coordinator"]
 }

--- a/skills/delegate/skill.json
+++ b/skills/delegate/skill.json
@@ -20,5 +20,6 @@
   "capabilities": [
     "bus",
     "agentRegistry"
-  ]
+  ],
+  "allowed_callers": ["coordinator"]
 }

--- a/skills/deny-action/skill.json
+++ b/skills/deny-action/skill.json
@@ -13,5 +13,6 @@
   "permissions": [],
   "secrets": [],
   "timeout": 15000,
-  "capabilities": ["bus", "actionLogRepo"]
+  "capabilities": ["bus", "actionLogRepo"],
+  "allowed_callers": ["coordinator"]
 }

--- a/skills/dismiss-action/skill.json
+++ b/skills/dismiss-action/skill.json
@@ -13,5 +13,6 @@
   "permissions": [],
   "secrets": [],
   "timeout": 15000,
-  "capabilities": ["bus", "actionLogRepo"]
+  "capabilities": ["bus", "actionLogRepo"],
+  "allowed_callers": ["coordinator"]
 }

--- a/skills/file-parse/skill.json
+++ b/skills/file-parse/skill.json
@@ -18,6 +18,5 @@
   "permissions": [],
   "secrets": [],
   "timeout": 30000,
-  "capabilities": ["infraLlm"],
-  "allowed_callers": ["system", "ceo-inbox", "coordinator"]
+  "capabilities": ["infraLlm"]
 }

--- a/skills/set-autonomy/skill.json
+++ b/skills/set-autonomy/skill.json
@@ -18,5 +18,6 @@
   "action_risk": "high",
   "capabilities": [
     "autonomyService"
-  ]
+  ],
+  "allowed_callers": ["coordinator"]
 }

--- a/src/skills/loader.test.ts
+++ b/src/skills/loader.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import pino from 'pino';
-import { loadSkillsFromDirectory } from './loader.js';
+import { loadSkillsFromDirectory, validateAllowedCallers } from './loader.js';
 import { SkillRegistry } from './registry.js';
 
 // Silent logger — these tests do not assert on log output
@@ -150,6 +150,133 @@ describe('loader: capability validation', () => {
       expect(() => {
         skill!.manifest.capabilities!.push('bus');
       }).toThrow(TypeError);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// allowed_callers: freeze and startup validation
+// ---------------------------------------------------------------------------
+
+describe('loader: allowed_callers', () => {
+  it('freezes allowed_callers array after loading', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_ac_freeze__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'restricted-skill', {
+        name: 'restricted-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        allowed_callers: ['coordinator'],
+      });
+      const registry = new SkillRegistry();
+      await loadSkillsFromDirectory(tmpDir, registry, logger);
+
+      const skill = registry.get('restricted-skill');
+      expect(Object.isFrozen(skill?.manifest.allowed_callers)).toBe(true);
+      // A handler cannot escalate by adding itself to the caller list
+      expect(() => {
+        skill!.manifest.allowed_callers!.push('rogue-agent');
+      }).toThrow(TypeError);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('validateAllowedCallers', () => {
+  it('passes when all callers are known agents', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_ac_valid__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'governed-skill', {
+        name: 'governed-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        allowed_callers: ['coordinator'],
+      });
+      const registry = new SkillRegistry();
+      await loadSkillsFromDirectory(tmpDir, registry, logger);
+
+      const knownAgents = new Set(['coordinator', 'calendar', 'ceo-inbox']);
+      expect(() => validateAllowedCallers(registry, knownAgents)).not.toThrow();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('always accepts "system" as a valid caller without it being a known agent', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_ac_system__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'infra-skill', {
+        name: 'infra-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        allowed_callers: ['system'],
+      });
+      const registry = new SkillRegistry();
+      await loadSkillsFromDirectory(tmpDir, registry, logger);
+
+      // 'system' is not in the known agents set — but it's always valid
+      const knownAgents = new Set(['coordinator']);
+      expect(() => validateAllowedCallers(registry, knownAgents)).not.toThrow();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws on unknown agent name (catches typos at startup)', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_ac_typo__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'typo-skill', {
+        name: 'typo-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        allowed_callers: ['coordinatorrr'],
+      });
+      const registry = new SkillRegistry();
+      await loadSkillsFromDirectory(tmpDir, registry, logger);
+
+      const knownAgents = new Set(['coordinator', 'calendar']);
+      expect(() => validateAllowedCallers(registry, knownAgents)).toThrow('coordinatorrr');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('passes when allowed_callers is omitted', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_ac_omit__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'open-skill', {
+        name: 'open-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+      });
+      const registry = new SkillRegistry();
+      await loadSkillsFromDirectory(tmpDir, registry, logger);
+
+      const knownAgents = new Set(['coordinator']);
+      expect(() => validateAllowedCallers(registry, knownAgents)).not.toThrow();
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## **User description**
## Summary

Closes #653

- Add `allowed_callers: ["coordinator"]` to 5 governance/orchestration skills: **set-autonomy**, **approve-action**, **deny-action**, **dismiss-action**, **delegate**. These are structural invariants — a specialist invoking them is always a security bug regardless of deployment.
- Remove `allowed_callers` from **file-parse** — the existing restriction `["system", "ceo-inbox", "coordinator"]` couples core to specific deployments and blocks custom agents (e.g. T2125-expense-tracker) that legitimately need file parsing.
- Document the two-tier `allowed_callers` pattern in dev docs: core skills use it only for structural invariants; custom/deploy skills default to restricting to their intended agent(s).
- Add 5 tests for `validateAllowedCallers` (known agents pass, system always valid, unknown names throw, omitted passes, array freezing).

### Audit decision summary

| Category | Skills | Decision | Rationale |
|----------|--------|----------|-----------|
| Governance | set-autonomy, approve/deny/dismiss-action, delegate | **RESTRICT** `["coordinator"]` | Privilege escalation / self-approval / rogue delegation |
| File parsing | file-parse | **REMOVE** restriction | Couples core to deployment; blocks custom agents |
| Outbound comms | email-send, email-reply, signal-send, email-draft-save | **LEAVE OPEN** | Custom agents need these; rely on autonomy gates + pinning |
| CEO inbox | ceo-inbox-* | **LEAVE OPEN** | Same — rely on pinning + discovery gating |
| Calendar writes | calendar-create/update/delete | **LEAVE OPEN** | Future custom agents may need calendar; rely on autonomy (80) + pinning |

See [plan file](https://github.com/josephfung/curia/issues/653) for full analysis.

## Test plan

- [x] `vitest run src/skills/loader.test.ts` — 9 tests pass (4 existing + 5 new)
- [x] `vitest run src/skills/execution.test.ts` — 42 tests pass (unchanged)
- [x] Full suite: 206 passed, 3 pre-existing failures (smoke loader, unrelated)
- [x] Grep all `allowed_callers` in skill manifests — matches expected set


___

## **CodeAnt-AI Description**
**Tighten access to governance skills and remove an unnecessary file parsing restriction**

### What Changed
- Only the coordinator can now use the governance and delegation skills for setting autonomy, approving or denying actions, dismissing actions, and delegating tasks
- File parsing is no longer limited to a fixed set of callers, so custom agents can use it when needed
- Added startup checks that reject unknown caller names, treat `system` as always valid, and keep caller lists from being changed at runtime
- Updated the developer docs to explain when core skills should use caller restrictions and how custom skills should be handled

### Impact
`✅ Fewer unauthorized governance actions`
`✅ Custom agents can parse files without extra setup`
`✅ Safer startup checks for caller restrictions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
