### PR TITLE
fix(install): wizard "About you" step no longer skipped on fresh installs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,11 +59,21 @@ NYLAS_SELF_EMAIL=curia@yourdomain.com
 # SIGNAL_PHONE_NUMBER=+12223334444
 
 
-# CEO's primary email address. Required for email channel deployments.
-# At startup, Curia ensures this contact exists as confirmed + verified so the
-# CEO's messages are never held. Without this, the first inbound email from the
-# CEO auto-creates them as provisional, causing their messages to be held.
-CEO_PRIMARY_EMAIL=you@yourdomain.com
+# CEO's primary email address. Optional.
+#
+# When set to a real address, Curia ensures a CEO contact exists at boot with
+# this address pre-bound as a confirmed + verified email channel identity, so
+# the first inbound email from the CEO is never held as provisional. This is
+# the historical back-compat path for deployments that pre-date the in-app
+# onboarding wizard.
+#
+# When unset (default), the wizard at http://localhost:<HTTP_PORT>/setup creates
+# the principal contact from a display name alone; channel identities are bound
+# later via the per-channel verification flows. This is the recommended path for
+# fresh installs.
+#
+# Leave commented out unless you want the boot-time bootstrap with a real email.
+# CEO_PRIMARY_EMAIL=you@yourdomain.com
 
 # Timezone — IANA timezone for the CEO's default location.
 # Used to resolve relative dates ("next Friday") in agent prompts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **`.env.example` `CEO_PRIMARY_EMAIL`** — commented out by default and treated as unset at boot if left as the literal `you@yourdomain.com`; prevents a fresh `pnpm run setup` from creating a phantom "CEO" principal that auto-skips the wizard's "About you" step.
