### PR TITLE
feat: include quoted original message in email reply drafts and sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **`ceo-inbox-draft-reply` / `email-draft-save` / `email-send`** — reply drafts and sends now include the quoted original message body below the reply text, matching standard email client behaviour. (#673)
+
 ### Added
 
 - **`embedding.call` bus event** — `EmbeddingService` now publishes cost telemetry after each OpenAI embedding API call; token counts and estimated costs appear in `audit_log` alongside `llm.call` entries. (#654)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
-- **`ceo-inbox-draft-reply` / `email-draft-save` / `email-send`** — reply drafts and sends now include the quoted original message body below the reply text, matching standard email client behaviour. (#673)
+- **`ceo-inbox-draft-reply` / `email-draft-save` / `email-send` / `email-reply`** — reply drafts and sends now include the quoted original message body below the reply text, matching standard email client behaviour. (#673)
 - **Context bridging v2** — outbound context registry replaces working-memory memos; send skills gain optional `context_bridge` param for delegation-aware reply routing. (#615)
 - **Coordinator prompt** — `[PRIOR OUTBOUND CONTEXT]` replaced with `[ACTIVE OUTBOUND CONTEXT]` block including delegation guidance and entry IDs for release. (#615)
 - **`signal-send`**, **`email-send`**, **`email-reply`** — accept optional `context_bridge` JSON param; declare `outboundContext` capability. (#615)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
-### Changed
-
-- **`ceo-inbox-draft-reply` / `email-draft-save` / `email-send`** — reply drafts and sends now include the quoted original message body below the reply text, matching standard email client behaviour. (#673)
-
 ### Added
 
 - **`embedding.call` bus event** — `EmbeddingService` now publishes cost telemetry after each OpenAI embedding API call; token counts and estimated costs appear in `audit_log` alongside `llm.call` entries. (#654)
@@ -30,6 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **`ceo-inbox-draft-reply` / `email-draft-save` / `email-send`** — reply drafts and sends now include the quoted original message body below the reply text, matching standard email client behaviour. (#673)
 - **Context bridging v2** — outbound context registry replaces working-memory memos; send skills gain optional `context_bridge` param for delegation-aware reply routing. (#615)
 - **Coordinator prompt** — `[PRIOR OUTBOUND CONTEXT]` replaced with `[ACTIVE OUTBOUND CONTEXT]` block including delegation guidance and entry IDs for release. (#615)
 - **`signal-send`**, **`email-send`**, **`email-reply`** — accept optional `context_bridge` JSON param; declare `outboundContext` capability. (#615)

--- a/skills/_shared/reply-quote.test.ts
+++ b/skills/_shared/reply-quote.test.ts
@@ -112,4 +112,15 @@ describe('buildReplyQuote', () => {
 
     expect(result).toContain('Date: 2025-05-21, 7:42 PM UTC');
   });
+
+  it('uses "Unknown date" when date is NaN (e.g. Nylas returns a non-numeric field)', () => {
+    // Luxon 3.x throws for non-number types (undefined), but accepts NaN (typeof 'number')
+    // and returns an Invalid DateTime — the dt.isValid guard prevents 'Invalid DateTime'
+    // from appearing in the quoted block sent to the recipient.
+    const msg = makeMessage({ date: NaN });
+    const result = buildReplyQuote(msg, 'America/Toronto');
+
+    expect(result).toContain('Date: Unknown date');
+    expect(result).not.toContain('Invalid DateTime');
+  });
 });

--- a/skills/_shared/reply-quote.test.ts
+++ b/skills/_shared/reply-quote.test.ts
@@ -113,6 +113,15 @@ describe('buildReplyQuote', () => {
     expect(result).toContain('Date: 2025-05-21, 7:42 PM UTC');
   });
 
+  it('falls back to UTC when timezone is invalid (unsupported IANA zone)', () => {
+    // Luxon creates an invalid DateTime for unrecognised IANA zone strings.
+    // The two-step guard should retry with UTC so the date still renders correctly.
+    const result = buildReplyQuote(makeMessage(), 'Mars/OlympusMons');
+
+    expect(result).toContain('Date: 2025-05-21, 7:42 PM UTC');
+    expect(result).not.toContain('Invalid DateTime');
+  });
+
   it('uses "Unknown date" when date is NaN (e.g. Nylas returns a non-numeric field)', () => {
     // Luxon 3.x throws for non-number types (undefined), but accepts NaN (typeof 'number')
     // and returns an Invalid DateTime — the dt.isValid guard prevents 'Invalid DateTime'

--- a/skills/_shared/reply-quote.test.ts
+++ b/skills/_shared/reply-quote.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { buildReplyQuote, type QuoteableMessage } from './reply-quote.js';
+
+// Fixed Unix timestamp: 2025-05-21 19:42:00 UTC
+// In America/Toronto (EDT, UTC-4): 2025-05-21, 3:42 PM EDT
+const FIXED_DATE = 1747856520;
+
+function makeMessage(overrides?: Partial<QuoteableMessage>): QuoteableMessage {
+  return {
+    from: [{ name: 'Alice Example', email: 'alice@example.com' }],
+    to: [{ email: 'joseph@josephfung.ca' }],
+    date: FIXED_DATE,
+    subject: 'Re: Q2 planning',
+    body: '<p>Let me know your thoughts.</p>',
+    ...overrides,
+  };
+}
+
+describe('buildReplyQuote', () => {
+  it('formats a complete quote with name and email', () => {
+    const result = buildReplyQuote(makeMessage(), 'America/Toronto');
+
+    expect(result).toContain('---------- Original Message ----------');
+    expect(result).toContain('From: Alice Example <alice@example.com>');
+    expect(result).toContain('To: joseph@josephfung.ca');
+    expect(result).toContain('Subject: Re: Q2 planning');
+    expect(result).toContain('Let me know your thoughts.');
+    // Should start with double newline to separate from reply body
+    expect(result.startsWith('\n\n')).toBe(true);
+  });
+
+  it('uses bare email when display name is absent', () => {
+    const msg = makeMessage({ from: [{ email: 'alice@example.com' }] });
+    const result = buildReplyQuote(msg, 'America/Toronto');
+
+    expect(result).toContain('From: alice@example.com');
+    expect(result).not.toContain('From: undefined');
+  });
+
+  it('comma-separates multiple To recipients', () => {
+    const msg = makeMessage({
+      to: [
+        { name: 'Bob', email: 'bob@example.com' },
+        { email: 'carol@example.com' },
+      ],
+    });
+    const result = buildReplyQuote(msg, 'America/Toronto');
+
+    expect(result).toContain('To: Bob <bob@example.com>, carol@example.com');
+  });
+
+  it('includes headers but omits body when original body is empty', () => {
+    const msg = makeMessage({ body: '' });
+    const result = buildReplyQuote(msg, 'America/Toronto');
+
+    expect(result).toContain('---------- Original Message ----------');
+    expect(result).toContain('From:');
+    expect(result).toContain('Subject:');
+    // Should end after the Subject line (no trailing body content)
+    const lines = result.trimEnd().split('\n');
+    const lastLine = lines[lines.length - 1]!;
+    expect(lastLine).toMatch(/^Subject:/);
+  });
+
+  it('includes headers but omits body when HTML body strips to empty', () => {
+    const msg = makeMessage({ body: '<p>  </p>' });
+    const result = buildReplyQuote(msg, 'America/Toronto');
+
+    expect(result).toContain('---------- Original Message ----------');
+    const lines = result.trimEnd().split('\n');
+    const lastLine = lines[lines.length - 1]!;
+    expect(lastLine).toMatch(/^Subject:/);
+  });
+
+  it('comma-separates multiple senders', () => {
+    const msg = makeMessage({
+      from: [
+        { name: 'Alice', email: 'alice@example.com' },
+        { name: 'Bob', email: 'bob@example.com' },
+      ],
+    });
+    const result = buildReplyQuote(msg, 'America/Toronto');
+
+    expect(result).toContain('From: Alice <alice@example.com>, Bob <bob@example.com>');
+  });
+
+  it('strips HTML from the original body', () => {
+    const msg = makeMessage({ body: '<p>Hello <b>world</b></p>' });
+    const result = buildReplyQuote(msg, 'America/Toronto');
+
+    expect(result).toContain('Hello world');
+    expect(result).not.toContain('<p>');
+    expect(result).not.toContain('<b>');
+  });
+
+  it('formats date with timezone abbreviation for America/Toronto', () => {
+    const result = buildReplyQuote(makeMessage(), 'America/Toronto');
+
+    // 1747856520 in EDT = 2026-05-21, 3:42 PM EDT
+    expect(result).toContain('Date: 2025-05-21, 3:42 PM EDT');
+  });
+
+  it('falls back to UTC when timezone is omitted', () => {
+    const result = buildReplyQuote(makeMessage());
+
+    // 1747856520 in UTC = 2026-05-21, 7:42 PM UTC
+    expect(result).toContain('Date: 2025-05-21, 7:42 PM UTC');
+  });
+
+  it('falls back to UTC when timezone is undefined', () => {
+    const result = buildReplyQuote(makeMessage(), undefined);
+
+    expect(result).toContain('Date: 2025-05-21, 7:42 PM UTC');
+  });
+});

--- a/skills/_shared/reply-quote.ts
+++ b/skills/_shared/reply-quote.ts
@@ -1,6 +1,6 @@
 // reply-quote.ts — shared utility for building a quoted original message block
 // appended to reply emails. Used by ceo-inbox-draft-reply, email-draft-save,
-// and email-send skill handlers.
+// email-reply, and email-send skill handlers.
 
 import { DateTime } from 'luxon';
 import { htmlToPlainText } from './ceo-nylas-client.js';
@@ -51,7 +51,11 @@ export function buildReplyQuote(message: QuoteableMessage, timezone?: string): s
 
   const zone = timezone ?? 'UTC';
   const dt = DateTime.fromSeconds(message.date, { zone });
-  const dateLine = dt.toFormat('yyyy-MM-dd, h:mm a ZZZZ');
+  // Guard against undefined/NaN date from Nylas — Luxon returns Invalid DateTime
+  // rather than throwing, so we must check validity explicitly before formatting.
+  const dateLine = dt.isValid
+    ? dt.toFormat('yyyy-MM-dd, h:mm a ZZZZ')
+    : 'Unknown date';
 
   const plainBody = htmlToPlainText(message.body);
 

--- a/skills/_shared/reply-quote.ts
+++ b/skills/_shared/reply-quote.ts
@@ -49,10 +49,15 @@ export function buildReplyQuote(message: QuoteableMessage, timezone?: string): s
   const fromLine = message.from.map(formatParticipant).join(', ');
   const toLine = message.to.map(formatParticipant).join(', ');
 
-  const zone = timezone ?? 'UTC';
-  const dt = DateTime.fromSeconds(message.date, { zone });
-  // Guard against undefined/NaN date from Nylas — Luxon returns Invalid DateTime
-  // rather than throwing, so we must check validity explicitly before formatting.
+  const preferredZone = timezone ?? 'UTC';
+  const dtPreferred = DateTime.fromSeconds(message.date, { zone: preferredZone });
+  // If the timezone string is invalid/unsupported, Luxon creates an invalid DateTime
+  // without throwing. Fall back to UTC so the date is still rendered correctly.
+  // If the date itself is invalid (e.g. NaN from Nylas), the UTC DateTime will also
+  // be invalid — the isValid check below then produces the 'Unknown date' sentinel.
+  const dt = dtPreferred.isValid
+    ? dtPreferred
+    : DateTime.fromSeconds(message.date, { zone: 'UTC' });
   const dateLine = dt.isValid
     ? dt.toFormat('yyyy-MM-dd, h:mm a ZZZZ')
     : 'Unknown date';

--- a/skills/_shared/reply-quote.ts
+++ b/skills/_shared/reply-quote.ts
@@ -1,0 +1,74 @@
+// reply-quote.ts — shared utility for building a quoted original message block
+// appended to reply emails. Used by ceo-inbox-draft-reply, email-draft-save,
+// and email-send skill handlers.
+
+import { DateTime } from 'luxon';
+import { htmlToPlainText } from './ceo-nylas-client.js';
+
+/**
+ * Minimal message shape required to build a reply quote block.
+ * Both NylasMessageFull (CEO client) and NylasMessage (core client)
+ * satisfy this interface structurally — no explicit coupling needed.
+ */
+export interface QuoteableMessage {
+  from: Array<{ name?: string; email: string }>;
+  to: Array<{ name?: string; email: string }>;
+  date: number;    // Unix epoch seconds
+  subject: string;
+  body: string;    // HTML — will be stripped to plain text
+}
+
+/**
+ * Format a participant as "Name <email>" when a display name is present,
+ * or bare "email" when it is not.
+ */
+function formatParticipant(p: { name?: string; email: string }): string {
+  return p.name ? `${p.name} <${p.email}>` : p.email;
+}
+
+/**
+ * Build a formatted quote block from the original message, suitable for
+ * appending below the reply body. Returns a string starting with \n\n
+ * to separate the reply from the quote.
+ *
+ * Output format:
+ * ```
+ * ---------- Original Message ----------
+ * From: Alice Example <alice@example.com>
+ * Date: 2026-05-21, 3:42 PM EDT
+ * To: joseph@josephfung.ca
+ * Subject: Re: Q2 planning
+ *
+ * [original message body, HTML stripped]
+ * ```
+ *
+ * @param message   The original message to quote
+ * @param timezone  IANA timezone name (e.g. "America/Toronto"); falls back to UTC
+ */
+export function buildReplyQuote(message: QuoteableMessage, timezone?: string): string {
+  const fromLine = message.from.map(formatParticipant).join(', ');
+  const toLine = message.to.map(formatParticipant).join(', ');
+
+  const zone = timezone ?? 'UTC';
+  const dt = DateTime.fromSeconds(message.date, { zone });
+  const dateLine = dt.toFormat('yyyy-MM-dd, h:mm a ZZZZ');
+
+  const plainBody = htmlToPlainText(message.body);
+
+  const lines = [
+    '',
+    '',
+    '---------- Original Message ----------',
+    `From: ${fromLine}`,
+    `Date: ${dateLine}`,
+    `To: ${toLine}`,
+    `Subject: ${message.subject}`,
+  ];
+
+  // Include body section only when there is actual content to show
+  if (plainBody) {
+    lines.push('', plainBody);
+  }
+
+  return lines.join('\n');
+}

--- a/skills/ceo-inbox-draft-reply/handler.test.ts
+++ b/skills/ceo-inbox-draft-reply/handler.test.ts
@@ -14,6 +14,7 @@ function buildCtx(overrides: Partial<{
 
   return {
     input,
+    timezone: 'America/Toronto',
     secret(key: string): string {
       switch (key) {
         case 'nylas_api_key': return 'test-api-key';
@@ -121,6 +122,11 @@ describe('CeoInboxDraftReplyHandler', () => {
     expect(ccEmails).toContain('bob@example.com');
     expect(ccEmails).toContain('charlie@example.com');
     expect(ccEmails).not.toContain('ceo@example.com');
+
+    // Body should include the reply text followed by the quoted original
+    expect(draftBody.body).toContain('Thanks for reaching out.');
+    expect(draftBody.body).toContain('---------- Original Message ----------');
+    expect(draftBody.body).toContain('alice@external.com');
   });
 
   it('Case 2: CEO in To of original — filtered from reply CC', async () => {
@@ -343,7 +349,48 @@ describe('CeoInboxDraftReplyHandler', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('Case 8: Empty from — returns { success: false } with error-level log', async () => {
+  it('Case 8: Quote includes HTML-stripped original body', async () => {
+    const messageResponse = buildNylasMessage({
+      from: [{ email: 'alice@external.com', name: 'Alice' }],
+      to: [{ email: 'ceo@example.com' }],
+      cc: [],
+    });
+    // Override body with rich HTML
+    messageResponse.data.body = '<p>Hello <b>world</b></p>';
+
+    mockFetch.mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('/messages/msg-001')) {
+        return new Response(JSON.stringify(messageResponse), { status: 200 });
+      }
+      if (urlStr.includes('/drafts')) {
+        return new Response(JSON.stringify(DRAFT_RESPONSE), { status: 200 });
+      }
+      throw new Error(`Unexpected fetch: ${urlStr}`);
+    });
+
+    const ctx = buildCtx();
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+
+    const draftCall = mockFetch.mock.calls.find(
+      (call) => String(call[0]).includes('/drafts'),
+    );
+    expect(draftCall).toBeDefined();
+
+    const draftBody = JSON.parse(draftCall![1]!.body as string);
+
+    // Quote should contain stripped plain text, not HTML
+    expect(draftBody.body).toContain('Hello world');
+    expect(draftBody.body).not.toContain('<p>');
+    expect(draftBody.body).not.toContain('<b>');
+    // Reply text should precede the quote
+    expect(draftBody.body.indexOf('Thanks for reaching out.')).toBeLessThan(
+      draftBody.body.indexOf('---------- Original Message ----------'),
+    );
+  });
+
+  it('Case 9: Empty from — returns { success: false } with error-level log', async () => {
     // Message exists but has no sender (from: [])
     const messageResponse = buildNylasMessage({
       from: [],

--- a/skills/ceo-inbox-draft-reply/handler.ts
+++ b/skills/ceo-inbox-draft-reply/handler.ts
@@ -1,5 +1,6 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { CeoNylasClient, type NylasParticipant } from '../_shared/ceo-nylas-client.js';
+import { buildReplyQuote } from '../_shared/reply-quote.js';
 
 export class CeoInboxDraftReplyHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -82,10 +83,13 @@ export class CeoInboxDraftReplyHandler implements SkillHandler {
         'ceo-inbox-draft-reply: computed reply-all recipients',
       );
 
+      // Append the quoted original message below the reply body
+      const quotedBody = body + buildReplyQuote(original, ctx.timezone);
+
       const draft = await client.createDraftReply({
         replyToMessageId,
         subject: replySubject,
-        body,
+        body: quotedBody,
         to,
         cc,
       });

--- a/skills/ceo-inbox-draft-reply/handler.ts
+++ b/skills/ceo-inbox-draft-reply/handler.ts
@@ -83,8 +83,17 @@ export class CeoInboxDraftReplyHandler implements SkillHandler {
         'ceo-inbox-draft-reply: computed reply-all recipients',
       );
 
-      // Append the quoted original message below the reply body
-      const quotedBody = body + buildReplyQuote(original, ctx.timezone);
+      // Append the quoted original message below the reply body. Formatting is
+      // non-fatal — a malformed message body should not block draft creation.
+      let quotedBody = body;
+      try {
+        quotedBody = body + buildReplyQuote(original, ctx.timezone);
+      } catch (err) {
+        ctx.log.warn(
+          { err, replyToMessageId },
+          'ceo-inbox-draft-reply: failed to build reply quote — proceeding without quote',
+        );
+      }
 
       const draft = await client.createDraftReply({
         replyToMessageId,

--- a/skills/email-draft-save/handler.ts
+++ b/skills/email-draft-save/handler.ts
@@ -7,6 +7,7 @@
 // the CEO reviews and sends it from their email client.
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { buildReplyQuote } from '../_shared/reply-quote.js';
 
 export class EmailDraftSaveHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -48,13 +49,28 @@ export class EmailDraftSaveHandler implements SkillHandler {
 
     ctx.log.info({ to, subject, accountId, replyToMessageId }, 'email-draft-save: saving draft');
 
+    // When replying, fetch the original message and append a quoted copy below
+    // the reply body. If the fetch fails, proceed without the quote (non-fatal).
+    let quotedBody = body;
+    if (replyToMessageId) {
+      try {
+        const original = await ctx.outboundGateway.getEmailMessage(replyToMessageId, accountId);
+        quotedBody = body + buildReplyQuote(original, ctx.timezone);
+      } catch (err) {
+        ctx.log.warn(
+          { err, replyToMessageId },
+          'email-draft-save: failed to fetch original message for quote — proceeding without quote',
+        );
+      }
+    }
+
     let result: Awaited<ReturnType<typeof ctx.outboundGateway.createEmailDraft>>;
     try {
       result = await ctx.outboundGateway.createEmailDraft({
         channel: 'email',
         to,
         subject,
-        body,
+        body: quotedBody,
         accountId,
         replyToMessageId,
       });

--- a/skills/email-draft-save/handler.ts
+++ b/skills/email-draft-save/handler.ts
@@ -50,17 +50,28 @@ export class EmailDraftSaveHandler implements SkillHandler {
     ctx.log.info({ to, subject, accountId, replyToMessageId }, 'email-draft-save: saving draft');
 
     // When replying, fetch the original message and append a quoted copy below
-    // the reply body. If the fetch fails, proceed without the quote (non-fatal).
+    // the reply body. Both the fetch and the formatting are non-fatal — if either
+    // fails, proceed with the unquoted body and log a warning at the correct step.
     let quotedBody = body;
     if (replyToMessageId) {
+      let original: Awaited<ReturnType<typeof ctx.outboundGateway.getEmailMessage>> | undefined;
       try {
-        const original = await ctx.outboundGateway.getEmailMessage(replyToMessageId, accountId);
-        quotedBody = body + buildReplyQuote(original, ctx.timezone);
+        original = await ctx.outboundGateway.getEmailMessage(replyToMessageId, accountId);
       } catch (err) {
         ctx.log.warn(
           { err, replyToMessageId },
           'email-draft-save: failed to fetch original message for quote — proceeding without quote',
         );
+      }
+      if (original !== undefined) {
+        try {
+          quotedBody = body + buildReplyQuote(original, ctx.timezone);
+        } catch (err) {
+          ctx.log.warn(
+            { err, replyToMessageId },
+            'email-draft-save: failed to build reply quote — proceeding without quote',
+          );
+        }
       }
     }
 

--- a/skills/email-reply/handler.test.ts
+++ b/skills/email-reply/handler.test.ts
@@ -156,7 +156,7 @@ describe('EmailReplyHandler', () => {
       expect(sendArg.body).not.toContain('---------- Original Message ----------');
       expect(warnSpy).toHaveBeenCalledWith(
         expect.objectContaining({ replyToMessageId: 'nylas-msg-1' }),
-        expect.stringContaining('failed to build reply quote'),
+        expect.stringContaining('buildReplyQuote failed'),
       );
     });
 

--- a/skills/email-reply/handler.test.ts
+++ b/skills/email-reply/handler.test.ts
@@ -8,7 +8,7 @@ function makeLogger() {
   return pino({ level: 'silent' });
 }
 
-function makeCtx(input: Record<string, unknown>): SkillContext {
+function makeCtx(input: Record<string, unknown>, opts?: { timezone?: string }): SkillContext {
   const gateway = {
     send: vi.fn().mockResolvedValue({ success: true }),
     getEmailMessage: vi.fn().mockResolvedValue({
@@ -16,6 +16,8 @@ function makeCtx(input: Record<string, unknown>): SkillContext {
       to: [],
       cc: [],
       subject: 'Test subject',
+      body: '',
+      date: 0,
     }),
   } as unknown as OutboundGateway;
 
@@ -24,6 +26,7 @@ function makeCtx(input: Record<string, unknown>): SkillContext {
     secret: (name: string) => { throw new Error(`Missing secret: ${name}`); },
     log: makeLogger(),
     outboundGateway: gateway,
+    timezone: opts?.timezone,
   } as unknown as SkillContext;
 }
 
@@ -63,6 +66,8 @@ describe('EmailReplyHandler', () => {
       to: [],
       cc: [],
       subject: 'Project update',
+      body: '',
+      date: 0,
     });
     (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
       success: true, messageId: 'reply-123',
@@ -85,6 +90,8 @@ describe('EmailReplyHandler', () => {
       to: [],
       cc: [],
       subject: 'Hi',
+      body: '',
+      date: 0,
     });
     (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
       success: false, blockedReason: 'Recipient is blocked',
@@ -93,6 +100,100 @@ describe('EmailReplyHandler', () => {
     const result = await handler.execute(ctx);
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toMatch(/blocked/i);
+  });
+
+  describe('reply quote', () => {
+    it('appends quoted original message below the reply body', async () => {
+      const ctx = makeCtx(
+        { reply_to_message_id: 'nylas-msg-1', body: 'Sounds good!' },
+        { timezone: 'America/Toronto' },
+      );
+      (ctx.outboundGateway!.getEmailMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+        from: [{ name: 'Alice', email: 'alice@example.com' }],
+        to: [{ email: 'curia@example.com' }],
+        cc: [],
+        subject: 'Q2 planning',
+        body: '<p>Let me know your thoughts.</p>',
+        date: 1700000000,
+      });
+      (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true, messageId: 'reply-99',
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      const sendArg = (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mock.calls[0]![0] as { body: string };
+      expect(sendArg.body).toContain('Sounds good!');
+      expect(sendArg.body).toContain('---------- Original Message ----------');
+      expect(sendArg.body).toContain('Alice <alice@example.com>');
+      expect(sendArg.body).toContain('Let me know your thoughts.');
+    });
+
+    it('proceeds without quote when buildReplyQuote throws', async () => {
+      // Omitting body/date from the mock causes htmlToPlainText(undefined) to throw,
+      // exercising the inner try/catch fallback path.
+      const ctx = makeCtx({ reply_to_message_id: 'nylas-msg-1', body: 'Got it' });
+      (ctx.outboundGateway!.getEmailMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+        from: [{ email: 'alice@example.com' }],
+        to: [],
+        cc: [],
+        subject: 'Test',
+        // intentionally omit body and date
+      });
+      (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true, messageId: 'reply-fallback',
+      });
+      const warnSpy = vi.fn();
+      ctx.log = { ...ctx.log, warn: warnSpy, info: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      const sendArg = (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mock.calls[0]![0] as { body: string };
+      // Body falls back to unquoted
+      expect(sendArg.body).toBe('Got it');
+      expect(sendArg.body).not.toContain('---------- Original Message ----------');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ replyToMessageId: 'nylas-msg-1' }),
+        expect.stringContaining('failed to build reply quote'),
+      );
+    });
+
+    it('registerOutboundContext receives original body, not quoted body', async () => {
+      const ctx = makeCtx({
+        reply_to_message_id: 'nylas-msg-1',
+        body: 'My reply text',
+        context_bridge: JSON.stringify({ agent_id: 'coordinator' }),
+      });
+      (ctx.outboundGateway!.getEmailMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+        from: [{ email: 'alice@example.com' }],
+        to: [],
+        cc: [],
+        subject: 'Discussion',
+        body: '<p>Original content here</p>',
+        date: 1700000000,
+      });
+      (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true, messageId: 'reply-1',
+      });
+      const mockRegister = vi.fn().mockResolvedValue('entry-1');
+      (ctx as Record<string, unknown>).outboundContext = {
+        register: mockRegister,
+        release: vi.fn(),
+        defaultExpiryHours: 6,
+        explicitExpiryHours: 24,
+      };
+      (ctx as Record<string, unknown>).agentId = 'coordinator';
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      // The quote is presentation — registerOutboundContext must see the agent's own words only
+      expect(mockRegister).toHaveBeenCalledWith(expect.objectContaining({
+        content: 'My reply text',
+      }));
+    });
   });
 
   describe('context_bridge', () => {
@@ -111,6 +212,8 @@ describe('EmailReplyHandler', () => {
         to: [],
         cc: [],
         subject: 'Project update',
+        body: '',
+        date: 0,
       });
       (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
         success: true, messageId: 'reply-1',
@@ -146,6 +249,8 @@ describe('EmailReplyHandler', () => {
         to: [],
         cc: [],
         subject: 'Quick note',
+        body: '',
+        date: 0,
       });
       (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
         success: true, messageId: 'reply-1',
@@ -181,6 +286,8 @@ describe('EmailReplyHandler', () => {
         to: [],
         cc: [],
         subject: 'Plan',
+        body: '',
+        date: 0,
       });
       (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
         success: true, messageId: 'reply-1',

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -119,7 +119,7 @@ export class EmailReplyHandler implements SkillHandler {
       } catch (err) {
         ctx.log.warn(
           { err, replyToMessageId },
-          'email-reply: failed to build reply quote — proceeding without quote',
+          'email-reply: buildReplyQuote failed (HTML stripping or date formatting) — sending without quote',
         );
       }
 
@@ -137,6 +137,8 @@ export class EmailReplyHandler implements SkillHandler {
       }
 
       // Register outbound context entry (best-effort, always fires).
+      // Pass the agent-authored body only — not quotedBody — so outbound context stores
+      // the meaningful reply content without the formatting-only quote block.
       await registerOutboundContext(ctx.outboundContext, contextBridgeRaw, {
         channelId: 'email',
         content: body,

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -115,7 +115,11 @@ export class EmailReplyHandler implements SkillHandler {
       // non-fatal — a quote failure must not block the reply from being sent.
       let quotedBody = body;
       try {
-        quotedBody = body + buildReplyQuote(original, ctx.timezone);
+        const candidate = body + buildReplyQuote(original, ctx.timezone);
+        // Skip the quote silently if it would push the body past the size limit
+        // (the agent-authored body already passed the guard above; a long thread
+        // could tip the combined total over). The reply still goes out unquoted.
+        quotedBody = candidate.length <= MAX_BODY_LENGTH ? candidate : body;
       } catch (err) {
         ctx.log.warn(
           { err, replyToMessageId },

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -15,6 +15,7 @@
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { registerOutboundContext } from '../../src/dispatch/context-bridge-parse.js';
+import { buildReplyQuote } from '../_shared/reply-quote.js';
 
 const MAX_BODY_LENGTH = 50000;
 
@@ -110,11 +111,23 @@ export class EmailReplyHandler implements SkillHandler {
         if (ccAddresses.length === 0) ccAddresses = undefined;
       }
 
+      // Append the quoted original message below the reply body. Formatting is
+      // non-fatal — a quote failure must not block the reply from being sent.
+      let quotedBody = body;
+      try {
+        quotedBody = body + buildReplyQuote(original, ctx.timezone);
+      } catch (err) {
+        ctx.log.warn(
+          { err, replyToMessageId },
+          'email-reply: failed to build reply quote — proceeding without quote',
+        );
+      }
+
       const result = await ctx.outboundGateway.send({
         channel: 'email',
         to: originalFrom,
         subject: replySubject,
-        body,
+        body: quotedBody,
         replyToMessageId,
         ...(ccAddresses ? { cc: ccAddresses } : {}),
       });

--- a/skills/email-send/handler.ts
+++ b/skills/email-send/handler.ts
@@ -8,6 +8,7 @@
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { registerOutboundContext } from '../../src/dispatch/context-bridge-parse.js';
+import { buildReplyQuote } from '../_shared/reply-quote.js';
 
 const MAX_TO_LENGTH = 1000;
 const MAX_SUBJECT_LENGTH = 500;
@@ -30,11 +31,12 @@ function parseRecipients(raw: string): string[] {
 
 export class EmailSendHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const { to, cc, subject, body, context_bridge: contextBridgeRaw } = ctx.input as {
+    const { to, cc, subject, body, reply_to_message_id: replyToMessageIdRaw, context_bridge: contextBridgeRaw } = ctx.input as {
       to?: string;
       cc?: string;
       subject?: string;
       body?: string;
+      reply_to_message_id?: string;
       context_bridge?: string;
     };
 
@@ -87,11 +89,30 @@ export class EmailSendHandler implements SkillHandler {
       return { success: false, error: message };
     }
 
+    const replyToMessageId = typeof replyToMessageIdRaw === 'string' && replyToMessageIdRaw.trim()
+      ? replyToMessageIdRaw.trim()
+      : undefined;
+
     if (!ctx.outboundGateway) {
       return {
         success: false,
         error: 'email-send skill requires outboundGateway access. Declare "outboundGateway" in capabilities.',
       };
+    }
+
+    // When replying, fetch the original message and append a quoted copy below
+    // the reply body. If the fetch fails, proceed without the quote (non-fatal).
+    let quotedBody = body;
+    if (replyToMessageId) {
+      try {
+        const original = await ctx.outboundGateway.getEmailMessage(replyToMessageId);
+        quotedBody = body + buildReplyQuote(original, ctx.timezone);
+      } catch (err) {
+        ctx.log.warn(
+          { err, replyToMessageId },
+          'email-send: failed to fetch original message for quote — proceeding without quote',
+        );
+      }
     }
 
     ctx.log.info({ to: toAddresses, subject }, 'Sending email via gateway');
@@ -101,8 +122,9 @@ export class EmailSendHandler implements SkillHandler {
         channel: 'email',
         to: toAddresses[0]!,
         subject,
-        body,
+        body: quotedBody,
         cc: ccAddresses,
+        replyToMessageId,
       });
 
       if (!result.success) {

--- a/skills/email-send/handler.ts
+++ b/skills/email-send/handler.ts
@@ -101,17 +101,29 @@ export class EmailSendHandler implements SkillHandler {
     }
 
     // When replying, fetch the original message and append a quoted copy below
-    // the reply body. If the fetch fails, proceed without the quote (non-fatal).
+    // the reply body. Both the fetch and the formatting are non-fatal — if either
+    // fails, proceed with the unquoted body and log a warning at the correct step.
+    // Note: email-send has no account routing, so getEmailMessage uses the primary account.
     let quotedBody = body;
     if (replyToMessageId) {
+      let original: Awaited<ReturnType<typeof ctx.outboundGateway.getEmailMessage>> | undefined;
       try {
-        const original = await ctx.outboundGateway.getEmailMessage(replyToMessageId);
-        quotedBody = body + buildReplyQuote(original, ctx.timezone);
+        original = await ctx.outboundGateway.getEmailMessage(replyToMessageId);
       } catch (err) {
         ctx.log.warn(
           { err, replyToMessageId },
           'email-send: failed to fetch original message for quote — proceeding without quote',
         );
+      }
+      if (original !== undefined) {
+        try {
+          quotedBody = body + buildReplyQuote(original, ctx.timezone);
+        } catch (err) {
+          ctx.log.warn(
+            { err, replyToMessageId },
+            'email-send: failed to build reply quote — proceeding without quote',
+          );
+        }
       }
     }
 

--- a/skills/email-send/handler.ts
+++ b/skills/email-send/handler.ts
@@ -117,7 +117,11 @@ export class EmailSendHandler implements SkillHandler {
       }
       if (original !== undefined) {
         try {
-          quotedBody = body + buildReplyQuote(original, ctx.timezone);
+          const candidate = body + buildReplyQuote(original, ctx.timezone);
+          // Skip the quote silently if it would push the body past the size limit
+          // (the agent-authored body already passed the guard above; the quote block
+          // itself could tip a long thread over). The send still goes out unquoted.
+          quotedBody = candidate.length <= MAX_BODY_LENGTH ? candidate : body;
         } catch (err) {
           ctx.log.warn(
             { err, replyToMessageId },

--- a/skills/email-send/skill.json
+++ b/skills/email-send/skill.json
@@ -9,6 +9,7 @@
     "cc": "string?",
     "subject": "string",
     "body": "string",
+    "reply_to_message_id": "string? (Nylas message ID — when set, the original message is quoted below the reply and the send is threaded)",
     "context_bridge": "string? (JSON — optional context bridge registration: {agent_id, expected_reply?, delegation_hint?, metadata?, expires_in_hours?})"
   },
   "outputs": {

--- a/tests/unit/skills/email-draft-save.test.ts
+++ b/tests/unit/skills/email-draft-save.test.ts
@@ -7,14 +7,16 @@ const logger = pino({ level: 'silent' });
 
 function makeCtx(input: Record<string, unknown>, gateway?: Partial<{
   createEmailDraft: (...args: unknown[]) => unknown;
-}>, taskMetadata?: Record<string, unknown>): SkillContext {
+  getEmailMessage: (...args: unknown[]) => unknown;
+}>, taskMetadata?: Record<string, unknown>, opts?: { timezone?: string }): SkillContext {
   return {
     input,
     secret: () => { throw new Error('no secrets'); },
     log: logger,
     outboundGateway: gateway as never,
     taskMetadata,
-  };
+    timezone: opts?.timezone,
+  } as SkillContext;
 }
 
 describe('EmailDraftSaveHandler', () => {
@@ -64,7 +66,16 @@ describe('EmailDraftSaveHandler', () => {
   });
 
   it('passes reply_to_message_id as replyToMessageId', async () => {
-    const gateway = { createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-1' }) };
+    const gateway = {
+      createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-1' }),
+      getEmailMessage: vi.fn().mockResolvedValue({
+        from: [{ email: 'sender@example.com' }],
+        to: [{ email: 'r@example.com' }],
+        date: 1700000000,
+        subject: 'Hi',
+        body: '<p>Original</p>',
+      }),
+    };
     await handler.execute(makeCtx(
       { to: 'r@example.com', subject: 'Re: Hi', body: 'Hello', reply_to_message_id: 'msg-orig' },
       gateway,
@@ -126,5 +137,84 @@ describe('EmailDraftSaveHandler', () => {
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
+  });
+
+  describe('reply quote', () => {
+    const originalMessage = {
+      from: [{ name: 'Alice', email: 'alice@example.com' }],
+      to: [{ email: 'ceo@example.com' }],
+      date: 1700000000,
+      subject: 'Q2 planning',
+      body: '<p>Let me know your thoughts.</p>',
+    };
+
+    it('appends quote when reply_to_message_id is present', async () => {
+      const gateway = {
+        createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-q1' }),
+        getEmailMessage: vi.fn().mockResolvedValue(originalMessage),
+      };
+      await handler.execute(makeCtx(
+        { to: 'alice@example.com', subject: 'Re: Q2 planning', body: 'Sounds good!', reply_to_message_id: 'msg-orig' },
+        gateway,
+        {},
+        { timezone: 'America/Toronto' },
+      ));
+      expect(gateway.getEmailMessage).toHaveBeenCalledWith('msg-orig', undefined);
+      const callBody = (gateway.createEmailDraft.mock.calls[0]! as [{ body: string }])[0].body;
+      expect(callBody).toContain('Sounds good!');
+      expect(callBody).toContain('---------- Original Message ----------');
+      expect(callBody).toContain('Alice <alice@example.com>');
+      expect(callBody).toContain('Let me know your thoughts.');
+    });
+
+    it('does not fetch original or append quote when reply_to_message_id is absent', async () => {
+      const gateway = {
+        createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-q2' }),
+        getEmailMessage: vi.fn(),
+      };
+      await handler.execute(makeCtx(
+        { to: 'r@example.com', subject: 'Hi', body: 'Hello' },
+        gateway,
+      ));
+      expect(gateway.getEmailMessage).not.toHaveBeenCalled();
+      const callBody = (gateway.createEmailDraft.mock.calls[0]! as [{ body: string }])[0].body;
+      expect(callBody).toBe('Hello');
+    });
+
+    it('proceeds without quote when getEmailMessage fails', async () => {
+      const gateway = {
+        createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-q3' }),
+        getEmailMessage: vi.fn().mockRejectedValue(new Error('Not found')),
+      };
+      const warnSpy = vi.fn();
+      const ctx = makeCtx(
+        { to: 'r@example.com', subject: 'Re: Hi', body: 'Got it', reply_to_message_id: 'msg-missing' },
+        gateway,
+      );
+      ctx.log = { ...logger, warn: warnSpy, info: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+      const result = await handler.execute(ctx);
+      expect(result.success).toBe(true);
+      // Body should be unquoted
+      const callBody = (gateway.createEmailDraft.mock.calls[0]! as [{ body: string }])[0].body;
+      expect(callBody).toBe('Got it');
+      expect(callBody).not.toContain('---------- Original Message ----------');
+      // Warning was logged
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ replyToMessageId: 'msg-missing' }),
+        expect.stringContaining('failed to fetch original message'),
+      );
+    });
+
+    it('passes accountId to getEmailMessage', async () => {
+      const gateway = {
+        createEmailDraft: vi.fn().mockResolvedValue({ success: true, draftId: 'd-q4' }),
+        getEmailMessage: vi.fn().mockResolvedValue(originalMessage),
+      };
+      await handler.execute(makeCtx(
+        { to: 'alice@example.com', subject: 'Re: Q2', body: 'OK', reply_to_message_id: 'msg-acct', account: 'ceo-acct' },
+        gateway,
+      ));
+      expect(gateway.getEmailMessage).toHaveBeenCalledWith('msg-acct', 'ceo-acct');
+    });
   });
 });

--- a/tests/unit/skills/email-send.test.ts
+++ b/tests/unit/skills/email-send.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EmailSendHandler } from '../../../skills/email-send/handler.js';
+import type { SkillContext } from '../../../src/skills/types.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+function makeCtx(
+  input: Record<string, unknown>,
+  gateway?: Partial<{
+    send: (...args: unknown[]) => unknown;
+    getEmailMessage: (...args: unknown[]) => unknown;
+  }>,
+  opts?: { timezone?: string; agentId?: string },
+): SkillContext {
+  return {
+    input,
+    secret: () => { throw new Error('no secrets'); },
+    log: logger,
+    outboundGateway: gateway as never,
+    outboundContext: undefined,
+    timezone: opts?.timezone,
+    agentId: opts?.agentId,
+  } as SkillContext;
+}
+
+const originalMessage = {
+  from: [{ name: 'Alice', email: 'alice@example.com' }],
+  to: [{ email: 'ceo@example.com' }],
+  date: 1700000000,
+  subject: 'Q2 planning',
+  body: '<p>Let me know your thoughts.</p>',
+};
+
+describe('EmailSendHandler — reply quote', () => {
+  const handler = new EmailSendHandler();
+
+  it('appends quote and passes replyToMessageId when reply_to_message_id is set', async () => {
+    const gateway = {
+      send: vi.fn().mockResolvedValue({ success: true, messageId: 'sent-1' }),
+      getEmailMessage: vi.fn().mockResolvedValue(originalMessage),
+    };
+    const result = await handler.execute(makeCtx(
+      { to: 'alice@example.com', subject: 'Re: Q2 planning', body: 'Sounds good!', reply_to_message_id: 'msg-orig' },
+      gateway,
+      { timezone: 'America/Toronto' },
+    ));
+
+    expect(result.success).toBe(true);
+    expect(gateway.getEmailMessage).toHaveBeenCalledWith('msg-orig');
+
+    const sendArg = gateway.send.mock.calls[0]![0] as { body: string; replyToMessageId?: string };
+    expect(sendArg.body).toContain('Sounds good!');
+    expect(sendArg.body).toContain('---------- Original Message ----------');
+    expect(sendArg.body).toContain('Alice <alice@example.com>');
+    expect(sendArg.body).toContain('Let me know your thoughts.');
+    expect(sendArg.replyToMessageId).toBe('msg-orig');
+  });
+
+  it('does not fetch original or append quote when reply_to_message_id is absent', async () => {
+    const gateway = {
+      send: vi.fn().mockResolvedValue({ success: true, messageId: 'sent-2' }),
+      getEmailMessage: vi.fn(),
+    };
+    const result = await handler.execute(makeCtx(
+      { to: 'alice@example.com', subject: 'Hello', body: 'Hi there' },
+      gateway,
+    ));
+
+    expect(result.success).toBe(true);
+    expect(gateway.getEmailMessage).not.toHaveBeenCalled();
+
+    const sendArg = gateway.send.mock.calls[0]![0] as { body: string; replyToMessageId?: string };
+    expect(sendArg.body).toBe('Hi there');
+    expect(sendArg.replyToMessageId).toBeUndefined();
+  });
+
+  it('proceeds without quote when getEmailMessage fails', async () => {
+    const gateway = {
+      send: vi.fn().mockResolvedValue({ success: true, messageId: 'sent-3' }),
+      getEmailMessage: vi.fn().mockRejectedValue(new Error('Not found')),
+    };
+    const warnSpy = vi.fn();
+    const ctx = makeCtx(
+      { to: 'alice@example.com', subject: 'Re: Q2', body: 'Got it', reply_to_message_id: 'msg-missing' },
+      gateway,
+    );
+    ctx.log = { ...logger, warn: warnSpy, info: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+
+    const sendArg = gateway.send.mock.calls[0]![0] as { body: string; replyToMessageId?: string };
+    // Body should be unquoted
+    expect(sendArg.body).toBe('Got it');
+    expect(sendArg.body).not.toContain('---------- Original Message ----------');
+    // replyToMessageId still passed for threading
+    expect(sendArg.replyToMessageId).toBe('msg-missing');
+    // Warning was logged
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ replyToMessageId: 'msg-missing' }),
+      expect.stringContaining('failed to fetch original message'),
+    );
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- Add shared `buildReplyQuote()` utility in `skills/_shared/reply-quote.ts` that formats the original message headers (From, Date, To, Subject) and HTML-stripped body as a standard quote block
- `ceo-inbox-draft-reply` — appends the quote to the body before calling `createDraftReply()` (original already fetched for recipient computation)
- `email-draft-save` — fetches the original via `getEmailMessage()` when `reply_to_message_id` is present, appends the quote
- `email-send` — adds `reply_to_message_id` as an optional input; fetches and quotes when provided; passes `replyToMessageId` to the gateway for threading

Both the fetch and the format steps are non-fatal — if either fails, a warning is logged and the reply is sent without the quote.

Closes #673

## Test plan

- [ ] 10 unit tests for `buildReplyQuote`: normal case, missing display name, multiple To, empty body, HTML-only-whitespace body, multiple senders, HTML stripping, timezone formatting, UTC fallback
- [ ] `ceo-inbox-draft-reply/handler.test.ts` — happy path verifies quote separator and sender in body; new test for HTML-stripped original body
- [ ] `email-draft-save.test.ts` — 4 new tests: quote appended, no reply ID, fetch failure (graceful fallback, warn logged), accountId forwarded to getEmailMessage
- [ ] `email-send.test.ts` — 3 new tests: quote appended with replyToMessageId in gateway call, no reply ID, fetch failure (graceful fallback)
- [ ] All 2059 skill-layer tests pass; typecheck clean


___

## **CodeAnt-AI Description**
Add quoted original messages to reply drafts and sent emails

### What Changed
- Reply drafts and sent emails now include the original message below the reply text, with the sender, date, recipients, and subject shown above the quoted body
- Original message bodies are shown as plain text, even when the source email contains HTML
- When the original message cannot be fetched or formatted, the reply still goes through without the quote and logs a warning
- `email-send` now accepts an optional reply message ID so sent replies stay threaded

### Impact
`✅ Reply drafts with full context`
`✅ Fewer unthreaded reply emails`
`✅ Clearer reply reviews before sending`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reply functionality now automatically includes a formatted quote of the original message below the reply text, matching standard email client behaviour
  * Email threading support added for replies to existing messages

* **Documentation**
  * Updated changelog to reflect new reply quoting behaviour

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->