### PR TITLE
feat: port Autonomy view to new console app (#752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Autonomy console view** — Autonomy settings ported to the new console app at `/settings/autonomy`; includes the score display, live-preview slider, reason field, save, and paginated history. Removed the Autonomy view from the legacy `/old` UI. (#752)
+
 - **Console app scaffold** — new `apps/console/` Vite + React + TanStack Router app; Fastify serves the static bundle at `/` with SPA fallback; auth-gated dashboard placeholder; design-system components (Sidebar, Topbar, Icons) copied and converted to TypeScript. `pnpm dev` starts both the backend and the Vite dev server concurrently. (#750)
 
 ### Fixed

--- a/apps/console/pnpm-lock.yaml
+++ b/apps/console/pnpm-lock.yaml
@@ -1,0 +1,668 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@tanstack/react-router':
+        specifier: ^1.127.0
+        version: 1.170.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/react':
+        specifier: ^19.1.0
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.1.0
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react-oxc':
+        specifier: ^0.4.3
+        version: 0.4.3(vite@8.0.14)
+      react:
+        specifier: ^19.1.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.6(react@19.2.6)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.14
+        version: 8.0.14
+
+packages:
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.132.0':
+    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-beta.47':
+    resolution: {integrity: sha512-8QagwMH3kNCuzD8EWL8R2YPW5e4OrHNSAHRFDdmFqEwEaD/KcNKjVoumo+gP2vW5eKB2UPbM6vTYiGZX0ixLnw==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@tanstack/history@1.162.0':
+    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/react-router@1.170.9':
+    resolution: {integrity: sha512-rXXztp6GyXFwResQR0jdvkf52wy/sAQqze3OR08+8uNM7nHir1P46qBrwg2TL5EEtX+0WUho4BZ/nMpAgQVB6A==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.171.7':
+    resolution: {integrity: sha512-AboyQD0OPIu0adJi6HeCupTU9Wx7zr4q4ceJYQdBL3mLH18m4M57XXdzJdtzOg/twl8DtWej0RGJ12ma8CV1iQ==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.15':
+    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+
+  '@vitejs/plugin-react-oxc@0.4.3':
+    resolution: {integrity: sha512-eJv6hHOIOVXzA4b2lZwccu/7VNmk9372fGOqsx5tNxiJHLtFBokyCTQUhlgjjXxl7guLPauHp0TqGTVyn1HvQA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^6.3.0 || ^7.0.0
+
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  isbot@5.1.40:
+    resolution: {integrity: sha512-yNeeynhhtIVRBk12tBV4eHNxwB42HzR4Q3Ea7vCOiJhImGaAIdIMrbJtacQlBizGLjUPw+akkFI5Dn9T70XoVQ==}
+    engines: {node: '>=18'}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
+  rolldown@1.0.2:
+    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  vite@8.0.14:
+    resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+snapshots:
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@oxc-project/types@0.132.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.47': {}
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@tanstack/history@1.162.0': {}
+
+  '@tanstack/react-router@1.170.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/router-core': 1.171.7
+      isbot: 5.1.40
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@tanstack/react-store@0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
+
+  '@tanstack/router-core@1.171.7':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      cookie-es: 3.1.1
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  '@tanstack/store@0.9.3': {}
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+    dependencies:
+      '@types/react': 19.2.15
+
+  '@types/react@19.2.15':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react-oxc@0.4.3(vite@8.0.14)':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.47
+      vite: 8.0.14
+
+  cookie-es@3.1.1: {}
+
+  csstype@3.2.3: {}
+
+  detect-libc@2.1.2: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  isbot@5.1.40: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  nanoid@3.3.12: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react@19.2.6: {}
+
+  rolldown@1.0.2:
+    dependencies:
+      '@oxc-project/types': 0.132.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.2
+      '@rolldown/binding-darwin-arm64': 1.0.2
+      '@rolldown/binding-darwin-x64': 1.0.2
+      '@rolldown/binding-freebsd-x64': 1.0.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.2
+      '@rolldown/binding-linux-arm64-gnu': 1.0.2
+      '@rolldown/binding-linux-arm64-musl': 1.0.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.2
+      '@rolldown/binding-linux-s390x-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-musl': 1.0.2
+      '@rolldown/binding-openharmony-arm64': 1.0.2
+      '@rolldown/binding-wasm32-wasi': 1.0.2
+      '@rolldown/binding-win32-arm64-msvc': 1.0.2
+      '@rolldown/binding-win32-x64-msvc': 1.0.2
+
+  scheduler@0.27.0: {}
+
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
+
+  source-map-js@1.2.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@6.0.3: {}
+
+  use-sync-external-store@1.6.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
+  vite@8.0.14:
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3

--- a/apps/console/src/components/Icons.tsx
+++ b/apps/console/src/components/Icons.tsx
@@ -147,6 +147,17 @@ export function IconSend({ size }: IconProps) {
   );
 }
 
+export function IconAutonomy({ size }: IconProps) {
+  return (
+    <Icon size={size}>
+      <path d="M12 2a10 10 0 0 1 7.38 16.75" />
+      <path d="M4.62 18.75A10 10 0 0 1 12 2" />
+      <circle cx="12" cy="12" r="1" />
+      <line x1="12" y1="11" x2="16" y2="7" />
+    </Icon>
+  );
+}
+
 // Inline Curia wordmark SVG — uses currentColor for theme tracking
 export function CuriaWordmark(props: SVGProps<SVGSVGElement>) {
   return (

--- a/apps/console/src/components/Sidebar.tsx
+++ b/apps/console/src/components/Sidebar.tsx
@@ -10,7 +10,6 @@ import {
   IconClock,
   IconSettings,
   IconWand,
-  IconAutonomy,
   IconChevron,
 } from './Icons';
 
@@ -49,9 +48,8 @@ function ThemeToggle({ theme, onChange }: { theme: Theme; onChange: (t: Theme) =
 
 export function Sidebar({ activeView, onNavigate, theme, onThemeChange }: SidebarProps) {
   const [memoryOpen, setMemoryOpen] = useState(true);
-  // Auto-open Settings group when an autonomy view is active.
   const [settingsOpen, setSettingsOpen] = useState(
-    activeView === 'autonomy' || activeView === 'settings' || activeView === 'wizard',
+    activeView === 'settings' || activeView === 'wizard',
   );
   const { setOpen } = useMobileMenu();
 
@@ -136,13 +134,6 @@ export function Sidebar({ activeView, onNavigate, theme, onThemeChange }: Sideba
               >
                 <IconWand />
                 Setup Wizard
-              </button>
-              <button
-                className={`nav-sub-item${activeView === 'autonomy' ? ' active' : ''}`}
-                onClick={() => go('autonomy')}
-              >
-                <IconAutonomy />
-                Autonomy
               </button>
             </div>
           )}

--- a/apps/console/src/components/Sidebar.tsx
+++ b/apps/console/src/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   IconClock,
   IconSettings,
   IconWand,
+  IconAutonomy,
   IconChevron,
 } from './Icons';
 
@@ -48,7 +49,10 @@ function ThemeToggle({ theme, onChange }: { theme: Theme; onChange: (t: Theme) =
 
 export function Sidebar({ activeView, onNavigate, theme, onThemeChange }: SidebarProps) {
   const [memoryOpen, setMemoryOpen] = useState(true);
-  const [settingsOpen, setSettingsOpen] = useState(false);
+  // Auto-open Settings group when an autonomy view is active.
+  const [settingsOpen, setSettingsOpen] = useState(
+    activeView === 'autonomy' || activeView === 'settings' || activeView === 'wizard',
+  );
   const { setOpen } = useMobileMenu();
 
   const go = (v: string) => {
@@ -132,6 +136,13 @@ export function Sidebar({ activeView, onNavigate, theme, onThemeChange }: Sideba
               >
                 <IconWand />
                 Setup Wizard
+              </button>
+              <button
+                className={`nav-sub-item${activeView === 'autonomy' ? ' active' : ''}`}
+                onClick={() => go('autonomy')}
+              >
+                <IconAutonomy />
+                Autonomy
               </button>
             </div>
           )}

--- a/apps/console/src/hooks/useTheme.ts
+++ b/apps/console/src/hooks/useTheme.ts
@@ -5,7 +5,9 @@ export type Theme = 'light' | 'system' | 'dark';
 export function useTheme(): [Theme, (t: Theme) => void] {
   const [theme, setTheme] = useState<Theme>(() => {
     try {
-      return (localStorage.getItem('curia-theme') as Theme) ?? 'system';
+      const stored = localStorage.getItem('curia-theme');
+      if (stored === 'light' || stored === 'system' || stored === 'dark') return stored;
+      return 'system';
     } catch (err) {
       console.error('[useTheme] failed reading curia-theme from localStorage:', err);
       return 'system';

--- a/apps/console/src/hooks/useTheme.ts
+++ b/apps/console/src/hooks/useTheme.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+
+export type Theme = 'light' | 'system' | 'dark';
+
+export function useTheme(): [Theme, (t: Theme) => void] {
+  const [theme, setTheme] = useState<Theme>(() => {
+    try {
+      return (localStorage.getItem('curia-theme') as Theme) ?? 'system';
+    } catch (err) {
+      console.error('[useTheme] failed reading curia-theme from localStorage:', err);
+      return 'system';
+    }
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'system') {
+      root.removeAttribute('data-theme');
+    } else {
+      root.setAttribute('data-theme', theme);
+    }
+    try {
+      localStorage.setItem('curia-theme', theme);
+    } catch (err) {
+      console.error('[useTheme] failed writing curia-theme to localStorage:', err);
+    }
+  }, [theme]);
+
+  return [theme, setTheme];
+}

--- a/apps/console/src/pages/DashboardPage.tsx
+++ b/apps/console/src/pages/DashboardPage.tsx
@@ -1,49 +1,29 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from '@tanstack/react-router';
 import { MobileMenuContext } from '../context/MobileMenu';
 import { Sidebar } from '../components/Sidebar';
 import { Topbar } from '../components/Topbar';
-
-type Theme = 'light' | 'system' | 'dark';
-
-function useTheme(): [Theme, (t: Theme) => void] {
-  const [theme, setTheme] = useState<Theme>(() => {
-    try {
-      return (localStorage.getItem('curia-theme') as Theme) ?? 'system';
-    } catch (err) {
-      console.error('[useTheme] failed reading curia-theme from localStorage:', err);
-      return 'system';
-    }
-  });
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (theme === 'system') {
-      root.removeAttribute('data-theme');
-    } else {
-      root.setAttribute('data-theme', theme);
-    }
-    try {
-      localStorage.setItem('curia-theme', theme);
-    } catch (err) {
-      console.error('[useTheme] failed writing curia-theme to localStorage:', err);
-    }
-  }, [theme]);
-
-  return [theme, setTheme];
-}
+import { useTheme } from '../hooks/useTheme.js';
 
 export default function DashboardPage() {
   const [theme, setTheme] = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
   }, [mobileOpen]);
 
+  function handleNavigate(view: string) {
+    if (view === 'autonomy') {
+      void navigate({ to: '/settings/autonomy' });
+    }
+  }
+
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
       <div className="app-root">
-        <Sidebar activeView="dashboard" onNavigate={() => undefined} theme={theme} onThemeChange={setTheme} />
+        <Sidebar activeView="dashboard" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
         <main className="main">
           <Topbar crumb="Console" title="Dashboard" />
           <div className="placeholder-body">

--- a/apps/console/src/pages/DashboardPage.tsx
+++ b/apps/console/src/pages/DashboardPage.tsx
@@ -16,7 +16,9 @@ export default function DashboardPage() {
 
   function handleNavigate(view: string) {
     if (view === 'autonomy') {
-      void navigate({ to: '/settings/autonomy' });
+      navigate({ to: '/settings/autonomy' }).catch(err => {
+        console.error('[DashboardPage] navigation to /settings/autonomy failed:', err);
+      });
     }
   }
 

--- a/apps/console/src/pages/DashboardPage.tsx
+++ b/apps/console/src/pages/DashboardPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { MobileMenuContext } from '../context/MobileMenu';
 import { Sidebar } from '../components/Sidebar';
 import { Topbar } from '../components/Topbar';
-import { useTheme } from '../hooks/useTheme.js';
+import { useTheme } from '../hooks/useTheme';
 
 export default function DashboardPage() {
   const [theme, setTheme] = useTheme();

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -351,9 +351,9 @@ function SettingsLayout({ activeSection, children }: SettingsLayoutProps) {
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
       <div className="app-root">
-        <Sidebar activeView={activeSection === 'autonomy' ? 'autonomy' : 'settings'} onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
+        <Sidebar activeView="settings" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
         <main className="main">
-          <Topbar crumb="Settings" title={activeSection === 'autonomy' ? 'Autonomy' : 'Settings'} />
+          <Topbar crumb="Settings" title="Workspace" />
           <div className="settings-shell">
             <nav className="settings-nav">
               <div className="settings-nav-title">Settings</div>

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -3,20 +3,20 @@ import { Link, useNavigate } from '@tanstack/react-router';
 import { MobileMenuContext } from '../context/MobileMenu';
 import { Sidebar } from '../components/Sidebar';
 import { Topbar } from '../components/Topbar';
-import { apiFetch } from '../api.js';
-import { useTheme } from '../hooks/useTheme.js';
+import { apiFetch } from '../api';
+import { useTheme } from '../hooks/useTheme';
 
 // ── Band metadata ─────────────────────────────────────────────────────────────
 
 type AutonomyBand = 'full' | 'spot-check' | 'approval-required' | 'draft-only' | 'restricted';
 
 // Band colors match the legacy UI and the app's design token palette.
-const BAND_META: Record<AutonomyBand, { label: string; color: string }> = {
-  'full':              { label: 'Full',              color: '#5E9E6B' },
-  'spot-check':        { label: 'Spot-check',        color: '#6BAED6' },
-  'approval-required': { label: 'Approval Required', color: '#C9874A' },
-  'draft-only':        { label: 'Draft Only',        color: '#7E6BA8' },
-  'restricted':        { label: 'Restricted',        color: '#E86040' },
+const BAND_META: Record<AutonomyBand, { label: string; color: string; description: string }> = {
+  'full':              { label: 'Full',              color: '#5E9E6B', description: 'Curia acts independently with no confirmation required for any standard operation.' },
+  'spot-check':        { label: 'Spot-check',        color: '#6BAED6', description: 'Curia proceeds with most actions and flags a small random sample for your review.' },
+  'approval-required': { label: 'Approval Required', color: '#C9874A', description: 'Curia drafts and plans, then pauses for your explicit approval before acting.' },
+  'draft-only':        { label: 'Draft Only',        color: '#7E6BA8', description: 'Curia prepares drafts and summaries but does not send, schedule, or commit anything.' },
+  'restricted':        { label: 'Restricted',        color: '#E86040', description: 'Curia operates in read-only mode. No writes, sends, or external actions.' },
 };
 
 function bandForScore(score: number): AutonomyBand {
@@ -74,6 +74,18 @@ interface HistoryEntry {
   changedAt: string;
 }
 
+// Safe error message extraction — guards against non-JSON error bodies (e.g. rate-limiter HTML).
+async function errorMessage(res: Response): Promise<string> {
+  const ct = res.headers.get('content-type') ?? '';
+  if (ct.includes('application/json')) {
+    try {
+      const d = await res.json() as { error?: string };
+      if (d.error) return d.error;
+    } catch { /* fall through */ }
+  }
+  return `HTTP ${res.status}`;
+}
+
 // ── Autonomy section ──────────────────────────────────────────────────────────
 
 function AutonomySection() {
@@ -93,10 +105,9 @@ function AutonomySection() {
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyError, setHistoryError] = useState<string | null>(null);
 
-  // The description shown follows the slider live — fall back to the API-supplied
-  // description for the current saved band when the slider hasn't moved yet.
+  // Both the badge and description follow the slider live — BAND_META owns the copy.
   const liveBand = bandForScore(sliderScore);
-  const liveDescription = config?.bandDescription ?? '';
+  const liveDescription = BAND_META[liveBand].description;
 
   const loadHistory = useCallback(async (offset: number) => {
     setHistoryLoading(true);
@@ -104,8 +115,7 @@ function AutonomySection() {
     try {
       const res = await apiFetch(`/api/autonomy/history?limit=5&offset=${offset}`);
       if (!res.ok) {
-        const d = await res.json() as { error?: string };
-        throw new Error(d.error ?? `HTTP ${res.status}`);
+        throw new Error(await errorMessage(res));
       }
       const data = await res.json() as { history: HistoryEntry[]; total: number };
       setHistory(prev => offset === 0 ? data.history : [...prev, ...data.history]);
@@ -123,15 +133,16 @@ function AutonomySection() {
       try {
         const res = await apiFetch('/api/autonomy');
         if (!res.ok) {
-          const d = await res.json() as { error?: string };
-          throw new Error(d.error ?? `HTTP ${res.status}`);
+          throw new Error(await errorMessage(res));
         }
         const data = await res.json() as { autonomy: AutonomyConfig | null };
-        if (data.autonomy) {
-          setConfig(data.autonomy);
-          setSliderScore(data.autonomy.score);
-          setSavedScore(data.autonomy.score);
+        if (!data.autonomy) {
+          setLoadError('Autonomy settings have not been initialized on this instance.');
+          return;
         }
+        setConfig(data.autonomy);
+        setSliderScore(data.autonomy.score);
+        setSavedScore(data.autonomy.score);
       } catch (err) {
         setLoadError(err instanceof Error ? err.message : 'Failed to load autonomy settings');
       }
@@ -150,8 +161,7 @@ function AutonomySection() {
         body: JSON.stringify({ score: sliderScore, reason: reason.trim() || undefined }),
       });
       if (!res.ok) {
-        const d = await res.json() as { error?: string };
-        throw new Error(d.error ?? `HTTP ${res.status}`);
+        throw new Error(await errorMessage(res));
       }
       const data = await res.json() as {
         autonomy: AutonomyConfig;
@@ -163,19 +173,9 @@ function AutonomySection() {
       setSaveStatus('Saved');
       setTimeout(() => setSaveStatus(''), 2000);
 
-      // Prepend new entry to history without refetching.
-      const newEntry: HistoryEntry = {
-        id: crypto.randomUUID(),
-        score: data.autonomy.score,
-        previousScore: data.previousScore,
-        band: data.autonomy.band,
-        changedBy: 'web-ui',
-        changedAt: new Date().toISOString(),
-        reason: reason.trim() || null,
-      };
-      setHistory(prev => [newEntry, ...prev]);
-      setHistoryTotal(t => t + 1);
-      setHistoryOffset(o => o + 1);
+      // Refetch history from the start so the new entry comes from the server
+      // with a real ID — avoids duplicate rows when "Show more" is clicked.
+      void loadHistory(0);
     } catch (err) {
       setSaveStatus(`Error: ${err instanceof Error ? err.message : 'unknown error'}`);
     } finally {

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -1,0 +1,391 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Link, useNavigate } from '@tanstack/react-router';
+import { MobileMenuContext } from '../context/MobileMenu';
+import { Sidebar } from '../components/Sidebar';
+import { Topbar } from '../components/Topbar';
+import { apiFetch } from '../api.js';
+import { useTheme } from '../hooks/useTheme.js';
+
+// ── Band metadata ─────────────────────────────────────────────────────────────
+
+type AutonomyBand = 'full' | 'spot-check' | 'approval-required' | 'draft-only' | 'restricted';
+
+// Band colors match the legacy UI and the app's design token palette.
+const BAND_META: Record<AutonomyBand, { label: string; color: string }> = {
+  'full':              { label: 'Full',              color: '#5E9E6B' },
+  'spot-check':        { label: 'Spot-check',        color: '#6BAED6' },
+  'approval-required': { label: 'Approval Required', color: '#C9874A' },
+  'draft-only':        { label: 'Draft Only',        color: '#7E6BA8' },
+  'restricted':        { label: 'Restricted',        color: '#E86040' },
+};
+
+function bandForScore(score: number): AutonomyBand {
+  if (score >= 90) return 'full';
+  if (score >= 80) return 'spot-check';
+  if (score >= 70) return 'approval-required';
+  if (score >= 60) return 'draft-only';
+  return 'restricted';
+}
+
+function BandBadge({ band }: { band: AutonomyBand }) {
+  const meta = BAND_META[band] ?? { label: band, color: '#999' };
+  return (
+    <span
+      className="band-badge"
+      style={{
+        background: meta.color + '22',
+        color: meta.color,
+        borderColor: meta.color + '44',
+      }}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface AutonomyConfig {
+  score: number;
+  band: AutonomyBand;
+  bandDescription: string;
+  updatedAt: string;
+  updatedBy: string;
+}
+
+interface HistoryEntry {
+  id: string;
+  score: number;
+  previousScore: number | null;
+  band: AutonomyBand;
+  changedBy: string;
+  reason: string | null;
+  changedAt: string;
+}
+
+// ── Autonomy section ──────────────────────────────────────────────────────────
+
+function AutonomySection() {
+  const [config, setConfig] = useState<AutonomyConfig | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Slider live-preview: track score independently so the badge updates as the user drags.
+  const [sliderScore, setSliderScore] = useState(75);
+  const [savedScore, setSavedScore] = useState<number | null>(null);
+  const [reason, setReason] = useState('');
+  const [saveStatus, setSaveStatus] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [historyTotal, setHistoryTotal] = useState(0);
+  const [historyOffset, setHistoryOffset] = useState(0);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+
+  // The description shown follows the slider live — fall back to the API-supplied
+  // description for the current saved band when the slider hasn't moved yet.
+  const liveBand = bandForScore(sliderScore);
+  const liveDescription = config?.bandDescription ?? '';
+
+  const loadHistory = useCallback(async (offset: number) => {
+    setHistoryLoading(true);
+    setHistoryError(null);
+    try {
+      const res = await apiFetch(`/api/autonomy/history?limit=5&offset=${offset}`);
+      if (!res.ok) {
+        const d = await res.json() as { error?: string };
+        throw new Error(d.error ?? `HTTP ${res.status}`);
+      }
+      const data = await res.json() as { history: HistoryEntry[]; total: number };
+      setHistory(prev => offset === 0 ? data.history : [...prev, ...data.history]);
+      setHistoryTotal(data.total);
+      setHistoryOffset(offset + data.history.length);
+    } catch (err) {
+      setHistoryError(err instanceof Error ? err.message : 'Failed to load history');
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await apiFetch('/api/autonomy');
+        if (!res.ok) {
+          const d = await res.json() as { error?: string };
+          throw new Error(d.error ?? `HTTP ${res.status}`);
+        }
+        const data = await res.json() as { autonomy: AutonomyConfig | null };
+        if (data.autonomy) {
+          setConfig(data.autonomy);
+          setSliderScore(data.autonomy.score);
+          setSavedScore(data.autonomy.score);
+        }
+      } catch (err) {
+        setLoadError(err instanceof Error ? err.message : 'Failed to load autonomy settings');
+      }
+    }
+    void load();
+    void loadHistory(0);
+  }, [loadHistory]);
+
+  async function handleSave() {
+    setSaving(true);
+    setSaveStatus('Saving…');
+    try {
+      const res = await apiFetch('/api/autonomy', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: sliderScore, reason: reason.trim() || undefined }),
+      });
+      if (!res.ok) {
+        const d = await res.json() as { error?: string };
+        throw new Error(d.error ?? `HTTP ${res.status}`);
+      }
+      const data = await res.json() as {
+        autonomy: AutonomyConfig;
+        previousScore: number;
+      };
+      setConfig(data.autonomy);
+      setSavedScore(data.autonomy.score);
+      setReason('');
+      setSaveStatus('Saved');
+      setTimeout(() => setSaveStatus(''), 2000);
+
+      // Prepend new entry to history without refetching.
+      const newEntry: HistoryEntry = {
+        id: crypto.randomUUID(),
+        score: data.autonomy.score,
+        previousScore: data.previousScore,
+        band: data.autonomy.band,
+        changedBy: 'web-ui',
+        changedAt: new Date().toISOString(),
+        reason: reason.trim() || null,
+      };
+      setHistory(prev => [newEntry, ...prev]);
+      setHistoryTotal(t => t + 1);
+      setHistoryOffset(o => o + 1);
+    } catch (err) {
+      setSaveStatus(`Error: ${err instanceof Error ? err.message : 'unknown error'}`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loadError) {
+    return (
+      <div className="settings-page-header">
+        <p className="autonomy-error">{loadError}</p>
+      </div>
+    );
+  }
+
+  const isDirty = savedScore !== null && sliderScore !== savedScore;
+
+  return (
+    <>
+      <div className="settings-page-header">
+        <h2 className="settings-page-title">Autonomy</h2>
+        <p className="settings-page-sub">
+          How far Curia is allowed to act before stopping for your confirmation.
+        </p>
+      </div>
+
+      {/* Current state */}
+      <div style={{ marginBottom: 28 }}>
+        <div className="autonomy-current">
+          <span className="autonomy-score">{config ? sliderScore : '—'}</span>
+          {config && <BandBadge band={liveBand} />}
+        </div>
+        <p className="autonomy-band-desc">
+          {config ? liveDescription : 'Loading…'}
+        </p>
+      </div>
+
+      {/* Adjust score */}
+      {config && (
+        <div className="autonomy-control">
+          <div className="autonomy-control-label">Adjust Score</div>
+          <input
+            type="range"
+            className="autonomy-slider"
+            min={0}
+            max={100}
+            step={1}
+            value={sliderScore}
+            onChange={e => setSliderScore(Number(e.target.value))}
+          />
+          <div className="slider-labels">
+            <span>Restricted</span>
+            <span>Full</span>
+          </div>
+          <div>
+            <label className="autonomy-reason-label" htmlFor="autonomy-reason">
+              Reason (optional)
+            </label>
+            <textarea
+              id="autonomy-reason"
+              rows={2}
+              placeholder="Reason for change (optional)"
+              value={reason}
+              onChange={e => setReason(e.target.value)}
+            />
+          </div>
+          <div className="autonomy-save-row">
+            <button
+              type="button"
+              className="btn btn-primary"
+              disabled={!isDirty || saving}
+              onClick={() => void handleSave()}
+            >
+              Save
+            </button>
+            {saveStatus && <span className="autonomy-save-status">{saveStatus}</span>}
+          </div>
+        </div>
+      )}
+
+      {/* History */}
+      <div className="autonomy-history">
+        <div className="autonomy-history-label">Recent Changes</div>
+        <div className="autonomy-history-list">
+          {history.map(entry => {
+            const meta = BAND_META[entry.band] ?? { label: entry.band, color: '#999' };
+            const scoreText = entry.previousScore !== null
+              ? `${entry.previousScore} → ${entry.score}`
+              : `— → ${entry.score}`;
+            return (
+              <div key={entry.id} className="autonomy-history-entry">
+                <div className="autonomy-history-score">
+                  {scoreText}
+                  <span
+                    className="band-badge"
+                    style={{
+                      fontSize: 11,
+                      background: meta.color + '22',
+                      color: meta.color,
+                      borderColor: meta.color + '44',
+                    }}
+                  >
+                    {meta.label}
+                  </span>
+                </div>
+                <div className="autonomy-history-meta">
+                  {entry.changedBy} &middot; {timeAgo(entry.changedAt)}
+                </div>
+                {entry.reason && (
+                  <div className="autonomy-history-reason">{entry.reason}</div>
+                )}
+              </div>
+            );
+          })}
+          {historyError && <p className="autonomy-error">{historyError}</p>}
+        </div>
+        {historyOffset < historyTotal && (
+          <button
+            type="button"
+            className="btn btn-secondary"
+            style={{ marginTop: 12 }}
+            disabled={historyLoading}
+            onClick={() => void loadHistory(historyOffset)}
+          >
+            {historyLoading ? 'Loading…' : 'Show more'}
+          </button>
+        )}
+      </div>
+    </>
+  );
+}
+
+// ── Settings layout ───────────────────────────────────────────────────────────
+
+// The settings nav sections. Only 'autonomy' is functional; others are stubs
+// for future PRs. Rendered as <Link> elements so the URL changes on click and
+// back/forward navigation works correctly within the settings shell.
+const SETTINGS_SECTIONS = [
+  { id: 'autonomy',  label: 'Autonomy',    href: '/settings/autonomy' },
+  { id: 'workspace', label: 'Workspace',   href: '/settings/workspace' },
+];
+
+interface SettingsLayoutProps {
+  activeSection: string;
+  children: React.ReactNode;
+}
+
+function SettingsLayout({ activeSection, children }: SettingsLayoutProps) {
+  const [theme, setTheme] = useTheme();
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
+  }, [mobileOpen]);
+
+  function handleNavigate(view: string) {
+    if (view === 'autonomy') {
+      void navigate({ to: '/settings/autonomy' });
+    } else if (view === 'dashboard') {
+      void navigate({ to: '/' });
+    }
+  }
+
+  return (
+    <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
+      <div className="app-root">
+        <Sidebar activeView="autonomy" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
+        <main className="main">
+          <Topbar crumb="Settings" title={activeSection === 'autonomy' ? 'Autonomy' : 'Settings'} />
+          <div className="settings-shell">
+            <nav className="settings-nav">
+              <div className="settings-nav-title">Settings</div>
+              {SETTINGS_SECTIONS.map(s => (
+                <Link
+                  key={s.id}
+                  to={s.href}
+                  className={`settings-nav-item${activeSection === s.id ? ' active' : ''}`}
+                >
+                  {s.label}
+                </Link>
+              ))}
+            </nav>
+            <div className="settings-content">
+              {children}
+            </div>
+          </div>
+        </main>
+      </div>
+    </MobileMenuContext.Provider>
+  );
+}
+
+// ── Exported page components (one per child route) ────────────────────────────
+
+export function AutonomyPage() {
+  return (
+    <SettingsLayout activeSection="autonomy">
+      <AutonomySection />
+    </SettingsLayout>
+  );
+}
+
+export function WorkspacePage() {
+  return (
+    <SettingsLayout activeSection="workspace">
+      <div className="settings-page-header">
+        <h2 className="settings-page-title">Workspace</h2>
+        <p className="settings-page-sub">Workspace settings — coming soon.</p>
+      </div>
+    </SettingsLayout>
+  );
+}

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -81,7 +81,9 @@ async function errorMessage(res: Response): Promise<string> {
     try {
       const d = await res.json() as { error?: string };
       if (d.error) return d.error;
-    } catch { /* fall through */ }
+    } catch (err) {
+      console.error('[errorMessage] failed to read JSON error body:', err);
+    }
   }
   return `HTTP ${res.status}`;
 }
@@ -175,7 +177,9 @@ function AutonomySection() {
 
       // Refetch history from the start so the new entry comes from the server
       // with a real ID — avoids duplicate rows when "Show more" is clicked.
-      void loadHistory(0);
+      loadHistory(0).catch(err => {
+        console.error('[handleSave] post-save history refresh failed:', err);
+      });
     } catch (err) {
       setSaveStatus(`Error: ${err instanceof Error ? err.message : 'unknown error'}`);
     } finally {
@@ -334,9 +338,13 @@ function SettingsLayout({ activeSection, children }: SettingsLayoutProps) {
 
   function handleNavigate(view: string) {
     if (view === 'autonomy') {
-      void navigate({ to: '/settings/autonomy' });
+      navigate({ to: '/settings/autonomy' }).catch(err => {
+        console.error('[SettingsLayout] navigation to /settings/autonomy failed:', err);
+      });
     } else if (view === 'dashboard') {
-      void navigate({ to: '/' });
+      navigate({ to: '/' }).catch(err => {
+        console.error('[SettingsLayout] navigation to / failed:', err);
+      });
     }
   }
 

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -341,6 +341,10 @@ function SettingsLayout({ activeSection, children }: SettingsLayoutProps) {
       navigate({ to: '/settings/autonomy' }).catch(err => {
         console.error('[SettingsLayout] navigation to /settings/autonomy failed:', err);
       });
+    } else if (view === 'settings') {
+      navigate({ to: '/settings/workspace' }).catch(err => {
+        console.error('[SettingsLayout] navigation to /settings/workspace failed:', err);
+      });
     } else if (view === 'dashboard') {
       navigate({ to: '/' }).catch(err => {
         console.error('[SettingsLayout] navigation to / failed:', err);

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -343,7 +343,7 @@ function SettingsLayout({ activeSection, children }: SettingsLayoutProps) {
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
       <div className="app-root">
-        <Sidebar activeView="autonomy" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
+        <Sidebar activeView={activeSection === 'autonomy' ? 'autonomy' : 'settings'} onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
         <main className="main">
           <Topbar crumb="Settings" title={activeSection === 'autonomy' ? 'Autonomy' : 'Settings'} />
           <div className="settings-shell">

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -11,6 +11,12 @@ import { checkSession } from './api';
 
 // Route components are lazy-loaded so Vite produces separate chunks per route.
 const DashboardPage = lazy(() => import('./pages/DashboardPage'));
+const AutonomyPage = lazy(() =>
+  import('./pages/SettingsPage').then(m => ({ default: m.AutonomyPage })),
+);
+const WorkspacePage = lazy(() =>
+  import('./pages/SettingsPage').then(m => ({ default: m.WorkspacePage })),
+);
 
 const rootRoute = createRootRoute({
   component: () => (
@@ -38,6 +44,34 @@ const dashboardRoute = createRoute({
   component: DashboardPage,
 });
 
+// Settings layout route — bare /settings redirects to the default section.
+const settingsRoute = createRoute({
+  getParentRoute: () => authedRoute,
+  path: '/settings',
+  beforeLoad: ({ location }) => {
+    if (location.pathname === '/settings' || location.pathname === '/settings/') {
+      throw redirect({ to: '/settings/autonomy' });
+    }
+  },
+  component: () => (
+    <Suspense fallback={null}>
+      <Outlet />
+    </Suspense>
+  ),
+});
+
+const autonomyRoute = createRoute({
+  getParentRoute: () => settingsRoute,
+  path: '/autonomy',
+  component: AutonomyPage,
+});
+
+const workspaceRoute = createRoute({
+  getParentRoute: () => settingsRoute,
+  path: '/workspace',
+  component: WorkspacePage,
+});
+
 const loginRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/login',
@@ -45,7 +79,10 @@ const loginRoute = createRoute({
 });
 
 const routeTree = rootRoute.addChildren([
-  authedRoute.addChildren([dashboardRoute]),
+  authedRoute.addChildren([
+    dashboardRoute,
+    settingsRoute.addChildren([autonomyRoute, workspaceRoute]),
+  ]),
   loginRoute,
 ]);
 

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -349,3 +349,186 @@ input:focus, textarea:focus, select:focus {
   font-family: Lora, Georgia, serif;
   font-size: 16px;
 }
+
+/* ── 10. Settings shell ──────────────────────────────────────────────── */
+.settings-shell {
+  flex: 1; display: flex; overflow: hidden; min-height: 0;
+}
+
+.settings-nav {
+  flex: none; width: 200px;
+  border-right: 1px solid var(--app-border);
+  background: var(--app-side);
+  padding: 16px 10px;
+  overflow-y: auto;
+}
+.settings-nav-title {
+  padding: 6px 10px 12px;
+  font-size: 10px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.10em;
+  color: var(--app-fg-muted);
+}
+.settings-nav-item {
+  display: block; width: 100%;
+  padding: 7px 10px;
+  border: none; background: none;
+  font-family: inherit; font-size: 13px; font-weight: 500;
+  color: var(--app-fg-muted); text-align: left;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 120ms, color 120ms;
+  text-decoration: none;
+}
+.settings-nav-item:hover { color: var(--app-fg); background: var(--app-muted); }
+.settings-nav-item.active { color: var(--app-fg); background: var(--app-muted); }
+
+.settings-content {
+  flex: 1; overflow-y: auto;
+  padding: 32px 40px 80px;
+}
+.settings-page-header {
+  max-width: 720px;
+  margin-bottom: 28px;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.settings-page-title {
+  font-family: Lora, Georgia, serif;
+  font-size: 28px; font-weight: 500;
+  margin: 0; color: var(--app-fg);
+  line-height: 1.2;
+}
+.settings-page-sub {
+  font-size: 14px; color: var(--app-fg-muted); margin: 0;
+  max-width: 600px;
+}
+
+.settings-section {
+  max-width: 720px;
+  margin-bottom: 28px;
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.settings-section-head {
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--app-border);
+}
+.settings-section-title {
+  margin: 0 0 4px;
+  font-size: 14px; font-weight: 600;
+  color: var(--app-fg);
+}
+.settings-section-sub {
+  margin: 0;
+  font-size: 12px; color: var(--app-fg-muted);
+}
+
+/* ── 11. Autonomy view ───────────────────────────────────────────────── */
+.autonomy-current {
+  display: flex; align-items: baseline; gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+.autonomy-score {
+  font-size: 2.25rem; font-weight: 700; color: var(--app-fg);
+  line-height: 1;
+}
+.band-badge {
+  display: inline-flex; align-items: center;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 12px; font-weight: 600;
+  border: 1px solid transparent;
+}
+.autonomy-band-desc {
+  font-size: 13px; color: var(--app-fg-muted);
+  line-height: 1.55; margin: 0 0 28px;
+  max-width: 600px;
+}
+
+.autonomy-control {
+  max-width: 720px;
+  margin-bottom: 28px;
+  padding: 20px;
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+}
+.autonomy-control-label {
+  font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.10em;
+  color: var(--app-fg-muted);
+  margin-bottom: 12px;
+}
+.autonomy-slider { width: 100%; accent-color: var(--app-teal); margin-bottom: 4px; }
+.slider-labels {
+  display: flex; justify-content: space-between;
+  font-size: 11px; color: var(--app-fg-muted);
+  margin-bottom: 16px;
+}
+.autonomy-reason-label {
+  display: block;
+  font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.10em;
+  color: var(--app-fg-muted);
+  margin-bottom: 6px;
+}
+.autonomy-save-row {
+  display: flex; align-items: center; gap: 12px;
+  margin-top: 12px;
+}
+.autonomy-save-status {
+  font-size: 12px; color: var(--app-fg-muted);
+}
+
+.autonomy-history { max-width: 720px; }
+.autonomy-history-label {
+  font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.10em;
+  color: var(--app-fg-muted);
+  margin-bottom: 12px;
+}
+.autonomy-history-list {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.autonomy-history-entry {
+  padding: 12px 16px;
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+}
+.autonomy-history-score {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 14px; font-weight: 600; color: var(--app-fg);
+  margin-bottom: 4px;
+}
+.autonomy-history-meta {
+  font-size: 12px; color: var(--app-fg-muted);
+  margin-bottom: 2px;
+}
+.autonomy-history-reason {
+  font-size: 12px; color: var(--app-fg-muted);
+  font-style: italic;
+  margin-top: 4px;
+}
+.autonomy-error {
+  font-size: 13px; color: var(--app-destructive);
+  margin: 0;
+}
+
+/* ── 12. Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .settings-shell { flex-direction: column; }
+  .settings-nav {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--app-border);
+    padding: 10px;
+    display: flex; flex-direction: row; flex-wrap: wrap; gap: 4px;
+  }
+  .settings-nav-title { display: none; }
+  .settings-nav-item { width: auto; }
+  .settings-content { padding: 22px 18px 80px; }
+  .settings-page-title { font-size: 22px; }
+}

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -826,27 +826,6 @@ function createUiHtml(): string {
       color: var(--accent);
       margin-bottom: 8px;
     }
-    .autonomy-history-entry {
-      padding: 10px 14px;
-      background: var(--card);
-      border: 1px solid var(--border);
-      border-radius: var(--radius-md);
-    }
-    .autonomy-history-entry .score-change {
-      font-weight: 600;
-      font-size: 0.875rem;
-    }
-    .autonomy-history-entry .meta {
-      font-size: 0.75rem;
-      color: var(--fg-muted);
-      margin-top: 3px;
-    }
-    .autonomy-history-entry .reason {
-      font-size: 0.8125rem;
-      font-style: italic;
-      color: var(--fg-muted);
-      margin-top: 4px;
-    }
     .posture-grid { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 28px; }
     .posture-card {
       flex: 1;
@@ -1089,14 +1068,6 @@ function createUiHtml(): string {
                 <path d="M8 5l3.5-3.5"/>
               </svg>
               Setup Wizard
-            </button>
-            <button id="nav-autonomy" class="nav-sub-item" onclick="navigate('autonomy', 'Autonomy', 'nav-autonomy')">
-              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M6.5 11.5a5 5 0 1 1 0-10 5 5 0 0 1 0 10z"/>
-                <path d="M6.5 3.5v1"/>
-                <path d="M6.5 6.5l2-2"/>
-              </svg>
-              Autonomy
             </button>
           </div>
         </div>
@@ -1344,43 +1315,6 @@ function createUiHtml(): string {
         </div>
       </div>
 
-      <!-- Autonomy settings view — hidden until user clicks the Autonomy nav item -->
-      <div id="view-autonomy" style="display: none; height: 100%; flex-direction: column; overflow-y: auto; padding: 24px 32px; max-width: 720px;">
-
-        <h2 style="font-family: 'Lora', Georgia, serif; font-size: 1.375rem; font-weight: 500; margin: 0 0 24px;">Autonomy</h2>
-
-        <!-- Current state display -->
-        <div id="autonomy-current" style="margin-bottom: 28px;">
-          <div style="display: flex; align-items: baseline; gap: 12px; margin-bottom: 8px;">
-            <span id="autonomy-score-display" style="font-size: 2rem; font-weight: 700; color: var(--fg);"></span>
-            <span id="autonomy-band-badge" class="badge"></span>
-          </div>
-          <p id="autonomy-band-description" style="font-size: 0.875rem; color: var(--fg-muted); margin: 0; line-height: 1.5;"></p>
-        </div>
-
-        <!-- Score adjustment control -->
-        <div style="margin-bottom: 32px; padding: 20px; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-lg);">
-          <div style="font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--fg-muted); margin-bottom: 12px;">Adjust Score</div>
-          <input id="autonomy-slider" type="range" min="0" max="100" step="1" value="75"
-            style="width: 100%; accent-color: var(--primary); margin-bottom: 6px;" />
-          <div class="slider-labels"><span>Restricted</span><span>Full</span></div>
-
-          <div style="margin-top: 16px;">
-            <label for="autonomy-reason" style="display: block; font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--fg-muted); margin-bottom: 6px;">Reason (optional)</label>
-            <textarea id="autonomy-reason" rows="2" placeholder="Reason for change (optional)" style="width: 100%; resize: vertical;"></textarea>
-          </div>
-
-          <button id="autonomy-save-btn" class="btn-primary" disabled style="margin-top: 12px;">Save</button>
-          <span id="autonomy-save-status" style="font-size: 0.75rem; color: var(--fg-muted); margin-left: 10px;"></span>
-        </div>
-
-        <!-- History section -->
-        <div>
-          <div style="font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--fg-muted); margin-bottom: 12px;">Recent Changes</div>
-          <div id="autonomy-history-list" style="display: flex; flex-direction: column; gap: 8px;"></div>
-          <button id="autonomy-show-more-btn" class="btn-primary" style="margin-top: 12px; display: none; background: var(--muted); color: var(--fg);">Show more</button>
-        </div>
-      </div>
 
       <!-- Chat view — hidden until user clicks the Chat nav item -->
       <div id="view-chat" style="display: none; height: 100%; flex-direction: row;">
@@ -1571,40 +1505,6 @@ function createUiHtml(): string {
     var jobs = [];
     var selectedJobId = null;
     var jobsMode = 'create';
-
-    // -- Autonomy state --
-    var autonomySavedScore = null; // last-saved score (to detect slider changes)
-    var autonomyHistoryOffset = 0;
-    var autonomyHistoryTotal = 0;
-
-    var AUTONOMY_BANDS = {
-      'full':              { label: 'Full',              color: '#5E9E6B', description: 'Act independently. No confirmation needed for standard operations. Flag only genuinely novel, irreversible, or high-stakes actions \u2014 where the downside of acting without checking outweighs the cost of the pause.' },
-      'spot-check':        { label: 'Spot-check',        color: '#6BAED6', description: 'Proceed on routine tasks. For consequential actions \u2014 sending external communications, creating commitments, or acting on behalf of the CEO \u2014 note what you are doing in your response so the CEO maintains visibility. No need to stop and ask.' },
-      'approval-required': { label: 'Approval Required', color: '#C9874A', description: 'For any consequential action, present your plan and explicitly ask for confirmation before proceeding. Routine reporting, summarization, and information retrieval can proceed without approval. When in doubt, draft and ask.' },
-      'draft-only':        { label: 'Draft Only',        color: '#7E6BA8', description: 'Prepare drafts, plans, and analysis, but do not send, publish, schedule, or act on behalf of the CEO without an explicit instruction to do so. Surface your work for review; execution requires a direct go-ahead.' },
-      'restricted':        { label: 'Restricted',        color: '#E86040', description: 'Present options and analysis only. Take no independent action. All outputs are advisory. Every step that would have an external effect requires explicit CEO instruction.' },
-    };
-
-    function bandForScore(score) {
-      if (score >= 90) return 'full';
-      if (score >= 80) return 'spot-check';
-      if (score >= 70) return 'approval-required';
-      if (score >= 60) return 'draft-only';
-      return 'restricted';
-    }
-
-    function timeAgo(dateStr) {
-      var now = Date.now();
-      var then = new Date(dateStr).getTime();
-      var seconds = Math.floor((now - then) / 1000);
-      if (seconds < 60) return 'just now';
-      var minutes = Math.floor(seconds / 60);
-      if (minutes < 60) return minutes + 'm ago';
-      var hours = Math.floor(minutes / 60);
-      if (hours < 24) return hours + 'h ago';
-      var days = Math.floor(hours / 24);
-      return days + 'd ago';
-    }
 
     // ── Chat state ─────────────────────────────────────────────────────
     // Active EventSource for SSE — one per conversation, null when idle.
@@ -1942,7 +1842,6 @@ function createUiHtml(): string {
       var contactsView      = document.getElementById('view-contacts');
       var tasksView         = document.getElementById('view-tasks');
       var scheduledJobsView = document.getElementById('view-scheduled-jobs');
-      var autonomyView      = document.getElementById('view-autonomy');
       var viewWizard        = document.getElementById('view-wizard');
 
       // When navigating to the wizard, fetch the current identity to pre-fill fields,
@@ -1976,7 +1875,6 @@ function createUiHtml(): string {
       contactsView.style.display      = view === 'contacts'       ? 'flex' : 'none';
       tasksView.style.display         = view === 'tasks'          ? 'flex' : 'none';
       scheduledJobsView.style.display = view === 'scheduled-jobs' ? 'flex' : 'none';
-      if (autonomyView) autonomyView.style.display = view === 'autonomy' ? 'flex' : 'none';
       if (viewWizard) viewWizard.style.display = 'none'; // always hide when navigating elsewhere
       // When returning to the KG view, tell Cytoscape to re-measure the container.
       // The canvas dimensions may be stale if the view was hidden (display:none)
@@ -2006,9 +1904,6 @@ function createUiHtml(): string {
       }
       if (view === 'scheduled-jobs') {
         loadJobs();
-      }
-      if (view === 'autonomy') {
-        loadAutonomy();
       }
 
       // On first entry into the Chat view with no conversations yet, ensure
@@ -3366,168 +3261,6 @@ function createUiHtml(): string {
         .finally(function() { jobsDeleteBtn.disabled = false; });
     }
 
-    // -- Autonomy functions --
-
-    function loadAutonomy() {
-      fetch('/api/autonomy')
-        .then(function(res) {
-          if (!res.ok) return res.json().then(function(d) { throw new Error(d.error || ('HTTP ' + res.status)); });
-          return res.json();
-        })
-        .then(function(data) {
-          if (!data.autonomy) {
-            // Render into individual child elements rather than setting textContent on the
-            // parent — setting textContent destroys all children (#autonomy-score-display,
-            // #autonomy-band-badge, #autonomy-band-description), which breaks any subsequent
-            // call to renderAutonomyState() that tries to getElementById on them.
-            document.getElementById('autonomy-score-display').textContent = '—';
-            document.getElementById('autonomy-band-badge').textContent = 'Not configured';
-            document.getElementById('autonomy-band-description').textContent =
-              'Autonomy not configured. Run migration 011 first.';
-            return;
-          }
-          autonomySavedScore = data.autonomy.score;
-          renderAutonomyState(data.autonomy.score, data.autonomy.band, data.autonomy.bandDescription);
-          document.getElementById('autonomy-slider').value = data.autonomy.score;
-          // Reset stale form state from a previous session so we don't show a dirty form
-          // with an enabled save button or leftover reason text on reload.
-          document.getElementById('autonomy-reason').value = '';
-          document.getElementById('autonomy-save-status').textContent = '';
-          document.getElementById('autonomy-save-btn').disabled = true;
-        })
-        .catch(function(err) {
-          document.getElementById('autonomy-current').textContent =
-            'Failed to load autonomy settings: ' + (err && err.message ? err.message : 'unknown error');
-        });
-
-      // Reset and load history
-      autonomyHistoryOffset = 0;
-      document.getElementById('autonomy-history-list').replaceChildren();
-      loadAutonomyHistory();
-    }
-
-    function renderAutonomyState(score, band, description) {
-      var bandInfo = AUTONOMY_BANDS[band] || { label: band, color: '#999' };
-      document.getElementById('autonomy-score-display').textContent = score;
-      var badge = document.getElementById('autonomy-band-badge');
-      badge.textContent = bandInfo.label;
-      badge.style.background = bandInfo.color + '22';
-      badge.style.color = bandInfo.color;
-      badge.style.border = '1px solid ' + bandInfo.color + '44';
-      document.getElementById('autonomy-band-description').textContent = description;
-    }
-
-    function buildHistoryEntry(entry) {
-      var bandInfo = AUTONOMY_BANDS[entry.band] || { label: entry.band, color: '#999' };
-      var div = document.createElement('div');
-      div.className = 'autonomy-history-entry';
-
-      // Score change line
-      var scoreDiv = document.createElement('div');
-      scoreDiv.className = 'score-change';
-      var scoreText = (entry.previousScore !== null && entry.previousScore !== undefined)
-        ? entry.previousScore + ' \u2192 ' + entry.score
-        : '\u2014 \u2192 ' + entry.score;
-      scoreDiv.appendChild(document.createTextNode(scoreText + ' '));
-      var badge = document.createElement('span');
-      badge.className = 'badge';
-      badge.style.fontSize = '0.6875rem';
-      badge.style.background = bandInfo.color + '22';
-      badge.style.color = bandInfo.color;
-      badge.style.border = '1px solid ' + bandInfo.color + '44';
-      badge.textContent = bandInfo.label;
-      scoreDiv.appendChild(badge);
-      div.appendChild(scoreDiv);
-
-      // Meta line (who + when)
-      var metaDiv = document.createElement('div');
-      metaDiv.className = 'meta';
-      metaDiv.textContent = entry.changedBy + ' \u00b7 ' + timeAgo(entry.changedAt);
-      div.appendChild(metaDiv);
-
-      // Reason (if present)
-      if (entry.reason) {
-        var reasonDiv = document.createElement('div');
-        reasonDiv.className = 'reason';
-        reasonDiv.textContent = entry.reason;
-        div.appendChild(reasonDiv);
-      }
-
-      return div;
-    }
-
-    function loadAutonomyHistory() {
-      var btn = document.getElementById('autonomy-show-more-btn');
-      btn.disabled = true;  // prevent double-click during load
-
-      fetch('/api/autonomy/history?limit=5&offset=' + autonomyHistoryOffset)
-        .then(function(res) {
-          if (!res.ok) return res.json().then(function(d) { throw new Error(d.error || ('HTTP ' + res.status)); });
-          return res.json();
-        })
-        .then(function(data) {
-          autonomyHistoryTotal = data.total;
-          var list = document.getElementById('autonomy-history-list');
-          data.history.forEach(function(entry) {
-            list.appendChild(buildHistoryEntry(entry));
-          });
-          autonomyHistoryOffset += data.history.length;
-          btn.disabled = false;
-          btn.style.display = (autonomyHistoryOffset < autonomyHistoryTotal) ? 'inline-block' : 'none';
-        })
-        .catch(function(err) {
-          btn.disabled = false;
-          var errEl = document.createElement('p');
-          errEl.style.color = 'var(--destructive)';
-          errEl.textContent = 'Failed to load history: ' + (err && err.message ? err.message : 'unknown error');
-          document.getElementById('autonomy-history-list').appendChild(errEl);
-          btn.style.display = 'none';
-        });
-    }
-
-    function saveAutonomy() {
-      var score = parseInt(document.getElementById('autonomy-slider').value, 10);
-      var reason = document.getElementById('autonomy-reason').value.trim() || undefined;
-      var saveBtn = document.getElementById('autonomy-save-btn');
-      var status = document.getElementById('autonomy-save-status');
-      saveBtn.disabled = true;
-      status.textContent = 'Saving\u2026';
-
-      fetch('/api/autonomy', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ score: score, reason: reason }),
-      })
-        .then(function(res) {
-          if (!res.ok) return res.json().then(function(d) { throw new Error(d.error); });
-          return res.json();
-        })
-        .then(function(data) {
-          autonomySavedScore = data.autonomy.score;
-          renderAutonomyState(data.autonomy.score, data.autonomy.band, data.autonomy.bandDescription);
-          document.getElementById('autonomy-reason').value = '';
-          status.textContent = 'Saved';
-          setTimeout(function() { status.textContent = ''; }, 2000);
-
-          // Prepend new entry to history
-          var newEntry = {
-            score: data.autonomy.score,
-            previousScore: data.previousScore,
-            band: data.autonomy.band,
-            changedBy: 'web-ui',
-            changedAt: new Date().toISOString(),
-            reason: reason || null,
-          };
-          var list = document.getElementById('autonomy-history-list');
-          list.insertBefore(buildHistoryEntry(newEntry), list.firstChild);
-          autonomyHistoryTotal++;
-          autonomyHistoryOffset++;
-        })
-        .catch(function(err) {
-          status.textContent = 'Error: ' + (err && err.message ? err.message : 'unknown error');
-          saveBtn.disabled = false;
-        });
-    }
 
     jobsForm.addEventListener('submit', saveJob);
     jobsDeleteBtn.addEventListener('click', deleteJob);
@@ -3762,23 +3495,6 @@ function createUiHtml(): string {
 
     chatForm.addEventListener('submit', sendChatMessage);
 
-    // -- Autonomy event bindings --
-
-    document.getElementById('autonomy-slider').addEventListener('input', function() {
-      var score = parseInt(this.value, 10);
-      var band = bandForScore(score);
-      var bandInfo = AUTONOMY_BANDS[band];
-      renderAutonomyState(score, band, bandInfo.description);
-      document.getElementById('autonomy-save-btn').disabled = (score === autonomySavedScore);
-    });
-
-    document.getElementById('autonomy-save-btn').addEventListener('click', function() {
-      saveAutonomy();
-    });
-
-    document.getElementById('autonomy-show-more-btn').addEventListener('click', function() {
-      loadAutonomyHistory();
-    });
   </script>
 </body>
 </html>`;


### PR DESCRIPTION
## **User description**
## Summary

- Autonomy settings are now accessible at `/settings/autonomy` in the new console app
- Score display, live-preview slider (badge + description update as you drag), reason field, save action, and paginated history all match the legacy UI
- Removed the Autonomy view from the legacy `/old` UI (`kg.ts`)
- Extracted `useTheme` into a shared hook (`apps/console/src/hooks/useTheme.ts`)
- Added Settings shell with secondary left-nav (URL-based routing so deep-links and browser back/forward work)

Closes #752

## Test plan

- [ ] Navigate to `/settings/autonomy` — score, band badge, and description display correctly
- [ ] Drag the slider — score, badge colour, and description all update live without saving
- [ ] Save button is disabled when slider matches saved score; enabled when dirty
- [ ] Save with a reason — history list refreshes with the new entry at the top (server-sourced, not optimistic)
- [ ] "Show more" loads the next page of history without duplicating the first entry
- [ ] Navigate to `/settings` — redirects to `/settings/autonomy`
- [ ] Navigate to `/settings/workspace` — shows the stub page; sidebar highlights Settings correctly
- [ ] Browser back/forward between `/` and `/settings/autonomy` works
- [ ] Mobile viewport (< 768px): settings nav stacks above content
- [ ] `/old/autonomy` no longer exists in the legacy UI


___

## **CodeAnt-AI Description**
**Move Autonomy settings into the new console app and fix its saving, history, and error handling**

### What Changed
- Autonomy settings now open in the new console app at `/settings/autonomy`, with the score, live-updating band label and description, optional reason field, save action, and paginated history
- The settings area now has its own left navigation, redirects `/settings` to Autonomy, and keeps the Workspace page available as a stub
- Saving now refreshes history from the server so new entries do not duplicate when loading more
- Empty or non-JSON error responses are handled cleanly instead of breaking the page, and a missing Autonomy config now shows a clear message
- The legacy `/old` Autonomy view was removed

### Impact
`✅ Access Autonomy settings in the new console`
`✅ Fewer duplicate history rows after saving`
`✅ Clearer error messages when Autonomy fails to load`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
