### PR TITLE
fix: use mkdtemp for unique temp paths in file-parse tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Security
 
 - **HTML sanitization** — hardened `htmlToText`, `stripHtmlTags`, and `htmlToPlainText` closing-tag regexes and tag-strip loops against bypass attacks; added `<script>`/`<style>` content stripping to `ceo-nylas-client.ts`. (CodeQL #55, #61–68)
+- **Insecure temp file** — `file-parse` tests now create a unique `mkdtemp` subdirectory under `/tmp/curia-tempfiles/` instead of a fixed path. (CodeQL #69, #70)
 
 ### Fixed
 

--- a/skills/file-parse/handler.test.ts
+++ b/skills/file-parse/handler.test.ts
@@ -393,18 +393,26 @@ describe('FileParseHandler', () => {
 
   describe('temp_file_url support', () => {
     const handler = new FileParseHandler();
-    // Use /tmp/curia-tempfiles/ which is in the allowed prefix list
-    const tempDir = '/tmp/curia-tempfiles';
+    // Use /tmp/curia-tempfiles/ which is in the handler's allowed prefix list.
+    // mkdtemp creates a uniquely-named subdirectory so the path is not
+    // predictable — avoids the js/insecure-temporary-file CodeQL pattern.
+    // The unique subdir still starts with /tmp/curia-tempfiles/ so it passes
+    // the handler's allow-list check.
+    const TEMPFILES_BASE = '/tmp/curia-tempfiles';
+    let tempDir: string;
     let testFilePath: string;
 
     beforeAll(async () => {
-      await fs.mkdir(tempDir, { recursive: true });
+      await fs.mkdir(TEMPFILES_BASE, { recursive: true });
+      tempDir = await fs.mkdtemp(path.join(TEMPFILES_BASE, 'test-'));
       testFilePath = path.join(tempDir, 'test-file.csv');
       await fs.writeFile(testFilePath, 'vendor,amount\nAcme,50.00');
     });
 
     afterAll(async () => {
-      try { await fs.unlink(testFilePath); } catch { /* cleanup best-effort */ }
+      if (tempDir) {
+        try { await fs.rm(tempDir, { recursive: true, force: true }); } catch { /* cleanup best-effort */ }
+      }
     });
 
     it('reads file from temp_file_url when content_base64 is empty', async () => {


### PR DESCRIPTION
## **User description**
## Summary

- Replace the fixed `/tmp/curia-tempfiles/test-file.csv` path with a `mkdtemp`-generated subdirectory under `/tmp/curia-tempfiles/`, so temp paths are no longer predictable
- The unique subdirectory still starts with the handler's allowed prefix (`/tmp/curia-tempfiles/`), so the allow-list validation in `handler.ts` is unaffected
- `afterAll` now removes the unique subdirectory recursively with a `tempDir` guard to handle the case where `beforeAll` failed before `mkdtemp` completed

Fixes CodeQL `js/insecure-temporary-file` alerts #69 and #70.

## Test plan

- [ ] All 34 existing `file-parse` unit tests pass unchanged
- [ ] CodeQL re-scan closes alerts #69 and #70
- [ ] No changes to production code — test-only fix


___

## **CodeAnt-AI Description**
**Use unique temporary file paths in file-parse tests**

### What Changed
- File-parse tests now create a unique temporary subfolder instead of using a fixed, predictable path
- Temporary test files are cleaned up by removing the whole test folder after the run
- The changelog now records the security fix for the insecure temp file issue

### Impact
`✅ Fewer insecure temporary file findings`
`✅ Less predictable test file paths`
`✅ Cleaner temporary file cleanup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced file-parse handler test suite to use unique temporary directories created for each test execution, replacing the previous fixed directory approach. Improved test cleanup routines to ensure proper removal of all temporary test files and directories.

* **Chores**
  * Updated changelog to document test infrastructure improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->