### PR TITLE
fix(install): make `pnpm run setup` Docker path work end-to-end on a fresh host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ OPENAI_API_KEY=sk-...
 HTTP_PORT=3000
 API_TOKEN=your-secret-token-here
 
+# Postgres host port (Docker Compose). Override only if 5432 is already bound on
+# the host — e.g. running a parallel curia stack against a sibling clone for
+# install testing. Leave at the default for the common case.
+# POSTGRES_PORT=5432
+
 # Knowledge Graph web explorer
 # Secret required by /api/kg/* endpoints (sent as x-web-bootstrap-secret from the /kg UI).
 # If unset, the knowledge graph explorer API is disabled.

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
 # Database
 DB_USER=curia
 DB_PASSWORD=your-db-password
-# DATABASE_URL is constructed from DB_USER and DB_PASSWORD by pnpm setup.
-# For manual setup, substitute the values below:
+# DATABASE_URL is constructed from DB_USER, DB_PASSWORD, and POSTGRES_PORT
+# (default 5432) by `pnpm setup`. For manual setup, substitute the values below.
+# The port here MUST match POSTGRES_PORT below — `pnpm migrate` runs host-side
+# against the published postgres port; a mismatch silently routes migrations
+# at the wrong DB (or no DB at all).
 DATABASE_URL=postgres://curia:your-db-password@localhost:5432/curia
 
 # LLM Providers
@@ -32,6 +35,8 @@ API_TOKEN=your-secret-token-here
 # Postgres host port (Docker Compose). Override only if 5432 is already bound on
 # the host — e.g. running a parallel curia stack against a sibling clone for
 # install testing. Leave at the default for the common case.
+# IMPORTANT: if you change this, update the port in DATABASE_URL above to match —
+# host-side migrations connect via DATABASE_URL, not via the docker network.
 # POSTGRES_PORT=5432
 
 # Knowledge Graph web explorer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
