### PR TITLE
feat(console): wizard 'About you' step for principal identity (PR 2 of #771)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Setup-required boot mode** — a missing principal contact no longer crash-loops the process; the dispatcher and HTTP adapter stay up while email + Signal are skipped, so the onboarding wizard can be reached at `/setup`. Restart picks up the new principal and brings external channels online. (#766, #771)
 - **`POST /api/setup/principal`** — name-only principal contact creation, idempotent, for the wizard's "About you" step. (#771)
 - **`GET /api/setup/status`** — reports `{ principalExists, identityConfigured, externalAdaptersPending }` so the console router can land on the correct onboarding screen. (#771)
+- **Onboarding wizard "About you" step** — new Step 1 captures the principal's name and creates the principal contact via `POST /api/setup/principal` before the assistant identity is configured; auto-skipped on deployments where a principal already exists. (#771)
 
 ### Removed
 

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -115,10 +115,11 @@ export default function WizardPage() {
     }
   }, [principalExists, currentStep, navigate]);
 
-  function goTo(step: number) {
-    // Step navigation is non-critical — if the router rejects, the user stays on
-    // the current step. Void the promise explicitly rather than using an empty catch.
-    void navigate({ to: '/setup', search: { step } });
+  // Returns the navigation promise so callers that need to know whether the
+  // route change succeeded (handlePrincipalContinue) can await it and surface
+  // an error if the router rejects after a server-side write already landed.
+  function goTo(step: number): Promise<void> {
+    return navigate({ to: '/setup', search: { step } });
   }
 
   // Step 1 ("About you") writes through to the backend before advancing so the
@@ -141,7 +142,10 @@ export default function WizardPage() {
       });
       if (!res.ok) throw new Error(await extractError(res));
       setPrincipalExists(true);
-      goTo(2);
+      // Await goTo so a router rejection (extremely unlikely, but possible
+      // under route-guard changes) doesn't leave the user looking at Step 1
+      // with no feedback after the write already succeeded.
+      await goTo(2);
     } catch (err) {
       setPrincipalError(err instanceof Error ? err.message : 'Could not save your name.');
     } finally {
@@ -242,7 +246,17 @@ export default function WizardPage() {
     );
   }
 
