### PR TITLE
fix: restrict ceo-inbox polling to 6am-11pm local time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+
+- **`ceo-inbox`** — restricted polling schedule from 24/7 to 6am–11pm local time, reducing idle LLM calls during dead hours.
+
 ### Added
 
 - **Console app scaffold** — new `apps/console/` Vite + React + TanStack Router app; Fastify serves the static bundle at `/` with SPA fallback; auth-gated dashboard placeholder; design-system components (Sidebar, Topbar, Icons) copied and converted to TypeScript. `pnpm dev` starts both the backend and the Vite dev server concurrently. (#750)

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -42,7 +42,7 @@ error_budget:
   max_cost_usd: 0.50
 
 schedule:
-  - cron: "*/15 * * * *"
+  - cron: "*/15 6-23 * * *"  # restricted to 6am–11pm local time; dead hours don't justify the cost
     task: >
       Check the CEO's inbox for unread messages. For each unread message,
       triage it using the protocol below. Process messages oldest-first.

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -53,7 +53,7 @@ system_prompt: |
 
   You operate in two modes depending on how you were invoked:
 
-  **Scheduled mode** (default — 15-minute cron trigger):
+  **Scheduled mode** (default — 15-minute cron trigger, 6am–11pm):
   If you received a scheduled task like "Check the CEO's inbox for unread
   messages", execute the full triage protocol below (Steps 1-6).
 
@@ -75,7 +75,8 @@ system_prompt: |
   ---
 
   You are the CEO inbox triage agent. You monitor the CEO's personal email
-  inbox every 15 minutes and process unread messages autonomously.
+  inbox every 15 minutes (6am–11pm local time) and process unread messages
+  autonomously.
 
   You are NOT the sender's intended recipient. You are NOT the coordinator.
   You must never reply to senders directly — you only create drafts, archive


### PR DESCRIPTION
## **User description**
## Summary

- Changed `ceo-inbox` schedule from `*/15 * * * *` (24/7) to `*/15 6-23 * * *` (6am–11pm local time)
- Updated two lines in the system prompt that implied 24/7 coverage

## Motivation

Every cron tick — even zero-message runs — executes Steps 1, 2, and 2b unconditionally (config-store ×2, executive-profile-get) before reaching the message check. That's 3–4 LLM calls per idle tick. With 28 dead-hours ticks per night (midnight–06:00) fully wasted, the restriction saves ~$0.70–$1/night for no loss in coverage.

The high-water mark correctly bridges the gap: the 06:00 run uses `last_processed_at` from the 23:45 run, so overnight arrivals are caught on the first morning tick.

## Test plan

- [ ] Verify cron expression `*/15 6-23 * * *` is accepted at startup (no `validateCronFrequency` error)
- [ ] Verify old `*/15 * * * *` row is cancelled and new `*/15 6-23 * * *` row is created in `scheduled_jobs` on first restart after deploy
- [ ] Confirm no ticks fire between 23:45 and 06:00
- [ ] Confirm first 06:00 tick uses `last_processed_at` from the previous night and processes any overnight messages


___

## **CodeAnt-AI Description**
Restrict CEO inbox polling to daytime hours

### What Changed
- The CEO inbox now checks for unread messages only between 6am and 11pm local time instead of running around the clock
- Scheduled runs now describe the active window clearly so the inbox does not imply 24/7 coverage
- The release notes now reflect the reduced polling schedule

### Impact
`✅ Fewer overnight inbox polls`
`✅ Lower idle processing cost`
`✅ Clearer schedule expectations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
