### PR TITLE
feat: add drive-download-file skill for attaching Drive files to emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **Jun 1 email incident plan** — incident reconstruction and two-PR fix plan for the 18-hour email-channel silence + triple-reply burst. See `docs/wip/2026-06-02-jun1-email-incident.md`. (#846, #847)
 - **Tasks & Backlog v1 design** — design memo for a unified task model with deferred work, CEO-visible backlog, and a 3×/day coordinator sweep. See `docs/wip/2026-06-01-tasks-and-backlog-design.md`.
 - **SBOM generation** — SPDX JSON Software Bill of Materials generated on every push to `main` and attached to each GitHub release as a release asset; failure is non-fatal. (#564)
+- **`drive-download-file`** — new skill that downloads a Google Drive file (native or Google-native export) to TempFileStore and returns a `file://` URL, enabling Drive files to be attached to outbound emails. Closes #857.
 
 ### Fixed
 - **`email-draft-save` unknown account error** — `OutboundGateway` now lists available accounts when unknown `accountId` is passed. (#815)

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.2.1"
+version: "0.3.0"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -476,6 +476,16 @@ system_prompt: |
   If create_drive_file fails for other reasons (quota, auth, permissions),
   tell the CEO the upload failed and include the error. Do NOT claim success.
 
+  **Attaching a Drive file to an email:** When the CEO asks you to send an email
+  with a Drive file attached, use this sequence:
+  1. If you only have a file name (not an ID or URL), call search_drive_files first.
+  2. Call drive-download-file with the file ID or Drive URL. It returns a temp_file_url.
+  3. Pass temp_file_url in the attachments array of email-send or email-reply,
+     using the returned filename and content_type fields.
+
+  Do NOT use get_drive_file_content for attachments — it returns text only and
+  cannot produce binary-safe attachments.
+
   ### Delegation acknowledgment on synchronous channels
   When delegating a task that will take significant time (essay polishing, research,
   multi-step workflows) and the message arrived via any synchronous channel (e.g. cli,
@@ -588,6 +598,7 @@ pinned_skills:
   - manage_drive_access
   - set_drive_file_permissions
   - get_drive_shareable_link
+  - drive-download-file
   - executive-profile-get
   - executive-profile-update
   - email-send

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -476,15 +476,8 @@ system_prompt: |
   If create_drive_file fails for other reasons (quota, auth, permissions),
   tell the CEO the upload failed and include the error. Do NOT claim success.
 
-  **Attaching a Drive file to an email:** When the CEO asks you to send an email
-  with a Drive file attached, use this sequence:
-  1. If you only have a file name (not an ID or URL), call search_drive_files first.
-  2. Call drive-download-file with the file ID or Drive URL. It returns a temp_file_url.
-  3. Pass temp_file_url in the attachments array of email-send or email-reply,
-     using the returned filename and content_type fields.
-
-  Do NOT use get_drive_file_content for attachments — it returns text only and
-  cannot produce binary-safe attachments.
+  To attach a Drive file to an email, use drive-download-file (not get_drive_file_content —
+  text only, not binary-safe).
 
   ### Delegation acknowledgment on synchronous channels
   When delegating a task that will take significant time (essay polishing, research,

--- a/docs/wip/2026-06-02-drive-download-file-design.md
+++ b/docs/wip/2026-06-02-drive-download-file-design.md
@@ -1,0 +1,211 @@
+# Design: `drive-download-file` skill
+
+**Date:** 2026-06-02
+**Issue:** #857
+**Branch:** `feat/drive-download-file`
+
+---
+
+## Problem
+
+PR #855 added file attachment support to all outbound email skills. Attachments are passed as `file://` URLs pointing to `/run/curia-tempfiles/`. The only skill that currently produces those URLs is `email-download-attachment`, which sources bytes from inbound email attachments.
+
+No equivalent bridge exists for Google Drive. When asked to attach a Drive file to an email, the agent correctly identifies the gap and falls back to sending a shareable link. Root cause: getting binary bytes from Drive requires an authenticated `drive.files.get?alt=media` API call, and no existing tool exposes that.
+
+---
+
+## Solution
+
+A new local Curia skill `drive-download-file` that:
+1. Accepts a Drive file ID or URL
+2. Fetches the file bytes via the Google Drive API
+3. Writes bytes to TempFileStore
+4. Returns a `file://` URL ready for use with any outbound email skill
+
+This mirrors `email-download-attachment` exactly — same output shape, same size limits, same TempFileStore integration.
+
+---
+
+## Skill Interface
+
+### Input
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `file_id_or_url` | string | yes | Drive file ID (`1BxiM...`) or full Drive URL (`https://drive.google.com/file/d/<id>/view`) |
+| `filename` | string | no | Filename hint for the output. Falls back to the name from Drive metadata. |
+| `export_mime_type` | string | no | For Google-native formats only (Docs/Sheets/Slides). Defaults to `application/pdf`. |
+
+**URL parsing:** Extract the file ID from URLs matching:
+- `https://drive.google.com/file/d/<id>/...`
+- `https://drive.google.com/open?id=<id>`
+- `https://drive.google.com/uc?id=<id>` (direct download links)
+- `https://docs.google.com/document/d/<id>/...`
+- `https://docs.google.com/spreadsheets/d/<id>/...`
+- `https://docs.google.com/presentation/d/<id>/...`
+
+Strings that don't match any URL pattern are treated as raw file IDs.
+
+### Output
+
+```ts
+{
+  temp_file_url: string;   // file:///run/curia-tempfiles/<uuid>-<filename>
+  filename: string;
+  content_type: string;
+  size: number;            // bytes
+}
+```
+
+Same shape as `email-download-attachment` — the agent can pass `temp_file_url` directly to `email-send` / `email-reply` without any transformation.
+
+### Errors
+
+All errors return `{ success: false, error: string }`:
+
+| Condition | Error message |
+|---|---|
+| File not found | `"Drive file <id> not found or not shared with Curia"` |
+| Access denied (403) | `"Curia does not have access to Drive file <id>. Share it with Curia's Gmail address."` |
+| File exceeds 10 MB | `"Drive file \"<name>\" is <N> MB — exceeds the 10 MB download limit"` |
+| Token cache missing | `"Google OAuth token cache not found at <path>. Complete the Drive auth setup (docs/dev/google-drive.md)."` |
+| Token cache malformed | `"Google OAuth token cache at <path> is missing refresh_token. Re-run the OAuth flow."` |
+| Google-native format, unsupported export type | `"Cannot export Google <type> to <mime_type>. Use application/pdf or a supported Office format."` |
+
+### Skill manifest
+
+```json
+{
+  "name": "drive-download-file",
+  "description": "Download a file from Google Drive to temporary storage. Returns a file:// URL for use with email-send or email-reply attachments.",
+  "action_risk": "none",
+  "version": "0.1.0"
+}
+```
+
+---
+
+## Authentication
+
+The skill reuses the OAuth credentials already established for workspace-mcp — no new setup required.
+
+**Token loading (lazy, cached per process):**
+
+1. Read `${HOME}/.google_workspace_mcp/credentials/${CURIA_GOOGLE_EMAIL}.json`
+2. Extract `refresh_token` from the JSON
+3. Construct a `googleapis` `OAuth2Client` with:
+   - `client_id`: `GOOGLE_OAUTH_CLIENT_ID` (env var, already in `.env`)
+   - `client_secret`: `GOOGLE_OAUTH_CLIENT_SECRET` (env var, already in `.env`)
+   - `refresh_token`: from the token cache file
+4. The googleapis library auto-refreshes the access token as needed
+
+The skill never writes back to the token cache, so there is no race condition with the workspace-mcp subprocess.
+
+**Shared module:** `src/google/drive-auth.ts` — a small module (~30 lines) that handles token loading and `OAuth2Client` construction. Extracted so future Drive skills can reuse it.
+
+---
+
+## Download Logic
+
+A metadata call (`drive.files.get({ fileId, fields: 'name,mimeType,size' })`) determines which path to take:
+
+### Native binary files
+
+Any file whose MIME type does not start with `application/vnd.google-apps.`:
+
+```
+drive.files.get({ fileId, alt: 'media' })
+```
+
+Returns raw bytes. Content-Type is the file's native MIME type.
+
+### Google-native formats
+
+Files with `application/vnd.google-apps.*` MIME types:
+
+```
+drive.files.export({ fileId, mimeType: export_mime_type })
+```
+
+Default export targets:
+
+| Google format | Default export MIME type |
+|---|---|
+| `application/vnd.google-apps.document` | `application/pdf` |
+| `application/vnd.google-apps.spreadsheet` | `application/pdf` |
+| `application/vnd.google-apps.presentation` | `application/pdf` |
+| Any other `vnd.google-apps.*` | `application/pdf` |
+
+The agent can override via `export_mime_type` (e.g. `application/vnd.openxmlformats-officedocument.wordprocessingml.document` for DOCX from a Google Doc).
+
+### Size enforcement
+
+1. **Pre-download check:** If `Content-Length` is present in the response headers, reject immediately if it exceeds `MAX_TEMP_FILE_BYTES` (10 MB). Note: Google Drive export responses often omit `Content-Length`, so this check is opportunistic.
+2. **Streaming guard:** Accumulate the response stream into a buffer and abort if the buffer exceeds 10 MB before the stream completes. Return an error — do not write a partial file.
+3. **Post-download check:** Hard check on the final buffer size before calling `writeTempFile`.
+
+---
+
+## File & Folder Layout
+
+```
+skills/drive-download-file/
+  skill.json          — manifest
+  handler.ts          — skill handler
+  handler.test.ts     — unit tests
+
+src/google/
+  drive-auth.ts       — shared OAuth2Client construction (new)
+  drive-auth.test.ts  — unit tests for token loading
+```
+
+No changes to existing skill files. `src/google/` is a new directory.
+
+---
+
+## Coordinator Wiring
+
+### `agents/coordinator.yaml` — pinned skills
+
+Add `drive-download-file` to the `pinned_skills` list alongside the other Drive tools.
+
+### `agents/coordinator.yaml` — system prompt
+
+Add a workflow note in the Drive section (near the existing `create_drive_file` guidance):
+
+> **Attaching a Drive file to an email**
+>
+> 1. If you have the file name but not the ID, call `search_drive_files` first.
+> 2. Call `drive-download-file` with the file ID or Drive URL. It returns a `temp_file_url`.
+> 3. Pass `temp_file_url` in the `attachments` array of `email-send` or `email-reply`.
+>
+> Do not use `get_drive_file_content` for this — it returns text only and cannot produce attachments.
+
+---
+
+## Testing
+
+Unit tests in `handler.test.ts` cover:
+
+| Case | What's verified |
+|---|---|
+| Native PDF download | Returns `temp_file_url`, correct `content_type`, correct `size` |
+| Google Doc export (default PDF) | Calls `files.export` with `application/pdf`; returns `temp_file_url` |
+| Google Doc export (custom DOCX) | Calls `files.export` with `application/vnd.openxmlformats-...`; returns `temp_file_url` |
+| File exceeds 10 MB (Content-Length) | Returns `{ success: false, error: "... exceeds the 10 MB ..." }` |
+| File exceeds 10 MB (streaming) | Returns `{ success: false, error: "..." }`, no partial file written |
+| File not found (404) | Returns `{ success: false, error: "... not found or not shared ..." }` |
+| Access denied (403) | Returns `{ success: false, error: "... does not have access ..." }` |
+| Drive URL input | File ID correctly extracted; download succeeds |
+| Token cache missing | Returns `{ success: false, error: "... token cache not found ..." }` |
+| Token cache missing refresh_token | Returns `{ success: false, error: "... missing refresh_token ..." }` |
+
+Tests mock `googleapis` and `ctx.writeTempFile`. Token loading is tested in `src/google/drive-auth.test.ts`.
+
+---
+
+## Out of Scope
+
+- Folder downloads (zip an entire Drive folder) — not needed for issue #857
+- Uploading files to Drive — already handled by `create_drive_file` MCP tool
+- Listing folder contents — already handled by `list_drive_items` MCP tool

--- a/docs/wip/2026-06-02-drive-download-file.md
+++ b/docs/wip/2026-06-02-drive-download-file.md
@@ -1,0 +1,968 @@
+# drive-download-file Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `drive-download-file` skill that downloads a Google Drive file to TempFileStore and returns a `file://` URL, enabling the coordinator to attach Drive files to outbound emails.
+
+**Architecture:** New local skill `drive-download-file` mirrors `email-download-attachment`. A shared `src/google/drive-auth.ts` module loads the OAuth credentials from the workspace-mcp token cache and constructs a `googleapis` `OAuth2Client` cached per process. The handler calls `drive.files.get` (native binary) or `drive.files.export` (Google-native formats), streams bytes into a buffer with a 10 MB hard limit, writes to TempFileStore, and returns the `file://` URL.
+
+**Tech Stack:** Node 22, TypeScript ESM, `googleapis` npm package, `SkillContext.writeTempFile`, Vitest
+
+**Worktree:** `/Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file`
+
+---
+
+## File Map
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `src/google/drive-auth.ts` | Load workspace-mcp token cache → `OAuth2Client` |
+| Create | `src/google/drive-auth.test.ts` | Unit tests for token loading |
+| Create | `skills/drive-download-file/skill.json` | Skill manifest |
+| Create | `skills/drive-download-file/handler.ts` | Skill handler |
+| Create | `skills/drive-download-file/handler.test.ts` | Unit tests for handler |
+| Modify | `package.json` | Add `googleapis` dependency |
+| Modify | `agents/coordinator.yaml` | Pin skill + add Drive→email workflow note |
+| Modify | `CHANGELOG.md` | Entry under `[Unreleased]` |
+
+---
+
+## Task 1: Install dependencies and set up worktree
+
+**Files:** `package.json`
+
+- [ ] **Step 1: Install node_modules in the worktree**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file install
+```
+
+- [ ] **Step 2: Add googleapis**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file add googleapis
+```
+
+- [ ] **Step 3: Verify typecheck still passes**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file run typecheck
+```
+
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file add package.json pnpm-lock.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file commit -m "chore: add googleapis dependency"
+```
+
+---
+
+## Task 2: `src/google/drive-auth.ts` — token loading module
+
+**Files:**
+- Create: `src/google/drive-auth.ts`
+- Create: `src/google/drive-auth.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/google/drive-auth.test.ts`:
+
+```typescript
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { getDriveClient, clearDriveClientCache } from './drive-auth.js';
+
+// Prevent real OAuth2 construction — we only test token loading logic.
+vi.mock('googleapis', () => ({
+  google: {
+    auth: {
+      OAuth2: vi.fn().mockImplementation((clientId: string, clientSecret: string) => ({
+        clientId,
+        clientSecret,
+        setCredentials: vi.fn(),
+      })),
+    },
+  },
+}));
+
+let tmpDir: string;
+let tokenCachePath: string;
+
+const validTokenJson = JSON.stringify({
+  refresh_token: 'test-refresh-token',
+  token: 'test-access-token',
+  token_uri: 'https://oauth2.googleapis.com/token',
+});
+
+beforeEach(async () => {
+  clearDriveClientCache();
+  process.env.GOOGLE_OAUTH_CLIENT_ID = 'test-client-id';
+  process.env.GOOGLE_OAUTH_CLIENT_SECRET = 'test-client-secret';
+  process.env.CURIA_GOOGLE_EMAIL = 'curia@test.com';
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drive-auth-test-'));
+  tokenCachePath = path.join(tmpDir, 'tokens.json');
+});
+
+afterEach(async () => {
+  clearDriveClientCache();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  delete process.env.GOOGLE_OAUTH_CLIENT_ID;
+  delete process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  delete process.env.CURIA_GOOGLE_EMAIL;
+});
+
+describe('getDriveClient — env var validation', () => {
+  it('throws when GOOGLE_OAUTH_CLIENT_ID is missing', async () => {
+    delete process.env.GOOGLE_OAUTH_CLIENT_ID;
+    await expect(getDriveClient({ tokenCachePath })).rejects.toThrow('GOOGLE_OAUTH_CLIENT_ID');
+  });
+
+  it('throws when GOOGLE_OAUTH_CLIENT_SECRET is missing', async () => {
+    delete process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+    await expect(getDriveClient({ tokenCachePath })).rejects.toThrow('GOOGLE_OAUTH_CLIENT_SECRET');
+  });
+
+  it('throws when CURIA_GOOGLE_EMAIL is missing', async () => {
+    delete process.env.CURIA_GOOGLE_EMAIL;
+    await expect(getDriveClient({ tokenCachePath })).rejects.toThrow('CURIA_GOOGLE_EMAIL');
+  });
+});
+
+describe('getDriveClient — token cache', () => {
+  it('throws with setup instructions when cache file is missing', async () => {
+    const err = await getDriveClient({ tokenCachePath: '/nonexistent/path.json' }).catch(e => e as Error);
+    expect(err.message).toContain('token cache not found');
+    expect(err.message).toContain('docs/dev/google-drive.md');
+  });
+
+  it('throws when refresh_token is absent from cache', async () => {
+    await fs.writeFile(tokenCachePath, JSON.stringify({ token: 'access-only' }));
+    await expect(getDriveClient({ tokenCachePath })).rejects.toThrow('missing refresh_token');
+  });
+
+  it('returns an OAuth2Client with setCredentials called on success', async () => {
+    await fs.writeFile(tokenCachePath, validTokenJson);
+    const client = await getDriveClient({ tokenCachePath });
+    expect(client).toBeDefined();
+    expect((client as unknown as { setCredentials: ReturnType<typeof vi.fn> }).setCredentials)
+      .toHaveBeenCalledWith({ refresh_token: 'test-refresh-token' });
+  });
+
+  it('returns cached client on subsequent calls (reads file only once)', async () => {
+    await fs.writeFile(tokenCachePath, validTokenJson);
+    const a = await getDriveClient({ tokenCachePath });
+    const b = await getDriveClient({ tokenCachePath });
+    expect(a).toBe(b);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect all to fail**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file run test src/google/drive-auth.test.ts
+```
+
+Expected: failures because `drive-auth.ts` does not exist yet.
+
+- [ ] **Step 3: Implement `src/google/drive-auth.ts`**
+
+```typescript
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { google } from 'googleapis';
+
+// Cached per process — googleapis auto-refreshes the access token using the
+// long-lived refresh_token, so we only need to load from disk once.
+let cachedClient: InstanceType<typeof google.auth.OAuth2> | null = null;
+
+export interface DriveAuthOptions {
+  tokenCachePath?: string;
+  clientId?: string;
+  clientSecret?: string;
+  email?: string;
+}
+
+export async function getDriveClient(
+  options?: DriveAuthOptions,
+): Promise<InstanceType<typeof google.auth.OAuth2>> {
+  if (cachedClient) return cachedClient;
+
+  const clientId = options?.clientId ?? process.env.GOOGLE_OAUTH_CLIENT_ID;
+  const clientSecret = options?.clientSecret ?? process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  const email = options?.email ?? process.env.CURIA_GOOGLE_EMAIL;
+
+  if (!clientId) throw new Error('GOOGLE_OAUTH_CLIENT_ID is not set');
+  if (!clientSecret) throw new Error('GOOGLE_OAUTH_CLIENT_SECRET is not set');
+  if (!email) throw new Error('CURIA_GOOGLE_EMAIL is not set');
+
+  const tokenCachePath =
+    options?.tokenCachePath ??
+    path.join(
+      process.env.HOME ?? '/root',
+      '.google_workspace_mcp',
+      'credentials',
+      `${email}.json`,
+    );
+
+  let tokenData: Record<string, unknown>;
+  try {
+    const raw = await fs.readFile(tokenCachePath, 'utf-8');
+    tokenData = JSON.parse(raw) as Record<string, unknown>;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(
+        `Google OAuth token cache not found at ${tokenCachePath}. ` +
+          `Complete the Drive auth setup (docs/dev/google-drive.md).`,
+      );
+    }
+    throw new Error(
+      `Failed to read Google OAuth token cache at ${tokenCachePath}: ${String(err)}`,
+    );
+  }
+
+  const refreshToken =
+    typeof tokenData['refresh_token'] === 'string' ? tokenData['refresh_token'] : undefined;
+  if (!refreshToken) {
+    throw new Error(
+      `Google OAuth token cache at ${tokenCachePath} is missing refresh_token. Re-run the OAuth flow.`,
+    );
+  }
+
+  const auth = new google.auth.OAuth2(clientId, clientSecret);
+  auth.setCredentials({ refresh_token: refreshToken });
+  cachedClient = auth;
+  return auth;
+}
+
+/** Reset the cached client. For tests only. */
+export function clearDriveClientCache(): void {
+  cachedClient = null;
+}
+```
+
+- [ ] **Step 4: Run tests — expect all to pass**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file run test src/google/drive-auth.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file run typecheck
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file add src/google/drive-auth.ts src/google/drive-auth.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file commit -m "feat: drive-auth module for loading workspace-mcp OAuth token cache"
+```
+
+---
+
+## Task 3: Skill manifest
+
+**Files:**
+- Create: `skills/drive-download-file/skill.json`
+
+- [ ] **Step 1: Create the manifest**
+
+```json
+{
+  "name": "drive-download-file",
+  "description": "Download a file from Google Drive to temporary storage and return a file:// URL for use with email-send or email-reply attachments. Accepts a Drive file ID or any drive.google.com / docs.google.com URL. Google Docs/Sheets/Slides are exported to PDF by default; pass export_mime_type to override. Pass the returned temp_file_url in the attachments array of email-send or email-reply.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "file_id_or_url": "string (Google Drive file ID or full Drive URL — drive.google.com/file/d/<id>/..., drive.google.com/open?id=<id>, drive.google.com/uc?id=<id>, docs.google.com/document/d/<id>/..., docs.google.com/spreadsheets/d/<id>/..., docs.google.com/presentation/d/<id>/...)",
+    "filename": "string? (filename hint for the output. Falls back to the name from Drive metadata.)",
+    "export_mime_type": "string? (for Google-native formats — Docs/Sheets/Slides — the MIME type to export to. Defaults to application/pdf. Use application/vnd.openxmlformats-officedocument.wordprocessingml.document for DOCX from a Google Doc.)"
+  },
+  "outputs": {
+    "temp_file_url": "string (file:// URL of the downloaded bytes on disk — pass this as file_url in the attachments array of email-send or email-reply)",
+    "filename": "string (filename of the downloaded file, with appropriate extension)",
+    "content_type": "string (MIME type of the downloaded/exported content)",
+    "size": "number (byte count after download)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 60000,
+  "capabilities": ["tempFileStore"]
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file add skills/drive-download-file/skill.json
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file commit -m "feat: drive-download-file skill manifest"
+```
+
+---
+
+## Task 4: Handler — input validation and URL extraction
+
+**Files:**
+- Create: `skills/drive-download-file/handler.ts` (partial — validation + extraction only)
+- Create: `skills/drive-download-file/handler.test.ts` (validation + extraction tests)
+
+- [ ] **Step 1: Write failing tests for input validation and URL extraction**
+
+Create `skills/drive-download-file/handler.test.ts`:
+
+```typescript
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { Readable } from 'node:stream';
+import type { SkillContext } from '../../src/skills/types.js';
+import { createSilentLogger } from '../../src/logger.js';
+import { MAX_TEMP_FILE_BYTES } from '../../src/skills/temp-file-store.js';
+
+// vi.hoisted ensures these are available inside the vi.mock factories,
+// which are hoisted before top-level variable declarations.
+const { mockFilesGet, mockFilesExport } = vi.hoisted(() => ({
+  mockFilesGet: vi.fn(),
+  mockFilesExport: vi.fn(),
+}));
+
+vi.mock('googleapis', () => ({
+  google: {
+    drive: vi.fn(() => ({ files: { get: mockFilesGet, export: mockFilesExport } })),
+  },
+}));
+
+vi.mock('../../src/google/drive-auth.js', () => ({
+  getDriveClient: vi.fn().mockResolvedValue({}),
+}));
+
+import { DriveDownloadFileHandler } from './handler.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReadable(content: Buffer): Readable {
+  return Readable.from([content]);
+}
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: { file_id_or_url: '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms' },
+    secret: () => { throw new Error('no secret in test'); },
+    log: createSilentLogger(),
+    writeTempFile: vi.fn().mockResolvedValue('file:///run/curia-tempfiles/abc123.pdf'),
+    taskMetadata: {},
+    taskEventId: undefined,
+    ...overrides,
+  } as unknown as SkillContext;
+}
+
+function setupMetadata(opts: { name: string; mimeType: string; size?: string | null }) {
+  mockFilesGet.mockResolvedValueOnce({
+    data: { name: opts.name, mimeType: opts.mimeType, size: opts.size ?? null },
+  });
+}
+
+function setupDownloadStream(content: Buffer) {
+  mockFilesGet.mockResolvedValueOnce({ data: makeReadable(content) });
+}
+
+function setupExportStream(content: Buffer) {
+  mockFilesExport.mockResolvedValueOnce({ data: makeReadable(content) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — input validation', () => {
+  it('returns error when writeTempFile is missing', async () => {
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx({ writeTempFile: undefined }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('tempFileStore');
+  });
+
+  it('returns error when file_id_or_url is missing', async () => {
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx({ input: {} }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('file_id_or_url');
+  });
+
+  it('returns error when file_id_or_url is empty string', async () => {
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx({ input: { file_id_or_url: '   ' } }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('file_id_or_url');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URL extraction — covered by ensuring metadata is fetched with correct ID
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — URL extraction', () => {
+  const pdfContent = Buffer.from('PDF bytes');
+
+  it('extracts file ID from /file/d/<id>/view URL', async () => {
+    setupMetadata({ name: 'doc.pdf', mimeType: 'application/pdf', size: '9' });
+    setupDownloadStream(pdfContent);
+    const handler = new DriveDownloadFileHandler();
+    await handler.execute(makeCtx({ input: { file_id_or_url: 'https://drive.google.com/file/d/FILE_ID_123/view' } }));
+    expect(mockFilesGet).toHaveBeenNthCalledWith(1, expect.objectContaining({ fileId: 'FILE_ID_123' }));
+  });
+
+  it('extracts file ID from ?id=<id> URL', async () => {
+    setupMetadata({ name: 'doc.pdf', mimeType: 'application/pdf', size: '9' });
+    setupDownloadStream(pdfContent);
+    const handler = new DriveDownloadFileHandler();
+    await handler.execute(makeCtx({ input: { file_id_or_url: 'https://drive.google.com/open?id=FILE_ID_456' } }));
+    expect(mockFilesGet).toHaveBeenNthCalledWith(1, expect.objectContaining({ fileId: 'FILE_ID_456' }));
+  });
+
+  it('treats a bare string as a raw file ID', async () => {
+    setupMetadata({ name: 'doc.pdf', mimeType: 'application/pdf', size: '9' });
+    setupDownloadStream(pdfContent);
+    const handler = new DriveDownloadFileHandler();
+    await handler.execute(makeCtx({ input: { file_id_or_url: 'RAW_FILE_ID' } }));
+    expect(mockFilesGet).toHaveBeenNthCalledWith(1, expect.objectContaining({ fileId: 'RAW_FILE_ID' }));
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect failures**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file run test skills/drive-download-file/handler.test.ts
+```
+
+Expected: module not found error (handler.ts doesn't exist yet).
+
+- [ ] **Step 3: Create `skills/drive-download-file/handler.ts` skeleton with validation + extraction**
+
+```typescript
+import { Readable } from 'node:stream';
+import { google } from 'googleapis';
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { MAX_TEMP_FILE_BYTES } from '../../src/skills/temp-file-store.js';
+import { getDriveClient } from '../../src/google/drive-auth.js';
+
+const GOOGLE_APPS_PREFIX = 'application/vnd.google-apps.';
+const DEFAULT_EXPORT_MIME = 'application/pdf';
+
+// Maps export MIME types to filename extensions for Google-native files.
+// Used to append a meaningful extension (e.g. .pdf) when Drive metadata
+// has no extension (Google Docs are typically named without one).
+const EXPORT_EXTENSIONS: Record<string, string> = {
+  'application/pdf': '.pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': '.pptx',
+  'text/plain': '.txt',
+  'text/csv': '.csv',
+};
+
+function extractFileId(fileIdOrUrl: string): string {
+  const trimmed = fileIdOrUrl.trim();
+  const pathMatch = /\/d\/([a-zA-Z0-9_-]+)/.exec(trimmed);
+  if (pathMatch) return pathMatch[1]!;
+  const queryMatch = /[?&]id=([a-zA-Z0-9_-]+)/.exec(trimmed);
+  if (queryMatch) return queryMatch[1]!;
+  return trimmed;
+}
+
+function resolveOutputFilename(
+  driveName: string,
+  hint: string | undefined,
+  isGoogleNative: boolean,
+  exportMime: string,
+): string {
+  if (hint) return hint;
+  if (!isGoogleNative) return driveName;
+  const ext = EXPORT_EXTENSIONS[exportMime] ?? '.pdf';
+  if (driveName.toLowerCase().endsWith(ext)) return driveName;
+  return driveName + ext;
+}
+
+async function streamToBuffer(stream: Readable, maxBytes: number): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+
+    stream.on('data', (chunk: Buffer) => {
+      totalBytes += chunk.length;
+      if (totalBytes > maxBytes) {
+        stream.destroy(new Error('SIZE_EXCEEDED'));
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    stream.on('end', () => resolve(Buffer.concat(chunks)));
+    stream.on('error', reject);
+  });
+}
+
+export class DriveDownloadFileHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.writeTempFile) {
+      return { success: false, error: 'drive-download-file requires tempFileStore capability' };
+    }
+
+    const input =
+      ctx.input && typeof ctx.input === 'object' ? (ctx.input as Record<string, unknown>) : {};
+    const { file_id_or_url: rawIdOrUrl, filename: rawFilename, export_mime_type: rawExportMime } =
+      input as { file_id_or_url?: string; filename?: string; export_mime_type?: string };
+
+    const rawInput = typeof rawIdOrUrl === 'string' ? rawIdOrUrl.trim() : '';
+    if (!rawInput) {
+      return { success: false, error: 'Missing required input: file_id_or_url' };
+    }
+
+    const fileId = extractFileId(rawInput);
+    const exportMime =
+      typeof rawExportMime === 'string' && rawExportMime.trim()
+        ? rawExportMime.trim()
+        : DEFAULT_EXPORT_MIME;
+    const filenameHint =
+      typeof rawFilename === 'string' && rawFilename.trim() ? rawFilename.trim() : undefined;
+
+    // Auth
+    let auth: Awaited<ReturnType<typeof getDriveClient>>;
+    try {
+      auth = await getDriveClient();
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    const drive = google.drive({ version: 'v3', auth });
+
+    // Metadata
+    let driveName: string;
+    let driveMimeType: string;
+    let declaredSize: number | null;
+    try {
+      const res = await drive.files.get({ fileId, fields: 'name,mimeType,size' });
+      driveName = res.data.name ?? fileId;
+      driveMimeType = res.data.mimeType ?? 'application/octet-stream';
+      declaredSize =
+        typeof res.data.size === 'string' ? parseInt(res.data.size, 10) : null;
+    } catch (err) {
+      const status = (err as { response?: { status?: number } }).response?.status;
+      if (status === 404) {
+        return {
+          success: false,
+          error: `Drive file ${fileId} not found or not shared with Curia`,
+        };
+      }
+      if (status === 403) {
+        return {
+          success: false,
+          error: `Curia does not have access to Drive file ${fileId}. Share it with Curia's Gmail address.`,
+        };
+      }
+      const detail = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        error: `Failed to fetch Drive file metadata for ${fileId}: ${detail}`,
+      };
+    }
+
+    const isGoogleNative = driveMimeType.startsWith(GOOGLE_APPS_PREFIX);
+    const outputFilename = resolveOutputFilename(driveName, filenameHint, isGoogleNative, exportMime);
+
+    // Pre-download size check for native binary files where metadata includes size
+    if (!isGoogleNative && declaredSize !== null && !Number.isNaN(declaredSize)) {
+      if (declaredSize > MAX_TEMP_FILE_BYTES) {
+        const sizeMB = (declaredSize / (1024 * 1024)).toFixed(1);
+        return {
+          success: false,
+          error: `Drive file "${driveName}" is ${sizeMB} MB — exceeds the 10 MB download limit`,
+        };
+      }
+    }
+
+    ctx.log.info(
+      { fileId, filename: outputFilename, mimeType: driveMimeType, isGoogleNative },
+      'drive-download-file: downloading',
+    );
+
+    // Download
+    let buffer: Buffer;
+    let contentType: string;
+    try {
+      if (isGoogleNative) {
+        const res = await drive.files.export(
+          { fileId, mimeType: exportMime },
+          { responseType: 'stream' },
+        );
+        buffer = await streamToBuffer(res.data as unknown as Readable, MAX_TEMP_FILE_BYTES);
+        contentType = exportMime;
+      } else {
+        const res = await drive.files.get(
+          { fileId, alt: 'media' },
+          { responseType: 'stream' },
+        );
+        buffer = await streamToBuffer(res.data as unknown as Readable, MAX_TEMP_FILE_BYTES);
+        contentType = driveMimeType;
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message === 'SIZE_EXCEEDED') {
+        return {
+          success: false,
+          error: `Drive file "${driveName}" exceeds the 10 MB download limit`,
+        };
+      }
+      const status = (err as { response?: { status?: number } }).response?.status;
+      if (status === 403) {
+        return {
+          success: false,
+          error: `Curia does not have access to Drive file ${fileId}. Share it with Curia's Gmail address.`,
+        };
+      }
+      const detail = err instanceof Error ? err.message : String(err);
+      return { success: false, error: `Failed to download Drive file "${driveName}": ${detail}` };
+    }
+
+    // TempFileStore write
+    let tempFileUrl: string;
+    try {
+      tempFileUrl = await ctx.writeTempFile(buffer, outputFilename);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, filename: outputFilename }, 'drive-download-file: writeTempFile failed');
+      return { success: false, error: `Failed to write Drive file to temp storage: ${detail}` };
+    }
+
+    return {
+      success: true,
+      data: {
+        temp_file_url: tempFileUrl,
+        filename: outputFilename,
+        content_type: contentType,
+        size: buffer.length,
+      },
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run the validation + URL extraction tests — expect pass**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file run test skills/drive-download-file/handler.test.ts
+```
+
+Expected: the 6 tests in `input validation` and `URL extraction` groups pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file add skills/drive-download-file/handler.ts skills/drive-download-file/handler.test.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file commit -m "feat: drive-download-file handler skeleton with input validation"
+```
+
+---
+
+## Task 5: Handler tests — metadata, download, export, errors
+
+These tests cover the rest of the handler behavior. The handler is already fully implemented from Task 4 Step 3, so these tests should pass immediately. Add them to `handler.test.ts` after the existing tests.
+
+- [ ] **Step 1: Add remaining tests to `skills/drive-download-file/handler.test.ts`**
+
+Append these `describe` blocks after the existing ones:
+
+```typescript
+// ---------------------------------------------------------------------------
+// Metadata errors
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — metadata errors', () => {
+  it('returns not-found error on 404', async () => {
+    mockFilesGet.mockRejectedValueOnce({ response: { status: 404 } });
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('not found or not shared');
+  });
+
+  it('returns access-denied error on 403', async () => {
+    mockFilesGet.mockRejectedValueOnce({ response: { status: 403 } });
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('does not have access');
+  });
+
+  it('returns error when getDriveClient throws (bad token cache)', async () => {
+    const { getDriveClient } = await import('../../src/google/drive-auth.js');
+    vi.mocked(getDriveClient).mockRejectedValueOnce(
+      new Error('Google OAuth token cache not found at /root/.google_workspace_mcp/credentials/curia@test.com.json. Complete the Drive auth setup (docs/dev/google-drive.md).'),
+    );
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('token cache not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre-download size check (declared size in metadata)
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — size pre-check', () => {
+  it('rejects before download when declared size exceeds 10 MB', async () => {
+    const oversizeBytes = (MAX_TEMP_FILE_BYTES + 1).toString();
+    setupMetadata({ name: 'huge.zip', mimeType: 'application/zip', size: oversizeBytes });
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('exceeds the 10 MB download limit');
+    // Drive download should NOT have been called
+    expect(mockFilesGet).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Successful native binary download
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — native binary download', () => {
+  it('downloads a PDF and returns temp_file_url, filename, content_type, size', async () => {
+    const pdfContent = Buffer.from('PDF content here');
+    setupMetadata({ name: 'report.pdf', mimeType: 'application/pdf', size: String(pdfContent.length) });
+    setupDownloadStream(pdfContent);
+
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+
+    expect(result.success).toBe(true);
+    const data = (result as { data: Record<string, unknown> }).data;
+    expect(data.temp_file_url).toBe('file:///run/curia-tempfiles/abc123.pdf');
+    expect(data.filename).toBe('report.pdf');
+    expect(data.content_type).toBe('application/pdf');
+    expect(data.size).toBe(pdfContent.length);
+  });
+
+  it('uses hint filename over Drive metadata name', async () => {
+    const content = Buffer.from('bytes');
+    setupMetadata({ name: 'original.pdf', mimeType: 'application/pdf', size: '5' });
+    setupDownloadStream(content);
+
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(
+      makeCtx({ input: { file_id_or_url: 'FILE_ID', filename: 'custom-name.pdf' } }),
+    );
+    const data = (result as { data: Record<string, unknown> }).data;
+    expect(data.filename).toBe('custom-name.pdf');
+  });
+
+  it('returns error when stream exceeds 10 MB (no declared size)', async () => {
+    setupMetadata({ name: 'sneaky.bin', mimeType: 'application/octet-stream', size: null });
+    // Stream that emits one chunk just over the limit
+    const bigChunk = Buffer.alloc(MAX_TEMP_FILE_BYTES + 1);
+    mockFilesGet.mockResolvedValueOnce({ data: makeReadable(bigChunk) });
+
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('10 MB download limit');
+  });
+
+  it('returns error when drive.files.get download throws', async () => {
+    setupMetadata({ name: 'file.pdf', mimeType: 'application/pdf', size: '100' });
+    mockFilesGet.mockRejectedValueOnce(new Error('Network error'));
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('Failed to download');
+    expect((result as { error: string }).error).toContain('Network error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Google-native export
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — Google-native export', () => {
+  it('exports a Google Doc to PDF by default and appends .pdf extension', async () => {
+    const pdfBytes = Buffer.from('exported PDF');
+    setupMetadata({ name: 'My Bio', mimeType: 'application/vnd.google-apps.document', size: null });
+    setupExportStream(pdfBytes);
+
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+
+    expect(result.success).toBe(true);
+    const data = (result as { data: Record<string, unknown> }).data;
+    expect(data.filename).toBe('My Bio.pdf');
+    expect(data.content_type).toBe('application/pdf');
+    expect(mockFilesExport).toHaveBeenCalledWith(
+      expect.objectContaining({ mimeType: 'application/pdf' }),
+      expect.objectContaining({ responseType: 'stream' }),
+    );
+  });
+
+  it('respects export_mime_type override (Doc → DOCX)', async () => {
+    const docxBytes = Buffer.from('DOCX content');
+    setupMetadata({ name: 'My Bio', mimeType: 'application/vnd.google-apps.document', size: null });
+    setupExportStream(docxBytes);
+
+    const docxMime = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(
+      makeCtx({ input: { file_id_or_url: 'FILE_ID', export_mime_type: docxMime } }),
+    );
+
+    const data = (result as { data: Record<string, unknown> }).data;
+    expect(data.filename).toBe('My Bio.docx');
+    expect(data.content_type).toBe(docxMime);
+  });
+
+  it('returns error when export stream exceeds 10 MB', async () => {
+    setupMetadata({ name: 'Big Doc', mimeType: 'application/vnd.google-apps.document', size: null });
+    const bigChunk = Buffer.alloc(MAX_TEMP_FILE_BYTES + 1);
+    mockFilesExport.mockResolvedValueOnce({ data: makeReadable(bigChunk) });
+
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('10 MB download limit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeTempFile failure
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — writeTempFile failure', () => {
+  it('returns error when writeTempFile throws', async () => {
+    const content = Buffer.from('PDF');
+    setupMetadata({ name: 'file.pdf', mimeType: 'application/pdf', size: '3' });
+    setupDownloadStream(content);
+
+    const failingWriteTempFile = vi.fn().mockRejectedValue(new Error('disk full'));
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx({ writeTempFile: failingWriteTempFile }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('temp storage');
+    expect((result as { error: string }).error).toContain('disk full');
+  });
+});
+```
+
+- [ ] **Step 2: Run all handler tests — expect all to pass**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file run test skills/drive-download-file/handler.test.ts
+```
+
+Expected: all tests pass (handler was fully implemented in Task 4).
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file run typecheck
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file add skills/drive-download-file/handler.test.ts skills/drive-download-file/handler.ts
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file commit -m "feat: drive-download-file handler with full test coverage"
+```
+
+---
+
+## Task 6: Wire coordinator
+
+**Files:**
+- Modify: `agents/coordinator.yaml`
+
+The coordinator's Drive section currently ends at line ~477 (after the `create_drive_file` guidance). The `pinned_skills` Drive block starts around line 580.
+
+- [ ] **Step 1: Add workflow note to the `## Google Workspace` section**
+
+In `agents/coordinator.yaml`, after the paragraph ending with `Do NOT claim success.` (the `create_drive_file` failure paragraph, around line 477), add a new paragraph:
+
+```yaml
+  **Attaching a Drive file to an email:** When the CEO asks you to send an email
+  with a Drive file attached, use this sequence:
+  1. If you only have a file name (not an ID or URL), call search_drive_files first.
+  2. Call drive-download-file with the file ID or Drive URL. It returns a temp_file_url.
+  3. Pass temp_file_url in the attachments array of email-send or email-reply,
+     using the returned filename and content_type fields.
+
+  Do NOT use get_drive_file_content for attachments — it returns text only and
+  cannot produce binary-safe attachments.
+```
+
+- [ ] **Step 2: Pin the skill**
+
+In `agents/coordinator.yaml`, in the `pinned_skills` section after `get_drive_shareable_link` (around line 590), add:
+
+```yaml
+  - drive-download-file
+```
+
+- [ ] **Step 3: Bump coordinator version**
+
+The coordinator YAML has a `version` field. Bump the minor version (new pinned skill = new capability per CLAUDE.md versioning rules). Find the current version with:
+
+```bash
+grep "^version:" /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file/agents/coordinator.yaml
+```
+
+Then edit the `version:` line to the next minor version (e.g. `0.14.0` → `0.15.0`).
+
+- [ ] **Step 4: Run full test suite to verify no regressions**
+
+```bash
+pnpm --prefix /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file run test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file add agents/coordinator.yaml
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file commit -m "feat: pin drive-download-file to coordinator and add Drive-to-email workflow note"
+```
+
+---
+
+## Task 7: CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add entry under `## [Unreleased]`**
+
+Open `CHANGELOG.md` and add under the `## [Unreleased]` heading:
+
+```markdown
+### Added
+- **`drive-download-file`** — new skill that downloads a Google Drive file (native or Google-native export) to TempFileStore and returns a `file://` URL, enabling Drive files to be attached to outbound emails. Closes #857.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file add CHANGELOG.md
+git -C /Users/josephfung/Projects/office-of-the-ceo/repos/worktrees/curia-drive-download-file commit -m "chore: changelog entry for drive-download-file"
+```

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "cytoscape": "^3.33.4",
     "cytoscape-fcose": "^2.2.0",
     "fastify": "^5.8.5",
+    "googleapis": "^173.0.0",
     "js-yaml": "^4.2.0",
     "layout-base": "^2.0.1",
     "luxon": "^3.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       fastify:
         specifier: ^5.8.5
         version: 5.8.5
+      googleapis:
+        specifier: ^173.0.0
+        version: 173.0.0
       js-yaml:
         specifier: ^4.2.0
         version: 4.2.0
@@ -3418,6 +3421,10 @@ packages:
   googleapis-common@8.0.1:
     resolution: {integrity: sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==}
     engines: {node: '>=18.0.0'}
+
+  googleapis@173.0.0:
+    resolution: {integrity: sha512-xEJJYLZ4qeenVyfzispNfRjCe9bsv7CzBv5zYFLvScOze9snJ8S9W6hjQ729CWPQt5mvn/JrcRaCHzQiukt0ng==}
+    engines: {node: '>=18'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -7741,8 +7748,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  base64-js@1.5.1:
-    optional: true
+  base64-js@1.5.1: {}
 
   base64id@2.0.0: {}
 
@@ -7791,8 +7797,7 @@ snapshots:
   bson@7.2.0:
     optional: true
 
-  buffer-equal-constant-time@1.0.1:
-    optional: true
+  buffer-equal-constant-time@1.0.1: {}
 
   bundle-name@4.1.0:
     dependencies:
@@ -8171,7 +8176,6 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   editions@6.22.0:
     dependencies:
@@ -8789,7 +8793,6 @@ snapshots:
       jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   google-logging-utils@1.1.3: {}
 
@@ -8802,7 +8805,13 @@ snapshots:
       url-template: 2.0.8
     transitivePeerDependencies:
       - supports-color
-    optional: true
+
+  googleapis@173.0.0:
+    dependencies:
+      google-auth-library: 10.6.2
+      googleapis-common: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   gopd@1.2.0: {}
 
@@ -9085,13 +9094,11 @@ snapshots:
       buffer-equal-constant-time: 1.0.1
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
-    optional: true
 
   jws@4.0.1:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
-    optional: true
 
   kareem@3.3.0:
     optional: true
@@ -10806,8 +10813,7 @@ snapshots:
       requires-port: 1.0.0
     optional: true
 
-  url-template@2.0.8:
-    optional: true
+  url-template@2.0.8: {}
 
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:

--- a/skills/drive-download-file/handler.test.ts
+++ b/skills/drive-download-file/handler.test.ts
@@ -1,0 +1,121 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { Readable } from 'node:stream';
+import type { SkillContext } from '../../src/skills/types.js';
+import { createSilentLogger } from '../../src/logger.js';
+import { MAX_TEMP_FILE_BYTES } from '../../src/skills/temp-file-store.js';
+
+// vi.hoisted ensures these are available inside the vi.mock factories,
+// which are hoisted before top-level variable declarations.
+const { mockFilesGet, mockFilesExport } = vi.hoisted(() => ({
+  mockFilesGet: vi.fn(),
+  mockFilesExport: vi.fn(),
+}));
+
+vi.mock('googleapis', () => ({
+  google: {
+    drive: vi.fn(() => ({ files: { get: mockFilesGet, export: mockFilesExport } })),
+  },
+}));
+
+vi.mock('../../src/google/drive-auth.js', () => ({
+  getDriveClient: vi.fn().mockResolvedValue({}),
+}));
+
+import { DriveDownloadFileHandler } from './handler.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReadable(content: Buffer): Readable {
+  return Readable.from([content]);
+}
+
+function makeCtx(overrides?: Partial<SkillContext>): SkillContext {
+  return {
+    input: { file_id_or_url: '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms' },
+    secret: () => { throw new Error('no secret in test'); },
+    log: createSilentLogger(),
+    writeTempFile: vi.fn().mockResolvedValue('file:///run/curia-tempfiles/abc123.pdf'),
+    taskMetadata: {},
+    taskEventId: undefined,
+    ...overrides,
+  } as unknown as SkillContext;
+}
+
+function setupMetadata(opts: { name: string; mimeType: string; size?: string | null }) {
+  mockFilesGet.mockResolvedValueOnce({
+    data: { name: opts.name, mimeType: opts.mimeType, size: opts.size ?? null },
+  });
+}
+
+function setupDownloadStream(content: Buffer) {
+  mockFilesGet.mockResolvedValueOnce({ data: makeReadable(content) });
+}
+
+function setupExportStream(content: Buffer) {
+  mockFilesExport.mockResolvedValueOnce({ data: makeReadable(content) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — input validation', () => {
+  it('returns error when writeTempFile is missing', async () => {
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx({ writeTempFile: undefined }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('tempFileStore');
+  });
+
+  it('returns error when file_id_or_url is missing', async () => {
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx({ input: {} }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('file_id_or_url');
+  });
+
+  it('returns error when file_id_or_url is empty string', async () => {
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx({ input: { file_id_or_url: '   ' } }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('file_id_or_url');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URL extraction — covered by ensuring metadata is fetched with correct ID
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — URL extraction', () => {
+  const pdfContent = Buffer.from('PDF bytes');
+
+  it('extracts file ID from /file/d/<id>/view URL', async () => {
+    setupMetadata({ name: 'doc.pdf', mimeType: 'application/pdf', size: '9' });
+    setupDownloadStream(pdfContent);
+    const handler = new DriveDownloadFileHandler();
+    await handler.execute(makeCtx({ input: { file_id_or_url: 'https://drive.google.com/file/d/FILE_ID_123/view' } }));
+    expect(mockFilesGet).toHaveBeenNthCalledWith(1, expect.objectContaining({ fileId: 'FILE_ID_123' }));
+  });
+
+  it('extracts file ID from ?id=<id> URL', async () => {
+    setupMetadata({ name: 'doc.pdf', mimeType: 'application/pdf', size: '9' });
+    setupDownloadStream(pdfContent);
+    const handler = new DriveDownloadFileHandler();
+    await handler.execute(makeCtx({ input: { file_id_or_url: 'https://drive.google.com/open?id=FILE_ID_456' } }));
+    expect(mockFilesGet).toHaveBeenNthCalledWith(1, expect.objectContaining({ fileId: 'FILE_ID_456' }));
+  });
+
+  it('treats a bare string as a raw file ID', async () => {
+    setupMetadata({ name: 'doc.pdf', mimeType: 'application/pdf', size: '9' });
+    setupDownloadStream(pdfContent);
+    const handler = new DriveDownloadFileHandler();
+    await handler.execute(makeCtx({ input: { file_id_or_url: 'RAW_FILE_ID' } }));
+    expect(mockFilesGet).toHaveBeenNthCalledWith(1, expect.objectContaining({ fileId: 'RAW_FILE_ID' }));
+  });
+});

--- a/skills/drive-download-file/handler.test.ts
+++ b/skills/drive-download-file/handler.test.ts
@@ -119,3 +119,180 @@ describe('DriveDownloadFileHandler — URL extraction', () => {
     expect(mockFilesGet).toHaveBeenNthCalledWith(1, expect.objectContaining({ fileId: 'RAW_FILE_ID' }));
   });
 });
+
+// ---------------------------------------------------------------------------
+// Metadata errors
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — metadata errors', () => {
+  it('returns not-found error on 404', async () => {
+    mockFilesGet.mockRejectedValueOnce({ response: { status: 404 } });
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('not found or not shared');
+  });
+
+  it('returns access-denied error on 403', async () => {
+    mockFilesGet.mockRejectedValueOnce({ response: { status: 403 } });
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('does not have access');
+  });
+
+  it('returns error when getDriveClient throws (bad token cache)', async () => {
+    const { getDriveClient } = await import('../../src/google/drive-auth.js');
+    vi.mocked(getDriveClient).mockRejectedValueOnce(
+      new Error('Google OAuth token cache not found at /root/.google_workspace_mcp/credentials/curia@test.com.json. Complete the Drive auth setup (docs/dev/google-drive.md).'),
+    );
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('token cache not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre-download size check (declared size in metadata)
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — size pre-check', () => {
+  it('rejects before download when declared size exceeds 10 MB', async () => {
+    const oversizeBytes = (MAX_TEMP_FILE_BYTES + 1).toString();
+    setupMetadata({ name: 'huge.zip', mimeType: 'application/zip', size: oversizeBytes });
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('exceeds the 10 MB download limit');
+    // Drive download should NOT have been called (only 1 call: metadata)
+    expect(mockFilesGet).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Successful native binary download
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — native binary download', () => {
+  it('downloads a PDF and returns temp_file_url, filename, content_type, size', async () => {
+    const pdfContent = Buffer.from('PDF content here');
+    setupMetadata({ name: 'report.pdf', mimeType: 'application/pdf', size: String(pdfContent.length) });
+    setupDownloadStream(pdfContent);
+
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+
+    expect(result.success).toBe(true);
+    const data = (result as { data: Record<string, unknown> }).data;
+    expect(data.temp_file_url).toBe('file:///run/curia-tempfiles/abc123.pdf');
+    expect(data.filename).toBe('report.pdf');
+    expect(data.content_type).toBe('application/pdf');
+    expect(data.size).toBe(pdfContent.length);
+  });
+
+  it('uses hint filename over Drive metadata name', async () => {
+    const content = Buffer.from('bytes');
+    setupMetadata({ name: 'original.pdf', mimeType: 'application/pdf', size: '5' });
+    setupDownloadStream(content);
+
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(
+      makeCtx({ input: { file_id_or_url: 'FILE_ID', filename: 'custom-name.pdf' } }),
+    );
+    const data = (result as { data: Record<string, unknown> }).data;
+    expect(data.filename).toBe('custom-name.pdf');
+  });
+
+  it('returns error when stream exceeds 10 MB (no declared size)', async () => {
+    setupMetadata({ name: 'sneaky.bin', mimeType: 'application/octet-stream', size: null });
+    // Stream that emits one chunk just over the limit
+    const bigChunk = Buffer.alloc(MAX_TEMP_FILE_BYTES + 1);
+    mockFilesGet.mockResolvedValueOnce({ data: makeReadable(bigChunk) });
+
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('10 MB download limit');
+  });
+
+  it('returns error when drive.files.get download throws', async () => {
+    setupMetadata({ name: 'file.pdf', mimeType: 'application/pdf', size: '100' });
+    mockFilesGet.mockRejectedValueOnce(new Error('Network error'));
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('Failed to download');
+    expect((result as { error: string }).error).toContain('Network error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Google-native export
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — Google-native export', () => {
+  it('exports a Google Doc to PDF by default and appends .pdf extension', async () => {
+    const pdfBytes = Buffer.from('exported PDF');
+    setupMetadata({ name: 'My Bio', mimeType: 'application/vnd.google-apps.document', size: null });
+    setupExportStream(pdfBytes);
+
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+
+    expect(result.success).toBe(true);
+    const data = (result as { data: Record<string, unknown> }).data;
+    expect(data.filename).toBe('My Bio.pdf');
+    expect(data.content_type).toBe('application/pdf');
+    expect(mockFilesExport).toHaveBeenCalledWith(
+      expect.objectContaining({ mimeType: 'application/pdf' }),
+      expect.objectContaining({ responseType: 'stream' }),
+    );
+  });
+
+  it('respects export_mime_type override (Doc → DOCX)', async () => {
+    const docxBytes = Buffer.from('DOCX content');
+    setupMetadata({ name: 'My Bio', mimeType: 'application/vnd.google-apps.document', size: null });
+    setupExportStream(docxBytes);
+
+    const docxMime = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(
+      makeCtx({ input: { file_id_or_url: 'FILE_ID', export_mime_type: docxMime } }),
+    );
+
+    const data = (result as { data: Record<string, unknown> }).data;
+    expect(data.filename).toBe('My Bio.docx');
+    expect(data.content_type).toBe(docxMime);
+  });
+
+  it('returns error when export stream exceeds 10 MB', async () => {
+    setupMetadata({ name: 'Big Doc', mimeType: 'application/vnd.google-apps.document', size: null });
+    const bigChunk = Buffer.alloc(MAX_TEMP_FILE_BYTES + 1);
+    mockFilesExport.mockResolvedValueOnce({ data: makeReadable(bigChunk) });
+
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx());
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('10 MB download limit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeTempFile failure
+// ---------------------------------------------------------------------------
+
+describe('DriveDownloadFileHandler — writeTempFile failure', () => {
+  it('returns error when writeTempFile throws', async () => {
+    const content = Buffer.from('PDF');
+    setupMetadata({ name: 'file.pdf', mimeType: 'application/pdf', size: '3' });
+    setupDownloadStream(content);
+
+    const failingWriteTempFile = vi.fn().mockRejectedValue(new Error('disk full'));
+    const handler = new DriveDownloadFileHandler();
+    const result = await handler.execute(makeCtx({ writeTempFile: failingWriteTempFile }));
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain('temp storage');
+    expect((result as { error: string }).error).toContain('disk full');
+  });
+});

--- a/skills/drive-download-file/handler.ts
+++ b/skills/drive-download-file/handler.ts
@@ -118,7 +118,7 @@ export class DriveDownloadFileHandler implements SkillHandler {
     let driveMimeType: string;
     let declaredSize: number | null;
     try {
-      const res = await drive.files.get({ fileId, fields: 'name,mimeType,size' });
+      const res = await drive.files.get({ fileId, fields: 'name,mimeType,size', supportsAllDrives: true });
       driveName = res.data.name ?? fileId;
       driveMimeType = res.data.mimeType ?? 'application/octet-stream';
       declaredSize =
@@ -170,14 +170,14 @@ export class DriveDownloadFileHandler implements SkillHandler {
     try {
       if (isGoogleNative) {
         const res = await drive.files.export(
-          { fileId, mimeType: exportMime },
+          { fileId, mimeType: exportMime, supportsAllDrives: true },
           { responseType: 'stream' },
         );
         buffer = await streamToBuffer(res.data as unknown as Readable, MAX_TEMP_FILE_BYTES);
         contentType = exportMime;
       } else {
         const res = await drive.files.get(
-          { fileId, alt: 'media' },
+          { fileId, alt: 'media', supportsAllDrives: true },
           { responseType: 'stream' },
         );
         buffer = await streamToBuffer(res.data as unknown as Readable, MAX_TEMP_FILE_BYTES);

--- a/skills/drive-download-file/handler.ts
+++ b/skills/drive-download-file/handler.ts
@@ -1,0 +1,204 @@
+import { Readable } from 'node:stream';
+import { google } from 'googleapis';
+import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
+import { MAX_TEMP_FILE_BYTES } from '../../src/skills/temp-file-store.js';
+import { getDriveClient } from '../../src/google/drive-auth.js';
+
+const GOOGLE_APPS_PREFIX = 'application/vnd.google-apps.';
+const DEFAULT_EXPORT_MIME = 'application/pdf';
+
+// Maps export MIME types to filename extensions for Google-native files.
+// Used to append a meaningful extension (e.g. .pdf) when Drive metadata
+// has no extension (Google Docs are typically named without one).
+const EXPORT_EXTENSIONS: Record<string, string> = {
+  'application/pdf': '.pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': '.pptx',
+  'text/plain': '.txt',
+  'text/csv': '.csv',
+};
+
+function extractFileId(fileIdOrUrl: string): string {
+  const trimmed = fileIdOrUrl.trim();
+  const pathMatch = /\/d\/([a-zA-Z0-9_-]+)/.exec(trimmed);
+  if (pathMatch) return pathMatch[1]!;
+  const queryMatch = /[?&]id=([a-zA-Z0-9_-]+)/.exec(trimmed);
+  if (queryMatch) return queryMatch[1]!;
+  return trimmed;
+}
+
+function resolveOutputFilename(
+  driveName: string,
+  hint: string | undefined,
+  isGoogleNative: boolean,
+  exportMime: string,
+): string {
+  if (hint) return hint;
+  if (!isGoogleNative) return driveName;
+  const ext = EXPORT_EXTENSIONS[exportMime] ?? '.pdf';
+  if (driveName.toLowerCase().endsWith(ext)) return driveName;
+  return driveName + ext;
+}
+
+async function streamToBuffer(stream: Readable, maxBytes: number): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+
+    stream.on('data', (chunk: Buffer) => {
+      totalBytes += chunk.length;
+      if (totalBytes > maxBytes) {
+        stream.destroy(new Error('SIZE_EXCEEDED'));
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    stream.on('end', () => resolve(Buffer.concat(chunks)));
+    stream.on('error', reject);
+  });
+}
+
+export class DriveDownloadFileHandler implements SkillHandler {
+  async execute(ctx: SkillContext): Promise<SkillResult> {
+    if (!ctx.writeTempFile) {
+      return { success: false, error: 'drive-download-file requires tempFileStore capability' };
+    }
+
+    const input =
+      ctx.input && typeof ctx.input === 'object' ? (ctx.input as Record<string, unknown>) : {};
+    const { file_id_or_url: rawIdOrUrl, filename: rawFilename, export_mime_type: rawExportMime } =
+      input as { file_id_or_url?: string; filename?: string; export_mime_type?: string };
+
+    const rawInput = typeof rawIdOrUrl === 'string' ? rawIdOrUrl.trim() : '';
+    if (!rawInput) {
+      return { success: false, error: 'Missing required input: file_id_or_url' };
+    }
+
+    const fileId = extractFileId(rawInput);
+    const exportMime =
+      typeof rawExportMime === 'string' && rawExportMime.trim()
+        ? rawExportMime.trim()
+        : DEFAULT_EXPORT_MIME;
+    const filenameHint =
+      typeof rawFilename === 'string' && rawFilename.trim() ? rawFilename.trim() : undefined;
+
+    // Auth
+    let auth: Awaited<ReturnType<typeof getDriveClient>>;
+    try {
+      auth = await getDriveClient();
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    const drive = google.drive({ version: 'v3', auth });
+
+    // Metadata
+    let driveName: string;
+    let driveMimeType: string;
+    let declaredSize: number | null;
+    try {
+      const res = await drive.files.get({ fileId, fields: 'name,mimeType,size' });
+      driveName = res.data.name ?? fileId;
+      driveMimeType = res.data.mimeType ?? 'application/octet-stream';
+      declaredSize =
+        typeof res.data.size === 'string' ? parseInt(res.data.size, 10) : null;
+    } catch (err) {
+      const status = (err as { response?: { status?: number } }).response?.status;
+      if (status === 404) {
+        return {
+          success: false,
+          error: `Drive file ${fileId} not found or not shared with Curia`,
+        };
+      }
+      if (status === 403) {
+        return {
+          success: false,
+          error: `Curia does not have access to Drive file ${fileId}. Share it with Curia's Gmail address.`,
+        };
+      }
+      const detail = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        error: `Failed to fetch Drive file metadata for ${fileId}: ${detail}`,
+      };
+    }
+
+    const isGoogleNative = driveMimeType.startsWith(GOOGLE_APPS_PREFIX);
+    const outputFilename = resolveOutputFilename(driveName, filenameHint, isGoogleNative, exportMime);
+
+    // Pre-download size check for native binary files where metadata includes size
+    if (!isGoogleNative && declaredSize !== null && !Number.isNaN(declaredSize)) {
+      if (declaredSize > MAX_TEMP_FILE_BYTES) {
+        const sizeMB = (declaredSize / (1024 * 1024)).toFixed(1);
+        return {
+          success: false,
+          error: `Drive file "${driveName}" is ${sizeMB} MB — exceeds the 10 MB download limit`,
+        };
+      }
+    }
+
+    ctx.log.info(
+      { fileId, filename: outputFilename, mimeType: driveMimeType, isGoogleNative },
+      'drive-download-file: downloading',
+    );
+
+    // Download
+    let buffer: Buffer;
+    let contentType: string;
+    try {
+      if (isGoogleNative) {
+        const res = await drive.files.export(
+          { fileId, mimeType: exportMime },
+          { responseType: 'stream' },
+        );
+        buffer = await streamToBuffer(res.data as unknown as Readable, MAX_TEMP_FILE_BYTES);
+        contentType = exportMime;
+      } else {
+        const res = await drive.files.get(
+          { fileId, alt: 'media' },
+          { responseType: 'stream' },
+        );
+        buffer = await streamToBuffer(res.data as unknown as Readable, MAX_TEMP_FILE_BYTES);
+        contentType = driveMimeType;
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message === 'SIZE_EXCEEDED') {
+        return {
+          success: false,
+          error: `Drive file "${driveName}" exceeds the 10 MB download limit`,
+        };
+      }
+      const status = (err as { response?: { status?: number } }).response?.status;
+      if (status === 403) {
+        return {
+          success: false,
+          error: `Curia does not have access to Drive file ${fileId}. Share it with Curia's Gmail address.`,
+        };
+      }
+      const detail = err instanceof Error ? err.message : String(err);
+      return { success: false, error: `Failed to download Drive file "${driveName}": ${detail}` };
+    }
+
+    // TempFileStore write
+    let tempFileUrl: string;
+    try {
+      tempFileUrl = await ctx.writeTempFile(buffer, outputFilename);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, filename: outputFilename }, 'drive-download-file: writeTempFile failed');
+      return { success: false, error: `Failed to write Drive file to temp storage: ${detail}` };
+    }
+
+    return {
+      success: true,
+      data: {
+        temp_file_url: tempFileUrl,
+        filename: outputFilename,
+        content_type: contentType,
+        size: buffer.length,
+      },
+    };
+  }
+}

--- a/skills/drive-download-file/handler.ts
+++ b/skills/drive-download-file/handler.ts
@@ -46,6 +46,14 @@ async function streamToBuffer(stream: Readable, maxBytes: number): Promise<Buffe
     const chunks: Buffer[] = [];
     let totalBytes = 0;
     let destroyed = false;
+    let settled = false;
+
+    const settle = (fn: () => void) => {
+      if (!settled) {
+        settled = true;
+        fn();
+      }
+    };
 
     stream.on('data', (chunk: Buffer) => {
       totalBytes += chunk.length;
@@ -57,10 +65,13 @@ async function streamToBuffer(stream: Readable, maxBytes: number): Promise<Buffe
       chunks.push(chunk);
     });
 
-    stream.on('end', () => {
-      if (!destroyed) resolve(Buffer.concat(chunks));
+    stream.on('end', () => { settle(() => resolve(Buffer.concat(chunks))); });
+    stream.on('error', (err) => { settle(() => reject(err)); });
+    // Some stream implementations (Axios/http) emit 'close' instead of 'error'
+    // after destroy() — ensure the promise always settles.
+    stream.on('close', () => {
+      if (destroyed) settle(() => reject(new Error('SIZE_EXCEEDED')));
     });
-    stream.on('error', reject);
   });
 }
 

--- a/skills/drive-download-file/handler.ts
+++ b/skills/drive-download-file/handler.ts
@@ -45,17 +45,21 @@ async function streamToBuffer(stream: Readable, maxBytes: number): Promise<Buffe
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     let totalBytes = 0;
+    let destroyed = false;
 
     stream.on('data', (chunk: Buffer) => {
       totalBytes += chunk.length;
       if (totalBytes > maxBytes) {
+        destroyed = true;
         stream.destroy(new Error('SIZE_EXCEEDED'));
         return;
       }
       chunks.push(chunk);
     });
 
-    stream.on('end', () => resolve(Buffer.concat(chunks)));
+    stream.on('end', () => {
+      if (!destroyed) resolve(Buffer.concat(chunks));
+    });
     stream.on('error', reject);
   });
 }

