### PR TITLE
feat: surface last_run_outcome and last_run_summary in jobs UI (#241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+
+- **Scheduled jobs — last run outcome and summary** — Jobs page now shows `last_run_outcome` as a colour-coded badge (green/red/amber) in the table and edit drawer, and surfaces the agent-written `last_run_summary` in the detail panel when present. (#241)
+
+### Changed
+
+- **Scheduled jobs — default filter** — Jobs page opens on the "Pending" filter instead of "All", reducing noise on instances with a long job history.
+
 ### Removed
 
 - **Legacy `/old` dev proxy** — removed dead proxy entries and stale comment now that the old hand-rolled SPA is fully replaced by the React console.

--- a/apps/console/src/pages/JobsPage.tsx
+++ b/apps/console/src/pages/JobsPage.tsx
@@ -355,7 +355,8 @@ function JobEditDrawer({ job, creating, onClose, onSaved, onDeleted }: DrawerPro
                 </div>
               )}
 
-              {job?.lastRunAt && (
+              {/* Show when any prior-run data exists — lastRunAt may be null for timed_out jobs recovered by recoverStuckJob */}
+              {(job?.lastRunAt || job?.lastRunOutcome || job?.lastRunSummary) && (
                 <>
                   <div className="form-grid">
                     <div className="form-field">

--- a/apps/console/src/pages/JobsPage.tsx
+++ b/apps/console/src/pages/JobsPage.tsx
@@ -52,6 +52,10 @@ function utcToLocal(utcIso: string | null): string {
   return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
 }
 
+function formatOutcome(outcome: NonNullable<LastRunOutcome>): string {
+  return outcome.replace(/_/g, ' ');
+}
+
 function formatSchedule(job: Job): string {
   if (job.cronExpr) return job.cronExpr;
   if (job.runAt) return formatDate(job.runAt);
@@ -362,7 +366,7 @@ function JobEditDrawer({ job, creating, onClose, onSaved, onDeleted }: DrawerPro
                       <label>Outcome</label>
                       <div className="form-field-readonly">
                         {job.lastRunOutcome
-                          ? <span className={`status-pill ${job.lastRunOutcome}`}>{job.lastRunOutcome}</span>
+                          ? <span className={`status-pill ${job.lastRunOutcome}`}>{formatOutcome(job.lastRunOutcome)}</span>
                           : '—'
                         }
                       </div>
@@ -690,7 +694,7 @@ export default function JobsPage() {
                             <td className="cell-mono col-updated">{formatDate(j.nextRunAt)}</td>
                             <td>
                               {j.lastRunOutcome
-                                ? <span className={`status-pill ${j.lastRunOutcome}`}>{j.lastRunOutcome}</span>
+                                ? <span className={`status-pill ${j.lastRunOutcome}`}>{formatOutcome(j.lastRunOutcome)}</span>
                                 : <span className="cell-muted">—</span>
                               }
                             </td>

--- a/apps/console/src/pages/JobsPage.tsx
+++ b/apps/console/src/pages/JobsPage.tsx
@@ -352,16 +352,31 @@ function JobEditDrawer({ job, creating, onClose, onSaved, onDeleted }: DrawerPro
               )}
 
               {job?.lastRunAt && (
-                <div className="form-grid">
-                  <div className="form-field">
-                    <label>Last run</label>
-                    <div className="form-field-readonly cell-mono">{formatDate(job.lastRunAt)}</div>
+                <>
+                  <div className="form-grid">
+                    <div className="form-field">
+                      <label>Last run</label>
+                      <div className="form-field-readonly cell-mono">{formatDate(job.lastRunAt)}</div>
+                    </div>
+                    <div className="form-field">
+                      <label>Outcome</label>
+                      <div className="form-field-readonly">
+                        {job.lastRunOutcome
+                          ? <span className={`status-pill ${job.lastRunOutcome}`}>{job.lastRunOutcome}</span>
+                          : '—'
+                        }
+                      </div>
+                    </div>
                   </div>
-                  <div className="form-field">
-                    <label>Outcome</label>
-                    <div className="form-field-readonly">{job.lastRunOutcome ?? '—'}</div>
-                  </div>
-                </div>
+                  {job.lastRunSummary && (
+                    <div className="form-field">
+                      <label>Last run summary</label>
+                      <div className="form-field-readonly" style={{ fontSize: 12, wordBreak: 'break-word' }}>
+                        {job.lastRunSummary}
+                      </div>
+                    </div>
+                  )}
+                </>
               )}
 
               {job?.lastError && (
@@ -436,7 +451,7 @@ export default function JobsPage() {
   const [jobs, setJobs] = useState<Job[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('pending');
   const [sort, setSort] = useState<{ key: keyof Job; dir: 'asc' | 'desc' }>({ key: 'createdAt', dir: 'desc' });
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
@@ -673,7 +688,12 @@ export default function JobsPage() {
                             </td>
                             <td className="cell-mono">{formatSchedule(j)}</td>
                             <td className="cell-mono col-updated">{formatDate(j.nextRunAt)}</td>
-                            <td>{j.lastRunOutcome ?? <span className="cell-muted">—</span>}</td>
+                            <td>
+                              {j.lastRunOutcome
+                                ? <span className={`status-pill ${j.lastRunOutcome}`}>{j.lastRunOutcome}</span>
+                                : <span className="cell-muted">—</span>
+                              }
+                            </td>
                             <td className="cell-mono col-updated">{formatDate(j.createdAt)}</td>
                             <td>
                               <div className="cell-actions" onClick={e => e.stopPropagation()}>

--- a/apps/console/src/styles/app.css
+++ b/apps/console/src/styles/app.css
@@ -918,6 +918,8 @@ input:focus, textarea:focus, select:focus {
 .status-pill.suspended::before  { background: var(--app-destructive); }
 /* Jobs: paused = amber */
 .status-pill.paused::before     { background: var(--app-amber); }
+/* last_run_outcome values — timed_out gets amber (partial/warning tone) */
+.status-pill.timed_out::before  { background: var(--app-amber); }
 
 /* Tasks: paused = blue — scoped to override the job rule above */
 .tasks-page .status-pill.paused::before { background: var(--app-blue); }


### PR DESCRIPTION
## **User description**
## Summary

- **Last run outcome** — table row and edit drawer now show `last_run_outcome` as a colour-coded badge: green for `completed`, red for `failed`, amber for `timed out`
- **Last run summary** — edit drawer shows the agent-written `last_run_summary` sentence below the last-run row when present
- **Default filter** — jobs page opens on "Pending" instead of "All" to reduce noise on instances with a long job history

Closes #241

## Test plan

- [ ] Open the jobs page — should land on "Pending" filter by default
- [ ] Click "All" — all jobs visible, outcome column shows coloured badges for any jobs that have run
- [ ] Open an edit drawer for a job with a prior run — "Last run" row visible with coloured outcome badge and (if available) summary text below it
- [ ] Open an edit drawer for a job that has never run — no "Last run" row at all
- [ ] Verify `timed_out` outcome renders as "timed out" (space, not underscore) and shows amber dot


___

## **CodeAnt-AI Description**
**Show the latest job outcome and summary in the jobs list and drawer, and open the page on Pending jobs**

### What Changed
- The jobs table and edit drawer now show the last run outcome as a colored badge instead of plain text, with clear labels for completed, failed, and timed out runs
- The edit drawer now shows the last run summary when one is available
- The jobs page now opens on the Pending filter instead of All, reducing noise from older jobs
- Timed out runs now display as "timed out" instead of "timed_out"

### Impact
`✅ Clearer job run status`
`✅ Easier review of recent job results`
`✅ Less noise on busy jobs pages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
