### PR TITLE
feat: inject ${principal_contact_id} runtime placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **`${principal_contact_id}` runtime placeholder** — agent system prompts can now reference the principal's contact ID directly; `meeting-debrief` and `calendar` no longer call `contact-lookup` by role on every invocation. (#716)
+
 ### Changed
 
 - **`meeting-debrief`** — system prompt now instructs the agent not to retry `bullpen.post` on timeout; on `<skill_error>...timed out</skill_error>` it records the meeting as `prompt_unconfirmed` and reconciles on the next tick. Stopgap until #721 lands a proper contract. (#722)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,24 @@ When adding a new agent, ensure it receives the autonomy block via the runtime i
 1. Create `agents/<name>.yaml` with required fields (name, description, model, system_prompt)
 2. Optionally add `handler: ./<name>.handler.ts` for custom logic
 
+### Reaching the principal
+
+Agents that need to send messages to, look up calendars for, or otherwise act
+on behalf of the principal MUST reference `${principal_contact_id}` in their
+system prompt. The runtime injects this placeholder at bootstrap from
+`contactService.findContactBySystemRole('principal')`.
+
+Pass `${principal_contact_id}` to `entity-context` to discover the principal's
+verified email addresses, Signal number, calendar IDs, and timezone. Do not
+hardcode addresses or phone numbers in agent prompts, and do not call
+`contact-lookup` by role for the principal — the platform resolves the ID
+once at bootstrap so every cron tick doesn't spend a skill call on an
+immutable value.
+
+This mirrors the existing `${agent_contact_id}` placeholder pattern (the
+agent's own identity). Both are opt-in: only agents that reference the
+placeholder pay the prompt-bytes cost.
+
 ## Creating Issues
 
 When creating a new GitHub issue:

--- a/agents/calendar.yaml
+++ b/agents/calendar.yaml
@@ -41,8 +41,9 @@ system_prompt: |
   - **Default for scheduling on behalf of the CEO** → always use the CEO's
     calendar unless the CEO explicitly says to use yours
 
-  To find the CEO's calendar: resolve the CEO via `contact-lookup` (by role),
-  then use `entity-context` to get their registered calendar IDs.
+  To find the CEO's calendar: use `${principal_contact_id}` (injected at
+  bootstrap), then call `entity-context` on that ID to get their registered
+  calendar IDs. Do NOT call `contact-lookup` by role for the CEO.
 
   ## Account Identity for Calendar Skills
   When creating, updating, or deleting events on behalf of the CEO, use the

--- a/agents/meeting-debrief.yaml
+++ b/agents/meeting-debrief.yaml
@@ -86,9 +86,9 @@ system_prompt: |
   1. Call `contact-lookup` to resolve to a contact ID.
   2. Call `entity-context` with the contact ID for enrichment.
 
-  At the start of the detection pipeline, resolve the CEO's contact via
-  `contact-lookup` (by role) and cache their contact ID for the run.
-  Use `entity-context` on the CEO's contact ID to discover their known
+  The CEO's contact ID is `${principal_contact_id}` — injected at bootstrap.
+  Use it directly; do NOT call `contact-lookup` by role for the CEO.
+  Call `entity-context` on `${principal_contact_id}` to discover their known
   email addresses — you need these for the solo-event filter in Step 3.
 
   ## Date and Timezone

