### PR TITLE
refactor: centralize console sidebar routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 - **Console static asset auth** — `@fastify/static` v9 with `wildcard:false` registers an individual Fastify route per file in `consoleDist`, so `routeOptions.url` returns the exact asset path (e.g. `/assets/index-CU1g6HdR.js`) rather than `/*`; the old bypass list missed these routes and every static asset returned 401. Auth hook now skips bearer auth for all non-`/api/` routes.
 - **Chat max-width** — thread and composer are now constrained to an 800px column on wide desktop screens, eliminating the large empty side margins.
+- **Sidebar navigation routing** — each page had its own copy of the sidebar route map, causing silent drift (Tasks routed to `/` on three pages; chat/kg/jobs wrong on Tasks page; Workspace sub-item routed to `/settings/autonomy` instead of `/settings/workspace`). Route map is now centralized in `Sidebar.tsx`.
 
 ### Added
 

--- a/apps/console/src/components/Sidebar.tsx
+++ b/apps/console/src/components/Sidebar.tsx
@@ -18,10 +18,19 @@ type Theme = 'light' | 'system' | 'dark';
 
 interface SidebarProps {
   activeView: string;
-  onNavigate: (view: string) => void;
   theme: Theme;
   onThemeChange: (theme: Theme) => void;
 }
