### PR TITLE
fix: bypass bearer auth for GET / served by @fastify/static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Console root path auth bypass** — `GET /` now skips bearer auth; `@fastify/static` registers it as a distinct route when `wildcard: false`, so the `/*` bypass added in #769 did not cover it.
 - **`file-parse` PDF extraction** — call the v2 `PDFParse` class; the v1 API was throwing on every PDF, misreported as "image-only". (#770)
 - **Migration `016_kg_node_uniqueness`** — Step 4 now checks for pre-existing contacts on canonical KG nodes before re-pointing, preventing a duplicate-key violation on `idx_contacts_kg_node_unique` when a canonical node already had its own contact row.
 - **Console Vite dev proxy** — `/old` and the four cytoscape assets (`cytoscape.min.js`, `layout-base.js`, `cose-base.js`, `cytoscape-fcose.js`) are now proxied to Fastify in the Vite dev server; without this the Vite SPA intercepted `/old` requests and the legacy UI was unreachable in dev. (#750)

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -121,7 +121,8 @@ export class HttpAdapter {
       // Job routes bypass bearer auth — the dashboard accesses them via session cookie,
       // and jobRoutes calls assertSecret on every handler.
       if (
-        routeUrl === '/*' ||        // console SPA — static files + client-side routes
+        routeUrl === '/' ||         // @fastify/static registers GET / for index.html when wildcard:false
+        routeUrl === '/*' ||        // console SPA catch-all for client-side routes (/login, etc.)
         routeUrl === '/auth' ||
         routeUrl === '/old' ||      // legacy UI shell — exact matches prevent accidental
         routeUrl === '/old/*' ||    // bypass for any future /old-prefixed routes


### PR DESCRIPTION
## **User description**
## Summary

- Adds `routeUrl === '/'` to the auth bypass list in the `onRequest` hook

## Root cause

`@fastify/static` with `wildcard: false` scans the dist directory at startup and registers individual Fastify routes for each file found, including a `GET /` route for `index.html` (the directory index). That route's `routeOptions.url` is `'/'` — a distinct registered pattern from the SPA catch-all `'/*'` added in #769.

The `onRequest` auth hook checked `routeUrl === '/*'` to skip bearer auth for the console, but `'/' !== '/*'`, so every visit to the root URL hit the auth check and got a 401 instead of the login page.

## Test plan

- [ ] Visiting the root URL unauthenticated → console loads, TanStack Router redirects to `/login`
- [ ] `/api/health` still returns 200 without a token
- [ ] Bearer-protected API endpoints (e.g. `POST /api/messages`) still require a token
- [ ] CI passes


___

## **CodeAnt-AI Description**
**Allow the console home page to load without bearer auth**

### What Changed
- Visiting `GET /` now skips bearer authentication, so the console can load its login page instead of returning a 401.
- The existing auth bypass for the console’s client-side routes stays in place, along with the other unauthenticated paths such as health checks and public app assets.

### Impact
`✅ Console root page loads for signed-out users`
`✅ Fewer 401s on first visit`
`✅ Clearer login entry for the web app`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
