### PR TITLE
feat: working memory TTL cleanup (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **SBOM generation** — SPDX JSON Software Bill of Materials generated on every push to `main` and attached to each GitHub release as a release asset; failure is non-fatal. (#564)
 
 ### Fixed
+- **Working memory TTL** — `expires_at` is now populated on every `working_memory` INSERT (30-day default); DreamEngine purges expired rows nightly after the decay pass. Prevents unbounded table growth on long-running deployments. (#220)
 - **Automatic scheduled run summaries** — scheduler auto-captures `agent.response.content` as `last_run_summary` via COALESCE; agents no longer need to call `scheduler-report` explicitly. (#817)
 - **Runtime job UUID injection** — valid `scheduler:<uuid>:<run-id>` conversationIds inject a `Job ID` line so agents can optionally override with a structured summary. (#817)
 - **`scheduler-report` pinned to contacts** — contacts agent `pinned_skills` now includes `scheduler-report`. (#817)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **SBOM generation** — SPDX JSON Software Bill of Materials generated on every push to `main` and attached to each GitHub release as a release asset; failure is non-fatal. (#564)
 
 ### Fixed
-- **Working memory TTL** — `expires_at` is now populated on every `working_memory` INSERT (30-day default); DreamEngine purges expired rows nightly after the decay pass. Prevents unbounded table growth on long-running deployments. (#220)
+- **Working memory TTL** — 30-day expiry on inserts; nightly purge trims expired non-archived turns. (#220)
 - **Automatic scheduled run summaries** — scheduler auto-captures `agent.response.content` as `last_run_summary` via COALESCE; agents no longer need to call `scheduler-report` explicitly. (#817)
 - **Runtime job UUID injection** — valid `scheduler:<uuid>:<run-id>` conversationIds inject a `Job ID` line so agents can optionally override with a structured summary. (#817)
 - **`scheduler-report` pinned to contacts** — contacts agent `pinned_skills` now includes `scheduler-report`. (#817)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -88,6 +88,12 @@ dispatch:
     max_global: 100         # total messages per window across all senders
 
 workingMemory:
+  # TTL for working memory turns. Rows are expired by DreamEngine's nightly purge
+  # pass (DELETE WHERE expires_at < now()). The idx_wm_expires partial index makes
+  # this efficient. 30 days is long enough that re-opening a conversation after a
+  # week still has full context; tune downward for high-volume deployments.
+  ttlDays: 30
+
   # Rolling context summarization (spec §01-memory-system.md).
   # When the active turn count for a conversation exceeds `threshold`, the oldest
   # (count - keepWindow) turns are condensed into a synthetic summary turn via an

--- a/schemas/default-config.schema.json
+++ b/schemas/default-config.schema.json
@@ -80,6 +80,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "ttlDays": { "type": "integer", "minimum": 1 },
         "summarization": {
           "type": "object",
           "additionalProperties": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -449,33 +449,42 @@ export function loadYamlConfig(configDir: string): YamlConfig {
     }
   }
 
-  if (config.workingMemory?.ttlDays !== undefined) {
-    const ttlDays = config.workingMemory.ttlDays;
-    if (!Number.isInteger(ttlDays) || ttlDays < 1) {
-      throw new Error(`workingMemory.ttlDays must be a positive integer, got: ${ttlDays}`);
-    }
-  }
-
-  if (config.workingMemory?.summarization !== undefined) {
-    const summarizationThreshold = config.workingMemory.summarization.threshold;
-    if (summarizationThreshold !== undefined && (!Number.isInteger(summarizationThreshold) || summarizationThreshold < 2)) {
-      throw new Error(`workingMemory.summarization.threshold must be an integer >= 2, got: ${summarizationThreshold}`);
+  const workingMemory = config.workingMemory;
+  if (workingMemory !== undefined) {
+    if (workingMemory === null || typeof workingMemory !== 'object' || Array.isArray(workingMemory)) {
+      throw new Error('workingMemory must be a YAML mapping');
     }
 
-    const summarizationKeepWindow = config.workingMemory.summarization.keepWindow;
-    if (summarizationKeepWindow !== undefined && (!Number.isInteger(summarizationKeepWindow) || summarizationKeepWindow < 1)) {
-      throw new Error(`workingMemory.summarization.keepWindow must be a positive integer, got: ${summarizationKeepWindow}`);
+    if (workingMemory.ttlDays !== undefined) {
+      const ttlDays = workingMemory.ttlDays;
+      // Upper bound of 36500 (100 years) prevents JS date arithmetic overflow
+      // (Date.now() + ttlDays * 86_400_000 must stay within the safe Date range).
+      if (!Number.isInteger(ttlDays) || ttlDays < 1 || ttlDays > 36500) {
+        throw new Error(`workingMemory.ttlDays must be a positive integer no greater than 36500, got: ${ttlDays}`);
+      }
     }
 
-    // Cross-validate using effective values (same defaults as index.ts bootstrap) so a
-    // config like { keepWindow: 25 } (no explicit threshold) is caught here rather than
-    // silently passing validation and failing at runtime.
-    const effectiveThreshold = summarizationThreshold ?? 20;
-    const effectiveKeepWindow = summarizationKeepWindow ?? 10;
-    if (effectiveKeepWindow >= effectiveThreshold) {
-      throw new Error(
-        `workingMemory.summarization.keepWindow (${effectiveKeepWindow}) must be less than threshold (${effectiveThreshold})`,
-      );
+    if (workingMemory.summarization !== undefined) {
+      const summarizationThreshold = workingMemory.summarization.threshold;
+      if (summarizationThreshold !== undefined && (!Number.isInteger(summarizationThreshold) || summarizationThreshold < 2)) {
+        throw new Error(`workingMemory.summarization.threshold must be an integer >= 2, got: ${summarizationThreshold}`);
+      }
+
+      const summarizationKeepWindow = workingMemory.summarization.keepWindow;
+      if (summarizationKeepWindow !== undefined && (!Number.isInteger(summarizationKeepWindow) || summarizationKeepWindow < 1)) {
+        throw new Error(`workingMemory.summarization.keepWindow must be a positive integer, got: ${summarizationKeepWindow}`);
+      }
+
+      // Cross-validate using effective values (same defaults as index.ts bootstrap) so a
+      // config like { keepWindow: 25 } (no explicit threshold) is caught here rather than
+      // silently passing validation and failing at runtime.
+      const effectiveThreshold = summarizationThreshold ?? 20;
+      const effectiveKeepWindow = summarizationKeepWindow ?? 10;
+      if (effectiveKeepWindow >= effectiveThreshold) {
+        throw new Error(
+          `workingMemory.summarization.keepWindow (${effectiveKeepWindow}) must be less than threshold (${effectiveThreshold})`,
+        );
+      }
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -115,6 +115,8 @@ export interface YamlConfig {
     coordinator?: { config_path?: string };
   };
   workingMemory?: {
+    /** Days before a working memory turn expires and is purged by the nightly DreamEngine pass. Default: 30. */
+    ttlDays?: number;
     summarization?: {
       /** Active turn count that triggers a summarization pass. Default: 20. Must be >= 2. */
       threshold?: number;
@@ -444,6 +446,13 @@ export function loadYamlConfig(configDir: string): YamlConfig {
       throw new Error(
         `dispatch.rate_limit.max_global (${effectiveMaxGlobal}) must be >= max_per_sender (${effectiveMaxPerSender})`,
       );
+    }
+  }
+
+  if (config.workingMemory?.ttlDays !== undefined) {
+    const ttlDays = config.workingMemory.ttlDays;
+    if (!Number.isInteger(ttlDays) || ttlDays < 1) {
+      throw new Error(`workingMemory.ttlDays must be a positive integer, got: ${ttlDays}`);
     }
   }
 

--- a/src/config.working-memory.test.ts
+++ b/src/config.working-memory.test.ts
@@ -42,4 +42,24 @@ describe('loadYamlConfig: workingMemory.ttlDays', () => {
     const config = loadYamlConfig(dir);
     expect(config.workingMemory?.ttlDays).toBeUndefined();
   });
+
+  it('accepts ttlDays: 36500 (maximum)', () => {
+    const dir = writeTempConfig(`workingMemory:\n  ttlDays: 36500\n`);
+    expect(() => loadYamlConfig(dir)).not.toThrow();
+  });
+
+  it('rejects ttlDays > 36500 to prevent date arithmetic overflow', () => {
+    const dir = writeTempConfig(`workingMemory:\n  ttlDays: 36501\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('workingMemory.ttlDays');
+  });
+
+  it('rejects workingMemory: false (non-mapping)', () => {
+    const dir = writeTempConfig(`workingMemory: false\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('workingMemory must be a YAML mapping');
+  });
+
+  it('rejects workingMemory: [] (array)', () => {
+    const dir = writeTempConfig(`workingMemory: []\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('workingMemory must be a YAML mapping');
+  });
 });

--- a/src/config.working-memory.test.ts
+++ b/src/config.working-memory.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { loadYamlConfig } from './config.js';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+function writeTempConfig(content: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'curia-config-'));
+  fs.writeFileSync(path.join(dir, 'default.yaml'), content);
+  return dir;
+}
+
+describe('loadYamlConfig: workingMemory.ttlDays', () => {
+  it('accepts a valid positive integer', () => {
+    const dir = writeTempConfig(`workingMemory:\n  ttlDays: 60\n`);
+    const config = loadYamlConfig(dir);
+    expect(config.workingMemory?.ttlDays).toBe(60);
+  });
+
+  it('accepts ttlDays: 1 (minimum)', () => {
+    const dir = writeTempConfig(`workingMemory:\n  ttlDays: 1\n`);
+    expect(() => loadYamlConfig(dir)).not.toThrow();
+  });
+
+  it('rejects zero', () => {
+    const dir = writeTempConfig(`workingMemory:\n  ttlDays: 0\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('workingMemory.ttlDays');
+  });
+
+  it('rejects a negative value', () => {
+    const dir = writeTempConfig(`workingMemory:\n  ttlDays: -5\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('workingMemory.ttlDays');
+  });
+
+  it('rejects a non-integer', () => {
+    const dir = writeTempConfig(`workingMemory:\n  ttlDays: 30.5\n`);
+    expect(() => loadYamlConfig(dir)).toThrow('workingMemory.ttlDays');
+  });
+
+  it('is absent when workingMemory block is omitted', () => {
+    const dir = writeTempConfig(`skillOutput:\n  maxLength: 100000\n`);
+    const config = loadYamlConfig(dir);
+    expect(config.workingMemory?.ttlDays).toBeUndefined();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -390,6 +390,8 @@ async function main(): Promise<void> {
   // for summarization — it's a medium-complexity task that doesn't need the full
   // flagship model but benefits from better instruction-following than a fast tier.
   const summarizationModel = modelRouter.resolve('standard').model;
+  const workingMemoryTtlDays = yamlConfig.workingMemory?.ttlDays ?? 30;
+  logger.info({ ttlDays: workingMemoryTtlDays, fromConfig: yamlConfig.workingMemory?.ttlDays !== undefined }, 'Working memory TTL configured');
   const memory = WorkingMemory.createWithPostgres(
     pool,
     logger,
@@ -404,7 +406,7 @@ async function main(): Promise<void> {
           model: summarizationModel,
         }
       : undefined,
-    yamlConfig.workingMemory?.ttlDays ?? 30,
+    workingMemoryTtlDays,
   );
 
   // Entity memory — optional, requires OPENAI_API_KEY for embeddings.

--- a/src/index.ts
+++ b/src/index.ts
@@ -390,17 +390,21 @@ async function main(): Promise<void> {
   // for summarization — it's a medium-complexity task that doesn't need the full
   // flagship model but benefits from better instruction-following than a fast tier.
   const summarizationModel = modelRouter.resolve('standard').model;
-  const memory = WorkingMemory.createWithPostgres(pool, logger, summarizationCfg
-    ? {
-        threshold: summarizationCfg.threshold ?? 20,
-        keepWindow: summarizationCfg.keepWindow ?? 10,
-        // Resolve the provider from the registry so that remapping 'standard' to
-        // an OpenRouter model routes summarization through OpenRouterProvider, not
-        // the hardwired Anthropic singleton. (#646)
-        provider: resolveProviderForModel(summarizationModel, 'WorkingMemory summarization'),
-        model: summarizationModel,
-      }
-    : undefined,
+  const memory = WorkingMemory.createWithPostgres(
+    pool,
+    logger,
+    summarizationCfg
+      ? {
+          threshold: summarizationCfg.threshold ?? 20,
+          keepWindow: summarizationCfg.keepWindow ?? 10,
+          // Resolve the provider from the registry so that remapping 'standard' to
+          // an OpenRouter model routes summarization through OpenRouterProvider, not
+          // the hardwired Anthropic singleton. (#646)
+          provider: resolveProviderForModel(summarizationModel, 'WorkingMemory summarization'),
+          model: summarizationModel,
+        }
+      : undefined,
+    yamlConfig.workingMemory?.ttlDays ?? 30,
   );
 
   // Entity memory — optional, requires OPENAI_API_KEY for embeddings.
@@ -1151,7 +1155,7 @@ async function main(): Promise<void> {
   const scoringPass = new AutonomyScoringPass(actionLogRepo, autonomyService, scoringProvider, logger, scoringPassConfig);
   logger.info({ scoringPassConfig }, 'AutonomyScoringPass configured');
 
-  const dreamEngine = new DreamEngine(pool, bus, logger, decayConfig, scoringPass);
+  const dreamEngine = new DreamEngine(pool, bus, logger, decayConfig, scoringPass, memory);
   logger.info({ decayConfig }, 'DreamEngine configured');
 
   // Outbound context bridge — delegation-aware context registry for

--- a/src/memory/dream-engine.ts
+++ b/src/memory/dream-engine.ts
@@ -4,6 +4,7 @@ import { createMemoryDecayWarning } from '../bus/events.js';
 import type { MemoryDecayWarningPayload } from '../bus/events.js';
 import type { Logger } from '../logger.js';
 import type { AutonomyScoringPass } from '../autonomy/scoring-pass.js';
+import type { WorkingMemory } from './working-memory.js';
 
 // Config shape mirrors YamlConfig.dreaming.decay — all fields required at construction
 // time (caller resolves defaults before passing in).
@@ -58,18 +59,20 @@ export class DreamEngine {
   private intervalHandle: ReturnType<typeof setInterval> | null = null;
   private scoringIntervalHandle: ReturnType<typeof setInterval> | null = null;
   private scoringPass?: AutonomyScoringPass;
+  private workingMemory?: WorkingMemory;
   // Guard flag: prevents a new scoring pass from starting while the previous one
   // is still awaiting LLM responses. Without this, a slow judge call (e.g. rate
   // limit backoff) could let two passes read the same unscored rows concurrently,
   // wasting LLM spend and applying the adjustment formula twice.
   private scoringPassInFlight = false;
 
-  constructor(pool: Pool, bus: EventBus, logger: Logger, config: DecayConfig, scoringPass?: AutonomyScoringPass) {
+  constructor(pool: Pool, bus: EventBus, logger: Logger, config: DecayConfig, scoringPass?: AutonomyScoringPass, workingMemory?: WorkingMemory) {
     this.pool = pool;
     this.bus = bus;
     this.logger = logger;
     this.config = config;
     this.scoringPass = scoringPass;
+    this.workingMemory = workingMemory;
   }
 
   /**
@@ -175,6 +178,17 @@ export class DreamEngine {
             { err, nodeId: row.id },
             'DreamEngine: failed to emit memory.decay_warning — node is warned in DB but audit event was not delivered',
           );
+        }
+      }
+
+      // Working memory purge runs after the KG transaction so a purge failure
+      // can never roll back committed decay state. Best-effort: log and continue.
+      if (this.workingMemory) {
+        try {
+          const purgedTurns = await this.workingMemory.purgeExpired();
+          this.logger.info({ purgedTurns }, 'DreamEngine: working memory purge complete');
+        } catch (purgeErr) {
+          this.logger.error({ err: purgeErr }, 'DreamEngine: working memory purge failed — will retry on next pass');
         }
       }
 

--- a/src/memory/dream-engine.ts
+++ b/src/memory/dream-engine.ts
@@ -188,7 +188,11 @@ export class DreamEngine {
           const purgedTurns = await this.workingMemory.purgeExpired();
           this.logger.info({ purgedTurns }, 'DreamEngine: working memory purge complete');
         } catch (purgeErr) {
-          this.logger.error({ err: purgeErr }, 'DreamEngine: working memory purge failed — will retry on next pass');
+          this.logger.error(
+            { err: purgeErr },
+            'DreamEngine: working memory purge failed — will retry on next pass. ' +
+            'To check backlog: SELECT COUNT(*) FROM working_memory WHERE expires_at IS NOT NULL AND expires_at < now() AND archived = false',
+          );
         }
       }
 

--- a/src/memory/working-memory.ts
+++ b/src/memory/working-memory.ts
@@ -26,6 +26,8 @@ export interface SummarizationConfig {
 interface StorageBackend {
   add(conversationId: string, agentId: string, turn: ConversationTurn): Promise<void>;
   get(conversationId: string, agentId: string, maxTurns?: number): Promise<ConversationTurn[]>;
+  /** Delete all turns whose expires_at is in the past. Returns the number of rows deleted. */
+  purgeExpired(): Promise<number>;
 }
 
 /**
@@ -52,8 +54,9 @@ export class WorkingMemory {
     pool: DbPool,
     logger: Logger,
     summarization?: SummarizationConfig,
+    ttlDays?: number,
   ): WorkingMemory {
-    return new WorkingMemory(new PostgresBackend(pool, logger, summarization));
+    return new WorkingMemory(new PostgresBackend(pool, logger, summarization, ttlDays));
   }
 
   /** Create an in-memory instance for testing */
@@ -76,6 +79,11 @@ export class WorkingMemory {
   ): Promise<ConversationTurn[]> {
     return this.backend.get(conversationId, agentId, options?.maxTurns);
   }
+
+  /** Delete all turns whose expires_at is in the past. Called by DreamEngine nightly. */
+  async purgeExpired(): Promise<number> {
+    return this.backend.purgeExpired();
+  }
 }
 
 /**
@@ -91,14 +99,18 @@ class PostgresBackend implements StorageBackend {
     private pool: DbPool,
     private logger: Logger,
     private summarization?: SummarizationConfig,
+    private ttlDays?: number,
   ) {}
 
   async add(conversationId: string, agentId: string, turn: ConversationTurn): Promise<void> {
     this.logger.debug({ conversationId, agentId, role: turn.role }, 'working_memory: adding turn');
+    const expiresAt = this.ttlDays != null
+      ? new Date(Date.now() + this.ttlDays * 24 * 60 * 60 * 1000)
+      : null;
     await this.pool.query(
-      `INSERT INTO working_memory (conversation_id, agent_id, role, content)
-       VALUES ($1, $2, $3, $4)`,
-      [conversationId, agentId, turn.role, turn.content],
+      `INSERT INTO working_memory (conversation_id, agent_id, role, content, expires_at)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [conversationId, agentId, turn.role, turn.content, expiresAt],
     );
 
     // After writing, check whether we've crossed the summarization threshold.
@@ -141,6 +153,14 @@ class PostgresBackend implements StorageBackend {
       role: row.role as ConversationTurn['role'],
       content: row.content,
     }));
+  }
+
+  async purgeExpired(): Promise<number> {
+    // The idx_wm_expires partial index (WHERE expires_at IS NOT NULL) covers this query.
+    const result = await this.pool.query(
+      `DELETE FROM working_memory WHERE expires_at IS NOT NULL AND expires_at < now()`,
+    );
+    return result.rowCount ?? 0;
   }
 
   /**
@@ -351,5 +371,9 @@ class InMemoryBackend implements StorageBackend {
       return turns.slice(-maxTurns);
     }
     return [...turns];
+  }
+
+  async purgeExpired(): Promise<number> {
+    return 0; // No expiry mechanism in in-memory backend
   }
 }

--- a/src/memory/working-memory.ts
+++ b/src/memory/working-memory.ts
@@ -157,8 +157,13 @@ class PostgresBackend implements StorageBackend {
 
   async purgeExpired(): Promise<number> {
     // The idx_wm_expires partial index (WHERE expires_at IS NOT NULL) covers this query.
+    // Archived rows are excluded: they are retained for audit even after their TTL
+    // has passed (the summarization path marks originals archived = true).
     const result = await this.pool.query(
-      `DELETE FROM working_memory WHERE expires_at IS NOT NULL AND expires_at < now()`,
+      `DELETE FROM working_memory
+       WHERE expires_at IS NOT NULL
+         AND expires_at < now()
+         AND archived = false`,
     );
     return result.rowCount ?? 0;
   }

--- a/src/memory/working-memory.ts
+++ b/src/memory/working-memory.ts
@@ -311,10 +311,13 @@ class PostgresBackend implements StorageBackend {
         [archiveIds],
       );
 
+      const summaryExpiresAt = this.ttlDays != null
+        ? new Date(Date.now() + this.ttlDays * 24 * 60 * 60 * 1000)
+        : null;
       await client.query(
-        `INSERT INTO working_memory (conversation_id, agent_id, role, content, created_at)
-         VALUES ($1, $2, 'system', $3, $4)`,
-        [conversationId, agentId, `[Conversation summary]\n${summaryContent}`, summaryTimestamp],
+        `INSERT INTO working_memory (conversation_id, agent_id, role, content, created_at, expires_at)
+         VALUES ($1, $2, 'system', $3, $4, $5)`,
+        [conversationId, agentId, `[Conversation summary]\n${summaryContent}`, summaryTimestamp, summaryExpiresAt],
       );
 
       await client.query('COMMIT');

--- a/tests/unit/memory/dream-engine-purge.test.ts
+++ b/tests/unit/memory/dream-engine-purge.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit test verifying DreamEngine calls workingMemory.purgeExpired()
+ * after the decay pass commits — issue #220.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { DreamEngine } from '../../../src/memory/dream-engine.js';
+import type { EventBus } from '../../../src/bus/bus.js';
+import type { WorkingMemory } from '../../../src/memory/working-memory.js';
+
+function makeBus(): EventBus {
+  return { publish: vi.fn().mockResolvedValue(undefined), subscribe: vi.fn() } as unknown as EventBus;
+}
+
+function makeSilentLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+}
+
+function makePool() {
+  const client = {
+    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    release: vi.fn(),
+  };
+  return {
+    pool: {
+      connect: vi.fn().mockResolvedValue(client),
+      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    },
+    client,
+  };
+}
+
+const baseConfig = {
+  intervalMs: 86_400_000,
+  archiveThreshold: 0.05,
+  halfLifeDays: { permanent: null as null, slow_decay: 180, fast_decay: 21 },
+  edgeCountPercentile: 0.95,
+  edgeCountFloor: 5,
+  warnHoldBackDays: 7,
+};
+
+describe('DreamEngine — working memory purge', () => {
+  it('calls purgeExpired() after the decay pass completes', async () => {
+    const { pool } = makePool();
+    const mockWorkingMemory = {
+      purgeExpired: vi.fn().mockResolvedValue(3),
+    } as unknown as WorkingMemory;
+
+    const engine = new DreamEngine(
+      pool as never,
+      makeBus(),
+      makeSilentLogger(),
+      baseConfig,
+      undefined,
+      mockWorkingMemory,
+    );
+
+    await engine.runDecayPass();
+
+    expect(mockWorkingMemory.purgeExpired).toHaveBeenCalledOnce();
+  });
+
+  it('does not call purgeExpired() when workingMemory is not injected', async () => {
+    const { pool } = makePool();
+    const mockWorkingMemory = {
+      purgeExpired: vi.fn().mockResolvedValue(0),
+    } as unknown as WorkingMemory;
+
+    // No workingMemory passed
+    const engine = new DreamEngine(
+      pool as never,
+      makeBus(),
+      makeSilentLogger(),
+      baseConfig,
+    );
+
+    await engine.runDecayPass();
+
+    expect(mockWorkingMemory.purgeExpired).not.toHaveBeenCalled();
+  });
+
+  it('logs a purge failure but does not throw', async () => {
+    const { pool } = makePool();
+    const logger = makeSilentLogger();
+    const mockWorkingMemory = {
+      purgeExpired: vi.fn().mockRejectedValue(new Error('DB connection lost')),
+    } as unknown as WorkingMemory;
+
+    const engine = new DreamEngine(
+      pool as never,
+      makeBus(),
+      logger,
+      baseConfig,
+      undefined,
+      mockWorkingMemory,
+    );
+
+    // Should not throw — purge failure is best-effort
+    await expect(engine.runDecayPass()).resolves.toBeDefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      expect.stringContaining('working memory purge failed'),
+    );
+  });
+});

--- a/tests/unit/memory/dream-engine-purge.test.ts
+++ b/tests/unit/memory/dream-engine-purge.test.ts
@@ -59,13 +59,8 @@ describe('DreamEngine — working memory purge', () => {
     expect(mockWorkingMemory.purgeExpired).toHaveBeenCalledOnce();
   });
 
-  it('does not call purgeExpired() when workingMemory is not injected', async () => {
+  it('does not throw when workingMemory is not injected', async () => {
     const { pool } = makePool();
-    const mockWorkingMemory = {
-      purgeExpired: vi.fn().mockResolvedValue(0),
-    } as unknown as WorkingMemory;
-
-    // No workingMemory passed
     const engine = new DreamEngine(
       pool as never,
       makeBus(),
@@ -73,9 +68,9 @@ describe('DreamEngine — working memory purge', () => {
       baseConfig,
     );
 
-    await engine.runDecayPass();
-
-    expect(mockWorkingMemory.purgeExpired).not.toHaveBeenCalled();
+    // Engine must complete the decay pass without error even though no
+    // workingMemory was provided — the guard skips the purge step entirely.
+    await expect(engine.runDecayPass()).resolves.toBeDefined();
   });
 
   it('logs a purge failure but does not throw', async () => {

--- a/tests/unit/memory/working-memory-ttl.test.ts
+++ b/tests/unit/memory/working-memory-ttl.test.ts
@@ -6,8 +6,9 @@
  *   - expires_at is NULL in INSERT when ttlDays is omitted
  *   - purgeExpired() issues the right DELETE and returns rowCount
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { WorkingMemory } from '../../../src/memory/working-memory.js';
+import type { SummarizationConfig } from '../../../src/memory/working-memory.js';
 import type { DbPool } from '../../../src/db/connection.js';
 
 // ---------------------------------------------------------------------------
@@ -152,5 +153,105 @@ describe('WorkingMemory — TTL', () => {
       const deleted = await memory.purgeExpired();
       expect(deleted).toBe(0);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers for the summarization-path expires_at tests
+// ---------------------------------------------------------------------------
+
+function makeSummarizationPool() {
+  const client = {
+    query: vi.fn().mockImplementation(() => Promise.resolve({ rows: [], rowCount: 1 })),
+    release: vi.fn(),
+  };
+  const pool = {
+    query: vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('SELECT COUNT(*)')) {
+        // Report 3 active turns so that with threshold=2 we exceed the limit
+        return Promise.resolve({ rows: [{ count: '3' }] });
+      }
+      if (sql.includes('AND id != ALL')) {
+        // Oldest kept turn — 1ms after the archived turn
+        return Promise.resolve({ rows: [{ created_at: new Date(1_000_000) }] });
+      }
+      if (sql.includes('SELECT id, role, content')) {
+        // Old turns to archive
+        return Promise.resolve({
+          rows: [{ id: 'aaaaaaaa-0000-0000-0000-000000000001', role: 'user', content: 'old turn', created_at: new Date(0) }],
+        });
+      }
+      return Promise.resolve({ rows: [], rowCount: 1 });
+    }),
+    connect: vi.fn().mockResolvedValue(client),
+  } as unknown as DbPool;
+  return { pool, client };
+}
+
+describe('addTurn() — summarization path respects expires_at', () => {
+  const CONV = 'conv-summarization';
+  const AGENT = 'coordinator';
+
+  it('summary INSERT includes expires_at when ttlDays is set', async () => {
+    const { pool, client } = makeSummarizationPool();
+    let capturedSummarySql: string | undefined;
+    let capturedSummaryParams: unknown[] | undefined;
+
+    // Capture the summary INSERT from the transaction client
+    (client.query as ReturnType<typeof vi.fn>).mockImplementation((sql: string, params?: unknown[]) => {
+      if (sql.includes('INSERT INTO working_memory')) {
+        capturedSummarySql = sql;
+        capturedSummaryParams = params;
+      }
+      return Promise.resolve({ rows: [], rowCount: 1 });
+    });
+
+    const mockProvider = {
+      chat: vi.fn().mockResolvedValue({ type: 'text', content: 'Conversation summary.' }),
+    };
+    const summarization = {
+      threshold: 2,
+      keepWindow: 2,
+      provider: mockProvider,
+      model: 'test-model',
+    } as unknown as SummarizationConfig;
+
+    const memory = WorkingMemory.createWithPostgres(pool, silentLogger(), summarization, 30);
+    await memory.addTurn(CONV, AGENT, { role: 'user', content: 'new turn' });
+
+    expect(capturedSummarySql).toBeDefined();
+    expect(capturedSummarySql).toContain('expires_at');
+    const expiresAt = capturedSummaryParams![4] as Date;
+    expect(expiresAt).toBeInstanceOf(Date);
+    const expectedMs = 30 * 24 * 60 * 60 * 1000;
+    expect(expiresAt.getTime()).toBeGreaterThan(Date.now() - 2000 + expectedMs);
+  });
+
+  it('summary INSERT sets expires_at to NULL when ttlDays is not set', async () => {
+    const { pool, client } = makeSummarizationPool();
+    let capturedSummaryParams: unknown[] | undefined;
+
+    (client.query as ReturnType<typeof vi.fn>).mockImplementation((sql: string, params?: unknown[]) => {
+      if (sql.includes('INSERT INTO working_memory')) {
+        capturedSummaryParams = params;
+      }
+      return Promise.resolve({ rows: [], rowCount: 1 });
+    });
+
+    const mockProvider = {
+      chat: vi.fn().mockResolvedValue({ type: 'text', content: 'Conversation summary.' }),
+    };
+    const summarization = {
+      threshold: 2,
+      keepWindow: 2,
+      provider: mockProvider,
+      model: 'test-model',
+    } as unknown as SummarizationConfig;
+
+    const memory = WorkingMemory.createWithPostgres(pool, silentLogger(), summarization); // no ttlDays
+    await memory.addTurn(CONV, AGENT, { role: 'user', content: 'new turn' });
+
+    expect(capturedSummaryParams).toBeDefined();
+    expect(capturedSummaryParams![4]).toBeNull();
   });
 });

--- a/tests/unit/memory/working-memory-ttl.test.ts
+++ b/tests/unit/memory/working-memory-ttl.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for WorkingMemory TTL — issue #220.
+ *
+ * Verifies:
+ *   - expires_at is populated in INSERT when ttlDays is configured
+ *   - expires_at is NULL in INSERT when ttlDays is omitted
+ *   - purgeExpired() issues the right DELETE and returns rowCount
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WorkingMemory } from '../../../src/memory/working-memory.js';
+import type { DbPool } from '../../../src/db/connection.js';
+
+// ---------------------------------------------------------------------------
+// Minimal mock pool builder
+// ---------------------------------------------------------------------------
+
+type QueryResult = { rows: unknown[]; rowCount?: number };
+
+function buildSimplePool(
+  handler: (sql: string, params?: unknown[]) => QueryResult,
+): DbPool {
+  return {
+    query: vi.fn().mockImplementation((sql: string, params?: unknown[]) =>
+      Promise.resolve(handler(sql, params)),
+    ),
+    connect: vi.fn(),
+  } as unknown as DbPool;
+}
+
+function silentLogger() {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WorkingMemory — TTL', () => {
+  const CONV = 'conv-ttl';
+  const AGENT = 'coordinator';
+
+  describe('addTurn() — expires_at', () => {
+    it('populates expires_at when ttlDays is set', async () => {
+      let capturedParams: unknown[] | undefined;
+
+      const pool = buildSimplePool((sql, params) => {
+        if (sql.includes('INSERT INTO working_memory')) {
+          capturedParams = params;
+        }
+        return { rows: [] };
+      });
+
+      const memory = WorkingMemory.createWithPostgres(pool, silentLogger(), undefined, 30);
+      const before = Date.now();
+      await memory.addTurn(CONV, AGENT, { role: 'user', content: 'Hello' });
+      const after = Date.now();
+
+      expect(capturedParams).toBeDefined();
+      const expiresAt = capturedParams![4] as Date;
+      expect(expiresAt).toBeInstanceOf(Date);
+      // Should be approximately 30 days from now
+      const expectedMs = 30 * 24 * 60 * 60 * 1000;
+      expect(expiresAt.getTime()).toBeGreaterThanOrEqual(before + expectedMs - 1000);
+      expect(expiresAt.getTime()).toBeLessThanOrEqual(after + expectedMs + 1000);
+    });
+
+    it('sets expires_at to NULL when ttlDays is omitted', async () => {
+      let capturedParams: unknown[] | undefined;
+
+      const pool = buildSimplePool((sql, params) => {
+        if (sql.includes('INSERT INTO working_memory')) {
+          capturedParams = params;
+        }
+        return { rows: [] };
+      });
+
+      // No ttlDays — fourth positional param omitted
+      const memory = WorkingMemory.createWithPostgres(pool, silentLogger());
+      await memory.addTurn(CONV, AGENT, { role: 'user', content: 'Hello' });
+
+      expect(capturedParams).toBeDefined();
+      expect(capturedParams![4]).toBeNull();
+    });
+
+    it('INSERT includes expires_at column', async () => {
+      let capturedSql: string | undefined;
+
+      const pool = buildSimplePool((sql) => {
+        if (sql.includes('INSERT INTO working_memory')) {
+          capturedSql = sql;
+        }
+        return { rows: [] };
+      });
+
+      const memory = WorkingMemory.createWithPostgres(pool, silentLogger(), undefined, 7);
+      await memory.addTurn(CONV, AGENT, { role: 'user', content: 'Hello' });
+
+      expect(capturedSql).toContain('expires_at');
+    });
+  });
+
+  describe('purgeExpired()', () => {
+    it('issues DELETE WHERE expires_at IS NOT NULL AND expires_at < now()', async () => {
+      let capturedSql: string | undefined;
+
+      const pool = buildSimplePool((sql) => {
+        if (sql.includes('DELETE FROM working_memory')) {
+          capturedSql = sql;
+        }
+        return { rows: [], rowCount: 0 };
+      });
+
+      const memory = WorkingMemory.createWithPostgres(pool, silentLogger());
+      await memory.purgeExpired();
+
+      expect(capturedSql).toBeDefined();
+      const normalized = capturedSql!.replace(/\s+/g, ' ').trim();
+      expect(normalized).toContain('DELETE FROM working_memory');
+      expect(normalized).toContain('expires_at IS NOT NULL');
+      expect(normalized).toContain('expires_at < now()');
+    });
+
+    it('returns the number of rows deleted', async () => {
+      const pool = buildSimplePool((sql) => {
+        if (sql.includes('DELETE FROM working_memory')) {
+          return { rows: [], rowCount: 5 };
+        }
+        return { rows: [] };
+      });
+
+      const memory = WorkingMemory.createWithPostgres(pool, silentLogger());
+      const deleted = await memory.purgeExpired();
+
+      expect(deleted).toBe(5);
+    });
+
+    it('returns 0 when rowCount is undefined', async () => {
+      const pool = buildSimplePool(() => ({ rows: [], rowCount: undefined }));
+
+      const memory = WorkingMemory.createWithPostgres(pool, silentLogger());
+      const deleted = await memory.purgeExpired();
+
+      expect(deleted).toBe(0);
+    });
+  });
+
+  describe('InMemoryBackend', () => {
+    it('purgeExpired() returns 0 — no-op in in-memory backend', async () => {
+      const memory = WorkingMemory.createInMemory();
+      const deleted = await memory.purgeExpired();
+      expect(deleted).toBe(0);
+    });
+  });
+});

--- a/tests/unit/memory/working-memory-ttl.test.ts
+++ b/tests/unit/memory/working-memory-ttl.test.ts
@@ -100,7 +100,7 @@ describe('WorkingMemory — TTL', () => {
   });
 
   describe('purgeExpired()', () => {
-    it('issues DELETE WHERE expires_at IS NOT NULL AND expires_at < now()', async () => {
+    it('issues DELETE WHERE expires_at IS NOT NULL AND expires_at < now() AND archived = false', async () => {
       let capturedSql: string | undefined;
 
       const pool = buildSimplePool((sql) => {
@@ -118,6 +118,8 @@ describe('WorkingMemory — TTL', () => {
       expect(normalized).toContain('DELETE FROM working_memory');
       expect(normalized).toContain('expires_at IS NOT NULL');
       expect(normalized).toContain('expires_at < now()');
+      // Archived rows must not be purged — they are retained for audit
+      expect(normalized).toContain('archived = false');
     });
 
     it('returns the number of rows deleted', async () => {


### PR DESCRIPTION
## **User description**
## Summary

- **`WorkingMemory.addTurn()`** now populates `expires_at` on every insert: `NOW() + ttlDays days` (default 30). Rows inserted before this change remain with `expires_at = NULL` and are never purged until manually cleaned up.
- **`WorkingMemory.purgeExpired()`** issues `DELETE WHERE expires_at IS NOT NULL AND expires_at < now() AND archived = false`. Archived rows (summarized conversation turns retained for audit) are explicitly excluded.
- **DreamEngine** receives an optional `WorkingMemory` injection and calls `purgeExpired()` after each nightly decay pass. Purge failure is best-effort: it logs at `error` level and retries the following night.
- **Config** — `workingMemory.ttlDays` (default: 30) added to `config/default.yaml`, `src/config.ts` interface, config validation, and `schemas/default-config.schema.json`. Startup log confirms the resolved value and whether it came from config or the default.
- **No new migration needed** — `expires_at` and `idx_wm_expires` were already added in migration 002.

Closes #220

## Test plan

- [ ] `src/config.working-memory.test.ts` — validates `workingMemory.ttlDays` accepts positive integers, rejects zero/negative/non-integer
- [ ] `tests/unit/memory/working-memory-ttl.test.ts` — verifies `expires_at` is set in INSERT (with TTL), is NULL (without TTL), and `purgeExpired()` issues the right DELETE including `archived = false`
- [ ] `tests/unit/memory/dream-engine-purge.test.ts` — verifies DreamEngine calls `purgeExpired()` after decay pass, skips when not injected, and logs purge failures without throwing
- [ ] `pnpm run typecheck` — passes clean
- [ ] Full test suite — 2871 passing (only pre-existing failures requiring DATABASE_URL)


___

## **CodeAnt-AI Description**
**Add working memory expiry and nightly cleanup**

### What Changed
- Every new working memory turn now gets an expiry date, using a 30-day default unless a different value is set in config
- The nightly DreamEngine decay pass now removes expired working memory rows after it finishes, and logs the cleanup result
- Archived conversation turns are kept during cleanup so audit history is not deleted
- Startup now logs the resolved working memory TTL so operators can confirm the active setting
- Added tests for TTL validation, expiry handling, cleanup behavior, and the no-op in-memory path

### Impact
`✅ Prevents unbounded working memory growth`
`✅ Keeps archived audit turns intact`
`✅ Clearer TTL setup at startup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable working memory time-to-live (TTL) with a default 30-day expiration window for turns
  * Working memory turns are now automatically purged nightly after decay operations complete
* **Bug Fixes**
  * Prevents unbounded growth of working memory storage on long-running deployments
* **Tests**
  * Added comprehensive test coverage for TTL configuration and purge behaviour

<!-- end of auto-generated comment: release notes by coderabbit.ai -->