### PR TITLE
fix: file-parse accepts temp_file_url as alternative to content_base64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Authorization trust gating** — effective trust is now `max(channelTrust, contactTrustLevel)`, so confirmed contacts with an explicit `trust_level` grant (e.g. `high`, `ceo`) are no longer downgraded by the email channel's inherent low-trust floor. Fixes the CEO being unable to request their own calendar via email.
 - **Authorization trust fallback** — when a contact's free-text role has no config match, the system now falls back to `trust_level_defaults` (new section in `role-defaults.yaml`) before reaching `unknown`. Family members and other free-text-role contacts with an explicit trust grant now get appropriate permissions.
 - **Authorization boundary hardening** — unknown `trustLevel` values from the DB now throw (caught safely by contact-resolver, degrades to `authorization=null`) instead of silently collapsing to low trust; permissions with unrecognized sensitivity values escalate to the CEO instead of silently landing in `trustBlocked`; config loader validates that `trust_level_defaults` is a YAML mapping at startup.
+- **`file-parse`** — accepts `temp_file_url` as alternative to `content_base64`, bridging the gap with `ceo-inbox-download-attachment` which omits base64 content when temp storage is available.
 
 ### Added
 

--- a/skills/file-parse/handler.test.ts
+++ b/skills/file-parse/handler.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import pino from 'pino';
 import { parseCsv } from './csv.js';
 import { FileParseHandler } from './handler.js';
@@ -386,6 +389,109 @@ describe('FileParseHandler', () => {
         expect(data.confidence).toBeLessThan(0.5);
         expect(data.structured).toBeNull();
       }
+    });
+  });
+
+  describe('temp_file_url support', () => {
+    const handler = new FileParseHandler();
+    // Use /tmp/curia-tempfiles/ which is in the allowed prefix list
+    const tempDir = '/tmp/curia-tempfiles';
+    let testFilePath: string;
+
+    beforeAll(async () => {
+      await fs.mkdir(tempDir, { recursive: true });
+      testFilePath = path.join(tempDir, 'test-file.csv');
+      await fs.writeFile(testFilePath, 'vendor,amount\nAcme,50.00');
+    });
+
+    afterAll(async () => {
+      try { await fs.unlink(testFilePath); } catch { /* cleanup best-effort */ }
+    });
+
+    it('reads file from temp_file_url when content_base64 is empty', async () => {
+      const result = await handler.execute(makeCtx({
+        content_base64: '',
+        temp_file_url: `file://${testFilePath}`,
+        mime_type: 'text/csv',
+      }, makeInfraLlm('{}')));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { type: string; structured: Array<Record<string, string>> };
+        expect(data.type).toBe('csv');
+        expect(data.structured).toEqual([{ vendor: 'Acme', amount: '50.00' }]);
+      }
+    });
+
+    it('reads file from temp_file_url when content_base64 is absent', async () => {
+      const result = await handler.execute(makeCtx({
+        temp_file_url: `file://${testFilePath}`,
+        mime_type: 'text/csv',
+      }, makeInfraLlm('{}')));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { type: string; structured: Array<Record<string, string>> };
+        expect(data.type).toBe('csv');
+        expect(data.structured).toEqual([{ vendor: 'Acme', amount: '50.00' }]);
+      }
+    });
+
+    it('prefers content_base64 over temp_file_url when both are provided', async () => {
+      const directCsv = 'name,value\nDirect,100';
+      const result = await handler.execute(makeCtx({
+        content_base64: Buffer.from(directCsv).toString('base64'),
+        temp_file_url: `file://${testFilePath}`,
+        mime_type: 'text/csv',
+      }, makeInfraLlm('{}')));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as { structured: Array<Record<string, string>> };
+        // Should use content_base64, not the temp file
+        expect(data.structured).toEqual([{ name: 'Direct', value: '100' }]);
+      }
+    });
+
+    it('rejects temp_file_url outside allowed directories', async () => {
+      const result = await handler.execute(makeCtx({
+        temp_file_url: 'file:///etc/passwd',
+        mime_type: 'text/csv',
+      }, makeInfraLlm('{}')));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/invalid temp_file_url/i);
+    });
+
+    it('rejects temp_file_url with path traversal', async () => {
+      const result = await handler.execute(makeCtx({
+        temp_file_url: 'file:///tmp/curia-tempfiles/../../etc/passwd',
+        mime_type: 'text/csv',
+      }, makeInfraLlm('{}')));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/invalid temp_file_url/i);
+    });
+
+    it('rejects non-file:// URLs', async () => {
+      const result = await handler.execute(makeCtx({
+        temp_file_url: 'https://example.com/file.csv',
+        mime_type: 'text/csv',
+      }, makeInfraLlm('{}')));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/invalid temp_file_url/i);
+    });
+
+    it('returns error when temp file has been cleaned up', async () => {
+      const result = await handler.execute(makeCtx({
+        temp_file_url: 'file:///tmp/curia-tempfiles/nonexistent-file.csv',
+        mime_type: 'text/csv',
+      }, makeInfraLlm('{}')));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/expired/i);
+    });
+
+    it('error message mentions temp_file_url as alternative when both inputs are missing', async () => {
+      const result = await handler.execute(makeCtx({
+        mime_type: 'text/csv',
+      }, makeInfraLlm('{}')));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toMatch(/temp_file_url/);
     });
   });
 });

