### PR TITLE
fix: prevent duplicate bullpen threads via source_message_id idempotency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`bullpen`** — `post` action is now idempotent when `source_message_id` is provided: a duplicate call returns the existing thread instead of opening a second one. Prevents duplicate specialist dispatches when a ceo-inbox run is interrupted before its high-water mark saves. (#708)
+- **`bullpen`** — `post` is now idempotent when `source_message_id` is provided; returns existing thread on duplicate. (#708)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`bullpen`** — `post` action is now idempotent when `source_message_id` is provided: a duplicate call returns the existing thread instead of opening a second one. Prevents duplicate specialist dispatches when a ceo-inbox run is interrupted before its high-water mark saves. (#708)
+
 ### Changed
 
 - **`ceo-inbox`** — restricted polling schedule from 24/7 to 6am–11pm local time, reducing idle LLM calls during dead hours.

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -407,10 +407,13 @@ system_prompt: |
 
   - **URGENT**: Open a bullpen thread mentioning the coordinator with a
     structured send request (Urgency: immediate, Channel: Signal, Message,
-    Context bridge with agent_id=ceo-inbox and delegation_hint). Do NOT
-    archive.
+    Context bridge with agent_id=ceo-inbox and delegation_hint). Pass
+    source_message_id: <the email's message_id> to prevent duplicate threads
+    if this run is retried. Do NOT archive.
   - **ACTIONABLE**: Open a bullpen thread mentioning the capable specialist
-    with a clear handoff summary. Call ceo-inbox-archive with the message_id.
+    with a clear handoff summary. Pass source_message_id: <the email's
+    message_id> to prevent duplicate threads if this run is retried. Call
+    ceo-inbox-archive with the message_id.
   - **NEEDS DRAFT**: Execute the full NEEDS DRAFT procedure from step 4e
     (read full message, check for prior replies, memory-query for context,
     evaluate LEAVE FOR CEO guard conditions, then draft using voice profile

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -365,7 +365,7 @@ system_prompt: |
   - Apply a label (call ceo-inbox-label)
   - Override the classification you just made (e.g. "classify as NOISE"
     means archive the message even if you originally chose LEAVE FOR CEO)
-  - Delegate to a specialist (call bullpen)
+  - Delegate to a specialist (call bullpen — pass source_message_id: <the email's message_id> to prevent duplicate threads if this run is retried)
   - Take any other action available via your pinned skills
 
   If a rule overrides your classification, update the classification you

--- a/skills/bullpen/handler.test.ts
+++ b/skills/bullpen/handler.test.ts
@@ -267,6 +267,46 @@ describe('BullpenHandler', () => {
     expect((ctx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
   });
 
+  it('post: concurrent duplicate posts (23505 race) — one thread, one publish', async () => {
+    // Two handler.execute calls race with the same source_message_id on a shared
+    // bullpenService. The in-memory backend now mirrors Postgres by throwing code
+    // '23505' when the duplicate insert arrives. BullpenService.openThread catches
+    // that, re-fetches the winning thread, and returns deduplicated: true — so the
+    // handler skips the second bus.publish.
+    const bullpenService = BullpenService.createInMemory();
+    const bus = {
+      publish: vi.fn().mockResolvedValue(undefined),
+      subscribe: vi.fn(),
+    } as unknown as SkillContext['bus'];
+
+    const makeRaceCtx = () => makeCtx(
+      {
+        action: 'post',
+        topic: 'concurrent topic',
+        participants: ['coordinator', 'agent-b'],
+        content: 'racing message',
+        source_message_id: 'email-race-concurrent',
+      },
+      { bullpenService, bus },
+    );
+
+    const [r1, r2] = await Promise.all([
+      handler.execute(makeRaceCtx()),
+      handler.execute(makeRaceCtx()),
+    ]);
+
+    expect(r1.success).toBe(true);
+    expect(r2.success).toBe(true);
+    const d1 = (r1 as { success: true; data: Record<string, unknown> }).data;
+    const d2 = (r2 as { success: true; data: Record<string, unknown> }).data;
+    // Both must reference the same winning thread
+    expect(d1.thread_id).toBe(d2.thread_id);
+    // Exactly one call was marked as a dedup hit
+    expect([d1.deduplicated, d2.deduplicated].filter(Boolean)).toHaveLength(1);
+    // bus.publish fired exactly once — no duplicate agent.discuss
+    expect((bus.publish as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+  });
+
   it('post: a publish rejection does not surface as a handler failure', async () => {
     const failingPublish = vi.fn().mockRejectedValue(new Error('bus exploded'));
     const ctx = makeCtx(

--- a/skills/bullpen/handler.test.ts
+++ b/skills/bullpen/handler.test.ts
@@ -233,6 +233,40 @@ describe('BullpenHandler', () => {
     publishResolve!();
   });
 
+  it('post: returns existing thread when source_message_id matches a prior post', async () => {
+    const ctx = makeCtx({
+      action: 'post',
+      topic: 'expense receipt',
+      participants: ['coordinator', 't2125-expense-tracker'],
+      content: 'Please process this receipt',
+      source_message_id: 'email-msg-abc123',
+    });
+
+    const first = await handler.execute(ctx);
+    expect(first.success).toBe(true);
+    const firstData = (first as { success: true; data: Record<string, unknown> }).data;
+
+    // Second post with the same source_message_id — simulates a duplicate ceo-inbox run
+    const ctx2 = makeCtx({
+      action: 'post',
+      topic: 'expense receipt',
+      participants: ['coordinator', 't2125-expense-tracker'],
+      content: 'Please process this receipt',
+      source_message_id: 'email-msg-abc123',
+    }, { bullpenService: ctx.bullpenService, bus: ctx.bus });
+
+    const second = await handler.execute(ctx2);
+    expect(second.success).toBe(true);
+    const secondData = (second as { success: true; data: Record<string, unknown> }).data;
+
+    // Must return the same thread — no new thread opened
+    expect(secondData.thread_id).toBe(firstData.thread_id);
+    // Dedup flag must be set
+    expect(secondData.deduplicated).toBe(true);
+    // Bus publish called exactly once — no duplicate agent.discuss event
+    expect((ctx.bus!.publish as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+  });
+
   it('post: a publish rejection does not surface as a handler failure', async () => {
     const failingPublish = vi.fn().mockRejectedValue(new Error('bus exploded'));
     const ctx = makeCtx(

--- a/skills/bullpen/handler.ts
+++ b/skills/bullpen/handler.ts
@@ -64,13 +64,31 @@ export class BullpenHandler implements SkillHandler {
             ? (rawMentioned as string[]).map(m => m.trim()).filter(m => m.length > 0 && cleanParticipants.includes(m))
             : cleanParticipants;
 
+          // Optional dedup key — when provided, openThread returns the existing thread
+          // if one was already created for this source message. (issue #708)
+          const rawSourceMessageId = input['source_message_id'];
+          const sourceMessageId = typeof rawSourceMessageId === 'string' && rawSourceMessageId.trim()
+            ? rawSourceMessageId.trim()
+            : undefined;
+
           // Capture originator before openThread so we can pass it both to the thread
           // record (for poll-fallback rehydration) and to the agent.discuss event payload.
           const originator = ctx.taskMetadata?.originator as TaskOriginator | undefined;
 
-          const { thread, message } = await ctx.bullpenService.openThread(
-            topic, ctx.agentId, cleanParticipants, content, mentionedAgentIds, originator,
+          const { thread, message, deduplicated } = await ctx.bullpenService.openThread(
+            topic, ctx.agentId, cleanParticipants, content, mentionedAgentIds, originator, sourceMessageId,
           );
+
+          // Skip publish entirely on dedup hit — the existing thread's participants were
+          // already notified when the original thread was opened. Re-publishing would
+          // cause duplicate agent.discuss events and therefore duplicate task dispatches.
+          if (deduplicated) {
+            ctx.log.info(
+              { threadId: thread.id, sourceMessageId },
+              'Bullpen: dedup hit — returning existing thread, skipping agent.discuss publish',
+            );
+            return { success: true, data: { thread_id: thread.id, message_id: message.id, deduplicated: true } };
+          }
 
           // Publish is fire-and-forget — thread is already persisted. We do NOT
           // await here because bus.publish dispatches subscribers sequentially
@@ -101,7 +119,7 @@ export class BullpenHandler implements SkillHandler {
             );
           });
 
-          return { success: true, data: { thread_id: thread.id, message_id: message.id } };
+          return { success: true, data: { thread_id: thread.id, message_id: message.id, deduplicated: false } };
         }
 
         case 'reply': {

--- a/skills/bullpen/skill.json
+++ b/skills/bullpen/skill.json
@@ -10,11 +10,13 @@
     "participants": "string[]? (agent IDs to include in the thread; required when action is 'post')",
     "mentioned_agent_ids": "string[]? (agent IDs to at-mention; defaults to all participants when action is 'post')",
     "content": "string? (message body; required when action is 'post' or 'reply')",
-    "thread_id": "string? (thread ID; required when action is 'reply', 'get_thread', or 'close')"
+    "thread_id": "string? (thread ID; required when action is 'reply', 'get_thread', or 'close')",
+    "source_message_id": "string? (dedup key for 'post'; if a thread already exists with this ID the existing thread is returned instead of creating a new one)"
   },
   "outputs": {
     "thread_id": "string: the thread ID",
     "message_id": "string: the persisted message ID (post/reply)",
+    "deduplicated": "boolean: true when source_message_id matched an existing thread and no new thread was opened (post only)",
     "thread": "object: full thread + messages (get_thread)",
     "status": "string: 'closed' (close)"
   },

--- a/src/db/migrations/046_add_bullpen_threads_source_message_id.sql
+++ b/src/db/migrations/046_add_bullpen_threads_source_message_id.sql
@@ -1,0 +1,14 @@
+-- Up Migration
+
+ALTER TABLE bullpen_threads ADD COLUMN source_message_id TEXT;
+
+-- Unique constraint scoped to non-null values only (partial index).
+-- Null source_message_id means "no dedup key" — threads without one are
+-- always created unconditionally and must not block each other.
+CREATE UNIQUE INDEX idx_bullpen_threads_source_message_id
+  ON bullpen_threads (source_message_id)
+  WHERE source_message_id IS NOT NULL;
+
+-- Rollback:
+-- DROP INDEX IF EXISTS idx_bullpen_threads_source_message_id;
+-- ALTER TABLE bullpen_threads DROP COLUMN source_message_id;

--- a/src/db/migrations/046_add_bullpen_threads_source_message_id.sql
+++ b/src/db/migrations/046_add_bullpen_threads_source_message_id.sql
@@ -2,12 +2,12 @@
 
 ALTER TABLE bullpen_threads ADD COLUMN source_message_id TEXT;
 
--- Unique constraint scoped to non-null values only (partial index).
--- Null source_message_id means "no dedup key" — threads without one are
--- always created unconditionally and must not block each other.
+-- Unique constraint scoped to non-null, non-empty values only (partial index).
+-- Null or empty source_message_id means "no dedup key" — threads without one
+-- are always created unconditionally and must not block each other.
 CREATE UNIQUE INDEX idx_bullpen_threads_source_message_id
   ON bullpen_threads (source_message_id)
-  WHERE source_message_id IS NOT NULL;
+  WHERE source_message_id IS NOT NULL AND source_message_id <> '';
 
 -- Rollback:
 -- DROP INDEX IF EXISTS idx_bullpen_threads_source_message_id;

--- a/src/memory/bullpen.ts
+++ b/src/memory/bullpen.ts
@@ -3,6 +3,12 @@ import type { Pool } from 'pg';
 import type { Logger } from '../logger.js';
 import type { TaskOriginator } from '../contacts/types.js';
 
+// Postgres error code for unique_violation — used to detect concurrent duplicate
+// INSERT on source_message_id and recover into the dedup path instead of failing.
+function isUniqueConstraintViolation(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: unknown }).code === '23505';
+}
+
 // -- Public types --
 
 export interface BullpenThread {
@@ -18,6 +24,11 @@ export interface BullpenThread {
   // agent.discuss publish fails) can rehydrate the originator when dispatching
   // participant tasks. null for threads opened without an authenticated originator.
   originator: TaskOriginator | null;
+  // Optional dedup key. When set, openThread is idempotent: a second call with the
+  // same sourceMessageId returns the existing thread instead of creating a new one.
+  // Used by ceo-inbox to prevent duplicate bullpen threads when the high-water mark
+  // save is interrupted and the next run re-processes the same email. (issue #708)
+  sourceMessageId: string | null;
 }
 
 export interface BullpenMessage {
@@ -49,6 +60,7 @@ interface BullpenBackend {
   postMessage(threadId: string, message: BullpenMessage): Promise<void>;
   closeThread(threadId: string): Promise<void>;
   getThread(threadId: string): Promise<{ thread: BullpenThread; messages: BullpenMessage[] } | null>;
+  findThreadBySourceMessageId(sourceMessageId: string): Promise<{ thread: BullpenThread; message: BullpenMessage } | null>;
   getPendingThreadsForAgent(agentId: string, windowMs: number): Promise<PendingThreadContext[]>;
 }
 
@@ -57,10 +69,24 @@ interface BullpenBackend {
 class InMemoryBullpenBackend implements BullpenBackend {
   private threads = new Map<string, BullpenThread>();
   private messages = new Map<string, BullpenMessage[]>();
+  // Maps sourceMessageId -> threadId for dedup lookups.
+  private sourceIdToThreadId = new Map<string, string>();
 
   async openThread(thread: BullpenThread, message: BullpenMessage): Promise<void> {
     this.threads.set(thread.id, { ...thread });
     this.messages.set(thread.id, [{ ...message }]);
+    if (thread.sourceMessageId) {
+      this.sourceIdToThreadId.set(thread.sourceMessageId, thread.id);
+    }
+  }
+
+  async findThreadBySourceMessageId(sourceMessageId: string): Promise<{ thread: BullpenThread; message: BullpenMessage } | null> {
+    const threadId = this.sourceIdToThreadId.get(sourceMessageId);
+    if (!threadId) return null;
+    const thread = this.threads.get(threadId);
+    const msgs = this.messages.get(threadId);
+    if (!thread || !msgs || msgs.length === 0) return null;
+    return { thread: { ...thread }, message: { ...msgs[0]! } };
   }
 
   async postMessage(threadId: string, message: BullpenMessage): Promise<void> {
@@ -129,9 +155,9 @@ class PostgresBullpenBackend implements BullpenBackend {
     try {
       await client.query('BEGIN');
       await client.query(
-        `INSERT INTO bullpen_threads (id, topic, creator_agent_id, participants, status, message_count, last_message_at, created_at, originator)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-        [thread.id, thread.topic, thread.creatorAgentId, thread.participants, thread.status, thread.messageCount, thread.lastMessageAt, thread.createdAt, thread.originator ? JSON.stringify(thread.originator) : null],
+        `INSERT INTO bullpen_threads (id, topic, creator_agent_id, participants, status, message_count, last_message_at, created_at, originator, source_message_id)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+        [thread.id, thread.topic, thread.creatorAgentId, thread.participants, thread.status, thread.messageCount, thread.lastMessageAt, thread.createdAt, thread.originator ? JSON.stringify(thread.originator) : null, thread.sourceMessageId ?? null],
       );
       await client.query(
         `INSERT INTO bullpen_messages (id, thread_id, sender_type, sender_id, content, mentioned_agent_ids, created_at)
@@ -140,7 +166,7 @@ class PostgresBullpenBackend implements BullpenBackend {
       );
       await client.query('COMMIT');
     } catch (err) {
-      this.logger.error({ err, threadId: thread.id }, 'Bullpen openThread transaction failed');
+      this.logger.error({ err, threadId: thread.id, sourceMessageId: thread.sourceMessageId }, 'Bullpen openThread transaction failed');
       await client.query('ROLLBACK');
       throw err;
     } finally {
@@ -193,9 +219,9 @@ class PostgresBullpenBackend implements BullpenBackend {
     const threadRes = await this.pool.query<{
       id: string; topic: string; creator_agent_id: string; participants: string[];
       status: string; message_count: number; last_message_at: Date | null; created_at: Date;
-      originator: Record<string, unknown> | null;
+      originator: Record<string, unknown> | null; source_message_id: string | null;
     }>(
-      `SELECT id, topic, creator_agent_id, participants, status, message_count, last_message_at, created_at, originator
+      `SELECT id, topic, creator_agent_id, participants, status, message_count, last_message_at, created_at, originator, source_message_id
        FROM bullpen_threads WHERE id = $1`,
       [threadId],
     );
@@ -206,6 +232,7 @@ class PostgresBullpenBackend implements BullpenBackend {
       participants: row.participants, status: row.status as 'open' | 'closed',
       messageCount: row.message_count, lastMessageAt: row.last_message_at, createdAt: row.created_at,
       originator: row.originator as TaskOriginator | null,
+      sourceMessageId: row.source_message_id,
     };
 
     const msgRes = await this.pool.query<{
@@ -224,6 +251,47 @@ class PostgresBullpenBackend implements BullpenBackend {
     }));
 
     return { thread, messages };
+  }
+
+  async findThreadBySourceMessageId(sourceMessageId: string): Promise<{ thread: BullpenThread; message: BullpenMessage } | null> {
+    // Single JOIN avoids the two-query split-snapshot window: if the thread row and
+    // its first message row are in the same committed transaction, this query reads
+    // them atomically. If the thread exists but has no messages (data corruption),
+    // the JOIN returns no rows and we return null.
+    const res = await this.pool.query<{
+      id: string; topic: string; creator_agent_id: string; participants: string[];
+      status: string; message_count: number; last_message_at: Date | null; created_at: Date;
+      originator: Record<string, unknown> | null; source_message_id: string | null;
+      msg_id: string; msg_sender_id: string; msg_content: unknown;
+      msg_mentioned_agent_ids: string[]; msg_created_at: Date;
+    }>(
+      `SELECT t.id, t.topic, t.creator_agent_id, t.participants, t.status,
+              t.message_count, t.last_message_at, t.created_at, t.originator, t.source_message_id,
+              m.id AS msg_id, m.sender_id AS msg_sender_id, m.content AS msg_content,
+              m.mentioned_agent_ids AS msg_mentioned_agent_ids, m.created_at AS msg_created_at
+       FROM bullpen_threads t
+       JOIN bullpen_messages m ON m.thread_id = t.id
+       WHERE t.source_message_id = $1
+       ORDER BY m.created_at ASC
+       LIMIT 1`,
+      [sourceMessageId],
+    );
+    if (res.rows.length === 0) return null;
+    const row = res.rows[0]!;
+    const thread: BullpenThread = {
+      id: row.id, topic: row.topic, creatorAgentId: row.creator_agent_id,
+      participants: row.participants, status: row.status as 'open' | 'closed',
+      messageCount: row.message_count, lastMessageAt: row.last_message_at, createdAt: row.created_at,
+      originator: row.originator as TaskOriginator | null,
+      sourceMessageId: row.source_message_id,
+    };
+    const message: BullpenMessage = {
+      id: row.msg_id, threadId: row.id, senderType: 'agent' as const,
+      senderId: row.msg_sender_id,
+      content: typeof row.msg_content === 'string' ? row.msg_content : JSON.stringify(row.msg_content),
+      mentionedAgentIds: row.msg_mentioned_agent_ids, createdAt: row.msg_created_at,
+    };
+    return { thread, message };
   }
 
   async getPendingThreadsForAgent(agentId: string, windowMs: number): Promise<PendingThreadContext[]> {
@@ -291,7 +359,16 @@ export class BullpenService {
     initialContent: string,
     mentionedAgentIds: string[],
     originator?: TaskOriginator,
-  ): Promise<{ thread: BullpenThread; message: BullpenMessage }> {
+    sourceMessageId?: string,
+  ): Promise<{ thread: BullpenThread; message: BullpenMessage; deduplicated: boolean }> {
+    // Idempotency: if a sourceMessageId was provided and a thread already exists for
+    // that message, return it instead of creating a duplicate. Protects against the
+    // ceo-inbox race where the high-water mark save is interrupted between runs. (#708)
+    if (sourceMessageId) {
+      const existing = await this.backend.findThreadBySourceMessageId(sourceMessageId);
+      if (existing) return { ...existing, deduplicated: true };
+    }
+
     // Normalize: always include the creator, deduplicate, preserve order.
     const normalizedParticipants = [...new Set([creatorAgentId, ...participants])];
     const now = new Date();
@@ -301,14 +378,27 @@ export class BullpenService {
       // Persist originator so BullpenDispatcher can rehydrate it on the poll-fallback
       // path if the initial agent.discuss event publish fails.
       originator: originator ?? null,
+      sourceMessageId: sourceMessageId ?? null,
     };
     const message: BullpenMessage = {
       id: randomUUID(), threadId: thread.id, senderType: 'agent',
       senderId: creatorAgentId, content: initialContent,
       mentionedAgentIds, createdAt: now,
     };
-    await this.backend.openThread(thread, message);
-    return { thread, message };
+    try {
+      await this.backend.openThread(thread, message);
+    } catch (err: unknown) {
+      // If a concurrent openThread call won the race and its INSERT committed
+      // first, we hit the unique constraint on source_message_id (Postgres error
+      // code 23505). Re-fetch the winning thread and return it as a dedup hit
+      // rather than propagating a skill failure to the caller.
+      if (sourceMessageId && isUniqueConstraintViolation(err)) {
+        const existing = await this.backend.findThreadBySourceMessageId(sourceMessageId);
+        if (existing) return { ...existing, deduplicated: true };
+      }
+      throw err;
+    }
+    return { thread, message, deduplicated: false };
   }
 
   async postMessage(

--- a/src/memory/bullpen.ts
+++ b/src/memory/bullpen.ts
@@ -73,6 +73,13 @@ class InMemoryBullpenBackend implements BullpenBackend {
   private sourceIdToThreadId = new Map<string, string>();
 
   async openThread(thread: BullpenThread, message: BullpenMessage): Promise<void> {
+    if (thread.sourceMessageId && this.sourceIdToThreadId.has(thread.sourceMessageId)) {
+      // Mirrors Postgres 23505 unique_violation so BullpenService.openThread's
+      // catch-and-retry path exercises the same recovery logic in unit tests.
+      const err = new Error('unique constraint violation (source_message_id)');
+      (err as unknown as { code: string }).code = '23505';
+      throw err;
+    }
     this.threads.set(thread.id, { ...thread });
     this.messages.set(thread.id, [{ ...message }]);
     if (thread.sourceMessageId) {


### PR DESCRIPTION
## **User description**
## Summary

Closes #708

- Adds optional `source_message_id` input to the `bullpen` skill's `post` action — when provided, `openThread` checks for an existing thread with that key before creating a new one, returning the existing thread with `deduplicated: true` instead of opening a duplicate
- Handles the sequential-retry case (interrupted ceo-inbox run reprocessing the same email on the next tick) and the concurrent-race case (two overlapping runs both pass the existence check; the second INSERT hits the Postgres unique constraint and we recover by re-fetching the winning thread)
- `ceo-inbox` agent now passes `source_message_id: <message_id>` for all URGENT and ACTIONABLE bullpen dispatches
- Migration 046 adds `source_message_id TEXT` column with a partial unique index (`WHERE source_message_id IS NOT NULL`) so threads without a dedup key never block each other

## Test plan

- [ ] New regression test: two `bullpen post` calls with the same `source_message_id` on the same `BullpenService` instance return the same `thread_id` and set `deduplicated: true`
- [ ] Bus publish is called exactly once (no duplicate `agent.discuss` event on dedup hit)
- [ ] Full unit test suite passes (218/230 test files; the 2 failures are pre-existing integration tests requiring `DATABASE_URL`)
- [ ] Typecheck passes clean
- [ ] Migration 046 uses a partial unique index — verify `WHERE source_message_id IS NOT NULL` is preserved so unconditional threads (no dedup key) are unaffected


___

## **CodeAnt-AI Description**
**Prevent duplicate bullpen threads when the same email is processed again**

### What Changed
- `bullpen post` now accepts an optional `source_message_id` and returns the existing thread when that ID was already used
- Duplicate retries no longer publish a second agent discussion event, so the same thread is not dispatched twice
- If two runs race to create the same thread, the second one now reuses the winning thread instead of failing
- `ceo-inbox` now sends the email message ID for URGENT and ACTIONABLE bullpen posts
- Added a database rule so deduplication only applies when a source message ID is present

### Impact
`✅ Fewer duplicate specialist dispatches`
`✅ Safer retry after interrupted inbox runs`
`✅ No extra threads for repeated source messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thread deduplication now prevents duplicate specialist dispatches when requests are retried or interrupted, improving reliability during system interruptions.

* **New Features**
  * Post actions now support idempotent behaviour with automatic duplicate detection and reuse of existing threads to prevent duplicate processing.

* **Tests**
  * Added regression tests for deduplication scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->