### PR TITLE
fix: correct memory write rate limit key mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Turn budget injection** — all agents now receive their exact turn limit in the system prompt at runtime, framed as a planning constraint so models can pace their tool use from turn 1 rather than hitting the ceiling silently. (#689)
 
+### Fixed
+
+- **Memory write rate limit** — `storeFact` source keys now match the format that `AgentRuntime.resetRateLimit()` clears, so the per-task write counter is properly scoped and cleaned up instead of accumulating globally until process restart. Affected skills: `config-store`, `memory-store`, `extract-facts`, `template-doc-request`.
+
 ### Changed
 
 - **Context bridging v2** — outbound context registry replaces working-memory memos; send skills gain optional `context_bridge` param for delegation-aware reply routing. (#615)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Turn budget injection** — all agents now receive their exact turn limit in the system prompt at runtime, framed as a planning constraint so models can pace their tool use from turn 1 rather than hitting the ceiling silently. (#689)
 
-### Fixed
-
-- **Memory write rate limit** — `storeFact` source keys now match the format that `AgentRuntime.resetRateLimit()` clears, so the per-task write counter is properly scoped and cleaned up instead of accumulating globally until process restart. Affected skills: `config-store`, `memory-store`, `extract-facts`, `template-doc-request`.
-
 ### Changed
 
 - **Context bridging v2** — outbound context registry replaces working-memory memos; send skills gain optional `context_bridge` param for delegation-aware reply routing. (#615)
@@ -36,6 +32,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Memory write rate limit** — `storeFact` source keys now match the format that `AgentRuntime.resetRateLimit()` clears, so the per-task write counter is properly scoped and cleaned up instead of accumulating globally until process restart. Affected skills: `config-store`, `memory-store`, `extract-facts`, `template-doc-request`.
 - **`workspace-mcp` tool tier** — upgraded to `complete`; `create_sheet` and `append_table_rows` require this tier, fixing T2125 expense-tracker setup and ingestion flows. (curia-deploy#65)
 - **`ceo-inbox-update-folders`** — added empty-folders guard matching `ceo-inbox-label`: falls back to the computed folder list when Nylas omits `folders` from the PUT response. (#596)
 - **`ceo-inbox-draft-reply`** — empty `from` now returns `{ success: false }` with an error log instead of silently creating a draft addressed to `unknown`. (#598)

--- a/skills/_shared/template-base.ts
+++ b/skills/_shared/template-base.ts
@@ -50,7 +50,7 @@ export async function savePolicy(
       properties: { policy: custom_policy },
       confidence: 1.0,
       decayClass: 'permanent',
-      source: skillSource,
+      source: ctx.memoryWriteSource ?? skillSource,
     });
     ctx.log.info('Saved custom email policy to knowledge graph');
     return { success: true, data: { saved: true } };
@@ -96,7 +96,7 @@ export async function updatePolicy(
       properties: { refinement, addedAt: timestamp },
       confidence: 1.0,
       decayClass: 'permanent',
-      source: skillSource,
+      source: ctx.memoryWriteSource ?? skillSource,
     });
 
     ctx.log.info({ refinement }, 'Stored policy refinement');
@@ -131,7 +131,7 @@ export async function resetPolicy(
           properties: { policy: '', cleared: true },
           confidence: 1.0,
           decayClass: 'permanent',
-          source: skillSource,
+          source: ctx.memoryWriteSource ?? skillSource,
         });
         // Mark all existing refinements as cleared — resolvePolicy will
         // ignore refinements with addedAt before this timestamp.
@@ -141,7 +141,7 @@ export async function resetPolicy(
           properties: { clearedAt: new Date().toISOString() },
           confidence: 1.0,
           decayClass: 'permanent',
-          source: skillSource,
+          source: ctx.memoryWriteSource ?? skillSource,
         });
       }
     }

