### PR TITLE
fix: contact email lookup fails, contact-merge blocked for delegated specialists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Authorization trust fallback** — when a contact's free-text role has no config match, the system now falls back to `trust_level_defaults` (new section in `role-defaults.yaml`) before reaching `unknown`. Family members and other free-text-role contacts with an explicit trust grant now get appropriate permissions.
 - **Authorization boundary hardening** — unknown `trustLevel` values from the DB now throw (caught safely by contact-resolver, degrades to `authorization=null`) instead of silently collapsing to low trust; permissions with unrecognized sensitivity values escalate to the CEO instead of silently landing in `trustBlocked`; config loader validates that `trust_level_defaults` is a YAML mapping at startup.
 - **`file-parse`** — accepts `temp_file_url` as alternative to `content_base64`, bridging the gap with `ceo-inbox-download-attachment` which omits base64 content when temp storage is available.
+- **`contact-lookup`** — channel/email lookups now return status and identities (previously omitted); skill manifest documents input format so the LLM knows to use `by: "channel"` with `email:addr` syntax.
+- **`contact-merge`** — removed stale `ctx.caller` guard that blocked all delegated specialists; principal origination is already enforced by the execution layer's elevated-skill gate.
+- **`contact-grant-permission`** — falls back to originator contactId when caller context is unavailable (delegated specialist path).
+- **Email case sensitivity** — `linkIdentity` now normalizes email addresses to lowercase; `resolveByChannelIdentity` uses case-insensitive matching so mixed-case emails are found.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`contact-lookup`** — channel/email lookups now return status and identities (previously omitted); skill manifest documents input format so the LLM knows to use `by: "channel"` with `email:addr` syntax.
 - **`contact-merge`** — removed stale `ctx.caller` guard that blocked all delegated specialists; principal origination is already enforced by the execution layer's elevated-skill gate.
 - **`contact-grant-permission`** — falls back to originator contactId when caller context is unavailable (delegated specialist path).
-- **Email case sensitivity** — `linkIdentity` now normalizes email addresses to lowercase; `resolveByChannelIdentity` uses case-insensitive matching so mixed-case emails are found.
+- **Email case sensitivity** — `linkIdentity` now normalizes email addresses to lowercase; `resolveByChannelIdentity` uses case-insensitive matching so mixed-case emails are found. Migration 044 adds a functional unique index on `LOWER(channel_identifier)` for the email channel.
 
 ### Added
 

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -99,6 +99,9 @@ system_prompt: |
     then respond based on what it returns. Skipping this step and guessing is not
     acceptable.
   - contact-lookup supports partial name matching. "Joe" will find "Joe Brennan".
+  - To look up a contact by email address, use by: "channel" with
+    query: "email:address@domain.com". By-name lookup only matches display names,
+    not email addresses.
   - Always search contacts before asking the coordinator to ask the CEO for details.
   - The lookup returns channel identities (email, phone, etc.) alongside the contact.
   - If a contact's status is "provisional", flag this in your response — provisional

