### PR TITLE
fix(bullpen): fire-and-forget agent.discuss publish to prevent timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Changed
 
 - **`buildReplyQuote`** — quoted reply blocks are now rendered as a sanitized HTML `<blockquote>` with styled attribution headers instead of plain text; original body HTML is preserved through `sanitize-html` (strips scripts, styles, event handlers, and `javascript:` URLs). `ceo-inbox-draft-reply` now also converts the LLM reply body to HTML before creating the Nylas draft. (#734)
-- **`meeting-debrief`** — system prompt now instructs the agent not to retry `bullpen.post` on timeout; on `<skill_error>...timed out</skill_error>` it records the meeting as `prompt_unconfirmed` and reconciles on the next tick. Stopgap until #721 lands a proper contract. (#722)
 
 ### Fixed
 
-- **`bullpen`** — `post` and `reply` now fire-and-forget the `agent.discuss` publish instead of awaiting it, so a slow subscriber no longer pushes the handler past its skill timeout and triggers duplicate-thread retries. (#721)
+- **`bullpen`** — `post` and `reply` now fire-and-forget the `agent.discuss` publish instead of awaiting it, so a slow subscriber no longer pushes the handler past its skill timeout and triggers duplicate-thread retries. Also unwinds the #722 `meeting-debrief` stopgap (no more `prompt_unconfirmed` state) since timeouts are no longer a realistic failure mode. (#721)
 - **Scheduler task drift** — coordinator's system prompt now includes a hard scope restriction when invoked via a scheduled job (`channelId: 'scheduler'`), preventing it from treating injected outbound-context entries as action triggers. (#730)
 - **`calendar-list-events`** — non-UUID caller contactId (e.g. `"system"` from scheduled jobs) now returns a clear, actionable error instead of a raw Postgres UUID parse failure. (#723)
 - **Email reply quoting** — natural agent-response replies (no skill invocation) now include the quoted original message, matching the skill-driven paths. `buildReplyQuote` moved to `src/skills/_shared/` so the email channel adapter can share it. (#720)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`bullpen`** — `post` and `reply` now fire-and-forget the `agent.discuss` publish instead of awaiting it, so a slow subscriber no longer pushes the handler past its skill timeout and triggers duplicate-thread retries. (#721)
 - **Scheduler task drift** — coordinator's system prompt now includes a hard scope restriction when invoked via a scheduled job (`channelId: 'scheduler'`), preventing it from treating injected outbound-context entries as action triggers. (#730)
 - **`calendar-list-events`** — non-UUID caller contactId (e.g. `"system"` from scheduled jobs) now returns a clear, actionable error instead of a raw Postgres UUID parse failure. (#723)
 - **Email reply quoting** — natural agent-response replies (no skill invocation) now include the quoted original message, matching the skill-driven paths. `buildReplyQuote` moved to `src/skills/_shared/` so the email channel adapter can share it. (#720)

--- a/agents/meeting-debrief.yaml
+++ b/agents/meeting-debrief.yaml
@@ -264,37 +264,6 @@ system_prompt: |
   entry for this meeting:
   - title, endedAt, promptedAt (now), attendees, status: "prompted"
 
-  ### Bullpen timeout handling
-
-  If a bullpen `post` call returns a timeout error (e.g.
-  `<skill_error>Skill 'bullpen' timed out after 10000ms</skill_error>`),
-  DO NOT retry the call. The thread may have been created on the server
-  side even though you saw a timeout — retrying will create a duplicate
-  thread and the CEO will receive duplicate prompts. Instead: record the
-  meeting in `pendingDebriefs` with status "prompt_unconfirmed" (title,
-  endedAt, attendees, promptedAt = now, reminderSentAt = null) and
-  continue to the next meeting.
-
-  On subsequent ticks, do NOT re-post for `prompt_unconfirmed` entries —
-  there is no skill action to query Bullpen for an existing thread, so
-  re-posting would risk the duplicate the rule above is meant to prevent.
-  Leave the entry as-is. One of two things will happen:
-  - The CEO replies (because the thread did get created server-side) —
-    delegated mode will process it normally; see Step D5 for the
-    status-transition rule.
-  - No reply arrives — Step 8 will prune the entry at TTL like any
-    other stale pending debrief.
-
-  Surface the count of `prompt_unconfirmed` entries in your
-  `scheduler-report` summary (Step 8) so the situation is observable.
-
-  This rule applies only to timeouts. Other bullpen errors (validation,
-  auth, missing fields) should be handled normally — fix the input and
-  retry as usual.
-
-  (Stopgap until #721 lands a proper post contract; revisit once the
-  skill can confirm thread creation atomically.)
-
   ## Step 7: Check reminders
 
   Scan `pendingDebriefs` for entries where:
@@ -331,9 +300,6 @@ system_prompt: |
   - summary: a brief human-readable description, e.g.:
     "Scanned 3 meetings, prompted for 1 (Acme sync), 0 reminders sent.
     2 debriefs pending response."
-    If any `pendingDebriefs` entries have status "prompt_unconfirmed"
-    (i.e. a prior bullpen.post timed out — see Step 6), call out the
-    count explicitly so the situation is observable.
   - context: your full state object:
     ```json
     {
@@ -414,9 +380,7 @@ system_prompt: |
   ## Step D5: Update state
 
   Call `scheduler-report` to update your state:
-  - Move the debrief entry to status "completed" (regardless of prior
-    status — "prompted" or "prompt_unconfirmed" both transition to
-    "completed" here)
+  - Move the debrief entry to status "completed"
   - Include a brief summary of what actions were taken
 
   ---

--- a/skills/bullpen/handler.test.ts
+++ b/skills/bullpen/handler.test.ts
@@ -156,4 +156,103 @@ describe('BullpenHandler', () => {
     expect(result.success).toBe(false);
     expect((result as { success: false; error: string }).error).toMatch(/unknown action/i);
   });
+
+  // Regression test for #721: bus.publish awaits subscribers sequentially
+  // (see src/bus/bus.ts), so a slow agent.discuss subscriber would block
+  // bullpen.post past its 10s skill timeout — even though the thread row was
+  // already committed. The handler must return as soon as openThread commits;
+  // publish is fire-and-forget per the handler comments.
+  it('post: returns immediately even when bus.publish is slow', async () => {
+    let publishResolve: (() => void) | undefined;
+    const slowPublish = vi.fn().mockImplementation(
+      () => new Promise<void>((resolve) => { publishResolve = resolve; }),
+    );
+    const ctx = makeCtx(
+      {
+        action: 'post',
+        topic: 'slow subscriber',
+        participants: ['coordinator', 'agent-b'],
+        content: 'Should not block',
+      },
+      {
+        bus: {
+          publish: slowPublish,
+          subscribe: vi.fn(),
+        } as unknown as SkillContext['bus'],
+      },
+    );
+
+    const start = Date.now();
+    const result = await handler.execute(ctx);
+    const elapsed = Date.now() - start;
+
+    expect(result.success).toBe(true);
+    // Publish is still in-flight, but handler returned without awaiting it.
+    expect(slowPublish).toHaveBeenCalledOnce();
+    expect(publishResolve).toBeDefined();
+    // Generous upper bound — openThread is in-memory, should be milliseconds.
+    expect(elapsed).toBeLessThan(500);
+
+    // Cleanup so the dangling promise doesn't keep vitest open.
+    publishResolve!();
+  });
+
+  it('reply: returns immediately even when bus.publish is slow', async () => {
+    // Open a thread normally first.
+    const openCtx = makeCtx({
+      action: 'post',
+      topic: 'slow reply',
+      participants: ['coordinator', 'agent-b'],
+      content: 'Start',
+    });
+    const openResult = await handler.execute(openCtx);
+    const threadId = ((openResult as { success: true; data: Record<string, unknown> }).data).thread_id as string;
+
+    let publishResolve: (() => void) | undefined;
+    const slowPublish = vi.fn().mockImplementation(
+      () => new Promise<void>((resolve) => { publishResolve = resolve; }),
+    );
+    const replyCtx = makeCtx(
+      { action: 'reply', thread_id: threadId, content: 'reply body' },
+      {
+        bullpenService: openCtx.bullpenService,
+        agentId: 'agent-b',
+        bus: { publish: slowPublish, subscribe: vi.fn() } as unknown as SkillContext['bus'],
+      },
+    );
+
+    const start = Date.now();
+    const result = await handler.execute(replyCtx);
+    const elapsed = Date.now() - start;
+
+    expect(result.success).toBe(true);
+    expect(slowPublish).toHaveBeenCalledOnce();
+    expect(publishResolve).toBeDefined();
+    expect(elapsed).toBeLessThan(500);
+
+    publishResolve!();
+  });
+
+  it('post: a publish rejection does not surface as a handler failure', async () => {
+    const failingPublish = vi.fn().mockRejectedValue(new Error('bus exploded'));
+    const ctx = makeCtx(
+      {
+        action: 'post',
+        topic: 'publish fail',
+        participants: ['coordinator'],
+        content: 'still ok',
+      },
+      {
+        bus: { publish: failingPublish, subscribe: vi.fn() } as unknown as SkillContext['bus'],
+      },
+    );
+
+    const result = await handler.execute(ctx);
+    expect(result.success).toBe(true);
+
+    // Let the rejected promise settle so the .catch() runs before the test
+    // exits — otherwise vitest may flag an unhandled rejection.
+    await new Promise((r) => setImmediate(r));
+    expect(failingPublish).toHaveBeenCalledOnce();
+  });
 });

--- a/skills/bullpen/handler.ts
+++ b/skills/bullpen/handler.ts
@@ -72,31 +72,34 @@ export class BullpenHandler implements SkillHandler {
             topic, ctx.agentId, cleanParticipants, content, mentionedAgentIds, originator,
           );
 
-          // Publish is best-effort — thread is already persisted. If publish fails,
-          // agents will still see the thread via pending-thread context injection.
-          // The originator is also stored on the thread row, so BullpenDispatcher can
-          // rehydrate it from DB when processing poll-fallback replies.
-          try {
-            await ctx.bus.publish('agent', createAgentDiscuss({
-              threadId: thread.id,
-              messageId: message.id,
-              topic: thread.topic,
-              senderAgentId: ctx.agentId,
-              participants: thread.participants,
-              mentionedAgentIds,
-              content,
-              // Forward the parent task's originator so BullpenDispatcher can stamp it
-              // on the reply tasks it creates for each participant. This ensures
-              // isPrincipalOriginated() returns correctly for CEO-authorized bullpen work.
-              originator,
-              parentEventId: ctx.taskEventId,
-            }));
-          } catch (publishErr) {
+          // Publish is fire-and-forget — thread is already persisted. We do NOT
+          // await here because bus.publish dispatches subscribers sequentially
+          // (see src/bus/bus.ts) and a slow agent.discuss subscriber would push
+          // the handler past its skill timeout, causing the caller to retry
+          // and create duplicate threads even though the side-effects are
+          // already committed (issue #721). If publish fails, agents will still
+          // see the thread via pending-thread context injection, and the
+          // originator is stored on the thread row so BullpenDispatcher can
+          // rehydrate it when processing poll-fallback replies.
+          void ctx.bus.publish('agent', createAgentDiscuss({
+            threadId: thread.id,
+            messageId: message.id,
+            topic: thread.topic,
+            senderAgentId: ctx.agentId,
+            participants: thread.participants,
+            mentionedAgentIds,
+            content,
+            // Forward the parent task's originator so BullpenDispatcher can stamp it
+            // on the reply tasks it creates for each participant. This ensures
+            // isPrincipalOriginated() returns correctly for CEO-authorized bullpen work.
+            originator,
+            parentEventId: ctx.taskEventId,
+          })).catch((publishErr: unknown) => {
             ctx.log.error(
               { err: publishErr, threadId: thread.id, originatorRole: originator?.systemRole ?? 'none' },
               'Bullpen: thread created but discuss event publish failed — agents will see it on next poll (originator preserved in thread row)',
             );
-          }
+          });
 
           return { success: true, data: { thread_id: thread.id, message_id: message.id } };
         }
@@ -127,28 +130,28 @@ export class BullpenHandler implements SkillHandler {
 
           const message = await ctx.bullpenService.postMessage(threadId, ctx.agentId, content, mentionedAgentIds);
 
-          // Publish is best-effort — reply is already persisted. If publish fails,
-          // agents will still see the message via pending-thread context injection.
-          try {
-            await ctx.bus.publish('agent', createAgentDiscuss({
-              threadId,
-              messageId: message.id,
-              topic: existing.thread.topic,
-              senderAgentId: ctx.agentId,
-              participants: existing.thread.participants,
-              mentionedAgentIds,
-              content,
-              // Forward the parent task's originator so BullpenDispatcher can stamp it
-              // on the reply tasks it creates for each participant.
-              originator: ctx.taskMetadata?.originator as TaskOriginator | undefined,
-              parentEventId: ctx.taskEventId,
-            }));
-          } catch (publishErr) {
+          // Publish is fire-and-forget — reply is already persisted. Same
+          // rationale as `post`: bus.publish dispatches subscribers sequentially,
+          // so awaiting here would re-introduce the timeout hazard from #721.
+          // Agents will still see the message via pending-thread context injection.
+          void ctx.bus.publish('agent', createAgentDiscuss({
+            threadId,
+            messageId: message.id,
+            topic: existing.thread.topic,
+            senderAgentId: ctx.agentId,
+            participants: existing.thread.participants,
+            mentionedAgentIds,
+            content,
+            // Forward the parent task's originator so BullpenDispatcher can stamp it
+            // on the reply tasks it creates for each participant.
+            originator: ctx.taskMetadata?.originator as TaskOriginator | undefined,
+            parentEventId: ctx.taskEventId,
+          })).catch((publishErr: unknown) => {
             ctx.log.error(
               { err: publishErr, threadId },
               'Bullpen: reply posted but discuss event publish failed — agents will see it on next poll',
             );
-          }
+          });
 
           return { success: true, data: { thread_id: threadId, message_id: message.id } };
         }

--- a/tests/unit/agents/loader.test.ts
+++ b/tests/unit/agents/loader.test.ts
@@ -102,17 +102,6 @@ schedule:
     fs.rmSync(tempDir, { recursive: true });
   });
 
-  it('meeting-debrief system prompt instructs no-retry on bullpen timeout (issue #722)', () => {
-    // Regression guard for #722 — without this instruction the LLM falls back
-    // to its retry heuristic when it sees `<skill_error>...timed out</skill_error>`
-    // from `bullpen.post`, creating duplicate threads (#721 contract bug means
-    // the thread is created server-side even when post times out).
-    const config = loadAgentConfig(path.join(agentsDir, 'meeting-debrief.yaml'));
-    expect(config.system_prompt).toContain('Bullpen timeout handling');
-    expect(config.system_prompt).toMatch(/do not retry/i);
-    expect(config.system_prompt).toContain('prompt_unconfirmed');
-  });
-
   it('parses model tier with needs array', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-test-'));
     const yamlContent = `


### PR DESCRIPTION
## Summary

- `bullpen.post` and `bullpen.reply` no longer `await` the `agent.discuss` publish. Because `bus.publish` ([src/bus/bus.ts L71-84](https://github.com/josephfung/curia/blob/main/src/bus/bus.ts#L71-L84)) dispatches subscribers sequentially with `await`, a slow `agent.discuss` subscriber would push the handler past its 10s skill timeout — but the thread row was already committed, so callers retried and created duplicate threads (and 4 duplicate Signal messages on 2026-05-26).
- Unwinds the #722 `meeting-debrief` stopgap (`prompt_unconfirmed` state + no-retry instructions) since bullpen timeouts are no longer a realistic failure mode.
- Closes #721.

## Approach

The handler's own comment already described publish as "best-effort"; the `await` was just wrong. Drop it and chain `.catch()` so publish errors are still logged, but the handler returns as soon as `openThread` commits. Applied identically to `post` and `reply`.

Rejected: Option C (partial-success envelope) was disproportionate to this fix and would have required plumbing in `execution.ts`. A bus-level fix (dispatch subscribers without awaiting) is the right long-term answer but changes semantics for every event type — out of scope for a P1 incident response. See issue #721 comment for the full reasoning.

## Commits

1. `fix(bullpen): fire-and-forget agent.discuss publish to prevent timeout (#721)` — the core fix + regression tests
2. `chore(meeting-debrief): unwind #722 timeout stopgap` — removes the scaffolding now that the root cause is fixed

## Out of scope (potential follow-ups flagged by review)

The same `await bus.publish` anti-pattern exists in other call sites — worth a separate audit issue if it bites again:

- `src/dispatch/dispatcher.ts` — 14 `await bus.publish` calls on the inbound message path
- `src/scheduler/scheduler.ts:398` — comment acknowledges the await behavior
- `src/agents/runtime.ts` — 10+ `await bus.publish` calls (some may genuinely need ordering)
- `skills/send-draft/handler.ts:194` — same pattern, comment says "non-fatal"

## Test plan

- [x] `npx vitest run skills/bullpen/handler.test.ts tests/unit/agents/loader.test.ts` — 25 tests pass
- [x] `pnpm run typecheck` — clean
- [x] Full worktree test suite — only failures are pre-existing integration tests requiring `DATABASE_URL`
- [ ] Watch next `meeting-debrief` cron tick after merge: it should successfully post one bullpen thread, no duplicate Signal messages.