--- a/docs/wip/2026-05-26-principal-contact-id-design.md
+++ b/docs/wip/2026-05-26-principal-contact-id-design.md
@@ -1,0 +1,135 @@
+# Design: Inject `${principal_contact_id}` as a runtime template variable
+
+**Issue:** [#716](https://github.com/josephfung/curia/issues/716)
+**Date:** 2026-05-26
+**Size:** S
+
+## Problem
+
+Scheduled agents that need the CEO's contact ID currently resolve it at runtime
+via `contact-lookup` by role. This is fragile: every cron tick spends an extra
+skill call (and tokens) on a value that does not change within a deployment, and
+the lookup can fail or be misinterpreted by the LLM.
+
+Two agents currently work around this:
+
+- **`meeting-debrief`** ([agents/meeting-debrief.yaml](../../agents/meeting-debrief.yaml),
+  Entity Resolution section, lines 89–92) — calls `contact-lookup` by role on
+  every 15-minute cron tick to discover the CEO's known email addresses for the
+  solo-event filter (Step 3).
+- **`calendar`** ([agents/calendar.yaml](../../agents/calendar.yaml), line 44) —
+  calls `contact-lookup` by role to identify the CEO's calendar.
+
+The runtime already injects `${agent_contact_id}` (the agent's own identity)
+via `interpolateRuntimeContext()` in [src/agents/loader.ts](../../src/agents/loader.ts).
+The same mechanism should inject `${principal_contact_id}`. The data is
+already loaded at bootstrap — `principalContact` is materialized at
+[src/index.ts:873](../../src/index.ts).
+
+## Scope
+
+**In scope:** Inject only the principal's contact UUID as `${principal_contact_id}`.
+This mirrors the existing `${agent_contact_id}` pattern.
+
+**Out of scope (explicit non-goals):**
+
+- Pre-resolving the principal's email identities, calendar IDs, timezone, or any
+  other enrichment data. Agents continue to call `entity-context` with the
+  injected ID when they need that information.
+- Per-turn refresh. The principal contact ID is immutable for a deployment, so
+  bootstrap-time injection is correct. (Identities and calendars *can* change,
+  which is why they are excluded — bootstrap-time injection of those would go
+  stale.)
+
+## Design
+
+### 1. `interpolateRuntimeContext()` — add the placeholder
+
+[src/agents/loader.ts](../../src/agents/loader.ts):
+
+- Add `principalContactId?: string` to the context parameter object.
+- Add a `.replace(/\$\{principal_contact_id\}/g, …)` clause to the existing
+  chain.
+- Gate it with the same `UUID_FORMAT` defense-in-depth check used for
+  `agent_contact_id`. Anything that doesn't match the UUID v4 regex resolves to
+  an empty string. This protects against future changes to the ID source from
+  accidentally injecting arbitrary text into the system prompt.
+- Update the JSDoc comment to list `${principal_contact_id}` alongside
+  `${agent_contact_id}`.
+
+### 2. Bootstrap wiring
+
+[src/index.ts](../../src/index.ts):
+
+- `principalContact` is already loaded at line 873. Pass `principalContact?.id`
+  (which is `string | undefined`) into both `interpolateRuntimeContext()` call
+  sites — the coordinator branch (line 1240) and the `inject_specialists` branch
+  (line 1248).
+- If `principalContact` is null (fresh deployment, before bootstrap), the value
+  passed is `undefined`, the UUID check fails, and the placeholder resolves to
+  an empty string — matching the behavior of `agent_contact_id` when its source
+  is missing.
+- Log a one-time `logger.warn` at boot when `principalContact` is null,
+  unconditionally (mirroring the existing line-507 warning for agent
+  self-identity). The message names the affected placeholder so the
+  misconfiguration is searchable in logs.
+
+### 3. Agent YAML updates
+
+**[agents/meeting-debrief.yaml](../../agents/meeting-debrief.yaml):**
+
+- Replace the prose at lines 89–92 ("At the start of the detection pipeline,
+  resolve the CEO's contact via `contact-lookup`…") with explicit reference to
+  `${principal_contact_id}`. The new prose tells the agent to use that ID
+  directly and to call `entity-context` on it to discover known email addresses.
+- Keep `contact-lookup` in `pinned_skills` (line 19) — it is still used for
+  non-CEO name resolution at line 86.
+
+**[agents/calendar.yaml](../../agents/calendar.yaml):**
+
+- Replace the prose at line 44 ("To find the CEO's calendar: resolve the CEO
+  via `contact-lookup` (by role)…") to use `${principal_contact_id}` directly,
+  then call `entity-context` to get the CEO's registered calendar IDs.
+- Keep `contact-lookup` in `pinned_skills` (line 173) — still used for other
+  name resolution.
+
+### 4. Tests
+
+New `describe('interpolateRuntimeContext')` block in
+[tests/unit/agents/loader.test.ts](../../tests/unit/agents/loader.test.ts).
+
+Cases for the new variable:
+
+1. Replaces `${principal_contact_id}` with a valid UUID when provided.
+2. Resolves to empty string when `principalContactId` is `undefined`.
+3. Resolves to empty string when `principalContactId` is a non-UUID string
+   (defense-in-depth check).
+4. Leaves other placeholders (`${agent_contact_id}`, `${office_identity_block}`)
+   untouched while interpolating `${principal_contact_id}`.
+
+## Acceptance Criteria
+
+(Reproduced from issue #716 with the warn-on-null clarification.)
+
+- [ ] `interpolateRuntimeContext()` resolves and injects `${principal_contact_id}`.
+- [ ] If no principal contact exists, the variable resolves to an empty string
+      and a warning is logged at boot (unconditional warn-on-null).
+- [ ] `meeting-debrief.yaml` and `calendar.yaml` use `${principal_contact_id}`
+      instead of runtime `contact-lookup`-by-role for the CEO. Both agents
+      retain `contact-lookup` in `pinned_skills` for non-CEO name resolution.
+- [ ] Unit test for `interpolateRuntimeContext()` covers the new variable
+      (UUID-present, undefined, non-UUID, and isolation from other placeholders).
+- [ ] CHANGELOG.md updated under `## [Unreleased]` (per CLAUDE.md).
+
+## Risks & Mitigations
+
+- **Prompt injection via the ID source.** Mitigated by reusing the existing
+  `UUID_FORMAT` regex check — any non-UUID string becomes empty.
+- **Silent failure on fresh deployments.** The boot warning makes the
+  misconfiguration visible in logs. Empty-string fallback matches the
+  established behavior for `agent_contact_id`.
+- **Agents drifting back to `contact-lookup`-by-role.** Not blocked structurally
+  — the prose update relies on the LLM following the new instructions. This is
+  acceptable because (a) the same risk applies to `${agent_contact_id}` today,
+  (b) a regression would still produce correct behavior (just one wasted skill
+  call), and (c) the change reduces, not removes, reliance on `contact-lookup`.

--- a/docs/wip/2026-05-26-principal-contact-id-design.md
+++ b/docs/wip/2026-05-26-principal-contact-id-design.md
@@ -28,11 +28,32 @@ already loaded at bootstrap — `principalContact` is materialized at
 
 ## Scope
 
-**In scope:** Inject only the principal's contact UUID as `${principal_contact_id}`.
-This mirrors the existing `${agent_contact_id}` pattern.
+**In scope (this PR, curia repo):**
+
+- Inject the principal's contact UUID as `${principal_contact_id}` via
+  `interpolateRuntimeContext()`. Mirrors the existing `${agent_contact_id}`
+  pattern (opt-in placeholder, not auto-injected).
+- Update `meeting-debrief.yaml` and `calendar.yaml` to use the placeholder.
+- Add a CLAUDE.md convention documenting that agents needing to reach the
+  principal MUST use `${principal_contact_id}` rather than hardcoding addresses
+  or calling `contact-lookup`-by-role.
+
+**Cross-repo follow-up (separate PR, curia-deploy repo):**
+
+- Update `T2125-expense-tracker.yaml` to reference `${principal_contact_id}` in
+  a new entity-resolution paragraph. T2125 already has `entity-context` pinned;
+  the change is prose-only. This lands *after* the curia release that ships the
+  platform support, so the placeholder resolves rather than appearing as a
+  literal string.
 
 **Out of scope (explicit non-goals):**
 
+- **Auto-injecting** the principal contact ID into every agent prompt. Rejected
+  because (a) it expands the attack surface — unrelated agents like
+  research-analyst would be invited to contact the CEO directly when they have
+  no business doing so; (b) it diverges from the established `${agent_contact_id}`
+  opt-in pattern; (c) the real fix for poorly-written agents is the documented
+  convention plus review, not silent injection.
 - Pre-resolving the principal's email identities, calendar IDs, timezone, or any
   other enrichment data. Agents continue to call `entity-context` with the
   injected ID when they need that information.
@@ -40,6 +61,11 @@ This mirrors the existing `${agent_contact_id}` pattern.
   bootstrap-time injection is correct. (Identities and calendars *can* change,
   which is why they are excluded — bootstrap-time injection of those would go
   stale.)
+- Refactoring `digest.yaml` (curia-deploy) to replace its hardcoded Signal
+  number with the placeholder + entity-context. The existing
+  `@TODO(signal-config)` flags this work; it stays a separate ticket because
+  it changes runtime cost (adds a per-fire entity-context call) and pinned
+  skills, not just prose.
 
 ## Design
 
@@ -93,7 +119,23 @@ This mirrors the existing `${agent_contact_id}` pattern.
 - Keep `contact-lookup` in `pinned_skills` (line 173) — still used for other
   name resolution.
 
-### 4. Tests
+### 4. CLAUDE.md convention
+
+Add a short section to [repos/curia/CLAUDE.md](../../CLAUDE.md), near the
+existing "Adding Things" / "New Agent" guidance. Suggested wording:
+
+> **Reaching the principal.** Agents that need to send messages to, look up
+> calendars for, or otherwise act on behalf of the principal MUST reference
+> `${principal_contact_id}` in their system prompt. Pass that ID to
+> `entity-context` to discover the principal's verified email addresses,
+> Signal number, calendar IDs, and timezone. Do not hardcode addresses or
+> phone numbers in agent prompts, and do not use `contact-lookup`-by-role
+> for the principal — the platform resolves the ID at bootstrap.
+
+This is the durable countermeasure to "poorly written agents" — it documents
+the convention so reviewers and future agent authors can apply it consistently.
+
+### 5. Tests
 
 New `describe('interpolateRuntimeContext')` block in
 [tests/unit/agents/loader.test.ts](../../tests/unit/agents/loader.test.ts).
@@ -120,6 +162,22 @@ Cases for the new variable:
 - [ ] Unit test for `interpolateRuntimeContext()` covers the new variable
       (UUID-present, undefined, non-UUID, and isolation from other placeholders).
 - [ ] CHANGELOG.md updated under `## [Unreleased]` (per CLAUDE.md).
+- [ ] CLAUDE.md "Reaching the principal" convention added near the
+      "Adding Things" / "New Agent" section.
+
+## Cross-Repo Follow-Up (curia-deploy)
+
+After this PR ships and a curia release is cut that includes the new
+placeholder, open a follow-up PR against `curia-deploy`:
+
+- **`custom/agents/T2125-expense-tracker.yaml`** — add a small "Entity
+  Resolution" paragraph (mirroring `calendar.yaml`) instructing the agent
+  to use `${principal_contact_id}` and `entity-context` to discover the
+  CEO's email/Signal address before any `email-send` or `signal-send`
+  call. No skill manifest changes; `entity-context` is already pinned.
+
+Tracked separately so the curia release is the gate — the placeholder must
+exist in the platform before the curia-deploy YAML references it.
 
 ## Risks & Mitigations
 

--- a/docs/wip/2026-05-26-principal-contact-id.md
+++ b/docs/wip/2026-05-26-principal-contact-id.md
@@ -1,0 +1,747 @@
+# `${principal_contact_id}` Runtime Injection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Inject the principal contact UUID into agent system prompts as `${principal_contact_id}`, so scheduled agents stop spending tokens on `contact-lookup`-by-role for an immutable value.
+
+**Architecture:** Extend `interpolateRuntimeContext()` in `src/agents/loader.ts` with a new placeholder, gated by the same UUID-format defense-in-depth check used for `${agent_contact_id}`. Wire `principalContact?.id` (already loaded at bootstrap, [src/index.ts:873](../../src/index.ts)) into both call sites. Update `meeting-debrief.yaml` and `calendar.yaml` to use the placeholder. Document the convention in CLAUDE.md so future agents follow it.
+
+**Tech Stack:** TypeScript 5 / Node 22 / ESM, Vitest, pino, js-yaml, pnpm.
+
+**Spec:** [docs/wip/2026-05-26-principal-contact-id-design.md](2026-05-26-principal-contact-id-design.md)
+
+---
+
+## File Structure
+
+**Create:** *(none)*
+
+**Modify:**
+- `src/agents/loader.ts` — add `principalContactId` to context, add `.replace()` clause, update JSDoc
+- `src/index.ts` — pass `principalContact?.id` to both `interpolateRuntimeContext()` call sites; add boot warning when null
+- `agents/meeting-debrief.yaml` — replace `contact-lookup`-by-role prose with `${principal_contact_id}` reference
+- `agents/calendar.yaml` — replace `contact-lookup`-by-role prose with `${principal_contact_id}` reference
+- `CLAUDE.md` — add "Reaching the principal" convention near "New Agent" section
+- `CHANGELOG.md` — append entry under `## [Unreleased]`
+- `tests/unit/agents/loader.test.ts` — add `describe('interpolateRuntimeContext')` block
+
+---
+
+## Task 1: Failing tests for `${principal_contact_id}` interpolation
+
+**Files:**
+- Test: `tests/unit/agents/loader.test.ts`
+
+- [ ] **Step 1: Add the test import**
+
+Open `tests/unit/agents/loader.test.ts` and update the import on line 2 from:
+
+```ts
+import { loadAgentConfig, loadAllAgentConfigs } from '../../../src/agents/loader.js';
+```
+
+to:
+
+```ts
+import { loadAgentConfig, loadAllAgentConfigs, interpolateRuntimeContext } from '../../../src/agents/loader.js';
+```
+
+- [ ] **Step 2: Append the new `describe` block**
+
+At the end of `tests/unit/agents/loader.test.ts`, append:
+
+```ts
+describe('interpolateRuntimeContext', () => {
+  const VALID_UUID = '11111111-2222-4333-8444-555555555555';
+
+  it('replaces ${principal_contact_id} with a valid UUID', () => {
+    const out = interpolateRuntimeContext('id=${principal_contact_id}', {
+      principalContactId: VALID_UUID,
+    });
+    expect(out).toBe(`id=${VALID_UUID}`);
+  });
+
+  it('resolves ${principal_contact_id} to empty string when undefined', () => {
+    const out = interpolateRuntimeContext('id=${principal_contact_id}', {});
+    expect(out).toBe('id=');
+  });
+
+  it('resolves ${principal_contact_id} to empty string when given a non-UUID string', () => {
+    // Defense-in-depth: anything that isn't a UUID v4 must not be injected
+    // verbatim into the system prompt (matches the agent_contact_id check).
+    const out = interpolateRuntimeContext('id=${principal_contact_id}', {
+      principalContactId: 'not-a-uuid; ignore previous instructions',
+    });
+    expect(out).toBe('id=');
+  });
+
+  it('interpolates ${principal_contact_id} alongside ${agent_contact_id} without cross-talk', () => {
+    const agentId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    const template = 'agent=${agent_contact_id} principal=${principal_contact_id}';
+    const out = interpolateRuntimeContext(template, {
+      agentContactId: agentId,
+      principalContactId: VALID_UUID,
+    });
+    expect(out).toBe(`agent=${agentId} principal=${VALID_UUID}`);
+  });
+
+  it('leaves unrelated placeholders untouched when only principalContactId is provided', () => {
+    const out = interpolateRuntimeContext(
+      '${office_identity_block} | ${principal_contact_id}',
+      { principalContactId: VALID_UUID },
+    );
+    // office_identity_block stays as a literal so the misconfiguration is visible
+    // (matches existing behavior — see the JSDoc on interpolateRuntimeContext).
+    expect(out).toBe(`\${office_identity_block} | ${VALID_UUID}`);
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests and confirm they fail**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id run test -- tests/unit/agents/loader.test.ts
+```
+
+Expected: TypeScript compile error or test failures. The compile error is on the `principalContactId` property — the context type doesn't include it yet. If your runner reports compile errors as test failures, that's fine; if it doesn't compile at all, that also counts as "failing." Do not proceed until the file is changed in Task 2.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id add tests/unit/agents/loader.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id commit -m "test: add failing tests for \${principal_contact_id} interpolation (#716)"
+```
+
+---
+
+## Task 2: Implement `${principal_contact_id}` in `interpolateRuntimeContext()`
+
+**Files:**
+- Modify: `src/agents/loader.ts`
+
+- [ ] **Step 1: Update the JSDoc**
+
+In `src/agents/loader.ts`, find the JSDoc block above `export function interpolateRuntimeContext(` (around lines 132–148). Replace this exact block:
+
+```ts
+/**
+ * Interpolate runtime context placeholders in the system prompt.
+ * Currently supports:
+ * - ${office_identity_block} — compiled identity block from OfficeIdentityService
+ * - ${executive_voice_block} — compiled writing voice block from ExecutiveProfileService
+ * - ${available_specialists} — list of specialist agents from the agent registry
+ * - ${current_date} — today's date in the configured timezone (YYYY-MM-DD, Day)
+ * - ${timezone} — the configured IANA timezone name
+ * - ${agent_contact_id} — the agent's own contact ID (seeded at bootstrap)
+ *
+ * This runs at bootstrap time (after all agents are registered) and is separate
+ * from persona interpolation which runs at config load time.
+ *
+ * Note: ${executive_voice_block} is also replaced per-turn in runtime.ts (for hot
+ * reload support), but the bootstrap-time pass here handles the static case and
+ * ensures the placeholder is resolved even if the runtime injection path is skipped.
+ */
+```
+
+with:
+
+```ts
+/**
+ * Interpolate runtime context placeholders in the system prompt.
+ * Currently supports:
+ * - ${office_identity_block} — compiled identity block from OfficeIdentityService
+ * - ${executive_voice_block} — compiled writing voice block from ExecutiveProfileService
+ * - ${available_specialists} — list of specialist agents from the agent registry
+ * - ${current_date} — today's date in the configured timezone (YYYY-MM-DD, Day)
+ * - ${timezone} — the configured IANA timezone name
+ * - ${agent_contact_id} — the agent's own contact ID (seeded at bootstrap)
+ * - ${principal_contact_id} — the principal's contact ID (loaded at bootstrap from
+ *   contactService.findContactBySystemRole('principal')). Agents that need to act
+ *   on behalf of the principal should reference this rather than calling
+ *   contact-lookup-by-role on every invocation. See CLAUDE.md "Reaching the
+ *   principal" for the authoring convention.
+ *
+ * This runs at bootstrap time (after all agents are registered) and is separate
+ * from persona interpolation which runs at config load time.
+ *
+ * Note: ${executive_voice_block} is also replaced per-turn in runtime.ts (for hot
+ * reload support), but the bootstrap-time pass here handles the static case and
+ * ensures the placeholder is resolved even if the runtime injection path is skipped.
+ */
+```
+
+- [ ] **Step 2: Add `principalContactId` to the context parameter**
+
+In the same file, replace this exact function signature:
+
+```ts
+export function interpolateRuntimeContext(
+  systemPrompt: string,
+  context: {
+    availableSpecialists?: string;
+    agentContactId?: string;
+    officeIdentityBlock?: string;
+    executiveVoiceBlock?: string;
+  },
+): string {
+```
+
+with:
+
+```ts
+export function interpolateRuntimeContext(
+  systemPrompt: string,
+  context: {
+    availableSpecialists?: string;
+    agentContactId?: string;
+    principalContactId?: string;
+    officeIdentityBlock?: string;
+    executiveVoiceBlock?: string;
+  },
+): string {
+```
+
+- [ ] **Step 3: Add the `.replace()` clause for `${principal_contact_id}`**
+
+In the same function body, find the existing `.replace()` for `${agent_contact_id}` (around lines 178–186):
+
+```ts
+    .replace(
+      /\$\{agent_contact_id\}/g,
+      // Validate UUID format before interpolation — defense-in-depth against
+      // prompt injection if the ID source ever changes from gen_random_uuid().
+      // The current bootstrap always produces a Postgres-generated UUID, but an
+      // explicit check here ensures a future change (env var, config, etc.) can't
+      // accidentally inject arbitrary text into the system prompt.
+      UUID_FORMAT.test(context.agentContactId ?? '') ? (context.agentContactId ?? '') : '',
+    );
+```
+
+Replace it with the same clause followed by the new `principal_contact_id` clause (note: the chained `.replace()` ends with `;` on the last clause only — make sure the `agent_contact_id` clause now ends with `)` and the new clause ends with `);`):
+
+```ts
+    .replace(
+      /\$\{agent_contact_id\}/g,
+      // Validate UUID format before interpolation — defense-in-depth against
+      // prompt injection if the ID source ever changes from gen_random_uuid().
+      // The current bootstrap always produces a Postgres-generated UUID, but an
+      // explicit check here ensures a future change (env var, config, etc.) can't
+      // accidentally inject arbitrary text into the system prompt.
+      UUID_FORMAT.test(context.agentContactId ?? '') ? (context.agentContactId ?? '') : '',
+    )
+    .replace(
+      /\$\{principal_contact_id\}/g,
+      // Same UUID-format defense-in-depth as agent_contact_id above. Source is
+      // contactService.findContactBySystemRole('principal') in src/index.ts;
+      // a missing principal resolves to empty string and is flagged by a
+      // boot-time warning rather than silently injecting placeholder text.
+      UUID_FORMAT.test(context.principalContactId ?? '') ? (context.principalContactId ?? '') : '',
+    );
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id run typecheck
+```
+
+Expected: PASS. If it fails on `src/index.ts` call sites complaining about the new optional property, that's not possible (it's optional) — recheck the field is `principalContactId?: string` with the `?`.
+
+- [ ] **Step 5: Run the test file**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id run test -- tests/unit/agents/loader.test.ts
+```
+
+Expected: all five new tests pass, all existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id add src/agents/loader.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id commit -m "feat(loader): inject \${principal_contact_id} via interpolateRuntimeContext (#716)"
+```
+
+---
+
+## Task 3: Wire `principalContact?.id` through bootstrap + warn on null
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Add a boot-time warning when principalContact is null**
+
+In `src/index.ts`, find this block (around lines 870–886):
+
+```ts
+  // Load principal's channel identities for the outbound gateway recipient check.
+  // Cached for the lifetime of the process — restart picks up changes.
+  // Load principal contact reference and cache it for the readiness check below (avoid a redundant DB query).
+  let principalIdentities: ChannelIdentity[] = [];
+  let principalContact: Contact | null = null;
+  try {
+    principalContact = await contactService.findContactBySystemRole('principal');
+    if (principalContact) {
+      const withIdentities = await contactService.getContactWithIdentities(principalContact.id);
+      // Only use verified identities for the autonomy-bypass check — an unverified
+      // identity should not grant principal-bypass to an unverified address.
+      principalIdentities = (withIdentities?.identities ?? []).filter((id) => id.verified);
+    }
+  } catch (err) {
+    logger.fatal(
+      { err },
+      'Failed to load principal contact — check that migration 035 (add_system_role) has been applied',
+    );
+    process.exit(1);
+  }
+```
+
+Add a warning *immediately after* this block (after the closing `}` of the catch), so the warn fires when load succeeded but no principal exists. Insert these lines on a new line right after the `catch` block closes:
+
+```ts
+
+  // If no principal contact exists yet (fresh deployment, before bootstrap),
+  // ${principal_contact_id} resolves to empty string in agent system prompts.
+  // Mirror the agent_contact_id warning (line ~507) so the misconfiguration
+  // is visible in logs and searchable by the placeholder name.
+  if (!principalContact) {
+    logger.warn(
+      'No contact with system_role=principal found — agent system prompt ${principal_contact_id} will be empty until setup is complete',
+    );
+  }
+```
+
+- [ ] **Step 2: Pass `principalContact?.id` into the coordinator call site**
+
+In the same file, find this block (around lines 1235–1243):
+
+```ts
+    let systemPrompt = agentConfig.system_prompt;
+    if (agentConfig.role === 'coordinator') {
+      // Do NOT pass officeIdentityBlock here — leave ${office_identity_block}
+      // as a literal placeholder. It is replaced per-turn in AgentRuntime.processTask()
+      // by the officeIdentityService passed below, enabling hot-reload without a restart.
+      systemPrompt = interpolateRuntimeContext(systemPrompt, {
+        availableSpecialists: agentRegistry.specialistSummary(),
+        agentContactId: agentIdentityContactId,
+      });
+    } else if (agentConfig.inject_specialists) {
+```
+
+Replace it with:
+
+```ts
+    let systemPrompt = agentConfig.system_prompt;
+    if (agentConfig.role === 'coordinator') {
+      // Do NOT pass officeIdentityBlock here — leave ${office_identity_block}
+      // as a literal placeholder. It is replaced per-turn in AgentRuntime.processTask()
+      // by the officeIdentityService passed below, enabling hot-reload without a restart.
+      systemPrompt = interpolateRuntimeContext(systemPrompt, {
+        availableSpecialists: agentRegistry.specialistSummary(),
+        agentContactId: agentIdentityContactId,
+        principalContactId: principalContact?.id,
+      });
+    } else if (agentConfig.inject_specialists) {
+```
+
+- [ ] **Step 3: Pass `principalContact?.id` into the `inject_specialists` call site**
+
+In the same file, find this block (around lines 1244–1254):
+
+```ts
+    } else if (agentConfig.inject_specialists) {
+      // Specialists that need to know about available agents
+      // opt in via inject_specialists: true in their YAML.
+      try {
+        systemPrompt = interpolateRuntimeContext(systemPrompt, {
+          availableSpecialists: agentRegistry.specialistSummary(),
+        });
+      } catch (err) {
+        logger.error({ err, agentName: agentConfig.name }, 'Failed to interpolate specialists into agent system prompt');
+        throw err;
+      }
+    }
+```
+
+Replace it with:
+
+```ts
+    } else if (agentConfig.inject_specialists) {
+      // Specialists that need to know about available agents
+      // opt in via inject_specialists: true in their YAML.
+      // Pass principalContactId so specialists (e.g. meeting-debrief) can
+      // reference ${principal_contact_id} without calling contact-lookup-by-role.
+      try {
+        systemPrompt = interpolateRuntimeContext(systemPrompt, {
+          availableSpecialists: agentRegistry.specialistSummary(),
+          principalContactId: principalContact?.id,
+        });
+      } catch (err) {
+        logger.error({ err, agentName: agentConfig.name }, 'Failed to interpolate specialists into agent system prompt');
+        throw err;
+      }
+    }
+```
+
+- [ ] **Step 4: Check that specialists *without* `inject_specialists` also get the placeholder resolved**
+
+`calendar.yaml` does NOT set `inject_specialists`. Its system prompt is loaded but never passed through `interpolateRuntimeContext()` in the current code (only the `coordinator` branch and the `inject_specialists` branch call it). To verify:
+
+```bash
+grep -n "inject_specialists" /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id/agents/calendar.yaml
+```
+
+Expected: no output. This means calendar.yaml falls through both branches and the `${principal_contact_id}` placeholder would be left literal in its system prompt — defeating the whole change.
+
+Fix: add an `else` branch that runs `interpolateRuntimeContext` with just the principalContactId for everyone else. In the same file, modify the if/else chain so the structure becomes:
+
+```ts
+    let systemPrompt = agentConfig.system_prompt;
+    if (agentConfig.role === 'coordinator') {
+      // ... existing coordinator branch (already updated in Step 2) ...
+      systemPrompt = interpolateRuntimeContext(systemPrompt, {
+        availableSpecialists: agentRegistry.specialistSummary(),
+        agentContactId: agentIdentityContactId,
+        principalContactId: principalContact?.id,
+      });
+    } else if (agentConfig.inject_specialists) {
+      // ... existing inject_specialists branch (already updated in Step 3) ...
+      try {
+        systemPrompt = interpolateRuntimeContext(systemPrompt, {
+          availableSpecialists: agentRegistry.specialistSummary(),
+          principalContactId: principalContact?.id,
+        });
+      } catch (err) {
+        logger.error({ err, agentName: agentConfig.name }, 'Failed to interpolate specialists into agent system prompt');
+        throw err;
+      }
+    } else {
+      // All other specialists: resolve ${principal_contact_id} so any agent
+      // that references the placeholder gets the principal's contact ID at
+      // bootstrap. Specialists list is not needed here (those agents don't
+      // route work to other specialists). principalContactId is safe to pass
+      // unconditionally — interpolateRuntimeContext only acts on prompts that
+      // contain the literal placeholder.
+      systemPrompt = interpolateRuntimeContext(systemPrompt, {
+        principalContactId: principalContact?.id,
+      });
+    }
+```
+
+To make this concrete: in the current file, the chain ends with `} else if (agentConfig.inject_specialists) { ... }` and then proceeds to the next statement (likely "Resolve this agent's capability tier..."). Insert the `else { ... }` branch shown above directly between the closing `}` of the `inject_specialists` branch and the next statement.
+
+- [ ] **Step 5: Type-check**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id run test
+```
+
+Expected: all tests pass. If any unrelated test fails, stop and investigate — do not proceed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id add src/index.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id commit -m "feat(bootstrap): wire principalContact.id into interpolateRuntimeContext (#716)"
+```
+
+---
+
+## Task 4: Update `meeting-debrief.yaml` to use `${principal_contact_id}`
+
+**Files:**
+- Modify: `agents/meeting-debrief.yaml`
+
+- [ ] **Step 1: Replace the CEO entity-resolution prose**
+
+In `agents/meeting-debrief.yaml`, find this exact block (lines 89–92):
+
+```yaml
+  At the start of the detection pipeline, resolve the CEO's contact via
+  `contact-lookup` (by role) and cache their contact ID for the run.
+  Use `entity-context` on the CEO's contact ID to discover their known
+  email addresses — you need these for the solo-event filter in Step 3.
+```
+
+Replace it with:
+
+```yaml
+  The CEO's contact ID is `${principal_contact_id}` — injected at bootstrap.
+  Use it directly; do NOT call `contact-lookup` by role for the CEO.
+  Call `entity-context` on `${principal_contact_id}` to discover their known
+  email addresses — you need these for the solo-event filter in Step 3.
+```
+
+- [ ] **Step 2: Verify `contact-lookup` is still pinned**
+
+`contact-lookup` is still used for non-CEO name resolution at line 86 of the file. Confirm it's still in `pinned_skills`:
+
+```bash
+grep -n "contact-lookup" /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id/agents/meeting-debrief.yaml
+```
+
+Expected: at least two matches — one in `pinned_skills` (line ~19), and the line in the "When given only a name" instructions.
+
+- [ ] **Step 3: Verify the loader still parses the YAML**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id run test -- tests/unit/agents/loader.test.ts
+```
+
+Expected: PASS. (`loadAllAgentConfigs` iterates the `agents/` directory; if the YAML is malformed it will throw.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id add agents/meeting-debrief.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id commit -m "feat(meeting-debrief): use \${principal_contact_id} instead of contact-lookup by role (#716)"
+```
+
+---
+
+## Task 5: Update `calendar.yaml` to use `${principal_contact_id}`
+
+**Files:**
+- Modify: `agents/calendar.yaml`
+
+- [ ] **Step 1: Replace the CEO calendar-resolution prose**
+
+In `agents/calendar.yaml`, find this exact block (lines 44–45):
+
+```yaml
+  To find the CEO's calendar: resolve the CEO via `contact-lookup` (by role),
+  then use `entity-context` to get their registered calendar IDs.
+```
+
+Replace it with:
+
+```yaml
+  To find the CEO's calendar: use `${principal_contact_id}` (injected at
+  bootstrap), then call `entity-context` on that ID to get their registered
+  calendar IDs. Do NOT call `contact-lookup` by role for the CEO.
+```
+
+- [ ] **Step 2: Verify `contact-lookup` is still pinned**
+
+`contact-lookup` is still used for non-CEO name resolution (line 28 of calendar.yaml). Confirm it's still in `pinned_skills`:
+
+```bash
+grep -n "contact-lookup" /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id/agents/calendar.yaml
+```
+
+Expected: at least two matches — one in the "When given only a name" instructions, and one in `pinned_skills`.
+
+- [ ] **Step 3: Verify the loader still parses the YAML**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id run test -- tests/unit/agents/loader.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id add agents/calendar.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id commit -m "feat(calendar): use \${principal_contact_id} instead of contact-lookup by role (#716)"
+```
+
+---
+
+## Task 6: Add "Reaching the principal" convention to CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Insert the new subsection**
+
+In `CLAUDE.md`, find this exact subsection heading and its body:
+
+```markdown
+### New Agent
+1. Create `agents/<name>.yaml` with required fields (name, description, model, system_prompt)
+2. Optionally add `handler: ./<name>.handler.ts` for custom logic
+```
+
+Insert a new subsection immediately after that two-item list, before the next top-level `##` heading. Replace the block above with:
+
+```markdown
+### New Agent
+1. Create `agents/<name>.yaml` with required fields (name, description, model, system_prompt)
+2. Optionally add `handler: ./<name>.handler.ts` for custom logic
+
+### Reaching the principal
+
+Agents that need to send messages to, look up calendars for, or otherwise act
+on behalf of the principal MUST reference `${principal_contact_id}` in their
+system prompt. The runtime injects this placeholder at bootstrap from
+`contactService.findContactBySystemRole('principal')`.
+
+Pass `${principal_contact_id}` to `entity-context` to discover the principal's
+verified email addresses, Signal number, calendar IDs, and timezone. Do not
+hardcode addresses or phone numbers in agent prompts, and do not call
+`contact-lookup` by role for the principal — the platform resolves the ID
+once at bootstrap so every cron tick doesn't spend a skill call on an
+immutable value.
+
+This mirrors the existing `${agent_contact_id}` placeholder pattern (the
+agent's own identity). Both are opt-in: only agents that reference the
+placeholder pay the prompt-bytes cost.
+```
+
+- [ ] **Step 2: Verify the file still renders as valid markdown**
+
+```bash
+grep -n "Reaching the principal" /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id/CLAUDE.md
+```
+
+Expected: exactly one match (the new subsection heading).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id add CLAUDE.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id commit -m "docs(claude-md): add 'Reaching the principal' convention (#716)"
+```
+
+---
+
+## Task 7: CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add an entry under `## [Unreleased]`**
+
+In `CHANGELOG.md`, find this exact block (lines 14–18):
+
+```markdown
+## [Unreleased]
+
+### Fixed
+
+- **Email reply quoting** — natural agent-response replies (no skill invocation) now include the quoted original message, matching the skill-driven paths. `buildReplyQuote` moved to `src/skills/_shared/` so the email channel adapter can share it. (#720)
+```
+
+Replace it with:
+
+```markdown
+## [Unreleased]
+
+### Added
+
+- **`${principal_contact_id}` runtime placeholder** — agent system prompts can now reference the principal's contact ID directly; `meeting-debrief` and `calendar` no longer call `contact-lookup` by role on every invocation. (#716)
+
+### Fixed
+
+- **Email reply quoting** — natural agent-response replies (no skill invocation) now include the quoted original message, matching the skill-driven paths. `buildReplyQuote` moved to `src/skills/_shared/` so the email channel adapter can share it. (#720)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id commit -m "docs(changelog): note \${principal_contact_id} placeholder (#716)"
+```
+
+---
+
+## Task 8: Final verification
+
+**Files:** *(none modified)*
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id run test
+```
+
+Expected: PASS. No test count regression vs. main.
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run lint (if defined)**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id run lint
+```
+
+Expected: PASS. If `lint` script does not exist (`npm ERR! Missing script: "lint"`), skip — not all projects have it.
+
+- [ ] **Step 4: Sanity-check the YAML interpolation by hand**
+
+Confirm that loading each updated agent YAML and running the bootstrap interpolation produces a system prompt with no literal `${principal_contact_id}` left behind. Run this one-liner:
+
+```bash
+node --input-type=module --eval "
+import { loadAgentConfig, interpolateRuntimeContext } from './src/agents/loader.js';
+import * as path from 'node:path';
+const FAKE = '11111111-2222-4333-8444-555555555555';
+for (const f of ['meeting-debrief.yaml', 'calendar.yaml']) {
+  const c = loadAgentConfig(path.join('agents', f));
+  const out = interpolateRuntimeContext(c.system_prompt, { principalContactId: FAKE });
+  const remaining = (out.match(/\\\${principal_contact_id}/g) || []).length;
+  console.log(f, 'remaining literal placeholders:', remaining, 'fake-id occurrences:', (out.match(new RegExp(FAKE, 'g')) || []).length);
+}
+" 2>&1
+```
+
+You may need to compile TypeScript first. If the inline import fails (TS extension issue), skip this step and rely on the loader.test.ts pass from Step 1.
+
+Expected (if it ran): `remaining literal placeholders: 0` and `fake-id occurrences: >= 1` for each file.
+
+- [ ] **Step 5: Survey commit history**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/worktrees/curia-principal-contact-id log --oneline main..HEAD
+```
+
+Expected commits, in order:
+1. `docs(wip): design for ${principal_contact_id} runtime injection (#716)`
+2. `docs(wip): expand design — add CLAUDE.md convention and T2125 follow-up note`
+3. `test: add failing tests for ${principal_contact_id} interpolation (#716)`
+4. `feat(loader): inject ${principal_contact_id} via interpolateRuntimeContext (#716)`
+5. `feat(bootstrap): wire principalContact.id into interpolateRuntimeContext (#716)`
+6. `feat(meeting-debrief): use ${principal_contact_id} instead of contact-lookup by role (#716)`
+7. `feat(calendar): use ${principal_contact_id} instead of contact-lookup by role (#716)`
+8. `docs(claude-md): add 'Reaching the principal' convention (#716)`
+9. `docs(changelog): note ${principal_contact_id} placeholder (#716)`
+
+Eight or nine commits is fine; the exact count depends on whether the design spec was committed in one or two passes.
+
+- [ ] **Step 6: Spot-check that all spec acceptance criteria pass**
+
+Re-read [docs/wip/2026-05-26-principal-contact-id-design.md](2026-05-26-principal-contact-id-design.md) "Acceptance Criteria" section. Confirm each box can be checked:
+
+- [ ] `interpolateRuntimeContext()` resolves `${principal_contact_id}` (Task 2)
+- [ ] Empty string + warning when null (Task 2 empty-string, Task 3 warning)
+- [ ] `meeting-debrief.yaml` + `calendar.yaml` updated; `contact-lookup` retained for non-CEO names (Tasks 4 & 5)
+- [ ] Unit tests cover the new variable (Task 1)
+- [ ] CHANGELOG updated (Task 7)
+- [ ] CLAUDE.md "Reaching the principal" convention added (Task 6)
+
+If anything is missing, stop and add a task before opening the PR.
+
+---
+
+## After This Plan Completes
+
+Per the spec's "Cross-Repo Follow-Up" section, once the curia PR is merged and a release is cut that includes the new placeholder, open a follow-up PR against `curia-deploy`:
+
+- `custom/agents/T2125-expense-tracker.yaml` — add a small entity-resolution paragraph telling it to use `${principal_contact_id}` + `entity-context` for the CEO's email/Signal. No skill manifest changes required.
+
+That is **out of scope for this PR** but tracked here so it isn't forgotten.

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -193,9 +193,11 @@ export function interpolateRuntimeContext(
     .replace(
       /\$\{principal_contact_id\}/g,
       // Same UUID-format defense-in-depth as agent_contact_id above. Source is
-      // contactService.findContactBySystemRole('principal') in src/index.ts;
-      // a missing principal resolves to empty string and is flagged by a
-      // boot-time warning rather than silently injecting placeholder text.
+      // contactService.findContactBySystemRole('principal') in src/index.ts.
+      // A missing principal is treated as a hard startup failure by the
+      // readiness gate (check: principal-contact) before this code ever runs
+      // on a real prompt, so the empty-string fallback is unreachable in
+      // practice — pure belt-and-suspenders.
       UUID_FORMAT.test(context.principalContactId ?? '') ? (context.principalContactId ?? '') : '',
     );
 }

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -138,6 +138,11 @@ function interpolatePersona(
  * - ${current_date} — today's date in the configured timezone (YYYY-MM-DD, Day)
  * - ${timezone} — the configured IANA timezone name
  * - ${agent_contact_id} — the agent's own contact ID (seeded at bootstrap)
+ * - ${principal_contact_id} — the principal's contact ID (loaded at bootstrap from
+ *   contactService.findContactBySystemRole('principal')). Agents that need to act
+ *   on behalf of the principal should reference this rather than calling
+ *   contact-lookup-by-role on every invocation. See CLAUDE.md "Reaching the
+ *   principal" for the authoring convention.
  *
  * This runs at bootstrap time (after all agents are registered) and is separate
  * from persona interpolation which runs at config load time.
@@ -151,6 +156,7 @@ export function interpolateRuntimeContext(
   context: {
     availableSpecialists?: string;
     agentContactId?: string;
+    principalContactId?: string;
     officeIdentityBlock?: string;
     executiveVoiceBlock?: string;
   },
@@ -183,5 +189,13 @@ export function interpolateRuntimeContext(
       // explicit check here ensures a future change (env var, config, etc.) can't
       // accidentally inject arbitrary text into the system prompt.
       UUID_FORMAT.test(context.agentContactId ?? '') ? (context.agentContactId ?? '') : '',
+    )
+    .replace(
+      /\$\{principal_contact_id\}/g,
+      // Same UUID-format defense-in-depth as agent_contact_id above. Source is
+      // contactService.findContactBySystemRole('principal') in src/index.ts;
+      // a missing principal resolves to empty string and is flagged by a
+      // boot-time warning rather than silently injecting placeholder text.
+      UUID_FORMAT.test(context.principalContactId ?? '') ? (context.principalContactId ?? '') : '',
     );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -885,15 +885,12 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // If no principal contact exists yet (fresh deployment, before bootstrap),
-  // ${principal_contact_id} resolves to empty string in agent system prompts.
-  // Mirror the agent_contact_id warning (line ~507) so the misconfiguration
-  // is visible in logs and searchable by the placeholder name.
-  if (!principalContact) {
-    logger.warn(
-      'No contact with system_role=principal found — agent system prompt ${principal_contact_id} will be empty until setup is complete',
-    );
-  }
+  // Note: a missing principal does NOT degrade — the readiness check below
+  // converts it into a fatal startup error with a searchable `check: principal-contact`
+  // log line and aborts boot. No separate warn here; that would duplicate the
+  // readiness error and misleadingly imply degraded operation. The empty-string
+  // fallback for ${principal_contact_id} in src/agents/loader.ts is therefore
+  // pure defense-in-depth — unreachable while the readiness gate stands.
 
   // --- Startup readiness checks ---
   // All checks must pass before the system accepts inbound messages.

--- a/src/index.ts
+++ b/src/index.ts
@@ -885,6 +885,16 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // If no principal contact exists yet (fresh deployment, before bootstrap),
+  // ${principal_contact_id} resolves to empty string in agent system prompts.
+  // Mirror the agent_contact_id warning (line ~507) so the misconfiguration
+  // is visible in logs and searchable by the placeholder name.
+  if (!principalContact) {
+    logger.warn(
+      'No contact with system_role=principal found — agent system prompt ${principal_contact_id} will be empty until setup is complete',
+    );
+  }
+
   // --- Startup readiness checks ---
   // All checks must pass before the system accepts inbound messages.
   // See docs/wip/2026-05-10-principal-identity-design.md
@@ -1240,18 +1250,32 @@ async function main(): Promise<void> {
       systemPrompt = interpolateRuntimeContext(systemPrompt, {
         availableSpecialists: agentRegistry.specialistSummary(),
         agentContactId: agentIdentityContactId,
+        principalContactId: principalContact?.id,
       });
     } else if (agentConfig.inject_specialists) {
       // Specialists that need to know about available agents
       // opt in via inject_specialists: true in their YAML.
+      // Pass principalContactId so specialists (e.g. meeting-debrief) can
+      // reference ${principal_contact_id} without calling contact-lookup-by-role.
       try {
         systemPrompt = interpolateRuntimeContext(systemPrompt, {
           availableSpecialists: agentRegistry.specialistSummary(),
+          principalContactId: principalContact?.id,
         });
       } catch (err) {
         logger.error({ err, agentName: agentConfig.name }, 'Failed to interpolate specialists into agent system prompt');
         throw err;
       }
+    } else {
+      // All other specialists: resolve ${principal_contact_id} so any agent
+      // that references the placeholder gets the principal's contact ID at
+      // bootstrap. Specialists list is not needed here (those agents don't
+      // route work to other specialists). principalContactId is safe to pass
+      // unconditionally — interpolateRuntimeContext only acts on prompts that
+      // contain the literal placeholder.
+      systemPrompt = interpolateRuntimeContext(systemPrompt, {
+        principalContactId: principalContact?.id,
+      });
     }
 
     // Resolve this agent's capability tier to a concrete model, then look up

--- a/src/index.ts
+++ b/src/index.ts
@@ -1255,11 +1255,13 @@ async function main(): Promise<void> {
     } else if (agentConfig.inject_specialists) {
       // Specialists that need to know about available agents
       // opt in via inject_specialists: true in their YAML.
-      // Pass principalContactId so specialists (e.g. meeting-debrief) can
-      // reference ${principal_contact_id} without calling contact-lookup-by-role.
+      // Pass agentContactId AND principalContactId so specialists can reference
+      // their own identity (${agent_contact_id}) and the principal's contact ID
+      // (${principal_contact_id}) without calling contact-lookup-by-role.
       try {
         systemPrompt = interpolateRuntimeContext(systemPrompt, {
           availableSpecialists: agentRegistry.specialistSummary(),
+          agentContactId: agentIdentityContactId,
           principalContactId: principalContact?.id,
         });
       } catch (err) {
@@ -1267,13 +1269,16 @@ async function main(): Promise<void> {
         throw err;
       }
     } else {
-      // All other specialists: resolve ${principal_contact_id} so any agent
-      // that references the placeholder gets the principal's contact ID at
-      // bootstrap. Specialists list is not needed here (those agents don't
-      // route work to other specialists). principalContactId is safe to pass
-      // unconditionally — interpolateRuntimeContext only acts on prompts that
-      // contain the literal placeholder.
+      // All other specialists: resolve ${agent_contact_id} (the agent's own
+      // identity, e.g. calendar.yaml's "Your contact ID is ${agent_contact_id}")
+      // and ${principal_contact_id} so both placeholders work without each
+      // specialist needing inject_specialists. interpolateRuntimeContext runs
+      // its full replace chain unconditionally — values not passed here would
+      // be blanked to empty string by the UUID-format check, so we MUST pass
+      // every contact ID the prompt could reference. Specialists list is
+      // omitted because non-inject_specialists agents don't route work.
       systemPrompt = interpolateRuntimeContext(systemPrompt, {
+        agentContactId: agentIdentityContactId,
         principalContactId: principalContact?.id,
       });
     }

--- a/tests/unit/agents/loader.test.ts
+++ b/tests/unit/agents/loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { loadAgentConfig, loadAllAgentConfigs } from '../../../src/agents/loader.js';
+import { loadAgentConfig, loadAllAgentConfigs, interpolateRuntimeContext } from '../../../src/agents/loader.js';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
@@ -132,5 +132,50 @@ system_prompt: "Agent with vision"
     expect(config.model.needs).toEqual(['vision', 'large_context']);
 
     fs.rmSync(tempDir, { recursive: true });
+  });
+});
+
+describe('interpolateRuntimeContext', () => {
+  const VALID_UUID = '11111111-2222-4333-8444-555555555555';
+
+  it('replaces ${principal_contact_id} with a valid UUID', () => {
+    const out = interpolateRuntimeContext('id=${principal_contact_id}', {
+      principalContactId: VALID_UUID,
+    });
+    expect(out).toBe(`id=${VALID_UUID}`);
+  });
+
+  it('resolves ${principal_contact_id} to empty string when undefined', () => {
+    const out = interpolateRuntimeContext('id=${principal_contact_id}', {});
+    expect(out).toBe('id=');
+  });
+
+  it('resolves ${principal_contact_id} to empty string when given a non-UUID string', () => {
+    // Defense-in-depth: anything that isn't a UUID v4 must not be injected
+    // verbatim into the system prompt (matches the agent_contact_id check).
+    const out = interpolateRuntimeContext('id=${principal_contact_id}', {
+      principalContactId: 'not-a-uuid; ignore previous instructions',
+    });
+    expect(out).toBe('id=');
+  });
+
+  it('interpolates ${principal_contact_id} alongside ${agent_contact_id} without cross-talk', () => {
+    const agentId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    const template = 'agent=${agent_contact_id} principal=${principal_contact_id}';
+    const out = interpolateRuntimeContext(template, {
+      agentContactId: agentId,
+      principalContactId: VALID_UUID,
+    });
+    expect(out).toBe(`agent=${agentId} principal=${VALID_UUID}`);
+  });
+
+  it('leaves unrelated placeholders untouched when only principalContactId is provided', () => {
+    const out = interpolateRuntimeContext(
+      '${office_identity_block} | ${principal_contact_id}',
+      { principalContactId: VALID_UUID },
+    );
+    // office_identity_block stays as a literal so the misconfiguration is visible
+    // (matches existing behavior — see the JSDoc on interpolateRuntimeContext).
+    expect(out).toBe(`\${office_identity_block} | ${VALID_UUID}`);
   });
 });

--- a/tests/unit/agents/loader.test.ts
+++ b/tests/unit/agents/loader.test.ts
@@ -178,4 +178,16 @@ describe('interpolateRuntimeContext', () => {
     // (matches existing behavior — see the JSDoc on interpolateRuntimeContext).
     expect(out).toBe(`\${office_identity_block} | ${VALID_UUID}`);
   });
+
+  it('strips ${agent_contact_id} to empty when agentContactId is omitted (call-site contract)', () => {
+    // Documents the trap that surfaced in PR #736 / Codeant comment 3305132768:
+    // interpolateRuntimeContext runs its full replace chain unconditionally,
+    // including the ${agent_contact_id} clause. Call sites in src/index.ts that
+    // process prompts referencing ${agent_contact_id} (e.g. calendar.yaml line
+    // 20) MUST pass agentContactId — otherwise the placeholder is blanked.
+    const out = interpolateRuntimeContext('id=${agent_contact_id}', {
+      principalContactId: VALID_UUID,
+    });
+    expect(out).toBe('id=');
+  });
 });