--- a/skills/contact-grant-permission/handler.ts
+++ b/skills/contact-grant-permission/handler.ts
@@ -1,6 +1,8 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { TaskOriginator } from '../../src/contacts/types.js';
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export class ContactGrantPermissionHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     const { contact_id, permission, granted } = ctx.input as {
@@ -35,10 +37,14 @@ export class ContactGrantPermissionHandler implements SkillHandler {
     // agent runtime has senderContext), fall back to originator (always forwarded
     // through delegation). Delegated specialists don't receive senderContext, so
     // caller is undefined — but originator carries the principal's contactId.
+    // The execution layer's elevated-skill gate ensures the originator has
+    // systemRole === 'principal' before we reach here, which implies the
+    // originator object has the correct shape. The explicit UUID check below
+    // guards the audit trail against malformed metadata.
     const originator = ctx.taskMetadata?.originator as TaskOriginator | undefined;
     const actorContactId = ctx.caller?.contactId ?? originator?.contactId;
-    if (!actorContactId) {
-      return { success: false, error: 'Cannot determine actor identity for audit trail — neither caller nor originator available' };
+    if (!actorContactId || !UUID_RE.test(actorContactId)) {
+      return { success: false, error: 'Cannot determine valid actor identity for audit trail — neither caller nor originator provides a valid UUID contactId' };
     }
 
     try {

--- a/skills/contact-grant-permission/handler.ts
+++ b/skills/contact-grant-permission/handler.ts
@@ -1,4 +1,5 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import type { TaskOriginator } from '../../src/contacts/types.js';
 
 export class ContactGrantPermissionHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -30,15 +31,18 @@ export class ContactGrantPermissionHandler implements SkillHandler {
       return { success: false, error: 'contact-grant-permission: contactService not available — this is a universal service, check ExecutionLayer configuration.' };
     }
 
-    // Defensive guard — the execution layer guarantees caller is defined for
-    // elevated skills, but guard explicitly so a broken invariant produces a
-    // clear error instead of a cryptic TypeError.
-    if (!ctx.caller) {
-      return { success: false, error: 'Caller context is required for this skill but was not provided' };
+    // Derive actor identity for the audit trail. Prefer caller (set when the
+    // agent runtime has senderContext), fall back to originator (always forwarded
+    // through delegation). Delegated specialists don't receive senderContext, so
+    // caller is undefined — but originator carries the principal's contactId.
+    const originator = ctx.taskMetadata?.originator as TaskOriginator | undefined;
+    const actorContactId = ctx.caller?.contactId ?? originator?.contactId;
+    if (!actorContactId) {
+      return { success: false, error: 'Cannot determine actor identity for audit trail — neither caller nor originator available' };
     }
 
     try {
-      await ctx.contactService.grantPermission(contact_id, permission, granted, ctx.caller.contactId);
+      await ctx.contactService.grantPermission(contact_id, permission, granted, actorContactId);
       const action = granted ? 'granted' : 'denied';
       ctx.log.info({ contactId: contact_id, permission, granted }, `Permission ${action}`);
       return { success: true, data: { contact_id, permission, granted } };

--- a/skills/contact-lookup/handler.ts
+++ b/skills/contact-lookup/handler.ts
@@ -100,18 +100,20 @@ export class ContactLookupHandler implements SkillHandler {
         };
       }
 
+      // Use enrichContact (same as name/role paths) so the response includes
+      // status and channel identities — previously omitted, which prevented
+      // the LLM from determining whether a contact was provisional.
+      const contact = {
+        id: resolved.contactId,
+        displayName: resolved.displayName,
+        role: resolved.role,
+        status: resolved.status,
+        kgNodeId: resolved.kgNodeId,
+      };
+      const enriched = await enrichContact(ctx, contact);
       return {
         success: true,
-        data: {
-          contacts: [{
-            contact_id: resolved.contactId,
-            display_name: resolved.displayName,
-            role: resolved.role,
-            kg_node_id: resolved.kgNodeId,
-            verified: resolved.verified,
-          }],
-          count: 1,
-        },
+        data: { contacts: [enriched], count: 1 },
       };
     } catch (err) {
       ctx.log.error({ err, query, by }, 'Contact lookup failed');

--- a/skills/contact-lookup/skill.json
+++ b/skills/contact-lookup/skill.json
@@ -5,8 +5,8 @@
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
-    "query": "string",
-    "by": "string"
+    "query": "string (for name: a name or partial name; for channel: format as 'channel:identifier' e.g. 'email:jenna@acme.com')",
+    "by": "string (name | role | channel)"
   },
   "outputs": {
     "contacts": "array",

--- a/skills/contact-merge/handler.ts
+++ b/skills/contact-merge/handler.ts
@@ -4,7 +4,9 @@
 // before committing. The Coordinator MUST present the preview to the CEO and
 // get confirmation before calling with dry_run: false.
 //
-// Elevated skill — requires caller context (same pattern as contact-grant-permission).
+// Elevated skill — principal origination enforced by the execution layer's
+// elevated-skill gate (isPrincipalOriginated). No handler-level caller guard
+// needed; caller may be undefined for delegated specialists.
 //
 // @TODO (autonomy): When the autonomy engine reaches "supervised" or higher, consider
 // lowering the confirmation requirement for `certain`-confidence merges. At "full" autonomy,
@@ -41,11 +43,6 @@ export class ContactMergeHandler implements SkillHandler {
     }
     if (!ctx.contactService) {
       return { success: false, error: 'contact-merge: contactService not available — this is a universal service, check ExecutionLayer configuration.' };
-    }
-    // Elevated skill — execution layer guarantees caller is set, but guard explicitly
-    // so a broken invariant produces a clear error instead of a cryptic TypeError.
-    if (!ctx.caller) {
-      return { success: false, error: 'caller context is required for this elevated skill.' };
     }
 
     // Default dry_run: true — safe default, prevents accidental merges without CEO confirmation

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -473,11 +473,19 @@ export class ContactService {
       throw new Error('Cannot force-verify a self_claimed identity — CEO confirmation required');
     }
 
+    // Normalize email addresses to lowercase for case-insensitive matching.
+    // RFC 5321 allows case-sensitive local-parts, but in practice no major
+    // provider enforces this — storing mixed-case causes lookup misses when
+    // the LLM or inbound adapter uses a different casing.
+    const normalizedIdentifier = options.channel === 'email'
+      ? options.channelIdentifier.toLowerCase()
+      : options.channelIdentifier;
+
     const identity: ChannelIdentity = {
       id: randomUUID(),
       contactId: options.contactId,
       channel: options.channel,
-      channelIdentifier: options.channelIdentifier,
+      channelIdentifier: normalizedIdentifier,
       label: options.label ?? null,
       verified,
       verifiedAt: verified ? now : null,
@@ -1098,6 +1106,12 @@ class PostgresContactBackend implements ContactServiceBackend {
     channel: string,
     channelIdentifier: string,
   ): Promise<ResolvedSender | null> {
+    // Normalize email lookups to lowercase so mixed-case entries (stored before
+    // write-time normalization was added) are still matched.
+    const normalizedId = channel === 'email'
+      ? channelIdentifier.toLowerCase()
+      : channelIdentifier;
+
     const result = await this.pool.query<{
       id: string;
       display_name: string;
@@ -1113,8 +1127,8 @@ class PostgresContactBackend implements ContactServiceBackend {
               c.contact_confidence, c.trust_level
        FROM contact_channel_identities cci
        JOIN contacts c ON c.id = cci.contact_id
-       WHERE cci.channel = $1 AND cci.channel_identifier = $2`,
-      [channel, channelIdentifier],
+       WHERE cci.channel = $1 AND LOWER(cci.channel_identifier) = $2`,
+      [channel, normalizedId],
     );
 
     const row = result.rows[0];
@@ -1623,9 +1637,17 @@ class InMemoryContactBackend implements ContactServiceBackend {
     channel: string,
     channelIdentifier: string,
   ): Promise<ResolvedSender | null> {
+    // Normalize email lookups to lowercase (mirrors Postgres backend).
+    const normalizedId = channel === 'email'
+      ? channelIdentifier.toLowerCase()
+      : channelIdentifier;
+
     // Find the matching identity, then look up the contact
     for (const identity of this.identities.values()) {
-      if (identity.channel === channel && identity.channelIdentifier === channelIdentifier) {
+      const storedId = channel === 'email'
+        ? identity.channelIdentifier.toLowerCase()
+        : identity.channelIdentifier;
+      if (identity.channel === channel && storedId === normalizedId) {
         const contact = this.contacts.get(identity.contactId);
         if (contact) {
           return {

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -1127,7 +1127,9 @@ class PostgresContactBackend implements ContactServiceBackend {
               c.contact_confidence, c.trust_level
        FROM contact_channel_identities cci
        JOIN contacts c ON c.id = cci.contact_id
-       WHERE cci.channel = $1 AND LOWER(cci.channel_identifier) = $2`,
+       WHERE cci.channel = $1
+         AND CASE WHEN $1 = 'email' THEN LOWER(cci.channel_identifier) = $2
+                  ELSE cci.channel_identifier = $2 END`,
       [channel, normalizedId],
     );
 

--- a/src/db/migrations/044_cci_email_lower_unique_index.sql
+++ b/src/db/migrations/044_cci_email_lower_unique_index.sql
@@ -1,0 +1,45 @@
+-- Migration 044: Case-insensitive unique index on contact_channel_identities email identifiers.
+--
+-- Background: contact-lookup and resolveByChannelIdentity now use LOWER() when searching
+-- by email channel to handle mixed-case email addresses. Without a functional index,
+-- the LOWER() predicate causes a sequential scan on the full table.
+--
+-- This migration adds a functional index on (channel, LOWER(channel_identifier)) scoped
+-- to the email channel. It also enforces uniqueness at the DB level, closing the gap
+-- where linkIdentity could theoretically insert both 'Jenna@Acme.com' and 'jenna@acme.com'
+-- as separate rows (both pass the original exact-match UNIQUE constraint).
+--
+-- Non-email channels (phone, signal, telegram) are left with the original exact-match
+-- constraint; their identifiers may be legitimately case-sensitive.
+--
+-- Dedup step: if legacy data contains case-variant duplicates for the same email
+-- address, the unique index creation would fail. We deterministically keep the row
+-- with the lowest UUID (arbitrary but stable) and delete the rest before building
+-- the index.
+
+-- Step 1: Remove case-variant duplicate email identities (keep lowest id per group).
+-- Cast to text because PostgreSQL has no built-in MIN() aggregate for uuid.
+DELETE FROM contact_channel_identities
+WHERE channel = 'email'
+  AND id::text NOT IN (
+    SELECT MIN(id::text)
+    FROM contact_channel_identities
+    WHERE channel = 'email'
+    GROUP BY channel, LOWER(channel_identifier)
+  );
+
+-- Step 2: Normalize surviving email identifiers to lowercase (aligns stored data
+-- with the write-time normalization added to linkIdentity in this release).
+UPDATE contact_channel_identities
+SET channel_identifier = LOWER(channel_identifier)
+WHERE channel = 'email'
+  AND channel_identifier <> LOWER(channel_identifier);
+
+-- Step 3: Create the unique functional index.
+-- NOTE: Cannot use CONCURRENTLY inside a transaction (node-pg-migrate wraps each
+-- migration file in a transaction by default). The index is small (email-only subset)
+-- so a regular CREATE INDEX is acceptable; for very large tables, split this into a
+-- separate non-transactional migration.
+CREATE UNIQUE INDEX idx_cci_email_lower_unique
+  ON contact_channel_identities (channel, LOWER(channel_identifier))
+  WHERE channel = 'email';

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -306,6 +306,50 @@ describe('ContactService', () => {
       expect(resolved).toBeNull();
     });
 
+    it('resolves by email regardless of case (case-insensitive match)', async () => {
+      const contact = await service.createContact({ displayName: 'Jane', source: 'email_participant', status: 'provisional' });
+      await service.linkIdentity({
+        contactId: contact.id,
+        channel: 'email',
+        channelIdentifier: 'Jane.Doe@Example.GOV',  // mixed-case as stored by old code
+        source: 'email_participant',
+      });
+      // Lookup with all-lowercase should still find it
+      const resolved = await service.resolveByChannelIdentity('email', 'jane.doe@example.gov');
+      expect(resolved).not.toBeNull();
+      expect(resolved!.displayName).toBe('Jane');
+      expect(resolved!.status).toBe('provisional');
+    });
+
+    it('normalizes email to lowercase on linkIdentity write', async () => {
+      const contact = await service.createContact({ displayName: 'Test', source: 'ceo_stated' });
+      await service.linkIdentity({
+        contactId: contact.id,
+        channel: 'email',
+        channelIdentifier: 'Mixed.Case@Example.COM',
+        source: 'ceo_stated',
+      });
+      // Should be stored and findable in lowercase
+      const resolved = await service.resolveByChannelIdentity('email', 'mixed.case@example.com');
+      expect(resolved).not.toBeNull();
+      // Uppercase lookup should also work (because lookups normalize too)
+      const resolvedUpper = await service.resolveByChannelIdentity('email', 'MIXED.CASE@EXAMPLE.COM');
+      expect(resolvedUpper).not.toBeNull();
+    });
+
+    it('does not apply case normalization to non-email channels', async () => {
+      const contact = await service.createContact({ displayName: 'Signal User', source: 'signal_participant' });
+      await service.linkIdentity({
+        contactId: contact.id,
+        channel: 'signal',
+        channelIdentifier: '+14165550123',
+        source: 'signal_participant',
+      });
+      // Exact match works
+      const resolved = await service.resolveByChannelIdentity('signal', '+14165550123');
+      expect(resolved).not.toBeNull();
+    });
+
     it('resolveByChannelIdentity returns contactConfidence and trustLevel', async () => {
       // Create a contact with non-default confidence
       const contactId = (await service.createContact({

--- a/tests/unit/skills/contact-merge.test.ts
+++ b/tests/unit/skills/contact-merge.test.ts
@@ -62,16 +62,28 @@ describe('ContactMergeHandler', () => {
     if (!result.success) expect(result.error).toContain('contactService');
   });
 
-  it('returns failure when caller context is missing', async () => {
+  it('proceeds without caller context (elevated gate enforced by execution layer)', async () => {
+    // The handler no longer guards on ctx.caller — principal origination is
+    // enforced by the execution layer's elevated-skill gate. Delegated specialists
+    // don't receive senderContext, so caller is undefined in that path.
+    const goldenRecord = {
+      displayName: 'Jenna Torres', role: 'CFO', notes: null,
+      status: 'confirmed', identities: [], authOverrides: [],
+    };
     const contactService = {
-      mergeContacts: vi.fn().mockResolvedValue({ dryRun: true }),
+      mergeContacts: vi.fn().mockResolvedValue({
+        primaryContactId: VALID_UUID_A,
+        secondaryContactId: VALID_UUID_B,
+        goldenRecord,
+        dryRun: true,
+      }),
     };
     const result = await handler.execute(makeCtx(
       { primary_contact_id: VALID_UUID_A, secondary_contact_id: VALID_UUID_B },
       { contactService: contactService as never, caller: undefined },
     ));
-    expect(result.success).toBe(false);
-    if (!result.success) expect(result.error).toContain('caller');
+    expect(result.success).toBe(true);
+    expect(contactService.mergeContacts).toHaveBeenCalledWith(VALID_UUID_A, VALID_UUID_B, true);
   });
 
   it('calls mergeContacts with dry_run: true by default', async () => {


### PR DESCRIPTION
## **User description**
## Summary

Fixes two production bugs found in conversation `kg-web-a3925788-9e62-42ea-808b-b37cc61c9151`:

- **Bug 1 — `contact-lookup` by email returned no results:** The `by: "channel"` path manually constructed a stripped response (missing `status` and identities), and the skill manifest had no input documentation so the LLM defaulted to `by: "name"` with the email address as query (which never matches). Fixed by: adding input format docs to `skill.json`, adding channel lookup guidance to the contacts specialist prompt, and routing the channel path through `enrichContact()` like the other paths.
- **Bug 2 — `contact-merge` blocked for delegated specialists:** The handler guarded on `ctx.caller`, which is always `undefined` for delegated specialists (the delegate skill forwards `originator` but not `senderContext`). The elevated-skill gate in the execution layer already enforces principal origination — the handler guard was redundant and incorrect. Also fixed `contact-grant-permission` to fall back to `originator.contactId` (with UUID validation) when caller is unavailable.
- **Hardening — case-insensitive email matching:** `linkIdentity` now normalizes email to lowercase; both backends use case-insensitive comparison on lookup. Migration 044 adds a functional unique index on `LOWER(channel_identifier)` for the email channel (fixes seq scan from `LOWER()` query, and enforces case-insensitive uniqueness at the DB level).

Related: follow-up issue josephfung/curia#710 tracks the architectural fix (delegate skill forwarding senderContext).

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] All unit tests pass (skills, contacts, channels)
- [x] New tests: `contact-service.test.ts` — 3 new cases covering case-insensitive lookup, write normalization, and non-email passthrough
- [x] Updated `contact-merge.test.ts` — caller-undefined test now verifies the merge proceeds (not rejects)
- [ ] Deploy to staging and re-run the production conversation scenario manually


___

## **CodeAnt-AI Description**
**Fix contact email lookup and delegated merge access**

### What Changed
- Contact lookup by email now returns the contact's status and identities, so provisional contacts are shown correctly.
- The contacts guidance now tells the system to use `by: "channel"` with `email:address@domain.com` for email lookups.
- Contact merge now works for delegated specialists instead of failing when caller context is missing.
- Email addresses are matched without case sensitivity, so mixed-case emails still resolve.
- Permission changes now record the actor correctly even when caller context is unavailable.

### Impact
`✅ Fewer missed contact lookups`
`✅ Fewer blocked delegated merges`
`✅ Clearer provisional contact results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Email-based contact lookups now available with case-insensitive matching
  * File parsing now accepts temporary file URLs as an alternative input method
  * Contact lookup results enhanced to include identity information

* **Improvements**
  * Email identifiers normalized to lowercase for consistent identity linking across the platform
  * Contact permission granting and merge operations enhanced for improved reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->