### PR TITLE
fix(runtime): publish agent.error when empty-response recovery fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Agent runtime** — empty-response recovery failure now publishes `agent.error` in addition to `agent.response(isError: true)`, giving the scheduler the completion signal it needs to mark the job failed instead of waiting for the watchdog timeout. (#801)
+
 ### Added
 
 - **Setup-required boot mode** — a missing principal contact no longer crash-loops the process; the dispatcher and HTTP adapter stay up while email + Signal are skipped, so the onboarding wizard can be reached at `/setup`. Restart picks up the new principal and brings external channels online. (#766, #771)

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1060,6 +1060,20 @@ export class AgentRuntime {
             },
             'LLM returned empty text response after tool use — recovery also failed, sending fallback',
           );
+          // Publish agent.error so the scheduler subscriber receives a completion signal.
+          // Without this, the scheduler only sees agent.response(isError: true), which it
+          // explicitly skips — leaving the job stuck in "running" until the watchdog fires.
+          await this.publishAgentError(
+            {
+              type: 'PROVIDER_ERROR',
+              source: 'runtime',
+              message: 'LLM returned empty text after tool use; recovery prompt also produced no output',
+              retryable: false,
+              context: { recoveryType: recovery.type, inputTokens: response.usage.inputTokens },
+              timestamp: new Date(),
+            },
+            taskEvent,
+          );
           isResponseError = true;
           responseContent = "I'm sorry, I wasn't able to formulate a response. Please try again.";
         }

