### PR TITLE
feat: file attachment support for all five outbound email skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Added
+- **File attachments in outbound email** — all five email skills (`email-send`, `email-reply`, `email-draft-save`, `ceo-inbox-draft-compose`, `ceo-inbox-draft-reply`) now accept an `attachments` input field. Attachments are read from `file://` URLs (TempFileStore), validated, and forwarded to Nylas. The CEO inbox path uses multipart FormData; the Curia outbound path passes `Buffer` content via the Nylas SDK. 20 MB total / 10 attachment limit enforced. (#818)
+
 ### Fixed
 - **coordinator delegation hint** — `delegation_hint` in active outbound context is now treated as a binding contract; coordinator no longer handles replies directly when a specialist is named, preventing meeting debriefs from getting stuck at `"prompted"`. (#763)
 

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -339,7 +339,10 @@ export class CeoNylasClient {
     this.log.debug({ operation, attachmentCount: attachments.length }, `nylas: ${operation} (multipart)`);
 
     const form = new FormData();
-    form.append('message', new Blob([JSON.stringify(messagePayload)], { type: 'application/json' }));
+    // Append as a plain string (not a Blob) so the part has no filename= attribute
+    // in Content-Disposition — a Blob would produce filename="blob", causing Nylas
+    // to treat the message metadata as a file upload and reject the request.
+    form.append('message', JSON.stringify(messagePayload));
     for (let i = 0; i < attachments.length; i++) {
       const att = attachments[i]!;
       form.append(`file${i}`, new Blob([att.content], { type: att.contentType }), att.filename);

--- a/skills/_shared/ceo-nylas-client.ts
+++ b/skills/_shared/ceo-nylas-client.ts
@@ -60,6 +60,16 @@ export interface EmailAttachmentMeta {
   size: number;
 }
 
+/**
+ * A resolved outbound attachment ready to include in a draft.
+ * Content is raw bytes — callers must read the file before constructing this.
+ */
+export interface DraftAttachment {
+  filename: string;
+  contentType: string;
+  content: Buffer;
+}
+
 // ── List options ────────────────────────────────────────────────────────────
 
 export interface ListMessagesOptions {
@@ -169,18 +179,19 @@ export class CeoNylasClient {
     body: string;
     to: NylasParticipant[];
     cc?: NylasParticipant[];
+    attachments?: DraftAttachment[];
   }): Promise<NylasDraft> {
     const url = `${this.baseUrl}/drafts`;
-    const payload: Record<string, unknown> = {
+    const messagePayload: Record<string, unknown> = {
       reply_to_message_id: options.replyToMessageId,
       subject: options.subject,
       body: options.body,
       to: options.to,
     };
     if (options.cc && options.cc.length > 0) {
-      payload.cc = options.cc;
+      messagePayload.cc = options.cc;
     }
-    const data = await this.request<NylasApiDraft>('POST', url, 'createDraftReply', payload);
+    const data = await this.requestDraft(url, 'createDraftReply', messagePayload, options.attachments);
     return {
       id: data.id,
       subject: data.subject ?? '',
@@ -197,17 +208,18 @@ export class CeoNylasClient {
     body: string;
     to: NylasParticipant[];
     cc?: NylasParticipant[];
+    attachments?: DraftAttachment[];
   }): Promise<NylasDraft> {
     const url = `${this.baseUrl}/drafts`;
-    const payload: Record<string, unknown> = {
+    const messagePayload: Record<string, unknown> = {
       subject: options.subject,
       body: options.body,
       to: options.to,
     };
     if (options.cc && options.cc.length > 0) {
-      payload.cc = options.cc;
+      messagePayload.cc = options.cc;
     }
-    const data = await this.request<NylasApiDraft>('POST', url, 'createDraft', payload);
+    const data = await this.requestDraft(url, 'createDraft', messagePayload, options.attachments);
     return {
       id: data.id,
       subject: data.subject ?? '',
@@ -300,6 +312,58 @@ export class CeoNylasClient {
   }
 
   // ── Internal fetch wrapper ──────────────────────────────────────────────
+
+  /**
+   * POST a draft creation request to the Nylas REST API.
+   *
+   * When `attachments` is absent or empty, sends a plain JSON body (same as before).
+   * When attachments are present, switches to multipart/form-data:
+   *   - Part "message": JSON string of the draft metadata
+   *   - Parts "file0", "file1", …: binary attachment content
+   *
+   * Nylas v3 REST requires multipart for any draft that includes file attachments.
+   * The Node.js global `FormData` (available since Node 18) handles boundary encoding.
+   * We intentionally omit the Content-Type header when using FormData so that fetch
+   * can set it automatically with the correct multipart boundary.
+   */
+  private async requestDraft(
+    url: string,
+    operation: string,
+    messagePayload: Record<string, unknown>,
+    attachments?: DraftAttachment[],
+  ): Promise<NylasApiDraft> {
+    if (!attachments || attachments.length === 0) {
+      return this.request<NylasApiDraft>('POST', url, operation, messagePayload);
+    }
+
+    this.log.debug({ operation, attachmentCount: attachments.length }, `nylas: ${operation} (multipart)`);
+
+    const form = new FormData();
+    form.append('message', new Blob([JSON.stringify(messagePayload)], { type: 'application/json' }));
+    for (let i = 0; i < attachments.length; i++) {
+      const att = attachments[i]!;
+      form.append(`file${i}`, new Blob([att.content], { type: att.contentType }), att.filename);
+    }
+
+    // Omit Content-Type — fetch sets it automatically with the multipart boundary.
+    const { 'Content-Type': _ct, ...headersWithoutContentType } = this.headers;
+    let res: Response;
+    try {
+      res = await fetch(url, { method: 'POST', headers: headersWithoutContentType, body: form });
+    } catch (err) {
+      this.log.error({ err, operation }, `nylas: ${operation} fetch failed`);
+      throw new NylasApiError(0, operation, `Fetch failed: ${String(err)}`);
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '(unreadable body)');
+      this.log.error({ status: res.status, operation }, `nylas: ${operation} API error`);
+      throw new NylasApiError(res.status, operation, `Nylas ${operation}: HTTP ${res.status} — ${text}`);
+    }
+
+    const json = (await res.json()) as { data: NylasApiDraft };
+    return json.data;
+  }
 
   private async request<T>(
     method: string,

--- a/skills/_shared/parse-attachments.test.ts
+++ b/skills/_shared/parse-attachments.test.ts
@@ -48,8 +48,8 @@ describe('parseAttachmentInputs', () => {
     expect(Array.isArray(result)).toBe(true);
     if (Array.isArray(result)) {
       expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({ fileUrl: 'file:///tmp/a.pdf', filename: 'a.pdf', contentType: 'application/pdf' });
-      expect(result[1]).toEqual({ fileUrl: 'file:///tmp/b.png', filename: 'b.png', contentType: 'image/png' });
+      expect(result[0]!).toEqual({ fileUrl: 'file:///tmp/a.pdf', filename: 'a.pdf', contentType: 'application/pdf' });
+      expect(result[1]!).toEqual({ fileUrl: 'file:///tmp/b.png', filename: 'b.png', contentType: 'image/png' });
     }
   });
 

--- a/skills/_shared/parse-attachments.test.ts
+++ b/skills/_shared/parse-attachments.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { parseAttachmentInputs } from './parse-attachments.js';
+
+describe('parseAttachmentInputs', () => {
+  it('returns empty array for undefined', () => {
+    expect(parseAttachmentInputs(undefined)).toEqual([]);
+  });
+
+  it('returns empty array for null', () => {
+    expect(parseAttachmentInputs(null)).toEqual([]);
+  });
+
+  it('returns an error string when input is not an array', () => {
+    const result = parseAttachmentInputs('not-an-array');
+    expect(typeof result).toBe('string');
+    expect(result).toContain('array');
+  });
+
+  it('returns an error string when an element is not an object', () => {
+    const result = parseAttachmentInputs(['string-element']);
+    expect(typeof result).toBe('string');
+    expect(result).toContain('attachments[0]');
+  });
+
+  it('returns an error string when file_url is missing', () => {
+    const result = parseAttachmentInputs([{ filename: 'a.pdf', content_type: 'application/pdf' }]);
+    expect(typeof result).toBe('string');
+    expect(result).toContain('file_url');
+  });
+
+  it('returns an error string when filename is missing', () => {
+    const result = parseAttachmentInputs([{ file_url: 'file:///tmp/a.pdf', content_type: 'application/pdf' }]);
+    expect(typeof result).toBe('string');
+    expect(result).toContain('filename');
+  });
+
+  it('returns an error string when content_type is missing', () => {
+    const result = parseAttachmentInputs([{ file_url: 'file:///tmp/a.pdf', filename: 'a.pdf' }]);
+    expect(typeof result).toBe('string');
+    expect(result).toContain('content_type');
+  });
+
+  it('returns a valid OutboundAttachmentInput[] for well-formed input', () => {
+    const result = parseAttachmentInputs([
+      { file_url: 'file:///tmp/a.pdf', filename: 'a.pdf', content_type: 'application/pdf' },
+      { file_url: 'file:///tmp/b.png', filename: 'b.png', content_type: 'image/png' },
+    ]);
+    expect(Array.isArray(result)).toBe(true);
+    if (Array.isArray(result)) {
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ fileUrl: 'file:///tmp/a.pdf', filename: 'a.pdf', contentType: 'application/pdf' });
+      expect(result[1]).toEqual({ fileUrl: 'file:///tmp/b.png', filename: 'b.png', contentType: 'image/png' });
+    }
+  });
+
+  it('returns empty array for an empty array input', () => {
+    expect(parseAttachmentInputs([])).toEqual([]);
+  });
+
+  it('errors on second element when first is valid but second is malformed', () => {
+    const result = parseAttachmentInputs([
+      { file_url: 'file:///tmp/a.pdf', filename: 'a.pdf', content_type: 'application/pdf' },
+      { file_url: 'file:///tmp/b.pdf', filename: '', content_type: 'application/pdf' },
+    ]);
+    expect(typeof result).toBe('string');
+    expect(result).toContain('attachments[1]');
+  });
+});

--- a/skills/_shared/parse-attachments.ts
+++ b/skills/_shared/parse-attachments.ts
@@ -1,0 +1,50 @@
+// parse-attachments.ts — validates and normalises the raw `attachments` input
+// from an LLM skill call into the OutboundAttachmentInput shape expected by
+// the outbound gateway and CEO inbox handlers.
+//
+// Returns an error string on validation failure (caller returns { success: false, error }).
+// Returns an empty array when attachments is undefined/null (not an error).
+
+import type { OutboundAttachmentInput } from '../../src/skills/_shared/read-attachments.js';
+
+/**
+ * Parse and validate the raw `attachments` value from a skill input.
+ *
+ * @param raw  The raw value from ctx.input — may be undefined, null, or an unknown array.
+ * @returns    A validated OutboundAttachmentInput[] on success, or an error string on failure.
+ */
+export function parseAttachmentInputs(raw: unknown): OutboundAttachmentInput[] | string {
+  if (raw === undefined || raw === null) return [];
+
+  if (!Array.isArray(raw)) {
+    return 'attachments must be an array of {file_url, filename, content_type} objects';
+  }
+
+  const result: OutboundAttachmentInput[] = [];
+
+  for (let i = 0; i < raw.length; i++) {
+    const entry = raw[i];
+    if (typeof entry !== 'object' || entry === null) {
+      return `attachments[${i}] must be an object with file_url, filename, and content_type`;
+    }
+
+    const obj = entry as Record<string, unknown>;
+    const fileUrl = obj['file_url'];
+    const filename = obj['filename'];
+    const contentType = obj['content_type'];
+
+    if (typeof fileUrl !== 'string' || !fileUrl) {
+      return `attachments[${i}].file_url must be a non-empty string (got ${JSON.stringify(fileUrl)})`;
+    }
+    if (typeof filename !== 'string' || !filename) {
+      return `attachments[${i}].filename must be a non-empty string (got ${JSON.stringify(filename)})`;
+    }
+    if (typeof contentType !== 'string' || !contentType) {
+      return `attachments[${i}].content_type must be a non-empty string (got ${JSON.stringify(contentType)})`;
+    }
+
+    result.push({ fileUrl, filename, contentType });
+  }
+
+  return result;
+}

--- a/skills/ceo-inbox-draft-compose/handler.test.ts
+++ b/skills/ceo-inbox-draft-compose/handler.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CeoInboxDraftComposeHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
+import { readFile } from 'node:fs/promises';
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+const mockReadFile = readFile as ReturnType<typeof vi.fn>;
 
 function buildCtx(input?: Record<string, unknown>): SkillContext {
   return {
@@ -42,10 +48,14 @@ describe('CeoInboxDraftComposeHandler', () => {
   beforeEach(() => {
     handler = new CeoInboxDraftComposeHandler();
     mockFetch = vi.spyOn(globalThis, 'fetch');
+    mockReadFile.mockReset();
+    // readAttachmentFiles reads CURIA_TEMPFILE_DIR lazily; stub so file:///tmp/... passes the boundary check.
+    vi.stubEnv('CURIA_TEMPFILE_DIR', '/tmp');
   });
 
   afterEach(() => {
     mockFetch.mockRestore();
+    vi.unstubAllEnvs();
   });
 
   it('Case 1: Happy path — creates draft and returns draft_id', async () => {
@@ -255,5 +265,77 @@ describe('CeoInboxDraftComposeHandler', () => {
     expect((result as { error: string }).error).toContain('configured');
     // No Nylas call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  describe('attachments', () => {
+    it('uses multipart FormData when attachments are provided', async () => {
+      mockReadFile.mockResolvedValue(Buffer.from('pdf content'));
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(DRAFT_RESPONSE), { status: 200 }),
+      );
+
+      const ctx = buildCtx({
+        to: ['alice@example.com'],
+        subject: 'See attached',
+        body: 'Please review.',
+        attachments: [
+          { file_url: 'file:///tmp/report.pdf', filename: 'report.pdf', content_type: 'application/pdf' },
+        ],
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      // The fetch body must be FormData (not a JSON string) when attachments are present
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect((init as RequestInit).body).toBeInstanceOf(FormData);
+    });
+
+    it('uses plain JSON when no attachments are provided', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(DRAFT_RESPONSE), { status: 200 }),
+      );
+
+      const ctx = buildCtx();
+      await handler.execute(ctx);
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      // Without attachments, body is a JSON string (not FormData)
+      expect(typeof (init as RequestInit).body).toBe('string');
+    });
+
+    it('returns error when attachments input is malformed', async () => {
+      const ctx = buildCtx({
+        to: ['alice@example.com'],
+        subject: 'Hello',
+        body: 'Hi',
+        attachments: 'not-an-array',
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(false);
+      expect((result as { error: string }).error).toContain('array');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns error when attachment file cannot be read', async () => {
+      mockReadFile.mockRejectedValue(new Error('ENOENT: no such file'));
+
+      const ctx = buildCtx({
+        to: ['alice@example.com'],
+        subject: 'Hello',
+        body: 'Hi',
+        attachments: [
+          { file_url: 'file:///tmp/missing.pdf', filename: 'missing.pdf', content_type: 'application/pdf' },
+        ],
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(false);
+      expect((result as { error: string }).error).toContain('Attachment error');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/skills/ceo-inbox-draft-compose/handler.test.ts
+++ b/skills/ceo-inbox-draft-compose/handler.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CeoInboxDraftComposeHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
-import { readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
+  realpath: vi.fn(),
 }));
 const mockReadFile = readFile as ReturnType<typeof vi.fn>;
+const mockRealpath = realpath as ReturnType<typeof vi.fn>;
 
 function buildCtx(input?: Record<string, unknown>): SkillContext {
   return {
@@ -49,6 +51,9 @@ describe('CeoInboxDraftComposeHandler', () => {
     handler = new CeoInboxDraftComposeHandler();
     mockFetch = vi.spyOn(globalThis, 'fetch');
     mockReadFile.mockReset();
+    mockRealpath.mockReset();
+    // Default: realpath is identity (no symlinks to resolve).
+    mockRealpath.mockImplementation(async (p: string) => p);
     // readAttachmentFiles reads CURIA_TEMPFILE_DIR lazily; stub so file:///tmp/... passes the boundary check.
     vi.stubEnv('CURIA_TEMPFILE_DIR', '/tmp');
   });
@@ -328,6 +333,49 @@ describe('CeoInboxDraftComposeHandler', () => {
         body: 'Hi',
         attachments: [
           { file_url: 'file:///tmp/missing.pdf', filename: 'missing.pdf', content_type: 'application/pdf' },
+        ],
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(false);
+      expect((result as { error: string }).error).toContain('Attachment error');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns error when more than 10 attachments are provided', async () => {
+      const ctx = buildCtx({
+        to: ['alice@example.com'],
+        subject: 'Hello',
+        body: 'Hi',
+        attachments: Array.from({ length: 11 }, (_, i) => ({
+          file_url: `file:///tmp/file${i}.pdf`,
+          filename: `file${i}.pdf`,
+          content_type: 'application/pdf',
+        })),
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(false);
+      expect((result as { error: string }).error).toContain('Attachment error');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns error when attachments exceed the 20 MB total size limit', async () => {
+      // Two 11 MB buffers = 22 MB > 20 MB limit
+      mockReadFile.mockResolvedValue(Buffer.alloc(11 * 1024 * 1024));
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(DRAFT_RESPONSE), { status: 200 }),
+      );
+
+      const ctx = buildCtx({
+        to: ['alice@example.com'],
+        subject: 'Hello',
+        body: 'Hi',
+        attachments: [
+          { file_url: 'file:///tmp/a.pdf', filename: 'a.pdf', content_type: 'application/pdf' },
+          { file_url: 'file:///tmp/b.pdf', filename: 'b.pdf', content_type: 'application/pdf' },
         ],
       });
 

--- a/skills/ceo-inbox-draft-compose/handler.ts
+++ b/skills/ceo-inbox-draft-compose/handler.ts
@@ -1,8 +1,11 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
-import { CeoNylasClient, type NylasParticipant } from '../_shared/ceo-nylas-client.js';
+import { CeoNylasClient, type NylasParticipant, type DraftAttachment } from '../_shared/ceo-nylas-client.js';
 import { markdownToHtml } from '../../src/channels/email/markdown-to-html.js';
+import { parseAttachmentInputs } from '../_shared/parse-attachments.js';
+import { readAttachmentFiles } from '../../src/skills/_shared/read-attachments.js';
 
 const MAX_BODY_LENGTH = 50_000;
+const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export class CeoInboxDraftComposeHandler implements SkillHandler {
@@ -64,11 +67,26 @@ export class CeoInboxDraftComposeHandler implements SkillHandler {
       }
     }
 
+    const attachmentInputsParsed = parseAttachmentInputs(input.attachments);
+    if (typeof attachmentInputsParsed === 'string') {
+      return { success: false, error: attachmentInputsParsed };
+    }
+
+    let attachments: DraftAttachment[] = [];
+    if (attachmentInputsParsed.length > 0) {
+      try {
+        attachments = await readAttachmentFiles(attachmentInputsParsed, MAX_ATTACHMENT_BYTES);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, error: `Attachment error: ${message}` };
+      }
+    }
+
     const to: NylasParticipant[] = toStrings.map((email) => ({ email }));
     const cc: NylasParticipant[] = ccStrings.map((email) => ({ email }));
 
     ctx.log.info(
-      { toCount: to.length, ccCount: cc.length, subject },
+      { toCount: to.length, ccCount: cc.length, subject, attachmentCount: attachments.length },
       'ceo-inbox-draft-compose: creating compose draft',
     );
 
@@ -86,6 +104,7 @@ export class CeoInboxDraftComposeHandler implements SkillHandler {
         body: htmlBody,
         to,
         ...(cc.length > 0 ? { cc } : {}),
+        ...(attachments.length > 0 ? { attachments } : {}),
       });
 
       ctx.log.info(

--- a/skills/ceo-inbox-draft-compose/handler.ts
+++ b/skills/ceo-inbox-draft-compose/handler.ts
@@ -2,10 +2,9 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 import { CeoNylasClient, type NylasParticipant, type DraftAttachment } from '../_shared/ceo-nylas-client.js';
 import { markdownToHtml } from '../../src/channels/email/markdown-to-html.js';
 import { parseAttachmentInputs } from '../_shared/parse-attachments.js';
-import { readAttachmentFiles } from '../../src/skills/_shared/read-attachments.js';
+import { readAttachmentFiles, MAX_ATTACHMENT_BYTES } from '../../src/skills/_shared/read-attachments.js';
 
 const MAX_BODY_LENGTH = 50_000;
-const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export class CeoInboxDraftComposeHandler implements SkillHandler {

--- a/skills/ceo-inbox-draft-compose/skill.json
+++ b/skills/ceo-inbox-draft-compose/skill.json
@@ -1,14 +1,15 @@
 {
   "name": "ceo-inbox-draft-compose",
   "description": "Compose a brand-new draft email in the CEO's personal inbox for cold outreach (no existing thread). The draft is saved to Gmail Drafts — the CEO reviews and sends it from their email client. Use when the CEO wants to initiate a new email to someone, not reply to an existing message. Intended for use by the ceo-inbox agent — accesses the CEO's personal email via dedicated secrets, do not call from other agents.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
     "to": "string[] (recipient email addresses)",
     "cc": "string[]? (CC email addresses)",
     "subject": "string (email subject line)",
-    "body": "string (email body; markdown supported, converted to HTML automatically)"
+    "body": "string (email body; markdown supported, converted to HTML automatically)",
+    "attachments": "object[]? (file attachments — array of {file_url: string, filename: string, content_type: string}. file_url must be a file:// URL from ceo-inbox-download-attachment or similar. Max 10 attachments, 20 MB total.)"
   },
   "outputs": {
     "draft_id": "string (Nylas draft ID)",
@@ -18,6 +19,6 @@
   },
   "permissions": [],
   "secrets": ["nylas_api_key", "ceo_nylas_grant_id"],
-  "timeout": 15000,
+  "timeout": 30000,
   "capabilities": []
 }

--- a/skills/ceo-inbox-draft-reply/handler.test.ts
+++ b/skills/ceo-inbox-draft-reply/handler.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CeoInboxDraftReplyHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
-import { readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
+  realpath: vi.fn(),
 }));
 
 const mockReadFile = readFile as ReturnType<typeof vi.fn>;
+const mockRealpath = realpath as ReturnType<typeof vi.fn>;
 
 // Helper to build a minimal mock SkillContext
 function buildCtx(overrides: Partial<{
@@ -38,7 +40,7 @@ function buildCtx(overrides: Partial<{
       error: vi.fn(),
       debug: vi.fn(),
     },
-  };
+  } as unknown as SkillContext;
 }
 
 // Helper to build a Nylas API message response
@@ -84,6 +86,9 @@ describe('CeoInboxDraftReplyHandler', () => {
     handler = new CeoInboxDraftReplyHandler();
     mockFetch = vi.spyOn(globalThis, 'fetch');
     mockReadFile.mockReset();
+    mockRealpath.mockReset();
+    // Default: realpath is identity (no symlinks to resolve).
+    mockRealpath.mockImplementation(async (p: string) => p);
     // readAttachmentFiles reads CURIA_TEMPFILE_DIR lazily; stub so file:///tmp/... passes the boundary check.
     vi.stubEnv('CURIA_TEMPFILE_DIR', '/tmp');
   });

--- a/skills/ceo-inbox-draft-reply/handler.test.ts
+++ b/skills/ceo-inbox-draft-reply/handler.test.ts
@@ -1,16 +1,25 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CeoInboxDraftReplyHandler } from './handler.js';
 import type { SkillContext } from '../../src/skills/types.js';
+import { readFile } from 'node:fs/promises';
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+const mockReadFile = readFile as ReturnType<typeof vi.fn>;
 
 // Helper to build a minimal mock SkillContext
 function buildCtx(overrides: Partial<{
   reply_to_message_id: string;
   body: string;
+  attachments: unknown;
 }>= {}): SkillContext {
-  const input = {
+  const input: Record<string, unknown> = {
     reply_to_message_id: overrides.reply_to_message_id ?? 'msg-001',
     body: overrides.body ?? 'Thanks for reaching out.',
   };
+  if ('attachments' in overrides) input.attachments = overrides.attachments;
 
   return {
     input,
@@ -74,10 +83,14 @@ describe('CeoInboxDraftReplyHandler', () => {
   beforeEach(() => {
     handler = new CeoInboxDraftReplyHandler();
     mockFetch = vi.spyOn(globalThis, 'fetch');
+    mockReadFile.mockReset();
+    // readAttachmentFiles reads CURIA_TEMPFILE_DIR lazily; stub so file:///tmp/... passes the boundary check.
+    vi.stubEnv('CURIA_TEMPFILE_DIR', '/tmp');
   });
 
   afterEach(() => {
     mockFetch.mockRestore();
+    vi.unstubAllEnvs();
   });
 
   it('Case 1: Happy path — reply-all with correct to and cc', async () => {
@@ -425,5 +438,97 @@ describe('CeoInboxDraftReplyHandler', () => {
       (call) => String(call[0]).includes('/drafts'),
     );
     expect(draftCall).toBeUndefined();
+  });
+
+  describe('attachments', () => {
+    it('uses multipart FormData when attachments are provided', async () => {
+      mockReadFile.mockResolvedValue(Buffer.from('pdf content'));
+
+      const messageResponse = buildNylasMessage({
+        from: [{ email: 'alice@external.com', name: 'Alice' }],
+        to: [{ email: 'ceo@example.com' }],
+        cc: [],
+      });
+
+      mockFetch.mockImplementation(async (url) => {
+        const urlStr = String(url);
+        if (urlStr.includes('/messages/msg-001')) {
+          return new Response(JSON.stringify(messageResponse), { status: 200 });
+        }
+        if (urlStr.includes('/drafts')) {
+          return new Response(JSON.stringify(DRAFT_RESPONSE), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch: ${urlStr}`);
+      });
+
+      const ctx = buildCtx({
+        attachments: [
+          { file_url: 'file:///tmp/report.pdf', filename: 'report.pdf', content_type: 'application/pdf' },
+        ],
+      });
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      const draftCall = mockFetch.mock.calls.find(
+        (call) => String(call[0]).includes('/drafts'),
+      );
+      expect(draftCall).toBeDefined();
+      // Body must be FormData (not a JSON string) when attachments are present
+      expect((draftCall![1] as RequestInit).body).toBeInstanceOf(FormData);
+    });
+
+    it('uses plain JSON when no attachments are provided', async () => {
+      const messageResponse = buildNylasMessage({
+        from: [{ email: 'alice@external.com' }],
+        to: [{ email: 'ceo@example.com' }],
+        cc: [],
+      });
+
+      mockFetch.mockImplementation(async (url) => {
+        const urlStr = String(url);
+        if (urlStr.includes('/messages/msg-001')) {
+          return new Response(JSON.stringify(messageResponse), { status: 200 });
+        }
+        if (urlStr.includes('/drafts')) {
+          return new Response(JSON.stringify(DRAFT_RESPONSE), { status: 200 });
+        }
+        throw new Error(`Unexpected fetch: ${urlStr}`);
+      });
+
+      const ctx = buildCtx();
+      await handler.execute(ctx);
+
+      const draftCall = mockFetch.mock.calls.find(
+        (call) => String(call[0]).includes('/drafts'),
+      );
+      expect(draftCall).toBeDefined();
+      // Without attachments, body is a JSON string (not FormData)
+      expect(typeof (draftCall![1] as RequestInit).body).toBe('string');
+    });
+
+    it('returns error when attachments input is malformed', async () => {
+      const ctx = buildCtx({ attachments: 'not-an-array' });
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(false);
+      expect((result as { error: string }).error).toContain('array');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns error when attachment file cannot be read', async () => {
+      // readAttachmentFiles is called before getMessage, so no fetch is issued
+      mockReadFile.mockRejectedValue(new Error('ENOENT: no such file'));
+
+      const ctx = buildCtx({
+        attachments: [
+          { file_url: 'file:///tmp/missing.pdf', filename: 'missing.pdf', content_type: 'application/pdf' },
+        ],
+      });
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(false);
+      expect((result as { error: string }).error).toContain('Attachment error');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/skills/ceo-inbox-draft-reply/handler.ts
+++ b/skills/ceo-inbox-draft-reply/handler.ts
@@ -1,13 +1,25 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
-import { CeoNylasClient, type NylasParticipant } from '../_shared/ceo-nylas-client.js';
+import { CeoNylasClient, type NylasParticipant, type DraftAttachment } from '../_shared/ceo-nylas-client.js';
 import { buildReplyQuote } from '../../src/skills/_shared/reply-quote.js';
 import { markdownToHtml } from '../../src/channels/email/markdown-to-html.js';
+import { parseAttachmentInputs } from '../_shared/parse-attachments.js';
+import { readAttachmentFiles } from '../../src/skills/_shared/read-attachments.js';
+
+const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 
 export class CeoInboxDraftReplyHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const apiKey = ctx.secret('nylas_api_key');
-    const grantId = ctx.secret('ceo_nylas_grant_id');
-    const selfEmail = ctx.secret('ceo_self_email').toLowerCase();
+    let apiKey: string;
+    let grantId: string;
+    let selfEmail: string;
+    try {
+      apiKey = ctx.secret('nylas_api_key');
+      grantId = ctx.secret('ceo_nylas_grant_id');
+      selfEmail = ctx.secret('ceo_self_email').toLowerCase();
+    } catch (err) {
+      ctx.log.error({ err }, 'ceo-inbox-draft-reply: required secret not available');
+      return { success: false, error: 'CEO inbox is not configured (missing credentials)' };
+    }
 
     // Guard: selfEmail must be set — without it we cannot filter the CEO's own address
     // from reply recipients, which would cause self-addressed drafts.
@@ -33,8 +45,23 @@ export class CeoInboxDraftReplyHandler implements SkillHandler {
       return { success: false, error: 'body is required' };
     }
 
+    const attachmentInputsParsed = parseAttachmentInputs(input.attachments);
+    if (typeof attachmentInputsParsed === 'string') {
+      return { success: false, error: attachmentInputsParsed };
+    }
+
+    let attachments: DraftAttachment[] = [];
+    if (attachmentInputsParsed.length > 0) {
+      try {
+        attachments = await readAttachmentFiles(attachmentInputsParsed, MAX_ATTACHMENT_BYTES);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, error: `Attachment error: ${message}` };
+      }
+    }
+
     ctx.log.info(
-      { replyToMessageId, bodyLength: body.length },
+      { replyToMessageId, bodyLength: body.length, attachmentCount: attachments.length },
       'ceo-inbox-draft-reply: creating reply-all draft',
     );
 
@@ -110,6 +137,7 @@ export class CeoInboxDraftReplyHandler implements SkillHandler {
         body: draftBody,
         to,
         cc,
+        ...(attachments.length > 0 ? { attachments } : {}),
       });
 
       ctx.log.info(

--- a/skills/ceo-inbox-draft-reply/handler.ts
+++ b/skills/ceo-inbox-draft-reply/handler.ts
@@ -3,9 +3,7 @@ import { CeoNylasClient, type NylasParticipant, type DraftAttachment } from '../
 import { buildReplyQuote } from '../../src/skills/_shared/reply-quote.js';
 import { markdownToHtml } from '../../src/channels/email/markdown-to-html.js';
 import { parseAttachmentInputs } from '../_shared/parse-attachments.js';
-import { readAttachmentFiles } from '../../src/skills/_shared/read-attachments.js';
-
-const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+import { readAttachmentFiles, MAX_ATTACHMENT_BYTES } from '../../src/skills/_shared/read-attachments.js';
 
 export class CeoInboxDraftReplyHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {

--- a/skills/ceo-inbox-draft-reply/skill.json
+++ b/skills/ceo-inbox-draft-reply/skill.json
@@ -1,12 +1,13 @@
 {
   "name": "ceo-inbox-draft-reply",
   "description": "Create a reply-all draft in the CEO's personal email inbox. The draft is never sent automatically — the CEO reviews and sends from Gmail. Always replies to the original sender and CCs all other recipients. Intended for use by the ceo-inbox agent — accesses the CEO's personal email, do not call from other agents.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
     "reply_to_message_id": "string (Nylas message ID of the message being replied to)",
-    "body": "string (HTML body of the draft reply)"
+    "body": "string (HTML body of the draft reply)",
+    "attachments": "object[]? (file attachments — array of {file_url: string, filename: string, content_type: string}. file_url must be a file:// URL from ceo-inbox-download-attachment or similar. Max 10 attachments, 20 MB total.)"
   },
   "outputs": {
     "draft_id": "string (Nylas draft ID)",
@@ -16,6 +17,6 @@
   },
   "permissions": [],
   "secrets": ["nylas_api_key", "ceo_nylas_grant_id", "ceo_self_email"],
-  "timeout": 15000,
+  "timeout": 30000,
   "capabilities": []
 }

--- a/skills/email-draft-save/handler.test.ts
+++ b/skills/email-draft-save/handler.test.ts
@@ -93,3 +93,65 @@ describe('EmailDraftSaveHandler — baseline', () => {
     expect((result as { error: string }).error).toContain('Failed to save draft');
   });
 });
+
+describe('EmailDraftSaveHandler — attachments', () => {
+  it('passes attachments to the gateway when provided', async () => {
+    const mockCreate = vi.fn().mockResolvedValue({ success: true, draftId: 'draft-with-attach' });
+    const handler = new EmailDraftSaveHandler();
+    const result = await handler.execute(makeCtx({
+      input: {
+        ...BASE_INPUT,
+        attachments: [
+          { file_url: 'file:///tmp/report.pdf', filename: 'report.pdf', content_type: 'application/pdf' },
+        ],
+      },
+      outboundGateway: makeMockGateway({ createEmailDraft: mockCreate }),
+    }));
+
+    expect(result.success).toBe(true);
+    const callArg = mockCreate.mock.calls[0]![0] as Record<string, unknown>;
+    expect(callArg.attachments).toEqual([
+      { fileUrl: 'file:///tmp/report.pdf', filename: 'report.pdf', contentType: 'application/pdf' },
+    ]);
+  });
+
+  it('does not include attachments key when attachments is absent', async () => {
+    const mockCreate = vi.fn().mockResolvedValue({ success: true, draftId: 'draft-no-attach' });
+    const handler = new EmailDraftSaveHandler();
+    await handler.execute(makeCtx({
+      outboundGateway: makeMockGateway({ createEmailDraft: mockCreate }),
+    }));
+
+    const callArg = mockCreate.mock.calls[0]![0] as Record<string, unknown>;
+    expect(callArg.attachments).toBeUndefined();
+  });
+
+  it('returns error when attachments is not an array', async () => {
+    const mockCreate = vi.fn();
+    const handler = new EmailDraftSaveHandler();
+    const result = await handler.execute(makeCtx({
+      input: { ...BASE_INPUT, attachments: 'not-an-array' },
+      outboundGateway: makeMockGateway({ createEmailDraft: mockCreate }),
+    }));
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('array');
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns error when an attachment entry is missing filename', async () => {
+    const mockCreate = vi.fn();
+    const handler = new EmailDraftSaveHandler();
+    const result = await handler.execute(makeCtx({
+      input: {
+        ...BASE_INPUT,
+        attachments: [{ file_url: 'file:///tmp/a.pdf', content_type: 'application/pdf' }],
+      },
+      outboundGateway: makeMockGateway({ createEmailDraft: mockCreate }),
+    }));
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('filename');
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});

--- a/skills/email-draft-save/handler.ts
+++ b/skills/email-draft-save/handler.ts
@@ -8,6 +8,7 @@
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { buildReplyQuote } from '../../src/skills/_shared/reply-quote.js';
+import { parseAttachmentInputs } from '../_shared/parse-attachments.js';
 
 export class EmailDraftSaveHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
@@ -18,13 +19,19 @@ export class EmailDraftSaveHandler implements SkillHandler {
     // Handlers must never throw — destructuring a non-object ctx.input would.
     const input =
       ctx.input && typeof ctx.input === 'object' ? (ctx.input as Record<string, unknown>) : {};
-    const { to: rawTo, subject, body, account, reply_to_message_id } = input as {
+    const { to: rawTo, subject, body, account, reply_to_message_id, attachments: attachmentsRaw } = input as {
       to?: string;
       subject?: string;
       body?: string;
       account?: string;
       reply_to_message_id?: string;
+      attachments?: unknown;
     };
+
+    const attachmentsParsed = parseAttachmentInputs(attachmentsRaw);
+    if (typeof attachmentsParsed === 'string') {
+      return { success: false, error: attachmentsParsed };
+    }
 
     const to = typeof rawTo === 'string' ? rawTo.trim() : undefined;
     if (!to) return { success: false, error: 'Missing required input: to (string)' };
@@ -84,6 +91,7 @@ export class EmailDraftSaveHandler implements SkillHandler {
         body: quotedBody,
         accountId,
         replyToMessageId,
+        ...(attachmentsParsed.length > 0 ? { attachments: attachmentsParsed } : {}),
       });
     } catch (err) {
       ctx.log.error({ err, to, accountId }, 'email-draft-save: unexpected error saving draft');

--- a/skills/email-draft-save/skill.json
+++ b/skills/email-draft-save/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "email-draft-save",
   "description": "Save an email as a draft without sending it. The CEO can review and send the draft from their email client. Use when composing a reply that needs CEO approval before sending.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
@@ -9,7 +9,8 @@
     "subject": "string (email subject line)",
     "body": "string (email body; markdown supported, converted to HTML automatically)",
     "account": "string? (named account to draft from, as configured in channel_accounts.email. Defaults to the primary account.)",
-    "reply_to_message_id": "string? (Nylas message ID to reply to; threads the draft as a reply when set)"
+    "reply_to_message_id": "string? (Nylas message ID to reply to; threads the draft as a reply when set)",
+    "attachments": "object[]? (file attachments — array of {file_url: string, filename: string, content_type: string}. file_url must be a file:// URL from email-download-attachment or similar. Max 10 attachments, 20 MB total.)"
   },
   "outputs": {
     "draft_id": "string"

--- a/skills/email-reply/handler.test.ts
+++ b/skills/email-reply/handler.test.ts
@@ -307,4 +307,86 @@ describe('EmailReplyHandler', () => {
       expect(result.success).toBe(true);
     });
   });
+
+  describe('attachments', () => {
+    it('passes attachments to the gateway when provided', async () => {
+      const ctx = makeCtx({
+        reply_to_message_id: 'nylas-msg-1',
+        body: 'See attached.',
+        attachments: [
+          { file_url: 'file:///tmp/report.pdf', filename: 'report.pdf', content_type: 'application/pdf' },
+        ],
+      });
+      (ctx.outboundGateway!.getEmailMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+        from: [{ email: 'alice@example.com' }],
+        to: [],
+        cc: [],
+        subject: 'Project',
+        body: '',
+        date: 0,
+      });
+      (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true, messageId: 'reply-attach-1',
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      const callArg = (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mock.calls[0]![0] as Record<string, unknown>;
+      expect(callArg.attachments).toEqual([
+        { fileUrl: 'file:///tmp/report.pdf', filename: 'report.pdf', contentType: 'application/pdf' },
+      ]);
+    });
+
+    it('does not include attachments key when attachments is undefined', async () => {
+      const ctx = makeCtx({
+        reply_to_message_id: 'nylas-msg-1',
+        body: 'Thanks.',
+      });
+      (ctx.outboundGateway!.getEmailMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+        from: [{ email: 'alice@example.com' }],
+        to: [],
+        cc: [],
+        subject: 'Hi',
+        body: '',
+        date: 0,
+      });
+      (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true, messageId: 'reply-1',
+      });
+
+      await handler.execute(ctx);
+
+      const callArg = (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mock.calls[0]![0] as Record<string, unknown>;
+      expect(callArg.attachments).toBeUndefined();
+    });
+
+    it('returns error when attachments is not an array', async () => {
+      const ctx = makeCtx({
+        reply_to_message_id: 'nylas-msg-1',
+        body: 'Hi',
+        attachments: 'not-an-array',
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('array');
+      expect(ctx.outboundGateway!.send).not.toHaveBeenCalled();
+    });
+
+    it('returns error when an attachment entry is missing file_url', async () => {
+      const ctx = makeCtx({
+        reply_to_message_id: 'nylas-msg-1',
+        body: 'Hi',
+        attachments: [{ filename: 'a.pdf', content_type: 'application/pdf' }],
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('file_url');
+      expect(ctx.outboundGateway!.send).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/skills/email-reply/handler.ts
+++ b/skills/email-reply/handler.ts
@@ -16,17 +16,24 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { registerOutboundContext } from '../../src/dispatch/context-bridge-parse.js';
 import { buildReplyQuote } from '../../src/skills/_shared/reply-quote.js';
+import { parseAttachmentInputs } from '../_shared/parse-attachments.js';
 
 const MAX_BODY_LENGTH = 50000;
 
 export class EmailReplyHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const { reply_to_message_id: replyToMessageId, body, cc: ccInput, context_bridge: contextBridgeRaw } = ctx.input as {
+    const { reply_to_message_id: replyToMessageId, body, cc: ccInput, attachments: attachmentsRaw, context_bridge: contextBridgeRaw } = ctx.input as {
       reply_to_message_id?: string;
       body?: string;
       cc?: string;
+      attachments?: unknown;
       context_bridge?: string;
     };
+
+    const attachmentsParsed = parseAttachmentInputs(attachmentsRaw);
+    if (typeof attachmentsParsed === 'string') {
+      return { success: false, error: attachmentsParsed };
+    }
 
     if (!replyToMessageId || typeof replyToMessageId !== 'string') {
       return { success: false, error: 'Missing required input: reply_to_message_id (string)' };
@@ -137,6 +144,7 @@ export class EmailReplyHandler implements SkillHandler {
         replyToMessageId,
         htmlQuote,
         ...(ccAddresses ? { cc: ccAddresses } : {}),
+        ...(attachmentsParsed.length > 0 ? { attachments: attachmentsParsed } : {}),
       }, {
         taskEventId: ctx.taskEventId,
         conversationId: ctx.conversationId,

--- a/skills/email-reply/skill.json
+++ b/skills/email-reply/skill.json
@@ -1,13 +1,14 @@
 {
   "name": "email-reply",
   "description": "Reply to an existing email thread. By default, replies to all participants (reply-all). Pass cc as empty string to reply to sender only, or as a comma-separated list to explicitly set recipients. Provide the Nylas message ID to reply to and the reply body.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {
     "reply_to_message_id": "string",
     "body": "string",
     "cc": "string? (comma-separated — omit for reply-all default, empty string to reply to sender only)",
+    "attachments": "object[]? (file attachments — array of {file_url: string, filename: string, content_type: string}. file_url must be a file:// URL from email-download-attachment or similar. Max 10 attachments, 20 MB total.)",
     "context_bridge": "string? (JSON — optional context bridge registration: {agent_id, expected_reply?, delegation_hint?, metadata?, expires_in_hours?})"
   },
   "outputs": {

--- a/skills/email-send/handler.test.ts
+++ b/skills/email-send/handler.test.ts
@@ -103,6 +103,76 @@ describe('EmailSendHandler', () => {
     if (!result.success) expect(result.error).toMatch(/blocked/i);
   });
 
+  describe('attachments', () => {
+    it('passes attachments to the gateway when provided', async () => {
+      const ctx = makeCtx({
+        to: 'alice@example.com',
+        subject: 'See attached',
+        body: 'Please find attached.',
+        attachments: [
+          { file_url: 'file:///tmp/report.pdf', filename: 'report.pdf', content_type: 'application/pdf' },
+        ],
+      });
+      (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true, messageId: 'msg-attach-1',
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      const callArgs = (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mock.calls[0]![0] as Record<string, unknown>;
+      expect(callArgs.attachments).toEqual([
+        { fileUrl: 'file:///tmp/report.pdf', filename: 'report.pdf', contentType: 'application/pdf' },
+      ]);
+    });
+
+    it('does not include attachments key when attachments is undefined', async () => {
+      const ctx = makeCtx({
+        to: 'alice@example.com',
+        subject: 'Hello',
+        body: 'Hi there',
+      });
+      (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true, messageId: 'msg-1',
+      });
+
+      await handler.execute(ctx);
+
+      const callArgs = (ctx.outboundGateway!.send as ReturnType<typeof vi.fn>).mock.calls[0]![0] as Record<string, unknown>;
+      expect(callArgs.attachments).toBeUndefined();
+    });
+
+    it('returns error when attachments is not an array', async () => {
+      const ctx = makeCtx({
+        to: 'alice@example.com',
+        subject: 'Hello',
+        body: 'Hi',
+        attachments: 'not-an-array',
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('array');
+      expect(ctx.outboundGateway!.send).not.toHaveBeenCalled();
+    });
+
+    it('returns error when an attachment entry is missing file_url', async () => {
+      const ctx = makeCtx({
+        to: 'alice@example.com',
+        subject: 'Hello',
+        body: 'Hi',
+        attachments: [{ filename: 'a.pdf', content_type: 'application/pdf' }],
+      });
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toContain('file_url');
+      expect(ctx.outboundGateway!.send).not.toHaveBeenCalled();
+    });
+  });
+
   describe('context_bridge', () => {
     it('registers a context bridge entry after successful send', async () => {
       const ctx = makeCtx({

--- a/skills/email-send/handler.ts
+++ b/skills/email-send/handler.ts
@@ -9,6 +9,7 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { registerOutboundContext } from '../../src/dispatch/context-bridge-parse.js';
 import { buildReplyQuote } from '../../src/skills/_shared/reply-quote.js';
+import { parseAttachmentInputs } from '../_shared/parse-attachments.js';
 
 const MAX_TO_LENGTH = 1000;
 const MAX_SUBJECT_LENGTH = 500;
@@ -31,12 +32,13 @@ function parseRecipients(raw: string): string[] {
 
 export class EmailSendHandler implements SkillHandler {
   async execute(ctx: SkillContext): Promise<SkillResult> {
-    const { to, cc, subject, body, reply_to_message_id: replyToMessageIdRaw, context_bridge: contextBridgeRaw } = ctx.input as {
+    const { to, cc, subject, body, reply_to_message_id: replyToMessageIdRaw, attachments: attachmentsRaw, context_bridge: contextBridgeRaw } = ctx.input as {
       to?: string;
       cc?: string;
       subject?: string;
       body?: string;
       reply_to_message_id?: string;
+      attachments?: unknown;
       context_bridge?: string;
     };
 
@@ -93,6 +95,11 @@ export class EmailSendHandler implements SkillHandler {
       ? replyToMessageIdRaw.trim()
       : undefined;
 
+    const attachmentsParsed = parseAttachmentInputs(attachmentsRaw);
+    if (typeof attachmentsParsed === 'string') {
+      return { success: false, error: attachmentsParsed };
+    }
+
     if (!ctx.outboundGateway) {
       return {
         success: false,
@@ -133,7 +140,7 @@ export class EmailSendHandler implements SkillHandler {
       }
     }
 
-    ctx.log.info({ to: toAddresses, subject }, 'Sending email via gateway');
+    ctx.log.info({ to: toAddresses, subject, attachmentCount: attachmentsParsed.length }, 'Sending email via gateway');
 
     try {
       const result = await ctx.outboundGateway.send({
@@ -144,6 +151,7 @@ export class EmailSendHandler implements SkillHandler {
         cc: ccAddresses,
         replyToMessageId,
         htmlQuote,
+        ...(attachmentsParsed.length > 0 ? { attachments: attachmentsParsed } : {}),
       }, {
         taskEventId: ctx.taskEventId,
         conversationId: ctx.conversationId,

--- a/skills/email-send/skill.json
+++ b/skills/email-send/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "email-send",
   "description": "Send a new email. Provide comma-separated recipient email addresses, subject, and body. Emails are sent from the agent's configured email address.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "sensitivity": "normal",
   "action_risk": "medium",
   "inputs": {
@@ -10,6 +10,7 @@
     "subject": "string",
     "body": "string",
     "reply_to_message_id": "string? (Nylas message ID — when set, the original message is quoted below the reply and the send is threaded)",
+    "attachments": "object[]? (file attachments — array of {file_url: string, filename: string, content_type: string}. file_url must be a file:// URL from email-download-attachment or similar. Max 10 attachments, 20 MB total.)",
     "context_bridge": "string? (JSON — optional context bridge registration: {agent_id, expected_reply?, delegation_hint?, metadata?, expires_in_hours?})"
   },
   "outputs": {

--- a/src/channels/email/nylas-client.ts
+++ b/src/channels/email/nylas-client.ts
@@ -22,6 +22,7 @@ import type {
   MessageFields,
   Draft as NylasDraft,
   CreateDraftRequest,
+  CreateAttachmentRequest,
 } from 'nylas';
 import type { Logger } from '../../logger.js';
 
@@ -144,12 +145,25 @@ export interface NylasFolder {
   name: string;
 }
 
+/**
+ * A resolved attachment ready to include in an outbound send or draft.
+ * Content is raw bytes — the caller is responsible for reading the file
+ * before constructing this object (see readAttachmentFiles in read-attachments.ts).
+ */
+export interface AttachmentContent {
+  filename: string;
+  contentType: string;
+  content: Buffer;
+}
+
 export interface SendEmailOptions {
   to: Array<{ name?: string; email: string }>;
   cc?: Array<{ name?: string; email: string }>;
   subject: string;
   body: string;
   replyToMessageId?: string;
+  /** File attachments to include. Each entry's content is passed as-is to Nylas. */
+  attachments?: AttachmentContent[];
 }
 
 export interface ListMessagesOptions {
@@ -299,6 +313,11 @@ export class NylasClient {
     );
 
     try {
+      const attachments: CreateAttachmentRequest[] | undefined = options.attachments?.map((a) => ({
+        filename: a.filename,
+        contentType: a.contentType,
+        content: a.content,
+      }));
       const response = await this.nylas.messages.send({
         identifier: this.grantId,
         requestBody: {
@@ -307,6 +326,7 @@ export class NylasClient {
           subject: options.subject,
           body: options.body,
           replyToMessageId: options.replyToMessageId,
+          ...(attachments && attachments.length > 0 ? { attachments } : {}),
         },
       });
       return this.normalizeMessage(response.data);
@@ -336,6 +356,11 @@ export class NylasClient {
     );
 
     try {
+      const attachments: CreateAttachmentRequest[] | undefined = options.attachments?.map((a) => ({
+        filename: a.filename,
+        contentType: a.contentType,
+        content: a.content,
+      }));
       const response = await this.nylas.drafts.create({
         identifier: this.grantId,
         requestBody: {
@@ -344,6 +369,7 @@ export class NylasClient {
           subject: options.subject,
           body: options.body,
           replyToMessageId: options.replyToMessageId,
+          ...(attachments && attachments.length > 0 ? { attachments } : {}),
         },
       });
       // Draft and NylasSdkMessage (Message) both extend BaseMessage — the fields we

--- a/src/skills/_shared/read-attachments.test.ts
+++ b/src/skills/_shared/read-attachments.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readAttachmentFiles } from './read-attachments.js';
+import type { OutboundAttachmentInput } from './read-attachments.js';
+import { readFile } from 'node:fs/promises';
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+const mockReadFile = readFile as ReturnType<typeof vi.fn>;
+
+const MAX_20MB = 20 * 1024 * 1024;
+
+// Pass /tmp as the allowed store dir for all fixture-based tests so file URLs
+// like file:///tmp/... pass the directory boundary check.
+const STORE_DIR = '/tmp';
+
+describe('readAttachmentFiles', () => {
+  beforeEach(() => {
+    mockReadFile.mockReset();
+  });
+
+  it('returns empty array for empty input', async () => {
+    const result = await readAttachmentFiles([], MAX_20MB, STORE_DIR);
+    expect(result).toEqual([]);
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it('reads a file and returns AttachmentContent', async () => {
+    const buf = Buffer.from('hello pdf');
+    mockReadFile.mockResolvedValue(buf);
+
+    const input: OutboundAttachmentInput[] = [
+      { fileUrl: 'file:///tmp/abc123.pdf', filename: 'report.pdf', contentType: 'application/pdf' },
+    ];
+
+    const result = await readAttachmentFiles(input, MAX_20MB, STORE_DIR);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!).toMatchObject({
+      filename: 'report.pdf',
+      contentType: 'application/pdf',
+      content: buf,
+    });
+    expect(mockReadFile).toHaveBeenCalledWith('/tmp/abc123.pdf');
+  });
+
+  it('reads multiple files', async () => {
+    const buf1 = Buffer.from('file one');
+    const buf2 = Buffer.from('file two');
+    mockReadFile
+      .mockResolvedValueOnce(buf1)
+      .mockResolvedValueOnce(buf2);
+
+    const input: OutboundAttachmentInput[] = [
+      { fileUrl: 'file:///tmp/a.pdf', filename: 'a.pdf', contentType: 'application/pdf' },
+      { fileUrl: 'file:///tmp/b.png', filename: 'b.png', contentType: 'image/png' },
+    ];
+
+    const result = await readAttachmentFiles(input, MAX_20MB, STORE_DIR);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]!.filename).toBe('a.pdf');
+    expect(result[1]!.filename).toBe('b.png');
+  });
+
+  it('throws when file_url does not start with file://', async () => {
+    const input: OutboundAttachmentInput[] = [
+      { fileUrl: '/tmp/secret.pdf', filename: 'secret.pdf', contentType: 'application/pdf' },
+    ];
+
+    await expect(readAttachmentFiles(input, MAX_20MB, STORE_DIR)).rejects.toThrow('must start with file://');
+  });
+
+  it('throws on path traversal in file_url', async () => {
+    const input: OutboundAttachmentInput[] = [
+      { fileUrl: 'file:///tmp/../etc/passwd', filename: 'passwd', contentType: 'text/plain' },
+    ];
+
+    await expect(readAttachmentFiles(input, MAX_20MB, STORE_DIR)).rejects.toThrow('path traversal not allowed');
+  });
+
+  it('throws when path is outside the allowed store directory', async () => {
+    // This simulates a prompt-injection attack: the LLM supplies a file:// URL
+    // pointing at an arbitrary file (e.g. /etc/passwd) that has no .. segments
+    // and would bypass only the literal-dot check. The storeDir boundary must catch it.
+    const input: OutboundAttachmentInput[] = [
+      { fileUrl: 'file:///etc/passwd', filename: 'passwd', contentType: 'text/plain' },
+    ];
+
+    await expect(readAttachmentFiles(input, MAX_20MB, STORE_DIR)).rejects.toThrow('outside the allowed temp store directory');
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it('throws when total size exceeds limit', async () => {
+    const bigBuf = Buffer.alloc(15 * 1024 * 1024); // 15 MB
+    mockReadFile.mockResolvedValue(bigBuf);
+
+    const input: OutboundAttachmentInput[] = [
+      { fileUrl: 'file:///tmp/a.pdf', filename: 'a.pdf', contentType: 'application/pdf' },
+      { fileUrl: 'file:///tmp/b.pdf', filename: 'b.pdf', contentType: 'application/pdf' },
+    ];
+
+    // 15 MB + 15 MB = 30 MB > 20 MB limit
+    await expect(readAttachmentFiles(input, MAX_20MB, STORE_DIR)).rejects.toThrow('20 MB');
+  });
+
+  it('throws when more than 10 attachments are provided', async () => {
+    const input: OutboundAttachmentInput[] = Array.from({ length: 11 }, (_, i) => ({
+      fileUrl: `file:///tmp/file${i}.pdf`,
+      filename: `file${i}.pdf`,
+      contentType: 'application/pdf',
+    }));
+
+    await expect(readAttachmentFiles(input, MAX_20MB, STORE_DIR)).rejects.toThrow('Too many attachments');
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it('throws when readFile fails', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT: no such file'));
+
+    const input: OutboundAttachmentInput[] = [
+      { fileUrl: 'file:///tmp/missing.pdf', filename: 'missing.pdf', contentType: 'application/pdf' },
+    ];
+
+    await expect(readAttachmentFiles(input, MAX_20MB, STORE_DIR)).rejects.toThrow('Failed to read attachment');
+  });
+});

--- a/src/skills/_shared/read-attachments.test.ts
+++ b/src/skills/_shared/read-attachments.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readAttachmentFiles } from './read-attachments.js';
 import type { OutboundAttachmentInput } from './read-attachments.js';
-import { readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
+  realpath: vi.fn(),
 }));
 
 const mockReadFile = readFile as ReturnType<typeof vi.fn>;
+const mockRealpath = realpath as ReturnType<typeof vi.fn>;
 
 const MAX_20MB = 20 * 1024 * 1024;
 
@@ -18,6 +20,9 @@ const STORE_DIR = '/tmp';
 describe('readAttachmentFiles', () => {
   beforeEach(() => {
     mockReadFile.mockReset();
+    mockRealpath.mockReset();
+    // Default: realpath is identity (no symlinks to resolve).
+    mockRealpath.mockImplementation(async (p: string) => p);
   });
 
   it('returns empty array for empty input', async () => {
@@ -72,12 +77,44 @@ describe('readAttachmentFiles', () => {
     await expect(readAttachmentFiles(input, MAX_20MB, STORE_DIR)).rejects.toThrow('must start with file://');
   });
 
-  it('throws on path traversal in file_url', async () => {
+  it('throws when file_url path traversal resolves outside the store directory', async () => {
+    // file:///tmp/../etc/passwd resolves to /etc/passwd after realpath (identity mock),
+    // which is outside /tmp — caught by the path.relative boundary check.
     const input: OutboundAttachmentInput[] = [
       { fileUrl: 'file:///tmp/../etc/passwd', filename: 'passwd', contentType: 'text/plain' },
     ];
 
-    await expect(readAttachmentFiles(input, MAX_20MB, STORE_DIR)).rejects.toThrow('path traversal not allowed');
+    await expect(readAttachmentFiles(input, MAX_20MB, STORE_DIR)).rejects.toThrow('outside the allowed temp store directory');
+  });
+
+  it('allows filenames containing ".." that resolve safely inside the store', async () => {
+    // A filename like "weird..name.txt" is benign — the URL resolves to a path
+    // inside STORE_DIR and the boundary check passes.
+    const buf = Buffer.from('content');
+    mockReadFile.mockResolvedValue(buf);
+
+    const input: OutboundAttachmentInput[] = [
+      { fileUrl: 'file:///tmp/weird..name.txt', filename: 'weird..name.txt', contentType: 'text/plain' },
+    ];
+
+    const result = await readAttachmentFiles(input, MAX_20MB, STORE_DIR);
+    expect(result).toHaveLength(1);
+    expect(mockReadFile).toHaveBeenCalledWith('/tmp/weird..name.txt');
+  });
+
+  it('throws when a symlink inside the store resolves to a path outside it', async () => {
+    // Simulate a symlink at /tmp/evil-link that realpath resolves to /etc/passwd.
+    mockRealpath.mockImplementation(async (p: string) => {
+      if (p === '/tmp/evil-link') return '/etc/passwd';
+      return p;
+    });
+
+    const input: OutboundAttachmentInput[] = [
+      { fileUrl: 'file:///tmp/evil-link', filename: 'evil-link', contentType: 'text/plain' },
+    ];
+
+    await expect(readAttachmentFiles(input, MAX_20MB, STORE_DIR)).rejects.toThrow('outside the allowed temp store directory');
+    expect(mockReadFile).not.toHaveBeenCalled();
   });
 
   it('throws when path is outside the allowed store directory', async () => {

--- a/src/skills/_shared/read-attachments.ts
+++ b/src/skills/_shared/read-attachments.ts
@@ -5,7 +5,7 @@
 // validates the URLs, reads the Buffers from disk, and enforces size limits
 // before the content is handed to a transport (NylasClient or CeoNylasClient).
 
-import { readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -27,6 +27,9 @@ export interface AttachmentContent {
 }
 
 const MAX_ATTACHMENTS = 10;
+
+/** Maximum combined size of all attachments on a single outbound email (20 MB). */
+export const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 
 /**
  * Validate and read attachment files from disk.
@@ -58,18 +61,16 @@ export async function readAttachmentFiles(
     storeDir ?? process.env['CURIA_TEMPFILE_DIR'] ?? '/run/curia-tempfiles',
   );
 
+  // Canonicalise the store dir once so the boundary check works even when the
+  // store dir path itself contains symlinks.
+  const canonicalStoreDir = await realpath(resolvedStoreDir);
+
   const results: AttachmentContent[] = [];
   let totalBytes = 0;
 
   for (const att of attachments) {
     if (!att.fileUrl.startsWith('file://')) {
       throw new Error(`Invalid attachment file_url "${att.fileUrl}": must start with file://`);
-    }
-    // Defense-in-depth: reject literal .. before URL-parsing so URL-encoded
-    // variants don't bypass this check. The storeDir boundary below catches
-    // anything that makes it through URL decoding.
-    if (att.fileUrl.includes('..')) {
-      throw new Error(`Invalid attachment file_url "${att.fileUrl}": path traversal not allowed`);
     }
     if (!att.filename || typeof att.filename !== 'string') {
       throw new Error('Each attachment must have a non-empty filename');
@@ -79,15 +80,26 @@ export async function readAttachmentFiles(
     }
 
     // fileURLToPath decodes percent-encoded characters (e.g. %20 → space) and handles
-    // platform-specific file URL rules. URL.pathname leaves encoding in place, which
-    // breaks the startsWith boundary check when the store dir contains spaces.
-    const filePath = fileURLToPath(att.fileUrl);
+    // platform-specific file URL rules. Wrap in try/catch so a malformed file:// URL
+    // surfaces a clear attachment error rather than a raw Node internal.
+    let resolvedPath: string;
+    try {
+      // realpath resolves the canonical path including any symlinks, so a symlink
+      // inside the temp store that points outside it is caught by the boundary
+      // check below rather than slipping through. Matches TempFileStore.delete().
+      resolvedPath = await realpath(fileURLToPath(att.fileUrl));
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`Invalid attachment file_url "${att.fileUrl}": ${detail}`);
+    }
 
     // Enforce that the resolved path stays within the temp store directory — prevents
     // LLM-driven prompt injection from exfiltrating arbitrary files (e.g. /etc/passwd,
-    // .env) as email attachments. Matches the same boundary check in TempFileStore.delete().
-    const resolvedPath = path.resolve(filePath);
-    if (!resolvedPath.startsWith(resolvedStoreDir + path.sep)) {
+    // .env, symlink targets) as email attachments.
+    // path.relative() returns a relative path; if it starts with '..' or is absolute,
+    // the target is outside the allowed directory.
+    const relativePath = path.relative(canonicalStoreDir, resolvedPath);
+    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
       throw new Error(
         `Attachment path is outside the allowed temp store directory: ${att.fileUrl}`,
       );

--- a/src/skills/_shared/read-attachments.ts
+++ b/src/skills/_shared/read-attachments.ts
@@ -1,0 +1,114 @@
+// Shared helper for resolving outbound email attachments from temp file URLs.
+//
+// Skills receive attachments as { file_url, filename, content_type } from the
+// LLM — file_url is a file:// URL written by TempFileStore. This helper
+// validates the URLs, reads the Buffers from disk, and enforces size limits
+// before the content is handed to a transport (NylasClient or CeoNylasClient).
+
+import { readFile } from 'node:fs/promises';
+import * as path from 'node:path';
+
+/** Per-attachment metadata as supplied by the LLM via a skill input. */
+export interface OutboundAttachmentInput {
+  /** file:// URL returned by email-download-attachment or a similar tool. */
+  fileUrl: string;
+  /** Display filename (e.g. "report.pdf"). */
+  filename: string;
+  /** MIME type (e.g. "application/pdf"). */
+  contentType: string;
+}
+
+/** Resolved attachment ready for transport — URL replaced with raw bytes. */
+export interface AttachmentContent {
+  filename: string;
+  contentType: string;
+  content: Buffer;
+}
+
+const MAX_ATTACHMENTS = 10;
+
+/**
+ * Validate and read attachment files from disk.
+ *
+ * Validates each file_url (must be a file:// URL within the temp store directory),
+ * reads each file, and enforces a total size cap.
+ *
+ * @param attachments  Raw attachment list from skill input.
+ * @param maxTotalBytes  Maximum combined size of all attachments in bytes.
+ * @param storeDir  Allowed directory — resolved paths must be within this prefix.
+ *   Defaults to CURIA_TEMPFILE_DIR env var or /run/curia-tempfiles (matches TempFileStore).
+ *   Read at call time so tests can override via process.env or explicit argument.
+ * @returns Resolved attachment contents ready to pass to a transport.
+ * @throws Error with a user-visible message on any validation or I/O failure.
+ */
+export async function readAttachmentFiles(
+  attachments: OutboundAttachmentInput[],
+  maxTotalBytes: number,
+  storeDir?: string,
+): Promise<AttachmentContent[]> {
+  if (attachments.length === 0) return [];
+  if (attachments.length > MAX_ATTACHMENTS) {
+    throw new Error(`Too many attachments: ${attachments.length} provided, maximum is ${MAX_ATTACHMENTS}`);
+  }
+
+  // Resolve the store dir at call time so tests can set CURIA_TEMPFILE_DIR before calling.
+  // Matches TempFileStore constructor: CURIA_TEMPFILE_DIR env var → /run/curia-tempfiles fallback.
+  const resolvedStoreDir = path.resolve(
+    storeDir ?? process.env['CURIA_TEMPFILE_DIR'] ?? '/run/curia-tempfiles',
+  );
+
+  const results: AttachmentContent[] = [];
+  let totalBytes = 0;
+
+  for (const att of attachments) {
+    if (!att.fileUrl.startsWith('file://')) {
+      throw new Error(`Invalid attachment file_url "${att.fileUrl}": must start with file://`);
+    }
+    // Defense-in-depth: reject literal .. before URL-parsing so URL-encoded
+    // variants don't bypass this check. The storeDir boundary below catches
+    // anything that makes it through URL decoding.
+    if (att.fileUrl.includes('..')) {
+      throw new Error(`Invalid attachment file_url "${att.fileUrl}": path traversal not allowed`);
+    }
+    if (!att.filename || typeof att.filename !== 'string') {
+      throw new Error('Each attachment must have a non-empty filename');
+    }
+    if (!att.contentType || typeof att.contentType !== 'string') {
+      throw new Error(`Attachment "${att.filename}" must have a non-empty content_type`);
+    }
+
+    // Use URL parsing so percent-encoded characters are decoded before path resolution.
+    const filePath = new URL(att.fileUrl).pathname;
+
+    // Enforce that the resolved path stays within the temp store directory — prevents
+    // LLM-driven prompt injection from exfiltrating arbitrary files (e.g. /etc/passwd,
+    // .env) as email attachments. Matches the same boundary check in TempFileStore.delete().
+    const resolvedPath = path.resolve(filePath);
+    if (!resolvedPath.startsWith(resolvedStoreDir + path.sep)) {
+      throw new Error(
+        `Attachment path is outside the allowed temp store directory: ${att.fileUrl}`,
+      );
+    }
+
+    let content: Buffer;
+    try {
+      content = await readFile(resolvedPath);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to read attachment "${att.filename}" from ${att.fileUrl}: ${detail}`);
+    }
+
+    totalBytes += content.length;
+    if (totalBytes > maxTotalBytes) {
+      const limitMB = (maxTotalBytes / (1024 * 1024)).toFixed(0);
+      throw new Error(
+        `Attachments exceed the ${limitMB} MB total size limit. ` +
+        `Reduce attachment size or count before sending.`,
+      );
+    }
+
+    results.push({ filename: att.filename, contentType: att.contentType, content });
+  }
+
+  return results;
+}

--- a/src/skills/_shared/read-attachments.ts
+++ b/src/skills/_shared/read-attachments.ts
@@ -7,6 +7,7 @@
 
 import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /** Per-attachment metadata as supplied by the LLM via a skill input. */
 export interface OutboundAttachmentInput {
@@ -77,8 +78,10 @@ export async function readAttachmentFiles(
       throw new Error(`Attachment "${att.filename}" must have a non-empty content_type`);
     }
 
-    // Use URL parsing so percent-encoded characters are decoded before path resolution.
-    const filePath = new URL(att.fileUrl).pathname;
+    // fileURLToPath decodes percent-encoded characters (e.g. %20 → space) and handles
+    // platform-specific file URL rules. URL.pathname leaves encoding in place, which
+    // breaks the startsWith boundary check when the store dir contains spaces.
+    const filePath = fileURLToPath(att.fileUrl);
 
     // Enforce that the resolved path stays within the temp store directory — prevents
     // LLM-driven prompt injection from exfiltrating arbitrary files (e.g. /etc/passwd,

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -21,7 +21,7 @@
 
 import { randomUUID } from 'node:crypto';
 import type { NylasClient, NylasMessage, NylasFolder, ListMessagesOptions, SendEmailOptions, AttachmentContent } from '../channels/email/nylas-client.js';
-import { readAttachmentFiles, type OutboundAttachmentInput } from './_shared/read-attachments.js';
+import { readAttachmentFiles, MAX_ATTACHMENT_BYTES, type OutboundAttachmentInput } from './_shared/read-attachments.js';
 import type { SignalRpcClient } from '../channels/signal/signal-rpc-client.js';
 import type { ContactService } from '../contacts/contact-service.js';
 import type { TrustLevel, ChannelIdentity } from '../contacts/types.js';
@@ -204,9 +204,6 @@ export interface OutboundGatewayConfig {
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-/** Maximum combined size of all attachments on a single outbound email (20 MB). */
-const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/skills/outbound-gateway.ts
+++ b/src/skills/outbound-gateway.ts
@@ -20,7 +20,8 @@
 //   run for all channels before dispatch.
 
 import { randomUUID } from 'node:crypto';
-import type { NylasClient, NylasMessage, NylasFolder, ListMessagesOptions, SendEmailOptions } from '../channels/email/nylas-client.js';
+import type { NylasClient, NylasMessage, NylasFolder, ListMessagesOptions, SendEmailOptions, AttachmentContent } from '../channels/email/nylas-client.js';
+import { readAttachmentFiles, type OutboundAttachmentInput } from './_shared/read-attachments.js';
 import type { SignalRpcClient } from '../channels/signal/signal-rpc-client.js';
 import type { ContactService } from '../contacts/contact-service.js';
 import type { TrustLevel, ChannelIdentity } from '../contacts/types.js';
@@ -57,7 +58,14 @@ export interface EmailSendRequest {
    *  Used for the quoted original message block: the HTML quote must not pass
    *  through markdownToHtml because that converter escapes < and > characters. */
   htmlQuote?: string;
+  /** File attachments to include. Each entry must have a file:// URL pointing
+   *  to a temp file (from email-download-attachment or similar). The gateway
+   *  reads the files from disk before passing them to Nylas. */
+  attachments?: OutboundAttachmentInput[];
 }
+
+// Re-export so callers can construct attachment lists without importing from read-attachments directly.
+export type { OutboundAttachmentInput };
 
 export interface SignalOutboundRequest {
   channel: 'signal';
@@ -192,6 +200,13 @@ export interface OutboundGatewayConfig {
    */
   confidencePipeline?: import('../contacts/confidence-pipeline.js').ConfidencePipeline;
 }
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum combined size of all attachments on a single outbound email (20 MB). */
+const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1610,6 +1625,16 @@ export class OutboundGateway {
     // htmlQuote is appended after conversion so it is not re-escaped by markdownToHtml.
     const htmlBody = markdownToHtml(request.body) + (request.htmlQuote ?? '');
 
+    let attachments: AttachmentContent[] | undefined;
+    if (request.attachments && request.attachments.length > 0) {
+      try {
+        attachments = await readAttachmentFiles(request.attachments, MAX_ATTACHMENT_BYTES);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, blockedReason: `Attachment error: ${message}` };
+      }
+    }
+
     try {
       const sendOptions: SendEmailOptions = {
         to: [{ email: request.to }],
@@ -1617,6 +1642,7 @@ export class OutboundGateway {
         subject: request.subject ?? '',
         body: htmlBody,
         replyToMessageId: request.replyToMessageId,
+        attachments,
       };
 
       const draft = await nylasClient.createDraft(sendOptions);
@@ -1653,6 +1679,16 @@ export class OutboundGateway {
     // htmlQuote is appended after conversion so it is not re-escaped by markdownToHtml.
     const htmlBody = markdownToHtml(request.body) + (request.htmlQuote ?? '');
 
+    let attachments: AttachmentContent[] | undefined;
+    if (request.attachments && request.attachments.length > 0) {
+      try {
+        attachments = await readAttachmentFiles(request.attachments, MAX_ATTACHMENT_BYTES);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, blockedReason: `Attachment error: ${message}` };
+      }
+    }
+
     try {
       const sendOptions: SendEmailOptions = {
         to: [{ email: request.to }],
@@ -1660,6 +1696,7 @@ export class OutboundGateway {
         subject: request.subject ?? '',
         body: htmlBody,
         replyToMessageId: request.replyToMessageId,
+        attachments,
       };
 
       const sent = await nylasClient.sendMessage(sendOptions);

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -9,12 +9,14 @@ import type { BusEvent } from '../../../src/bus/events.js';
 import type { AutonomyService, AutonomyConfig } from '../../../src/autonomy/autonomy-service.js';
 import type { PiiRedactor } from '../../../src/dispatch/pii-redactor.js';
 import type { ActionLogRepo } from '../../../src/autonomy/action-log-repo.js';
-import { readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
+  realpath: vi.fn(),
 }));
 const mockReadFile = readFile as ReturnType<typeof vi.fn>;
+const mockRealpath = realpath as ReturnType<typeof vi.fn>;
 
 /**
  * Build fresh vi.fn() mocks for each test. Using beforeEach + createMocks()
@@ -702,6 +704,9 @@ describe('OutboundGateway — attachment support', () => {
 
   beforeEach(() => {
     mockReadFile.mockReset();
+    mockRealpath.mockReset();
+    // Default: realpath is identity (no symlinks to resolve).
+    mockRealpath.mockImplementation(async (p: string) => p);
     // readAttachmentFiles reads CURIA_TEMPFILE_DIR lazily; stub it so file:///tmp/... URLs pass
     // the store-dir boundary check without needing a real tmpfs mount.
     vi.stubEnv('CURIA_TEMPFILE_DIR', '/tmp');
@@ -774,10 +779,17 @@ describe('OutboundGateway — attachment support', () => {
     });
 
     expect(result.success).toBe(true);
-    const draftArgs = (nylasClient.createDraft as ReturnType<typeof vi.fn>).mock.calls[0]![0] as Record<string, unknown>;
-    const attachments = draftArgs.attachments as Array<{ filename: string }>;
-    expect(attachments).toHaveLength(1);
-    expect(attachments[0]!.filename).toBe('contract.pdf');
+    expect(nylasClient.createDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            filename: 'contract.pdf',
+            contentType: 'application/pdf',
+            content: pdfContent,
+          }),
+        ],
+      }),
+    );
   });
 
   it('blocks draft creation when attachment file is missing', async () => {

--- a/tests/unit/skills/outbound-gateway.test.ts
+++ b/tests/unit/skills/outbound-gateway.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { OutboundGateway } from '../../../src/skills/outbound-gateway.js';
 import { createLogger } from '../../../src/logger.js';
 import type { NylasClient } from '../../../src/channels/email/nylas-client.js';
@@ -9,6 +9,12 @@ import type { BusEvent } from '../../../src/bus/events.js';
 import type { AutonomyService, AutonomyConfig } from '../../../src/autonomy/autonomy-service.js';
 import type { PiiRedactor } from '../../../src/dispatch/pii-redactor.js';
 import type { ActionLogRepo } from '../../../src/autonomy/action-log-repo.js';
+import { readFile } from 'node:fs/promises';
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+const mockReadFile = readFile as ReturnType<typeof vi.fn>;
 
 /**
  * Build fresh vi.fn() mocks for each test. Using beforeEach + createMocks()
@@ -663,6 +669,151 @@ describe('OutboundGateway.createEmailDraft', () => {
     expect(result.blockedReason).toContain('Contact resolution failed');
     expect(nylasClient.createDraft).not.toHaveBeenCalled();
     expect(nylasClient.sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('OutboundGateway — attachment support', () => {
+  function makeGatewayWithAttachments(nylasClientOverrides: Partial<NylasClient> = {}) {
+    const logger = createLogger('error');
+    const nylasClient = {
+      sendMessage: vi.fn().mockResolvedValue({ id: 'msg-attach-1' }),
+      createDraft: vi.fn().mockResolvedValue({ id: 'draft-attach-1' }),
+      getMessage: vi.fn().mockResolvedValue({ id: 'm1', from: [{ email: 's@example.com' }], subject: 'S' }),
+      listMessages: vi.fn().mockResolvedValue([]),
+      ...nylasClientOverrides,
+    } as unknown as NylasClient;
+    const gateway = new OutboundGateway({
+      nylasClients: new Map([['curia', nylasClient]]),
+      contactService: {
+        resolveByChannelIdentity: vi.fn().mockResolvedValue(null),
+      } as unknown as ContactService,
+      contentFilter: {
+        check: vi.fn().mockResolvedValue({ passed: true, findings: [] }),
+      } as unknown as OutboundContentFilter,
+      bus: {
+        publish: vi.fn().mockResolvedValue(undefined),
+        subscribe: vi.fn(),
+      } as unknown as EventBus,
+      principalIdentities: [],
+      logger,
+    });
+    return { gateway, nylasClient };
+  }
+
+  beforeEach(() => {
+    mockReadFile.mockReset();
+    // readAttachmentFiles reads CURIA_TEMPFILE_DIR lazily; stub it so file:///tmp/... URLs pass
+    // the store-dir boundary check without needing a real tmpfs mount.
+    vi.stubEnv('CURIA_TEMPFILE_DIR', '/tmp');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('reads attachment files and passes them to sendMessage', async () => {
+    const pdfContent = Buffer.from('fake pdf bytes');
+    mockReadFile.mockResolvedValue(pdfContent);
+
+    const { gateway, nylasClient } = makeGatewayWithAttachments();
+
+    const result = await gateway.send({
+      channel: 'email',
+      to: 'recipient@example.com',
+      subject: 'With attachment',
+      body: 'See attached.',
+      attachments: [
+        { fileUrl: 'file:///tmp/report.pdf', filename: 'report.pdf', contentType: 'application/pdf' },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    const sendArgs = (nylasClient.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0]![0] as Record<string, unknown>;
+    const attachments = sendArgs.attachments as Array<{ filename: string; contentType: string; content: Buffer }>;
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]!.filename).toBe('report.pdf');
+    expect(attachments[0]!.contentType).toBe('application/pdf');
+    expect(attachments[0]!.content).toEqual(pdfContent);
+  });
+
+  it('blocks send and returns error when attachment file cannot be read', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT: no such file'));
+
+    const { gateway, nylasClient } = makeGatewayWithAttachments();
+
+    const result = await gateway.send({
+      channel: 'email',
+      to: 'recipient@example.com',
+      subject: 'With attachment',
+      body: 'See attached.',
+      attachments: [
+        { fileUrl: 'file:///tmp/missing.pdf', filename: 'missing.pdf', contentType: 'application/pdf' },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.blockedReason).toContain('Attachment error');
+    expect(nylasClient.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('reads attachment files and passes them to createDraft', async () => {
+    const pdfContent = Buffer.from('fake pdf bytes');
+    mockReadFile.mockResolvedValue(pdfContent);
+
+    const { gateway, nylasClient } = makeGatewayWithAttachments();
+
+    const result = await gateway.createEmailDraft({
+      channel: 'email',
+      to: 'partner@example.com',
+      accountId: 'curia',
+      subject: 'Draft with attachment',
+      body: 'Please review.',
+      attachments: [
+        { fileUrl: 'file:///tmp/contract.pdf', filename: 'contract.pdf', contentType: 'application/pdf' },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    const draftArgs = (nylasClient.createDraft as ReturnType<typeof vi.fn>).mock.calls[0]![0] as Record<string, unknown>;
+    const attachments = draftArgs.attachments as Array<{ filename: string }>;
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]!.filename).toBe('contract.pdf');
+  });
+
+  it('blocks draft creation when attachment file is missing', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+    const { gateway, nylasClient } = makeGatewayWithAttachments();
+
+    const result = await gateway.createEmailDraft({
+      channel: 'email',
+      to: 'partner@example.com',
+      accountId: 'curia',
+      subject: 'Draft with attachment',
+      body: 'Please review.',
+      attachments: [
+        { fileUrl: 'file:///tmp/missing.pdf', filename: 'missing.pdf', contentType: 'application/pdf' },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.blockedReason).toContain('Attachment error');
+    expect(nylasClient.createDraft).not.toHaveBeenCalled();
+  });
+
+  it('does not set attachments on sendMessage when none are provided', async () => {
+    const { gateway, nylasClient } = makeGatewayWithAttachments();
+
+    await gateway.send({
+      channel: 'email',
+      to: 'recipient@example.com',
+      subject: 'No attachments',
+      body: 'Hello.',
+    });
+
+    const sendArgs = (nylasClient.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0]![0] as Record<string, unknown>;
+    expect(sendArgs.attachments).toBeUndefined();
+    expect(mockReadFile).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## **User description**
## Summary

- All five email skills (`email-send`, `email-reply`, `email-draft-save`, `ceo-inbox-draft-compose`, `ceo-inbox-draft-reply`) now accept an `attachments` input field containing `file://` URLs from TempFileStore
- Curia outbound path: `OutboundGateway` reads attachment Buffers via `readAttachmentFiles()` and passes them to the Nylas SDK's `sendMessage`/`createDraft`
- CEO inbox path: `CeoNylasClient` switches from plain JSON to multipart FormData when attachments are present (Nylas v3 REST requirement)
- 20 MB total / 10 attachment limit enforced; path-traversal and store-directory boundary checks prevent LLM-driven file exfiltration

## Key new files

- `src/skills/_shared/read-attachments.ts` — validates `file://` URLs, enforces store-dir boundary (same logic as `TempFileStore.delete`), reads Buffers, enforces size/count limits
- `skills/_shared/parse-attachments.ts` — validates raw LLM attachment input → typed `OutboundAttachmentInput[]`

## Security

`readAttachmentFiles` enforces that all resolved attachment paths are within `CURIA_TEMPFILE_DIR` (default `/run/curia-tempfiles`), rejecting attempts to attach arbitrary filesystem files even when no `..` traversal is present. A test covering `file:///etc/passwd` is included.

## Test plan

- [x] `pnpm run test` — 2935 tests pass (2 pre-existing DB integration failures unrelated)
- [x] `pnpm run typecheck` — no errors
- [x] Attachment tests added for all five skill handlers plus shared helpers and gateway

Closes #818


___

## **CodeAnt-AI Description**
**Add file attachments to outbound email drafts and sends**

### What Changed
- All outbound email skills now accept an optional `attachments` field, so users can include files when sending a message or saving a draft
- CEO inbox drafts now upload attachments in the format required by the email service, while Curia outbound email passes the files through directly
- Attachment inputs are checked before use, with clear errors for invalid shapes, missing file details, unreadable files, too many files, or files over the size limit
- Attachment handling is restricted to TempFileStore file URLs, blocking attempts to attach files outside the allowed temp directory

### Impact
`✅ Send emails with file attachments`
`✅ Save draft emails with attached files`
`✅ Fewer failed sends from invalid attachment input`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added file attachment support for outbound email operations: send, reply, compose drafts, and save drafts
  * Supports up to 10 file attachments per email with a combined 20 MB size limit
  * Attachments are sourced from temporary file URLs and validated automatically
  * Comprehensive error handling provides clear feedback for invalid, oversized, or missing attachment files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->