### PR TITLE
feat: audit sensitive skills for allowed_callers restrictions (#653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Context bridging v2** — outbound context registry replaces working-memory memos; send skills gain optional `context_bridge` param for delegation-aware reply routing. (#615)
 - **Coordinator prompt** — `[PRIOR OUTBOUND CONTEXT]` replaced with `[ACTIVE OUTBOUND CONTEXT]` block including delegation guidance and entry IDs for release. (#615)
 - **`signal-send`**, **`email-send`**, **`email-reply`** — accept optional `context_bridge` JSON param; declare `outboundContext` capability. (#615)
+- **`file-parse` access relaxed** — `allowed_callers` restriction removed; skill is now invocable by any agent (previously restricted to `system`, `ceo-inbox`, `coordinator`). Custom agents that parse files (e.g., expense trackers processing receipt attachments) were previously blocked at runtime despite having the skill pinned. (#681)
 
 ### Fixed
 
@@ -35,6 +36,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **`qs`** — pinned transitive dependency to `>=6.15.2` via pnpm override, closing CVE-2026-8723 (DoS via crash in `qs.stringify` with null/undefined in comma-format arrays).
 - **`package-lock.json`** — deleted stale npm lockfile and added it to `.gitignore`; the project uses pnpm exclusively and the file was generating spurious Dependabot alerts (#30, #32, #33).
+- **Governance skill caller restrictions** — `set-autonomy`, `approve-action`, `deny-action`, `dismiss-action`, and `delegate` now declare `"allowed_callers": ["coordinator"]`; prevents privilege escalation (rogue autonomy raise, self-approval) and rogue delegation chains from specialist agents. (#681)
 
 ### Removed
 

--- a/docs/dev/adding-a-skill.md
+++ b/docs/dev/adding-a-skill.md
@@ -114,13 +114,22 @@ A raw integer (0–100) may be used for precision when the named levels are too 
 Restricts which agents may invoke this skill. When set, only the named agents (and system-layer callers via `"system"`) can invoke the skill — all others are rejected with a structured failure. The caller gate runs after the elevated-skill gate but before score-based autonomy gates, so structurally forbidden callers are rejected without creating pointless approval requests.
 
 ```json
-"allowed_callers": ["contacts", "coordinator"]
+"allowed_callers": ["coordinator"]
 ```
 
 - Agent names are validated against the loaded agent registry at startup — unknown names cause a hard startup failure.
 - CEO-approved re-executions (`humanApproved: true`) bypass the caller gate.
 - Omit `allowed_callers` entirely (or set to `[]`) to allow any agent to invoke the skill — this is the default behavior.
 - The `skillSearch` closure also respects `allowed_callers`: skills whose caller list excludes the searching agent are filtered from discovery results (defense-in-depth).
+
+**When to use `allowed_callers`:**
+
+The right choice depends on whether the skill lives in the core repo or a deployment repo:
+
+- **Core skills** (`skills/` in curia): use `allowed_callers` only for **structural invariants** — restrictions that must hold across every deployment regardless of what custom agents exist. Examples: `["system"]` for infrastructure-only skills (extract-facts, extract-relationships), `["coordinator"]` for governance primitives (set-autonomy, approve-action, delegate). **Never reference deployment-specific agent names** in core skill manifests — the startup validator hard-fails on unknown names, and coupling core to a specific deployment's agents breaks other deployments.
+- **Custom/deploy skills** (`custom/skills/` in a deploy repo): **default to restricting** to the intended agent(s) unless the skill is designed for general use. Since the skill and its agents live in the same repo, referencing each other is safe. Restricting reduces discovery noise in the skill registry and documents the skill's intended consumer.
+
+For deployment-level access control of core skills, rely on the existing mechanisms instead: `pinned_skills` (agents only see skills they pin), `allow_discovery: false` (specialists can't discover unpinned skills), autonomy score gates, and sensitivity levels.
 
 #### `capabilities` (optional)
 
@@ -502,7 +511,7 @@ See [Adding an Agent — Using config-store](adding-an-agent.md#using-config-sto
 - [ ] `action_risk` is declared in `skill.json`
 - [ ] `sensitivity` matches whether the skill has external effects (remember: `"elevated"` = CEO-or-CLI-only gate)
 - [ ] `capabilities` declares only the privileged services actually used — omit if using only universal services
-- [ ] `allowed_callers` is set if the skill should only be invocable by specific agents (validated at startup)
+- [ ] `allowed_callers` is set appropriately: for core skills, only for structural invariants (coordinator-only governance, system-only infrastructure); for custom/deploy skills, default to restricting to the intended agent(s)
 - [ ] All optional inputs are suffixed with `?` in the manifest
 - [ ] Handler exports a **class** implementing `SkillHandler`, not a bare function
 - [ ] Handler never throws — all errors returned as `{ success: false, error }`

--- a/docs/dev/adding-an-agent.md
+++ b/docs/dev/adding-an-agent.md
@@ -150,6 +150,8 @@ Browse the `skills/` directory for available skills. As a heuristic:
 - Don't pin skills that are rarely needed — use `allow_discovery: true` instead so they're available on demand without cluttering the tool list
 - The Coordinator should pin a broad set since it handles all inbound routing
 
+**`allowed_callers` and custom skills:** If a custom skill in your deploy repo has `allowed_callers` set and your new agent needs to use it, add your agent's name to that skill's `allowed_callers` list. This only applies to custom skills in the same deploy repo — core skills should never restrict by deployment-specific agent name. See [Adding a Skill — `allowed_callers`](adding-a-skill.md#allowed_callers-optional) for the full pattern.
+
 Current built-in skills include (see `skills/` for the full list):
 
 | Category | Skills |

--- a/skills/approve-action/skill.json
+++ b/skills/approve-action/skill.json
@@ -13,5 +13,6 @@
   "permissions": [],
   "secrets": [],
   "timeout": 60000,
-  "capabilities": ["bus", "actionLogRepo", "executionLayer"]
+  "capabilities": ["bus", "actionLogRepo", "executionLayer"],
+  "allowed_callers": ["coordinator"]
 }

--- a/skills/delegate/skill.json
+++ b/skills/delegate/skill.json
@@ -20,5 +20,6 @@
   "capabilities": [
     "bus",
     "agentRegistry"
-  ]
+  ],
+  "allowed_callers": ["coordinator"]
 }

--- a/skills/deny-action/skill.json
+++ b/skills/deny-action/skill.json
@@ -13,5 +13,6 @@
   "permissions": [],
   "secrets": [],
   "timeout": 15000,
-  "capabilities": ["bus", "actionLogRepo"]
+  "capabilities": ["bus", "actionLogRepo"],
+  "allowed_callers": ["coordinator"]
 }

--- a/skills/dismiss-action/skill.json
+++ b/skills/dismiss-action/skill.json
@@ -13,5 +13,6 @@
   "permissions": [],
   "secrets": [],
   "timeout": 15000,
-  "capabilities": ["bus", "actionLogRepo"]
+  "capabilities": ["bus", "actionLogRepo"],
+  "allowed_callers": ["coordinator"]
 }

--- a/skills/file-parse/skill.json
+++ b/skills/file-parse/skill.json
@@ -18,6 +18,5 @@
   "permissions": [],
   "secrets": [],
   "timeout": 30000,
-  "capabilities": ["infraLlm"],
-  "allowed_callers": ["system", "ceo-inbox", "coordinator"]
+  "capabilities": ["infraLlm"]
 }

--- a/skills/set-autonomy/skill.json
+++ b/skills/set-autonomy/skill.json
@@ -18,5 +18,6 @@
   "action_risk": "high",
   "capabilities": [
     "autonomyService"
-  ]
+  ],
+  "allowed_callers": ["coordinator"]
 }

--- a/src/skills/execution.test.ts
+++ b/src/skills/execution.test.ts
@@ -1009,6 +1009,25 @@ describe('allowed_callers gate', () => {
 
     expect(result.success).toBe(false);
   });
+
+  it('allows CEO-approved re-execution with no agentId (approve-action path)', async () => {
+    const registry = new SkillRegistry();
+    // Mirrors a governance skill restricted to coordinator only
+    const manifest = { ...makeManifest('governance-skill'), allowed_callers: ['coordinator'] };
+    registry.register(manifest, makeHandler('ok'));
+    const layer = new ExecutionLayer(registry, logger);
+
+    // approve-action re-invokes with humanApproved: true but no agentId — this is
+    // the real code path used when a CEO approves a held governance action.
+    // Without humanApproved, no-agentId falls back to 'system' which is not in
+    // allowed_callers and would be blocked. With humanApproved, the gate is bypassed.
+    const result = await layer.invoke('governance-skill', { query: 'test' }, undefined, {
+      humanApproved: true,
+      // agentId deliberately omitted — matches approve-action handler behaviour
+    });
+
+    expect(result.success).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -356,11 +356,13 @@ export class ExecutionLayer {
     }
 
     // Log every humanApproved invocation for operator traceability.
-    // The gate logic below is skipped when this flag is set.
+    // Both the caller gate (above) and the autonomy gates (below) are skipped
+    // when this flag is set — emit a single entry that names both bypasses so
+    // the audit log is complete even when governance skills are re-executed.
     if (options?.humanApproved) {
       skillLogger.info(
-        { skillName, agentId: options.agentId },
-        'autonomy gates skipped — humanApproved flag set (CEO-authorized re-execution, see ADR-018)',
+        { skillName, agentId: options.agentId, allowedCallers: manifest.allowed_callers },
+        'caller gate and autonomy gates skipped — humanApproved flag set (CEO-authorized re-execution, see ADR-018)',
       );
     }
 

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -360,8 +360,17 @@ export class ExecutionLayer {
     // when this flag is set — emit a single entry that names both bypasses so
     // the audit log is complete even when governance skills are re-executed.
     if (options?.humanApproved) {
+      // agentId is intentionally absent on the approve-action re-execution path.
+      // Log taskEventId (correlates to the original action log entry) and
+      // originator (the CEO who triggered the task chain) for forensic attribution.
       skillLogger.info(
-        { skillName, agentId: options.agentId, allowedCallers: manifest.allowed_callers },
+        {
+          skillName,
+          agentId: options.agentId,
+          taskEventId: options.taskEventId,
+          originator: options.taskMetadata?.['originator'],
+          allowedCallers: manifest.allowed_callers,
+        },
         'caller gate and autonomy gates skipped — humanApproved flag set (CEO-authorized re-execution, see ADR-018)',
       );
     }

--- a/src/skills/loader.test.ts
+++ b/src/skills/loader.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import pino from 'pino';
-import { loadSkillsFromDirectory } from './loader.js';
+import { loadSkillsFromDirectory, validateAllowedCallers } from './loader.js';
 import { SkillRegistry } from './registry.js';
 
 // Silent logger — these tests do not assert on log output
@@ -150,6 +150,133 @@ describe('loader: capability validation', () => {
       expect(() => {
         skill!.manifest.capabilities!.push('bus');
       }).toThrow(TypeError);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// allowed_callers: freeze and startup validation
+// ---------------------------------------------------------------------------
+
+describe('loader: allowed_callers', () => {
+  it('freezes allowed_callers array after loading', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_ac_freeze__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'restricted-skill', {
+        name: 'restricted-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        allowed_callers: ['coordinator'],
+      });
+      const registry = new SkillRegistry();
+      await loadSkillsFromDirectory(tmpDir, registry, logger);
+
+      const skill = registry.get('restricted-skill');
+      expect(Object.isFrozen(skill?.manifest.allowed_callers)).toBe(true);
+      // A handler cannot escalate by adding itself to the caller list
+      expect(() => {
+        skill!.manifest.allowed_callers!.push('rogue-agent');
+      }).toThrow(TypeError);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('validateAllowedCallers', () => {
+  it('passes when all callers are known agents', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_ac_valid__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'governed-skill', {
+        name: 'governed-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        allowed_callers: ['coordinator'],
+      });
+      const registry = new SkillRegistry();
+      await loadSkillsFromDirectory(tmpDir, registry, logger);
+
+      const knownAgents = new Set(['coordinator', 'calendar', 'ceo-inbox']);
+      expect(() => validateAllowedCallers(registry, knownAgents)).not.toThrow();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('always accepts "system" as a valid caller without it being a known agent', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_ac_system__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'infra-skill', {
+        name: 'infra-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        allowed_callers: ['system'],
+      });
+      const registry = new SkillRegistry();
+      await loadSkillsFromDirectory(tmpDir, registry, logger);
+
+      // 'system' is not in the known agents set — but it's always valid
+      const knownAgents = new Set(['coordinator']);
+      expect(() => validateAllowedCallers(registry, knownAgents)).not.toThrow();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws on unknown agent name (catches typos at startup)', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_ac_typo__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'typo-skill', {
+        name: 'typo-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        allowed_callers: ['coordinatorrr'],
+      });
+      const registry = new SkillRegistry();
+      await loadSkillsFromDirectory(tmpDir, registry, logger);
+
+      const knownAgents = new Set(['coordinator', 'calendar']);
+      expect(() => validateAllowedCallers(registry, knownAgents)).toThrow('coordinatorrr');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('passes when allowed_callers is omitted', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_ac_omit__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      setupSkillDir(tmpDir, 'open-skill', {
+        name: 'open-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+      });
+      const registry = new SkillRegistry();
+      await loadSkillsFromDirectory(tmpDir, registry, logger);
+
+      const knownAgents = new Set(['coordinator']);
+      expect(() => validateAllowedCallers(registry, knownAgents)).not.toThrow();
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/src/skills/loader.test.ts
+++ b/src/skills/loader.test.ts
@@ -281,4 +281,29 @@ describe('validateAllowedCallers', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it('passes when allowed_callers is an explicit empty array', async () => {
+    const tmpDir = path.join(import.meta.dirname, '__test_ac_empty__');
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      // An explicit [] means "unrestricted" (same as omitted) — not "no one can call it".
+      // The ?? operator in validateAllowedCallers does not replace [] since it is not nullish.
+      setupSkillDir(tmpDir, 'open-skill', {
+        name: 'open-skill',
+        description: 'test skill',
+        version: '1.0.0',
+        action_risk: 'none',
+        inputs: {},
+        outputs: {},
+        allowed_callers: [],
+      });
+      const registry = new SkillRegistry();
+      await loadSkillsFromDirectory(tmpDir, registry, logger);
+
+      const knownAgents = new Set(['coordinator']);
+      expect(() => validateAllowedCallers(registry, knownAgents)).not.toThrow();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## **User description**
Closes #653

## Summary

Audits all sensitive skills and applies `allowed_callers` restrictions where appropriate, following the two-tier pattern established in this PR.

**Design principle:** `allowed_callers` in core skill manifests is for structural invariants only — restrictions that must hold across every deployment regardless of custom agents. Deployment-level access control belongs in agent YAML (`pinned_skills`, `allow_discovery: false`) and autonomy gates.

## Changes

### Core skill manifests (`skills/`)

**Restricted to coordinator (governance/orchestration primitives):**
- `set-autonomy` — privilege escalation: a rogue agent could raise autonomy to 100 and bypass all gates
- `approve-action` — self-approval is a privilege escalation vector; has `executionLayer` capability
- `deny-action` — CEO governance function; only coordinator relays CEO decisions
- `dismiss-action` — CEO governance function; only coordinator relays CEO decisions
- `delegate` — hub-and-spoke invariant; unrestricted delegate enables rogue delegation chains and resource exhaustion

**Access relaxed:**
- `file-parse` — removes `["system", "ceo-inbox", "coordinator"]` restriction; custom agents that parse files (e.g., expense trackers processing receipt attachments) were blocked at runtime despite pinning the skill

### Developer docs

- `docs/dev/adding-a-skill.md` — adds "When to use `allowed_callers`" section documenting the two-tier pattern (core = structural invariants only; custom/deploy = default-restrict to intended agent)
- `docs/dev/adding-an-agent.md` — adds note in `pinned_skills` section: if a custom skill has `allowed_callers` set, new agents must be added to that list

### Tests (`src/skills/`)

- `loader.test.ts` — adds `describe('loader: allowed_callers')` (freeze + mutation rejection) and `describe('validateAllowedCallers')` (6 cases: known agents, system bypass, typo detection, omitted, explicit empty array)
- `execution.ts` — `humanApproved` log now names both caller gate and autonomy gates as bypassed; adds `allowedCallers` to log data for audit traceability (ADR-018)
- `execution.test.ts` — adds test for CEO-approved re-execution with no `agentId` (the exact `approve-action` re-invocation path against a coordinator-only skill)

### CHANGELOG

- **Security**: governance skill caller restrictions
- **Changed**: `file-parse` access relaxation (previously `["system", "ceo-inbox", "coordinator"]`, now unrestricted)

## Skills left open (rely on existing gates)

For all other audited skills, existing defense layers are sufficient. Adding `allowed_callers` would couple core manifests to deployment-specific agent names:

| Skill | Existing gates |
|---|---|
| `email-send`, `email-reply`, `signal-send` | Autonomy (70), outbound content filter, pinning |
| `ceo-inbox-*` | Autonomy (60–70), pinning, discovery gating |
| `calendar-create/update/delete-event` | Autonomy (80), pinning |

## Test plan

- [ ] All tests pass: `vitest run src/skills/loader.test.ts src/skills/execution.test.ts`
- [ ] Grep confirms 5 new `allowed_callers` entries and `file-parse` has none
- [ ] `validateAllowedCallers` throws on unknown agent names at startup
- [ ] `humanApproved` path logs `allowedCallers` in audit record


___

## **CodeAnt-AI Description**
**Restrict governance skills to the coordinator and let file parsing work for all agents**

### What Changed
- Locked down governance and delegation skills so only the coordinator can use them, reducing the risk of unauthorized approval, denial, dismissal, delegation, or autonomy changes.
- Removed the caller restriction from file parsing so custom agents can parse documents without being blocked at runtime.
- Added checks that catch invalid caller lists at startup, freeze caller lists after loading, and confirm empty or omitted caller lists behave as unrestricted.
- Improved audit logging for CEO-approved re-execution and documented when to restrict skills by caller in the developer guides.

### Impact
`✅ Fewer privilege-escalation paths`
`✅ Fewer blocked document-parsing tasks`
`✅ Clearer approval audit logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced governance skill access control by restricting approval, denial, dismissal, and delegation skills to coordinator agents only.

* **Bug Fixes**
  * Removed calling restrictions on file-parse skill to allow broader agent access.

* **Documentation**
  * Expanded guidance on skill caller restrictions and agent configuration requirements.

* **Tests**
  * Added validation coverage for caller access controls and CEO-authorized re-execution scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->