### PR TITLE
feat: inject turn budget into agent system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Outbound context cleanup** — scheduler now purges expired and released `outbound_context` rows at startup and daily; count is logged at info level. (#679)
 - **Declarative job originator** — YAML-defined scheduled jobs now stamped with `systemRole: 'system'` originator at startup, distinguishing operator-configured work from principal-initiated and agent-decided tasks. (#558)
 
+- **Turn budget injection** — all agents now receive their exact turn limit in the system prompt at runtime, framed as a planning constraint so models can pace their tool use from turn 1 rather than hitting the ceiling silently. (#689)
+
 ### Changed
 
 - **Context bridging v2** — outbound context registry replaces working-memory memos; send skills gain optional `context_bridge` param for delegation-aware reply routing. (#615)

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -16,6 +16,7 @@ import { DEFAULT_ERROR_BUDGET, type AgentError, type ErrorBudget } from '../erro
 // Value import (not type-only) — we call AutonomyService.formatPromptBlock() as a static method.
 import { AutonomyService } from '../autonomy/autonomy-service.js';
 import { formatTimeContextBlock } from '../time/time-context.js';
+import { formatTurnBudgetBlock } from './turn-budget.js';
 import type { OfficeIdentityService } from '../identity/service.js';
 import { compileWritingVoiceBlock, type ExecutiveProfileService } from '../executive/service.js';
 import { formatBullpenContext, type BullpenService } from '../memory/bullpen.js';
@@ -331,6 +332,12 @@ export class AgentRuntime {
       turnsUsed: 0,
       consecutiveErrors: 0,
     };
+
+    // Append turn budget block — tells the model the exact number of turns it has
+    // so it can plan tool use from turn 1 rather than treating the budget as unlimited.
+    // Uses budget.maxTurns (post-resolution) so per-agent YAML overrides are reflected.
+    // Injected for ALL agents, same as the date/time and contact details blocks.
+    effectiveSystemPrompt += '\n\n' + formatTurnBudgetBlock(budget.maxTurns);
 
     // Create context budget for token-aware assembly.
     const modelName = this.config.resolvedModel ?? this.config.modelName;

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -315,16 +315,10 @@ export class AgentRuntime {
       effectiveSystemPrompt += '\n\n' + lines.join('\n');
     }
 
-    // Append intent anchor — present only for persistent scheduler tasks that have a
-    // linked agent_task record. Injected last so it sits closest to the conversation,
-    // making it maximally salient. It is non-negotiable: the agent may evolve its
-    // approach across bursts, but cannot abandon the original mandate.
-    if (taskEvent.payload.intentAnchor) {
-      effectiveSystemPrompt += '\n\n## Original Task Intent\n' + taskEvent.payload.intentAnchor;
-    }
-
     // Initialize the error budget for this task.
     // Config values override defaults; budget tracks runtime counters.
+    // Initialized here (before the intent anchor) so budget.maxTurns can be
+    // embedded in the turn budget block below while the intent anchor remains last.
     const budgetConfig = this.config.errorBudget;
     const budget: ErrorBudget = {
       maxTurns: budgetConfig?.maxTurns ?? DEFAULT_ERROR_BUDGET.maxTurns,
@@ -337,7 +331,16 @@ export class AgentRuntime {
     // so it can plan tool use from turn 1 rather than treating the budget as unlimited.
     // Uses budget.maxTurns (post-resolution) so per-agent YAML overrides are reflected.
     // Injected for ALL agents, same as the date/time and contact details blocks.
+    // Must come before the intent anchor so the anchor stays the final (most salient) section.
     effectiveSystemPrompt += '\n\n' + formatTurnBudgetBlock(budget.maxTurns);
+
+    // Append intent anchor — present only for persistent scheduler tasks that have a
+    // linked agent_task record. Injected last so it sits closest to the conversation,
+    // making it maximally salient. It is non-negotiable: the agent may evolve its
+    // approach across bursts, but cannot abandon the original mandate.
+    if (taskEvent.payload.intentAnchor) {
+      effectiveSystemPrompt += '\n\n## Original Task Intent\n' + taskEvent.payload.intentAnchor;
+    }
 
     // Create context budget for token-aware assembly.
     const modelName = this.config.resolvedModel ?? this.config.modelName;

--- a/src/agents/turn-budget.test.ts
+++ b/src/agents/turn-budget.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { formatTurnBudgetBlock } from './turn-budget.js';
+
+describe('formatTurnBudgetBlock', () => {
+  it('contains the section header', () => {
+    const block = formatTurnBudgetBlock(20);
+    expect(block).toContain('## Turn budget');
+  });
+
+  it('embeds the max turns count', () => {
+    const block = formatTurnBudgetBlock(20);
+    expect(block).toContain('20');
+  });
+
+  it('embeds the correct count for a custom value', () => {
+    const block = formatTurnBudgetBlock(15);
+    expect(block).toContain('15');
+  });
+
+  it('frames the budget as a planning constraint from turn 1', () => {
+    const block = formatTurnBudgetBlock(20);
+    // Should instruct the model to plan, not just warn when close to the limit.
+    expect(block).toContain('Plan your tool use');
+  });
+
+  it('instructs the model to limit exploratory calls', () => {
+    const block = formatTurnBudgetBlock(20);
+    expect(block).toContain('exploratory');
+  });
+
+  it('instructs the model not to retry searches repeatedly', () => {
+    const block = formatTurnBudgetBlock(20);
+    expect(block).toContain('retry');
+  });
+
+  it('instructs the model to produce a partial result near the limit', () => {
+    const block = formatTurnBudgetBlock(20);
+    expect(block).toContain('partial');
+  });
+
+  it('specifies the 3-turn proximity threshold for early summary', () => {
+    const block = formatTurnBudgetBlock(20);
+    expect(block).toContain('3 turns');
+  });
+});

--- a/src/agents/turn-budget.ts
+++ b/src/agents/turn-budget.ts
@@ -1,0 +1,33 @@
+// turn-budget.ts — helper for injecting the agent turn budget into system prompts.
+//
+// Called once per task turn (after ErrorBudget is initialized) so the model always
+// sees the effective limit — including any per-agent override from the YAML. The
+// language frames the budget as a planning constraint, not just a late-stage warning,
+// so models consider it from turn 1 rather than treating their budget as unlimited.
+// See issue #689.
+
+/**
+ * Format the turn-budget block appended to every agent's system prompt each task turn.
+ * Uses the resolved maxTurns value (config override or DEFAULT_ERROR_BUDGET.maxTurns)
+ * so the number in the prompt always matches the enforced ceiling.
+ *
+ * Example output:
+ *   ## Turn budget
+ *   You have a total budget of 20 turns for this task. A "turn" is one round
+ *   of tool calls followed by your response. Plan your tool use accordingly:
+ *   - Do not issue exploratory or speculative tool calls when you can act on what you know
+ *   - If a search returns no results, try one alternative then move on — do not retry repeatedly
+ *   - If you are within 3 turns of the limit and the task is incomplete, stop and produce
+ *     a partial result or summary rather than continuing to tool-call into silence
+ */
+export function formatTurnBudgetBlock(maxTurns: number): string {
+  return [
+    '## Turn budget',
+    `You have a total budget of ${maxTurns} turns for this task. A "turn" is one round`,
+    'of tool calls followed by your response. Plan your tool use accordingly:',
+    '- Do not issue exploratory or speculative tool calls when you can act on what you know',
+    '- If a search returns no results, try one alternative then move on — do not retry repeatedly',
+    '- If you are within 3 turns of the limit and the task is incomplete, stop and produce',
+    '  a partial result or summary rather than continuing to tool-call into silence',
+  ].join('\n');
+}

--- a/tests/integration/vertical-slice.test.ts
+++ b/tests/integration/vertical-slice.test.ts
@@ -120,6 +120,12 @@ describe('Vertical Slice: CLI → Dispatch → Coordinator → Response', () => 
         ],
       }),
     );
+
+    // Verify turn budget block is wired into the system prompt at runtime.
+    const firstCall = (mockProvider.chat as ReturnType<typeof vi.fn>).mock.calls[0]![0] as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(firstCall.messages[0]!.content).toContain('## Turn budget');
   });
 });
 