### PR DESCRIPTION
## **User description**
## Summary

- Adds `${principal_contact_id}` as a bootstrap-time placeholder in agent system prompts, gated by the same UUID-format defense-in-depth check used for `${agent_contact_id}`. Wired through all three `interpolateRuntimeContext()` call sites in `src/index.ts` (coordinator, `inject_specialists`, and a new `else` branch for all other specialists).
- Updates `meeting-debrief.yaml` and `calendar.yaml` to reference the placeholder directly instead of calling `contact-lookup` by role on every cron tick. `contact-lookup` remains pinned in both for non-CEO name resolution.
- Adds a "Reaching the principal" convention to `CLAUDE.md` so future agents follow the pattern, and a one-time boot warning if no principal contact exists yet.

Closes #716

## What's NOT in this PR (deliberate)

- **Auto-injection into every agent prompt.** Opt-in placeholder, matching `${agent_contact_id}`. The CLAUDE.md convention is the durable countermeasure to poorly-written agents.
- **Pre-resolved email/Signal/calendar enrichment.** Agents still call `entity-context` with the injected ID — bootstrap-time injection of those fields would go stale.
- **`T2125-expense-tracker.yaml` update (`curia-deploy`).** Cross-repo follow-up tracked in the design doc; depends on this PR shipping a release.
- **`digest.yaml` hardcoded Signal number refactor.** Existing `@TODO(signal-config)` remains the tracker.

