### PR TITLE
fix: unblock scheduled agents from calendar and scheduler skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`calendar-list-events`** — added optional `contactId` input so scheduled agents can look up calendars by contact UUID (e.g. `${principal_contact_id}`) instead of relying on caller identity, which is `"system"` in cron context and was causing a hard failure on every `meeting-debrief` tick.
-- **`meeting-debrief`** — Step 2 now passes `contactId: ${principal_contact_id}` to `calendar-list-events`, eliminating the first-turn failure and the LLM fallback that sometimes guessed an invalid calendar ID.
-- **`scheduler-report`, `scheduler-list`** — removed `sensitivity: elevated`; these are agent self-management reads/writes, not principal-gated operations. `meeting-debrief` was burning 6+ blocked turns per scheduled run trying to persist state it could never write.
-- **`ceo-inbox-read`** — increased timeout from 15 s to 30 s to accommodate Nylas API latency spikes that were intermittently aborting email reads.
+- **`calendar-list-events`** — adds optional `contactId` input for scheduled agents to look up calendars by contact UUID.
+- **`meeting-debrief`** — now passes `contactId: ${principal_contact_id}` to `calendar-list-events`, fixing cron-context calendar failures.
+- **`scheduler-report`, `scheduler-list`** — sensitivity changed to normal; `meeting-debrief` was blocking 6+ turns per tick on state writes.
+- **`ceo-inbox-read`** — timeout raised from 15 s to 30 s to absorb intermittent Nylas latency spikes.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **`outbound.delivered`** — canonical audit event emitted by the gateway after every successful email or Signal send, closing the visibility gap for skill-invoked sends. HTTP/web conversations are already captured by `agent.response`; CLI is dev-only and excluded by design. (#729)
 
+### Fixed
+
+- **`calendar-list-events`** — added optional `contactId` input so scheduled agents can look up calendars by contact UUID (e.g. `${principal_contact_id}`) instead of relying on caller identity, which is `"system"` in cron context and was causing a hard failure on every `meeting-debrief` tick.
+- **`meeting-debrief`** — Step 2 now passes `contactId: ${principal_contact_id}` to `calendar-list-events`, eliminating the first-turn failure and the LLM fallback that sometimes guessed an invalid calendar ID.
+- **`scheduler-report`, `scheduler-list`** — removed `sensitivity: elevated`; these are agent self-management reads/writes, not principal-gated operations. `meeting-debrief` was burning 6+ blocked turns per scheduled run trying to persist state it could never write.
+- **`ceo-inbox-read`** — increased timeout from 15 s to 30 s to accommodate Nylas API latency spikes that were intermittently aborting email reads.
+
 ### Added
 
 - **`${principal_contact_id}` runtime placeholder** — agent system prompts can now reference the principal's contact ID directly; `meeting-debrief` and `calendar` no longer call `contact-lookup` by role on every invocation. (#716)

--- a/agents/meeting-debrief.yaml
+++ b/agents/meeting-debrief.yaml
@@ -162,8 +162,11 @@ system_prompt: |
   Call `calendar-list-events` with:
   - timeMin: lastScanTimestamp (from prior run) or now minus 20 minutes
   - timeMax: now (the current time)
+  - contactId: ${principal_contact_id}
 
-  Omit calendarId — the skill auto-queries all CEO calendars.
+  Always pass contactId — this agent runs as a scheduled job (system context),
+  so the skill cannot auto-resolve calendars from the caller. Using
+  ${principal_contact_id} looks up all calendars registered to the CEO.
 
   ## Step 3: Filter candidates
 

--- a/skills/calendar-list-events/handler.test.ts
+++ b/skills/calendar-list-events/handler.test.ts
@@ -138,7 +138,7 @@ describe('CalendarListEventsHandler — explicit contactId input', () => {
     expect(contactService!.getCalendarsForContact).not.toHaveBeenCalled();
   });
 
-  it('explicit contactId takes precedence over caller contactId', async () => {
+  it('explicit contactId takes precedence over caller contactId when caller is principal', async () => {
     const handler = new CalendarListEventsHandler();
     const principalId = 'deadbeef-0000-0000-0000-000000000001';
     const callerId = 'cafebabe-0000-0000-0000-000000000002';
@@ -148,21 +148,65 @@ describe('CalendarListEventsHandler — explicit contactId input', () => {
       ]),
     } as unknown as SkillContext['contactService'];
 
-    await handler.execute(makeCtx({
+    const result = await handler.execute(makeCtx({
       input: {
         contactId: principalId,
         timeMin: '2026-05-26T00:00:00Z',
         timeMax: '2026-05-26T23:59:59Z',
       },
-      caller: { contactId: callerId, role: null, channel: 'signal' },
+      caller: { contactId: callerId, role: 'ceo', channel: 'signal' },
       contactService,
       nylasCalendarClient: {
         listEvents: vi.fn().mockResolvedValue([]),
       } as unknown as SkillContext['nylasCalendarClient'],
     }));
 
-    // Should use principalId, not callerId
     expect(contactService!.getCalendarsForContact).toHaveBeenCalledWith(principalId);
     expect(contactService!.getCalendarsForContact).not.toHaveBeenCalledWith(callerId);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects contactId override for non-principal, non-system callers', async () => {
+    const handler = new CalendarListEventsHandler();
+    const someContactId = 'deadbeef-0000-0000-0000-000000000001';
+    const callerContactId = 'cafebabe-0000-0000-0000-000000000002';
+    const contactService = {
+      getCalendarsForContact: vi.fn(),
+    } as unknown as SkillContext['contactService'];
+
+    const result = await handler.execute(makeCtx({
+      input: {
+        contactId: someContactId,
+        timeMin: '2026-05-26T00:00:00Z',
+        timeMax: '2026-05-26T23:59:59Z',
+      },
+      // Regular UUID caller with no ceo role — should be blocked
+      caller: { contactId: callerContactId, role: null, channel: 'signal' },
+      contactService,
+    }));
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('not allowed');
+    expect(contactService!.getCalendarsForContact).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a clear error when getCalendarsForContact throws in the contactId path', async () => {
+    const handler = new CalendarListEventsHandler();
+    const contactService = {
+      getCalendarsForContact: vi.fn().mockRejectedValue(new Error('connection terminated unexpectedly')),
+    } as unknown as SkillContext['contactService'];
+
+    const result = await handler.execute(makeCtx({
+      input: {
+        contactId: 'deadbeef-0000-0000-0000-000000000001',
+        timeMin: '2026-05-26T00:00:00Z',
+        timeMax: '2026-05-26T23:59:59Z',
+      },
+      caller: { contactId: 'system', role: null, channel: 'internal' },
+      contactService,
+    }));
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('Failed to list events');
   });
 });

--- a/skills/calendar-list-events/handler.test.ts
+++ b/skills/calendar-list-events/handler.test.ts
@@ -107,6 +107,7 @@ describe('CalendarListEventsHandler — explicit contactId input', () => {
       },
       // System caller — would normally be rejected without an explicit contactId
       caller: { contactId: 'system', role: null, channel: 'internal' },
+      taskMetadata: { originator: { systemRole: 'system' } },
       contactService,
       nylasCalendarClient: {
         listEvents: vi.fn().mockResolvedValue([]),
@@ -130,6 +131,7 @@ describe('CalendarListEventsHandler — explicit contactId input', () => {
         timeMax: '2026-05-26T23:59:59Z',
       },
       caller: { contactId: 'system', role: null, channel: 'internal' },
+      taskMetadata: { originator: { systemRole: 'system' } },
       contactService,
     }));
 
@@ -155,6 +157,7 @@ describe('CalendarListEventsHandler — explicit contactId input', () => {
         timeMax: '2026-05-26T23:59:59Z',
       },
       caller: { contactId: callerId, role: 'ceo', channel: 'signal' },
+      taskMetadata: { originator: { systemRole: 'principal' } },
       contactService,
       nylasCalendarClient: {
         listEvents: vi.fn().mockResolvedValue([]),
@@ -203,6 +206,7 @@ describe('CalendarListEventsHandler — explicit contactId input', () => {
         timeMax: '2026-05-26T23:59:59Z',
       },
       caller: { contactId: 'system', role: null, channel: 'internal' },
+      taskMetadata: { originator: { systemRole: 'system' } },
       contactService,
     }));
 

--- a/skills/calendar-list-events/handler.test.ts
+++ b/skills/calendar-list-events/handler.test.ts
@@ -87,3 +87,82 @@ describe('CalendarListEventsHandler — system caller guard', () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe('CalendarListEventsHandler — explicit contactId input', () => {
+  it('uses explicit contactId input to look up calendars, bypassing caller identity', async () => {
+    // Simulates a scheduled agent passing ${principal_contact_id} explicitly
+    const handler = new CalendarListEventsHandler();
+    const principalId = 'deadbeef-0000-0000-0000-000000000001';
+    const contactService = {
+      getCalendarsForContact: vi.fn().mockResolvedValue([
+        { nylasCalendarId: 'joseph@josephfung.ca' },
+      ]),
+    } as unknown as SkillContext['contactService'];
+
+    const result = await handler.execute(makeCtx({
+      input: {
+        contactId: principalId,
+        timeMin: '2026-05-26T00:00:00Z',
+        timeMax: '2026-05-26T23:59:59Z',
+      },
+      // System caller — would normally be rejected without an explicit contactId
+      caller: { contactId: 'system', role: null, channel: 'internal' },
+      contactService,
+      nylasCalendarClient: {
+        listEvents: vi.fn().mockResolvedValue([]),
+      } as unknown as SkillContext['nylasCalendarClient'],
+    }));
+
+    expect(contactService!.getCalendarsForContact).toHaveBeenCalledWith(principalId);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a non-UUID contactId input', async () => {
+    const handler = new CalendarListEventsHandler();
+    const contactService = {
+      getCalendarsForContact: vi.fn(),
+    } as unknown as SkillContext['contactService'];
+
+    const result = await handler.execute(makeCtx({
+      input: {
+        contactId: 'joseph',
+        timeMin: '2026-05-26T00:00:00Z',
+        timeMax: '2026-05-26T23:59:59Z',
+      },
+      caller: { contactId: 'system', role: null, channel: 'internal' },
+      contactService,
+    }));
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('UUID');
+    expect(contactService!.getCalendarsForContact).not.toHaveBeenCalled();
+  });
+
+  it('explicit contactId takes precedence over caller contactId', async () => {
+    const handler = new CalendarListEventsHandler();
+    const principalId = 'deadbeef-0000-0000-0000-000000000001';
+    const callerId = 'cafebabe-0000-0000-0000-000000000002';
+    const contactService = {
+      getCalendarsForContact: vi.fn().mockResolvedValue([
+        { nylasCalendarId: 'cal-principal' },
+      ]),
+    } as unknown as SkillContext['contactService'];
+
+    await handler.execute(makeCtx({
+      input: {
+        contactId: principalId,
+        timeMin: '2026-05-26T00:00:00Z',
+        timeMax: '2026-05-26T23:59:59Z',
+      },
+      caller: { contactId: callerId, role: null, channel: 'signal' },
+      contactService,
+      nylasCalendarClient: {
+        listEvents: vi.fn().mockResolvedValue([]),
+      } as unknown as SkillContext['nylasCalendarClient'],
+    }));
+
+    // Should use principalId, not callerId
+    expect(contactService!.getCalendarsForContact).toHaveBeenCalledWith(principalId);
+    expect(contactService!.getCalendarsForContact).not.toHaveBeenCalledWith(callerId);
+  });
+});

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -14,6 +14,7 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { NylasCalendarEvent } from '../../src/channels/calendar/nylas-calendar-client.js';
 import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
+import { isSystemOriginated, isPrincipalOriginated } from '../../src/contacts/principal.js';
 
 export class CalendarListEventsHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -57,8 +58,10 @@ export class CalendarListEventsHandler implements SkillHandler {
         //   2. Principal caller (role === 'ceo') — the CEO can look up any contact's calendars
         // This prevents LLM-driven non-principal agents from reading other contacts' calendars
         // by constructing a contactId value.
-        const callerIsSystem = !UUID_RE.test(ctx.caller?.contactId ?? '');
-        const callerIsPrincipal = ctx.caller?.role === 'ceo';
+        // Use trusted originator metadata, not caller shape, to avoid misclassifying
+        // agent-originated delegated tasks (which can have non-UUID contactIds) as system.
+        const callerIsSystem = isSystemOriginated(ctx.taskMetadata);
+        const callerIsPrincipal = isPrincipalOriginated(ctx.taskMetadata);
         if (!callerIsSystem && !callerIsPrincipal) {
           return {
             success: false,

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -51,6 +51,20 @@ export class CalendarListEventsHandler implements SkillHandler {
       } else if (contactId && typeof contactId === 'string') {
         // Explicit contactId provided — used by scheduled agents that don't have a
         // real caller contact (e.g. pass ${principal_contact_id} to look up the CEO's calendars).
+        //
+        // Only allow this override in two cases:
+        //   1. System/scheduled context (caller contactId is not a UUID — it's 'system' etc.)
+        //   2. Principal caller (role === 'ceo') — the CEO can look up any contact's calendars
+        // This prevents LLM-driven non-principal agents from reading other contacts' calendars
+        // by constructing a contactId value.
+        const callerIsSystem = !UUID_RE.test(ctx.caller?.contactId ?? '');
+        const callerIsPrincipal = ctx.caller?.role === 'ceo';
+        if (!callerIsSystem && !callerIsPrincipal) {
+          return {
+            success: false,
+            error: `contactId override is not allowed for this caller — only system-context (scheduled) invocations and principal callers may look up calendars by contactId`,
+          };
+        }
         if (!UUID_RE.test(contactId)) {
           return {
             success: false,
@@ -181,7 +195,7 @@ export class CalendarListEventsHandler implements SkillHandler {
       return { success: true, data };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      ctx.log.error({ err, calendarId }, 'Failed to list events');
+      ctx.log.error({ err, calendarId, contactId }, 'Failed to list events');
       return { success: false, error: `Failed to list events: ${message}` };
     }
   }

--- a/skills/calendar-list-events/handler.ts
+++ b/skills/calendar-list-events/handler.ts
@@ -22,8 +22,9 @@ export class CalendarListEventsHandler implements SkillHandler {
       return { success: false, error: 'Calendar not configured — Nylas credentials missing' };
     }
 
-    const { calendarId, timeMin, timeMax, maxResults, query, attendeeEmail } = ctx.input as {
+    const { calendarId, contactId, timeMin, timeMax, maxResults, query, attendeeEmail } = ctx.input as {
       calendarId?: string;
+      contactId?: string;
       timeMin?: string;
       timeMax?: string;
       maxResults?: number;
@@ -40,27 +41,46 @@ export class CalendarListEventsHandler implements SkillHandler {
 
     try {
       // Resolve which calendar(s) to query.
-      // If the caller provided a specific calendarId, use that.
-      // Otherwise, look up all calendars registered to the caller's contact.
+      // Priority: explicit calendarId > explicit contactId lookup > caller auto-lookup.
       let calendarIds: string[];
+
+      const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
       if (calendarId && typeof calendarId === 'string') {
         calendarIds = [calendarId];
+      } else if (contactId && typeof contactId === 'string') {
+        // Explicit contactId provided — used by scheduled agents that don't have a
+        // real caller contact (e.g. pass ${principal_contact_id} to look up the CEO's calendars).
+        if (!UUID_RE.test(contactId)) {
+          return {
+            success: false,
+            error: `Invalid contactId — must be a UUID, got "${contactId}"`,
+          };
+        }
+        if (!ctx.contactService) {
+          return { success: false, error: 'contactService not available — cannot look up calendars by contactId' };
+        }
+        const calendars = await ctx.contactService.getCalendarsForContact(contactId);
+        if (calendars.length === 0) {
+          return { success: false, error: `No calendars registered for contact ${contactId} — register a calendar first` };
+        }
+        calendarIds = calendars.map((c) => c.nylasCalendarId);
+        ctx.log.info({ contactId, calendarCount: calendarIds.length }, 'Resolved calendars for explicit contactId');
       } else if (ctx.contactService && ctx.caller) {
+        // Fall back to the caller's own contact — works for human-initiated tasks
+        // where the caller is a real contact UUID.
         // Two non-UUID sentinel values can appear in ctx.caller.contactId:
         //   'system'       — scheduled-job invocations (see makeSystemOriginator in contacts/principal.ts)
         //   'primary-user' — CLI sessions where the principal DB lookup failed at bootstrap
         // Both cause a Postgres parse error if passed to a UUID column.
-        // Reject early with an actionable message so the LLM can retry with an explicit calendarId.
-        const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
         if (!UUID_RE.test(ctx.caller.contactId)) {
           ctx.log.warn(
             { contactId: ctx.caller.contactId },
-            'calendar-list-events: rejecting non-UUID contactId — calendarId is required for system-context invocations',
+            'calendar-list-events: caller contactId is not a UUID — pass contactId (e.g. ${principal_contact_id}) for scheduled invocations',
           );
           return {
             success: false,
-            error: `calendarId is required when invoked from a non-contact-resolved context (caller contactId "${ctx.caller.contactId}" is not a UUID)`,
+            error: `calendarId or contactId is required when invoked from a non-contact-resolved context (caller contactId "${ctx.caller.contactId}" is not a UUID)`,
           };
         }
         const calendars = await ctx.contactService.getCalendarsForContact(ctx.caller.contactId);
@@ -70,7 +90,7 @@ export class CalendarListEventsHandler implements SkillHandler {
         calendarIds = calendars.map((c) => c.nylasCalendarId);
         ctx.log.info({ contactId: ctx.caller.contactId, calendarCount: calendarIds.length }, 'Resolved caller calendars');
       } else {
-        return { success: false, error: 'Missing required input: calendarId (and unable to resolve caller calendars)' };
+        return { success: false, error: 'Missing required input: calendarId or contactId (and unable to resolve caller calendars)' };
       }
 
       // Pass maxResults as the upstream fetch limit so callers asking for >200 events aren't silently capped.

--- a/skills/calendar-list-events/skill.json
+++ b/skills/calendar-list-events/skill.json
@@ -1,11 +1,12 @@
 {
   "name": "calendar-list-events",
-  "description": "Fetch events within a date range. Omit calendarId to automatically query all of the caller's registered calendars (preferred — do NOT look up calendar IDs manually). Only pass calendarId when the user explicitly asks about a specific calendar. Supports filtering by text query (title/description) and attendee email.",
-  "version": "1.0.0",
+  "description": "Fetch events within a date range. Pass contactId to look up all calendars registered to that contact (use ${principal_contact_id} in scheduled agents). Pass calendarId only when targeting a specific calendar by Nylas ID. Supports filtering by text query (title/description) and attendee email.",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
-    "calendarId": "string? (omit to auto-query all caller calendars — only pass when targeting a specific calendar)",
+    "calendarId": "string? (specific Nylas calendar ID — omit to auto-query all calendars for the resolved contact)",
+    "contactId": "string? (UUID — look up calendars registered to this contact; required in scheduled/system-context where the caller is not a real contact, e.g. pass ${principal_contact_id})",
     "timeMin": "timestamp (start of range, inclusive)",
     "timeMax": "timestamp (end of range, exclusive)",
     "maxResults": "number?",

--- a/skills/ceo-inbox-read/skill.json
+++ b/skills/ceo-inbox-read/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "ceo-inbox-read",
   "description": "Read a specific email message from the CEO's personal inbox, returning both plain text and HTML body. Intended for use by the ceo-inbox agent — accesses the CEO's personal email, do not call from other agents.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
@@ -22,6 +22,6 @@
   },
   "permissions": [],
   "secrets": ["nylas_api_key", "ceo_nylas_grant_id"],
-  "timeout": 15000,
+  "timeout": 30000,
   "capabilities": []
 }

--- a/skills/scheduler-list/skill.json
+++ b/skills/scheduler-list/skill.json
@@ -1,8 +1,8 @@
 {
   "name": "scheduler-list",
   "description": "List scheduled jobs. Optionally filter by status (pending, running, completed, failed, suspended, cancelled) or agent_id.",
-  "version": "1.0.0",
-  "sensitivity": "elevated",
+  "version": "1.1.0",
+  "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
     "status": "string?",

--- a/skills/scheduler-report/skill.json
+++ b/skills/scheduler-report/skill.json
@@ -1,8 +1,8 @@
 {
   "name": "scheduler-report",
   "description": "Report the outcome of a scheduled job run. Writes a summary and optional structured context to the job's run record so the CEO and agents can review what happened on the last execution.",
-  "version": "1.0.0",
-  "sensitivity": "elevated",
+  "version": "1.1.0",
+  "sensitivity": "normal",
   "action_risk": "none",
   "inputs": {
     "job_id": "string",


### PR DESCRIPTION
## **User description**
## Summary

- **`calendar-list-events`** — added optional `contactId` input for scheduled agents that run as `caller='system'` and can't auto-resolve calendars from their caller identity. Updated `meeting-debrief` Step 2 to pass `${principal_contact_id}`. The override is restricted to system-context or principal callers to prevent non-principal agents from reading other contacts' calendars.
- **`scheduler-report`, `scheduler-list`** — removed `sensitivity: elevated`. These are agent self-management ops (writing tick state, reading own job record), not principal-gated operations. `meeting-debrief` was burning 6+ blocked turns every scheduled run and never persisting its state.
- **`ceo-inbox-read`** — timeout 15 s → 30 s to absorb intermittent Nylas API latency spikes.

## Test plan

- [ ] `calendar-list-events` system-context guard still blocks `caller='system'` without a `contactId`
- [ ] `calendar-list-events` accepts `contactId` from system-context callers and looks up the right calendars
- [ ] `calendar-list-events` rejects `contactId` from non-principal UUID callers
- [ ] `calendar-list-events` accepts `contactId` from principal (`role='ceo'`) callers
- [ ] `getCalendarsForContact` DB throw in the new path surfaces as `"Failed to list events"` (not a silent failure)
- [ ] `pnpm run typecheck` passes
- [ ] After deploy: `meeting-debrief` scheduled tick completes without the 2-turn calendar failure loop and without the 6-turn `scheduler-report` block loop


___

## **CodeAnt-AI Description**
**Unblock scheduled calendar scans and job state updates**

### What Changed
- Scheduled calendar scans can now pass a principal contact ID directly, so `meeting-debrief` can find the CEO’s calendars instead of failing when the caller is `"system"`.
- The calendar lookup now only accepts this contact-based override for scheduled/system runs or the CEO, which prevents other callers from using it to read someone else’s events.
- Scheduled job reporting and job listing are no longer blocked, so `meeting-debrief` can save its state instead of wasting turns on denied requests.
- CEO inbox reads now wait longer before timing out, reducing failures during slow email fetches.

### Impact
`✅ Fewer failed scheduled debrief runs`
`✅ Fewer blocked state-saving calls`
`✅ Fewer inbox read timeouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional contact ID parameter to calendar lookup, enabling scheduled tasks to resolve calendars without direct caller context.

* **Bug Fixes**
  * Increased CEO inbox retrieval timeout from 15 to 30 seconds to improve reliability during API latency spikes.
  * Fixed meeting debrief calendar resolution for scheduled jobs by explicitly passing contact information.
  * Removed unnecessary security restrictions from scheduler operations.

* **Documentation**
  * Updated guidance on calendar resolution requirements for scheduled jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->