### PR TITLE
fix: strengthen turn-budget prompt with anti-retry guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **`turn-budget`** — added anti-retry, error acceptance, and structured output guidance; proximity threshold widened from 3 to 5 turns remaining. (#689)
+
 ### Added
 
 - **`embedding.call` bus event** — `EmbeddingService` now publishes cost telemetry after each OpenAI embedding API call; token counts and estimated costs appear in `audit_log` alongside `llm.call` entries. (#654)

--- a/src/agents/turn-budget.test.ts
+++ b/src/agents/turn-budget.test.ts
@@ -33,13 +33,18 @@ describe('formatTurnBudgetBlock', () => {
     expect(block).toContain('retry');
   });
 
+  it('instructs the model to accept errors and move on', () => {
+    const block = formatTurnBudgetBlock(20);
+    expect(block).toContain('accept it and move on');
+  });
+
   it('instructs the model to produce a partial result near the limit', () => {
     const block = formatTurnBudgetBlock(20);
     expect(block).toContain('partial');
   });
 
-  it('specifies the 3-turn proximity threshold for early summary', () => {
+  it('specifies the 5-turn proximity threshold for final output', () => {
     const block = formatTurnBudgetBlock(20);
-    expect(block).toContain('3 turns');
+    expect(block).toContain('fewer than 5 turns remaining');
   });
 });

--- a/src/agents/turn-budget.test.ts
+++ b/src/agents/turn-budget.test.ts
@@ -43,17 +43,22 @@ describe('formatTurnBudgetBlock', () => {
     expect(block).toContain('partial');
   });
 
-  it('scales the proximity threshold with maxTurns (default 20 → 6)', () => {
+  it('uses default proximity threshold of 5 for normal budgets (20)', () => {
     const block = formatTurnBudgetBlock(20);
-    expect(block).toContain('fewer than 6 turns remaining');
+    expect(block).toContain('fewer than 5 turns remaining');
   });
 
-  it('scales the proximity threshold for 15 turns → 5', () => {
+  it('uses default proximity threshold of 5 for 15-turn budget', () => {
     const block = formatTurnBudgetBlock(15);
     expect(block).toContain('fewer than 5 turns remaining');
   });
 
-  it('clamps the proximity threshold to minimum 2 for low budgets', () => {
+  it('scales down proximity threshold for small budgets (6 → 3)', () => {
+    const block = formatTurnBudgetBlock(6);
+    expect(block).toContain('fewer than 3 turns remaining');
+  });
+
+  it('clamps proximity threshold to minimum 2 for very low budgets (3)', () => {
     const block = formatTurnBudgetBlock(3);
     expect(block).toContain('fewer than 2 turns remaining');
   });

--- a/src/agents/turn-budget.test.ts
+++ b/src/agents/turn-budget.test.ts
@@ -43,8 +43,18 @@ describe('formatTurnBudgetBlock', () => {
     expect(block).toContain('partial');
   });
 
-  it('specifies the 5-turn proximity threshold for final output', () => {
+  it('scales the proximity threshold with maxTurns (default 20 → 6)', () => {
     const block = formatTurnBudgetBlock(20);
+    expect(block).toContain('fewer than 6 turns remaining');
+  });
+
+  it('scales the proximity threshold for 15 turns → 5', () => {
+    const block = formatTurnBudgetBlock(15);
     expect(block).toContain('fewer than 5 turns remaining');
+  });
+
+  it('clamps the proximity threshold to minimum 2 for low budgets', () => {
+    const block = formatTurnBudgetBlock(3);
+    expect(block).toContain('fewer than 2 turns remaining');
   });
 });

--- a/src/agents/turn-budget.ts
+++ b/src/agents/turn-budget.ts
@@ -21,11 +21,20 @@
  *     retry the same tool with different parameters — note the failure in your final output
  *   - After completing your tool calls, produce your final structured response immediately.
  *     Do not make additional tool calls unless genuinely necessary for the task
- *   - When you have fewer than 5 turns remaining, your next response MUST include your
+ *   - When you have fewer than 6 turns remaining, your next response MUST include your
  *     final output, even if the task is incomplete. A partial result with noted gaps is
  *     always better than silence
+ *
+ * The proximity threshold (the "fewer than N turns remaining" number) scales with
+ * maxTurns so low-budget agents aren't told to finalize from turn 1. Formula:
+ * max(2, floor(maxTurns / 3)) — roughly the last third of the budget.
  */
 export function formatTurnBudgetBlock(maxTurns: number): string {
+  // Scale the proximity threshold so low-budget agents still get usable tool turns.
+  // floor(maxTurns / 3) gives ~33% of budget; clamped to min 2 so the guidance
+  // is always present, even for very small budgets.
+  const proximityThreshold = Math.max(2, Math.floor(maxTurns / 3));
+
   return [
     '## Turn budget',
     `You have a total budget of ${maxTurns} turns for this task. A "turn" is one round`,
@@ -36,7 +45,7 @@ export function formatTurnBudgetBlock(maxTurns: number): string {
     '  retry the same tool with different parameters — note the failure in your final output',
     '- After completing your tool calls, produce your final structured response immediately.',
     '  Do not make additional tool calls unless genuinely necessary for the task',
-    '- When you have fewer than 5 turns remaining, your next response MUST include your',
+    `- When you have fewer than ${proximityThreshold} turns remaining, your next response MUST include your`,
     '  final output, even if the task is incomplete. A partial result with noted gaps is',
     '  always better than silence',
   ].join('\n');

--- a/src/agents/turn-budget.ts
+++ b/src/agents/turn-budget.ts
@@ -21,19 +21,19 @@
  *     retry the same tool with different parameters — note the failure in your final output
  *   - After completing your tool calls, produce your final structured response immediately.
  *     Do not make additional tool calls unless genuinely necessary for the task
- *   - When you have fewer than 6 turns remaining, your next response MUST include your
+ *   - When you have fewer than 5 turns remaining, your next response MUST include your
  *     final output, even if the task is incomplete. A partial result with noted gaps is
  *     always better than silence
  *
- * The proximity threshold (the "fewer than N turns remaining" number) scales with
- * maxTurns so low-budget agents aren't told to finalize from turn 1. Formula:
- * max(2, floor(maxTurns / 3)) — roughly the last third of the budget.
+ * The proximity threshold (the "fewer than N turns remaining" number) defaults to 5
+ * but is clamped to at most half the budget so low-budget agents (maxTurns 3–4) aren't
+ * told to finalize from turn 1. Formula: max(2, min(5, floor(maxTurns / 2))).
  */
 export function formatTurnBudgetBlock(maxTurns: number): string {
-  // Scale the proximity threshold so low-budget agents still get usable tool turns.
-  // floor(maxTurns / 3) gives ~33% of budget; clamped to min 2 so the guidance
-  // is always present, even for very small budgets.
-  const proximityThreshold = Math.max(2, Math.floor(maxTurns / 3));
+  // Default threshold of 5 turns, but never more than half the budget so
+  // low-turn agents still get usable tool turns. Min 2 so the guidance is
+  // always present.
+  const proximityThreshold = Math.max(2, Math.min(5, Math.floor(maxTurns / 2)));
 
   return [
     '## Turn budget',

--- a/src/agents/turn-budget.ts
+++ b/src/agents/turn-budget.ts
@@ -17,8 +17,13 @@
  *   of tool calls followed by your response. Plan your tool use accordingly:
  *   - Do not issue exploratory or speculative tool calls when you can act on what you know
  *   - If a search returns no results, try one alternative then move on — do not retry repeatedly
- *   - If you are within 3 turns of the limit and the task is incomplete, stop and produce
- *     a partial result or summary rather than continuing to tool-call into silence
+ *   - If a tool call returns an error or unexpected result, accept it and move on. Do not
+ *     retry the same tool with different parameters — note the failure in your final output
+ *   - After completing your tool calls, produce your final structured response immediately.
+ *     Do not make additional tool calls unless genuinely necessary for the task
+ *   - When you have fewer than 5 turns remaining, your next response MUST include your
+ *     final output, even if the task is incomplete. A partial result with noted gaps is
+ *     always better than silence
  */
 export function formatTurnBudgetBlock(maxTurns: number): string {
   return [
@@ -27,7 +32,12 @@ export function formatTurnBudgetBlock(maxTurns: number): string {
     'of tool calls followed by your response. Plan your tool use accordingly:',
     '- Do not issue exploratory or speculative tool calls when you can act on what you know',
     '- If a search returns no results, try one alternative then move on — do not retry repeatedly',
-    '- If you are within 3 turns of the limit and the task is incomplete, stop and produce',
-    '  a partial result or summary rather than continuing to tool-call into silence',
+    '- If a tool call returns an error or unexpected result, accept it and move on. Do not',
+    '  retry the same tool with different parameters — note the failure in your final output',
+    '- After completing your tool calls, produce your final structured response immediately.',
+    '  Do not make additional tool calls unless genuinely necessary for the task',
+    '- When you have fewer than 5 turns remaining, your next response MUST include your',
+    '  final output, even if the task is incomplete. A partial result with noted gaps is',
+    '  always better than silence',
   ].join('\n');
 }


### PR DESCRIPTION
## **User description**
## Summary

- Adds anti-retry, error acceptance, and structured output guidance to the turn-budget block injected into every agent's system prompt
- Widens the proximity threshold from "within 3 turns" to "fewer than 5 turns remaining" (relative, not absolute)
- Mirrors the eval harness change in curia-deploy#84

Addresses DeepSeek v4 Pro's documented tool-retry loop behavior (deepseek-ai/DeepSeek-V3#15, #301, #1108) where the model exhausts turn budgets by retrying failed tool calls with variant parameters instead of accepting errors and moving on.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `turn-budget.test.ts` — all assertions updated and passing (25/25)


___

## **CodeAnt-AI Description**
Strengthen turn-budget guidance so agents stop retrying failures and finish with a clear result

### What Changed
- Agents are now told to accept tool errors or unexpected results instead of retrying the same tool with different parameters
- After tool use, agents are instructed to return their final structured response right away unless another call is truly needed
- The early-stop warning now starts when fewer than 5 turns remain, and agents must return their final output at that point even if the task is incomplete
- Tests were updated to check for the new error-handling guidance and the new 5-turn threshold

### Impact
`✅ Fewer repeated tool retries`
`✅ More complete final answers near the turn limit`
`✅ Clearer failure handling in agent responses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
