### PR TITLE
feat: port Contacts view to new console app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Contacts view** — Contacts are now accessible at `/contacts` in the new console app with full create, edit, and delete support. Trust level is editable in the drawer. The legacy `/old/contacts` view has been removed. (#781)
+- **Contacts view** — new console page at `/contacts` with full CRUD and editable trust level; legacy `/old/contacts` removed. (#781)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **Contacts view** — Contacts are now accessible at `/contacts` in the new console app with full create, edit, and delete support. Trust level is editable in the drawer. The legacy `/old/contacts` view has been removed. (#781)
+
+### Changed
+
+- **`/api/kg/contacts`** — GET and PATCH responses now include `trustLevel`; PATCH accepts `trustLevel` to update it via `ContactService.setTrustLevel`.
+
 ### Fixed
 
 - **Migration 015 collision** — merged `015_create_bullpen` and `015_scheduler_resilience` into a single `015_bullpen_and_scheduler_resilience` to resolve a duplicate-prefix conflict.

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -1,0 +1,508 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { MobileMenuContext } from '../context/MobileMenu.js';
+import { Sidebar } from '../components/Sidebar.js';
+import { Topbar, TopbarSearch, TopbarDivider } from '../components/Topbar.js';
+import { apiFetch } from '../api.js';
+import { useTheme } from '../hooks/useTheme.js';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type ContactStatus = 'confirmed' | 'provisional' | 'blocked';
+type TrustLevel = 'ceo' | 'high' | 'medium' | 'low' | null;
+
+interface Contact {
+  id: string;
+  kgNodeId: string | null;
+  displayName: string;
+  role: string | null;
+  status: ContactStatus;
+  notes: string | null;
+  trustLevel: TrustLevel;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function initials(name: string): string {
+  return name.split(' ').map(s => s[0] ?? '').slice(0, 2).join('').toUpperCase();
+}
+
+function formatDate(iso: string): string {
+  return iso.slice(0, 10); // YYYY-MM-DD
+}
+
+async function errorMessage(res: Response): Promise<string> {
+  const ct = res.headers.get('content-type') ?? '';
+  if (ct.includes('application/json')) {
+    try {
+      const d = await res.json() as { error?: string };
+      if (d.error) return d.error;
+    } catch (err) {
+      console.error('[errorMessage] failed to parse JSON error body:', err);
+    }
+  }
+  return `HTTP ${res.status}`;
+}
+
+// ── Pagination component ──────────────────────────────────────────────────────
+
+interface PaginationProps {
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  onPage: (p: number) => void;
+  onPageSize: (n: number) => void;
+}
+
+function Pagination({ total, page, pageSize, totalPages, onPage, onPageSize }: PaginationProps) {
+  const start = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const end = Math.min(page * pageSize, total);
+
+  // @TODO: cap at 7 buttons with ellipsis when totalPages grows large.
+  const pages: number[] = [];
+  for (let i = 1; i <= totalPages; i++) pages.push(i);
+
+  return (
+    <div className="records-pagination">
+      <div className="records-pagination-info">
+        Showing <strong style={{ color: 'var(--app-fg)' }}>{start}–{end}</strong> of {total}
+      </div>
+      <div className="records-page-size">
+        Rows
+        <select value={pageSize} onChange={e => onPageSize(Number(e.target.value))}>
+          <option value="10">10</option>
+          <option value="25">25</option>
+          <option value="50">50</option>
+        </select>
+      </div>
+      <div className="records-pagination-controls">
+        <button className="records-page-btn" onClick={() => onPage(page - 1)} disabled={page <= 1}>‹</button>
+        {pages.map(p => (
+          <button key={p} className={`records-page-btn${p === page ? ' active' : ''}`} onClick={() => onPage(p)}>{p}</button>
+        ))}
+        <button className="records-page-btn" onClick={() => onPage(page + 1)} disabled={page >= totalPages}>›</button>
+      </div>
+    </div>
+  );
+}
+
+// ── Edit / Create drawer ──────────────────────────────────────────────────────
+
+interface DrawerProps {
+  contact: Contact | null;
+  creating: boolean;
+  onClose: () => void;
+  onSaved: (contact: Contact) => void;
+  onDeleted: (id: string) => void;
+}
+
+function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: DrawerProps) {
+  const [displayName, setDisplayName] = useState(contact?.displayName ?? '');
+  const [role, setRole] = useState(contact?.role ?? '');
+  const [status, setStatus] = useState<ContactStatus>(contact?.status ?? 'provisional');
+  const [trustLevel, setTrustLevel] = useState<TrustLevel>(contact?.trustLevel ?? null);
+  const [kgNodeId, setKgNodeId] = useState(contact?.kgNodeId ?? '');
+  const [notes, setNotes] = useState(contact?.notes ?? '');
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSave() {
+    if (!displayName.trim()) {
+      setError('Display name is required.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const body = {
+        displayName: displayName.trim(),
+        role: role.trim() || null,
+        status,
+        trustLevel: trustLevel ?? null,
+        notes: notes.trim() || null,
+        kgNodeId: kgNodeId.trim() || null,
+      };
+
+      let res: Response;
+      if (creating) {
+        res = await apiFetch('/api/kg/contacts', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+      } else {
+        res = await apiFetch(`/api/kg/contacts/${contact!.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+      }
+
+      if (!res.ok) {
+        throw new Error(await errorMessage(res));
+      }
+
+      const data = await res.json() as { contact: Contact };
+      onSaved(data.contact);
+    } catch (err) {
+      console.error('[ContactEditDrawer] save failed:', err);
+      setError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!contact) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await apiFetch(`/api/kg/contacts/${contact.id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error(await errorMessage(res));
+      onDeleted(contact.id);
+    } catch (err) {
+      console.error('[ContactEditDrawer] delete failed:', err);
+      setError(err instanceof Error ? err.message : 'Delete failed');
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <aside className="drawer">
+      <div className="drawer-header">
+        <div className="drawer-header-top">
+          <span className="badge badge-person">contact</span>
+          <button className="drawer-close" onClick={onClose} aria-label="Close">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <line x1="6" y1="6" x2="18" y2="18" /><line x1="18" y1="6" x2="6" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <h2 className="drawer-title-h2">{creating ? 'New contact' : (contact?.displayName ?? '')}</h2>
+        {!creating && contact && (
+          <div className="drawer-subtitle">{[contact.role].filter(Boolean).join(' · ')}</div>
+        )}
+      </div>
+
+      <div className="drawer-body">
+        <div className="edit-drawer-form">
+          {error && <p style={{ color: 'var(--app-destructive)', margin: 0, fontSize: 13 }}>{error}</p>}
+
+          <div className="form-grid">
+            <div className="form-field">
+              <label htmlFor="cf-name">Display name</label>
+              <input id="cf-name" type="text" value={displayName} onChange={e => setDisplayName(e.target.value)} placeholder="Full name" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-role">Role</label>
+              <input id="cf-role" type="text" value={role} onChange={e => setRole(e.target.value)} placeholder="Title" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-status">Status</label>
+              <select id="cf-status" value={status} onChange={e => setStatus(e.target.value as ContactStatus)}>
+                <option value="confirmed">Confirmed</option>
+                <option value="provisional">Provisional</option>
+                <option value="blocked">Blocked</option>
+              </select>
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-trust">Trust level</label>
+              <select id="cf-trust" value={trustLevel ?? ''} onChange={e => setTrustLevel((e.target.value || null) as TrustLevel)}>
+                <option value="">None</option>
+                <option value="ceo">CEO</option>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="cf-kg">KG node ID</label>
+            <input id="cf-kg" type="text" value={kgNodeId} onChange={e => setKgNodeId(e.target.value)} placeholder="UUID — optional" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="cf-notes">Notes</label>
+            <textarea id="cf-notes" rows={4} value={notes} onChange={e => setNotes(e.target.value)} />
+          </div>
+        </div>
+      </div>
+
+      <div className="drawer-footer">
+        {!creating && (
+          <button className="btn btn-danger btn-sm" onClick={() => void handleDelete()} disabled={deleting}>
+            {deleting ? 'Deleting…' : 'Delete'}
+          </button>
+        )}
+        <div style={{ flex: 1 }} />
+        <button className="btn btn-secondary btn-sm" onClick={onClose}>Cancel</button>
+        <button className="btn btn-primary btn-sm" onClick={() => void handleSave()} disabled={saving}>
+          {saving ? 'Saving…' : creating ? 'Create' : 'Save changes'}
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function ContactsPage() {
+  const [theme, setTheme] = useTheme();
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'all' | ContactStatus>('all');
+  const [sort, setSort] = useState<{ key: keyof Contact; dir: 'asc' | 'desc' }>({ key: 'updatedAt', dir: 'desc' });
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [editing, setEditing] = useState<Contact | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
+  }, [mobileOpen]);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await apiFetch('/api/kg/contacts');
+      if (!res.ok) throw new Error(await errorMessage(res));
+      const data = await res.json() as { contacts: Contact[] };
+      setContacts(data.contacts);
+    } catch (err) {
+      console.error('[ContactsPage] failed to load contacts:', err);
+      setLoadError(err instanceof Error ? err.message : 'Failed to load contacts');
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  function handleNavigate(view: string) {
+    const routes: Record<string, string> = {
+      contacts:  '/contacts',
+      kg:        '/',
+      chat:      '/',
+      tasks:     '/',
+      jobs:      '/',
+      autonomy:  '/settings/autonomy',
+      settings:  '/settings/autonomy',
+      wizard:    '/setup',
+    };
+    const to = routes[view];
+    if (to) {
+      navigate({ to }).catch(err => {
+        console.error(`[ContactsPage] navigation to ${to} failed:`, err);
+      });
+    }
+  }
+
+  const counts = useMemo(() => ({
+    all:         contacts.length,
+    confirmed:   contacts.filter(c => c.status === 'confirmed').length,
+    provisional: contacts.filter(c => c.status === 'provisional').length,
+    blocked:     contacts.filter(c => c.status === 'blocked').length,
+  }), [contacts]);
+
+  const filtered = useMemo(() => {
+    let rows = contacts;
+    if (statusFilter !== 'all') rows = rows.filter(c => c.status === statusFilter);
+    if (search) {
+      const q = search.toLowerCase();
+      rows = rows.filter(c =>
+        (c.displayName + ' ' + (c.role ?? '')).toLowerCase().includes(q)
+      );
+    }
+    const dir = sort.dir === 'asc' ? 1 : -1;
+    rows = [...rows].sort((a, b) => {
+      const av = (a[sort.key] ?? '') as string;
+      const bv = (b[sort.key] ?? '') as string;
+      if (av < bv) return -1 * dir;
+      if (av > bv) return  1 * dir;
+      return 0;
+    });
+    return rows;
+  }, [contacts, statusFilter, search, sort]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
+  const safePage = Math.min(page, totalPages);
+  const pageRows = filtered.slice((safePage - 1) * pageSize, safePage * pageSize);
+
+  function toggleSort(key: keyof Contact) {
+    setSort(s => s.key === key
+      ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
+      : { key, dir: 'asc' });
+  }
+  const sortArrow = (key: keyof Contact) => sort.key === key ? (sort.dir === 'asc' ? '↑' : '↓') : '';
+
+  function handleSaved(contact: Contact) {
+    setContacts(prev => {
+      const idx = prev.findIndex(c => c.id === contact.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = contact;
+        return next;
+      }
+      return [...prev, contact];
+    });
+    setEditing(contact);
+    setCreating(false);
+  }
+
+  function handleDeleted(id: string) {
+    setContacts(prev => prev.filter(c => c.id !== id));
+    setEditing(null);
+    setCreating(false);
+  }
+
+  return (
+    <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
+      <div className="app-root">
+        <Sidebar activeView="contacts" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
+        {mobileOpen && (
+          <div
+            className="sidebar-backdrop"
+            onClick={() => setMobileOpen(false)}
+            aria-hidden="true"
+          />
+        )}
+        <main className="main">
+          <Topbar crumb="Memory" title="Contacts">
+            <TopbarSearch
+              placeholder="Search name or role…"
+              value={search}
+              onChange={v => { setSearch(v); setPage(1); }}
+            />
+            <TopbarDivider />
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={() => { setEditing(null); setCreating(true); }}
+            >
+              + New contact
+            </button>
+          </Topbar>
+
+          {loadError ? (
+            <div style={{ padding: 32, color: 'var(--app-destructive)', fontSize: 13 }}>{loadError}</div>
+          ) : (
+            <>
+              <div className="records-toolbar">
+                <div className="records-toolbar-left">
+                  {(['all', 'confirmed', 'provisional', 'blocked'] as const).map(v => (
+                    <button
+                      key={v}
+                      className={`records-filter-chip${statusFilter === v ? ' active' : ''}`}
+                      onClick={() => { setStatusFilter(v); setPage(1); }}
+                    >
+                      {v === 'all' ? 'All' : v.charAt(0).toUpperCase() + v.slice(1)}
+                      <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, opacity: 0.7 }}>
+                        {counts[v]}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+                <div className="records-toolbar-right">
+                  <span className="topbar-meta">{filtered.length} of {contacts.length}</span>
+                </div>
+              </div>
+
+              <div className="records-layout">
+                <div className="records-main">
+                  <div className="records-table-wrap">
+                    <table className="records-table">
+                      <thead>
+                        <tr>
+                          <th className="sortable" onClick={() => toggleSort('displayName')}>
+                            Name <span className="sort-arrow">{sortArrow('displayName')}</span>
+                          </th>
+                          <th className="sortable" onClick={() => toggleSort('role')}>
+                            Role <span className="sort-arrow">{sortArrow('role')}</span>
+                          </th>
+                          <th className="col-org">Organization</th>
+                          <th className="sortable" onClick={() => toggleSort('status')}>
+                            Status <span className="sort-arrow">{sortArrow('status')}</span>
+                          </th>
+                          <th className="col-email">Email</th>
+                          <th className="sortable col-updated" onClick={() => toggleSort('updatedAt')}>
+                            Updated <span className="sort-arrow">{sortArrow('updatedAt')}</span>
+                          </th>
+                          <th style={{ textAlign: 'right' }}>Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {pageRows.map(c => (
+                          <tr
+                            key={c.id}
+                            className={editing?.id === c.id ? 'active' : ''}
+                            onClick={() => { setCreating(false); setEditing(c); }}
+                          >
+                            <td>
+                              <div className="cell-with-avatar">
+                                <span className="avatar-sm">{initials(c.displayName)}</span>
+                                <span className="cell-primary">{c.displayName}</span>
+                              </div>
+                            </td>
+                            <td>{c.role ?? ''}</td>
+                            <td className="cell-muted col-org"></td>
+                            <td><span className={`status-pill ${c.status}`}>{c.status}</span></td>
+                            <td className="cell-mono col-email"></td>
+                            <td className="cell-mono col-updated">{formatDate(c.updatedAt)}</td>
+                            <td>
+                              <div className="cell-actions" onClick={e => e.stopPropagation()}>
+                                <button
+                                  className="btn-icon"
+                                  title="Edit"
+                                  onClick={() => { setCreating(false); setEditing(c); }}
+                                >
+                                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                    <path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"/>
+                                  </svg>
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        ))}
+                        {pageRows.length === 0 && (
+                          <tr>
+                            <td colSpan={7} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
+                              No contacts match.
+                            </td>
+                          </tr>
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                  <Pagination
+                    total={filtered.length}
+                    page={safePage}
+                    pageSize={pageSize}
+                    totalPages={totalPages}
+                    onPage={setPage}
+                    onPageSize={n => { setPageSize(n); setPage(1); }}
+                  />
+                </div>
+
+                {(editing !== null || creating) && (
+                  <ContactEditDrawer
+                    key={editing?.id ?? 'new'}
+                    contact={editing}
+                    creating={creating}
+                    onClose={() => { setEditing(null); setCreating(false); }}
+                    onSaved={handleSaved}
+                    onDeleted={handleDeleted}
+                  />
+                )}
+              </div>
+            </>
+          )}
+        </main>
+      </div>
+    </MobileMenuContext.Provider>
+  );
+}

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -10,6 +10,7 @@ import { useTheme } from '../hooks/useTheme.js';
 
 type ContactStatus = 'confirmed' | 'provisional' | 'blocked';
 type TrustLevel = 'ceo' | 'high' | 'medium' | 'low' | null;
+type SystemRole = 'principal' | 'agent' | 'system' | null;
 
 interface Contact {
   id: string;
@@ -19,6 +20,7 @@ interface Contact {
   status: ContactStatus;
   notes: string | null;
   trustLevel: TrustLevel;
+  systemRole: SystemRole;
   createdAt: string;
   updatedAt: string;
 }
@@ -235,7 +237,12 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
 
       <div className="drawer-footer">
         {!creating && (
-          <button className="btn btn-danger btn-sm" onClick={() => void handleDelete()} disabled={deleting}>
+          <button
+            className="btn btn-danger btn-sm"
+            onClick={() => void handleDelete()}
+            disabled={deleting || contact?.systemRole !== null && contact?.systemRole !== undefined}
+            title={contact?.systemRole ? 'System contacts cannot be deleted' : undefined}
+          >
             {deleting ? 'Deleting…' : 'Delete'}
           </button>
         )}
@@ -446,6 +453,12 @@ export default function ContactsPage() {
                               <div className="cell-with-avatar">
                                 <span className="avatar-sm">{initials(c.displayName)}</span>
                                 <span className="cell-primary">{c.displayName}</span>
+                                {c.systemRole === 'principal' && (
+                                  <span className="system-role-badge system-role-principal">Principal</span>
+                                )}
+                                {c.systemRole === 'agent' && (
+                                  <span className="system-role-badge system-role-agent">Agent</span>
+                                )}
                               </div>
                             </td>
                             <td>{c.role ?? ''}</td>

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -399,6 +399,16 @@ export default function ContactsPage() {
             <div style={{ padding: 32, color: 'var(--app-destructive)', fontSize: 13 }}>{loadError}</div>
           ) : (
             <>
+              {/* Mobile search — TopbarSearch is hidden below 768px by the shared stylesheet */}
+              <div className="contacts-mobile-search">
+                <input
+                  type="text"
+                  placeholder="Search name or role…"
+                  value={search}
+                  onChange={e => { setSearch(e.target.value); setPage(1); }}
+                />
+              </div>
+
               <div className="records-toolbar">
                 <div className="records-toolbar-left">
                   {(['all', 'confirmed', 'provisional', 'blocked'] as const).map(v => (
@@ -425,19 +435,25 @@ export default function ContactsPage() {
                     <table className="records-table">
                       <thead>
                         <tr>
-                          <th className="sortable" onClick={() => toggleSort('displayName')}>
-                            Name <span className="sort-arrow">{sortArrow('displayName')}</span>
+                          <th className="sortable" aria-sort={sort.key === 'displayName' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('displayName')}>
+                              Name <span className="sort-arrow">{sortArrow('displayName')}</span>
+                            </button>
                           </th>
-                          <th className="sortable" onClick={() => toggleSort('role')}>
-                            Role <span className="sort-arrow">{sortArrow('role')}</span>
+                          <th className="sortable" aria-sort={sort.key === 'role' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('role')}>
+                              Role <span className="sort-arrow">{sortArrow('role')}</span>
+                            </button>
                           </th>
-                          <th className="col-org">Organization</th>
-                          <th className="sortable" onClick={() => toggleSort('status')}>
-                            Status <span className="sort-arrow">{sortArrow('status')}</span>
+                          <th className="sortable" aria-sort={sort.key === 'status' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('status')}>
+                              Status <span className="sort-arrow">{sortArrow('status')}</span>
+                            </button>
                           </th>
-                          <th className="col-email">Email</th>
-                          <th className="sortable col-updated" onClick={() => toggleSort('updatedAt')}>
-                            Updated <span className="sort-arrow">{sortArrow('updatedAt')}</span>
+                          <th className="sortable col-updated" aria-sort={sort.key === 'updatedAt' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('updatedAt')}>
+                              Updated <span className="sort-arrow">{sortArrow('updatedAt')}</span>
+                            </button>
                           </th>
                           <th style={{ textAlign: 'right' }}>Actions</th>
                         </tr>
@@ -462,9 +478,7 @@ export default function ContactsPage() {
                               </div>
                             </td>
                             <td>{c.role ?? ''}</td>
-                            <td className="cell-muted col-org"></td>
                             <td><span className={`status-pill ${c.status}`}>{c.status}</span></td>
-                            <td className="cell-mono col-email"></td>
                             <td className="cell-mono col-updated">{formatDate(c.updatedAt)}</td>
                             <td>
                               <div className="cell-actions" onClick={e => e.stopPropagation()}>
@@ -483,7 +497,7 @@ export default function ContactsPage() {
                         ))}
                         {pageRows.length === 0 && (
                           <tr>
-                            <td colSpan={7} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
+                            <td colSpan={5} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
                               No contacts match.
                             </td>
                           </tr>

--- a/apps/console/src/pages/DashboardPage.tsx
+++ b/apps/console/src/pages/DashboardPage.tsx
@@ -15,7 +15,11 @@ export default function DashboardPage() {
   }, [mobileOpen]);
 
   function handleNavigate(view: string) {
-    if (view === 'autonomy') {
+    if (view === 'contacts') {
+      navigate({ to: '/contacts' }).catch(err => {
+        console.error('[DashboardPage] navigation to /contacts failed:', err);
+      });
+    } else if (view === 'autonomy' || view === 'settings') {
       navigate({ to: '/settings/autonomy' }).catch(err => {
         console.error('[DashboardPage] navigation to /settings/autonomy failed:', err);
       });

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -337,7 +337,11 @@ function SettingsLayout({ activeSection, children }: SettingsLayoutProps) {
   }, [mobileOpen]);
 
   function handleNavigate(view: string) {
-    if (view === 'autonomy') {
+    if (view === 'contacts') {
+      navigate({ to: '/contacts' }).catch(err => {
+        console.error('[SettingsLayout] navigation to /contacts failed:', err);
+      });
+    } else if (view === 'autonomy') {
       navigate({ to: '/settings/autonomy' }).catch(err => {
         console.error('[SettingsLayout] navigation to /settings/autonomy failed:', err);
       });

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -18,6 +18,7 @@ const WorkspacePage = lazy(() =>
   import('./pages/SettingsPage').then(m => ({ default: m.WorkspacePage })),
 );
 const WizardPage = lazy(() => import('./pages/WizardPage'));
+const ContactsPage = lazy(() => import('./pages/ContactsPage'));
 
 const rootRoute = createRootRoute({
   component: () => (
@@ -95,10 +96,17 @@ const loginRoute = createRoute({
   component: LoginPage,
 });
 
+const contactsRoute = createRoute({
+  getParentRoute: () => authedRoute,
+  path: '/contacts',
+  component: ContactsPage,
+});
+
 const routeTree = rootRoute.addChildren([
   authedRoute.addChildren([
     dashboardRoute,
     setupRoute,
+    contactsRoute,
     settingsRoute.addChildren([autonomyRoute, workspaceRoute]),
   ]),
   loginRoute,

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -251,10 +251,16 @@ body {
   min-width: 180px;
 }
 .topbar-search-icon { flex: none; color: var(--app-fg-muted); }
-.topbar-search input {
+/* Higher specificity than the global input[type="text"] rule to prevent double border. */
+.topbar-search input,
+.topbar-search input[type="text"] {
   flex: 1; border: none; background: transparent;
   color: var(--app-fg); font-family: inherit; font-size: 13px;
-  outline: none; padding: 0;
+  outline: none; padding: 0; width: auto; box-shadow: none;
+}
+.topbar-search input:focus,
+.topbar-search input[type="text"]:focus {
+  border: none; box-shadow: none;
 }
 @media (max-width: 768px) { .topbar-search { display: none; } }
 
@@ -1000,7 +1006,26 @@ table.records-table tbody tr.active td { background: transparent; }
 .cell-muted   { color: var(--app-fg-muted); font-size: 12px; }
 .cell-mono    { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--app-fg-muted); }
 .cell-actions { display: flex; gap: 4px; justify-content: flex-end; }
-.cell-with-avatar { display: flex; align-items: center; gap: 10px; }
+.cell-with-avatar { display: flex; align-items: center; gap: 8px; }
+.system-role-badge {
+  display: inline-block;
+  font-size: 10px; font-weight: 700; letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 1px 6px; border-radius: 4px;
+  border: 1px solid;
+  line-height: 1.6;
+  flex-shrink: 0;
+}
+.system-role-principal {
+  background: color-mix(in srgb, var(--app-teal) 12%, transparent);
+  color: var(--app-teal);
+  border-color: color-mix(in srgb, var(--app-teal) 30%, transparent);
+}
+.system-role-agent {
+  background: color-mix(in srgb, var(--app-fg-muted) 12%, transparent);
+  color: var(--app-fg-muted);
+  border-color: color-mix(in srgb, var(--app-fg-muted) 30%, transparent);
+}
 
 .avatar-sm {
   width: 26px; height: 26px;

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -909,7 +909,7 @@ input:focus, textarea:focus, select:focus {
 }
 .drawer-title-h2 {
   margin: 2px 0 0;
-  font-family: 'Lora', Georgia, serif;
+  font-family: Lora, Georgia, serif;
   font-weight: 500; font-size: 22px; line-height: 1.2;
   color: var(--app-fg);
 }
@@ -937,6 +937,10 @@ input:focus, textarea:focus, select:focus {
 .edit-drawer-form { padding: 16px 18px; display: flex; flex-direction: column; gap: 14px; }
 
 /* ── Records (CRUD table views) ────────────────────────────────────── */
+/* Mobile-only search bar (TopbarSearch is hidden below 768px by the shared stylesheet) */
+.contacts-mobile-search { display: none; padding: 8px 16px; }
+.contacts-mobile-search input { width: 100%; }
+
 .records-layout { flex: 1; display: flex; overflow: hidden; min-height: 0; }
 .records-main {
   flex: 1; display: flex; flex-direction: column; overflow: hidden; min-width: 0;
@@ -981,8 +985,13 @@ table.records-table thead th {
   white-space: nowrap;
   z-index: 1;
 }
-table.records-table thead th.sortable { cursor: pointer; user-select: none; }
+table.records-table thead th.sortable { user-select: none; }
 table.records-table thead th.sortable:hover { color: var(--app-fg); }
+table.records-table thead th.sortable .sort-btn {
+  background: none; border: none; padding: 0;
+  font: inherit; color: inherit; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 4px;
+}
 table.records-table thead th .sort-arrow {
   display: inline-block; margin-left: 4px; opacity: 0.6; font-size: 10px;
 }
@@ -1093,9 +1102,9 @@ table.records-table tbody tr.active td { background: transparent; }
   }
   .form-grid { grid-template-columns: 1fr; }
   /* Hide lower-priority columns on narrow screens */
-  table.records-table .col-org,
-  table.records-table .col-email,
   table.records-table .col-updated { display: none; }
   .records-toolbar { padding: 8px 14px; }
   .records-pagination { padding: 8px 14px; }
+  /* Show the mobile search bar (TopbarSearch is hidden at this breakpoint) */
+  .contacts-mobile-search { display: block; }
 }

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -849,3 +849,228 @@ input:focus, textarea:focus, select:focus {
   font-size: 0.8125rem;
   margin-bottom: 12px;
 }
+
+/* ── Badges ────────────────────────────────────────────────────────── */
+.badge {
+  display: inline-block; padding: 2px 9px; border-radius: 999px;
+  font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+  color: #fff; line-height: 1.4;
+}
+.badge-person       { background: var(--app-teal); }
+.badge-organization { background: var(--app-blue-soft); color: #111; }
+.badge-project      { background: var(--app-violet); }
+.badge-decision     { background: var(--app-amber); }
+.badge-event        { background: var(--app-green); }
+.badge-concept      { background: #888; }
+.badge-fact         { background: #444; }
+
+/* Status pills — outlined, subtle, with a colored leading dot */
+.status-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 2px 10px 2px 8px;
+  border-radius: 999px;
+  font-size: 11px; font-weight: 600;
+  background: var(--app-muted);
+  color: var(--app-fg);
+  letter-spacing: 0.02em;
+  text-transform: capitalize;
+}
+.status-pill::before {
+  content: ''; width: 6px; height: 6px; border-radius: 50%;
+  background: var(--app-fg-muted);
+}
+.status-pill.confirmed::before  { background: var(--app-green); }
+.status-pill.provisional::before { background: var(--app-amber); }
+.status-pill.blocked::before    { background: var(--app-destructive); }
+
+/* ── Drawer (right-anchored) ───────────────────────────────────────── */
+.drawer {
+  flex: none;
+  width: 340px;
+  border-left: 1px solid var(--app-border);
+  background: var(--app-card);
+  display: flex; flex-direction: column; overflow: hidden;
+  box-shadow: var(--shadow-drawer);
+}
+.drawer-header {
+  flex: none;
+  padding: 16px 18px 14px;
+  border-bottom: 1px solid var(--app-border);
+  display: flex; flex-direction: column; gap: 8px;
+}
+.drawer-header-top {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 12px;
+}
+.drawer-title-h2 {
+  margin: 2px 0 0;
+  font-family: 'Lora', Georgia, serif;
+  font-weight: 500; font-size: 22px; line-height: 1.2;
+  color: var(--app-fg);
+}
+.drawer-subtitle {
+  font-size: 12px; color: var(--app-fg-muted);
+}
+.drawer-close {
+  background: none; border: none; color: var(--app-fg-muted); cursor: pointer;
+  padding: 4px; border-radius: 4px;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: background 120ms, color 120ms;
+}
+.drawer-close:hover { color: var(--app-fg); background: var(--app-muted); }
+.drawer-body {
+  flex: 1; overflow-y: auto; padding: 14px 0;
+  display: flex; flex-direction: column;
+}
+.drawer-footer {
+  flex: none;
+  padding: 10px 14px;
+  border-top: 1px solid var(--app-border);
+  display: flex; gap: 8px; justify-content: flex-end;
+  background: var(--app-card);
+}
+.edit-drawer-form { padding: 16px 18px; display: flex; flex-direction: column; gap: 14px; }
+
+/* ── Records (CRUD table views) ────────────────────────────────────── */
+.records-layout { flex: 1; display: flex; overflow: hidden; min-height: 0; }
+.records-main {
+  flex: 1; display: flex; flex-direction: column; overflow: hidden; min-width: 0;
+}
+.records-toolbar {
+  flex: none;
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 20px;
+  border-bottom: 1px solid var(--app-border);
+  background: var(--app-bg);
+}
+.records-toolbar-left  { display: flex; align-items: center; gap: 10px; }
+.records-toolbar-right { margin-left: auto; display: flex; align-items: center; gap: 8px; }
+.records-filter-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px;
+  background: var(--app-card);
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  font-size: 12px; color: var(--app-fg-muted);
+  cursor: pointer;
+  transition: all 120ms;
+}
+.records-filter-chip:hover { color: var(--app-fg); border-color: var(--app-input-bd); }
+.records-filter-chip.active { color: var(--app-fg); border-color: var(--app-teal); background: var(--app-teal-soft); }
+
+.records-table-wrap { flex: 1; overflow: auto; background: var(--app-bg); }
+table.records-table {
+  width: 100%;
+  border-collapse: separate; border-spacing: 0;
+  font-size: 13px;
+}
+table.records-table thead th {
+  position: sticky; top: 0;
+  background: var(--app-bg);
+  border-bottom: 1px solid var(--app-border);
+  text-align: left;
+  font-size: 11px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--app-fg-muted);
+  padding: 10px 16px;
+  white-space: nowrap;
+  z-index: 1;
+}
+table.records-table thead th.sortable { cursor: pointer; user-select: none; }
+table.records-table thead th.sortable:hover { color: var(--app-fg); }
+table.records-table thead th .sort-arrow {
+  display: inline-block; margin-left: 4px; opacity: 0.6; font-size: 10px;
+}
+table.records-table tbody td {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--app-border-soft);
+  color: var(--app-fg);
+  vertical-align: middle;
+}
+table.records-table tbody tr {
+  cursor: pointer;
+  transition: background 120ms;
+}
+table.records-table tbody tr:hover { background: var(--app-row-hover); }
+table.records-table tbody tr.active { background: var(--app-teal-soft); }
+table.records-table tbody tr:nth-child(even) td { background: var(--app-row-zebra); }
+table.records-table tbody tr:hover td { background: transparent; }
+table.records-table tbody tr.active td { background: transparent; }
+
+.cell-primary { font-weight: 600; color: var(--app-fg); }
+.cell-muted   { color: var(--app-fg-muted); font-size: 12px; }
+.cell-mono    { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--app-fg-muted); }
+.cell-actions { display: flex; gap: 4px; justify-content: flex-end; }
+.cell-with-avatar { display: flex; align-items: center; gap: 10px; }
+
+.avatar-sm {
+  width: 26px; height: 26px;
+  background: var(--app-muted);
+  border: 1px solid var(--app-border);
+  border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 10px; font-weight: 700;
+  color: var(--app-fg);
+  flex: none;
+}
+
+/* Pagination */
+.records-pagination {
+  flex: none;
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 20px;
+  border-top: 1px solid var(--app-border);
+  background: var(--app-bg);
+  font-size: 12px; color: var(--app-fg-muted);
+}
+.records-pagination-info { color: var(--app-fg-muted); }
+.records-pagination-controls { margin-left: auto; display: flex; align-items: center; gap: 4px; }
+.records-page-btn {
+  min-width: 28px; height: 28px; padding: 0 8px;
+  border: 1px solid var(--app-border);
+  background: var(--app-card);
+  color: var(--app-fg);
+  border-radius: 6px;
+  font-family: inherit; font-size: 12px; font-weight: 500;
+  cursor: pointer;
+  transition: all 120ms;
+}
+.records-page-btn:hover:not(:disabled) { border-color: var(--app-input-bd); background: var(--app-muted); }
+.records-page-btn.active { background: var(--app-fg); color: var(--app-bg); border-color: var(--app-fg); }
+.records-page-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.records-page-size {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 12px; color: var(--app-fg-muted);
+}
+.records-page-size select { width: auto; padding: 4px 8px; font-size: 12px; }
+
+/* Edit drawer form grid */
+.form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.form-field { display: flex; flex-direction: column; gap: 6px; }
+.form-field label {
+  font-size: 11px; color: var(--app-fg-muted);
+  text-transform: uppercase; letter-spacing: 0.06em;
+  font-weight: 600;
+}
+.form-field-readonly {
+  font-size: 13px; color: var(--app-fg);
+  padding: 8px 12px;
+  background: var(--app-muted);
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+}
+
+/* Responsive adjustments for records views */
+@media (max-width: 768px) {
+  .drawer {
+    position: fixed; inset: 0;
+    width: 100%; box-shadow: none;
+    z-index: 50;
+  }
+  .form-grid { grid-template-columns: 1fr; }
+  /* Hide lower-priority columns on narrow screens */
+  table.records-table .col-org,
+  table.records-table .col-email,
+  table.records-table .col-updated { display: none; }
+  .records-toolbar { padding: 8px 14px; }
+  .records-pagination { padding: 8px 14px; }
+}

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -2992,6 +2992,7 @@ export async function knowledgeGraphRoutes(
         role: contact.role,
         status: contact.status,
         trustLevel: contact.trustLevel,
+        systemRole: contact.systemRole,
         notes: contact.notes,
         createdAt: contact.createdAt.toISOString(),
         updatedAt: contact.updatedAt.toISOString(),

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -7,7 +7,7 @@ import type { EventBus } from '../../../bus/bus.js';
 import { createInboundMessage } from '../../../bus/events.js';
 import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
-import type { ContactStatus } from '../../../contacts/types.js';
+import type { ContactStatus, TrustLevel } from '../../../contacts/types.js';
 import { MessageRejectedError, type EventRouter } from '../event-router.js';
 import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
 
@@ -534,48 +534,6 @@ function createUiHtml(): string {
     .conv-item:hover  { background: var(--accent); color: var(--fg); }
     .conv-item.active { background: var(--muted);  color: var(--fg); }
 
-    /* Contacts view */
-    .contacts-layout {
-      flex: 1;
-      display: flex;
-      overflow: hidden;
-    }
-    .contacts-list-panel {
-      flex: none;
-      width: 360px;
-      border-right: 1px solid var(--border);
-      display: flex;
-      flex-direction: column;
-      overflow: hidden;
-    }
-    .contacts-list {
-      flex: 1;
-      overflow-y: auto;
-      padding: 10px;
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-    .contact-card {
-      padding: 10px;
-      border: 1px solid var(--border);
-      border-radius: var(--radius-md);
-      cursor: pointer;
-      transition: border-color 0.12s, background 0.12s;
-    }
-    .contact-card:hover { border-color: var(--teal); }
-    .contact-card.active {
-      border-color: var(--teal);
-      background: rgba(71,129,137,0.08);
-    }
-    .contacts-editor {
-      flex: 1;
-      overflow-y: auto;
-      padding: 16px;
-      display: flex;
-      flex-direction: column;
-      gap: 14px;
-    }
     .tasks-layout {
       flex: 1;
       display: flex;
@@ -798,15 +756,6 @@ function createUiHtml(): string {
               Knowledge Graph
             </button>
 
-            <button id="nav-contacts" class="nav-sub-item" onclick="navigate('contacts', 'Contacts', 'nav-contacts')">
-              <!-- person icon -->
-              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                <circle cx="6.5" cy="4" r="2.5"/>
-                <path d="M1 12c0-3.038 2.462-5.5 5.5-5.5S12 8.962 12 12"/>
-              </svg>
-              Contacts
-            </button>
-
             <button id="nav-tasks" class="nav-sub-item" onclick="navigate('tasks', 'Tasks', 'nav-tasks')">
               <!-- checklist icon -->
               <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -898,61 +847,6 @@ function createUiHtml(): string {
             </div>
           </div>
 
-        </div>
-      </div>
-
-      <!-- Contacts view -->
-      <div id="view-contacts" style="display: none; height: 100%; flex-direction: column;">
-        <div style="flex: none; display: flex; align-items: center; gap: 10px; padding: 10px 16px; border-bottom: 1px solid var(--border);">
-          <input id="contacts-search-input" type="text" placeholder="Search contacts by name or role\u2026" style="max-width: 360px;" />
-          <button id="contacts-search-btn" class="btn-primary">Search</button>
-          <button id="contacts-new-btn" class="btn-primary">+ New Contact</button>
-          <span id="contacts-status" style="font-size: 0.75rem; color: var(--fg-muted); margin-left: 4px;"></span>
-        </div>
-        <div class="contacts-layout">
-          <div class="contacts-list-panel">
-            <div style="padding: 10px 12px 0; font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--fg-muted);">Contacts</div>
-            <div id="contacts-list" class="contacts-list"></div>
-          </div>
-          <div class="contacts-editor">
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-              <h2 id="contacts-editor-title" style="font-family: 'Lora', Georgia, serif; font-size: 1.375rem; font-weight: 500; margin: 0;">Create Contact</h2>
-              <button id="contacts-delete-btn" class="btn-primary" style="display: none; background: var(--destructive); color: var(--fg);">Delete</button>
-            </div>
-
-            <form id="contacts-form" style="display: flex; flex-direction: column; gap: 12px; max-width: 720px;">
-              <div class="form-grid">
-                <div class="form-field">
-                  <label for="contact-display-name">Display name</label>
-                  <input id="contact-display-name" type="text" placeholder="e.g. Ada Lovelace" required />
-                </div>
-                <div class="form-field">
-                  <label for="contact-role">Role</label>
-                  <input id="contact-role" type="text" placeholder="e.g. CTO" />
-                </div>
-                <div class="form-field">
-                  <label for="contact-status">Status</label>
-                  <select id="contact-status">
-                    <option value="confirmed">confirmed</option>
-                    <option value="provisional">provisional</option>
-                    <option value="blocked">blocked</option>
-                  </select>
-                </div>
-                <div class="form-field">
-                  <label for="contact-kg-node-id">KG node ID (optional)</label>
-                  <input id="contact-kg-node-id" type="text" placeholder="UUID (optional)" />
-                </div>
-              </div>
-              <div class="form-field">
-                <label for="contact-notes">Notes</label>
-                <textarea id="contact-notes" rows="4" placeholder="Notes about this contact\u2026"></textarea>
-              </div>
-              <div style="display: flex; gap: 10px;">
-                <button type="submit" id="contacts-save-btn" class="btn-primary">Create Contact</button>
-                <button type="button" id="contacts-cancel-btn" class="btn-primary" style="background: var(--muted); color: var(--fg);">Cancel</button>
-              </div>
-            </form>
-          </div>
         </div>
       </div>
 
@@ -1130,9 +1024,6 @@ function createUiHtml(): string {
     var settingsOpen = true; // Settings nav section expanded by default
 
     var activeNavId = 'nav-kg';
-    var contacts = [];
-    var selectedContactId = null;
-    var contactsMode = 'create';
     var tasks = [];
     var selectedTaskId = null;
     var tasksMode = 'create';
@@ -1172,21 +1063,6 @@ function createUiHtml(): string {
     var memorySubmenu = document.getElementById('memory-submenu');
     var settingsSubmenu = document.getElementById('settings-submenu');
     var settingsCaret   = document.getElementById('settings-chevron');
-    var contactsStatusEl = document.getElementById('contacts-status');
-    var contactsSearchInput = document.getElementById('contacts-search-input');
-    var contactsSearchBtn = document.getElementById('contacts-search-btn');
-    var contactsNewBtn = document.getElementById('contacts-new-btn');
-    var contactsListEl = document.getElementById('contacts-list');
-    var contactsForm = document.getElementById('contacts-form');
-    var contactsEditorTitle = document.getElementById('contacts-editor-title');
-    var contactsDeleteBtn = document.getElementById('contacts-delete-btn');
-    var contactsSaveBtn = document.getElementById('contacts-save-btn');
-    var contactsCancelBtn = document.getElementById('contacts-cancel-btn');
-    var contactDisplayNameInput = document.getElementById('contact-display-name');
-    var contactRoleInput = document.getElementById('contact-role');
-    var contactStatusInput = document.getElementById('contact-status');
-    var contactKgNodeIdInput = document.getElementById('contact-kg-node-id');
-    var contactNotesInput = document.getElementById('contact-notes');
     var tasksStatusEl = document.getElementById('tasks-status');
     var tasksSearchInput = document.getElementById('tasks-search-input');
     var tasksSearchBtn = document.getElementById('tasks-search-btn');
@@ -1234,11 +1110,6 @@ function createUiHtml(): string {
     if (!authWall || !mainApp || !authForm || !authInput || !authError ||
         !statusEl || !resultsEl || !searchInput || !searchBtn ||
         !memoryCaret || !memorySubmenu || !settingsSubmenu || !settingsCaret ||
-        !contactsStatusEl || !contactsSearchInput || !contactsSearchBtn ||
-        !contactsNewBtn || !contactsListEl || !contactsForm || !contactsEditorTitle ||
-        !contactsDeleteBtn || !contactsSaveBtn || !contactsCancelBtn ||
-        !contactDisplayNameInput || !contactRoleInput || !contactStatusInput ||
-        !contactKgNodeIdInput || !contactNotesInput ||
         !tasksStatusEl || !tasksSearchInput || !tasksSearchBtn || !tasksNewBtn ||
         !tasksListEl || !tasksForm || !tasksEditorTitle || !tasksDeleteBtn ||
         !tasksSaveBtn || !tasksCancelBtn || !taskAgentIdInput || !taskStatusInput ||
@@ -1438,12 +1309,10 @@ function createUiHtml(): string {
     function navigate(view, title, navId) {
       var kgView            = document.getElementById('view-kg');
       var chatView          = document.getElementById('view-chat');
-      var contactsView      = document.getElementById('view-contacts');
       var tasksView         = document.getElementById('view-tasks');
       var scheduledJobsView = document.getElementById('view-scheduled-jobs');
       kgView.style.display            = view === 'kg'             ? 'flex' : 'none';
       chatView.style.display          = view === 'chat'           ? 'flex' : 'none';
-      contactsView.style.display      = view === 'contacts'       ? 'flex' : 'none';
       tasksView.style.display         = view === 'tasks'          ? 'flex' : 'none';
       scheduledJobsView.style.display = view === 'scheduled-jobs' ? 'flex' : 'none';
       // When returning to the KG view, tell Cytoscape to re-measure the container.
@@ -1465,9 +1334,6 @@ function createUiHtml(): string {
         if (cy && cy.elements().length === 0) {
           loadDefaultGraph();
         }
-      }
-      if (view === 'contacts') {
-        loadContacts();
       }
       if (view === 'tasks') {
         loadTasks();
@@ -1906,174 +1772,6 @@ function createUiHtml(): string {
 
     searchBtn.addEventListener('click', search);
     searchInput.addEventListener('keydown', function(e) { if (e.key === 'Enter') search(); });
-
-    // ── Contacts ──────────────────────────────────────────────────────
-    function setContactsStatus(msg, isError) {
-      contactsStatusEl.textContent = msg;
-      contactsStatusEl.style.color = isError ? 'var(--destructive)' : 'var(--fg-muted)';
-    }
-
-    function resetContactForm() {
-      contactsMode = 'create';
-      selectedContactId = null;
-      contactsEditorTitle.textContent = 'Create Contact';
-      contactsSaveBtn.textContent = 'Create Contact';
-      contactsDeleteBtn.style.display = 'none';
-      contactDisplayNameInput.value = '';
-      contactRoleInput.value = '';
-      contactStatusInput.value = 'confirmed';
-      contactKgNodeIdInput.value = '';
-      contactNotesInput.value = '';
-      renderContactsList(contacts);
-    }
-
-    function fillContactForm(contact) {
-      contactsMode = 'edit';
-      selectedContactId = contact.id;
-      contactsEditorTitle.textContent = 'Edit Contact';
-      contactsSaveBtn.textContent = 'Save Changes';
-      contactsDeleteBtn.style.display = 'inline-flex';
-      contactDisplayNameInput.value = contact.displayName;
-      contactRoleInput.value = contact.role || '';
-      contactStatusInput.value = contact.status;
-      contactKgNodeIdInput.value = contact.kgNodeId || '';
-      contactNotesInput.value = contact.notes || '';
-      renderContactsList(contacts);
-    }
-
-    function renderContactsList(list) {
-      contactsListEl.replaceChildren();
-      if (!list.length) {
-        var empty = document.createElement('p');
-        empty.style.cssText = 'font-size: 0.8125rem; color: var(--fg-muted); margin: 4px 2px;';
-        empty.textContent = 'No contacts found.';
-        contactsListEl.appendChild(empty);
-        return;
-      }
-      list.forEach(function(contact) {
-        var card = document.createElement('div');
-        card.className = 'contact-card' + (selectedContactId === contact.id ? ' active' : '');
-        var name = document.createElement('div');
-        name.style.cssText = 'font-size: 0.875rem; font-weight: 600; color: var(--fg);';
-        name.textContent = contact.displayName;
-        var meta = document.createElement('div');
-        meta.style.cssText = 'font-size: 0.75rem; color: var(--fg-muted); margin-top: 3px;';
-        meta.textContent = (contact.role || 'No role') + ' · ' + contact.status;
-        card.append(name, meta);
-        card.addEventListener('click', function() { fillContactForm(contact); });
-        contactsListEl.appendChild(card);
-      });
-    }
-
-    function loadContacts() {
-      setContactsStatus('Loading contacts…');
-      fetchJson('/api/kg/contacts')
-        .then(function(data) {
-          contacts = data.contacts || [];
-          renderContactsList(contacts);
-          setContactsStatus(contacts.length + ' contact' + (contacts.length === 1 ? '' : 's'));
-          if (contactsMode === 'edit') {
-            var selected = contacts.find(function(c) { return c.id === selectedContactId; });
-            if (selected) {
-              fillContactForm(selected);
-            } else {
-              resetContactForm();
-            }
-          }
-        })
-        .catch(function(err) { setContactsStatus(String(err), true); });
-    }
-
-    function filterContacts() {
-      var q = contactsSearchInput.value.trim().toLowerCase();
-      if (!q) {
-        renderContactsList(contacts);
-        setContactsStatus(contacts.length + ' contact' + (contacts.length === 1 ? '' : 's'));
-        return;
-      }
-      var filtered = contacts.filter(function(c) {
-        return c.displayName.toLowerCase().includes(q) || (c.role || '').toLowerCase().includes(q);
-      });
-      renderContactsList(filtered);
-      setContactsStatus(filtered.length + ' result' + (filtered.length === 1 ? '' : 's'));
-    }
-
-    function saveContact(e) {
-      e.preventDefault();
-      var displayName = contactDisplayNameInput.value.trim();
-      if (!displayName) {
-        setContactsStatus('Display name is required.', true);
-        return;
-      }
-
-      var payload = {
-        displayName: displayName,
-        role: contactRoleInput.value.trim() || null,
-        status: contactStatusInput.value,
-        kgNodeId: contactKgNodeIdInput.value.trim() || null,
-        notes: contactNotesInput.value.trim() || null,
-      };
-
-      contactsSaveBtn.disabled = true;
-      setContactsStatus(contactsMode === 'create' ? 'Creating contact…' : 'Saving contact…');
-
-      var request = contactsMode === 'create'
-        ? fetch('/api/kg/contacts', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
-          })
-        : fetch('/api/kg/contacts/' + encodeURIComponent(selectedContactId), {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
-          });
-
-      request
-        .then(function(res) {
-          return res.json().then(function(body) {
-            if (!res.ok) throw new Error(body.error || ('HTTP ' + res.status));
-            return body;
-          });
-        })
-        .then(function() {
-          setContactsStatus(contactsMode === 'create' ? 'Contact created.' : 'Contact updated.');
-          loadContacts();
-          if (contactsMode === 'create') resetContactForm();
-        })
-        .catch(function(err) { setContactsStatus(err.message || String(err), true); })
-        .finally(function() { contactsSaveBtn.disabled = false; });
-    }
-
-    function deleteContact() {
-      if (!selectedContactId) return;
-      if (!confirm('Delete this contact? This action cannot be undone.')) return;
-      contactsDeleteBtn.disabled = true;
-      setContactsStatus('Deleting contact…');
-      fetch('/api/kg/contacts/' + encodeURIComponent(selectedContactId), { method: 'DELETE' })
-        .then(function(res) {
-          if (!res.ok) return res.json().then(function(body) { throw new Error(body.error || ('HTTP ' + res.status)); });
-        })
-        .then(function() {
-          setContactsStatus('Contact deleted.');
-          resetContactForm();
-          loadContacts();
-        })
-        .catch(function(err) { setContactsStatus(err.message || String(err), true); })
-        .finally(function() { contactsDeleteBtn.disabled = false; });
-    }
-
-    contactsForm.addEventListener('submit', saveContact);
-    contactsDeleteBtn.addEventListener('click', deleteContact);
-    contactsNewBtn.addEventListener('click', resetContactForm);
-    contactsCancelBtn.addEventListener('click', resetContactForm);
-    contactsSearchBtn.addEventListener('click', filterContacts);
-    contactsSearchInput.addEventListener('keydown', function(e) {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        filterContacts();
-      }
-    });
 
     // ── Agent Tasks ──────────────────────────────────────────────────
     function setTasksStatus(msg, isError) {
@@ -3293,6 +2991,7 @@ export async function knowledgeGraphRoutes(
         displayName: contact.displayName,
         role: contact.role,
         status: contact.status,
+        trustLevel: contact.trustLevel,
         notes: contact.notes,
         createdAt: contact.createdAt.toISOString(),
         updatedAt: contact.updatedAt.toISOString(),
@@ -3306,6 +3005,7 @@ export async function knowledgeGraphRoutes(
       displayName?: unknown;
       role?: unknown;
       status?: unknown;
+      trustLevel?: unknown;
       notes?: unknown;
       kgNodeId?: unknown;
     };
@@ -3316,6 +3016,11 @@ export async function knowledgeGraphRoutes(
     const status = typeof body.status === 'string' ? body.status : 'confirmed';
     if (!validContactStatuses.includes(status as ContactStatus)) {
       return reply.status(400).send({ error: 'Invalid status.' });
+    }
+    const validTrustLevelsCreate = ['ceo', 'high', 'medium', 'low'];
+    if (body.trustLevel !== undefined && body.trustLevel !== null &&
+        (typeof body.trustLevel !== 'string' || !validTrustLevelsCreate.includes(body.trustLevel))) {
+      return reply.status(400).send({ error: 'Invalid trustLevel.' });
     }
 
     const kgNodeId =
@@ -3335,16 +3040,28 @@ export async function knowledgeGraphRoutes(
       source: 'kg_web_ui',
     });
 
+    // Apply trustLevel if provided — createContact always initialises it to null.
+    if (typeof body.trustLevel === 'string') {
+      await contactService.setTrustLevel(created.id, body.trustLevel as TrustLevel);
+    }
+
+    const freshCreated = await contactService.getContact(created.id);
+    if (!freshCreated) {
+      // Should never happen — contact was just created — but guard rather than return stale data.
+      logger.error({ contactId: created.id }, 'POST /api/kg/contacts: contact not found after creation');
+      return reply.status(500).send({ error: 'Contact created but could not be retrieved.' });
+    }
     return reply.status(201).send({
       contact: {
-        id: created.id,
-        kgNodeId: created.kgNodeId,
-        displayName: created.displayName,
-        role: created.role,
-        status: created.status,
-        notes: created.notes,
-        createdAt: created.createdAt.toISOString(),
-        updatedAt: created.updatedAt.toISOString(),
+        id: freshCreated.id,
+        kgNodeId: freshCreated.kgNodeId,
+        displayName: freshCreated.displayName,
+        role: freshCreated.role,
+        status: freshCreated.status,
+        trustLevel: freshCreated.trustLevel,
+        notes: freshCreated.notes,
+        createdAt: freshCreated.createdAt.toISOString(),
+        updatedAt: freshCreated.updatedAt.toISOString(),
       },
     });
   });
@@ -3356,12 +3073,26 @@ export async function knowledgeGraphRoutes(
       displayName?: unknown;
       role?: unknown;
       status?: unknown;
+      trustLevel?: unknown;
       notes?: unknown;
       kgNodeId?: unknown;
     };
     const contact = await contactService.getContact(id);
     if (!contact) {
       return reply.status(404).send({ error: 'Contact not found.' });
+    }
+
+    // Validate all inputs before any mutations to avoid partial writes on bad input.
+    if (typeof body.status === 'string' && !validContactStatuses.includes(body.status as ContactStatus)) {
+      return reply.status(400).send({ error: 'Invalid status.' });
+    }
+    const validTrustLevels = ['ceo', 'high', 'medium', 'low'];
+    if ('trustLevel' in body && body.trustLevel !== null &&
+        (typeof body.trustLevel !== 'string' || !validTrustLevels.includes(body.trustLevel))) {
+      return reply.status(400).send({ error: 'Invalid trustLevel.' });
+    }
+    if (typeof body.kgNodeId === 'string' && body.kgNodeId.trim().length > 0 && !UUID_RE.test(body.kgNodeId.trim())) {
+      return reply.status(400).send({ error: 'Invalid kgNodeId: must be a valid UUID.' });
     }
 
     if (typeof body.displayName === 'string') {
@@ -3377,17 +3108,14 @@ export async function knowledgeGraphRoutes(
       ]);
     }
     if (typeof body.status === 'string') {
-      if (!validContactStatuses.includes(body.status as ContactStatus)) {
-        return reply.status(400).send({ error: 'Invalid status.' });
-      }
       await contactService.setStatus(id, body.status as ContactStatus);
+    }
+    if ('trustLevel' in body) {
+      await contactService.setTrustLevel(id, (body.trustLevel as TrustLevel | null));
     }
 
     // Notes and kgNodeId are updated directly by preserving the rest of the contact.
     // This route exists only for the web UI and does not expose generic backend mutation.
-    if (typeof body.kgNodeId === 'string' && body.kgNodeId.trim().length > 0 && !UUID_RE.test(body.kgNodeId.trim())) {
-      return reply.status(400).send({ error: 'Invalid kgNodeId: must be a valid UUID.' });
-    }
     if (typeof body.notes === 'string' || typeof body.kgNodeId === 'string' || body.notes === null || body.kgNodeId === null) {
       const refreshed = await contactService.getContact(id);
       if (!refreshed) {
@@ -3407,19 +3135,21 @@ export async function knowledgeGraphRoutes(
     }
 
     const updated = await contactService.getContact(id);
+    if (!updated) {
+      return reply.status(500).send({ error: 'Contact not found after update.' });
+    }
     return reply.send({
-      contact: updated
-        ? {
-            id: updated.id,
-            kgNodeId: updated.kgNodeId,
-            displayName: updated.displayName,
-            role: updated.role,
-            status: updated.status,
-            notes: updated.notes,
-            createdAt: updated.createdAt.toISOString(),
-            updatedAt: updated.updatedAt.toISOString(),
-          }
-        : null,
+      contact: {
+        id: updated.id,
+        kgNodeId: updated.kgNodeId,
+        displayName: updated.displayName,
+        role: updated.role,
+        status: updated.status,
+        trustLevel: updated.trustLevel,
+        notes: updated.notes,
+        createdAt: updated.createdAt.toISOString(),
+        updatedAt: updated.updatedAt.toISOString(),
+      },
     });
   });
 

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -3092,7 +3092,14 @@ export async function knowledgeGraphRoutes(
         (typeof body.trustLevel !== 'string' || !validTrustLevels.includes(body.trustLevel))) {
       return reply.status(400).send({ error: 'Invalid trustLevel.' });
     }
-    if (typeof body.kgNodeId === 'string' && body.kgNodeId.trim().length > 0 && !UUID_RE.test(body.kgNodeId.trim())) {
+    // Trim once; collapse whitespace-only strings to null so they don't reach the DB as invalid UUIDs.
+    const normalizedKgNodeId: string | null | undefined =
+      typeof body.kgNodeId === 'string'
+        ? (body.kgNodeId.trim() || null)
+        : body.kgNodeId === null
+        ? null
+        : undefined;
+    if (typeof normalizedKgNodeId === 'string' && !UUID_RE.test(normalizedKgNodeId)) {
       return reply.status(400).send({ error: 'Invalid kgNodeId: must be a valid UUID.' });
     }
 
@@ -3129,7 +3136,7 @@ export async function knowledgeGraphRoutes(
         [
           id,
           typeof body.notes === 'string' ? body.notes : body.notes === null ? null : refreshed.notes,
-          typeof body.kgNodeId === 'string' ? body.kgNodeId : body.kgNodeId === null ? null : refreshed.kgNodeId,
+          normalizedKgNodeId !== undefined ? normalizedKgNodeId : refreshed.kgNodeId,
           new Date().toISOString(),
         ],
       );
@@ -3137,7 +3144,7 @@ export async function knowledgeGraphRoutes(
 
     const updated = await contactService.getContact(id);
     if (!updated) {
-      return reply.status(500).send({ error: 'Contact not found after update.' });
+      return reply.status(404).send({ error: 'Contact not found after update.' });
     }
     return reply.send({
       contact: {


### PR DESCRIPTION
## **User description**
## Summary

- Adds `/contacts` route to the new console app with a full CRUD UI: table, filter chips (All / Confirmed / Provisional / Blocked), sortable columns, search, and an edit/create drawer including editable `trustLevel` select
- Extends `/api/kg/contacts` GET, POST, and PATCH to include and accept `trustLevel`
- Removes the old contacts view from the legacy `kg.ts` HTML UI (`/old`)

Closes #781

## Changes by file

- **`apps/console/src/pages/ContactsPage.tsx`** (new) — contacts page component
- **`apps/console/src/styles/app.css`** — records table, status pills, drawer, pagination styles
- **`apps/console/src/router.tsx`** — adds `/contacts` route under `authedRoute`
- **`apps/console/src/pages/DashboardPage.tsx`** / **`SettingsPage.tsx`** — wire sidebar contacts nav to `/contacts`
- **`src/channels/http/routes/kg.ts`** — contacts API changes + old contacts UI removal

## Test plan

- [ ] Navigate to `/contacts` — table loads with existing contacts, status filter chips show correct counts
- [ ] Click a contact row — drawer opens with correct data pre-filled
- [ ] Click a different row without closing — drawer resets to new contact's data (key prop enforces remount)
- [ ] Edit name/role/status/trustLevel/notes and Save — row updates in-place, drawer stays open
- [ ] Create a new contact with a trustLevel set — confirm trustLevel persists in the response (re-fetch path)
- [ ] Delete a contact — row removed, drawer closes
- [ ] Invalid kgNodeId (non-UUID) — 400 returned before any mutations applied
- [ ] `/old` contacts nav button and view are gone from the legacy UI
- [ ] Browser back/forward navigates correctly between `/contacts` and other routes
- [ ] Mobile viewport: table scrolls horizontally, drawer full-width


___

## **CodeAnt-AI Description**
**Move Contacts into the new console and add trust level editing**

### What Changed
- Contacts are now available at `/contacts` in the new console, with create, edit, delete, search, sorting, filtering, and pagination
- The contact editor now includes trust level, and saves it when creating or updating a contact
- The contacts table shows status counts and adapts to smaller screens with a full-width drawer
- The legacy contacts view was removed from the old UI
- Contact API responses now include trust level, and updates reject invalid status, trust level, or KG node ID before making changes

### Impact
`✅ Contacts managed in the new console`
`✅ Trust level stays in sync after saves`
`✅ Fewer partial or invalid contact updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New Contacts management view with searchable, sortable table and pagination controls
  * Complete contact lifecycle management: create new contacts, edit existing information, and delete entries
  * Trust level configuration for each contact
  * Navigation menu updated to provide quick access to Contacts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->