### PR TITLE
fix: strip Outlook VML <style> blocks from reply quote body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **Email reply quoting** — natural agent-response replies (no skill invocation) now include the quoted original message, matching the skill-driven paths. `buildReplyQuote` moved to `src/skills/_shared/` so the email channel adapter can share it. (#720)
+- **`reply-quote`** — Outlook-on-Windows VML CSS from `<style>` blocks no longer leaks into the quoted body as visible text; delegates to `html-to-text.ts` which strips style/script block contents. (#733)
 
 ## [0.31.0] — 2026-05-26 — "TARS"
 

--- a/src/skills/_shared/reply-quote.test.ts
+++ b/src/skills/_shared/reply-quote.test.ts
@@ -132,4 +132,36 @@ describe('buildReplyQuote', () => {
     expect(result).toContain('Date: Unknown date');
     expect(result).not.toContain('Invalid DateTime');
   });
+
+  // Regression: #733 — Outlook-on-Windows emails embed VML CSS in <style> blocks.
+  // The old local htmlToPlainText() stripped only tags, leaving the CSS text visible.
+  it('strips Outlook VML <style> block contents from the quoted body', () => {
+    // Minimal but realistic Outlook HTML: a <style> block with VML CSS rules
+    // followed by the actual message body. This is what enterprise senders produce.
+    const outlookVmlHtml = [
+      '<html><head>',
+      '<style>',
+      'v\\:* {behavior:url(#default#VML);}',
+      'o\\:* {behavior:url(#default#VML);}',
+      'w\\:* {behavior:url(#default#VML);}',
+      '.shape {behavior:url(#default#VML);}',
+      '</style>',
+      '</head><body>',
+      '<p>Hi Joseph,</p>',
+      '<p>Let me know your thoughts on the proposal.</p>',
+      '</body></html>',
+    ].join('\n');
+
+    const msg = makeMessage({ body: outlookVmlHtml });
+    const result = buildReplyQuote(msg, 'America/Toronto');
+
+    // VML CSS must not appear as visible text
+    expect(result).not.toContain('behavior:url');
+    expect(result).not.toContain('v\\:*');
+    expect(result).not.toContain('{behavior');
+
+    // Actual message text must survive
+    expect(result).toContain('Hi Joseph');
+    expect(result).toContain('Let me know your thoughts on the proposal.');
+  });
 });

