### PR TITLE
fix: treat delegation_hint as binding contract in coordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Fixed
+- **coordinator delegation hint** — `delegation_hint` in active outbound context is now treated as a binding contract; coordinator no longer handles replies directly when a specialist is named, preventing meeting debriefs from getting stuck at `"prompted"`. (#763)
+
 ### Added
 - **`ceo-inbox-draft-compose`** — compose cold-outreach drafts to CEO's Gmail Drafts via `CEO_NYLAS_GRANT_ID`. (#815)
 - **Outbound audience-leak plan** — implementation plan for Stage 2 LLM judge + structured `compose-reply` skill to prevent the coordinator from sending internal reasoning to external recipients. See `docs/wip/2026-06-02-outbound-audience-leak.md`.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.2.0"
+version: "0.2.1"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -200,13 +200,23 @@ system_prompt: |
   When your input includes an [ACTIVE OUTBOUND CONTEXT] section, these are messages
   you previously sent that may receive replies. For each entry:
 
-  - Check if the inbound message plausibly relates to one of the active entries
-  - If it does, delegate to the specialist named in the delegation hint, including
-    the CEO's message and relevant context from the entry
-  - If the message is clearly about something else, handle it normally — entries
-    are advisory, not binding
-  - When a delegated task completes and the conversation is done, release the
-    context entry using context-bridge-release (pass the entry_id shown in the block)
+  - Check if the inbound message plausibly relates to one of the active entries.
+    When uncertain whether a message relates to an entry, prefer treating it as
+    a match and delegating rather than handling it directly.
+  - If a matching entry has a `delegation_hint` set:
+    Always delegate to the named specialist — even if you could handle the
+    request yourself (research, simple questions, acknowledgments). The
+    delegation hint is a binding contract: the specialist owns the full state
+    lifecycle for that conversation (marking it complete, releasing the context
+    entry, sending confirmations). Do not answer the CEO's questions, run
+    research, or send any reply before delegating. Pass the CEO's full message
+    and the entry_id.
+  - If a matching entry has no `delegation_hint`, handle it directly.
+  - If the message is clearly unrelated to all active entries, handle it normally.
+  - After delegating and the exchange is complete, call context-bridge-release
+    with the entry_id from the matched entry. Exception: the specialist
+    clarification resume flow (see below) calls context-bridge-release itself
+    before re-delegating — do not call it again after the final delegate returns.
 
   ### Enriching outbound context
   When you call signal-send, email-send, or email-reply and you know which


### PR DESCRIPTION
## **User description**
## Summary

Fixes #763.

The coordinator was ignoring `delegation_hint` in `[ACTIVE OUTBOUND CONTEXT]` entries when it could handle the CEO's reply itself (research questions, simple acknowledgments). This caused the meeting-debrief lifecycle to stall: D5 never ran, `context-bridge-release` was never called, and reminders re-fired even after the CEO had already responded.

Root cause: the prior wording said "entries are advisory, not binding" — which the coordinator interpreted as permission to handle anything it was capable of doing directly.

**Changes to `agents/coordinator.yaml`:**
- `delegation_hint` is now a hard contract, not a suggestion: the coordinator must always delegate when one is set, even if it could handle the request itself
- Added a "when uncertain, prefer to delegate" tie-breaker on the matching step, so ambiguous replies don't silently fall through to direct handling
- Explicitly prohibits sending any reply to the CEO before or instead of delegating
- Adds a carve-out for the clarification resume flow (which calls `context-bridge-release` itself before re-delegating), preventing a double-release

## Test plan

- [ ] Coordinator receives a CEO reply to a meeting debrief prompt with `delegation_hint: "meeting-debrief"` set — verifies it delegates to `meeting-debrief` and calls `context-bridge-release` after
- [ ] CEO replies with a research request (e.g. "can you look into X?") to a debrief prompt — verifies coordinator still delegates rather than doing the research directly
- [ ] CEO replies "nothing to do" — verifies coordinator delegates (D5 fires, debrief marked completed, no re-prompt)
- [ ] Message with no active outbound context entry continues to be handled directly (no regression)
- [ ] Specialist clarification resume flow: context-bridge-release called exactly once (not double-released)


___

## **CodeAnt-AI Description**
**Treat named delegation replies as mandatory**

### What Changed
- When an active outbound context has a delegation hint, the coordinator now always hands the reply to that specialist instead of answering it itself
- Ambiguous replies are now treated as matches more often, so debrief and follow-up threads are less likely to stall
- The coordinator no longer sends a direct reply before delegating, and it avoids double-releasing the conversation in the clarification resume flow

### Impact
`✅ Fewer stuck meeting debriefs`
`✅ Fewer missed specialist handoffs`
`✅ Fewer repeated reminders after a reply`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