+
+const ROUTES: Record<string, string> = {
+  chat:     '/chat',
+  kg:       '/kg',
+  contacts: '/contacts',
+  tasks:    '/tasks',
+  jobs:     '/jobs',
+  settings: '/settings/autonomy',
+  wizard:   '/setup',
+};
 
 function ThemeToggle({ theme, onChange }: { theme: Theme; onChange: (t: Theme) => void }) {
   const options: Array<{ v: Theme; label: string }> = [
@@ -47,7 +56,7 @@ function ThemeToggle({ theme, onChange }: { theme: Theme; onChange: (t: Theme) =
   );
 }
 
-export function Sidebar({ activeView, onNavigate, theme, onThemeChange }: SidebarProps) {
+export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
   const [memoryOpen, setMemoryOpen] = useState(true);
   const [settingsOpen, setSettingsOpen] = useState(
     activeView === 'settings' || activeView === 'wizard',
@@ -55,8 +64,13 @@ export function Sidebar({ activeView, onNavigate, theme, onThemeChange }: Sideba
   const { setOpen } = useMobileMenu();
   const navigate = useNavigate();
 
-  const go = (v: string) => {
-    onNavigate(v);
+  const go = (view: string) => {
+    const to = ROUTES[view];
+    if (to) {
+      navigate({ to }).catch((err: unknown) => {
+        console.error(`[Sidebar] navigation to ${to} failed:`, err);
+      });
+    }
     setOpen(false);
   };
 
@@ -69,12 +83,7 @@ export function Sidebar({ activeView, onNavigate, theme, onThemeChange }: Sideba
       <div className="nav-group">
         <button
           className={`nav-item${activeView === 'chat' ? ' active' : ''}`}
-          onClick={() => {
-            navigate({ to: '/chat' }).catch((err: unknown) => {
-              console.error('[Sidebar] navigation to /chat failed:', err);
-            });
-            setOpen(false);
-          }}
+          onClick={() => go('chat')}
         >
           <IconChat />
           Chat

--- a/apps/console/src/components/Sidebar.tsx
+++ b/apps/console/src/components/Sidebar.tsx
@@ -10,7 +10,6 @@ import {
   IconChecklist,
   IconClock,
   IconSettings,
-  IconWand,
   IconChevron,
 } from './Icons';
 
@@ -29,7 +28,6 @@ const ROUTES: Record<string, string> = {
   tasks:    '/tasks',
   jobs:     '/jobs',
   settings: '/settings/workspace',
-  wizard:   '/setup',
 };
 
 function ThemeToggle({ theme, onChange }: { theme: Theme; onChange: (t: Theme) => void }) {
@@ -58,9 +56,7 @@ function ThemeToggle({ theme, onChange }: { theme: Theme; onChange: (t: Theme) =
 
 export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
   const [memoryOpen, setMemoryOpen] = useState(true);
-  const [settingsOpen, setSettingsOpen] = useState(
-    activeView === 'settings' || activeView === 'wizard',
-  );
+  const [settingsOpen, setSettingsOpen] = useState(activeView === 'settings');
   const { setOpen } = useMobileMenu();
   const navigate = useNavigate();
 
@@ -146,13 +142,7 @@ export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
                 <IconSettings />
                 Workspace
               </button>
-              <button
-                className={`nav-sub-item${activeView === 'wizard' ? ' active' : ''}`}
-                onClick={() => go('wizard')}
-              >
-                <IconWand />
-                Setup Wizard
-              </button>
+
             </div>
           )}
         </div>

--- a/apps/console/src/components/Sidebar.tsx
+++ b/apps/console/src/components/Sidebar.tsx
@@ -28,7 +28,7 @@ const ROUTES: Record<string, string> = {
   contacts: '/contacts',
   tasks:    '/tasks',
   jobs:     '/jobs',
-  settings: '/settings/autonomy',
+  settings: '/settings/workspace',
   wizard:   '/setup',
 };
 
@@ -70,6 +70,8 @@ export function Sidebar({ activeView, theme, onThemeChange }: SidebarProps) {
       navigate({ to }).catch((err: unknown) => {
         console.error(`[Sidebar] navigation to ${to} failed:`, err);
       });
+    } else {
+      console.error(`[Sidebar] go() called with unknown view key: "${view}"`);
     }
     setOpen(false);
   };

--- a/apps/console/src/pages/ChatPage.tsx
+++ b/apps/console/src/pages/ChatPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from '@tanstack/react-router';
 import { MobileMenuContext } from '../context/MobileMenu.js';
 import { Sidebar } from '../components/Sidebar.js';
 import { Topbar } from '../components/Topbar.js';
@@ -11,7 +10,6 @@ import { useChatSession } from './chat/useChatSession.js';
 export default function ChatPage() {
   const [theme, setTheme] = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const navigate = useNavigate();
   const { messages, sending, hasMore, loadingHistory, send, loadMore } = useChatSession();
 
   useEffect(() => {
@@ -23,27 +21,10 @@ export default function ChatPage() {
     return () => { delete document.documentElement.dataset['mobileSidebar']; };
   }, [mobileOpen]);
 
-  function handleNavigate(view: string) {
-    const routes: Record<string, string> = {
-      contacts: '/contacts',
-      jobs:     '/jobs',
-      kg:       '/kg',
-      tasks:    '/',
-      settings: '/settings',
-      wizard:   '/setup',
-      autonomy: '/settings/autonomy',
-    };
-    const to = routes[view];
-    if (!to) return;
-    navigate({ to }).catch((err: unknown) => {
-      console.error(`[ChatPage] navigation to ${to} failed:`, err);
-    });
-  }
-
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
       <div className="app-root">
-        <Sidebar activeView="chat" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
+        <Sidebar activeView="chat" theme={theme} onThemeChange={setTheme} />
         <main className="main">
           <Topbar crumb="Curia" title="Chat" />
           <div className="chat-page">

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { useNavigate } from '@tanstack/react-router';
 import { MobileMenuContext } from '../context/MobileMenu.js';
 import { Sidebar } from '../components/Sidebar.js';
 import { Topbar, TopbarSearch, TopbarDivider } from '../components/Topbar.js';
@@ -261,7 +260,6 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
 export default function ContactsPage() {
   const [theme, setTheme] = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const navigate = useNavigate();
 
   const [contacts, setContacts] = useState<Contact[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -290,24 +288,6 @@ export default function ContactsPage() {
   }, []);
 
   useEffect(() => { void load(); }, [load]);
-
-  function handleNavigate(view: string) {
-    const routes: Record<string, string> = {
-      contacts:  '/contacts',
-      kg:        '/kg',
-      tasks:     '/tasks',
-      jobs:      '/jobs',
-      autonomy:  '/settings/autonomy',
-      settings:  '/settings/autonomy',
-      wizard:    '/setup',
-    };
-    const to = routes[view];
-    if (to) {
-      navigate({ to }).catch(err => {
-        console.error(`[ContactsPage] navigation to ${to} failed:`, err);
-      });
-    }
-  }
 
   const counts = useMemo(() => ({
     all:         contacts.length,
@@ -370,7 +350,7 @@ export default function ContactsPage() {
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
       <div className="app-root">
-        <Sidebar activeView="contacts" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
+        <Sidebar activeView="contacts" theme={theme} onThemeChange={setTheme} />
         {mobileOpen && (
           <div
             className="sidebar-backdrop"

--- a/apps/console/src/pages/DashboardPage.tsx
+++ b/apps/console/src/pages/DashboardPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from '@tanstack/react-router';
 import { MobileMenuContext } from '../context/MobileMenu';
 import { Sidebar } from '../components/Sidebar';
 import { Topbar } from '../components/Topbar';
@@ -8,33 +7,15 @@ import { useTheme } from '../hooks/useTheme';
 export default function DashboardPage() {
   const [theme, setTheme] = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const navigate = useNavigate();
 
   useEffect(() => {
     document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
   }, [mobileOpen]);
 
-  function handleNavigate(view: string) {
-    const routes: Record<string, string> = {
-      contacts: '/contacts',
-      jobs:     '/jobs',
-      kg:       '/kg',
-      autonomy: '/settings/autonomy',
-      settings: '/settings/autonomy',
-      wizard:   '/setup',
-    };
-    const to = routes[view];
-    if (to) {
-      navigate({ to }).catch(err => {
-        console.error(`[DashboardPage] navigation to ${to} failed:`, err);
-      });
-    }
-  }
-
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
       <div className="app-root">
-        <Sidebar activeView="dashboard" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
+        <Sidebar activeView="dashboard" theme={theme} onThemeChange={setTheme} />
         <main className="main">
           <Topbar crumb="Console" title="Dashboard" />
           <div className="placeholder-body">

--- a/apps/console/src/pages/JobsPage.tsx
+++ b/apps/console/src/pages/JobsPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { useNavigate } from '@tanstack/react-router';
 import { MobileMenuContext } from '../context/MobileMenu.js';
 import { Sidebar } from '../components/Sidebar.js';
 import { Topbar, TopbarSearch, TopbarDivider } from '../components/Topbar.js';
@@ -451,7 +450,6 @@ const ALL_STATUSES: JobStatus[] = ['pending', 'running', 'suspended', 'paused', 
 export default function JobsPage() {
   const [theme, setTheme] = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const navigate = useNavigate();
 
   const [jobs, setJobs] = useState<Job[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -483,24 +481,6 @@ export default function JobsPage() {
   }, []);
 
   useEffect(() => { void load(); }, [load]);
-
-  function handleNavigate(view: string) {
-    const routes: Record<string, string> = {
-      contacts:  '/contacts',
-      jobs:      '/jobs',
-      kg:        '/kg',
-      tasks:     '/',
-      autonomy:  '/settings/autonomy',
-      settings:  '/settings/autonomy',
-      wizard:    '/setup',
-    };
-    const to = routes[view];
-    if (to) {
-      navigate({ to }).catch(err => {
-        console.error(`[JobsPage] navigation to ${to} failed:`, err);
-      });
-    }
-  }
 
   const counts = useMemo(() => {
     const c: Record<string, number> = { all: jobs.length };
@@ -572,7 +552,7 @@ export default function JobsPage() {
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
       <div className="app-root">
-        <Sidebar activeView="jobs" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
+        <Sidebar activeView="jobs" theme={theme} onThemeChange={setTheme} />
         {mobileOpen && (
           <div
             className="sidebar-backdrop"

--- a/apps/console/src/pages/KgPage.tsx
+++ b/apps/console/src/pages/KgPage.tsx
@@ -611,33 +611,12 @@ export default function KgPage() {
     });
   }
 
-  // ── Navigation ────────────────────────────────────────────────────────────
-
-  function handleNavigate(view: string) {
-    const routes: Record<string, string> = {
-      contacts:  '/contacts',
-      jobs:      '/jobs',
-      kg:        '/kg',
-      tasks:     '/',
-      chat:      '/chat',
-      autonomy:  '/settings/autonomy',
-      settings:  '/settings/autonomy',
-      wizard:    '/setup',
-    };
-    const to = routes[view];
-    if (to) {
-      navigate({ to }).catch(err => {
-        console.error(`[KgPage] navigation to ${to} failed:`, err);
-      });
-    }
-  }
-
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
       <div className="app-root">
-        <Sidebar activeView="kg" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
+        <Sidebar activeView="kg" theme={theme} onThemeChange={setTheme} />
         {mobileOpen && (
           <div
             className="sidebar-backdrop"

--- a/apps/console/src/pages/SettingsPage.tsx
+++ b/apps/console/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
 import { MobileMenuContext } from '../context/MobileMenu';
 import { Sidebar } from '../components/Sidebar';
 import { Topbar } from '../components/Topbar';
@@ -330,34 +330,15 @@ interface SettingsLayoutProps {
 function SettingsLayout({ activeSection, children }: SettingsLayoutProps) {
   const [theme, setTheme] = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const navigate = useNavigate();
 
   useEffect(() => {
     document.documentElement.dataset['mobileSidebar'] = mobileOpen ? 'open' : '';
   }, [mobileOpen]);
 
-  function handleNavigate(view: string) {
-    const routes: Record<string, string> = {
-      contacts:  '/contacts',
-      jobs:      '/jobs',
-      kg:        '/kg',
-      autonomy:  '/settings/autonomy',
-      settings:  '/settings/workspace',
-      dashboard: '/',
-      wizard:    '/setup',
-    };
-    const to = routes[view];
-    if (to) {
-      navigate({ to }).catch(err => {
-        console.error(`[SettingsLayout] navigation to ${to} failed:`, err);
-      });
-    }
-  }
-
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
       <div className="app-root">
-        <Sidebar activeView="settings" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
+        <Sidebar activeView="settings" theme={theme} onThemeChange={setTheme} />
         <main className="main">
           <Topbar crumb="Settings" title="Workspace" />
           <div className="settings-shell">

--- a/apps/console/src/pages/TasksPage.tsx
+++ b/apps/console/src/pages/TasksPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { useNavigate } from '@tanstack/react-router';
 import { MobileMenuContext } from '../context/MobileMenu.js';
 import { Sidebar } from '../components/Sidebar.js';
 import { Topbar, TopbarSearch, TopbarDivider } from '../components/Topbar.js';
@@ -291,7 +290,6 @@ type StatusFilter = typeof STATUS_FILTERS[number];
 export default function TasksPage() {
   const [theme, setTheme] = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const navigate = useNavigate();
 
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -321,25 +319,6 @@ export default function TasksPage() {
   }, []);
 
   useEffect(() => { void load(); }, [load]);
-
-  function handleNavigate(view: string) {
-    const routes: Record<string, string> = {
-      tasks:    '/tasks',
-      contacts: '/contacts',
-      kg:       '/',
-      chat:     '/',
-      jobs:     '/',
-      autonomy: '/settings/autonomy',
-      settings: '/settings/autonomy',
-      wizard:   '/setup',
-    };
-    const to = routes[view];
-    if (to) {
-      navigate({ to }).catch(err => {
-        console.error(`[TasksPage] navigation to ${to} failed:`, err);
-      });
-    }
-  }
 
   const counts = useMemo(() => {
     const c: Record<StatusFilter, number> = { all: tasks.length, active: 0, pending: 0, paused: 0, completed: 0, failed: 0, cancelled: 0 };
@@ -403,7 +382,7 @@ export default function TasksPage() {
   return (
     <MobileMenuContext.Provider value={{ open: mobileOpen, setOpen: setMobileOpen }}>
       <div className="app-root">
-        <Sidebar activeView="tasks" onNavigate={handleNavigate} theme={theme} onThemeChange={setTheme} />
+        <Sidebar activeView="tasks" theme={theme} onThemeChange={setTheme} />
         {mobileOpen && (
           <div
             className="sidebar-backdrop"


### PR DESCRIPTION
## **User description**
## Summary

- Removes the duplicated `handleNavigate` route map from all 7 console page files and centralizes it as a module-level `ROUTES` constant in `Sidebar.tsx`
- Fixes 4 silent routing bugs: Tasks routed to `/` on Chat, KG, and Jobs pages; chat/kg/jobs routed to `/` on Tasks page; Workspace sub-item routed to `/settings/autonomy` instead of `/settings/workspace`
- Adds a `console.error` fallback in `go()` for unrecognized view keys so regressions surface immediately during development
- `KgPage` retains its `useNavigate` import — it uses `navigate` for URL search-param syncing, unrelated to sidebar routing

## Test plan

- [ ] Click Tasks from Chat page → lands on `/tasks`
- [ ] Click Tasks from Knowledge Graph page → lands on `/tasks`
- [ ] Click Tasks from Scheduled Jobs page → lands on `/tasks`
- [ ] Click all sidebar items from each page — verify correct destination
- [ ] Settings > Workspace sub-item → lands on `/settings/workspace` (not `/settings/autonomy`)
- [ ] `pnpm --prefix apps/console run typecheck` passes clean


___

## **CodeAnt-AI Description**
**Fix sidebar links so every console page goes to the correct place**

### What Changed
- Sidebar navigation now uses one shared set of destinations across the console, removing page-specific routing drift
- Tasks now opens `/tasks` from Chat, Knowledge Graph, Jobs, and other console pages instead of sending users to the wrong page
- Settings > Workspace now opens `/settings/workspace` instead of `/settings/autonomy`
- Unknown sidebar targets now show an error during development instead of failing silently

### Impact
`✅ Correct sidebar navigation`
`✅ Fewer wrong-page clicks`
`✅ Clearer routing errors during development`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
