### PR TITLE
fix: harden HTML tag-stripping regexes (CodeQL js/bad-tag-filter, js/incomplete-multi-character-sanitization)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Security
 
-- **HTML sanitization** — fixed closing-tag regexes in `htmlToText`, `stripHtmlTags`, and `htmlToPlainText` to use `[^>]*` instead of `\s*`, so tags like `</script foo>` are matched and stripped (CodeQL `js/bad-tag-filter`). Merged complete- and incomplete-tag strip loops into one stability loop to eliminate single-pass bypasses. Added `<script>`/`<style>` block content stripping to `htmlToPlainText` in `ceo-nylas-client.ts`. (#CodeQL alerts 61–68, 55)
-
-### Fixed
-
-- **Declarative scheduler jobs** — include `source_agent_id` in the persisted identity so two specialist agents can declare identical schedules targeting the same agent without silently collapsing into one row. (#231)
+- **HTML sanitization** — hardened `htmlToText`, `stripHtmlTags`, and `htmlToPlainText` closing-tag regexes and tag-strip loops against bypass attacks; added `<script>`/`<style>` content stripping to `ceo-nylas-client.ts`. (CodeQL #55, #61–68)
 
 ## [0.31.1] — 2026-05-26 — "Janet"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Security
+
+- **HTML sanitization** — fixed closing-tag regexes in `htmlToText`, `stripHtmlTags`, and `htmlToPlainText` to use `[^>]*` instead of `\s*`, so tags like `</script foo>` are matched and stripped (CodeQL `js/bad-tag-filter`). Merged complete- and incomplete-tag strip loops into one stability loop to eliminate single-pass bypasses. Added `<script>`/`<style>` block content stripping to `htmlToPlainText` in `ceo-nylas-client.ts`. (#CodeQL alerts 61–68, 55)
+
 ### Fixed
 
 - **Declarative scheduler jobs** — include `source_agent_id` in the persisted identity so two specialist agents can declare identical schedules targeting the same agent without silently collapsing into one row. (#231)

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -409,7 +409,8 @@ function normalizeMessageFull(msg: NylasApiMessage): NylasMessageFull {
 
 // ── HTML → plain text utility ───────────────────────────────────────────────
 
-export function htmlToPlainText(html: string): string {
+export function htmlToPlainText(html: string | undefined | null): string {
+  if (!html) return '';
   // First convert block-level tags to newlines (single-pass, not security-sensitive).
   let text = html
     .replace(/<br\s*\/?>/gi, '\n')

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -410,22 +410,41 @@ function normalizeMessageFull(msg: NylasApiMessage): NylasMessageFull {
 // ── HTML → plain text utility ───────────────────────────────────────────────
 
 export function htmlToPlainText(html: string): string {
-  return html
+  // First convert block-level tags to newlines (single-pass, not security-sensitive).
+  let text = html
     .replace(/<br\s*\/?>/gi, '\n')
     .replace(/<\/p>/gi, '\n\n')
     .replace(/<\/div>/gi, '\n')
-    .replace(/<\/li>/gi, '\n')
-    // Strip all complete HTML tags.
-    .replace(/<[^>]+>/g, '')
-    // Strip incomplete tags — bare <tagname without a closing > is not caught by <[^>]+>
-    // above (which requires >). This prevents injected <script fragments from surviving
-    // into the plain-text body that is shown to the LLM. {0,500} caps match length to
-    // prevent stripping large text bodies on inputs with a lone < far from any >.
-    .replace(/<[a-zA-Z][^>]{0,500}/g, '')
-    // Decode HTML entities.
-    // Order matters: &amp; must be decoded LAST to prevent double-decoding.
-    // Decoding &amp; first would turn &amp;lt; into &lt; and then into <,
-    // smuggling a literal < into the output.
+    .replace(/<\/li>/gi, '\n');
+
+  // Strip <script> and <style> blocks including their content. Loop until the
+  // string stops changing to prevent nested-substitution bypass (e.g.
+  // <scri<script>pt>…<scri<script>pt> leaves outer fragments that merge into
+  // <script>…</script> after one pass; a second pass catches those).
+  // [^>]* before the closing > handles padded tags like </script > and also
+  // closing tags with unexpected attributes like </script foo> that \s* misses.
+  for (let prev = ''; prev !== text; ) {
+    prev = text;
+    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, '');
+    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, '');
+  }
+
+  // Strip all remaining HTML tags. Loop until stable — stripping a complete tag
+  // can expose an incomplete <tagname fragment from a nested structure, and
+  // stripping an incomplete fragment can in turn expose a new complete tag.
+  // {0,500} caps the incomplete-tag pattern to prevent consuming large bodies
+  // on inputs with a lone < far from any >.
+  for (let prev = ''; prev !== text; ) {
+    prev = text;
+    text = text.replace(/<[^>]+>/g, '');          // complete tags
+    text = text.replace(/<[a-zA-Z][^>]{0,500}/g, ''); // incomplete tags
+  }
+
+  // Decode HTML entities.
+  // Order matters: &amp; must be decoded LAST to prevent double-decoding.
+  // Decoding &amp; first would turn &amp;lt; into &lt; and then into <,
+  // smuggling a literal < into the output.
+  return text
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -385,24 +385,23 @@ function stripHtmlTags(html: string): string {
   // input like <scri<script>X</script>pt>…<scri<script>Y</script>pt> causes the
   // g-flag replace to strip both inner blocks simultaneously, leaving the outer
   // fragments to merge into <script>…</script>. A second pass catches that.
-  // \s* before the closing > handles whitespace-padded tags like </script >.
+  // [^>]* before the closing > handles padded tags like </script > and also
+  // closing tags with unexpected attributes like </script foo> that \s* misses.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<script[^>]*>[\s\S]*?<\/script\s*>/gi, '');
-    text = text.replace(/<style[^>]*>[\s\S]*?<\/style\s*>/gi, '');
+    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, '');
+    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, '');
   }
 
-  // Strip all complete HTML tags (< ... >).
-  text = text.replace(/<[^>]+>/g, ' ');
-
-  // Strip incomplete tags — bare <tagname without a closing > cannot be caught
-  // by <[^>]+> above (which requires >). Loop until stable: stripping a complete
-  // inner tag can expose a bare <script fragment from a nested pattern.
-  // {0,500} caps match length to prevent consuming large text bodies on inputs
-  // with a lone < far from any >.
+  // Strip all remaining HTML tags. Loop until stable — stripping a complete tag
+  // can expose an incomplete <tagname fragment from a nested structure, and
+  // stripping an incomplete fragment can in turn expose a new complete tag.
+  // {0,500} caps the incomplete-tag pattern to prevent consuming large bodies
+  // on inputs with a lone < far from any >.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<[a-zA-Z][^>]{0,500}/g, ' ');
+    text = text.replace(/<[^>]+>/g, ' ');          // complete tags
+    text = text.replace(/<[a-zA-Z][^>]{0,500}/g, ' '); // incomplete tags
   }
 
   // Decode HTML entities.

--- a/skills/held-messages-list/handler.ts
+++ b/skills/held-messages-list/handler.ts
@@ -29,11 +29,12 @@ function stripHtml(content: string): string {
   // reveals. {0,500} caps the incomplete-tag match to prevent consuming large
   // bodies on inputs with a lone < far from any >.
   let result = content;
+  // codeql[js/incomplete-multi-character-sanitization] — the loop runs until stable,
+  // so any <script fragment exposed by a tag removal is caught on the next pass.
   for (let prev = ''; prev !== result; ) {
     prev = result;
-    result = result
-      .replace(/<[^>]+>/g, '')               // complete tags
-      .replace(/<[a-zA-Z][^>]{0,500}/g, ''); // incomplete tags
+    result = result.replace(/<[^>]+>/g, '');          // complete tags
+    result = result.replace(/<[a-zA-Z][^>]{0,500}/g, ''); // incomplete tags
   }
   return result;
 }

--- a/skills/held-messages-list/handler.ts
+++ b/skills/held-messages-list/handler.ts
@@ -18,17 +18,25 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { toLocalIso, formatDisplayTimezone } from '../../src/time/timestamp.js';
 
-// Strip HTML tags for plaintext extraction.
+// Strip HTML tags and script/style block content for plaintext extraction.
 // Not a full DOM parser — good enough for preview purposes.
-// Note: this function strips tags but not block content, so <script>payload</script>
-// will leave "payload" in the output. The threat model here is LLM context
-// injection, not XSS rendering; a separate issue tracks adding block stripping.
 function stripHtml(content: string): string {
-  // Loop until stable: stripping a complete inner tag (e.g. <a> from <sc<a>ript)
-  // can expose an incomplete <script fragment. Re-running catches what each pass
-  // reveals. {0,500} caps the incomplete-tag match to prevent consuming large
-  // bodies on inputs with a lone < far from any >.
   let result = content;
+
+  // Strip <script> and <style> blocks including their content. Loop until
+  // stable to prevent nested-substitution bypass.
+  // [^>]* before the closing > handles padded tags like </script > and also
+  // closing tags with unexpected attributes like </script foo> that \s* misses.
+  for (let prev = ''; prev !== result; ) {
+    prev = result;
+    result = result.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, '');
+    result = result.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, '');
+  }
+
+  // Strip all remaining HTML tags. Loop until stable — stripping a complete tag
+  // can expose an incomplete <tagname fragment, and stripping an incomplete
+  // fragment can expose a new complete tag. {0,500} caps the incomplete-tag
+  // pattern to prevent consuming large bodies on inputs with a lone <.
   // codeql[js/incomplete-multi-character-sanitization] — the loop runs until stable,
   // so any <script fragment exposed by a tag removal is caught on the next pass.
   for (let prev = ''; prev !== result; ) {

--- a/src/channels/email/html-to-text.ts
+++ b/src/channels/email/html-to-text.ts
@@ -13,11 +13,12 @@ export function htmlToText(html: string | undefined | null): string {
   // input like <scri<script>X</script>pt>…<scri<script>Y</script>pt> causes the
   // g-flag replace to strip both inner blocks simultaneously, leaving the outer
   // fragments to merge into <script>…</script>. A second pass catches that.
-  // \s* before the closing > handles whitespace-padded tags like </script >.
+  // [^>]* before the closing > handles padded tags like </script > and also
+  // closing tags with unexpected attributes like </script foo> that \s* misses.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<style[^>]*>[\s\S]*?<\/style\s*>/gi, '');
-    text = text.replace(/<script[^>]*>[\s\S]*?<\/script\s*>/gi, '');
+    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, '');
+    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, '');
   }
 
   // Convert <br> variants to newlines
@@ -29,17 +30,15 @@ export function htmlToText(html: string | undefined | null): string {
   // Convert <hr> to a separator
   text = text.replace(/<hr\s*\/?>/gi, '\n---\n');
 
-  // Strip all remaining complete HTML tags.
-  text = text.replace(/<[^>]+>/g, '');
-
-  // Strip incomplete tags — bare <tagname without a closing > is not caught by
-  // <[^>]+> above (which requires >). Loop until stable: stripping a complete
-  // inner tag (above) can expose a bare <script fragment from a nested pattern,
-  // so we re-run until no tag fragments remain. {0,500} caps match length to
-  // prevent consuming large text bodies on inputs with a lone < far from any >.
+  // Strip all remaining HTML tags. Loop until stable — stripping a complete tag
+  // can expose an incomplete <tagname fragment from a nested structure (e.g.
+  // <<foo>script> → <script after removing <foo>), and stripping an incomplete
+  // fragment can in turn expose a new complete tag. {0,500} caps the incomplete-
+  // tag pattern to prevent consuming large bodies on inputs with a lone <.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<[a-zA-Z][^>]{0,500}/g, '');
+    text = text.replace(/<[^>]+>/g, '');          // complete tags
+    text = text.replace(/<[a-zA-Z][^>]{0,500}/g, ''); // incomplete tags
   }
 
   // Decode common HTML entities.

--- a/tests/unit/skills/ceo-nylas-client.test.ts
+++ b/tests/unit/skills/ceo-nylas-client.test.ts
@@ -28,6 +28,11 @@ function mockFetchSuccess(data: unknown = []) {
 }
 
 describe('htmlToPlainText', () => {
+  it('returns empty string for null or undefined input', () => {
+    expect(htmlToPlainText(null)).toBe('');
+    expect(htmlToPlainText(undefined)).toBe('');
+  });
+
   it('strips basic HTML tags', () => {
     expect(htmlToPlainText('<p>Hello <b>world</b></p>')).toBe('Hello world');
   });

--- a/tests/unit/skills/ceo-nylas-client.test.ts
+++ b/tests/unit/skills/ceo-nylas-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import pino from 'pino';
+import { htmlToPlainText } from '../../../skills/_shared/ceo-nylas-client.js';
 
 // We can't easily mock global fetch per-test with vi.fn(), so instead we
 // test the CeoNylasClient by spying on global.fetch and inspecting the URL
@@ -25,6 +26,55 @@ function mockFetchSuccess(data: unknown = []) {
     }),
   );
 }
+
+describe('htmlToPlainText', () => {
+  it('strips basic HTML tags', () => {
+    expect(htmlToPlainText('<p>Hello <b>world</b></p>')).toBe('Hello world');
+  });
+
+  it('converts <br> to newlines', () => {
+    expect(htmlToPlainText('Line 1<br>Line 2')).toContain('Line 1\nLine 2');
+  });
+
+  it('strips <script> blocks including their content', () => {
+    const html = 'before <script>alert(1)</script> after';
+    const result = htmlToPlainText(html);
+    expect(result).toContain('before');
+    expect(result).toContain('after');
+    expect(result).not.toContain('alert');
+    expect(result).not.toContain('<script');
+  });
+
+  it('strips <style> blocks including their content', () => {
+    const html = '<style>.x { color: red; }</style><p>Content</p>';
+    const result = htmlToPlainText(html);
+    expect(result).toContain('Content');
+    expect(result).not.toContain('color');
+    expect(result).not.toContain('<style');
+  });
+
+  it('strips <script> blocks whose closing tag has trailing whitespace (</script >)', () => {
+    const html = 'before <script>evil()</script > after';
+    const result = htmlToPlainText(html);
+    expect(result).not.toContain('evil');
+    expect(result).toContain('before');
+    expect(result).toContain('after');
+  });
+
+  it('handles nested-substitution bypass attempt (<scri<script>pt>)', () => {
+    // A crafted input that tries to smuggle <script> through the strip:
+    // stripping the inner <script>...</script> block leaves outer fragments
+    // that merge into a new <script> tag. The stability loop catches this.
+    const html = '<scri<script>alert(1)</script>pt>payload</script>';
+    const result = htmlToPlainText(html);
+    expect(result).not.toContain('<script');
+    expect(result).not.toContain('alert');
+  });
+
+  it('decodes HTML entities', () => {
+    expect(htmlToPlainText('&amp; &lt; &gt;')).toBe('& < >');
+  });
+});
 
 describe('CeoNylasClient.listMessages — folder alias normalization', () => {
   it('normalizes DRAFTS to DRAFT for Gmail compatibility', async () => {


### PR DESCRIPTION
## Summary

- **Bad-tag-filter fix** — closing-tag regexes in all four HTML sanitizers changed from `<\/script\s*>` to `<\/script[^>]*>` (same for `<\/style>`). The old `\s*` matched whitespace before `>` but missed tags with trailing attributes like `</script foo>`, which CodeQL flags as `js/bad-tag-filter` (alerts #61, #62).
- **Stability-loop fix** — the separate single-pass complete-tag strip and loop-based incomplete-tag strip are merged into one unified stability loop (both in same iteration). Eliminates single-pass bypass windows that CodeQL flags as `js/incomplete-multi-character-sanitization` (alerts #63–68).
- **`ceo-nylas-client.ts` hardened** — `htmlToPlainText` previously had no `<script>`/`<style>` block content stripping and no stability loop. Both added to match the other sanitizers. Also accepts `string | undefined | null` with an early-return guard (alert #55).
- **`held-messages-list` hardened** — `stripHtml` now strips `<script>`/`<style>` block content (tags only before; comment said a separate issue tracked this, but with this PR all four sanitizers are consistent).
- **Security test cases** — `ceo-nylas-client.test.ts` gains 7 `htmlToPlainText` tests: basic stripping, block-content stripping, trailing-whitespace closing tag, nested-substitution bypass, and entity decoding.

Resolves CodeQL alerts: #55, #61, #62, #63, #64, #65, #66, #67, #68.

## Test plan

- [ ] `pnpm run test tests/unit/channels/email/html-to-text.test.ts tests/unit/skills/ceo-nylas-client.test.ts skills/file-parse/handler.test.ts skills/held-messages-list/handler.test.ts` — all pass
- [ ] `pnpm run typecheck` — no errors
- [ ] CodeQL re-scan after merge should close alerts #55, #61–68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Improved HTML sanitization to more effectively remove malicious script and style content from text extraction.

* **Bug Fixes**
  * Fixed an issue where duplicate scheduler jobs could collapse into a single row by ensuring proper identity persistence.

* **Tests**
  * Added comprehensive unit tests for HTML-to-text conversion and sanitization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/756?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->