--- a/skills/drive-download-file/handler.ts
+++ b/skills/drive-download-file/handler.ts
@@ -65,7 +65,10 @@ async function streamToBuffer(stream: Readable, maxBytes: number): Promise<Buffe
       chunks.push(chunk);
     });
 
-    stream.on('end', () => { settle(() => resolve(Buffer.concat(chunks))); });
+    stream.on('end', () => {
+      if (destroyed) return;
+      settle(() => resolve(Buffer.concat(chunks)));
+    });
     stream.on('error', (err) => { settle(() => reject(err)); });
     // Some stream implementations (Axios/http) emit 'close' instead of 'error'
     // after destroy() — ensure the promise always settles.
@@ -104,6 +107,7 @@ export class DriveDownloadFileHandler implements SkillHandler {
     try {
       auth = await getDriveClient();
     } catch (err) {
+      ctx.log.error({ err }, 'drive-download-file: getDriveClient failed');
       return { success: false, error: err instanceof Error ? err.message : String(err) };
     }
 
@@ -134,6 +138,7 @@ export class DriveDownloadFileHandler implements SkillHandler {
         };
       }
       const detail = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, fileId }, 'drive-download-file: metadata fetch failed');
       return {
         success: false,
         error: `Failed to fetch Drive file metadata for ${fileId}: ${detail}`,
@@ -193,6 +198,7 @@ export class DriveDownloadFileHandler implements SkillHandler {
         };
       }
       const detail = err instanceof Error ? err.message : String(err);
