### PR TITLE
feat(meeting-debrief): idempotency guard via config-store (#724)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **`${principal_contact_id}` runtime placeholder** — agent system prompts can now reference the principal's contact ID directly; `meeting-debrief` and `calendar` no longer call `contact-lookup` by role on every invocation. (#716)
-- **`meeting-debrief` idempotency guard** — agent now checks `config-store` for a `prompted:<eventId>` key before opening a Bullpen thread, and writes the key (with `thread_id`) immediately after a successful post. Prevents duplicate debrief prompts if a tick crashes between post and state-write, or if a stale `pendingDebriefs` map is replayed. (#724)
+- **`meeting-debrief` idempotency guard** — `config-store` key `prompted:<eventId>` now blocks duplicate Bullpen threads when `pendingDebriefs` state is lost between ticks. (#724)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **`${principal_contact_id}` runtime placeholder** — agent system prompts can now reference the principal's contact ID directly; `meeting-debrief` and `calendar` no longer call `contact-lookup` by role on every invocation. (#716)
+- **`meeting-debrief` idempotency guard** — agent now checks `config-store` for a `prompted:<eventId>` key before opening a Bullpen thread, and writes the key (with `thread_id`) immediately after a successful post. Prevents duplicate debrief prompts if a tick crashes between post and state-write, or if a stale `pendingDebriefs` map is replayed. (#724)
 
 ### Changed
 

--- a/agents/meeting-debrief.yaml
+++ b/agents/meeting-debrief.yaml
@@ -234,7 +234,25 @@ system_prompt: |
   > Your meeting with Sarah Chen (Acme Corp) and David Park just wrapped
   > up. Any takeaways or follow-ups you'd like me to handle?
 
-  Then open a Bullpen thread to the coordinator requesting delivery:
+  ### Idempotency guard
+
+  Before opening a Bullpen thread, check whether a debrief prompt has already
+  been sent for this calendar event. Call `config-store` with:
+  - action: "retrieve"
+  - namespace: "debrief"
+  - key: "prompted:<eventId>" (use the actual calendar event ID)
+
+  If `found: true`:
+  - Skip this meeting. Do not post to Bullpen again.
+  - Log: "Skipping debrief for <eventId> — idempotency key already present."
+  - If the event is not already in `pendingDebriefs`, restore it using the
+    thread_id from the stored value. Move on to the next YES meeting.
+
+  If `found: false`, proceed with the Bullpen post below.
+
+  ### Bullpen post
+
+  Open a Bullpen thread to the coordinator requesting delivery:
 
   Call `bullpen` with:
   - action: "post"
@@ -260,8 +278,16 @@ system_prompt: |
   [your composed debrief prompt message]
   ```
 
-  After posting the Bullpen thread, update `pendingDebriefs` with a new
-  entry for this meeting:
+  ### After a successful post
+
+  Immediately after `bullpen` returns a thread_id, write the idempotency key so
+  any subsequent tick or retry will find it. Call `config-store` with:
+  - action: "store"
+  - namespace: "debrief"
+  - key: "prompted:<eventId>"
+  - value: `{"thread_id":"<returned thread_id>","promptedAt":"<ISO timestamp>","title":"<meeting title>"}`
+
+  Then update `pendingDebriefs` with a new entry for this meeting:
   - title, endedAt, promptedAt (now), attendees, status: "prompted"
 
   ## Step 7: Check reminders

--- a/agents/meeting-debrief.yaml
+++ b/agents/meeting-debrief.yaml
@@ -285,7 +285,14 @@ system_prompt: |
   - action: "store"
   - namespace: "debrief"
   - key: "prompted:<eventId>"
-  - value: `{"thread_id":"<returned thread_id>","promptedAt":"<ISO timestamp>","title":"<meeting title>"}`
+  - value: a JSON-encoded **string** (not an object), e.g.
+    `'{"thread_id":"<returned thread_id>","promptedAt":"<ISO timestamp>","title":"<meeting title>"}'`
+
+  If the store call returns `success: false` or `data.stored: false`, log the
+  failure and include a note in your Step 8 summary that the idempotency key for
+  `<eventId>` may not have persisted. Do NOT retry the Bullpen post — continue
+  to the next meeting. The guard may not hold until the next successful write,
+  but a duplicate is preferable to an infinite retry loop.
 
   Then update `pendingDebriefs` with a new entry for this meeting:
   - title, endedAt, promptedAt (now), attendees, status: "prompted"

--- a/tests/unit/agent.meeting-debrief-idempotency.test.ts
+++ b/tests/unit/agent.meeting-debrief-idempotency.test.ts
@@ -53,8 +53,9 @@ describe('meeting-debrief idempotency guard (issue #724)', () => {
   });
 
   it('instructs the agent to skip posting when the idempotency key is already present', () => {
-    // Prevents re-posting to Bullpen when config-store already has the prompted: key.
-    expect(step6).toMatch(/found.*true|if.*found|already.*prompted|skip|do not post/i);
+    // Skipping must be explicitly tied to the found: true condition, not just any
+    // use of the word "skip". Matches "If `found: true`" / "if found" constructs only.
+    expect(step6).toMatch(/found.*true|if.*found|already.*prompted/i);
   });
 
   it('instructs the agent to write the idempotency key to config-store after the post, not before', () => {
@@ -77,5 +78,8 @@ describe('meeting-debrief idempotency guard (issue #724)', () => {
     // If the idempotency key write fails, the agent must NOT retry the bullpen post.
     // Without this guard, a write failure defeats the entire duplicate-prevention mechanism.
     expect(step6).toMatch(/stored.*false|store.*fail|success.*false|not.*persist|key.*not.*persisted|may not.*persist/i);
+    // Separately verify the no-retry instruction exists. A prompt that acknowledges write
+    // failure but still retries defeats the guard; this catches that regression.
+    expect(step6).toMatch(/do not retry|not retry|no.*retry/i);
   });
 });

--- a/tests/unit/agent.meeting-debrief-idempotency.test.ts
+++ b/tests/unit/agent.meeting-debrief-idempotency.test.ts
@@ -1,0 +1,64 @@
+// tests/unit/agent.meeting-debrief-idempotency.test.ts
+//
+// Guards against regression of #724 (5 duplicate Bullpen prompts for the same
+// meeting on 2026-05-26). Verifies that the meeting-debrief system prompt
+// contains the config-store idempotency check in Step 6: check before posting,
+// skip if already sent, write the key after a successful post.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+
+function loadSystemPrompt(): string {
+  const agentPath = path.resolve(import.meta.dirname, '../../agents/meeting-debrief.yaml');
+  const raw = fs.readFileSync(agentPath, 'utf-8');
+  const parsed = yaml.load(raw) as Record<string, unknown>;
+  if (typeof parsed.system_prompt !== 'string') {
+    throw new Error('meeting-debrief.yaml missing system_prompt string');
+  }
+  return parsed.system_prompt;
+}
+
+function extractStep6Section(prompt: string): string {
+  const start = prompt.indexOf('## Step 6');
+  const end = prompt.indexOf('## Step 7');
+  if (start === -1 || end === -1) {
+    throw new Error('Step 6 or Step 7 section not found in system prompt');
+  }
+  return prompt.slice(start, end);
+}
+
+describe('meeting-debrief idempotency guard (issue #724)', () => {
+  let step6: string;
+
+  beforeEach(() => {
+    step6 = extractStep6Section(loadSystemPrompt());
+  });
+
+  it('checks config-store for prompted:<eventId> key before opening a Bullpen thread', () => {
+    // The idempotency key must be referenced before the bullpen "post" action in Step 6.
+    // If this fails, the agent can post duplicate threads on the same calendar event.
+    expect(step6).toMatch(/prompted:/);
+    const idxKey = step6.indexOf('prompted:');
+    const idxPost = step6.search(/"post"/);
+    expect(idxPost).toBeGreaterThan(-1);
+    expect(idxKey).toBeLessThan(idxPost);
+  });
+
+  it('instructs the agent to skip posting when the idempotency key is already present', () => {
+    // Prevents re-posting to Bullpen when config-store already has the prompted: key.
+    expect(step6).toMatch(/found.*true|if.*found|already.*prompted|skip|do not post/i);
+  });
+
+  it('instructs the agent to write the idempotency key to config-store after a successful post', () => {
+    // Without this, the guard is useless on the very next tick after the first post.
+    expect(step6).toMatch(/action.*['"']store['"']|store.*prompted:|prompted:.*store/i);
+  });
+
+  it('includes thread_id in the stored idempotency value', () => {
+    // The stored value must include the thread_id so a future debug session can
+    // trace which Bullpen thread was the canonical one.
+    expect(step6).toMatch(/thread_id/);
+  });
+});

--- a/tests/unit/agent.meeting-debrief-idempotency.test.ts
+++ b/tests/unit/agent.meeting-debrief-idempotency.test.ts
@@ -3,39 +3,45 @@
 // Guards against regression of #724 (5 duplicate Bullpen prompts for the same
 // meeting on 2026-05-26). Verifies that the meeting-debrief system prompt
 // contains the config-store idempotency check in Step 6: check before posting,
-// skip if already sent, write the key after a successful post.
+// skip if already sent, write the key after a successful post, and handle write
+// failures gracefully.
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import yaml from 'js-yaml';
 
-function loadSystemPrompt(): string {
+let step6: string;
+
+beforeAll(() => {
   const agentPath = path.resolve(import.meta.dirname, '../../agents/meeting-debrief.yaml');
-  const raw = fs.readFileSync(agentPath, 'utf-8');
+  let raw: string;
+  try {
+    raw = fs.readFileSync(agentPath, 'utf-8');
+  } catch (err) {
+    throw new Error(
+      `Cannot load meeting-debrief.yaml from ${agentPath}: ${(err as Error).message}. ` +
+      `Is the test running from the repo root?`,
+    );
+  }
   const parsed = yaml.load(raw) as Record<string, unknown>;
   if (typeof parsed.system_prompt !== 'string') {
-    throw new Error('meeting-debrief.yaml missing system_prompt string');
+    throw new Error('meeting-debrief.yaml is missing a system_prompt string field');
   }
-  return parsed.system_prompt;
-}
+  const prompt = parsed.system_prompt;
 
-function extractStep6Section(prompt: string): string {
   const start = prompt.indexOf('## Step 6');
   const end = prompt.indexOf('## Step 7');
   if (start === -1 || end === -1) {
-    throw new Error('Step 6 or Step 7 section not found in system prompt');
+    throw new Error('Step 6 or Step 7 heading not found in system_prompt — was a heading renamed?');
   }
-  return prompt.slice(start, end);
-}
+  step6 = prompt.slice(start, end);
+  if (step6.length < 50) {
+    throw new Error(`Step 6 section is suspiciously short (${step6.length} chars) — may have been truncated`);
+  }
+});
 
 describe('meeting-debrief idempotency guard (issue #724)', () => {
-  let step6: string;
-
-  beforeEach(() => {
-    step6 = extractStep6Section(loadSystemPrompt());
-  });
-
   it('checks config-store for prompted:<eventId> key before opening a Bullpen thread', () => {
     // The idempotency key must be referenced before the bullpen "post" action in Step 6.
     // If this fails, the agent can post duplicate threads on the same calendar event.
@@ -51,14 +57,25 @@ describe('meeting-debrief idempotency guard (issue #724)', () => {
     expect(step6).toMatch(/found.*true|if.*found|already.*prompted|skip|do not post/i);
   });
 
-  it('instructs the agent to write the idempotency key to config-store after a successful post', () => {
-    // Without this, the guard is useless on the very next tick after the first post.
+  it('instructs the agent to write the idempotency key to config-store after the post, not before', () => {
+    // The store must come AFTER the bullpen post — writing before would create a phantom
+    // key that blocks all future posts if the bullpen call then fails.
     expect(step6).toMatch(/action.*['"']store['"']|store.*prompted:|prompted:.*store/i);
+    const idxPost = step6.search(/"post"/);
+    const idxStore = step6.search(/action.*['"']store['"']/);
+    expect(idxPost).toBeGreaterThan(-1);
+    expect(idxStore).toBeGreaterThan(idxPost);
   });
 
   it('includes thread_id in the stored idempotency value', () => {
     // The stored value must include the thread_id so a future debug session can
     // trace which Bullpen thread was the canonical one.
     expect(step6).toMatch(/thread_id/);
+  });
+
+  it('instructs the agent to handle a failed config-store write without retrying the Bullpen post', () => {
+    // If the idempotency key write fails, the agent must NOT retry the bullpen post.
+    // Without this guard, a write failure defeats the entire duplicate-prevention mechanism.
+    expect(step6).toMatch(/stored.*false|store.*fail|success.*false|not.*persist|key.*not.*persisted|may not.*persist/i);
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

- Before opening a Bullpen thread in Step 6, the agent now checks `config-store` for a `prompted:<eventId>` key in the `debrief` namespace. If found, it skips and logs; if not found, it proceeds.
- After a successful `bullpen` post, the key is written immediately with the returned `thread_id`, `promptedAt`, and meeting title (as a JSON-encoded string).
- If the write returns `success: false` or `stored: false`, the agent logs the failure and notes it in the Step 8 summary — without retrying the post.

Closes #724

## Test plan

- [ ] New test file `tests/unit/agent.meeting-debrief-idempotency.test.ts` with 5 structural tests on the system prompt:
  - `prompted:` key appears before the bullpen `"post"` action in Step 6
  - Skip instruction present when key is found
  - Store action appears after (not before) the bullpen post
  - `thread_id` is included in the stored value
  - Write-failure handling instruction is present
- [ ] All 2797 non-DB-dependent tests pass (`npm test` on the worktree — 2 pre-existing DB failures unaffected)
- [ ] Type-check passes clean

## Notes

The pre-existing `action: "get"` bug in the Runtime Configuration block (line 106 of the agent YAML) was identified during review but is out of scope for this PR. It predates this branch. Flagged as a follow-up.


___

## **CodeAnt-AI Description**
**Prevent duplicate debrief prompts for the same meeting**

### What Changed
- The meeting debrief flow now checks whether a prompt was already sent for the event before opening a Bullpen thread, which stops duplicate messages when state is lost between ticks.
- If the prompt was already sent, the meeting is skipped and the stored thread can be reused instead of posting again.
- After a successful Bullpen post, the idempotency key is saved right away with the thread ID, prompt time, and meeting title.
- If saving that key fails, the flow logs the problem, notes it in the summary, and does not retry the Bullpen post.
- Added tests that verify the check happens before posting, the skip path is present, the saved value includes the thread ID, and write failures are handled.

### Impact
`✅ Fewer duplicate debrief threads`
`✅ Safer retries after lost state`
`✅ Clearer recovery when config storage fails`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
