### PR TITLE
fix: add deepseek/deepseek-v4-pro to model registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **`deepseek/deepseek-v4-pro`** — added to model registry so it can be used as a standard-tier model in deployment config.
+
 ### Fixed
 
 - **Delegated specialist `ctx.caller`** — the agent runtime now synthesizes `CallerContext` from `taskMetadata.originator` when `senderContext` is absent, so specialists invoked by `delegate` always have `ctx.caller` populated. (#710)

--- a/src/agents/llm/model-registry.test.ts
+++ b/src/agents/llm/model-registry.test.ts
@@ -117,9 +117,18 @@ describe('ModelRegistry', () => {
       const meta = registry.getModel('deepseek/deepseek-v4-pro');
       expect(meta).toBeDefined();
       expect(meta!.provider).toBe('openrouter');
-      expect(meta!.contextWindow).toBe(128_000);
+      expect(meta!.contextWindow).toBe(1_000_000);
       expect(meta!.capabilities).toContain('coding');
       expect(meta!.capabilities).toContain('reasoning');
+    });
+
+    it('returns correct pricing for deepseek/deepseek-v4-pro', () => {
+      const pricing = registry.getPricing('deepseek/deepseek-v4-pro');
+      expect(pricing).toBeDefined();
+      expect(pricing!.inputPerMToken).toBe(0.435);
+      expect(pricing!.outputPerMToken).toBe(0.87);
+      expect(pricing!.cacheCreationPerMToken).toBeUndefined();
+      expect(pricing!.cacheReadPerMToken).toBeUndefined();
     });
 
     it('resolves openai/gpt-4o with provider openrouter', () => {

--- a/src/agents/llm/model-registry.test.ts
+++ b/src/agents/llm/model-registry.test.ts
@@ -113,6 +113,15 @@ describe('ModelRegistry', () => {
       expect(meta!.capabilities).toContain('coding');
     });
 
+    it('resolves deepseek/deepseek-v4-pro with provider openrouter', () => {
+      const meta = registry.getModel('deepseek/deepseek-v4-pro');
+      expect(meta).toBeDefined();
+      expect(meta!.provider).toBe('openrouter');
+      expect(meta!.contextWindow).toBe(128_000);
+      expect(meta!.capabilities).toContain('coding');
+      expect(meta!.capabilities).toContain('reasoning');
+    });
+
     it('resolves openai/gpt-4o with provider openrouter', () => {
       const meta = registry.getModel('openai/gpt-4o');
       expect(meta).toBeDefined();

--- a/src/agents/llm/model-registry.ts
+++ b/src/agents/llm/model-registry.ts
@@ -95,6 +95,17 @@ const MODEL_REGISTRY: Record<string, ModelMetadata> = {
     capabilities: ['coding'],
     maxOutputTokens: 8_192,
   },
+  // TODO: verify pricing against OpenRouter's pricing page — using v3 rates as placeholder.
+  'deepseek/deepseek-v4-pro': {
+    provider: 'openrouter',
+    contextWindow: 128_000,
+    pricing: {
+      inputPerMToken: 0.27,
+      outputPerMToken: 1.10,
+    },
+    capabilities: ['coding', 'reasoning'],
+    maxOutputTokens: 8_192,
+  },
   'openai/gpt-4o': {
     provider: 'openrouter',
     contextWindow: 128_000,

--- a/src/agents/llm/model-registry.ts
+++ b/src/agents/llm/model-registry.ts
@@ -95,13 +95,12 @@ const MODEL_REGISTRY: Record<string, ModelMetadata> = {
     capabilities: ['coding'],
     maxOutputTokens: 8_192,
   },
-  // TODO: verify pricing against OpenRouter's pricing page — using v3 rates as placeholder.
   'deepseek/deepseek-v4-pro': {
     provider: 'openrouter',
-    contextWindow: 128_000,
+    contextWindow: 1_000_000,
     pricing: {
-      inputPerMToken: 0.27,
-      outputPerMToken: 1.10,
+      inputPerMToken: 0.435,
+      outputPerMToken: 0.87,
     },
     capabilities: ['coding', 'reasoning'],
     maxOutputTokens: 8_192,


### PR DESCRIPTION
## **User description**
## Summary

`ModelRouter` validates all configured model IDs against the registry at startup and throws a fatal error for unknown models. `deepseek/deepseek-v4-pro` was set as the standard tier in curia-deploy (PR #96) but had no registry entry, causing a crash-loop on every restart.

- Adds `deepseek/deepseek-v4-pro` to `MODEL_REGISTRY` in `model-registry.ts`
- Provider: `openrouter`, context window: 128K, capabilities: `['coding', 'reasoning']`
- Pricing is placeholder (v3 rates) — **TODO: verify against OpenRouter's pricing page before cutting a release**
- Adds a test covering the new entry

**This is a prod outage fix** — curia is crash-looping on the current deployment.

## Test plan

- [x] `model-registry.test.ts` — 25/25 passing
- [x] TypeScript clean
- [ ] Deploy succeeds and curia starts without fatal error
- [ ] Standard-tier tasks route through deepseek/deepseek-v4-pro


___

## **CodeAnt-AI Description**
**Register `deepseek/deepseek-v4-pro` so deployments start cleanly**

### What Changed
- Added `deepseek/deepseek-v4-pro` to the model registry so it can be used as the standard-tier model in deployment settings
- The model now resolves with the OpenRouter provider, a 128K context window, and coding plus reasoning support
- Added a test to confirm the model is available in the registry
- Updated the changelog to note the new model entry

### Impact
`✅ Fewer startup crashes`
`✅ Standard-tier deployments can use deepseek-v4-pro`
`✅ Clearer release notes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