+      ctx.log.error({ err, fileId, filename: outputFilename }, 'drive-download-file: download failed');
       return { success: false, error: `Failed to download Drive file "${driveName}": ${detail}` };
     }
 

--- a/skills/drive-download-file/skill.json
+++ b/skills/drive-download-file/skill.json
@@ -1,0 +1,22 @@
+{
+  "name": "drive-download-file",
+  "description": "Download a file from Google Drive to temporary storage and return a file:// URL for use with email-send or email-reply attachments. Accepts a Drive file ID or any drive.google.com / docs.google.com URL. Google Docs/Sheets/Slides are exported to PDF by default; pass export_mime_type to override. Pass the returned temp_file_url in the attachments array of email-send or email-reply.",
+  "version": "0.1.0",
+  "sensitivity": "normal",
+  "action_risk": "none",
+  "inputs": {
+    "file_id_or_url": "string (Google Drive file ID or full Drive URL — drive.google.com/file/d/<id>/..., drive.google.com/open?id=<id>, drive.google.com/uc?id=<id>, docs.google.com/document/d/<id>/..., docs.google.com/spreadsheets/d/<id>/..., docs.google.com/presentation/d/<id>/...)",
+    "filename": "string? (filename hint for the output. Falls back to the name from Drive metadata.)",
+    "export_mime_type": "string? (for Google-native formats — Docs/Sheets/Slides — the MIME type to export to. Defaults to application/pdf. Use application/vnd.openxmlformats-officedocument.wordprocessingml.document for DOCX from a Google Doc.)"
+  },
+  "outputs": {
+    "temp_file_url": "string (file:// URL of the downloaded bytes on disk — pass this as file_url in the attachments array of email-send or email-reply)",
+    "filename": "string (filename of the downloaded file, with appropriate extension)",
+    "content_type": "string (MIME type of the downloaded/exported content)",
+    "size": "number (byte count after download)"
+  },
+  "permissions": [],
+  "secrets": [],
+  "timeout": 60000,
+  "capabilities": ["tempFileStore"]
+}

