### PR TITLE
chore: disable js/incomplete-multi-character-sanitization CodeQL query

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,3 +3,12 @@ name: "Curia CodeQL config"
 paths-ignore:
   - dist
   - node_modules
+
+# js/incomplete-multi-character-sanitization fires on every .replace() inside
+# our loop-until-stable HTML stripping pattern. CodeQL cannot model the loop
+# invariant, so every instance is a false positive. Inline suppression comments
+# (// codeql[...]) were tried but ignored by the analyzer. Disabling the query
+# avoids permanent whack-a-mole with new alert numbers on every scan.
+query-filters:
+  - exclude:
+      id: js/incomplete-multi-character-sanitization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **HTML sanitization** — hardened `htmlToText`, `stripHtmlTags`, and `htmlToPlainText` closing-tag regexes and tag-strip loops against bypass attacks; added `<script>`/`<style>` content stripping to `ceo-nylas-client.ts`. (CodeQL #55, #61–68)
 - **Insecure temp file** — `file-parse` tests now create a unique `mkdtemp` subdirectory under `/tmp/curia-tempfiles/` instead of a fixed path. (CodeQL #69, #70)
 - **ip-address XSS** — bumped transitive `ip-address` from 10.1.0 to 10.2.0 via lockfile refresh and added a defensive `>=10.1.1` override. (CodeQL #54)
-- **CodeQL suppression** — added inline `codeql[js/incomplete-multi-character-sanitization]` annotations on the loop-until-stable HTML strip lines in `html-to-text.ts`, `ceo-nylas-client.ts`, `file-parse/handler.ts`, and `held-messages-list/handler.ts`; CodeQL cannot model the loop invariant and flags individual passes as incomplete. (CodeQL #71–81)
+- **CodeQL false-positive** — disabled `js/incomplete-multi-character-sanitization` in `codeql-config.yml`; all flagged sites use a loop-until-stable pattern the rule cannot model, making every alert a false positive; inline suppression comments were ineffective. (CodeQL #71–92)
 
 ### Fixed
 

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -426,8 +426,8 @@ export function htmlToPlainText(html: string | undefined | null): string {
   // closing tags with unexpected attributes like </script foo> that \s* misses.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
-    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
+    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, '');
+    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, '');
   }
 
   // Strip all remaining HTML tags. Loop until stable — stripping a complete tag
@@ -437,7 +437,7 @@ export function htmlToPlainText(html: string | undefined | null): string {
   // on inputs with a lone < far from any >.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<[^>]+>/g, ''); // codeql[js/incomplete-multi-character-sanitization] complete tags
+    text = text.replace(/<[^>]+>/g, ''); // complete tags
     text = text.replace(/<[a-zA-Z][^>]{0,500}/g, ''); // incomplete tags
   }
 

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -389,8 +389,8 @@ function stripHtmlTags(html: string): string {
   // closing tags with unexpected attributes like </script foo> that \s* misses.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
-    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
+    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, '');
+    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, '');
   }
 
   // Strip all remaining HTML tags. Loop until stable — stripping a complete tag

--- a/skills/held-messages-list/handler.ts
+++ b/skills/held-messages-list/handler.ts
@@ -29,19 +29,17 @@ function stripHtml(content: string): string {
   // closing tags with unexpected attributes like </script foo> that \s* misses.
   for (let prev = ''; prev !== result; ) {
     prev = result;
-    result = result.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
-    result = result.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
+    result = result.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, '');
+    result = result.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, '');
   }
 
   // Strip all remaining HTML tags. Loop until stable — stripping a complete tag
   // can expose an incomplete <tagname fragment, and stripping an incomplete
   // fragment can expose a new complete tag. {0,500} caps the incomplete-tag
   // pattern to prevent consuming large bodies on inputs with a lone <.
-  // codeql[js/incomplete-multi-character-sanitization] — the loop runs until stable,
-  // so any <script fragment exposed by a tag removal is caught on the next pass.
   for (let prev = ''; prev !== result; ) {
     prev = result;
-    result = result.replace(/<[^>]+>/g, ''); // codeql[js/incomplete-multi-character-sanitization] complete tags
+    result = result.replace(/<[^>]+>/g, ''); // complete tags
     result = result.replace(/<[a-zA-Z][^>]{0,500}/g, ''); // incomplete tags
   }
   return result;

--- a/src/channels/email/html-to-text.ts
+++ b/src/channels/email/html-to-text.ts
@@ -17,8 +17,8 @@ export function htmlToText(html: string | undefined | null): string {
   // closing tags with unexpected attributes like </script foo> that \s* misses.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
-    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, ''); // codeql[js/incomplete-multi-character-sanitization]
+    text = text.replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, '');
+    text = text.replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, '');
   }
 
   // Convert <br> variants to newlines
@@ -37,7 +37,7 @@ export function htmlToText(html: string | undefined | null): string {
   // tag pattern to prevent consuming large bodies on inputs with a lone <.
   for (let prev = ''; prev !== text; ) {
     prev = text;
-    text = text.replace(/<[^>]+>/g, ''); // codeql[js/incomplete-multi-character-sanitization] complete tags
+    text = text.replace(/<[^>]+>/g, ''); // complete tags
     text = text.replace(/<[a-zA-Z][^>]{0,500}/g, ''); // incomplete tags
   }
 


### PR DESCRIPTION
## **User description**
## Summary

- Adds `query-filters` to `.github/codeql/codeql-config.yml` disabling the `js/incomplete-multi-character-sanitization` query.
- Removes the now-dead `// codeql[...]` inline suppression comments from `html-to-text.ts`, `ceo-nylas-client.ts`, `file-parse/handler.ts`, and `held-messages-list/handler.ts` that were added in #760.

## Why

All flagged sites use a loop-until-stable HTML stripping pattern. CodeQL's rule cannot model loop invariants, so it flags each individual `.replace()` pass as incomplete — every instance is a confirmed false positive.

Inline suppression comments (`// codeql[js/incomplete-multi-character-sanitization]`) were tried in #760 but ignored by the analyzer: alerts #71-81 closed as Fixed, then alerts #82-92 immediately opened for the exact same lines on the next scan. Disabling the query in config is the only reliable fix.

## Test plan

- [ ] CodeQL scan after merge should show zero `js/incomplete-multi-character-sanitization` alerts
- [ ] Alerts #82-92 should close as Fixed (query disabled = no results produced)
- [ ] No TypeScript or other check regressions (config-only change + comment removal)


___

## **CodeAnt-AI Description**
**Stop repeated CodeQL alerts for the same HTML sanitization checks**

### What Changed
- Disabled the `js/incomplete-multi-character-sanitization` CodeQL rule so scans no longer keep flagging the same HTML stripping code as a false positive
- Removed obsolete inline suppression comments from the HTML-to-text and plain-text cleanup code
- Updated the changelog to note the CodeQL false-positive fix

### Impact
`✅ Fewer repeated CodeQL alerts`
`✅ Cleaner security scan results`
`✅ Less time spent re-opening the same false positives`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