+- **Docker fresh-install path** — `pnpm run setup` now produces a working install on a clean host; six bugs from #805 fixed in one cut. (#805)
+- **`schemasDir` threading** — JSON Schemas are now found via an explicit dir from the entrypoint, so the tsup-bundled image no longer ENOENTs on `/schemas`. (#805)
+- **Dockerfile `NODE_ENV=production`** — pino logs to stdout so `docker logs curia` shows fatal startup errors instead of swallowing them into `/app/curia.log`. (#805)
+- **Dockerfile CMD** — invokes `./node_modules/.bin/tsx` directly; the pnpm/corepack roundtrip at runtime no longer hangs on the silent download prompt. (#805)
+- **Docker Compose parallelism** — explicit `container_name: curia` dropped and Postgres host port parameterized via `POSTGRES_PORT`; two curia stacks can now coexist on one host. (#805)
+- **`pnpm run setup` health gate** — polls the curia healthcheck before printing the success banner; broken installs no longer report green. (#805)
 - **`.env.example` `CEO_PRIMARY_EMAIL`** — commented out by default; literal `you@yourdomain.com` treated as unset, preventing a phantom CEO principal.
 - **`bootstrapAgentIdentity`** — agent contact `display_name` now updates via `ON CONFLICT` so wizard renames stick across restarts.
 - **Agent runtime** — empty-response recovery failure now publishes `agent.error` in addition to `agent.response(isError: true)`, giving the scheduler the completion signal it needs to mark the job failed instead of waiting for the watchdog timeout. (#801)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Fixed
 
-- **Docker fresh-install path** — `pnpm run setup` now produces a working install on a clean host; six bugs from #805 fixed in one cut. (#805)
-- **`schemasDir` threading** — JSON Schemas are now found via an explicit dir from the entrypoint, so the tsup-bundled image no longer ENOENTs on `/schemas`. (#805)
-- **Dockerfile `NODE_ENV=production`** — pino logs to stdout so `docker logs curia` shows fatal startup errors instead of swallowing them into `/app/curia.log`. (#805)
-- **Dockerfile CMD** — invokes `./node_modules/.bin/tsx` directly; the pnpm/corepack roundtrip at runtime no longer hangs on the silent download prompt. (#805)
-- **Docker Compose parallelism** — explicit `container_name: curia` dropped and Postgres host port parameterized via `POSTGRES_PORT`; two curia stacks can now coexist on one host. (#805)
-- **`pnpm run setup` health gate** — polls the curia healthcheck before printing the success banner; broken installs no longer report green. (#805)
+- **Docker fresh-install path** — `pnpm run setup` now produces a working install on a clean host. (#805)
+- **`schemasDir` threading** — schemas resolved from the entrypoint so the tsup bundle finds `/app/schemas`. (#805)
+- **`NODE_ENV=production` in image** — pino logs to stdout; `docker compose logs curia` now shows fatal startup errors. (#805)
+- **Dockerfile CMD** — invokes `tsx` directly, skipping the runtime `pnpm exec` corepack roundtrip. (#805)
+- **Compose parallelism** — `container_name: curia` dropped, Postgres host port parameterized via `POSTGRES_PORT`. (#805)
+- **`pnpm run setup` health gate** — polls the curia healthcheck before printing the success banner. (#805)
 - **`.env.example` `CEO_PRIMARY_EMAIL`** — commented out by default; literal `you@yourdomain.com` treated as unset, preventing a phantom CEO principal.
 - **`bootstrapAgentIdentity`** — agent contact `display_name` now updates via `ON CONFLICT` so wizard renames stick across restarts.
 - **Agent runtime** — empty-response recovery failure now publishes `agent.error` in addition to `agent.response(isError: true)`, giving the scheduler the completion signal it needs to mark the job failed instead of waiting for the watchdog timeout. (#801)

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,12 @@ COPY --from=build /app/apps/console/dist ./apps/console/dist
 COPY agents/ ./agents/
 COPY skills/ ./skills/
 COPY config/ ./config/
+# JSON Schemas consumed by src/startup/validator.ts at boot. tsup bundles every
+# source file into a single dist/index.js, so the file-relative path that used
+# to compute schemasDir from `import.meta.dirname` would land at /schemas in
+# the container. The validator now takes schemasDir as an explicit parameter
+# computed from src/index.ts (../schemas), which resolves to /app/schemas here.
+COPY schemas/ ./schemas/
 COPY src/ ./src/
 
 # node_modules were installed as root above, so we chown the entire /app tree
@@ -89,8 +95,12 @@ RUN mkdir -p /tmp/.google_workspace_mcp \
 
 EXPOSE 3000
 
-# Health check matches the Fastify /api/health route
-HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+# Health check matches the Fastify /api/health route.
+# start_period bumped 15s → 60s to cover the realistic cold-boot cost:
+# JIT, agent loading, KG migrations check, scheduler init can take 20-30s
+# on small hosts. The previous 15s window flapped the container as "unhealthy"
+# before it had finished starting up.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
   CMD curl -f http://localhost:3000/api/health || exit 1
 
 # Drop to non-root before starting the process.
@@ -99,12 +109,36 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
 # a missing home they would get ENOENT. /tmp is world-writable and always exists.
 # USER and LOGNAME are not set automatically by Docker when using exec-form CMD
 # (no shell login), so we set them explicitly for MCP subprocess environments.
+#
+# NODE_ENV=production switches the pino logger to stdout JSON (default branch in
+# src/logger.ts). Without it, pino-pretty writes to `curia.log` *inside* the
+# container — invisible to `docker logs` and lost when the container exits.
+# That made #805 bug 3 effectively undebuggable: every fatal startup error
+# vanished before anyone could see it. File-based logging is an anti-pattern
+# inside containers; production-mode logging is the only sane default for the
+# Docker image.
+#
+# COREPACK_ENABLE_DOWNLOAD_PROMPT=0 is defence-in-depth: the CMD below invokes
+# tsx directly (no pnpm/corepack at runtime), but if anyone changes CMD back to
+# go through pnpm, modern corepack would prompt non-interactively and exit 1
+# silently. Keeping the env var means future corepack invocations don't block.
 ENV HOME=/tmp \
     USER=curia \
-    LOGNAME=curia
+    LOGNAME=curia \
+    NODE_ENV=production \
+    COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 USER curia
 
-# tsx handles dynamic .ts skill imports with ESM .js→.ts extension resolution.
-# The compiled dist/index.js is the entrypoint, but it dynamically imports
-# raw .ts skill handlers at runtime.
-CMD ["pnpm", "exec", "tsx", "dist/index.js"]
+# Invoke tsx directly rather than going through `pnpm exec tsx ...`. The pnpm
+# route triggers corepack at runtime, which in turn looks for a pnpm tarball
+# in /tmp/.cache/corepack (HOME=/tmp for the curia user). That cache is empty
+# at runtime because the build-stage pnpm install ran as root and populated
+# /root/.cache/corepack, and corepack then prompts before downloading. In a
+# non-TTY container the prompt sees EOF and the process exits 1 silently —
+# exactly the failure mode that took two hours to debug in #805.
+#
+# tsx is needed because dist/index.js dynamically imports raw .ts skill handlers
+# at runtime via ESM .js→.ts extension resolution. node alone cannot do that.
+# The .bin shim is created by `pnpm add tsx` above and is the documented way
+# to call tsx without a package manager wrapper.
+CMD ["./node_modules/.bin/tsx", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,11 @@ services:
       context: .
       dockerfile: docker/postgres.Dockerfile
     restart: unless-stopped
+    # POSTGRES_PORT is parameterized so a second stack can coexist on the same
+    # host (e.g. testing a fresh `pnpm run setup` against a sibling clone while
+    # the dev stack runs on 5432). Defaults to the standard port if unset.
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
       # pgAudit init script runs on first database creation only
@@ -36,7 +39,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: curia
+    # No explicit container_name — Docker Compose generates `<project>-curia-1`,
+    # which is namespaced by COMPOSE_PROJECT_NAME. The previous `container_name: curia`
+    # was global to the Docker daemon and made it impossible to run a second curia
+    # stack on the same host (e.g. for testing a fresh install alongside a dev one).
     restart: unless-stopped
     ports:
       - "${HTTP_PORT:-3000}:3000"
@@ -53,7 +59,9 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
       interval: 30s
       timeout: 5s
-      start_period: 15s
+      # start_period matches the Dockerfile's HEALTHCHECK — see the Dockerfile
+      # comment for why 60s. Keep the two values in sync.
+      start_period: 60s
       retries: 3
     volumes:
       # Persist OAuth token cache for the google-workspace MCP server.

--- a/docs/dev/google-drive.md
+++ b/docs/dev/google-drive.md
@@ -145,7 +145,8 @@ repeat Step 5 to re-authenticate and copy fresh tokens to the VPS.
 
 `uvx` is not on the PATH inside the container. The Dockerfile installs `uv`/`uvx` into
 `/usr/local/bin/` via `COPY --from=ghcr.io/astral-sh/uv`. Verify with
-`docker exec curia which uvx` — if missing, rebuild the image.
+`docker compose exec curia which uvx` — if missing, rebuild the image.
+(The compose-service form resolves the container regardless of project name.)
 
 **`INFO MCP server tools registered {"registered":0}`**
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -111,7 +111,12 @@ generate_secrets() {
     DB_PASSWORD=$(openssl rand -hex 32)
     API_TOKEN=$(openssl rand -hex 32)
     WEB_APP_BOOTSTRAP_SECRET=$(openssl rand -hex 32)
-    DATABASE_URL="postgres://curia:${DB_PASSWORD}@localhost:5432/curia"
+    # DATABASE_URL is consumed by host-side `pnpm migrate` (against the postgres
+    # container's published port), so the port here must match POSTGRES_PORT.
+    # When unset, both default to 5432. Keep this in lockstep with the postgres
+    # service's `ports:` line in docker-compose.yml.
+    local pg_host_port="${POSTGRES_PORT:-5432}"
+    DATABASE_URL="postgres://curia:${DB_PASSWORD}@localhost:${pg_host_port}/curia"
 }
 
 # Templates ENV_EXAMPLE into ENV_FILE, substituting generated secrets.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -227,6 +227,113 @@ wait_for_postgres() {
     exit 1
 }
 
+# Polls docker for Curia healthy status every 2s, up to 120s. Returns 0 on healthy,
+# 1 on timeout or detected failure. Does not exit — caller decides what to do
+# (typically: print a red failure and exit, so the operator doesn't see a green
+# success banner against a container that's actually in a restart loop).
+#
+# 120s is generous: Curia's HEALTHCHECK has start_period=60s + interval=30s, so the
+# first probe lands at ~60s and a healthy verdict needs at least one successful
+# probe. 120s = first probe + one retry window + slack for slow hosts.
+#
+# Failure detection beyond timeout:
+#  - Once the container has been observed at least once, an empty `ps -q` result
+#    means it was removed (crash without restart, or `docker rm`). Bail rather
+#    than wait the full 120s with a misleading "did not become healthy" message.
+#  - `.State.Status == exited` with a non-zero exit code or rising restart count
+#    means the container is in a fast crash-loop. Bail immediately.
+#  - `.State.Health.Status` is validated against {starting, healthy, unhealthy}.
+#    Any other value (e.g. `<no value>` when no healthcheck is defined, or the
+#    field being missing) is treated as a configuration error, not a "wait longer".
+wait_for_curia() {
+    local max_wait=120
+    local elapsed=0
+    local ever_seen=0   # 0 until we observe a container id at least once
+    local last_seen_id=""
+
+    info "Waiting for Curia to become healthy (up to ${max_wait}s)..."
+    while [[ $elapsed -lt $max_wait ]]; do
+        local container_id ps_err
+        if ! ps_err=$(docker compose --project-directory "$REPO_ROOT" ps -q curia 2>&1); then
+            error "docker compose ps failed: $ps_err"
+            hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs curia"
+            return 1
+        fi
+        container_id="$ps_err"
+
+        if [[ -z "$container_id" ]]; then
+            if [[ "$ever_seen" -eq 1 ]]; then
+                # Container existed earlier in this loop and is gone now — Docker
+                # removed it (e.g. it crashed and the restart policy isn't bringing
+                # it back, or someone ran `docker rm`). Don't wait the full timeout.
+                error "Curia container disappeared (last seen: ${last_seen_id:0:12}) — likely a crash without restart."
+                hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs curia"
+                return 1
+            fi
+            # Not seen yet — keep waiting. Compose may still be creating the container.
+        else
+            ever_seen=1
+            last_seen_id="$container_id"
+
+            # Read State.Status and RestartCount alongside Health.Status so we can
+            # bail on a clear failure rather than wait the full timeout. Format
+            # uses a sentinel separator that's unlikely to appear in any value.
+            local inspect_out inspect_err
+            if ! inspect_out=$(docker inspect \
+                --format='{{.State.Status}}|{{.RestartCount}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}NO_HEALTHCHECK{{end}}' \
+                "$container_id" 2>&1); then
+                inspect_err="$inspect_out"
+                # The container may have been removed between `ps -q` and `inspect` —
+                # let the next loop iteration handle that via the empty-id branch.
+                echo -e "${GREY}   ... inspect transient error: ${inspect_err}${RESET}"
+            else
+                local state restarts health
+                state="${inspect_out%%|*}"
+                local rest="${inspect_out#*|}"
+                restarts="${rest%%|*}"
+                health="${rest#*|}"
+
+                if [[ "$state" == "exited" || "$state" == "dead" ]] && [[ "${restarts:-0}" -ge 1 ]]; then
+                    error "Curia container is in a crash loop (state=${state}, restarts=${restarts})."
+                    hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs curia"
+                    return 1
+                fi
+
+                case "$health" in
+                    healthy)
+                        success "Curia is healthy"
+                        return 0
+                        ;;
+                    starting|unhealthy)
+                        # Both are transient; keep polling. The Dockerfile's retries
+                        # let an unhealthy container recover within a probe or two.
+                        ;;
+                    NO_HEALTHCHECK)
+                        error "Curia container has no healthcheck — cannot verify install."
+                        hint "Was the Dockerfile rebuilt? Expected HEALTHCHECK on /api/health."
+                        return 1
+                        ;;
+                    *)
+                        # Unknown value — flag rather than silently keep waiting.
+                        error "Unexpected Health.Status value: '$health' (expected starting/healthy/unhealthy)."
+                        hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs curia"
+                        return 1
+                        ;;
+                esac
+            fi
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+        echo -e "${GREY}   ... still waiting (${elapsed}s)${RESET}"
+    done
+
+    error "Curia did not become healthy within ${max_wait}s."
+    hint "The container may be slow or stuck — check logs:"
+    hint "  docker compose --project-directory \"$REPO_ROOT\" logs curia"
+    return 1
+}
+
 # Starts Postgres, runs migrations, starts the full stack, writes SETUP_COMPLETE marker.
 # Parses .env to get DATABASE_URL, HTTP_PORT, and WEB_APP_BOOTSTRAP_SECRET for use at runtime.
 run_infra() {
@@ -269,7 +376,16 @@ run_infra() {
         hint "Check logs: docker compose --project-directory \"$REPO_ROOT\" logs"
         exit 1
     fi
-    success "Curia is up"
+
+    # `docker compose up -d` exits 0 once the container has *started*, not once
+    # the app inside is healthy. The Curia process can crash-loop in the seconds
+    # after start (corepack misconfig, missing schemas, bad config) and the
+    # operator would still see "Curia is up" against a broken install. Poll the
+    # healthcheck so the success banner reflects reality.
+    if ! wait_for_curia; then
+        error "Curia container is not healthy — refusing to print success banner."
+        exit 1
+    fi
 
     # Mark setup as complete so the idempotency menu can distinguish restart vs recovery.
     printf "\n# SETUP_COMPLETE\n" >> "$ENV_FILE"

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,6 +185,14 @@ async function main(): Promise<void> {
       configDir,
       agentsDir: path.resolve(import.meta.dirname, '../agents'),
       skillsDir: path.resolve(import.meta.dirname, '../skills'),
+      // `schemasDir` is computed here (the entrypoint) — not inside the validator —
+      // because tsup bundles every source file into a single `dist/index.js`,
+      // collapsing `import.meta.dirname` to `dist/` regardless of which source file
+      // referenced it. Computing the offset here means `../schemas` resolves to the
+      // repo root under tsx (src/) and to `/app/schemas` under the bundled image
+      // (dist/), both correct. See docs/specs/06-audit-and-security.md (Input Validation)
+      // and the Dockerfile's `COPY schemas/ ./schemas/` line.
+      schemasDir: path.resolve(import.meta.dirname, '../schemas'),
       logger,
     });
   } catch (err) {

--- a/src/startup/validator.ts
+++ b/src/startup/validator.ts
@@ -16,13 +16,16 @@ import { Ajv, type ErrorObject } from 'ajv';
 import yaml from 'js-yaml';
 import type { Logger } from '../logger.js';
 
-// Schemas live at the project root in schemas/, sibling of config/ and agents/.
-// Resolving two levels up from src/startup/ reaches the project root.
-// This works from both tsx (src/startup/) and compiled dist (dist/startup/).
-const SCHEMAS_DIR = path.resolve(import.meta.dirname, '../../schemas');
-
-function loadSchema(name: string): object {
-  const schemaPath = path.join(SCHEMAS_DIR, name);
+// loadSchema takes the schemas dir as a parameter rather than computing it from
+// `import.meta.dirname`. The tsup bundle collapses every source file into a single
+// `dist/index.js`, so a file-local relative path that resolves correctly under tsx
+// (src/startup/ → ../../schemas → repo root) resolves *wrong* in the bundle
+// (dist/ → ../../schemas → filesystem root /schemas — ENOENT). Callers compute
+// `schemasDir` from `src/index.ts` (the entrypoint), where `../schemas` lands at
+// the right place under both tsx and the bundle. Tests pass an explicit fixture
+// or the real repo schemas dir.
+function loadSchema(schemasDir: string, name: string): object {
+  const schemaPath = path.join(schemasDir, name);
   return JSON.parse(fs.readFileSync(schemaPath, 'utf-8')) as object;
 }
 
@@ -60,19 +63,20 @@ export async function runStartupValidation(opts: {
   configDir: string;
   agentsDir: string;
   skillsDir: string;
+  schemasDir: string;
   logger: Logger;
   /** Override config filename for testing. Defaults to 'default.yaml'. */
   configFileName?: string;
 }): Promise<void> {
-  const { configDir, agentsDir, skillsDir, logger } = opts;
+  const { configDir, agentsDir, skillsDir, schemasDir, logger } = opts;
   const configFileName = opts.configFileName ?? 'default.yaml';
 
   // Compile schemas once — Ajv compilation is expensive; reuse across files.
   const ajv = new Ajv({ allErrors: true });
-  const validateConfig = ajv.compile(loadSchema('default-config.schema.json'));
-  const validateSkillsConfig = ajv.compile(loadSchema('skills-config.json'));
-  const validateAgent = ajv.compile(loadSchema('agent-config.schema.json'));
-  const validateSkill = ajv.compile(loadSchema('skill-manifest.schema.json'));
+  const validateConfig = ajv.compile(loadSchema(schemasDir, 'default-config.schema.json'));
+  const validateSkillsConfig = ajv.compile(loadSchema(schemasDir, 'skills-config.json'));
+  const validateAgent = ajv.compile(loadSchema(schemasDir, 'agent-config.schema.json'));
+  const validateSkill = ajv.compile(loadSchema(schemasDir, 'skill-manifest.schema.json'));
 
   // 1. Validate config/default.yaml (absent file is OK — all fields are optional)
   const configPath = path.join(configDir, configFileName);

--- a/tests/unit/startup/validator.test.ts
+++ b/tests/unit/startup/validator.test.ts
@@ -5,15 +5,21 @@ import { runStartupValidation } from '../../../src/startup/validator.js';
 import { createSilentLogger } from '../../../src/logger.js';
 
 const F = path.resolve(import.meta.dirname, 'fixtures');
+// The real repo schemas dir — four levels up from this file
+// (tests/unit/startup/validator.test.ts → tests/unit/startup → tests/unit → tests → repo root).
+// Tests use the real schemas because they're the source of truth and are stable;
+// fixturing them would just duplicate the production JSON.
+const REAL_SCHEMAS = path.resolve(import.meta.dirname, '../../../schemas');
 const logger = createSilentLogger();
 
 // Shorthand: run validation with specific fixture directories.
 // For components not under test, point at a valid fixture to avoid false positives.
-function runWith(opts: { agents?: string; skills?: string; config?: string }) {
+function runWith(opts: { agents?: string; skills?: string; config?: string; schemas?: string }) {
   return runStartupValidation({
     agentsDir: opts.agents ?? path.join(F, 'agents/valid'),
     skillsDir: opts.skills ?? path.join(F, 'skills/valid-skill'),
     configDir: opts.config ?? path.join(F, 'config/empty'),
+    schemasDir: opts.schemas ?? REAL_SCHEMAS,
     logger,
   });
 }
@@ -174,6 +180,7 @@ describe('startup validator — real project files', () => {
         // Point agents/skills at valid fixtures so only the config is under test.
         agentsDir: path.join(F, 'agents/valid'),
         skillsDir: path.join(F, 'skills/valid-skill'),
+        schemasDir: REAL_SCHEMAS,
         logger,
       }),
     ).resolves.toBeUndefined();
@@ -185,6 +192,7 @@ describe('startup validator — real project files', () => {
         agentsDir: path.join(ROOT, 'agents'),
         configDir: path.join(F, 'config/empty'),
         skillsDir: path.join(F, 'skills/valid-skill'),
+        schemasDir: REAL_SCHEMAS,
         logger,
       }),
     ).resolves.toBeUndefined();
@@ -196,8 +204,29 @@ describe('startup validator — real project files', () => {
         skillsDir: path.join(ROOT, 'skills'),
         configDir: path.join(F, 'config/empty'),
         agentsDir: path.join(F, 'agents/valid'),
+        schemasDir: REAL_SCHEMAS,
         logger,
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it('throws a clear ENOENT when schemasDir is wrong (regression test for #805 bug 3)', async () => {
+    // Previously the validator computed `schemasDir` from `import.meta.dirname` of
+    // validator.ts. That resolved correctly under tsx (`src/startup/` → `../../schemas`
+    // = repo root schemas) but tsup bundled all source into a single `dist/index.js`,
+    // collapsing `import.meta.dirname` to `dist/` — so the same relative path landed
+    // at filesystem root `/schemas`, which doesn't exist in the container, and the
+    // validator threw ENOENT with no useful context once pino's async transport ate
+    // the log. Threading `schemasDir` from the entrypoint avoids the bundle problem;
+    // this test pins the failure mode if someone ever passes a wrong dir again.
+    await expect(
+      runStartupValidation({
+        configDir: path.join(F, 'config/empty'),
+        agentsDir: path.join(F, 'agents/valid'),
+        skillsDir: path.join(F, 'skills/valid-skill'),
+        schemasDir: '/nonexistent/schemas/path',
+        logger,
+      }),
+    ).rejects.toThrow(/ENOENT|no such file/);
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Closes #805. Six bugs in the documented `pnpm run setup` Docker install path, fixed in one cut. Each is small individually; the value is shipping them together so the documented path actually works end-to-end on a clean host. None of them bite `pnpm dev` (the path every developer uses daily), which is why the regression went undetected.

The previous behavior on a fresh host: `pnpm run setup` completed with a green "Curia is running" banner, then `http://localhost:3000` returned 404 because the curia container was crash-looping silently. Three separate failure modes had to be peeled back during debugging before the root cause (missing `schemas/` directory) surfaced.

### What's fixed

1. **Schemas not bundled into the image.** `src/startup/validator.ts` computed `SCHEMAS_DIR` from `import.meta.dirname` of validator.ts. Worked under tsx (`src/startup/` → `../../schemas` = repo root), broke under the tsup bundle (collapses all source into `dist/index.js`, lands `../../schemas` at filesystem root `/schemas` — ENOENT). Now: thread `schemasDir` as an explicit parameter through `runStartupValidation`, computed at the entrypoint `src/index.ts` from `../schemas` — works under both tsx and the bundle. Plus `COPY schemas/ ./schemas/` so the dir is in the image. Regression test added.

2. **`NODE_ENV=production` set in Dockerfile.** Without it, `src/logger.ts` routes pino through `pino-pretty` to `curia.log` *inside the container* — invisible to `docker logs`. That made bug 1 effectively undebuggable; every fatal log vanished. Now: clean JSON to stdout.

3. **CMD invokes `tsx` directly, not via `pnpm`.** The pnpm/corepack roundtrip at runtime tried to download pnpm into the curia user's empty `/tmp/.cache/corepack`, prompted before downloading, saw EOF in the non-TTY container, and exited 1 silently. `./node_modules/.bin/tsx` bypasses the whole roundtrip. `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` added as defence-in-depth.

4. **`container_name: curia` dropped** from `docker-compose.yml`. It was global to the Docker daemon and made it impossible to run a second curia stack on the same host (e.g. testing a fresh install alongside a dev one). Let compose generate `<project>-curia-1` instead.

5. **Postgres host port parameterized** as `${POSTGRES_PORT:-5432}`. Same family as (4) — blocked parallelism. Documented in `.env.example`.

6. **`pnpm run setup` polls healthcheck before printing success.** `docker compose up -d` returning 0 means "container started," not "app healthy." With any of (1)–(3) in play, the operator got a green banner against a restart-looping container. New `wait_for_curia()` helper gates the banner on health = `healthy`, with hard failure paths for: container disappeared after being seen (crash without restart), `State=exited/dead` with `RestartCount ≥ 1` (crash loop), unexpected `Health.Status` values (no healthcheck, etc.). 120s timeout; same shape as `wait_for_postgres()`.

Also:
- `HEALTHCHECK start_period` bumped 15s → 60s (Dockerfile + compose) to cover realistic cold-boot cost.
- Stale `docker exec curia which uvx` in `docs/dev/google-drive.md` rewritten to `docker compose exec curia` (the container is no longer named just `curia` after fix #4).

## Files

- `src/startup/validator.ts`, `src/index.ts` — `schemasDir` threaded through; regression test in `tests/unit/startup/validator.test.ts`.
- `Dockerfile` — `COPY schemas/`, `NODE_ENV=production`, `COREPACK_ENABLE_DOWNLOAD_PROMPT=0`, CMD switched to `./node_modules/.bin/tsx`, `start_period: 60s`.
- `docker-compose.yml` — `container_name` removed, postgres port parameterized, `start_period: 60s`.
- `.env.example` — documents `POSTGRES_PORT`.
- `scripts/setup.sh` — `wait_for_curia()` + call before success banner; treats container-disappeared and crash-loop as immediate failures.
- `docs/dev/google-drive.md` — stale docker exec command updated.
- `CHANGELOG.md` — six "Fixed" bullets under `[Unreleased]`, all tagged `(#805)`.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm test` — 2910 passed / 3 skipped / 0 failed
- [x] New regression test (`tests/unit/startup/validator.test.ts`) pins the schemas-path failure mode
- [x] End-to-end smoke: `docker build`, `docker run`, container reached `healthy` in ~70s, `/api/health → 200`, logs are clean JSON to stdout
- [ ] Manual: post-merge, nuke local docker state, fresh clone, `pnpm run setup` on a clean host, walk the wizard, confirm setup → wizard → restart → `/chat` works end-to-end with no patches

## Reviewer notes

Two review subagents (code-reviewer + silent-failure-hunter) ran in parallel and surfaced three real items, all addressed before commit:

- `wait_for_curia()` originally couldn't distinguish "not yet started" from "crashed and removed" — both produced empty `container_id`. The committed version tracks `ever_seen` and bails immediately if the container disappears after first sighting.
- `docker inspect ... '{{.State.Health.Status}}'` returns the literal `<no value>` when no healthcheck is defined; the original guard checked only command success, not value validity. The committed version validates the value against `{starting, healthy, unhealthy, NO_HEALTHCHECK}` and bails on anything unexpected.
- Stale `docker exec curia` in `docs/dev/google-drive.md` — now `docker compose exec curia`.


___

## **CodeAnt-AI Description**
**Make fresh Docker installs complete cleanly and report failures accurately**

### What Changed
- The setup flow now waits for the Curia container to become healthy before showing success, so a broken install no longer ends with a green banner.
- Startup now finds schema files from the app entrypoint and includes them in the Docker image, fixing the fresh-host failure where Curia could crash at boot because schemas were missing.
- Docker logging now goes to standard output, so startup errors appear in `docker logs` instead of being hidden inside the container.
- The container starts Curia directly and avoids the runtime package-manager download path that could fail silently in a non-interactive container.
- Docker Compose no longer forces the Curia container name, and the Postgres host port can be changed, allowing two stacks to run on the same machine at once.

### Impact
`✅ Fewer green-but-broken installs`
`✅ Clearer startup failure messages`
`✅ Easier fresh install testing on one host`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker fresh installations to complete successfully with proper startup validation gates.
  * Fixed JSON schema discovery during application boot.
  * Improved production logging for startup errors visibility.
  * Extended container healthcheck startup period to reduce false failure detection.
  * Enabled running multiple Docker Compose stacks simultaneously on the same host.

* **Documentation**
  * Updated Docker troubleshooting guides for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->