--- a/skills/config-store/handler.test.ts
+++ b/skills/config-store/handler.test.ts
@@ -22,11 +22,13 @@ function makeEntityMemory(overrides: Record<string, unknown> = {}) {
 function makeCtx(
   entityMemory: ReturnType<typeof makeEntityMemory> | null | undefined,
   input: Record<string, unknown>,
+  overrides: Partial<SkillContext> = {},
 ): SkillContext {
   return {
     input,
     entityMemory: entityMemory === null ? undefined : (entityMemory ?? makeEntityMemory()),
     log: pino({ level: 'silent' }),
+    ...overrides,
   } as unknown as SkillContext;
 }
 
@@ -189,6 +191,44 @@ describe('ConfigStoreHandler', () => {
     // skipped when the value write was rejected, otherwise list_namespaces would
     // advertise a namespace with no stored config values (phantom namespace).
     expect(mem.storeFact).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses memoryWriteSource as the storeFact source when available', async () => {
+    const handler = new ConfigStoreHandler();
+    const mem = makeEntityMemory({
+      findEntities: vi.fn()
+        .mockResolvedValueOnce([{ id: 'anchor-existing' }]) // anchor lookup
+        .mockResolvedValueOnce([{ id: 'index-existing' }]), // index lookup
+    });
+    const memoryWriteSource = 'agent:ceo-inbox/task:task-123/channel:http';
+    const ctx = makeCtx(
+      mem,
+      { action: 'store', namespace: 'ceo_inbox', key: 'rules', value: '[]' },
+      { memoryWriteSource },
+    );
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    // Both storeFact calls (value + namespace registration) should use memoryWriteSource
+    expect(mem.storeFact).toHaveBeenCalledTimes(2);
+    expect(mem.storeFact.mock.calls[0]![0].source).toBe(memoryWriteSource);
+    expect(mem.storeFact.mock.calls[1]![0].source).toBe(memoryWriteSource);
+  });
+
+  it('falls back to skill:config-store when memoryWriteSource is not set', async () => {
+    const handler = new ConfigStoreHandler();
+    const mem = makeEntityMemory({
+      findEntities: vi.fn()
+        .mockResolvedValueOnce([{ id: 'anchor-existing' }])
+        .mockResolvedValueOnce([{ id: 'index-existing' }]),
+    });
+    // No memoryWriteSource on context — simulates test / CLI invocations
+    const ctx = makeCtx(mem, { action: 'store', namespace: 'ns', key: 'k', value: 'v' });
+
+    await handler.execute(ctx);
+
+    expect(mem.storeFact.mock.calls[0]![0].source).toBe('skill:config-store');
   });
 
   it('skips namespace registration when namespace is already in the meta-index', async () => {

--- a/skills/config-store/handler.ts
+++ b/skills/config-store/handler.ts
@@ -73,6 +73,19 @@ export class ConfigStoreHandler implements SkillHandler {
     // even though they are assigned inside the try block.
     let anchor: { id: string };
     let storeResult: { stored: boolean; action: string };
+
+    // Use the context-aware source key so the rate limit counter matches what
+    // AgentRuntime.resetRateLimit() clears. Without this, the counter accumulates
+    // globally under 'skill:config-store' and is never reset.
+    // Declared before the try block so Phase 2 (registerNamespace) can reuse it.
+    const writeSource = ctx.memoryWriteSource ?? 'skill:config-store';
+    if (!ctx.memoryWriteSource) {
+      // memoryWriteSource is only absent in test/CLI contexts where no agentId or
+      // taskEventId is available. If this fires in production, it means channelId
+      // or agentId wasn't threaded through InvokeOptions — check the caller.
+      ctx.log.debug({ namespace, key }, 'config-store: memoryWriteSource not set — using skill:config-store fallback');
+    }
+
     try {
       anchor = await this.findOrCreateAnchor(ctx, namespace);
 
@@ -83,7 +96,7 @@ export class ConfigStoreHandler implements SkillHandler {
         confidence: 1.0,
         // Config values are permanent — stable URLs / IDs the CEO provides once
         decayClass: 'permanent',
-        source: 'skill:config-store',
+        source: writeSource,
       });
 
       if (!storeResult.stored) {
@@ -108,7 +121,7 @@ export class ConfigStoreHandler implements SkillHandler {
     // leave list_namespaces advertising a namespace with no stored config values.
     if (storeResult.stored) {
       try {
-        await this.registerNamespace(ctx, namespace);
+        await this.registerNamespace(ctx, namespace, writeSource);
       } catch (err) {
         ctx.log.error(
           { err, namespace, key },
@@ -241,7 +254,7 @@ export class ConfigStoreHandler implements SkillHandler {
     return entity;
   }
 
-  private async registerNamespace(ctx: SkillContext, namespace: string): Promise<void> {
+  private async registerNamespace(ctx: SkillContext, namespace: string, writeSource: string): Promise<void> {
     const indexNodes = await ctx.entityMemory!.findEntities(INDEX_LABEL);
 
     let indexNodeId: string;
@@ -273,7 +286,7 @@ export class ConfigStoreHandler implements SkillHandler {
       properties: { namespace },
       confidence: 1.0,
       decayClass: 'permanent',
-      source: 'skill:config-store',
+      source: writeSource,
     });
   }
 }

--- a/skills/extract-facts/handler.test.ts
+++ b/skills/extract-facts/handler.test.ts
@@ -238,6 +238,33 @@ describe('ExtractFactsHandler', () => {
     expect(storeFact).toHaveBeenCalledOnce();
   });
 
+  it('uses memoryWriteSource as storeFact source, overriding the LLM-provided source', async () => {
+    const entityMemory = makeEntityMemory();
+    const facts = JSON.stringify([
+      { subject: 'Jane Doe', subjectType: 'person', attribute: 'home_city', value: 'Toronto', confidence: 0.9, decayClass: 'slow_decay' },
+    ]);
+    const infraLlm = makeMockInfraLlm(['yes', facts]);
+    const handler = new ExtractFactsHandler();
+
+    const storeFact = vi.spyOn(entityMemory, 'storeFact').mockResolvedValueOnce({ stored: true, action: 'created' });
+
+    const memoryWriteSource = 'agent:ceo-inbox/task:task-abc/channel:http';
+    const ctx = {
+      input: { text: 'Jane Doe lives in Toronto.', source: 'agent:ceo-inbox' },
+      secret: () => 'test-api-key',
+      log: pino({ level: 'silent' }),
+      entityMemory,
+      infraLlm,
+      memoryWriteSource,
+    } as unknown as SkillContext;
+
+    const result = await handler.execute(ctx);
+
+    expect(result).toEqual({ success: true, data: { stored: 1, skipped: false, failed: 0 } });
+    // storeFact should use memoryWriteSource (task-scoped), not the LLM-provided 'agent:ceo-inbox'
+    expect(storeFact.mock.calls[0]![0].source).toBe(memoryWriteSource);
+  });
+
   it('breaks immediately on rate_limited mid-batch — increments failed, skips remaining facts', async () => {
     const entityMemory = makeEntityMemory();
     // Three facts — first stored successfully, second hits rate limit, third should never be attempted.

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -221,7 +221,9 @@ ${text}`,
             properties: { attribute, value },
             confidence,
             decayClass,
-            source,
+            // Use the context-aware source key so the rate limit counter matches
+            // what AgentRuntime.resetRateLimit() clears after each task.
+            source: ctx.memoryWriteSource ?? source,
           });
 
           if (result.stored) {

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -215,22 +215,31 @@ ${text}`,
           // The validator uses semantic similarity on this label for near-duplicate detection.
           const label = `${attribute}: ${value}`;
 
+          // Use the context-aware source key so the rate limit counter matches
+          // what AgentRuntime.resetRateLimit() clears after each task. The
+          // LLM-provided `source` is a fallback for test/CLI contexts.
+          const effectiveSource = ctx.memoryWriteSource ?? source;
+          if (!ctx.memoryWriteSource) {
+            ctx.log.debug(
+              { fallbackSource: source },
+              'extract-facts: memoryWriteSource not set — using input source fallback',
+            );
+          }
+
           const result = await ctx.entityMemory.storeFact({
             entityNodeId: entityNode.id,
             label,
             properties: { attribute, value },
             confidence,
             decayClass,
-            // Use the context-aware source key so the rate limit counter matches
-            // what AgentRuntime.resetRateLimit() clears after each task.
-            source: ctx.memoryWriteSource ?? source,
+            source: effectiveSource,
           });
 
           if (result.stored) {
             if (result.action === 'auto_resolved') {
               // Incoming fact superseded a lower-confidence existing fact — audit trail preserved.
               ctx.log.info(
-                { subject, attribute, source, nodeId: result.nodeId },
+                { subject, attribute, source: effectiveSource, nodeId: result.nodeId },
                 'extract-facts: fact auto-resolved — existing superseded by higher-confidence incoming',
               );
             }
@@ -240,14 +249,14 @@ ${text}`,
             // in this batch will also fail, so break immediately rather than burning
             // through the rest of the loop and mis-reporting them as conflicts.
             ctx.log.error(
-              { subject, attribute, source, reason: result.conflict },
+              { subject, attribute, source: effectiveSource, reason: result.conflict },
               'extract-facts: write rate limit exceeded — aborting remaining facts in batch',
             );
             failed++;
             break;
           } else {
             // conflict, auto_rejected, or entity_not_found — expected semantic outcomes, not infra failures.
-            ctx.log.warn({ subject, attribute, conflict: result.conflict, action: result.action, source }, 'extract-facts: fact not stored');
+            ctx.log.warn({ subject, attribute, conflict: result.conflict, action: result.action, source: effectiveSource }, 'extract-facts: fact not stored');
           }
         } catch (err) {
           // Re-throw programming errors — these indicate bugs in this handler (wrong

--- a/skills/memory-store/handler.test.ts
+++ b/skills/memory-store/handler.test.ts
@@ -285,6 +285,44 @@ describe('MemoryStoreHandler', () => {
     });
   });
 
+  describe('memoryWriteSource', () => {
+    it('uses memoryWriteSource as the storeFact source when available on context', async () => {
+      const mockMem = makeMockEntityMemory({ stored: true, action: 'created', nodeId: 'fact-1' });
+      const memoryWriteSource = 'agent:ceo-inbox/task:task-abc/channel:internal';
+      const ctx = {
+        input: VALID_INPUT,
+        secret: () => 'test-key',
+        log: pino({ level: 'silent' }),
+        entityMemory: mockMem,
+        memoryWriteSource,
+      } as unknown as SkillContext;
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      // storeFact should have been called with the context-aware source, not the LLM-provided one
+      expect(mockMem.storeFact).toHaveBeenCalledTimes(1);
+      expect(mockMem.storeFact.mock.calls[0]![0].source).toBe(memoryWriteSource);
+    });
+
+    it('falls back to LLM-provided source when memoryWriteSource is not set', async () => {
+      const mockMem = makeMockEntityMemory({ stored: true, action: 'created', nodeId: 'fact-1' });
+      const ctx = {
+        input: VALID_INPUT,
+        secret: () => 'test-key',
+        log: pino({ level: 'silent' }),
+        entityMemory: mockMem,
+        // No memoryWriteSource — simulates test / CLI invocations
+      } as unknown as SkillContext;
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      // Should fall back to the LLM-provided source from VALID_INPUT
+      expect(mockMem.storeFact.mock.calls[0]![0].source).toBe(VALID_INPUT.source);
+    });
+  });
+
   describe('action: rate_limited', () => {
     it('returns rate_limited with reason when storeFact hits the write limit', async () => {
       const ctx = {

--- a/skills/memory-store/handler.ts
+++ b/skills/memory-store/handler.ts
@@ -179,13 +179,27 @@ export class MemoryStoreHandler implements SkillHandler {
       // validateContradiction() can detect same-field conflicts.
       const label = `${field}: ${value}`;
 
+      // Use the context-aware source key for storeFact so the rate limit counter
+      // matches what AgentRuntime.resetRateLimit() clears after each task. The
+      // LLM-provided `source` is a fallback for test contexts where memoryWriteSource
+      // isn't set.
+      const effectiveSource = ctx.memoryWriteSource ?? source;
+      if (!ctx.memoryWriteSource) {
+        // memoryWriteSource is only absent in test/CLI contexts where no agentId or
+        // taskEventId is available. If this fires in production, it means channelId
+        // or agentId wasn't threaded through InvokeOptions — check the caller.
+        ctx.log.debug(
+          { entity, field, fallbackSource: source },
+          'memory-store: memoryWriteSource not set — using LLM-provided source fallback',
+        );
+      }
       const result = await ctx.entityMemory.storeFact({
         entityNodeId: entityNode.id,
         label,
         properties: { attribute: field, value },
         confidence: confidence ?? 0.8,
         decayClass: (decay_class as DecayClass | undefined) ?? 'slow_decay',
-        source,
+        source: effectiveSource,
         sensitivity: sensitivity as Sensitivity | undefined,
         sensitivityCategory: sensitivity_category,
       });

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -20,6 +20,7 @@ import { formatTurnBudgetBlock } from './turn-budget.js';
 import type { OfficeIdentityService } from '../identity/service.js';
 import { compileWritingVoiceBlock, type ExecutiveProfileService } from '../executive/service.js';
 import { formatBullpenContext, type BullpenService } from '../memory/bullpen.js';
+import { buildRateLimitSourceKey } from '../memory/rate-limit-key.js';
 import type { AgentRegistry } from './agent-registry.js';
 
 export interface AgentConfig {
@@ -181,7 +182,7 @@ export class AgentRuntime {
       if (this.config.entityMemory) {
         const { agentId } = this.config;
         const { channelId } = taskEvent.payload;
-        const sourceKey = `agent:${agentId}/task:${taskEvent.id}/channel:${channelId}`;
+        const sourceKey = buildRateLimitSourceKey(agentId, taskEvent.id, channelId);
         // Guard against cleanup errors suppressing original exceptions.
         // resetRateLimit() is synchronous and currently cannot throw, but wrapping
         // defensively ensures future changes don't cause silent error replacement.
@@ -752,6 +753,7 @@ export class AgentRuntime {
         const result = await executionLayer.invoke(toolCall.name, skillInput, caller, {
           taskEventId: taskEvent.id,
           agentId,
+          channelId: taskEvent.payload.channelId,
           conversationId,
           parentEventId: invokeEvent.id,
           // Pass task-level metadata so skill handlers can inspect task-wide signals

--- a/src/memory/rate-limit-key.ts
+++ b/src/memory/rate-limit-key.ts
@@ -1,0 +1,28 @@
+// src/memory/rate-limit-key.ts
+//
+// Single definition of the rate limit source key format used by both the write
+// path (skills → storeFact) and the reset path (AgentRuntime.resetRateLimit).
+//
+// Keeping this in one place prevents the two paths from drifting apart — if
+// either side constructs a different string, the counter written under one key
+// is never cleaned up by the reset under a different key, silently
+// re-introducing the accumulation bug this module was created to fix.
+
+/**
+ * Builds the source key used for both memory write accounting and rate limit
+ * cleanup. The format encodes the (agent, task, channel) tuple so the per-task
+ * 50-write budget is correctly scoped and reset after each task completes.
+ *
+ * @param agentId    - The agent ID running the task (e.g. "ceo-inbox")
+ * @param taskId     - The task event ID (a UUID)
+ * @param channelId  - The originating channel (e.g. "http", "internal"). Falls
+ *                     back to "unknown" only for non-standard code paths that
+ *                     don't originate from a channel task event.
+ */
+export function buildRateLimitSourceKey(
+  agentId: string,
+  taskId: string,
+  channelId: string | undefined,
+): string {
+  return `agent:${agentId}/task:${taskId}/channel:${channelId ?? 'unknown'}`;
+}

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -530,8 +530,11 @@ export class ExecutionLayer {
       // per agent+task and cleaned up after each task completes.
       // buildRateLimitSourceKey() is the single definition of this format — both
       // the write path (here) and the reset path (AgentRuntime) use it.
-      memoryWriteSource: options?.agentId && options?.taskEventId
-        ? buildRateLimitSourceKey(options.agentId, options.taskEventId, options.channelId)
+      // When agentId is absent (e.g. human-approved re-invokes), use a stable fallback
+      // identifier so the key is still scoped per task rather than falling back to the
+      // global 'skill:config-store' key that accumulates across all conversations.
+      memoryWriteSource: options?.taskEventId
+        ? buildRateLimitSourceKey(options.agentId ?? 'human-approved', options.taskEventId, options.channelId)
         : undefined,
       // Forward task-level metadata so skills can inspect task-wide signals.
       taskMetadata: options?.taskMetadata,

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -42,6 +42,7 @@ import type { ApprovalTriggerService } from '../autonomy/approval-trigger.js';
 import { TempFileStore } from './temp-file-store.js';
 import type { InfraLlmService } from './infra-llm.js';
 import { OutboundContextService, ScopedOutboundContext } from '../dispatch/outbound-context.js';
+import { buildRateLimitSourceKey } from '../memory/rate-limit-key.js';
 
 // Default max output length — used when no value is configured in default.yaml.
 // Skills returning more than this will have their output truncated before it
@@ -52,6 +53,7 @@ const DEFAULT_SKILL_OUTPUT_MAX_LENGTH = 200_000;
 export interface InvokeOptions {
   taskEventId?: string;
   agentId?: string;
+  channelId?: string;
   conversationId?: string;
   parentEventId?: string;
   /** Task-level metadata forwarded from the agent.task event payload. */
@@ -517,10 +519,20 @@ export class ExecutionLayer {
       // contactService is available to all skills — read-only contact lookups
       // (calendars, display names, etc.) are not a privilege escalation.
       contactService: this.contactService,
-      // Thread agentId and taskEventId into context unconditionally — capability-gated
-      // skills (bullpen) need these for event publishing; harmless for others.
+      // Thread agentId, taskEventId, and channelId into context unconditionally —
+      // capability-gated skills (bullpen) need these for event publishing; harmless for others.
       agentId: options?.agentId,
       taskEventId: options?.taskEventId,
+      channelId: options?.channelId,
+      // Pre-construct the memory write source key so skills pass a rate-limit-compatible
+      // source to entityMemory.storeFact(). This key matches the format that
+      // AgentRuntime.resetRateLimit() uses, ensuring the counter is properly scoped
+      // per agent+task and cleaned up after each task completes.
+      // buildRateLimitSourceKey() is the single definition of this format — both
+      // the write path (here) and the reset path (AgentRuntime) use it.
+      memoryWriteSource: options?.agentId && options?.taskEventId
+        ? buildRateLimitSourceKey(options.agentId, options.taskEventId, options.channelId)
+        : undefined,
       // Forward task-level metadata so skills can inspect task-wide signals.
       taskMetadata: options?.taskMetadata,
       // Expose the configured timezone so skills can format output timestamps

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -162,6 +162,14 @@ export interface SkillContext {
   agentId?: string;
   /** ID of the originating agent.task event — for causal chain tracing in event payloads */
   taskEventId?: string;
+  /** Channel ID from the originating task event (e.g. "http", "internal", "signal").
+   *  Used with agentId and taskEventId to construct the memory write source key. */
+  channelId?: string;
+  /** Pre-constructed source key for entityMemory.storeFact() calls, matching the
+   *  format that AgentRuntime.resetRateLimit() uses: `agent:{id}/task:{id}/channel:{id}`.
+   *  Skills writing to entity memory should use this as the `source` parameter so the
+   *  per-task rate limit counter is correctly scoped and reset after each task. */
+  memoryWriteSource?: string;
   /** Caller identity — populated from the task event's sender context.
    *  Guaranteed to be defined for elevated skills (execution layer rejects without it).
    *  Available but optional for normal skills. */

--- a/tests/unit/skills/execution.test.ts
+++ b/tests/unit/skills/execution.test.ts
@@ -628,10 +628,12 @@ describe('ExecutionLayer', () => {
       reg.register(makeManifest({ name: 'source-skill-3' }), handler);
       const exec = new ExecutionLayer(reg, logger);
 
-      // No agentId — simulates system-invoked skills or test contexts
+      // No agentId — simulates human-approved re-invokes or system-invoked skills.
+      // memoryWriteSource is still set (scoped per task) using the 'human-approved' fallback
+      // so writes don't fall back to the global 'skill:config-store' accumulation key.
       await exec.invoke('source-skill-3', {}, undefined, { taskEventId: 'task-only' });
 
-      expect(capturedSource).toBeUndefined();
+      expect(capturedSource).toBe('agent:human-approved/task:task-only/channel:unknown');
     });
   });
 

--- a/tests/unit/skills/execution.test.ts
+++ b/tests/unit/skills/execution.test.ts
@@ -573,6 +573,66 @@ describe('ExecutionLayer', () => {
 
       delete process.env.TRACED_SECRET;
     });
+
+    it('constructs memoryWriteSource from agentId, taskEventId, and channelId', async () => {
+      let capturedSource: string | undefined;
+      const handler: SkillHandler = {
+        execute: async (ctx: SkillContext) => {
+          capturedSource = ctx.memoryWriteSource;
+          return { success: true, data: 'ok' };
+        },
+      };
+      const reg = new SkillRegistry();
+      reg.register(makeManifest({ name: 'source-skill' }), handler);
+      const exec = new ExecutionLayer(reg, logger);
+
+      await exec.invoke('source-skill', {}, undefined, {
+        agentId: 'ceo-inbox',
+        taskEventId: 'task-abc',
+        channelId: 'http',
+      });
+
+      expect(capturedSource).toBe('agent:ceo-inbox/task:task-abc/channel:http');
+    });
+
+    it('sets memoryWriteSource channel to unknown when channelId is omitted', async () => {
+      let capturedSource: string | undefined;
+      const handler: SkillHandler = {
+        execute: async (ctx: SkillContext) => {
+          capturedSource = ctx.memoryWriteSource;
+          return { success: true, data: 'ok' };
+        },
+      };
+      const reg = new SkillRegistry();
+      reg.register(makeManifest({ name: 'source-skill-2' }), handler);
+      const exec = new ExecutionLayer(reg, logger);
+
+      await exec.invoke('source-skill-2', {}, undefined, {
+        agentId: 'coordinator',
+        taskEventId: 'task-xyz',
+        // no channelId
+      });
+
+      expect(capturedSource).toBe('agent:coordinator/task:task-xyz/channel:unknown');
+    });
+
+    it('leaves memoryWriteSource undefined when agentId is absent', async () => {
+      let capturedSource: string | undefined;
+      const handler: SkillHandler = {
+        execute: async (ctx: SkillContext) => {
+          capturedSource = ctx.memoryWriteSource;
+          return { success: true, data: 'ok' };
+        },
+      };
+      const reg = new SkillRegistry();
+      reg.register(makeManifest({ name: 'source-skill-3' }), handler);
+      const exec = new ExecutionLayer(reg, logger);
+
+      // No agentId — simulates system-invoked skills or test contexts
+      await exec.invoke('source-skill-3', {}, undefined, { taskEventId: 'task-only' });
+
+      expect(capturedSource).toBeUndefined();
+    });
   });
 
   describe('integration: large and malicious payloads', () => {


### PR DESCRIPTION
## **User description**
## Summary

- The per-task memory write rate limit (50 writes/task) was never being reset between tasks, causing it to accumulate globally across all conversations until process restart.
- Root cause: `storeFact()` calls used hardcoded source strings (e.g. `'skill:config-store'`) while `AgentRuntime.resetRateLimit()` used a different key format (`agent:{id}/task:{id}/channel:{id}`). The reset was always a no-op.
- Fix: adds a shared `buildRateLimitSourceKey()` helper used by both the write path and the reset path, threading `channelId` through `InvokeOptions` → `SkillContext` → `memoryWriteSource`. Fallback to original strings is preserved for test/CLI contexts and logged at debug level.
- Affected skills: `config-store`, `memory-store`, `extract-facts`, `template-doc-request`.

## Test plan

- [ ] `skills/config-store/handler.test.ts` — new tests: `memoryWriteSource` used when set, fallback to `'skill:config-store'` when not
- [ ] `skills/memory-store/handler.test.ts` — new tests: `memoryWriteSource` overrides LLM-provided source, fallback when not set
- [ ] `skills/extract-facts/handler.test.ts` — new test: `memoryWriteSource` takes precedence over LLM-provided source
- [ ] `tests/unit/skills/execution.test.ts` — new tests: `memoryWriteSource` constructed from all three fields, `channel:unknown` fallback, undefined when `agentId` absent
- [ ] All 2614 non-database tests pass; 3 pre-existing failures (DATABASE_URL/smoke fixtures) unchanged
- [ ] Verify in production: restart the Curia container (clears accumulated counter), then add a triaging rule — should succeed without hitting rate limit


___

## **CodeAnt-AI Description**
**Keep memory write limits scoped to each task**

### What Changed
- Memory writes now use the same task-scoped source key when saving facts and when clearing the per-task write counter, so the limit resets after each task instead of carrying over across conversations
- Config storage, fact extraction, memory storage, and policy-saving flows now use the task-based source key, with a fallback to the previous source in test and CLI runs
- Added coverage to verify the task-based source key is passed through correctly, and updated the changelog entry

### Impact
`✅ Fewer memory write limit hits across tasks`
`✅ Per-task write limits reset after each job`
`✅ Clearer behavior in long-running agents`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed memory write rate limit accounting to properly clean up per-task write counters after task completion, preventing accumulation until process restart.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->