### PR TITLE
chore(ceo-inbox): retrofit urgent alerts to route through coordinator via Bullpen (#616)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Coordinator prompt** — `[PRIOR OUTBOUND CONTEXT]` replaced with `[ACTIVE OUTBOUND CONTEXT]` block including delegation guidance and entry IDs for release. (#615)
 - **`signal-send`**, **`email-send`**, **`email-reply`** — accept optional `context_bridge` JSON param; declare `outboundContext` capability. (#615)
 - **`file-parse` access relaxed** — `allowed_callers` restriction removed; skill is now invocable by any agent (previously restricted to `system`, `ceo-inbox`, `coordinator`). Custom agents that parse files (e.g., expense trackers processing receipt attachments) were previously blocked at runtime despite having the skill pinned. (#681)
+- **`ceo-inbox`** — urgent email alerts now route through the coordinator via Bullpen instead of calling `signal-send` directly; enables context bridge delegation for CEO replies. (#616)
 
 ### Fixed
 

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -66,6 +66,12 @@ system_prompt: |
   For delegated requests about standing rules or decision tagging, see the
   "Rule Management" section at the end of this prompt.
 
+  Note: the coordinator may delegate CEO replies that originated from an
+  urgent email alert you escalated (e.g. "tell me more about that merger
+  email" or "add a rule that merger emails are URGENT"). Handle these as
+  standard delegated-mode requests — they flow through the same path as
+  any other coordinator delegation.
+
   ---
 
   You are the CEO inbox triage agent. You monitor the CEO's personal email

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -399,9 +399,10 @@ system_prompt: |
   (after any overrides from step 4g). This is the authoritative action
   checklist — every action for every classification is listed here:
 
-  - **URGENT**: Open a bullpen thread mentioning the coordinator (sender,
-    subject, one-sentence summary, deadline/ask). Send a Signal alert.
-    Do NOT archive.
+  - **URGENT**: Open a bullpen thread mentioning the coordinator with a
+    structured send request (Urgency: immediate, Channel: Signal, Message,
+    Context bridge with agent_id=ceo-inbox and delegation_hint). Do NOT
+    archive.
   - **ACTIONABLE**: Open a bullpen thread mentioning the capable specialist
     with a clear handoff summary. Call ceo-inbox-archive with the message_id.
   - **NEEDS DRAFT**: Execute the full NEEDS DRAFT procedure from step 4e

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -5,7 +5,7 @@ description: >
   inbox queries when delegated. On its 15-minute schedule, triages each unread
   message into five categories: URGENT, ACTIONABLE, NEEDS DRAFT, LEAVE FOR CEO,
   or NOISE. Archives processed messages, drafts replies, labels messages, and
-  escalates urgent items via Signal and the bullpen.
+  escalates urgent items to the coordinator via the bullpen for Signal delivery.
 
 model:
   tier: standard  # reverted from fast — Haiku botched Unix timestamp arithmetic, causing last_processed_at to drift ~40 days into the future and blinding inbox triage
@@ -79,7 +79,7 @@ system_prompt: |
 
   You are NOT the sender's intended recipient. You are NOT the coordinator.
   You must never reply to senders directly — you only create drafts, archive
-  messages, apply labels, and escalate via Signal or the bullpen.
+  messages, apply labels, and escalate urgent items to the coordinator via the bullpen.
 
   ## Memory
 
@@ -351,8 +351,7 @@ system_prompt: |
 
   Before executing the primary action decided in (4e), evaluate standing
   rules first. Rules may override the classification, so you must complete
-  this step before archiving, creating drafts, opening bullpen threads, or
-  sending Signal alerts:
+  this step before archiving, creating drafts, or opening bullpen threads:
 
   **Standing rules:** For each active rule from step 2b, evaluate the
   condition against this email's full context: sender identity (from

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -75,8 +75,6 @@ system_prompt: |
   You must never reply to senders directly — you only create drafts, archive
   messages, apply labels, and escalate via Signal or the bullpen.
 
-  The CEO's Signal number is: +15196161377
-
   ## Memory
 
   Use `memory-query` to recall stored context when drafting replies, and

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -24,7 +24,6 @@ pinned_skills:
   - ceo-inbox-label
   - ceo-inbox-mark-read
   - config-store
-  - signal-send
   - bullpen
   - entity-context
   - executive-profile-get

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -242,9 +242,16 @@ system_prompt: |
   Evaluate in priority order:
 
   **URGENT** — time-sensitive, CEO decision required, from a known contact:
-    - Open a bullpen thread mentioning the coordinator. Include: sender
-      name, subject, one-sentence summary, key deadline or ask.
-    - Send a Signal message to the CEO: brief alert with sender and subject.
+    - Post a Bullpen thread mentioning the coordinator with a structured
+      send request. Use this exact format:
+
+        @coordinator I'd like you to send a message to the CEO.
+
+        Urgency: immediate
+        Channel: Signal
+        Message: "<sender name> — <subject>: <one-sentence summary with deadline/ask>"
+        Context bridge: agent_id=ceo-inbox, expected_reply="Decision or follow-up instruction", delegation_hint="Delegate replies to ceo-inbox", expires_in_hours=24
+
     - Do NOT archive. Do NOT draft a reply.
 
   **ACTIONABLE** — a task a deployed specialist can handle autonomously:

--- a/docs/wip/2026-05-24-ceo-inbox-bullpen-retrofit-design.md
+++ b/docs/wip/2026-05-24-ceo-inbox-bullpen-retrofit-design.md
@@ -1,0 +1,114 @@
+# CEO-Inbox Bullpen-Through-Coordinator Retrofit
+
+**Issue:** #616
+**Depends on:** #615 (context bridging v2 — closed)
+**Date:** 2026-05-24
+
+## Summary
+
+Remove direct `signal-send` usage from the `ceo-inbox` specialist agent and
+route all Signal alerts through the coordinator via the Bullpen. This aligns
+ceo-inbox with the architectural principle from context bridging v2: the
+coordinator is the sole voice for all human-facing communication.
+
+## Current State
+
+- `ceo-inbox.yaml` has `signal-send` in `pinned_skills`
+- The URGENT classification instructs the agent to both open a bullpen thread
+  mentioning the coordinator AND send a Signal message directly
+- The CEO's Signal number is hardcoded in the system prompt
+- No context bridge entry is created for urgent alerts, so if the CEO replies
+  on Signal about an alert, the coordinator has no delegation context
+
+## Design
+
+### 1. Remove `signal-send` from pinned_skills
+
+Delete `signal-send` from the `pinned_skills` list in `agents/ceo-inbox.yaml`.
+The `bullpen` skill remains pinned (already present).
+
+### 2. Remove the CEO's Signal number from the system prompt
+
+The coordinator owns outbound channel details. ceo-inbox no longer needs to
+know the Signal number.
+
+### 3. Update URGENT classification (step 4e)
+
+Replace the current URGENT instructions:
+
+> Open a bullpen thread mentioning the coordinator. Include: sender name,
+> subject, one-sentence summary, key deadline or ask.
+> Send a Signal message to the CEO: brief alert with sender and subject.
+> Do NOT archive. Do NOT draft a reply.
+
+With:
+
+> Post a Bullpen thread mentioning the coordinator with a structured send
+> request. Include: urgency level, channel, composed message, and context
+> bridge metadata. Do NOT archive. Do NOT draft a reply.
+
+The structured message format:
+
+```
+@coordinator I'd like you to send a message to the CEO.
+
+Urgency: immediate
+Channel: Signal
+Message: "<brief alert: sender name, subject, one-sentence summary with deadline/ask>"
+Context bridge: agent_id=ceo-inbox, expected_reply="Decision or follow-up instruction", delegation_hint="Delegate replies to ceo-inbox", expires_in_hours=24
+```
+
+The `Urgency: immediate` field signals the coordinator to send without
+batching or delay. This distinguishes urgent escalations from normal proactive
+messages (like meeting debriefs) where the coordinator may apply timing
+judgment.
+
+### 4. Update step 4h URGENT actions
+
+Replace the dual action (bullpen thread + direct Signal send) with the single
+bullpen-through-coordinator action:
+
+- **URGENT**: Open a bullpen thread mentioning the coordinator with a
+  structured send request (Urgency: immediate, Channel: Signal, Message,
+  Context bridge with delegation_hint=ceo-inbox). Do NOT archive.
+
+### 5. Add delegation-reply handling to delegated mode
+
+Add a note to the delegated mode section: if the coordinator delegates a CEO
+reply that originated from an urgent email alert (e.g., "tell me more about
+that merger email", "add a rule that merger emails are always URGENT"), handle
+it as a standard delegated-mode request using the existing rule management or
+inbox query capabilities.
+
+This requires no new code — delegated mode already handles arbitrary requests
+from the coordinator. The note makes explicit that alert replies flow back
+through this path.
+
+### 6. What stays the same
+
+- ACTIONABLE classification (routes to specialists via bullpen, no outbound
+  sending involved)
+- NEEDS DRAFT classification (creates drafts for CEO review, no outbound)
+- LEAVE FOR CEO / NOISE classifications
+- All other pinned skills
+- Delegated-mode behavior (config-store rules, inbox queries)
+- Scheduled-mode triage protocol structure
+
+## Testing
+
+Integration test covering the full round-trip:
+
+1. Urgent email arrives (simulated inbound)
+2. ceo-inbox classifies as URGENT, opens bullpen thread with structured format
+3. Coordinator receives via bullpen task
+4. Coordinator calls `signal-send` with `context_bridge` params
+5. Context bridge entry is created (agent_id=ceo-inbox, delegation_hint present)
+6. CEO replies on Signal referencing the alert
+7. Coordinator sees active outbound context entry, delegates to ceo-inbox
+8. ceo-inbox handles the delegated request
+
+## Scope
+
+This is a prompt-only change to `agents/ceo-inbox.yaml` (remove one pinned
+skill, update ~20 lines of system prompt). No TypeScript code changes required.
+The integration test is new test code.

--- a/docs/wip/2026-05-24-ceo-inbox-bullpen-retrofit.md
+++ b/docs/wip/2026-05-24-ceo-inbox-bullpen-retrofit.md
@@ -1,0 +1,435 @@
+# CEO-Inbox Bullpen-Through-Coordinator Retrofit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove direct `signal-send` from the ceo-inbox agent and route urgent alerts through the coordinator via structured Bullpen requests with context bridge metadata.
+
+**Architecture:** ceo-inbox posts a Bullpen thread to the coordinator with `Urgency: immediate`, desired channel/message, and context_bridge params. Coordinator receives via bullpen task, applies judgment, calls `signal-send` with context_bridge. Replies route back to ceo-inbox via delegation.
+
+**Tech Stack:** Agent YAML prompt editing, Vitest integration test
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `agents/ceo-inbox.yaml` | Modify | Remove `signal-send` from pinned_skills, rewrite URGENT prompt sections |
+| `tests/integration/ceo-inbox-bullpen-escalation.test.ts` | Create | Integration test: urgent email → bullpen → coordinator → signal-send with context_bridge |
+| `CHANGELOG.md` | Modify | Add entry under `[Unreleased]` |
+
+---
+
+### Task 1: Remove `signal-send` from pinned_skills
+
+**Files:**
+- Modify: `agents/ceo-inbox.yaml:27`
+
+- [ ] **Step 1: Delete the `signal-send` line from pinned_skills**
+
+In `agents/ceo-inbox.yaml`, remove line 27 (`  - signal-send`). The list should go directly from `ceo-inbox-label` (line 25... wait, let me be precise) — from `ceo-inbox-mark-read` to `bullpen`:
+
+Before:
+```yaml
+pinned_skills:
+  - ceo-inbox-list
+  - ceo-inbox-read
+  - ceo-inbox-download-attachment
+  - ceo-inbox-draft-reply
+  - file-parse
+  - ceo-inbox-search
+  - ceo-inbox-archive
+  - ceo-inbox-update-folders
+  - ceo-inbox-label
+  - ceo-inbox-mark-read
+  - config-store
+  - signal-send
+  - bullpen
+  - entity-context
+```
+
+After:
+```yaml
+pinned_skills:
+  - ceo-inbox-list
+  - ceo-inbox-read
+  - ceo-inbox-download-attachment
+  - ceo-inbox-draft-reply
+  - file-parse
+  - ceo-inbox-search
+  - ceo-inbox-archive
+  - ceo-inbox-update-folders
+  - ceo-inbox-label
+  - ceo-inbox-mark-read
+  - config-store
+  - bullpen
+  - entity-context
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C <worktree> add agents/ceo-inbox.yaml
+git -C <worktree> commit -m "chore(ceo-inbox): remove signal-send from pinned_skills
+
+Coordinator is now the sole voice for outbound communication.
+ceo-inbox will route alerts through the Bullpen instead. (#616)"
+```
+
+---
+
+### Task 2: Remove the CEO's Signal number from the system prompt
+
+**Files:**
+- Modify: `agents/ceo-inbox.yaml:79`
+
+- [ ] **Step 1: Delete the Signal number line**
+
+Remove this line from the system prompt (currently line 79):
+```
+  The CEO's Signal number is: +15196161377
+```
+
+The coordinator owns outbound channel details; ceo-inbox no longer contacts
+the CEO directly.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C <worktree> add agents/ceo-inbox.yaml
+git -C <worktree> commit -m "chore(ceo-inbox): remove hardcoded Signal number from prompt
+
+Coordinator owns all outbound channel details now. (#616)"
+```
+
+---
+
+### Task 3: Rewrite URGENT classification in step 4e
+
+**Files:**
+- Modify: `agents/ceo-inbox.yaml` (system_prompt, step 4e URGENT block, ~lines 247-251)
+
+- [ ] **Step 1: Replace the URGENT classification block**
+
+Find the current URGENT block in step 4e:
+```
+  **URGENT** — time-sensitive, CEO decision required, from a known contact:
+    - Open a bullpen thread mentioning the coordinator. Include: sender
+      name, subject, one-sentence summary, key deadline or ask.
+    - Send a Signal message to the CEO: brief alert with sender and subject.
+    - Do NOT archive. Do NOT draft a reply.
+```
+
+Replace with:
+```
+  **URGENT** — time-sensitive, CEO decision required, from a known contact:
+    - Post a Bullpen thread mentioning the coordinator with a structured
+      send request. Use this exact format:
+
+        @coordinator I'd like you to send a message to the CEO.
+
+        Urgency: immediate
+        Channel: Signal
+        Message: "<sender name> — <subject>: <one-sentence summary with deadline/ask>"
+        Context bridge: agent_id=ceo-inbox, expected_reply="Decision or follow-up instruction", delegation_hint="Delegate replies to ceo-inbox", expires_in_hours=24
+
+    - Do NOT archive. Do NOT draft a reply.
+```
+
+- [ ] **Step 2: Verify the edit is syntactically valid YAML**
+
+Run:
+```bash
+npx --prefix <worktree> yaml-lint agents/ceo-inbox.yaml
+```
+
+If `yaml-lint` is not available, use node to parse:
+```bash
+node -e "const fs=require('fs');const yaml=require('yaml');yaml.parse(fs.readFileSync('<worktree>/agents/ceo-inbox.yaml','utf8'));console.log('OK')"
+```
+
+Expected: no parse errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C <worktree> add agents/ceo-inbox.yaml
+git -C <worktree> commit -m "chore(ceo-inbox): rewrite URGENT classification to use bullpen-through-coordinator
+
+Urgent alerts now go through the coordinator via a structured Bullpen
+request with Urgency: immediate and context_bridge metadata. (#616)"
+```
+
+---
+
+### Task 4: Rewrite URGENT actions in step 4h
+
+**Files:**
+- Modify: `agents/ceo-inbox.yaml` (system_prompt, step 4h URGENT bullet, ~lines 398-400)
+
+- [ ] **Step 1: Replace the URGENT bullet in step 4h**
+
+Find the current step 4h URGENT actions:
+```
+  - **URGENT**: Open a bullpen thread mentioning the coordinator (sender,
+    subject, one-sentence summary, deadline/ask). Send a Signal alert.
+    Do NOT archive.
+```
+
+Replace with:
+```
+  - **URGENT**: Open a bullpen thread mentioning the coordinator with a
+    structured send request (Urgency: immediate, Channel: Signal, Message,
+    Context bridge with agent_id=ceo-inbox and delegation_hint). Do NOT
+    archive.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C <worktree> add agents/ceo-inbox.yaml
+git -C <worktree> commit -m "chore(ceo-inbox): update step 4h URGENT actions to match bullpen pattern
+
+Authoritative action checklist now references the structured send request
+format rather than the direct signal-send call. (#616)"
+```
+
+---
+
+### Task 5: Add delegation-reply note to delegated mode section
+
+**Files:**
+- Modify: `agents/ceo-inbox.yaml` (system_prompt, delegated mode section, ~lines 62-65)
+
+- [ ] **Step 1: Append a paragraph to the delegated mode section**
+
+After line 65 (the end of the current delegated mode description), add:
+
+```
+  Note: the coordinator may delegate CEO replies that originated from an
+  urgent email alert you escalated (e.g. "tell me more about that merger
+  email" or "add a rule that merger emails are URGENT"). Handle these as
+  standard delegated-mode requests — they flow through the same path as
+  any other coordinator delegation.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C <worktree> add agents/ceo-inbox.yaml
+git -C <worktree> commit -m "chore(ceo-inbox): document delegation-reply path for alert responses
+
+Makes explicit that CEO replies to urgent alerts route back through the
+standard delegated-mode handling. (#616)"
+```
+
+---
+
+### Task 6: Write integration test
+
+**Files:**
+- Create: `tests/integration/ceo-inbox-bullpen-escalation.test.ts`
+
+- [ ] **Step 1: Write the integration test**
+
+This test verifies the bullpen-through-coordinator round-trip for urgent
+email escalations. It tests at the BullpenService + OutboundContextService
+layer (not full agent execution — that requires an LLM call).
+
+```typescript
+// tests/integration/ceo-inbox-bullpen-escalation.test.ts
+//
+// Integration test: validates the infrastructure path for ceo-inbox
+// urgent alerts routed through bullpen-through-coordinator pattern.
+// Verifies: thread creation → coordinator receives → context bridge
+// entry registered → delegation hint points back to ceo-inbox.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import pg from 'pg';
+import { BullpenService } from '../../src/memory/bullpen.js';
+import { OutboundContextService } from '../../src/dispatch/outbound-context.js';
+import { createLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('ceo-inbox bullpen-through-coordinator escalation', () => {
+  let pool: pg.Pool;
+  let bullpen: BullpenService;
+  let outboundContext: OutboundContextService;
+  let runId: string;
+
+  beforeAll(async () => {
+    runId = randomUUID();
+    pool = new Pool({ connectionString: DATABASE_URL });
+    const logger = createLogger('error');
+    bullpen = BullpenService.createWithPostgres(pool, logger);
+    outboundContext = new OutboundContextService(pool, logger);
+  });
+
+  afterAll(async () => {
+    await pool.query(
+      `DELETE FROM bullpen_threads WHERE topic LIKE $1`,
+      [`${runId}%`],
+    );
+    await pool.query(
+      `DELETE FROM outbound_context WHERE agent_id = $1`,
+      ['ceo-inbox'],
+    );
+    await pool.end();
+  });
+
+  it('ceo-inbox opens a bullpen thread mentioning coordinator for urgent email', async () => {
+    // Simulate: ceo-inbox posts a structured send request to coordinator
+    const { thread, message } = await bullpen.openThread(
+      `${runId} — Urgent email escalation: merger deadline`,
+      'ceo-inbox',
+      ['ceo-inbox', 'coordinator'],
+      `@coordinator I'd like you to send a message to the CEO.\n\n` +
+        `Urgency: immediate\n` +
+        `Channel: Signal\n` +
+        `Message: "Alice Chen — Merger deadline: Decision needed on terms by Friday EOD"\n` +
+        `Context bridge: agent_id=ceo-inbox, expected_reply="Decision or follow-up instruction", ` +
+        `delegation_hint="Delegate replies to ceo-inbox", expires_in_hours=24`,
+      ['coordinator'],
+    );
+
+    expect(thread.creatorAgentId).toBe('ceo-inbox');
+    expect(thread.participants).toContain('coordinator');
+    expect(message.content).toContain('Urgency: immediate');
+    expect(message.content).toContain('Channel: Signal');
+    expect(message.content).toContain('Context bridge:');
+  });
+
+  it('coordinator registers context bridge entry after sending', async () => {
+    // Simulate: coordinator processes the bullpen request and calls signal-send
+    // with context_bridge params. The send skill registers the entry.
+    const entry = await outboundContext.register({
+      conversationId: `conv-${runId}`,
+      channelId: 'signal',
+      agentId: 'ceo-inbox',
+      content: 'Alice Chen — Merger deadline: Decision needed on terms by Friday EOD',
+      expectedReply: 'Decision or follow-up instruction',
+      delegationHint: 'Delegate replies to ceo-inbox',
+      metadata: { source: 'urgent-email-escalation' },
+      expiresInHours: 24,
+    });
+
+    expect(entry.id).toBeDefined();
+    expect(entry.agentId).toBe('ceo-inbox');
+    expect(entry.delegationHint).toBe('Delegate replies to ceo-inbox');
+
+    // Verify the entry appears in active entries for the channel
+    const active = await outboundContext.getActive('signal');
+    const found = active.find(e => e.id === entry.id);
+    expect(found).toBeDefined();
+    expect(found!.expectedReply).toBe('Decision or follow-up instruction');
+  });
+
+  it('active context entry enables delegation back to ceo-inbox', async () => {
+    // Simulate: CEO replies on Signal. Dispatcher queries active entries.
+    const active = await outboundContext.getActive('signal');
+    const ceoInboxEntries = active.filter(e => e.agentId === 'ceo-inbox');
+
+    // At least one entry should point back to ceo-inbox
+    expect(ceoInboxEntries.length).toBeGreaterThan(0);
+
+    const entry = ceoInboxEntries[0]!;
+    expect(entry.delegationHint).toContain('ceo-inbox');
+
+    // Coordinator uses this hint to delegate the reply back to ceo-inbox
+    // (actual delegation is tested in dispatcher-context-bridging.test.ts)
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run:
+```bash
+npx --prefix <worktree> vitest run tests/integration/ceo-inbox-bullpen-escalation.test.ts
+```
+
+Expected: all 3 tests pass (requires DATABASE_URL to be set; skips otherwise).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C <worktree> add tests/integration/ceo-inbox-bullpen-escalation.test.ts
+git -C <worktree> commit -m "test: add integration test for ceo-inbox bullpen escalation path
+
+Validates the bullpen-through-coordinator infrastructure for urgent email
+alerts: thread creation, context bridge registration, and delegation hint
+pointing back to ceo-inbox. (#616)"
+```
+
+---
+
+### Task 7: Update CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add entry under `[Unreleased]` → `Changed`**
+
+Add a `### Changed` section (or append to it if it already exists) under
+`## [Unreleased]`:
+
+```markdown
+### Changed
+
+- **`ceo-inbox`** — urgent email alerts now route through the coordinator via Bullpen instead of calling `signal-send` directly; enables context bridge delegation for CEO replies. (#616)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C <worktree> add CHANGELOG.md
+git -C <worktree> commit -m "chore: add changelog entry for ceo-inbox bullpen retrofit (#616)"
+```
+
+---
+
+### Task 8: Typecheck and final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run typecheck**
+
+```bash
+pnpm --prefix <worktree> run typecheck
+```
+
+Expected: no errors (this PR is prompt-only + one new test file).
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+pnpm --prefix <worktree> test
+```
+
+Expected: all tests pass, including the new integration test.
+
+- [ ] **Step 3: Verify signal-send is fully removed from ceo-inbox**
+
+```bash
+grep -n "signal-send" <worktree>/agents/ceo-inbox.yaml
+```
+
+Expected: no output (zero matches).
+
+```bash
+grep -n "Signal number" <worktree>/agents/ceo-inbox.yaml
+```
+
+Expected: no output (zero matches).
+
+- [ ] **Step 4: Verify bullpen is still pinned**
+
+```bash
+grep -n "bullpen" <worktree>/agents/ceo-inbox.yaml
+```
+
+Expected: at least one match showing `- bullpen` in pinned_skills.

--- a/tests/integration/ceo-inbox-bullpen-escalation.test.ts
+++ b/tests/integration/ceo-inbox-bullpen-escalation.test.ts
@@ -10,7 +10,7 @@ import { randomUUID } from 'node:crypto';
 import pg from 'pg';
 import { BullpenService } from '../../src/memory/bullpen.js';
 import { OutboundContextService } from '../../src/dispatch/outbound-context.js';
-import { createLogger } from '../../src/logger.js';
+import { createSilentLogger } from '../../src/logger.js';
 
 const { Pool } = pg;
 const DATABASE_URL = process.env.DATABASE_URL;
@@ -21,29 +21,36 @@ describeIf('ceo-inbox bullpen-through-coordinator escalation', () => {
   let bullpen: BullpenService;
   let outboundContext: OutboundContextService;
   let runId: string;
+  // Suite-level so test 3 can guard against test 2 not having run/succeeded.
+  let registeredEntryId: string | undefined;
 
   beforeAll(async () => {
     runId = randomUUID();
     pool = new Pool({ connectionString: DATABASE_URL });
     await pool.query('SELECT 1 FROM bullpen_threads LIMIT 0');
     await pool.query('SELECT 1 FROM outbound_context LIMIT 0');
-    const logger = createLogger('error');
+    const logger = createSilentLogger();
     bullpen = BullpenService.createWithPostgres(pool, logger);
     outboundContext = new OutboundContextService(pool, logger);
   });
 
   afterAll(async () => {
-    await pool.query(
-      `DELETE FROM bullpen_threads WHERE topic LIKE $1`,
-      [`${runId}%`],
-    );
-    // Remove only the specific entry created by this test run, identified by
-    // conversation_id scoped to runId, to avoid colliding with other test runs.
-    await pool.query(
-      `DELETE FROM outbound_context WHERE conversation_id = $1`,
-      [`conv-${runId}`],
-    );
-    await pool.end();
+    // Wrap cleanup in try/finally so pool.end() always runs, and cleanup errors
+    // don't produce confusing secondary failures that obscure the root cause.
+    try {
+      await pool.query(
+        `DELETE FROM bullpen_threads WHERE topic LIKE $1`,
+        [`${runId}%`],
+      );
+      // Remove only the specific entry created by this test run, identified by
+      // conversation_id scoped to runId, to avoid colliding with other test runs.
+      await pool.query(
+        `DELETE FROM outbound_context WHERE conversation_id = $1`,
+        [`conv-${runId}`],
+      );
+    } finally {
+      await pool.end();
+    }
   });
 
   it('ceo-inbox opens a bullpen thread mentioning coordinator for urgent email', async () => {
@@ -74,7 +81,7 @@ describeIf('ceo-inbox bullpen-through-coordinator escalation', () => {
     //
     // register() returns only the UUID; fetch the full row via pool.query to
     // verify the persisted field values.
-    const registeredEntryId = await outboundContext.register({
+    registeredEntryId = await outboundContext.register({
       conversationId: `conv-${runId}`,
       channelId: 'signal',
       agentId: 'ceo-inbox',
@@ -113,6 +120,11 @@ describeIf('ceo-inbox bullpen-through-coordinator escalation', () => {
   });
 
   it('active context entry enables delegation back to ceo-inbox', async () => {
+    // Guard: this test depends on test 2 having registered the outbound context entry.
+    if (!registeredEntryId) {
+      throw new Error('Precondition failed: registeredEntryId not set — did test 2 fail?');
+    }
+
     // Simulate: CEO replies on Signal. Dispatcher queries active entries.
     // We verify the entry we registered in test 2 is still present and has the
     // correct delegation hint. Use the conversation_id scoped to this run to

--- a/tests/integration/ceo-inbox-bullpen-escalation.test.ts
+++ b/tests/integration/ceo-inbox-bullpen-escalation.test.ts
@@ -1,0 +1,131 @@
+// tests/integration/ceo-inbox-bullpen-escalation.test.ts
+//
+// Integration test: validates the infrastructure path for ceo-inbox
+// urgent alerts routed through bullpen-through-coordinator pattern.
+// Verifies: thread creation → coordinator receives → context bridge
+// entry registered → delegation hint points back to ceo-inbox.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import pg from 'pg';
+import { BullpenService } from '../../src/memory/bullpen.js';
+import { OutboundContextService } from '../../src/dispatch/outbound-context.js';
+import { createLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('ceo-inbox bullpen-through-coordinator escalation', () => {
+  let pool: pg.Pool;
+  let bullpen: BullpenService;
+  let outboundContext: OutboundContextService;
+  let runId: string;
+  // Track the registered context entry ID for cleanup and cross-test assertions.
+  let registeredEntryId: string;
+
+  beforeAll(async () => {
+    runId = randomUUID();
+    pool = new Pool({ connectionString: DATABASE_URL });
+    const logger = createLogger('error');
+    bullpen = BullpenService.createWithPostgres(pool, logger);
+    outboundContext = new OutboundContextService(pool, logger);
+  });
+
+  afterAll(async () => {
+    await pool.query(
+      `DELETE FROM bullpen_threads WHERE topic LIKE $1`,
+      [`${runId}%`],
+    );
+    // Remove only the specific entry created by this test run, identified by
+    // conversation_id scoped to runId, to avoid colliding with other test runs.
+    await pool.query(
+      `DELETE FROM outbound_context WHERE conversation_id = $1`,
+      [`conv-${runId}`],
+    );
+    await pool.end();
+  });
+
+  it('ceo-inbox opens a bullpen thread mentioning coordinator for urgent email', async () => {
+    // Simulate: ceo-inbox posts a structured send request to coordinator
+    const { thread, message } = await bullpen.openThread(
+      `${runId} — Urgent email escalation: merger deadline`,
+      'ceo-inbox',
+      ['ceo-inbox', 'coordinator'],
+      `@coordinator I'd like you to send a message to the CEO.\n\n` +
+        `Urgency: immediate\n` +
+        `Channel: Signal\n` +
+        `Message: "Alice Chen — Merger deadline: Decision needed on terms by Friday EOD"\n` +
+        `Context bridge: agent_id=ceo-inbox, expected_reply="Decision or follow-up instruction", ` +
+        `delegation_hint="Delegate replies to ceo-inbox", expires_in_hours=24`,
+      ['coordinator'],
+    );
+
+    expect(thread.creatorAgentId).toBe('ceo-inbox');
+    expect(thread.participants).toContain('coordinator');
+    expect(message.content).toContain('Urgency: immediate');
+    expect(message.content).toContain('Channel: Signal');
+    expect(message.content).toContain('Context bridge:');
+  });
+
+  it('coordinator registers context bridge entry after sending', async () => {
+    // Simulate: coordinator processes the bullpen request and calls signal-send
+    // with context_bridge params. The send skill registers the entry.
+    //
+    // register() returns only the UUID; fetch the full row via pool.query to
+    // verify the persisted field values.
+    registeredEntryId = await outboundContext.register({
+      conversationId: `conv-${runId}`,
+      channelId: 'signal',
+      agentId: 'ceo-inbox',
+      content: 'Alice Chen — Merger deadline: Decision needed on terms by Friday EOD',
+      expectedReply: 'Decision or follow-up instruction',
+      delegationHint: 'Delegate replies to ceo-inbox',
+      metadata: { source: 'urgent-email-escalation' },
+      expiresInHours: 24,
+    });
+
+    expect(registeredEntryId).toBeDefined();
+
+    // Fetch the persisted row to verify field values were stored correctly.
+    const result = await pool.query<{
+      id: string;
+      agent_id: string;
+      delegation_hint: string;
+      expected_reply: string;
+    }>(
+      `SELECT id, agent_id, delegation_hint, expected_reply
+       FROM outbound_context WHERE id = $1`,
+      [registeredEntryId],
+    );
+
+    expect(result.rows).toHaveLength(1);
+    const row = result.rows[0]!;
+    expect(row.agent_id).toBe('ceo-inbox');
+    expect(row.delegation_hint).toBe('Delegate replies to ceo-inbox');
+
+    // Verify the entry appears in active entries (no channel filter — getActive
+    // returns all active entries; filter by agentId client-side).
+    const active = await outboundContext.getActive();
+    const found = active.find(e => e.id === registeredEntryId);
+    expect(found).toBeDefined();
+    expect(found!.expectedReply).toBe('Decision or follow-up instruction');
+  });
+
+  it('active context entry enables delegation back to ceo-inbox', async () => {
+    // Simulate: CEO replies on Signal. Dispatcher queries active entries.
+    const active = await outboundContext.getActive();
+    // Filter to entries belonging to the ceo-inbox agent (getActive returns all
+    // channels; channel-scoping happens at the dispatcher layer, not here).
+    const ceoInboxEntries = active.filter(e => e.agentId === 'ceo-inbox');
+
+    // At least one entry should point back to ceo-inbox
+    expect(ceoInboxEntries.length).toBeGreaterThan(0);
+
+    const entry = ceoInboxEntries[0]!;
+    expect(entry.delegationHint).toContain('ceo-inbox');
+
+    // Coordinator uses this hint to delegate the reply back to ceo-inbox
+    // (actual delegation is tested in dispatcher-context-bridging.test.ts)
+  });
+});

--- a/tests/integration/ceo-inbox-bullpen-escalation.test.ts
+++ b/tests/integration/ceo-inbox-bullpen-escalation.test.ts
@@ -21,8 +21,8 @@ describeIf('ceo-inbox bullpen-through-coordinator escalation', () => {
   let bullpen: BullpenService;
   let outboundContext: OutboundContextService;
   let runId: string;
-  // Suite-level so test 3 can guard against test 2 not having run/succeeded.
-  let registeredEntryId: string | undefined;
+  // Registered in beforeAll so all tests are independent of each other's execution order.
+  let registeredEntryId: string;
 
   beforeAll(async () => {
     runId = randomUUID();
@@ -32,6 +32,17 @@ describeIf('ceo-inbox bullpen-through-coordinator escalation', () => {
     const logger = createSilentLogger();
     bullpen = BullpenService.createWithPostgres(pool, logger);
     outboundContext = new OutboundContextService(pool, logger);
+    // Register the outbound context entry once so tests 2 and 3 are self-contained.
+    registeredEntryId = await outboundContext.register({
+      conversationId: `conv-${runId}`,
+      channelId: 'signal',
+      agentId: 'ceo-inbox',
+      content: 'Alice Chen — Merger deadline: Decision needed on terms by Friday EOD',
+      expectedReply: 'Decision or follow-up instruction',
+      delegationHint: 'Delegate replies to ceo-inbox',
+      metadata: { source: 'urgent-email-escalation' },
+      expiresInHours: 24,
+    });
   });
 
   afterAll(async () => {
@@ -76,25 +87,9 @@ describeIf('ceo-inbox bullpen-through-coordinator escalation', () => {
   });
 
   it('coordinator registers context bridge entry after sending', async () => {
-    // Simulate: coordinator processes the bullpen request and calls signal-send
-    // with context_bridge params. The send skill registers the entry.
-    //
-    // register() returns only the UUID; fetch the full row via pool.query to
-    // verify the persisted field values.
-    registeredEntryId = await outboundContext.register({
-      conversationId: `conv-${runId}`,
-      channelId: 'signal',
-      agentId: 'ceo-inbox',
-      content: 'Alice Chen — Merger deadline: Decision needed on terms by Friday EOD',
-      expectedReply: 'Decision or follow-up instruction',
-      delegationHint: 'Delegate replies to ceo-inbox',
-      metadata: { source: 'urgent-email-escalation' },
-      expiresInHours: 24,
-    });
-
-    expect(registeredEntryId).toBeDefined();
-
-    // Fetch the persisted row to verify field values were stored correctly.
+    // Verify the entry registered in beforeAll was persisted with the correct field values.
+    // Query directly by id rather than via getActive() to avoid the default LIMIT 10 window,
+    // which can exclude our row in a shared DB with many active entries.
     const result = await pool.query<{
       id: string;
       agent_id: string;
@@ -110,25 +105,13 @@ describeIf('ceo-inbox bullpen-through-coordinator escalation', () => {
     const row = result.rows[0]!;
     expect(row.agent_id).toBe('ceo-inbox');
     expect(row.delegation_hint).toBe('Delegate replies to ceo-inbox');
-
-    // Verify the entry appears in active entries (no channel filter — getActive
-    // returns all active entries; filter by agentId client-side).
-    const active = await outboundContext.getActive();
-    const found = active.find(e => e.id === registeredEntryId);
-    expect(found).toBeDefined();
-    expect(found?.expectedReply).toBe('Decision or follow-up instruction');
+    expect(row.expected_reply).toBe('Decision or follow-up instruction');
   });
 
   it('active context entry enables delegation back to ceo-inbox', async () => {
-    // Guard: this test depends on test 2 having registered the outbound context entry.
-    if (!registeredEntryId) {
-      throw new Error('Precondition failed: registeredEntryId not set — did test 2 fail?');
-    }
-
     // Simulate: CEO replies on Signal. Dispatcher queries active entries.
-    // We verify the entry we registered in test 2 is still present and has the
-    // correct delegation hint. Use the conversation_id scoped to this run to
-    // avoid depending on getActive()'s limit or parallel test state.
+    // Query by conversation_id scoped to this run — avoids getActive()'s LIMIT 10 window
+    // and parallel test state interference.
     const result = await pool.query<{ agent_id: string; delegation_hint: string }>(
       `SELECT agent_id, delegation_hint FROM outbound_context
        WHERE conversation_id = $1 AND released = false`,

--- a/tests/integration/ceo-inbox-bullpen-escalation.test.ts
+++ b/tests/integration/ceo-inbox-bullpen-escalation.test.ts
@@ -21,12 +21,12 @@ describeIf('ceo-inbox bullpen-through-coordinator escalation', () => {
   let bullpen: BullpenService;
   let outboundContext: OutboundContextService;
   let runId: string;
-  // Track the registered context entry ID for cleanup and cross-test assertions.
-  let registeredEntryId: string;
 
   beforeAll(async () => {
     runId = randomUUID();
     pool = new Pool({ connectionString: DATABASE_URL });
+    await pool.query('SELECT 1 FROM bullpen_threads LIMIT 0');
+    await pool.query('SELECT 1 FROM outbound_context LIMIT 0');
     const logger = createLogger('error');
     bullpen = BullpenService.createWithPostgres(pool, logger);
     outboundContext = new OutboundContextService(pool, logger);
@@ -74,7 +74,7 @@ describeIf('ceo-inbox bullpen-through-coordinator escalation', () => {
     //
     // register() returns only the UUID; fetch the full row via pool.query to
     // verify the persisted field values.
-    registeredEntryId = await outboundContext.register({
+    const registeredEntryId = await outboundContext.register({
       conversationId: `conv-${runId}`,
       channelId: 'signal',
       agentId: 'ceo-inbox',
@@ -109,21 +109,24 @@ describeIf('ceo-inbox bullpen-through-coordinator escalation', () => {
     const active = await outboundContext.getActive();
     const found = active.find(e => e.id === registeredEntryId);
     expect(found).toBeDefined();
-    expect(found!.expectedReply).toBe('Decision or follow-up instruction');
+    expect(found?.expectedReply).toBe('Decision or follow-up instruction');
   });
 
   it('active context entry enables delegation back to ceo-inbox', async () => {
     // Simulate: CEO replies on Signal. Dispatcher queries active entries.
-    const active = await outboundContext.getActive();
-    // Filter to entries belonging to the ceo-inbox agent (getActive returns all
-    // channels; channel-scoping happens at the dispatcher layer, not here).
-    const ceoInboxEntries = active.filter(e => e.agentId === 'ceo-inbox');
+    // We verify the entry we registered in test 2 is still present and has the
+    // correct delegation hint. Use the conversation_id scoped to this run to
+    // avoid depending on getActive()'s limit or parallel test state.
+    const result = await pool.query<{ agent_id: string; delegation_hint: string }>(
+      `SELECT agent_id, delegation_hint FROM outbound_context
+       WHERE conversation_id = $1 AND released = false`,
+      [`conv-${runId}`],
+    );
 
-    // At least one entry should point back to ceo-inbox
-    expect(ceoInboxEntries.length).toBeGreaterThan(0);
-
-    const entry = ceoInboxEntries[0]!;
-    expect(entry.delegationHint).toContain('ceo-inbox');
+    expect(result.rows.length).toBeGreaterThan(0);
+    const row = result.rows[0]!;
+    expect(row.agent_id).toBe('ceo-inbox');
+    expect(row.delegation_hint).toContain('ceo-inbox');
 
     // Coordinator uses this hint to delegate the reply back to ceo-inbox
     // (actual delegation is tested in dispatcher-context-bridging.test.ts)


### PR DESCRIPTION
## **User description**
## Summary

- Removes `signal-send` from `ceo-inbox`'s `pinned_skills` — coordinator is now the sole voice for all outbound communication
- Rewrites the URGENT classification (steps 4e and 4h) to post a structured Bullpen thread to the coordinator with `Urgency: immediate`, the composed Signal message, and `context_bridge` metadata — enabling CEO replies to be delegated back to ceo-inbox
- Removes the hardcoded CEO Signal number from the system prompt (coordinator owns channel details)
- Fixes 3 stale "ceo-inbox sends Signal" capability references in the agent description and prompt
- Adds a delegation-reply note to the delegated mode section making explicit that alert replies route through the standard coordinator-delegation path
- Adds an integration test validating the bullpen-through-coordinator infrastructure round-trip

Closes #616

## Test Plan

- [ ] `pnpm --prefix worktrees/curia-ceo-inbox-bullpen test` — full suite passes; new integration test skips cleanly without DATABASE_URL (or runs all 3 tests with it set)
- [ ] `grep -n "signal-send" worktrees/curia-ceo-inbox-bullpen/agents/ceo-inbox.yaml` — no output (zero matches)
- [ ] `grep -n "Signal number" worktrees/curia-ceo-inbox-bullpen/agents/ceo-inbox.yaml` — no output (zero matches)
- [ ] `grep -n "bullpen" worktrees/curia-ceo-inbox-bullpen/agents/ceo-inbox.yaml` — at least one match showing `- bullpen` in pinned_skills


___

## **CodeAnt-AI Description**
**Route urgent CEO inbox alerts through the coordinator**

### What Changed
- Urgent email alerts from `ceo-inbox` now go through the coordinator via Bullpen instead of sending Signal alerts directly
- The urgent-alert instructions now include a structured handoff with urgency, message content, and reply routing details so replies can come back to `ceo-inbox`
- The prompt now states that coordinator replies to these alerts should be handled as normal delegated requests
- Added an integration test that checks the urgent-alert thread, stored reply context, and delegation path back to `ceo-inbox`
- Updated the changelog to describe the new alert flow

### Impact
`✅ Fewer direct Signal sends from inbox triage`
`✅ Clearer reply routing for urgent CEO alerts`
`✅ Safer urgent-alert delegation handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changed**
  * Urgent email alerts now route through the coordinator via Bullpen instead of direct signalling, enabling improved context management and delegation handling for CEO replies.

* **Documentation**
  * Added comprehensive design and implementation documentation for the alert escalation retrofit.

* **Tests**
  * Added integration tests verifying urgent email escalation and coordinator delegation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->