--- a/skills/file-parse/handler.test.ts
+++ b/skills/file-parse/handler.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import os from 'node:os';
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import pino from 'pino';
 import { parseCsv } from './csv.js';
@@ -483,7 +482,26 @@ describe('FileParseHandler', () => {
         mime_type: 'text/csv',
       }, makeInfraLlm('{}')));
       expect(result.success).toBe(false);
-      if (!result.success) expect(result.error).toMatch(/expired/i);
+      if (!result.success) {
+        expect(result.error).toMatch(/expired|cleaned up/i);
+        // Error should include remediation guidance for the calling agent
+        expect(result.error).toMatch(/re-download/i);
+      }
+    });
+
+    it('returns specific error for empty (0-byte) temp files', async () => {
+      const emptyFilePath = path.join(tempDir, 'empty-file.csv');
+      await fs.writeFile(emptyFilePath, '');
+      try {
+        const result = await handler.execute(makeCtx({
+          temp_file_url: `file://${emptyFilePath}`,
+          mime_type: 'text/csv',
+        }, makeInfraLlm('{}')));
+        expect(result.success).toBe(false);
+        if (!result.success) expect(result.error).toMatch(/empty.*0 bytes/i);
+      } finally {
+        await fs.unlink(emptyFilePath).catch(() => {});
+      }
     });
 
     it('error message mentions temp_file_url as alternative when both inputs are missing', async () => {

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -324,8 +324,13 @@ export class FileParseHandler implements SkillHandler {
 
     // Allow paths under the production tmpfs mount or the /tmp fallback (local dev).
     // Both are restricted directories where only TempFileStore writes.
-    // TODO: read CURIA_TEMPFILE_DIR env var to stay in sync with TempFileStore config
+    // Include CURIA_TEMPFILE_DIR if set, so this stays in sync with TempFileStore config.
     const allowedPrefixes = ['/run/curia-tempfiles/', '/tmp/curia-tempfiles/'];
+    const customDir = process.env.CURIA_TEMPFILE_DIR;
+    if (customDir) {
+      const normalized = path.resolve(customDir);
+      allowedPrefixes.push(normalized.endsWith('/') ? normalized : normalized + '/');
+    }
     const logicallyAllowed = allowedPrefixes.some((prefix) => filePath.startsWith(prefix));
     if (!logicallyAllowed) return null;
 

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -9,6 +9,8 @@
 // All LLM calls go through the constrained InfraLlm service (classify + extract
 // only) so costs and latency are tracked by the telemetry infrastructure.
 
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { createRequire } from 'node:module';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { InfraLlm } from '../../src/skills/infra-llm.js';
@@ -45,15 +47,38 @@ export class FileParseHandler implements SkillHandler {
     const infraLlm = ctx.infraLlm;
 
     // --- Input validation ---
-    const contentBase64 = typeof ctx.input.content_base64 === 'string'
+    let contentBase64 = typeof ctx.input.content_base64 === 'string'
       ? ctx.input.content_base64.trim() : '';
+    const tempFileUrl = typeof ctx.input.temp_file_url === 'string'
+      ? ctx.input.temp_file_url.trim() : '';
     const mimeType = typeof ctx.input.mime_type === 'string'
       ? ctx.input.mime_type.trim().toLowerCase() : '';
     const extractAs = typeof ctx.input.extract_as === 'string'
       ? ctx.input.extract_as.trim().toLowerCase() as ExtractAs : 'raw';
 
+    // When temp_file_url is provided but content_base64 is not, read the file from
+    // disk. This bridges the gap with ceo-inbox-download-attachment which omits
+    // content_base64 when temp storage is available (to avoid output size limits).
+    if (!contentBase64 && tempFileUrl) {
+      const resolved = this.resolveTempFileUrl(tempFileUrl);
+      if (!resolved) {
+        return { success: false, error: 'Invalid temp_file_url: must be a file:// URL under the temp store directory' };
+      }
+      try {
+        const fileBuffer = await fs.readFile(resolved);
+        contentBase64 = fileBuffer.toString('base64');
+        ctx.log.info(
+          { tempFileUrl, bytes: fileBuffer.length },
+          'file-parse: read content from temp_file_url (content_base64 was empty)',
+        );
+      } catch (err) {
+        ctx.log.error({ err, tempFileUrl }, 'file-parse: failed to read temp file');
+        return { success: false, error: 'Failed to read file from temp_file_url — file may have expired' };
+      }
+    }
+
     if (!contentBase64) {
-      return { success: false, error: 'Missing required input: content_base64' };
+      return { success: false, error: 'Missing required input: content_base64 (or provide temp_file_url)' };
     }
     if (!mimeType) {
       return { success: false, error: 'Missing required input: mime_type' };
@@ -275,6 +300,25 @@ export class FileParseHandler implements SkillHandler {
         },
       };
     }
+  }
+
+  /**
+   * Validate and resolve a file:// URL to an absolute filesystem path.
+   * Only allows paths under known temp store directories to prevent path traversal.
+   * Returns null if the URL is invalid or points outside the allowed directories.
+   */
+  private resolveTempFileUrl(url: string): string | null {
+    if (!url.startsWith('file://')) return null;
+
+    const filePath = path.resolve(url.slice('file://'.length));
+
+    // Allow paths under the production tmpfs mount or the /tmp fallback (local dev).
+    // Both are restricted directories where only TempFileStore writes.
+    const allowedPrefixes = ['/run/curia-tempfiles/', '/tmp/curia-tempfiles/'];
+    const allowed = allowedPrefixes.some((prefix) => filePath.startsWith(prefix));
+    if (!allowed) return null;
+
+    return filePath;
   }
 }
 

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -60,20 +60,29 @@ export class FileParseHandler implements SkillHandler {
     // disk. This bridges the gap with ceo-inbox-download-attachment which omits
     // content_base64 when temp storage is available (to avoid output size limits).
     if (!contentBase64 && tempFileUrl) {
-      const resolved = this.resolveTempFileUrl(tempFileUrl);
+      const resolved = await this.resolveTempFileUrl(tempFileUrl);
       if (!resolved) {
+        ctx.log.warn({ tempFileUrl }, 'file-parse: rejected temp_file_url — must be file:// under allowed prefix');
         return { success: false, error: 'Invalid temp_file_url: must be a file:// URL under the temp store directory' };
       }
       try {
         const fileBuffer = await fs.readFile(resolved);
+        if (fileBuffer.length === 0) {
+          ctx.log.error({ tempFileUrl }, 'file-parse: temp file exists but is empty (0 bytes)');
+          return { success: false, error: 'Temp file at temp_file_url is empty (0 bytes) — file may have been corrupted or partially written' };
+        }
         contentBase64 = fileBuffer.toString('base64');
         ctx.log.info(
           { tempFileUrl, bytes: fileBuffer.length },
           'file-parse: read content from temp_file_url (content_base64 was empty)',
         );
       } catch (err) {
-        ctx.log.error({ err, tempFileUrl }, 'file-parse: failed to read temp file');
-        return { success: false, error: 'Failed to read file from temp_file_url — file may have expired' };
+        const code = (err as NodeJS.ErrnoException).code;
+        ctx.log.error({ err, tempFileUrl, errCode: code }, 'file-parse: failed to read temp file');
+        if (code === 'ENOENT') {
+          return { success: false, error: 'Failed to read file from temp_file_url — temp file has expired or been cleaned up. Re-download the attachment to get a fresh temp_file_url.' };
+        }
+        return { success: false, error: `Failed to read file from temp_file_url — filesystem error (${code ?? 'unknown'})` };
       }
     }
 
@@ -305,20 +314,49 @@ export class FileParseHandler implements SkillHandler {
   /**
    * Validate and resolve a file:// URL to an absolute filesystem path.
    * Only allows paths under known temp store directories to prevent path traversal.
+   * Resolves symlinks to prevent symlink-based escape from the allowed directory.
    * Returns null if the URL is invalid or points outside the allowed directories.
    */
-  private resolveTempFileUrl(url: string): string | null {
+  private async resolveTempFileUrl(url: string): Promise<string | null> {
     if (!url.startsWith('file://')) return null;
 
     const filePath = path.resolve(url.slice('file://'.length));
 
     // Allow paths under the production tmpfs mount or the /tmp fallback (local dev).
     // Both are restricted directories where only TempFileStore writes.
+    // TODO: read CURIA_TEMPFILE_DIR env var to stay in sync with TempFileStore config
     const allowedPrefixes = ['/run/curia-tempfiles/', '/tmp/curia-tempfiles/'];
-    const allowed = allowedPrefixes.some((prefix) => filePath.startsWith(prefix));
-    if (!allowed) return null;
+    const logicallyAllowed = allowedPrefixes.some((prefix) => filePath.startsWith(prefix));
+    if (!logicallyAllowed) return null;
 
-    return filePath;
+    // Resolve symlinks to prevent a symlink inside the allowed directory from
+    // pointing to files outside it (e.g. ln -s /etc/shadow /tmp/curia-tempfiles/x).
+    let realPath: string;
+    try {
+      realPath = await fs.realpath(filePath);
+    } catch {
+      // File doesn't exist (ENOENT) — return the logical path and let the
+      // caller's fs.readFile produce the "expired" error message.
+      return filePath;
+    }
+
+    // Resolve the prefix directories too — on macOS /tmp is a symlink to
+    // /private/tmp, so both sides of the comparison must be resolved.
+    const resolvedPrefixes = await Promise.all(
+      allowedPrefixes.map(async (prefix) => {
+        try {
+          // realpath the directory (without trailing slash), then re-add it
+          return await fs.realpath(prefix.slice(0, -1)) + '/';
+        } catch {
+          return prefix; // directory doesn't exist, keep the original
+        }
+      }),
+    );
+    const allPrefixes = [...new Set([...allowedPrefixes, ...resolvedPrefixes])];
+    const reallyAllowed = allPrefixes.some((prefix) => realPath.startsWith(prefix));
+    if (!reallyAllowed) return null;
+
+    return realPath;
   }
 }
 

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -339,10 +339,16 @@ export class FileParseHandler implements SkillHandler {
     let realPath: string;
     try {
       realPath = await fs.realpath(filePath);
-    } catch {
-      // File doesn't exist (ENOENT) — return the logical path and let the
-      // caller's fs.readFile produce the "expired" error message.
-      return filePath;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        // File doesn't exist — return the logical path and let the
+        // caller's fs.readFile produce the "expired" error message.
+        return filePath;
+      }
+      // EACCES, EIO, etc. — can't verify the real path, reject the URL.
+      // Don't fall back to the logical path since that would bypass the
+      // symlink check on a path we couldn't resolve.
+      return null;
     }
 
     // Resolve the prefix directories too — on macOS /tmp is a symlink to
@@ -352,8 +358,13 @@ export class FileParseHandler implements SkillHandler {
         try {
           // realpath the directory (without trailing slash), then re-add it
           return await fs.realpath(prefix.slice(0, -1)) + '/';
-        } catch {
-          return prefix; // directory doesn't exist, keep the original
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+            // Unexpected error resolving a prefix dir — fall back to the
+            // original string rather than failing the entire validation.
+            // This is less security-critical since we control the prefix values.
+          }
+          return prefix;
         }
       }),
     );

