### PR TITLE
feat: preserve rich-text formatting in quoted reply bodies (HTML blockquote)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Changed
 
+- **`buildReplyQuote`** — quoted reply blocks are now rendered as a sanitized HTML `<blockquote>` with styled attribution headers instead of plain text; original body HTML is preserved through `sanitize-html` (strips scripts, styles, event handlers, and `javascript:` URLs). `ceo-inbox-draft-reply` now also converts the LLM reply body to HTML before creating the Nylas draft. (#734)
 - **`meeting-debrief`** — system prompt now instructs the agent not to retry `bullpen.post` on timeout; on `<skill_error>...timed out</skill_error>` it records the meeting as `prompt_unconfirmed` and reconciles on the next tick. Stopgap until #721 lands a proper contract. (#722)
 
 ### Fixed

--- a/skills/ceo-inbox-draft-reply/handler.test.ts
+++ b/skills/ceo-inbox-draft-reply/handler.test.ts
@@ -123,9 +123,10 @@ describe('CeoInboxDraftReplyHandler', () => {
     expect(ccEmails).toContain('charlie@example.com');
     expect(ccEmails).not.toContain('ceo@example.com');
 
-    // Body should include the reply text followed by the quoted original
+    // Body should be HTML: reply text converted from markdown + HTML quoted original
     expect(draftBody.body).toContain('Thanks for reaching out.');
-    expect(draftBody.body).toContain('---------- Original Message ----------');
+    // HTML blockquote attribution
+    expect(draftBody.body).toContain('<strong>From:</strong>');
     expect(draftBody.body).toContain('alice@external.com');
   });
 
@@ -380,13 +381,14 @@ describe('CeoInboxDraftReplyHandler', () => {
 
     const draftBody = JSON.parse(draftCall![1]!.body as string);
 
-    // Quote should contain stripped plain text, not HTML
-    expect(draftBody.body).toContain('Hello world');
-    expect(draftBody.body).not.toContain('<p>');
-    expect(draftBody.body).not.toContain('<b>');
-    // Reply text should precede the quote
+    // HTML mode: original body HTML is preserved inside the blockquote, not stripped
+    // The original `<p>Hello <b>world</b></p>` survives sanitization intact.
+    expect(draftBody.body).toContain('Hello');
+    expect(draftBody.body).toContain('<b>world</b>');
+    expect(draftBody.body).toContain('<blockquote');
+    // Reply text (converted from markdown by markdownToHtml) precedes the HTML quote block
     expect(draftBody.body.indexOf('Thanks for reaching out.')).toBeLessThan(
-      draftBody.body.indexOf('---------- Original Message ----------'),
+      draftBody.body.indexOf('<blockquote'),
     );
   });
 

--- a/skills/ceo-inbox-draft-reply/handler.ts
+++ b/skills/ceo-inbox-draft-reply/handler.ts
@@ -1,6 +1,7 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { CeoNylasClient, type NylasParticipant } from '../_shared/ceo-nylas-client.js';
 import { buildReplyQuote } from '../../src/skills/_shared/reply-quote.js';
+import { markdownToHtml } from '../../src/channels/email/markdown-to-html.js';
 
 export class CeoInboxDraftReplyHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -83,11 +84,12 @@ export class CeoInboxDraftReplyHandler implements SkillHandler {
         'ceo-inbox-draft-reply: computed reply-all recipients',
       );
 
-      // Append the quoted original message below the reply body. Formatting is
-      // non-fatal — a malformed message body should not block draft creation.
-      let quotedBody = body;
+      // Convert the LLM-authored markdown body to HTML before combining with the
+      // quote — this path bypasses the gateway, so markdownToHtml is not called there.
+      // Formatting is non-fatal — a failure must not block draft creation.
+      let quotedBody = markdownToHtml(body);
       try {
-        quotedBody = body + buildReplyQuote(original, ctx.timezone);
+        quotedBody = quotedBody + buildReplyQuote(original, ctx.timezone, { format: 'html' });
       } catch (err) {
         ctx.log.warn(
           { err, replyToMessageId },

--- a/skills/ceo-inbox-draft-reply/handler.ts
+++ b/skills/ceo-inbox-draft-reply/handler.ts
@@ -75,9 +75,10 @@ export class CeoInboxDraftReplyHandler implements SkillHandler {
 
       // Nylas v3 does not auto-populate the subject from reply_to_message_id —
       // we must set it explicitly or the draft lands with a blank subject.
-      const replySubject = original.subject.startsWith('Re: ')
-        ? original.subject
-        : `Re: ${original.subject}`;
+      // Strip existing Re: prefix (case-insensitive) before prepending our own to
+      // avoid "Re: RE: Re: ..." chains — matches the pattern used by email-reply
+      // and email-adapter.
+      const replySubject = `Re: ${original.subject.replace(/^Re:\s*/i, '')}`;
 
       ctx.log.info(
         { replyToMessageId, toCount: to.length, ccCount: cc.length, replySubject },
@@ -87,9 +88,15 @@ export class CeoInboxDraftReplyHandler implements SkillHandler {
       // Convert the LLM-authored markdown body to HTML before combining with the
       // quote — this path bypasses the gateway, so markdownToHtml is not called there.
       // Formatting is non-fatal — a failure must not block draft creation.
-      let quotedBody = markdownToHtml(body);
+      const htmlBody = markdownToHtml(body);
+      let draftBody = htmlBody;
       try {
-        quotedBody = quotedBody + buildReplyQuote(original, ctx.timezone, { format: 'html' });
+        const htmlQuote = buildReplyQuote(original, ctx.timezone, { format: 'html' });
+        // Apply the same size guard used by the other reply callers — a long quoted
+        // thread should not produce an oversized Nylas draft payload.
+        if (htmlBody.length + htmlQuote.length <= 50_000) {
+          draftBody = htmlBody + htmlQuote;
+        }
       } catch (err) {
         ctx.log.warn(
           { err, replyToMessageId },
@@ -100,7 +107,7 @@ export class CeoInboxDraftReplyHandler implements SkillHandler {
       const draft = await client.createDraftReply({
         replyToMessageId,
         subject: replySubject,
-        body: quotedBody,
+        body: draftBody,
         to,
         cc,
       });

--- a/skills/email-reply/handler.test.ts
+++ b/skills/email-reply/handler.test.ts
@@ -123,11 +123,13 @@ describe('EmailReplyHandler', () => {
       const result = await handler.execute(ctx);
 
       expect(result.success).toBe(true);
-      const sendArg = (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mock.calls[0]![0] as { body: string };
+      const sendArg = (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mock.calls[0]![0] as { body: string; htmlQuote?: string };
+      // Reply body stays as markdown; gateway converts it to HTML
       expect(sendArg.body).toContain('Sounds good!');
-      expect(sendArg.body).toContain('---------- Original Message ----------');
-      expect(sendArg.body).toContain('Alice <alice@example.com>');
-      expect(sendArg.body).toContain('Let me know your thoughts.');
+      // HTML quote passed separately so markdownToHtml does not re-escape it
+      expect(sendArg.htmlQuote).toContain('<blockquote');
+      expect(sendArg.htmlQuote).toContain('alice@example.com');
+      expect(sendArg.htmlQuote).toContain('Let me know your thoughts.');
     });
 
     it('proceeds without quote when buildReplyQuote throws', async () => {

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -113,13 +113,15 @@ export class EmailReplyHandler implements SkillHandler {
 
       // Append the quoted original message below the reply body. Formatting is
       // non-fatal — a quote failure must not block the reply from being sent.
-      let quotedBody = body;
+      // htmlQuote is passed separately so it is appended after markdownToHtml(body)
+      // in the gateway, preventing the HTML from being re-escaped.
+      let htmlQuote: string | undefined;
       try {
-        const candidate = body + buildReplyQuote(original, ctx.timezone);
+        const candidate = buildReplyQuote(original, ctx.timezone, { format: 'html' });
         // Skip the quote silently if it would push the body past the size limit
         // (the agent-authored body already passed the guard above; a long thread
         // could tip the combined total over). The reply still goes out unquoted.
-        quotedBody = candidate.length <= MAX_BODY_LENGTH ? candidate : body;
+        htmlQuote = body.length + candidate.length <= MAX_BODY_LENGTH ? candidate : undefined;
       } catch (err) {
         ctx.log.warn(
           { err, replyToMessageId },
@@ -131,8 +133,9 @@ export class EmailReplyHandler implements SkillHandler {
         channel: 'email',
         to: originalFrom,
         subject: replySubject,
-        body: quotedBody,
+        body,
         replyToMessageId,
+        ...(htmlQuote ? { htmlQuote } : {}),
         ...(ccAddresses ? { cc: ccAddresses } : {}),
       });
 

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -135,7 +135,7 @@ export class EmailReplyHandler implements SkillHandler {
         subject: replySubject,
         body,
         replyToMessageId,
-        ...(htmlQuote ? { htmlQuote } : {}),
+        htmlQuote,
         ...(ccAddresses ? { cc: ccAddresses } : {}),
       });
 

--- a/skills/email-send/handler.ts
+++ b/skills/email-send/handler.ts
@@ -143,7 +143,7 @@ export class EmailSendHandler implements SkillHandler {
         body,
         cc: ccAddresses,
         replyToMessageId,
-        ...(htmlQuote ? { htmlQuote } : {}),
+        htmlQuote,
       });
 
       if (!result.success) {

--- a/skills/email-send/handler.ts
+++ b/skills/email-send/handler.ts
@@ -104,7 +104,9 @@ export class EmailSendHandler implements SkillHandler {
     // the reply body. Both the fetch and the formatting are non-fatal — if either
     // fails, proceed with the unquoted body and log a warning at the correct step.
     // Note: email-send has no account routing, so getEmailMessage uses the primary account.
-    let quotedBody = body;
+    // htmlQuote is passed separately so it is appended after markdownToHtml(body)
+    // in the gateway, preventing the HTML from being re-escaped.
+    let htmlQuote: string | undefined;
     if (replyToMessageId) {
       let original: Awaited<ReturnType<typeof ctx.outboundGateway.getEmailMessage>> | undefined;
       try {
@@ -117,11 +119,11 @@ export class EmailSendHandler implements SkillHandler {
       }
       if (original !== undefined) {
         try {
-          const candidate = body + buildReplyQuote(original, ctx.timezone);
+          const candidate = buildReplyQuote(original, ctx.timezone, { format: 'html' });
           // Skip the quote silently if it would push the body past the size limit
           // (the agent-authored body already passed the guard above; the quote block
           // itself could tip a long thread over). The send still goes out unquoted.
-          quotedBody = candidate.length <= MAX_BODY_LENGTH ? candidate : body;
+          htmlQuote = body.length + candidate.length <= MAX_BODY_LENGTH ? candidate : undefined;
         } catch (err) {
           ctx.log.warn(
             { err, replyToMessageId },
@@ -138,9 +140,10 @@ export class EmailSendHandler implements SkillHandler {
         channel: 'email',
         to: toAddresses[0]!,
         subject,
-        body: quotedBody,
+        body,
         cc: ccAddresses,
         replyToMessageId,
+        ...(htmlQuote ? { htmlQuote } : {}),
       });
 
       if (!result.success) {

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -505,7 +505,7 @@ export class EmailAdapter {
         subject: `Re: ${baseSubject}`,
         body,
         replyToMessageId: threadMessage.id,
-        ...(htmlQuote ? { htmlQuote } : {}),
+        htmlQuote,
         ...(ccAddresses.length > 0 ? { cc: ccAddresses } : {}),
       };
 

--- a/src/channels/email/email-adapter.ts
+++ b/src/channels/email/email-adapter.ts
@@ -482,11 +482,14 @@ export class EmailAdapter {
       // used by email-send / email-reply / email-draft-save skills. The quote
       // is best-effort — if formatting fails or the total body would exceed
       // MAX_REPLY_BODY_LENGTH, the reply still goes out without the quote.
-      let body = outbound.payload.content;
+      // htmlQuote is passed separately so it is appended after markdownToHtml(body)
+      // in the gateway, preventing the HTML from being re-escaped.
+      const body = outbound.payload.content;
+      let htmlQuote: string | undefined;
       try {
-        const candidate = body + buildReplyQuote(threadMessage, this.config.timezone);
-        if (candidate.length <= MAX_REPLY_BODY_LENGTH) {
-          body = candidate;
+        const candidate = buildReplyQuote(threadMessage, this.config.timezone, { format: 'html' });
+        if (body.length + candidate.length <= MAX_REPLY_BODY_LENGTH) {
+          htmlQuote = candidate;
         }
       } catch (err) {
         logger.warn(
@@ -502,6 +505,7 @@ export class EmailAdapter {
         subject: `Re: ${baseSubject}`,
         body,
         replyToMessageId: threadMessage.id,
+        ...(htmlQuote ? { htmlQuote } : {}),
         ...(ccAddresses.length > 0 ? { cc: ccAddresses } : {}),
       };
 

--- a/src/skills/_shared/reply-quote.test.ts
+++ b/src/skills/_shared/reply-quote.test.ts
@@ -17,6 +17,10 @@ function makeMessage(overrides?: Partial<QuoteableMessage>): QuoteableMessage {
 }
 
 describe('buildReplyQuote', () => {
+  // ---------------------------------------------------------------------------
+  // Plain-text mode (default) — existing behaviour must be preserved
+  // ---------------------------------------------------------------------------
+
   it('formats a complete quote with name and email', () => {
     const result = buildReplyQuote(makeMessage(), 'America/Toronto');
 
@@ -163,5 +167,155 @@ describe('buildReplyQuote', () => {
     // Actual message text must survive
     expect(result).toContain('Hi Joseph');
     expect(result).toContain('Let me know your thoughts on the proposal.');
+  });
+
+  // ---------------------------------------------------------------------------
+  // HTML mode — format: 'html'
+  // ---------------------------------------------------------------------------
+
+  describe('format: html', () => {
+    it('wraps output in a blockquote with attribution headers', () => {
+      const result = buildReplyQuote(makeMessage(), 'America/Toronto', { format: 'html' });
+
+      expect(result).toContain('<blockquote');
+      expect(result).toContain('</blockquote>');
+      expect(result).toContain('<strong>From:</strong>');
+      expect(result).toContain('<strong>Date:</strong>');
+      expect(result).toContain('<strong>To:</strong>');
+      expect(result).toContain('<strong>Subject:</strong>');
+      // Should start with double newline to separate from reply body
+      expect(result.startsWith('\n\n')).toBe(true);
+    });
+
+    it('HTML-escapes participant names and email addresses in headers', () => {
+      const msg = makeMessage({
+        from: [{ name: 'Alice & Bob', email: 'alice+bob@example.com' }],
+      });
+      const result = buildReplyQuote(msg, 'America/Toronto', { format: 'html' });
+
+      expect(result).toContain('Alice &amp; Bob');
+      // Email address angle brackets rendered as entities in the attribution header
+      expect(result).toContain('&lt;alice+bob@example.com&gt;');
+      // Raw < and > must not appear unescaped in the header
+      expect(result).not.toMatch(/<alice\+bob@example\.com>/);
+    });
+
+    it('HTML-escapes subject line', () => {
+      const msg = makeMessage({ subject: 'Q2 <budget> & forecast' });
+      const result = buildReplyQuote(msg, 'America/Toronto', { format: 'html' });
+
+      expect(result).toContain('Q2 &lt;budget&gt; &amp; forecast');
+    });
+
+    it('preserves bold and links from a Gmail-style HTML body', () => {
+      const gmailHtml = '<p>Please review the <a href="https://example.com/doc">proposal</a> and the <b>Q2 numbers</b>.</p>';
+      const msg = makeMessage({ body: gmailHtml });
+      const result = buildReplyQuote(msg, 'America/Toronto', { format: 'html' });
+
+      expect(result).toContain('<a href="https://example.com/doc">proposal</a>');
+      expect(result).toContain('<b>Q2 numbers</b>');
+    });
+
+    it('fully removes <script> tag and its content', () => {
+      const xssHtml = '<p>Hello</p><script>alert(1)</script><p>World</p>';
+      const msg = makeMessage({ body: xssHtml });
+      const result = buildReplyQuote(msg, 'America/Toronto', { format: 'html' });
+
+      expect(result).not.toContain('<script');
+      expect(result).not.toContain('alert(1)');
+      expect(result).toContain('Hello');
+      expect(result).toContain('World');
+    });
+
+    it('strips onclick and other event-handler attributes', () => {
+      const html = '<p onclick="evil()">Click me</p><a href="https://example.com" onmouseover="steal()">link</a>';
+      const msg = makeMessage({ body: html });
+      const result = buildReplyQuote(msg, 'America/Toronto', { format: 'html' });
+
+      expect(result).not.toContain('onclick');
+      expect(result).not.toContain('onmouseover');
+      expect(result).toContain('Click me');
+      expect(result).toContain('link');
+    });
+
+    it('strips javascript: URLs from href attributes', () => {
+      const html = '<a href="javascript:alert(1)">click</a>';
+      const msg = makeMessage({ body: html });
+      const result = buildReplyQuote(msg, 'America/Toronto', { format: 'html' });
+
+      expect(result).not.toContain('javascript:');
+    });
+
+    it('strips VML behavior: CSS from style attributes (Outlook fixture)', () => {
+      // behavior: in an inline style attribute (not a <style> block) — the
+      // transformTags sanitizer strips it while preserving other CSS.
+      const outlookHtml = [
+        '<p style="behavior:url(#default#VML);font-size:12pt">Meeting notes</p>',
+        '<div style="font-family:Arial;behavior:url(#default#VML);">Content</div>',
+      ].join('\n');
+      const msg = makeMessage({ body: outlookHtml });
+      const result = buildReplyQuote(msg, 'America/Toronto', { format: 'html' });
+
+      expect(result).not.toContain('behavior:url');
+      expect(result).toContain('Meeting notes');
+      expect(result).toContain('Content');
+      // Harmless CSS properties should survive
+      expect(result).toContain('font-size:12pt');
+      expect(result).toContain('font-family:Arial');
+    });
+
+    it('strips <style> block content entirely (Outlook VML fixture)', () => {
+      const outlookVmlHtml = [
+        '<html><head>',
+        '<style>v\\:* {behavior:url(#default#VML);}</style>',
+        '</head><body>',
+        '<p>Hi Joseph,</p>',
+        '</body></html>',
+      ].join('\n');
+      const msg = makeMessage({ body: outlookVmlHtml });
+      const result = buildReplyQuote(msg, 'America/Toronto', { format: 'html' });
+
+      expect(result).not.toContain('behavior:url');
+      expect(result).toContain('Hi Joseph');
+    });
+
+    it('omits blockquote when sanitized body is empty', () => {
+      const msg = makeMessage({ body: '<style>.x{}</style>' });
+      const result = buildReplyQuote(msg, 'America/Toronto', { format: 'html' });
+
+      // Headers must be present
+      expect(result).toContain('<strong>From:</strong>');
+      // No blockquote since body sanitised to empty
+      expect(result).not.toContain('<blockquote');
+    });
+
+    it('omits blockquote when body is null or undefined', () => {
+      for (const body of [null, undefined]) {
+        const msg = makeMessage({ body });
+        const result = buildReplyQuote(msg, 'America/Toronto', { format: 'html' });
+
+        expect(result).toContain('<strong>From:</strong>');
+        expect(result).not.toContain('<blockquote');
+      }
+    });
+
+    it('includes date with timezone in HTML output', () => {
+      const result = buildReplyQuote(makeMessage(), 'America/Toronto', { format: 'html' });
+
+      expect(result).toContain('2025-05-21, 3:42 PM EDT');
+    });
+
+    it('comma-separates multiple recipients in HTML output', () => {
+      const msg = makeMessage({
+        to: [
+          { name: 'Bob', email: 'bob@example.com' },
+          { email: 'carol@example.com' },
+        ],
+      });
+      const result = buildReplyQuote(msg, 'America/Toronto', { format: 'html' });
+
+      expect(result).toContain('Bob');
+      expect(result).toContain('carol@example.com');
+    });
   });
 });

--- a/src/skills/_shared/reply-quote.ts
+++ b/src/skills/_shared/reply-quote.ts
@@ -122,7 +122,8 @@ const QUOTE_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
         ? {
             ...attribs,
             style: style
-              .replace(/\bexpression\s*\([^)]*\)/gi, '')
+              // dotAll (s flag) + lazy quantifier handles nested parens in the expression
+              .replace(/\bexpression\s*\(.*?\)/gis, '')
               .replace(/\bbehavior\s*:[^;]*/gi, ''),
           }
         : attribs;

--- a/src/skills/_shared/reply-quote.ts
+++ b/src/skills/_shared/reply-quote.ts
@@ -8,6 +8,7 @@
 // utilities (same pattern they use for SkillContext / SkillHandler types).
 
 import { DateTime } from 'luxon';
+import sanitizeHtml from 'sanitize-html';
 import { htmlToText } from '../../channels/email/html-to-text.js';
 
 /**
@@ -23,6 +24,16 @@ export interface QuoteableMessage {
   body: string | undefined | null;  // HTML — will be stripped to plain text; undefined/null treated as empty
 }
 
+export interface BuildReplyQuoteOptions {
+  /** Output format. 'plain' (default): plain-text block for legacy / LLM context.
+   *  'html': HTML <blockquote> with sanitized original body, for outbound email via Nylas. */
+  format?: 'plain' | 'html';
+}
+
+// ---------------------------------------------------------------------------
+// Plain-text helpers
+// ---------------------------------------------------------------------------
+
 /**
  * Format a participant as "Name <email>" when a display name is present,
  * or bare "email" when it is not.
@@ -31,28 +42,122 @@ function formatParticipant(p: { name?: string; email: string }): string {
   return p.name ? `${p.name} <${p.email}>` : p.email;
 }
 
+// ---------------------------------------------------------------------------
+// HTML helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape text for safe embedding in an HTML text node or attribute value.
+ * Used for attribution header values we generate ourselves (date, subject, names).
+ */
+function esc(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Format a participant for HTML output: "Name &lt;email&gt;" or bare "email".
+ * Both name and email are HTML-escaped.
+ */
+function formatParticipantHtml(p: { name?: string; email: string }): string {
+  return p.name
+    ? `${esc(p.name)} &lt;${esc(p.email)}&gt;`
+    : esc(p.email);
+}
+
+// Sanitization config for quoted email bodies.
+// allowedTags covers all structural / inline / table elements that appear in real
+// email HTML. nonTextTags ensures <script>/<style>/<head> content is removed entirely
+// (not just the tags). transformTags strips Outlook/IE-specific CSS from style attributes.
+const QUOTE_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: [
+    // Block / sectioning
+    'address', 'article', 'blockquote', 'dd', 'details', 'div', 'dl', 'dt',
+    'figcaption', 'figure', 'footer', 'header', 'hr', 'li', 'main', 'nav',
+    'ol', 'p', 'pre', 'section', 'summary', 'ul',
+    // Headings
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    // Inline text semantics
+    'abbr', 'b', 'br', 'cite', 'code', 'del', 'dfn', 'em', 'i', 'ins', 'kbd',
+    'mark', 'q', 's', 'samp', 'small', 'span', 'strong', 'sub', 'sup', 'u', 'var',
+    // Links and images
+    'a', 'img',
+    // Table elements (common in email HTML)
+    'caption', 'col', 'colgroup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr',
+  ],
+  allowedAttributes: {
+    '*': ['class', 'dir', 'lang', 'style'],
+    'a': ['href', 'title', 'name'],
+    'blockquote': ['cite'],
+    'col': ['span', 'width'],
+    'colgroup': ['span', 'width'],
+    'img': ['alt', 'height', 'src', 'title', 'width'],
+    'ol': ['reversed', 'start', 'type'],
+    'q': ['cite'],
+    'table': ['align', 'border', 'cellpadding', 'cellspacing', 'width'],
+    'td': ['abbr', 'align', 'colspan', 'rowspan', 'valign', 'width'],
+    'th': ['abbr', 'align', 'colspan', 'rowspan', 'scope', 'valign', 'width'],
+    'ul': ['type'],
+  },
+  // Only http/https/mailto in href/src; cid/data additionally allowed on <img> for
+  // inline attachments. This strips javascript: URLs.
+  allowedSchemes: ['http', 'https', 'mailto'],
+  allowedSchemesByTag: {
+    img: ['http', 'https', 'cid', 'data'],
+  },
+  // Strip content entirely for raw-text/dangerous elements — not just the tags.
+  // This prevents <style> CSS text and <script> code from appearing as plain text
+  // in the sanitized output.
+  nonTextTags: ['script', 'style', 'head', 'noscript', 'template', 'xml'],
+  // Remove Outlook/IE-specific CSS attack patterns from style attributes:
+  //   behavior: triggers ActiveX / VML behaviours in old IE and Outlook
+  //   expression(): executes JavaScript in the old IE CSS engine
+  transformTags: {
+    '*': (tagName: string, attribs: sanitizeHtml.Attributes): sanitizeHtml.Tag => {
+      const style = attribs['style'];
+      const newAttribs: sanitizeHtml.Attributes = style
+        ? {
+            ...attribs,
+            style: style
+              .replace(/\bexpression\s*\([^)]*\)/gi, '')
+              .replace(/\bbehavior\s*:[^;]*/gi, ''),
+          }
+        : attribs;
+      return { tagName, attribs: newAttribs };
+    },
+  },
+};
+
+function sanitizeQuoteBody(html: string): string {
+  return sanitizeHtml(html, QUOTE_SANITIZE_OPTIONS);
+}
+
+// ---------------------------------------------------------------------------
+// Core function
+// ---------------------------------------------------------------------------
+
 /**
  * Build a formatted quote block from the original message, suitable for
- * appending below the reply body. Returns a string starting with \n\n
- * to separate the reply from the quote.
+ * appending below the reply body.
  *
- * Output format:
- * ```
- * ---------- Original Message ----------
- * From: Alice Example <alice@example.com>
- * Date: 2026-05-21, 3:42 PM EDT
- * To: joseph@josephfung.ca
- * Subject: Re: Q2 planning
- *
- * [original message body, HTML stripped]
- * ```
+ * Plain mode (default): returns a string starting with \n\n for plain-text
+ * emails or legacy use. HTML mode: returns an HTML fragment (attribution
+ * headers + sanitized <blockquote>) starting with \n\n, ready to be
+ * appended to the HTML body of an outbound Nylas email.
  *
  * @param message   The original message to quote
  * @param timezone  IANA timezone name (e.g. "America/Toronto"); falls back to UTC
+ * @param options   format: 'plain' (default) | 'html'
  */
-export function buildReplyQuote(message: QuoteableMessage, timezone?: string): string {
-  const fromLine = message.from.map(formatParticipant).join(', ');
-  const toLine = message.to.map(formatParticipant).join(', ');
+export function buildReplyQuote(
+  message: QuoteableMessage,
+  timezone?: string,
+  options?: BuildReplyQuoteOptions,
+): string {
+  const format = options?.format ?? 'plain';
 
   const preferredZone = timezone ?? 'UTC';
   const dtPreferred = DateTime.fromSeconds(message.date, { zone: preferredZone });
@@ -67,6 +172,36 @@ export function buildReplyQuote(message: QuoteableMessage, timezone?: string): s
     ? dt.toFormat('yyyy-MM-dd, h:mm a ZZZZ')
     : 'Unknown date';
 
+  if (format === 'html') {
+    const fromLine = message.from.map(formatParticipantHtml).join(', ');
+    const toLine = message.to.map(formatParticipantHtml).join(', ');
+    const safeBody = sanitizeQuoteBody(message.body ?? '');
+
+    const parts = [
+      '',
+      '',
+      '<div style="margin-top:1em;padding-top:0.75em;border-top:1px solid #cccccc;font-size:0.9em;color:#555555;">',
+      `  <p style="margin:0 0 0.25em 0;"><strong>From:</strong> ${fromLine}</p>`,
+      `  <p style="margin:0 0 0.25em 0;"><strong>Date:</strong> ${esc(dateLine)}</p>`,
+      `  <p style="margin:0 0 0.25em 0;"><strong>To:</strong> ${toLine}</p>`,
+      `  <p style="margin:0 0 0.75em 0;"><strong>Subject:</strong> ${esc(message.subject)}</p>`,
+      '</div>',
+    ];
+
+    if (safeBody) {
+      parts.push(
+        '<blockquote style="margin:0;padding:0 0 0 1em;border-left:3px solid #cccccc;color:#333333;">',
+        safeBody,
+        '</blockquote>',
+      );
+    }
+
+    return parts.join('\n');
+  }
+
+  // Plain-text mode (default) — original behaviour
+  const fromLine = message.from.map(formatParticipant).join(', ');
+  const toLine = message.to.map(formatParticipant).join(', ');
   const plainBody = htmlToText(message.body);
 
   const lines = [
@@ -79,7 +214,6 @@ export function buildReplyQuote(message: QuoteableMessage, timezone?: string): s
     `Subject: ${message.subject}`,
   ];
 
-  // Include body section only when there is actual content to show
   if (plainBody) {
     lines.push('', plainBody);
   }

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -53,6 +53,10 @@ export interface EmailSendRequest {
   cc?: string[];
   /** When set, Nylas threads the outbound message as a reply */
   replyToMessageId?: string;
+  /** Pre-formed HTML fragment appended verbatim after markdownToHtml(body).
+   *  Used for the quoted original message block: the HTML quote must not pass
+   *  through markdownToHtml because that converter escapes < and > characters. */
+  htmlQuote?: string;
 }
 
 export interface SignalOutboundRequest {
@@ -1531,7 +1535,8 @@ export class OutboundGateway {
       return { success: false, blockedReason: 'Email client not configured' };
     }
 
-    const htmlBody = markdownToHtml(request.body);
+    // htmlQuote is appended after conversion so it is not re-escaped by markdownToHtml.
+    const htmlBody = markdownToHtml(request.body) + (request.htmlQuote ?? '');
 
     try {
       const sendOptions: SendEmailOptions = {
@@ -1573,7 +1578,8 @@ export class OutboundGateway {
     // markdownToHtml is a pure function (no I/O, no realistic throw path).
     // Called outside the Nylas try-catch so that any future regression in the
     // converter is not silently misattributed as "Nylas send failed" in logs.
-    const htmlBody = markdownToHtml(request.body);
+    // htmlQuote is appended after conversion so it is not re-escaped by markdownToHtml.
+    const htmlBody = markdownToHtml(request.body) + (request.htmlQuote ?? '');
 
     try {
       const sendOptions: SendEmailOptions = {

--- a/tests/unit/channels/email/email-adapter.test.ts
+++ b/tests/unit/channels/email/email-adapter.test.ts
@@ -266,13 +266,16 @@ describe('EmailAdapter — sendOutboundReply', () => {
     await triggerOutbound(makeOutboundEvent('email:thread-abc'));
 
     const callArg = (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+    // Reply body stays as markdown in body field; gateway converts it to HTML
     expect(callArg.body).toContain('Here is my reply.');
-    expect(callArg.body).toContain('---------- Original Message ----------');
-    expect(callArg.body).toContain('From: CEO <ceo@example.com>');
-    expect(callArg.body).toContain('Subject: Q2 planning');
-    // HTML stripped to plain text — angle brackets gone, content preserved
-    expect(callArg.body).toContain('Hi Curia, can we sync on Q2?');
-    expect(callArg.body).not.toContain('<p>');
+    // HTML quote is passed separately so it is not re-escaped by markdownToHtml
+    expect(callArg.htmlQuote).toContain('<strong>From:</strong>');
+    expect(callArg.htmlQuote).toContain('CEO');
+    expect(callArg.htmlQuote).toContain('ceo@example.com');
+    expect(callArg.htmlQuote).toContain('Q2 planning');
+    // Original HTML body is preserved inside the blockquote (not stripped to plain text)
+    expect(callArg.htmlQuote).toContain('<blockquote');
+    expect(callArg.htmlQuote).toContain('Hi Curia, can we sync on Q2?');
   });
 
   it('uses the configured timezone when rendering the quoted Date line', async () => {
@@ -287,7 +290,7 @@ describe('EmailAdapter — sendOutboundReply', () => {
     await triggerOutbound(makeOutboundEvent('email:thread-abc'));
 
     const callArg = (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mock.calls[0]![0];
-    expect(callArg.body).toMatch(/Date: 2023-11-14, 5:13 PM EST/);
+    expect(callArg.htmlQuote).toMatch(/2023-11-14, 5:13 PM EST/);
   });
 
   it('sends with quote headers (bodyless) when original body is undefined', async () => {
@@ -306,13 +309,14 @@ describe('EmailAdapter — sendOutboundReply', () => {
 
     await triggerOutbound(makeOutboundEvent('email:thread-abc'));
 
-    // Send still happens — quoted headers are included, body section is omitted
+    // Send still happens — quoted headers are included, no blockquote (empty body)
     expect(mocks.outboundGateway.send).toHaveBeenCalledOnce();
     const callArg = (mocks.outboundGateway.send as ReturnType<typeof vi.fn>).mock.calls[0]![0];
     expect(callArg.body).toContain('Here is my reply.');
-    expect(callArg.body).toContain('---------- Original Message ----------');
-    // No body content after the headers (Subject: is the last line)
-    expect(callArg.body).toMatch(/Subject:.*$/m);
+    expect(callArg.htmlQuote).toContain('<strong>From:</strong>');
+    expect(callArg.htmlQuote).toContain('<strong>Subject:</strong>');
+    // No blockquote when the original body is empty
+    expect(callArg.htmlQuote).not.toContain('<blockquote');
     // No warning — buildReplyQuote succeeded
     expect(warnSpy).not.toHaveBeenCalled();
   });

--- a/tests/unit/skills/email-send.test.ts
+++ b/tests/unit/skills/email-send.test.ts
@@ -49,11 +49,13 @@ describe('EmailSendHandler — reply quote', () => {
     expect(result.success).toBe(true);
     expect(gateway.getEmailMessage).toHaveBeenCalledWith('msg-orig');
 
-    const sendArg = gateway.send.mock.calls[0]![0] as { body: string; replyToMessageId?: string };
+    const sendArg = gateway.send.mock.calls[0]![0] as { body: string; htmlQuote?: string; replyToMessageId?: string };
+    // Reply body stays as markdown; gateway converts it to HTML
     expect(sendArg.body).toContain('Sounds good!');
-    expect(sendArg.body).toContain('---------- Original Message ----------');
-    expect(sendArg.body).toContain('Alice <alice@example.com>');
-    expect(sendArg.body).toContain('Let me know your thoughts.');
+    // HTML quote passed separately so markdownToHtml does not re-escape it
+    expect(sendArg.htmlQuote).toContain('<blockquote');
+    expect(sendArg.htmlQuote).toContain('alice@example.com');
+    expect(sendArg.htmlQuote).toContain('Let me know your thoughts.');
     expect(sendArg.replyToMessageId).toBe('msg-orig');
   });
 


### PR DESCRIPTION
## **User description**
## Summary

- `buildReplyQuote()` gains a `{ format: 'html' }` option that emits a sanitized HTML `<blockquote>` with styled attribution headers instead of plain text
- `sanitize-html` strips `<script>`, `<style>`, event-handler attributes, `javascript:` URLs, Outlook VML `behavior:` CSS, and IE `expression()` CSS while preserving bold, links, tables, and other visual structure
- `EmailSendRequest` gains an optional `htmlQuote?: string` field — the HTML quote is appended in the gateway *after* `markdownToHtml(body)` so the angle brackets are never re-escaped (the custom `markdownToHtml` escapes HTML, which is the key reason this field exists)
- All four call sites switched to `{ format: 'html' }`
- `ceo-inbox-draft-reply` now also applies `markdownToHtml()` to the LLM reply body before creating the Nylas draft — that path bypasses the gateway so the conversion was previously missing

## Test plan

- [ ] 26 unit tests in `reply-quote.test.ts` pass — including VML fixture, Gmail bold/link fixture, XSS `<script>` payload, event-handler stripping, `javascript:` URL stripping, `behavior:` CSS in inline style attributes
- [ ] All existing reply tests updated and passing — adapter, email-reply, email-send, ceo-inbox-draft-reply
- [ ] `pnpm run typecheck` clean
- [ ] Full test suite: 2717 passing (4 pre-existing DB failures unrelated to this change)
- [ ] Manual: reply to a richly-formatted email and inspect the sent message source in Gmail/Outlook

Closes #734


___

## **CodeAnt-AI Description**
**Preserve rich quoted replies in outgoing email**

### What Changed
- Reply emails now keep the original message as a sanitized HTML quote block instead of turning it into plain text
- The quoted message preserves readable formatting like bold text, links, tables, and line structure, while stripping scripts, event handlers, unsafe URLs, and Outlook-specific CSS
- Reply bodies are now sent as markdown converted to HTML first, so quoted content is not re-escaped in the final email
- CEO draft replies now also include the reply text as HTML before adding the quoted message, and long quotes are skipped when the full draft would exceed the size limit
- Replies no longer build repeated `Re:` prefixes in the subject line

### Impact
`✅ Clearer quoted replies`
`✅ Fewer broken formatting issues in reply emails`
`✅ Safer handling of pasted email HTML`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