--- a/src/skills/_shared/reply-quote.ts
+++ b/src/skills/_shared/reply-quote.ts
@@ -20,7 +20,7 @@ export interface QuoteableMessage {
   to: Array<{ name?: string; email: string }>;
   date: number;    // Unix epoch seconds
   subject: string;
-  body: string;    // HTML — will be stripped to plain text
+  body: string | undefined | null;  // HTML — will be stripped to plain text; undefined/null treated as empty
 }
 
 /**

--- a/src/skills/_shared/reply-quote.ts
+++ b/src/skills/_shared/reply-quote.ts
@@ -8,6 +8,7 @@
 // utilities (same pattern they use for SkillContext / SkillHandler types).
 
 import { DateTime } from 'luxon';
+import { htmlToText } from '../../channels/email/html-to-text.js';
 
 /**
  * Minimal message shape required to build a reply quote block.
@@ -20,39 +21,6 @@ export interface QuoteableMessage {
   date: number;    // Unix epoch seconds
   subject: string;
   body: string;    // HTML — will be stripped to plain text
-}
-
-/**
- * Strip HTML tags and decode common entities, leaving plain text suitable for
- * a quoted email block. Kept inline (rather than reusing src/channels/email/
- * html-to-text) so behavior matches the previous skills/_shared/ceo-nylas-client
- * implementation exactly — same regexes, same entity handling, same output.
- */
-function htmlToPlainText(html: string): string {
-  return html
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<\/p>/gi, '\n\n')
-    .replace(/<\/div>/gi, '\n')
-    .replace(/<\/li>/gi, '\n')
-    // Strip all complete HTML tags.
-    .replace(/<[^>]+>/g, '')
-    // Strip incomplete tags — bare <tagname without a closing > is not caught by <[^>]+>
-    // above (which requires >). This prevents injected <script fragments from surviving
-    // into the plain-text body that is shown to the LLM. {0,500} caps match length to
-    // prevent stripping large text bodies on inputs with a lone < far from any >.
-    .replace(/<[a-zA-Z][^>]{0,500}/g, '')
-    // Decode HTML entities.
-    // Order matters: &amp; must be decoded LAST to prevent double-decoding.
-    // Decoding &amp; first would turn &amp;lt; into &lt; and then into <,
-    // smuggling a literal < into the output.
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
 }
 
 /**
@@ -99,7 +67,7 @@ export function buildReplyQuote(message: QuoteableMessage, timezone?: string): s
     ? dt.toFormat('yyyy-MM-dd, h:mm a ZZZZ')
     : 'Unknown date';
 
-  const plainBody = htmlToPlainText(message.body);
+  const plainBody = htmlToText(message.body);
 
   const lines = [
     '',

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -290,9 +290,9 @@ describe('EmailAdapter — sendOutboundReply', () => {
     expect(callArg.body).toMatch(/Date: 2023-11-14, 5:13 PM EST/);
   });
 
-  it('sends without quote when buildReplyQuote throws', async () => {
-    // Match the email-reply skill's pattern: a message with body undefined causes
-    // htmlToPlainText(undefined) inside buildReplyQuote to throw. The recipient-
+  it('sends with quote headers (bodyless) when original body is undefined', async () => {
+    // htmlToText(undefined) returns '' gracefully, so buildReplyQuote succeeds and
+    // produces a quote block with headers but no body section. The recipient-
     // resolution code only touches from/to, so it still resolves cleanly.
     const brokenMessage = {
       ...makeMockMessage({
@@ -306,13 +306,16 @@ describe('EmailAdapter — sendOutboundReply', () => {
 
     await triggerOutbound(makeOutboundEvent('email:thread-abc'));
 
-    // Send still happens — unquoted
+    // Send still happens — quoted headers are included, body section is omitted
     expect(mocks.outboundGateway.send).toHaveBeenCalledOnce();
     const callArg = (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mock.calls[0]![0];
-    expect(callArg.body).toBe('Here is my reply.');
-    expect(callArg.body).not.toContain('---------- Original Message ----------');
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ threadId: 'thread-abc' }),
+    expect(callArg.body).toContain('Here is my reply.');
+    expect(callArg.body).toContain('---------- Original Message ----------');
+    // No body content after the headers (Subject: is the last line)
+    expect(callArg.body).toMatch(/Subject:.*$/m);
+    // No warning — buildReplyQuote succeeded
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
       expect.stringContaining('failed to build reply quote'),
     );
   });

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -314,8 +314,34 @@ describe('EmailAdapter — sendOutboundReply', () => {
     // No body content after the headers (Subject: is the last line)
     expect(callArg.body).toMatch(/Subject:.*$/m);
     // No warning — buildReplyQuote succeeded
-    expect(warnSpy).not.toHaveBeenCalledWith(
-      expect.anything(),
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('sends without quote and logs warning when buildReplyQuote throws', async () => {
+    // Force buildReplyQuote to throw by providing a null `to` field (null.map() throws
+    // TypeError inside buildReplyQuote). The adapter only accesses `to` when the latest
+    // message is ours; since `from` here is the human's address, `latestIsOurs` is false
+    // and recipient resolution succeeds — the throw happens inside buildReplyQuote itself.
+    // This exercises the try/catch at email-adapter.ts:486-496.
+    const throwingMessage = {
+      ...makeMockMessage({
+        from: [{ email: CEO_EMAIL }],
+        to: [{ email: SELF_EMAIL }],
+      }),
+      to: null as unknown as Array<{ email: string }>,
+    };
+    (mocks.outboundGateway.listEmailMessages as ReturnType<typeof vi.fn>).mockResolvedValue([throwingMessage]);
+    const warnSpy = vi.spyOn(mocks.logger, 'warn');
+
+    await triggerOutbound(makeOutboundEvent('email:thread-abc'));
+
+    // Send still happens — unquoted
+    expect(mocks.outboundGateway.send).toHaveBeenCalledOnce();
+    const callArg = (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    expect(callArg.body).toBe('Here is my reply.');
+    expect(callArg.body).not.toContain('---------- Original Message ----------');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: 'thread-abc' }),
       expect.stringContaining('failed to build reply quote'),
     );
   });


### PR DESCRIPTION
## **User description**
## Summary

Fixes #733.

- Deletes the local `htmlToPlainText()` in `src/skills/_shared/reply-quote.ts` and delegates to `htmlToText()` from `src/channels/email/html-to-text.ts`, which correctly loop-strips `<style>` and `<script>` block contents before tag-stripping.
- Adds a regression test using a real Outlook VML fixture (VML CSS selectors with `behavior:url(#default#VML)` declarations); asserts the CSS is absent and the message text survives.
- Widens `QuoteableMessage.body` to `string | undefined | null` to honestly reflect what `htmlToText()` accepts.
- Adds a test that exercises the email-adapter's `buildReplyQuote` try/catch path (previously untested after the behavior change).

## Behavior change

`htmlToText(undefined)` returns `''` instead of throwing. When Nylas returns a message with no body, `buildReplyQuote` now succeeds and produces quote headers without a body section (rather than throwing and omitting the quote entirely). The email-adapter test was updated to reflect this.

## Follow-up filed

Issue from the silent-failure review: stale comment in `skills/email-reply/handler.test.ts` asserting that `undefined` body causes `htmlToPlainText` to throw — that comment is now factually wrong and the inner catch path is untested. Logged as a follow-up so it doesn't block this fix.

## Test plan

- [ ] `src/skills/_shared/reply-quote.test.ts` — 13 tests pass (12 original + VML regression)
- [ ] `tests/unit/channels/email/email-adapter.test.ts` — 47 tests pass (44 original + 2 updated + 1 new catch-path test)
- [ ] `pnpm run typecheck` — clean
- [ ] Manual: draft a reply to an Outlook-sourced email; confirm no `behavior:url` / VML fragments in the quoted block


___

## **CodeAnt-AI Description**
**Stop Outlook VML style text from appearing in quoted replies**

### What Changed
- Quoted email replies now hide Outlook VML/CSS inside `<style>` blocks, so only the real message text appears
- Reply quoting now handles missing message bodies without failing, while still keeping the quoted header section
- Added coverage for both the Outlook VML case and the reply path that should still log a warning if quoting truly fails

### Impact
`✅ Cleaner quoted replies from Outlook emails`
`✅ Fewer reply failures when an email body is missing`
`✅ Clearer behavior when quote building does fail`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
