### PR TITLE
feat: web chat improvements — markdown, timestamps, history, infinite scroll (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Added
 
 - **Knowledge Graph view** — new `/kg` console page with Cytoscape/fcose canvas, node search sidebar, in-place neighborhood expansion, color-by-type/sensitivity/decay toggle, node detail drawer, and URL-persisted `?q=`/`?node=` state; removes legacy `createUiHtml()` and `/old` routes. (#780)
+- **Chat view improvements** — agent replies now render markdown (bold, lists, code, italics) via server-side conversion; messages show timestamps; history hydrates from `working_memory` on reload (persisted via localStorage); scrolling up loads older pages. (#175)
 - **Scheduled Jobs view** — new `/jobs` console page with CRUD, status filters, and resume action for suspended jobs; removes legacy nav item. (#782)
 - **Tasks view** — new console page at `/tasks` with full CRUD, sortable columns, and status filter chips; legacy `/old/tasks` removed. (#783)
 - **Contacts view** — new console page at `/contacts` with full CRUD and editable trust level; legacy `/old/contacts` removed. (#781)

--- a/apps/console/src/pages/ChatPage.tsx
+++ b/apps/console/src/pages/ChatPage.tsx
@@ -12,7 +12,7 @@ export default function ChatPage() {
   const [theme, setTheme] = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
   const navigate = useNavigate();
-  const { messages, sending, send } = useChatSession();
+  const { messages, sending, hasMore, loadingHistory, send, loadMore } = useChatSession();
 
   useEffect(() => {
     if (mobileOpen) {
@@ -47,7 +47,12 @@ export default function ChatPage() {
         <main className="main">
           <Topbar crumb="Curia" title="Chat" />
           <div className="chat-page">
-            <ChatThread messages={messages} />
+            <ChatThread
+              messages={messages}
+              hasMore={hasMore}
+              loadingHistory={loadingHistory}
+              loadMore={loadMore}
+            />
             <ChatComposer disabled={sending} onSend={send} />
           </div>
         </main>

--- a/apps/console/src/pages/ChatPage.tsx
+++ b/apps/console/src/pages/ChatPage.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from '@tanstack/react-router';
-import { MobileMenuContext } from '../context/MobileMenu';
-import { Sidebar } from '../components/Sidebar';
-import { Topbar } from '../components/Topbar';
-import { useTheme } from '../hooks/useTheme';
-import { ChatThread } from './chat/ChatThread';
-import { ChatComposer } from './chat/ChatComposer';
-import { useChatSession } from './chat/useChatSession';
+import { MobileMenuContext } from '../context/MobileMenu.js';
+import { Sidebar } from '../components/Sidebar.js';
+import { Topbar } from '../components/Topbar.js';
+import { useTheme } from '../hooks/useTheme.js';
+import { ChatThread } from './chat/ChatThread.js';
+import { ChatComposer } from './chat/ChatComposer.js';
+import { useChatSession } from './chat/useChatSession.js';
 
 export default function ChatPage() {
   const [theme, setTheme] = useTheme();

--- a/apps/console/src/pages/chat/ChatThread.tsx
+++ b/apps/console/src/pages/chat/ChatThread.tsx
@@ -14,25 +14,23 @@ export function ChatThread({ messages, hasMore, loadingHistory, loadMore }: Chat
   const bottomRef = useRef<HTMLDivElement>(null);
   const topSentinelRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
-  // Track message count so auto-scroll fires only when new messages arrive at
-  // the bottom — not when older history is prepended at the top.
-  const prevMessageCount = useRef(messages.length);
+  // Tracks the ID of the last rendered message and how many messages were
+  // visible before the most recent render so we can distinguish three cases:
+  //   • empty → initial history load: prev=0, don't scroll (would yank to bottom)
+  //   • new user/agent message: prev>0 and last ID changes, scroll to bottom
+  //   • history prepended: last ID unchanged, don't scroll
+  const prevCount = useRef(0);
+  const lastMessageId = useRef<string | undefined>(undefined);
 
-  // Scroll to bottom on new messages. Skips when history is prepended (the
-  // message count grows but the last message ID hasn't changed).
-  const lastMessageId = useRef<string | undefined>(messages[messages.length - 1]?.id);
   useEffect(() => {
+    const prev = prevCount.current;
+    prevCount.current = messages.length;
     const currentLastId = messages[messages.length - 1]?.id;
-    const countGrew = messages.length > prevMessageCount.current;
-    prevMessageCount.current = messages.length;
 
-    // If the last message ID changed, a new message arrived at the bottom.
-    if (countGrew && currentLastId !== lastMessageId.current) {
-      lastMessageId.current = currentLastId;
+    if (prev > 0 && currentLastId !== lastMessageId.current) {
       bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-    } else {
-      lastMessageId.current = currentLastId;
     }
+    lastMessageId.current = currentLastId;
   }, [messages]);
 
   // IntersectionObserver on the top sentinel triggers loadMore when the user
@@ -50,11 +48,14 @@ export function ChatThread({ messages, hasMore, loadingHistory, loadMore }: Chat
           const prevScrollHeight = container?.scrollHeight ?? 0;
 
           void loadMore().then(() => {
-            // After React re-renders the prepended messages, shift scrollTop by
-            // the height delta so the user stays at the same visual position.
-            if (container) {
-              container.scrollTop += container.scrollHeight - prevScrollHeight;
-            }
+            // Defer until after the browser paints the prepended messages;
+            // React's setState is async so scrollHeight hasn't grown yet
+            // by the time the promise resolves.
+            requestAnimationFrame(() => {
+              if (container) {
+                container.scrollTop += container.scrollHeight - prevScrollHeight;
+              }
+            });
           });
         }
       },

--- a/apps/console/src/pages/chat/ChatThread.tsx
+++ b/apps/console/src/pages/chat/ChatThread.tsx
@@ -56,6 +56,8 @@ export function ChatThread({ messages, hasMore, loadingHistory, loadMore }: Chat
                 container.scrollTop += container.scrollHeight - prevScrollHeight;
               }
             });
+          }).catch((err: unknown) => {
+            console.error('[ChatThread] loadMore rejected:', err);
           });
         }
       },

--- a/apps/console/src/pages/chat/ChatThread.tsx
+++ b/apps/console/src/pages/chat/ChatThread.tsx
@@ -1,27 +1,112 @@
 // apps/console/src/pages/chat/ChatThread.tsx
 import { useEffect, useRef } from 'react';
+import { formatTimestamp } from './chat-utils.js';
 import type { Message } from './types.js';
 
 interface ChatThreadProps {
   messages: Message[];
+  hasMore: boolean;
+  loadingHistory: boolean;
+  loadMore: () => Promise<void>;
 }
 
-export function ChatThread({ messages }: ChatThreadProps) {
+export function ChatThread({ messages, hasMore, loadingHistory, loadMore }: ChatThreadProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
+  const topSentinelRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  // Track message count so auto-scroll fires only when new messages arrive at
+  // the bottom — not when older history is prepended at the top.
+  const prevMessageCount = useRef(messages.length);
 
-  // Scroll to the latest message whenever the list grows.
+  // Scroll to bottom on new messages. Skips when history is prepended (the
+  // message count grows but the last message ID hasn't changed).
+  const lastMessageId = useRef<string | undefined>(messages[messages.length - 1]?.id);
   useEffect(() => {
-    if (messages.length === 0) return;
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const currentLastId = messages[messages.length - 1]?.id;
+    const countGrew = messages.length > prevMessageCount.current;
+    prevMessageCount.current = messages.length;
+
+    // If the last message ID changed, a new message arrived at the bottom.
+    if (countGrew && currentLastId !== lastMessageId.current) {
+      lastMessageId.current = currentLastId;
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    } else {
+      lastMessageId.current = currentLastId;
+    }
   }, [messages]);
 
+  // IntersectionObserver on the top sentinel triggers loadMore when the user
+  // scrolls near the top of the thread and older history is available.
+  useEffect(() => {
+    const sentinel = topSentinelRef.current;
+    if (!sentinel || !hasMore) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry?.isIntersecting && !loadingHistory) {
+          // Capture scrollHeight before prepending so we can restore position after.
+          const container = scrollRef.current;
+          const prevScrollHeight = container?.scrollHeight ?? 0;
+
+          void loadMore().then(() => {
+            // After React re-renders the prepended messages, shift scrollTop by
+            // the height delta so the user stays at the same visual position.
+            if (container) {
+              container.scrollTop += container.scrollHeight - prevScrollHeight;
+            }
+          });
+        }
+      },
+      { root: scrollRef.current, threshold: 0.1 },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, loadingHistory, loadMore]);
+
   return (
-    <div className="chat-messages" role="log" aria-live="polite" aria-relevant="additions text">
-      {messages.map(msg => (
-        <div key={msg.id} className={`msg-bubble ${msg.kind}`}>
-          {msg.text}
-        </div>
-      ))}
+    <div
+      className="chat-messages"
+      ref={scrollRef}
+      role="log"
+      aria-live="polite"
+      aria-relevant="additions text"
+    >
+      {/* Top sentinel — watched by IntersectionObserver to trigger loadMore. */}
+      <div ref={topSentinelRef} className="chat-history-sentinel">
+        {loadingHistory && <div className="chat-history-loading">Loading…</div>}
+      </div>
+
+      {messages.map((msg) => {
+        if (msg.kind === 'status' || msg.kind === 'error') {
+          return (
+            <div key={msg.id} className={`msg-bubble ${msg.kind}`}>
+              {msg.text}
+            </div>
+          );
+        }
+
+        return (
+          <div key={msg.id} className={`msg-group ${msg.kind}`}>
+            <div className={`msg-bubble ${msg.kind}`}>
+              {msg.html ? (
+                // Safe: html is produced server-side by markdownToHtml(), which
+                // runs escapeHtml() (converting < > & to HTML entities) BEFORE
+                // inserting any markup. LLM output such as <script> becomes
+                // &lt;script&gt; before bold/italic/code patterns are applied.
+                // No raw user input ever reaches dangerouslySetInnerHTML.
+                <span dangerouslySetInnerHTML={{ __html: msg.html }} />
+              ) : (
+                msg.text
+              )}
+            </div>
+            {msg.timestamp && (
+              <div className="msg-time">{formatTimestamp(msg.timestamp)}</div>
+            )}
+          </div>
+        );
+      })}
+
       <div ref={bottomRef} />
     </div>
   );

--- a/apps/console/src/pages/chat/ChatThread.tsx
+++ b/apps/console/src/pages/chat/ChatThread.tsx
@@ -27,9 +27,17 @@ export function ChatThread({ messages, hasMore, loadingHistory, loadMore }: Chat
     prevCount.current = messages.length;
     const currentLastId = messages[messages.length - 1]?.id;
 
-    if (prev > 0 && currentLastId !== lastMessageId.current) {
+    if (messages.length === 0) {
+      // Nothing to scroll — thread is empty.
+    } else if (prev === 0) {
+      // Initial history load: jump instantly so the user lands on the newest message
+      // rather than the top of the thread (where the oldest loaded message sits).
+      bottomRef.current?.scrollIntoView({ behavior: 'instant' });
+    } else if (currentLastId !== lastMessageId.current) {
+      // New user/agent message appended: smooth scroll to bottom.
       bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
+    // If prev > 0 and lastId is unchanged, history was prepended — don't scroll.
     lastMessageId.current = currentLastId;
   }, [messages]);
 

--- a/apps/console/src/pages/chat/chat-utils.test.ts
+++ b/apps/console/src/pages/chat/chat-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseSseEvent, makeMessage } from './chat-utils.js';
+import { parseSseEvent, makeMessage, formatTimestamp } from './chat-utils.js';
 
 describe('parseSseEvent', () => {
   it('returns status text for skill.invoke events', () => {
@@ -54,5 +54,35 @@ describe('makeMessage', () => {
     const a = makeMessage('agent', 'x');
     const b = makeMessage('agent', 'x');
     expect(a.id).not.toBe(b.id);
+  });
+
+  it('forwards html and timestamp opts onto the message', () => {
+    const ts = new Date('2026-05-30T09:24:00Z');
+    const msg = makeMessage('agent', 'hi', { html: '<p>hi</p>', timestamp: ts });
+    expect(msg.html).toBe('<p>hi</p>');
+    expect(msg.timestamp).toBe(ts);
+  });
+
+  it('leaves html and timestamp undefined when opts are omitted', () => {
+    const msg = makeMessage('user', 'hello');
+    expect(msg.html).toBeUndefined();
+    expect(msg.timestamp).toBeUndefined();
+  });
+});
+
+describe('formatTimestamp', () => {
+  it('returns "Today · <time>" for a timestamp from today', () => {
+    const now = new Date();
+    const result = formatTimestamp(now);
+    expect(result).toMatch(/^Today · /);
+  });
+
+  it('returns "<Mon DD> · <time>" for a timestamp from a different day', () => {
+    const old = new Date('2026-04-01T10:00:00');
+    const result = formatTimestamp(old);
+    // Should not start with "Today ·"
+    expect(result).not.toMatch(/^Today · /);
+    // Should contain a middle dot
+    expect(result).toContain(' · ');
   });
 });

--- a/apps/console/src/pages/chat/chat-utils.ts
+++ b/apps/console/src/pages/chat/chat-utils.ts
@@ -25,6 +25,28 @@ export function parseSseEvent(data: string): string | null {
 }
 
 /** Returns a new Message with a stable random ID. */
-export function makeMessage(kind: Message['kind'], text: string): Message {
-  return { id: crypto.randomUUID(), kind, text };
+export function makeMessage(
+  kind: Message['kind'],
+  text: string,
+  opts?: { html?: string; timestamp?: Date },
+): Message {
+  return { id: crypto.randomUUID(), kind, text, ...opts };
+}
+
+/**
+ * Format a Date for display in the chat thread.
+ * Shows "Today · 9:24 AM" for messages from today, "May 28 · 9:24 AM" otherwise.
+ */
+export function formatTimestamp(ts: Date): string {
+  const now = new Date();
+  const isToday =
+    ts.getFullYear() === now.getFullYear() &&
+    ts.getMonth() === now.getMonth() &&
+    ts.getDate() === now.getDate();
+
+  const time = ts.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  if (isToday) return `Today · ${time}`;
+
+  const date = ts.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  return `${date} · ${time}`;
 }

--- a/apps/console/src/pages/chat/types.ts
+++ b/apps/console/src/pages/chat/types.ts
@@ -4,4 +4,6 @@ export interface Message {
   id: string;        // crypto.randomUUID() — stable React key
   kind: MessageKind;
   text: string;
+  html?: string;     // Pre-rendered HTML for agent messages (server-side markdown conversion)
+  timestamp?: Date;  // Display time; absent for status and error messages
 }

--- a/apps/console/src/pages/chat/useChatSession.ts
+++ b/apps/console/src/pages/chat/useChatSession.ts
@@ -56,8 +56,13 @@ export function useChatSession(): ChatSession {
   // Holds the active EventSource so cleanup can close it on unmount.
   const sourceRef = useRef<EventSource | null>(null);
   // One conversationId per chat thread — persisted in localStorage.
+  // localStorage.getItem can throw SecurityError in restricted browsing contexts
+  // (e.g. Safari private mode with strict settings), so we guard the read.
   const conversationId = useRef<string | null>(
-    typeof window !== 'undefined' ? localStorage.getItem(CONV_ID_KEY) : null,
+    (() => {
+      if (typeof window === 'undefined') return null;
+      try { return localStorage.getItem(CONV_ID_KEY); } catch { return null; }
+    })(),
   );
   // ISO timestamp of the oldest loaded message — used as the pagination cursor.
   const oldestTimestamp = useRef<string | null>(null);
@@ -70,28 +75,37 @@ export function useChatSession(): ChatSession {
     const convId = conversationId.current;
     if (!convId) return;
 
-    setLoadingHistory(true);
-    apiFetch(
-      `/api/kg/chat/history?conversationId=${encodeURIComponent(convId)}&limit=${HISTORY_PAGE_SIZE}`,
-    )
-      .then((res) => {
-        if (!res.ok) return;
-        return res.json() as Promise<HistoryResponse>;
-      })
-      .then((data) => {
-        if (!data || data.messages.length === 0) return;
+    // Using an inner async function inside useEffect so we can await cleanly
+    // while still returning a synchronous cleanup function from the effect.
+    const load = async () => {
+      setLoadingHistory(true);
+      try {
+        const res = await apiFetch(
+          `/api/kg/chat/history?conversationId=${encodeURIComponent(convId)}&limit=${HISTORY_PAGE_SIZE}`,
+        );
+        if (!res.ok) {
+          console.error('[useChatSession] initial history fetch returned non-ok status:', res.status);
+          return;
+        }
+        const data = (await res.json()) as HistoryResponse;
+        if (data.messages.length === 0) return;
         const loaded = historyToMessages(data.messages);
-        setMessages(loaded);
+        // Functional update guards against a race where the user sends a message
+        // before history arrives: only replace state if no messages have been added yet.
+        setMessages((prev) => (prev.length === 0 ? loaded : [...loaded, ...prev]));
         setHasMore(data.hasMore);
         // Record the timestamp of the oldest loaded message for subsequent loadMore calls.
         const first = data.messages[0];
         if (first) oldestTimestamp.current = first.timestamp;
-      })
-      .catch((err: unknown) => {
+      } catch (err: unknown) {
         // History fetch is best-effort — a failure doesn't prevent new messages.
-        console.debug('[useChatSession] initial history fetch failed:', err);
-      })
-      .finally(() => setLoadingHistory(false));
+        console.error('[useChatSession] initial history fetch failed:', err);
+      } finally {
+        setLoadingHistory(false);
+      }
+    };
+
+    void load();
   // Run once on mount; conversationId.current is a ref, not a reactive dep.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -110,7 +124,10 @@ export function useChatSession(): ChatSession {
         `/api/kg/chat/history?conversationId=${encodeURIComponent(convId)}&limit=${HISTORY_PAGE_SIZE}${cursor}`,
       );
       if (!res.ok) {
-        console.debug('[useChatSession] loadMore returned non-ok status:', res.status);
+        // Treat non-ok as terminal to prevent the IntersectionObserver from
+        // re-triggering loadMore in an infinite retry loop while hasMore is still true.
+        console.error('[useChatSession] loadMore returned non-ok status:', res.status);
+        setHasMore(false);
         return;
       }
       const data = (await res.json()) as HistoryResponse;
@@ -124,8 +141,9 @@ export function useChatSession(): ChatSession {
       const first = data.messages[0];
       if (first) oldestTimestamp.current = first.timestamp;
     } catch (err) {
-      // loadMore failures are non-fatal — the visible thread is unaffected.
-      console.debug('[useChatSession] loadMore failed:', err);
+      // Treat network errors as terminal (same infinite-retry guard as non-ok above).
+      console.error('[useChatSession] loadMore failed:', err);
+      setHasMore(false);
     } finally {
       isLoadingMore.current = false;
       setLoadingHistory(false);
@@ -138,7 +156,8 @@ export function useChatSession(): ChatSession {
     if (!conversationId.current) {
       const newId = crypto.randomUUID();
       conversationId.current = newId;
-      localStorage.setItem(CONV_ID_KEY, newId);
+      // Guarded for restricted browsing contexts (e.g. Safari private mode).
+      try { localStorage.setItem(CONV_ID_KEY, newId); } catch { /* best-effort */ }
     }
     const convId = conversationId.current;
 

--- a/apps/console/src/pages/chat/useChatSession.ts
+++ b/apps/console/src/pages/chat/useChatSession.ts
@@ -47,8 +47,12 @@ export function useChatSession(): ChatSession {
   const [hasMore, setHasMore] = useState(false);
   const [loadingHistory, setLoadingHistory] = useState(false);
 
-  // isSending is a ref so the double-send guard is immune to stale closures.
+  // isSending and isLoadingMore are refs so their guards are immune to stale closures.
+  // Using refs rather than state prevents the IntersectionObserver from tearing
+  // down and re-mounting on every loadMore cycle (which could cause a double-fetch
+  // during the brief window when state hasn't propagated to the observer's closure).
   const isSending = useRef(false);
+  const isLoadingMore = useRef(false);
   // Holds the active EventSource so cleanup can close it on unmount.
   const sourceRef = useRef<EventSource | null>(null);
   // One conversationId per chat thread — persisted in localStorage.
@@ -83,8 +87,9 @@ export function useChatSession(): ChatSession {
         const first = data.messages[0];
         if (first) oldestTimestamp.current = first.timestamp;
       })
-      .catch(() => {
+      .catch((err: unknown) => {
         // History fetch is best-effort — a failure doesn't prevent new messages.
+        console.debug('[useChatSession] initial history fetch failed:', err);
       })
       .finally(() => setLoadingHistory(false));
   // Run once on mount; conversationId.current is a ref, not a reactive dep.
@@ -93,8 +98,9 @@ export function useChatSession(): ChatSession {
 
   const loadMore = useCallback(async () => {
     const convId = conversationId.current;
-    if (!convId || loadingHistory || !hasMore) return;
+    if (!convId || isLoadingMore.current || !hasMore) return;
 
+    isLoadingMore.current = true;
     setLoadingHistory(true);
     try {
       const cursor = oldestTimestamp.current
@@ -103,7 +109,10 @@ export function useChatSession(): ChatSession {
       const res = await apiFetch(
         `/api/kg/chat/history?conversationId=${encodeURIComponent(convId)}&limit=${HISTORY_PAGE_SIZE}${cursor}`,
       );
-      if (!res.ok) return;
+      if (!res.ok) {
+        console.debug('[useChatSession] loadMore returned non-ok status:', res.status);
+        return;
+      }
       const data = (await res.json()) as HistoryResponse;
       if (data.messages.length === 0) {
         setHasMore(false);
@@ -114,12 +123,14 @@ export function useChatSession(): ChatSession {
       setHasMore(data.hasMore);
       const first = data.messages[0];
       if (first) oldestTimestamp.current = first.timestamp;
-    } catch {
+    } catch (err) {
       // loadMore failures are non-fatal — the visible thread is unaffected.
+      console.debug('[useChatSession] loadMore failed:', err);
     } finally {
+      isLoadingMore.current = false;
       setLoadingHistory(false);
     }
-  }, [loadingHistory, hasMore]);
+  }, [hasMore]);
 
   async function send(text: string): Promise<void> {
     if (isSending.current || text.trim().length === 0) return;
@@ -193,11 +204,13 @@ export function useChatSession(): ChatSession {
         setMessages((prev) => [...prev, makeMessage('error', 'Received an unexpected response.')]);
         return;
       }
-      const data = raw as { reply: string; html: string; conversationId: string };
+      // Runtime guard above confirmed `reply` is a string; cast through unknown
+      // per project convention for narrowing from Record<string, unknown>.
+      const data = raw as unknown as { reply: string; html: string | null; conversationId: string };
       setMessages((prev) => [
         ...prev,
         makeMessage('agent', data.reply, {
-          html: data.html,
+          html: data.html ?? undefined,
           timestamp: new Date(),
         }),
       ]);

--- a/apps/console/src/pages/chat/useChatSession.ts
+++ b/apps/console/src/pages/chat/useChatSession.ts
@@ -1,38 +1,141 @@
 // apps/console/src/pages/chat/useChatSession.ts
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { apiFetch } from '../../api.js';
 import { makeMessage, parseSseEvent } from './chat-utils.js';
 import type { Message } from './types.js';
 
+// localStorage key for persisting the conversationId across page reloads.
+const CONV_ID_KEY = 'curia:chat:conversationId';
+
+const HISTORY_PAGE_SIZE = 25;
+
 interface ChatSession {
   messages: Message[];
   sending: boolean;
+  hasMore: boolean;
+  loadingHistory: boolean;
   send: (text: string) => Promise<void>;
+  loadMore: () => Promise<void>;
+}
+
+interface HistoryMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  html: string | null;
+  timestamp: string;
+}
+
+interface HistoryResponse {
+  messages: HistoryMessage[];
+  hasMore: boolean;
+}
+
+function historyToMessages(items: HistoryMessage[]): Message[] {
+  return items.map((item) => ({
+    id: item.id,
+    kind: (item.role === 'assistant' ? 'agent' : 'user') as Message['kind'],
+    text: item.content,
+    html: item.html ?? undefined,
+    timestamp: new Date(item.timestamp),
+  }));
 }
 
 export function useChatSession(): ChatSession {
   const [messages, setMessages] = useState<Message[]>([]);
   const [sending, setSending] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingHistory, setLoadingHistory] = useState(false);
+
   // isSending is a ref so the double-send guard is immune to stale closures.
   const isSending = useRef(false);
   // Holds the active EventSource so cleanup can close it on unmount.
   const sourceRef = useRef<EventSource | null>(null);
-  // One conversationId per page session — generated on first send and reused.
-  const conversationId = useRef<string | null>(null);
+  // One conversationId per chat thread — persisted in localStorage.
+  const conversationId = useRef<string | null>(
+    typeof window !== 'undefined' ? localStorage.getItem(CONV_ID_KEY) : null,
+  );
+  // ISO timestamp of the oldest loaded message — used as the pagination cursor.
+  const oldestTimestamp = useRef<string | null>(null);
 
   // Close any in-flight SSE connection when the component unmounts.
   useEffect(() => () => { sourceRef.current?.close(); }, []);
+
+  // On mount, if we have a stored conversationId, load the most recent history page.
+  useEffect(() => {
+    const convId = conversationId.current;
+    if (!convId) return;
+
+    setLoadingHistory(true);
+    apiFetch(
+      `/api/kg/chat/history?conversationId=${encodeURIComponent(convId)}&limit=${HISTORY_PAGE_SIZE}`,
+    )
+      .then((res) => {
+        if (!res.ok) return;
+        return res.json() as Promise<HistoryResponse>;
+      })
+      .then((data) => {
+        if (!data || data.messages.length === 0) return;
+        const loaded = historyToMessages(data.messages);
+        setMessages(loaded);
+        setHasMore(data.hasMore);
+        // Record the timestamp of the oldest loaded message for subsequent loadMore calls.
+        const first = data.messages[0];
+        if (first) oldestTimestamp.current = first.timestamp;
+      })
+      .catch(() => {
+        // History fetch is best-effort — a failure doesn't prevent new messages.
+      })
+      .finally(() => setLoadingHistory(false));
+  // Run once on mount; conversationId.current is a ref, not a reactive dep.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const loadMore = useCallback(async () => {
+    const convId = conversationId.current;
+    if (!convId || loadingHistory || !hasMore) return;
+
+    setLoadingHistory(true);
+    try {
+      const cursor = oldestTimestamp.current
+        ? `&before=${encodeURIComponent(oldestTimestamp.current)}`
+        : '';
+      const res = await apiFetch(
+        `/api/kg/chat/history?conversationId=${encodeURIComponent(convId)}&limit=${HISTORY_PAGE_SIZE}${cursor}`,
+      );
+      if (!res.ok) return;
+      const data = (await res.json()) as HistoryResponse;
+      if (data.messages.length === 0) {
+        setHasMore(false);
+        return;
+      }
+      const older = historyToMessages(data.messages);
+      setMessages((prev) => [...older, ...prev]);
+      setHasMore(data.hasMore);
+      const first = data.messages[0];
+      if (first) oldestTimestamp.current = first.timestamp;
+    } catch {
+      // loadMore failures are non-fatal — the visible thread is unaffected.
+    } finally {
+      setLoadingHistory(false);
+    }
+  }, [loadingHistory, hasMore]);
 
   async function send(text: string): Promise<void> {
     if (isSending.current || text.trim().length === 0) return;
 
     if (!conversationId.current) {
-      conversationId.current = crypto.randomUUID();
+      const newId = crypto.randomUUID();
+      conversationId.current = newId;
+      localStorage.setItem(CONV_ID_KEY, newId);
     }
     const convId = conversationId.current;
 
     // Optimistic append so the user sees their message immediately.
-    setMessages(prev => [...prev, makeMessage('user', text)]);
+    setMessages((prev) => [
+      ...prev,
+      makeMessage('user', text, { timestamp: new Date() }),
+    ]);
     isSending.current = true;
     setSending(true);
 
@@ -50,7 +153,7 @@ export function useChatSession(): ChatSession {
       source.onmessage = (event: MessageEvent<string>) => {
         const statusText = parseSseEvent(event.data);
         if (statusText) {
-          setMessages(prev => [...prev, makeMessage('status', statusText)]);
+          setMessages((prev) => [...prev, makeMessage('status', statusText)]);
         }
       };
       source.onerror = (event) => {
@@ -60,6 +163,7 @@ export function useChatSession(): ChatSession {
         // source is always defined here — onerror can only fire after construction.
         source!.close();
       };
+
       const res = await apiFetch('/api/kg/chat/messages', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -75,7 +179,7 @@ export function useChatSession(): ChatSession {
           // Non-JSON error body — log for debugging, fall back to HTTP status.
           console.error('[useChatSession] failed to parse error response body:', bodyErr);
         }
-        setMessages(prev => [...prev, makeMessage('error', errMsg)]);
+        setMessages((prev) => [...prev, makeMessage('error', errMsg)]);
         return;
       }
 
@@ -86,14 +190,20 @@ export function useChatSession(): ChatSession {
         typeof (raw as Record<string, unknown>)['reply'] !== 'string'
       ) {
         console.error('[useChatSession] unexpected response shape:', raw);
-        setMessages(prev => [...prev, makeMessage('error', 'Received an unexpected response.')]);
+        setMessages((prev) => [...prev, makeMessage('error', 'Received an unexpected response.')]);
         return;
       }
-      const data = raw as { reply: string; conversationId: string };
-      setMessages(prev => [...prev, makeMessage('agent', data.reply)]);
+      const data = raw as { reply: string; html: string; conversationId: string };
+      setMessages((prev) => [
+        ...prev,
+        makeMessage('agent', data.reply, {
+          html: data.html,
+          timestamp: new Date(),
+        }),
+      ]);
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Network error';
-      setMessages(prev => [...prev, makeMessage('error', msg)]);
+      setMessages((prev) => [...prev, makeMessage('error', msg)]);
     } finally {
       isSending.current = false;
       source?.close();
@@ -102,5 +212,5 @@ export function useChatSession(): ChatSession {
     }
   }
 
-  return { messages, sending, send };
+  return { messages, sending, hasMore, loadingHistory, send, loadMore };
 }

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -1167,6 +1167,34 @@ table.records-table tbody tr.active td { background: transparent; }
   gap: 10px;
 }
 
+/* History load sentinel — zero-height trigger element at the top of the thread. */
+.chat-history-sentinel {
+  min-height: 1px;
+}
+.chat-history-loading {
+  text-align: center;
+  font-size: 11px;
+  color: var(--app-fg-subtle);
+  padding: 4px 0 8px;
+  font-style: italic;
+}
+
+/* Wrapper for user/agent messages: stacks bubble + timestamp in a column,
+   aligned to the correct side. Status/error messages remain standalone bubbles. */
+.msg-group {
+  display: flex;
+  flex-direction: column;
+}
+.msg-group.user { align-items: flex-end; }
+.msg-group.agent { align-items: flex-start; }
+
+.msg-time {
+  font-size: 11px;
+  color: var(--app-fg-subtle);
+  margin-top: 3px;
+  padding: 0 2px;
+}
+
 /* Base bubble — kind-specific classes override alignment and background. */
 .msg-bubble {
   width: fit-content;
@@ -1180,16 +1208,29 @@ table.records-table tbody tr.active td { background: transparent; }
 }
 
 .msg-bubble.user {
-  align-self: flex-end;
   background: var(--app-card-elev);
   border-radius: 12px 12px 2px 12px;
 }
 
 .msg-bubble.agent {
-  align-self: flex-start;
   background: var(--app-card);
   border: 1px solid var(--app-border);
   border-radius: 12px 12px 12px 2px;
+  /* Markdown-rendered content resets: prevent browser defaults from adding
+     excessive margin inside the constrained bubble width. */
+  white-space: normal;
+}
+.msg-bubble.agent p { margin: 0 0 8px; }
+.msg-bubble.agent p:last-child { margin-bottom: 0; }
+.msg-bubble.agent ul { margin: 0 0 8px; padding-left: 18px; }
+.msg-bubble.agent ul:last-child { margin-bottom: 0; }
+.msg-bubble.agent li { margin-bottom: 2px; }
+.msg-bubble.agent code {
+  font-family: var(--app-font-mono, monospace);
+  font-size: 0.88em;
+  background: var(--app-card-elev);
+  padding: 1px 4px;
+  border-radius: 3px;
 }
 
 /* Status and error: no bubble, centered, small text only. */

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -1216,9 +1216,9 @@ table.records-table tbody tr.active td { background: transparent; }
   background: var(--app-card);
   border: 1px solid var(--app-border);
   border-radius: 12px 12px 12px 2px;
-  /* Markdown-rendered content resets: prevent browser defaults from adding
-     excessive margin inside the constrained bubble width. */
-  white-space: normal;
+  /* Keep pre-wrap (from .msg-bubble base) so that agent messages displaying
+     plain text (html: null fallback) still preserve newlines. HTML content
+     from markdownToHtml() uses block elements that manage their own spacing. */
 }
 .msg-bubble.agent p { margin: 0 0 8px; }
 .msg-bubble.agent p:last-child { margin-bottom: 0; }

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -792,7 +792,15 @@ export async function knowledgeGraphRoutes(
 
     try {
       const content = await responsePromise;
-      return reply.send({ reply: content, html: markdownToHtml(content), conversationId });
+      // Per-try/catch so a markdownToHtml failure falls back gracefully rather
+      // than turning a successful agent response into a 500.
+      let html: string | null = null;
+      try {
+        html = markdownToHtml(content);
+      } catch (convErr) {
+        logger.warn({ err: convErr, conversationId }, 'markdownToHtml failed for chat reply; sending plain text');
+      }
+      return reply.send({ reply: content, html, conversationId });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logger.error({ err, conversationId }, 'KG chat message handling failed');

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -906,31 +906,18 @@ export async function knowledgeGraphRoutes(
     try {
       // Fetch limit+1 rows so we can tell if there are more pages without a COUNT query.
       // Rows arrive newest-first; we reverse after slicing to serve them chronologically.
-      let result;
-      if (beforeDate) {
-        result = await pool.query<HistoryRow>(
-          `SELECT id, role, content, created_at
-           FROM working_memory
-           WHERE conversation_id = $1
-             AND archived = false
-             AND role IN ('user', 'assistant')
-             AND created_at < $2
-           ORDER BY created_at DESC
-           LIMIT $3`,
-          [conversationId, beforeDate.toISOString(), limit + 1],
-        );
-      } else {
-        result = await pool.query<HistoryRow>(
-          `SELECT id, role, content, created_at
-           FROM working_memory
-           WHERE conversation_id = $1
-             AND archived = false
-             AND role IN ('user', 'assistant')
-           ORDER BY created_at DESC
-           LIMIT $2`,
-          [conversationId, limit + 1],
-        );
-      }
+      // The $2::timestamptz IS NULL check makes the before-cursor optional in a single query.
+      const result = await pool.query<HistoryRow>(
+        `SELECT id, role, content, created_at
+         FROM working_memory
+         WHERE conversation_id = $1
+           AND archived = false
+           AND role IN ('user', 'assistant')
+           AND ($2::timestamptz IS NULL OR created_at < $2)
+         ORDER BY created_at DESC
+         LIMIT $3`,
+        [conversationId, beforeDate?.toISOString() ?? null, limit + 1],
+      );
 
       const hasMore = result.rows.length > limit;
       // Take at most `limit` rows, then restore chronological order.

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -8,6 +8,7 @@ import type { ContactService } from '../../../contacts/contact-service.js';
 import type { ContactStatus, TrustLevel } from '../../../contacts/types.js';
 import { MessageRejectedError, type EventRouter } from '../event-router.js';
 import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
+import { markdownToHtml } from '../../../utils/markdown-to-html.js';
 
 export interface KnowledgeGraphRouteOptions {
   pool: Pool;
@@ -791,7 +792,7 @@ export async function knowledgeGraphRoutes(
 
     try {
       const content = await responsePromise;
-      return reply.send({ reply: content, conversationId });
+      return reply.send({ reply: content, html: markdownToHtml(content), conversationId });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logger.error({ err, conversationId }, 'KG chat message handling failed');
@@ -852,5 +853,103 @@ export async function knowledgeGraphRoutes(
       clearInterval(heartbeat);
       cleanup();
     });
+  });
+
+  /**
+   * GET /api/kg/chat/history — fetch paginated chat history from working_memory.
+   *
+   * Query params:
+   *   - conversationId: string (required)
+   *   - before: string (optional ISO timestamp — returns messages older than this cursor)
+   *   - limit: number (optional, default 25, max 50)
+   *
+   * Returns messages in chronological order (oldest first) so the client can
+   * prepend them to the thread. Fetches one extra row to determine hasMore.
+   *
+   * Only user/assistant turns are returned — system turns (synthetic summaries
+   * inserted by the summarisation pass) are excluded since they are internal
+   * artifacts not intended for display.
+   */
+  app.get('/api/kg/chat/history', async (request, reply) => {
+    if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
+
+    const query = request.query as {
+      conversationId?: string;
+      before?: string;
+      limit?: string;
+    };
+
+    if (typeof query.conversationId !== 'string' || query.conversationId.trim().length === 0) {
+      return reply.status(400).send({ error: 'Missing required query param: conversationId' });
+    }
+    const conversationId = query.conversationId.trim();
+
+    const rawLimit = parseInt(query.limit ?? '25', 10);
+    const limit = isNaN(rawLimit) || rawLimit < 1 ? 25 : Math.min(rawLimit, 50);
+
+    // Validate the before cursor: must be a parseable ISO date if provided.
+    let beforeDate: Date | undefined;
+    if (query.before !== undefined && query.before.trim().length > 0) {
+      beforeDate = new Date(query.before);
+      if (isNaN(beforeDate.getTime())) {
+        return reply.status(400).send({ error: 'Invalid before param: must be an ISO timestamp' });
+      }
+    }
+
+    interface HistoryRow {
+      id: string;
+      role: string;
+      content: string;
+      created_at: Date;
+    }
+
+    try {
+      // Fetch limit+1 rows so we can tell if there are more pages without a COUNT query.
+      // Rows arrive newest-first; we reverse after slicing to serve them chronologically.
+      let result;
+      if (beforeDate) {
+        result = await pool.query<HistoryRow>(
+          `SELECT id, role, content, created_at
+           FROM working_memory
+           WHERE conversation_id = $1
+             AND archived = false
+             AND role IN ('user', 'assistant')
+             AND created_at < $2
+           ORDER BY created_at DESC
+           LIMIT $3`,
+          [conversationId, beforeDate.toISOString(), limit + 1],
+        );
+      } else {
+        result = await pool.query<HistoryRow>(
+          `SELECT id, role, content, created_at
+           FROM working_memory
+           WHERE conversation_id = $1
+             AND archived = false
+             AND role IN ('user', 'assistant')
+           ORDER BY created_at DESC
+           LIMIT $2`,
+          [conversationId, limit + 1],
+        );
+      }
+
+      const hasMore = result.rows.length > limit;
+      // Take at most `limit` rows, then restore chronological order.
+      const rows = result.rows.slice(0, limit).reverse();
+
+      const messages = rows.map((row) => ({
+        id: row.id,
+        role: row.role as 'user' | 'assistant',
+        content: row.content,
+        // Pre-render HTML only for assistant messages — user text is displayed as-is.
+        html: row.role === 'assistant' ? markdownToHtml(row.content) : null,
+        timestamp: row.created_at.toISOString(),
+      }));
+
+      return reply.send({ messages, hasMore });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error({ err, conversationId }, 'KG chat history fetch failed');
+      return reply.status(500).send({ error: message });
+    }
   });
 }

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -923,20 +923,29 @@ export async function knowledgeGraphRoutes(
       // Take at most `limit` rows, then restore chronological order.
       const rows = result.rows.slice(0, limit).reverse();
 
-      const messages = rows.map((row) => ({
-        id: row.id,
-        role: row.role as 'user' | 'assistant',
-        content: row.content,
-        // Pre-render HTML only for assistant messages — user text is displayed as-is.
-        html: row.role === 'assistant' ? markdownToHtml(row.content) : null,
-        timestamp: row.created_at.toISOString(),
-      }));
+      const messages = rows.map((row) => {
+        // Per-row try/catch so one bad message doesn't fail the whole page.
+        let html: string | null = null;
+        if (row.role === 'assistant') {
+          try {
+            html = markdownToHtml(row.content);
+          } catch (convErr) {
+            logger.warn({ err: convErr, messageId: row.id }, 'markdownToHtml failed for history row; falling back to plain text');
+          }
+        }
+        return {
+          id: row.id,
+          role: row.role as 'user' | 'assistant',
+          content: row.content,
+          html,
+          timestamp: row.created_at.toISOString(),
+        };
+      });
 
       return reply.send({ messages, hasMore });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
       logger.error({ err, conversationId }, 'KG chat history fetch failed');
-      return reply.status(500).send({ error: message });
+      return reply.status(500).send({ error: 'Failed to fetch chat history' });
     }
   });
 }

--- a/src/utils/markdown-to-html.ts
+++ b/src/utils/markdown-to-html.ts
@@ -55,8 +55,14 @@ export function markdownToHtml(markdown: string): string {
 function applyInline(text: string): string {
   let out = escapeHtml(text);
 
-  // Inline code first to avoid re-processing its contents
-  out = out.replace(/`([^`]+)`/g, '<code>$1</code>');
+  // Replace code spans with stable placeholders before bold/italic processing so
+  // that content like `**inside code**` is not transformed by the bold regex.
+  // \x00 is safe here: escapeHtml doesn't produce it and LLM text won't contain it.
+  const codePlaceholders: string[] = [];
+  out = out.replace(/`([^`]+)`/g, (_, inner: string) => {
+    codePlaceholders.push(`<code>${inner}</code>`);
+    return `\x00CODE${codePlaceholders.length - 1}\x00`;
+  });
 
   // Bold: **text** or __text__
   out = out.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
@@ -66,6 +72,9 @@ function applyInline(text: string): string {
   out = out.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, '<em>$1</em>');
   // Italic: _text_ (word-boundary anchored to avoid matching underscores in identifiers)
   out = out.replace(/(?<!_)\b_(?!_)(.+?)(?<!_)_\b(?!_)/g, '<em>$1</em>');
+
+  // Restore code spans
+  out = out.replace(/\x00CODE(\d+)\x00/g, (_, i: string) => codePlaceholders[parseInt(i, 10)]!);
 
   return out;
 }

--- a/src/utils/markdown-to-html.ts
+++ b/src/utils/markdown-to-html.ts
@@ -1,0 +1,78 @@
+// markdown-to-html.ts — converts LLM-generated markdown to clean HTML.
+//
+// Shares the same conversion logic as src/channels/email/markdown-to-html.ts
+// but returns the inner HTML blocks without any email-specific wrapper div or
+// inline styles. Used by the chat API endpoints.
+
+/**
+ * Convert a markdown-formatted string into clean HTML.
+ *
+ * Handles:
+ *   - Paragraphs (blank lines → <p> blocks)
+ *   - Unordered lists (lines starting with "- " or "* ")
+ *   - Bold (**text** or __text__)
+ *   - Italic (*text* or _text_)
+ *   - Inline code (`code`)
+ *   - Horizontal rules (--- or ***)
+ *   - Plain line breaks within paragraphs
+ */
+export function markdownToHtml(markdown: string): string {
+  // Normalise line endings
+  const text = markdown.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+  // Split into blocks separated by one or more blank lines.
+  const rawBlocks = text.split(/\n\s*\n+/);
+
+  const htmlBlocks: string[] = rawBlocks.map((block) => {
+    const trimmed = block.trim();
+    if (trimmed === '') return '';
+
+    // Horizontal rule: a line of only dashes OR only asterisks (3+, all same).
+    if (/^(-{3,}|\*{3,})$/.test(trimmed)) {
+      return '<hr>';
+    }
+
+    // Unordered list block: every line starts with "- " or "* "
+    const lines = trimmed.split('\n');
+    const isListBlock = lines.every((l) => /^[-*]\s+/.test(l.trim()));
+    if (isListBlock) {
+      const items = lines
+        .map((l) => `  <li>${applyInline(l.trim().replace(/^[-*]\s+/, ''))}</li>`)
+        .join('\n');
+      return `<ul>\n${items}\n</ul>`;
+    }
+
+    // Paragraph: join lines with <br>, apply inline formatting
+    const paragraphText = lines
+      .map((l) => applyInline(l.trim()))
+      .join('<br>');
+    return `<p>${paragraphText}</p>`;
+  });
+
+  return htmlBlocks.filter((b) => b !== '').join('\n');
+}
+
+function applyInline(text: string): string {
+  let out = escapeHtml(text);
+
+  // Inline code first to avoid re-processing its contents
+  out = out.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+  // Bold: **text** or __text__
+  out = out.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  out = out.replace(/__(.+?)__/g, '<strong>$1</strong>');
+
+  // Italic: *text*
+  out = out.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, '<em>$1</em>');
+  // Italic: _text_ (word-boundary anchored to avoid matching underscores in identifiers)
+  out = out.replace(/(?<!_)\b_(?!_)(.+?)(?<!_)_\b(?!_)/g, '<em>$1</em>');
+
+  return out;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}

--- a/src/utils/markdown-to-html.ts
+++ b/src/utils/markdown-to-html.ts
@@ -49,7 +49,10 @@ export function markdownToHtml(markdown: string): string {
     return `<p>${paragraphText}</p>`;
   });
 
-  return htmlBlocks.filter((b) => b !== '').join('\n');
+  // Join with no separator: block elements (p, ul, hr) handle their own spacing.
+  // A '\n' separator would create a stray whitespace text node between blocks,
+  // visible as a blank line when the parent container has white-space: pre-wrap.
+  return htmlBlocks.filter((b) => b !== '').join('');
 }
 
 function applyInline(text: string): string {


### PR DESCRIPTION
## **User description**
## Summary

Closes #175

- **Markdown rendering** — agent replies are now converted to HTML server-side (bold, italic, code spans, lists, paragraphs, horizontal rules) via a new `markdownToHtml` utility. XSS safety is enforced by running `escapeHtml()` before any markup is constructed, so LLM output like `<script>` becomes `&lt;script&gt;` before bold/italic patterns run.
- **History hydration** — on load, the most recent 25 messages are fetched from `working_memory` and displayed, persisting `conversationId` in localStorage.
- **Infinite scroll** — an IntersectionObserver on a top sentinel triggers cursor-paginated fetches as the user scrolls up. Scroll position is restored after prepend via `requestAnimationFrame`.
- **Timestamps** — messages display a human-readable time below each bubble (e.g. "Today · 2:34 PM", "May 28 · 10:15 AM").

## Implementation notes

- New `GET /api/kg/chat/history` endpoint with ISO timestamp cursor pagination
- `POST /api/kg/chat/messages` now returns `html` alongside `reply`
- `useChatSession` tracks `conversationId` via `localStorage` with `SecurityError` guards
- `loadMore` sets `hasMore=false` on non-ok and network errors to prevent an infinite IntersectionObserver retry loop
- Per-row `try/catch` on `markdownToHtml` in history endpoint so one bad message doesn't fail the whole page
- History 500 returns a generic message instead of raw DB error

## Test plan

- [ ] Send a message with bold, italic, inline code, and a list — verify it renders as formatted HTML
- [ ] Reload the page — verify the last 25 messages rehydrate
- [ ] Scroll to the top of a thread with >25 messages — verify older messages load without the viewport jumping
- [ ] Verify timestamps appear below each bubble with correct today/date logic
- [ ] Verify a new conversation (no stored ID) works end-to-end
- [ ] Open in Safari private mode — verify app doesn't crash when localStorage is restricted


___

## **CodeAnt-AI Description**
**Show formatted chat replies, saved history, and older messages on scroll**

### What Changed
- Agent replies now render formatted text such as bold, italics, lists, and inline code instead of plain markdown
- Chat messages now show a timestamp under each user and agent bubble
- Reloading the chat restores the latest saved conversation history, and scrolling to the top loads older messages
- Chat history loading now avoids repeat fetch loops and keeps the page stable if history cannot be loaded

### Impact
`✅ Clearer chat replies`
`✅ Chat history survives page reloads`
`✅ Fewer lost messages after reopening chat`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Server-side markdown rendering for agent replies with improved formatting
  * Message timestamps now displayed in the chat thread
  * Chat history persists across page reloads via local storage
  * Scroll to top to load older chat messages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/josephfung/curia/pull/792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->