### PR TITLE
feat: thread TaskOriginator through declarative scheduled jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`context-bridge-release`** — new coordinator skill to release outbound context entries when conversations complete. (#615)
 - **`outbound_context` table** — dedicated Postgres table replaces working-memory memos for outbound context tracking. (#615)
 - **Outbound context cleanup** — scheduler now purges expired and released `outbound_context` rows at startup and daily; count is logged at info level. (#679)
+- **Declarative job originator** — YAML-defined scheduled jobs now stamped with `systemRole: 'system'` originator at startup, distinguishing operator-configured work from principal-initiated and agent-decided tasks. (#558)
 
 ### Changed
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -31,7 +31,7 @@ import type {
   ResolvedSender,
   IdentitySource,
   IdentityStatus,
-  SystemRole,
+  ContactSystemRole,
   TrustLevel,
 } from './types.js';
 import type { DedupService } from './dedup-service.js';
@@ -44,7 +44,7 @@ interface ContactServiceBackend {
   getContact(id: string): Promise<Contact | undefined>;
   findContactByName(name: string): Promise<Contact[]>;
   findContactByRole(role: string): Promise<Contact[]>;
-  findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null>;
+  findContactBySystemRole(systemRole: ContactSystemRole): Promise<Contact | null>;
   listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]>;
   updateContact(contact: Contact): Promise<void>;
   createIdentity(identity: ChannelIdentity): Promise<void>;
@@ -316,7 +316,7 @@ export class ContactService {
   }
 
   /** Find the single contact with the given system role, or null. */
-  async findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null> {
+  async findContactBySystemRole(systemRole: ContactSystemRole): Promise<Contact | null> {
     return this.backend.findContactBySystemRole(systemRole);
   }
 
@@ -942,7 +942,7 @@ class PostgresContactBackend implements ContactServiceBackend {
     return result.rows.map((row) => this.rowToContact(row));
   }
 
-  async findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null> {
+  async findContactBySystemRole(systemRole: ContactSystemRole): Promise<Contact | null> {
     const result = await this.pool.query<{
       id: string;
       kg_node_id: string | null;
@@ -1521,7 +1521,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return results;
   }
 
-  async findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null> {
+  async findContactBySystemRole(systemRole: ContactSystemRole): Promise<Contact | null> {
     for (const contact of this.contacts.values()) {
       if (contact.systemRole === systemRole) return contact;
     }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -31,7 +31,7 @@ import type {
   ResolvedSender,
   IdentitySource,
   IdentityStatus,
-  ContactSystemRole,
+  SystemRole,
   TrustLevel,
 } from './types.js';
 import type { DedupService } from './dedup-service.js';
@@ -44,7 +44,7 @@ interface ContactServiceBackend {
   getContact(id: string): Promise<Contact | undefined>;
   findContactByName(name: string): Promise<Contact[]>;
   findContactByRole(role: string): Promise<Contact[]>;
-  findContactBySystemRole(systemRole: ContactSystemRole): Promise<Contact | null>;
+  findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null>;
   listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]>;
   updateContact(contact: Contact): Promise<void>;
   createIdentity(identity: ChannelIdentity): Promise<void>;
@@ -316,7 +316,7 @@ export class ContactService {
   }
 
   /** Find the single contact with the given system role, or null. */
-  async findContactBySystemRole(systemRole: ContactSystemRole): Promise<Contact | null> {
+  async findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null> {
     return this.backend.findContactBySystemRole(systemRole);
   }
 
@@ -942,7 +942,7 @@ class PostgresContactBackend implements ContactServiceBackend {
     return result.rows.map((row) => this.rowToContact(row));
   }
 
-  async findContactBySystemRole(systemRole: ContactSystemRole): Promise<Contact | null> {
+  async findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null> {
     const result = await this.pool.query<{
       id: string;
       kg_node_id: string | null;
@@ -1521,7 +1521,7 @@ class InMemoryContactBackend implements ContactServiceBackend {
     return results;
   }
 
-  async findContactBySystemRole(systemRole: ContactSystemRole): Promise<Contact | null> {
+  async findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null> {
     for (const contact of this.contacts.values()) {
       if (contact.systemRole === systemRole) return contact;
     }

--- a/src/contacts/principal.ts
+++ b/src/contacts/principal.ts
@@ -35,3 +35,31 @@ export function isAgentOriginated(
   const originator = metadata.originator as TaskOriginator | undefined;
   return originator?.systemRole === 'agent';
 }
+
+/**
+ * Check whether a task was originated by the system (operator-configured,
+ * platform-executed — e.g. declarative YAML jobs loaded at startup).
+ *
+ * @param metadata  Task metadata (from ctx.taskMetadata or agent.task payload)
+ */
+export function isSystemOriginated(
+  metadata: Record<string, unknown> | undefined,
+): boolean {
+  if (!metadata) return false;
+  const originator = metadata.originator as TaskOriginator | undefined;
+  return originator?.systemRole === 'system';
+}
+
+/**
+ * Create a TaskOriginator representing operator-configured, platform-executed work.
+ * Used by upsertDeclarativeJob() to stamp YAML-defined scheduled jobs.
+ * A factory (not a constant) so `initiatedAt` reflects the actual upsert time.
+ */
+export function makeSystemOriginator(): TaskOriginator {
+  return {
+    contactId: 'system',
+    systemRole: 'system',
+    channel: 'declarative',
+    initiatedAt: new Date().toISOString(),
+  };
+}

--- a/src/contacts/principal.ts
+++ b/src/contacts/principal.ts
@@ -46,7 +46,8 @@ export function isSystemOriginated(
   metadata: Record<string, unknown> | undefined,
 ): boolean {
   if (!metadata) return false;
-  const originator = metadata.originator as TaskOriginator | undefined;
+  // Runtime-validated in callers; cast through unknown per repo policy.
+  const originator = metadata.originator as unknown as TaskOriginator | undefined;
   return originator?.systemRole === 'system';
 }
 

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -172,6 +172,10 @@ export type TrustLevel = 'ceo' | 'high' | 'medium' | 'low';
  *  - 'principal' — the human CEO who Curia serves
  *  - 'agent'     — Curia itself or another autonomous agent
  *  - 'system'    — operator-configured, platform-executed (e.g. declarative YAML jobs)
+ *
+ *  Note: the contacts.system_role column (migration 035) has a CHECK constraint
+ *  allowing only 'principal' and 'agent'. The 'system' value is valid for
+ *  TaskOriginator.systemRole (stored in JSONB) but NOT for the contacts table.
  */
 export type SystemRole = 'principal' | 'agent' | 'system';
 

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -168,8 +168,12 @@ export interface PermissionDef {
 
 export type TrustLevel = 'ceo' | 'high' | 'medium' | 'low';
 
-/** System designation — drives authorization. Separate from the free-text `role` field. */
-export type SystemRole = 'principal' | 'agent';
+/** System designation — drives authorization. Separate from the free-text `role` field.
+ *  - 'principal' — the human CEO who Curia serves
+ *  - 'agent'     — Curia itself or another autonomous agent
+ *  - 'system'    — operator-configured, platform-executed (e.g. declarative YAML jobs)
+ */
+export type SystemRole = 'principal' | 'agent' | 'system';
 
 // Ordinal ranking for trust level comparison. Higher rank = more trusted.
 // Used by meetsMinimumTrust() so callers don't need to enumerate every level.

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -5,7 +5,7 @@ export interface Contact {
   kgNodeId: string | null;
   displayName: string;
   role: string | null;
-  systemRole: ContactSystemRole | null;
+  systemRole: SystemRole | null;
   status: ContactStatus;
   // Trust scoring fields (migration 020)
   contactConfidence: number;         // 0.0–1.0; accumulated over time
@@ -101,7 +101,7 @@ export interface ResolvedSender {
   contactId: string;
   displayName: string;
   role: string | null;
-  systemRole: ContactSystemRole | null;
+  systemRole: SystemRole | null;
   status: ContactStatus;
   kgNodeId: string | null;
   verified: boolean;
@@ -115,7 +115,7 @@ export interface SenderContext {
   contactId: string;
   displayName: string;
   role: string | null;
-  systemRole: ContactSystemRole | null;
+  systemRole: SystemRole | null;
   status: ContactStatus;
   verified: boolean;
   kgNodeId: string | null;
@@ -168,18 +168,14 @@ export interface PermissionDef {
 
 export type TrustLevel = 'ceo' | 'high' | 'medium' | 'low';
 
-/** DB-safe subset — matches the CHECK constraint on contacts.system_role (migration 035).
- *  Use this for Contact, ResolvedSender, SenderContext, and findContactBySystemRole(). */
-export type ContactSystemRole = 'principal' | 'agent';
-
-/** Full system designation — includes 'system' for operator-configured, platform-executed
- *  work (e.g. declarative YAML jobs). Used by TaskOriginator.systemRole (stored as JSONB,
- *  not in the contacts table).
+/** System designation — drives authorization. Separate from the free-text `role` field.
  *  - 'principal' — the human CEO who Curia serves
  *  - 'agent'     — Curia itself or another autonomous agent
  *  - 'system'    — operator-configured, platform-executed (e.g. declarative YAML jobs)
+ *
+ *  DB CHECK constraint widened in migration 048 to include 'system'.
  */
-export type SystemRole = ContactSystemRole | 'system';
+export type SystemRole = 'principal' | 'agent' | 'system';
 
 // Ordinal ranking for trust level comparison. Higher rank = more trusted.
 // Used by meetsMinimumTrust() so callers don't need to enumerate every level.

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -5,7 +5,7 @@ export interface Contact {
   kgNodeId: string | null;
   displayName: string;
   role: string | null;
-  systemRole: SystemRole | null;
+  systemRole: ContactSystemRole | null;
   status: ContactStatus;
   // Trust scoring fields (migration 020)
   contactConfidence: number;         // 0.0–1.0; accumulated over time
@@ -101,7 +101,7 @@ export interface ResolvedSender {
   contactId: string;
   displayName: string;
   role: string | null;
-  systemRole: SystemRole | null;
+  systemRole: ContactSystemRole | null;
   status: ContactStatus;
   kgNodeId: string | null;
   verified: boolean;
@@ -115,7 +115,7 @@ export interface SenderContext {
   contactId: string;
   displayName: string;
   role: string | null;
-  systemRole: SystemRole | null;
+  systemRole: ContactSystemRole | null;
   status: ContactStatus;
   verified: boolean;
   kgNodeId: string | null;
@@ -168,16 +168,18 @@ export interface PermissionDef {
 
 export type TrustLevel = 'ceo' | 'high' | 'medium' | 'low';
 
-/** System designation — drives authorization. Separate from the free-text `role` field.
+/** DB-safe subset — matches the CHECK constraint on contacts.system_role (migration 035).
+ *  Use this for Contact, ResolvedSender, SenderContext, and findContactBySystemRole(). */
+export type ContactSystemRole = 'principal' | 'agent';
+
+/** Full system designation — includes 'system' for operator-configured, platform-executed
+ *  work (e.g. declarative YAML jobs). Used by TaskOriginator.systemRole (stored as JSONB,
+ *  not in the contacts table).
  *  - 'principal' — the human CEO who Curia serves
  *  - 'agent'     — Curia itself or another autonomous agent
  *  - 'system'    — operator-configured, platform-executed (e.g. declarative YAML jobs)
- *
- *  Note: the contacts.system_role column (migration 035) has a CHECK constraint
- *  allowing only 'principal' and 'agent'. The 'system' value is valid for
- *  TaskOriginator.systemRole (stored in JSONB) but NOT for the contacts table.
  */
-export type SystemRole = 'principal' | 'agent' | 'system';
+export type SystemRole = ContactSystemRole | 'system';
 
 // Ordinal ranking for trust level comparison. Higher rank = more trusted.
 // Used by meetsMinimumTrust() so callers don't need to enumerate every level.

--- a/src/db/migrations/043_widen_system_role_check.sql
+++ b/src/db/migrations/043_widen_system_role_check.sql
@@ -1,0 +1,16 @@
+-- 043_widen_system_role_check.sql
+--
+-- Widen the CHECK constraint on contacts.system_role to include 'system',
+-- matching the expanded SystemRole type (issue #558).
+-- 'system' represents operator-configured, platform-executed entities
+-- (e.g. declarative YAML-defined scheduled jobs).
+
+-- Drop the old unnamed CHECK and re-add with the wider set.
+-- Postgres does not support ALTER CONSTRAINT for CHECK constraints,
+-- so we drop-and-recreate.
+ALTER TABLE contacts
+  DROP CONSTRAINT IF EXISTS contacts_system_role_check;
+
+ALTER TABLE contacts
+  ADD CONSTRAINT contacts_system_role_check
+  CHECK (system_role IN ('principal', 'agent', 'system'));

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -26,7 +26,7 @@ export interface CreateJobParams {
   /** Who originally initiated the task chain that created this schedule entry.
    *  Preserved in the DB so fireJob() can stamp it on the resulting agent.task,
    *  allowing isPrincipalOriginated() to return true for principal-authorized scheduled work.
-   *  Null for declarative (YAML-defined) jobs and jobs created before migration 040. */
+   *  Null for jobs created before migration 040. Declarative jobs use systemRole: 'system'. */
   originator?: TaskOriginator;
 }
 
@@ -60,8 +60,9 @@ export interface JobRow {
   lastRunOutcome: 'completed' | 'failed' | 'timed_out' | null;
   lastRunSummary: string | null;
   lastRunContext: Record<string, unknown> | null;
-  /** TaskOriginator stored at schedule-creation time. Null for declarative jobs and
-   *  jobs created before migration 040. Stamped on the resulting agent.task by fireJob(). */
+  /** TaskOriginator stored at schedule-creation time. Null for jobs created before
+   *  migration 040. Declarative jobs use systemRole: 'system'. Stamped on the resulting
+   *  agent.task by fireJob(). */
   originator: TaskOriginator | null;
 }
 

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -26,7 +26,8 @@ export interface CreateJobParams {
   /** Who originally initiated the task chain that created this schedule entry.
    *  Preserved in the DB so fireJob() can stamp it on the resulting agent.task,
    *  allowing isPrincipalOriginated() to return true for principal-authorized scheduled work.
-   *  Null for jobs created before migration 040. Declarative jobs use systemRole: 'system'. */
+   *  Null for pre-040 rows, or when a job is created without an originator.
+   *  Declarative jobs use systemRole: 'system'. */
   originator?: TaskOriginator;
 }
 
@@ -60,9 +61,9 @@ export interface JobRow {
   lastRunOutcome: 'completed' | 'failed' | 'timed_out' | null;
   lastRunSummary: string | null;
   lastRunContext: Record<string, unknown> | null;
-  /** TaskOriginator stored at schedule-creation time. Null for jobs created before
-   *  migration 040. Declarative jobs use systemRole: 'system'. Stamped on the resulting
-   *  agent.task by fireJob(). */
+  /** TaskOriginator stored at schedule-creation time. Null for pre-040 rows or rows
+   *  created without an originator. Declarative jobs use systemRole: 'system'. Stamped on
+   *  the resulting agent.task by fireJob(). */
   originator: TaskOriginator | null;
 }
 

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -5,6 +5,7 @@ import type { EventBus } from '../bus/bus.js';
 import type { Logger } from '../logger.js';
 import { createScheduleCreated } from '../bus/events.js';
 import type { TaskOriginator } from '../contacts/types.js';
+import { makeSystemOriginator } from '../contacts/principal.js';
 
 // -- Public types --
 
@@ -484,13 +485,19 @@ export class SchedulerService {
     // expected_duration_seconds is always included (as $8) so the DO UPDATE can clear it to NULL
     // when the field is removed from the YAML — the conditional-column pattern would leave a
     // stale value in place.
+    // Stamp a system originator so declarative jobs have non-null originator in the DB.
+    // systemRole: 'system' distinguishes operator-configured work from principal-initiated
+    // ('principal') and agent-decided ('agent') tasks. See issue #558.
+    const originator = makeSystemOriginator();
+
     const sql = `
-      INSERT INTO scheduled_jobs (agent_id, cron_expr, task_payload, status, next_run_at, created_by, timezone, expected_duration_seconds)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      INSERT INTO scheduled_jobs (agent_id, cron_expr, task_payload, status, next_run_at, created_by, timezone, expected_duration_seconds, originator)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
       ON CONFLICT (agent_id, cron_expr, (task_payload::text)) WHERE created_by = 'system'
       DO UPDATE SET next_run_at = $5,
                     timezone = $7,
-                    expected_duration_seconds = $8
+                    expected_duration_seconds = $8,
+                    originator = COALESCE(scheduled_jobs.originator, $9)
       RETURNING id
     `;
     const params: unknown[] = [
@@ -502,6 +509,7 @@ export class SchedulerService {
       'system',
       this.timezone,
       durationToWrite,
+      JSON.stringify(originator),
     ];
 
     const { rows } = await this.pool.query(sql, params);

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -274,7 +274,7 @@ export class Scheduler {
           lastRunOutcome: row.last_run_outcome ?? null,
           lastRunSummary: row.last_run_summary ?? null,
           lastRunContext: row.last_run_context ?? null,
-          // pg returns JSONB as a plain object; null for pre-040 rows and declarative jobs.
+          // pg returns JSONB as a plain object; null for pre-040 rows only.
           originator: row.originator ?? null,
         };
         try {
@@ -380,7 +380,7 @@ export class Scheduler {
       // Pass the duration hint so the runtime can widen the delegate timeout for
       // long-running scheduled tasks. null (no explicit duration) becomes undefined.
       expectedDurationSeconds: job.expectedDurationSeconds ?? undefined,
-      // Thread the stored originator through — null (declarative / pre-040 jobs) becomes undefined.
+      // Thread the stored originator through — null (pre-040 jobs) becomes undefined.
       metadata: job.originator ? { originator: job.originator } : undefined,
       parentEventId: firedEvent.id,
     });

--- a/tests/unit/contacts/principal.test.ts
+++ b/tests/unit/contacts/principal.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { isPrincipalOriginated, isAgentOriginated, isSystemOriginated, makeSystemOriginator } from '../../../src/contacts/principal.js';
 import type { TaskOriginator } from '../../../src/contacts/types.js';
 
@@ -154,10 +154,14 @@ describe('makeSystemOriginator', () => {
   });
 
   it('generates a fresh initiatedAt timestamp on each call', () => {
+    vi.useFakeTimers({ now: new Date('2026-01-01T00:00:00Z') });
     const a = makeSystemOriginator();
+    vi.advanceTimersByTime(1000);
     const b = makeSystemOriginator();
-    // Both should be valid ISO timestamps (may or may not differ depending on timing)
+    vi.useRealTimers();
+
     expect(new Date(a.initiatedAt).getTime()).not.toBeNaN();
     expect(new Date(b.initiatedAt).getTime()).not.toBeNaN();
+    expect(a.initiatedAt).not.toBe(b.initiatedAt);
   });
 });

--- a/tests/unit/contacts/principal.test.ts
+++ b/tests/unit/contacts/principal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isPrincipalOriginated, isAgentOriginated } from '../../../src/contacts/principal.js';
+import { isPrincipalOriginated, isAgentOriginated, isSystemOriginated, makeSystemOriginator } from '../../../src/contacts/principal.js';
 import type { TaskOriginator } from '../../../src/contacts/types.js';
 
 describe('isPrincipalOriginated', () => {
@@ -70,7 +70,94 @@ describe('isAgentOriginated', () => {
     expect(isAgentOriginated(metadata)).toBe(false);
   });
 
+  it('returns false when originator systemRole is system', () => {
+    const metadata = {
+      originator: {
+        contactId: 'system',
+        systemRole: 'system',
+        channel: 'declarative',
+        initiatedAt: new Date().toISOString(),
+      } satisfies TaskOriginator,
+    };
+    expect(isAgentOriginated(metadata)).toBe(false);
+  });
+
   it('returns false when metadata is missing', () => {
     expect(isAgentOriginated(undefined)).toBe(false);
+  });
+});
+
+describe('isSystemOriginated', () => {
+  it('returns true when originator systemRole is system', () => {
+    const metadata = {
+      originator: {
+        contactId: 'system',
+        systemRole: 'system',
+        channel: 'declarative',
+        initiatedAt: new Date().toISOString(),
+      } satisfies TaskOriginator,
+    };
+    expect(isSystemOriginated(metadata)).toBe(true);
+  });
+
+  it('returns false when originator systemRole is principal', () => {
+    const metadata = {
+      originator: {
+        contactId: 'c-1',
+        systemRole: 'principal',
+        channel: 'email',
+        initiatedAt: new Date().toISOString(),
+      } satisfies TaskOriginator,
+    };
+    expect(isSystemOriginated(metadata)).toBe(false);
+  });
+
+  it('returns false when originator systemRole is agent', () => {
+    const metadata = {
+      originator: {
+        contactId: 'c-2',
+        systemRole: 'agent',
+        channel: 'scheduler',
+        initiatedAt: new Date().toISOString(),
+      } satisfies TaskOriginator,
+    };
+    expect(isSystemOriginated(metadata)).toBe(false);
+  });
+
+  it('returns false when metadata is missing', () => {
+    expect(isSystemOriginated(undefined)).toBe(false);
+    expect(isSystemOriginated({})).toBe(false);
+  });
+});
+
+describe('isPrincipalOriginated — system role regression', () => {
+  it('returns false for system-originated tasks', () => {
+    const metadata = {
+      originator: {
+        contactId: 'system',
+        systemRole: 'system',
+        channel: 'declarative',
+        initiatedAt: new Date().toISOString(),
+      } satisfies TaskOriginator,
+    };
+    expect(isPrincipalOriginated(metadata)).toBe(false);
+  });
+});
+
+describe('makeSystemOriginator', () => {
+  it('returns a TaskOriginator with systemRole system and channel declarative', () => {
+    const originator = makeSystemOriginator();
+    expect(originator.contactId).toBe('system');
+    expect(originator.systemRole).toBe('system');
+    expect(originator.channel).toBe('declarative');
+    expect(originator.initiatedAt).toBeTruthy();
+  });
+
+  it('generates a fresh initiatedAt timestamp on each call', () => {
+    const a = makeSystemOriginator();
+    const b = makeSystemOriginator();
+    // Both should be valid ISO timestamps (may or may not differ depending on timing)
+    expect(new Date(a.initiatedAt).getTime()).not.toBeNaN();
+    expect(new Date(b.initiatedAt).getTime()).not.toBeNaN();
   });
 });

--- a/tests/unit/contacts/principal.test.ts
+++ b/tests/unit/contacts/principal.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { isPrincipalOriginated, isAgentOriginated, isSystemOriginated, makeSystemOriginator } from '../../../src/contacts/principal.js';
 import type { TaskOriginator } from '../../../src/contacts/types.js';
 

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -714,8 +714,8 @@ describe('SchedulerService', () => {
       const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
       // Column is always present so DO UPDATE can clear a stale value
       expect(sql).toContain('expected_duration_seconds');
-      // NULL (not a number) is written
-      expect(params[params.length - 1]).toBeNull();
+      // NULL (not a number) is written — second-to-last param (last is originator)
+      expect(params[params.length - 2]).toBeNull();
     });
 
     it('writes NULL for invalid expectedDurationSeconds values (0, negative, NaN, non-integer)', async () => {
@@ -733,7 +733,8 @@ describe('SchedulerService', () => {
         const [sql, params] = pool.query.mock.calls[pool.query.mock.calls.length - 1] as [string, unknown[]];
         // Column is always included — invalid value falls back to NULL
         expect(sql).toContain('expected_duration_seconds');
-        expect(params[params.length - 1]).toBeNull();
+        // Second-to-last param (last is originator)
+        expect(params[params.length - 2]).toBeNull();
       }
     });
 
@@ -796,6 +797,26 @@ describe('SchedulerService', () => {
 
       // Only the scheduled_jobs upsert — no second query.
       expect(pool.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('stamps a system originator with systemRole system and channel declarative', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-orig' }] });
+
+      await svc.upsertDeclarativeJob('coordinator', {
+        cron: '*/15 * * * *',
+        task: 'Check inbox',
+      });
+
+      const [sql, params] = pool.query.mock.calls[0]! as [string, unknown[]];
+      expect(sql).toContain('originator');
+
+      // The originator is the last parameter, serialized as JSON.
+      const originatorJson = params[params.length - 1] as string;
+      const originator = JSON.parse(originatorJson) as Record<string, unknown>;
+      expect(originator.contactId).toBe('system');
+      expect(originator.systemRole).toBe('system');
+      expect(originator.channel).toBe('declarative');
+      expect(originator.initiatedAt).toBeTruthy();
     });
   });
 

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -715,7 +715,7 @@ describe('SchedulerService', () => {
       // Column is always present so DO UPDATE can clear a stale value
       expect(sql).toContain('expected_duration_seconds');
       // NULL (not a number) is written — second-to-last param (last is originator)
-      expect(params[params.length - 2]).toBeNull();
+      expect(params[params.length - 2]!).toBeNull();
     });
 
     it('writes NULL for invalid expectedDurationSeconds values (0, negative, NaN, non-integer)', async () => {
@@ -730,11 +730,11 @@ describe('SchedulerService', () => {
           expectedDurationSeconds: invalid,
         });
 
-        const [sql, params] = pool.query.mock.calls[pool.query.mock.calls.length - 1] as [string, unknown[]];
+        const [sql, params] = pool.query.mock.calls[pool.query.mock.calls.length - 1]! as [string, unknown[]];
         // Column is always included — invalid value falls back to NULL
         expect(sql).toContain('expected_duration_seconds');
         // Second-to-last param (last is originator)
-        expect(params[params.length - 2]).toBeNull();
+        expect(params[params.length - 2]!).toBeNull();
       }
     });
 
@@ -811,7 +811,7 @@ describe('SchedulerService', () => {
       expect(sql).toContain('originator');
 
       // The originator is the last parameter, serialized as JSON.
-      const originatorJson = params[params.length - 1] as string;
+      const originatorJson = params[params.length - 1]! as string;
       const originator = JSON.parse(originatorJson) as Record<string, unknown>;
       expect(originator.contactId).toBe('system');
       expect(originator.systemRole).toBe('system');


### PR DESCRIPTION
## **User description**
## Summary

Closes #558

- Extends `SystemRole` union with `'system'` to represent operator-configured, platform-executed work (distinct from `'principal'` and `'agent'`)
- Adds `makeSystemOriginator()` factory and `isSystemOriginated()` helper in `src/contacts/principal.ts`
- Stamps system originator in `upsertDeclarativeJob()` — new jobs get it on INSERT, existing NULL rows get backfilled via `COALESCE` on next restart
- No migration needed — the `originator JSONB` column already exists (migration 040)

## Test plan

- [x] `isSystemOriginated()` returns true for `systemRole: 'system'`, false for `'principal'`, `'agent'`, null, undefined
- [x] `isPrincipalOriginated()` returns false for system-originated tasks (regression test)
- [x] `isAgentOriginated()` returns false for system-originated tasks
- [x] `makeSystemOriginator()` produces correct shape with fresh `initiatedAt`
- [x] `upsertDeclarativeJob()` includes originator in SQL params with `systemRole: 'system'` and `channel: 'declarative'`
- [x] Typecheck passes
- [x] All existing tests pass (no regressions)


___

## **CodeAnt-AI Description**
**Stamp declarative scheduled jobs as system-originated work**

### What Changed
- YAML-defined scheduled jobs now get a system originator when they are saved, so they are no longer treated as missing originator data.
- System-originated tasks are now recognized as their own category, separate from principal-initiated and agent-decided work.
- Existing declarative jobs with no stored originator are backfilled on the next restart.
- Scheduled-job handling now preserves the stored originator when firing the task.

### Impact
`✅ Clearer task provenance`
`✅ Fewer misclassified scheduled jobs`
`✅ Safer handling of operator-configured automation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Declarative scheduled jobs are now identified with a system originator to differentiate operator-configured work from user-initiated and agent-decided tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->