### PR TITLE
fix: copy pnpm-workspace.yaml into Docker build stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Declarative scheduler jobs** — include `source_agent_id` in the persisted identity so two specialist agents can declare identical schedules targeting the same agent without silently collapsing into one row. (#231)
 - **Trivy Docker Image Scan** — add `onlyBuiltDependencies: ["esbuild"]` to `package.json` so pnpm 11's build-script approval check doesn't abort the Docker build cold.
+- **Dockerfile esbuild build** — include `pnpm-workspace.yaml` in the build-stage `COPY` so `allowBuilds` reaches pnpm inside Docker.
 
 ## [0.31.1] — 2026-05-26 — "Janet"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 RUN corepack enable
 
 # Install dependencies first (layer caching — deps change less often than src)
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Copy source and build
@@ -40,7 +40,7 @@ WORKDIR /app
 RUN corepack enable
 
 # Copy manifest and lockfile, then install production deps only
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile --prod
 
 # tsx is needed at runtime: skill handlers are .ts files loaded via dynamic


### PR DESCRIPTION
## **User description**
## Summary

- Adds `pnpm-workspace.yaml` to both `COPY` instructions in the Dockerfile (build stage and production stage).
- Without this file in the Docker context, pnpm v11 never sees `allowBuilds: esbuild: true` and fails with `ERR_PNPM_IGNORED_BUILDS` during the build stage install.

Closes (related to #764 — that PR fixed the host-side install; this fixes the Docker build.)

## Test plan

- [ ] `pnpm run setup` on a fresh clone completes without `ERR_PNPM_IGNORED_BUILDS` in Docker build output
- [ ] Curia container starts and `/api/health` responds 200


___

## **CodeAnt-AI Description**
**Make Docker builds pick up pnpm workspace settings**

### What Changed
- Docker builds now include `pnpm-workspace.yaml` when installing dependencies
- This lets pnpm see the workspace build settings during both build and runtime image setup
- Prevents Docker builds from stopping with the esbuild build approval error

### Impact
`✅ Fewer Docker build failures`
`✅ Successful esbuild installs in containers`
`✅ More reliable image builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
