### PR TITLE
fix: meeting-debrief no longer retries bullpen on timeout (#722)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **`meeting-debrief`** — system prompt now instructs the agent not to retry `bullpen.post` on timeout; on `<skill_error>...timed out</skill_error>` it records the meeting as `prompt_unconfirmed` and reconciles on the next tick. Stopgap until #721 lands a proper contract. (#722)
+
 ### Fixed
 
 - **Email reply quoting** — natural agent-response replies (no skill invocation) now include the quoted original message, matching the skill-driven paths. `buildReplyQuote` moved to `src/skills/_shared/` so the email channel adapter can share it. (#720)

--- a/agents/meeting-debrief.yaml
+++ b/agents/meeting-debrief.yaml
@@ -264,6 +264,37 @@ system_prompt: |
   entry for this meeting:
   - title, endedAt, promptedAt (now), attendees, status: "prompted"
 
+  ### Bullpen timeout handling
+
+  If a bullpen `post` call returns a timeout error (e.g.
+  `<skill_error>Skill 'bullpen' timed out after 10000ms</skill_error>`),
+  DO NOT retry the call. The thread may have been created on the server
+  side even though you saw a timeout — retrying will create a duplicate
+  thread and the CEO will receive duplicate prompts. Instead: record the
+  meeting in `pendingDebriefs` with status "prompt_unconfirmed" (title,
+  endedAt, attendees, promptedAt = now, reminderSentAt = null) and
+  continue to the next meeting.
+
+  On subsequent ticks, do NOT re-post for `prompt_unconfirmed` entries —
+  there is no skill action to query Bullpen for an existing thread, so
+  re-posting would risk the duplicate the rule above is meant to prevent.
+  Leave the entry as-is. One of two things will happen:
+  - The CEO replies (because the thread did get created server-side) —
+    delegated mode will process it normally; see Step D5 for the
+    status-transition rule.
+  - No reply arrives — Step 8 will prune the entry at TTL like any
+    other stale pending debrief.
+
+  Surface the count of `prompt_unconfirmed` entries in your
+  `scheduler-report` summary (Step 8) so the situation is observable.
+
+  This rule applies only to timeouts. Other bullpen errors (validation,
+  auth, missing fields) should be handled normally — fix the input and
+  retry as usual.
+
+  (Stopgap until #721 lands a proper post contract; revisit once the
+  skill can confirm thread creation atomically.)
+
   ## Step 7: Check reminders
 
   Scan `pendingDebriefs` for entries where:
@@ -300,6 +331,9 @@ system_prompt: |
   - summary: a brief human-readable description, e.g.:
     "Scanned 3 meetings, prompted for 1 (Acme sync), 0 reminders sent.
     2 debriefs pending response."
+    If any `pendingDebriefs` entries have status "prompt_unconfirmed"
+    (i.e. a prior bullpen.post timed out — see Step 6), call out the
+    count explicitly so the situation is observable.
   - context: your full state object:
     ```json
     {
@@ -380,7 +414,9 @@ system_prompt: |
   ## Step D5: Update state
 
   Call `scheduler-report` to update your state:
-  - Move the debrief entry from status "prompted" to "completed"
+  - Move the debrief entry to status "completed" (regardless of prior
+    status — "prompted" or "prompt_unconfirmed" both transition to
+    "completed" here)
   - Include a brief summary of what actions were taken
 
   ---

--- a/tests/unit/agents/loader.test.ts
+++ b/tests/unit/agents/loader.test.ts
@@ -102,6 +102,17 @@ schedule:
     fs.rmSync(tempDir, { recursive: true });
   });
 
+  it('meeting-debrief system prompt instructs no-retry on bullpen timeout (issue #722)', () => {
+    // Regression guard for #722 — without this instruction the LLM falls back
+    // to its retry heuristic when it sees `<skill_error>...timed out</skill_error>`
+    // from `bullpen.post`, creating duplicate threads (#721 contract bug means
+    // the thread is created server-side even when post times out).
+    const config = loadAgentConfig(path.join(agentsDir, 'meeting-debrief.yaml'));
+    expect(config.system_prompt).toContain('Bullpen timeout handling');
+    expect(config.system_prompt).toMatch(/do not retry/i);
+    expect(config.system_prompt).toContain('prompt_unconfirmed');
+  });
+
   it('parses model tier with needs array', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-test-'));
     const yamlContent = `


### PR DESCRIPTION
Closes #722

## Summary

- Adds a **Bullpen timeout handling** subsection to the `meeting-debrief` system prompt telling the LLM not to retry `bullpen.post` on `<skill_error>...timed out</skill_error>`. The thread is created server-side even on timeout (the #721 contract bug), so retrying produces duplicates (5 threads in 70s on 2026-05-26).
- Agent now records the meeting with status `prompt_unconfirmed` and stops. It does **not** re-post on subsequent ticks — the bullpen skill has no `list`/`search` action, so any reconciliation that "checks if a thread exists" is currently unimplementable. Re-posting would risk the exact duplicate this rule prevents.
- Step D5 reply-handling now transitions to `completed` from either `prompted` or `prompt_unconfirmed`, so a CEO reply on the "ghost" thread still resolves cleanly.
- Step 8 `scheduler-report` summary now calls out the `prompt_unconfirmed` count so the situation is observable.

Stopgap until #721 lands a proper post contract.

## Acceptance criteria

- [x] System prompt instructs the agent to not retry on `bullpen` timeout.
- [x] CHANGELOG.md entry under **Changed** referencing the incident.
- [ ] Offline LLM eval (input: timeout error after a `post`) shows the agent moves on rather than retrying.

The third criterion is partially addressed by a regression-guard unit test asserting the prompt contains the no-retry instruction (`tests/unit/agents/loader.test.ts`). A full behavioral LLM eval would require extending the smoke harness to support scheduled-mode task injection with mocked skill responses — out of scope for this stopgap. Once #721 lands the proper post contract, the eval should target the new contract directly.

## Trade-off

A genuinely-failed `post` (no thread created server-side) will now silently miss the CEO prompt until the entry is pruned at TTL. Accepted because:
- A missed prompt is recoverable (CEO can ask about the meeting; debrief preferences can be set per-recurring-meeting).
- A duplicate prompt train is not (the CEO got 4 duplicate Signal messages in 70 seconds in the original incident).
- The `prompt_unconfirmed` status + Step 8 summary makes the situation observable.

## Test plan

- [x] `tests/unit/agents/loader.test.ts` — new regression test asserts the prompt contains "Bullpen timeout handling" + a no-retry instruction + `prompt_unconfirmed` status.
- [x] `pnpm test tests/unit/agents/` passes (91 tests).
- [x] `pnpm run typecheck` clean.
- [ ] After deploy: monitor the next meeting-debrief timeout incident — confirm no duplicate threads and `prompt_unconfirmed` count appears in scheduler logs.