+- **`bootstrapAgentIdentity` rename propagation** — agent contact's `display_name` now updates via `ON CONFLICT` when the assistant is renamed in the wizard, instead of being frozen at the first-boot default.
 - **Agent runtime** — empty-response recovery failure now publishes `agent.error` in addition to `agent.response(isError: true)`, giving the scheduler the completion signal it needs to mark the job failed instead of waiting for the watchdog timeout. (#801)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **`.env.example` `CEO_PRIMARY_EMAIL`** — commented out by default and treated as unset at boot if left as the literal `you@yourdomain.com`; prevents a fresh `pnpm run setup` from creating a phantom "CEO" principal that auto-skips the wizard's "About you" step.
-- **`bootstrapAgentIdentity` rename propagation** — agent contact's `display_name` now updates via `ON CONFLICT` when the assistant is renamed in the wizard, instead of being frozen at the first-boot default.
+- **`.env.example` `CEO_PRIMARY_EMAIL`** — commented out by default; literal `you@yourdomain.com` treated as unset, preventing a phantom CEO principal.
+- **`bootstrapAgentIdentity`** — agent contact `display_name` now updates via `ON CONFLICT` so wizard renames stick across restarts.
 - **Agent runtime** — empty-response recovery failure now publishes `agent.error` in addition to `agent.response(isError: true)`, giving the scheduler the completion signal it needs to mark the job failed instead of waiting for the watchdog timeout. (#801)
 
 ### Added

--- a/src/config.ts
+++ b/src/config.ts
@@ -778,6 +778,33 @@ export function resolveChannelAccounts(yamlConfig: YamlConfig, config: Config): 
   return [];
 }
 
+/**
+ * The literal placeholder shipped in `.env.example`. If the operator runs
+ * `pnpm run setup` and never edits the generated `.env`, this string ends up
+ * as a real env value at boot. Treat it as unset — the in-app wizard handles
+ * principal creation now, so no boot-time bootstrap is needed for fresh installs.
+ *
+ * Exported for use by `loadConfig`'s telemetry hook below.
+ */
+export const CEO_PRIMARY_EMAIL_PLACEHOLDER = 'you@yourdomain.com';
+
+function normalizeCeoPrimaryEmail(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim().toLowerCase();
+  if (!trimmed) return undefined;
+  if (trimmed === CEO_PRIMARY_EMAIL_PLACEHOLDER) return undefined;
+  return trimmed;
+}
+
+/**
+ * Returns true if the raw `CEO_PRIMARY_EMAIL` env var was set to the literal
+ * `.env.example` placeholder. Callers use this to log a warning once the
+ * logger has been initialized — `loadConfig` itself runs before the logger
+ * exists and cannot warn directly.
+ */
+export function ceoPrimaryEmailIsPlaceholder(): boolean {
+  return process.env.CEO_PRIMARY_EMAIL?.trim().toLowerCase() === CEO_PRIMARY_EMAIL_PLACEHOLDER;
+}
+
 export function loadConfig(): Config {
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
@@ -818,7 +845,13 @@ export function loadConfig(): Config {
     nylasGrantId: process.env.NYLAS_GRANT_ID,
     nylasPollingIntervalMs,
     nylasSelfEmail: process.env.NYLAS_SELF_EMAIL ?? '',
-    ceoPrimaryEmail: process.env.CEO_PRIMARY_EMAIL?.trim().toLowerCase() || undefined,
+    // Reject the literal `.env.example` placeholder so a user who runs
+    // `pnpm run setup` and never edits the generated .env doesn't get a phantom
+    // CEO contact named "CEO" bound to `you@yourdomain.com` created at boot —
+    // which then trips the wizard's principal-exists auto-skip and prevents the
+    // "About you" step from being shown. Lowercase comparison matches the
+    // .toLowerCase() normalization on real values.
+    ceoPrimaryEmail: normalizeCeoPrimaryEmail(process.env.CEO_PRIMARY_EMAIL),
     ceoSignalNumber: process.env.CEO_SIGNAL_NUMBER?.trim() || undefined,
     // .trim() prevents a whitespace-only value (e.g. "  ") from activating the
     // Signal adapter with a bogus socket path or phone number.

--- a/src/entity-context/bootstrap.ts
+++ b/src/entity-context/bootstrap.ts
@@ -72,11 +72,18 @@ export async function bootstrapAgentIdentity(
     // The partial unique index idx_contacts_kg_node_unique (migration 010) ensures
     // ON CONFLICT fires when a concurrent INSERT tries to create a second contact for
     // the same KG node.
+    //
+    // display_name is included in DO UPDATE so renames made via the wizard
+    // (PUT /api/identity → version bump → process restart → bootstrap re-runs with
+    // the new name) actually reach the contacts row. Without this, the contact
+    // would stay frozen at whatever name was first inserted (typically the
+    // DEFAULT_OFFICE_IDENTITY seed) even after the operator changes it. The KG
+    // node label clause above already does the same thing for the same reason.
     const contactResult = await pool.query<{ id: string }>(
       `INSERT INTO contacts (kg_node_id, display_name, role, status, system_role, created_at, updated_at)
        VALUES ($1, $2, 'agent', 'confirmed', 'agent', now(), now())
        ON CONFLICT (kg_node_id) WHERE kg_node_id IS NOT NULL
-       DO UPDATE SET role = 'agent', system_role = 'agent', updated_at = now()
+       DO UPDATE SET display_name = EXCLUDED.display_name, role = 'agent', system_role = 'agent', updated_at = now()
        RETURNING id`,
       [kgNodeId, displayName],
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@
 
 import * as path from 'node:path';
 import { runner } from 'node-pg-migrate';
-import { loadConfig, loadYamlConfig, resolveChannelAccounts } from './config.js';
+import { ceoPrimaryEmailIsPlaceholder, loadConfig, loadYamlConfig, resolveChannelAccounts } from './config.js';
 import { createLogger } from './logger.js';
 import { HttpAdapter } from './channels/http/http-adapter.js';
 import { createPool } from './db/connection.js';
@@ -121,6 +121,17 @@ async function main(): Promise<void> {
   const yamlConfig = loadYamlConfig(configDir);
   const logger = createLogger(config.logLevel);
   logger.info('Curia starting...');
+
+  // Surface the `.env.example` placeholder case so it's obvious in logs why
+  // CEO_PRIMARY_EMAIL appears to be ignored. loadConfig() normalized the value
+  // to undefined silently because the logger doesn't exist yet at that point;
+  // warn here once the logger is available.
+  if (ceoPrimaryEmailIsPlaceholder()) {
+    logger.warn(
+      'CEO_PRIMARY_EMAIL is the literal .env.example placeholder ("you@yourdomain.com") — treating as unset. ' +
+        'Comment the line out or set a real address; fresh installs should rely on the /setup wizard to create the principal.',
+    );
+  }
 
   // Compile the security context block from config at startup.
   // runStartupValidation (below) enforces the JSON schema, which requires trust_thresholds
@@ -521,6 +532,10 @@ async function main(): Promise<void> {
   // provisional (the extractParticipants default), causing their messages to be held.
   // Also creates (or backfills) a KG person node so entity context enrichment works
   // for the CEO. See issue #380.
+  //
+  // Note: `config.ceoPrimaryEmail` is normalized in loadConfig() so the literal
+  // `.env.example` placeholder `you@yourdomain.com` reads as undefined here — this
+  // block is therefore a no-op for fresh installs that didn't customize that line.
   let ceoContactId: string | undefined;
   if (config.ceoPrimaryEmail) {
     try {
@@ -557,7 +572,13 @@ async function main(): Promise<void> {
       }
     }
   } else {
-    logger.warn('CEO_PRIMARY_EMAIL not set — CEO contact bootstrap skipped. Set this to prevent CEO emails from being held on first contact.');
+    // No CEO_PRIMARY_EMAIL configured (or it was the .env.example placeholder, which
+    // loadConfig() normalizes to undefined). This is the normal path for fresh
+    // installs post-#771 — the in-app onboarding wizard creates the principal without
+    // an email channel binding; per-channel verification flows attach identities later.
+    // Only operators running the historical email-channel back-compat path need to
+    // set CEO_PRIMARY_EMAIL.
+    logger.info('CEO_PRIMARY_EMAIL not set — CEO contact bootstrap skipped (principal will be created via the onboarding wizard at /setup).');
   }
 
   // Look up the CEO's display name from the contact system for the executive voice

--- a/tests/integration/agent-bootstrap.test.ts
+++ b/tests/integration/agent-bootstrap.test.ts
@@ -1,0 +1,113 @@
+// tests/integration/agent-bootstrap.test.ts
+//
+// Integration tests for bootstrapAgentIdentity — the agent self-identity helper
+// run once at startup. The function must be idempotent across restarts AND must
+// reconcile the contact row's display_name when the operator renames the
+// assistant via the wizard (PUT /api/identity → version bump → process restart →
+// bootstrapAgentIdentity called with the new name).
+//
+// Without that reconciliation, an assistant renamed in the wizard from "Alex Curia"
+// to e.g. "Nate Curia" stays known as "Alex Curia" in the contacts table forever
+// (because the contacts INSERT ON CONFLICT clause only updates role / system_role
+// / updated_at). The KG node label already updates correctly via its own ON CONFLICT.
+//
+// Requires a running Postgres with migrations applied.
+// Skips gracefully when DATABASE_URL is not set.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import pg from 'pg';
+import { bootstrapAgentIdentity } from '../../src/entity-context/bootstrap.js';
+import { createLogger } from '../../src/logger.js';
+
+const { Pool } = pg;
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIf = DATABASE_URL ? describe : describe.skip;
+
+describeIf('bootstrapAgentIdentity', () => {
+  let pool: pg.Pool;
+  const logger = createLogger('silent');
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    await pool.query('SELECT 1 FROM contacts LIMIT 0');
+    await pool.query('SELECT 1 FROM kg_nodes LIMIT 0');
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  // Strip the singleton agent rows before each test. The partial unique indexes
+  // (idx_kg_nodes_agent_singleton, idx_contacts_kg_node_unique, idx_contacts_system_role_agent)
+  // mean we can only have one agent at a time, so wipe completely before each case.
+  beforeEach(async () => {
+    await pool.query(`DELETE FROM contacts WHERE system_role = 'agent'`);
+    await pool.query(`DELETE FROM kg_nodes WHERE (properties->>'is_agent') = 'true'`);
+  });
+
+  it('creates a fresh agent identity (KG node + contact) with the given display name', async () => {
+    const result = await bootstrapAgentIdentity('Agent Test First', pool, logger);
+
+    expect(result.contactId).toBeTruthy();
+    expect(result.kgNodeId).toBeTruthy();
+
+    const contact = await pool.query<{ display_name: string; role: string; system_role: string }>(
+      `SELECT display_name, role, system_role FROM contacts WHERE id = $1`,
+      [result.contactId],
+    );
+    expect(contact.rows[0]?.display_name).toBe('Agent Test First');
+    expect(contact.rows[0]?.role).toBe('agent');
+    expect(contact.rows[0]?.system_role).toBe('agent');
+
+    const node = await pool.query<{ label: string }>(
+      `SELECT label FROM kg_nodes WHERE id = $1`,
+      [result.kgNodeId],
+    );
+    expect(node.rows[0]?.label).toBe('Agent Test First');
+  });
+
+  it('is idempotent on repeated calls with the same name (same contact id, no duplicates)', async () => {
+    const first = await bootstrapAgentIdentity('Agent Test Idem', pool, logger);
+    const second = await bootstrapAgentIdentity('Agent Test Idem', pool, logger);
+
+    expect(second.contactId).toBe(first.contactId);
+    expect(second.kgNodeId).toBe(first.kgNodeId);
+
+    const count = await pool.query<{ count: string }>(
+      `SELECT count(*)::text AS count FROM contacts WHERE system_role = 'agent'`,
+    );
+    expect(count.rows[0]?.count).toBe('1');
+  });
+
+  it('updates the contact display_name when called again with a renamed identity', async () => {
+    // First boot — wizard hasn't run yet, so we boot with the default name.
+    const first = await bootstrapAgentIdentity('Agent Test Old Name', pool, logger);
+    expect(first.contactId).toBeTruthy();
+
+    const before = await pool.query<{ display_name: string }>(
+      `SELECT display_name FROM contacts WHERE id = $1`,
+      [first.contactId],
+    );
+    expect(before.rows[0]?.display_name).toBe('Agent Test Old Name');
+
+    // Second boot — operator finished the wizard, identity was renamed, process
+    // restarted, bootstrapAgentIdentity is called with the new name. The KG node's
+    // ON CONFLICT clause already updates label via DO UPDATE SET label = EXCLUDED.label;
+    // the contact's ON CONFLICT clause must mirror that for display_name.
+    const second = await bootstrapAgentIdentity('Agent Test New Name', pool, logger);
+    expect(second.contactId).toBe(first.contactId);
+
+    const afterContact = await pool.query<{ display_name: string }>(
+      `SELECT display_name FROM contacts WHERE id = $1`,
+      [first.contactId],
+    );
+    expect(afterContact.rows[0]?.display_name).toBe('Agent Test New Name');
+
+    const afterNode = await pool.query<{ label: string }>(
+      `SELECT label FROM kg_nodes WHERE id = $1`,
+      [first.kgNodeId],
+    );
+    expect(afterNode.rows[0]?.label).toBe('Agent Test New Name');
+  });
+});

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { loadConfig } from '../../src/config.js';
+import { ceoPrimaryEmailIsPlaceholder, loadConfig } from '../../src/config.js';
 
 describe('loadConfig', () => {
   const originalEnv = process.env;
@@ -36,5 +36,45 @@ describe('loadConfig', () => {
     delete process.env.LOG_LEVEL;
     const config = loadConfig();
     expect(config.logLevel).toBe('info');
+  });
+
+  describe('CEO_PRIMARY_EMAIL placeholder handling', () => {
+    beforeEach(() => {
+      process.env.DATABASE_URL = 'postgres://test:test@localhost:5432/test';
+    });
+
+    it('normalizes a real email to lowercase trimmed value', () => {
+      process.env.CEO_PRIMARY_EMAIL = '  Joe@Example.COM  ';
+      expect(loadConfig().ceoPrimaryEmail).toBe('joe@example.com');
+    });
+
+    it('treats the literal .env.example placeholder as unset', () => {
+      process.env.CEO_PRIMARY_EMAIL = 'you@yourdomain.com';
+      expect(loadConfig().ceoPrimaryEmail).toBeUndefined();
+    });
+
+    it('treats a case-and-whitespace variant of the placeholder as unset', () => {
+      process.env.CEO_PRIMARY_EMAIL = '  YOU@YourDomain.com  ';
+      expect(loadConfig().ceoPrimaryEmail).toBeUndefined();
+    });
+
+    it('treats an empty string env var as unset', () => {
+      process.env.CEO_PRIMARY_EMAIL = '';
+      expect(loadConfig().ceoPrimaryEmail).toBeUndefined();
+    });
+
+    it('ceoPrimaryEmailIsPlaceholder() returns true only for the literal placeholder', () => {
+      process.env.CEO_PRIMARY_EMAIL = 'you@yourdomain.com';
+      expect(ceoPrimaryEmailIsPlaceholder()).toBe(true);
+
+      process.env.CEO_PRIMARY_EMAIL = '  YOU@YourDomain.com  ';
+      expect(ceoPrimaryEmailIsPlaceholder()).toBe(true);
+
+      process.env.CEO_PRIMARY_EMAIL = 'joe@example.com';
+      expect(ceoPrimaryEmailIsPlaceholder()).toBe(false);
+
+      delete process.env.CEO_PRIMARY_EMAIL;
+      expect(ceoPrimaryEmailIsPlaceholder()).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Fixes three install-path bugs that left a fresh `pnpm run setup` in a broken state where the assistant never learned the operator's name. All three were uncovered while validating the #771 onboarding wizard against a genuinely clean install.

1. **`.env.example` placeholder bootstrapped a phantom principal.** The file shipped `CEO_PRIMARY_EMAIL=you@yourdomain.com` uncommented; `scripts/setup.sh` templates it into `.env` verbatim. At boot, `bootstrapCeoContact` created a real `system_role='principal'` contact named "CEO" bound to that placeholder email — the wizard then auto-skipped its "About you" step (`principalExists=true`) and the operator never set their real name.

2. **`bootstrapAgentIdentity` didn't propagate renames to the contact.** The agent contact's `INSERT … ON CONFLICT DO UPDATE` clause set `role`/`system_role`/`updated_at` but not `display_name`. Renaming the assistant via the wizard (`PUT /api/identity` → process restart → bootstrap re-runs with the new name) updated the KG node label (its own clause handles it) but the contact's `display_name` stayed frozen at the `DEFAULT_OFFICE_IDENTITY` seed.

3. **Defence in depth.** `loadConfig()` now normalizes the literal `.env.example` placeholder to `undefined`, with case + whitespace insensitivity matching the existing real-value normalization. `ceoPrimaryEmailIsPlaceholder()` lets `main()` warn once the logger is up (config loads first).

### Bonus: log-level downgrade

The "CEO_PRIMARY_EMAIL not set" log was warn → info. Post-#771 this is the *recommended* path (wizard creates the principal); warn-level was crying wolf for every fresh install. The placeholder-specific case still warns.

## Files

- `.env.example` — `CEO_PRIMARY_EMAIL` commented out + comment rewritten as "optional, back-compat".
- `src/config.ts` — `CEO_PRIMARY_EMAIL_PLACEHOLDER` const, `normalizeCeoPrimaryEmail()` helper, exported `ceoPrimaryEmailIsPlaceholder()`.
- `src/index.ts` — placeholder warning right after logger init; `else` branch downgraded warn → info.
- `src/entity-context/bootstrap.ts` — `display_name = EXCLUDED.display_name` added to the contacts ON CONFLICT clause.
- `tests/integration/agent-bootstrap.test.ts` — new file. Three cases: create, idempotent, rename. The rename case directly reproduces bug 2.
- `tests/unit/config.test.ts` — new cases for placeholder normalization and the `ceoPrimaryEmailIsPlaceholder()` contract.
- `CHANGELOG.md` — two new "Fixed" entries.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm test` — 2909 passed / 3 skipped / 0 failed
- [x] The new rename test fails without the `bootstrap.ts` fix and passes with it (verified by checking out the fix in isolation)
- [ ] End-to-end install test after merge: nuke local docker state, clone fresh, `pnpm run setup`, walk the wizard. The "About you" step should appear; after the restart-and-wait, both `display_name` (agent contact) and the principal contact's name should reflect what was entered in the wizard.


___

## **CodeAnt-AI Description**
**Fix fresh installs skipping the onboarding wizard and keep renamed assistant names in sync**

### What Changed
- Fresh installs now treat the default `CEO_PRIMARY_EMAIL=you@yourdomain.com` value as unset, so the setup wizard shows the “About you” step instead of creating a phantom CEO contact.
- If the assistant is renamed in the wizard, the saved contact name now updates on the next startup instead of staying stuck on the first name.
- The startup message for an unset CEO email is now informational, and the example environment file now leaves this setting commented out by default.
- Added tests for fresh agent setup, repeated startup, rename handling, and placeholder email handling.

### Impact
`✅ Fewer skipped onboarding steps`
`✅ No phantom CEO contact on fresh setup`
`✅ Renamed assistant names stay consistent after restart`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed initial setup to prevent creating an unintended CEO contact when CEO_PRIMARY_EMAIL is unconfigured.
  * Fixed contact display names to properly update during identity renames on subsequent startup runs.

* **Configuration**
  * Made CEO_PRIMARY_EMAIL optional in setup; when unset, the setup wizard guides users through primary contact configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->