--- a/tests/integration/vertical-slice.test.ts
+++ b/tests/integration/vertical-slice.test.ts
@@ -112,12 +112,14 @@ describe('Vertical Slice: CLI → Dispatch → Coordinator → Response', () => 
     // The coordinator must prepend the system prompt before the user's content.
     // Verifying the call shape ensures we're not passing raw bus payloads straight
     // to the model (which would include routing fields the model shouldn't see).
-    expect(mockProvider.chat).toHaveBeenCalledWith({
-      messages: [
-        { role: 'system', content: 'You are a helpful assistant.' },
-        { role: 'user', content: 'Good morning!' },
-      ],
-    });
+    expect(mockProvider.chat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          { role: 'system', content: expect.stringContaining('You are a helpful assistant.') },
+          { role: 'user', content: 'Good morning!' },
+        ],
+      }),
+    );
   });
 });
 

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -72,7 +72,7 @@ describe('AgentRuntime', () => {
     expect(provider.chat).toHaveBeenCalledWith(
       expect.objectContaining({
         messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
+          { role: 'system', content: expect.stringContaining('You are a helpful assistant.') },
           { role: 'user', content: 'Hello' },
         ],
       }),
@@ -223,10 +223,12 @@ describe('AgentRuntime', () => {
     await bus.publish('dispatch', task);
 
     // LLM should receive system + history + new message
+    // System content includes the appended turn budget block; use stringContaining
+    // since this test cares about conversation history, not system prompt assembly.
     expect(provider.chat).toHaveBeenCalledWith(
       expect.objectContaining({
         messages: [
-          { role: 'system', content: 'You are helpful.' },
+          { role: 'system', content: expect.stringContaining('You are helpful.') },
           { role: 'user', content: 'First message' },
           { role: 'assistant', content: 'First response' },
           { role: 'user', content: 'Second message' },
@@ -415,7 +417,10 @@ describe('AgentRuntime', () => {
 
     const callArgs = provider.chat.mock.calls[0]?.[0] as { messages: Array<{ role: string; content: string }> };
     const systemMsg = callArgs?.messages?.[0];
-    expect(systemMsg?.content).toBe('Base prompt.');
+    // When autonomyService returns null, the autonomy block must NOT be appended.
+    // The turn budget block is unconditionally appended (expected behavior).
+    expect(systemMsg?.content).toContain('Base prompt.');
+    expect(systemMsg?.content).not.toContain('Autonomy Level');
   });
 
   it('appends intent anchor to system prompt when intentAnchor is present', async () => {

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -77,6 +77,12 @@ describe('AgentRuntime', () => {
         ],
       }),
     );
+
+    // Verify turn budget block is wired into the system prompt.
+    const firstCall = provider.chat.mock.calls[0]![0] as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(firstCall.messages[0]!.content).toContain('## Turn budget');
   });
 
   it('publishes error response when LLM fails', async () => {
@@ -421,6 +427,7 @@ describe('AgentRuntime', () => {
     // The turn budget block is unconditionally appended (expected behavior).
     expect(systemMsg?.content).toContain('Base prompt.');
     expect(systemMsg?.content).not.toContain('Autonomy Level');
+    expect(systemMsg?.content).toContain('## Turn budget');
   });
 
   it('appends intent anchor to system prompt when intentAnchor is present', async () => {


### PR DESCRIPTION
## **User description**
## Summary

Closes #689

- New `formatTurnBudgetBlock(maxTurns)` helper (`src/agents/turn-budget.ts`) follows the established `formatTimeContextBlock` pattern
- All agents receive their exact turn limit in the system prompt at runtime, framed as a planning constraint from turn 1
- Uses `budget.maxTurns` (post-resolution) so per-agent YAML overrides (e.g. `ceo-inbox: 30`) and the system default (20) are both correctly reflected
- Injected before the intent anchor so the anchor remains the last (most salient) section

## Test plan

- [ ] `src/agents/turn-budget.test.ts` — 8 unit tests covering header, embedded count, planning language, retry guidance, partial result instruction, and 3-turn proximity threshold; all pass
- [ ] `tsc --noEmit` clean
- [ ] Verify turn budget block appears in agent logs on next deployment (check `effectiveSystemPrompt` for `## Turn budget` section)


___

## **CodeAnt-AI Description**
**Show the agent’s turn limit in the prompt and keep the task intent last**

### What Changed
- Every agent now sees its exact turn limit in the system prompt, with guidance to plan tool use from the first turn
- The turn limit message tells the agent to avoid speculative calls, stop repeated failed retries, and return a partial result when it is close to the limit
- The original task intent is kept as the final section of the prompt so it stays the most prominent instruction
- Added coverage for the turn-limit message format and the custom turn count used in it

### Impact
`✅ Fewer tool-call dead ends`
`✅ Fewer repeated search retries`
`✅ Earlier partial results near task limits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents now receive their exact turn limit information in the system prompt at runtime. This planning constraint helps them develop consistent pacing strategies starting from the first turn, enabling more balanced task execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->