### PR TITLE
fix(calendar-list-events): guard against non-UUID contactId before DB call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`calendar-list-events`** — non-UUID caller contactId (e.g. `"system"` from scheduled jobs) now returns a clear, actionable error instead of a raw Postgres UUID parse failure. (#723)
 - **Email reply quoting** — natural agent-response replies (no skill invocation) now include the quoted original message, matching the skill-driven paths. `buildReplyQuote` moved to `src/skills/_shared/` so the email channel adapter can share it. (#720)
 - **`reply-quote`** — Outlook-on-Windows VML CSS from `<style>` blocks no longer leaks into the quoted body as visible text; delegates to `html-to-text.ts` which strips style/script block contents. (#733)
 

--- a/skills/calendar-list-events/handler.test.ts
+++ b/skills/calendar-list-events/handler.test.ts
@@ -1,0 +1,89 @@
+// handler.test.ts — unit tests for calendar-list-events skill.
+
+import { describe, it, expect, vi } from 'vitest';
+import { CalendarListEventsHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+import { createSilentLogger } from '../../src/logger.js';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: {
+      timeMin: '2026-05-26T00:00:00Z',
+      timeMax: '2026-05-26T23:59:59Z',
+    },
+    secret: () => { throw new Error('no secret in test'); },
+    log: createSilentLogger(),
+    nylasCalendarClient: {
+      listEvents: vi.fn().mockResolvedValue([]),
+    } as unknown as SkillContext['nylasCalendarClient'],
+    ...overrides,
+  } as SkillContext;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CalendarListEventsHandler — system caller guard', () => {
+  it('returns a clear error when ctx.caller.contactId is "system" and no calendarId is provided', async () => {
+    const handler = new CalendarListEventsHandler();
+    const contactService = {
+      getCalendarsForContact: vi.fn().mockRejectedValue(
+        new Error('invalid input syntax for type uuid: "system"'),
+      ),
+    } as unknown as SkillContext['contactService'];
+
+    const result = await handler.execute(makeCtx({
+      caller: { contactId: 'system', role: null, channel: 'internal' },
+      contactService,
+    }));
+
+    expect(result.success).toBe(false);
+    // Should surface an actionable error, not a raw Postgres UUID parse error
+    expect((result as { error: string }).error).toContain('calendarId');
+    // contactService should never have been called — the guard fires before the DB hit
+    expect(contactService!.getCalendarsForContact).not.toHaveBeenCalled();
+  });
+
+  it('returns a clear error when ctx.caller.contactId is "primary-user" and no calendarId is provided', async () => {
+    const handler = new CalendarListEventsHandler();
+    const contactService = {
+      getCalendarsForContact: vi.fn(),
+    } as unknown as SkillContext['contactService'];
+
+    const result = await handler.execute(makeCtx({
+      caller: { contactId: 'primary-user', role: 'ceo', channel: 'cli' },
+      contactService,
+    }));
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('calendarId');
+    expect(contactService!.getCalendarsForContact).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire the guard for a valid UUID contactId — proceeds to getCalendarsForContact', async () => {
+    const handler = new CalendarListEventsHandler();
+    const contactService = {
+      getCalendarsForContact: vi.fn().mockResolvedValue([
+        { nylasCalendarId: 'cal-work' },
+      ]),
+    } as unknown as SkillContext['contactService'];
+
+    const result = await handler.execute(makeCtx({
+      caller: { contactId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', role: 'ceo', channel: 'signal' },
+      contactService,
+      nylasCalendarClient: {
+        listEvents: vi.fn().mockResolvedValue([]),
+      } as unknown as SkillContext['nylasCalendarClient'],
+    }));
+
+    // Guard must not have fired — contactService was called with the UUID
+    expect(contactService!.getCalendarsForContact).toHaveBeenCalledWith('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
+    // Result: no events but success (the calendar exists, range is empty)
+    expect(result.success).toBe(true);
+  });
+});

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -47,6 +47,22 @@ export class CalendarListEventsHandler implements SkillHandler {
       if (calendarId && typeof calendarId === 'string') {
         calendarIds = [calendarId];
       } else if (ctx.contactService && ctx.caller) {
+        // Two non-UUID sentinel values can appear in ctx.caller.contactId:
+        //   'system'       — scheduled-job invocations (see makeSystemOriginator in contacts/principal.ts)
+        //   'primary-user' — CLI sessions where the principal DB lookup failed at bootstrap
+        // Both cause a Postgres parse error if passed to a UUID column.
+        // Reject early with an actionable message so the LLM can retry with an explicit calendarId.
+        const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+        if (!UUID_RE.test(ctx.caller.contactId)) {
+          ctx.log.warn(
+            { contactId: ctx.caller.contactId },
+            'calendar-list-events: rejecting non-UUID contactId — calendarId is required for system-context invocations',
+          );
+          return {
+            success: false,
+            error: `calendarId is required when invoked from a non-contact-resolved context (caller contactId "${ctx.caller.contactId}" is not a UUID)`,
+          };
+        }
         const calendars = await ctx.contactService.getCalendarsForContact(ctx.caller.contactId);
         if (calendars.length === 0) {
           return { success: false, error: 'No calendars registered for this contact — register a calendar first' };

--- a/tests/unit/skills/calendar-list-events.test.ts
+++ b/tests/unit/skills/calendar-list-events.test.ts
@@ -134,7 +134,7 @@ describe('CalendarListEventsHandler', () => {
       {
         nylasCalendarClient: nylasCalendarClient as never,
         contactService: contactService as never,
-        caller: { contactId: 'primary-user', role: 'ceo', channel: 'cli' },
+        caller: { contactId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', role: 'ceo', channel: 'cli' },
       },
     ));
 
@@ -143,7 +143,7 @@ describe('CalendarListEventsHandler', () => {
     expect(nylasCalendarClient.listEvents).toHaveBeenCalledTimes(2);
     expect(nylasCalendarClient.listEvents).toHaveBeenCalledWith('cal-work', '2026-04-01T00:00:00Z', '2026-04-02T00:00:00Z', undefined);
     expect(nylasCalendarClient.listEvents).toHaveBeenCalledWith('cal-personal', '2026-04-01T00:00:00Z', '2026-04-02T00:00:00Z', undefined);
-    expect(contactService.getCalendarsForContact).toHaveBeenCalledWith('primary-user');
+    expect(contactService.getCalendarsForContact).toHaveBeenCalledWith('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
   });
 
   it('merges and sorts events from multiple calendars chronologically', async () => {
@@ -171,7 +171,7 @@ describe('CalendarListEventsHandler', () => {
       {
         nylasCalendarClient: nylasCalendarClient as never,
         contactService: contactService as never,
-        caller: { contactId: 'primary-user', role: 'ceo', channel: 'cli' },
+        caller: { contactId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', role: 'ceo', channel: 'cli' },
       },
     ));
 
@@ -371,7 +371,7 @@ describe('CalendarListEventsHandler', () => {
       {
         nylasCalendarClient: nylasCalendarClient as never,
         contactService: contactService as never,
-        caller: { contactId: 'primary-user', role: 'ceo', channel: 'cli' },
+        caller: { contactId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', role: 'ceo', channel: 'cli' },
       },
     ));
 
@@ -402,7 +402,7 @@ describe('CalendarListEventsHandler', () => {
       {
         nylasCalendarClient: nylasCalendarClient as never,
         contactService: contactService as never,
-        caller: { contactId: 'primary-user', role: 'ceo', channel: 'cli' },
+        caller: { contactId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', role: 'ceo', channel: 'cli' },
       },
     ));
 
@@ -428,7 +428,7 @@ describe('CalendarListEventsHandler', () => {
       {
         nylasCalendarClient: nylasCalendarClient as never,
         contactService: contactService as never,
-        caller: { contactId: 'primary-user', role: 'ceo', channel: 'cli' },
+        caller: { contactId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', role: 'ceo', channel: 'cli' },
       },
     ));
 
@@ -457,7 +457,7 @@ describe('CalendarListEventsHandler', () => {
       {
         nylasCalendarClient: nylasCalendarClient as never,
         contactService: contactService as never,
-        caller: { contactId: 'primary-user', role: 'ceo', channel: 'cli' },
+        caller: { contactId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', role: 'ceo', channel: 'cli' },
       },
     ));
 


### PR DESCRIPTION
## **User description**
## Summary

Closes #723

- `calendar-list-events` handler now validates that `ctx.caller.contactId` is a UUID before passing it to `contactService.getCalendarsForContact()`.
- When the contactId is a sentinel string (e.g. `"system"` from scheduled jobs, `"primary-user"` from degraded CLI bootstrap), the skill returns a clear, actionable error and logs a `warn` — instead of propagating a raw Postgres `invalid input syntax for type uuid` failure.
- Existing tests updated to use a valid UUID contactId fixture (was `"primary-user"`, which also isn't a UUID).
- Added three new test cases: `"system"` sentinel, `"primary-user"` sentinel, and valid-UUID pass-through (verifies the guard doesn't block real contacts).

## Test plan

- [ ] `skills/calendar-list-events/handler.test.ts` — 3 new cases all pass
- [ ] `tests/unit/skills/calendar-list-events.test.ts` — all 19 existing cases still pass
- [ ] `npm run typecheck` — clean


___

## **CodeAnt-AI Description**
Stop calendar lookups from failing on non-UUID caller IDs

### What Changed
- Calendar event listing now rejects non-UUID caller contact IDs before trying to load that user’s calendars, and returns a clear error that asks for an explicit calendarId.
- Scheduled-job and fallback CLI caller IDs like `"system"` and `"primary-user"` now fail cleanly instead of triggering a raw database UUID parse error.
- Added tests for the blocked sentinel IDs and for a valid UUID caller, and updated existing tests to use a real UUID contact ID.

### Impact
`✅ Clearer calendar lookup errors`
`✅ Fewer raw UUID parse failures`
`✅ Safer scheduled-job calendar requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
