### PR TITLE
fix: constrain chat to 800px column on wide desktop screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 
 - **Console static asset auth** — `@fastify/static` v9 with `wildcard:false` registers an individual Fastify route per file in `consoleDist`, so `routeOptions.url` returns the exact asset path (e.g. `/assets/index-CU1g6HdR.js`) rather than `/*`; the old bypass list missed these routes and every static asset returned 401. Auth hook now skips bearer auth for all non-`/api/` routes.
+- **Chat max-width** — thread and composer are now constrained to an 800px column on wide desktop screens, eliminating the large empty side margins.
 
 ### Added
 

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -1165,8 +1165,9 @@ table.records-table tbody tr.active td { background: transparent; }
      centered even on platforms with classic (non-overlay) scrollbars. */
   scrollbar-gutter: stable both-edges;
   /* On wide screens, keep content in an 800px column centered in the pane.
-     max(24px, …) ensures at least 24px side padding on narrow viewports. */
-  padding: 20px max(24px, calc((100% - 800px) / 2));
+     max(20px, …) ensures at least 20px side padding on narrow viewports.
+     Must match the composer's minimum so both clamp at the same container width. */
+  padding: 20px max(20px, calc((100% - 800px) / 2));
   display: flex;
   flex-direction: column;
   gap: 10px;

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -1161,6 +1161,9 @@ table.records-table tbody tr.active td { background: transparent; }
 .chat-messages {
   flex: 1;
   overflow-y: auto;
+  /* Reserve scrollbar gutter symmetrically so the content column stays
+     centered even on platforms with classic (non-overlay) scrollbars. */
+  scrollbar-gutter: stable both-edges;
   /* On wide screens, keep content in an 800px column centered in the pane.
      max(24px, …) ensures at least 24px side padding on narrow viewports. */
   padding: 20px max(24px, calc((100% - 800px) / 2));

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -1161,7 +1161,9 @@ table.records-table tbody tr.active td { background: transparent; }
 .chat-messages {
   flex: 1;
   overflow-y: auto;
-  padding: 20px 24px;
+  /* On wide screens, keep content in an 800px column centered in the pane.
+     max(24px, …) ensures at least 24px side padding on narrow viewports. */
+  padding: 20px max(24px, calc((100% - 800px) / 2));
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -1257,7 +1259,8 @@ table.records-table tbody tr.active td { background: transparent; }
 
 .chat-composer {
   flex: none;
-  padding: 12px 20px;
+  /* Match the 800px column constraint of .chat-messages so the input aligns. */
+  padding: 12px max(20px, calc((100% - 800px) / 2));
   border-top: 1px solid var(--app-border);
   display: flex;
   gap: 10px;


### PR DESCRIPTION
## **User description**
## Summary

- Thread and composer padding now uses `max(24px, calc((100% - 800px) / 2))` to center content in an 800px column on wide screens, falling back to the original 24px/20px minimum on narrow viewports
- Added `scrollbar-gutter: stable both-edges` on `.chat-messages` so the centered column stays aligned with the composer on platforms with classic (non-overlay) scrollbars (Windows/Linux)
- Pure CSS change — no HTML or JS touched

## Test plan

- [ ] On a wide desktop screen (>~850px content area), chat messages and composer input are centered in a ~800px column with symmetrical gray space on each side
- [ ] On a narrow window (<850px), padding falls back to 24px/20px with no layout shift
- [ ] Scrolling a long conversation: scrollbar gutter appears on both sides, keeping the column centered
- [ ] Mobile view unaffected (media query breakpoints unchanged)


___

## **CodeAnt-AI Description**
**Keep chat messages and the composer centered in a narrower column on wide screens**

### What Changed
- Chat messages now stay centered in an 800px-wide column on large desktop screens instead of stretching across the full pane
- The composer input follows the same width, so it lines up with the message thread
- Side spacing stays at a sensible minimum on narrower windows, and scrollbars no longer shift the column off-center on classic scrollbar systems

### Impact
`✅ Less empty space in chat on wide screens`
`✅ Aligned message and input layout`
`✅ Fewer column shifts while scrolling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
