### PR TITLE
fix(contacts): normalize phone/signal identifiers to E.164 (#731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`calendar-list-events`** — non-UUID caller contactId (e.g. `"system"` from scheduled jobs) now returns a clear, actionable error instead of a raw Postgres UUID parse failure. (#723)
 - **Email reply quoting** — natural agent-response replies (no skill invocation) now include the quoted original message, matching the skill-driven paths. `buildReplyQuote` moved to `src/skills/_shared/` so the email channel adapter can share it. (#720)
 - **`reply-quote`** — Outlook-on-Windows VML CSS from `<style>` blocks no longer leaks into the quoted body as visible text; delegates to `html-to-text.ts` which strips style/script block contents. (#733)
+- **`contact_channel_identities` phone/signal format** — five non-E.164 phone identifiers normalized to E.164 in place; CHECK constraint added to enforce format going forward; `linkIdentity` now strips formatting from `+`-prefixed phone/signal identifiers at write time. (#731)
 
 ## [0.31.0] — 2026-05-26 — "TARS"
 

--- a/docs/wip/2026-05-26-cci-audit.md
+++ b/docs/wip/2026-05-26-cci-audit.md
@@ -1,0 +1,64 @@
+# contact_channel_identities — Integrity Audit Results
+
+**Issue:** [#731](https://github.com/josephfung/curia/issues/731)
+**Date:** 2026-05-26
+**Triggered by:** Wrong-recipient incident ([#727](https://github.com/josephfung/curia/issues/727)) — Xiaopu Fung's phone row was storing the CEO's Signal number in dash format.
+
+---
+
+## Table snapshot at audit time
+
+| channel | row count |
+|---------|-----------|
+| email   | 198       |
+| phone   | 6         |
+| signal  | 2         |
+| **total** | **206** |
+
+---
+
+## Audit 1 — Format violations (phone/signal not in E.164)
+
+**5 rows found**, all `channel='phone'`, all `verified=true`.
+
+| Contact | Stored value | Problem | Normalized to |
+|---|---|---|---|
+| Evan Fung | `+1 (226) 989-6622` | Spaces + parentheses | `+12269896622` |
+| Xiaopu Fung | `+1-519-504-0098` | Dashes | `+15195040098` |
+| Sandra Hanmer | `519-574-0061` | Missing `+1`, dashes | `+15195740061` |
+| Jacqui Murphy | `519-574-2973` | Missing `+1`, dashes | `+15195742973` |
+| Sheldon McCormick | `647.389.4377` | Missing `+1`, dots | `+16473894377` |
+
+The two `signal` rows were already E.164 and required no changes.
+
+---
+
+## Audit 2 — Cross-row exact collisions
+
+**0 rows.** No `channel_identifier` appears more than once for the same channel.
+
+---
+
+## Audit 3 — Cross-channel collisions (same normalized number, different contacts)
+
+**0 rows.** No phone number resolves to the same real-world digits for two different contacts across any pair of channels.
+
+Note: the original incident (#727) was not a collision of this type — Xiaopu's row stored the CEO's actual number verbatim, not a format variant of her own number. That was a manual data-entry error that predated this audit, and was corrected directly in production on 2026-05-26.
+
+---
+
+## Audit 4 — Stale verified rows in legacy format (>6 months untouched)
+
+**0 rows.** All five format violations were last updated within 6 months of this audit.
+
+---
+
+## Fix applied — migration 045
+
+`045_cci_phone_signal_e164_normalize.sql` executed in migration run:
+
+1. **Step 1** — Normalized 2 rows with `+` prefix but non-E.164 formatting (Evan Fung, Xiaopu Fung).
+2. **Step 2** — Normalized 3 rows without `+` prefix (Sandra Hanmer, Jacqui Murphy, Sheldon McCormick) by prepending `+1`. All three confirmed as NANP numbers (519 = Ontario, 647 = Toronto).
+3. **Step 3** — Added `CHECK` constraint `cci_phone_signal_e164_format` enforcing `^\+[1-9][0-9]{6,14}$` for `channel IN ('phone', 'signal')`.
+
+Application-level guard added to `ContactService.linkIdentity()`: phone/signal identifiers with a `+` prefix are stripped of formatting at write time. Identifiers without `+` are left as-is and rejected by the DB constraint.

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -119,6 +119,17 @@ const AUTO_VERIFIED_SOURCES: ReadonlySet<IdentitySource> = new Set([
   'agent_called',
 ]);
 
+// Strip formatting characters from a phone identifier that already carries
+// a '+' prefix, producing a clean E.164 string (e.g. '+1-519-504-0098' → '+15195040098').
+// Identifiers without a '+' are returned as-is; the DB CHECK constraint will reject
+// them so the caller must supply a properly-formatted E.164 number.
+function normalizePhoneE164(identifier: string): string {
+  if (identifier.startsWith('+')) {
+    return '+' + identifier.slice(1).replace(/\D/g, '');
+  }
+  return identifier;
+}
+
 /**
  * ContactService manages the lifecycle of contacts and their channel identities.
  *
@@ -477,9 +488,17 @@ export class ContactService {
     // RFC 5321 allows case-sensitive local-parts, but in practice no major
     // provider enforces this — storing mixed-case causes lookup misses when
     // the LLM or inbound adapter uses a different casing.
-    const normalizedIdentifier = options.channel === 'email'
-      ? options.channelIdentifier.toLowerCase()
-      : options.channelIdentifier;
+    //
+    // Normalize phone/signal identifiers to E.164 (DB constraint enforces this).
+    // If the identifier already carries a '+' prefix, strip all formatting chars
+    // after it. Numbers lacking a '+' are left as-is — the DB CHECK constraint
+    // will reject them with a clear error so the caller must supply valid E.164.
+    const normalizedIdentifier =
+      options.channel === 'email'
+        ? options.channelIdentifier.toLowerCase()
+        : options.channel === 'phone' || options.channel === 'signal'
+        ? normalizePhoneE164(options.channelIdentifier)
+        : options.channelIdentifier;
 
     const identity: ChannelIdentity = {
       id: randomUUID(),
@@ -527,7 +546,16 @@ export class ContactService {
     channel: string,
     channelIdentifier: string,
   ): Promise<ResolvedSender | null> {
-    return this.backend.resolveByChannelIdentity(channel, channelIdentifier);
+    // Normalize the lookup key the same way linkIdentity normalizes at write time,
+    // so callers can look up by denormalized forms (e.g. '+1-519-504-0098') and
+    // still match the stored E.164 value ('+15195040098').
+    const normalizedIdentifier =
+      channel === 'email'
+        ? channelIdentifier.toLowerCase()
+        : channel === 'phone' || channel === 'signal'
+        ? normalizePhoneE164(channelIdentifier)
+        : channelIdentifier;
+    return this.backend.resolveByChannelIdentity(channel, normalizedIdentifier);
   }
 
   /** Get a contact together with all its linked channel identities. */
@@ -1639,16 +1667,23 @@ class InMemoryContactBackend implements ContactServiceBackend {
     channel: string,
     channelIdentifier: string,
   ): Promise<ResolvedSender | null> {
-    // Normalize email lookups to lowercase (mirrors Postgres backend).
-    const normalizedId = channel === 'email'
-      ? channelIdentifier.toLowerCase()
-      : channelIdentifier;
+    // Normalize lookup key to match stored form (mirrors Postgres backend + service layer).
+    // Email: lowercase. Phone/signal: E.164 (strip formatting from +-prefixed numbers).
+    const normalizedId =
+      channel === 'email'
+        ? channelIdentifier.toLowerCase()
+        : channel === 'phone' || channel === 'signal'
+        ? normalizePhoneE164(channelIdentifier)
+        : channelIdentifier;
 
     // Find the matching identity, then look up the contact
     for (const identity of this.identities.values()) {
-      const storedId = channel === 'email'
-        ? identity.channelIdentifier.toLowerCase()
-        : identity.channelIdentifier;
+      const storedId =
+        channel === 'email'
+          ? identity.channelIdentifier.toLowerCase()
+          : channel === 'phone' || channel === 'signal'
+          ? normalizePhoneE164(identity.channelIdentifier)
+          : identity.channelIdentifier;
       if (identity.channel === channel && storedId === normalizedId) {
         const contact = this.contacts.get(identity.contactId);
         if (contact) {

--- a/src/db/migrations/045_cci_phone_signal_e164_normalize.sql
+++ b/src/db/migrations/045_cci_phone_signal_e164_normalize.sql
@@ -1,0 +1,73 @@
+-- Migration 045: Normalize phone/signal channel identifiers to E.164 format
+-- and add a CHECK constraint to prevent future format drift.
+--
+-- Background: During the 2026-05-26 wrong-recipient incident (#727), Xiaopu Fung's
+-- phone channel identifier was found to be stored as '+1-519-504-0098' (dash-formatted)
+-- instead of canonical E.164 '+15195040098'. A post-incident audit (issue #731) found
+-- 5 total format violations across 8 phone/signal rows, all on the 'phone' channel.
+-- Signal rows were already E.164 (signal-cli delivers them that way).
+--
+-- Audit results (2026-05-26):
+--   Format violations:    5 rows (all channel='phone', all verified=true)
+--   Exact collisions:     0 rows
+--   Cross-channel clashes (same number, different contacts): 0 rows
+--   Stale verified rows (>6 months, legacy format):          0 rows
+--
+-- Violations found and their normalized forms:
+--   Evan Fung         '+1 (226) 989-6622'  → '+12269896622'  (spaces + parens)
+--   Xiaopu Fung       '+1-519-504-0098'    → '+15195040098'  (dashes)
+--   Sandra Hanmer     '519-574-0061'       → '+15195740061'  (missing +1, dashes)
+--   Jacqui Murphy     '519-574-2973'       → '+15195742973'  (missing +1, dashes)
+--   Sheldon McCormick '647.389.4377'       → '+16473894377'  (missing +1, dots)
+--
+-- Fix strategy:
+--   Step 1: Normalize numbers that already carry a '+' prefix — strip all non-digit
+--           characters after the '+', leaving a pure E.164 string.
+--   Step 2: For 10-digit NANP numbers without a '+' prefix (area codes 200-999),
+--           prepend '+1'. All three uncoded rows were confirmed as Canadian NANP
+--           numbers (area codes 519 = Ontario, 647 = Toronto).
+--   Step 3: Add a CHECK constraint so future inserts/updates with non-E.164
+--           phone/signal identifiers are rejected at the database level.
+--
+-- Application-level normalization (see contact-service.ts linkIdentity) is added
+-- alongside this migration to normalize at write time before the constraint fires.
+--
+-- Down Migration:
+--   The data normalization steps are NOT reversible (original strings are not kept).
+--   The CHECK constraint can be dropped:
+--     ALTER TABLE contact_channel_identities
+--       DROP CONSTRAINT cci_phone_signal_e164_format;
+
+-- Step 1: Normalize phone/signal identifiers that already have a '+' prefix.
+-- Strip all non-digit characters after the leading '+'.
+UPDATE contact_channel_identities
+SET
+  channel_identifier = '+' || regexp_replace(substring(channel_identifier FROM 2), '[^0-9]', '', 'g'),
+  updated_at         = now()
+WHERE channel IN ('phone', 'signal')
+  AND channel_identifier LIKE '+%'
+  AND channel_identifier !~ '^\+[1-9][0-9]{6,14}$';
+
+-- Step 2: Normalize 10-digit NANP phone/signal identifiers that have no '+' prefix.
+-- These are confirmed North American numbers; prepend country code +1.
+-- Guard: digit-only form must be exactly 10 digits starting with a valid NANP area
+-- code digit (2–9) to avoid misidentifying already-short or malformed values.
+UPDATE contact_channel_identities
+SET
+  channel_identifier = '+1' || regexp_replace(channel_identifier, '[^0-9]', '', 'g'),
+  updated_at         = now()
+WHERE channel IN ('phone', 'signal')
+  AND channel_identifier NOT LIKE '+%'
+  AND regexp_replace(channel_identifier, '[^0-9]', '', 'g') ~ '^[2-9][0-9]{9}$';
+
+-- Step 3: Add a CHECK constraint enforcing E.164 format for phone and signal channels.
+-- Regex: '+' followed by 7–15 digits, first digit non-zero (country code cannot be 0).
+-- The 7-digit floor is stricter than the ITU minimum (2 digits) but matches the
+-- shortest real PSTN subscriber numbers; it intentionally rejects obviously-malformed
+-- values like bare country codes. Other channels are unaffected.
+ALTER TABLE contact_channel_identities
+  ADD CONSTRAINT cci_phone_signal_e164_format
+  CHECK (
+    channel NOT IN ('phone', 'signal')
+    OR channel_identifier ~ '^\+[1-9][0-9]{6,14}$'
+  );


### PR DESCRIPTION
## **User description**
## Summary

Closes #731

- **Migration 045** normalizes 5 non-E.164 phone identifiers in-place (dashes, dots, parentheses, missing country code) and adds a `CHECK` constraint (`cci_phone_signal_e164_format`) so future inserts/updates on phone/signal channels must be valid E.164
- **`ContactService.linkIdentity()`** strips formatting from `+`-prefixed phone/signal identifiers at write time, mirroring the existing email lowercase normalization
- **`ContactService.resolveByChannelIdentity()`** normalizes the lookup key for phone/signal before passing to either backend, so callers can look up by denormalized forms and still match the stored E.164 value
- **Audit results** documented in `docs/wip/2026-05-26-cci-audit.md` (5 format violations, 0 collisions, 0 cross-channel clashes, 0 stale rows)

## Audit findings (2026-05-26)

| Check | Result |
|---|---|
| Format violations | **5 rows** — all `channel='phone'`, all `verified=true` |
| Exact cross-row collisions | 0 |
| Cross-channel collisions (same number, different contacts) | 0 |
| Stale verified rows in legacy format (>6 months) | 0 |

All 2 `signal` rows were already E.164. No collisions found, so no human review required.

## Test plan

- [ ] Apply migration on a local DB and verify all 8 phone/signal rows are now valid E.164
- [ ] Confirm `CHECK` constraint rejects a test INSERT with a dash-formatted phone number
- [ ] Confirm `linkIdentity('phone', '+1-519-504-0098')` stores `+15195040098`
- [ ] Confirm `resolveByChannelIdentity('phone', '+1-519-504-0098')` matches the stored `+15195040098` row
- [ ] `pnpm run typecheck` — clean


___

## **CodeAnt-AI Description**
**Normalize phone and Signal numbers to E.164 and enforce the format going forward**

### What Changed
- Existing phone records with spaces, dashes, dots, parentheses, or missing country code were normalized to valid E.164 values
- New phone and Signal entries now strip formatting from `+`-prefixed numbers before saving, and invalid non-E.164 values are rejected
- Phone and Signal lookups now also accept denormalized numbers, so callers can find matches using formatted input

### Impact
`✅ Fewer wrong-recipient lookups`
`✅ Clearer phone number validation`
`✅ Consistent contact matching for formatted input`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
