### PR TITLE
feat: port Tasks view to new console app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **Scheduled Jobs view** — new `/jobs` console page with CRUD, status filters, and resume action for suspended jobs; removes legacy nav item. (#782)
+- **Tasks view** — new console page at `/tasks` with full CRUD, sortable columns, and status filter chips; legacy `/old/tasks` removed. (#783)
 - **Contacts view** — new console page at `/contacts` with full CRUD and editable trust level; legacy `/old/contacts` removed. (#781)
 
 ### Changed

--- a/apps/console/src/pages/TasksPage.tsx
+++ b/apps/console/src/pages/TasksPage.tsx
@@ -8,31 +8,39 @@ import { useTheme } from '../hooks/useTheme.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type ContactStatus = 'confirmed' | 'provisional' | 'blocked';
-type TrustLevel = 'ceo' | 'high' | 'medium' | 'low' | null;
-type SystemRole = 'principal' | 'agent' | 'system' | null;
+type TaskStatus = 'active' | 'pending' | 'paused' | 'completed' | 'failed' | 'cancelled';
 
-interface Contact {
+interface Task {
   id: string;
-  kgNodeId: string | null;
-  displayName: string;
-  role: string | null;
-  status: ContactStatus;
-  notes: string | null;
-  trustLevel: TrustLevel;
-  systemRole: SystemRole;
+  agentId: string;
+  intentAnchor: string;
+  status: TaskStatus;
+  progress: Record<string, unknown>;
+  errorBudget: Record<string, unknown>;
+  conversationId: string | null;
+  scheduledJobId: string | null;
   createdAt: string;
   updatedAt: string;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function initials(name: string): string {
-  return name.split(' ').map(s => s[0] ?? '').slice(0, 2).join('').toUpperCase();
-}
-
 function formatDate(iso: string): string {
   return iso.slice(0, 10); // YYYY-MM-DD
+}
+
+function prettyJson(value: Record<string, unknown>): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function parseJsonField(raw: string, fieldLabel: string): Record<string, unknown> {
+  const v = raw.trim();
+  if (!v) return {};
+  try {
+    return JSON.parse(v) as Record<string, unknown>;
+  } catch {
+    throw new Error(`${fieldLabel} must be valid JSON.`);
+  }
 }
 
 async function errorMessage(res: Response): Promise<string> {
@@ -94,50 +102,67 @@ function Pagination({ total, page, pageSize, totalPages, onPage, onPageSize }: P
 // ── Edit / Create drawer ──────────────────────────────────────────────────────
 
 interface DrawerProps {
-  contact: Contact | null;
+  task: Task | null;
   creating: boolean;
   onClose: () => void;
-  onSaved: (contact: Contact) => void;
+  onSaved: (task: Task) => void;
   onDeleted: (id: string) => void;
 }
 
-function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: DrawerProps) {
-  const [displayName, setDisplayName] = useState(contact?.displayName ?? '');
-  const [role, setRole] = useState(contact?.role ?? '');
-  const [status, setStatus] = useState<ContactStatus>(contact?.status ?? 'provisional');
-  const [trustLevel, setTrustLevel] = useState<TrustLevel>(contact?.trustLevel ?? null);
-  const [kgNodeId, setKgNodeId] = useState(contact?.kgNodeId ?? '');
-  const [notes, setNotes] = useState(contact?.notes ?? '');
+function TaskEditDrawer({ task, creating, onClose, onSaved, onDeleted }: DrawerProps) {
+  const [agentId, setAgentId] = useState(task?.agentId ?? '');
+  const [intentAnchor, setIntentAnchor] = useState(task?.intentAnchor ?? '');
+  const [status, setStatus] = useState<TaskStatus>(task?.status ?? 'pending');
+  const [conversationId, setConversationId] = useState(task?.conversationId ?? '');
+  const [scheduledJobId, setScheduledJobId] = useState(task?.scheduledJobId ?? '');
+  const [errorBudget, setErrorBudget] = useState(prettyJson(task?.errorBudget ?? {}));
+  const [progress, setProgress] = useState(prettyJson(task?.progress ?? {}));
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   async function handleSave() {
-    if (!displayName.trim()) {
-      setError('Display name is required.');
+    if (!agentId.trim()) {
+      setError('Agent ID is required.');
       return;
     }
+    if (!intentAnchor.trim()) {
+      setError('Intent anchor is required.');
+      return;
+    }
+
+    let parsedErrorBudget: Record<string, unknown>;
+    let parsedProgress: Record<string, unknown>;
+    try {
+      parsedErrorBudget = parseJsonField(errorBudget, 'Error budget');
+      parsedProgress = parseJsonField(progress, 'Progress');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Invalid JSON');
+      return;
+    }
+
     setSaving(true);
     setError(null);
     try {
       const body = {
-        displayName: displayName.trim(),
-        role: role.trim() || null,
+        agentId: agentId.trim(),
+        intentAnchor: intentAnchor.trim(),
         status,
-        trustLevel: trustLevel ?? null,
-        notes: notes.trim() || null,
-        kgNodeId: kgNodeId.trim() || null,
+        conversationId: conversationId.trim() || null,
+        scheduledJobId: scheduledJobId.trim() || null,
+        errorBudget: parsedErrorBudget,
+        progress: parsedProgress,
       };
 
       let res: Response;
       if (creating) {
-        res = await apiFetch('/api/kg/contacts', {
+        res = await apiFetch('/api/kg/tasks', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
         });
       } else {
-        res = await apiFetch(`/api/kg/contacts/${contact!.id}`, {
+        res = await apiFetch(`/api/kg/tasks/${task!.id}`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
@@ -148,10 +173,10 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
         throw new Error(await errorMessage(res));
       }
 
-      const data = await res.json() as { contact: Contact };
-      onSaved(data.contact);
+      const data = await res.json() as { task: Task };
+      onSaved(data.task);
     } catch (err) {
-      console.error('[ContactEditDrawer] save failed:', err);
+      console.error('[TaskEditDrawer] save failed:', err);
       setError(err instanceof Error ? err.message : 'Save failed');
     } finally {
       setSaving(false);
@@ -159,15 +184,15 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
   }
 
   async function handleDelete() {
-    if (!contact) return;
+    if (!task) return;
     setDeleting(true);
     setError(null);
     try {
-      const res = await apiFetch(`/api/kg/contacts/${contact.id}`, { method: 'DELETE' });
+      const res = await apiFetch(`/api/kg/tasks/${task.id}`, { method: 'DELETE' });
       if (!res.ok) throw new Error(await errorMessage(res));
-      onDeleted(contact.id);
+      onDeleted(task.id);
     } catch (err) {
-      console.error('[ContactEditDrawer] delete failed:', err);
+      console.error('[TaskEditDrawer] delete failed:', err);
       setError(err instanceof Error ? err.message : 'Delete failed');
     } finally {
       setDeleting(false);
@@ -178,16 +203,16 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
     <aside className="drawer">
       <div className="drawer-header">
         <div className="drawer-header-top">
-          <span className="badge badge-person">contact</span>
+          <span className="badge badge-task">task</span>
           <button className="drawer-close" onClick={onClose} aria-label="Close">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
               <line x1="6" y1="6" x2="18" y2="18" /><line x1="18" y1="6" x2="6" y2="18" />
             </svg>
           </button>
         </div>
-        <h2 className="drawer-title-h2">{creating ? 'New contact' : (contact?.displayName ?? '')}</h2>
-        {!creating && contact && (
-          <div className="drawer-subtitle">{[contact.role].filter(Boolean).join(' · ')}</div>
+        <h2 className="drawer-title-h2">{creating ? 'New task' : (task?.agentId ?? '')}</h2>
+        {!creating && task && (
+          <div className="drawer-subtitle">{task.status}</div>
         )}
       </div>
 
@@ -197,40 +222,41 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
 
           <div className="form-grid">
             <div className="form-field">
-              <label htmlFor="cf-name">Display name</label>
-              <input id="cf-name" type="text" value={displayName} onChange={e => setDisplayName(e.target.value)} placeholder="Full name" />
+              <label htmlFor="tf-agent-id">Agent ID</label>
+              <input id="tf-agent-id" type="text" value={agentId} onChange={e => setAgentId(e.target.value)} placeholder="e.g. coordinator" />
             </div>
             <div className="form-field">
-              <label htmlFor="cf-role">Role</label>
-              <input id="cf-role" type="text" value={role} onChange={e => setRole(e.target.value)} placeholder="Title" />
-            </div>
-            <div className="form-field">
-              <label htmlFor="cf-status">Status</label>
-              <select id="cf-status" value={status} onChange={e => setStatus(e.target.value as ContactStatus)}>
-                <option value="confirmed">Confirmed</option>
-                <option value="provisional">Provisional</option>
-                <option value="blocked">Blocked</option>
+              <label htmlFor="tf-status">Status</label>
+              <select id="tf-status" value={status} onChange={e => setStatus(e.target.value as TaskStatus)}>
+                <option value="active">active</option>
+                <option value="pending">pending</option>
+                <option value="paused">paused</option>
+                <option value="completed">completed</option>
+                <option value="failed">failed</option>
+                <option value="cancelled">cancelled</option>
               </select>
             </div>
             <div className="form-field">
-              <label htmlFor="cf-trust">Trust level</label>
-              <select id="cf-trust" value={trustLevel ?? ''} onChange={e => setTrustLevel((e.target.value || null) as TrustLevel)}>
-                <option value="">None</option>
-                <option value="ceo">CEO</option>
-                <option value="high">High</option>
-                <option value="medium">Medium</option>
-                <option value="low">Low</option>
-              </select>
+              <label htmlFor="tf-conv-id">Conversation ID (UUID)</label>
+              <input id="tf-conv-id" type="text" value={conversationId} onChange={e => setConversationId(e.target.value)} placeholder="UUID — optional" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="tf-job-id">Scheduled Job ID (UUID)</label>
+              <input id="tf-job-id" type="text" value={scheduledJobId} onChange={e => setScheduledJobId(e.target.value)} placeholder="UUID — optional" />
             </div>
           </div>
 
           <div className="form-field">
-            <label htmlFor="cf-kg">KG node ID</label>
-            <input id="cf-kg" type="text" value={kgNodeId} onChange={e => setKgNodeId(e.target.value)} placeholder="UUID — optional" />
+            <label htmlFor="tf-intent">Intent anchor</label>
+            <textarea id="tf-intent" rows={3} value={intentAnchor} onChange={e => setIntentAnchor(e.target.value)} placeholder="Persistent task goal/context…" />
           </div>
           <div className="form-field">
-            <label htmlFor="cf-notes">Notes</label>
-            <textarea id="cf-notes" rows={4} value={notes} onChange={e => setNotes(e.target.value)} />
+            <label htmlFor="tf-budget">Error budget JSON</label>
+            <textarea id="tf-budget" rows={4} value={errorBudget} onChange={e => setErrorBudget(e.target.value)} placeholder='{"maxTurns": 12, "maxConsecutiveErrors": 3}' style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 12 }} />
+          </div>
+          <div className="form-field">
+            <label htmlFor="tf-progress">Progress JSON</label>
+            <textarea id="tf-progress" rows={4} value={progress} onChange={e => setProgress(e.target.value)} placeholder='{"phase": "initializing"}' style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 12 }} />
           </div>
         </div>
       </div>
@@ -240,8 +266,7 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
           <button
             className="btn btn-danger btn-sm"
             onClick={() => void handleDelete()}
-            disabled={deleting || contact?.systemRole !== null && contact?.systemRole !== undefined}
-            title={contact?.systemRole ? 'System contacts cannot be deleted' : undefined}
+            disabled={deleting}
           >
             {deleting ? 'Deleting…' : 'Delete'}
           </button>
@@ -258,19 +283,24 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
 
 // ── Main page ─────────────────────────────────────────────────────────────────
 
-export default function ContactsPage() {
+type SortKey = 'agentId' | 'intentAnchor' | 'status' | 'updatedAt';
+
+const STATUS_FILTERS = ['all', 'active', 'pending', 'paused', 'completed', 'failed', 'cancelled'] as const;
+type StatusFilter = typeof STATUS_FILTERS[number];
+
+export default function TasksPage() {
   const [theme, setTheme] = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
   const navigate = useNavigate();
 
-  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [tasks, setTasks] = useState<Task[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<'all' | ContactStatus>('all');
-  const [sort, setSort] = useState<{ key: keyof Contact; dir: 'asc' | 'desc' }>({ key: 'updatedAt', dir: 'desc' });
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' }>({ key: 'updatedAt', dir: 'desc' });
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
-  const [editing, setEditing] = useState<Contact | null>(null);
+  const [editing, setEditing] = useState<Task | null>(null);
   const [creating, setCreating] = useState(false);
 
   useEffect(() => {
@@ -278,14 +308,15 @@ export default function ContactsPage() {
   }, [mobileOpen]);
 
   const load = useCallback(async () => {
+    setLoadError(null);
     try {
-      const res = await apiFetch('/api/kg/contacts');
+      const res = await apiFetch('/api/kg/tasks');
       if (!res.ok) throw new Error(await errorMessage(res));
-      const data = await res.json() as { contacts: Contact[] };
-      setContacts(data.contacts);
+      const data = await res.json() as { tasks: Task[] };
+      setTasks(data.tasks);
     } catch (err) {
-      console.error('[ContactsPage] failed to load contacts:', err);
-      setLoadError(err instanceof Error ? err.message : 'Failed to load contacts');
+      console.error('[TasksPage] failed to load tasks:', err);
+      setLoadError(err instanceof Error ? err.message : 'Failed to load tasks');
     }
   }, []);
 
@@ -293,37 +324,36 @@ export default function ContactsPage() {
 
   function handleNavigate(view: string) {
     const routes: Record<string, string> = {
-      contacts:  '/contacts',
-      kg:        '/',
-      chat:      '/',
-      tasks:     '/tasks',
-      jobs:      '/jobs',
-      autonomy:  '/settings/autonomy',
-      settings:  '/settings/autonomy',
-      wizard:    '/setup',
+      tasks:    '/tasks',
+      contacts: '/contacts',
+      kg:       '/',
+      chat:     '/',
+      jobs:     '/',
+      autonomy: '/settings/autonomy',
+      settings: '/settings/autonomy',
+      wizard:   '/setup',
     };
     const to = routes[view];
     if (to) {
       navigate({ to }).catch(err => {
-        console.error(`[ContactsPage] navigation to ${to} failed:`, err);
+        console.error(`[TasksPage] navigation to ${to} failed:`, err);
       });
     }
   }
 
-  const counts = useMemo(() => ({
-    all:         contacts.length,
-    confirmed:   contacts.filter(c => c.status === 'confirmed').length,
-    provisional: contacts.filter(c => c.status === 'provisional').length,
-    blocked:     contacts.filter(c => c.status === 'blocked').length,
-  }), [contacts]);
+  const counts = useMemo(() => {
+    const c: Record<StatusFilter, number> = { all: tasks.length, active: 0, pending: 0, paused: 0, completed: 0, failed: 0, cancelled: 0 };
+    for (const t of tasks) c[t.status]++;
+    return c;
+  }, [tasks]);
 
   const filtered = useMemo(() => {
-    let rows = contacts;
-    if (statusFilter !== 'all') rows = rows.filter(c => c.status === statusFilter);
+    let rows = tasks;
+    if (statusFilter !== 'all') rows = rows.filter(t => t.status === statusFilter);
     if (search) {
       const q = search.toLowerCase();
-      rows = rows.filter(c =>
-        (c.displayName + ' ' + (c.role ?? '')).toLowerCase().includes(q)
+      rows = rows.filter(t =>
+        (t.agentId + ' ' + t.intentAnchor).toLowerCase().includes(q)
       );
     }
     const dir = sort.dir === 'asc' ? 1 : -1;
@@ -335,35 +365,37 @@ export default function ContactsPage() {
       return 0;
     });
     return rows;
-  }, [contacts, statusFilter, search, sort]);
+  }, [tasks, statusFilter, search, sort]);
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   const safePage = Math.min(page, totalPages);
   const pageRows = filtered.slice((safePage - 1) * pageSize, safePage * pageSize);
 
-  function toggleSort(key: keyof Contact) {
+  function toggleSort(key: SortKey) {
     setSort(s => s.key === key
       ? { key, dir: s.dir === 'asc' ? 'desc' : 'asc' }
       : { key, dir: 'asc' });
   }
-  const sortArrow = (key: keyof Contact) => sort.key === key ? (sort.dir === 'asc' ? '↑' : '↓') : '';
+  const sortArrow = (key: SortKey) => sort.key === key ? (sort.dir === 'asc' ? '↑' : '↓') : '';
+  const ariaSort = (key: SortKey): 'ascending' | 'descending' | 'none' =>
+    sort.key === key ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none';
 
-  function handleSaved(contact: Contact) {
-    setContacts(prev => {
-      const idx = prev.findIndex(c => c.id === contact.id);
+  function handleSaved(task: Task) {
+    setTasks(prev => {
+      const idx = prev.findIndex(t => t.id === task.id);
       if (idx >= 0) {
         const next = [...prev];
-        next[idx] = contact;
+        next[idx] = task;
         return next;
       }
-      return [...prev, contact];
+      return [...prev, task];
     });
-    setEditing(contact);
+    setEditing(task);
     setCreating(false);
   }
 
   function handleDeleted(id: string) {
-    setContacts(prev => prev.filter(c => c.id !== id));
+    setTasks(prev => prev.filter(t => t.id !== id));
     setEditing(null);
     setCreating(false);
   }
@@ -371,7 +403,7 @@ export default function ContactsPage() {
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
       <div className="app-root">
-        <Sidebar activeView="contacts" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
+        <Sidebar activeView="tasks" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
         {mobileOpen && (
           <div
             className="sidebar-backdrop"
@@ -380,9 +412,9 @@ export default function ContactsPage() {
           />
         )}
         <main className="main">
-          <Topbar crumb="Memory" title="Contacts">
+          <Topbar crumb="Memory" title="Tasks">
             <TopbarSearch
-              placeholder="Search name or role…"
+              placeholder="Search agent or intent…"
               value={search}
               onChange={v => { setSearch(v); setPage(1); }}
             />
@@ -391,7 +423,7 @@ export default function ContactsPage() {
               className="btn btn-primary btn-sm"
               onClick={() => { setEditing(null); setCreating(true); }}
             >
-              + New contact
+              + New task
             </button>
           </Topbar>
 
@@ -400,10 +432,10 @@ export default function ContactsPage() {
           ) : (
             <>
               {/* Mobile search — TopbarSearch is hidden below 768px by the shared stylesheet */}
-              <div className="contacts-mobile-search">
+              <div className="tasks-mobile-search">
                 <input
                   type="text"
-                  placeholder="Search name or role…"
+                  placeholder="Search agent or intent…"
                   value={search}
                   onChange={e => { setSearch(e.target.value); setPage(1); }}
                 />
@@ -411,7 +443,7 @@ export default function ContactsPage() {
 
               <div className="records-toolbar">
                 <div className="records-toolbar-left">
-                  {(['all', 'confirmed', 'provisional', 'blocked'] as const).map(v => (
+                  {STATUS_FILTERS.map(v => (
                     <button
                       key={v}
                       className={`records-filter-chip${statusFilter === v ? ' active' : ''}`}
@@ -425,7 +457,7 @@ export default function ContactsPage() {
                   ))}
                 </div>
                 <div className="records-toolbar-right">
-                  <span className="topbar-meta">{filtered.length} of {contacts.length}</span>
+                  <span className="topbar-meta">{filtered.length} of {tasks.length}</span>
                 </div>
               </div>
 
@@ -435,22 +467,22 @@ export default function ContactsPage() {
                     <table className="records-table">
                       <thead>
                         <tr>
-                          <th className="sortable" aria-sort={sort.key === 'displayName' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-                            <button className="sort-btn" onClick={() => toggleSort('displayName')}>
-                              Name <span className="sort-arrow">{sortArrow('displayName')}</span>
+                          <th className="sortable" aria-sort={ariaSort('agentId')}>
+                            <button className="sort-btn" onClick={() => toggleSort('agentId')}>
+                              Agent <span className="sort-arrow">{sortArrow('agentId')}</span>
                             </button>
                           </th>
-                          <th className="sortable" aria-sort={sort.key === 'role' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-                            <button className="sort-btn" onClick={() => toggleSort('role')}>
-                              Role <span className="sort-arrow">{sortArrow('role')}</span>
+                          <th className="sortable" aria-sort={ariaSort('intentAnchor')}>
+                            <button className="sort-btn" onClick={() => toggleSort('intentAnchor')}>
+                              Intent anchor <span className="sort-arrow">{sortArrow('intentAnchor')}</span>
                             </button>
                           </th>
-                          <th className="sortable" aria-sort={sort.key === 'status' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                          <th className="sortable" aria-sort={ariaSort('status')}>
                             <button className="sort-btn" onClick={() => toggleSort('status')}>
                               Status <span className="sort-arrow">{sortArrow('status')}</span>
                             </button>
                           </th>
-                          <th className="sortable col-updated" aria-sort={sort.key === 'updatedAt' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                          <th className="sortable col-updated" aria-sort={ariaSort('updatedAt')}>
                             <button className="sort-btn" onClick={() => toggleSort('updatedAt')}>
                               Updated <span className="sort-arrow">{sortArrow('updatedAt')}</span>
                             </button>
@@ -459,33 +491,24 @@ export default function ContactsPage() {
                         </tr>
                       </thead>
                       <tbody>
-                        {pageRows.map(c => (
+                        {pageRows.map(t => (
                           <tr
-                            key={c.id}
-                            className={editing?.id === c.id ? 'active' : ''}
-                            onClick={() => { setCreating(false); setEditing(c); }}
+                            key={t.id}
+                            className={editing?.id === t.id ? 'active' : ''}
+                            onClick={() => { setCreating(false); setEditing(t); }}
                           >
                             <td>
-                              <div className="cell-with-avatar">
-                                <span className="avatar-sm">{initials(c.displayName)}</span>
-                                <span className="cell-primary">{c.displayName}</span>
-                                {c.systemRole === 'principal' && (
-                                  <span className="system-role-badge system-role-principal">Principal</span>
-                                )}
-                                {c.systemRole === 'agent' && (
-                                  <span className="system-role-badge system-role-agent">Agent</span>
-                                )}
-                              </div>
+                              <span className="cell-primary">{t.agentId}</span>
                             </td>
-                            <td>{c.role ?? ''}</td>
-                            <td><span className={`status-pill ${c.status}`}>{c.status}</span></td>
-                            <td className="cell-mono col-updated">{formatDate(c.updatedAt)}</td>
+                            <td className="cell-intent">{t.intentAnchor}</td>
+                            <td><span className={`status-pill ${t.status}`}>{t.status}</span></td>
+                            <td className="cell-mono col-updated">{formatDate(t.updatedAt)}</td>
                             <td>
                               <div className="cell-actions" onClick={e => e.stopPropagation()}>
                                 <button
                                   className="btn-icon"
                                   title="Edit"
-                                  onClick={() => { setCreating(false); setEditing(c); }}
+                                  onClick={() => { setCreating(false); setEditing(t); }}
                                 >
                                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                                     <path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"/>
@@ -498,7 +521,7 @@ export default function ContactsPage() {
                         {pageRows.length === 0 && (
                           <tr>
                             <td colSpan={5} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
-                              No contacts match.
+                              No tasks match.
                             </td>
                           </tr>
                         )}
@@ -516,9 +539,9 @@ export default function ContactsPage() {
                 </div>
 
                 {(editing !== null || creating) && (
-                  <ContactEditDrawer
-                    key={editing?.id ?? 'new'}
-                    contact={editing}
+                  <TaskEditDrawer
+                    key={editing ? `${editing.id}-${editing.updatedAt}` : 'new'}
+                    task={editing}
                     creating={creating}
                     onClose={() => { setEditing(null); setCreating(false); }}
                     onSaved={handleSaved}

--- a/apps/console/src/pages/TasksPage.tsx
+++ b/apps/console/src/pages/TasksPage.tsx
@@ -411,7 +411,7 @@ export default function TasksPage() {
             aria-hidden="true"
           />
         )}
-        <main className="main">
+        <main className="main tasks-page">
           <Topbar crumb="Memory" title="Tasks">
             <TopbarSearch
               placeholder="Search agent or intent…"

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -20,6 +20,7 @@ const WorkspacePage = lazy(() =>
 const WizardPage = lazy(() => import('./pages/WizardPage'));
 const ContactsPage = lazy(() => import('./pages/ContactsPage'));
 const JobsPage = lazy(() => import('./pages/JobsPage'));
+const TasksPage = lazy(() => import('./pages/TasksPage'));
 const ChatPage = lazy(() => import('./pages/ChatPage'));
 
 const rootRoute = createRootRoute({
@@ -116,6 +117,12 @@ const jobsRoute = createRoute({
   component: JobsPage,
 });
 
+const tasksRoute = createRoute({
+  getParentRoute: () => authedRoute,
+  path: '/tasks',
+  component: TasksPage,
+});
+
 const routeTree = rootRoute.addChildren([
   authedRoute.addChildren([
     dashboardRoute,
@@ -123,6 +130,7 @@ const routeTree = rootRoute.addChildren([
     setupRoute,
     contactsRoute,
     jobsRoute,
+    tasksRoute,
     settingsRoute.addChildren([autonomyRoute, workspaceRoute]),
   ]),
   loginRoute,

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -906,21 +906,21 @@ input:focus, textarea:focus, select:focus {
 .status-pill.confirmed::before  { background: var(--app-green); }
 .status-pill.provisional::before { background: var(--app-amber); }
 .status-pill.blocked::before    { background: var(--app-destructive); }
-/* Task statuses */
+/* Shared task + job statuses */
 .status-pill.active::before     { background: var(--app-teal); }
 .status-pill.pending::before    { background: var(--app-amber); }
-.status-pill.paused::before     { background: var(--app-blue); }
 .status-pill.completed::before  { background: var(--app-green); }
 .status-pill.failed::before     { background: var(--app-destructive); }
 .status-pill.cancelled::before  { background: var(--app-fg-muted); }
 
-/* Job statuses */
-.status-pill.pending::before    { background: var(--app-amber); }
+/* Job-specific statuses */
 .status-pill.running::before    { background: var(--app-teal); }
 .status-pill.suspended::before  { background: var(--app-destructive); }
+/* Jobs: paused = amber */
 .status-pill.paused::before     { background: var(--app-amber); }
-.status-pill.completed::before  { background: var(--app-green); }
-.status-pill.failed::before     { background: var(--app-destructive); }
+
+/* Tasks: paused = blue — scoped to override the job rule above */
+.tasks-page .status-pill.paused::before { background: var(--app-blue); }
 
 /* ── Drawer (right-anchored) ───────────────────────────────────────── */
 .drawer {
@@ -991,7 +991,6 @@ input:focus, textarea:focus, select:focus {
 }
 .records-toolbar-left  { display: flex; align-items: center; gap: 10px; }
 .records-toolbar-right { margin-left: auto; display: flex; align-items: center; gap: 8px; }
-.topbar-meta { font-size: 12px; color: var(--app-fg-muted); }
 .records-filter-chip {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 5px 10px;

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -315,18 +315,19 @@ input:focus, textarea:focus, select:focus {
 .btn-secondary:hover { background: var(--app-muted); }
 
 .btn-danger { background: var(--app-destructive); color: #fff; border: none; }
-.btn-danger:hover { opacity: 0.88; }
+.btn-danger:hover    { opacity: 0.88; }
 .btn-danger:disabled { opacity: 0.5; cursor: not-allowed; }
 
-.btn-sm { padding: 5px 10px; font-size: 12px; }
+.btn-sm { padding: 5px 12px; font-size: 13px; }
 
 .btn-icon {
-  background: none; border: none;
-  color: var(--app-fg-muted); padding: 4px; border-radius: 4px;
-  cursor: pointer; display: inline-flex; align-items: center;
-  transition: all 120ms;
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px;
+  border: none; background: transparent; cursor: pointer;
+  border-radius: 4px; color: var(--app-fg-muted);
+  transition: background 120ms, color 120ms;
 }
-.btn-icon:hover { color: var(--app-fg); background: var(--app-muted); }
+.btn-icon:hover { background: var(--app-muted); color: var(--app-fg); }
 
 .topbar-meta { font-size: 12px; color: var(--app-fg-muted); }
 
@@ -879,6 +880,7 @@ input:focus, textarea:focus, select:focus {
   color: #fff; line-height: 1.4;
 }
 .badge-person       { background: var(--app-teal); }
+.badge-task         { background: var(--app-violet); }
 .badge-organization { background: var(--app-blue-soft); color: #111; }
 .badge-project      { background: var(--app-violet); }
 .badge-decision     { background: var(--app-amber); }
@@ -904,6 +906,13 @@ input:focus, textarea:focus, select:focus {
 .status-pill.confirmed::before  { background: var(--app-green); }
 .status-pill.provisional::before { background: var(--app-amber); }
 .status-pill.blocked::before    { background: var(--app-destructive); }
+/* Task statuses */
+.status-pill.active::before     { background: var(--app-teal); }
+.status-pill.pending::before    { background: var(--app-amber); }
+.status-pill.paused::before     { background: var(--app-blue); }
+.status-pill.completed::before  { background: var(--app-green); }
+.status-pill.failed::before     { background: var(--app-destructive); }
+.status-pill.cancelled::before  { background: var(--app-fg-muted); }
 
 /* Job statuses */
 .status-pill.pending::before    { background: var(--app-amber); }
@@ -966,6 +975,8 @@ input:focus, textarea:focus, select:focus {
 .contacts-mobile-search input { width: 100%; }
 .jobs-mobile-search { display: none; padding: 8px 16px; }
 .jobs-mobile-search input { width: 100%; }
+.tasks-mobile-search { display: none; padding: 8px 16px; }
+.tasks-mobile-search input { width: 100%; }
 
 .records-layout { flex: 1; display: flex; overflow: hidden; min-height: 0; }
 .records-main {
@@ -980,6 +991,7 @@ input:focus, textarea:focus, select:focus {
 }
 .records-toolbar-left  { display: flex; align-items: center; gap: 10px; }
 .records-toolbar-right { margin-left: auto; display: flex; align-items: center; gap: 8px; }
+.topbar-meta { font-size: 12px; color: var(--app-fg-muted); }
 .records-filter-chip {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 5px 10px;
@@ -1042,6 +1054,8 @@ table.records-table tbody tr.active td { background: transparent; }
 .cell-mono    { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--app-fg-muted); }
 .cell-actions { display: flex; gap: 4px; justify-content: flex-end; }
 .cell-with-avatar { display: flex; align-items: center; gap: 8px; }
+/* Truncate long text in the intent anchor column */
+.cell-intent { max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--app-fg-muted); font-size: 12px; }
 .system-role-badge {
   display: inline-block;
   font-size: 10px; font-weight: 700; letter-spacing: 0.04em;
@@ -1134,6 +1148,7 @@ table.records-table tbody tr.active td { background: transparent; }
   /* Show the mobile search bars (TopbarSearch is hidden at this breakpoint) */
   .contacts-mobile-search { display: block; }
   .jobs-mobile-search { display: block; }
+  .tasks-mobile-search { display: block; }
 }
 
 /* ── Chat layout ─────────────────────────────────────────────────────── */

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -534,47 +534,6 @@ function createUiHtml(): string {
     .conv-item:hover  { background: var(--accent); color: var(--fg); }
     .conv-item.active { background: var(--muted);  color: var(--fg); }
 
-    .tasks-layout {
-      flex: 1;
-      display: flex;
-      overflow: hidden;
-    }
-    .tasks-list-panel {
-      flex: none;
-      width: 380px;
-      border-right: 1px solid var(--border);
-      display: flex;
-      flex-direction: column;
-      overflow: hidden;
-    }
-    .tasks-list {
-      flex: 1;
-      overflow-y: auto;
-      padding: 10px;
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-    .task-card {
-      padding: 10px;
-      border: 1px solid var(--border);
-      border-radius: var(--radius-md);
-      cursor: pointer;
-      transition: border-color 0.12s, background 0.12s;
-    }
-    .task-card:hover { border-color: var(--teal); }
-    .task-card.active {
-      border-color: var(--teal);
-      background: rgba(71,129,137,0.08);
-    }
-    .tasks-editor {
-      flex: 1;
-      overflow-y: auto;
-      padding: 16px;
-      display: flex;
-      flex-direction: column;
-      gap: 14px;
-    }
     .jobs-layout {
       flex: 1;
       display: flex;
@@ -756,16 +715,8 @@ function createUiHtml(): string {
               Knowledge Graph
             </button>
 
-            <button id="nav-tasks" class="nav-sub-item" onclick="navigate('tasks', 'Tasks', 'nav-tasks')">
-              <!-- checklist icon -->
-              <svg width="13" height="13" viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                <rect x="1.5" y="1.5" width="10" height="10" rx="1.5"/>
-                <path d="M4 6.5L5.5 8L9 4.5"/>
-              </svg>
-              Tasks
-            </button>
-
             <!-- Scheduled Jobs removed: ported to /jobs in the new console app (#782) -->
+            <!-- Tasks removed: ported to /tasks in the new console app (#783) -->
           </div>
         </div>
 
@@ -840,74 +791,6 @@ function createUiHtml(): string {
             </div>
           </div>
 
-        </div>
-      </div>
-
-      <!-- Agent Tasks view -->
-      <div id="view-tasks" style="display: none; height: 100%; flex-direction: column;">
-        <div style="flex: none; display: flex; align-items: center; gap: 10px; padding: 10px 16px; border-bottom: 1px solid var(--border);">
-          <input id="tasks-search-input" type="text" placeholder="Search agent tasks by agent, intent, or status…" style="max-width: 420px;" />
-          <button id="tasks-search-btn" class="btn-primary">Search</button>
-          <button id="tasks-new-btn" class="btn-primary">+ New Agent Task</button>
-          <span id="tasks-status" style="font-size: 0.75rem; color: var(--fg-muted); margin-left: 4px;"></span>
-        </div>
-        <div class="tasks-layout">
-          <div class="tasks-list-panel">
-            <div style="padding: 10px 12px 0; font-size: 0.6875rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--fg-muted);">Agent Tasks</div>
-            <div id="tasks-list" class="tasks-list"></div>
-          </div>
-          <div class="tasks-editor">
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-              <h2 id="tasks-editor-title" style="font-family: 'Lora', Georgia, serif; font-size: 1.375rem; font-weight: 500; margin: 0;">Create Agent Task</h2>
-              <button id="tasks-delete-btn" class="btn-primary" style="display: none; background: var(--destructive); color: var(--fg);">Delete</button>
-            </div>
-
-            <form id="tasks-form" style="display: flex; flex-direction: column; gap: 12px; max-width: 900px;">
-              <div class="form-grid">
-                <div class="form-field">
-                  <label for="task-agent-id">Agent ID</label>
-                  <input id="task-agent-id" type="text" placeholder="e.g. coordinator" required />
-                </div>
-                <div class="form-field">
-                  <label for="task-status">Status</label>
-                  <select id="task-status">
-                    <option value="active">active</option>
-                    <option value="pending">pending</option>
-                    <option value="paused">paused</option>
-                    <option value="completed">completed</option>
-                    <option value="failed">failed</option>
-                    <option value="cancelled">cancelled</option>
-                  </select>
-                </div>
-              </div>
-              <div class="form-field">
-                <label for="task-intent-anchor">Intent anchor</label>
-                <textarea id="task-intent-anchor" rows="2" placeholder="Persistent task goal/context..." required></textarea>
-              </div>
-              <div class="form-grid">
-                <div class="form-field">
-                  <label for="task-conversation-id">Conversation ID (optional UUID)</label>
-                  <input id="task-conversation-id" type="text" placeholder="UUID (optional)" />
-                </div>
-                <div class="form-field">
-                  <label for="task-scheduled-job-id">Scheduled Job ID (optional UUID)</label>
-                  <input id="task-scheduled-job-id" type="text" placeholder="UUID (optional)" />
-                </div>
-              </div>
-              <div class="form-field">
-                <label for="task-error-budget">Error budget JSON</label>
-                <textarea id="task-error-budget" rows="4" placeholder='{"maxTurns": 12, "maxConsecutiveErrors": 3}'></textarea>
-              </div>
-              <div class="form-field">
-                <label for="task-progress">Progress JSON</label>
-                <textarea id="task-progress" rows="5" placeholder='{"phase":"initializing"}'></textarea>
-              </div>
-              <div style="display: flex; gap: 10px;">
-                <button type="submit" id="tasks-save-btn" class="btn-primary">Create Agent Task</button>
-                <button type="button" id="tasks-cancel-btn" class="btn-primary" style="background: var(--muted); color: var(--fg);">Cancel</button>
-              </div>
-            </form>
-          </div>
         </div>
       </div>
 
@@ -1017,9 +900,6 @@ function createUiHtml(): string {
     var settingsOpen = true; // Settings nav section expanded by default
 
     var activeNavId = 'nav-kg';
-    var tasks = [];
-    var selectedTaskId = null;
-    var tasksMode = 'create';
     var jobs = [];
     var selectedJobId = null;
     var jobsMode = 'create';
@@ -1056,23 +936,6 @@ function createUiHtml(): string {
     var memorySubmenu = document.getElementById('memory-submenu');
     var settingsSubmenu = document.getElementById('settings-submenu');
     var settingsCaret   = document.getElementById('settings-chevron');
-    var tasksStatusEl = document.getElementById('tasks-status');
-    var tasksSearchInput = document.getElementById('tasks-search-input');
-    var tasksSearchBtn = document.getElementById('tasks-search-btn');
-    var tasksNewBtn = document.getElementById('tasks-new-btn');
-    var tasksListEl = document.getElementById('tasks-list');
-    var tasksForm = document.getElementById('tasks-form');
-    var tasksEditorTitle = document.getElementById('tasks-editor-title');
-    var tasksDeleteBtn = document.getElementById('tasks-delete-btn');
-    var tasksSaveBtn = document.getElementById('tasks-save-btn');
-    var tasksCancelBtn = document.getElementById('tasks-cancel-btn');
-    var taskAgentIdInput = document.getElementById('task-agent-id');
-    var taskStatusInput = document.getElementById('task-status');
-    var taskIntentAnchorInput = document.getElementById('task-intent-anchor');
-    var taskConversationIdInput = document.getElementById('task-conversation-id');
-    var taskScheduledJobIdInput = document.getElementById('task-scheduled-job-id');
-    var taskErrorBudgetInput = document.getElementById('task-error-budget');
-    var taskProgressInput = document.getElementById('task-progress');
     var jobsStatusEl = document.getElementById('jobs-status');
     var jobsSearchInput = document.getElementById('jobs-search-input');
     var jobsSearchBtn = document.getElementById('jobs-search-btn');
@@ -1103,11 +966,6 @@ function createUiHtml(): string {
     if (!authWall || !mainApp || !authForm || !authInput || !authError ||
         !statusEl || !resultsEl || !searchInput || !searchBtn ||
         !memoryCaret || !memorySubmenu || !settingsSubmenu || !settingsCaret ||
-        !tasksStatusEl || !tasksSearchInput || !tasksSearchBtn || !tasksNewBtn ||
-        !tasksListEl || !tasksForm || !tasksEditorTitle || !tasksDeleteBtn ||
-        !tasksSaveBtn || !tasksCancelBtn || !taskAgentIdInput || !taskStatusInput ||
-        !taskIntentAnchorInput || !taskConversationIdInput || !taskScheduledJobIdInput ||
-        !taskErrorBudgetInput || !taskProgressInput ||
         !jobsStatusEl || !jobsSearchInput || !jobsSearchBtn || !jobsNewBtn || !jobsListEl ||
         !jobsForm || !jobsEditorTitle || !jobsDeleteBtn || !jobsSaveBtn || !jobsCancelBtn ||
         !jobAgentIdInput || !jobStatusInput || !jobCronExprInput || !jobRunAtInput ||
@@ -1302,11 +1160,9 @@ function createUiHtml(): string {
     function navigate(view, title, navId) {
       var kgView            = document.getElementById('view-kg');
       var chatView          = document.getElementById('view-chat');
-      var tasksView         = document.getElementById('view-tasks');
       var scheduledJobsView = document.getElementById('view-scheduled-jobs');
       kgView.style.display            = view === 'kg'             ? 'flex' : 'none';
       chatView.style.display          = view === 'chat'           ? 'flex' : 'none';
-      tasksView.style.display         = view === 'tasks'          ? 'flex' : 'none';
       scheduledJobsView.style.display = view === 'scheduled-jobs' ? 'flex' : 'none';
       // When returning to the KG view, tell Cytoscape to re-measure the container.
       // The canvas dimensions may be stale if the view was hidden (display:none)
@@ -1327,9 +1183,6 @@ function createUiHtml(): string {
         if (cy && cy.elements().length === 0) {
           loadDefaultGraph();
         }
-      }
-      if (view === 'tasks') {
-        loadTasks();
       }
       if (view === 'scheduled-jobs') {
         loadJobs();
@@ -1766,228 +1619,7 @@ function createUiHtml(): string {
     searchBtn.addEventListener('click', search);
     searchInput.addEventListener('keydown', function(e) { if (e.key === 'Enter') search(); });
 
-    // ── Agent Tasks ──────────────────────────────────────────────────
-    function setTasksStatus(msg, isError) {
-      tasksStatusEl.textContent = msg;
-      tasksStatusEl.style.color = isError ? 'var(--destructive)' : 'var(--fg-muted)';
-    }
 
-    function prettyJson(value) {
-      return JSON.stringify(value || {}, null, 2);
-    }
-
-    function parseJsonField(raw, fallback, fieldName) {
-      var value = raw.trim();
-      if (!value) return fallback;
-      try {
-        return JSON.parse(value);
-      } catch {
-        throw new Error(fieldName + ' must be valid JSON.');
-      }
-    }
-
-    function resetTaskForm() {
-      tasksMode = 'create';
-      selectedTaskId = null;
-      tasksEditorTitle.textContent = 'Create Agent Task';
-      tasksSaveBtn.textContent = 'Create Agent Task';
-      tasksDeleteBtn.style.display = 'none';
-      taskAgentIdInput.value = '';
-      taskStatusInput.value = 'active';
-      taskIntentAnchorInput.value = '';
-      taskConversationIdInput.value = '';
-      taskScheduledJobIdInput.value = '';
-      taskErrorBudgetInput.value = prettyJson({ maxTurns: 12, maxConsecutiveErrors: 3 });
-      taskProgressInput.value = prettyJson({});
-      renderTasksList(tasks);
-    }
-
-    function fillTaskForm(task) {
-      tasksMode = 'edit';
-      selectedTaskId = task.id;
-      tasksEditorTitle.textContent = 'Edit Agent Task';
-      tasksSaveBtn.textContent = 'Save Changes';
-      tasksDeleteBtn.style.display = 'inline-flex';
-      taskAgentIdInput.value = task.agentId;
-      taskStatusInput.value = task.status;
-      taskIntentAnchorInput.value = task.intentAnchor;
-      taskConversationIdInput.value = task.conversationId || '';
-      taskScheduledJobIdInput.value = task.scheduledJobId || '';
-      taskErrorBudgetInput.value = prettyJson(task.errorBudget);
-      taskProgressInput.value = prettyJson(task.progress);
-      renderTasksList(tasks);
-    }
-
-    function renderTasksList(list) {
-      tasksListEl.replaceChildren();
-      if (!list.length) {
-        var empty = document.createElement('p');
-        empty.style.cssText = 'font-size: 0.8125rem; color: var(--fg-muted); margin: 4px 2px;';
-        empty.textContent = 'No agent tasks found.';
-        tasksListEl.appendChild(empty);
-        return;
-      }
-      list.forEach(function(task) {
-        var card = document.createElement('div');
-        card.className = 'task-card' + (selectedTaskId === task.id ? ' active' : '');
-
-        var title = document.createElement('div');
-        title.style.cssText = 'font-size: 0.875rem; font-weight: 600; color: var(--fg);';
-        title.textContent = task.agentId + ' · ' + task.status;
-
-        var intent = document.createElement('div');
-        intent.style.cssText = 'font-size: 0.75rem; color: var(--fg-muted); margin-top: 4px; line-height: 1.35;';
-        intent.textContent = task.intentAnchor;
-
-        var meta = document.createElement('div');
-        meta.style.cssText = 'font-size: 0.6875rem; color: var(--fg-muted); margin-top: 6px;';
-        meta.textContent = 'Updated ' + new Date(task.updatedAt).toLocaleString();
-
-        card.append(title, intent, meta);
-        card.addEventListener('click', function() { fillTaskForm(task); });
-        tasksListEl.appendChild(card);
-      });
-    }
-
-    function loadTasks() {
-      setTasksStatus('Loading agent tasks…');
-      fetchJson('/api/kg/tasks')
-        .then(function(data) {
-          tasks = data.tasks || [];
-          // Re-apply active search filter after reload instead of always showing the full list.
-          // Without this, saving/deleting a task would silently clear the user's filter while
-          // leaving the search input populated — a misleading UI state.
-          if (tasksSearchInput.value.trim()) {
-            filterTasks();
-          } else {
-            renderTasksList(tasks);
-            setTasksStatus(tasks.length + ' agent task' + (tasks.length === 1 ? '' : 's'));
-          }
-          if (tasksMode === 'create' && !taskAgentIdInput.value) {
-            resetTaskForm();
-            return;
-          }
-          if (tasksMode === 'edit') {
-            var selected = tasks.find(function(t) { return t.id === selectedTaskId; });
-            if (selected) {
-              fillTaskForm(selected);
-            } else {
-              resetTaskForm();
-            }
-          }
-        })
-        .catch(function(err) { setTasksStatus(String(err), true); });
-    }
-
-    function filterTasks() {
-      var q = tasksSearchInput.value.trim().toLowerCase();
-      if (!q) {
-        renderTasksList(tasks);
-        setTasksStatus(tasks.length + ' agent task' + (tasks.length === 1 ? '' : 's'));
-        return;
-      }
-      var filtered = tasks.filter(function(task) {
-        return task.agentId.toLowerCase().includes(q) ||
-          task.intentAnchor.toLowerCase().includes(q) ||
-          task.status.toLowerCase().includes(q);
-      });
-      renderTasksList(filtered);
-      setTasksStatus(filtered.length + ' result' + (filtered.length === 1 ? '' : 's'));
-    }
-
-    function saveTask(e) {
-      e.preventDefault();
-      var agentId = taskAgentIdInput.value.trim();
-      var intentAnchor = taskIntentAnchorInput.value.trim();
-      if (!agentId) {
-        setTasksStatus('Agent ID is required.', true);
-        return;
-      }
-      if (!intentAnchor) {
-        setTasksStatus('Intent anchor is required.', true);
-        return;
-      }
-
-      var errorBudget;
-      var progress;
-      try {
-        errorBudget = parseJsonField(taskErrorBudgetInput.value, {}, 'Error budget');
-        progress = parseJsonField(taskProgressInput.value, {}, 'Progress');
-      } catch (err) {
-        setTasksStatus(err.message || String(err), true);
-        return;
-      }
-
-      var payload = {
-        agentId: agentId,
-        intentAnchor: intentAnchor,
-        status: taskStatusInput.value,
-        conversationId: taskConversationIdInput.value.trim() || null,
-        scheduledJobId: taskScheduledJobIdInput.value.trim() || null,
-        errorBudget: errorBudget,
-        progress: progress,
-      };
-
-      tasksSaveBtn.disabled = true;
-      setTasksStatus(tasksMode === 'create' ? 'Creating agent task…' : 'Saving agent task…');
-      var request = tasksMode === 'create'
-        ? fetch('/api/kg/tasks', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
-          })
-        : fetch('/api/kg/tasks/' + encodeURIComponent(selectedTaskId), {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
-          });
-
-      request
-        .then(function(res) {
-          return res.json().then(function(body) {
-            if (!res.ok) throw new Error(body.error || ('HTTP ' + res.status));
-            return body;
-          });
-        })
-        .then(function() {
-          setTasksStatus(tasksMode === 'create' ? 'Agent task created.' : 'Agent task updated.');
-          loadTasks();
-          if (tasksMode === 'create') resetTaskForm();
-        })
-        .catch(function(err) { setTasksStatus(err.message || String(err), true); })
-        .finally(function() { tasksSaveBtn.disabled = false; });
-    }
-
-    function deleteTask() {
-      if (!selectedTaskId) return;
-      if (!confirm('Delete this agent task? This action cannot be undone.')) return;
-      tasksDeleteBtn.disabled = true;
-      setTasksStatus('Deleting agent task…');
-      fetch('/api/kg/tasks/' + encodeURIComponent(selectedTaskId), { method: 'DELETE' })
-        .then(function(res) {
-          if (!res.ok) return res.json().then(function(body) { throw new Error(body.error || ('HTTP ' + res.status)); });
-        })
-        .then(function() {
-          setTasksStatus('Agent task deleted.');
-          resetTaskForm();
-          loadTasks();
-        })
-        .catch(function(err) { setTasksStatus(err.message || String(err), true); })
-        .finally(function() { tasksDeleteBtn.disabled = false; });
-    }
-
-    tasksForm.addEventListener('submit', saveTask);
-    tasksDeleteBtn.addEventListener('click', deleteTask);
-    tasksNewBtn.addEventListener('click', resetTaskForm);
-    tasksCancelBtn.addEventListener('click', resetTaskForm);
-    tasksSearchBtn.addEventListener('click', filterTasks);
-    tasksSearchInput.addEventListener('keydown', function(e) {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        filterTasks();
-      }
-    });
-    resetTaskForm();
 
     // ── Scheduled Jobs ───────────────────────────────────────────────
     function setJobsStatus(msg, isError) {
@@ -2469,6 +2101,8 @@ export async function knowledgeGraphRoutes(
   // Using 302 (temporary) rather than 301 (permanent) while the new view stabilises.
   // Fastify 5 signature: redirect(url, statusCode?) — url comes first.
   app.get('/old/chat', (_req, reply) => reply.redirect('/chat', 302));
+  // /old/tasks is now served by the React console at /tasks.
+  app.get('/old/tasks', (_req, reply) => reply.redirect('/tasks', 302));
 
   app.get('/old', serveOldUi);
   // Wildcard catches /old/kg, /old/contacts, etc. The * captures
@@ -2837,9 +2471,12 @@ export async function knowledgeGraphRoutes(
         scheduledJobId,
       ],
     );
+    if (!inserted.rowCount) {
+      return reply.status(500).send({ error: 'Failed to create task.' });
+    }
     return reply.status(201).send({
       task: serializeTask(
-        inserted.rows[0] as {
+        inserted.rows[0]! as {
           id: string;
           agent_id: string;
           intent_anchor: string;
@@ -2950,9 +2587,13 @@ export async function knowledgeGraphRoutes(
         scheduledJobId,
       ],
     );
+    // Guard against concurrent deletes between the existence check and the UPDATE.
+    if (!updated.rowCount) {
+      return reply.status(404).send({ error: 'Agent task not found.' });
+    }
     return reply.send({
       task: serializeTask(
-        updated.rows[0] as {
+        updated.rows[0]! as {
           id: string;
           agent_id: string;
           intent_anchor: string;

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -2472,6 +2472,7 @@ export async function knowledgeGraphRoutes(
       ],
     );
     if (!inserted.rowCount) {
+      logger.error('kg: INSERT agent_tasks returned no rows');
       return reply.status(500).send({ error: 'Failed to create task.' });
     }
     return reply.status(201).send({
@@ -2589,6 +2590,7 @@ export async function knowledgeGraphRoutes(
     );
     // Guard against concurrent deletes between the existence check and the UPDATE.
     if (!updated.rowCount) {
+      logger.warn({ taskId: id }, 'kg: PATCH agent_tasks matched 0 rows — likely concurrent delete');
       return reply.status(404).send({ error: 'Agent task not found.' });
     }
     return reply.send({

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -107,7 +107,7 @@ describe('knowledgeGraphRoutes', () => {
       sessions: new Map(),
     });
 
-    // /old/chat and /old/tasks are excluded here — they redirect (see tests below)
+    // /old/chat and /old/tasks are excluded here — they redirect (see other redirect tests)
     const response = await app.inject({ method: 'GET', url: '/old/contacts' });
     expect(response.statusCode).toBe(200);
     expect(response.body).toContain('Knowledge Graph');

--- a/tests/unit/channels/http/kg-routes.test.ts
+++ b/tests/unit/channels/http/kg-routes.test.ts
@@ -107,12 +107,10 @@ describe('knowledgeGraphRoutes', () => {
       sessions: new Map(),
     });
 
-    // /old/chat is excluded here — it redirects to /chat (see the test below)
-    for (const path of ['/old/contacts', '/old/tasks']) {
-      const response = await app.inject({ method: 'GET', url: path });
-      expect(response.statusCode).toBe(200);
-      expect(response.body).toContain('Knowledge Graph');
-    }
+    // /old/chat and /old/tasks are excluded here — they redirect (see tests below)
+    const response = await app.inject({ method: 'GET', url: '/old/contacts' });
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain('Knowledge Graph');
 
     await app.close();
   });
@@ -130,6 +128,23 @@ describe('knowledgeGraphRoutes', () => {
     const response = await app.inject({ method: 'GET', url: '/old/chat' });
     expect(response.statusCode).toBe(302);
     expect(response.headers['location']).toBe('/chat');
+
+    await app.close();
+  });
+
+  it('redirects /old/tasks to /tasks', async () => {
+    const app = Fastify();
+    await app.register(knowledgeGraphRoutes, {
+      pool,
+      logger: createLogger(),
+      webAppBootstrapSecret: 'secret-1',
+      secureCookies: false,
+      sessions: new Map(),
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/old/tasks' });
+    expect(response.statusCode).toBe(302);
+    expect(response.headers['location']).toBe('/tasks');
 
     await app.close();
   });


### PR DESCRIPTION
## **User description**
## Summary

- New `TasksPage` at `/tasks` following the `ContactsPage` layout, CSS class conventions, drawer pattern, and API route structure
- Full CRUD (list, create, edit, delete) with sortable column headers, 7 status filter chips, and in-page mobile search
- Removes tasks from the legacy `/old` shell; adds `/old/tasks → /tasks` 302 redirect
- Fixes a latent PATCH bug (500 on concurrent delete) and adds POST row guard

## Changes

**New files:**
- `apps/console/src/pages/TasksPage.tsx` — Tasks page and `TaskEditDrawer` component

**Modified files:**
- `apps/console/src/router.tsx` — add `/tasks` route
- `apps/console/src/pages/ContactsPage.tsx` — wire `tasks` nav target to `/tasks`
- `apps/console/src/styles/app.css` — add `.tasks-mobile-search`, `.btn-danger`, `.btn-sm`, `.btn-icon`, `.topbar-meta`, `.badge-task`, and task status pill variants
- `src/channels/http/routes/kg.ts` — PATCH 404 guard + POST rowCount guard; remove tasks HTML/CSS/JS from old shell; add `/old/tasks` redirect
- `CHANGELOG.md` — Unreleased entry

## Test plan

- [ ] `/tasks` loads and displays the task list
- [ ] Create a new task with all fields — appears in list, drawer stays open in edit mode with server-returned values
- [ ] Edit a task — save updates the row and re-initializes the drawer form
- [ ] Delete a task — removed from list, drawer closes
- [ ] Sort by Agent, Intent anchor, Status, Updated columns — `aria-sort` toggles correctly
- [ ] Status filter chips count and filter correctly for all 6 statuses
- [ ] Search filters by agentId and intentAnchor
- [ ] Mobile viewport (< 768px): `.tasks-mobile-search` input visible and functional
- [ ] Navigate to `/old/tasks` — redirects to `/tasks`
- [ ] Sidebar Tasks link from `/contacts` routes to `/tasks`
- [ ] PATCH with whitespace-only `conversationId` / `scheduledJobId` — normalized to null, no 500
- [ ] CHANGELOG entry present under Unreleased

Closes #783


___

## **CodeAnt-AI Description**
**Move Tasks management into the new console and fix save/delete edge cases**

### What Changed
- Tasks now open in the new console at `/tasks`, with the same table-and-drawer layout used by other console pages
- You can create, edit, delete, sort, filter, and search tasks from the new page, including mobile search and status counts
- Saving a task now reopens the drawer with the server’s updated values, so edited fields stay in sync after save
- `/old/tasks` now redirects to `/tasks`, and the legacy Tasks screen was removed from the old shell
- Creating and updating tasks now handles missing or deleted rows without crashing, so concurrent changes return a clean error instead of a server failure

### Impact
`✅ Faster task management`
`✅ Fewer task save crashes`
`✅ Clearer task update and delete errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Tasks console page (`/tasks`) with searchable, filterable task management.
  * Added full CRUD functionality: create, edit, update, and delete tasks with a dedicated drawer interface.
  * Implemented sortable columns, status filter chips, and pagination for improved task navigation.

* **Bug Fixes**
  * Enhanced backend task API reliability by adding validation for concurrent write operations.

* **Migration**
  * Legacy `/old/tasks` endpoint now redirects to the new `/tasks` page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->