### PR TITLE
fix: call pdf-parse via v2 PDFParse class — all PDF parsing was broken (#770)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`file-parse` PDF extraction** — call `pdf-parse` via its v2 `PDFParse` class instead of the removed v1 function export; every PDF had been throwing and getting misreported to agents as "image-only," silently breaking receipt and bank-statement parsing. (#770)
+- **`file-parse` PDF extraction** — call the v2 `PDFParse` class; the v1 API was throwing on every PDF, misreported as "image-only". (#770)
 - **Migration `016_kg_node_uniqueness`** — Step 4 now checks for pre-existing contacts on canonical KG nodes before re-pointing, preventing a duplicate-key violation on `idx_contacts_kg_node_unique` when a canonical node already had its own contact row.
 - **Console Vite dev proxy** — `/old` and the four cytoscape assets (`cytoscape.min.js`, `layout-base.js`, `cose-base.js`, `cytoscape-fcose.js`) are now proxied to Fastify in the Vite dev server; without this the Vite SPA intercepted `/old` requests and the legacy UI was unreachable in dev. (#750)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`file-parse` PDF extraction** — call `pdf-parse` via its v2 `PDFParse` class instead of the removed v1 function export; every PDF had been throwing and getting misreported to agents as "image-only," silently breaking receipt and bank-statement parsing. (#770)
 - **Migration `016_kg_node_uniqueness`** — Step 4 now checks for pre-existing contacts on canonical KG nodes before re-pointing, preventing a duplicate-key violation on `idx_contacts_kg_node_unique` when a canonical node already had its own contact row.
 - **Console Vite dev proxy** — `/old` and the four cytoscape assets (`cytoscape.min.js`, `layout-base.js`, `cose-base.js`, `cytoscape-fcose.js`) are now proxied to Fastify in the Vite dev server; without this the Vite SPA intercepted `/old` requests and the legacy UI was unreachable in dev. (#750)
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@types/js-yaml": "^4.0.9",
     "@types/luxon": "^3.7.1",
     "@types/node": "^25.9.1",
-    "@types/pdf-parse": "^1.1.5",
     "@types/pg": "^8.20.0",
     "@types/sanitize-html": "^2.16.1",
     "@typescript-eslint/eslint-plugin": "^8.59.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,9 +105,6 @@ importers:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
-      '@types/pdf-parse':
-        specifier: ^1.1.5
-        version: 1.1.5
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -1058,9 +1055,6 @@ packages:
 
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
-
-  '@types/pdf-parse@1.1.5':
-    resolution: {integrity: sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
@@ -3381,10 +3375,6 @@ snapshots:
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
-
-  '@types/pdf-parse@1.1.5':
-    dependencies:
-      '@types/node': 25.9.1
 
   '@types/pg@8.20.0':
     dependencies:

--- a/skills/file-parse/__fixtures__/no-text-layer.pdf
+++ b/skills/file-parse/__fixtures__/no-text-layer.pdf
@@ -1,0 +1,28 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 0 >>
+stream
+
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000202 00000 n 
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+251
+%%EOF

--- a/skills/file-parse/__fixtures__/sample-receipt.pdf
+++ b/skills/file-parse/__fixtures__/sample-receipt.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 126 >>
+stream
+BT /F1 18 Tf 72 720 Td (Acme Corp Invoice) Tj 0 -28 Td (Total Amount Due \(CAD\) 123.45) Tj 0 -28 Td (HST 13.00 % 14.20) Tj ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000311 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+488
+%%EOF

--- a/skills/file-parse/handler.test.ts
+++ b/skills/file-parse/handler.test.ts
@@ -379,6 +379,28 @@ describe('FileParseHandler', () => {
       }
     });
 
+    it('flags a no-text-layer PDF with a machine-readable reason, not an LLM call', async () => {
+      const infraLlm = makeInfraLlm('{}');
+      const handler = new FileParseHandler();
+      const fixturePath = path.join(import.meta.dirname, '__fixtures__', 'no-text-layer.pdf');
+      const content = (await fs.readFile(fixturePath)).toString('base64');
+      const result = await handler.execute(makeCtx({
+        content_base64: content,
+        mime_type: 'application/pdf',
+        extract_as: 'receipt',
+      }, infraLlm));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as Record<string, unknown>;
+        expect(data.raw_text).toBe('');
+        expect(data.confidence).toBe(0);
+        expect(data.reason).toBe('no_text_layer');
+      }
+      // A PDF with no text layer must not be shipped to the LLM as junk.
+      expect(infraLlm.extract).not.toHaveBeenCalled();
+    });
+
     it('passes extracted PDF text to the LLM for structured extraction', async () => {
       const infraLlm = makeInfraLlm('{"vendor":"Acme Corp","amount":"123.45"}');
       const handler = new FileParseHandler();

--- a/skills/file-parse/handler.test.ts
+++ b/skills/file-parse/handler.test.ts
@@ -341,6 +341,16 @@ describe('FileParseHandler', () => {
   });
 
   describe('PDF handling', () => {
+    // A minimal, valid text-layer PDF with known content. Guards against the
+    // pdf-parse v1→v2 API regression where the library was called as a function
+    // (v1) on a class export (v2), making every PDF throw and be misreported as
+    // "image-only". See issue #770.
+    async function readSampleReceiptPdfBase64(): Promise<string> {
+      const fixturePath = path.join(import.meta.dirname, '__fixtures__', 'sample-receipt.pdf');
+      const buffer = await fs.readFile(fixturePath);
+      return buffer.toString('base64');
+    }
+
     it('returns error for corrupt PDF content', async () => {
       const content = Buffer.from('not a pdf').toString('base64');
       const handler = new FileParseHandler();
@@ -350,6 +360,39 @@ describe('FileParseHandler', () => {
       }, makeInfraLlm('{}')));
       expect(result.success).toBe(false);
       if (!result.success) expect(result.error).toMatch(/pdf/i);
+    });
+
+    it('extracts the text layer from a real text-based PDF (extract_as: raw)', async () => {
+      const handler = new FileParseHandler();
+      const result = await handler.execute(makeCtx({
+        content_base64: await readSampleReceiptPdfBase64(),
+        mime_type: 'application/pdf',
+        extract_as: 'raw',
+      }, makeInfraLlm('{}')));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.type).toBe('pdf');
+        expect(result.data.raw_text).toContain('Acme Corp');
+        expect(result.data.raw_text).toContain('123.45');
+        expect(result.data.confidence).toBeGreaterThan(0);
+      }
+    });
+
+    it('passes extracted PDF text to the LLM for structured extraction', async () => {
+      const infraLlm = makeInfraLlm('{"vendor":"Acme Corp","amount":"123.45"}');
+      const handler = new FileParseHandler();
+      const result = await handler.execute(makeCtx({
+        content_base64: await readSampleReceiptPdfBase64(),
+        mime_type: 'application/pdf',
+        extract_as: 'receipt',
+      }, infraLlm));
+
+      expect(result.success).toBe(true);
+      expect(infraLlm.extract).toHaveBeenCalledOnce();
+      // The text layer (not an empty string) must reach the LLM prompt.
+      const promptArg = (infraLlm.extract as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+      expect(promptArg).toContain('123.45');
     });
   });
 

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -15,10 +15,10 @@ import { createRequire } from 'node:module';
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import type { InfraLlm } from '../../src/skills/infra-llm.js';
 
-// pdf-parse is CJS-only and doesn't provide a default ESM export.
-// Use createRequire to load it reliably under Node ESM + tsx.
+// pdf-parse v2 exposes a class (`PDFParse`), not a callable default export.
+// Load via createRequire so the CJS build is used reliably under Node ESM + tsx.
 const require = createRequire(import.meta.url);
-const pdfParse = require('pdf-parse') as typeof import('pdf-parse');
+const { PDFParse } = require('pdf-parse') as typeof import('pdf-parse');
 import { parseCsv } from './csv.js';
 import { getExtractionPrompt, type ExtractAs } from './prompts.js';
 
@@ -185,15 +185,23 @@ export class FileParseHandler implements SkillHandler {
   ): Promise<SkillResult> {
     let rawText: string;
     try {
-      const parsed = await pdfParse(buffer);
-      rawText = parsed.text;
+      const parser = new PDFParse({ data: buffer });
+      try {
+        const parsed = await parser.getText();
+        rawText = parsed.text;
+      } finally {
+        // Release the underlying pdfjs worker/resources even on error.
+        await parser.destroy();
+      }
     } catch (err) {
       ctx.log.error({ err }, 'file-parse: PDF text extraction failed');
-      return { success: false, error: 'Failed to extract text from PDF — file may be corrupt or image-only' };
+      return { success: false, error: 'Failed to extract text from PDF — the file may be corrupt or unreadable' };
     }
 
     if (!rawText.trim()) {
-      // Image-only PDF — no text layer. Return with guidance.
+      // No extractable text layer. This is a genuinely scanned/image-only PDF
+      // (or one whose fonts carry no extractable text). Distinct from an
+      // extraction *error* above — here parsing succeeded but yielded nothing.
       return {
         success: true,
         data: {

--- a/skills/file-parse/handler.ts
+++ b/skills/file-parse/handler.ts
@@ -187,11 +187,18 @@ export class FileParseHandler implements SkillHandler {
     try {
       const parser = new PDFParse({ data: buffer });
       try {
-        const parsed = await parser.getText();
-        rawText = parsed.text;
+        // pageJoiner: '' suppresses pdf-parse v2's default "-- N of M --" page
+        // markers. Without this, a text-less PDF yields marker noise instead of
+        // an empty string (defeating the image-only check below), and extracted
+        // text is polluted with separators.
+        const parsed = await parser.getText({ pageJoiner: '' });
+        rawText = parsed.text ?? '';
       } finally {
-        // Release the underlying pdfjs worker/resources even on error.
-        await parser.destroy();
+        // Release the pdfjs worker/resources, but never let a cleanup failure
+        // overwrite a real extraction error (or a good result) on the way out.
+        await parser.destroy().catch((destroyErr) => {
+          ctx.log.warn({ err: destroyErr }, 'file-parse: PDF parser cleanup failed');
+        });
       }
     } catch (err) {
       ctx.log.error({ err }, 'file-parse: PDF text extraction failed');
@@ -199,9 +206,11 @@ export class FileParseHandler implements SkillHandler {
     }
 
     if (!rawText.trim()) {
-      // No extractable text layer. This is a genuinely scanned/image-only PDF
-      // (or one whose fonts carry no extractable text). Distinct from an
-      // extraction *error* above — here parsing succeeded but yielded nothing.
+      // No extractable text layer: a genuinely scanned/image-only PDF (or one
+      // whose fonts carry no extractable text). Parsing succeeded but yielded
+      // nothing — distinct from the extraction *error* above. `reason` gives the
+      // caller a machine-readable fact so it reports the cause instead of
+      // inferring one from an empty string.
       return {
         success: true,
         data: {
@@ -209,6 +218,7 @@ export class FileParseHandler implements SkillHandler {
           raw_text: '',
           structured: null,
           confidence: 0,
+          reason: 'no_text_layer',
         },
       };
     }


### PR DESCRIPTION
## **User description**
## Summary

- `file-parse` was upgraded to `pdf-parse@2.4.5` but still called it with the **v1 API** (`pdfParse(buffer)`). v2 exports a **class** (`PDFParse`), so every PDF threw `pdfParse is not a function`, hit the catch block, and returned an error containing the words *"image-only"* — which agents relayed to the CEO as fact. All PDF receipt **and** bank-statement parsing were silently broken.
- The stale `@types/pdf-parse@^1.1.5` (v1 types) masked the break from the typechecker, and the only PDF test fed the string `'not a pdf'` and asserted failure, so it passed regardless.

## Changes

- Migrate to `new PDFParse({ data: buffer }).getText({ pageJoiner: '' })`; `pageJoiner: ''` suppresses v2's `-- N of M --` page markers so a genuinely text-less PDF is still detected as having no text layer (and the extracted text isn't polluted).
- `destroy()` runs in a `finally`, wrapped in `.catch(log)` so a cleanup failure can never overwrite the real extraction error.
- Empty-text branch returns a machine-readable `reason: 'no_text_layer'` so a caller reports the cause as fact instead of inferring it from an empty string; image-only PDFs are no longer shipped to the LLM as junk.
- Remove `@types/pdf-parse` (v2 ships its own types); reword the catch/branch messages so a parse failure is no longer mislabeled "image-only".
- Add real PDF fixtures (a text-layer receipt and a no-text-layer page) plus tests that fail against the old v1-style call and pass after the fix.

## Verification

- `vitest run skills/file-parse/handler.test.ts` → **37/37 pass** (confirmed red against the old call, then green).
- `pnpm run typecheck` → clean project-wide.
- Reproduced the original failure against the real Deloitte invoice PDF, then confirmed the v2 path extracts the full text (total, HST, line items).

## Follow-up (out of scope)

When a tool returns a degenerate result, the agent confabulates a plausible technical cause (e.g. a fabricated "Nylas attachment ID isn't resolving server-side" message that matches no code path) instead of surfacing the real error. Noted on #770 for a separate issue.

Closes #770


___

## **CodeAnt-AI Description**
**Fix PDF parsing so real PDFs are read correctly and scanned PDFs are handled as no-text PDFs**

### What Changed
- PDF files are now parsed successfully again, so receipt and bank-statement text can be extracted instead of failing and being mislabeled as “image-only.”
- PDFs with real text now return the extracted text and can be sent to the LLM for structured parsing.
- PDFs with no text layer now return a clear `no_text_layer` reason, with empty text and zero confidence, and are not sent to the LLM.
- Added real PDF test fixtures to cover text-based PDFs, no-text-layer PDFs, and the text sent to the LLM.

### Impact
`✅ Fewer broken receipt extractions`
`✅ Clearer scanned-PDF handling`
`✅ Fewer false "image-only" reports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed PDF parsing failures previously misreported as "image-only" errors, restoring reliable receipt and bank statement extraction
* Improved handling of PDFs without text layers with clearer feedback instead of parse failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->