### PR TITLE
fix: synthesize CallerContext from originator for delegated specialist tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Delegated specialist `ctx.caller`** — the agent runtime now synthesizes `CallerContext` from `taskMetadata.originator` when `senderContext` is absent, so specialists invoked by `delegate` always have `ctx.caller` populated. (#710)
+
 - **Authorization role lookup** — role name is now normalized to lowercase before config lookup, so LLM-assigned roles like `'Spouse'` correctly match the `spouse` key in `role-defaults.yaml` instead of falling through to `unknown` (denied: \*).
 - **Authorization trust gating** — effective trust is now `max(channelTrust, contactTrustLevel)`, so confirmed contacts with an explicit `trust_level` grant (e.g. `high`, `ceo`) are no longer downgraded by the email channel's inherent low-trust floor. Fixes the CEO being unable to request their own calendar via email.
 - **Authorization trust fallback** — when a contact's free-text role has no config match, the system now falls back to `trust_level_defaults` (new section in `role-defaults.yaml`) before reaching `unknown`. Family members and other free-text-role contacts with an explicit trust grant now get appropriate permissions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **Delegated specialist `ctx.caller`** — the agent runtime now synthesizes `CallerContext` from `taskMetadata.originator` when `senderContext` is absent, so specialists invoked by `delegate` always have `ctx.caller` populated. (#710)
-
 - **Authorization role lookup** — role name is now normalized to lowercase before config lookup, so LLM-assigned roles like `'Spouse'` correctly match the `spouse` key in `role-defaults.yaml` instead of falling through to `unknown` (denied: \*).
 - **Authorization trust gating** — effective trust is now `max(channelTrust, contactTrustLevel)`, so confirmed contacts with an explicit `trust_level` grant (e.g. `high`, `ceo`) are no longer downgraded by the email channel's inherent low-trust floor. Fixes the CEO being unable to request their own calendar via email.
 - **Authorization trust fallback** — when a contact's free-text role has no config match, the system now falls back to `trust_level_defaults` (new section in `role-defaults.yaml`) before reaching `unknown`. Family members and other free-text-role contacts with an explicit trust grant now get appropriate permissions.

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -617,12 +617,24 @@ export class AgentRuntime {
     // Truly unknown senders (no senderContext AND no originator) remain undefined, which
     // triggers the execution layer's fail-closed gate on elevated skills.
     const callerSenderCtx = taskEvent.payload.senderContext;
-    const originator = taskEvent.payload.metadata?.originator as TaskOriginator | undefined;
-    const caller: CallerContext | undefined = (callerSenderCtx && callerSenderCtx.resolved)
-      ? { contactId: callerSenderCtx.contactId, role: callerSenderCtx.role, channel: taskEvent.payload.channelId }
-      : originator
-        ? { contactId: originator.contactId, role: null, channel: originator.channel }
+    const rawOriginator = taskEvent.payload.metadata?.originator;
+    // Validate the originator shape before using it — metadata is Record<string, unknown>
+    // so a malformed originator must not silently produce wrong audit fields downstream.
+    const originator: TaskOriginator | undefined =
+      typeof (rawOriginator as Record<string, unknown> | undefined)?.contactId === 'string' &&
+      typeof (rawOriginator as Record<string, unknown> | undefined)?.channel === 'string'
+        ? rawOriginator as unknown as TaskOriginator
         : undefined;
+    let caller: CallerContext | undefined;
+    if (callerSenderCtx && callerSenderCtx.resolved) {
+      caller = { contactId: callerSenderCtx.contactId, role: callerSenderCtx.role, channel: taskEvent.payload.channelId };
+    } else if (originator) {
+      // Delegated task path: synthesize caller from originator so elevated skills can
+      // read ctx.caller (e.g. for grantedBy audit fields). role is null because originator
+      // does not carry the contact's role — only the systemRole used by the elevated gate.
+      logger.debug({ agentId, taskEventId: taskEvent.id, originatorContactId: originator.contactId }, 'Synthesizing CallerContext from originator (delegated task path)');
+      caller = { contactId: originator.contactId, role: null, channel: originator.channel };
+    }
 
     // Accumulate skill names across all tool-use turns so we can report them
     // on the agent.response event for audit and monitoring.

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -10,6 +10,7 @@ import type { WorkingMemory } from '../memory/working-memory.js';
 import type { EntityMemory } from '../memory/entity-memory.js';
 import type { ExecutionLayer } from '../skills/execution.js';
 import type { CallerContext } from '../skills/types.js';
+import type { TaskOriginator } from '../contacts/types.js';
 import { sanitizeOutput } from '../skills/sanitize.js';
 import { classifySkillError, formatTaskError } from '../errors/classify.js';
 import { DEFAULT_ERROR_BUDGET, type AgentError, type ErrorBudget } from '../errors/types.js';
@@ -609,12 +610,19 @@ export class AgentRuntime {
     if (!response) return; // chatWithRetry already published error events
 
     // Extract caller context once — it doesn't change between tool-use rounds.
-    // Unresolved senders produce undefined, which triggers the execution layer's
-    // fail-closed gate on elevated skills — unknown senders can't modify permissions.
+    // Primary source: senderContext from the inbound message (set by the dispatcher).
+    // Fallback: taskMetadata.originator, which the delegate skill forwards when it creates
+    // a specialist task. Without this fallback, ctx.caller is always undefined for delegated
+    // specialists even when the original task was principal-originated (#710).
+    // Truly unknown senders (no senderContext AND no originator) remain undefined, which
+    // triggers the execution layer's fail-closed gate on elevated skills.
     const callerSenderCtx = taskEvent.payload.senderContext;
+    const originator = taskEvent.payload.metadata?.originator as TaskOriginator | undefined;
     const caller: CallerContext | undefined = (callerSenderCtx && callerSenderCtx.resolved)
       ? { contactId: callerSenderCtx.contactId, role: callerSenderCtx.role, channel: taskEvent.payload.channelId }
-      : undefined;
+      : originator
+        ? { contactId: originator.contactId, role: null, channel: originator.channel }
+        : undefined;
 
     // Accumulate skill names across all tool-use turns so we can report them
     // on the agent.response event for audit and monitoring.

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -665,6 +665,60 @@ describe('AgentRuntime tool-use loop', () => {
     expect(responseContent).toContain('Call count: 2');
   });
 
+  it('synthesizes caller from originator when senderContext is absent (delegated task path)', async () => {
+    // Regression test for #710: when the delegate skill creates a specialist task it omits
+    // senderContext. The runtime must fall back to taskMetadata.originator so ctx.caller
+    // is populated for elevated skills that need an audit contactId.
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+    const provider = createToolUseProvider('some-skill', {});
+
+    let capturedCaller: unknown;
+    const mockExecution = {
+      invoke: vi.fn().mockImplementation((_name: string, _input: unknown, caller: unknown) => {
+        capturedCaller = caller;
+        return Promise.resolve({ success: true, data: 'ok' });
+      }),
+    } as unknown as ExecutionLayer;
+
+    const agent = new AgentRuntime({
+      agentId: 'research-analyst',
+      systemPrompt: 'You are a specialist.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      skillToolDefs: [{ name: 'some-skill', description: 'A skill', input_schema: { type: 'object' as const, properties: {}, required: [] } }],
+    });
+    agent.register();
+
+    const originator = {
+      contactId: 'ceo-contact-id',
+      systemRole: 'principal' as const,
+      channel: 'email',
+      initiatedAt: '2026-05-01T10:00:00.000Z',
+    };
+
+    // No senderContext — simulates what delegate skill produces
+    const task = createAgentTask({
+      agentId: 'research-analyst',
+      conversationId: 'conv-delegate-1',
+      channelId: 'internal',
+      senderId: 'coordinator',
+      content: 'Do some research',
+      metadata: { originator },
+      parentEventId: 'delegate-parent-1',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(capturedCaller).toEqual({
+      contactId: 'ceo-contact-id',
+      role: null,
+      channel: 'email',
+    });
+  });
+
   it('handles skill failure gracefully in the tool loop', async () => {
     const logger = createLogger('error');
     const bus = new EventBus(logger);

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -671,6 +671,7 @@ describe('AgentRuntime tool-use loop', () => {
     // is populated for elevated skills that need an audit contactId.
     const logger = createLogger('error');
     const bus = new EventBus(logger);
+    bus.subscribe('agent.response', 'dispatch', () => {});
     const provider = createToolUseProvider('some-skill', {});
 
     let capturedCaller: unknown;


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause**: `delegate` skill creates specialist tasks without `senderContext`. The runtime derived `ctx.caller` exclusively from `senderContext`, so it was always `undefined` for delegated specialists.
- **Fix**: Agent runtime now falls back to `taskMetadata.originator` when `senderContext` is absent, synthesizing a minimal `CallerContext` with `contactId` and `channel` (role is `null` since originator doesn't carry it). Validates the originator shape before use to prevent malformed metadata writing garbage to audit fields.
- **`contact-grant-permission`**: Removes the now-redundant dead-code early-exit guard (the runtime guarantee is now structural), replacing it with a logged error response so an invariant violation still produces a clear signal instead of a cryptic TypeError.

Closes #710

## Test plan

- [ ] New test `synthesizes caller from originator when senderContext is absent (delegated task path)` in `tests/unit/agents/runtime.test.ts` confirms the fallback produces the correct `CallerContext` shape
- [ ] All existing elevated-skill gate tests in `tests/unit/skills/execution.test.ts` continue to pass unchanged
- [ ] All existing delegate skill tests in `tests/unit/skills/delegate.test.ts` continue to pass unchanged
- [ ] `pnpm run typecheck` passes clean
- [ ] Full test suite: 1080 tests passing


___

## **CodeAnt-AI Description**
**Populate caller context for delegated specialist tasks and keep permission writes safe**

### What Changed
- Specialist tasks created through delegation now get a caller context even when the original sender context is missing, so elevated skills can still record the right person in audit fields.
- The delegated-task fallback uses the task originator only when it looks valid, preventing malformed task metadata from writing incorrect contact details.
- Permission changes now fail with a clear logged error if caller context is unexpectedly missing, instead of crashing with a vague error.

### Impact
`✅ Fewer failed delegated permission updates`
`✅ Correct audit names on delegated specialist actions`
`✅ Clearer error messages when runtime context is missing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where delegated specialists were missing caller information in certain scenarios. The runtime now reliably synthesizes caller context from task metadata when the primary context source is unavailable, ensuring specialists always have access to caller details needed for their operations.

* **Tests**
  * Added regression test coverage for delegated specialist caller context handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->