--- a/skills/file-parse/skill.json
+++ b/skills/file-parse/skill.json
@@ -1,11 +1,12 @@
 {
   "name": "file-parse",
-  "description": "Parse a document (CSV, PDF, HTML, or image) and extract structured data. Accepts base64-encoded content and a MIME type. Optionally provide extract_as to get structured fields (receipt, bank_statement, invoice) instead of raw text. For CSV files, parsing is direct and deterministic. For images, PDFs, and HTML, uses Claude for text extraction and structuring. Returns a confidence score (0–1) for LLM-extracted results.",
-  "version": "1.0.0",
+  "description": "Parse a document (CSV, PDF, HTML, or image) and extract structured data. Accepts base64-encoded content OR a temp_file_url (file:// URL from ceo-inbox-download-attachment), plus a MIME type. Optionally provide extract_as to get structured fields (receipt, bank_statement, invoice) instead of raw text. For CSV files, parsing is direct and deterministic. For images, PDFs, and HTML, uses Claude for text extraction and structuring. Returns a confidence score (0–1) for LLM-extracted results.",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {
-    "content_base64": "string (base64-encoded file content)",
+    "content_base64": "string? (base64-encoded file content — required unless temp_file_url is provided)",
+    "temp_file_url": "string? (file:// URL pointing to a temp file on disk — alternative to content_base64; use the temp_file_url returned by ceo-inbox-download-attachment or email-download-attachment)",
     "mime_type": "string (MIME type, e.g. 'text/csv', 'application/pdf', 'image/jpeg', 'text/html')",
     "extract_as": "string? (optional extraction schema hint; defaults to 'raw'. Known schemas with tailored prompts: 'receipt', 'bank_statement', 'invoice'. Use 'raw' to skip LLM structuring. Any other non-empty string (e.g. 'purchase_order', 'business_card') triggers a generic extraction prompt using the schema name as a hint.)"
   },

--- a/skills/file-parse/skill.json
+++ b/skills/file-parse/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "file-parse",
   "description": "Parse a document (CSV, PDF, HTML, or image) and extract structured data. Accepts base64-encoded content OR a temp_file_url (file:// URL from ceo-inbox-download-attachment), plus a MIME type. Optionally provide extract_as to get structured fields (receipt, bank_statement, invoice) instead of raw text. For CSV files, parsing is direct and deterministic. For images, PDFs, and HTML, uses Claude for text extraction and structuring. Returns a confidence score (0–1) for LLM-extracted results.",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {


### PR DESCRIPTION
## **User description**
## Summary

- **file-parse** now reads temp files from disk when `content_base64` is empty but `temp_file_url` is provided
- Bridges the data flow gap introduced in commit 7e69293d (May 19), where `ceo-inbox-download-attachment` omits `content_base64` when temp storage is available
- Path validation restricts reads to `/run/curia-tempfiles/` and `/tmp/curia-tempfiles/` to prevent path traversal
- Fixes the T2125 expense tracker's "image-only" false positive on perfectly readable PDF receipts

## Context

On 2026-05-25, the T2125 expense tracker called `file-parse` with `content_base64: ""` because `ceo-inbox-download-attachment` returned only `temp_file_url`. `file-parse` rejected the empty input and the agent concluded the PDF was "image-only," filing an expense with a missing amount and emailing the CEO for manual entry.

Root cause confirmed via audit log: both parallel agent tasks hit `skill.result: {"error": "Missing required input: content_base64", "success": false}`.

## Test plan

- [x] 8 new unit tests covering: temp file read, absent content_base64, preference for content_base64, path traversal rejection, non-file URL rejection, expired file handling, updated error message
- [x] All 83 existing tests pass
- [x] TypeScript type check passes
- [ ] CI green


___

## **CodeAnt-AI Description**
**File parsing can use temp files when base64 content is missing**

### What Changed
- `file-parse` now accepts a `temp_file_url` when `content_base64` is empty, so documents saved to temp storage can still be parsed
- When both are provided, it uses the base64 content first
- Invalid temp file links, non-file links, and paths outside the allowed temp directories are rejected
- If the temp file is gone, the tool now returns a clear expired-file error
- The missing-input error now tells users they can provide `temp_file_url` instead

### Impact
`✅ Fewer failed receipt parses`
`✅ Fewer manual re-uploads`
`✅ Clearer file-missing errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File parsing now supports temporary file URLs as an alternative to direct file content, enabling streamlined integration with attachment-based workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->