### PR TITLE
chore: externalize delegate timeout and scheduler duration to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **Delegate timeout** — `DEFAULT_SPECIALIST_TIMEOUT_MS` moved from a hardcoded constant to `config.delegate.default_timeout_ms` (default 90s); deployments can override in `local.yaml` to match their standard-tier model latency without a code change. (#713)
+- **Scheduler recovery timeout** — `DEFAULT_EXPECTED_DURATION_SECONDS` moved to `config.scheduler.default_expected_duration_seconds` (default 600s); deployments can adjust the watchdog fallback without patching the runtime. (#713)
+- **Scheduled task durations** — `expectedDurationSeconds` bumped across coordinator (120→360s) and contacts (dedup 300→900s, daily promotion 180→540s) scheduled tasks to reflect higher-latency standard-tier model. (#713)
+- **`SkillContext`** — added `defaultDelegateTimeoutMs?: number` field (sourced from config, read by the delegate skill). (#713)
+
 ### Fixed
 
 - **Delegated specialist `ctx.caller`** — the agent runtime now synthesizes `CallerContext` from `taskMetadata.originator` when `senderContext` is absent, so specialists invoked by `delegate` always have `ctx.caller` populated. (#710)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,6 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
-### Changed
-
-- **Delegate timeout** — `DEFAULT_SPECIALIST_TIMEOUT_MS` moved from a hardcoded constant to `config.delegate.default_timeout_ms` (default 90s); deployments can override in `local.yaml` to match their standard-tier model latency without a code change. (#713)
-- **Scheduler recovery timeout** — `DEFAULT_EXPECTED_DURATION_SECONDS` moved to `config.scheduler.default_expected_duration_seconds` (default 600s); deployments can adjust the watchdog fallback without patching the runtime. (#713)
-- **Scheduled task durations** — `expectedDurationSeconds` bumped across coordinator (120→360s) and contacts (dedup 300→900s, daily promotion 180→540s) scheduled tasks to reflect higher-latency standard-tier model. (#713)
-- **`SkillContext`** — added `defaultDelegateTimeoutMs?: number` field (sourced from config, read by the delegate skill). (#713)
-
 ### Fixed
 
 - **Delegated specialist `ctx.caller`** — the agent runtime now synthesizes `CallerContext` from `taskMetadata.originator` when `senderContext` is absent, so specialists invoked by `delegate` always have `ctx.caller` populated. (#710)
@@ -50,6 +43,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **Delegate timeout** — `DEFAULT_SPECIALIST_TIMEOUT_MS` moved from a hardcoded constant to `config.delegate.defaultTimeoutMs` (default 90s); deployments can override in `local.yaml` to match their standard-tier model latency without a code change. (#713)
+- **Scheduler recovery timeout** — `DEFAULT_EXPECTED_DURATION_SECONDS` moved to `config.scheduler.defaultExpectedDurationSeconds` (default 600s); deployments can adjust the watchdog fallback without patching the runtime. (#713)
+- **Scheduled task durations** — `expectedDurationSeconds` bumped across coordinator (120→360s) and contacts (dedup 300→900s, daily promotion 180→540s) scheduled tasks to reflect higher-latency standard-tier model. (#713)
+- **`SkillContext`** — added `defaultDelegateTimeoutMs?: number` field (sourced from config, read by the delegate skill). (#713)
 - **Multi-turn clarification protocol** — moved from hand-written prompt conventions (~145 lines across coordinator + research-analyst YAML) to a code-backed `request-clarification` skill with runtime short-circuit and DelegateHandler resume_token support. Coordinator prompt reduced by ~50 lines, research-analyst by ~55 lines.
 - **`turn-budget`** — added anti-retry, error acceptance, and structured output guidance; proximity threshold widened from 3 to 5 turns remaining. (#689)
 - **`ceo-inbox-draft-reply` / `email-draft-save` / `email-send` / `email-reply`** — reply drafts and sends now include the quoted original message body below the reply text, matching standard email client behaviour. (#673)

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -236,7 +236,7 @@ pinned_skills:
 schedule:
   - cron: "0 9 * * 1"   # Mondays at 9 AM
     task: "Run your weekly contacts dedup scan — find probable and certain duplicate contact pairs, present them to the CEO for review one pair at a time, and merge confirmed pairs."
-    expectedDurationSeconds: 300
+    expectedDurationSeconds: 900
 
   - cron: "0 8 * * *"   # Daily at 8 AM
     task: >
@@ -277,4 +277,4 @@ schedule:
       5. Report a clear summary: how many provisional contacts were checked, how many
          were promoted, which signal triggered each promotion (curia_outbound,
          ceo_has_sent, or calendar_accepted), and how many provisional contacts remain.
-    expectedDurationSeconds: 180
+    expectedDurationSeconds: 540

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -603,8 +603,8 @@ allow_discovery: true
 schedule:
   - cron: "0 * * * *"
     task: "Run the approval expiry sweep — find and expire any pending approval requests that have passed their expiry time."
-    expectedDurationSeconds: 120
+    expectedDurationSeconds: 360
 
   - cron: "0 8 * * *"
     task: "Run the pending-actions digest — if any approval requests are still awaiting a decision, send a summary to the CEO."
-    expectedDurationSeconds: 120
+    expectedDurationSeconds: 360

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -110,6 +110,23 @@ skillOutput:
   # to reduce LLM context pressure on installations with many concurrent agents.
   maxLength: 200000  # 200k characters (~50k tokens at 4 chars/token)
 
+# Delegate skill configuration.
+# Controls the default timeout for specialist agent delegations when no explicit
+# timeout_ms is provided by the caller or runtime. Deployment-specific model
+# latency (e.g. switching the standard tier to a higher-latency model) can be
+# accommodated here without a code change or release.
+# Override in config/local.yaml to match your deployment's model latency.
+delegate:
+  default_timeout_ms: 90000   # 90s — appropriate for interactive delegations with Sonnet-class models
+
+# Scheduler configuration.
+# Controls runtime defaults for the scheduler watchdog and recovery logic.
+scheduler:
+  # Assumed task duration for scheduled jobs that declare no expectedDurationSeconds.
+  # Used by the watchdog to compute the recovery timeout (LEAST(expected × 7.5, expected + 3600)).
+  # Raise this if you run long-running scheduled jobs without explicit duration hints.
+  default_expected_duration_seconds: 600  # 10 minutes
+
 # Context bridge TTL configuration.
 # Controls how long outbound context entries remain active before automatic expiry.
 # Auto-registered entries (when the caller doesn't pass explicit context_bridge metadata)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -117,7 +117,7 @@ skillOutput:
 # accommodated here without a code change or release.
 # Override in config/local.yaml to match your deployment's model latency.
 delegate:
-  default_timeout_ms: 90000   # 90s — appropriate for interactive delegations with Sonnet-class models
+  defaultTimeoutMs: 90000   # 90s — appropriate for interactive delegations with Sonnet-class models
 
 # Scheduler configuration.
 # Controls runtime defaults for the scheduler watchdog and recovery logic.
@@ -125,7 +125,7 @@ scheduler:
   # Assumed task duration for scheduled jobs that declare no expectedDurationSeconds.
   # Used by the watchdog to compute the recovery timeout (LEAST(expected × 7.5, expected + 3600)).
   # Raise this if you run long-running scheduled jobs without explicit duration hints.
-  default_expected_duration_seconds: 600  # 10 minutes
+  defaultExpectedDurationSeconds: 600  # 10 minutes
 
 # Context bridge TTL configuration.
 # Controls how long outbound context entries remain active before automatic expiry.

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -294,14 +294,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "default_timeout_ms": { "type": "integer", "minimum": 1 }
+        "defaultTimeoutMs": { "type": "integer", "minimum": 1 }
       }
     },
     "scheduler": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "default_expected_duration_seconds": { "type": "integer", "minimum": 1 }
+        "defaultExpectedDurationSeconds": { "type": "integer", "minimum": 1 }
       }
     }
   },

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -289,6 +289,20 @@
         "reminderDelayMinutes": { "type": "integer", "minimum": 1 },
         "contextBridgeTtlHours": { "type": "integer", "minimum": 1 }
       }
+    },
+    "delegate": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "default_timeout_ms": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "scheduler": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "default_expected_duration_seconds": { "type": "integer", "minimum": 1 }
+      }
     }
   },
   "definitions": {

--- a/skills/delegate/handler.ts
+++ b/skills/delegate/handler.ts
@@ -65,7 +65,7 @@ export class DelegateHandler implements SkillHandler {
       Number.isInteger(timeout_ms) &&
       timeout_ms > 0 &&
       Number.isFinite(timeout_ms);
-    const specialistTimeoutMs = isValidTimeout ? (timeout_ms as number) : DEFAULT_SPECIALIST_TIMEOUT_MS;
+    const specialistTimeoutMs = isValidTimeout ? (timeout_ms as number) : (ctx.defaultDelegateTimeoutMs ?? DEFAULT_SPECIALIST_TIMEOUT_MS);
 
     if (timeout_ms !== undefined && !isValidTimeout) {
       ctx.log.warn(

--- a/src/config.ts
+++ b/src/config.ts
@@ -265,6 +265,17 @@ export interface YamlConfig {
     /** TTL in hours for context bridge entries linking replies to the debrief agent. Default: 48. */
     contextBridgeTtlHours?: number;
   };
+
+  delegate?: {
+    /** Default timeout in ms for specialist delegations when no timeout_ms is passed. Default: 90000.
+     *  Override in local.yaml to match your deployment's standard-tier model latency. */
+    default_timeout_ms?: number;
+  };
+  scheduler?: {
+    /** Default assumed duration in seconds for scheduled jobs that declare no expectedDurationSeconds.
+     *  Used by the watchdog to compute recovery timeouts. Default: 600. */
+    default_expected_duration_seconds?: number;
+  };
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -658,17 +658,35 @@ export function loadYamlConfig(configDir: string): YamlConfig {
     }
   }
 
-  // Validate delegate if present — a zero or negative timeout would let every delegation
-  // immediately time out, producing difficult-to-trace runtime symptoms.
+  // Validate delegate if present.
+  // Guard: if set to a scalar (e.g. `delegate: 90000`) optional chaining would silently
+  // return undefined and the override would be dropped — fail loudly instead.
+  if (config.delegate !== undefined && (typeof config.delegate !== 'object' || Array.isArray(config.delegate) || config.delegate === null)) {
+    throw new Error(`delegate must be a YAML mapping, got: ${typeof config.delegate}`);
+  }
   const delegateTimeoutMs = config.delegate?.defaultTimeoutMs;
-  if (delegateTimeoutMs !== undefined && (!Number.isInteger(delegateTimeoutMs) || delegateTimeoutMs <= 0)) {
-    throw new Error(`delegate.defaultTimeoutMs must be a positive integer (milliseconds), got: ${delegateTimeoutMs}`);
+  if (delegateTimeoutMs !== undefined) {
+    // A zero or negative value would let every delegation time out immediately.
+    if (!Number.isInteger(delegateTimeoutMs) || delegateTimeoutMs <= 0) {
+      throw new Error(`delegate.defaultTimeoutMs must be a positive integer (milliseconds), got: ${delegateTimeoutMs}`);
+    }
+    // Node.js setTimeout silently overflows values > 2^31-1, treating them as ~0 ms.
+    const NODE_MAX_TIMER_MS = 2_147_483_647;
+    if (delegateTimeoutMs > NODE_MAX_TIMER_MS) {
+      throw new Error(
+        `delegate.defaultTimeoutMs exceeds Node.js timer limit (${NODE_MAX_TIMER_MS} ms), got: ${delegateTimeoutMs}`,
+      );
+    }
   }
 
-  // Validate scheduler if present — a zero or negative duration would make the watchdog
-  // immediately flag every job with no explicit expectedDurationSeconds as stuck.
+  // Validate scheduler if present.
+  // Guard: same scalar-config pitfall as delegate above.
+  if (config.scheduler !== undefined && (typeof config.scheduler !== 'object' || Array.isArray(config.scheduler) || config.scheduler === null)) {
+    throw new Error(`scheduler must be a YAML mapping, got: ${typeof config.scheduler}`);
+  }
   const schedulerDefaultDuration = config.scheduler?.defaultExpectedDurationSeconds;
   if (schedulerDefaultDuration !== undefined && (!Number.isInteger(schedulerDefaultDuration) || schedulerDefaultDuration <= 0)) {
+    // A zero or negative duration would make the watchdog immediately flag all jobs as stuck.
     throw new Error(
       `scheduler.defaultExpectedDurationSeconds must be a positive integer (seconds), got: ${schedulerDefaultDuration}`,
     );

--- a/src/config.ts
+++ b/src/config.ts
@@ -658,6 +658,22 @@ export function loadYamlConfig(configDir: string): YamlConfig {
     }
   }
 
+  // Validate delegate if present — a zero or negative timeout would let every delegation
+  // immediately time out, producing difficult-to-trace runtime symptoms.
+  const delegateTimeoutMs = config.delegate?.default_timeout_ms;
+  if (delegateTimeoutMs !== undefined && (!Number.isInteger(delegateTimeoutMs) || delegateTimeoutMs <= 0)) {
+    throw new Error(`delegate.default_timeout_ms must be a positive integer (milliseconds), got: ${delegateTimeoutMs}`);
+  }
+
+  // Validate scheduler if present — a zero or negative duration would make the watchdog
+  // immediately flag every job with no explicit expectedDurationSeconds as stuck.
+  const schedulerDefaultDuration = config.scheduler?.default_expected_duration_seconds;
+  if (schedulerDefaultDuration !== undefined && (!Number.isInteger(schedulerDefaultDuration) || schedulerDefaultDuration <= 0)) {
+    throw new Error(
+      `scheduler.default_expected_duration_seconds must be a positive integer (seconds), got: ${schedulerDefaultDuration}`,
+    );
+  }
+
   return config;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -269,12 +269,12 @@ export interface YamlConfig {
   delegate?: {
     /** Default timeout in ms for specialist delegations when no timeout_ms is passed. Default: 90000.
      *  Override in local.yaml to match your deployment's standard-tier model latency. */
-    default_timeout_ms?: number;
+    defaultTimeoutMs?: number;
   };
   scheduler?: {
     /** Default assumed duration in seconds for scheduled jobs that declare no expectedDurationSeconds.
      *  Used by the watchdog to compute recovery timeouts. Default: 600. */
-    default_expected_duration_seconds?: number;
+    defaultExpectedDurationSeconds?: number;
   };
 }
 
@@ -660,17 +660,17 @@ export function loadYamlConfig(configDir: string): YamlConfig {
 
   // Validate delegate if present — a zero or negative timeout would let every delegation
   // immediately time out, producing difficult-to-trace runtime symptoms.
-  const delegateTimeoutMs = config.delegate?.default_timeout_ms;
+  const delegateTimeoutMs = config.delegate?.defaultTimeoutMs;
   if (delegateTimeoutMs !== undefined && (!Number.isInteger(delegateTimeoutMs) || delegateTimeoutMs <= 0)) {
-    throw new Error(`delegate.default_timeout_ms must be a positive integer (milliseconds), got: ${delegateTimeoutMs}`);
+    throw new Error(`delegate.defaultTimeoutMs must be a positive integer (milliseconds), got: ${delegateTimeoutMs}`);
   }
 
   // Validate scheduler if present — a zero or negative duration would make the watchdog
   // immediately flag every job with no explicit expectedDurationSeconds as stuck.
-  const schedulerDefaultDuration = config.scheduler?.default_expected_duration_seconds;
+  const schedulerDefaultDuration = config.scheduler?.defaultExpectedDurationSeconds;
   if (schedulerDefaultDuration !== undefined && (!Number.isInteger(schedulerDefaultDuration) || schedulerDefaultDuration <= 0)) {
     throw new Error(
-      `scheduler.default_expected_duration_seconds must be a positive integer (seconds), got: ${schedulerDefaultDuration}`,
+      `scheduler.defaultExpectedDurationSeconds must be a positive integer (seconds), got: ${schedulerDefaultDuration}`,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1074,7 +1074,7 @@ async function main(): Promise<void> {
       })
     : undefined;
 
-  const scheduler = new Scheduler({ pool, bus, logger, schedulerService, driftDetector, dreamEngine, outboundContextService });
+  const scheduler = new Scheduler({ pool, bus, logger, schedulerService, driftDetector, dreamEngine, outboundContextService, defaultExpectedDurationSeconds: yamlConfig.scheduler?.default_expected_duration_seconds });
 
   // SuspensionNotifier — emails the CEO when a scheduled job is auto-suspended.
   // Bypasses the LLM pipeline: notifies even when Anthropic is the thing that's down.
@@ -1163,7 +1163,7 @@ async function main(): Promise<void> {
   // entityContextAssembler enables entity_enrichment pre-enrichment and the
   // entity-context skill. agentContactId enables entity_enrichment default='agent'.
   // infraLlmService provides constrained LLM access (classify/extract) with telemetry.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, actionLogRepo, confidencePipeline, tempFileStore, infraLlmService, outboundContextService, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, actionLogRepo, confidencePipeline, tempFileStore, infraLlmService, outboundContextService, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength, defaultDelegateTimeoutMs: yamlConfig.delegate?.default_timeout_ms });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete

--- a/src/index.ts
+++ b/src/index.ts
@@ -1074,7 +1074,7 @@ async function main(): Promise<void> {
       })
     : undefined;
 
-  const scheduler = new Scheduler({ pool, bus, logger, schedulerService, driftDetector, dreamEngine, outboundContextService, defaultExpectedDurationSeconds: yamlConfig.scheduler?.default_expected_duration_seconds });
+  const scheduler = new Scheduler({ pool, bus, logger, schedulerService, driftDetector, dreamEngine, outboundContextService, defaultExpectedDurationSeconds: yamlConfig.scheduler?.defaultExpectedDurationSeconds });
 
   // SuspensionNotifier — emails the CEO when a scheduled job is auto-suspended.
   // Bypasses the LLM pipeline: notifies even when Anthropic is the thing that's down.
@@ -1163,7 +1163,7 @@ async function main(): Promise<void> {
   // entityContextAssembler enables entity_enrichment pre-enrichment and the
   // entity-context skill. agentContactId enables entity_enrichment default='agent'.
   // infraLlmService provides constrained LLM access (classify/extract) with telemetry.
-  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, actionLogRepo, confidencePipeline, tempFileStore, infraLlmService, outboundContextService, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength, defaultDelegateTimeoutMs: yamlConfig.delegate?.default_timeout_ms });
+  const executionLayer = new ExecutionLayer(skillRegistry, logger, { bus, agentRegistry, contactService, outboundGateway, heldMessages, schedulerService, entityMemory, agentPersona, nylasCalendarClient, entityContextAssembler, agentContactId: agentIdentityContactId, autonomyService, executiveProfileService, browserService, bullpenService, approvalTrigger, actionLogRepo, confidencePipeline, tempFileStore, infraLlmService, outboundContextService, timezone: config.timezone, selfEmail: resolvedEmailAccounts[0]?.selfEmail, skillOutputMaxLength: yamlConfig.skillOutput?.maxLength, defaultDelegateTimeoutMs: yamlConfig.delegate?.defaultTimeoutMs });
 
   // Two-pass agent registration:
   // Pass 1: Register all agents in the registry so specialistSummary() is complete

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -90,6 +90,9 @@ export interface SchedulerConfig {
   dreamEngine?: DreamEngine;
   /** Outbound context service — when present, expired/released rows are purged daily and at startup. */
   outboundContextService?: OutboundContextService;
+  /** Assumed task duration for jobs with no explicit expectedDurationSeconds.
+   *  Sourced from config.scheduler.default_expected_duration_seconds. Default: 600. */
+  defaultExpectedDurationSeconds?: number;
 }
 
 export class Scheduler {
@@ -100,6 +103,7 @@ export class Scheduler {
   private driftDetector?: DriftDetector;
   private dreamEngine?: DreamEngine;
   private outboundContextService?: OutboundContextService;
+  private defaultExpectedDurationSeconds: number;
   private intervalHandle: ReturnType<typeof setInterval> | null = null;
   private watchdogHandle: ReturnType<typeof setInterval> | null = null;
   private cleanupHandle: ReturnType<typeof setInterval> | null = null;
@@ -120,6 +124,7 @@ export class Scheduler {
     this.driftDetector = config.driftDetector;
     this.dreamEngine = config.dreamEngine;
     this.outboundContextService = config.outboundContextService;
+    this.defaultExpectedDurationSeconds = config.defaultExpectedDurationSeconds ?? DEFAULT_EXPECTED_DURATION_SECONDS;
   }
 
   /**
@@ -693,7 +698,7 @@ export class Scheduler {
       FOR UPDATE SKIP LOCKED
     `;
     const { rows } = await this.pool.query(sql, [
-      DEFAULT_EXPECTED_DURATION_SECONDS,
+      this.defaultExpectedDurationSeconds,
       RECOVERY_TIMEOUT_MULTIPLIER,
       RECOVERY_TIMEOUT_CAP_SECONDS,
     ]);

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -91,7 +91,7 @@ export interface SchedulerConfig {
   /** Outbound context service — when present, expired/released rows are purged daily and at startup. */
   outboundContextService?: OutboundContextService;
   /** Assumed task duration for jobs with no explicit expectedDurationSeconds.
-   *  Sourced from config.scheduler.default_expected_duration_seconds. Default: 600. */
+   *  Sourced from config.scheduler.defaultExpectedDurationSeconds. Default: 600. */
   defaultExpectedDurationSeconds?: number;
 }
 

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -547,7 +547,7 @@ export class ExecutionLayer {
       timezone: this.timezone,
       // Expose Curia's own email address so email skills can filter self from CC lists.
       selfEmail: this.selfEmail,
-      // Configurable fallback timeout for the delegate skill (sourced from config.delegate.default_timeout_ms).
+      // Configurable fallback timeout for the delegate skill (sourced from config.delegate.defaultTimeoutMs).
       defaultDelegateTimeoutMs: this.defaultDelegateTimeoutMs,
     };
 

--- a/src/skills/execution.ts
+++ b/src/skills/execution.ts
@@ -96,6 +96,8 @@ export class ExecutionLayer {
   private selfEmail?: string;
   /** Max character length for sanitized skill output before truncation. */
   private skillOutputMaxLength: number;
+  /** Configurable fallback timeout for the delegate skill when no timeout_ms is supplied. */
+  private defaultDelegateTimeoutMs?: number;
 
   constructor(registry: SkillRegistry, logger: Logger, options?: {
     bus?: EventBus;
@@ -122,6 +124,7 @@ export class ExecutionLayer {
     timezone?: string;
     selfEmail?: string;
     skillOutputMaxLength?: number;
+    defaultDelegateTimeoutMs?: number;
   }) {
     this.registry = registry;
     this.logger = logger;
@@ -149,6 +152,7 @@ export class ExecutionLayer {
     this.timezone = options?.timezone ?? 'UTC';
     this.selfEmail = options?.selfEmail;
     this.skillOutputMaxLength = options?.skillOutputMaxLength ?? DEFAULT_SKILL_OUTPUT_MAX_LENGTH;
+    this.defaultDelegateTimeoutMs = options?.defaultDelegateTimeoutMs;
   }
 
   /**
@@ -543,6 +547,8 @@ export class ExecutionLayer {
       timezone: this.timezone,
       // Expose Curia's own email address so email skills can filter self from CC lists.
       selfEmail: this.selfEmail,
+      // Configurable fallback timeout for the delegate skill (sourced from config.delegate.default_timeout_ms).
+      defaultDelegateTimeoutMs: this.defaultDelegateTimeoutMs,
     };
 
     // Capability-gated service injection.

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -231,6 +231,9 @@ export interface SkillContext {
    *  Provides a narrow surface (register + release) for managing outbound context bridge entries.
    *  Pre-scoped with conversationId by the execution layer. */
   outboundContext?: import('../dispatch/outbound-context.js').OutboundContextCapability;
+  /** Configurable fallback timeout for specialist delegations when no timeout_ms is supplied.
+   *  Sourced from config.delegate.default_timeout_ms. Relevant to the delegate skill only. */
+  defaultDelegateTimeoutMs?: number;
 }
 
 /**

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -232,7 +232,7 @@ export interface SkillContext {
    *  Pre-scoped with conversationId by the execution layer. */
   outboundContext?: import('../dispatch/outbound-context.js').OutboundContextCapability;
   /** Configurable fallback timeout for specialist delegations when no timeout_ms is supplied.
-   *  Sourced from config.delegate.default_timeout_ms. Relevant to the delegate skill only. */
+   *  Sourced from config.delegate.defaultTimeoutMs. Relevant to the delegate skill only. */
   defaultDelegateTimeoutMs?: number;
 }
 


### PR DESCRIPTION
## **User description**
## Summary

Closes #713

- Moves `DEFAULT_SPECIALIST_TIMEOUT_MS` (90s) from a hardcoded constant in `skills/delegate/handler.ts` into `config/default.yaml` as `delegate.default_timeout_ms`. Deployments can now override in `local.yaml` when switching to a higher-latency standard-tier model without a code change or release.
- Moves `DEFAULT_EXPECTED_DURATION_SECONDS` (600s) from a hardcoded constant in `src/scheduler/scheduler.ts` into `config/default.yaml` as `scheduler.default_expected_duration_seconds`. Deployments can adjust the watchdog fallback duration independently.
- Bumps `expectedDurationSeconds` on coordinator (120→360s) and contacts (dedup 300→900s, daily promotion 180→540s) scheduled tasks to reflect ~3× latency of higher-latency standard-tier models.
- Adds runtime validation in `loadYamlConfig()` for both new config keys — zero or negative values now fail loudly at startup rather than silently timing out every delegation or perpetually flagging all scheduler jobs as stuck.

**Config flow:**
`config/default.yaml` → `YamlConfig` interface → `index.ts` → `ExecutionLayer` options → `SkillContext.defaultDelegateTimeoutMs` → `skills/delegate/handler.ts`
`config/default.yaml` → `YamlConfig` interface → `index.ts` → `SchedulerConfig.defaultExpectedDurationSeconds` → `Scheduler` instance field

The companion curia-deploy PR overrides `delegate.default_timeout_ms: 240000` and bumps writing-scout and essay-editor scheduled task durations.

## Test plan

- [x] `tsc --noEmit` passes cleanly
- [x] Unit tests for delegate skill and scheduler pass (62 tests)
- [x] Existing behavior preserved: `DEFAULT_SPECIALIST_TIMEOUT_MS` and `DEFAULT_EXPECTED_DURATION_SECONDS` constants remain as the in-code fallback when config is absent (e.g. test/CI environments)
- [x] `config/default.yaml` documents both new fields with explanatory comments
- [x] JSON schema updated with `delegate` and `scheduler` sections


___

## **CodeAnt-AI Description**
**Make delegation and scheduler timeouts configurable**

### What Changed
- Specialist delegations now use a configurable default timeout when no timeout is supplied, instead of a fixed built-in value
- Scheduler recovery now uses a configurable default duration for jobs that do not set an expected runtime
- Startup now fails fast if either new setting is zero or negative, preventing delegations that time out immediately or jobs that are always treated as stuck
- Coordinator and contacts scheduled jobs now have longer expected durations to match slower model responses

### Impact
`✅ Fewer delegation timeouts`
`✅ Fewer stuck-job alerts`
`✅ Safer config overrides`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable delegation timeout setting (default: 90 seconds) for specialist agent operations when no explicit timeout is provided.
  * Added configurable scheduler expected duration setting (default: 600 seconds) for monitoring scheduled tasks.

* **Chores**
  * Updated scheduled task duration settings for contact deduplication, contact promotion sweeps, and approval workflows to reflect operational requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->