### PR TITLE
fix: handle pre-existing canonical contact in migration 016 Step 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Migration `016_kg_node_uniqueness`** — Step 4 now checks for pre-existing contacts on canonical KG nodes before re-pointing, preventing a duplicate-key violation on `idx_contacts_kg_node_unique` when a canonical node already had its own contact row.
+
 ### Changed
 
 - **Legacy web UI** — moved from `/` to `/old` and `/old/*`; `/` now returns a 404 placeholder pending the new console app. (#749)

--- a/src/db/migrations/016_kg_node_uniqueness.sql
+++ b/src/db/migrations/016_kg_node_uniqueness.sql
@@ -57,9 +57,17 @@ WHERE target_node_id = m.duplicate_id;
 
 -- Step 4: Re-point contacts.kg_node_id to canonical.
 -- Use ROW_NUMBER() to deterministically pick one contact per canonical_id.
--- That contact gets re-pointed; all other contacts for the same canonical
--- are NULLed to avoid violating idx_contacts_kg_node_unique.
-WITH ranked AS (
+-- That contact gets re-pointed only if no contact already points to canonical_id
+-- (a pre-existing contact would violate idx_contacts_kg_node_unique). All other
+-- duplicate-linked contacts are NULLed regardless.
+WITH
+already_claimed AS (
+  -- canonical nodes that already have a contact pointing directly at them
+  SELECT DISTINCT kg_node_id AS canonical_id
+  FROM contacts
+  WHERE kg_node_id IN (SELECT canonical_id FROM _kg_node_canonical)
+),
+ranked AS (
   SELECT
     c.id           AS contact_id,
     m.canonical_id,
@@ -72,10 +80,11 @@ WITH ranked AS (
 )
 UPDATE contacts
 SET kg_node_id = CASE
-  WHEN r.rn = 1 THEN r.canonical_id
+  WHEN r.rn = 1 AND ac.canonical_id IS NULL THEN r.canonical_id
   ELSE NULL
 END
 FROM ranked r
+LEFT JOIN already_claimed ac ON ac.canonical_id = r.canonical_id
 WHERE contacts.id = r.contact_id;
 
 -- Step 5: Delete duplicate nodes (ON DELETE CASCADE removes remaining edges)


### PR DESCRIPTION
## **User description**
## Summary

- **Migration `016_kg_node_uniqueness`** — Step 4 failed with `duplicate key value violates unique constraint "idx_contacts_kg_node_unique"` when a canonical KG node already had a contact directly pointing to it.

## Root cause

The `ranked` CTE in Step 4 only walks contacts linked to *duplicate* nodes (`JOIN _kg_node_canonical m ON c.kg_node_id = m.duplicate_id`). It unconditionally re-pointed the `rn=1` contact to `canonical_id`. If a contact already existed with `kg_node_id = canonical_id`, the UPDATE created a second row with the same value, violating the partial unique index.

## Fix

Added an `already_claimed` CTE that identifies canonical nodes with a pre-existing contact. The re-point now only fires when the canonical is unclaimed (`ac.canonical_id IS NULL`); otherwise all duplicate-linked contacts are NULLed, preserving the existing canonical contact as the sole pointer.

## Test plan

- [ ] Run `pnpm run dev` against a database where `016_kg_node_uniqueness` has not yet been applied — migration should succeed end-to-end
- [ ] Verify `contacts` rows that had `kg_node_id` pointing to duplicate nodes are either re-pointed to canonical or NULLed, with no duplicates on `kg_node_id`
- [ ] Verify `idx_kg_nodes_unique` is created successfully (Step 6)


___

## **CodeAnt-AI Description**
**Prevent migration 016 from failing when a canonical contact already exists**

### What Changed
- Migration step 4 now checks whether a canonical KG node already has a contact before moving another one onto it
- If the canonical node is already claimed, duplicate-linked contacts are cleared instead of creating a duplicate contact reference
- The release notes were updated to describe this migration fix

### Impact
`✅ Fewer migration failures`
`✅ No duplicate contact conflicts on canonical KG nodes`
`✅ Safer upgrades on databases with existing canonical contacts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
