### PR TITLE
chore: remove legacy /old dev proxy and update spec 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Removed
+
+- **Legacy `/old` dev proxy** — removed dead proxy entries and stale comment now that the old hand-rolled SPA is fully replaced by the React console.
+
 ### Fixed
 
 - **Console static asset auth** — `@fastify/static` v9 with `wildcard:false` registers an individual Fastify route per file in `consoleDist`, so `routeOptions.url` returns the exact asset path (e.g. `/assets/index-CU1g6HdR.js`) rather than `/*`; the old bypass list missed these routes and every static asset returned 401. Auth hook now skips bearer auth for all non-`/api/` routes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Removed
 
 - **Legacy `/old` dev proxy** — removed dead proxy entries and stale comment now that the old hand-rolled SPA is fully replaced by the React console.
+- **Spec 12** — updated to reflect the React console replacing the Cytoscape SPA; corrected entry point (`GET /` not `GET /kg`) and removed outdated Cytoscape serving notes.
 
 ### Fixed
 

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -17,17 +17,6 @@ export default defineConfig({
     proxy: {
       '/api': 'http://localhost:3000',
       '/auth': 'http://localhost:3000',
-      // Legacy hand-rolled SPA lives at /old (served by knowledgeGraphRoutes,
-      // not by Vite). Proxy the shell and its sub-paths so the old UI remains
-      // accessible during development without needing a direct :3000 URL.
-      '/old': 'http://localhost:3000',
-      // Cytoscape and layout libraries are served by Fastify directly from
-      // node_modules. Without these proxy entries the browser would request
-      // them from the Vite dev server, which has no knowledge of those files.
-      '/assets/cytoscape.min.js': 'http://localhost:3000',
-      '/assets/layout-base.js': 'http://localhost:3000',
-      '/assets/cose-base.js': 'http://localhost:3000',
-      '/assets/cytoscape-fcose.js': 'http://localhost:3000',
     },
   },
 });

--- a/docs/specs/12-knowledge-graph-web-explorer.md
+++ b/docs/specs/12-knowledge-graph-web-explorer.md
@@ -4,24 +4,19 @@
 
 Provide a secure browser-based UI for inspecting Curia's knowledge graph directly from the existing Postgres schema (`kg_nodes`, `kg_edges`) without changing storage architecture.
 
-## Visualization layer choice
+## Implementation approach
 
-We selected **Cytoscape.js** as the visualization layer and wrapped it in Curia's Node/Fastify HTTP channel, serving the asset locally from `node_modules`.
+The original design used a hand-rolled Cytoscape.js SPA served directly by Fastify from `node_modules`. This was migrated to the React console (`apps/console/`) as part of the framework migration (#753). The console is now the sole UI; the legacy SPA has been removed.
 
-Why Cytoscape.js:
-- Mature open-source project (MIT licensed, long maintenance history).
-- Designed for interactive graph analysis (layout, styling, neighborhood-focused exploration).
-- Lightweight to embed in a single-page internal tool.
-- Works with plain JSON node/edge payloads, mapping directly to the Postgres-backed model Curia already has.
+The KG view in the React console uses the same `/api/kg/*` API routes, now rendered via React and Cytoscape.js bundled through Vite.
 
 ## Security model
 
 The web explorer is gated by `WEB_APP_BOOTSTRAP_SECRET` from `.env`:
-- `GET /kg` serves the UI shell (no graph data).
-- `GET /api/kg/nodes` requires `x-web-bootstrap-secret`.
-- `GET /api/kg/graph` requires `x-web-bootstrap-secret`.
+- `GET /` serves the React console shell (session cookie required for data).
+- All `/api/kg/*` routes require either `x-web-bootstrap-secret` header or a valid `curia_session` cookie.
 
-If `WEB_APP_BOOTSTRAP_SECRET` is missing, the feature is intentionally disabled.
+If `WEB_APP_BOOTSTRAP_SECRET` is missing, the KG API routes are not registered at all (intentional 404, not 503).
 
 ## API surface
 
@@ -33,18 +28,14 @@ If `WEB_APP_BOOTSTRAP_SECRET` is missing, the feature is intentionally disabled.
   - Query params: `node_id`, `depth`, `limit`
   - Purpose: neighborhood traversal for a selected node; falls back to recent nodes when no `node_id` is provided.
 
-## Notes
-
-This design intentionally keeps dependencies minimal and uses the existing Node.js runtime so operational dependencies stay aligned with Curia's current deployment profile.
-
 ---
 
 ## Implementation Status
 
 | Item | Status |
 |---|---|
-| `GET /kg` — serves the UI shell (Cytoscape.js single-page app) | Done |
 | `GET /api/kg/nodes` — text search with `query`, `type`, `limit` params | Done |
 | `GET /api/kg/graph` — neighborhood traversal with `node_id`, `depth`, `limit` params | Done |
 | `WEB_APP_BOOTSTRAP_SECRET` gating on all data API routes | Done |
-| Cytoscape.js served from `node_modules` (no external CDN dependency) | Done |
+| KG view ported to React console (`apps/console/src/pages/KgPage.tsx`) | Done |
+| Legacy Cytoscape SPA (`/old`) removed | Done |

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -271,7 +271,7 @@ export class HttpAdapter {
       });
     }
 
-    // Console app — registered last so all explicit API/KG/old routes above take priority
+    // Console app — registered last so all explicit API/KG routes above take priority
     // over its /* wildcard. The React app handles auth client-side via session cookie.
     await this.app.register(consoleRoutes);
 


### PR DESCRIPTION
## **User description**
## Summary

- Removed dead `/old` and Cytoscape asset proxy entries from `apps/console/vite.config.ts` — the legacy hand-rolled SPA was fully replaced by the React console and these routes no longer exist on the backend
- Updated stale comment in `src/channels/http/http-adapter.ts` (removed reference to "old routes")
- Updated `docs/specs/12-knowledge-graph-web-explorer.md` to reflect current reality: React console at `GET /` replaced the Cytoscape SPA at `GET /kg` → `GET /old`

Closes #135

## Test plan

- [ ] Confirm `GET /old` in production returns 404 (not 200/304 with stale HTML)
- [ ] Confirm `GET /` loads the React console as expected
- [ ] Confirm `/api/kg/*` endpoints still respond correctly (routes are unchanged)
- [ ] Confirm dev server starts without errors (`pnpm run dev` in `apps/console/`)


___

## **CodeAnt-AI Description**
**Remove the legacy `/old` route and update the knowledge graph spec**

### What Changed
- The old `/old` knowledge graph UI is no longer routed in development, so the React console is now the only entry point
- The console docs were updated to reflect the current setup: `GET /` serves the UI, `/api/kg/*` stays available, and the removed Cytoscape SPA notes were deleted
- The changelog now records the removal of the legacy proxy and the spec update

### Impact
`✅ No more access to a retired UI route`
`✅ Clearer knowledge graph entry point`
`✅ Up-to-date setup and release notes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
