### PR TITLE
fix: include source agent in declarative job identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Declarative scheduler jobs** — include `source_agent_id` in the persisted identity so two specialist agents can declare identical schedules targeting the same agent without silently collapsing into one row. (#231)
+
 ## [0.31.1] — 2026-05-26 — "Janet"
 
 > **Janet** *(The Good Place, 2016, Michael Schur)* — the neighborhood's vast informational assistant: appears when summoned, answers with total knowledge of every resident, performs only the function asked, never lies about what she did. v0.31.1 reshapes Curia's agents along the same lines — they know who the principal is at bootstrap, stay on the task they were scheduled for, don't retry into uncertainty, and leave an honest audit trail of every wire-level send.

--- a/docs/specs/07-scheduler.md
+++ b/docs/specs/07-scheduler.md
@@ -21,6 +21,7 @@ Built into the main process, backed by Postgres. Handles both user-defined recur
 ```sql
 CREATE TABLE scheduled_jobs (
   id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_agent_id TEXT NOT NULL DEFAULT '',
   agent_id      TEXT NOT NULL,
   cron_expr     TEXT,
   run_at        TIMESTAMPTZ,
@@ -205,6 +206,8 @@ schedule:
 ```
 
 These are created at startup from the agent's YAML config. `loadDeclarativeJobs` is **idempotent** — on each startup it reconciles the declared schedules against existing jobs and auto-cancels stale entries (jobs whose cron expression has changed or whose YAML entry has been removed). This prevents orphaned jobs from accumulating when agent configs are updated between restarts.
+
+Declarative job identity includes both the declaring agent (`source_agent_id`) and the target agent (`agent_id`). That means two specialist agents can declare the same cron/task payload against a shared coordinator without one schedule overwriting the other.
 
 #### `intent_anchor` (optional)
 

--- a/src/db/migrations/045_add_scheduled_jobs_source_agent_id.sql
+++ b/src/db/migrations/045_add_scheduled_jobs_source_agent_id.sql
@@ -1,0 +1,29 @@
+-- 045_add_scheduled_jobs_source_agent_id.sql
+--
+-- Include the declaring agent in declarative job identity. This lets two
+-- specialist agents declare identical schedules targeting the same agent
+-- without collapsing into one scheduled_jobs row.
+
+ALTER TABLE scheduled_jobs
+  ADD COLUMN source_agent_id TEXT NOT NULL DEFAULT '';
+
+-- Existing declarative jobs were keyed only by target agent. Preserve that
+-- legacy identity before switching to the source-aware unique index, otherwise
+-- startup can insert a duplicate row beside an operator-paused legacy job.
+UPDATE scheduled_jobs
+   SET source_agent_id = agent_id
+ WHERE created_by = 'system'
+   AND source_agent_id = '';
+
+DROP INDEX IF EXISTS scheduled_jobs_declarative_uq;
+
+CREATE UNIQUE INDEX scheduled_jobs_declarative_uq
+  ON scheduled_jobs (source_agent_id, agent_id, cron_expr, (task_payload::text))
+  WHERE created_by = 'system';
+
+-- Rollback:
+-- DROP INDEX IF EXISTS scheduled_jobs_declarative_uq;
+-- CREATE UNIQUE INDEX scheduled_jobs_declarative_uq
+--   ON scheduled_jobs (agent_id, cron_expr, (task_payload::text))
+--   WHERE created_by = 'system';
+-- ALTER TABLE scheduled_jobs DROP COLUMN source_agent_id;

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -443,7 +443,8 @@ export class SchedulerService {
   /**
    * Upsert a declarative job (system-created, idempotent on restart).
    * Uses ON CONFLICT with the column list matching the partial unique index
-   * scheduled_jobs_declarative_uq (agent_id, cron_expr, task_payload::text WHERE created_by = 'system').
+   * scheduled_jobs_declarative_uq
+   * (source_agent_id, agent_id, cron_expr, task_payload::text WHERE created_by = 'system').
    * Note: ON CONFLICT ON CONSTRAINT only works with named CONSTRAINTS, not named indexes —
    * so we use the column-based syntax here to match the CREATE UNIQUE INDEX definition.
    *
@@ -452,6 +453,7 @@ export class SchedulerService {
    * preserve the existing agent_task row (and its accumulated progress) across restarts.
    */
   async upsertDeclarativeJob(
+    sourceAgentId: string,
     agentId: string,
     schedule: { cron: string; task: string; expectedDurationSeconds?: number; intent_anchor?: string },
   ): Promise<string> {
@@ -471,7 +473,7 @@ export class SchedulerService {
 
     if (rawDuration !== undefined && !validDuration) {
       this.logger.warn(
-        { agentId, cron: schedule.cron, expectedDurationSeconds: rawDuration },
+        { sourceAgentId, agentId, cron: schedule.cron, expectedDurationSeconds: rawDuration },
         'upsertDeclarativeJob: expectedDurationSeconds is invalid (must be a positive finite integer) — falling back to system default watchdog threshold; check the agent YAML config',
       );
     }
@@ -493,16 +495,17 @@ export class SchedulerService {
     const originator = makeSystemOriginator();
 
     const sql = `
-      INSERT INTO scheduled_jobs (agent_id, cron_expr, task_payload, status, next_run_at, created_by, timezone, expected_duration_seconds, originator)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-      ON CONFLICT (agent_id, cron_expr, (task_payload::text)) WHERE created_by = 'system'
-      DO UPDATE SET next_run_at = $5,
-                    timezone = $7,
-                    expected_duration_seconds = $8,
-                    originator = COALESCE(scheduled_jobs.originator, $9)
+      INSERT INTO scheduled_jobs (source_agent_id, agent_id, cron_expr, task_payload, status, next_run_at, created_by, timezone, expected_duration_seconds, originator)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      ON CONFLICT (source_agent_id, agent_id, cron_expr, (task_payload::text)) WHERE created_by = 'system'
+      DO UPDATE SET next_run_at = $6,
+                    timezone = $8,
+                    expected_duration_seconds = $9,
+                    originator = COALESCE(scheduled_jobs.originator, $10)
       RETURNING id
     `;
     const params: unknown[] = [
+      sourceAgentId,
       agentId,
       schedule.cron,
       JSON.stringify(taskPayload),
@@ -573,10 +576,10 @@ export class SchedulerService {
    * Returns the number of rows cancelled.
    */
   async cancelStaleDeclarativeJobs(
-    liveTuples: Array<{ agentId: string; cronExpr: string; taskPayload: string }>,
+    liveTuples: Array<{ sourceAgentId: string; agentId: string; cronExpr: string; taskPayload: string }>,
   ): Promise<number> {
     // Build a parameterized exclusion clause. Each live tuple becomes a
-    // (agent_id, cron_expr, task_payload::text) triple in a VALUES list so
+    // (source_agent_id, agent_id, cron_expr, task_payload::text) tuple in a VALUES list so
     // the NOT IN check is a single set operation — no per-tuple subqueries.
     //
     // When there are zero live tuples, every system row is stale (all schedules
@@ -592,15 +595,15 @@ export class SchedulerService {
       // the cast, a multi-key payload could diverge between JS JSON.stringify
       // key order and PostgreSQL's canonical key order, silently failing to
       // shield a live job from cancellation.
-      valuePlaceholders.push(`($${idx}, $${idx + 1}, $${idx + 2}::jsonb::text)`);
-      params.push(tuple.agentId, tuple.cronExpr, tuple.taskPayload);
-      idx += 3;
+      valuePlaceholders.push(`($${idx}, $${idx + 1}, $${idx + 2}, $${idx + 3}::jsonb::text)`);
+      params.push(tuple.sourceAgentId, tuple.agentId, tuple.cronExpr, tuple.taskPayload);
+      idx += 4;
     }
 
     // When liveTuples is non-empty, exclude the live set. When empty, no exclusion
     // is needed — the UPDATE targets all system rows with pending/failed status.
     const exclusionClause = valuePlaceholders.length > 0
-      ? `AND (agent_id, cron_expr, task_payload::text) NOT IN (VALUES ${valuePlaceholders.join(', ')})`
+      ? `AND (source_agent_id, agent_id, cron_expr, task_payload::text) NOT IN (VALUES ${valuePlaceholders.join(', ')})`
       : '';
 
     const sql = `

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -562,11 +562,11 @@ export class Scheduler {
     const knownAgents = new Set(agentConfigs.map(config => config.name));
     // Collect all (source -> target) schedule edges for cycle detection after upserts.
     const edges: Array<{ source: string; target: string }> = [];
-    // Collect (agent_id, cron_expr, task_payload) tuples for every YAML-declared schedule that
+    // Collect (source_agent_id, agent_id, cron_expr, task_payload) tuples for every YAML-declared schedule that
     // passes the knownAgents guard. Used to shield existing DB rows from stale-job cleanup.
     // Populated BEFORE the upsert attempt so that a transient upsert failure cannot cause a
     // still-declared job's existing DB row to be misclassified as stale and cancelled.
-    const declaredTuples: Array<{ agentId: string; cronExpr: string; taskPayload: string }> = [];
+    const declaredTuples: Array<{ sourceAgentId: string; agentId: string; cronExpr: string; taskPayload: string }> = [];
 
     for (const config of agentConfigs) {
       if (!config.schedule || config.schedule.length === 0) {
@@ -593,6 +593,7 @@ export class Scheduler {
         // (A transient DB error during the upsert must not cause a still-declared
         // job's existing pending row to be cancelled on this startup pass.)
         declaredTuples.push({
+          sourceAgentId: config.name,
           agentId: targetAgentId,
           cronExpr: schedule.cron,
           taskPayload: JSON.stringify({ task: schedule.task }),
@@ -600,6 +601,7 @@ export class Scheduler {
 
         try {
           const jobId = await this.schedulerService.upsertDeclarativeJob(
+            config.name,
             targetAgentId,
             schedule,
           );

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -676,7 +676,7 @@ describe('SchedulerService', () => {
     it('upserts using ON CONFLICT and returns the job id', async () => {
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-decl' }] });
 
-      const id = await svc.upsertDeclarativeJob('agent-1', {
+      const id = await svc.upsertDeclarativeJob('source-1', 'agent-1', {
         cron: '0 8 * * 1',
         task: 'weekly-standup',
       });
@@ -685,13 +685,27 @@ describe('SchedulerService', () => {
       const [sql] = pool.query.mock.calls[0] as [string];
       // Column-based conflict syntax — matches the partial unique index definition.
       // ON CONFLICT ON CONSTRAINT only works with named CONSTRAINTs, not named indexes.
-      expect(sql).toContain('ON CONFLICT (agent_id, cron_expr, (task_payload::text)) WHERE created_by = \'system\'');
+      expect(sql).toContain('ON CONFLICT (source_agent_id, agent_id, cron_expr, (task_payload::text)) WHERE created_by = \'system\'');
+    });
+
+    it('persists sourceAgentId separately from the target agent id', async () => {
+      pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-source' }] });
+
+      await svc.upsertDeclarativeJob('writing-scout', 'coordinator', {
+        cron: '30 8 * * 2',
+        task: 'Run the writing scout',
+      });
+
+      const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('source_agent_id');
+      expect(params[0]).toBe('writing-scout');
+      expect(params[1]).toBe('coordinator');
     });
 
     it('writes expectedDurationSeconds when provided', async () => {
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-decl-1' }] });
 
-      await svc.upsertDeclarativeJob('coordinator', {
+      await svc.upsertDeclarativeJob('coordinator', 'coordinator', {
         cron: '30 7 * * *',
         task: 'Send morning brief',
         expectedDurationSeconds: 60,
@@ -705,7 +719,7 @@ describe('SchedulerService', () => {
     it('writes NULL for expected_duration_seconds when not provided, clearing any stale DB value', async () => {
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-decl-2' }] });
 
-      await svc.upsertDeclarativeJob('coordinator', {
+      await svc.upsertDeclarativeJob('coordinator', 'coordinator', {
         cron: '0 9 * * 1',
         task: 'Weekly standup',
         // no expectedDurationSeconds — should write NULL, not omit the column
@@ -724,7 +738,7 @@ describe('SchedulerService', () => {
       for (const invalid of invalids) {
         pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-x' }] });
 
-        await svc.upsertDeclarativeJob('coordinator', {
+        await svc.upsertDeclarativeJob('coordinator', 'coordinator', {
           cron: '0 9 * * *',
           task: 'test',
           expectedDurationSeconds: invalid,
@@ -743,7 +757,7 @@ describe('SchedulerService', () => {
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-anchor' }] });
       pool.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
-      await svc.upsertDeclarativeJob('coordinator', {
+      await svc.upsertDeclarativeJob('coordinator', 'coordinator', {
         cron: '0 9 * * 1',
         task: 'weekly digest',
         intent_anchor: 'Produce a weekly summary of key business metrics',
@@ -772,7 +786,7 @@ describe('SchedulerService', () => {
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-anchor-2' }] });
       pool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
 
-      await svc.upsertDeclarativeJob('coordinator', {
+      await svc.upsertDeclarativeJob('coordinator', 'coordinator', {
         cron: '0 9 * * 1',
         task: 'weekly digest',
         intent_anchor: 'Produce a weekly summary of key business metrics',
@@ -790,7 +804,7 @@ describe('SchedulerService', () => {
     it('does not create an agent_tasks row when intent_anchor is absent', async () => {
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-no-anchor' }] });
 
-      await svc.upsertDeclarativeJob('coordinator', {
+      await svc.upsertDeclarativeJob('coordinator', 'coordinator', {
         cron: '0 9 * * 1',
         task: 'weekly standup',
       });
@@ -802,7 +816,7 @@ describe('SchedulerService', () => {
     it('stamps a system originator with systemRole system and channel declarative', async () => {
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-orig' }] });
 
-      await svc.upsertDeclarativeJob('coordinator', {
+      await svc.upsertDeclarativeJob('coordinator', 'coordinator', {
         cron: '*/15 * * * *',
         task: 'Check inbox',
       });
@@ -831,7 +845,7 @@ describe('SchedulerService', () => {
       });
 
       const liveTuples = [
-        { agentId: 'coordinator', cronExpr: '*/30 6-17 * * *', taskPayload: '{"task":"old-cron"}' },
+        { sourceAgentId: 'coordinator', agentId: 'coordinator', cronExpr: '*/30 6-17 * * *', taskPayload: '{"task":"old-cron"}' },
       ];
 
       const count = await svc.cancelStaleDeclarativeJobs(liveTuples);
@@ -860,7 +874,7 @@ describe('SchedulerService', () => {
       pool.query.mockResolvedValueOnce({ rows: [] });
 
       await svc.cancelStaleDeclarativeJobs([
-        { agentId: 'coordinator', cronExpr: '0 9 * * *', taskPayload: '{"task":"brief"}' },
+        { sourceAgentId: 'coordinator', agentId: 'coordinator', cronExpr: '0 9 * * *', taskPayload: '{"task":"brief"}' },
       ]);
 
       const [sql] = pool.query.mock.calls[0] as [string];
@@ -874,17 +888,19 @@ describe('SchedulerService', () => {
       pool.query.mockResolvedValueOnce({ rows: [] });
 
       const liveTuples = [
-        { agentId: 'agent-a', cronExpr: '0 8 * * *', taskPayload: '{"task":"t1"}' },
-        { agentId: 'agent-b', cronExpr: '0 9 * * 1', taskPayload: '{"task":"t2"}' },
+        { sourceAgentId: 'source-a', agentId: 'agent-a', cronExpr: '0 8 * * *', taskPayload: '{"task":"t1"}' },
+        { sourceAgentId: 'source-b', agentId: 'agent-b', cronExpr: '0 9 * * 1', taskPayload: '{"task":"t2"}' },
       ];
 
       await svc.cancelStaleDeclarativeJobs(liveTuples);
 
       const [, params] = pool.query.mock.calls[0] as [string, unknown[]];
-      // All six values from the two tuples should appear in the params array
+      // All eight values from the two tuples should appear in the params array
+      expect(params).toContain('source-a');
       expect(params).toContain('agent-a');
       expect(params).toContain('0 8 * * *');
       expect(params).toContain('{"task":"t1"}');
+      expect(params).toContain('source-b');
       expect(params).toContain('agent-b');
       expect(params).toContain('0 9 * * 1');
       expect(params).toContain('{"task":"t2"}');

--- a/tests/unit/scheduler/scheduler.test.ts
+++ b/tests/unit/scheduler/scheduler.test.ts
@@ -809,9 +809,11 @@ describe('Scheduler', () => {
       expect(schedulerService.upsertDeclarativeJob).toHaveBeenCalledTimes(2);
       expect(schedulerService.upsertDeclarativeJob).toHaveBeenCalledWith(
         'coordinator',
+        'coordinator',
         { cron: '0 9 * * 1', task: 'weekly-standup' },
       );
       expect(schedulerService.upsertDeclarativeJob).toHaveBeenCalledWith(
+        'coordinator',
         'coordinator',
         { cron: '0 8 * * *', task: 'daily-brief' },
       );
@@ -868,10 +870,52 @@ describe('Scheduler', () => {
 
       await scheduler.loadDeclarativeJobs(configs);
 
-      // Should be called with 'coordinator', not 'writing-scout'
+      // The source stays 'writing-scout' while the target is 'coordinator'.
       expect(schedulerService.upsertDeclarativeJob).toHaveBeenCalledWith(
+        'writing-scout',
         'coordinator',
         { cron: '30 8 * * 2', task: 'Run the writing scout', agent_id: 'coordinator' },
+      );
+    });
+
+    it('passes distinct sourceAgentIds for identical schedules targeting the same agent', async () => {
+      schedulerService.upsertDeclarativeJob.mockResolvedValue('job-decl-1');
+
+      const configs: AgentYamlConfig[] = [
+        {
+          name: 'writing-scout',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Scout.',
+          schedule: [
+            { cron: '30 8 * * 2', task: 'Check the shared inbox', agent_id: 'coordinator' },
+          ],
+        },
+        {
+          name: 'researcher',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Research.',
+          schedule: [
+            { cron: '30 8 * * 2', task: 'Check the shared inbox', agent_id: 'coordinator' },
+          ],
+        },
+        {
+          name: 'coordinator',
+          model: { provider: 'anthropic', model: 'claude-3' },
+          system_prompt: 'Coord.',
+        },
+      ];
+
+      await scheduler.loadDeclarativeJobs(configs);
+
+      expect(schedulerService.upsertDeclarativeJob).toHaveBeenCalledWith(
+        'writing-scout',
+        'coordinator',
+        { cron: '30 8 * * 2', task: 'Check the shared inbox', agent_id: 'coordinator' },
+      );
+      expect(schedulerService.upsertDeclarativeJob).toHaveBeenCalledWith(
+        'researcher',
+        'coordinator',
+        { cron: '30 8 * * 2', task: 'Check the shared inbox', agent_id: 'coordinator' },
       );
     });
 
@@ -892,6 +936,7 @@ describe('Scheduler', () => {
       await scheduler.loadDeclarativeJobs(configs);
 
       expect(schedulerService.upsertDeclarativeJob).toHaveBeenCalledWith(
+        'my-agent',
         'my-agent',
         { cron: '0 9 * * 1', task: 'weekly task' },
       );
@@ -1013,6 +1058,7 @@ describe('Scheduler', () => {
 
       expect(schedulerService.upsertDeclarativeJob).toHaveBeenCalledWith(
         'coordinator',
+        'coordinator',
         {
           cron: '0 9 * * 1',
           task: 'weekly digest',
@@ -1041,15 +1087,17 @@ describe('Scheduler', () => {
 
       expect(schedulerService.cancelStaleDeclarativeJobs).toHaveBeenCalledTimes(1);
       const [declaredTuples] = schedulerService.cancelStaleDeclarativeJobs.mock.calls[0] as [
-        Array<{ agentId: string; cronExpr: string; taskPayload: string }>,
+        Array<{ sourceAgentId: string; agentId: string; cronExpr: string; taskPayload: string }>,
       ];
       expect(declaredTuples).toHaveLength(2);
       expect(declaredTuples).toContainEqual({
+        sourceAgentId: 'coordinator',
         agentId: 'coordinator',
         cronExpr: '0 9 * * 1',
         taskPayload: JSON.stringify({ task: 'weekly-standup' }),
       });
       expect(declaredTuples).toContainEqual({
+        sourceAgentId: 'coordinator',
         agentId: 'coordinator',
         cronExpr: '0 8 * * *',
         taskPayload: JSON.stringify({ task: 'daily-brief' }),
@@ -1080,23 +1128,25 @@ describe('Scheduler', () => {
       await scheduler.loadDeclarativeJobs(configs);
 
       const [declaredTuples] = schedulerService.cancelStaleDeclarativeJobs.mock.calls[0] as [
-        Array<{ agentId: string; cronExpr: string; taskPayload: string }>,
+        Array<{ sourceAgentId: string; agentId: string; cronExpr: string; taskPayload: string }>,
       ];
       // Both tuples — including the one whose upsert failed — must be in the declared set
       expect(declaredTuples).toHaveLength(2);
       expect(declaredTuples).toContainEqual({
+        sourceAgentId: 'agent-x',
         agentId: 'agent-x',
         cronExpr: '0 1 * * *',
         taskPayload: JSON.stringify({ task: 'fail-task' }),
       });
       expect(declaredTuples).toContainEqual({
+        sourceAgentId: 'agent-x',
         agentId: 'agent-x',
         cronExpr: '0 2 * * *',
         taskPayload: JSON.stringify({ task: 'ok-task' }),
       });
     });
 
-    it('uses targetAgentId (not source config.name) in the declared tuple', async () => {
+    it('keeps both sourceAgentId and targetAgentId in the declared tuple', async () => {
       schedulerService.upsertDeclarativeJob.mockResolvedValue('job-1');
       schedulerService.cancelStaleDeclarativeJobs.mockResolvedValue(0);
 
@@ -1119,11 +1169,11 @@ describe('Scheduler', () => {
       await scheduler.loadDeclarativeJobs(configs);
 
       const [declaredTuples] = schedulerService.cancelStaleDeclarativeJobs.mock.calls[0] as [
-        Array<{ agentId: string; cronExpr: string; taskPayload: string }>,
+        Array<{ sourceAgentId: string; agentId: string; cronExpr: string; taskPayload: string }>,
       ];
-      // The declared tuple must use 'coordinator' (the targetAgentId), not 'writing-scout'
       expect(declaredTuples).toEqual([
         {
+          sourceAgentId: 'writing-scout',
           agentId: 'coordinator',
           cronExpr: '30 8 * * 2',
           taskPayload: JSON.stringify({ task: 'Run the writing scout' }),


### PR DESCRIPTION
## **User description**
Fixes #231

## Changes
- Added `source_agent_id` to `scheduled_jobs` and rebuilt the declarative-job unique index around source + target + cron + payload.
- Threaded the declaring agent name through `loadDeclarativeJobs()` into `upsertDeclarativeJob()`.
- Updated stale declarative-job cleanup so it protects rows by the same source-aware identity.
- Added scheduler tests for identical schedules from two source agents targeting the same coordinator.

## Verification
- `pnpm vitest run tests/unit/scheduler/scheduler-service.test.ts tests/unit/scheduler/scheduler.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with one existing warning in `src/pii/scrubber.ts` about an unused eslint-disable)

I also tried the full `pnpm test`. The scheduler tests pass, but the full suite still hits unrelated local/environment failures: integration tests require `DATABASE_URL`, Signal RPC tests cannot bind the temp socket path on this Windows checkout (`EACCES`), and a few `file-parse` temp-file-url tests fail against the current local temp-store setup.

AI note: I used GPT assistance while working through the patch and test updates, then checked the actual diff and test output before submitting.


___

## **CodeAnt-AI Description**
**Keep declarative schedules separate by declaring agent**

### What Changed
- Declarative jobs now keep the declaring agent and target agent as separate identity fields, so two agents can declare the same schedule for the same target without one overwriting the other.
- Startup reconciliation now preserves and compares the declaring agent when creating, updating, and removing declarative jobs.
- Added coverage for shared schedules, stale-job cleanup, and the new identity behavior.

### Impact
`✅ Fewer lost schedules for shared coordinators`
`✅ No silent overwrite when two agents declare the same job`
`✅ Safer startup cleanup for declarative jobs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
