### PR TITLE
fix: add inline CodeQL suppression for loop-stable HTML sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **HTML sanitization** — hardened `htmlToText`, `stripHtmlTags`, and `htmlToPlainText` closing-tag regexes and tag-strip loops against bypass attacks; added `<script>`/`<style>` content stripping to `ceo-nylas-client.ts`. (CodeQL #55, #61–68)
 - **Insecure temp file** — `file-parse` tests now create a unique `mkdtemp` subdirectory under `/tmp/curia-tempfiles/` instead of a fixed path. (CodeQL #69, #70)
 - **ip-address XSS** — bumped transitive `ip-address` from 10.1.0 to 10.2.0 via lockfile refresh and added a defensive `>=10.1.1` override. (CodeQL #54)
+- **CodeQL suppression** — added inline `codeql[js/incomplete-multi-character-sanitization]` annotations on the loop-until-stable HTML strip lines in `html-to-text.ts`, `ceo-nylas-client.ts`, `file-parse/handler.ts`, and `held-messages-list/handler.ts`; CodeQL cannot model the loop invariant and flags individual passes as incomplete. (CodeQL #71–81)
 
 ### Fixed
 

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -426,8 +426,8 @@ export function htmlToPlainText(html: string | undefined | null): string {
   // closing tags with unexpected attributes like </script foo> that \s* misses.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, '');
-    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, '');
+    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
+    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
   }
 
   // Strip all remaining HTML tags. Loop until stable — stripping a complete tag
@@ -437,7 +437,7 @@ export function htmlToPlainText(html: string | undefined | null): string {
   // on inputs with a lone < far from any >.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<[^>]+>/g, '');          // complete tags
+    text = text.replace(/<[^>]+>/g, ''); // codeql[js/incomplete-multi-character-sanitization] complete tags
     text = text.replace(/<[a-zA-Z][^>]{0,500}/g, ''); // incomplete tags
   }
 

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -389,8 +389,8 @@ function stripHtmlTags(html: string): string {
   // closing tags with unexpected attributes like </script foo> that \s* misses.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, '');
-    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, '');
+    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
+    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
   }
 
   // Strip all remaining HTML tags. Loop until stable — stripping a complete tag

--- a/skills/held-messages-list/handler.ts
+++ b/skills/held-messages-list/handler.ts
@@ -29,8 +29,8 @@ function stripHtml(content: string): string {
   // closing tags with unexpected attributes like </script foo> that \s* misses.
   for (let prev = ''; prev !== result; ) {
     prev = result;
-    result = result.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, '');
-    result = result.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, '');
+    result = result.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
+    result = result.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
   }
 
   // Strip all remaining HTML tags. Loop until stable — stripping a complete tag
@@ -41,7 +41,7 @@ function stripHtml(content: string): string {
   // so any <script fragment exposed by a tag removal is caught on the next pass.
   for (let prev = ''; prev !== result; ) {
     prev = result;
-    result = result.replace(/<[^>]+>/g, '');          // complete tags
+    result = result.replace(/<[^>]+>/g, ''); // codeql[js/incomplete-multi-character-sanitization] complete tags
     result = result.replace(/<[a-zA-Z][^>]{0,500}/g, ''); // incomplete tags
   }
   return result;

--- a/src/channels/email/html-to-text.ts
+++ b/src/channels/email/html-to-text.ts
@@ -17,8 +17,8 @@ export function htmlToText(html: string | undefined | null): string {
   // closing tags with unexpected attributes like </script foo> that \s* misses.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, '');
-    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, '');
+    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
+    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
   }
 
   // Convert <br> variants to newlines
@@ -37,7 +37,7 @@ export function htmlToText(html: string | undefined | null): string {
   // tag pattern to prevent consuming large bodies on inputs with a lone <.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<[^>]+>/g, '');          // complete tags
+    text = text.replace(/<[^>]+>/g, ''); // codeql[js/incomplete-multi-character-sanitization] complete tags
     text = text.replace(/<[a-zA-Z][^>]{0,500}/g, ''); // incomplete tags
   }
 


### PR DESCRIPTION
## **User description**
## Summary

- Adds `// codeql[js/incomplete-multi-character-sanitization]` inline annotations on the individual `.replace()` lines inside loop-until-stable HTML stripping blocks in four files
- Closes CodeQL alerts #71, #72, #73, #74, #75, #76, #77, #78, #79, #80, #81

**Why suppression and not a code fix?** The loop-until-stable pattern is the correct mitigation for the nested-substitution bypass CodeQL is warning about (a crafted input like `<scri<script>X</script>pt>` can survive a single-pass replace; the loop re-runs until the string stops changing, so any reconstituted fragment is caught on the next pass). CodeQL cannot model the loop invariant — it sees each individual `.replace()` call as incomplete. The suppression annotation acknowledges that CodeQL is correct for a single pass in isolation but wrong about the full loop.

The existing code comments already document the bypass scenario and why the loop defeats it.

## Files changed

- `src/channels/email/html-to-text.ts` — alerts #79, #80, #81
- `skills/_shared/ceo-nylas-client.ts` — alerts #71, #72, #73
- `skills/file-parse/handler.ts` — alerts #74, #75
- `skills/held-messages-list/handler.ts` — alerts #76, #77, #78

## Test plan

- [ ] Typecheck passes (`pnpm run typecheck`)
- [ ] CodeQL scan after merge should auto-close alerts #71–81


___

## **CodeAnt-AI Description**
**Suppress CodeQL alerts on loop-based HTML stripping**

### What Changed
- Added CodeQL suppression comments to HTML stripping lines that already run until the text stops changing
- Kept the existing script/style removal and tag stripping behavior unchanged across email text conversion, held messages, and file parsing
- Documented the CodeQL suppression in the changelog

### Impact
`✅ Fewer false security alerts`
`✅ Cleaner CodeQL scans`
`✅ No change to HTML cleanup results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
