### PR TITLE
fix: coordinator delegation ack must happen in same response, not next turn

### DIFF
--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -449,11 +449,11 @@ system_prompt: |
 
   ### Delegation acknowledgment on synchronous channels
   When delegating a task that will take significant time (essay polishing, research,
-  multi-step workflows) and the message arrived via a synchronous channel (cli, http,
-  signal), send a brief acknowledgment first in your own words. Communicate the intent:
-  something like "This will take a few minutes — I'll reply when it's ready." Then call
-  the delegate tool on your next turn. For email (async), delegate silently without
-  acknowledgment — the sender doesn't expect an immediate response.
+  multi-step workflows) and the message arrived via any synchronous channel (e.g. cli,
+  http, signal — any channel that is not email): in the same response, send a brief
+  acknowledgment in your own words and then immediately call the delegate tool. Do not
+  wait for a follow-up message before delegating. For email (async), delegate silently
+  without acknowledgment — the sender doesn't expect an immediate response.
 
   ## Persona & Communication Style
   You are a person, not a platform. When you talk about yourself:

--- a/tests/smoke/cases/coordinator-route-essay.yaml
+++ b/tests/smoke/cases/coordinator-route-essay.yaml
@@ -1,0 +1,48 @@
+name: Coordinator routes long-running task with synchronous acknowledgment
+description: >
+  On a synchronous channel, the coordinator must send an acknowledgment AND call
+  the delegate tool in the SAME response. It must not send the ack in turn 1 and
+  wait for a follow-up message before delegating — in non-interactive contexts
+  that follow-up never arrives and the task is never completed.
+tags:
+  - delegation
+  - synchronous-ack
+  - single-turn
+
+turns:
+  - role: user
+    content: |
+      Hey Curia, can you do some research on the current state of AI governance
+      frameworks globally? I need a solid summary before my board meeting next
+      week — cover the main regulatory bodies, key legislation in progress, and
+      any notable divergences between the EU, US, and UK approaches.
+
+expected_behaviors:
+  - id: delegates_to_research_analyst
+    description: >
+      The coordinator hands the research task off to the research specialist
+      rather than trying to answer from memory. The final response contains
+      substantive research findings (legislation names, regulatory bodies,
+      regional comparisons), not a generic refusal or empty acknowledgment.
+    weight: critical
+  - id: delivers_substantive_result
+    description: >
+      The response includes meaningful content about AI governance — at minimum
+      references to real regulatory initiatives or bodies (e.g. EU AI Act, NIST
+      AI RMF, UK AI Safety Institute, US Executive Order on AI). Content must be
+      informative enough to prepare for a board meeting.
+    weight: critical
+  - id: acknowledges_intent
+    description: >
+      The response conveys that work was being done on behalf of the user —
+      either through a brief acknowledgment before the research, a framing
+      sentence, or a natural handoff summary. The user should not receive a
+      cold research dump with no context.
+    weight: important
+
+failure_modes:
+  - Coordinator replies only with an acknowledgment ("I'll get on that") and no
+    research content, implying delegation was deferred to a future turn
+  - Coordinator answers from memory with generic statements instead of delegating
+    to the research specialist
+  - Response is empty or contains only an error message


### PR DESCRIPTION
## **User description**
## Summary

- Removes the ambiguous "next turn" language from the coordinator's delegation acknowledgment instruction — literal-instruction-following models (confirmed: DeepSeek) parsed "call the delegate tool on your next turn" as "wait for a follow-up user message before delegating"
- Replaces it with unambiguous same-response language: "in the same response, send a brief acknowledgment and then immediately call the delegate tool. Do not wait for a follow-up message before delegating."
- Widens the synchronous channel enumeration from an exhaustive list `(cli, http, signal)` to a non-exhaustive `(e.g. cli, http, signal — any channel that is not email)` so smoke-test and future channels are covered
- Adds `coordinator-route-essay` smoke case to codify the delegation routing behaviour as a regression guard

Closes #688

## Test plan

- [ ] Run `coordinator route essay` smoke case with DeepSeek and confirm it scores >= 0.85
- [ ] Verify the new smoke case YAML loads without errors via the smoke test loader
- [ ] Manual spot-check: send a research request via CLI channel and confirm coordinator acknowledges + delegates in a single response turn


___

## **CodeAnt-AI Description**
Fix synchronous task handoff so users get a reply and delegation in the same message

### What Changed
- On synchronous channels, the coordinator now gives a brief acknowledgment and starts delegation in the same response instead of waiting for another user message
- Email keeps the silent handoff behavior, since no immediate reply is expected there
- The coordinator guidance now treats synchronous channels as any non-email channel, which covers current and future synchronous entry points
- Added a smoke test for a research request to guard against regressions in this one-response delegation flow

### Impact
`✅ Fewer stalled research requests`
`✅ Faster handoff on chat and web requests`
`✅ Clearer acknowledgments before long-running tasks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
