### PR TITLE
fix: unconditional outbound context registration (closes #609)

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -207,6 +207,16 @@ system_prompt: |
   - When a delegated task completes and the conversation is done, release the
     context entry using context-bridge-release (pass the entry_id shown in the block)
 
+  ### Enriching outbound context
+  When you call signal-send, email-send, or email-reply and you know which
+  specialist should handle any reply, pass the context_bridge parameter:
+
+    context_bridge: {"agent_id": "coordinator", "delegation_hint": "calendar-specialist", "expected_reply": "confirmation or reschedule request"}
+
+  This is optional — every outbound message is automatically tracked. But passing
+  context_bridge adds delegation hints that help you route replies faster without
+  needing to re-derive context.
+
   If no [ACTIVE OUTBOUND CONTEXT] section is present, apply this two-part test:
 
   1. Is the message **self-contained** — fully actionable on its own?

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -110,6 +110,15 @@ skillOutput:
   # to reduce LLM context pressure on installations with many concurrent agents.
   maxLength: 200000  # 200k characters (~50k tokens at 4 chars/token)
 
+# Context bridge TTL configuration.
+# Controls how long outbound context entries remain active before automatic expiry.
+# Auto-registered entries (when the caller doesn't pass explicit context_bridge metadata)
+# use defaultExpiryHours. Entries with explicit delegation hints use explicitExpiryHours.
+# A caller-specified expires_in_hours in the context_bridge JSON always overrides these.
+contextBridge:
+  defaultExpiryHours: 6      # auto-registered entries (proactive sends without metadata)
+  explicitExpiryHours: 24    # entries with explicit context_bridge JSON
+
 security:
   # Layer 1 prompt injection detection (spec §06-audit-and-security.md).
   #

--- a/docs/dev/configuration.md
+++ b/docs/dev/configuration.md
@@ -101,6 +101,29 @@ Skills that return large payloads (web search results, long calendar lists, craw
 
 ---
 
+### `contextBridge`
+
+Controls TTL (time-to-live) for outbound context entries — the records that let the coordinator link incoming replies to messages it previously sent.
+
+```yaml
+contextBridge:
+  defaultExpiryHours: 6     # TTL for auto-registered entries (no explicit context_bridge param). Default: 6.
+  explicitExpiryHours: 24   # TTL for entries with explicit context_bridge delegation metadata. Default: 24.
+```
+
+Every outbound message (Signal, email) automatically registers a context entry so that if the recipient replies, the coordinator knows what they're replying to. Entries registered without explicit `context_bridge` metadata get the shorter `defaultExpiryHours` TTL. Entries with delegation hints and expected-reply metadata get the longer `explicitExpiryHours` TTL.
+
+When a caller passes `expires_in_hours` inside the `context_bridge` JSON param, it overrides `explicitExpiryHours` for that individual entry.
+
+Expired entries are cleaned up automatically by the background scheduler. The coordinator can also release entries manually via the `context-bridge-release` skill.
+
+**Tuning guidance:**
+- Raise `defaultExpiryHours` if users commonly reply to proactive notifications after more than 6 hours.
+- Lower it if the `[ACTIVE OUTBOUND CONTEXT]` block is accumulating too many stale entries and causing noise.
+- `explicitExpiryHours` should be higher because explicit entries carry delegation metadata that's expensive to re-derive.
+
+---
+
 ### `security`
 
 Extra prompt injection detection patterns applied to every inbound message, in addition to the built-in defaults.

--- a/docs/wip/2026-05-24-context-bridge-autoregister-plan.md
+++ b/docs/wip/2026-05-24-context-bridge-autoregister-plan.md
@@ -1,0 +1,891 @@
+# Context Bridge Auto-Registration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make outbound context registration unconditional — every successful send registers an entry, closing the write-side gap in context bridging v2.
+
+**Architecture:** Modify `OutboundContextCapability` to expose configurable TTL defaults, add a unified `registerOutboundContext` utility that always registers (using explicit metadata when provided, minimal fallback otherwise), update the 3 send skills to call it unconditionally, and add config keys for TTL tuning.
+
+**Tech Stack:** TypeScript, Vitest, YAML config, JSON Schema
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `src/dispatch/outbound-context.ts` | Service + capability interface; gains config-driven TTLs |
+| `src/dispatch/context-bridge-parse.ts` | Shared utility; gains `registerOutboundContext` function |
+| `skills/signal-send/handler.ts` | Send skill; switches to unconditional registration |
+| `skills/email-send/handler.ts` | Send skill; switches to unconditional registration |
+| `skills/email-reply/handler.ts` | Send skill; switches to unconditional registration |
+| `src/config.ts` | YAML config interface + validation |
+| `schemas/default-config.schema.json` | JSON Schema for config validation |
+| `config/default.yaml` | Default config values |
+| `docs/dev/configuration.md` | Operator documentation |
+| `src/index.ts` | Bootstrap wiring |
+| `agents/coordinator.yaml` | Coordinator prompt guidance |
+| `src/dispatch/context-bridge-parse.test.ts` | Unit tests for new utility |
+| `skills/signal-send/handler.test.ts` | Updated skill tests |
+| `skills/email-send/handler.test.ts` | Updated skill tests |
+| `skills/email-reply/handler.test.ts` | Updated skill tests |
+
+---
+
+### Task 1: Add TTL config to `OutboundContextCapability` and `OutboundContextService`
+
+**Files:**
+- Modify: `src/dispatch/outbound-context.ts:49-53` (interface)
+- Modify: `src/dispatch/outbound-context.ts:119-123` (constructor)
+- Modify: `src/dispatch/outbound-context.ts:128-129` (register method DEFAULT_EXPIRY_HOURS usage)
+- Test: `src/dispatch/outbound-context.test.ts`
+
+- [ ] **Step 1: Write the failing test — service uses configured default TTL**
+
+Add to `src/dispatch/outbound-context.test.ts`:
+
+```typescript
+it('uses configured defaultExpiryHours when entry omits expiresInHours', async () => {
+  const customService = new OutboundContextService(pool, logger, {
+    defaultExpiryHours: 6,
+    explicitExpiryHours: 24,
+  });
+  (pool.query as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    rows: [{ id: 'id-1' }],
+  });
+
+  await customService.register({
+    conversationId: 'conv-1',
+    channelId: 'signal',
+    agentId: 'coordinator',
+    content: 'Test message',
+    // no expiresInHours — should use defaultExpiryHours (6h)
+  });
+
+  const call = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0]!;
+  const expiresAt = call[1][7] as Date;
+  const hoursFromNow = (expiresAt.getTime() - Date.now()) / 3_600_000;
+  expect(hoursFromNow).toBeGreaterThan(5.9);
+  expect(hoursFromNow).toBeLessThan(6.1);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run src/dispatch/outbound-context.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: FAIL — `OutboundContextService` constructor doesn't accept config options yet.
+
+- [ ] **Step 3: Update the interface and service to accept config**
+
+In `src/dispatch/outbound-context.ts`, add config interface and update the capability interface:
+
+```typescript
+// After the MAX_FIELD_LENGTH constant (line 16), add:
+/** Configuration for TTL defaults. */
+export interface OutboundContextConfig {
+  /** TTL for auto-registered entries (no explicit context_bridge). Default: 6. */
+  defaultExpiryHours?: number;
+  /** TTL for entries with explicit context_bridge metadata. Default: 24. */
+  explicitExpiryHours?: number;
+}
+
+const FALLBACK_DEFAULT_EXPIRY_HOURS = 6;
+const FALLBACK_EXPLICIT_EXPIRY_HOURS = 24;
+```
+
+Update `OutboundContextCapability` interface (line 50):
+
+```typescript
+/** Narrow interface exposed to skills via the outboundContext capability. */
+export interface OutboundContextCapability {
+  register(entry: Omit<OutboundContextEntry, 'conversationId'>): Promise<string>;
+  release(entryId: string): Promise<void>;
+  readonly defaultExpiryHours: number;
+  readonly explicitExpiryHours: number;
+}
+```
+
+Update `OutboundContextService` constructor (line 119):
+
+```typescript
+export class OutboundContextService {
+  private readonly _defaultExpiryHours: number;
+  private readonly _explicitExpiryHours: number;
+
+  constructor(
+    private pool: DbPool,
+    private logger: Logger,
+    config?: OutboundContextConfig,
+  ) {
+    this._defaultExpiryHours = config?.defaultExpiryHours ?? FALLBACK_DEFAULT_EXPIRY_HOURS;
+    this._explicitExpiryHours = config?.explicitExpiryHours ?? FALLBACK_EXPLICIT_EXPIRY_HOURS;
+  }
+
+  get defaultExpiryHours(): number { return this._defaultExpiryHours; }
+  get explicitExpiryHours(): number { return this._explicitExpiryHours; }
+```
+
+Update `register()` method — replace `DEFAULT_EXPIRY_HOURS` with `this._defaultExpiryHours`:
+
+```typescript
+  async register(entry: OutboundContextEntry): Promise<string> {
+    const preview = truncatePreview(entry.content);
+    const expiresAt = new Date(
+      Date.now() + (entry.expiresInHours ?? this._defaultExpiryHours) * 3_600_000,
+    );
+```
+
+Remove the old `const DEFAULT_EXPIRY_HOURS = 24;` line.
+
+- [ ] **Step 4: Update `ScopedOutboundContext` to expose TTL properties**
+
+At the bottom of `src/dispatch/outbound-context.ts`, update the `ScopedOutboundContext` class:
+
+```typescript
+export class ScopedOutboundContext implements OutboundContextCapability {
+  constructor(
+    private service: OutboundContextService,
+    private conversationId: string,
+  ) {}
+
+  get defaultExpiryHours(): number { return this.service.defaultExpiryHours; }
+  get explicitExpiryHours(): number { return this.service.explicitExpiryHours; }
+
+  async register(entry: Omit<OutboundContextEntry, 'conversationId'>): Promise<string> {
+    return this.service.register({ ...entry, conversationId: this.conversationId });
+  }
+
+  async release(entryId: string): Promise<void> {
+    return this.service.release(entryId, this.conversationId);
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run src/dispatch/outbound-context.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister add src/dispatch/outbound-context.ts src/dispatch/outbound-context.test.ts
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister commit -m "feat: add configurable TTLs to OutboundContextService and capability interface"
+```
+
+---
+
+### Task 2: Add `registerOutboundContext` to `context-bridge-parse.ts`
+
+**Files:**
+- Modify: `src/dispatch/context-bridge-parse.ts`
+- Create: `src/dispatch/context-bridge-parse.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/dispatch/context-bridge-parse.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { registerOutboundContext, parseContextBridge } from './context-bridge-parse.js';
+import type { OutboundContextCapability } from './outbound-context.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCap(overrides?: Partial<OutboundContextCapability>): OutboundContextCapability {
+  return {
+    register: vi.fn().mockResolvedValue('entry-id'),
+    release: vi.fn().mockResolvedValue(undefined),
+    defaultExpiryHours: 6,
+    explicitExpiryHours: 24,
+    ...overrides,
+  };
+}
+
+describe('registerOutboundContext', () => {
+  it('no-ops when outboundContext is undefined', async () => {
+    // Should not throw
+    await registerOutboundContext(undefined, null, {
+      channelId: 'signal',
+      content: 'Hello',
+      agentId: 'coordinator',
+      log: logger,
+    });
+  });
+
+  it('registers minimal entry with defaultExpiryHours when context_bridge is absent', async () => {
+    const cap = makeCap();
+    await registerOutboundContext(cap, undefined, {
+      channelId: 'signal',
+      content: 'Your held messages',
+      agentId: 'coordinator',
+      log: logger,
+    });
+
+    expect(cap.register).toHaveBeenCalledWith({
+      channelId: 'signal',
+      agentId: 'coordinator',
+      content: 'Your held messages',
+      expiresInHours: 6,
+    });
+  });
+
+  it('registers with explicit metadata and explicitExpiryHours when context_bridge is valid', async () => {
+    const cap = makeCap();
+    const bridgeJson = JSON.stringify({
+      agent_id: 'meeting-debrief',
+      expected_reply: 'Notes',
+      delegation_hint: 'Delegate to meeting-debrief',
+      metadata: { topic: 'sync' },
+    });
+
+    await registerOutboundContext(cap, bridgeJson, {
+      channelId: 'signal',
+      content: 'Any takeaways?',
+      agentId: 'coordinator',
+      log: logger,
+    });
+
+    expect(cap.register).toHaveBeenCalledWith({
+      channelId: 'signal',
+      agentId: 'meeting-debrief',
+      content: 'Any takeaways?',
+      expectedReply: 'Notes',
+      delegationHint: 'Delegate to meeting-debrief',
+      metadata: { topic: 'sync' },
+      expiresInHours: 24,
+    });
+  });
+
+  it('uses caller-specified expires_in_hours over explicitExpiryHours', async () => {
+    const cap = makeCap();
+    const bridgeJson = JSON.stringify({
+      agent_id: 'coordinator',
+      expires_in_hours: 48,
+    });
+
+    await registerOutboundContext(cap, bridgeJson, {
+      channelId: 'email',
+      content: 'Important email',
+      agentId: 'coordinator',
+      log: logger,
+    });
+
+    expect(cap.register).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresInHours: 48 }),
+    );
+  });
+
+  it('falls back to auto-registration when context_bridge is malformed JSON', async () => {
+    const cap = makeCap();
+    await registerOutboundContext(cap, 'not-json{{{', {
+      channelId: 'signal',
+      content: 'Hello',
+      agentId: 'coordinator',
+      log: logger,
+    });
+
+    expect(cap.register).toHaveBeenCalledWith({
+      channelId: 'signal',
+      agentId: 'coordinator',
+      content: 'Hello',
+      expiresInHours: 6,
+    });
+  });
+
+  it('falls back to auto-registration when context_bridge has missing agent_id', async () => {
+    const cap = makeCap();
+    await registerOutboundContext(cap, JSON.stringify({ expected_reply: 'hi' }), {
+      channelId: 'signal',
+      content: 'Hello',
+      agentId: 'coordinator',
+      log: logger,
+    });
+
+    expect(cap.register).toHaveBeenCalledWith({
+      channelId: 'signal',
+      agentId: 'coordinator',
+      content: 'Hello',
+      expiresInHours: 6,
+    });
+  });
+
+  it('does not throw when register() rejects', async () => {
+    const cap = makeCap({
+      register: vi.fn().mockRejectedValue(new Error('DB down')),
+    });
+
+    // Should not throw
+    await registerOutboundContext(cap, undefined, {
+      channelId: 'signal',
+      content: 'Hello',
+      agentId: 'coordinator',
+      log: logger,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run src/dispatch/context-bridge-parse.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: FAIL — `registerOutboundContext` is not exported from the module yet.
+
+- [ ] **Step 3: Implement `registerOutboundContext`**
+
+Add to the bottom of `src/dispatch/context-bridge-parse.ts`:
+
+```typescript
+/**
+ * Unified context registration — always registers an entry after a successful send.
+ *
+ * - If context_bridge JSON is valid: registers with explicit metadata + explicitExpiryHours TTL
+ * - If context_bridge is absent/malformed: registers a minimal entry + defaultExpiryHours TTL
+ * - Caller-specified expires_in_hours in the bridge JSON overrides explicitExpiryHours
+ * - Never throws — logs warnings on failure
+ */
+export async function registerOutboundContext(
+  outboundContext: OutboundContextCapability | undefined,
+  contextBridgeRaw: unknown,
+  opts: {
+    channelId: string;
+    content: string;
+    agentId: string;
+    log: Logger;
+  },
+): Promise<void> {
+  if (!outboundContext) return;
+
+  const bridge = parseContextBridge(contextBridgeRaw, opts.log);
+
+  try {
+    if (bridge) {
+      // Explicit context_bridge provided — use its metadata + explicit TTL
+      await outboundContext.register({
+        channelId: opts.channelId,
+        agentId: bridge.agent_id,
+        content: opts.content,
+        ...(bridge.expected_reply != null ? { expectedReply: bridge.expected_reply } : {}),
+        ...(bridge.delegation_hint != null ? { delegationHint: bridge.delegation_hint } : {}),
+        ...(bridge.metadata != null ? { metadata: bridge.metadata } : {}),
+        expiresInHours: bridge.expires_in_hours ?? outboundContext.explicitExpiryHours,
+      });
+    } else {
+      // No explicit bridge — auto-register minimal entry with default TTL
+      await outboundContext.register({
+        channelId: opts.channelId,
+        agentId: opts.agentId,
+        content: opts.content,
+        expiresInHours: outboundContext.defaultExpiryHours,
+      });
+    }
+  } catch (err) {
+    opts.log.warn({ err, channelId: opts.channelId }, 'Failed to register outbound context entry — send succeeded');
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run src/dispatch/context-bridge-parse.test.ts --reporter=verbose 2>&1 | tail -30`
+
+Expected: All 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister add src/dispatch/context-bridge-parse.ts src/dispatch/context-bridge-parse.test.ts
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister commit -m "feat: add registerOutboundContext utility for unconditional context registration"
+```
+
+---
+
+### Task 3: Update `signal-send` handler to use unconditional registration
+
+**Files:**
+- Modify: `skills/signal-send/handler.ts:5` (import)
+- Modify: `skills/signal-send/handler.ts:120-124` (group path registration)
+- Modify: `skills/signal-send/handler.ts:146-150` (1:1 path registration)
+- Modify: `skills/signal-send/handler.test.ts:221-238` (update "absent" test)
+
+- [ ] **Step 1: Update the test — "absent context_bridge" now DOES register**
+
+In `skills/signal-send/handler.test.ts`, find the test at line 221 "does not register when context_bridge is absent" and replace it:
+
+```typescript
+    it('registers a minimal entry when context_bridge is absent', async () => {
+      const ctx = makeCtx({
+        input: {
+          recipient: '+14155551234',
+          message: 'Hello',
+        },
+      });
+      (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true, messageId: 'msg-1',
+      });
+      const mockRegister = vi.fn().mockResolvedValue('entry-1');
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
+      (ctx as Record<string, unknown>).agentId = 'coordinator';
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      expect(mockRegister).toHaveBeenCalledWith({
+        channelId: 'signal',
+        agentId: 'coordinator',
+        content: 'Hello',
+        expiresInHours: 6,
+      });
+    });
+```
+
+- [ ] **Step 2: Run tests to verify the new test fails**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run skills/signal-send/handler.test.ts --reporter=verbose 2>&1 | tail -30`
+
+Expected: FAIL — handler still uses the conditional `if (bridge)` guard.
+
+- [ ] **Step 3: Update the handler import and registration logic**
+
+In `skills/signal-send/handler.ts`, change the import (line 5):
+
+```typescript
+import { registerOutboundContext } from '../../src/dispatch/context-bridge-parse.js';
+```
+
+(Remove the old imports `parseContextBridge, registerContextBridge`.)
+
+Replace the group-path registration block (after successful `ctx.outboundGateway.send` in the group section):
+
+```typescript
+        // Register outbound context entry (best-effort, always fires).
+        await registerOutboundContext(ctx.outboundContext, contextBridgeRaw, {
+          channelId: 'signal',
+          content: message,
+          agentId: ctx.agentId ?? 'coordinator',
+          log: ctx.log,
+        });
+```
+
+Replace the 1:1 path registration block (after successful send):
+
+```typescript
+      // Register outbound context entry (best-effort, always fires).
+      await registerOutboundContext(ctx.outboundContext, contextBridgeRaw, {
+        channelId: 'signal',
+        content: message,
+        agentId: ctx.agentId ?? 'coordinator',
+        log: ctx.log,
+      });
+```
+
+- [ ] **Step 4: Update the existing "registers a context bridge entry" test mock to include TTL properties**
+
+In `skills/signal-send/handler.test.ts`, find the mock at line 205 and update:
+
+```typescript
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
+```
+
+Update the expected call assertion to include `expiresInHours: 48` (from the `expires_in_hours` in the bridge JSON — this was already there) — verify it still passes.
+
+Also update the "does not register when send fails" test mock at line 252 similarly:
+
+```typescript
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
+```
+
+- [ ] **Step 5: Run all signal-send tests**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run skills/signal-send/handler.test.ts --reporter=verbose 2>&1 | tail -30`
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister add skills/signal-send/handler.ts skills/signal-send/handler.test.ts
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister commit -m "feat(signal-send): unconditional outbound context registration"
+```
+
+---
+
+### Task 4: Update `email-send` handler to use unconditional registration
+
+**Files:**
+- Modify: `skills/email-send/handler.ts`
+- Modify: `skills/email-send/handler.test.ts`
+
+- [ ] **Step 1: Read the current email-send handler to identify the registration block**
+
+Read: `skills/email-send/handler.ts` — find the `parseContextBridge` / `registerContextBridge` import and call site.
+
+- [ ] **Step 2: Update the test — "absent context_bridge" now registers**
+
+In `skills/email-send/handler.test.ts`, find the test that asserts register is NOT called when `context_bridge` is absent. Replace with:
+
+```typescript
+    it('registers a minimal entry when context_bridge is absent', async () => {
+      // ... setup ctx with successful send, outboundContext mock including TTL props
+      // Assert: mockRegister called with { channelId: 'email', agentId: 'coordinator', content: <message>, expiresInHours: 6 }
+    });
+```
+
+(Use the same pattern as Task 3 Step 1, adapted for `channelId: 'email'`.)
+
+- [ ] **Step 3: Run tests to verify it fails**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run skills/email-send/handler.test.ts --reporter=verbose 2>&1 | tail -20`
+
+- [ ] **Step 4: Update the handler**
+
+Change import to `registerOutboundContext`, remove `parseContextBridge`/`registerContextBridge`. Replace the conditional registration with:
+
+```typescript
+      await registerOutboundContext(ctx.outboundContext, contextBridgeRaw, {
+        channelId: 'email',
+        content: message,
+        agentId: ctx.agentId ?? 'coordinator',
+        log: ctx.log,
+      });
+```
+
+Update all outboundContext mocks in existing tests to include `defaultExpiryHours: 6, explicitExpiryHours: 24`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run skills/email-send/handler.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister add skills/email-send/handler.ts skills/email-send/handler.test.ts
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister commit -m "feat(email-send): unconditional outbound context registration"
+```
+
+---
+
+### Task 5: Update `email-reply` handler to use unconditional registration
+
+**Files:**
+- Modify: `skills/email-reply/handler.ts`
+- Modify: `skills/email-reply/handler.test.ts`
+
+- [ ] **Step 1: Read the current email-reply handler**
+
+Read: `skills/email-reply/handler.ts` — find the registration block.
+
+- [ ] **Step 2: Update the test — same pattern as Tasks 3 and 4**
+
+- [ ] **Step 3: Run tests to verify it fails**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run skills/email-reply/handler.test.ts --reporter=verbose 2>&1 | tail -20`
+
+- [ ] **Step 4: Update the handler — same pattern**
+
+Change import, replace conditional with `registerOutboundContext` call using `channelId: 'email'`. Update mocks.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run skills/email-reply/handler.test.ts --reporter=verbose 2>&1 | tail -20`
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister add skills/email-reply/handler.ts skills/email-reply/handler.test.ts
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister commit -m "feat(email-reply): unconditional outbound context registration"
+```
+
+---
+
+### Task 6: Add config keys — YAML interface, JSON Schema, defaults, validation
+
+**Files:**
+- Modify: `src/config.ts:249` (before closing brace of `YamlConfig`)
+- Modify: `schemas/default-config.schema.json:275` (before `definitions`)
+- Modify: `config/default.yaml` (after `skillOutput` block)
+- Modify: `src/config.ts:~420` (validation section)
+
+- [ ] **Step 1: Add `contextBridge` to the `YamlConfig` interface**
+
+In `src/config.ts`, before the closing `}` of `YamlConfig` (line 251), add:
+
+```typescript
+  contextBridge?: {
+    /** TTL in hours for auto-registered entries (no explicit context_bridge param). Default: 6. */
+    defaultExpiryHours?: number;
+    /** TTL in hours for entries with explicit context_bridge metadata. Default: 24. */
+    explicitExpiryHours?: number;
+  };
+```
+
+- [ ] **Step 2: Add validation in `loadYamlConfig`**
+
+In `src/config.ts`, after the existing `workingMemory` validation block (around line 440), add:
+
+```typescript
+  if (config.contextBridge !== undefined) {
+    const { defaultExpiryHours, explicitExpiryHours } = config.contextBridge;
+    if (defaultExpiryHours !== undefined && (!Number.isInteger(defaultExpiryHours) || defaultExpiryHours < 1)) {
+      throw new Error(`contextBridge.defaultExpiryHours must be a positive integer, got: ${defaultExpiryHours}`);
+    }
+    if (explicitExpiryHours !== undefined && (!Number.isInteger(explicitExpiryHours) || explicitExpiryHours < 1)) {
+      throw new Error(`contextBridge.explicitExpiryHours must be a positive integer, got: ${explicitExpiryHours}`);
+    }
+  }
+```
+
+- [ ] **Step 3: Add to JSON Schema**
+
+In `schemas/default-config.schema.json`, before the `"definitions"` key (line 277), add a new property inside `"properties"`:
+
+```json
+    "contextBridge": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "defaultExpiryHours": { "type": "integer", "minimum": 1 },
+        "explicitExpiryHours": { "type": "integer", "minimum": 1 }
+      }
+    },
+```
+
+- [ ] **Step 4: Add defaults to `config/default.yaml`**
+
+After the `skillOutput` block (line 111), add:
+
+```yaml
+
+# Context bridge TTL configuration.
+# Controls how long outbound context entries remain active before automatic expiry.
+# Auto-registered entries (when the caller doesn't pass explicit context_bridge metadata)
+# use defaultExpiryHours. Entries with explicit delegation hints use explicitExpiryHours.
+# A caller-specified expires_in_hours in the context_bridge JSON always overrides these.
+contextBridge:
+  defaultExpiryHours: 6      # auto-registered entries (proactive sends without metadata)
+  explicitExpiryHours: 24    # entries with explicit context_bridge JSON
+```
+
+- [ ] **Step 5: Run config validation tests (if they exist)**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run src/config --reporter=verbose 2>&1 | tail -20`
+
+If no config test file exists, run `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run --reporter=verbose 2>&1 | tail -40` to confirm nothing broke.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister add src/config.ts schemas/default-config.schema.json config/default.yaml
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister commit -m "feat: add contextBridge TTL config keys with validation"
+```
+
+---
+
+### Task 7: Wire config into `OutboundContextService` at bootstrap
+
+**Files:**
+- Modify: `src/index.ts:1065-1066`
+
+- [ ] **Step 1: Update bootstrap to pass config**
+
+In `src/index.ts`, find line 1065:
+
+```typescript
+  const outboundContextService = pool
+    ? new OutboundContextService(pool, logger)
+```
+
+Replace with:
+
+```typescript
+  const outboundContextService = pool
+    ? new OutboundContextService(pool, logger, {
+        defaultExpiryHours: yamlConfig.contextBridge?.defaultExpiryHours,
+        explicitExpiryHours: yamlConfig.contextBridge?.explicitExpiryHours,
+      })
+```
+
+- [ ] **Step 2: Run type check**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister tsc --noEmit 2>&1 | tail -20`
+
+Expected: Zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister add src/index.ts
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister commit -m "feat: wire contextBridge config into OutboundContextService at bootstrap"
+```
+
+---
+
+### Task 8: Update `docs/dev/configuration.md`
+
+**Files:**
+- Modify: `docs/dev/configuration.md` (after the `skillOutput` section, ~line 101)
+
+- [ ] **Step 1: Add documentation section**
+
+After the `skillOutput` section (after line 101 "Raise the limit if skills are cutting off important results..."), add:
+
+```markdown
+
+---
+
+### `contextBridge`
+
+Controls TTL (time-to-live) for outbound context entries — the records that let the coordinator link incoming replies to messages it previously sent.
+
+```yaml
+contextBridge:
+  defaultExpiryHours: 6     # TTL for auto-registered entries (no explicit context_bridge param). Default: 6.
+  explicitExpiryHours: 24   # TTL for entries with explicit context_bridge delegation metadata. Default: 24.
+```
+
+Every outbound message (Signal, email) automatically registers a context entry so that if the recipient replies, the coordinator knows what they're replying to. Entries registered without explicit `context_bridge` metadata get the shorter `defaultExpiryHours` TTL. Entries with delegation hints and expected-reply metadata get the longer `explicitExpiryHours` TTL.
+
+When a caller passes `expires_in_hours` inside the `context_bridge` JSON param, it overrides `explicitExpiryHours` for that individual entry.
+
+Expired entries are cleaned up automatically by the background scheduler. The coordinator can also release entries manually via the `context-bridge-release` skill.
+
+**Tuning guidance:**
+- Raise `defaultExpiryHours` if users commonly reply to proactive notifications after more than 6 hours.
+- Lower it if the `[ACTIVE OUTBOUND CONTEXT]` block is accumulating too many stale entries and causing noise.
+- `explicitExpiryHours` should be higher because explicit entries carry delegation metadata that's expensive to re-derive.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister add docs/dev/configuration.md
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister commit -m "docs: document contextBridge TTL config keys"
+```
+
+---
+
+### Task 9: Update coordinator prompt
+
+**Files:**
+- Modify: `agents/coordinator.yaml:209` (after the context-bridge-release line)
+
+- [ ] **Step 1: Add the "Enriching outbound context" subsection**
+
+In `agents/coordinator.yaml`, after line 208 ("context entry using context-bridge-release (pass the entry_id shown in the block)"), add:
+
+```yaml
+
+  ### Enriching outbound context
+  When you call signal-send, email-send, or email-reply and you know which
+  specialist should handle any reply, pass the context_bridge parameter:
+
+    context_bridge: {"agent_id": "coordinator", "delegation_hint": "calendar-specialist", "expected_reply": "confirmation or reschedule request"}
+
+  This is optional — every outbound message is automatically tracked. But passing
+  context_bridge adds delegation hints that help you route replies faster without
+  needing to re-derive context.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister add agents/coordinator.yaml
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister commit -m "feat(coordinator): add guidance for enriching outbound context with delegation hints"
+```
+
+---
+
+### Task 10: Full test suite and type check
+
+**Files:** None modified — verification only.
+
+- [ ] **Step 1: Run TypeScript type check**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister tsc --noEmit 2>&1 | tail -30`
+
+Expected: Zero errors.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run --reporter=verbose 2>&1 | tail -60`
+
+Expected: All tests pass (the 3 pre-existing autonomy integration test failures mentioned in PR #678's test plan are acceptable).
+
+- [ ] **Step 3: Specifically verify existing context bridging tests still pass**
+
+Run: `npx --prefix /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister vitest run tests/unit/dispatch/dispatcher-context-bridging.test.ts --reporter=verbose 2>&1 | tail -30`
+
+Expected: All existing context bridging tests pass unchanged.
+
+- [ ] **Step 4: If any failures, fix and commit fixes**
+
+---
+
+### Task 11: Create PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git -C /Users/josephfung/Projects/worktrees/curia-context-bridge-autoregister push -u origin fix/context-bridge-autoregister
+```
+
+- [ ] **Step 2: Run pre-PR review subagents** (per CLAUDE.md auto-review rule)
+
+Launch `pr-review-toolkit:code-reviewer` and `pr-review-toolkit:silent-failure-hunter` in parallel on all changes vs main.
+
+- [ ] **Step 3: Address findings and commit if needed**
+
+- [ ] **Step 4: Create PR**
+
+```bash
+gh pr create --repo josephfung/curia --base main --head fix/context-bridge-autoregister --title "fix: unconditional outbound context registration (closes #609)" --body "$(cat <<'EOF'
+## Summary
+
+- Every successful outbound send now registers a context entry (auto or explicit)
+- Removes the opt-in gap where proactive sends had no context tracking
+- Adds configurable TTLs: `contextBridge.defaultExpiryHours` (6h) and `contextBridge.explicitExpiryHours` (24h)
+- Coordinator prompt updated with guidance on enriching entries with delegation hints
+
+## Test plan
+
+- [ ] All new unit tests pass (registerOutboundContext utility, send skill handlers)
+- [ ] Existing 55 context bridging tests pass unchanged
+- [ ] `tsc --noEmit` — zero type errors
+- [ ] Config validation rejects invalid values
+- [ ] Full test suite passes (pre-existing autonomy integration failures acceptable)
+
+Closes #609
+EOF
+)"
+```
+
+- [ ] **Step 5: Confirm CI started**
+
+```bash
+gh run list --repo josephfung/curia --branch fix/context-bridge-autoregister --limit 1
+```
+
+Report PR URL and CI status.

--- a/docs/wip/2026-05-24-context-bridge-autoregister.md
+++ b/docs/wip/2026-05-24-context-bridge-autoregister.md
@@ -1,0 +1,185 @@
+# Context Bridge Auto-Registration
+
+**Issue:** [#609](https://github.com/josephfung/curia/issues/609)
+**Date:** 2026-05-24
+**Status:** Design approved, implementation pending
+
+## Problem
+
+Context bridging v2 (PR #678) built the read side correctly — the dispatcher
+injects `[ACTIVE OUTBOUND CONTEXT]` blocks on every inbound message from the
+`outbound_context` table. But the write side is opt-in: send skills only
+register an entry when the caller passes an explicit `context_bridge` JSON
+param. Nothing in the system currently passes it, so the table stays empty and
+the coordinator loses context on proactive outbounds.
+
+## Solution
+
+Make outbound context registration unconditional. Every successful send through
+`signal-send`, `email-send`, or `email-reply` registers an entry in the
+`outbound_context` table — whether or not `context_bridge` was explicitly
+passed.
+
+## Design
+
+### 1. New unified function in `context-bridge-parse.ts`
+
+```typescript
+export async function registerOutboundContext(
+  outboundContext: OutboundContextCapability | undefined,
+  contextBridgeRaw: unknown,
+  opts: {
+    channelId: string;
+    content: string;
+    agentId: string;
+    log: Logger;
+  },
+): Promise<void>
+```
+
+Behavior:
+- If `outboundContext` is undefined → no-op (graceful when capability unavailable)
+- Parses `contextBridgeRaw` via existing `parseContextBridge` logic
+- If parsed successfully → registers with explicit metadata; TTL is
+  `bridge.expires_in_hours ?? outboundContext.explicitExpiryHours`
+- If absent/null/malformed → registers minimal entry (agentId + channelId + content);
+  TTL is `outboundContext.defaultExpiryHours`
+- Never throws — logs warnings on failure
+
+TTL values are read from `outboundContext.defaultExpiryHours` and
+`outboundContext.explicitExpiryHours` — exposed as readonly properties on the
+`OutboundContextCapability` interface (see section 3 below).
+
+Existing `parseContextBridge` and `registerContextBridge` exports are preserved
+(they're tested and may be referenced elsewhere).
+
+### 2. Send skill handler changes
+
+Each of the 3 send skills replaces:
+```typescript
+const bridge = parseContextBridge(contextBridgeRaw, ctx.log);
+if (bridge) {
+  await registerContextBridge(ctx.outboundContext, bridge, 'signal', message, ctx.log);
+}
+```
+
+With:
+```typescript
+await registerOutboundContext(ctx.outboundContext, contextBridgeRaw, {
+  channelId: 'signal',  // or 'email'
+  content: message,
+  agentId: ctx.agentId ?? 'coordinator',
+  log: ctx.log,
+});
+```
+
+TTL values come from `ctx.outboundContext.defaultExpiryHours` and
+`ctx.outboundContext.explicitExpiryHours` — the utility reads them directly
+from the capability. Skills don't need config access.
+
+Registration happens only after a successful gateway send (same position as
+today's conditional write).
+
+### 3. Configuration and capability interface
+
+**New config keys** under `contextBridge`:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `contextBridge.defaultExpiryHours` | integer (>= 1) | 6 | TTL for auto-registered entries (no `context_bridge` param) |
+| `contextBridge.explicitExpiryHours` | integer (>= 1) | 24 | TTL for entries with explicit `context_bridge` metadata |
+
+A caller-specified `expires_in_hours` inside the `context_bridge` JSON always
+takes precedence over the configured `explicitExpiryHours`.
+
+**Config flow:** YAML → `src/config.ts` → `src/index.ts` bootstrap →
+`OutboundContextService` constructor → `ScopedOutboundContext` → skill context.
+
+**Capability interface change** (`OutboundContextCapability`):
+
+```typescript
+export interface OutboundContextCapability {
+  register(entry: Omit<OutboundContextEntry, 'conversationId'>): Promise<string>;
+  release(entryId: string): Promise<void>;
+  readonly defaultExpiryHours: number;   // NEW
+  readonly explicitExpiryHours: number;  // NEW
+}
+```
+
+`ScopedOutboundContext` exposes these as readonly properties, reading from the
+service which receives them at construction. The `registerOutboundContext`
+utility reads them from the capability — skills never touch config directly.
+
+**Files to update:**
+- `src/config.ts` — add to `YamlConfig` interface + validation
+- `schemas/default-config.schema.json` — add property definition
+- `config/default.yaml` — add commented example
+- `docs/dev/configuration.md` — document both keys
+- `src/dispatch/outbound-context.ts` — constructor accepts config; replaces
+  `DEFAULT_EXPIRY_HOURS` constant; `ScopedOutboundContext` exposes TTL properties
+- `src/index.ts` — pass config values to `OutboundContextService` constructor
+
+### 4. Coordinator prompt update
+
+Add to `agents/coordinator.yaml` after the "Active Outbound Context &
+Delegation" section:
+
+```
+### Enriching outbound context
+When you call signal-send, email-send, or email-reply and you know which
+specialist should handle any reply, pass the context_bridge parameter:
+
+  context_bridge: {"agent_id": "coordinator", "delegation_hint": "calendar-specialist", "expected_reply": "confirmation or reschedule request"}
+
+This is optional — every outbound message is automatically tracked. But passing
+context_bridge adds delegation hints that help you route replies faster without
+needing to re-derive context.
+```
+
+### 5. TTL strategy
+
+- Auto-registered (6h default): covers the common reply window without
+  accumulating stale noise
+- Explicit (24h default): richer metadata, intentionally set up by caller,
+  deserves longer life
+- Caller `expires_in_hours` overrides both (for special cases)
+- No opt-out mechanism — every outbound is tracked
+- Existing `cleanupExpired()` and `context-bridge-release` handle lifecycle
+
+### 6. What is NOT changing
+
+- `OutboundGateway` — stays pure transport, no new dependencies
+- `src/dispatch/dispatcher.ts` — injection logic (read side) unchanged
+- `context-bridge-release` skill — unchanged
+- `skill.json` manifests — `context_bridge` input stays optional
+- `OutboundContextService.register()` method signature — unchanged
+  (service already accepts `expiresInHours` per entry)
+- `OutboundContextService.getActive()` / `formatInjectionBlock()` — unchanged
+
+## Testing
+
+### Unit tests (`context-bridge-parse.ts`)
+- `registerOutboundContext` with no `context_bridge` → registers minimal entry with default TTL
+- `registerOutboundContext` with valid JSON → registers with explicit metadata + explicit TTL
+- `registerOutboundContext` with malformed JSON → falls back to auto-registration, logs warning
+- `registerOutboundContext` with `expires_in_hours` in JSON → uses caller-specified TTL
+- `registerOutboundContext` when capability undefined → no-op, no throw
+
+### Unit tests (send skill handlers)
+- Each skill: successful send without `context_bridge` → entry registered
+- Each skill: successful send with `context_bridge` → entry has delegation metadata
+- Each skill: failed send → no entry registered
+
+### Config tests
+- Custom `contextBridge.defaultExpiryHours` respected for auto-registered entries
+- Custom `contextBridge.explicitExpiryHours` respected for explicit entries
+- Caller `expires_in_hours` overrides configured values
+- Schema validation rejects non-integer / < 1 values
+
+### Integration test
+- Scheduled job → `signal-send` (no `context_bridge`) → entry in table →
+  inbound on that channel → dispatcher injects `[ACTIVE OUTBOUND CONTEXT]`
+  block referencing the proactive message
+
+### Regression
+- All 55 existing context bridging tests pass unchanged

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -272,6 +272,14 @@
         "max_per_message": { "type": "integer", "minimum": 1 },
         "max_per_hour": { "type": "integer", "minimum": 1 }
       }
+    },
+    "contextBridge": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "defaultExpiryHours": { "type": "integer", "minimum": 1 },
+        "explicitExpiryHours": { "type": "integer", "minimum": 1 }
+      }
     }
   },
   "definitions": {

--- a/skills/email-reply/handler.test.ts
+++ b/skills/email-reply/handler.test.ts
@@ -116,7 +116,13 @@ describe('EmailReplyHandler', () => {
         success: true, messageId: 'reply-1',
       });
       const mockRegister = vi.fn().mockResolvedValue('entry-1');
-      (ctx as Record<string, unknown>).outboundContext = { register: mockRegister, release: vi.fn() };
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
+      (ctx as Record<string, unknown>).agentId = 'coordinator';
 
       const result = await handler.execute(ctx);
 
@@ -130,7 +136,7 @@ describe('EmailReplyHandler', () => {
       });
     });
 
-    it('does not register when context_bridge is absent', async () => {
+    it('registers a minimal entry when context_bridge is absent', async () => {
       const ctx = makeCtx({
         reply_to_message_id: 'nylas-msg-1',
         body: 'Got it, thanks',
@@ -144,11 +150,24 @@ describe('EmailReplyHandler', () => {
       (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
         success: true, messageId: 'reply-1',
       });
-      const mockRegister = vi.fn();
-      (ctx as Record<string, unknown>).outboundContext = { register: mockRegister, release: vi.fn() };
+      const mockRegister = vi.fn().mockResolvedValue('entry-1');
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
+      (ctx as Record<string, unknown>).agentId = 'coordinator';
 
-      await handler.execute(ctx);
-      expect(mockRegister).not.toHaveBeenCalled();
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      expect(mockRegister).toHaveBeenCalledWith({
+        channelId: 'email',
+        agentId: 'coordinator',
+        content: 'Got it, thanks',
+        expiresInHours: 6,
+      });
     });
 
     it('logs warning but succeeds when bridge registration fails', async () => {
@@ -167,7 +186,13 @@ describe('EmailReplyHandler', () => {
         success: true, messageId: 'reply-1',
       });
       const mockRegister = vi.fn().mockRejectedValue(new Error('DB error'));
-      (ctx as Record<string, unknown>).outboundContext = { register: mockRegister, release: vi.fn() };
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
+      (ctx as Record<string, unknown>).agentId = 'coordinator';
 
       const result = await handler.execute(ctx);
       expect(result.success).toBe(true);

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -14,7 +14,7 @@
 // sensitivity: "elevated" — enforced by the gateway's security pipeline.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
-import { parseContextBridge, registerContextBridge } from '../../src/dispatch/context-bridge-parse.js';
+import { registerOutboundContext } from '../../src/dispatch/context-bridge-parse.js';
 
 const MAX_BODY_LENGTH = 50000;
 
@@ -123,11 +123,13 @@ export class EmailReplyHandler implements SkillHandler {
         return { success: false, error: result.blockedReason ?? 'Email reply failed' };
       }
 
-      // Register context bridge entry if requested (best-effort).
-      const bridge = parseContextBridge(contextBridgeRaw, ctx.log);
-      if (bridge) {
-        await registerContextBridge(ctx.outboundContext, bridge, 'email', body, ctx.log);
-      }
+      // Register outbound context entry (best-effort, always fires).
+      await registerOutboundContext(ctx.outboundContext, contextBridgeRaw, {
+        channelId: 'email',
+        content: body,
+        agentId: ctx.agentId ?? 'coordinator',
+        log: ctx.log,
+      });
 
       ctx.log.info(
         { messageId: result.messageId, to: originalFrom, subject: replySubject, cc: ccAddresses },

--- a/skills/email-send/handler.test.ts
+++ b/skills/email-send/handler.test.ts
@@ -119,7 +119,13 @@ describe('EmailSendHandler', () => {
         success: true, messageId: 'msg-1',
       });
       const mockRegister = vi.fn().mockResolvedValue('entry-1');
-      (ctx as Record<string, unknown>).outboundContext = { register: mockRegister, release: vi.fn() };
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
+      (ctx as Record<string, unknown>).agentId = 'coordinator';
 
       const result = await handler.execute(ctx);
 
@@ -134,7 +140,7 @@ describe('EmailSendHandler', () => {
       });
     });
 
-    it('does not register when context_bridge is absent', async () => {
+    it('registers a minimal entry when context_bridge is absent', async () => {
       const ctx = makeCtx({
         to: 'alice@example.com',
         subject: 'Hello',
@@ -143,11 +149,24 @@ describe('EmailSendHandler', () => {
       (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
         success: true, messageId: 'msg-1',
       });
-      const mockRegister = vi.fn();
-      (ctx as Record<string, unknown>).outboundContext = { register: mockRegister, release: vi.fn() };
+      const mockRegister = vi.fn().mockResolvedValue('entry-1');
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
+      (ctx as Record<string, unknown>).agentId = 'coordinator';
 
-      await handler.execute(ctx);
-      expect(mockRegister).not.toHaveBeenCalled();
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      expect(mockRegister).toHaveBeenCalledWith({
+        channelId: 'email',
+        agentId: 'coordinator',
+        content: 'Hi there',
+        expiresInHours: 6,
+      });
     });
 
     it('logs warning but succeeds when bridge registration fails', async () => {
@@ -161,7 +180,13 @@ describe('EmailSendHandler', () => {
         success: true, messageId: 'msg-1',
       });
       const mockRegister = vi.fn().mockRejectedValue(new Error('DB error'));
-      (ctx as Record<string, unknown>).outboundContext = { register: mockRegister, release: vi.fn() };
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
+      (ctx as Record<string, unknown>).agentId = 'coordinator';
 
       const result = await handler.execute(ctx);
       expect(result.success).toBe(true);

--- a/skills/email-send/handler.ts
+++ b/skills/email-send/handler.ts
@@ -7,7 +7,7 @@
 // sensitivity: "elevated" — enforced by the gateway's security pipeline.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
-import { parseContextBridge, registerContextBridge } from '../../src/dispatch/context-bridge-parse.js';
+import { registerOutboundContext } from '../../src/dispatch/context-bridge-parse.js';
 
 const MAX_TO_LENGTH = 1000;
 const MAX_SUBJECT_LENGTH = 500;
@@ -109,11 +109,13 @@ export class EmailSendHandler implements SkillHandler {
         return { success: false, error: result.blockedReason ?? 'Email send failed' };
       }
 
-      // Register context bridge entry if requested (best-effort).
-      const bridge = parseContextBridge(contextBridgeRaw, ctx.log);
-      if (bridge) {
-        await registerContextBridge(ctx.outboundContext, bridge, 'email', body, ctx.log);
-      }
+      // Register outbound context entry (best-effort, always fires).
+      await registerOutboundContext(ctx.outboundContext, contextBridgeRaw, {
+        channelId: 'email',
+        content: body,
+        agentId: ctx.agentId ?? 'coordinator',
+        log: ctx.log,
+      });
 
       return {
         success: true,

--- a/skills/signal-send/handler.test.ts
+++ b/skills/signal-send/handler.test.ts
@@ -202,7 +202,13 @@ describe('SignalSendHandler', () => {
         success: true, messageId: 'msg-1',
       });
       const mockRegister = vi.fn().mockResolvedValue('entry-1');
-      (ctx as Record<string, unknown>).outboundContext = { register: mockRegister, release: vi.fn() };
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
+      (ctx as Record<string, unknown>).agentId = 'coordinator';
 
       const result = await handler.execute(ctx);
 
@@ -218,23 +224,31 @@ describe('SignalSendHandler', () => {
       });
     });
 
-    it('does not register when context_bridge is absent', async () => {
+    it('registers a minimal entry when context_bridge is absent', async () => {
       const ctx = makeCtx({
-        input: {
-          recipient: '+14155551234',
-          message: 'Hello',
-        },
+        input: { recipient: '+14155551234', message: 'Hello' },
       });
       (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
         success: true, messageId: 'msg-1',
       });
-      const mockRegister = vi.fn();
-      (ctx as Record<string, unknown>).outboundContext = { register: mockRegister, release: vi.fn() };
+      const mockRegister = vi.fn().mockResolvedValue('entry-1');
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
+      (ctx as Record<string, unknown>).agentId = 'coordinator';
 
       const result = await handler.execute(ctx);
 
       expect(result.success).toBe(true);
-      expect(mockRegister).not.toHaveBeenCalled();
+      expect(mockRegister).toHaveBeenCalledWith({
+        channelId: 'signal',
+        agentId: 'coordinator',
+        content: 'Hello',
+        expiresInHours: 6,
+      });
     });
 
     it('does not register when send fails', async () => {
@@ -249,7 +263,12 @@ describe('SignalSendHandler', () => {
         success: false, blockedReason: 'Blocked',
       });
       const mockRegister = vi.fn();
-      (ctx as Record<string, unknown>).outboundContext = { register: mockRegister, release: vi.fn() };
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
 
       const result = await handler.execute(ctx);
 
@@ -269,7 +288,13 @@ describe('SignalSendHandler', () => {
         success: true, messageId: 'msg-1',
       });
       const mockRegister = vi.fn().mockRejectedValue(new Error('DB down'));
-      (ctx as Record<string, unknown>).outboundContext = { register: mockRegister, release: vi.fn() };
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
+      (ctx as Record<string, unknown>).agentId = 'coordinator';
 
       const result = await handler.execute(ctx);
       expect(result.success).toBe(true);

--- a/skills/signal-send/handler.ts
+++ b/skills/signal-send/handler.ts
@@ -12,7 +12,7 @@
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { checkGroupMemberTrust } from '../../src/channels/signal/group-trust.js';
-import { parseContextBridge, registerContextBridge } from '../../src/dispatch/context-bridge-parse.js';
+import { registerOutboundContext } from '../../src/dispatch/context-bridge-parse.js';
 
 const MAX_MESSAGE_LENGTH = 10_000;
 
@@ -139,11 +139,13 @@ export class SignalSendHandler implements SkillHandler {
           return { success: false, error: result.blockedReason ?? 'Signal send failed' };
         }
 
-        // Register context bridge entry if requested (best-effort).
-        const bridge = parseContextBridge(contextBridgeRaw, ctx.log);
-        if (bridge) {
-          await registerContextBridge(ctx.outboundContext, bridge, 'signal', message, ctx.log);
-        }
+        // Register outbound context entry (best-effort, always fires).
+        await registerOutboundContext(ctx.outboundContext, contextBridgeRaw, {
+          channelId: 'signal',
+          content: message,
+          agentId: ctx.agentId ?? 'coordinator',
+          log: ctx.log,
+        });
 
         return { success: true, data: { delivered_to: group_id, channel: 'signal' } };
       } catch (err) {
@@ -171,11 +173,13 @@ export class SignalSendHandler implements SkillHandler {
         };
       }
 
-      // Register context bridge entry if requested (best-effort).
-      const bridge = parseContextBridge(contextBridgeRaw, ctx.log);
-      if (bridge) {
-        await registerContextBridge(ctx.outboundContext, bridge, 'signal', message, ctx.log);
-      }
+      // Register outbound context entry (best-effort, always fires).
+      await registerOutboundContext(ctx.outboundContext, contextBridgeRaw, {
+        channelId: 'signal',
+        content: message,
+        agentId: ctx.agentId ?? 'coordinator',
+        log: ctx.log,
+      });
 
       return {
         success: true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -594,7 +594,7 @@ export function loadYamlConfig(configDir: string): YamlConfig {
   }
 
   // Validate contextBridge if present
-  if (config.contextBridge !== undefined) {
+  if (config.contextBridge != null && typeof config.contextBridge === 'object') {
     const { defaultExpiryHours, explicitExpiryHours } = config.contextBridge;
     if (defaultExpiryHours !== undefined && (!Number.isInteger(defaultExpiryHours) || defaultExpiryHours < 1)) {
       throw new Error(`contextBridge.defaultExpiryHours must be a positive integer, got: ${defaultExpiryHours}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -248,6 +248,13 @@ export interface YamlConfig {
     };
     default_tier: 'fast' | 'standard' | 'powerful';
   };
+
+  contextBridge?: {
+    /** TTL in hours for auto-registered entries (no explicit context_bridge param). Default: 6. */
+    defaultExpiryHours?: number;
+    /** TTL in hours for entries with explicit context_bridge metadata. Default: 24. */
+    explicitExpiryHours?: number;
+  };
 }
 
 /**
@@ -583,6 +590,17 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       if (autonomyScoring.errorRateThreshold !== undefined && (typeof autonomyScoring.errorRateThreshold !== 'number' || autonomyScoring.errorRateThreshold < 0 || autonomyScoring.errorRateThreshold > 1)) {
         throw new Error(`dreaming.autonomy_scoring.errorRateThreshold must be a number between 0 and 1, got: ${autonomyScoring.errorRateThreshold}`);
       }
+    }
+  }
+
+  // Validate contextBridge if present
+  if (config.contextBridge !== undefined) {
+    const { defaultExpiryHours, explicitExpiryHours } = config.contextBridge;
+    if (defaultExpiryHours !== undefined && (!Number.isInteger(defaultExpiryHours) || defaultExpiryHours < 1)) {
+      throw new Error(`contextBridge.defaultExpiryHours must be a positive integer, got: ${defaultExpiryHours}`);
+    }
+    if (explicitExpiryHours !== undefined && (!Number.isInteger(explicitExpiryHours) || explicitExpiryHours < 1)) {
+      throw new Error(`contextBridge.explicitExpiryHours must be a positive integer, got: ${explicitExpiryHours}`);
     }
   }
 

--- a/src/dispatch/context-bridge-parse.test.ts
+++ b/src/dispatch/context-bridge-parse.test.ts
@@ -111,6 +111,26 @@ describe('registerOutboundContext', () => {
     });
   });
 
+  it('preserves valid agent_id and drops malformed optional fields', async () => {
+    const cap = makeCap();
+    const bridge = JSON.stringify({
+      agent_id: 'sales-agent',
+      expected_reply: 123, // wrong type — should be string
+      delegation_hint: 'delegate to sales',
+    });
+
+    await registerOutboundContext(cap, bridge, baseOpts);
+
+    expect(cap.register).toHaveBeenCalledOnce();
+    expect(cap.register).toHaveBeenCalledWith({
+      channelId: 'signal',
+      agentId: 'sales-agent', // preserved from bridge, not fallback
+      content: 'Hello world',
+      delegationHint: 'delegate to sales', // valid field kept
+      expiresInHours: 24, // explicit path TTL
+    });
+  });
+
   it('does not throw when register() rejects (best-effort)', async () => {
     const cap = makeCap({
       register: vi.fn().mockRejectedValue(new Error('DB down')),

--- a/src/dispatch/context-bridge-parse.test.ts
+++ b/src/dispatch/context-bridge-parse.test.ts
@@ -1,0 +1,122 @@
+// src/dispatch/context-bridge-parse.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { registerOutboundContext } from './context-bridge-parse.js';
+import type { OutboundContextCapability } from './outbound-context.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCap(overrides?: Partial<OutboundContextCapability>): OutboundContextCapability {
+  return {
+    register: vi.fn().mockResolvedValue('entry-id'),
+    release: vi.fn().mockResolvedValue(undefined),
+    defaultExpiryHours: 6,
+    explicitExpiryHours: 24,
+    ...overrides,
+  };
+}
+
+const baseOpts = {
+  channelId: 'signal',
+  content: 'Hello world',
+  agentId: 'test-agent',
+  log: logger,
+};
+
+describe('registerOutboundContext', () => {
+  it('no-ops when outboundContext is undefined', async () => {
+    // Should complete without error and not call anything
+    await expect(registerOutboundContext(undefined, undefined, baseOpts)).resolves.toBeUndefined();
+  });
+
+  it('registers minimal entry with defaultExpiryHours when context_bridge is absent/undefined', async () => {
+    const cap = makeCap();
+    await registerOutboundContext(cap, undefined, baseOpts);
+
+    expect(cap.register).toHaveBeenCalledOnce();
+    expect(cap.register).toHaveBeenCalledWith({
+      channelId: 'signal',
+      agentId: 'test-agent',
+      content: 'Hello world',
+      expiresInHours: 6,
+    });
+  });
+
+  it('registers with explicit metadata and explicitExpiryHours when context_bridge is valid JSON', async () => {
+    const cap = makeCap();
+    const bridge = JSON.stringify({
+      agent_id: 'meeting-debrief',
+      expected_reply: 'Summary of decisions',
+      delegation_hint: 'Delegate to meeting-debrief',
+      metadata: { topic: 'standup' },
+    });
+
+    await registerOutboundContext(cap, bridge, baseOpts);
+
+    expect(cap.register).toHaveBeenCalledOnce();
+    expect(cap.register).toHaveBeenCalledWith({
+      channelId: 'signal',
+      agentId: 'meeting-debrief',
+      content: 'Hello world',
+      expectedReply: 'Summary of decisions',
+      delegationHint: 'Delegate to meeting-debrief',
+      metadata: { topic: 'standup' },
+      expiresInHours: 24,
+    });
+  });
+
+  it('uses caller-specified expires_in_hours over explicitExpiryHours', async () => {
+    const cap = makeCap();
+    const bridge = JSON.stringify({
+      agent_id: 'meeting-debrief',
+      expires_in_hours: 48,
+    });
+
+    await registerOutboundContext(cap, bridge, baseOpts);
+
+    expect(cap.register).toHaveBeenCalledOnce();
+    expect(cap.register).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresInHours: 48 }),
+    );
+  });
+
+  it('falls back to auto-registration when context_bridge is malformed JSON', async () => {
+    const cap = makeCap();
+    await registerOutboundContext(cap, 'not valid json {{{', baseOpts);
+
+    expect(cap.register).toHaveBeenCalledOnce();
+    expect(cap.register).toHaveBeenCalledWith({
+      channelId: 'signal',
+      agentId: 'test-agent',
+      content: 'Hello world',
+      expiresInHours: 6,
+    });
+  });
+
+  it('falls back to auto-registration when context_bridge has missing agent_id', async () => {
+    const cap = makeCap();
+    const bridge = JSON.stringify({
+      expected_reply: 'Something',
+      // agent_id is missing
+    });
+
+    await registerOutboundContext(cap, bridge, baseOpts);
+
+    expect(cap.register).toHaveBeenCalledOnce();
+    expect(cap.register).toHaveBeenCalledWith({
+      channelId: 'signal',
+      agentId: 'test-agent',
+      content: 'Hello world',
+      expiresInHours: 6,
+    });
+  });
+
+  it('does not throw when register() rejects (best-effort)', async () => {
+    const cap = makeCap({
+      register: vi.fn().mockRejectedValue(new Error('DB down')),
+    });
+
+    // Should not throw
+    await expect(registerOutboundContext(cap, undefined, baseOpts)).resolves.toBeUndefined();
+  });
+});

--- a/src/dispatch/context-bridge-parse.ts
+++ b/src/dispatch/context-bridge-parse.ts
@@ -69,3 +69,59 @@ export async function registerContextBridge(
     log.warn({ err, channelId }, 'Failed to register context bridge entry — send succeeded');
   }
 }
+
+/**
+ * Single-call outbound context registration that replaces the two-step
+ * parse+conditional-register pattern in send skills.
+ *
+ * - If `outboundContext` is undefined → no-op (graceful when capability unavailable)
+ * - If `contextBridgeRaw` parses successfully → registers with explicit metadata;
+ *   TTL = bridge.expires_in_hours ?? outboundContext.explicitExpiryHours
+ * - If absent/null/malformed → registers minimal entry (agentId + channelId + content);
+ *   TTL = outboundContext.defaultExpiryHours
+ * - Never throws — logs warnings on failure
+ */
+export async function registerOutboundContext(
+  outboundContext: OutboundContextCapability | undefined,
+  contextBridgeRaw: unknown,
+  opts: {
+    channelId: string;
+    content: string;
+    agentId: string;
+    log: Logger;
+  },
+): Promise<void> {
+  if (!outboundContext) return;
+
+  const { channelId, content, agentId, log } = opts;
+
+  try {
+    const bridge = parseContextBridge(contextBridgeRaw, log);
+
+    if (bridge) {
+      // Explicit registration — skill provided structured context_bridge metadata.
+      // TTL: use the caller-specified expires_in_hours, falling back to the
+      // capability's explicitExpiryHours (longer TTL for well-structured entries).
+      await outboundContext.register({
+        channelId,
+        agentId: bridge.agent_id,
+        content,
+        ...(bridge.expected_reply != null ? { expectedReply: bridge.expected_reply } : {}),
+        ...(bridge.delegation_hint != null ? { delegationHint: bridge.delegation_hint } : {}),
+        ...(bridge.metadata != null ? { metadata: bridge.metadata } : {}),
+        expiresInHours: bridge.expires_in_hours ?? outboundContext.explicitExpiryHours,
+      });
+    } else {
+      // Auto-registration — context_bridge was absent, null, or malformed.
+      // Register a minimal entry so inbound replies can still be correlated.
+      await outboundContext.register({
+        channelId,
+        agentId,
+        content,
+        expiresInHours: outboundContext.defaultExpiryHours,
+      });
+    }
+  } catch (err) {
+    log.warn({ err, channelId }, 'Failed to register outbound context — send succeeded');
+  }
+}

--- a/src/dispatch/context-bridge-parse.ts
+++ b/src/dispatch/context-bridge-parse.ts
@@ -31,11 +31,23 @@ export function parseContextBridge(raw: unknown, log: Logger): ContextBridgeInpu
       log.warn({ rawLength: raw.length }, 'context_bridge: missing or invalid agent_id — skipping registration');
       return null;
     }
-    // Validate optional field types — reject silently malformed payloads.
-    if (obj.expected_reply != null && typeof obj.expected_reply !== 'string') return null;
-    if (obj.delegation_hint != null && typeof obj.delegation_hint !== 'string') return null;
-    if (obj.metadata != null && (typeof obj.metadata !== 'object' || Array.isArray(obj.metadata))) return null;
-    if (obj.expires_in_hours != null && (typeof obj.expires_in_hours !== 'number' || !Number.isFinite(obj.expires_in_hours) || obj.expires_in_hours <= 0)) return null;
+    // Validate optional field types — malformed payloads fall through to auto-registration.
+    if (obj.expected_reply != null && typeof obj.expected_reply !== 'string') {
+      log.warn({ field: 'expected_reply', type: typeof obj.expected_reply }, 'context_bridge: optional field has wrong type — falling back to auto-registration');
+      return null;
+    }
+    if (obj.delegation_hint != null && typeof obj.delegation_hint !== 'string') {
+      log.warn({ field: 'delegation_hint', type: typeof obj.delegation_hint }, 'context_bridge: optional field has wrong type — falling back to auto-registration');
+      return null;
+    }
+    if (obj.metadata != null && (typeof obj.metadata !== 'object' || Array.isArray(obj.metadata))) {
+      log.warn({ field: 'metadata' }, 'context_bridge: metadata must be a plain object — falling back to auto-registration');
+      return null;
+    }
+    if (obj.expires_in_hours != null && (typeof obj.expires_in_hours !== 'number' || !Number.isFinite(obj.expires_in_hours) || obj.expires_in_hours <= 0)) {
+      log.warn({ field: 'expires_in_hours', value: obj.expires_in_hours }, 'context_bridge: expires_in_hours must be a positive finite number — falling back to auto-registration');
+      return null;
+    }
     return obj as unknown as ContextBridgeInput;
   } catch {
     log.warn({ rawLength: raw.length }, 'context_bridge: failed to parse JSON — skipping registration');
@@ -43,32 +55,6 @@ export function parseContextBridge(raw: unknown, log: Logger): ContextBridgeInpu
   }
 }
 
-/**
- * Best-effort context bridge registration. Call after a successful send.
- * Logs warnings on failure but never throws.
- */
-export async function registerContextBridge(
-  outboundContext: OutboundContextCapability | undefined,
-  bridge: ContextBridgeInput,
-  channelId: string,
-  content: string,
-  log: Logger,
-): Promise<void> {
-  if (!outboundContext) return;
-  try {
-    await outboundContext.register({
-      channelId,
-      agentId: bridge.agent_id,
-      content,
-      ...(bridge.expected_reply != null ? { expectedReply: bridge.expected_reply } : {}),
-      ...(bridge.delegation_hint != null ? { delegationHint: bridge.delegation_hint } : {}),
-      ...(bridge.metadata != null ? { metadata: bridge.metadata } : {}),
-      ...(bridge.expires_in_hours != null ? { expiresInHours: bridge.expires_in_hours } : {}),
-    });
-  } catch (err) {
-    log.warn({ err, channelId }, 'Failed to register context bridge entry — send succeeded');
-  }
-}
 
 /**
  * Single-call outbound context registration that replaces the two-step

--- a/src/dispatch/context-bridge-parse.ts
+++ b/src/dispatch/context-bridge-parse.ts
@@ -31,24 +31,35 @@ export function parseContextBridge(raw: unknown, log: Logger): ContextBridgeInpu
       log.warn({ rawLength: raw.length }, 'context_bridge: missing or invalid agent_id — skipping registration');
       return null;
     }
-    // Validate optional field types — malformed payloads fall through to auto-registration.
-    if (obj.expected_reply != null && typeof obj.expected_reply !== 'string') {
-      log.warn({ field: 'expected_reply', type: typeof obj.expected_reply }, 'context_bridge: optional field has wrong type — falling back to auto-registration');
-      return null;
+    // Validate optional fields — strip invalid ones but preserve valid agent_id.
+    // Returning null here would discard the agent_id and misroute reply correlation.
+    const result: ContextBridgeInput = { agent_id: obj.agent_id as string };
+
+    if (typeof obj.expected_reply === 'string') {
+      result.expected_reply = obj.expected_reply;
+    } else if (obj.expected_reply != null) {
+      log.warn({ field: 'expected_reply', type: typeof obj.expected_reply }, 'context_bridge: optional field has wrong type — dropping field');
     }
-    if (obj.delegation_hint != null && typeof obj.delegation_hint !== 'string') {
-      log.warn({ field: 'delegation_hint', type: typeof obj.delegation_hint }, 'context_bridge: optional field has wrong type — falling back to auto-registration');
-      return null;
+
+    if (typeof obj.delegation_hint === 'string') {
+      result.delegation_hint = obj.delegation_hint;
+    } else if (obj.delegation_hint != null) {
+      log.warn({ field: 'delegation_hint', type: typeof obj.delegation_hint }, 'context_bridge: optional field has wrong type — dropping field');
     }
-    if (obj.metadata != null && (typeof obj.metadata !== 'object' || Array.isArray(obj.metadata))) {
-      log.warn({ field: 'metadata' }, 'context_bridge: metadata must be a plain object — falling back to auto-registration');
-      return null;
+
+    if (obj.metadata != null && typeof obj.metadata === 'object' && !Array.isArray(obj.metadata)) {
+      result.metadata = obj.metadata as Record<string, unknown>;
+    } else if (obj.metadata != null) {
+      log.warn({ field: 'metadata' }, 'context_bridge: metadata must be a plain object — dropping field');
     }
-    if (obj.expires_in_hours != null && (typeof obj.expires_in_hours !== 'number' || !Number.isFinite(obj.expires_in_hours) || obj.expires_in_hours <= 0)) {
-      log.warn({ field: 'expires_in_hours', value: obj.expires_in_hours }, 'context_bridge: expires_in_hours must be a positive finite number — falling back to auto-registration');
-      return null;
+
+    if (typeof obj.expires_in_hours === 'number' && Number.isFinite(obj.expires_in_hours) && obj.expires_in_hours > 0) {
+      result.expires_in_hours = obj.expires_in_hours;
+    } else if (obj.expires_in_hours != null) {
+      log.warn({ field: 'expires_in_hours', value: obj.expires_in_hours }, 'context_bridge: expires_in_hours must be a positive finite number — dropping field');
     }
-    return obj as unknown as ContextBridgeInput;
+
+    return result;
   } catch {
     log.warn({ rawLength: raw.length }, 'context_bridge: failed to parse JSON — skipping registration');
     return null;

--- a/src/dispatch/outbound-context.test.ts
+++ b/src/dispatch/outbound-context.test.ts
@@ -65,7 +65,26 @@ describe('OutboundContextService', () => {
       expect(preview.endsWith('…')).toBe(true);
     });
 
-    it('defaults expiresInHours to 24 when not provided', async () => {
+    it('defaults expiresInHours to the configured defaultExpiryHours when entry omits expiresInHours', async () => {
+      const customService = new OutboundContextService(pool, logger, { defaultExpiryHours: 8 });
+      (pool.query as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        rows: [{ id: 'some-id' }],
+      });
+
+      await customService.register({
+        conversationId: 'conv-1',
+        channelId: 'signal',
+        agentId: 'coordinator',
+        content: 'Short message',
+      });
+
+      const call = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0]!;
+      const expiresAt = call[1][7] as Date;
+      const expectedMs = Date.now() + 8 * 60 * 60 * 1000;
+      expect(Math.abs(expiresAt.getTime() - expectedMs)).toBeLessThan(5000);
+    });
+
+    it('falls back to 6 hours when no config is provided and entry omits expiresInHours', async () => {
       (pool.query as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
         rows: [{ id: 'some-id' }],
       });
@@ -79,7 +98,7 @@ describe('OutboundContextService', () => {
 
       const call = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0]!;
       const expiresAt = call[1][7] as Date;
-      const expectedMs = Date.now() + 24 * 60 * 60 * 1000;
+      const expectedMs = Date.now() + 6 * 60 * 60 * 1000;
       expect(Math.abs(expiresAt.getTime() - expectedMs)).toBeLessThan(5000);
     });
   });
@@ -209,6 +228,48 @@ describe('OutboundContextService', () => {
       expect(result).not.toContain('delegation:');
       expect(result).not.toContain('context:');
     });
+  });
+});
+
+describe('OutboundContextService TTL config', () => {
+  it('exposes defaultExpiryHours = 6 when no config provided', () => {
+    const pool = makePool();
+    const service = new OutboundContextService(pool, logger);
+    expect(service.defaultExpiryHours).toBe(6);
+  });
+
+  it('exposes explicitExpiryHours = 24 when no config provided', () => {
+    const pool = makePool();
+    const service = new OutboundContextService(pool, logger);
+    expect(service.explicitExpiryHours).toBe(24);
+  });
+
+  it('respects configured defaultExpiryHours', () => {
+    const pool = makePool();
+    const service = new OutboundContextService(pool, logger, { defaultExpiryHours: 12 });
+    expect(service.defaultExpiryHours).toBe(12);
+  });
+
+  it('respects configured explicitExpiryHours', () => {
+    const pool = makePool();
+    const service = new OutboundContextService(pool, logger, { explicitExpiryHours: 48 });
+    expect(service.explicitExpiryHours).toBe(48);
+  });
+});
+
+describe('ScopedOutboundContext TTL delegation', () => {
+  it('exposes defaultExpiryHours from the underlying service', () => {
+    const pool = makePool();
+    const service = new OutboundContextService(pool, logger, { defaultExpiryHours: 10 });
+    const scoped = new ScopedOutboundContext(service, 'conv-1');
+    expect(scoped.defaultExpiryHours).toBe(10);
+  });
+
+  it('exposes explicitExpiryHours from the underlying service', () => {
+    const pool = makePool();
+    const service = new OutboundContextService(pool, logger, { explicitExpiryHours: 36 });
+    const scoped = new ScopedOutboundContext(service, 'conv-1');
+    expect(scoped.explicitExpiryHours).toBe(36);
   });
 });
 

--- a/src/dispatch/outbound-context.ts
+++ b/src/dispatch/outbound-context.ts
@@ -11,9 +11,18 @@ import type { DbPool } from '../db/connection.js';
 import type { Logger } from '../logger.js';
 
 const MAX_PREVIEW_LENGTH = 300;
-const DEFAULT_EXPIRY_HOURS = 24;
 const MAX_METADATA_LENGTH = 2000;
 const MAX_FIELD_LENGTH = 500;
+
+// ── Config ───────────────────────────────────────────────────────────────
+
+/** Optional configuration for OutboundContextService TTL defaults. */
+export interface OutboundContextConfig {
+  /** Hours until auto-registered entries expire. Default: 6. */
+  defaultExpiryHours?: number;
+  /** Hours until entries with explicit context_bridge metadata expire. Default: 24. */
+  explicitExpiryHours?: number;
+}
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -27,7 +36,7 @@ export interface OutboundContextEntry {
   expectedReply?: string;
   delegationHint?: string;
   metadata?: Record<string, unknown>;
-  /** Hours until automatic expiry. Default: 24. */
+  /** Hours until automatic expiry. Default: service's defaultExpiryHours (6). */
   expiresInHours?: number;
 }
 
@@ -48,6 +57,8 @@ export interface OutboundContextRow {
 
 /** Narrow interface exposed to skills via the outboundContext capability. */
 export interface OutboundContextCapability {
+  readonly defaultExpiryHours: number;
+  readonly explicitExpiryHours: number;
   register(entry: Omit<OutboundContextEntry, 'conversationId'>): Promise<string>;
   release(entryId: string): Promise<void>;
 }
@@ -117,16 +128,31 @@ function mapRow(row: Record<string, unknown>): OutboundContextRow {
 // ── Service ────────────────────────────────────────────────────────────────
 
 export class OutboundContextService {
+  private readonly _defaultExpiryHours: number;
+  private readonly _explicitExpiryHours: number;
+
   constructor(
     private pool: DbPool,
     private logger: Logger,
-  ) {}
+    config?: OutboundContextConfig,
+  ) {
+    this._defaultExpiryHours = config?.defaultExpiryHours ?? 6;
+    this._explicitExpiryHours = config?.explicitExpiryHours ?? 24;
+  }
+
+  get defaultExpiryHours(): number {
+    return this._defaultExpiryHours;
+  }
+
+  get explicitExpiryHours(): number {
+    return this._explicitExpiryHours;
+  }
 
   /** Write a new outbound context entry. Returns the generated UUID. */
   async register(entry: OutboundContextEntry): Promise<string> {
     const preview = truncatePreview(entry.content);
     const expiresAt = new Date(
-      Date.now() + (entry.expiresInHours ?? DEFAULT_EXPIRY_HOURS) * 3_600_000,
+      Date.now() + (entry.expiresInHours ?? this._defaultExpiryHours) * 3_600_000,
     );
 
     const result = await this.pool.query<{ id: string }>(
@@ -234,6 +260,14 @@ export class ScopedOutboundContext implements OutboundContextCapability {
     private service: OutboundContextService,
     private conversationId: string,
   ) {}
+
+  get defaultExpiryHours(): number {
+    return this.service.defaultExpiryHours;
+  }
+
+  get explicitExpiryHours(): number {
+    return this.service.explicitExpiryHours;
+  }
 
   async register(entry: Omit<OutboundContextEntry, 'conversationId'>): Promise<string> {
     return this.service.register({ ...entry, conversationId: this.conversationId });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1063,7 +1063,10 @@ async function main(): Promise<void> {
   // specialist-initiated outbound. Requires pool (Postgres).
   // Constructed here (before Scheduler) so the scheduler can run startup + daily cleanup.
   const outboundContextService = pool
-    ? new OutboundContextService(pool, logger)
+    ? new OutboundContextService(pool, logger, {
+        defaultExpiryHours: yamlConfig.contextBridge?.defaultExpiryHours,
+        explicitExpiryHours: yamlConfig.contextBridge?.explicitExpiryHours,
+      })
     : undefined;
 
   const scheduler = new Scheduler({ pool, bus, logger, schedulerService, driftDetector, dreamEngine, outboundContextService });


### PR DESCRIPTION
## **User description**
## Summary

- Every successful outbound send (signal-send, email-send, email-reply) now registers a context entry unconditionally
- Removes the opt-in gap where proactive sends had no context tracking — the coordinator no longer loses the thread when users reply to notifications
- Adds configurable TTLs: `contextBridge.defaultExpiryHours` (6h) and `contextBridge.explicitExpiryHours` (24h)
- Coordinator prompt updated with guidance on enriching entries with delegation hints
- Removes dead `registerContextBridge` export, adds warn-level logging to silent validation fallbacks

## Test plan

- [ ] All new unit tests pass (registerOutboundContext utility, send skill handlers)
- [ ] Existing context bridging tests pass unchanged (17/17 dispatcher tests)
- [ ] `tsc --noEmit` — zero type errors
- [ ] Config validation rejects invalid values at startup
- [ ] Full test suite passes (56 directly-related tests green)

Closes #609


___

## **CodeAnt-AI Description**
**Always register outbound context after successful sends**

### What Changed
- Signal, email send, and email replies now create a context entry after every successful send, even when no `context_bridge` data is provided
- When `context_bridge` is present, the entry keeps the extra delegation details; when it is absent or invalid, a minimal entry is still recorded so replies can be matched later
- Outbound context now uses separate TTLs for automatic entries and explicit entries, with config defaults added and validated
- The coordinator docs now explain how to add delegation hints to outbound messages

### Impact
`✅ Replies to proactive messages stay linked`
`✅ Fewer missed follow-up conversations`
`✅ Clearer context for routed replies`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic registration of outbound message context when sending messages via Signal and email channels.
  * New configuration options for specifying how long outbound message context is retained.

* **Documentation**
  * Added configuration documentation for managing outbound context expiration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->