--- a/skills/drive-download-file/skill.json
+++ b/skills/drive-download-file/skill.json
@@ -16,7 +16,11 @@
     "size": "number (byte count after download)"
   },
   "permissions": [],
-  "secrets": [],
+  "secrets": [
+    "GOOGLE_OAUTH_CLIENT_ID",
+    "GOOGLE_OAUTH_CLIENT_SECRET",
+    "CURIA_GOOGLE_EMAIL"
+  ],
   "timeout": 60000,
   "capabilities": ["tempFileStore"]
 }

--- a/src/google/drive-auth.test.ts
+++ b/src/google/drive-auth.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { getDriveClient, clearDriveClientCache } from './drive-auth.js';
+
+// Prevent real OAuth2 construction — we only test token loading logic.
+vi.mock('googleapis', () => ({
+  google: {
+    auth: {
+      OAuth2: vi.fn().mockImplementation(function (clientId: string, clientSecret: string) {
+        return {
+          clientId,
+          clientSecret,
+          setCredentials: vi.fn(),
+        };
+      }),
+    },
+  },
+}));
+
+let tmpDir: string;
+let tokenCachePath: string;
+
+const validTokenJson = JSON.stringify({
+  refresh_token: 'test-refresh-token',
+  token: 'test-access-token',
+  token_uri: 'https://oauth2.googleapis.com/token',
+});
+
+beforeEach(async () => {
+  clearDriveClientCache();
+  process.env.GOOGLE_OAUTH_CLIENT_ID = 'test-client-id';
+  process.env.GOOGLE_OAUTH_CLIENT_SECRET = 'test-client-secret';
+  process.env.CURIA_GOOGLE_EMAIL = 'curia@test.com';
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drive-auth-test-'));
+  tokenCachePath = path.join(tmpDir, 'tokens.json');
+});
+
+afterEach(async () => {
+  clearDriveClientCache();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  delete process.env.GOOGLE_OAUTH_CLIENT_ID;
+  delete process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  delete process.env.CURIA_GOOGLE_EMAIL;
+});
+
+describe('getDriveClient — env var validation', () => {
+  it('throws when GOOGLE_OAUTH_CLIENT_ID is missing', async () => {
+    delete process.env.GOOGLE_OAUTH_CLIENT_ID;
+    await expect(getDriveClient({ tokenCachePath })).rejects.toThrow('GOOGLE_OAUTH_CLIENT_ID');
+  });
+
+  it('throws when GOOGLE_OAUTH_CLIENT_SECRET is missing', async () => {
+    delete process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+    await expect(getDriveClient({ tokenCachePath })).rejects.toThrow('GOOGLE_OAUTH_CLIENT_SECRET');
+  });
+
+  it('throws when CURIA_GOOGLE_EMAIL is missing', async () => {
+    delete process.env.CURIA_GOOGLE_EMAIL;
+    await expect(getDriveClient({ tokenCachePath })).rejects.toThrow('CURIA_GOOGLE_EMAIL');
+  });
+});
+
+describe('getDriveClient — token cache', () => {
+  it('throws with setup instructions when cache file is missing', async () => {
+    const err = await getDriveClient({ tokenCachePath: '/nonexistent/path.json' }).then(
+      () => { throw new Error('expected rejection'); },
+      (e: unknown) => e as Error,
+    );
+    expect(err.message).toContain('token cache not found');
+    expect(err.message).toContain('docs/dev/google-drive.md');
+  });
+
+  it('throws when refresh_token is absent from cache', async () => {
+    await fs.writeFile(tokenCachePath, JSON.stringify({ token: 'access-only' }));
+    await expect(getDriveClient({ tokenCachePath })).rejects.toThrow('missing refresh_token');
+  });
+
+  it('returns an OAuth2Client with setCredentials called on success', async () => {
+    await fs.writeFile(tokenCachePath, validTokenJson);
+    const client = await getDriveClient({ tokenCachePath });
+    expect(client).toBeDefined();
+    expect((client as unknown as { setCredentials: ReturnType<typeof vi.fn> }).setCredentials)
+      .toHaveBeenCalledWith({ refresh_token: 'test-refresh-token' });
+  });
+
+  it('returns cached client on subsequent calls (reads file only once)', async () => {
+    await fs.writeFile(tokenCachePath, validTokenJson);
+    const a = await getDriveClient({ tokenCachePath });
+    const b = await getDriveClient({ tokenCachePath });
+    expect(a).toBe(b);
+  });
+});

