### PR TITLE
fix(contacts): pass principal contact ID to calendar-list-events in promotion sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ### Fixed
 - **Principal contact injection** — runtime now injects a `## Principal Contact Details` block (verified email, Signal, phone) into every agent's system prompt per-task, preventing the coordinator from hallucinating the principal's address when composing outbound messages. (#786)
 - **`fast` model tier** — repointed to `google/gemini-3.1-flash-lite` after OpenRouter removed `gemini-2.0-flash-001`; unblocks contacts, calendar, research-analyst, digest. (#812)
+- **Provisional contact sweep** — sweep step 3 now passes `${principal_contact_id}` to `calendar-list-events` (was passing nothing, causing a UUID validation error), and treats calendar failure as best-effort so Sent-folder promotions still fire. (#816)
 
 ## [0.32.0] — 2026-06-01 — "Ariadne"
 

--- a/agents/contacts.yaml
+++ b/agents/contacts.yaml
@@ -35,7 +35,9 @@ system_prompt: |
   3. Query memory-query for relevant stored context: preferences, relationship
      notes, standing instructions, communication style.
   4. Query calendar-list-events for recent meetings with this contact (last 90
-     days). Use their calendar ID from entity-context if available. Include
+     days). Use their calendar ID from entity-context if available. (For the
+     principal's own calendar, use contactId: ${principal_contact_id} — this ID
+     is injected at bootstrap and available throughout your context.) Include
      meeting titles and dates in the briefing.
   5. Return a natural-language briefing followed by a <resolved_entities> block.
 
@@ -126,6 +128,16 @@ system_prompt: |
 
   Use contact-set-identity-status to update an identity's status when the
   coordinator relays that an address is defunct, bounced, or back in service.
+
+  ## Promotion Sweep — Principal Context
+
+  When running the daily provisional contact promotion sweep, you need the
+  principal's contact ID to query their registered calendars. The principal's
+  contact ID is ${principal_contact_id} — resolved at bootstrap and embedded
+  here so you can pass it directly to calendar-list-events without a lookup.
+  Pass it as contactId: ${principal_contact_id}. If the calendar call fails
+  for any reason, note the error and continue with an empty calendar attendee
+  set — calendar enrichment is best-effort and must not abort the sweep.
 
   ## Contact Deduplication
 
@@ -258,8 +270,14 @@ schedule:
          @TODO: add pagination support to ceo-inbox-list to scan beyond 50 messages.
 
       3. Call calendar-list-events with a wide date range: timeMin 90 days ago,
-         timeMax 90 days from now. Collect all attendee email addresses from
-         non-cancelled events. Deduplicate into a set.
+         timeMax 90 days from now. Pass the principal's contact ID (from the
+         "Promotion Sweep — Principal Context" section in your system prompt) as
+         contactId so the skill can resolve all calendars registered to the principal.
+         Collect all attendee email addresses from non-cancelled events. Deduplicate
+         into a set.
+         If the call fails (skill error, calendar not connected, API unavailable),
+         record the error message and treat the calendar attendee set as empty —
+         calendar enrichment is best-effort and must not abort the sweep.
 
       4. For each provisional contact from step 1:
          - Use contact-lookup (by: "name") to get their channel identities (email addresses).
@@ -276,5 +294,9 @@ schedule:
 
       5. Report a clear summary: how many provisional contacts were checked, how many
          were promoted, which signal triggered each promotion (curia_outbound,
-         ceo_has_sent, or calendar_accepted), and how many provisional contacts remain.
+         ceo_has_sent, or calendar_accepted), how many provisional contacts remain,
+         and whether the calendar call in step 3 succeeded or failed. If it failed,
+         include the error message so operators can distinguish a transient outage
+         from a permanent misconfiguration (e.g. no calendar registered for the
+         principal).
     expectedDurationSeconds: 540


### PR DESCRIPTION
## **User description**
## Summary

- Adds a `## Promotion Sweep — Principal Context` section to `contacts.yaml` system_prompt with an explicit `${principal_contact_id}` reference so bootstrap interpolation fires and the UUID is embedded in the agent's context
- Sweep task step 3 now instructs the agent to read the principal's contact ID from that system_prompt section and pass it as `contactId` to `calendar-list-events`
- Calendar enrichment is now explicitly best-effort: on failure the agent records the error and continues with the Sent-folder signal only
- Step 5 summary now requires reporting calendar call success/failure so operators can distinguish transient outages from permanent misconfigurations (e.g. no calendar registered for the principal)

Closes #816

## Why the system_prompt section (not just the task string)

The scheduler stores task payload strings verbatim in the DB and publishes them as message content without interpolation. `${principal_contact_id}` only gets resolved in `system_prompt` via `interpolateRuntimeContext()` at bootstrap. Adding a dedicated section to `system_prompt` with the UUID reference (the same pattern used by `meeting-debrief.yaml`) ensures the actual UUID is embedded where the agent can read it, and the task step references that section by name.

## Test plan

- [ ] Restart the server and confirm the contacts agent system_prompt includes the real principal UUID in the "Promotion Sweep — Principal Context" section (check startup logs or `GET /debug/agents`)
- [ ] Manually trigger the sweep (fire the scheduled job via the HTTP routes) and confirm `calendar-list-events` is called with a valid UUID `contactId`
- [ ] Spot-check 5 known contacts (CEO has emailed them) — `status` should flip from `provisional` to `confirmed`
- [ ] Simulate a calendar failure (disable Nylas or use an account with no calendar registered) and confirm the sweep still completes and includes the error message in its step 5 summary


___

## **CodeAnt-AI Description**
**Pass the principal’s contact ID during the contact promotion sweep and keep going if calendar lookup fails**

### What Changed
- The daily provisional-contact sweep now sends the principal’s contact ID when checking calendar events, so calendar-based promotion can run for the right person.
- If the calendar lookup fails or no calendar is available, the sweep now records the error and continues using sent-email signals instead of stopping early.
- The sweep summary now reports whether calendar lookup succeeded or failed, along with the error message when it did not.

### Impact
`✅ Fewer failed contact promotions`
`✅ More provisional contacts promoted from sent emails`
`✅ Clearer sweep failure reports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
