### PR TITLE
fix: register gemini-3.1-flash-lite in model registry and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Fixed
-- **`fast` model tier** — repointed from `google/gemini-2.0-flash-001` (removed from OpenRouter ~2026-05-31) to `google/gemini-3.1-flash-lite`; restores contacts, calendar, research-analyst, and digest agents. (#812)
+- **`fast` model tier** — repointed to `google/gemini-3.1-flash-lite` after OpenRouter removed `gemini-2.0-flash-001`; unblocks contacts, calendar, research-analyst, digest. (#812)
 
 ## [0.32.0] — 2026-06-01 — "Ariadne"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+- **`fast` model tier** — repointed from `google/gemini-2.0-flash-001` (removed from OpenRouter ~2026-05-31) to `google/gemini-3.1-flash-lite`; restores contacts, calendar, research-analyst, and digest agents. (#812)
+
 ## [0.32.0] — 2026-06-01 — "Ariadne"
 
 > **Ariadne** *(Inception, 2010, Christopher Nolan)* — in Inception, she's the architect Cobb hires to build the dream worlds. Her first job is to walk a newcomer through the rules of the place, ask what they want to build, and shape the structure to fit. v0.32 does the same: one command brings Curia up, a five-step wizard captures who you are, and a new specialist meets you in your first chat to ask what kind of assistant you actually want.

--- a/src/agents/llm/model-registry.test.ts
+++ b/src/agents/llm/model-registry.test.ts
@@ -96,6 +96,24 @@ describe('ModelRegistry', () => {
   });
 
   describe('OpenRouter models', () => {
+    it('resolves google/gemini-3.1-flash-lite with provider openrouter', () => {
+      const meta = registry.getModel('google/gemini-3.1-flash-lite');
+      expect(meta).toBeDefined();
+      expect(meta!.provider).toBe('openrouter');
+      expect(meta!.contextWindow).toBe(1_000_000);
+      expect(meta!.capabilities).toContain('vision');
+      expect(meta!.capabilities).toContain('coding');
+    });
+
+    it('returns correct pricing for google/gemini-3.1-flash-lite', () => {
+      const pricing = registry.getPricing('google/gemini-3.1-flash-lite');
+      expect(pricing).toBeDefined();
+      expect(pricing!.inputPerMToken).toBe(0.25);
+      expect(pricing!.outputPerMToken).toBe(1.50);
+      expect(pricing!.cacheCreationPerMToken).toBeUndefined();
+      expect(pricing!.cacheReadPerMToken).toBeUndefined();
+    });
+
     it('resolves google/gemini-2.0-flash-001 with provider openrouter', () => {
       const meta = registry.getModel('google/gemini-2.0-flash-001');
       expect(meta).toBeDefined();

--- a/src/agents/llm/model-registry.ts
+++ b/src/agents/llm/model-registry.ts
@@ -75,6 +75,17 @@ const MODEL_REGISTRY: Record<string, ModelMetadata> = {
   // OpenRouter models — non-Claude models routed via OpenRouter's OpenAI-compatible API.
   // Registry keys are the model IDs that OpenRouter's API expects.
   // Pricing should be verified against OpenRouter's pricing page periodically.
+  'google/gemini-3.1-flash-lite': {
+    provider: 'openrouter',
+    contextWindow: 1_000_000,
+    pricing: {
+      inputPerMToken: 0.25,
+      outputPerMToken: 1.50,
+    },
+    capabilities: ['vision', 'coding'],
+    maxOutputTokens: 8_192,
+  },
+  // Removed from OpenRouter ~2026-05-31. Entry retained for audit log provenance.
   'google/gemini-2.0-flash-001': {
     provider: 'openrouter',
     contextWindow: 1_000_000,


### PR DESCRIPTION
## Summary

Closes #812

`google/gemini-2.0-flash-001` was removed from OpenRouter ~2026-05-31, breaking all fast-tier agents. The actual tier config change is in josephfung/curia-deploy PR #101.

This PR covers the curia-side changes required for that config to work:

- **`src/agents/llm/model-registry.ts`** — registers `google/gemini-3.1-flash-lite` (provider, pricing $0.25/$1.50 per MTok, 1M context, capabilities). Without this entry, `ModelRouter` throws at startup with `model not found in the model registry`, so Curia won't boot with the new config.
- **`src/agents/llm/model-registry.test.ts`** — adds two test cases: provider/context/capabilities and pricing for the new model.
- **`CHANGELOG.md`** — adds `[Unreleased] > Fixed` entry.
- `google/gemini-2.0-flash-001` is retained in the registry for audit log provenance (historical `llm.call` events reference it).

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test src/agents/llm/model-registry.test.ts` — 28 tests passing
- [ ] Deploy curia-deploy PR #101 and confirm `audit_log` shows successful `llm.call` for a contacts briefing delegation (no `agent.error` with `errorType: NOT_FOUND`)
- [ ] Manually trigger contacts dedup job; verify `last_run_outcome = 'completed'` and `last_run_summary` populated
- [ ] Spot-check calendar and digest agents for clean completion