### PR TITLE
feat: enable multi-turn research conversations (#611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Multi-turn research conversations** — research-analyst can pause mid-research to ask a clarifying question; coordinator routes it to the CEO and re-delegates automatically when the CEO replies. (#611)
+
 - **`embedding.call` bus event** — `EmbeddingService` now publishes cost telemetry after each OpenAI embedding API call; token counts and estimated costs appear in `audit_log` alongside `llm.call` entries. (#654)
 
 - **`context-bridge-release`** — new coordinator skill to release outbound context entries when conversations complete. (#615)

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -455,6 +455,78 @@ system_prompt: |
   wait for a follow-up message before delegating. For email (async), delegate silently
   without acknowledgment — the sender doesn't expect an immediate response.
 
+  ### Handling specialist clarification requests
+
+  Sometimes a specialist will return a structured clarification request rather than
+  a final result. This happens when the research hits a genuine fork and the CEO's
+  judgment is needed to choose the direction.
+
+  **Detecting a clarification request:** A delegate result that contains the line
+  `STATUS: NEEDS_CLARIFICATION` (after trimming any leading whitespace) is a
+  clarification request, not a finished response. Do NOT synthesize it as a final answer.
+
+  **What to do:**
+
+  1. Extract these fields from the result:
+     - `QUESTION:` — what the specialist needs the CEO to decide
+     - `PARTIAL_FINDINGS:` — what was found so far (use this to frame the question naturally)
+     - `TASK_CONTEXT:` — an opaque string you must preserve verbatim for re-delegation
+
+  2. Choose the best channel to reach the CEO (Signal for real-time; email if the
+     original request was async). Frame the question naturally in your own voice —
+     never expose internal mechanics. Example: "Working on the research you asked for.
+     I've found three competitors so far, but wanted to check with you: [QUESTION]"
+
+  3. Send the message to the CEO. Include `context_bridge` with this exact structure:
+
+     ```json
+     {
+       "agent_id": "coordinator",
+       "delegation_hint": "research-analyst clarification pending",
+       "expected_reply": "CEO's direction on the research question",
+       "metadata": { "task_context": "<TASK_CONTEXT verbatim>" },
+       "expires_in_hours": 24
+     }
+     ```
+
+     Replace `<TASK_CONTEXT verbatim>` with the exact TASK_CONTEXT string from the
+     specialist's response — do not summarise or paraphrase it.
+
+  4. For synchronous channels: after sending, let the CEO know you'll continue the
+     research once they reply. For async (email): no further acknowledgment needed.
+
+  **Routing the CEO's reply:**
+
+  When the CEO replies and the `[ACTIVE OUTBOUND CONTEXT]` block shows an entry
+  with `delegation: research-analyst clarification pending`:
+
+  1. Call `context-bridge-release` with that entry's `entry_id` to close it.
+
+  2. Parse the `context:` field as JSON and extract `task_context`. This is an
+     opaque string the specialist stored — do not modify it.
+
+  3. Re-delegate to `research-analyst` with this task content (the `TASK_CONTEXT:`
+     label must be present so the specialist knows to resume rather than restart):
+     ```
+     You are resuming a research task. The CEO has provided the direction you needed.
+
+     TASK_CONTEXT: <paste the task_context value here verbatim>
+
+     CEO's direction: <CEO's reply verbatim>
+
+     Continue the research from where you left off.
+     ```
+
+  4. Use the same `conversation_id` you used in the original delegation if it is
+     available in context; otherwise pass a fresh one.
+
+  5. When the specialist returns (either a final answer or another clarification
+     request), handle it the same way as above. Multiple clarification rounds are
+     supported — each round creates a new outbound context entry.
+
+  6. Synthesize the final result in your own voice once the specialist returns a
+     non-clarification response.
+
   ## Persona & Communication Style
   You are a person, not a platform. When you talk about yourself:
   - Say "I have contacts for..." not "I have a contact system that stores..."

--- a/agents/research-analyst.yaml
+++ b/agents/research-analyst.yaml
@@ -146,9 +146,14 @@ system_prompt: |
      via the `fast_decay` class — no explicit cleanup is needed.
 
   Multiple clarification rounds are supported — if you need to ask again after
-  the CEO's first answer, follow the same process: store updated state under
-  the same entity name (overwrite the previous partial_findings and
-  sources_consulted facts), then return another NEEDS_CLARIFICATION response.
+  the CEO's first answer, follow the same process: store updated state under a
+  **new versioned entity name** (e.g., append ` r2`, ` r3` to the original name
+  — `"research-scratchpad: AI competitor landscape Q2 2026 r2"`). Do not reuse
+  the same entity name: memory-store's conflict detection will reject same-field
+  overwrites at equal confidence, so the scratchpad will not update. The old
+  entity will expire naturally via `fast_decay` — no cleanup needed. Embed the
+  new entity name as the updated MEMORY_KEY in your TASK_CONTEXT line before
+  returning another NEEDS_CLARIFICATION response.
 
 pinned_skills:
   - web-search

--- a/agents/research-analyst.yaml
+++ b/agents/research-analyst.yaml
@@ -78,6 +78,78 @@ system_prompt: |
 
   Keep your responses focused and factual. Your findings will be reviewed
   and presented by the team coordinator — write for a busy executive audience.
+
+  ## Clarification requests
+
+  Sometimes mid-research you reach a genuine fork: you have substantive findings
+  but the CEO's judgment is needed to choose the direction before you can complete
+  the analysis. When this happens, you can pause and ask rather than guess.
+
+  ### When to ask for clarification
+
+  Ask only when:
+  - You have already done meaningful research and have real findings to share
+  - The CEO's judgment would materially change the direction of the remaining work
+    (e.g., "I found three acquisition targets — which strategic angle matters most:
+    valuation, talent, or technology?")
+  - A reasonable assumption on your part would produce a substantially different
+    and potentially wrong result
+
+  Do NOT ask for clarification when:
+  - The task is clear enough to complete with a reasonable interpretation
+  - You are simply uncertain about scope — make the most useful interpretation and note it
+  - You could answer both branches without much extra effort — just do both
+
+  ### Storing partial state
+
+  Before returning a clarification response, store your partial findings in memory
+  so they survive the gap while the CEO responds. Use a task-scoped entity name
+  in the format `"research-scratchpad: <short descriptive topic>"` — keep it under
+  60 characters (e.g. `"research-scratchpad: AI competitor landscape Q2 2026"`).
+
+  Store the key findings as facts:
+  - `field: "partial_findings"` — a concise summary of what you found so far
+  - `field: "sources_consulted"` — key sources or queries you already ran
+  - `decay_class: "fast_decay"` — this is short-lived working state, not permanent KG data
+  - `source: "agent:research-analyst"`
+
+  Note the entity name — you will include it in MEMORY_KEY so you can retrieve
+  it when the task resumes.
+
+  ### Structured clarification response format
+
+  Return exactly this format (no other content before or after):
+
+  ```
+  STATUS: NEEDS_CLARIFICATION
+  QUESTION: <one clear, specific question for the CEO — what decision do they need to make?>
+  PARTIAL_FINDINGS: <2–4 sentence summary of what you found so far — enough for the coordinator to frame the question naturally>
+  TASK_CONTEXT: ORIGINAL_TASK: <verbatim copy of the research task you received> | MEMORY_KEY: <the entity name you stored partial state under, e.g. "research-scratchpad: AI competitor landscape Q2 2026">
+  ```
+
+  Keep TASK_CONTEXT under 300 characters — it is stored in a metadata field and
+  will be passed back to you verbatim when the task resumes.
+
+  ### Resuming after clarification
+
+  When your task brief contains `TASK_CONTEXT:`, you are resuming a paused
+  research task. To resume:
+
+  1. Extract the MEMORY_KEY from TASK_CONTEXT and call `memory-query` with the
+     entity name (e.g. `"research-scratchpad: AI competitor landscape Q2 2026"`)
+     to retrieve your partial findings and sources consulted.
+  2. Extract the CEO's answer from the task brief — it will appear after the
+     TASK_CONTEXT block, introduced by the coordinator.
+  3. Use the retrieved state plus the CEO's direction to continue your research
+     from where you left off. Do not repeat work already done.
+  4. When the research is complete, the scratchpad facts will expire naturally
+     via the `fast_decay` class — no explicit cleanup is needed.
+
+  Multiple clarification rounds are supported — if you need to ask again after
+  the CEO's first answer, follow the same process: store updated state under
+  the same entity name (overwrite the previous partial_findings and
+  sources_consulted facts), then return another NEEDS_CLARIFICATION response.
+
 pinned_skills:
   - web-search
   - web-fetch

--- a/tests/integration/research-analyst-multi-turn.test.ts
+++ b/tests/integration/research-analyst-multi-turn.test.ts
@@ -238,7 +238,7 @@ describe('Research-analyst multi-turn clarification (issue #611)', () => {
                 name: 'delegate',
                 input: {
                   agent: 'research-analyst',
-                  task: `You are resuming a research task. The CEO has provided the direction you needed.\n\n${TASK_CONTEXT}\n\nCEO's direction: Focus on technology fit — we need AI capabilities we can integrate into our platform.\n\nContinue the research from where you left off.`,
+                  task: `You are resuming a research task. The CEO has provided the direction you needed.\n\nTASK_CONTEXT: ${TASK_CONTEXT}\n\nCEO's direction: Focus on technology fit — we need AI capabilities we can integrate into our platform.\n\nContinue the research from where you left off.`,
                   conversation_id: 'research-conv-001',
                 },
               }],

--- a/tests/integration/research-analyst-multi-turn.test.ts
+++ b/tests/integration/research-analyst-multi-turn.test.ts
@@ -1,0 +1,500 @@
+// Integration test for multi-turn research conversations (issue #611).
+//
+// Verifies the full stateless multi-turn pattern:
+//   1. Coordinator delegates research task to research-analyst
+//   2. Research-analyst returns STATUS: NEEDS_CLARIFICATION (partial findings + question)
+//   3. Coordinator sends clarifying question to CEO via Signal with context_bridge
+//   4. CEO replies → [ACTIVE OUTBOUND CONTEXT] block injected by dispatcher
+//   5. Coordinator releases context bridge entry, re-delegates with CEO's direction
+//   6. Research-analyst resumes and returns final answer
+//   7. Coordinator synthesizes final response
+//
+// Uses the same in-memory setup as multi-agent-delegation.test.ts — real bus, registry,
+// execution layer, and delegate handler; only the LLM providers and send skills are mocked.
+
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '../../src/bus/bus.js';
+import { AgentRuntime } from '../../src/agents/runtime.js';
+import { AgentRegistry } from '../../src/agents/agent-registry.js';
+import { SkillRegistry } from '../../src/skills/registry.js';
+import { ExecutionLayer } from '../../src/skills/execution.js';
+import { DelegateHandler } from '../../skills/delegate/handler.js';
+import type { LLMProvider, Message } from '../../src/agents/llm/provider.js';
+import type { SkillManifest, SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { createAgentTask } from '../../src/bus/events.js';
+import pino from 'pino';
+
+const logger = pino({ level: 'silent' });
+
+const MOCK_PROVENANCE = {
+  requestedModel: 'mock-model',
+  actualModel: 'mock-model',
+  providerRequestId: 'msg_mock_000',
+} as const;
+
+// The TASK_CONTEXT the research-analyst embeds in its clarification response.
+// Contains the original task and the memory key the analyst stored partial state under.
+const TASK_CONTEXT =
+  'ORIGINAL_TASK: Research the best AI acquisition targets in enterprise software | MEMORY_KEY: research-scratchpad: AI acquisition targets Q2 2026';
+
+// Simulated [ACTIVE OUTBOUND CONTEXT] block that the dispatcher would inject when
+// the CEO replies to the coordinator's Signal message. Includes the task_context
+// metadata the coordinator stored when it called signal-send with context_bridge.
+const ACTIVE_OUTBOUND_CONTEXT_BLOCK = `[ACTIVE OUTBOUND CONTEXT — messages you've sent that may receive replies]
+---
+entry_id: test-bridge-entry-001
+[sent 3 minutes ago via signal, on behalf of coordinator, expires in 23h]
+preview: "Working on your acquisition research. One question: which angle matters most..."
+expected reply: CEO's direction on the research question
+delegation: research-analyst clarification pending
+context: {"task_context":"${TASK_CONTEXT}"}
+---`;
+
+// Shared delegate skill manifest — used by both test cases to avoid duplication.
+const DELEGATE_MANIFEST: SkillManifest = {
+  name: 'delegate',
+  description: 'Delegate a task to a specialist agent',
+  version: '1.0.0',
+  sensitivity: 'normal',
+  action_risk: 'none',
+  capabilities: ['bus', 'agentRegistry'],
+  inputs: { agent: 'string', task: 'string', conversation_id: 'string?' },
+  outputs: { response: 'string', agent: 'string' },
+  permissions: [],
+  secrets: [],
+  timeout: 120000,
+};
+
+describe('Research-analyst multi-turn clarification (issue #611)', () => {
+  it('routes clarification → CEO question → re-delegation → final synthesis', async () => {
+    // ── 1. Registries ───────────────────────────────────────────────────────
+
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main coordinator' });
+    agentRegistry.register('research-analyst', {
+      role: 'specialist',
+      description: 'Research and analysis',
+    });
+
+    // Mock signal-send: captures what the coordinator sends, returns success.
+    // In production this would send a real Signal message and register an outbound
+    // context entry in Postgres. Here we skip both and simulate the injection manually.
+    let signalSendCallCount = 0;
+    let capturedSignalMessage = '';
+    let capturedContextBridge: Record<string, unknown> = {};
+    const mockSignalSend: SkillHandler = {
+      async execute(ctx: SkillContext): Promise<SkillResult> {
+        signalSendCallCount++;
+        const input = ctx.input as Record<string, unknown>;
+        capturedSignalMessage = (input.message as string) ?? '';
+        capturedContextBridge = JSON.parse((input.context_bridge as string) ?? '{}') as Record<string, unknown>;
+        return { success: true, data: { delivered_to: '+15551234567', channel: 'signal' } };
+      },
+    };
+
+    // Mock context-bridge-release: captures the entry_id the coordinator releases.
+    let releasedEntryId: string | undefined;
+    const mockContextBridgeRelease: SkillHandler = {
+      async execute(ctx: SkillContext): Promise<SkillResult> {
+        releasedEntryId = (ctx.input as Record<string, unknown>).entry_id as string;
+        return { success: true, data: {} };
+      },
+    };
+
+    const skillRegistry = new SkillRegistry();
+    skillRegistry.register(DELEGATE_MANIFEST, new DelegateHandler());
+
+    const signalSendManifest: SkillManifest = {
+      name: 'signal-send',
+      description: 'Send a Signal message',
+      version: '1.0.0',
+      sensitivity: 'normal',
+      action_risk: 'medium',
+      capabilities: [],  // no outboundGateway/outboundContext — mocked entirely
+      inputs: { recipient: 'string?', message: 'string', context_bridge: 'string?' },
+      outputs: { delivered_to: 'string', channel: 'string' },
+      permissions: [],
+      secrets: [],
+      timeout: 30000,
+    };
+    skillRegistry.register(signalSendManifest, mockSignalSend);
+
+    const contextBridgeReleaseManifest: SkillManifest = {
+      name: 'context-bridge-release',
+      description: 'Release an outbound context bridge entry',
+      version: '1.0.0',
+      sensitivity: 'normal',
+      action_risk: 'low',
+      capabilities: [],  // no outboundContext — mocked entirely
+      inputs: { entry_id: 'string' },
+      outputs: {},
+      permissions: [],
+      secrets: [],
+      timeout: 5000,
+    };
+    skillRegistry.register(contextBridgeReleaseManifest, mockContextBridgeRelease);
+
+    // ── 2. Bus and execution layer ──────────────────────────────────────────
+
+    const bus = new EventBus(logger);
+    const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry });
+
+    // ── 3. Coordinator mock LLM — 6 scripted responses ─────────────────────
+    //
+    //  Phase 1 (initial research task):
+    //    Call 1: delegate research task to research-analyst
+    //    Call 2: after NEEDS_CLARIFICATION result, send clarifying question via signal-send
+    //    Call 3: after signal-send success, acknowledge to CEO that we're waiting
+    //
+    //  Phase 2 (CEO's reply with ACTIVE OUTBOUND CONTEXT):
+    //    Call 4: release the context bridge entry
+    //    Call 5: re-delegate to research-analyst with CEO's direction
+    //    Call 6: synthesize the final research result
+
+    let coordinatorCalls = 0;
+    const coordinatorProvider: LLMProvider = {
+      id: 'mock-coordinator',
+      chat: async ({ messages }: { messages: Message[] }) => {
+        coordinatorCalls++;
+        const messageJson = JSON.stringify(messages);
+
+        switch (coordinatorCalls) {
+          case 1:
+            return {
+              type: 'tool_use' as const,
+              toolCalls: [{
+                id: 'call-1',
+                name: 'delegate',
+                input: {
+                  agent: 'research-analyst',
+                  task: 'Research the best AI acquisition targets in enterprise software — produce a shortlist.',
+                  conversation_id: 'research-conv-001',
+                },
+              }],
+              usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
+            };
+
+          case 2: {
+            // Verify the coordinator received the clarification response as a tool_result
+            expect(messageJson).toContain('NEEDS_CLARIFICATION');
+            return {
+              type: 'tool_use' as const,
+              toolCalls: [{
+                id: 'call-2',
+                name: 'signal-send',
+                input: {
+                  recipient: '+15551234567',
+                  message: "Working on your acquisition research. I've found several candidates, but wanted to check: which angle matters most to you — valuation, key talent, or technology fit?",
+                  context_bridge: JSON.stringify({
+                    agent_id: 'coordinator',
+                    delegation_hint: 'research-analyst clarification pending',
+                    expected_reply: "CEO's direction on which evaluation angle to prioritize",
+                    metadata: { task_context: TASK_CONTEXT },
+                    expires_in_hours: 24,
+                  }),
+                },
+              }],
+              usage: { inputTokens: 150, outputTokens: 80, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
+            };
+          }
+
+          case 3:
+            // Acknowledge to the original caller that we're waiting on CEO input
+            return {
+              type: 'text' as const,
+              content: "I'm on it — just sent you a quick question on Signal to make sure the research goes in the right direction. I'll follow up once you reply.",
+              usage: { inputTokens: 180, outputTokens: 40, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
+            };
+
+          case 4: {
+            // Verify the coordinator can see the ACTIVE OUTBOUND CONTEXT block
+            expect(messageJson).toContain('ACTIVE OUTBOUND CONTEXT');
+            expect(messageJson).toContain('research-analyst clarification pending');
+            return {
+              type: 'tool_use' as const,
+              toolCalls: [{
+                id: 'call-4',
+                name: 'context-bridge-release',
+                input: { entry_id: 'test-bridge-entry-001' },
+              }],
+              usage: { inputTokens: 220, outputTokens: 30, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
+            };
+          }
+
+          case 5:
+            // Re-delegate to research-analyst with the CEO's direction + TASK_CONTEXT
+            return {
+              type: 'tool_use' as const,
+              toolCalls: [{
+                id: 'call-5',
+                name: 'delegate',
+                input: {
+                  agent: 'research-analyst',
+                  task: `You are resuming a research task. The CEO has provided the direction you needed.\n\n${TASK_CONTEXT}\n\nCEO's direction: Focus on technology fit — we need AI capabilities we can integrate into our platform.\n\nContinue the research from where you left off.`,
+                  conversation_id: 'research-conv-001',
+                },
+              }],
+              usage: { inputTokens: 260, outputTokens: 110, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
+            };
+
+          case 6:
+            // Synthesize the final research result in the coordinator's own voice
+            return {
+              type: 'text' as const,
+              content: "Here's the acquisition shortlist, focused on technology fit: DataStream AI (strong NLP pipeline compatible with our APIs), Synthex (computer vision we don't have), and NeuralBase (enterprise ML infrastructure). DataStream looks most strategic given your platform roadmap.",
+              usage: { inputTokens: 310, outputTokens: 120, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
+            };
+
+          default:
+            throw new Error(`Unexpected coordinator LLM call #${coordinatorCalls}`);
+        }
+      },
+    };
+
+    // ── 4. Research-analyst mock LLM — 2 scripted responses ────────────────
+    //
+    //  Call 1: returns a structured NEEDS_CLARIFICATION response (partial findings
+    //          stored in memory, needs CEO to pick the research angle)
+    //  Call 2: returns the final research result after receiving CEO's direction
+
+    let specialistCalls = 0;
+    const specialistProvider: LLMProvider = {
+      id: 'mock-specialist',
+      chat: async () => {
+        specialistCalls++;
+        switch (specialistCalls) {
+          case 1:
+            return {
+              type: 'text' as const,
+              content: [
+                'STATUS: NEEDS_CLARIFICATION',
+                'QUESTION: Which angle matters most for evaluating these targets — valuation multiples, key talent retention, or technology integration fit with our platform?',
+                'PARTIAL_FINDINGS: Found 4 active enterprise AI acquisition targets in Q2 2026: DataStream AI, Synthex, NeuralBase, and Cortex Systems. Each has distinct strengths across valuation, talent density, and technology compatibility.',
+                `TASK_CONTEXT: ${TASK_CONTEXT}`,
+              ].join('\n'),
+              usage: { inputTokens: 80, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
+            };
+
+          case 2:
+            // Resumed — returns the final analysis focused on technology fit
+            return {
+              type: 'text' as const,
+              content: 'Top targets by technology fit: 1) DataStream AI — advanced NLP pipeline compatible with platform APIs; 2) Synthex — computer vision capabilities not currently in-house; 3) NeuralBase — enterprise ML infrastructure that could replace the current stack. DataStream AI is the strongest strategic fit given the platform roadmap.',
+              usage: { inputTokens: 130, outputTokens: 90, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+              provenance: MOCK_PROVENANCE,
+            };
+
+          default:
+            throw new Error(`Unexpected specialist LLM call #${specialistCalls}`);
+        }
+      },
+    };
+
+    // ── 5. Create agent runtimes ────────────────────────────────────────────
+
+    const coordinatorToolDefs = skillRegistry.toToolDefinitions([
+      'delegate',
+      'signal-send',
+      'context-bridge-release',
+    ]);
+
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a coordinator.',
+      provider: coordinatorProvider,
+      bus,
+      logger,
+      executionLayer,
+      pinnedSkills: ['delegate', 'signal-send', 'context-bridge-release'],
+      skillToolDefs: coordinatorToolDefs,
+    });
+    coordinator.register();
+
+    const specialist = new AgentRuntime({
+      agentId: 'research-analyst',
+      systemPrompt: 'You are a research analyst.',
+      provider: specialistProvider,
+      bus,
+      logger,
+    });
+    specialist.register();
+
+    // ── 6. Collect coordinator responses ────────────────────────────────────
+
+    const coordinatorResponses: string[] = [];
+    bus.subscribe('agent.response', 'system', async (event) => {
+      if (event.type === 'agent.response' && event.payload.agentId === 'coordinator') {
+        coordinatorResponses.push(event.payload.content);
+      }
+    });
+
+    // ── 7. Phase 1: initial research task ───────────────────────────────────
+    //
+    // The coordinator processes this task, hits a NEEDS_CLARIFICATION mid-delegation,
+    // sends a Signal message to the CEO with context_bridge, and responds to the
+    // original caller acknowledging it's waiting for CEO input.
+
+    const task1 = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'ceo-conv-001',
+      channelId: 'signal',
+      senderId: 'test-ceo',
+      content: 'Research the best AI acquisition targets for us — I want a shortlist.',
+      parentEventId: 'inbound-event-001',
+    });
+    await bus.publish('dispatch', task1);
+
+    // Verify the coordinator sent the clarifying question to the CEO
+    expect(signalSendCallCount).toBe(1);
+    expect(capturedSignalMessage).toContain('angle matters most');
+    expect(capturedContextBridge.delegation_hint).toBe('research-analyst clarification pending');
+    expect(capturedContextBridge.expires_in_hours).toBe(24);
+    const capturedMetadata = capturedContextBridge.metadata as Record<string, unknown>;
+    expect(capturedMetadata.task_context).toBe(TASK_CONTEXT);
+
+    // Coordinator responded to the original caller acknowledging the pending question
+    expect(coordinatorResponses).toHaveLength(1);
+    expect(coordinatorResponses[0]!).toContain('question on Signal');
+
+    // ── 8. Phase 2: CEO's Signal reply ─────────────────────────────────────
+    //
+    // In production, the dispatcher prepends the [ACTIVE OUTBOUND CONTEXT] block
+    // to every inbound message when there are active context bridge entries.
+    // We simulate that injection by prepending the block to the task content manually.
+
+    const ceoReplyContent = [
+      ACTIVE_OUTBOUND_CONTEXT_BLOCK,
+      '',
+      'Focus on technology fit — we need AI capabilities we can integrate into our platform.',
+    ].join('\n');
+
+    const task2 = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'ceo-conv-001',
+      channelId: 'signal',
+      senderId: 'test-ceo',
+      content: ceoReplyContent,
+      parentEventId: 'inbound-event-002',
+    });
+    await bus.publish('dispatch', task2);
+
+    // ── 9. Assertions ───────────────────────────────────────────────────────
+
+    // Full call count — no extra or missing turns
+    expect(coordinatorCalls).toBe(6);
+    expect(specialistCalls).toBe(2);
+
+    // Context bridge was released with the correct entry_id from the ACTIVE OUTBOUND CONTEXT block
+    expect(releasedEntryId).toBe('test-bridge-entry-001');
+
+    // Final coordinator response synthesizes the research result
+    expect(coordinatorResponses).toHaveLength(2);
+    expect(coordinatorResponses[1]!).toContain('DataStream');
+    expect(coordinatorResponses[1]!).toContain('technology fit');
+  });
+
+  it('one-shot research tasks still work as before (backward compatible)', async () => {
+    // Regression guard: when the specialist returns a normal text response
+    // (no STATUS: NEEDS_CLARIFICATION), the coordinator synthesizes it directly.
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.register('coordinator', { role: 'coordinator', description: 'Main coordinator' });
+    agentRegistry.register('research-analyst', { role: 'specialist', description: 'Research and analysis' });
+
+    const skillRegistry = new SkillRegistry();
+    skillRegistry.register(DELEGATE_MANIFEST, new DelegateHandler());
+
+    const bus = new EventBus(logger);
+    const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry });
+
+    let coordinatorCalls = 0;
+    const coordinatorProvider: LLMProvider = {
+      id: 'mock-coordinator-oneshot',
+      chat: async () => {
+        coordinatorCalls++;
+        if (coordinatorCalls === 1) {
+          return {
+            type: 'tool_use' as const,
+            toolCalls: [{
+              id: 'call-1',
+              name: 'delegate',
+              input: { agent: 'research-analyst', task: 'Research battery storage companies', conversation_id: 'conv-123' },
+            }],
+            usage: { inputTokens: 100, outputTokens: 50, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+            provenance: MOCK_PROVENANCE,
+          };
+        }
+        return {
+          type: 'text' as const,
+          content: 'Battery storage is led by QuantumCell, FluxEnergy, and IonDrive — all Series B or later.',
+          usage: { inputTokens: 200, outputTokens: 60, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        };
+      },
+    };
+
+    let specialistCalls = 0;
+    const specialistProvider: LLMProvider = {
+      id: 'mock-specialist-oneshot',
+      chat: async () => {
+        specialistCalls++;
+        return {
+          type: 'text' as const,
+          content: 'Top battery storage companies: QuantumCell, FluxEnergy, IonDrive.',
+          usage: { inputTokens: 50, outputTokens: 30, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        };
+      },
+    };
+
+    const toolDefs = skillRegistry.toToolDefinitions(['delegate']);
+
+    const coordinator = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are a coordinator.',
+      provider: coordinatorProvider,
+      bus,
+      logger,
+      executionLayer,
+      pinnedSkills: ['delegate'],
+      skillToolDefs: toolDefs,
+    });
+    coordinator.register();
+
+    const specialist = new AgentRuntime({
+      agentId: 'research-analyst',
+      systemPrompt: 'You are a research analyst.',
+      provider: specialistProvider,
+      bus,
+      logger,
+    });
+    specialist.register();
+
+    let finalResponse = '';
+    bus.subscribe('agent.response', 'system', async (event) => {
+      if (event.type === 'agent.response' && event.payload.agentId === 'coordinator') {
+        finalResponse = event.payload.content;
+      }
+    });
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'ceo-conv-002',
+      channelId: 'signal',
+      senderId: 'test-ceo',
+      content: 'Research battery storage companies.',
+      parentEventId: 'inbound-event-003',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(coordinatorCalls).toBe(2);
+    expect(specialistCalls).toBe(1);
+    expect(finalResponse).toContain('QuantumCell');
+  });
+});

--- a/tests/integration/research-analyst-multi-turn.test.ts
+++ b/tests/integration/research-analyst-multi-turn.test.ts
@@ -87,7 +87,11 @@ describe('Research-analyst multi-turn clarification (issue #611)', () => {
         signalSendCallCount++;
         const input = ctx.input as Record<string, unknown>;
         capturedSignalMessage = (input.message as string) ?? '';
-        capturedContextBridge = JSON.parse((input.context_bridge as string) ?? '{}') as Record<string, unknown>;
+        // Throw explicitly if context_bridge is absent — a missing field here means
+        // the coordinator mock forgot to include it, not that JSON.parse failed.
+        const rawBridge = input.context_bridge as string | undefined;
+        if (!rawBridge) throw new Error('mockSignalSend: context_bridge was not provided by the coordinator');
+        capturedContextBridge = JSON.parse(rawBridge) as Record<string, unknown>;
         return { success: true, data: { delivered_to: '+15551234567', channel: 'signal' } };
       },
     };
@@ -252,6 +256,9 @@ describe('Research-analyst multi-turn clarification (issue #611)', () => {
             };
 
           default:
+            // Use a Vitest assertion rather than a plain throw — AgentRuntime's outer
+            // catch swallows plain errors; an AssertionError surfaces correctly in the runner.
+            expect(coordinatorCalls, 'Unexpected coordinator LLM call — mock is being called more times than scripted').toBeLessThanOrEqual(6);
             throw new Error(`Unexpected coordinator LLM call #${coordinatorCalls}`);
         }
       },
@@ -292,6 +299,9 @@ describe('Research-analyst multi-turn clarification (issue #611)', () => {
             };
 
           default:
+            // Use a Vitest assertion rather than a plain throw — AgentRuntime's outer
+            // catch swallows plain errors; an AssertionError surfaces correctly in the runner.
+            expect(specialistCalls, 'Unexpected specialist LLM call — mock is being called more times than scripted').toBeLessThanOrEqual(2);
             throw new Error(`Unexpected specialist LLM call #${specialistCalls}`);
         }
       },
@@ -327,10 +337,13 @@ describe('Research-analyst multi-turn clarification (issue #611)', () => {
     specialist.register();
 
     // ── 6. Collect coordinator responses ────────────────────────────────────
+    //
+    // Only collect non-error responses — error responses (isError: true) contain
+    // runtime fallback text and would give misleading assertion failures.
 
     const coordinatorResponses: string[] = [];
     bus.subscribe('agent.response', 'system', async (event) => {
-      if (event.type === 'agent.response' && event.payload.agentId === 'coordinator') {
+      if (event.type === 'agent.response' && event.payload.agentId === 'coordinator' && !event.payload.isError) {
         coordinatorResponses.push(event.payload.content);
       }
     });
@@ -478,7 +491,7 @@ describe('Research-analyst multi-turn clarification (issue #611)', () => {
 
     let finalResponse = '';
     bus.subscribe('agent.response', 'system', async (event) => {
-      if (event.type === 'agent.response' && event.payload.agentId === 'coordinator') {
+      if (event.type === 'agent.response' && event.payload.agentId === 'coordinator' && !event.payload.isError) {
         finalResponse = event.payload.content;
       }
     });


### PR DESCRIPTION
## **User description**
## Summary

- **research-analyst** — new `## Clarification requests` section in its system prompt; when mid-research it hits a genuine fork, it stores partial findings in memory (with `fast_decay`) and returns a structured `STATUS: NEEDS_CLARIFICATION` response with `QUESTION`, `PARTIAL_FINDINGS`, and `TASK_CONTEXT`
- **coordinator** — new `### Handling specialist clarification requests` section; detects the structured response, forwards the question to the CEO via Signal/email with a `context_bridge` block that carries `delegation_hint` and `task_context`, then re-delegates to the research-analyst with the CEO's answer and the original `TASK_CONTEXT` block when the reply arrives
- **integration test** — `tests/integration/research-analyst-multi-turn.test.ts` covers the full multi-turn flow (6 coordinator turns, 2 specialist turns) plus a one-shot backward-compatibility case; in-memory, no Postgres

No new infrastructure — pure prompt engineering on top of existing context bridging v2.

Closes #611

## Test plan

- [ ] Run `pnpm --prefix worktrees/curia-multi-turn-research test tests/integration/research-analyst-multi-turn.test.ts` — all 2 new tests pass
- [ ] Run full integration suite — existing `multi-agent-delegation` test still passes (backward compat)
- [ ] Typecheck clean: `pnpm --prefix worktrees/curia-multi-turn-research run typecheck`


___

## **CodeAnt-AI Description**
**Support research tasks that pause for CEO clarification and resume after a reply**

### What Changed
- Research requests can now pause mid-way, ask the CEO one clear question, and return with partial findings instead of guessing
- The coordinator now forwards that question to the CEO, waits for the reply, then sends the specialist back with the original task context and the CEO’s direction
- The coordinator closes the temporary handoff when the CEO replies and then finishes with a normal final summary
- Added coverage for the full multi-turn flow and a backward-compatibility case where one-shot research still works as before
- Updated agent guidance and changelog to describe the new clarification flow and how to resume it

### Impact
`✅ Fewer wrong research answers`
`✅ Shorter follow-up loops for unclear requests`
`✅ Smooth handoff after CEO clarification`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Research agents can now pause mid-research to ask clarifying questions. Questions are automatically routed to leadership for guidance, and investigations resume with the provided direction.

* **Tests**
  * Added integration tests validating multi-turn research conversations with clarification workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->