--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1063,17 +1063,26 @@ export class AgentRuntime {
           // Publish agent.error so the scheduler subscriber receives a completion signal.
           // Without this, the scheduler only sees agent.response(isError: true), which it
           // explicitly skips — leaving the job stuck in "running" until the watchdog fires.
-          await this.publishAgentError(
-            {
-              type: 'PROVIDER_ERROR',
-              source: 'runtime',
-              message: 'LLM returned empty text after tool use; recovery prompt also produced no output',
-              retryable: false,
-              context: { recoveryType: recovery.type, inputTokens: response.usage.inputTokens },
-              timestamp: new Date(),
-            },
-            taskEvent,
-          );
+          // Wrapped in try-catch because a publish failure (e.g. audit hook / DB write)
+          // must not prevent the fallback agent.response below from being sent.
+          try {
+            await this.publishAgentError(
+              {
+                type: 'UNKNOWN',
+                source: 'runtime',
+                message: 'LLM returned empty text after tool use; recovery prompt also produced no output',
+                retryable: false,
+                context: { recoveryType: recovery.type, inputTokens: response.usage.inputTokens },
+                timestamp: new Date(),
+              },
+              taskEvent,
+            );
+          } catch (publishErr) {
+            logger.error(
+              { agentId, conversationId, err: publishErr },
+              'Failed to publish agent.error for empty-response recovery failure',
+            );
+          }
           isResponseError = true;
           responseContent = "I'm sorry, I wasn't able to formulate a response. Please try again.";
         }

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -1090,7 +1090,7 @@ describe('AgentRuntime tool-use loop', () => {
     expect(agentResponses[0]!.payload.isError).toBe(true);
     // agent.error must also be published so the scheduler receives a completion signal
     expect(agentErrors).toHaveLength(1);
-    expect(agentErrors[0]!.payload.errorType).toBe('PROVIDER_ERROR');
+    expect(agentErrors[0]!.payload.errorType).toBe('UNKNOWN');
   });
 
   it('does not publish agent.error when empty-response recovery succeeds', async () => {

--- a/tests/unit/agents/runtime.test.ts
+++ b/tests/unit/agents/runtime.test.ts
@@ -1009,6 +1009,162 @@ describe('AgentRuntime tool-use loop', () => {
     expect(mockExecution.invoke).toHaveBeenCalledTimes(4);
     expect(responseContent).toBeTruthy();
   });
+
+  // -- Empty-response recovery (Bug #801) --
+  // When Gemini (or any model) returns empty text after tool use AND the recovery
+  // prompt also fails, the runtime must emit agent.error so the scheduler can mark
+  // the job failed. Previously only agent.response(isError: true) was emitted,
+  // which the scheduler subscriber skips — leaving the job stuck in "running" until
+  // the watchdog times it out 70 minutes later.
+
+  it('publishes agent.error when empty-response recovery fails after tool use', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn()
+        .mockResolvedValueOnce({
+          // Turn 1: request a tool
+          type: 'tool_use' as const,
+          toolCalls: [{ id: 'call-recovery-1', name: 'web-fetch', input: { url: 'https://example.com' } }],
+          usage: { inputTokens: 50, outputTokens: 10, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        })
+        .mockResolvedValueOnce({
+          // Turn 2: empty text after tool result (the Gemini "do not output" pattern)
+          type: 'text' as const,
+          content: '',
+          usage: { inputTokens: 100, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        })
+        .mockResolvedValueOnce({
+          // Turn 3: recovery prompt also returns empty — recovery fails
+          type: 'text' as const,
+          content: '',
+          usage: { inputTokens: 120, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        }),
+    };
+
+    const mockExecution = {
+      invoke: vi.fn().mockResolvedValue({ success: true, data: 'page content' }),
+    } as unknown as ExecutionLayer;
+
+    const agentErrors: AgentErrorEvent[] = [];
+    bus.subscribe('agent.error', 'system', (event) => {
+      agentErrors.push(event as AgentErrorEvent);
+    });
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      pinnedSkills: ['web-fetch'],
+      skillToolDefs: [{ name: 'web-fetch', description: 'Fetch', input_schema: { type: 'object' as const, properties: { url: { type: 'string' } }, required: ['url'] } }],
+    });
+    agent.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-recovery-fail',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Fetch something',
+      parentEventId: 'parent-recovery-fail',
+    });
+    await bus.publish('dispatch', task);
+
+    // 3 LLM calls: tool_use → empty text → empty recovery
+    expect(provider.chat).toHaveBeenCalledTimes(3);
+    // Response must be flagged as an error
+    expect(agentResponses).toHaveLength(1);
+    expect(agentResponses[0]!.payload.isError).toBe(true);
+    // agent.error must also be published so the scheduler receives a completion signal
+    expect(agentErrors).toHaveLength(1);
+    expect(agentErrors[0]!.payload.errorType).toBe('PROVIDER_ERROR');
+  });
+
+  it('does not publish agent.error when empty-response recovery succeeds', async () => {
+    const logger = createLogger('error');
+    const bus = new EventBus(logger);
+
+    const provider: LLMProvider = {
+      id: 'mock',
+      chat: vi.fn()
+        .mockResolvedValueOnce({
+          type: 'tool_use' as const,
+          toolCalls: [{ id: 'call-recovery-ok-1', name: 'web-fetch', input: { url: 'https://example.com' } }],
+          usage: { inputTokens: 50, outputTokens: 10, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        })
+        .mockResolvedValueOnce({
+          type: 'text' as const,
+          content: '',
+          usage: { inputTokens: 100, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        })
+        .mockResolvedValueOnce({
+          // Recovery succeeds with non-empty text
+          type: 'text' as const,
+          content: 'Done.',
+          usage: { inputTokens: 120, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+          provenance: MOCK_PROVENANCE,
+        }),
+    };
+
+    const mockExecution = {
+      invoke: vi.fn().mockResolvedValue({ success: true, data: 'page content' }),
+    } as unknown as ExecutionLayer;
+
+    const agentErrors: AgentErrorEvent[] = [];
+    bus.subscribe('agent.error', 'system', (event) => {
+      agentErrors.push(event as AgentErrorEvent);
+    });
+    const agentResponses: AgentResponseEvent[] = [];
+    bus.subscribe('agent.response', 'dispatch', (event) => {
+      agentResponses.push(event as AgentResponseEvent);
+    });
+
+    const agent = new AgentRuntime({
+      agentId: 'coordinator',
+      systemPrompt: 'You are an assistant.',
+      provider,
+      resolvedModel: 'mock-model',
+      bus,
+      logger,
+      executionLayer: mockExecution,
+      pinnedSkills: ['web-fetch'],
+      skillToolDefs: [{ name: 'web-fetch', description: 'Fetch', input_schema: { type: 'object' as const, properties: { url: { type: 'string' } }, required: ['url'] } }],
+    });
+    agent.register();
+
+    const task = createAgentTask({
+      agentId: 'coordinator',
+      conversationId: 'conv-recovery-ok',
+      channelId: 'cli',
+      senderId: 'user',
+      content: 'Fetch something',
+      parentEventId: 'parent-recovery-ok',
+    });
+    await bus.publish('dispatch', task);
+
+    expect(provider.chat).toHaveBeenCalledTimes(3);
+    // Recovery succeeded: normal (non-error) response
+    expect(agentResponses).toHaveLength(1);
+    expect(agentResponses[0]!.payload.isError).toBeUndefined();
+    expect(agentResponses[0]!.payload.content).toBe('Done.');
+    // No agent.error when recovery succeeds
+    expect(agentErrors).toHaveLength(0);
+  });
 });
 
 // -- Error budget enforcement tests --


### PR DESCRIPTION
## **User description**
## Summary

- Closes #801
- When the LLM returns empty text after tool use **and** the recovery prompt also produces no output, the runtime now publishes `agent.error` (type `UNKNOWN`) before sending the fallback `agent.response(isError: true)`.
- The `publishAgentError` call is wrapped in a try-catch so an audit hook / DB write failure cannot prevent the fallback response from being delivered.
- Restores `pnpm-workspace.yaml` `esbuild: true` (overwritten with a placeholder string by `pnpm approve-builds` prompt during worktree install).

## Root cause

The scheduler's `agent.response` subscriber skips any event where `payload.isError === true` and relies solely on `agent.error` to call `handleCompletion()`. Without the `agent.error` event, the job status stayed `running` until the 70-minute watchdog fired and set it to `timed_out`. This was the proximate cause of the May 21-23 digest timeouts documented in #742.

## Test plan

- [ ] `publishes agent.error when empty-response recovery fails after tool use` — 3-call mock (tool_use → empty text → empty recovery); asserts both `agent.error(UNKNOWN)` and `agent.response(isError: true)` are emitted
- [ ] `does not publish agent.error when empty-response recovery succeeds` — same shape but recovery returns `"Done."`; asserts no `agent.error` and a clean response
- [ ] `pnpm run typecheck` passes
- [ ] All existing unit tests pass (1719 tests)
- [ ] Verify 3+ clean nightly digest runs after deploy (no more watchdog timeouts)


___

## **CodeAnt-AI Description**
**Show failed empty-response recovery as an actual job error instead of timing out**

### What Changed
- When the model returns empty text after tool use and the recovery prompt also fails, the runtime now sends an `agent.error` event before the fallback response.
- This lets the scheduler mark the job as failed right away instead of leaving it running until the watchdog timeout.
- If publishing the error event fails, the fallback response is still sent.
- Added coverage for both failure and recovery-success cases, and noted the behavior in the changelog.

### Impact
`✅ Fewer stuck jobs after empty model replies`
`✅ Faster failure reporting for tool-use runs`
`✅ Clearer recovery behavior when the model returns no text`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
