### PR TITLE
feat: port Scheduled Jobs view to new console app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
-- **Scheduled Jobs view** — new console page at `/jobs` with full CRUD, status filters, and Resume action for suspended jobs; legacy nav item removed. (#782)
+- **Scheduled Jobs view** — new `/jobs` console page with CRUD, status filters, and resume action for suspended jobs; removes legacy nav item. (#782)
 - **Contacts view** — new console page at `/contacts` with full CRUD and editable trust level; legacy `/old/contacts` removed. (#781)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 
+- **Scheduled Jobs view** — new console page at `/jobs` with full CRUD, status filters, and Resume action for suspended jobs; legacy nav item removed. (#782)
 - **Contacts view** — new console page at `/contacts` with full CRUD and editable trust level; legacy `/old/contacts` removed. (#781)
 
 ### Changed

--- a/apps/console/src/pages/ChatPage.tsx
+++ b/apps/console/src/pages/ChatPage.tsx
@@ -27,6 +27,8 @@ export default function ChatPage() {
     const routes: Record<string, string> = {
       contacts: '/contacts',
       jobs:     '/jobs',
+      kg:       '/',
+      tasks:    '/',
       settings: '/settings',
       wizard:   '/setup',
       autonomy: '/settings/autonomy',

--- a/apps/console/src/pages/ChatPage.tsx
+++ b/apps/console/src/pages/ChatPage.tsx
@@ -24,11 +24,14 @@ export default function ChatPage() {
   }, [mobileOpen]);
 
   function handleNavigate(view: string) {
-    const to =
-      view === 'settings' ? '/settings' :
-      view === 'wizard'   ? '/setup' :
-      view === 'autonomy' ? '/settings/autonomy' :
-      null;
+    const routes: Record<string, string> = {
+      contacts: '/contacts',
+      jobs:     '/jobs',
+      settings: '/settings',
+      wizard:   '/setup',
+      autonomy: '/settings/autonomy',
+    };
+    const to = routes[view];
     if (!to) return;
     navigate({ to }).catch((err: unknown) => {
       console.error(`[ChatPage] navigation to ${to} failed:`, err);

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -297,7 +297,7 @@ export default function ContactsPage() {
       kg:        '/',
       chat:      '/',
       tasks:     '/',
-      jobs:      '/',
+      jobs:      '/jobs',
       autonomy:  '/settings/autonomy',
       settings:  '/settings/autonomy',
       wizard:    '/setup',

--- a/apps/console/src/pages/DashboardPage.tsx
+++ b/apps/console/src/pages/DashboardPage.tsx
@@ -15,13 +15,17 @@ export default function DashboardPage() {
   }, [mobileOpen]);
 
   function handleNavigate(view: string) {
-    if (view === 'contacts') {
-      navigate({ to: '/contacts' }).catch(err => {
-        console.error('[DashboardPage] navigation to /contacts failed:', err);
-      });
-    } else if (view === 'autonomy' || view === 'settings') {
-      navigate({ to: '/settings/autonomy' }).catch(err => {
-        console.error('[DashboardPage] navigation to /settings/autonomy failed:', err);
+    const routes: Record<string, string> = {
+      contacts: '/contacts',
+      jobs:     '/jobs',
+      autonomy: '/settings/autonomy',
+      settings: '/settings/autonomy',
+      wizard:   '/setup',
+    };
+    const to = routes[view];
+    if (to) {
+      navigate({ to }).catch(err => {
+        console.error(`[DashboardPage] navigation to ${to} failed:`, err);
       });
     }
   }

--- a/apps/console/src/pages/JobsPage.tsx
+++ b/apps/console/src/pages/JobsPage.tsx
@@ -1,0 +1,715 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { MobileMenuContext } from '../context/MobileMenu.js';
+import { Sidebar } from '../components/Sidebar.js';
+import { Topbar, TopbarSearch, TopbarDivider } from '../components/Topbar.js';
+import { apiFetch } from '../api.js';
+import { useTheme } from '../hooks/useTheme.js';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type JobStatus = 'pending' | 'running' | 'suspended' | 'paused' | 'completed' | 'cancelled' | 'failed';
+type LastRunOutcome = 'completed' | 'failed' | 'timed_out' | null;
+
+interface Job {
+  id: string;
+  agentId: string;
+  cronExpr: string | null;
+  runAt: string | null;
+  taskPayload: Record<string, unknown>;
+  status: JobStatus;
+  lastRunAt: string | null;
+  nextRunAt: string | null;
+  lastError: string | null;
+  consecutiveFailures: number;
+  createdBy: string;
+  createdAt: string;
+  timezone: string;
+  agentTaskId: string | null;
+  intentAnchor: string | null;
+  progress: Record<string, unknown> | null;
+  runStartedAt: string | null;
+  expectedDurationSeconds: number | null;
+  lastRunOutcome: LastRunOutcome;
+  lastRunSummary: string | null;
+  lastRunContext: Record<string, unknown> | null;
+  originator: Record<string, unknown> | null;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return iso.slice(0, 16).replace('T', ' ');
+}
+
+function formatSchedule(job: Job): string {
+  if (job.cronExpr) return job.cronExpr;
+  if (job.runAt) return formatDate(job.runAt);
+  return '—';
+}
+
+async function errorMessage(res: Response): Promise<string> {
+  const ct = res.headers.get('content-type') ?? '';
+  if (ct.includes('application/json')) {
+    try {
+      const d = await res.json() as { error?: string };
+      if (d.error) return d.error;
+    } catch (err) {
+      console.error('[errorMessage] failed to parse JSON error body:', err);
+    }
+  }
+  return `HTTP ${res.status}`;
+}
+
+// ── Pagination ────────────────────────────────────────────────────────────────
+
+interface PaginationProps {
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  onPage: (p: number) => void;
+  onPageSize: (n: number) => void;
+}
+
+function Pagination({ total, page, pageSize, totalPages, onPage, onPageSize }: PaginationProps) {
+  const start = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const end = Math.min(page * pageSize, total);
+
+  // @TODO: cap at 7 buttons with ellipsis when totalPages grows large.
+  const pages: number[] = [];
+  for (let i = 1; i <= totalPages; i++) pages.push(i);
+
+  return (
+    <div className="records-pagination">
+      <div className="records-pagination-info">
+        Showing <strong style={{ color: 'var(--app-fg)' }}>{start}–{end}</strong> of {total}
+      </div>
+      <div className="records-page-size">
+        Rows
+        <select value={pageSize} onChange={e => onPageSize(Number(e.target.value))}>
+          <option value="10">10</option>
+          <option value="25">25</option>
+          <option value="50">50</option>
+        </select>
+      </div>
+      <div className="records-pagination-controls">
+        <button className="records-page-btn" onClick={() => onPage(page - 1)} disabled={page <= 1}>‹</button>
+        {pages.map(p => (
+          <button key={p} className={`records-page-btn${p === page ? ' active' : ''}`} onClick={() => onPage(p)}>{p}</button>
+        ))}
+        <button className="records-page-btn" onClick={() => onPage(page + 1)} disabled={page >= totalPages}>›</button>
+      </div>
+    </div>
+  );
+}
+
+// ── Edit / Create drawer ──────────────────────────────────────────────────────
+
+interface DrawerProps {
+  job: Job | null;
+  creating: boolean;
+  onClose: () => void;
+  onSaved: (job: Job) => void;
+  onDeleted: (id: string) => void;
+}
+
+function JobEditDrawer({ job, creating, onClose, onSaved, onDeleted }: DrawerProps) {
+  const isCronJob = job ? job.cronExpr !== null : true;
+
+  const [agentId, setAgentId] = useState(job?.agentId ?? '');
+  const [cronExpr, setCronExpr] = useState(job?.cronExpr ?? '');
+  const [runAt, setRunAt] = useState(job?.runAt?.slice(0, 16) ?? '');
+  const [scheduleType, setScheduleType] = useState<'cron' | 'run_at'>(isCronJob ? 'cron' : 'run_at');
+  const [taskPayload, setTaskPayload] = useState(
+    job ? JSON.stringify(job.taskPayload, null, 2) : '{\n  \n}',
+  );
+  const [intentAnchor, setIntentAnchor] = useState(job?.intentAnchor ?? '');
+  const [timezone, setTimezone] = useState(job?.timezone === 'UTC' ? '' : (job?.timezone ?? ''));
+
+  const [saving, setSaving] = useState(false);
+  const [resuming, setResuming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canResume = job?.status === 'suspended' || job?.status === 'paused';
+
+  async function handleSave() {
+    // Validate task_payload JSON before sending.
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(taskPayload) as Record<string, unknown>;
+      if (typeof parsed !== 'object' || Array.isArray(parsed) || parsed === null) {
+        setError('Task payload must be a JSON object, not an array or primitive.');
+        return;
+      }
+    } catch {
+      setError('Task payload is not valid JSON.');
+      return;
+    }
+
+    if (creating && !agentId.trim()) {
+      setError('Agent ID is required.');
+      return;
+    }
+    if (creating && scheduleType === 'cron' && !cronExpr.trim()) {
+      setError('Cron expression is required.');
+      return;
+    }
+    if (creating && scheduleType === 'run_at' && !runAt.trim()) {
+      setError('Run-at datetime is required.');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      let res: Response;
+      if (creating) {
+        const body: Record<string, unknown> = {
+          agent_id: agentId.trim(),
+          task_payload: parsed,
+        };
+        if (scheduleType === 'cron') {
+          body['cron_expr'] = cronExpr.trim();
+        } else {
+          body['run_at'] = new Date(runAt).toISOString();
+        }
+        if (intentAnchor.trim()) body['intent_anchor'] = intentAnchor.trim();
+        if (timezone.trim()) body['timezone'] = timezone.trim();
+
+        res = await apiFetch('/api/jobs', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+      } else {
+        const body: Record<string, unknown> = { task_payload: parsed };
+        // Only send the schedule field for the type this job uses.
+        if (isCronJob) {
+          body['cron_expr'] = cronExpr.trim() || job!.cronExpr;
+        } else {
+          body['run_at'] = runAt.trim()
+            ? new Date(runAt).toISOString()
+            : job!.runAt;
+        }
+        res = await apiFetch(`/api/jobs/${job!.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+      }
+
+      if (!res.ok) throw new Error(await errorMessage(res));
+
+      const data = await res.json() as { job: Job };
+      onSaved(data.job);
+    } catch (err) {
+      console.error('[JobEditDrawer] save failed:', err);
+      setError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleResume() {
+    if (!job) return;
+    setResuming(true);
+    setError(null);
+    try {
+      const res = await apiFetch(`/api/jobs/${job.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'pending' }),
+      });
+      if (!res.ok) throw new Error(await errorMessage(res));
+      const data = await res.json() as { job: Job };
+      onSaved(data.job);
+    } catch (err) {
+      console.error('[JobEditDrawer] resume failed:', err);
+      setError(err instanceof Error ? err.message : 'Resume failed');
+    } finally {
+      setResuming(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!job) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await apiFetch(`/api/jobs/${job.id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error(await errorMessage(res));
+      onDeleted(job.id);
+    } catch (err) {
+      console.error('[JobEditDrawer] delete failed:', err);
+      setError(err instanceof Error ? err.message : 'Delete failed');
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <aside className="drawer">
+      <div className="drawer-header">
+        <div className="drawer-header-top">
+          <span className="badge badge-organization">job</span>
+          <button className="drawer-close" onClick={onClose} aria-label="Close">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <line x1="6" y1="6" x2="18" y2="18" /><line x1="18" y1="6" x2="6" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <h2 className="drawer-title-h2">{creating ? 'New job' : (job?.agentId ?? '')}</h2>
+        {!creating && job && (
+          <div className="drawer-subtitle">
+            <span className={`status-pill ${job.status}`}>{job.status}</span>
+          </div>
+        )}
+      </div>
+
+      <div className="drawer-body">
+        <div className="edit-drawer-form">
+          {error && <p style={{ color: 'var(--app-destructive)', margin: 0, fontSize: 13 }}>{error}</p>}
+
+          {creating ? (
+            <>
+              <div className="form-field">
+                <label htmlFor="jf-agent">Agent ID</label>
+                <input id="jf-agent" type="text" value={agentId} onChange={e => setAgentId(e.target.value)} placeholder="coordinator" />
+              </div>
+
+              <div className="form-field">
+                <label>Schedule type</label>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, cursor: 'pointer' }}>
+                    <input type="radio" name="scheduleType" value="cron" checked={scheduleType === 'cron'} onChange={() => setScheduleType('cron')} />
+                    Cron
+                  </label>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13, cursor: 'pointer' }}>
+                    <input type="radio" name="scheduleType" value="run_at" checked={scheduleType === 'run_at'} onChange={() => setScheduleType('run_at')} />
+                    One-time
+                  </label>
+                </div>
+              </div>
+
+              {scheduleType === 'cron' ? (
+                <div className="form-field">
+                  <label htmlFor="jf-cron">Cron expression</label>
+                  <input id="jf-cron" type="text" value={cronExpr} onChange={e => setCronExpr(e.target.value)} placeholder="0 9 * * 1-5" />
+                </div>
+              ) : (
+                <div className="form-field">
+                  <label htmlFor="jf-run-at">Run at</label>
+                  <input id="jf-run-at" type="datetime-local" value={runAt} onChange={e => setRunAt(e.target.value)} />
+                </div>
+              )}
+
+              <div className="form-grid">
+                <div className="form-field">
+                  <label htmlFor="jf-tz">Timezone</label>
+                  <input id="jf-tz" type="text" value={timezone} onChange={e => setTimezone(e.target.value)} placeholder="UTC" />
+                </div>
+                <div className="form-field">
+                  <label htmlFor="jf-anchor">Intent anchor</label>
+                  <input id="jf-anchor" type="text" value={intentAnchor} onChange={e => setIntentAnchor(e.target.value)} placeholder="optional" />
+                </div>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="form-grid">
+                <div className="form-field">
+                  <label>Agent ID</label>
+                  <div className="form-field-readonly">{job?.agentId}</div>
+                </div>
+                <div className="form-field">
+                  <label>Timezone</label>
+                  <div className="form-field-readonly">{job?.timezone ?? 'UTC'}</div>
+                </div>
+              </div>
+
+              {isCronJob ? (
+                <div className="form-field">
+                  <label htmlFor="jf-cron">Cron expression</label>
+                  <input id="jf-cron" type="text" value={cronExpr} onChange={e => setCronExpr(e.target.value)} />
+                </div>
+              ) : (
+                <div className="form-field">
+                  <label htmlFor="jf-run-at">Run at</label>
+                  <input id="jf-run-at" type="datetime-local" value={runAt} onChange={e => setRunAt(e.target.value)} />
+                </div>
+              )}
+
+              {job?.lastRunAt && (
+                <div className="form-grid">
+                  <div className="form-field">
+                    <label>Last run</label>
+                    <div className="form-field-readonly cell-mono">{formatDate(job.lastRunAt)}</div>
+                  </div>
+                  <div className="form-field">
+                    <label>Outcome</label>
+                    <div className="form-field-readonly">{job.lastRunOutcome ?? '—'}</div>
+                  </div>
+                </div>
+              )}
+
+              {job?.lastError && (
+                <div className="form-field">
+                  <label>Last error</label>
+                  <div className="form-field-readonly" style={{ color: 'var(--app-destructive)', fontSize: 12, wordBreak: 'break-word' }}>
+                    {job.lastError}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+
+          <div className="form-field">
+            <label htmlFor="jf-payload">Task payload (JSON)</label>
+            <textarea
+              id="jf-payload"
+              rows={8}
+              value={taskPayload}
+              onChange={e => setTaskPayload(e.target.value)}
+              style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 12 }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="drawer-footer">
+        {!creating && (
+          <button
+            className="btn btn-danger btn-sm"
+            onClick={() => void handleDelete()}
+            disabled={deleting || job?.status === 'cancelled'}
+            title={job?.status === 'cancelled' ? 'Job is already cancelled' : undefined}
+          >
+            {deleting ? 'Cancelling…' : 'Cancel job'}
+          </button>
+        )}
+        <div style={{ flex: 1 }} />
+        {canResume && (
+          <button
+            className="btn btn-secondary btn-sm"
+            onClick={() => void handleResume()}
+            disabled={resuming}
+          >
+            {resuming ? 'Resuming…' : 'Resume'}
+          </button>
+        )}
+        <button className="btn btn-secondary btn-sm" onClick={onClose}>Cancel</button>
+        <button
+          className="btn btn-primary btn-sm"
+          onClick={() => void handleSave()}
+          disabled={saving}
+        >
+          {saving ? 'Saving…' : creating ? 'Create' : 'Save changes'}
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+type StatusFilter = 'all' | JobStatus;
+
+const ALL_STATUSES: JobStatus[] = ['pending', 'running', 'suspended', 'completed', 'cancelled', 'failed'];
+
+export default function JobsPage() {
+  const [theme, setTheme] = useTheme();
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [sort, setSort] = useState<{ key: keyof Job; dir: 'asc' | 'desc' }>({ key: 'createdAt', dir: 'desc' });
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [editing, setEditing] = useState<Job | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
+  }, [mobileOpen]);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await apiFetch('/api/jobs');
+      if (!res.ok) throw new Error(await errorMessage(res));
+      const data = await res.json() as { jobs: Job[] };
+      setJobs(data.jobs);
+    } catch (err) {
+      console.error('[JobsPage] failed to load jobs:', err);
+      setLoadError(err instanceof Error ? err.message : 'Failed to load jobs');
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  function handleNavigate(view: string) {
+    const routes: Record<string, string> = {
+      contacts:  '/contacts',
+      jobs:      '/jobs',
+      kg:        '/',
+      chat:      '/chat',
+      tasks:     '/',
+      autonomy:  '/settings/autonomy',
+      settings:  '/settings/autonomy',
+      wizard:    '/setup',
+    };
+    const to = routes[view];
+    if (to) {
+      navigate({ to }).catch(err => {
+        console.error(`[JobsPage] navigation to ${to} failed:`, err);
+      });
+    }
+  }
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { all: jobs.length };
+    for (const s of ALL_STATUSES) {
+      c[s] = jobs.filter(j => j.status === s).length;
+    }
+    return c;
+  }, [jobs]);
+
+  const filtered = useMemo(() => {
+    let rows = jobs;
+    if (statusFilter !== 'all') rows = rows.filter(j => j.status === statusFilter);
+    if (search) {
+      const q = search.toLowerCase();
+      rows = rows.filter(j =>
+        j.agentId.toLowerCase().includes(q) ||
+        (j.cronExpr ?? '').toLowerCase().includes(q) ||
+        (j.intentAnchor ?? '').toLowerCase().includes(q),
+      );
+    }
+    const dir = sort.dir === 'asc' ? 1 : -1;
+    rows = [...rows].sort((a, b) => {
+      const av = (a[sort.key] ?? '') as string;
+      const bv = (b[sort.key] ?? '') as string;
+      if (av < bv) return -1 * dir;
+      if (av > bv) return  1 * dir;
+      return 0;
+    });
+    return rows;
+  }, [jobs, statusFilter, search, sort]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
+  const safePage = Math.min(page, totalPages);
+  const pageRows = filtered.slice((safePage - 1) * pageSize, safePage * pageSize);
+
+  function toggleSort(key: keyof Job) {
+    setSort(s => s.key === key
+      ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
+      : { key, dir: 'asc' });
+  }
+  const sortArrow = (key: keyof Job) => sort.key === key ? (sort.dir === 'asc' ? '↑' : '↓') : '';
+  const ariaSortFor = (key: keyof Job): 'ascending' | 'descending' | 'none' =>
+    sort.key === key ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none';
+
+  function handleSaved(job: Job) {
+    setJobs(prev => {
+      const idx = prev.findIndex(j => j.id === job.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = job;
+        return next;
+      }
+      return [...prev, job];
+    });
+    setEditing(job);
+    setCreating(false);
+  }
+
+  function handleDeleted(id: string) {
+    setJobs(prev => prev.filter(j => j.id !== id));
+    setEditing(null);
+    setCreating(false);
+  }
+
+  return (
+    <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
+      <div className="app-root">
+        <Sidebar activeView="jobs" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
+        {mobileOpen && (
+          <div
+            className="sidebar-backdrop"
+            onClick={() => setMobileOpen(false)}
+            aria-hidden="true"
+          />
+        )}
+        <main className="main">
+          <Topbar crumb="Memory" title="Scheduled Jobs">
+            <TopbarSearch
+              placeholder="Search agent, cron, anchor…"
+              value={search}
+              onChange={v => { setSearch(v); setPage(1); }}
+            />
+            <TopbarDivider />
+            <button
+              className="btn btn-primary btn-sm"
+              onClick={() => { setEditing(null); setCreating(true); }}
+            >
+              + New job
+            </button>
+          </Topbar>
+
+          {loadError ? (
+            <div style={{ padding: 32, color: 'var(--app-destructive)', fontSize: 13 }}>{loadError}</div>
+          ) : (
+            <>
+              {/* Mobile search — TopbarSearch is hidden below 768px by the shared stylesheet */}
+              <div className="jobs-mobile-search">
+                <input
+                  type="text"
+                  placeholder="Search agent, cron, anchor…"
+                  value={search}
+                  onChange={e => { setSearch(e.target.value); setPage(1); }}
+                />
+              </div>
+
+              <div className="records-toolbar">
+                <div className="records-toolbar-left">
+                  <button
+                    className={`records-filter-chip${statusFilter === 'all' ? ' active' : ''}`}
+                    onClick={() => { setStatusFilter('all'); setPage(1); }}
+                  >
+                    All
+                    <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, opacity: 0.7 }}>
+                      {counts['all']}
+                    </span>
+                  </button>
+                  {ALL_STATUSES.map(s => (
+                    <button
+                      key={s}
+                      className={`records-filter-chip${statusFilter === s ? ' active' : ''}`}
+                      onClick={() => { setStatusFilter(s); setPage(1); }}
+                    >
+                      {s.charAt(0).toUpperCase() + s.slice(1)}
+                      <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, opacity: 0.7 }}>
+                        {counts[s]}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+                <div className="records-toolbar-right">
+                  <span className="topbar-meta">{filtered.length} of {jobs.length}</span>
+                </div>
+              </div>
+
+              <div className="records-layout">
+                <div className="records-main">
+                  <div className="records-table-wrap">
+                    <table className="records-table">
+                      <thead>
+                        <tr>
+                          <th className="sortable" aria-sort={ariaSortFor('agentId')}>
+                            <button className="sort-btn" onClick={() => toggleSort('agentId')}>
+                              Agent <span className="sort-arrow">{sortArrow('agentId')}</span>
+                            </button>
+                          </th>
+                          <th className="sortable" aria-sort={ariaSortFor('status')}>
+                            <button className="sort-btn" onClick={() => toggleSort('status')}>
+                              Status <span className="sort-arrow">{sortArrow('status')}</span>
+                            </button>
+                          </th>
+                          <th className="sortable" aria-sort={ariaSortFor('cronExpr')}>
+                            <button className="sort-btn" onClick={() => toggleSort('cronExpr')}>
+                              Schedule <span className="sort-arrow">{sortArrow('cronExpr')}</span>
+                            </button>
+                          </th>
+                          <th className="sortable col-updated" aria-sort={ariaSortFor('nextRunAt')}>
+                            <button className="sort-btn" onClick={() => toggleSort('nextRunAt')}>
+                              Next run <span className="sort-arrow">{sortArrow('nextRunAt')}</span>
+                            </button>
+                          </th>
+                          <th className="sortable" aria-sort={ariaSortFor('lastRunOutcome')}>
+                            <button className="sort-btn" onClick={() => toggleSort('lastRunOutcome')}>
+                              Last outcome <span className="sort-arrow">{sortArrow('lastRunOutcome')}</span>
+                            </button>
+                          </th>
+                          <th className="sortable col-updated" aria-sort={ariaSortFor('createdAt')}>
+                            <button className="sort-btn" onClick={() => toggleSort('createdAt')}>
+                              Created <span className="sort-arrow">{sortArrow('createdAt')}</span>
+                            </button>
+                          </th>
+                          <th style={{ textAlign: 'right' }}>Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {pageRows.map(j => (
+                          <tr
+                            key={j.id}
+                            className={editing?.id === j.id ? 'active' : ''}
+                            onClick={() => { setCreating(false); setEditing(j); }}
+                          >
+                            <td>
+                              <span className="cell-primary">{j.agentId}</span>
+                            </td>
+                            <td>
+                              <span className={`status-pill ${j.status}`}>{j.status}</span>
+                            </td>
+                            <td className="cell-mono">{formatSchedule(j)}</td>
+                            <td className="cell-mono col-updated">{formatDate(j.nextRunAt)}</td>
+                            <td>{j.lastRunOutcome ?? <span className="cell-muted">—</span>}</td>
+                            <td className="cell-mono col-updated">{formatDate(j.createdAt)}</td>
+                            <td>
+                              <div className="cell-actions" onClick={e => e.stopPropagation()}>
+                                <button
+                                  className="btn-icon"
+                                  title="Edit"
+                                  onClick={() => { setCreating(false); setEditing(j); }}
+                                >
+                                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                    <path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"/>
+                                  </svg>
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        ))}
+                        {pageRows.length === 0 && (
+                          <tr>
+                            <td colSpan={7} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
+                              No jobs match.
+                            </td>
+                          </tr>
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                  <Pagination
+                    total={filtered.length}
+                    page={safePage}
+                    pageSize={pageSize}
+                    totalPages={totalPages}
+                    onPage={setPage}
+                    onPageSize={n => { setPageSize(n); setPage(1); }}
+                  />
+                </div>
+
+                {(editing !== null || creating) && (
+                  <JobEditDrawer
+                    key={editing?.id ?? 'new'}
+                    job={editing}
+                    creating={creating}
+                    onClose={() => { setEditing(null); setCreating(false); }}
+                    onSaved={handleSaved}
+                    onDeleted={handleDeleted}
+                  />
+                )}
+              </div>
+            </>
+          )}
+        </main>
+      </div>
+    </MobileMenuContext.Provider>
+  );
+}

--- a/apps/console/src/pages/JobsPage.tsx
+++ b/apps/console/src/pages/JobsPage.tsx
@@ -43,6 +43,15 @@ function formatDate(iso: string | null): string {
   return iso.slice(0, 16).replace('T', ' ');
 }
 
+// Convert a UTC ISO timestamp to the datetime-local input format (local wall-clock time).
+// Slicing the UTC string directly produces a string the input treats as local time,
+// shifting the stored moment by the user's timezone offset on every save.
+function utcToLocal(utcIso: string | null): string {
+  if (!utcIso) return '';
+  const d = new Date(utcIso);
+  return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+}
+
 function formatSchedule(job: Job): string {
   if (job.cronExpr) return job.cronExpr;
   if (job.runAt) return formatDate(job.runAt);
@@ -120,7 +129,7 @@ function JobEditDrawer({ job, creating, onClose, onSaved, onDeleted }: DrawerPro
 
   const [agentId, setAgentId] = useState(job?.agentId ?? '');
   const [cronExpr, setCronExpr] = useState(job?.cronExpr ?? '');
-  const [runAt, setRunAt] = useState(job?.runAt?.slice(0, 16) ?? '');
+  const [runAt, setRunAt] = useState(utcToLocal(job?.runAt ?? null));
   const [scheduleType, setScheduleType] = useState<'cron' | 'run_at'>(isCronJob ? 'cron' : 'run_at');
   const [taskPayload, setTaskPayload] = useState(
     job ? JSON.stringify(job.taskPayload, null, 2) : '{\n  \n}',
@@ -495,8 +504,12 @@ export default function JobsPage() {
     }
     const dir = sort.dir === 'asc' ? 1 : -1;
     rows = [...rows].sort((a, b) => {
-      const av = (a[sort.key] ?? '') as string;
-      const bv = (b[sort.key] ?? '') as string;
+      // 'cronExpr' is the sort key for the Schedule column; fall back to runAt
+      // for one-time jobs so they sort by date rather than all comparing as ''.
+      const getVal = (j: Job): string =>
+        sort.key === 'cronExpr' ? formatSchedule(j) : ((j[sort.key] ?? '') as string);
+      const av = getVal(a);
+      const bv = getVal(b);
       if (av < bv) return -1 * dir;
       if (av > bv) return  1 * dir;
       return 0;

--- a/apps/console/src/pages/JobsPage.tsx
+++ b/apps/console/src/pages/JobsPage.tsx
@@ -417,7 +417,7 @@ function JobEditDrawer({ job, creating, onClose, onSaved, onDeleted }: DrawerPro
 
 type StatusFilter = 'all' | JobStatus;
 
-const ALL_STATUSES: JobStatus[] = ['pending', 'running', 'suspended', 'completed', 'cancelled', 'failed'];
+const ALL_STATUSES: JobStatus[] = ['pending', 'running', 'suspended', 'paused', 'completed', 'cancelled', 'failed'];
 
 export default function JobsPage() {
   const [theme, setTheme] = useTheme();
@@ -439,6 +439,9 @@ export default function JobsPage() {
   }, [mobileOpen]);
 
   const load = useCallback(async () => {
+    // Clear stale state before each fetch so error and data cannot coexist.
+    setLoadError(null);
+    setJobs([]);
     try {
       const res = await apiFetch('/api/jobs');
       if (!res.ok) throw new Error(await errorMessage(res));

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -343,6 +343,7 @@ function SettingsLayout({ activeSection, children }: SettingsLayoutProps) {
       autonomy:  '/settings/autonomy',
       settings:  '/settings/workspace',
       dashboard: '/',
+      wizard:    '/setup',
     };
     const to = routes[view];
     if (to) {

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -337,21 +337,17 @@ function SettingsLayout({ activeSection, children }: SettingsLayoutProps) {
   }, [mobileOpen]);
 
   function handleNavigate(view: string) {
-    if (view === 'contacts') {
-      navigate({ to: '/contacts' }).catch(err => {
-        console.error('[SettingsLayout] navigation to /contacts failed:', err);
-      });
-    } else if (view === 'autonomy') {
-      navigate({ to: '/settings/autonomy' }).catch(err => {
-        console.error('[SettingsLayout] navigation to /settings/autonomy failed:', err);
-      });
-    } else if (view === 'settings') {
-      navigate({ to: '/settings/workspace' }).catch(err => {
-        console.error('[SettingsLayout] navigation to /settings/workspace failed:', err);
-      });
-    } else if (view === 'dashboard') {
-      navigate({ to: '/' }).catch(err => {
-        console.error('[SettingsLayout] navigation to / failed:', err);
+    const routes: Record<string, string> = {
+      contacts:  '/contacts',
+      jobs:      '/jobs',
+      autonomy:  '/settings/autonomy',
+      settings:  '/settings/workspace',
+      dashboard: '/',
+    };
+    const to = routes[view];
+    if (to) {
+      navigate({ to }).catch(err => {
+        console.error(`[SettingsLayout] navigation to ${to} failed:`, err);
       });
     }
   }

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -19,6 +19,7 @@ const WorkspacePage = lazy(() =>
 );
 const WizardPage = lazy(() => import('./pages/WizardPage'));
 const ContactsPage = lazy(() => import('./pages/ContactsPage'));
+const JobsPage = lazy(() => import('./pages/JobsPage'));
 const ChatPage = lazy(() => import('./pages/ChatPage'));
 
 const rootRoute = createRootRoute({
@@ -109,12 +110,19 @@ const contactsRoute = createRoute({
   component: ContactsPage,
 });
 
+const jobsRoute = createRoute({
+  getParentRoute: () => authedRoute,
+  path: '/jobs',
+  component: JobsPage,
+});
+
 const routeTree = rootRoute.addChildren([
   authedRoute.addChildren([
     dashboardRoute,
     chatRoute,
     setupRoute,
     contactsRoute,
+    jobsRoute,
     settingsRoute.addChildren([autonomyRoute, workspaceRoute]),
   ]),
   loginRoute,

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -314,6 +314,22 @@ input:focus, textarea:focus, select:focus {
 .btn-secondary { background: var(--app-card); color: var(--app-fg); border: 1px solid var(--app-input-bd); }
 .btn-secondary:hover { background: var(--app-muted); }
 
+.btn-danger { background: var(--app-destructive); color: #fff; border: none; }
+.btn-danger:hover { opacity: 0.88; }
+.btn-danger:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-sm { padding: 5px 10px; font-size: 12px; }
+
+.btn-icon {
+  background: none; border: none;
+  color: var(--app-fg-muted); padding: 4px; border-radius: 4px;
+  cursor: pointer; display: inline-flex; align-items: center;
+  transition: all 120ms;
+}
+.btn-icon:hover { color: var(--app-fg); background: var(--app-muted); }
+
+.topbar-meta { font-size: 12px; color: var(--app-fg-muted); }
+
 /* ── 8. Login page ───────────────────────────────────────────────────── */
 .login-root {
   height: 100vh; width: 100%;
@@ -889,6 +905,14 @@ input:focus, textarea:focus, select:focus {
 .status-pill.provisional::before { background: var(--app-amber); }
 .status-pill.blocked::before    { background: var(--app-destructive); }
 
+/* Job statuses */
+.status-pill.pending::before    { background: var(--app-amber); }
+.status-pill.running::before    { background: var(--app-teal); }
+.status-pill.suspended::before  { background: var(--app-destructive); }
+.status-pill.paused::before     { background: var(--app-amber); }
+.status-pill.completed::before  { background: var(--app-green); }
+.status-pill.failed::before     { background: var(--app-destructive); }
+
 /* ── Drawer (right-anchored) ───────────────────────────────────────── */
 .drawer {
   flex: none;
@@ -937,9 +961,11 @@ input:focus, textarea:focus, select:focus {
 .edit-drawer-form { padding: 16px 18px; display: flex; flex-direction: column; gap: 14px; }
 
 /* ── Records (CRUD table views) ────────────────────────────────────── */
-/* Mobile-only search bar (TopbarSearch is hidden below 768px by the shared stylesheet) */
+/* Mobile-only search bars (TopbarSearch is hidden below 768px by the shared stylesheet) */
 .contacts-mobile-search { display: none; padding: 8px 16px; }
 .contacts-mobile-search input { width: 100%; }
+.jobs-mobile-search { display: none; padding: 8px 16px; }
+.jobs-mobile-search input { width: 100%; }
 
 .records-layout { flex: 1; display: flex; overflow: hidden; min-height: 0; }
 .records-main {
@@ -1105,8 +1131,9 @@ table.records-table tbody tr.active td { background: transparent; }
   table.records-table .col-updated { display: none; }
   .records-toolbar { padding: 8px 14px; }
   .records-pagination { padding: 8px 14px; }
-  /* Show the mobile search bar (TopbarSearch is hidden at this breakpoint) */
+  /* Show the mobile search bars (TopbarSearch is hidden at this breakpoint) */
   .contacts-mobile-search { display: block; }
+  .jobs-mobile-search { display: block; }
 }
 
 /* ── Chat layout ─────────────────────────────────────────────────────── */

--- a/src/channels/http/routes/jobs.ts
+++ b/src/channels/http/routes/jobs.ts
@@ -78,9 +78,12 @@ export async function jobRoutes(
 
     // Normalize whitespace-only string fields to absent so required-field
     // checks below behave consistently regardless of how the client submits them.
-    const agentId = body.agent_id?.trim() || undefined;
-    const cronExpr = body.cron_expr?.trim() || undefined;
-    const runAt = body.run_at?.trim() || undefined;
+    // typeof guards defend against non-string values (e.g. numbers) that bypass
+    // the TypeScript cast above — trimming a non-string would throw before our
+    // error handler runs.
+    const agentId = typeof body.agent_id === 'string' ? body.agent_id.trim() || undefined : undefined;
+    const cronExpr = typeof body.cron_expr === 'string' ? body.cron_expr.trim() || undefined : undefined;
+    const runAt = typeof body.run_at === 'string' ? body.run_at.trim() || undefined : undefined;
 
     if (!agentId) {
       return reply.status(400).send({ error: 'agent_id is required' });
@@ -137,8 +140,10 @@ export async function jobRoutes(
 
     // Normalize whitespace-only string schedule fields to absent so they don't
     // pass the hasUpdateFields check while carrying no real value.
-    const cronExpr = body.cron_expr?.trim() || undefined;
-    const runAt = body.run_at?.trim() || undefined;
+    // typeof guards defend against non-string values that would throw before the
+    // try/catch below runs.
+    const cronExpr = typeof body.cron_expr === 'string' ? body.cron_expr.trim() || undefined : undefined;
+    const runAt = typeof body.run_at === 'string' ? body.run_at.trim() || undefined : undefined;
 
     const hasUpdateFields =
       cronExpr !== undefined ||

--- a/src/channels/http/routes/jobs.ts
+++ b/src/channels/http/routes/jobs.ts
@@ -108,8 +108,12 @@ export async function jobRoutes(
       const job = await schedulerService.getJob(result.jobId);
       if (!job) {
         // Extremely unlikely: job was created then immediately cancelled between
-        // the insert and this read.
-        return reply.status(404).send({ error: 'Job not found after creation' });
+        // the insert and this read. Use 500 — the job exists in the DB, the
+        // failure is on our side (read-back), not the client's request.
+        return reply.status(500).send({
+          error: 'Job was created but could not be retrieved — refresh to see it.',
+          jobId: result.jobId,
+        });
       }
 
       return reply.status(201).send({ job });
@@ -141,14 +145,15 @@ export async function jobRoutes(
       runAt !== undefined ||
       body.task_payload !== undefined;
 
-    // Existence check: return 404 now rather than letting a downstream no-op
-    // UPDATE silently succeed or the unsuspend path throw an opaque error.
-    const existing = await schedulerService.getJob(id);
-    if (!existing) {
-      return reply.status(404).send({ error: 'Job not found' });
-    }
-
     try {
+      // Existence check inside try so any DB error is caught and serialized
+      // consistently with the rest of the route, rather than surfacing as an
+      // unstructured Fastify 500.
+      const existing = await schedulerService.getJob(id);
+      if (!existing) {
+        return reply.status(404).send({ error: 'Job not found' });
+      }
+
       // Setting status to 'pending' is the unsuspend/unpause path.
       if (body.status === 'pending') {
         await schedulerService.unsuspendJob(id);

--- a/src/channels/http/routes/jobs.ts
+++ b/src/channels/http/routes/jobs.ts
@@ -76,35 +76,50 @@ export async function jobRoutes(
       error_budget?: Record<string, unknown>;
     };
 
-    // Validate required fields
-    if (!body.agent_id) {
+    // Normalize whitespace-only string fields to absent so required-field
+    // checks below behave consistently regardless of how the client submits them.
+    const agentId = body.agent_id?.trim() || undefined;
+    const cronExpr = body.cron_expr?.trim() || undefined;
+    const runAt = body.run_at?.trim() || undefined;
+
+    if (!agentId) {
       return reply.status(400).send({ error: 'agent_id is required' });
     }
     if (!body.task_payload) {
       return reply.status(400).send({ error: 'task_payload is required' });
     }
-    if (!body.cron_expr && !body.run_at) {
+    if (!cronExpr && !runAt) {
       return reply.status(400).send({ error: 'Either cron_expr or run_at must be provided' });
     }
 
     try {
       const result = await schedulerService.createJob({
-        agentId: body.agent_id,
-        cronExpr: body.cron_expr,
-        runAt: body.run_at ? new Date(body.run_at) : undefined,
+        agentId,
+        cronExpr,
+        runAt: runAt ? new Date(runAt) : undefined,
         taskPayload: body.task_payload,
         createdBy: 'api',
         intentAnchor: body.intent_anchor,
         errorBudget: body.error_budget,
       });
-      return reply.status(201).send(result);
+
+      // Fetch the full job row so the caller can render it immediately without
+      // a separate GET request.
+      const job = await schedulerService.getJob(result.jobId);
+      if (!job) {
+        // Extremely unlikely: job was created then immediately cancelled between
+        // the insert and this read.
+        return reply.status(404).send({ error: 'Job not found after creation' });
+      }
+
+      return reply.status(201).send({ job });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to create job';
       return reply.status(400).send({ error: message });
     }
   });
 
-  // -- PATCH /api/jobs/:id — update an existing job --
+  // -- PATCH /api/jobs/:id — update or unsuspend an existing job --
 
   app.patch('/api/jobs/:id', async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
@@ -116,28 +131,46 @@ export async function jobRoutes(
       task_payload?: Record<string, unknown>;
     };
 
-    // When not unsuspending, require at least one updatable field so we don't
-    // report a successful update when nothing actually changes in the database.
+    // Normalize whitespace-only string schedule fields to absent so they don't
+    // pass the hasUpdateFields check while carrying no real value.
+    const cronExpr = body.cron_expr?.trim() || undefined;
+    const runAt = body.run_at?.trim() || undefined;
+
     const hasUpdateFields =
-      body.cron_expr !== undefined ||
-      body.run_at !== undefined ||
+      cronExpr !== undefined ||
+      runAt !== undefined ||
       body.task_payload !== undefined;
 
+    // Existence check: return 404 now rather than letting a downstream no-op
+    // UPDATE silently succeed or the unsuspend path throw an opaque error.
+    const existing = await schedulerService.getJob(id);
+    if (!existing) {
+      return reply.status(404).send({ error: 'Job not found' });
+    }
+
     try {
-      // If the caller is setting status back to 'pending', treat it as an unsuspend.
-      // The unsuspendJob method handles validation (must currently be suspended).
+      // Setting status to 'pending' is the unsuspend/unpause path.
       if (body.status === 'pending') {
         await schedulerService.unsuspendJob(id);
       } else if (!hasUpdateFields) {
         return reply.status(400).send({ error: 'At least one of cron_expr, run_at, or task_payload must be provided' });
       } else {
         await schedulerService.updateJob(id, {
-          cronExpr: body.cron_expr,
-          runAt: body.run_at ? new Date(body.run_at) : undefined,
+          cronExpr,
+          runAt: runAt ? new Date(runAt) : undefined,
           taskPayload: body.task_payload,
         });
       }
-      return reply.status(200).send({ updated: true, jobId: id });
+
+      // Read the updated row back so the caller can update its local state
+      // without a separate GET. Return 404 if the job disappeared between the
+      // mutation above and this read (e.g. concurrent cancel).
+      const job = await schedulerService.getJob(id);
+      if (!job) {
+        return reply.status(404).send({ error: 'Job not found after update' });
+      }
+
+      return reply.status(200).send({ job });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to update job';
       return reply.status(400).send({ error: message });

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -765,14 +765,7 @@ function createUiHtml(): string {
               Tasks
             </button>
 
-            <button id="nav-scheduled-jobs" class="nav-sub-item" onclick="navigate('scheduled-jobs', 'Scheduled Jobs', 'nav-scheduled-jobs')">
-              <!-- clock icon -->
-              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                <circle cx="6.5" cy="6.5" r="5"/>
-                <path d="M6.5 3.75v3.15l2 1.25"/>
-              </svg>
-              Scheduled Jobs
-            </button>
+            <!-- Scheduled Jobs removed: ported to /jobs in the new console app (#782) -->
           </div>
         </div>
 

--- a/tests/unit/channels/http/jobs-routes.test.ts
+++ b/tests/unit/channels/http/jobs-routes.test.ts
@@ -104,6 +104,26 @@ describe('Job routes', () => {
   // -- POST /api/jobs --
 
   it('POST /api/jobs creates a job (201)', async () => {
+    // Route calls getJob() after createJob() to return the full job row.
+    const createdJob: JobRow = {
+      id: 'job-1',
+      agentId: 'agent-a',
+      cronExpr: '0 9 * * *',
+      runAt: null,
+      taskPayload: { task: 'daily-report' },
+      status: 'pending',
+      lastRunAt: null,
+      nextRunAt: '2026-04-01T09:00:00Z',
+      lastError: null,
+      consecutiveFailures: 0,
+      createdBy: 'api',
+      createdAt: '2026-03-29T00:00:00Z',
+      agentTaskId: null,
+      intentAnchor: null,
+      progress: null,
+    };
+    vi.mocked(scheduler.getJob).mockResolvedValueOnce(createdJob);
+
     const response = await app.inject({
       method: 'POST',
       url: '/api/jobs',
@@ -116,7 +136,8 @@ describe('Job routes', () => {
     });
     expect(response.statusCode).toBe(201);
     const body = JSON.parse(response.body);
-    expect(body).toHaveProperty('jobId');
+    expect(body).toHaveProperty('job');
+    expect(body.job.id).toBe('job-1');
     expect(scheduler.createJob).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: 'agent-a',
@@ -183,7 +204,30 @@ describe('Job routes', () => {
 
   // -- PATCH /api/jobs/:id --
 
+  // Reusable job stub for PATCH tests — routes now call getJob() for existence
+  // checks and post-mutation read-backs, so we need a non-null mock return.
+  const patchJob: JobRow = {
+    id: 'job-50',
+    agentId: 'agent-b',
+    cronExpr: '0 9 * * *',
+    runAt: null,
+    taskPayload: { task: 'test' },
+    status: 'suspended',
+    lastRunAt: null,
+    nextRunAt: null,
+    lastError: null,
+    consecutiveFailures: 0,
+    createdBy: 'api',
+    createdAt: '2026-03-29T00:00:00Z',
+    agentTaskId: null,
+    intentAnchor: null,
+    progress: null,
+  };
+
   it('PATCH /api/jobs/:id unsuspends a suspended job', async () => {
+    // getJob called twice: existence check + post-mutation read-back.
+    vi.mocked(scheduler.getJob).mockResolvedValueOnce(patchJob).mockResolvedValueOnce({ ...patchJob, status: 'pending' });
+
     const response = await app.inject({
       method: 'PATCH',
       url: '/api/jobs/job-50',
@@ -192,11 +236,15 @@ describe('Job routes', () => {
     });
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(response.body);
-    expect(body).toEqual({ updated: true, jobId: 'job-50' });
+    expect(body).toHaveProperty('job');
+    expect(body.job.id).toBe('job-50');
     expect(scheduler.unsuspendJob).toHaveBeenCalledWith('job-50');
   });
 
   it('PATCH /api/jobs/:id calls updateJob for non-status changes', async () => {
+    // getJob called twice: existence check + post-mutation read-back.
+    vi.mocked(scheduler.getJob).mockResolvedValueOnce(patchJob).mockResolvedValueOnce(patchJob);
+
     const response = await app.inject({
       method: 'PATCH',
       url: '/api/jobs/job-50',
@@ -212,6 +260,8 @@ describe('Job routes', () => {
   });
 
   it('PATCH /api/jobs/:id returns 400 on service error', async () => {
+    // getJob returns the job (existence check passes), then unsuspendJob throws.
+    vi.mocked(scheduler.getJob).mockResolvedValueOnce(patchJob);
     vi.mocked(scheduler.unsuspendJob).mockRejectedValueOnce(new Error('Job job-50 not found or not suspended'));
 
     const response = await app.inject({


### PR DESCRIPTION
## **User description**
## Summary

- Adds `/jobs` route (`JobsPage.tsx`) following the ContactsPage pattern: sortable records table, status filter chips (All/Pending/Running/Suspended/Paused/Completed/Cancelled/Failed), mobile search input, and an edit drawer with a dedicated Resume action for suspended/paused jobs
- Updates jobs API: POST and PATCH now return the full `JobRow`; PATCH adds a pre-mutation existence check (404) and a post-update read-back (404 on race); whitespace-only `cron_expr`/`run_at` body fields are normalized to absent before validation
- Adds CSS utilities used by the new page (`btn-sm`, `btn-danger`, `btn-icon`, `topbar-meta`, `jobs-mobile-search`, job status pill variants)
- Fixes `handleNavigate` in ContactsPage, DashboardPage, ChatPage, and SettingsPage to route `jobs` → `/jobs` instead of `/`
- Removes the Scheduled Jobs nav item from the legacy `/old` sidebar

Closes #782

## Test plan

- [ ] Navigate to `/jobs` — table renders, sidebar "Scheduled Jobs" item is active
- [ ] Sidebar "Scheduled Jobs" link from every other page (Dashboard, Contacts, Chat, Settings) navigates to `/jobs`
- [ ] Browser back/forward between `/jobs` and other routes works correctly
- [ ] Status filter chips count and filter correctly; "Paused" chip appears when paused jobs exist
- [ ] Sort by each column (Agent, Status, Schedule, Next Run, Last Outcome, Created)
- [ ] Search filters by agent ID, cron expression, and intent anchor; mobile search input is visible below 768px
- [ ] Create a cron job: fill agent ID, select "Cron", enter expression, paste valid JSON payload, click Create
- [ ] Create a one-time job: select "One-time", pick a datetime, click Create
- [ ] Edit a job: open drawer, change cron expression or payload, click Save changes
- [ ] Resume a suspended job: open drawer, click Resume — status changes to pending
- [ ] Cancel a job: open drawer, click Cancel job — job is soft-deleted and removed from list
- [ ] PATCH a non-existent job ID returns 404 (not 500)
- [ ] POST/PATCH responses include the full job object (check network tab)
- [ ] `/old` sidebar no longer shows the Scheduled Jobs link


___

## **CodeAnt-AI Description**
**Add a new Scheduled Jobs page with full job management in the console**

### What Changed
- Added a new `/jobs` page with a searchable, sortable table of scheduled jobs, status filters, paging, and a side drawer for viewing and editing a job
- Users can create cron or one-time jobs, edit schedules and payloads, resume suspended or paused jobs, and cancel jobs from the drawer
- Jobs now load with their full details immediately after create or update, so the page updates without an extra refresh
- Fixed sidebar navigation so Scheduled Jobs opens the new page from Dashboard, Contacts, Chat, and Settings, and removed the old Scheduled Jobs entry from the legacy sidebar

### Impact
`✅ Faster access to scheduled jobs`
`✅ Fewer wrong-page navigation clicks`
`✅ Clearer job status filtering`
`✅ Immediate job updates after save`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New Scheduled Jobs management page with full create, read, update, and delete operations, search, filtering by status, and pagination support
  * Resume functionality for suspended jobs
  * Mobile-responsive interface for job management

* **Refactor**
  * Streamlined navigation routing structure across console pages

* **Style**
  * Added new button styles (danger, small, and icon variants)
  * Extended status pill styling for job states

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/789?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->