### PR TITLE
feat: add ceo-inbox-draft-compose skill for cold-outreach drafts (#815)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Added
+- **`ceo-inbox-draft-compose`** — new skill enabling the CEO to dictate cold-outreach drafts via Signal; saves directly to Gmail Drafts via `CEO_NYLAS_GRANT_ID`. (#815)
 - **Outbound audience-leak plan** — implementation plan for Stage 2 LLM judge + structured `compose-reply` skill to prevent the coordinator from sending internal reasoning to external recipients. See `docs/wip/2026-06-02-outbound-audience-leak.md`.
 - **Jun 1 email incident plan** — incident reconstruction and two-PR fix plan for the 18-hour email-channel silence + triple-reply burst. See `docs/wip/2026-06-02-jun1-email-incident.md`. (#846, #847)
 - **Tasks & Backlog v1 design** — design memo for a unified task model with deferred work, CEO-visible backlog, and a 3×/day coordinator sweep. See `docs/wip/2026-06-01-tasks-and-backlog-design.md`.
 - **SBOM generation** — SPDX JSON Software Bill of Materials generated on every push to `main` and attached to each GitHub release as a release asset; failure is non-fatal. (#564)
 
 ### Fixed
+- **`email-draft-save` unknown account error** — `OutboundGateway` now returns `"unknown account 'X'; available: [...]"` instead of the generic "Email client not configured" when an unrecognised `accountId` is passed. (#815)
 - **Working memory TTL** — 30-day expiry on inserts; nightly purge trims expired non-archived turns. (#220)
 - **Automatic scheduled run summaries** — scheduler auto-captures `agent.response.content` as `last_run_summary` via COALESCE; agents no longer need to call `scheduler-report` explicitly. (#817)
 - **Runtime job UUID injection** — valid `scheduler:<uuid>:<run-id>` conversationIds inject a `Job ID` line so agents can optionally override with a structured summary. (#817)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,14 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Added
-- **`ceo-inbox-draft-compose`** — new skill enabling the CEO to dictate cold-outreach drafts via Signal; saves directly to Gmail Drafts via `CEO_NYLAS_GRANT_ID`. (#815)
+- **`ceo-inbox-draft-compose`** — compose cold-outreach drafts to CEO's Gmail Drafts via `CEO_NYLAS_GRANT_ID`. (#815)
 - **Outbound audience-leak plan** — implementation plan for Stage 2 LLM judge + structured `compose-reply` skill to prevent the coordinator from sending internal reasoning to external recipients. See `docs/wip/2026-06-02-outbound-audience-leak.md`.
 - **Jun 1 email incident plan** — incident reconstruction and two-PR fix plan for the 18-hour email-channel silence + triple-reply burst. See `docs/wip/2026-06-02-jun1-email-incident.md`. (#846, #847)
 - **Tasks & Backlog v1 design** — design memo for a unified task model with deferred work, CEO-visible backlog, and a 3×/day coordinator sweep. See `docs/wip/2026-06-01-tasks-and-backlog-design.md`.
 - **SBOM generation** — SPDX JSON Software Bill of Materials generated on every push to `main` and attached to each GitHub release as a release asset; failure is non-fatal. (#564)
 
 ### Fixed
-- **`email-draft-save` unknown account error** — `OutboundGateway` now returns `"unknown account 'X'; available: [...]"` instead of the generic "Email client not configured" when an unrecognised `accountId` is passed. (#815)
+- **`email-draft-save` unknown account error** — `OutboundGateway` now lists available accounts when unknown `accountId` is passed. (#815)
 - **Working memory TTL** — 30-day expiry on inserts; nightly purge trims expired non-archived turns. (#220)
 - **Automatic scheduled run summaries** — scheduler auto-captures `agent.response.content` as `last_run_summary` via COALESCE; agents no longer need to call `scheduler-report` explicitly. (#817)
 - **Runtime job UUID injection** — valid `scheduler:<uuid>:<run-id>` conversationIds inject a `Job ID` line so agents can optionally override with a structured summary. (#817)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,16 @@ Two patterns that pass local checks but fail CI regularly:
 4. **Pin it to at least one agent.** Add the skill name to `pinned_skills` in the relevant agent YAML (`agents/coordinator.yaml` for most skills). A skill that isn't pinned to any agent is invisible to that agent unless dynamic discovery happens to surface it — which is unreliable. Exception: pure infrastructure skills invoked by the system (e.g. `extract-facts`, `extract-relationships`, `scheduler-report`) intentionally have no agent owner.
 5. **Timestamps:** When a skill returns timestamps for user-facing display, use `toLocalIso()` from `src/time/timestamp.ts` to convert to the user's local timezone (available as `ctx.timezone`). Never return raw UTC Z-suffix strings for times the user will see — LLMs cannot reliably perform timezone conversion. Include `displayTimezone: formatDisplayTimezone(ctx.timezone)` in the result data so the LLM can label its output.
 
+### Versioning skills and agents
+
+Bump the `version` field in `skill.json` (for skills) or the `version` field in `agents/<name>.yaml` (for agents) whenever you make a meaningful change:
+
+- New skill or agent → start at `"0.1.0"`.
+- New capability, new input/output field, new pinned skill → bump **minor** (`0.X.0`).
+- Bug fix, prompt clarification, error message improvement → bump **patch** (`0.x.Y`).
+
+The version is surfaced in structured logs and useful for correlating prod behaviour with a known config state. An unversioned file should get `"0.1.0"` as its first explicit version when you first touch it.
+
 ### Autonomy Awareness
 
 When adding a new skill, declare its action risk in `skill.json`. This field is **required** — manifests that omit it are rejected at startup, and the execution layer enforces it against the live autonomy score:

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,4 +1,5 @@
 name: ceo-inbox
+version: "0.2.0"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,11 +1,12 @@
 name: ceo-inbox
 role: specialist
 description: >
-  Manages the CEO's personal email inbox. Handles standing-rule management and
-  inbox queries when delegated. On its 15-minute schedule, triages each unread
-  message into five categories: URGENT, ACTIONABLE, NEEDS DRAFT, LEAVE FOR CEO,
-  or NOISE. Archives processed messages, drafts replies, labels messages, and
-  escalates urgent items to the coordinator via the bullpen for Signal delivery.
+  Manages the CEO's personal email inbox. Handles standing-rule management,
+  inbox queries, and composing new draft emails when delegated. On its 15-minute
+  schedule, triages each unread message into five categories: URGENT, ACTIONABLE,
+  NEEDS DRAFT, LEAVE FOR CEO, or NOISE. Archives processed messages, drafts
+  replies and new outbound emails, labels messages, and escalates urgent items
+  to the coordinator via the bullpen for Signal delivery.
 
 model:
   tier: standard  # reverted from fast — Haiku botched Unix timestamp arithmetic, causing last_processed_at to drift ~40 days into the future and blinding inbox triage
@@ -17,6 +18,7 @@ pinned_skills:
   - ceo-inbox-read
   - ceo-inbox-download-attachment
   - ceo-inbox-draft-reply
+  - ceo-inbox-draft-compose
   - file-parse
   - ceo-inbox-search
   - ceo-inbox-archive
@@ -61,8 +63,15 @@ system_prompt: |
   **Delegated mode** (invoked via bullpen by the coordinator):
   If you received a specific request from the coordinator (e.g. "add a rule
   that labels board emails as BOARD", "list my inbox rules", "check if I got
-  an email from Jim"), handle that request directly using your pinned skills.
+  an email from Jim", "draft a new email to alice@example.com about the
+  partnership"), handle that request directly using your pinned skills.
   Do NOT run the triage protocol. Respond to the specific request and return.
+
+  **Composing a new email (cold outreach):** When the coordinator asks you to
+  draft a new email to someone (not a reply to an existing thread), use
+  `ceo-inbox-draft-compose` with the recipient's email address(es), subject,
+  and body. The draft is saved to the CEO's Gmail Drafts folder. Return the
+  draft_id and the recipient summary to the coordinator.
 
   For delegated requests about standing rules or decision tagging, see the
   "Rule Management" section at the end of this prompt.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -357,6 +357,13 @@ system_prompt: |
   specialist with the specific request and present the result in your own voice.
   The ceo-inbox specialist owns both reply drafts and cold-compose drafts for
   the CEO's personal Gmail — do not call `email-draft-save` on the CEO's behalf.
+
+  **Important for cold-compose requests:** `ceo-inbox-draft-compose` requires
+  actual email addresses, not display names. Before delegating, resolve all
+  recipient names to email addresses using the `<resolved_entities>` block in
+  your context. If a recipient's email is not in `<resolved_entities>`, ask the
+  CEO to provide the full email address — do not pass bare names like "Alice"
+  to the ceo-inbox specialist.
   "Your inbox" or "Curia's inbox" refers to your own email account — use your
   own email skills for those.
 

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,4 +1,5 @@
 name: coordinator
+version: "0.2.0"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -349,10 +349,13 @@ system_prompt: |
   addressing. Only ask the CEO for contact details as a last resort.
 
   ## CEO Inbox Requests
-  When the CEO says "my inbox", "my email", or asks about a specific email they
-  received, they mean the CEO's personal inbox — not yours. Delegate to the
-  ceo-inbox specialist with the specific request and present the result in your
-  own voice.
+  When the CEO says "my inbox", "my email", asks about a specific email they
+  received, or asks you to **draft or compose a new email from their personal
+  account** (e.g. "draft an email to Alice about X", "save a draft to Bob",
+  "compose an email to vendor@example.com"), delegate to the ceo-inbox
+  specialist with the specific request and present the result in your own voice.
+  The ceo-inbox specialist owns both reply drafts and cold-compose drafts for
+  the CEO's personal Gmail — do not call `email-draft-save` on the CEO's behalf.
   "Your inbox" or "Curia's inbox" refers to your own email account — use your
   own email skills for those.
 

--- a/schemas/agent-config.schema.json
+++ b/schemas/agent-config.schema.json
@@ -6,6 +6,7 @@
   "additionalProperties": false,
   "properties": {
     "name": { "type": "string", "minLength": 1 },
+    "version": { "type": "string" },
     "description": { "type": "string", "minLength": 1 },
     "role": { "type": "string" },
     "persona": {

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -189,6 +189,33 @@ export class CeoNylasClient {
     };
   }
 
+  // Create a brand-new draft (cold compose, no reply thread).
+  // Unlike createDraftReply, this omits reply_to_message_id so the draft
+  // lands in the CEO's Drafts folder as a fresh outbound email.
+  async createDraft(options: {
+    subject: string;
+    body: string;
+    to: NylasParticipant[];
+    cc?: NylasParticipant[];
+  }): Promise<NylasDraft> {
+    const url = `${this.baseUrl}/drafts`;
+    const payload: Record<string, unknown> = {
+      subject: options.subject,
+      body: options.body,
+      to: options.to,
+    };
+    if (options.cc && options.cc.length > 0) {
+      payload.cc = options.cc;
+    }
+    const data = await this.request<NylasApiDraft>('POST', url, 'createDraft', payload);
+    return {
+      id: data.id,
+      subject: data.subject ?? '',
+      to: (data.to ?? []).map(normParticipant),
+      cc: (data.cc ?? []).map(normParticipant),
+    };
+  }
+
   // ── Message updates ──────────────────────────────────────────────────────
 
   async markAsRead(messageId: string): Promise<void> {

--- a/skills/ceo-inbox-draft-compose/handler.test.ts
+++ b/skills/ceo-inbox-draft-compose/handler.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CeoInboxDraftComposeHandler } from './handler.js';
+import type { SkillContext } from '../../src/skills/types.js';
+
+function buildCtx(input?: Record<string, unknown>): SkillContext {
+  return {
+    input: input ?? {
+      to: ['alice@example.com'],
+      subject: 'Hello from CEO',
+      body: 'Hi Alice, wanted to reach out.',
+    },
+    timezone: 'America/Toronto',
+    secret(key: string): string {
+      switch (key) {
+        case 'nylas_api_key': return 'test-api-key';
+        case 'ceo_nylas_grant_id': return 'test-grant-id';
+        default: return '';
+      }
+    },
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  } as unknown as SkillContext;
+}
+
+const DRAFT_RESPONSE = {
+  data: {
+    id: 'draft-compose-1',
+    subject: 'Hello from CEO',
+    to: [{ email: 'alice@example.com' }],
+    cc: [],
+  },
+};
+
+describe('CeoInboxDraftComposeHandler', () => {
+  let handler: CeoInboxDraftComposeHandler;
+  let mockFetch: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    handler = new CeoInboxDraftComposeHandler();
+    mockFetch = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    mockFetch.mockRestore();
+  });
+
+  it('Case 1: Happy path — creates draft and returns draft_id', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(DRAFT_RESPONSE), { status: 200 }),
+    );
+
+    const ctx = buildCtx();
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+    expect((result as { data: Record<string, unknown> }).data).toMatchObject({
+      draft_id: 'draft-compose-1',
+      subject: 'Hello from CEO',
+    });
+  });
+
+  it('Case 2: Draft payload does not include reply_to_message_id', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(DRAFT_RESPONSE), { status: 200 }),
+    );
+
+    const ctx = buildCtx();
+    await handler.execute(ctx);
+
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.reply_to_message_id).toBeUndefined();
+    expect(body.to).toEqual([{ email: 'alice@example.com' }]);
+    expect(body.subject).toBe('Hello from CEO');
+  });
+
+  it('Case 3: Multiple recipients in to array', async () => {
+    const multiDraftResponse = {
+      data: {
+        id: 'draft-compose-2',
+        subject: 'Team update',
+        to: [
+          { email: 'alice@example.com' },
+          { email: 'bob@example.com' },
+        ],
+        cc: [],
+      },
+    };
+
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(multiDraftResponse), { status: 200 }),
+    );
+
+    const ctx = buildCtx({
+      to: ['alice@example.com', 'bob@example.com'],
+      subject: 'Team update',
+      body: 'Hi team.',
+    });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.to).toHaveLength(2);
+    expect(body.to).toContainEqual({ email: 'alice@example.com' });
+    expect(body.to).toContainEqual({ email: 'bob@example.com' });
+  });
+
+  it('Case 4: CC addresses included in payload', async () => {
+    const ccDraftResponse = {
+      data: {
+        id: 'draft-compose-3',
+        subject: 'Hello',
+        to: [{ email: 'alice@example.com' }],
+        cc: [{ email: 'charlie@example.com' }],
+      },
+    };
+
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(ccDraftResponse), { status: 200 }),
+    );
+
+    const ctx = buildCtx({
+      to: ['alice@example.com'],
+      cc: ['charlie@example.com'],
+      subject: 'Hello',
+      body: 'Hi.',
+    });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(true);
+
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.cc).toEqual([{ email: 'charlie@example.com' }]);
+  });
+
+  it('Case 5: Empty to array — returns { success: false }', async () => {
+    const ctx = buildCtx({ to: [], subject: 'Hello', body: 'Hi.' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('to');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('Case 6: Missing subject — returns { success: false }', async () => {
+    const ctx = buildCtx({ to: ['alice@example.com'], subject: '', body: 'Hi.' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('subject');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('Case 7: Missing body — returns { success: false }', async () => {
+    const ctx = buildCtx({ to: ['alice@example.com'], subject: 'Hello', body: '' });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('body');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('Case 8: Nylas API error — returns { success: false }', async () => {
+    mockFetch.mockResolvedValue(
+      new Response('Internal Server Error', { status: 500 }),
+    );
+
+    const ctx = buildCtx();
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toBeTruthy();
+  });
+
+  it('Case 9: Body converted from markdown to HTML', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(DRAFT_RESPONSE), { status: 200 }),
+    );
+
+    const ctx = buildCtx({
+      to: ['alice@example.com'],
+      subject: 'Hello',
+      body: '**Bold text** and _italic_',
+    });
+    await handler.execute(ctx);
+
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    // markdownToHtml should produce HTML tags from the markdown input
+    expect(body.body).toContain('<strong>Bold text</strong>');
+  });
+
+  it('Case 10: No CC field in payload when cc is empty', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(DRAFT_RESPONSE), { status: 200 }),
+    );
+
+    const ctx = buildCtx({
+      to: ['alice@example.com'],
+      subject: 'Hello',
+      body: 'Hi.',
+    });
+    await handler.execute(ctx);
+
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    // cc should be absent when not provided (not an empty array)
+    expect(body.cc).toBeUndefined();
+  });
+
+  it('Case 11: Missing secret throws — returns { success: false } without calling Nylas', async () => {
+    const ctx: SkillContext = {
+      ...buildCtx(),
+      secret(key: string): string {
+        throw new Error(`secret '${key}' is not configured`);
+      },
+    } as unknown as SkillContext;
+
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('configured');
+    // No Nylas call should have been made
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/skills/ceo-inbox-draft-compose/handler.test.ts
+++ b/skills/ceo-inbox-draft-compose/handler.test.ts
@@ -215,7 +215,33 @@ describe('CeoInboxDraftComposeHandler', () => {
     expect(body.cc).toBeUndefined();
   });
 
-  it('Case 11: Missing secret throws — returns { success: false } without calling Nylas', async () => {
+  it('Case 11: Body exceeds max length — returns { success: false }', async () => {
+    const ctx = buildCtx({
+      to: ['alice@example.com'],
+      subject: 'Hello',
+      body: 'x'.repeat(50_001),
+    });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('50000');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('Case 12: Invalid email address in to — returns { success: false }', async () => {
+    const ctx = buildCtx({
+      to: ['not-an-email'],
+      subject: 'Hello',
+      body: 'Hi.',
+    });
+    const result = await handler.execute(ctx);
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('not-an-email');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('Case 13: Missing secret throws — returns { success: false } without calling Nylas', async () => {
     const ctx: SkillContext = {
       ...buildCtx(),
       secret(key: string): string {

--- a/skills/ceo-inbox-draft-compose/handler.ts
+++ b/skills/ceo-inbox-draft-compose/handler.ts
@@ -2,6 +2,9 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 import { CeoNylasClient, type NylasParticipant } from '../_shared/ceo-nylas-client.js';
 import { markdownToHtml } from '../../src/channels/email/markdown-to-html.js';
 
+const MAX_BODY_LENGTH = 50_000;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export class CeoInboxDraftComposeHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
     let apiKey: string;
@@ -45,6 +48,20 @@ export class CeoInboxDraftComposeHandler implements SkillHandler {
     }
     if (!body) {
       return { success: false, error: 'body is required' };
+    }
+    if (body.length > MAX_BODY_LENGTH) {
+      return { success: false, error: `body must be ${MAX_BODY_LENGTH} characters or fewer` };
+    }
+
+    for (const email of toStrings) {
+      if (!EMAIL_REGEX.test(email)) {
+        return { success: false, error: `Invalid email address in to: ${email}` };
+      }
+    }
+    for (const email of ccStrings) {
+      if (!EMAIL_REGEX.test(email)) {
+        return { success: false, error: `Invalid email address in cc: ${email}` };
+      }
     }
 
     const to: NylasParticipant[] = toStrings.map((email) => ({ email }));

--- a/skills/ceo-inbox-draft-compose/handler.ts
+++ b/skills/ceo-inbox-draft-compose/handler.ts
@@ -1,0 +1,96 @@
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { CeoNylasClient, type NylasParticipant } from '../_shared/ceo-nylas-client.js';
+import { markdownToHtml } from '../../src/channels/email/markdown-to-html.js';
+
+export class CeoInboxDraftComposeHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    let apiKey: string;
+    let grantId: string;
+    try {
+      apiKey = ctx.secret('nylas_api_key');
+      grantId = ctx.secret('ceo_nylas_grant_id');
+    } catch (err) {
+      ctx.log.error({ err }, 'ceo-inbox-draft-compose: required secret not available');
+      return { success: false, error: 'CEO inbox is not configured (missing credentials)' };
+    }
+
+    const client = new CeoNylasClient(apiKey, grantId, ctx.log);
+
+    const input =
+      ctx.input && typeof ctx.input === 'object' ? (ctx.input as Record<string, unknown>) : {};
+
+    // Normalise to: accept a single string or an array of strings.
+    const rawTo = input.to;
+    const toStrings: string[] = Array.isArray(rawTo)
+      ? rawTo.filter((v) => typeof v === 'string' && v.trim()).map((v) => (v as string).trim())
+      : typeof rawTo === 'string' && rawTo.trim()
+        ? [rawTo.trim()]
+        : [];
+
+    const rawCc = input.cc;
+    const ccStrings: string[] = Array.isArray(rawCc)
+      ? rawCc.filter((v) => typeof v === 'string' && v.trim()).map((v) => (v as string).trim())
+      : typeof rawCc === 'string' && rawCc.trim()
+        ? [rawCc.trim()]
+        : [];
+
+    const subject = typeof input.subject === 'string' ? input.subject.trim() : '';
+    const body = typeof input.body === 'string' ? input.body.trim() : '';
+
+    if (toStrings.length === 0) {
+      return { success: false, error: 'to is required (non-empty array of email addresses)' };
+    }
+    if (!subject) {
+      return { success: false, error: 'subject is required' };
+    }
+    if (!body) {
+      return { success: false, error: 'body is required' };
+    }
+
+    const to: NylasParticipant[] = toStrings.map((email) => ({ email }));
+    const cc: NylasParticipant[] = ccStrings.map((email) => ({ email }));
+
+    ctx.log.info(
+      { toCount: to.length, ccCount: cc.length, subject },
+      'ceo-inbox-draft-compose: creating compose draft',
+    );
+
+    let htmlBody: string;
+    try {
+      htmlBody = markdownToHtml(body);
+    } catch (err) {
+      ctx.log.error({ err, subject }, 'ceo-inbox-draft-compose: failed to convert body to HTML');
+      return { success: false, error: 'Failed to convert email body to HTML' };
+    }
+
+    try {
+      const draft = await client.createDraft({
+        subject,
+        body: htmlBody,
+        to,
+        ...(cc.length > 0 ? { cc } : {}),
+      });
+
+      ctx.log.info(
+        { draftId: draft.id, subject: draft.subject },
+        'ceo-inbox-draft-compose: draft created',
+      );
+
+      return {
+        success: true,
+        data: {
+          draft_id: draft.id,
+          subject: draft.subject,
+          to: draft.to,
+          cc: draft.cc,
+        },
+      };
+    } catch (err) {
+      ctx.log.error(
+        { err, subject },
+        'ceo-inbox-draft-compose: Nylas API call failed',
+      );
+      return { success: false, error: 'Failed to create draft in CEO inbox' };
+    }
+  }
+}

--- a/skills/ceo-inbox-draft-compose/skill.json
+++ b/skills/ceo-inbox-draft-compose/skill.json
@@ -1,0 +1,23 @@
+{
+  "name": "ceo-inbox-draft-compose",
+  "description": "Compose a brand-new draft email in the CEO's personal inbox for cold outreach (no existing thread). The draft is saved to Gmail Drafts — the CEO reviews and sends it from their email client. Use when the CEO wants to initiate a new email to someone, not reply to an existing message. Intended for use by the ceo-inbox agent — accesses the CEO's personal email via dedicated secrets, do not call from other agents.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "low",
+  "inputs": {
+    "to": "string[] (recipient email addresses)",
+    "cc": "string[]? (CC email addresses)",
+    "subject": "string (email subject line)",
+    "body": "string (email body; markdown supported, converted to HTML automatically)"
+  },
+  "outputs": {
+    "draft_id": "string (Nylas draft ID)",
+    "subject": "string (subject as saved)",
+    "to": "array of { name?, email }",
+    "cc": "array of { name?, email }"
+  },
+  "permissions": [],
+  "secrets": ["nylas_api_key", "ceo_nylas_grant_id"],
+  "timeout": 15000,
+  "capabilities": []
+}

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -14,6 +14,7 @@ const UUID_FORMAT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{1
  */
 export interface AgentYamlConfig {
   name: string;
+  version?: string;
   role?: string;
   description?: string;
   persona?: {

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -1600,7 +1600,11 @@ export class OutboundGateway {
   private async dispatchEmailDraft(request: EmailSendRequest): Promise<OutboundDraftResult> {
     const nylasClient = this.getNylasClient(request.accountId);
     if (!nylasClient) {
-      return { success: false, blockedReason: 'Email client not configured' };
+      const available = [...this.nylasClients.keys()];
+      const reason = request.accountId
+        ? `unknown account '${request.accountId}'; available: [${available.join(', ')}]`
+        : 'Email client not configured';
+      return { success: false, blockedReason: reason };
     }
 
     // htmlQuote is appended after conversion so it is not re-escaped by markdownToHtml.

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -603,12 +603,27 @@ describe('OutboundGateway.createEmailDraft', () => {
     expect(nylasClient.sendMessage).not.toHaveBeenCalled();
   });
 
-  it('returns false when no email client is configured', async () => {
+  it('returns false with available-accounts list when accountId is unknown', async () => {
+    // draftRequest has accountId: 'joseph' — not in the map (only 'curia' is).
+    const { gateway } = makeGateway({
+      nylasClients: new Map([['curia', {} as unknown as NylasClient]]),
+    });
+
+    const result = await gateway.createEmailDraft(draftRequest);
+
+    expect(result.success).toBe(false);
+    // Must name the unknown account and list what's available so the coordinator can recover.
+    expect(result.blockedReason).toContain("unknown account 'joseph'");
+    expect(result.blockedReason).toContain('curia');
+  });
+
+  it('returns generic error when no email clients are configured at all', async () => {
+    const requestWithoutAccount = { ...draftRequest, accountId: undefined };
     const { gateway } = makeGateway({
       nylasClients: new Map(), // empty — no primary client
     });
 
-    const result = await gateway.createEmailDraft(draftRequest);
+    const result = await gateway.createEmailDraft(requestWithoutAccount);
 
     expect(result.success).toBe(false);
     expect(result.blockedReason).toBe('Email client not configured');


### PR DESCRIPTION
## **User description**
## Summary

- **New `ceo-inbox-draft-compose` skill** — creates a brand-new draft in the CEO's personal Gmail (cold outreach, no existing thread) via `CEO_NYLAS_GRANT_ID`. Inputs: `to` (string[]), `cc?`, `subject`, `body`. The draft appears in Gmail Drafts and is editable/sendable from there.
- **`CeoNylasClient.createDraft()`** — new method for cold compose (no `reply_to_message_id`, distinct from `createDraftReply`).
- **`ceo-inbox` agent** — pins `ceo-inbox-draft-compose`, updates description to mention composing, extends delegated-mode prompt with explicit compose instructions.
- **Coordinator routing** — "CEO Inbox Requests" section now explicitly names cold-compose requests ("draft an email to X about Y") as `ceo-inbox` delegation triggers, closing the gap that caused the coordinator to try `email-draft-save` instead.
- **`OutboundGateway` error message** — unknown `accountId` now returns `"unknown account 'X'; available: [curia]"` instead of the generic `"Email client not configured"`, matching the format from issue #815.

**Note on `action_risk: "low"`:** Drafts are never sent automatically — the CEO reviews and sends from Gmail manually. This matches `ceo-inbox-draft-reply` and `email-draft-save`. The human is the send gate.

Closes #815

## Test plan

- [x] 11 new unit tests in `skills/ceo-inbox-draft-compose/handler.test.ts` covering: happy path, no `reply_to_message_id` in payload, multi-recipient `to`, CC, validation errors (empty `to`/`subject`/`body`), Nylas API failure, markdown-to-HTML conversion, empty CC omitted from payload, missing secret
- [x] 2 updated/new `OutboundGateway` tests for the improved error message (unknown account with available list, no clients configured)
- [x] `pnpm run typecheck` passes
- [x] All existing `ceo-inbox-draft-reply` tests still pass (9/9)
- [x] Manual verification: from Signal, ask "draft an email to alice@example.com about the partnership" — should produce a `ceo-inbox-draft-compose` invocation and a draft in Gmail Drafts within ~30s


___

## **CodeAnt-AI Description**
**Add a new way to save cold-outreach drafts in the CEO’s inbox and improve draft routing errors**

### What Changed
- The CEO inbox can now create a brand-new email draft for a new recipient, and save it directly to Gmail Drafts for review and sending later.
- New draft requests support multiple recipients, CCs, markdown-formatted bodies, and return the saved draft details.
- Requests for the CEO’s personal inbox now correctly route both reply drafts and new outgoing drafts to the CEO inbox specialist instead of falling back to the wrong email flow.
- When an email account is not recognized, the error now names the unknown account and shows the available accounts instead of a generic failure.

### Impact
`✅ Faster cold-outreach drafting`
`✅ Fewer misrouted CEO email requests`
`✅ Clearer email draft errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CEO inbox draft compose: Create and save cold-outreach email drafts directly to your Gmail Drafts folder. Includes full recipient tracking and draft management with support for carbon copy recipients.

* **Bug Fixes**
  * Enhanced error messages when email client configuration issues occur, now displaying which accounts are available to help troubleshoot setup problems more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->