### PR TITLE
chore: move legacy web UI from / to /old/*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **Legacy web UI** — moved from `/` to `/old` and `/old/*`; `/` now returns a 404 placeholder pending the new console app. (#749)
+
 ### Security
 
 - **HTML sanitization** — hardened `htmlToText`, `stripHtmlTags`, and `htmlToPlainText` closing-tag regexes and tag-strip loops against bypass attacks; added `<script>`/`<style>` content stripping to `ceo-nylas-client.ts`. (CodeQL #55, #61–68)

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -120,8 +120,9 @@ export class HttpAdapter {
       // Job routes bypass bearer auth — the dashboard accesses them via session cookie,
       // and jobRoutes calls assertSecret on every handler.
       if (
-        routeUrl === '/' ||
+        routeUrl === '/' ||         // 404 placeholder — public, no auth needed
         routeUrl === '/auth' ||
+        routeUrl.startsWith('/old') ||  // legacy UI shell at /old and /old/*
         routeUrl.startsWith('/assets') ||
         routeUrl.startsWith('/api/kg') ||
         routeUrl.startsWith('/api/identity') ||

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -122,7 +122,8 @@ export class HttpAdapter {
       if (
         routeUrl === '/' ||         // 404 placeholder — public, no auth needed
         routeUrl === '/auth' ||
-        routeUrl.startsWith('/old') ||  // legacy UI shell at /old and /old/*
+        routeUrl === '/old' ||      // legacy UI shell — exact matches prevent accidental
+        routeUrl === '/old/*' ||    // bypass for any future /old-prefixed routes
         routeUrl.startsWith('/assets') ||
         routeUrl.startsWith('/api/kg') ||
         routeUrl.startsWith('/api/identity') ||

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1,7 +1,7 @@
 import { randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { Pool } from 'pg';
 import type { EventBus } from '../../../bus/bus.js';
 import { createInboundMessage } from '../../../bus/events.js';
@@ -3791,7 +3791,19 @@ export async function knowledgeGraphRoutes(
   const { pool, logger, webAppBootstrapSecret, secureCookies, bus, eventRouter, contactService, sessions } = options;
   // sessions is managed by HttpAdapter — no local Map creation needed here.
 
+  // GET / — placeholder until the new console app claims this route.
   app.get('/', async (_request, reply) => {
+    return reply.status(404).type('text/html; charset=utf-8').send(
+      '<!doctype html><html lang="en"><head><meta charset="utf-8" /><title>Curia</title></head>' +
+      '<body><p>Console coming soon. Legacy UI available at <a href="/old">/old</a>.</p></body></html>',
+    );
+  });
+
+  // Shared handler for the legacy hand-rolled UI — served at /old and /old/* so
+  // bookmarks to any SPA sub-path (e.g. /old/contacts) continue to work.
+  // All navigation between views is client-side only; the server just needs to
+  // return the same HTML shell regardless of the path segment after /old.
+  const serveOldUi = async (_request: FastifyRequest, reply: FastifyReply): Promise<void> => {
     reply
       .type('text/html; charset=utf-8')
       // Prevent the page from being embedded in an iframe (clickjacking defence).
@@ -3799,7 +3811,12 @@ export async function knowledgeGraphRoutes(
       // Stop browsers from MIME-sniffing the response away from text/html.
       .header('X-Content-Type-Options', 'nosniff')
       .send(createUiHtml());
-  });
+  };
+
+  app.get('/old', serveOldUi);
+  // Wildcard catches /old/kg, /old/chat, /old/contacts, etc. The * captures
+  // the remainder including an empty string (i.e. /old/ also matches).
+  app.get('/old/*', serveOldUi);
 
   // POST /auth — exchanges the bootstrap secret for an HttpOnly session cookie.
   // Tighter rate limit than the global default: 10 attempts per 15 minutes per IP,

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -3800,10 +3800,9 @@ export async function knowledgeGraphRoutes(
   });
 
   // Shared handler for the legacy hand-rolled UI — served at /old and /old/* so
-  // bookmarks to any SPA sub-path (e.g. /old/contacts) continue to work.
-  // All navigation between views is client-side only; the server just needs to
-  // return the same HTML shell regardless of the path segment after /old.
-  const serveOldUi = async (_request: FastifyRequest, reply: FastifyReply): Promise<void> => {
+  // that /old/<view> paths (e.g. /old/contacts) resolve to the shell. All view
+  // navigation is client-side; the server serves the same HTML regardless of sub-path.
+  const serveOldUi = (_request: FastifyRequest, reply: FastifyReply): void => {
     reply
       .type('text/html; charset=utf-8')
       // Prevent the page from being embedded in an iframe (clickjacking defence).

--- a/tests/unit/channels/http/kg-chat-routes.test.ts
+++ b/tests/unit/channels/http/kg-chat-routes.test.ts
@@ -220,7 +220,7 @@ describe('KG chat routes', () => {
 });
 
 describe('KG web UI shell', () => {
-  it('GET / — response contains Chat nav button and #view-chat section', async () => {
+  it('GET /old — response contains Chat nav button and #view-chat section', async () => {
     const app = Fastify();
     await app.register(cookie);
     await app.register(knowledgeGraphRoutes, {
@@ -232,7 +232,7 @@ describe('KG web UI shell', () => {
       eventRouter: createMockEventRouter(),
     });
 
-    const response = await app.inject({ method: 'GET', url: '/' });
+    const response = await app.inject({ method: 'GET', url: '/old' });
 
     expect(response.statusCode).toBe(200);
     expect(response.headers['content-type']).toMatch(/text\/html/);

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -80,7 +80,43 @@ describe('knowledgeGraphRoutes', () => {
     await app.close();
   });
 
-  it('serves the UI shell', async () => {
+  it('serves the UI shell at /old', async () => {
+    const app = Fastify();
+    await app.register(knowledgeGraphRoutes, {
+      pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: 'secret-1',
+      secureCookies: false,
+      sessions: new Map(),
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/old' });
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain('Knowledge Graph');
+
+    await app.close();
+  });
+
+  it('serves the UI shell at /old/* sub-paths', async () => {
+    const app = Fastify();
+    await app.register(knowledgeGraphRoutes, {
+      pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: 'secret-1',
+      secureCookies: false,
+      sessions: new Map(),
+    });
+
+    for (const path of ['/old/chat', '/old/contacts', '/old/tasks']) {
+      const response = await app.inject({ method: 'GET', url: path });
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain('Knowledge Graph');
+    }
+
+    await app.close();
+  });
+
+  it('returns 404 at / pending the new console', async () => {
     const app = Fastify();
     await app.register(knowledgeGraphRoutes, {
       pool,
@@ -91,8 +127,7 @@ describe('knowledgeGraphRoutes', () => {
     });
 
     const response = await app.inject({ method: 'GET', url: '/' });
-    expect(response.statusCode).toBe(200);
-    expect(response.body).toContain('Knowledge Graph');
+    expect(response.statusCode).toBe(404);
 
     await app.close();
   });


### PR DESCRIPTION
## **User description**
## Summary

- Remounts the hand-rolled HTML SPA from `GET /` to `GET /old` and `GET /old/*` so the new console app can claim `/` from day one
- `GET /` now returns a 404 placeholder with a link to `/old`
- All `/api/kg/*` endpoints and `/auth` are unchanged
- Updated bearer-auth bypass in `HttpAdapter.onRequest` to allow `/old` and `/old/*` without a token (using exact pattern matches rather than a prefix to prevent future accidental bypasses)

Closes #749

## Test plan

- [ ] `GET /old` — 200, serves the full legacy HTML shell with all 7 views
- [ ] `GET /old/chat`, `GET /old/contacts`, `GET /old/tasks` — 200, same shell (wildcard handler)
- [ ] `GET /` — 404 with placeholder HTML pointing to `/old`
- [ ] `POST /auth` — unchanged, login flow works from `/old`
- [ ] `GET /api/kg/nodes` — unchanged, still requires session/secret auth
- [ ] All 259 unit tests in `tests/unit/channels/` pass


___

## **CodeAnt-AI Description**
**Move the legacy web UI to `/old` and reserve `/` for the new console**

### What Changed
- The legacy Knowledge Graph web UI now opens at `/old` and still works on `/old/*` paths like `/old/chat`, `/old/contacts`, and `/old/tasks`
- `/` now shows a simple 404 placeholder telling users to go to `/old`
- Public access still works for the legacy UI, while unrelated routes keep their existing authentication behavior

### Impact
`✅ Clearer entry point for the new console`
`✅ Fewer broken links in the legacy UI`
`✅ Preserved access to the old web interface during the migration`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Legacy web UI has been relocated to `/old` and `/old/*` routes for backward compatibility.
  * The root path (`/`) now returns a temporary 404 placeholder while the new console app is in development.
  * Authentication bypass extended to legacy UI routes.

* **Tests**
  * Updated test coverage to verify correct behaviour at new legacy UI paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->