--- a/src/google/drive-auth.ts
+++ b/src/google/drive-auth.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { google } from 'googleapis';
 
@@ -10,6 +11,7 @@ export interface DriveAuthOptions {
   tokenCachePath?: string;
   clientId?: string;
   clientSecret?: string;
+  /** Used to locate the token cache file, not passed to OAuth. */
   email?: string;
 }
 
@@ -29,7 +31,7 @@ export async function getDriveClient(
   const tokenCachePath =
     options?.tokenCachePath ??
     path.join(
-      process.env.HOME ?? '/root',
+      os.homedir(),
       '.google_workspace_mcp',
       'credentials',
       `${email}.json`,

--- a/src/google/drive-auth.ts
+++ b/src/google/drive-auth.ts
@@ -3,9 +3,9 @@ import os from 'node:os';
 import path from 'node:path';
 import { google } from 'googleapis';
 
-// Cached per process — googleapis auto-refreshes the access token using the
-// long-lived refresh_token, so we only need to load from disk once.
-let cachedClient: InstanceType<typeof google.auth.OAuth2> | null = null;
+// Keyed by resolved tokenCachePath so multiple identities in the same process
+// each get their own cached client (and tests with different paths stay isolated).
+const clientCache = new Map<string, InstanceType<typeof google.auth.OAuth2>>();
 
 export interface DriveAuthOptions {
   tokenCachePath?: string;
@@ -18,8 +18,6 @@ export interface DriveAuthOptions {
 export async function getDriveClient(
   options?: DriveAuthOptions,
 ): Promise<InstanceType<typeof google.auth.OAuth2>> {
-  if (cachedClient) return cachedClient;
-
   const clientId = options?.clientId ?? process.env.GOOGLE_OAUTH_CLIENT_ID;
   const clientSecret = options?.clientSecret ?? process.env.GOOGLE_OAUTH_CLIENT_SECRET;
   const email = options?.email ?? process.env.CURIA_GOOGLE_EMAIL;
@@ -36,6 +34,9 @@ export async function getDriveClient(
       'credentials',
       `${email}.json`,
     );
+
+  const cached = clientCache.get(tokenCachePath);
+  if (cached) return cached;
 
   let tokenData: Record<string, unknown>;
   try {
@@ -63,11 +64,11 @@ export async function getDriveClient(
 
   const auth = new google.auth.OAuth2(clientId, clientSecret);
   auth.setCredentials({ refresh_token: refreshToken });
-  cachedClient = auth;
+  clientCache.set(tokenCachePath, auth);
   return auth;
 }
 
-/** Reset the cached client. For tests only. */
+/** Reset the cached clients. For tests only. */
 export function clearDriveClientCache(): void {
-  cachedClient = null;
+  clientCache.clear();
 }

--- a/src/google/drive-auth.ts
+++ b/src/google/drive-auth.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { google } from 'googleapis';
+
+// Cached per process — googleapis auto-refreshes the access token using the
+// long-lived refresh_token, so we only need to load from disk once.
+let cachedClient: InstanceType<typeof google.auth.OAuth2> | null = null;
+
+export interface DriveAuthOptions {
+  tokenCachePath?: string;
+  clientId?: string;
+  clientSecret?: string;
+  email?: string;
+}
+
+export async function getDriveClient(
+  options?: DriveAuthOptions,
+): Promise<InstanceType<typeof google.auth.OAuth2>> {
+  if (cachedClient) return cachedClient;
+
+  const clientId = options?.clientId ?? process.env.GOOGLE_OAUTH_CLIENT_ID;
+  const clientSecret = options?.clientSecret ?? process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  const email = options?.email ?? process.env.CURIA_GOOGLE_EMAIL;
+
+  if (!clientId) throw new Error('GOOGLE_OAUTH_CLIENT_ID is not set');
+  if (!clientSecret) throw new Error('GOOGLE_OAUTH_CLIENT_SECRET is not set');
+  if (!email) throw new Error('CURIA_GOOGLE_EMAIL is not set');
+
+  const tokenCachePath =
+    options?.tokenCachePath ??
+    path.join(
+      process.env.HOME ?? '/root',
+      '.google_workspace_mcp',
+      'credentials',
+      `${email}.json`,
+    );
+
+  let tokenData: Record<string, unknown>;
+  try {
+    const raw = await fs.readFile(tokenCachePath, 'utf-8');
+    tokenData = JSON.parse(raw) as Record<string, unknown>;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(
+        `Google OAuth token cache not found at ${tokenCachePath}. ` +
+          `Complete the Drive auth setup (docs/dev/google-drive.md).`,
+      );
+    }
+    throw new Error(
+      `Failed to read Google OAuth token cache at ${tokenCachePath}: ${String(err)}`,
+    );
+  }
+
+  const refreshToken =
+    typeof tokenData['refresh_token'] === 'string' ? tokenData['refresh_token'] : undefined;
+  if (!refreshToken) {
+    throw new Error(
+      `Google OAuth token cache at ${tokenCachePath} is missing refresh_token. Re-run the OAuth flow.`,
+    );
+  }
+
+  const auth = new google.auth.OAuth2(clientId, clientSecret);
+  auth.setCredentials({ refresh_token: refreshToken });
+  cachedClient = auth;
+  return auth;
+}
+
+/** Reset the cached client. For tests only. */
+export function clearDriveClientCache(): void {
+  cachedClient = null;
+}


### PR DESCRIPTION
## **User description**
## Summary

- Adds `drive-download-file` skill that downloads a Google Drive file (native binary or Google-native export) to TempFileStore and returns a `file://` URL
- Adds `src/google/drive-auth.ts` shared module that loads the workspace-mcp OAuth token cache and constructs a `googleapis` `OAuth2Client`, reusable by future Drive skills
- Wires the skill into `agents/coordinator.yaml` with a 3-step workflow note for the Drive→email attachment flow

Closes #857.

## What this unlocks

The coordinator can now attach Drive files to outbound emails:
1. `search_drive_files` → get file ID (if needed)
2. `drive-download-file` → `{ temp_file_url, filename, content_type }`
3. `email-send` / `email-reply` with `attachments: [{ file_url: temp_file_url, ... }]`

Before this PR, the agent fell back to sending a shareable link because no skill bridged Drive bytes → TempFileStore.

## Test Plan

- [ ] 25 unit tests pass: `pnpm run test skills/drive-download-file/handler.test.ts src/google/drive-auth.test.ts`
- [ ] Handler covers: native binary download, Google Doc/Sheet/Slide PDF export, custom export MIME type override, 404/403 metadata errors, streaming 10 MB size guard, declared-size pre-check, auth failure, `writeTempFile` failure
- [ ] `drive-auth` covers: missing env vars, missing token cache file, missing `refresh_token`, successful path, process-level cache hit
- [ ] TypeScript typecheck passes: `pnpm run typecheck`
- [ ] `drive-download-file` appears in coordinator `pinned_skills` and the Drive section has the 3-step workflow note

## Known follow-up items (not blocking)

- **Secret access boundary** — the skill reads `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` from `process.env` via the shared `drive-auth.ts` module rather than `ctx.secret()`. These are startup-configuration values (same as workspace-mcp uses them), but a future refactor could thread them through the skill context for consistency with the execution layer's audit trail.
- **Cache key ignores identity** — `cachedClient` in `drive-auth.ts` is unkeyed; a multi-account scenario would need the cache keyed by email. Single-account deployments are unaffected.


___

## **CodeAnt-AI Description**
**Download Drive files for email attachments**

### What Changed
- Added a new `drive-download-file` skill that downloads a Google Drive file into temporary storage and returns a `file://` link ready for email attachments
- Supports Drive file IDs and Drive URLs, with automatic PDF export for Google Docs, Sheets, and Slides and optional export format overrides
- Added clearer errors for missing files, access denied, oversized files, and broken temp storage writes
- The coordinator now recognizes this skill in Drive-to-email workflows, so it can attach Drive files instead of falling back to shareable links

### Impact
`✅ Drive files can be attached to emails`
`✅ Fewer share-link fallbacks for email replies`
`✅ Clearer errors when a Drive file cannot be downloaded`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Google Drive file download functionality, enabling files to be downloaded by Drive ID or URL and attached to outbound emails. Supports format conversion for Google-native documents (defaulting to PDF with customizable export formats).

* **Documentation**
  * Added design and implementation documentation for the new Drive download capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->