## Test Plan

- [x] `npx vitest run` — 5 new `interpolateRuntimeContext` tests pass; no regressions in the 2700+ other tests (3 pre-existing failures unrelated: DATABASE_URL-dependent integration tests and a missing smoke fixture)
- [x] `tsc --noEmit` clean
- [x] Pre-PR code review (no blockers)
- [x] Pre-PR silent-failure review (no blockers)
- [ ] CI green on `feat/principal-contact-id`
- [ ] Manual smoke: after merge + restart, confirm `meeting-debrief` and `calendar` agents resolve the CEO without calling `contact-lookup` by role (logs)


___

## **CodeAnt-AI Description**
**Inject the principal contact ID into agents that need it**

### What Changed
- Agents can now use `${principal_contact_id}` directly in their system prompts instead of looking up the CEO by role each time
- `meeting-debrief` and `calendar` now use the injected ID for CEO-related email and calendar access, while keeping `contact-lookup` for other names
- If no principal contact is set yet, the system logs a warning and leaves the placeholder empty until setup is complete
- Added guidance for future agent prompts and test coverage for the new placeholder

### Impact
`✅ Fewer repeated CEO lookups`
`✅ Faster scheduled agent runs`
`✅ Clearer setup warnings for missing principal contact`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new `${principal_contact_id}` runtime placeholder for agent system prompts, enabling efficient principal contact resolution at bootstrap time.
  * Meeting-debrief and calendar agents now use optimized principal contact discovery, eliminating redundant contact lookups on every invocation.

* **Documentation**
  * Added guidance for properly referencing principal contacts in agent configurations using the new placeholder mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->