### PR TITLE
feat: wizard restart-and-wait flow (PR 3 of #771)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`POST /api/setup/principal`** — name-only principal contact creation, idempotent, for the wizard's "About you" step. (#771)
 - **`GET /api/setup/status`** — reports `{ principalExists, identityConfigured, externalAdaptersPending }` so the console router can land on the correct onboarding screen. (#771)
 - **Onboarding wizard "About you" step** — new Step 1 captures the principal's name and creates the principal contact via `POST /api/setup/principal` before the assistant identity is configured; auto-skipped on deployments where a principal already exists. (#771)
-- **`POST /api/setup/restart`** — wizard-triggered process exit so the supervisor (Docker, systemd) brings Curia back in normal mode after first-time setup; refused (409) when the process is not in setup-required mode. (#771)
-- **`bootStartedAt` on `GET /api/setup/status`** — ISO timestamp captured at process boot; the wizard's post-setup polling loop watches it to detect a successful restart. (#771)
-- **Wizard restart-and-wait flow** — after Step 5 save, the wizard triggers `/api/setup/restart` when needed, shows a "Setting up channels…" wait UI, polls `/api/setup/status` for the new boot, then lands the user on `/chat`. Timeout shows a retry card with dev-mode guidance. (#771)
+- **`POST /api/setup/restart`** — wizard-triggered process exit so a supervisor brings Curia back in normal mode. (#771)
+- **`bootStartedAt` on `GET /api/setup/status`** — boot timestamp the wizard polls to detect a successful restart. (#771)
+- **Wizard restart-and-wait flow** — Step 5 save triggers the restart, polls for the new boot, lands on `/chat`. (#771)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **`POST /api/setup/principal`** — name-only principal contact creation, idempotent, for the wizard's "About you" step. (#771)
 - **`GET /api/setup/status`** — reports `{ principalExists, identityConfigured, externalAdaptersPending }` so the console router can land on the correct onboarding screen. (#771)
 - **Onboarding wizard "About you" step** — new Step 1 captures the principal's name and creates the principal contact via `POST /api/setup/principal` before the assistant identity is configured; auto-skipped on deployments where a principal already exists. (#771)
+- **`POST /api/setup/restart`** — wizard-triggered process exit so the supervisor (Docker, systemd) brings Curia back in normal mode after first-time setup; refused (409) when the process is not in setup-required mode. (#771)
+- **`bootStartedAt` on `GET /api/setup/status`** — ISO timestamp captured at process boot; the wizard's post-setup polling loop watches it to detect a successful restart. (#771)
+- **Wizard restart-and-wait flow** — after Step 5 save, the wizard triggers `/api/setup/restart` when needed, shows a "Setting up channels…" wait UI, polls `/api/setup/status` for the new boot, then lands the user on `/chat`. Timeout shows a retry card with dev-mode guidance. (#771)
 
 ### Removed
 

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -163,6 +163,14 @@ export default function WizardPage() {
       }
       try {
         const res = await apiFetch('/api/setup/status');
+        if (res.status === 401 || res.status === 403) {
+          // Session is gone — re-auth required. No amount of polling will
+          // fix this; jump to timeout so the operator sees a recoverable
+          // state instead of waiting 60s and being told the restart took
+          // too long when the real failure is auth.
+          if (!cancelled) setRestartState({ kind: 'timeout', originalBootStartedAt });
+          return;
+        }
         if (res.ok) {
           const data = await res.json() as SetupStatusResponse;
           const restarted =
@@ -173,6 +181,8 @@ export default function WizardPage() {
             return;
           }
         }
+        // Non-2xx, non-auth: 5xx during the restart window, or transient. Fall
+        // through and retry on the next tick; the deadline above caps total wait.
       } catch {
         // Connection errors are expected while the process is restarting.
         // Swallow and re-schedule; the timeout above caps the total wait.
@@ -283,6 +293,11 @@ export default function WizardPage() {
       // below picks it up from there.
       const restartRes = await apiFetch('/api/setup/restart', { method: 'POST' });
       if (!restartRes.ok) throw new Error(await extractError(restartRes));
+      // Drop the submitting flag before swapping render states so the wizard
+      // doesn't leak a permanently-true `submitting` value into any future
+      // step view (e.g. via the retry-on-timeout path that returns the user
+      // to the wizard if we add one later).
+      setSubmitting(false);
       setRestartState({
         kind: 'waiting',
         originalBootStartedAt: status.bootStartedAt,

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -292,6 +292,16 @@ export default function WizardPage() {
       // switch the wizard's render into the wait state — the polling effect
       // below picks it up from there.
       const restartRes = await apiFetch('/api/setup/restart', { method: 'POST' });
+      if (restartRes.status === 409) {
+        // 409 means the backend refused: either the process is already in
+        // normal mode (a concurrent tab / earlier wizard run already restarted
+        // it between our status read and this POST) or setup prerequisites
+        // are missing. The first case is success-equivalent — channels are
+        // up — so just navigate. The second is theoretically reachable only
+        // by direct API use, since our own gating above won't allow it.
+        await navigate({ to: '/chat' });
+        return;
+      }
       if (!restartRes.ok) throw new Error(await extractError(restartRes));
       // Drop the submitting flag before swapping render states so the wizard
       // doesn't leak a permanently-true `submitting` value into any future

--- a/apps/console/src/pages/WizardPage.tsx
+++ b/apps/console/src/pages/WizardPage.tsx
@@ -32,7 +32,28 @@ interface SetupStatusResponse {
   principalExists: boolean;
   identityConfigured: boolean;
   externalAdaptersPending: boolean;
+  bootStartedAt: string;
 }
+
+// State machine for the post-save restart flow. `idle` covers both "haven't
+// submitted yet" and "submitted but no restart needed" (deployments where
+// setupRequiredAtBoot was false already had external channels running).
+// The timeout state carries originalBootStartedAt forward so a manual retry
+// can resume polling with the same "before any restart" reference point —
+// without that, a user who restarts manually during the dev-mode timeout
+// window would get a false-positive match against the timed-out process's
+// own stamp.
+type RestartState =
+  | { kind: 'idle' }
+  | { kind: 'waiting'; originalBootStartedAt: string; startedAt: number }
+  | { kind: 'timeout'; originalBootStartedAt: string };
+
+// Polling cadence + total wait budget. 60s is comfortable for a Docker
+// container restart on typical hardware; production-cold-boot in pathological
+// cases can exceed this, which is why the timeout-state has a retry button
+// rather than just giving up.
+const RESTART_POLL_INTERVAL_MS = 2_000;
+const RESTART_TIMEOUT_MS = 60_000;
 
 // ── Safe error extraction ─────────────────────────────────────────────────────
 
@@ -64,6 +85,7 @@ export default function WizardPage() {
   const [assistantNameError, setAssistantNameError] = useState('');
   const [submitError, setSubmitError] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [restartState, setRestartState] = useState<RestartState>({ kind: 'idle' });
 
   // Pre-populate form from current identity and check setup status on mount.
   // Run both fetches in parallel; setup status drives the Step 1 auto-skip
@@ -114,6 +136,58 @@ export default function WizardPage() {
       void navigate({ to: '/setup', search: { step: 2 } });
     }
   }, [principalExists, currentStep, navigate]);
+
+  // Post-restart polling loop. Runs only while restartState === 'waiting'.
+  // Polls /api/setup/status every RESTART_POLL_INTERVAL_MS, tolerating
+  // network errors (the process is dying then booting back; connection
+  // failures during that window are expected). The supervisor has brought
+  // a new process up when bootStartedAt has changed AND externalAdapters
+  // Pending is false — both required because the second condition alone
+  // could flicker false from the old process during graceful shutdown.
+  //
+  // The `cancelled` flag guards against setState-after-unmount when the
+  // user navigates away mid-poll. setInterval can't be used directly
+  // because async polls would stack on slow networks; recursive
+  // setTimeout schedules the next tick only after the current one settles.
+  useEffect(() => {
+    if (restartState.kind !== 'waiting') return;
+    const { originalBootStartedAt, startedAt } = restartState;
+    let cancelled = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    async function pollOnce() {
+      if (cancelled) return;
+      if (Date.now() - startedAt > RESTART_TIMEOUT_MS) {
+        setRestartState({ kind: 'timeout', originalBootStartedAt });
+        return;
+      }
+      try {
+        const res = await apiFetch('/api/setup/status');
+        if (res.ok) {
+          const data = await res.json() as SetupStatusResponse;
+          const restarted =
+            data.bootStartedAt !== originalBootStartedAt &&
+            !data.externalAdaptersPending;
+          if (restarted) {
+            if (!cancelled) await navigate({ to: '/chat' });
+            return;
+          }
+        }
+      } catch {
+        // Connection errors are expected while the process is restarting.
+        // Swallow and re-schedule; the timeout above caps the total wait.
+      }
+      if (!cancelled) {
+        timeoutHandle = setTimeout(() => void pollOnce(), RESTART_POLL_INTERVAL_MS);
+      }
+    }
+
+    void pollOnce();
+    return () => {
+      cancelled = true;
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    };
+  }, [restartState, navigate]);
 
   // Returns the navigation promise so callers that need to know whether the
   // route change succeeded (handlePrincipalContinue) can await it and surface
@@ -188,9 +262,32 @@ export default function WizardPage() {
       if (!putRes.ok) throw new Error(await extractError(putRes));
       const reloadRes = await apiFetch('/api/identity/reload', { method: 'POST' });
       if (!reloadRes.ok) throw new Error(await extractError(reloadRes));
-      // await inside the try block so navigation failures are caught and surface
-      // the submitError + re-enable buttons, rather than leaving a stuck spinner.
-      await navigate({ to: '/' });
+
+      // Decide whether we need a restart. After PUT /api/identity, the server
+      // recomputes externalAdaptersPending; if true, the process booted in
+      // setup-required mode and email/Signal are not running yet. If false,
+      // either the deployment never needed a restart (CEO_PRIMARY_EMAIL set
+      // a principal at boot) or we already restarted in a previous attempt.
+      const statusRes = await apiFetch('/api/setup/status');
+      if (!statusRes.ok) throw new Error(await extractError(statusRes));
+      const status = await statusRes.json() as SetupStatusResponse;
+
+      if (!status.externalAdaptersPending) {
+        await navigate({ to: '/chat' });
+        return;
+      }
+
+      // Capture the pre-restart bootStartedAt so the polling loop can detect
+      // the supervisor bringing a new process up. Trigger the restart, then
+      // switch the wizard's render into the wait state — the polling effect
+      // below picks it up from there.
+      const restartRes = await apiFetch('/api/setup/restart', { method: 'POST' });
+      if (!restartRes.ok) throw new Error(await extractError(restartRes));
+      setRestartState({
+        kind: 'waiting',
+        originalBootStartedAt: status.bootStartedAt,
+        startedAt: Date.now(),
+      });
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : 'Save failed');
       setSubmitting(false);
@@ -263,6 +360,66 @@ export default function WizardPage() {
         <div className="wizard-body">
           <div className="wizard-content" style={{ color: 'var(--app-fg-muted)' }}>
             Loading…
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Restart wait / timeout takeover ────────────────────────────────────────
+  //
+  // Replaces the wizard steps entirely once handleSubmit has triggered a
+  // process restart. The polling effect above will swap us to /chat on
+  // success or to the timeout state on the 60-second deadline.
+  if (restartState.kind === 'waiting') {
+    return (
+      <div className="wizard-page">
+        {header}
+        <div className="wizard-body">
+          <div className="wizard-content">
+            <div className="wizard-heading">Setting up channels…</div>
+            <div className="wizard-subheading">
+              Curia is restarting to bring email and Signal online. This usually takes
+              a few seconds. You'll be redirected automatically when it's ready.
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (restartState.kind === 'timeout') {
+    return (
+      <div className="wizard-page">
+        {header}
+        <div className="wizard-body">
+          <div className="wizard-content">
+            <div className="wizard-heading">Curia didn't come back yet</div>
+            <div className="wizard-subheading">
+              The restart is taking longer than expected. If you started Curia with{' '}
+              <code>pnpm dev</code>, run that command again and click below to keep
+              waiting. Otherwise check your deploy logs for errors.
+            </div>
+            <div className="wizard-nav">
+              <span />
+              <button
+                type="button"
+                className="btn-wizard-next"
+                onClick={() => setRestartState({
+                  // Resume polling without re-issuing the restart POST: the
+                  // operator may have already restarted manually, in which case
+                  // the next poll will see a different bootStartedAt and succeed.
+                  // The original stamp carries forward from the timeout state so
+                  // we don't accept the previous (already-timed-out) process's
+                  // own stamp as a "restart happened" match.
+                  kind: 'waiting',
+                  originalBootStartedAt: restartState.originalBootStartedAt,
+                  startedAt: Date.now(),
+                })}
+              >
+                Keep waiting
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -264,8 +264,16 @@ export class HttpAdapter {
         // Inject the actual exit trigger here rather than have setup.ts call
         // process.exit directly; this keeps the route handler unit-testable
         // and keeps the "kill the process" capability narrowly scoped.
+        //
+        // No .unref() on the timer: the whole point of this scheduled exit is
+        // to be the forcing function that brings the process down so the
+        // supervisor can boot it fresh. .unref() would let Node exit early
+        // (defeating the explicit exit), or — worse — let the process hang
+        // if some other ref is keeping the loop alive and the timer never
+        // fires. The 500ms delay is short enough that the active ref doesn't
+        // meaningfully prolong a healthy shutdown.
         scheduleProcessExit: (delayMs) => {
-          setTimeout(() => process.exit(0), delayMs).unref();
+          setTimeout(() => process.exit(0), delayMs);
         },
       });
     }

--- a/src/channels/http/http-adapter.ts
+++ b/src/channels/http/http-adapter.ts
@@ -66,6 +66,12 @@ export interface HttpAdapterConfig {
    * Captured at boot; never changes over the process lifetime.
    */
   setupRequiredAtBoot: boolean;
+  /**
+   * ISO timestamp captured at the very start of main() so the wizard's post-
+   * setup polling loop can detect a process restart (the value changes after
+   * the supervisor brings the new process up). Exposed via GET /api/setup/status.
+   */
+  bootStartedAt: string;
 }
 
 export class HttpAdapter {
@@ -254,6 +260,13 @@ export class HttpAdapter {
         pool,
         logger,
         setupRequiredAtBoot: this.config.setupRequiredAtBoot,
+        bootStartedAt: this.config.bootStartedAt,
+        // Inject the actual exit trigger here rather than have setup.ts call
+        // process.exit directly; this keeps the route handler unit-testable
+        // and keeps the "kill the process" capability narrowly scoped.
+        scheduleProcessExit: (delayMs) => {
+          setTimeout(() => process.exit(0), delayMs).unref();
+        },
       });
     }
 

--- a/src/channels/http/routes/setup.ts
+++ b/src/channels/http/routes/setup.ts
@@ -184,8 +184,39 @@ export async function setupRoutes(
     if (!setupRequiredAtBoot) {
       // The process was not started in setup-required mode, so there is
       // nothing to "come back into" — a restart here would just be downtime.
+      // The wizard sees this 409 and treats it as "another tab / earlier run
+      // already completed setup" → it navigates to /chat instead of erroring.
       return reply.status(409).send({
         error: 'Curia is already running in normal mode; no restart is needed.',
+      });
+    }
+
+    // Refuse a restart unless the setup prerequisites are actually satisfied.
+    // Without this check, an authenticated caller could trigger an exit before
+    // creating the principal / saving the identity; the supervisor brings the
+    // process back into setup-required mode (still missing prerequisites), and
+    // the cycle can repeat — pure churn that the operator can't escape via the
+    // UI. The 409 is informational; the wizard does its own gating before
+    // calling this endpoint, so a healthy frontend never sees this branch.
+    try {
+      const principalRow = await pool.query<{ exists: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1 FROM contacts WHERE system_role = 'principal'
+         ) AS exists`,
+      );
+      const principalExists = principalRow.rows[0]?.exists ?? false;
+      const identityConfigured = await isIdentityConfigured(pool);
+      if (!principalExists || !identityConfigured) {
+        return reply.status(409).send({
+          error: 'Setup is incomplete — create the principal and save the identity before restarting.',
+          principalExists,
+          identityConfigured,
+        });
+      }
+    } catch (err) {
+      logger.error({ err }, 'POST /api/setup/restart: failed to verify setup prerequisites');
+      return reply.status(500).send({
+        error: 'Failed to verify setup state before restart. Check server logs.',
       });
     }
 

--- a/src/channels/http/routes/setup.ts
+++ b/src/channels/http/routes/setup.ts
@@ -193,7 +193,17 @@ export async function setupRoutes(
       { bootStartedAt, delayMs: RESTART_EXIT_DELAY_MS },
       'POST /api/setup/restart: scheduling process exit so supervisor can bring Curia back in normal mode',
     );
-    scheduleProcessExit(RESTART_EXIT_DELAY_MS);
+    // The 200 reply has already gone out by the time the timer fires, but if
+    // scheduleProcessExit itself throws synchronously, Fastify's default error
+    // handler would try to send another response (and warn about it). The
+    // injected wrapper today is a plain setTimeout — won't throw — but the
+    // contract allows any impl. Log and proceed; the client has its 200 and
+    // the polling loop's timeout is the safety net if the exit never lands.
+    try {
+      scheduleProcessExit(RESTART_EXIT_DELAY_MS);
+    } catch (err) {
+      logger.error({ err }, 'POST /api/setup/restart: scheduleProcessExit threw — restart will not occur');
+    }
     return reply.send({ restarting: true, exitDelayMs: RESTART_EXIT_DELAY_MS });
   });
 }

--- a/src/channels/http/routes/setup.ts
+++ b/src/channels/http/routes/setup.ts
@@ -9,6 +9,8 @@
 // Endpoints:
 //   POST /api/setup/principal — name-only principal creation (idempotent)
 //   GET  /api/setup/status    — does the system need setup? what's done so far?
+//   POST /api/setup/restart   — terminate the process so the supervisor brings
+//                               it back into normal (non-setup-required) mode
 //
 // All routes require session cookie or x-web-bootstrap-secret authentication
 // (same pattern as identity routes). Routes are only registered when
@@ -34,6 +36,19 @@ export interface SetupRouteOptions {
    * can prompt the operator to restart once they've finished the wizard.
    */
   setupRequiredAtBoot: boolean;
+  /**
+   * ISO timestamp captured at the start of main() in src/index.ts. Exposed on
+   * GET /api/setup/status so the post-setup polling loop in the wizard can
+   * distinguish "old process still dying" from "new process up" — when this
+   * value changes across responses, the supervisor restart has completed.
+   */
+  bootStartedAt: string;
+  /**
+   * Triggers a process exit so the supervisor (Docker, systemd) can bring the
+   * process back up in normal mode. Injected for testability — production
+   * passes a small wrapper around process.exit; tests pass a spy.
+   */
+  scheduleProcessExit: (delayMs: number) => void;
 }
 
 // Match identity.ts: tighter rate limit on auth-sensitive routes (10/min vs the
@@ -48,7 +63,21 @@ export async function setupRoutes(
   app: FastifyInstance,
   options: SetupRouteOptions,
 ): Promise<void> {
-  const { webAppBootstrapSecret, sessions, pool, logger, setupRequiredAtBoot } = options;
+  const {
+    webAppBootstrapSecret,
+    sessions,
+    pool,
+    logger,
+    setupRequiredAtBoot,
+    bootStartedAt,
+    scheduleProcessExit,
+  } = options;
+
+  // Delay before process.exit so Fastify can finish flushing the 200 response.
+  // 500ms is comfortably more than the bytes-on-the-wire time for a tiny JSON
+  // body and well under the typical browser fetch timeout — the wizard's
+  // polling loop will already be running by the time the process actually dies.
+  const RESTART_EXIT_DELAY_MS = 500;
 
   function requireAuth(request: FastifyRequest, reply: FastifyReply): boolean {
     return assertSecret(request, reply, webAppBootstrapSecret, sessions);
@@ -124,6 +153,7 @@ export async function setupRoutes(
         principalExists,
         identityConfigured,
         externalAdaptersPending,
+        bootStartedAt,
       });
     } catch (err) {
       logger.error({ err }, 'GET /api/setup/status: failed to compute setup status');
@@ -131,5 +161,39 @@ export async function setupRoutes(
         error: 'Failed to compute setup status. Check server logs.',
       });
     }
+  });
+
+  // -- POST /api/setup/restart --
+  //
+  // Authoritative trigger for "I've finished setup, please come back in normal
+  // mode." Responds 200, then schedules a process exit so the supervisor
+  // (Docker restart policy, systemd, etc.) brings the process back. The wizard
+  // polls GET /api/setup/status for a different bootStartedAt + externalAdapters
+  // Pending=false to know the restart has landed.
+  //
+  // Guarded by `setupRequiredAtBoot`: a restart triggered against an already-
+  // healthy process would be a surprise side effect with no recovery story.
+  // Rejecting it here makes the endpoint inert in normal operation.
+  //
+  // In dev (`pnpm dev`), no supervisor exists — the process will die and stay
+  // dead until the developer re-runs the dev command. The wizard's polling
+  // loop times out gracefully and tells them so.
+  app.post('/api/setup/restart', AUTH_RATE, async (request, reply) => {
+    if (!requireAuth(request, reply)) return;
+
+    if (!setupRequiredAtBoot) {
+      // The process was not started in setup-required mode, so there is
+      // nothing to "come back into" — a restart here would just be downtime.
+      return reply.status(409).send({
+        error: 'Curia is already running in normal mode; no restart is needed.',
+      });
+    }
+
+    logger.warn(
+      { bootStartedAt, delayMs: RESTART_EXIT_DELAY_MS },
+      'POST /api/setup/restart: scheduling process exit so supervisor can bring Curia back in normal mode',
+    );
+    scheduleProcessExit(RESTART_EXIT_DELAY_MS);
+    return reply.send({ restarting: true, exitDelayMs: RESTART_EXIT_DELAY_MS });
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,13 @@ import { compileSecurityContextBlock } from './security/security-context.js';
 import { OutboundContextService } from './dispatch/outbound-context.js';
 
 async function main(): Promise<void> {
+  // Captured at the very start of main() so the wizard's post-setup polling
+  // loop can distinguish "old process still dying" from "new process up" by
+  // comparing this value across requests. Exposed on GET /api/setup/status.
+  // Plain ISO string — no need for a monotonic clock here, restarts always
+  // produce a strictly-later wall-clock time.
+  const bootStartedAt = new Date().toISOString();
+
   // 1. Config & logging — no dependencies, must come first.
   // loadConfig() throws synchronously if DATABASE_URL is missing, which is
   // intentional: we want a hard failure before any I/O is attempted.
@@ -1585,6 +1592,7 @@ async function main(): Promise<void> {
     contactService,
     autonomyService,
     setupRequiredAtBoot,
+    bootStartedAt,
   });
 
   try {

--- a/tests/integration/setup-routes.test.ts
+++ b/tests/integration/setup-routes.test.ts
@@ -306,35 +306,72 @@ describeIf('/api/setup/* routes', () => {
 
   describe('POST /api/setup/restart', () => {
     // The restart endpoint refuses (409) unless setup prerequisites are
-    // actually complete. Seed the prerequisites for the happy-path test so
-    // the assertion exercises the success branch.
+    // actually complete. Seed the prerequisites for the happy-path test.
+    //
+    // Robust against parallel test files (vitest workers share the DB): the
+    // prerequisite checks only need ANY principal to exist and ANY wizard/api
+    // identity version to exist, so we write our own and tolerate whatever
+    // else is in the database. INSERT...ON CONFLICT keeps this idempotent
+    // even when a parallel test file's principal still exists.
     async function seedSetupPrerequisites() {
-      await appSetupMode.inject({
-        method: 'POST',
-        url: '/api/setup/principal',
-        headers: { ...AUTH_HEADER, 'content-type': 'application/json' },
-        payload: { name: `${TEST_LABEL_PREFIX} RestartHappy` },
-      });
-      // Write a wizard-flagged identity version so isIdentityConfigured() returns true.
+      // Principal contact. The partial unique index on system_role='principal'
+      // means at most one row can have that role; ON CONFLICT DO NOTHING is
+      // the cheapest way to express "make sure one exists, don't care whose".
       await pool.query(
-        `INSERT INTO office_identity_versions (version, config, changed_by, note)
-         VALUES (
-           (SELECT COALESCE(MAX(version), 0) + 1 FROM office_identity_versions),
-           '{}'::jsonb,
-           'wizard',
-           'setup-routes test'
-         )`,
+        `INSERT INTO contacts (id, display_name, role, status, trust_level, system_role, created_at, updated_at)
+         VALUES (gen_random_uuid(), $1, 'ceo', 'confirmed', 'ceo', 'principal', now(), now())
+         ON CONFLICT DO NOTHING`,
+        [`${TEST_LABEL_PREFIX} RestartHappy`],
       );
+
+      // Identity version. UNIQUE(version) is the only constraint; the
+      // max+1 expression races with concurrent inserters but pg raises 23505
+      // rather than silently producing dup keys — retry once is enough for
+      // a two-worker collision in practice.
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          await pool.query(
+            `INSERT INTO office_identity_versions (version, config, changed_by, note)
+             VALUES (
+               (SELECT COALESCE(MAX(version), 0) + 1 FROM office_identity_versions),
+               '{}'::jsonb,
+               'wizard',
+               'setup-routes test'
+             )`,
+          );
+          break;
+        } catch (err) {
+          if ((err as { code?: string }).code !== '23505' || attempt === 2) throw err;
+        }
+      }
     }
 
     it('schedules a process exit when setup is complete in setup-required mode', async () => {
       await seedSetupPrerequisites();
+
+      // Sanity-check that the seed actually landed before exercising the
+      // endpoint under test. Integration tests share a single DB across
+      // worker processes, so a precondition that "should be" true can be
+      // raced out from under us (e.g. another file's beforeAll wiping
+      // principals). Asserting here means a 409 from the restart POST is
+      // unambiguous — it'd be a real bug in the endpoint, not seed flake.
+      const statusRes = await appSetupMode.inject({
+        method: 'GET',
+        url: '/api/setup/status',
+        headers: AUTH_HEADER,
+      });
+      const status = JSON.parse(statusRes.body);
+      expect(status.principalExists, 'principal must exist for happy-path seed').toBe(true);
+      expect(status.identityConfigured, 'identity must be configured for happy-path seed').toBe(true);
+
       const res = await appSetupMode.inject({
         method: 'POST',
         url: '/api/setup/restart',
         headers: AUTH_HEADER,
       });
-      expect(res.statusCode).toBe(200);
+      // If this assertion ever fails again on CI, surface the response body
+      // so the failure tells us which branch the endpoint took.
+      expect(res.statusCode, `restart POST body: ${res.body}`).toBe(200);
       const body = JSON.parse(res.body);
       expect(body.restarting).toBe(true);
       expect(typeof body.exitDelayMs).toBe('number');
@@ -345,17 +382,30 @@ describeIf('/api/setup/* routes', () => {
     });
 
     it('returns 409 in setup-required mode when prerequisites are not met', async () => {
-      // No principal, no identity — the endpoint must refuse rather than
-      // exiting into an unrecoverable churn loop.
+      // Wipe any principal a parallel test file (notably ceo-bootstrap.test.ts)
+      // may have created so the prerequisite check resolves to false. The
+      // wider cleanup in the outer beforeEach only filters by display_name
+      // prefix, which doesn't catch other files' principals. We can't
+      // realistically wipe identity versions (other workers may be racing
+      // inserts into office_identity_versions), so we don't assert on it.
+      await pool.query(
+        `DELETE FROM contact_channel_identities WHERE contact_id IN
+           (SELECT id FROM contacts WHERE system_role = 'principal')`,
+      );
+      await pool.query(`DELETE FROM contacts WHERE system_role = 'principal'`);
+
       const res = await appSetupMode.inject({
         method: 'POST',
         url: '/api/setup/restart',
         headers: AUTH_HEADER,
       });
-      expect(res.statusCode).toBe(409);
+      expect(res.statusCode, `restart POST body: ${res.body}`).toBe(409);
       expect(processExitCalls).toHaveLength(0);
       const body = JSON.parse(res.body);
       expect(body.principalExists).toBe(false);
+      // identityConfigured may be true (left over from a parallel test) or
+      // false (clean run). Either way, !principalExists is enough to trip
+      // the 409 branch — that's what we assert.
       expect(typeof body.identityConfigured).toBe('boolean');
     });
 

--- a/tests/integration/setup-routes.test.ts
+++ b/tests/integration/setup-routes.test.ts
@@ -38,8 +38,13 @@ describeIf('/api/setup/* routes', () => {
   // assert the status flag responds to the boot-time value, not live state.
   let appSetupMode: FastifyInstance;
   let appNormalMode: FastifyInstance;
+  let bootStartedAtSetupMode: string;
+  let bootStartedAtNormalMode: string;
   // Sessions intentionally empty — tests use the bootstrap-secret header.
   const sessions: Map<string, number> = new Map();
+  // Captured calls into the injected scheduleProcessExit hook; assert on this
+  // instead of actually exiting the test runner.
+  const processExitCalls: number[] = [];
 
   beforeAll(async () => {
     pool = new Pool({ connectionString: DATABASE_URL });
@@ -54,7 +59,17 @@ describeIf('/api/setup/* routes', () => {
     );
     await pool.query(`DELETE FROM contacts WHERE system_role = 'principal'`);
 
-    const buildApp = async (setupRequiredAtBoot: boolean) => {
+    // Each test app gets its own bootStartedAt — when we exercise the polling
+    // loop's "different boot" detection in the frontend later, the same logic
+    // applies here: a new process produces a strictly-later timestamp.
+    bootStartedAtSetupMode = '2026-05-31T18:00:00.000Z';
+    bootStartedAtNormalMode = '2026-05-31T18:30:00.000Z';
+
+    const buildApp = async (
+      setupRequiredAtBoot: boolean,
+      bootStartedAt: string,
+      scheduleProcessExit: (delayMs: number) => void,
+    ) => {
       const app = Fastify();
       // rate-limit plugin is required because setup routes attach { config: { rateLimit: ... } }
       // per route — without it Fastify errors on registration.
@@ -65,13 +80,19 @@ describeIf('/api/setup/* routes', () => {
         pool,
         logger,
         setupRequiredAtBoot,
+        bootStartedAt,
+        scheduleProcessExit,
       });
       await app.ready();
       return app;
     };
 
-    appSetupMode = await buildApp(true);
-    appNormalMode = await buildApp(false);
+    appSetupMode = await buildApp(true, bootStartedAtSetupMode, (delayMs) => {
+      processExitCalls.push(delayMs);
+    });
+    appNormalMode = await buildApp(false, bootStartedAtNormalMode, (delayMs) => {
+      processExitCalls.push(delayMs);
+    });
   });
 
   afterAll(async () => {
@@ -96,6 +117,9 @@ describeIf('/api/setup/* routes', () => {
       `DELETE FROM kg_nodes WHERE source = 'bootstrap' AND label LIKE $1`,
       [`${TEST_LABEL_PREFIX}%`],
     );
+    // Reset the captured restart-trigger calls between tests so each restart
+    // test sees a fresh array.
+    processExitCalls.length = 0;
   });
 
   describe('POST /api/setup/principal', () => {
@@ -214,6 +238,25 @@ describeIf('/api/setup/* routes', () => {
       expect(body.externalAdaptersPending).toBe(false);
     });
 
+    it('returns the bootStartedAt timestamp configured at app construction', async () => {
+      // The wizard's post-restart polling loop compares this value across
+      // responses to detect that the supervisor has brought the new process
+      // up; if the status response stopped including it, that detection
+      // would silently break. Each app instance gets a distinct boot stamp.
+      const setupRes = await appSetupMode.inject({
+        method: 'GET',
+        url: '/api/setup/status',
+        headers: AUTH_HEADER,
+      });
+      const normalRes = await appNormalMode.inject({
+        method: 'GET',
+        url: '/api/setup/status',
+        headers: AUTH_HEADER,
+      });
+      expect(JSON.parse(setupRes.body).bootStartedAt).toBe(bootStartedAtSetupMode);
+      expect(JSON.parse(normalRes.body).bootStartedAt).toBe(bootStartedAtNormalMode);
+    });
+
     it('reports principalExists=true after creating one', async () => {
       await appSetupMode.inject({
         method: 'POST',
@@ -258,6 +301,45 @@ describeIf('/api/setup/* routes', () => {
         url: '/api/setup/status',
       });
       expect(res.statusCode).toBe(401);
+    });
+  });
+
+  describe('POST /api/setup/restart', () => {
+    it('schedules a process exit in setup-required mode', async () => {
+      const res = await appSetupMode.inject({
+        method: 'POST',
+        url: '/api/setup/restart',
+        headers: AUTH_HEADER,
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.restarting).toBe(true);
+      expect(typeof body.exitDelayMs).toBe('number');
+      // Asserting on the captured spy rather than the wall clock so the test
+      // doesn't have to actually wait for the (mocked) exit to fire.
+      expect(processExitCalls).toHaveLength(1);
+      expect(processExitCalls[0]).toBe(body.exitDelayMs);
+    });
+
+    it('returns 409 in normal mode (nothing to restart for)', async () => {
+      const res = await appNormalMode.inject({
+        method: 'POST',
+        url: '/api/setup/restart',
+        headers: AUTH_HEADER,
+      });
+      expect(res.statusCode).toBe(409);
+      // Critical safety check: a 409 must not have side-effected the exit hook.
+      // If this ever flips, the endpoint became destructive in normal mode.
+      expect(processExitCalls).toHaveLength(0);
+    });
+
+    it('returns 401 without auth and does not schedule an exit', async () => {
+      const res = await appSetupMode.inject({
+        method: 'POST',
+        url: '/api/setup/restart',
+      });
+      expect(res.statusCode).toBe(401);
+      expect(processExitCalls).toHaveLength(0);
     });
   });
 });

--- a/tests/integration/setup-routes.test.ts
+++ b/tests/integration/setup-routes.test.ts
@@ -305,7 +305,30 @@ describeIf('/api/setup/* routes', () => {
   });
 
   describe('POST /api/setup/restart', () => {
-    it('schedules a process exit in setup-required mode', async () => {
+    // The restart endpoint refuses (409) unless setup prerequisites are
+    // actually complete. Seed the prerequisites for the happy-path test so
+    // the assertion exercises the success branch.
+    async function seedSetupPrerequisites() {
+      await appSetupMode.inject({
+        method: 'POST',
+        url: '/api/setup/principal',
+        headers: { ...AUTH_HEADER, 'content-type': 'application/json' },
+        payload: { name: `${TEST_LABEL_PREFIX} RestartHappy` },
+      });
+      // Write a wizard-flagged identity version so isIdentityConfigured() returns true.
+      await pool.query(
+        `INSERT INTO office_identity_versions (version, config, changed_by, note)
+         VALUES (
+           (SELECT COALESCE(MAX(version), 0) + 1 FROM office_identity_versions),
+           '{}'::jsonb,
+           'wizard',
+           'setup-routes test'
+         )`,
+      );
+    }
+
+    it('schedules a process exit when setup is complete in setup-required mode', async () => {
+      await seedSetupPrerequisites();
       const res = await appSetupMode.inject({
         method: 'POST',
         url: '/api/setup/restart',
@@ -319,6 +342,21 @@ describeIf('/api/setup/* routes', () => {
       // doesn't have to actually wait for the (mocked) exit to fire.
       expect(processExitCalls).toHaveLength(1);
       expect(processExitCalls[0]).toBe(body.exitDelayMs);
+    });
+
+    it('returns 409 in setup-required mode when prerequisites are not met', async () => {
+      // No principal, no identity — the endpoint must refuse rather than
+      // exiting into an unrecoverable churn loop.
+      const res = await appSetupMode.inject({
+        method: 'POST',
+        url: '/api/setup/restart',
+        headers: AUTH_HEADER,
+      });
+      expect(res.statusCode).toBe(409);
+      expect(processExitCalls).toHaveLength(0);
+      const body = JSON.parse(res.body);
+      expect(body.principalExists).toBe(false);
+      expect(typeof body.identityConfigured).toBe('boolean');
     });
 
     it('returns 409 in normal mode (nothing to restart for)', async () => {


### PR DESCRIPTION
## **User description**
## Summary

PR 3 of the in-app onboarding flow. PRs 1 + 2 are merged; this PR closes the loop so the operator never has to think about devops.

After Step 5 ("Confirm & save"), the wizard:
1. \`PUT /api/identity\` + reload (existing).
2. \`GET /api/setup/status\` — if \`externalAdaptersPending\` is false (CEO_PRIMARY_EMAIL bootstrap deployments where channels were never skipped), go straight to \`/chat\` with no restart.
3. Otherwise capture \`bootStartedAt\`, \`POST /api/setup/restart\`, swap to a "Setting up channels…" wait UI.
4. Poll \`/api/setup/status\` every 2s. Done when \`bootStartedAt\` differs AND \`externalAdaptersPending === false\`. Navigate to \`/chat\`.
5. 60s timeout → retry card with dev-mode guidance. "Keep waiting" preserves the original boot stamp so a manual restart during the timeout window still detects correctly.

Closes #771.

## Backend

- **\`src/index.ts\`** captures \`bootStartedAt\` at the start of \`main()\` and passes it through \`HttpAdapter\`.
- **\`POST /api/setup/restart\`** (new) — returns 200, then schedules \`process.exit(0)\` via an injected hook (so the route stays unit-testable). Refuses 409 in normal mode — a restart there would be downtime with no recovery story.
- **\`GET /api/setup/status\`** now returns \`bootStartedAt\` alongside the existing booleans.
- \`scheduleProcessExit\` is a plain \`setTimeout\` (no \`.unref()\` — the explicit \`process.exit(0)\` is the forcing function and shouldn't be droppable).
- Integration tests cover the new endpoint paths (200 in setup-required mode, 409 in normal mode, 401 without auth) using an injected spy in place of \`process.exit\`.

## Frontend

- **\`apps/console/src/pages/WizardPage.tsx\`** replaces the placeholder navigate-to-\`/\` at the end of \`handleSubmit\` with the three-stage restart flow above.
- New tagged-union \`RestartState\` (\`'idle' | 'waiting' | 'timeout'\`) drives the render — a single switch, no flag juggling.
- Polling loop uses recursive \`setTimeout\` (not \`setInterval\`) so slow polls can't stack, and a \`cancelled\` flag for clean unmount.
- 401/403 during polling jumps to the timeout state immediately — session loss is recoverable but no amount of waiting fixes it; making the operator stare at the spinner for 60s misdiagnoses the problem.

## Auto-review

Ran \`pr-review-toolkit:code-reviewer\` and \`pr-review-toolkit:silent-failure-hunter\` in parallel before opening. Real findings in commit 5689160a: dropped \`.unref()\` so the exit timer can't be elided, treat 401/403 as terminal in polling, reset \`submitting\` before transitioning to \`'waiting'\`, wrap the injected exit hook in try/catch. One claimed showstopper ("setup routes deregister after restart") was a misread — verified that registration is gated on \`webAppBootstrapSecret\` only, so \`GET /api/setup/status\` keeps working post-restart.

## Out of scope (deferred to #486)

- Welcome banner on \`/chat\` (the setup-wizard agent in #486 will replace this anyway).
- "External channels not running" persistent banner — without the ability to act on it post-setup, it'd just be frustration noise.

## Test plan

- [x] \`pnpm typecheck\` clean (root + console)
- [x] \`pnpm build\` clean (console wizard chunk is 18KB)
- [x] \`vitest wizard-utils\` — 34 of 34 tests pass
- [x] CI runs the new integration tests on the restart endpoint
- [ ] Manual e2e on a fresh DB: boot → setup-required mode → walk wizard → confirm restart triggers, polling waits, lands on \`/chat\`
- [ ] Manual e2e on a CEO_PRIMARY_EMAIL deployment: confirm restart is skipped (\`externalAdaptersPending: false\` short-circuit) and navigation to \`/chat\` is immediate
- [ ] Manual e2e in \`pnpm dev\`: confirm the 60s timeout fires with the dev-mode hint and "Keep waiting" picks back up after a manual re-run


___

## **CodeAnt-AI Description**
**Wizard now restarts Curia after setup and waits for it to come back**

### What Changed
- After saving the assistant identity, the wizard now checks whether a restart is needed, triggers it when required, and then shows a wait screen instead of sending users straight away
- The wizard now polls for the new process to come up and sends users to `/chat` once the restart is complete
- If the restart takes too long, the wizard shows a retry screen with guidance for local development
- `/api/setup/status` now includes the process boot timestamp, and `/api/setup/restart` was added to safely restart only when setup mode is still active

### Impact
`✅ Fewer manual restarts after first-time setup`
`✅ Faster path from setup completion to chat`
`✅ Clearer recovery when a dev restart takes too long`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Setup wizard now includes automatic restart capability to properly manage process recovery during initial configuration
  * Real-time setup progress monitoring via status polling mechanism, with built-in timeout detection and user-friendly recovery instructions  
  * Dedicated visual feedback screens that display setup progress messages and provide recovery action options when setup takes longer than expected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->