-  if (!existingIdentity) {
+  // Wait for BOTH the identity prefill AND the setup-status snapshot before
+  // rendering any step. Without this gate:
+  //   - Step 1 was reachable before principalExists resolved, so the auto-skip
+  //     effect couldn't decide whether to bounce the user forward — they could
+  //     fill in their name and submit before the wizard knew they shouldn't be
+  //     on this step in the first place.
+  //   - The Step 2 Back button rendered with `principalExists === null` (falsy),
+  //     so a Back click went to Step 1 and immediately bounced back, producing
+  //     a flicker.
+  // Both go away once we hold the render until both pieces of state are known.
+  if (!existingIdentity || principalExists === null) {
     return (
       <div className="wizard-page">
         {header}
@@ -277,9 +291,13 @@ export default function WizardPage() {
           placeholder="Jane Doe"
           maxLength={PRINCIPAL_NAME_MAX_LENGTH}
           autoFocus
+          disabled={principalSubmitting}
           onChange={e => {
             setState(s => ({ ...s, principalName: e.target.value }));
-            if (principalError) setPrincipalError('');
+            // Guard the error-clear on submit: if a keystroke and an in-flight
+            // POST rejection land in the same tick, an unguarded clear would
+            // wipe the about-to-arrive error before the user sees it.
+            if (principalError && !principalSubmitting) setPrincipalError('');
           }}
         />
         {principalError && <div className="wizard-step1-error">{principalError}</div>}

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearch } from '@tanstack/react-router';
 import { apiFetch } from '../api.js';
 import {
   DEFAULT_WIZARD_STATE,
+  PRINCIPAL_NAME_MAX_LENGTH,
   TONE_OPTIONS,
   toggleToneSelection,
   verbosityBand,
@@ -11,19 +12,26 @@ import {
   verbosityReviewDesc,
   directnessReviewDesc,
   postureReviewDesc,
-  validateStep1,
+  validateNonEmptyName,
+  validatePrincipalName,
   buildIdentityPayload,
   type WizardState,
   type LocalIdentity,
 } from './wizard-utils.js';
 
-const TOTAL_STEPS = 4;
+const TOTAL_STEPS = 5;
 
 // ── Identity API types ────────────────────────────────────────────────────────
 
 interface IdentityResponse {
   identity: LocalIdentity;
   configured: boolean;
+}
+
+interface SetupStatusResponse {
+  principalExists: boolean;
+  identityConfigured: boolean;
+  externalAdaptersPending: boolean;
 }
 
 // ── Safe error extraction ─────────────────────────────────────────────────────
@@ -49,21 +57,35 @@ export default function WizardPage() {
 
   const [state, setState] = useState<WizardState>(DEFAULT_WIZARD_STATE);
   const [existingIdentity, setExistingIdentity] = useState<LocalIdentity | null>(null);
+  const [principalExists, setPrincipalExists] = useState<boolean | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [step1Error, setStep1Error] = useState('');
+  const [principalError, setPrincipalError] = useState('');
+  const [principalSubmitting, setPrincipalSubmitting] = useState(false);
+  const [assistantNameError, setAssistantNameError] = useState('');
   const [submitError, setSubmitError] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
-  // Pre-populate form from current identity on mount.
+  // Pre-populate form from current identity and check setup status on mount.
+  // Run both fetches in parallel; setup status drives the Step 1 auto-skip
+  // (deployments that already have a principal — e.g. CEO_PRIMARY_EMAIL — go
+  // straight to step 2). identity drives the form's pre-fill so a wizard
+  // re-run shows the existing values instead of defaults.
   useEffect(() => {
     async function load() {
       try {
-        const res = await apiFetch('/api/identity');
-        if (!res.ok) throw new Error(await extractError(res));
-        const data = await res.json() as IdentityResponse;
+        const [identityRes, statusRes] = await Promise.all([
+          apiFetch('/api/identity'),
+          apiFetch('/api/setup/status'),
+        ]);
+        if (!identityRes.ok) throw new Error(await extractError(identityRes));
+        if (!statusRes.ok) throw new Error(await extractError(statusRes));
+        const data = await identityRes.json() as IdentityResponse;
+        const status = await statusRes.json() as SetupStatusResponse;
         const id = data.identity;
         setExistingIdentity(id);
+        setPrincipalExists(status.principalExists);
         setState({
+          principalName: DEFAULT_WIZARD_STATE.principalName,
           name: id.assistant.name || DEFAULT_WIZARD_STATE.name,
           title: id.assistant.title || DEFAULT_WIZARD_STATE.title,
           signature: id.assistant.emailSignature || '',
@@ -83,24 +105,68 @@ export default function WizardPage() {
     void load();
   }, []);
 
+  // Auto-skip Step 1 when the principal already exists. Runs after the mount
+  // fetch sets principalExists and on any subsequent step change. The route
+  // navigation updates `currentStep`, which re-runs this effect; the guard
+  // (`principalExists && currentStep === 1`) keeps it from looping.
+  useEffect(() => {
+    if (principalExists && currentStep === 1) {
+      void navigate({ to: '/setup', search: { step: 2 } });
+    }
+  }, [principalExists, currentStep, navigate]);
+
   function goTo(step: number) {
     // Step navigation is non-critical — if the router rejects, the user stays on
     // the current step. Void the promise explicitly rather than using an empty catch.
     void navigate({ to: '/setup', search: { step } });
   }
 
+  // Step 1 ("About you") writes through to the backend before advancing so the
+  // principal contact exists by the time the assistant identity is saved at
+  // step 5. The endpoint is idempotent — a retry after a transient failure is
+  // safe and will return alreadyExisted=true on success.
+  async function handlePrincipalContinue() {
+    const validationError = validatePrincipalName(state.principalName);
+    if (validationError) {
+      setPrincipalError(validationError);
+      return;
+    }
+    setPrincipalError('');
+    setPrincipalSubmitting(true);
+    try {
+      const res = await apiFetch('/api/setup/principal', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: state.principalName.trim() }),
+      });
+      if (!res.ok) throw new Error(await extractError(res));
+      setPrincipalExists(true);
+      goTo(2);
+    } catch (err) {
+      setPrincipalError(err instanceof Error ? err.message : 'Could not save your name.');
+    } finally {
+      setPrincipalSubmitting(false);
+    }
+  }
+
   function handleContinue() {
-    if (currentStep === 1) {
-      if (!validateStep1(state.name)) {
-        setStep1Error('Assistant name is required.');
+    // Step 2 is the assistant identity form (formerly step 1). Same non-empty
+    // assertion as before — the renamed validator is the only difference.
+    if (currentStep === 2) {
+      if (!validateNonEmptyName(state.name)) {
+        setAssistantNameError('Assistant name is required.');
         return;
       }
-      setStep1Error('');
+      setAssistantNameError('');
     }
     if (currentStep < TOTAL_STEPS) goTo(currentStep + 1);
   }
 
   function handleBack() {
+    // When the principal already exists, Step 1 is auto-skipped; going Back from
+    // Step 2 would bounce back to Step 2 via the auto-skip effect, so just no-op
+    // for clarity instead of flickering.
+    if (currentStep === 2 && principalExists) return;
     if (currentStep > 1) goTo(currentStep - 1);
   }
 
@@ -189,9 +255,52 @@ export default function WizardPage() {
     );
   }
 
-  // ── Step 1: Identity ─────────────────────────────────────────────────────────
+  // ── Step 1: About you (principal identity) ─────────────────────────────────
+  //
+  // Captures the operator's own name and POSTs it to /api/setup/principal so
+  // the principal contact exists before the assistant identity is saved on
+  // step 5. Auto-skipped (via the effect above) when a principal is already
+  // present — typically CEO_PRIMARY_EMAIL deployments that bootstrapped one.
 
   const step1 = (
+    <div className="wizard-content">
+      <div className="wizard-heading">Tell us about yourself</div>
+      <div className="wizard-subheading">
+        Your name is how your assistant will address you and identify you in messages.
+      </div>
+      <div className="wizard-field">
+        <label htmlFor="w-principal-name">Your name *</label>
+        <input
+          id="w-principal-name"
+          type="text"
+          value={state.principalName}
+          placeholder="Jane Doe"
+          maxLength={PRINCIPAL_NAME_MAX_LENGTH}
+          autoFocus
+          onChange={e => {
+            setState(s => ({ ...s, principalName: e.target.value }));
+            if (principalError) setPrincipalError('');
+          }}
+        />
+        {principalError && <div className="wizard-step1-error">{principalError}</div>}
+      </div>
+      <div className="wizard-nav">
+        <span />
+        <button
+          type="button"
+          className="btn-wizard-next"
+          onClick={() => void handlePrincipalContinue()}
+          disabled={principalSubmitting}
+        >
+          {principalSubmitting ? 'Saving…' : 'Next →'}
+        </button>
+      </div>
+    </div>
+  );
+
+  // ── Step 2: Assistant identity ─────────────────────────────────────────────
+
+  const step2Identity = (
     <div className="wizard-content">
       <div className="wizard-heading">What should your assistant be called?</div>
       <div className="wizard-subheading">
@@ -206,10 +315,10 @@ export default function WizardPage() {
           placeholder="Alex Curia"
           onChange={e => {
             setState(s => ({ ...s, name: e.target.value }));
-            if (step1Error) setStep1Error('');
+            if (assistantNameError) setAssistantNameError('');
           }}
         />
-        {step1Error && <div className="wizard-step1-error">{step1Error}</div>}
+        {assistantNameError && <div className="wizard-step1-error">{assistantNameError}</div>}
       </div>
       <div className="wizard-field">
         <label htmlFor="w-title">Title</label>
@@ -231,7 +340,13 @@ export default function WizardPage() {
         />
       </div>
       <div className="wizard-nav">
-        <span />
+        {principalExists ? (
+          <span />
+        ) : (
+          <button type="button" className="btn-wizard-back" onClick={handleBack}>
+            ← Back
+          </button>
+        )}
         <button type="button" className="btn-wizard-next" onClick={handleContinue}>
           Next →
         </button>
@@ -239,11 +354,11 @@ export default function WizardPage() {
     </div>
   );
 
-  // ── Step 2: Tone ─────────────────────────────────────────────────────────────
+  // ── Step 3: Tone ───────────────────────────────────────────────────────────
 
   const atToneMax = state.toneBaseline.length >= 3;
 
-  const step2 = (
+  const step3Tone = (
     <div className="wizard-content">
       <div className="wizard-heading">How should your assistant communicate?</div>
       <div className="wizard-subheading">Pick 1–3 words that describe the tone you want.</div>
@@ -310,7 +425,7 @@ export default function WizardPage() {
     </div>
   );
 
-  // ── Step 3: Posture & preferences ────────────────────────────────────────────
+  // ── Step 4: Posture & preferences ──────────────────────────────────────────
 
   const POSTURE_OPTIONS: Array<{
     value: WizardState['posture'];
@@ -322,7 +437,7 @@ export default function WizardPage() {
     { value: 'proactive',    title: 'Proactive',    desc: 'Bias toward action; less checking in' },
   ];
 
-  const step3 = (
+  const step4Posture = (
     <div className="wizard-content">
       <div className="wizard-heading">How should your assistant decide?</div>
       <div className="wizard-subheading">
@@ -370,7 +485,7 @@ export default function WizardPage() {
     </div>
   );
 
-  // ── Step 4: Review ───────────────────────────────────────────────────────────
+  // ── Step 5: Review ─────────────────────────────────────────────────────────
 
   const words = state.toneBaseline;
   const tonePhrase =
@@ -394,7 +509,7 @@ export default function WizardPage() {
     reviewRows.push({ label: 'Preference', value: `"${state.preferences.trim()}"` });
   }
 
-  const step4 = (
+  const step5Review = (
     <div className="wizard-content">
       <div className="wizard-heading">Does everything look right?</div>
       <div className="wizard-subheading">Go back to change anything, or save to get started.</div>
@@ -425,7 +540,13 @@ export default function WizardPage() {
 
   // ── Render ───────────────────────────────────────────────────────────────────
 
-  const steps: Record<number, JSX.Element> = { 1: step1, 2: step2, 3: step3, 4: step4 };
+  const steps: Record<number, JSX.Element> = {
+    1: step1,
+    2: step2Identity,
+    3: step3Tone,
+    4: step4Posture,
+    5: step5Review,
+  };
 
   return (
     <div className="wizard-page">

--- a/apps/console/src/pages/wizard-utils.test.ts
+++ b/apps/console/src/pages/wizard-utils.test.ts
@@ -7,7 +7,9 @@ import {
   verbosityReviewDesc,
   directnessReviewDesc,
   postureReviewDesc,
-  validateStep1,
+  validateNonEmptyName,
+  validatePrincipalName,
+  PRINCIPAL_NAME_MAX_LENGTH,
   buildIdentityPayload,
   type WizardState,
   type LocalIdentity,
@@ -125,19 +127,47 @@ describe('postureReviewDesc', () => {
   });
 });
 
-// ── validateStep1 ─────────────────────────────────────────────────────────────
+// ── validateNonEmptyName ──────────────────────────────────────────────────────
 
-describe('validateStep1', () => {
+describe('validateNonEmptyName', () => {
   it('returns true for a non-empty name', () => {
-    expect(validateStep1('Alex')).toBe(true);
+    expect(validateNonEmptyName('Alex')).toBe(true);
   });
 
   it('returns false for an empty name', () => {
-    expect(validateStep1('')).toBe(false);
+    expect(validateNonEmptyName('')).toBe(false);
   });
 
   it('returns false for whitespace-only name', () => {
-    expect(validateStep1('   ')).toBe(false);
+    expect(validateNonEmptyName('   ')).toBe(false);
+  });
+});
+
+// ── validatePrincipalName ─────────────────────────────────────────────────────
+
+describe('validatePrincipalName', () => {
+  it('returns null for a valid name', () => {
+    expect(validatePrincipalName('Jane Doe')).toBeNull();
+  });
+
+  it('returns an error message for an empty name', () => {
+    expect(validatePrincipalName('')).toBe('Your name is required.');
+  });
+
+  it('returns an error message for whitespace-only input', () => {
+    expect(validatePrincipalName('   ')).toBe('Your name is required.');
+  });
+
+  it('returns an error when over the length ceiling', () => {
+    const tooLong = 'X'.repeat(PRINCIPAL_NAME_MAX_LENGTH + 1);
+    expect(validatePrincipalName(tooLong)).toBe(
+      `Name must be ${PRINCIPAL_NAME_MAX_LENGTH} characters or fewer.`,
+    );
+  });
+
+  it('accepts a name exactly at the length ceiling', () => {
+    const atLimit = 'X'.repeat(PRINCIPAL_NAME_MAX_LENGTH);
+    expect(validatePrincipalName(atLimit)).toBeNull();
   });
 });
 
@@ -153,6 +183,7 @@ describe('buildIdentityPayload', () => {
   };
 
   const state: WizardState = {
+    principalName: 'Jane Doe',
     name: 'Alex Curia',
     title: 'Executive Assistant to the CEO',
     signature: 'Best, Alex',

--- a/apps/console/src/pages/wizard-utils.ts
+++ b/apps/console/src/pages/wizard-utils.ts
@@ -1,6 +1,12 @@
 // Pure helper functions for the wizard — no React, no DOM, fully testable.
 
 export interface WizardState {
+  // Step 1 — About you. Captured separately from the assistant identity below
+  // and POSTed to /api/setup/principal so the principal contact exists before
+  // the rest of the form is saved. Auto-skipped when a principal is already
+  // present (e.g. CEO_PRIMARY_EMAIL deployments).
+  principalName: string;
+  // Steps 2–5 — assistant identity, tone, posture, review.
   name: string;
   title: string;
   signature: string;
@@ -25,6 +31,7 @@ export interface LocalIdentity {
 }
 
 export const DEFAULT_WIZARD_STATE: WizardState = {
+  principalName: '',
   name: 'Alex Curia',
   title: 'Executive Assistant to the CEO',
   signature: '',
@@ -34,6 +41,10 @@ export const DEFAULT_WIZARD_STATE: WizardState = {
   posture: 'conservative',
   preferences: '',
 };
+
+// Backend's POST /api/setup/principal accepts up to 200 characters; enforce the
+// same ceiling client-side so the user sees the error before a round-trip.
+export const PRINCIPAL_NAME_MAX_LENGTH = 200;
 
 // All valid tone words — mirrors BASELINE_TONE_OPTIONS in src/identity/types.ts.
 // @TODO: consider exposing this via the API so both sides stay in sync automatically.
@@ -109,9 +120,24 @@ export function postureReviewDesc(posture: WizardState['posture']): string {
   return map[posture];
 }
 
-// Returns true if the user can advance past step 1 (name is required).
-export function validateStep1(name: string): boolean {
+// Returns true if a string is non-empty after trimming. Shared validator for
+// both the principal name (step 1) and the assistant name (step 2) — both
+// follow the same "must not be blank" rule.
+export function validateNonEmptyName(name: string): boolean {
   return name.trim().length > 0;
+}
+
+// Returns null if the principal name passes both the non-empty and length
+// checks; otherwise returns an error string suitable for inline display.
+// Two checks instead of a single boolean because the user-visible message
+// needs to distinguish "missing" from "too long".
+export function validatePrincipalName(name: string): string | null {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return 'Your name is required.';
+  if (trimmed.length > PRINCIPAL_NAME_MAX_LENGTH) {
+    return `Name must be ${PRINCIPAL_NAME_MAX_LENGTH} characters or fewer.`;
+  }
+  return null;
 }
 
 // Maps WizardState onto an existing LocalIdentity, appending preferences.

--- a/apps/console/src/router.tsx
+++ b/apps/console/src/router.tsx
@@ -65,8 +65,11 @@ const setupRoute = createRoute({
   getParentRoute: () => authedRoute,
   path: '/setup',
   validateSearch: (search: Record<string, unknown>) => ({
+    // Wizard now has 5 steps after the "About you" principal step was added at
+    // step 1 (issue #771). Clamp incoming ?step= values so a stale link from
+    // before the renumbering doesn't blow up route rendering.
     step: typeof search['step'] === 'number'
-      ? Math.max(1, Math.min(4, Math.round(search['step'] as number)))
+      ? Math.max(1, Math.min(5, Math.round(search['step'] as number)))
       : 1,
   }),
   component: WizardPage,


### PR DESCRIPTION
## **User description**
## Summary

Frontend half of the in-app onboarding flow. PR 1 (backend setup-required mode + name-only principal endpoint) is merged; this PR puts the wizard step on top of it.

- New **Step 1 \"About you\"** captures the operator's own name and POSTs it to \`/api/setup/principal\` before the assistant identity is saved at the end.
- Existing 4 steps renumber to 2–5 (Assistant identity → Tone → Posture → Review).
- On mount, the wizard runs \`GET /api/setup/status\` in parallel with \`GET /api/identity\`. If a principal already exists (CEO_PRIMARY_EMAIL bootstrap deployments), an effect auto-advances past Step 1. The Step 2 Back button stays hidden in that case so the user can't pong-pong against the gate.
- Router \`?step=\` clamp goes 4 → 5; older deep links still resolve to a real step.

Closes #771 only after PR 3 (chat handoff + restart banner) lands.

## Auto-review

Ran \`pr-review-toolkit:code-reviewer\` and \`pr-review-toolkit:silent-failure-hunter\` in parallel before opening. Both converged on the same root cause: the wizard was rendering Step 1 (and Step 2's Back button) before \`principalExists\` had resolved from the mount fetch. Fixed in commit 4dea4470 by extending the loading gate to wait for both \`existingIdentity\` and \`principalExists\` before rendering any step. Also picked up two related fixes from the silent-failure pass: disable the input while submitting (closes a tick-race where a keystroke could clear the about-to-arrive POST error) and \`await\` the post-POST navigation (so a router rejection doesn't leave the user staring at a re-enabled button with no progress signal).

Not addressed (left for follow-up):
- Stale \`principalExists\` if a principal is deleted server-side mid-session — extremely rare, surface area would be a re-fetch on Back click. Filed mentally.
- Polish banner explaining the silent redirect when a user deep-links to \`?step=1\` and a principal already exists. Pure UX, not a bug.
- CSS class \`wizard-step1-error\` is now shared between Step 1 (principal name) and Step 2 (assistant name). Same visual treatment, misleading class name. Rename to \`wizard-field-error\` worth doing in a future cleanup PR.

## Test plan

- [x] \`pnpm typecheck\` clean (root + console)
- [x] \`pnpm build\` clean (console produces wizard chunk of 17KB)
- [x] \`vitest wizard-utils\` — 34 of 34 tests pass (5 new for \`validatePrincipalName\`, fixture updated)
- [ ] Manual smoke once CI is green: fresh DB → boot → land on Step 1 → enter name → confirm POST /api/setup/principal returns 200 → walk steps 2–5 → confirm assistant identity saved
- [ ] Manual smoke with existing principal: open \`/setup\` → confirm auto-skip lands on Step 2 → confirm Back button on Step 2 is hidden


___

## **CodeAnt-AI Description**
**Add an “About you” step to the onboarding wizard and prevent step-skipping glitches**

### What Changed
- The setup flow now starts with a step that asks for the operator’s name before saving the assistant profile.
- That name is saved first, then the wizard moves on to assistant identity, tone, posture, and review.
- If a principal already exists, the wizard skips the new first step automatically and keeps the Back button from bouncing between steps.
- Stale setup links now still open a valid wizard step after the step order changed.
- The wizard now waits for both setup status and identity data before showing the form, which avoids brief wrong-step flashes and early submission on first load.

### Impact
`✅ Clearer first-time onboarding`
`✅ Fewer setup step glitches`
`✅ Fewer broken old setup links`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
