### PR TITLE
fix: persist sessions to Postgres so they survive process restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **HTTP session persistence** — sessions now survive process restarts; active browser tabs no longer lose auth on deploy. Sessions are stored in Postgres (token SHA-256 hashed) and restored into the in-memory Map at startup. (#748)
 - **`bullpen`** — `post` is now idempotent when `source_message_id` is provided; returns existing thread on duplicate. (#708)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **HTTP session persistence** — sessions now survive process restarts; active browser tabs no longer lose auth on deploy. Sessions are stored in Postgres (token SHA-256 hashed) and restored into the in-memory Map at startup. (#748)
+- **HTTP session persistence** — hashed tokens written to Postgres and restored on startup; browser auth survives restarts. (#748)
 - **`bullpen`** — `post` is now idempotent when `source_message_id` is provided; returns existing thread on duplicate. (#708)
 
 ### Changed

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -161,25 +161,35 @@ export class HttpAdapter {
         logger.info({ count: rows.length }, 'Restored sessions from Postgres');
       }
     } catch (err) {
-      // Non-fatal: existing sessions are lost on this restart, but new logins will work.
-      // 42P01 = undefined_table: migration 047_create_sessions.sql has not been applied yet.
+      // 42P01 = undefined_table: migration 047 has not been applied yet. Log and continue so
+      // operators see an actionable message; logins will fail until the migration runs.
       if ((err as { code?: string }).code === '42P01') {
-        logger.error({ err }, 'Session table does not exist — run pending migrations before deploying');
+        logger.error({ err }, 'Session table does not exist — run pending migrations; logins unavailable until migration 047 is applied');
       } else {
-        logger.error({ err }, 'Failed to restore sessions from Postgres; existing sessions lost on this restart');
+        // Any other error (bad credentials, connectivity) means we cannot guarantee sessions
+        // are restored. Fail fast so the process is restarted into a clean state rather than
+        // silently dropping every persisted session.
+        logger.error({ err }, 'Failed to restore sessions from Postgres');
+        throw err;
       }
     }
 
+    // In-flight guard: if Postgres is slow and a prune DELETE takes longer than 60 s, the next
+    // interval tick would launch a second concurrent DELETE against the same pool, eventually
+    // exhausting connections. Skip the DB prune for this tick if one is already running.
+    let isPruning = false;
     const pruneInterval = setInterval(() => {
       const now = Date.now();
       for (const [tokenHash, expiresAt] of sessions) {
         if (now > expiresAt) sessions.delete(tokenHash);
       }
-      // Mirror the in-memory sweep to Postgres. Fire-and-forget: a missed prune cycle is harmless
-      // because assertSecret re-checks the expiry timestamp on every request.
-      pool.query('DELETE FROM sessions WHERE expires_at < NOW()').catch((err: unknown) => {
-        logger.error({ err }, 'Session prune DELETE failed — Postgres session storage may be unavailable');
-      });
+      if (isPruning) return;
+      isPruning = true;
+      pool.query('DELETE FROM sessions WHERE expires_at < NOW()')
+        .catch((err: unknown) => {
+          logger.error({ err }, 'Session prune DELETE failed — Postgres session storage may be unavailable');
+        })
+        .finally(() => { isPruning = false; });
     }, 60_000);
     pruneInterval.unref();
 

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -162,7 +162,12 @@ export class HttpAdapter {
       }
     } catch (err) {
       // Non-fatal: existing sessions are lost on this restart, but new logins will work.
-      logger.error({ err }, 'Failed to restore sessions from Postgres');
+      // 42P01 = undefined_table: migration 047_create_sessions.sql has not been applied yet.
+      if ((err as { code?: string }).code === '42P01') {
+        logger.error({ err }, 'Session table does not exist — run pending migrations before deploying');
+      } else {
+        logger.error({ err }, 'Failed to restore sessions from Postgres; existing sessions lost on this restart');
+      }
     }
 
     const pruneInterval = setInterval(() => {
@@ -173,7 +178,7 @@ export class HttpAdapter {
       // Mirror the in-memory sweep to Postgres. Fire-and-forget: a missed prune cycle is harmless
       // because assertSecret re-checks the expiry timestamp on every request.
       pool.query('DELETE FROM sessions WHERE expires_at < NOW()').catch((err: unknown) => {
-        logger.warn({ err }, 'Session prune query failed');
+        logger.error({ err }, 'Session prune DELETE failed — Postgres session storage may be unavailable');
       });
     }, 60_000);
     pruneInterval.unref();

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -144,12 +144,37 @@ export class HttpAdapter {
 
     // Shared session store — used by both KG and identity routes to validate browser sessions.
     // Sessions are set by POST /auth (KG routes) and verified by both route registrations.
+    // Map keys are SHA-256 hashes of the raw token (matching the DB column).
     const sessions: SessionStore = new Map();
+
+    // Restore active sessions from Postgres so existing browser tabs survive a process restart.
+    // Only rows that haven't expired yet are loaded; the cookie expiry on the client enforces the
+    // 24-hour TTL independently, so there's no risk of surfacing stale sessions here.
+    try {
+      const { rows } = await pool.query<{ token_hash: string; expires_at: Date }>(
+        'SELECT token_hash, expires_at FROM sessions WHERE expires_at > NOW()',
+      );
+      for (const row of rows) {
+        sessions.set(row.token_hash, row.expires_at.getTime());
+      }
+      if (rows.length > 0) {
+        logger.info({ count: rows.length }, 'Restored sessions from Postgres');
+      }
+    } catch (err) {
+      // Non-fatal: existing sessions are lost on this restart, but new logins will work.
+      logger.error({ err }, 'Failed to restore sessions from Postgres');
+    }
+
     const pruneInterval = setInterval(() => {
       const now = Date.now();
-      for (const [token, expiresAt] of sessions) {
-        if (now > expiresAt) sessions.delete(token);
+      for (const [tokenHash, expiresAt] of sessions) {
+        if (now > expiresAt) sessions.delete(tokenHash);
       }
+      // Mirror the in-memory sweep to Postgres. Fire-and-forget: a missed prune cycle is harmless
+      // because assertSecret re-checks the expiry timestamp on every request.
+      pool.query('DELETE FROM sessions WHERE expires_at < NOW()').catch((err: unknown) => {
+        logger.warn({ err }, 'Session prune query failed');
+      });
     }, 60_000);
     pruneInterval.unref();
 

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -9,7 +9,7 @@ import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
 import type { ContactStatus } from '../../../contacts/types.js';
 import { MessageRejectedError, type EventRouter } from '../event-router.js';
-import { assertSecret, type SessionStore } from '../session-auth.js';
+import { assertSecret, hashToken, type SessionStore } from '../session-auth.js';
 
 export interface KnowledgeGraphRouteOptions {
   pool: Pool;
@@ -3549,7 +3549,18 @@ export async function knowledgeGraphRoutes(
 
     // Issue a 256-bit random session token. The secret itself never goes in the cookie.
     const token = randomBytes(32).toString('hex');
-    sessions.set(token, Date.now() + 24 * 60 * 60 * 1000); // expires in 24 hours
+    const tokenHash = hashToken(token);
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours from now
+    sessions.set(tokenHash, expiresAt.getTime());
+
+    // Persist to Postgres so the session survives a process restart. ON CONFLICT is a safety
+    // net against the astronomically unlikely case of a hash collision on a 256-bit token.
+    await pool.query(
+      `INSERT INTO sessions (token_hash, last_seen_at, expires_at)
+       VALUES ($1, NOW(), $2)
+       ON CONFLICT (token_hash) DO UPDATE SET expires_at = EXCLUDED.expires_at, last_seen_at = NOW()`,
+      [tokenHash, expiresAt],
+    );
 
     reply.setCookie('curia_session', token, {
       httpOnly: true,

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -1,4 +1,4 @@
-import { randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
+import { randomBytes, randomUUID } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
@@ -9,7 +9,7 @@ import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
 import type { ContactStatus } from '../../../contacts/types.js';
 import { MessageRejectedError, type EventRouter } from '../event-router.js';
-import { assertSecret, hashToken, type SessionStore } from '../session-auth.js';
+import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
 
 export interface KnowledgeGraphRouteOptions {
   pool: Pool;
@@ -3540,15 +3540,7 @@ export async function knowledgeGraphRoutes(
     const body = request.body as { secret?: unknown };
     const provided = typeof body?.secret === 'string' ? body.secret : '';
 
-    // Use buffer byte lengths, not String.length, before timingSafeEqual — multi-byte UTF-8
-    // secrets have the same char count but different byte count, which causes timingSafeEqual
-    // to throw a RangeError if the char-count guard passes but byte lengths differ.
-    const providedBuf = Buffer.from(provided);
-    const secretBuf = Buffer.from(webAppBootstrapSecret);
-    if (
-      providedBuf.length !== secretBuf.length ||
-      !timingSafeEqual(providedBuf, secretBuf)
-    ) {
+    if (!compareSecrets(provided, webAppBootstrapSecret)) {
       return reply.status(401).send({ error: 'Invalid access key.' });
     }
 

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -3540,34 +3540,41 @@ export async function knowledgeGraphRoutes(
     const body = request.body as { secret?: unknown };
     const provided = typeof body?.secret === 'string' ? body.secret : '';
 
+    // Use buffer byte lengths, not String.length, before timingSafeEqual — multi-byte UTF-8
+    // secrets have the same char count but different byte count, which causes timingSafeEqual
+    // to throw a RangeError if the char-count guard passes but byte lengths differ.
+    const providedBuf = Buffer.from(provided);
+    const secretBuf = Buffer.from(webAppBootstrapSecret);
     if (
-      provided.length !== webAppBootstrapSecret.length ||
-      !timingSafeEqual(Buffer.from(provided), Buffer.from(webAppBootstrapSecret))
+      providedBuf.length !== secretBuf.length ||
+      !timingSafeEqual(providedBuf, secretBuf)
     ) {
       return reply.status(401).send({ error: 'Invalid access key.' });
     }
 
     // Issue a 256-bit random session token. The secret itself never goes in the cookie.
+    const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
     const token = randomBytes(32).toString('hex');
     const tokenHash = hashToken(token);
-    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours from now
-    sessions.set(tokenHash, expiresAt.getTime());
+    const expiresAt = new Date(Date.now() + SESSION_TTL_MS);
 
-    // Persist to Postgres so the session survives a process restart. ON CONFLICT is a safety
-    // net against the astronomically unlikely case of a hash collision on a 256-bit token.
+    // Write to Postgres first — if the DB write fails, the Map is never updated and the
+    // cookie is never sent, so no phantom session can be created.
+    // ON CONFLICT is a safety net against an astronomically unlikely 256-bit hash collision.
     await pool.query(
       `INSERT INTO sessions (token_hash, last_seen_at, expires_at)
        VALUES ($1, NOW(), $2)
        ON CONFLICT (token_hash) DO UPDATE SET expires_at = EXCLUDED.expires_at, last_seen_at = NOW()`,
       [tokenHash, expiresAt],
     );
+    sessions.set(tokenHash, expiresAt.getTime());
 
     reply.setCookie('curia_session', token, {
       httpOnly: true,
       secure: secureCookies,  // true in prod (https://), false for http://localhost
       sameSite: 'strict',
       path: '/',
-      maxAge: 86400,          // 24 hours in seconds
+      maxAge: SESSION_TTL_MS / 1000,
     });
 
     return reply.status(200).send({ ok: true });

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -3561,12 +3561,17 @@ export async function knowledgeGraphRoutes(
     // Write to Postgres first — if the DB write fails, the Map is never updated and the
     // cookie is never sent, so no phantom session can be created.
     // ON CONFLICT is a safety net against an astronomically unlikely 256-bit hash collision.
-    await pool.query(
-      `INSERT INTO sessions (token_hash, last_seen_at, expires_at)
-       VALUES ($1, NOW(), $2)
-       ON CONFLICT (token_hash) DO UPDATE SET expires_at = EXCLUDED.expires_at, last_seen_at = NOW()`,
-      [tokenHash, expiresAt],
-    );
+    try {
+      await pool.query(
+        `INSERT INTO sessions (token_hash, last_seen_at, expires_at)
+         VALUES ($1, NOW(), $2)
+         ON CONFLICT (token_hash) DO UPDATE SET expires_at = EXCLUDED.expires_at, last_seen_at = NOW()`,
+        [tokenHash, expiresAt],
+      );
+    } catch (err) {
+      logger.error({ err }, 'Failed to persist session to Postgres');
+      return reply.status(503).send({ error: 'Login is temporarily unavailable. Please try again.' });
+    }
     sessions.set(tokenHash, expiresAt.getTime());
 
     reply.setCookie('curia_session', token, {

--- a/src/channels/http/session-auth.ts
+++ b/src/channels/http/session-auth.ts
@@ -22,6 +22,20 @@ export function hashToken(token: string): string {
 }
 
 /**
+ * Timing-safe string comparison using Buffer byte lengths.
+ * Returns true only when a and b are byte-for-byte identical.
+ *
+ * Why byteLength not charLength: a multi-byte UTF-8 secret can have the same char count
+ * as a different-byte-length string, causing timingSafeEqual to throw a RangeError if
+ * the char-count guard passes but byte lengths differ.
+ */
+export function compareSecrets(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a);
+  const bBuf = Buffer.from(b);
+  return aBuf.length === bBuf.length && timingSafeEqual(aBuf, bBuf);
+}
+
+/**
  * Verify that the request is authenticated via session cookie or bootstrap secret header.
  *
  * Returns true if authenticated. Returns false and sends an error response if not.
@@ -63,15 +77,7 @@ export function assertSecret(
     });
     return false;
   }
-  // Compare byte lengths (not char lengths) before calling timingSafeEqual — it throws if
-  // the two buffers differ in length. A multi-byte UTF-8 secret can have the same char count
-  // but different byte length, so using Buffer.byteLength rather than String.length is correct.
-  const providedBuf = Buffer.from(provided);
-  const configuredBuf = Buffer.from(configuredSecret);
-  if (
-    providedBuf.length !== configuredBuf.length ||
-    !timingSafeEqual(providedBuf, configuredBuf)
-  ) {
+  if (!compareSecrets(provided, configuredSecret)) {
     reply.status(401).send({
       error: 'Unauthorized. Authenticate via POST /auth or provide the x-web-bootstrap-secret header.',
     });

--- a/src/channels/http/session-auth.ts
+++ b/src/channels/http/session-auth.ts
@@ -6,11 +6,20 @@
 //
 // The sessions Map is created in HttpAdapter and passed to both route registrations.
 
-import { timingSafeEqual } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 import type { FastifyRequest, FastifyReply } from 'fastify';
 
 // token → expiry timestamp in ms. Lives in HttpAdapter, shared across route registrations.
+// Map keys are SHA-256 hashes of the raw token so the plaintext never touches the DB.
 export type SessionStore = Map<string, number>;
+
+/**
+ * SHA-256 hash of a session token. Used as the Map key and the DB column value so the
+ * raw 256-bit token stays only in the HttpOnly cookie and is never persisted anywhere.
+ */
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
 
 /**
  * Verify that the request is authenticated via session cookie or bootstrap secret header.
@@ -39,7 +48,8 @@ export function assertSecret(
   const cookies = (request as unknown as { cookies?: Record<string, string | undefined> }).cookies;
   const sessionToken = cookies?.['curia_session'];
   if (sessionToken) {
-    const expiresAt = sessions.get(sessionToken);
+    // Hash before lookup — the Map is keyed by SHA-256(token), matching what was stored.
+    const expiresAt = sessions.get(hashToken(sessionToken));
     if (expiresAt !== undefined && Date.now() < expiresAt) return true;
     // Expired or unknown token — fall through to header check below.
   }

--- a/src/db/migrations/047_create_sessions.sql
+++ b/src/db/migrations/047_create_sessions.sql
@@ -8,10 +8,8 @@ CREATE TABLE sessions (
   expires_at   TIMESTAMPTZ NOT NULL
 );
 
--- Lookup by token hash is the hot path on every session validation after a restart.
-CREATE INDEX idx_sessions_token_hash ON sessions (token_hash);
-
--- Used by the prune sweep to delete expired rows efficiently.
+-- The UNIQUE constraint on token_hash already creates a btree index for the hot lookup path.
+-- This separate index covers only the prune sweep (DELETE WHERE expires_at < NOW()).
 CREATE INDEX idx_sessions_expires_at ON sessions (expires_at);
 
 -- Rollback: DROP TABLE sessions;

--- a/src/db/migrations/047_create_sessions.sql
+++ b/src/db/migrations/047_create_sessions.sql
@@ -1,0 +1,17 @@
+-- Up Migration
+
+CREATE TABLE sessions (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  token_hash   TEXT        NOT NULL UNIQUE,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at   TIMESTAMPTZ NOT NULL
+);
+
+-- Lookup by token hash is the hot path on every session validation after a restart.
+CREATE INDEX idx_sessions_token_hash ON sessions (token_hash);
+
+-- Used by the prune sweep to delete expired rows efficiently.
+CREATE INDEX idx_sessions_expires_at ON sessions (expires_at);
+
+-- Rollback: DROP TABLE sessions;

--- a/tests/unit/channels/http/identity-routes.test.ts
+++ b/tests/unit/channels/http/identity-routes.test.ts
@@ -3,6 +3,7 @@ import cookie from '@fastify/cookie';
 import type { Pool } from 'pg';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { identityRoutes } from '../../../../src/channels/http/routes/identity.js';
+import { hashToken } from '../../../../src/channels/http/session-auth.js';
 import type { OfficeIdentityService } from '../../../../src/identity/service.js';
 import type { OfficeIdentity } from '../../../../src/identity/types.js';
 
@@ -89,7 +90,7 @@ describe('GET /api/identity — configured flag', () => {
 
   it('accepts a valid session cookie in place of the header', async () => {
     const token = 'valid-session-token';
-    sessions.set(token, Date.now() + 60_000);
+    sessions.set(hashToken(token), Date.now() + 60_000);
 
     const pool = {
       query: vi.fn().mockResolvedValue({ rows: [{ configured: true }] }),
@@ -142,7 +143,7 @@ describe('PUT /api/identity — session cookie auth', () => {
 
   it('accepts PUT with a valid session cookie', async () => {
     const token = 'put-session-token';
-    sessions.set(token, Date.now() + 60_000);
+    sessions.set(hashToken(token), Date.now() + 60_000);
 
     const pool = { query: vi.fn() } as unknown as Pool;
     const identityService = createMockIdentityService();

--- a/tests/unit/channels/http/session-auth.test.ts
+++ b/tests/unit/channels/http/session-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { FastifyRequest, FastifyReply } from 'fastify';
-import { assertSecret, type SessionStore } from '../../../../src/channels/http/session-auth.js';
+import { assertSecret, hashToken, type SessionStore } from '../../../../src/channels/http/session-auth.js';
 
 // Helper: build a minimal FastifyRequest with optional session cookie and optional secret header.
 function makeRequest(opts: {
@@ -44,7 +44,8 @@ describe('assertSecret', () => {
 
   it('accepts a valid session cookie', () => {
     const token = 'valid-token-abc';
-    sessions.set(token, Date.now() + 60_000);
+    // Map is keyed by hash; assertSecret hashes the cookie value before lookup.
+    sessions.set(hashToken(token), Date.now() + 60_000);
     const request = makeRequest({ sessionToken: token });
     const reply = makeReply();
     expect(assertSecret(request, reply as unknown as FastifyReply, configuredSecret, sessions)).toBe(true);
@@ -52,7 +53,7 @@ describe('assertSecret', () => {
 
   it('rejects an expired session cookie', () => {
     const token = 'expired-token';
-    sessions.set(token, Date.now() - 1000);
+    sessions.set(hashToken(token), Date.now() - 1000);
     const request = makeRequest({ sessionToken: token });
     const reply = makeReply();
     expect(assertSecret(request, reply as unknown as FastifyReply, configuredSecret, sessions)).toBe(false);

--- a/tests/unit/channels/http/session-auth.test.ts
+++ b/tests/unit/channels/http/session-auth.test.ts
@@ -73,4 +73,16 @@ describe('assertSecret', () => {
     expect(assertSecret(request, reply as unknown as FastifyReply, undefined, sessions)).toBe(false);
     expect(reply.statusCode).toBe(503);
   });
+
+  it('rejects a multi-byte secret mismatch without throwing', () => {
+    // 'éé' (2 chars, 4 bytes UTF-8) vs '€€' (2 chars, 6 bytes UTF-8):
+    // same char count, different byte length — the old String.length guard would have
+    // passed the length check and caused timingSafeEqual to throw a RangeError.
+    const request = makeRequest({ secretHeader: 'éé' });
+    const reply = makeReply();
+    expect(() =>
+      assertSecret(request, reply as unknown as FastifyReply, '€€', sessions),
+    ).not.toThrow();
+    expect(reply.statusCode).toBe(401);
+  });
 });


### PR DESCRIPTION
## **User description**
## Summary

- Adds migration `047_create_sessions.sql` — a `sessions` table with `token_hash` (SHA-256), `expires_at`, `created_at`, and `last_seen_at` columns
- `POST /auth` now writes the hashed token to Postgres (before updating the in-memory Map), so each session is durable from the moment it's issued
- `HttpAdapter.start()` pre-populates the in-memory Map from Postgres on startup, so existing browser tabs survive a process restart without re-authenticating
- The 60-second prune interval now also runs `DELETE WHERE expires_at < NOW()` to keep the table clean
- `assertSecret()` behavior is unchanged — it hashes the cookie value before the Map lookup (Map keys were switched from raw tokens to SHA-256 hashes)
- Pre-existing bug fixed: `POST /auth` was comparing `String.length` instead of `Buffer.byteLength` before calling `timingSafeEqual`, which would throw a `RangeError` on multi-byte UTF-8 secrets

## Test plan

- [ ] All unit tests pass (`pnpm test` — 2765 passing; 2 pre-existing integration failures require `DATABASE_URL`)
- [ ] TypeScript typecheck passes (`pnpm run typecheck`)
- [ ] Manual smoke test: log in, restart Curia process, verify existing tab still authenticates (no 401)
- [ ] Two-tab test: log in from two tabs, restart process, verify both tabs remain authenticated
- [ ] Verify `sessions` table is created after running migrations

Closes #748


___

## **CodeAnt-AI Description**
**Keep web sessions working after a restart and reject invalid logins safely**

### What Changed
- Browser sessions are now saved in Postgres and restored when the app starts, so users stay signed in after a deploy or process restart
- Session data is stored as a SHA-256 hash instead of the raw token, and expired sessions are cleaned up from both memory and the database
- Login now fails with a clear 503 message if session storage cannot be written, instead of creating a broken session
- Access-key checks now compare the actual byte values, which avoids crashes with multi-byte secrets
- Session-related tests were updated to match hashed session keys

### Impact
`✅ Fewer sign-ins after deploys`
`✅ Fewer session losses on restart`
`✅ Clearer login failures when storage is unavailable`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication sessions now persist across application restarts, maintaining your login state throughout service updates and maintenance.

* **Bug Fixes and Improvements**
  * Enhanced session token security and validation.
  * Improved session storage and automatic cleanup of expired sessions for better system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->