### PR TITLE
fix: allow esbuild build scripts so Docker image builds succeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **HTML sanitization** — hardened `htmlToText`, `stripHtmlTags`, and `htmlToPlainText` closing-tag regexes and tag-strip loops against bypass attacks; added `<script>`/`<style>` content stripping to `ceo-nylas-client.ts`. (CodeQL #55, #61–68)
 
+### Fixed
+
+- **Declarative scheduler jobs** — include `source_agent_id` in the persisted identity so two specialist agents can declare identical schedules targeting the same agent without silently collapsing into one row. (#231)
+- **Trivy Docker Image Scan** — add `onlyBuiltDependencies: ["esbuild"]` to `package.json` so pnpm 11's build-script approval check doesn't abort the Docker build cold.
+
 ## [0.31.1] — 2026-05-26 — "Janet"
 
 > **Janet** *(The Good Place, 2016, Michael Schur)* — the neighborhood's vast informational assistant: appears when summoned, answers with total knowledge of every resident, performs only the function asked, never lies about what she did. v0.31.1 reshapes Curia's agents along the same lines — they know who the principal is at bootstrap, stay on the task they were scheduled for, don't retry into uncertainty, and leave an honest audit trail of every wire-level send.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "sanitize-html": "^2.17.4"
   },
   "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"],
     "overrides": {
       "hono": ">=4.12.18",
       "fast-uri": ">=3.1.2",


### PR DESCRIPTION
## **User description**
## Summary

- Adds `onlyBuiltDependencies: ["esbuild"]` to the `pnpm` config in `package.json`
- Fixes the weekly Trivy Docker Image Scan, which has been failing because the Docker build aborts at `pnpm install --frozen-lockfile`

## Root cause

pnpm 11 blocks transitive dependency build scripts by default. When a dependency with an unapproved postinstall script is encountered during `pnpm install`, pnpm exits 1 with `ERR_PNPM_IGNORED_BUILDS`. `esbuild` (a transitive dep of both `tsup` and `vite`) needs its postinstall script to download the correct platform binary; without it, the binary is missing and `tsup` can't run.

The Trivy Docker Image Scan is the only CI job that builds a Docker image cold (no layer cache). That's why it fails while regular CI passes — `ci.yml` already worked around this via `--ignore-scripts` + `pnpm rebuild esbuild`. The Dockerfile never got the equivalent fix.

## Why this change is safe

- The `onlyBuiltDependencies` field is purely declarative: it approves what esbuild was already doing in all working environments
- The production Docker stage (`pnpm install --frozen-lockfile --prod`) excludes devDeps entirely, so esbuild is never installed there — no change in behavior
- `ci.yml`'s `--ignore-scripts` + `pnpm rebuild esbuild` pattern continues to work unchanged

## Test plan

- [ ] Verify CI passes on this PR (typecheck, lint, tests)
- [ ] Next Wednesday's Trivy scheduled scan passes (or manually trigger it via `gh workflow run trivy.yml`)


___

## **CodeAnt-AI Description**
**Allow Docker image builds to complete during Trivy scans**

### What Changed
- Docker builds now complete on cold installs instead of stopping when pnpm blocks esbuild’s required build script
- The Trivy Docker Image Scan can run again because the image build no longer fails at dependency installation
- The changelog now records this Docker scan fix

### Impact
`✅ Fewer Docker build failures`
`✅ Reliable Trivy image scans`
`✅ Clearer release notes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
