### PR TITLE
fix: exempt console static assets from bearer auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Console static asset auth** — `@fastify/static` v9 with `wildcard:false` registers an individual Fastify route per file in `consoleDist`, so `routeOptions.url` returns the exact asset path (e.g. `/assets/index-CU1g6HdR.js`) rather than `/*`; the old bypass list missed these routes and every static asset returned 401. Auth hook now skips bearer auth for all non-`/api/` routes.
+
 ### Added
 
 - **Knowledge Graph view** — new `/kg` console page with Cytoscape/fcose canvas, node search sidebar, in-place neighborhood expansion, color-by-type/sensitivity/decay toggle, node detail drawer, and URL-persisted `?q=`/`?node=` state; removes legacy `createUiHtml()` and `/old` routes. (#780)

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -111,17 +111,28 @@ export class HttpAdapter {
 
     // Auth hook — runs before every request
     this.app.addHook('onRequest', async (request, reply) => {
-      // Skip auth for health endpoint — it's used by load balancers and monitors.
-      // Use routeOptions.url (the registered pattern) so query strings don't break the match.
+      // routeOptions.url is the registered pattern (e.g. '/assets/index-CU1g6HdR.js' or '/*').
+      // request.url is the actual request path (with query string).
       const routeUrl = request.routeOptions.url ?? '';
-      if (routeUrl === '/api/health') return;
-      // These routes bypass bearer auth and enforce their own auth internally.
+
+      // Non-API routes are the console app (static assets, SPA pages, /auth) — no bearer auth.
+      //
+      // @fastify/static v9 with wildcard:false scans consoleDist at startup and registers
+      // an individual Fastify route per file (e.g. /assets/index-CU1g6HdR.js). These exact
+      // paths don't match a '/*' check, so we gate on !startsWith('/api/') instead.
+      //
+      // We also check request.url as a fallback: the console '/*' catch-all absorbs GET
+      // requests to unregistered paths, including probes like GET /api/nonexistent. Without
+      // the request.url check, those would get routeUrl='/*', skip auth, and silently return
+      // the React app HTML. Checking the actual URL keeps unregistered /api/ paths enforced.
+      if (!routeUrl.startsWith('/api/') && !request.url.startsWith('/api/')) return;
+
+      // These API routes use session-cookie auth and bypass bearer token enforcement.
       if (
-        routeUrl === '/' ||         // @fastify/static registers GET / for index.html when wildcard:false
-        routeUrl === '/*' ||        // console SPA catch-all for client-side routes (/login, etc.)
-        routeUrl === '/auth' ||
+        routeUrl === '/api/health' ||
         routeUrl.startsWith('/api/kg') ||
         routeUrl.startsWith('/api/identity') ||
+        routeUrl.startsWith('/api/executive') ||
         routeUrl.startsWith('/api/jobs') ||
         routeUrl.startsWith('/api/autonomy')
       ) return;

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -119,13 +119,18 @@ export class HttpAdapter {
       //
       // @fastify/static v9 with wildcard:false scans consoleDist at startup and registers
       // an individual Fastify route per file (e.g. /assets/index-CU1g6HdR.js). These exact
-      // paths don't match a '/*' check, so we gate on !startsWith('/api/') instead.
+      // paths don't match a '/*' check, so we gate on isApiPath() instead.
       //
       // We also check request.url as a fallback: the console '/*' catch-all absorbs GET
-      // requests to unregistered paths, including probes like GET /api/nonexistent. Without
-      // the request.url check, those would get routeUrl='/*', skip auth, and silently return
-      // the React app HTML. Checking the actual URL keeps unregistered /api/ paths enforced.
-      if (!routeUrl.startsWith('/api/') && !request.url.startsWith('/api/')) return;
+      // requests to unregistered paths (e.g. GET /api/nonexistent, GET /api). Without
+      // the request.url check, those get routeUrl='/*', skip auth, and silently return
+      // the React app HTML. Checking the actual URL keeps unregistered /api paths enforced.
+      //
+      // isApiPath matches '/api' exactly and '/api/...' — avoids false positives like
+      // '/api-docs' while catching the bare '/api' case that startsWith('/api/') misses.
+      const isApiPath = (p: string) => p === '/api' || p.startsWith('/api/');
+      const requestPath = (request.url ?? '').split('?')[0] ?? '';
+      if (!isApiPath(routeUrl) && !isApiPath(requestPath)) return;
 
       // These API routes use session-cookie auth and bypass bearer token enforcement.
       if (


### PR DESCRIPTION
## **User description**
## Summary

- `@fastify/static` v9 with `wildcard:false` scans `consoleDist` at startup and registers an individual Fastify route per file (e.g. `/assets/index-CU1g6HdR.js`). These exact paths never matched the old `'/*'` bypass check, so every console script and stylesheet returned 401 — making it impossible to log in to the console or the /old KG app.
- Replaces the per-route allowlist with `!routeUrl.startsWith('/api/') && !request.url.startsWith('/api/')` — covers all current and future Vite output paths without needing to know filenames.
- Adds `/api/executive` to the session-cookie bypass list (same pattern as `/api/identity`, `/api/autonomy`, `/api/jobs` — was an existing gap, found during review of this change).
- Closes the pre-existing `/*` catch-all gap: the console's SPA fallback would absorb probed `/api/nonexistent` GETs and skip auth silently; the dual `routeUrl`+`request.url` check prevents that.

## Root cause

curia-deploy PR #98 added `COPY --from=build /app/apps/console/dist ./apps/console/dist` to the Dockerfile. Before that, `consoleDist` didn't exist in the image, so `@fastify/static` registered no per-file routes and the 503 fallback kicked in. Once the console dist was present, the per-file route registration exposed the bypass gap.

## Security review

Reviewed: bearer-protected routes (`/api/messages`, `/api/messages/stream`, `/api/agents/status`) remain enforced. Method bypass (HEAD/OPTIONS), URL normalization, and `/*` catch-all absorbing probed paths all checked — no bypass vectors found.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test run` passes (42 tests)
- [ ] After deploy: load `https://office.josephfung.ca/` — JS and CSS assets return 200
- [ ] Login flow completes without 401 on static assets
- [ ] `POST /api/messages` with no Bearer token still returns 401


___

## **CodeAnt-AI Description**
**Console static assets now load without bearer auth errors**

### What Changed
- Console scripts, styles, and other non-API pages are no longer blocked by bearer authentication, so the app can load and sign in normally.
- Requests to `/api/health` still bypass bearer auth, and `/api/executive` now follows the same session-cookie access path as other internal API routes.
- Unregistered `/api/` paths still require auth, which keeps accidental public access from reaching API endpoints.

### Impact
`✅ Console pages load without 401 errors`
`✅ Fewer failed sign-in attempts`
`✅ Safer access to unregistered API routes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
