### PR TITLE
feat(contacts): promote canonical attributes onto Contact record (#829)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 ## [Unreleased]
 
 ### Added
+- **Contact canonical attributes** — 12 structured profile fields (`title`, `organization`, `primary_email`, etc.) persisted directly on the `contacts` row; backfill script populates from KG facts. (#829)
 - **File attachments in outbound email** — all five email skills (`email-send`, `email-reply`, `email-draft-save`, `ceo-inbox-draft-compose`, `ceo-inbox-draft-reply`) now accept an `attachments` input field. Attachments are read from `file://` URLs (TempFileStore), validated, and forwarded to Nylas. The CEO inbox path uses multipart FormData; the Curia outbound path passes `Buffer` content via the Nylas SDK. 20 MB total / 10 attachment limit enforced. (#818)
 
 ### Fixed

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -224,7 +224,7 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
         </div>
         <h2 className="drawer-title-h2">{creating ? 'New contact' : (contact?.displayName ?? '')}</h2>
         {!creating && contact && (
-          <div className="drawer-subtitle">{[contact.role].filter(Boolean).join(' · ')}</div>
+          <div className="drawer-subtitle">{[contact.title, contact.organization].filter(Boolean).join(' · ')}</div>
         )}
       </div>
 
@@ -412,7 +412,7 @@ export default function ContactsPage() {
     if (search) {
       const q = search.toLowerCase();
       rows = rows.filter(c =>
-        (c.displayName + ' ' + (c.role ?? '')).toLowerCase().includes(q)
+        (c.displayName + ' ' + (c.title ?? '') + ' ' + (c.organization ?? '') + ' ' + (c.role ?? '')).toLowerCase().includes(q)
       );
     }
     const dir = sort.dir === 'asc' ? 1 : -1;
@@ -473,7 +473,7 @@ export default function ContactsPage() {
         <main className="main">
           <Topbar crumb="Memory" title="Contacts">
             <TopbarSearch
-              placeholder="Search name or role…"
+              placeholder="Search name, title or org…"
               value={search}
               onChange={v => { setSearch(v); setPage(1); }}
             />
@@ -494,7 +494,7 @@ export default function ContactsPage() {
               <div className="contacts-mobile-search">
                 <input
                   type="text"
-                  placeholder="Search name or role…"
+                  placeholder="Search name, title or org…"
                   value={search}
                   onChange={e => { setSearch(e.target.value); setPage(1); }}
                 />

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -22,6 +22,19 @@ interface Contact {
   systemRole: SystemRole;
   createdAt: string;
   updatedAt: string;
+  // Canonical fields (migration 048)
+  preferredName: string | null;
+  title: string | null;
+  organization: string | null;
+  primaryEmail: string | null;
+  primaryPhone: string | null;
+  timezone: string | null;
+  locale: string | null;
+  location: string | null;
+  pronouns: string | null;
+  linkedinUrl: string | null;
+  bio: string | null;
+  birthday: string | null;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -107,6 +120,18 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
   const [trustLevel, setTrustLevel] = useState<TrustLevel>(contact?.trustLevel ?? null);
   const [kgNodeId, setKgNodeId] = useState(contact?.kgNodeId ?? '');
   const [notes, setNotes] = useState(contact?.notes ?? '');
+  const [preferredName, setPreferredName] = useState(contact?.preferredName ?? '');
+  const [pronouns, setPronouns] = useState(contact?.pronouns ?? '');
+  const [title, setTitle] = useState(contact?.title ?? '');
+  const [organization, setOrganization] = useState(contact?.organization ?? '');
+  const [primaryEmail, setPrimaryEmail] = useState(contact?.primaryEmail ?? '');
+  const [primaryPhone, setPrimaryPhone] = useState(contact?.primaryPhone ?? '');
+  const [timezone, setTimezone] = useState(contact?.timezone ?? '');
+  const [locale, setLocale] = useState(contact?.locale ?? '');
+  const [location, setLocation] = useState(contact?.location ?? '');
+  const [linkedinUrl, setLinkedinUrl] = useState(contact?.linkedinUrl ?? '');
+  const [bio, setBio] = useState(contact?.bio ?? '');
+  const [birthday, setBirthday] = useState(contact?.birthday ?? '');
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -126,6 +151,19 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
         trustLevel: trustLevel ?? null,
         notes: notes.trim() || null,
         kgNodeId: kgNodeId.trim() || null,
+        // Canonical fields
+        preferredName: preferredName.trim() || null,
+        pronouns: pronouns.trim() || null,
+        title: title.trim() || null,
+        organization: organization.trim() || null,
+        primaryEmail: primaryEmail.trim() || null,
+        primaryPhone: primaryPhone.trim() || null,
+        timezone: timezone.trim() || null,
+        locale: locale.trim() || null,
+        location: location.trim() || null,
+        linkedinUrl: linkedinUrl.trim() || null,
+        bio: bio.trim() || null,
+        birthday: birthday.trim() || null,
       };
 
       let res: Response;
@@ -194,15 +232,88 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
         <div className="edit-drawer-form">
           {error && <p style={{ color: 'var(--app-destructive)', margin: 0, fontSize: 13 }}>{error}</p>}
 
+          {/* Section: Identity */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '0 0 6px' }}>Identity</p>
           <div className="form-grid">
             <div className="form-field">
               <label htmlFor="cf-name">Display name</label>
               <input id="cf-name" type="text" value={displayName} onChange={e => setDisplayName(e.target.value)} placeholder="Full name" />
             </div>
             <div className="form-field">
-              <label htmlFor="cf-role">Role</label>
-              <input id="cf-role" type="text" value={role} onChange={e => setRole(e.target.value)} placeholder="Title" />
+              <label htmlFor="cf-preferred-name">Preferred name</label>
+              <input id="cf-preferred-name" type="text" value={preferredName} onChange={e => setPreferredName(e.target.value)} placeholder="Nickname or short form" />
             </div>
+            <div className="form-field">
+              <label htmlFor="cf-pronouns">Pronouns</label>
+              <input id="cf-pronouns" type="text" value={pronouns} onChange={e => setPronouns(e.target.value)} placeholder="they/them" />
+            </div>
+          </div>
+
+          {/* Section: Work */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>Work</p>
+          <div className="form-grid">
+            <div className="form-field">
+              <label htmlFor="cf-role">Role</label>
+              <input id="cf-role" type="text" value={role} onChange={e => setRole(e.target.value)} placeholder="Internal role label" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-title">Title</label>
+              <input id="cf-title" type="text" value={title} onChange={e => setTitle(e.target.value)} placeholder="Current job title" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-org">Organization</label>
+              <input id="cf-org" type="text" value={organization} onChange={e => setOrganization(e.target.value)} placeholder="Employer" />
+            </div>
+          </div>
+
+          {/* Section: Contact info */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>Contact info</p>
+          <div className="form-grid">
+            <div className="form-field">
+              <label htmlFor="cf-email">Primary email</label>
+              <input id="cf-email" type="text" value={primaryEmail} onChange={e => setPrimaryEmail(e.target.value)} placeholder="Lowercased on save" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-phone">Primary phone</label>
+              <input id="cf-phone" type="text" value={primaryPhone} onChange={e => setPrimaryPhone(e.target.value)} placeholder="+1 555 000 0000" />
+            </div>
+          </div>
+
+          {/* Section: Location & locale */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>Location &amp; locale</p>
+          <div className="form-grid">
+            <div className="form-field">
+              <label htmlFor="cf-tz">Timezone</label>
+              <input id="cf-tz" type="text" value={timezone} onChange={e => setTimezone(e.target.value)} placeholder="America/New_York" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-locale">Locale</label>
+              <input id="cf-locale" type="text" value={locale} onChange={e => setLocale(e.target.value)} placeholder="en-US" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-location">Location</label>
+              <input id="cf-location" type="text" value={location} onChange={e => setLocation(e.target.value)} placeholder="City, region" />
+            </div>
+          </div>
+
+          {/* Section: Links & bio */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>Links &amp; bio</p>
+          <div className="form-field">
+            <label htmlFor="cf-linkedin">LinkedIn URL</label>
+            <input id="cf-linkedin" type="text" value={linkedinUrl} onChange={e => setLinkedinUrl(e.target.value)} placeholder="https://linkedin.com/in/…" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="cf-bio">Bio</label>
+            <textarea id="cf-bio" rows={3} value={bio} onChange={e => setBio(e.target.value)} placeholder="Short narrative (max 500 chars)" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="cf-birthday">Birthday</label>
+            <input id="cf-birthday" type="text" value={birthday} onChange={e => setBirthday(e.target.value)} placeholder="YYYY-MM-DD or --MM-DD" />
+          </div>
+
+          {/* Section: System */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>System</p>
+          <div className="form-grid">
             <div className="form-field">
               <label htmlFor="cf-status">Status</label>
               <select id="cf-status" value={status} onChange={e => setStatus(e.target.value as ContactStatus)}>
@@ -222,7 +333,6 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
               </select>
             </div>
           </div>
-
           <div className="form-field">
             <label htmlFor="cf-kg">KG node ID</label>
             <input id="cf-kg" type="text" value={kgNodeId} onChange={e => setKgNodeId(e.target.value)} placeholder="UUID — optional" />
@@ -421,9 +531,14 @@ export default function ContactsPage() {
                               Name <span className="sort-arrow">{sortArrow('displayName')}</span>
                             </button>
                           </th>
-                          <th className="sortable" aria-sort={sort.key === 'role' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-                            <button className="sort-btn" onClick={() => toggleSort('role')}>
-                              Role <span className="sort-arrow">{sortArrow('role')}</span>
+                          <th className="sortable" aria-sort={sort.key === 'title' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('title')}>
+                              Title <span className="sort-arrow">{sortArrow('title')}</span>
+                            </button>
+                          </th>
+                          <th className="sortable" aria-sort={sort.key === 'organization' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('organization')}>
+                              Org <span className="sort-arrow">{sortArrow('organization')}</span>
                             </button>
                           </th>
                           <th className="sortable" aria-sort={sort.key === 'status' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
@@ -458,7 +573,8 @@ export default function ContactsPage() {
                                 )}
                               </div>
                             </td>
-                            <td>{c.role ?? ''}</td>
+                            <td>{c.title ?? ''}</td>
+                            <td>{c.organization ?? ''}</td>
                             <td><span className={`status-pill ${c.status}`}>{c.status}</span></td>
                             <td className="cell-mono col-updated">{formatDate(c.updatedAt)}</td>
                             <td>
@@ -478,7 +594,7 @@ export default function ContactsPage() {
                         ))}
                         {pageRows.length === 0 && (
                           <tr>
-                            <td colSpan={5} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
+                            <td colSpan={6} style={{ textAlign: 'center', padding: 40, color: 'var(--app-fg-muted)' }}>
                               No contacts match.
                             </td>
                           </tr>

--- a/apps/console/src/pages/ContactsPage.tsx
+++ b/apps/console/src/pages/ContactsPage.tsx
@@ -304,7 +304,7 @@ function ContactEditDrawer({ contact, creating, onClose, onSaved, onDeleted }: D
           </div>
           <div className="form-field">
             <label htmlFor="cf-bio">Bio</label>
-            <textarea id="cf-bio" rows={3} value={bio} onChange={e => setBio(e.target.value)} placeholder="Short narrative (max 500 chars)" />
+            <textarea id="cf-bio" rows={3} maxLength={500} value={bio} onChange={e => setBio(e.target.value)} placeholder="Short narrative (max 500 chars)" />
           </div>
           <div className="form-field">
             <label htmlFor="cf-birthday">Birthday</label>

--- a/docs/wip/2026-06-02-contact-canonical-attributes-design.md
+++ b/docs/wip/2026-06-02-contact-canonical-attributes-design.md
@@ -1,0 +1,329 @@
+# Contact Canonical Attributes — Design
+
+**Issue:** #829
+**Date:** 2026-06-02
+**Branch:** `feat/contact-canonical-attributes`
+**Follow-up:** #830 (wire enrichment + agents + stop new KG fact writes)
+
+## Problem
+
+The `contacts` table is thin by design. Everything the system "knows" about a person
+lives as `kg_nodes` of `type='fact'` linked via `relates_to` edges, surfaced by
+`EntityContextAssembler` as confidence-scored bullet points. This causes two problems:
+
+1. **Hallucinations.** Agents fabricate values (e.g. calendar IDs, email addresses) when
+   the KG fact list is thin. Even when the KG holds the truth, presenting it as a scored
+   fact list invites the LLM to "reason" instead of read a structured field.
+2. **Specialist friction.** Calendar, email composition, and research-analyst skills all
+   need the same canonical attributes. Each ends up parsing fact bullets or guessing.
+
+## Goal (this issue — foundation)
+
+Persist 12 canonical attributes directly on the `contacts` row. Backfill from KG once.
+Issue #830 wires these into agents/skills and stops new KG fact writes for them.
+
+## Fields Added
+
+All columns are `TEXT`, nullable. Added to `contacts` via `ALTER TABLE`.
+
+| Column | Notes |
+|---|---|
+| `preferred_name` | Short/familiar form; falls back to `display_name` |
+| `title` | Current job title |
+| `organization` | Current employer, free-text |
+| `primary_email` | Lowercased; app-layer validated against `contact_channel_identities` |
+| `primary_phone` | E.164-formatted (free-text, no DB constraint) |
+| `timezone` | IANA tz string (e.g. `America/New_York`) |
+| `locale` | BCP 47 (e.g. `en-US`) |
+| `location` | City/region, free-text |
+| `pronouns` | Free-text |
+| `linkedin_url` | Must start with `https?://` |
+| `bio` | Short narrative, max 500 chars |
+| `birthday` | ISO `YYYY-MM-DD` or `--MM-DD` (year-omitted) |
+
+## Architecture
+
+### Approach chosen: Approach B — Node.js backfill script
+
+The backfill logic is a 3-hop join (contacts → kg person node → kg_edges → fact nodes)
+with per-column highest-confidence tiebreaking. Implementing this as a standalone Node.js
+script rather than a SQL migration gives:
+- Structured logging (which contacts were updated, which columns changed)
+- Safe re-runs (only touches NULL columns)
+- Easier debugging if the KG schema has edge cases in prod
+
+The ALTER TABLE migration ships as `048_add_contact_canonical_attributes.sql`.
+The backfill runs separately via `npm run backfill:contact-attributes` during deploy.
+
+### Layer summary
+
+```
+Migration 048        → ALTER TABLE contacts ADD COLUMN × 12 + CHECK constraints
+Backfill script      → scripts/backfill-contact-attributes.ts
+Contact interface    → 12 new nullable string fields on Contact + ContactCanonicalFields type
+ContactService       → createContact accepts new fields; new public updateContactFields()
+  Postgres backend   → createContact INSERT, updateContact UPDATE, all SELECT lists updated
+  In-memory backend  → no changes (stores full Contact object)
+HTTP API (kg.ts)     → GET list + POST + PATCH accept/return all 12 new fields
+Console UI           → Contact interface widens; table replaces Role with Title+Organization;
+                       drawer gets 6 grouped sections
+Tests                → unit (service), integration (HTTP), unit (backfill script)
+```
+
+## Database Migration (`048_add_contact_canonical_attributes.sql`)
+
+```sql
+-- Up Migration
+
+ALTER TABLE contacts ADD COLUMN preferred_name  TEXT;
+ALTER TABLE contacts ADD COLUMN title           TEXT;
+ALTER TABLE contacts ADD COLUMN organization    TEXT;
+ALTER TABLE contacts ADD COLUMN primary_email   TEXT;
+ALTER TABLE contacts ADD COLUMN primary_phone   TEXT;
+ALTER TABLE contacts ADD COLUMN timezone        TEXT;
+ALTER TABLE contacts ADD COLUMN locale          TEXT;
+ALTER TABLE contacts ADD COLUMN location        TEXT;
+ALTER TABLE contacts ADD COLUMN pronouns        TEXT;
+ALTER TABLE contacts ADD COLUMN linkedin_url    TEXT;
+ALTER TABLE contacts ADD COLUMN bio             TEXT;
+ALTER TABLE contacts ADD COLUMN birthday        TEXT;
+
+ALTER TABLE contacts ADD CONSTRAINT contacts_primary_email_format_check
+  CHECK (primary_email ~ '^[^@\s]+@[^@\s]+\.[^@\s]+$');
+ALTER TABLE contacts ADD CONSTRAINT contacts_linkedin_url_format_check
+  CHECK (linkedin_url ~ '^https?://');
+ALTER TABLE contacts ADD CONSTRAINT contacts_bio_length_check
+  CHECK (length(bio) <= 500);
+ALTER TABLE contacts ADD CONSTRAINT contacts_birthday_format_check
+  CHECK (birthday ~ '^\d{4}-\d{2}-\d{2}$' OR birthday ~ '^--\d{2}-\d{2}$');
+
+-- Rollback:
+-- ALTER TABLE contacts DROP COLUMN preferred_name, DROP COLUMN title, ...
+-- (drop all 12 columns)
+```
+
+## Backfill Script (`scripts/backfill-contact-attributes.ts`)
+
+**Entry point:** `npm run backfill:contact-attributes` (added to `package.json`)
+
+**Algorithm:**
+1. Connect to Postgres via `DATABASE_URL`
+2. Fetch all contacts where `kg_node_id IS NOT NULL`
+3. For each contact:
+   a. Find all `kg_nodes` of `type='fact'` reachable via a single `relates_to` edge
+      from the contact's KG person node (either direction)
+   b. For each fact node, read `properties->>'attribute'` (case-insensitive) and
+      `properties->>'value'`
+   c. Map attribute keys to contact columns using the table below
+   d. For each target column that is currently NULL: pick the matching fact with the
+      highest `confidence`; tiebreak on most recent `last_confirmed_at`
+   e. Write the value; log column name, fact node ID, confidence used
+4. Print summary: contacts processed / columns written / already-populated / errors
+
+**Attribute key → column mapping:**
+
+| Contact column | Attribute keys matched (case-insensitive) |
+|---|---|
+| `preferred_name` | `preferred_name`, `nickname` |
+| `title` | `job_title`, `title`, `role` *(only when contact's `system_role` IS NULL)* |
+| `organization` | `organization`, `employer`, `company`, `current_employer` |
+| `primary_email` | `email`, `primary_email` |
+| `primary_phone` | `phone`, `phone_number`, `mobile` |
+| `timezone` | `timezone`, `tz` |
+| `locale` | `locale`, `language` |
+| `location` | `home_city`, `current_location`, `location`, `city` |
+| `pronouns` | `pronouns` |
+| `linkedin_url` | `linkedin`, `linkedin_url` |
+| `bio` | `bio`, `biography` |
+| `birthday` | `birthday`, `birthdate`, `dob` |
+
+**Safety:** Script is idempotent — a NULL check guards every write. Re-running
+after a partial failure produces the same result. KG fact nodes are not deleted.
+
+## TypeScript Types (`src/contacts/types.ts`)
+
+### `Contact` interface additions
+
+```typescript
+// Canonical profile attributes (migration 048). All nullable — populated by
+// backfill script or via updateContactFields(). Source of truth for specialists.
+preferredName: string | null;
+title: string | null;
+organization: string | null;
+primaryEmail: string | null;
+primaryPhone: string | null;
+timezone: string | null;
+locale: string | null;
+location: string | null;
+pronouns: string | null;
+linkedinUrl: string | null;
+bio: string | null;
+birthday: string | null;
+```
+
+### New `ContactCanonicalFields` type
+
+```typescript
+export interface ContactCanonicalFields {
+  preferredName?: string | null;
+  title?: string | null;
+  organization?: string | null;
+  primaryEmail?: string | null;
+  primaryPhone?: string | null;
+  timezone?: string | null;
+  locale?: string | null;
+  location?: string | null;
+  pronouns?: string | null;
+  linkedinUrl?: string | null;
+  bio?: string | null;
+  birthday?: string | null;
+}
+```
+
+`CreateContactOptions` also gets these 12 as optional fields for CRM import paths.
+
+## ContactService
+
+### `createContact`
+
+Spreads `ContactCanonicalFields` from `options` onto the `Contact` object, defaulting
+each to `null`. Postgres backend INSERT includes all 12 new columns.
+
+### `updateContactFields(contactId, fields)` (new public method)
+
+```typescript
+async updateContactFields(
+  contactId: string,
+  fields: ContactCanonicalFields,
+): Promise<Contact>
+```
+
+1. Fetches the contact; throws if not found
+2. If `fields.primaryEmail` is non-null, validates it exists in
+   `contact_channel_identities` for this contact with `channel = 'email'`.
+   Uses `backend.getIdentitiesForContact(contactId)` + in-memory filter
+   (works for both Postgres and in-memory backends). Comparison is
+   case-insensitive — both sides lowercased before comparing.
+   Throws a descriptive error if not found (caller maps to 400).
+3. Spreads `fields` onto the fetched contact, stamps `updatedAt`
+4. Calls `updateStoredContact` (which sanitizes display name and calls backend)
+5. Returns the updated contact
+
+### Postgres backend changes
+
+- `createContact`: INSERT adds all 12 columns
+- `updateContact`: UPDATE SET adds all 12 columns
+- All SELECT lists that return `Contact` (`getContact`, `listContacts`,
+  `findContactByName/Role/SystemRole`): add the 12 columns.
+  `resolveByChannelIdentity` is excluded — it returns `ResolvedSender`, not `Contact`,
+  and doesn't need the canonical fields.
+- `rowToContact`: maps the 12 new columns (all `string | null`, no parsing needed)
+
+### In-memory backend
+
+No changes. The backend stores and retrieves the full `Contact` object; the new fields
+ride along automatically once the interface is extended.
+
+## HTTP API (`src/channels/http/routes/kg.ts`)
+
+### `GET /api/kg/contacts`
+
+Serialization adds all 12 new fields to each contact in the response array.
+
+### `POST /api/kg/contacts`
+
+Body type widens to accept 12 optional fields. Validation before calling `createContact`:
+
+| Field | Validation |
+|---|---|
+| `primaryEmail` | Regex `^[^@\s]+@[^@\s]+` + CCI existence check (same as service) |
+| `linkedinUrl` | Must start with `https?://` if provided |
+| `bio` | Max 500 chars if provided |
+| `birthday` | Must match `YYYY-MM-DD` or `--MM-DD` if provided |
+| All others | Accepted as-is (free-text strings); trimmed, empty string → null |
+
+Response includes all 12 new fields.
+
+### `PATCH /api/kg/contacts/:id`
+
+Body type widens to accept 12 optional canonical fields. After existing field mutations
+(`displayName`, `role`, `status`, `trustLevel`, `notes`, `kgNodeId`), calls
+`contactService.updateContactFields(id, canonicalFields)` if any canonical fields are
+present in the body. Same format validation as POST. Response includes all 12 fields.
+
+### No new endpoints
+
+The list endpoint carries the full payload. No `GET /api/kg/contacts/:id` detail
+endpoint is added in this issue.
+
+## Console UI (`apps/console/src/pages/ContactsPage.tsx`)
+
+### `Contact` interface
+
+All 12 new fields added as `string | null`.
+
+### Table
+
+`Role` column replaced with `Title` and `Organization`. Role remains editable in the
+drawer. Sort works the same way (string comparison on the field value).
+
+### Drawer form — 6 sections
+
+| Section | Fields |
+|---|---|
+| **Identity** | `displayName` (existing), `preferredName`, `pronouns` |
+| **Work** | `role` (existing, moved here), `title`, `organization` |
+| **Contact info** | `primaryEmail`, `primaryPhone` |
+| **Location & locale** | `timezone`, `locale`, `location` |
+| **Links & bio** | `linkedinUrl`, `bio` (textarea), `birthday` |
+| **System** | `status`, `trustLevel`, `kgNodeId`, `notes` (existing) |
+
+Each section gets a small section header. All new inputs use `type="text"` except
+`bio` (textarea). `birthday` placeholder: `YYYY-MM-DD or --MM-DD`. `primaryEmail`
+placeholder: lowercased on save.
+
+`handleSave` sends all 12 canonical fields in the POST/PATCH body (empty string → null).
+
+## Tests
+
+### `tests/unit/contacts/contact-service.test.ts` (extend)
+
+- `createContact` with canonical fields → fetched contact has all 12 fields populated
+- `updateContactFields` round-trip → field persists, `updatedAt` bumps
+- `updateContactFields` with `primaryEmail` lacking a matching CCI row → throws
+- `updateContactFields` with `primaryEmail` matching a CCI row → succeeds
+- `updateContactFields` only touches provided fields → unprovided fields unchanged
+
+### `tests/integration/contacts.test.ts` (extend)
+
+- POST with canonical fields → 201, fields returned in response
+- POST with invalid `primaryEmail` format → 400
+- POST with `bio` over 500 chars → 400
+- POST with invalid `linkedinUrl` → 400
+- PATCH with canonical fields → 200, fields updated
+- GET list → response includes `title`, `organization`, and all other new fields
+
+### `scripts/backfill-contact-attributes.test.ts` (new, unit)
+
+- Contact with linked KG node + fact nodes → correct columns populated
+- Two competing facts for same column → highest confidence wins; `last_confirmed_at` tiebreak
+- Already-populated column is skipped
+- Contact with no `kg_node_id` is skipped
+- `role` KG fact not applied to `title` when contact has a `system_role`
+
+## Out of Scope (Issue #830)
+
+- `EntityContextAssembler` changes
+- Stopping fact-node creation from agents/skills
+- Specialist agent prompt updates
+
+## Acceptance Criteria
+
+- [ ] Migration adds the 12 columns with CHECK constraints; rolls back cleanly
+- [ ] Backfill script populates Contact columns from KG facts; re-run is idempotent
+- [ ] `ContactService` CRUD covers all new fields with `primaryEmail` validation
+- [ ] HTTP API exposes all new fields; rejects invalid input with 400 + field-level error
+- [ ] Console table replaces `Role` with `Title` + `Organization`
+- [ ] Console drawer shows all new fields in 6 grouped sections
+- [ ] All existing tests pass; new tests cover validation and backfill
+- [ ] Typecheck and lint clean

--- a/docs/wip/2026-06-02-contact-canonical-attributes.md
+++ b/docs/wip/2026-06-02-contact-canonical-attributes.md
@@ -1,0 +1,1778 @@
+# Contact Canonical Attributes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 12 canonical profile attributes to the `contacts` table, backfill from KG facts, and expose them via ContactService, HTTP API, and Console UI.
+
+**Architecture:** Migration 048 adds 12 nullable TEXT columns with CHECK constraints. `ContactService` gains `updateContactFields()` which validates `primaryEmail` against `contact_channel_identities` before writing. A standalone `scripts/backfill-contact-attributes.ts` reads KG fact nodes and writes NULL columns only (idempotent). HTTP API exposes all 12 fields on all three contact endpoints. Console UI replaces the Role column with Title + Organization and rewrites the drawer with 6 grouped sections.
+
+**Tech Stack:** PostgreSQL 16+ (node-pg-migrate plain SQL), TypeScript ESM with `tsx`, Vitest, React + TypeScript (Console UI)
+
+---
+
+## File Map
+
+| Action | Path |
+|---|---|
+| **Create** | `src/db/migrations/048_add_contact_canonical_attributes.sql` |
+| **Modify** | `src/contacts/types.ts` |
+| **Modify** | `src/contacts/contact-service.ts` |
+| **Modify** | `src/channels/http/routes/kg.ts` |
+| **Modify** | `apps/console/src/pages/ContactsPage.tsx` |
+| **Create** | `scripts/backfill-contact-attributes.ts` |
+| **Modify** | `package.json` |
+| **Modify** | `tests/unit/contacts/contact-service.test.ts` |
+| **Modify** | `tests/integration/contacts.test.ts` |
+| **Create** | `scripts/backfill-contact-attributes.test.ts` |
+
+---
+
+## Task 1: Database Migration
+
+**Files:**
+- Create: `src/db/migrations/048_add_contact_canonical_attributes.sql`
+
+- [ ] **Step 1: Verify migration numbering**
+
+Run:
+```bash
+ls src/db/migrations/ | sort | tail -5
+```
+Expected: `047_create_sessions.sql` is the last file. Confirm `048` is not yet taken.
+
+- [ ] **Step 2: Create the migration file**
+
+Create `src/db/migrations/048_add_contact_canonical_attributes.sql` with:
+
+```sql
+-- Up Migration
+
+ALTER TABLE contacts ADD COLUMN preferred_name  TEXT;
+ALTER TABLE contacts ADD COLUMN title           TEXT;
+ALTER TABLE contacts ADD COLUMN organization    TEXT;
+ALTER TABLE contacts ADD COLUMN primary_email   TEXT;
+ALTER TABLE contacts ADD COLUMN primary_phone   TEXT;
+ALTER TABLE contacts ADD COLUMN timezone        TEXT;
+ALTER TABLE contacts ADD COLUMN locale          TEXT;
+ALTER TABLE contacts ADD COLUMN location        TEXT;
+ALTER TABLE contacts ADD COLUMN pronouns        TEXT;
+ALTER TABLE contacts ADD COLUMN linkedin_url    TEXT;
+ALTER TABLE contacts ADD COLUMN bio             TEXT;
+ALTER TABLE contacts ADD COLUMN birthday        TEXT;
+
+ALTER TABLE contacts ADD CONSTRAINT contacts_primary_email_format_check
+  CHECK (primary_email ~ '^[^@\s]+@[^@\s]+\.[^@\s]+$');
+ALTER TABLE contacts ADD CONSTRAINT contacts_linkedin_url_format_check
+  CHECK (linkedin_url ~ '^https?://');
+ALTER TABLE contacts ADD CONSTRAINT contacts_bio_length_check
+  CHECK (length(bio) <= 500);
+ALTER TABLE contacts ADD CONSTRAINT contacts_birthday_format_check
+  CHECK (birthday ~ '^\d{4}-\d{2}-\d{2}$' OR birthday ~ '^--\d{2}-\d{2}$');
+
+-- Rollback: ALTER TABLE contacts
+--   DROP COLUMN preferred_name, DROP COLUMN title, DROP COLUMN organization,
+--   DROP COLUMN primary_email, DROP COLUMN primary_phone, DROP COLUMN timezone,
+--   DROP COLUMN locale, DROP COLUMN location, DROP COLUMN pronouns,
+--   DROP COLUMN linkedin_url, DROP COLUMN bio, DROP COLUMN birthday;
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add src/db/migrations/048_add_contact_canonical_attributes.sql
+git -C /path/to/worktree commit -m "feat: migration 048 — add 12 canonical columns to contacts"
+```
+
+---
+
+## Task 2: TypeScript Types
+
+**Files:**
+- Modify: `src/contacts/types.ts`
+
+- [ ] **Step 1: Add `ContactCanonicalFields` interface and extend `Contact` and `CreateContactOptions`**
+
+In `src/contacts/types.ts`, make three edits:
+
+**Edit 1:** After the `notes: string | null;` line (line 17) in the `Contact` interface, add the 12 new fields:
+
+```typescript
+  notes: string | null;
+  // Canonical profile attributes (migration 048). All nullable — populated by
+  // backfill script or via updateContactFields(). Source of truth for specialists.
+  preferredName: string | null;
+  title: string | null;
+  organization: string | null;
+  primaryEmail: string | null;
+  primaryPhone: string | null;
+  timezone: string | null;
+  locale: string | null;
+  location: string | null;
+  pronouns: string | null;
+  linkedinUrl: string | null;
+  bio: string | null;
+  birthday: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+```
+
+(Replace the existing `notes: string | null;` through `updatedAt: Date;` block.)
+
+**Edit 2:** Export a new `ContactCanonicalFields` interface. Add it right after the `Contact` interface closing brace:
+
+```typescript
+/** Subset of Contact fields that can be written via updateContactFields(). */
+export interface ContactCanonicalFields {
+  preferredName?: string | null;
+  title?: string | null;
+  organization?: string | null;
+  primaryEmail?: string | null;
+  primaryPhone?: string | null;
+  timezone?: string | null;
+  locale?: string | null;
+  location?: string | null;
+  pronouns?: string | null;
+  linkedinUrl?: string | null;
+  bio?: string | null;
+  birthday?: string | null;
+}
+```
+
+**Edit 3:** In `CreateContactOptions` (line 72), add the 12 optional canonical fields before the closing brace:
+
+```typescript
+  /** If provided, links to this existing KG node. Otherwise auto-creates one. */
+  kgNodeId?: string;
+  source: string;
+  // Canonical profile attributes — optional on create, used by CRM import paths.
+  preferredName?: string | null;
+  title?: string | null;
+  organization?: string | null;
+  primaryEmail?: string | null;
+  primaryPhone?: string | null;
+  timezone?: string | null;
+  locale?: string | null;
+  location?: string | null;
+  pronouns?: string | null;
+  linkedinUrl?: string | null;
+  bio?: string | null;
+  birthday?: string | null;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+pnpm --prefix /path/to/worktree run typecheck
+```
+Expected: No errors. (The service implementation in Task 4 will satisfy the new `Contact` shape.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /path/to/worktree add src/contacts/types.ts
+git -C /path/to/worktree commit -m "feat: add ContactCanonicalFields type and extend Contact + CreateContactOptions"
+```
+
+---
+
+## Task 3: ContactService Unit Tests (write first — they will fail)
+
+**Files:**
+- Modify: `tests/unit/contacts/contact-service.test.ts`
+
+- [ ] **Step 1: Add a `describe('canonical fields')` block to the test file**
+
+Append to the bottom of `tests/unit/contacts/contact-service.test.ts` (inside the outer `describe('ContactService')` block):
+
+```typescript
+  describe('canonical fields', () => {
+    it('createContact stores canonical fields when provided', async () => {
+      const contact = await service.createContact({
+        displayName: 'Canonical Test',
+        source: 'test',
+        title: 'VP Engineering',
+        organization: 'Acme Corp',
+        timezone: 'America/New_York',
+        bio: 'A short bio.',
+      });
+      expect(contact.title).toBe('VP Engineering');
+      expect(contact.organization).toBe('Acme Corp');
+      expect(contact.timezone).toBe('America/New_York');
+      expect(contact.bio).toBe('A short bio.');
+      // Unprovided fields default to null
+      expect(contact.preferredName).toBeNull();
+      expect(contact.primaryEmail).toBeNull();
+    });
+
+    it('createContact defaults unprovided canonical fields to null', async () => {
+      const contact = await service.createContact({
+        displayName: 'No Canonical',
+        source: 'test',
+      });
+      expect(contact.preferredName).toBeNull();
+      expect(contact.title).toBeNull();
+      expect(contact.organization).toBeNull();
+      expect(contact.primaryEmail).toBeNull();
+      expect(contact.primaryPhone).toBeNull();
+      expect(contact.timezone).toBeNull();
+      expect(contact.locale).toBeNull();
+      expect(contact.location).toBeNull();
+      expect(contact.pronouns).toBeNull();
+      expect(contact.linkedinUrl).toBeNull();
+      expect(contact.bio).toBeNull();
+      expect(contact.birthday).toBeNull();
+    });
+
+    it('updateContactFields round-trip: field persists and updatedAt bumps', async () => {
+      const contact = await service.createContact({
+        displayName: 'Update Test',
+        source: 'test',
+      });
+      const before = contact.updatedAt;
+
+      // Advance time so updatedAt will differ
+      await new Promise(r => setTimeout(r, 5));
+
+      const updated = await service.updateContactFields(contact.id, {
+        title: 'Director',
+        organization: 'Globex',
+      });
+      expect(updated.title).toBe('Director');
+      expect(updated.organization).toBe('Globex');
+      expect(updated.updatedAt.getTime()).toBeGreaterThan(before.getTime());
+    });
+
+    it('updateContactFields only touches provided fields', async () => {
+      const contact = await service.createContact({
+        displayName: 'Partial Test',
+        source: 'test',
+        title: 'CEO',
+        organization: 'StartupCo',
+        timezone: 'Europe/London',
+      });
+      const updated = await service.updateContactFields(contact.id, {
+        title: 'CTO',
+        // organization and timezone NOT provided
+      });
+      expect(updated.title).toBe('CTO');
+      expect(updated.organization).toBe('StartupCo'); // unchanged
+      expect(updated.timezone).toBe('Europe/London'); // unchanged
+    });
+
+    it('updateContactFields throws when contact not found', async () => {
+      await expect(
+        service.updateContactFields('non-existent-id', { title: 'X' }),
+      ).rejects.toThrow('not found');
+    });
+
+    it('updateContactFields with primaryEmail validates against CCI', async () => {
+      const contact = await service.createContact({
+        displayName: 'Email Test',
+        source: 'test',
+      });
+      // No CCI row exists — should throw
+      await expect(
+        service.updateContactFields(contact.id, { primaryEmail: 'test@example.com' }),
+      ).rejects.toThrow(/not found.*contact_channel_identities|contact_channel_identities.*not found/i);
+    });
+
+    it('updateContactFields with primaryEmail succeeds when CCI row exists', async () => {
+      const contact = await service.createContact({
+        displayName: 'Email Match Test',
+        source: 'test',
+      });
+      // Add the matching CCI row
+      await service.linkIdentity({
+        contactId: contact.id,
+        channel: 'email',
+        channelIdentifier: 'match@example.com',
+        source: 'ceo_stated',
+      });
+      // Case-insensitive comparison — provide uppercase
+      const updated = await service.updateContactFields(contact.id, {
+        primaryEmail: 'MATCH@EXAMPLE.COM',
+      });
+      // Stored as-is (lowercasing is app responsibility, not enforced here)
+      expect(updated.primaryEmail).toBe('MATCH@EXAMPLE.COM');
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+pnpm --prefix /path/to/worktree run test -- tests/unit/contacts/contact-service.test.ts
+```
+Expected: FAIL — `service.updateContactFields is not a function` or similar, and `contact.title` is undefined.
+
+---
+
+## Task 4: ContactService Implementation
+
+**Files:**
+- Modify: `src/contacts/contact-service.ts`
+
+This task touches five areas of the file. Make each edit in order.
+
+### 4a: Add `ContactCanonicalFields` import
+
+- [ ] **Step 1: Update the import from `./types.js`**
+
+In the `import type { ... } from './types.js'` block, add `ContactCanonicalFields`:
+
+```typescript
+import type {
+  AuthOverride,
+  Contact,
+  ContactCanonicalFields,
+  ContactStatus,
+  ChannelIdentity,
+  ContactServiceOptions,
+  CreateContactOptions,
+  DedupConfidence,
+  DuplicatePair,
+  LinkIdentityOptions,
+  MergeGoldenRecord,
+  MergeProposal,
+  MergeResult,
+  ResolvedSender,
+  IdentitySource,
+  IdentityStatus,
+  SystemRole,
+  TrustLevel,
+} from './types.js';
+```
+
+### 4b: Add a shared `ContactRow` type and `CONTACT_COLS` constant
+
+- [ ] **Step 2: Add a `ContactRow` type and `CONTACT_COLS` constant before the `PostgresContactBackend` class**
+
+Insert this block immediately before the `// -- Postgres backend --` comment:
+
+```typescript
+// -- Postgres-specific row shape (all 26 columns) --
+// Shared across all queries that return a full Contact record.
+// The 12 canonical fields (added in migration 048) are always
+// null-safe — they default to null when the column was added after
+// the row was first written.
+type ContactRow = {
+  id: string;
+  kg_node_id: string | null;
+  display_name: string;
+  role: string | null;
+  system_role: string | null;
+  status: string;
+  contact_confidence: string;
+  trust_level: string | null;
+  last_seen_at: Date | null;
+  inbound_message_count: string;
+  outbound_message_count: string;
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+  // Canonical fields (migration 048)
+  preferred_name: string | null;
+  title: string | null;
+  organization: string | null;
+  primary_email: string | null;
+  primary_phone: string | null;
+  timezone: string | null;
+  locale: string | null;
+  location: string | null;
+  pronouns: string | null;
+  linkedin_url: string | null;
+  bio: string | null;
+  birthday: string | null;
+};
+
+// Column list for all SELECT queries that return a full Contact row.
+const CONTACT_COLS =
+  'id, kg_node_id, display_name, role, system_role, status, contact_confidence, trust_level, ' +
+  'last_seen_at, inbound_message_count, outbound_message_count, notes, created_at, updated_at, ' +
+  'preferred_name, title, organization, primary_email, primary_phone, timezone, locale, location, ' +
+  'pronouns, linkedin_url, bio, birthday';
+```
+
+### 4c: Update `PostgresContactBackend` — SELECT queries + rowToContact
+
+- [ ] **Step 3: Replace `getContact` query to use `ContactRow` and `CONTACT_COLS`**
+
+Replace the entire `getContact` method body:
+
+```typescript
+  async getContact(id: string): Promise<Contact | undefined> {
+    const result = await this.pool.query<ContactRow>(
+      `SELECT ${CONTACT_COLS} FROM contacts WHERE id = $1`,
+      [id],
+    );
+    const row = result.rows[0];
+    if (!row) return undefined;
+    return this.rowToContact(row);
+  }
+```
+
+- [ ] **Step 4: Replace `findContactByName` query**
+
+```typescript
+  async findContactByName(name: string): Promise<Contact[]> {
+    // Substring match (case-insensitive) so partial names like "Jo" match "Jo Brennan".
+    const result = await this.pool.query<ContactRow>(
+      `SELECT ${CONTACT_COLS} FROM contacts WHERE display_name ILIKE $1`,
+      [`%${name}%`],
+    );
+    return result.rows.map((row) => this.rowToContact(row));
+  }
+```
+
+- [ ] **Step 5: Replace `findContactByRole` query**
+
+```typescript
+  async findContactByRole(role: string): Promise<Contact[]> {
+    const result = await this.pool.query<ContactRow>(
+      `SELECT ${CONTACT_COLS} FROM contacts WHERE role = $1 ORDER BY created_at ASC`,
+      [role],
+    );
+    return result.rows.map((row) => this.rowToContact(row));
+  }
+```
+
+- [ ] **Step 6: Replace `findContactBySystemRole` query**
+
+```typescript
+  async findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null> {
+    const result = await this.pool.query<ContactRow>(
+      `SELECT ${CONTACT_COLS} FROM contacts WHERE system_role = $1 LIMIT 1`,
+      [systemRole],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    return this.rowToContact(row);
+  }
+```
+
+- [ ] **Step 7: Replace `listContacts` to use `CONTACT_COLS`**
+
+Replace the body of `listContacts`. The key change is replacing the `cols` variable with `CONTACT_COLS` and updating the query type:
+
+```typescript
+  async listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]> {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (filters?.status != null) {
+      params.push(filters.status);
+      conditions.push(`status = $${params.length}`);
+    }
+
+    const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
+    let sql = `SELECT ${CONTACT_COLS} FROM contacts${where} ORDER BY created_at ASC`;
+
+    if (filters?.limit != null) {
+      params.push(filters.limit);
+      sql += ` LIMIT $${params.length}`;
+    }
+
+    const result = await this.pool.query<ContactRow>(sql, params);
+    return result.rows.map((row) => this.rowToContact(row));
+  }
+```
+
+- [ ] **Step 8: Update `rowToContact` to map all 26 columns**
+
+Replace the entire `rowToContact` private method with:
+
+```typescript
+  private rowToContact(row: ContactRow): Contact {
+    return {
+      id: row.id,
+      kgNodeId: row.kg_node_id,
+      displayName: row.display_name,
+      role: row.role,
+      systemRole: (row.system_role === 'principal' || row.system_role === 'agent' || row.system_role === 'system')
+        ? row.system_role
+        : null,
+      status: row.status as ContactStatus,
+      contactConfidence: (() => {
+        const v = parseFloat(row.contact_confidence);
+        return isFinite(v) ? v : 0.0;
+      })(),
+      trustLevel: (Object.keys(TRUST_RANK) as TrustLevel[]).includes(row.trust_level as TrustLevel)
+        ? row.trust_level as TrustLevel
+        : null,
+      lastSeenAt: row.last_seen_at,
+      inboundMessageCount: parseInt(row.inbound_message_count, 10) || 0,
+      outboundMessageCount: parseInt(row.outbound_message_count, 10) || 0,
+      notes: row.notes,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      // Canonical fields (migration 048)
+      preferredName: row.preferred_name,
+      title: row.title,
+      organization: row.organization,
+      primaryEmail: row.primary_email,
+      primaryPhone: row.primary_phone,
+      timezone: row.timezone,
+      locale: row.locale,
+      location: row.location,
+      pronouns: row.pronouns,
+      linkedinUrl: row.linkedin_url,
+      bio: row.bio,
+      birthday: row.birthday,
+    };
+  }
+```
+
+### 4d: Update Postgres `createContact` and `updateContact`
+
+- [ ] **Step 9: Update `PostgresContactBackend.createContact` INSERT**
+
+Replace the `createContact` method body in the Postgres backend class:
+
+```typescript
+  async createContact(contact: Contact): Promise<void> {
+    this.logger.debug({ contactId: contact.id }, 'contacts: creating contact');
+    await this.pool.query(
+      `INSERT INTO contacts (
+         id, kg_node_id, display_name, role, system_role, status, notes, created_at, updated_at,
+         preferred_name, title, organization, primary_email, primary_phone, timezone, locale,
+         location, pronouns, linkedin_url, bio, birthday
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,
+                 $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)`,
+      [
+        contact.id, contact.kgNodeId, contact.displayName, contact.role, contact.systemRole,
+        contact.status, contact.notes, contact.createdAt, contact.updatedAt,
+        contact.preferredName, contact.title, contact.organization, contact.primaryEmail,
+        contact.primaryPhone, contact.timezone, contact.locale, contact.location,
+        contact.pronouns, contact.linkedinUrl, contact.bio, contact.birthday,
+      ],
+    );
+  }
+```
+
+- [ ] **Step 10: Update `PostgresContactBackend.updateContact` SET clause**
+
+Replace the `updateContact` method body in the Postgres backend class:
+
+```typescript
+  async updateContact(contact: Contact): Promise<void> {
+    this.logger.debug({ contactId: contact.id }, 'contacts: updating contact');
+    await this.pool.query(
+      `UPDATE contacts SET
+         kg_node_id = $2, display_name = $3, role = $4, system_role = $5, status = $6,
+         notes = $7, trust_level = $8, updated_at = $9,
+         preferred_name = $10, title = $11, organization = $12, primary_email = $13,
+         primary_phone = $14, timezone = $15, locale = $16, location = $17,
+         pronouns = $18, linkedin_url = $19, bio = $20, birthday = $21
+       WHERE id = $1`,
+      [
+        contact.id, contact.kgNodeId, contact.displayName, contact.role, contact.systemRole,
+        contact.status, contact.notes, contact.trustLevel, contact.updatedAt,
+        contact.preferredName, contact.title, contact.organization, contact.primaryEmail,
+        contact.primaryPhone, contact.timezone, contact.locale, contact.location,
+        contact.pronouns, contact.linkedinUrl, contact.bio, contact.birthday,
+      ],
+    );
+  }
+```
+
+### 4e: Update `ContactService.createContact` and add `updateContactFields`
+
+- [ ] **Step 11: Spread canonical fields in `ContactService.createContact`**
+
+In `ContactService.createContact`, replace the `const contact: Contact = { ... }` object literal. Add the 12 canonical fields after `notes`:
+
+```typescript
+    const contact: Contact = {
+      id: randomUUID(),
+      kgNodeId,
+      displayName: safeName,
+      role: options.role ?? null,
+      systemRole: null,
+      status: options.status ?? 'confirmed',
+      contactConfidence: 0,
+      trustLevel: null,
+      lastSeenAt: null,
+      inboundMessageCount: 0,
+      outboundMessageCount: 0,
+      notes: options.notes ?? null,
+      createdAt: now,
+      updatedAt: now,
+      // Canonical fields (migration 048)
+      preferredName: options.preferredName ?? null,
+      title: options.title ?? null,
+      organization: options.organization ?? null,
+      primaryEmail: options.primaryEmail ?? null,
+      primaryPhone: options.primaryPhone ?? null,
+      timezone: options.timezone ?? null,
+      locale: options.locale ?? null,
+      location: options.location ?? null,
+      pronouns: options.pronouns ?? null,
+      linkedinUrl: options.linkedinUrl ?? null,
+      bio: options.bio ?? null,
+      birthday: options.birthday ?? null,
+    };
+```
+
+- [ ] **Step 12: Add `updateContactFields` public method to `ContactService`**
+
+Add this method immediately after the `setStatus` method (around line 560), before `promoteToConfirmed`:
+
+```typescript
+  /**
+   * Update canonical profile attributes on a contact.
+   *
+   * Only fields present in `fields` are changed — absent keys leave the current
+   * value untouched. If `fields.primaryEmail` is non-null, validates that the
+   * email exists in `contact_channel_identities` for this contact (channel = 'email'),
+   * case-insensitively. Throws with a descriptive message if not found.
+   */
+  async updateContactFields(
+    contactId: string,
+    fields: ContactCanonicalFields,
+  ): Promise<Contact> {
+    const contact = await this.backend.getContact(contactId);
+    if (!contact) {
+      throw new Error(`Contact not found: ${contactId}`);
+    }
+
+    // Validate primaryEmail against channel identities before writing.
+    if (fields.primaryEmail != null) {
+      const identities = await this.backend.getIdentitiesForContact(contactId);
+      const emailLower = fields.primaryEmail.toLowerCase();
+      const match = identities.find(
+        (i) => i.channel === 'email' && i.channelIdentifier.toLowerCase() === emailLower,
+      );
+      if (!match) {
+        throw new Error(
+          `primaryEmail '${fields.primaryEmail}' not found in contact_channel_identities for contact ${contactId}`,
+        );
+      }
+    }
+
+    const updated: Contact = {
+      ...contact,
+      ...fields,
+      updatedAt: new Date(),
+    };
+
+    return this.updateStoredContact(updated);
+  }
+```
+
+- [ ] **Step 13: Run unit tests — all canonical field tests should pass**
+
+```bash
+pnpm --prefix /path/to/worktree run test -- tests/unit/contacts/contact-service.test.ts
+```
+Expected: All tests PASS including the new `describe('canonical fields')` block.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git -C /path/to/worktree add src/contacts/contact-service.ts
+git -C /path/to/worktree commit -m "feat: ContactService canonical fields — SELECT lists, INSERT/UPDATE, updateContactFields()"
+```
+
+---
+
+## Task 5: HTTP API Integration Tests (write first — they will fail)
+
+**Files:**
+- Modify: `tests/integration/contacts.test.ts`
+
+The integration test file uses a real Postgres pool and requires `DATABASE_URL` in the environment. Tests are skipped when `DATABASE_URL` is unset.
+
+- [ ] **Step 1: Add HTTP API canonical field tests**
+
+Append a new `describe` block to `tests/integration/contacts.test.ts`. This block tests the HTTP API directly against a real DB via the service (not via Fastify — that integration is in a separate HTTP test suite). For these tests we verify the service layer behavior that the HTTP routes depend on.
+
+Add these tests inside the existing `describeIf('Contacts Integration', ...)` block:
+
+```typescript
+  describe('canonical fields — service layer', () => {
+    it('createContact stores and retrieves canonical fields', async () => {
+      const contact = await contactService.createContact({
+        displayName: 'Integration Canonical',
+        source: 'integration-test',
+        title: 'Principal Engineer',
+        organization: 'Acme Corp',
+        timezone: 'America/Chicago',
+        bio: 'Integration bio.',
+      });
+
+      const fetched = await contactService.getContact(contact.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.title).toBe('Principal Engineer');
+      expect(fetched!.organization).toBe('Acme Corp');
+      expect(fetched!.timezone).toBe('America/Chicago');
+      expect(fetched!.bio).toBe('Integration bio.');
+    });
+
+    it('updateContactFields round-trips through Postgres', async () => {
+      const contact = await contactService.createContact({
+        displayName: 'Update Integration',
+        source: 'integration-test',
+      });
+
+      const updated = await contactService.updateContactFields(contact.id, {
+        title: 'Senior Engineer',
+        linkedinUrl: 'https://linkedin.com/in/testperson',
+        birthday: '1990-04-15',
+      });
+
+      const fetched = await contactService.getContact(updated.id);
+      expect(fetched!.title).toBe('Senior Engineer');
+      expect(fetched!.linkedinUrl).toBe('https://linkedin.com/in/testperson');
+      expect(fetched!.birthday).toBe('1990-04-15');
+    });
+
+    it('listContacts returns canonical fields for all contacts', async () => {
+      const contact = await contactService.createContact({
+        displayName: 'List Canonical',
+        source: 'integration-test',
+        organization: 'TestOrg',
+      });
+
+      const all = await contactService.listContacts();
+      const found = all.find(c => c.id === contact.id);
+      expect(found).toBeDefined();
+      expect(found!.organization).toBe('TestOrg');
+      // Unprovided fields are null
+      expect(found!.preferredName).toBeNull();
+    });
+
+    it('updateContactFields primaryEmail validation rejects unknown email', async () => {
+      const contact = await contactService.createContact({
+        displayName: 'Email Reject',
+        source: 'integration-test',
+      });
+      await expect(
+        contactService.updateContactFields(contact.id, { primaryEmail: 'nobody@example.com' }),
+      ).rejects.toThrow(/not found.*contact_channel_identities|contact_channel_identities.*not found/i);
+    });
+
+    it('updateContactFields primaryEmail accepts email that exists in CCI', async () => {
+      const contact = await contactService.createContact({
+        displayName: 'Email Accept',
+        source: 'integration-test',
+      });
+      await contactService.linkIdentity({
+        contactId: contact.id,
+        channel: 'email',
+        channelIdentifier: 'cci-test@example.com',
+        source: 'ceo_stated',
+      });
+      const updated = await contactService.updateContactFields(contact.id, {
+        primaryEmail: 'CCI-TEST@EXAMPLE.COM',
+      });
+      expect(updated.primaryEmail).toBe('CCI-TEST@EXAMPLE.COM');
+    });
+  });
+```
+
+- [ ] **Step 2: Run integration tests — confirm new tests fail or are skipped (if no DB)**
+
+```bash
+pnpm --prefix /path/to/worktree run test -- tests/integration/contacts.test.ts
+```
+Expected: Tests pass if `DATABASE_URL` is set and migration 048 has been applied. Skipped if `DATABASE_URL` unset.
+
+---
+
+## Task 6: HTTP API Implementation
+
+**Files:**
+- Modify: `src/channels/http/routes/kg.ts`
+
+The three contact endpoints need updating. Make edits in the order below.
+
+### 6a: Helpers
+
+- [ ] **Step 1: Add a `serializeContact` helper near the top of the kg.ts contact section**
+
+Find the `GET /api/kg/contacts` handler. Just before it, add a local helper function:
+
+```typescript
+  // Serialize a Contact object to the HTTP response shape.
+  // Returns all canonical fields so the Console UI can display them
+  // without a separate detail fetch.
+  function serializeContact(c: Contact) {
+    return {
+      id: c.id,
+      kgNodeId: c.kgNodeId,
+      displayName: c.displayName,
+      role: c.role,
+      status: c.status,
+      trustLevel: c.trustLevel,
+      systemRole: c.systemRole,
+      notes: c.notes,
+      createdAt: c.createdAt.toISOString(),
+      updatedAt: c.updatedAt.toISOString(),
+      // Canonical fields (migration 048)
+      preferredName: c.preferredName,
+      title: c.title,
+      organization: c.organization,
+      primaryEmail: c.primaryEmail,
+      primaryPhone: c.primaryPhone,
+      timezone: c.timezone,
+      locale: c.locale,
+      location: c.location,
+      pronouns: c.pronouns,
+      linkedinUrl: c.linkedinUrl,
+      bio: c.bio,
+      birthday: c.birthday,
+    };
+  }
+```
+
+(You'll also need to import `Contact` from contacts/types — check whether it's already imported in this file, and add it to the import if not.)
+
+### 6b: Validation helper
+
+- [ ] **Step 2: Add a `validateCanonicalFields` helper**
+
+Add this function in the same local scope, after `serializeContact`:
+
+```typescript
+  // Validate canonical fields from a POST/PATCH body.
+  // Returns an error string if invalid, or null if all checks pass.
+  // `fields` entries are trimmed and empty-string-coerced to null.
+  function extractAndValidateCanonicalFields(body: Record<string, unknown>): {
+    error: string | null;
+    fields: import('../../../contacts/types.js').ContactCanonicalFields;
+  } {
+    const str = (v: unknown): string | null =>
+      typeof v === 'string' && v.trim().length > 0 ? v.trim() : null;
+
+    const fields: import('../../../contacts/types.js').ContactCanonicalFields = {};
+
+    if ('preferredName' in body) fields.preferredName = str(body.preferredName);
+    if ('title' in body) fields.title = str(body.title);
+    if ('organization' in body) fields.organization = str(body.organization);
+    if ('primaryPhone' in body) fields.primaryPhone = str(body.primaryPhone);
+    if ('timezone' in body) fields.timezone = str(body.timezone);
+    if ('locale' in body) fields.locale = str(body.locale);
+    if ('location' in body) fields.location = str(body.location);
+    if ('pronouns' in body) fields.pronouns = str(body.pronouns);
+    if ('birthday' in body) fields.birthday = str(body.birthday);
+    if ('linkedinUrl' in body) fields.linkedinUrl = str(body.linkedinUrl);
+    if ('bio' in body) fields.bio = str(body.bio);
+    if ('primaryEmail' in body) fields.primaryEmail = str(body.primaryEmail);
+
+    // Format validation
+    if (fields.primaryEmail != null && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(fields.primaryEmail)) {
+      return { error: 'Invalid primaryEmail format.', fields };
+    }
+    if (fields.linkedinUrl != null && !/^https?:\/\//.test(fields.linkedinUrl)) {
+      return { error: 'linkedinUrl must start with http:// or https://.', fields };
+    }
+    if (fields.bio != null && fields.bio.length > 500) {
+      return { error: 'bio must be 500 characters or fewer.', fields };
+    }
+    if (fields.birthday != null &&
+        !/^\d{4}-\d{2}-\d{2}$/.test(fields.birthday) &&
+        !/^--\d{2}-\d{2}$/.test(fields.birthday)) {
+      return { error: 'birthday must be YYYY-MM-DD or --MM-DD.', fields };
+    }
+
+    return { error: null, fields };
+  }
+```
+
+### 6c: Update GET endpoint
+
+- [ ] **Step 3: Replace the GET /api/kg/contacts response to use `serializeContact`**
+
+Find the GET handler body:
+```typescript
+      return reply.send({
+        contacts: contacts.map((contact) => ({
+          id: contact.id,
+          ...
+        })),
+      });
+```
+
+Replace the map with:
+```typescript
+      return reply.send({
+        contacts: contacts.map(serializeContact),
+      });
+```
+
+### 6d: Update POST endpoint
+
+- [ ] **Step 4: Update POST /api/kg/contacts to extract + validate canonical fields**
+
+In the POST handler, after the existing `displayName` / `status` / `trustLevel` / `kgNodeId` validation block, add:
+
+```typescript
+    const { error: canonicalError, fields: canonicalFields } = extractAndValidateCanonicalFields(body as Record<string, unknown>);
+    if (canonicalError) {
+      return reply.status(400).send({ error: canonicalError });
+    }
+```
+
+Then update the `createContact` call to spread the canonical fields:
+
+```typescript
+    const created = await contactService.createContact({
+      displayName: body.displayName,
+      role: typeof body.role === 'string' && body.role.trim().length > 0 ? body.role : undefined,
+      status: status as ContactStatus,
+      notes: typeof body.notes === 'string' && body.notes.trim().length > 0 ? body.notes : undefined,
+      kgNodeId,
+      source: 'kg_web_ui',
+      ...canonicalFields,
+    });
+```
+
+Replace the final `return reply.status(201).send(...)` to use `serializeContact`:
+
+```typescript
+    return reply.status(201).send({ contact: serializeContact(freshCreated) });
+```
+
+### 6e: Update PATCH endpoint
+
+- [ ] **Step 5: Update PATCH /api/kg/contacts/:id to handle canonical fields**
+
+In the PATCH handler, after the existing `kgNodeId` / `displayName` validation block, add the canonical fields extraction:
+
+```typescript
+    const { error: canonicalError, fields: canonicalFields } = extractAndValidateCanonicalFields(body as Record<string, unknown>);
+    if (canonicalError) {
+      return reply.status(400).send({ error: canonicalError });
+    }
+```
+
+After all the existing mutations (`displayName`, `role`, `status`, `trustLevel`, `notes`, `kgNodeId`), add a call to `updateContactFields` if any canonical fields were present in the body:
+
+```typescript
+    // Apply canonical fields if any were included in the request body.
+    const CANONICAL_KEYS: Array<keyof typeof canonicalFields> = [
+      'preferredName', 'title', 'organization', 'primaryEmail', 'primaryPhone',
+      'timezone', 'locale', 'location', 'pronouns', 'linkedinUrl', 'bio', 'birthday',
+    ];
+    const hasCanonicalFields = CANONICAL_KEYS.some(k => k in (body as Record<string, unknown>));
+    if (hasCanonicalFields) {
+      try {
+        await contactService.updateContactFields(id, canonicalFields);
+      } catch (err) {
+        // updateContactFields throws for primaryEmail CCI mismatch
+        return reply.status(400).send({ error: (err as Error).message });
+      }
+    }
+```
+
+Replace the final response to use `serializeContact`:
+
+```typescript
+    const updated = await contactService.getContact(id);
+    if (!updated) {
+      return reply.status(404).send({ error: 'Contact not found after update.' });
+    }
+    return reply.send({ contact: serializeContact(updated) });
+```
+
+- [ ] **Step 6: Run typecheck**
+
+```bash
+pnpm --prefix /path/to/worktree run typecheck
+```
+Expected: No errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /path/to/worktree add src/channels/http/routes/kg.ts
+git -C /path/to/worktree commit -m "feat: HTTP API exposes canonical fields on GET/POST/PATCH contacts"
+```
+
+---
+
+## Task 7: Console UI
+
+**Files:**
+- Modify: `apps/console/src/pages/ContactsPage.tsx`
+
+### 7a: Widen `Contact` interface
+
+- [ ] **Step 1: Add 12 new nullable string fields to the local `Contact` interface**
+
+Replace the current `Contact` interface (lines 14–25) with:
+
+```typescript
+interface Contact {
+  id: string;
+  kgNodeId: string | null;
+  displayName: string;
+  role: string | null;
+  status: ContactStatus;
+  notes: string | null;
+  trustLevel: TrustLevel;
+  systemRole: SystemRole;
+  createdAt: string;
+  updatedAt: string;
+  // Canonical fields (migration 048)
+  preferredName: string | null;
+  title: string | null;
+  organization: string | null;
+  primaryEmail: string | null;
+  primaryPhone: string | null;
+  timezone: string | null;
+  locale: string | null;
+  location: string | null;
+  pronouns: string | null;
+  linkedinUrl: string | null;
+  bio: string | null;
+  birthday: string | null;
+}
+```
+
+### 7b: Replace Role column with Title + Organization in the table
+
+- [ ] **Step 2: Update the table header — replace `Role` with `Title` and `Organization`**
+
+Find the thead row. Replace the `Role` `<th>`:
+```tsx
+                          <th className="sortable" aria-sort={sort.key === 'role' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('role')}>
+                              Role <span className="sort-arrow">{sortArrow('role')}</span>
+                            </button>
+                          </th>
+```
+
+with:
+```tsx
+                          <th className="sortable" aria-sort={sort.key === 'title' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('title')}>
+                              Title <span className="sort-arrow">{sortArrow('title')}</span>
+                            </button>
+                          </th>
+                          <th className="sortable" aria-sort={sort.key === 'organization' ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+                            <button className="sort-btn" onClick={() => toggleSort('organization')}>
+                              Org <span className="sort-arrow">{sortArrow('organization')}</span>
+                            </button>
+                          </th>
+```
+
+Also update the `colSpan` on the empty-state `<td>` from `5` to `6`.
+
+- [ ] **Step 3: Update the table body — replace `{c.role ?? ''}` with Title + Org cells**
+
+Find the tbody row. Replace:
+```tsx
+                            <td>{c.role ?? ''}</td>
+```
+
+with:
+```tsx
+                            <td>{c.title ?? ''}</td>
+                            <td>{c.organization ?? ''}</td>
+```
+
+### 7c: Rewrite the drawer with 6 sections
+
+- [ ] **Step 4: Add state variables for the 12 new fields in `ContactEditDrawer`**
+
+In the `ContactEditDrawer` function, after the existing `useState` declarations, add:
+
+```typescript
+  const [preferredName, setPreferredName] = useState(contact?.preferredName ?? '');
+  const [pronouns, setPronouns] = useState(contact?.pronouns ?? '');
+  const [title, setTitle] = useState(contact?.title ?? '');
+  const [organization, setOrganization] = useState(contact?.organization ?? '');
+  const [primaryEmail, setPrimaryEmail] = useState(contact?.primaryEmail ?? '');
+  const [primaryPhone, setPrimaryPhone] = useState(contact?.primaryPhone ?? '');
+  const [timezone, setTimezone] = useState(contact?.timezone ?? '');
+  const [locale, setLocale] = useState(contact?.locale ?? '');
+  const [location, setLocation] = useState(contact?.location ?? '');
+  const [linkedinUrl, setLinkedinUrl] = useState(contact?.linkedinUrl ?? '');
+  const [bio, setBio] = useState(contact?.bio ?? '');
+  const [birthday, setBirthday] = useState(contact?.birthday ?? '');
+```
+
+- [ ] **Step 5: Update `handleSave` to include canonical fields in the request body**
+
+Replace the `const body = { ... }` block inside `handleSave`:
+
+```typescript
+      const body = {
+        displayName: displayName.trim(),
+        role: role.trim() || null,
+        status,
+        trustLevel: trustLevel ?? null,
+        notes: notes.trim() || null,
+        kgNodeId: kgNodeId.trim() || null,
+        // Canonical fields
+        preferredName: preferredName.trim() || null,
+        pronouns: pronouns.trim() || null,
+        title: title.trim() || null,
+        organization: organization.trim() || null,
+        primaryEmail: primaryEmail.trim() || null,
+        primaryPhone: primaryPhone.trim() || null,
+        timezone: timezone.trim() || null,
+        locale: locale.trim() || null,
+        location: location.trim() || null,
+        linkedinUrl: linkedinUrl.trim() || null,
+        bio: bio.trim() || null,
+        birthday: birthday.trim() || null,
+      };
+```
+
+- [ ] **Step 6: Replace the drawer form body with 6 grouped sections**
+
+Replace the entire `<div className="drawer-body"> ... </div>` block with:
+
+```tsx
+      <div className="drawer-body">
+        <div className="edit-drawer-form">
+          {error && <p style={{ color: 'var(--app-destructive)', margin: 0, fontSize: 13 }}>{error}</p>}
+
+          {/* Section: Identity */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '0 0 6px' }}>Identity</p>
+          <div className="form-grid">
+            <div className="form-field">
+              <label htmlFor="cf-name">Display name</label>
+              <input id="cf-name" type="text" value={displayName} onChange={e => setDisplayName(e.target.value)} placeholder="Full name" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-preferred-name">Preferred name</label>
+              <input id="cf-preferred-name" type="text" value={preferredName} onChange={e => setPreferredName(e.target.value)} placeholder="Nickname or short form" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-pronouns">Pronouns</label>
+              <input id="cf-pronouns" type="text" value={pronouns} onChange={e => setPronouns(e.target.value)} placeholder="they/them" />
+            </div>
+          </div>
+
+          {/* Section: Work */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>Work</p>
+          <div className="form-grid">
+            <div className="form-field">
+              <label htmlFor="cf-role">Role</label>
+              <input id="cf-role" type="text" value={role} onChange={e => setRole(e.target.value)} placeholder="Internal role label" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-title">Title</label>
+              <input id="cf-title" type="text" value={title} onChange={e => setTitle(e.target.value)} placeholder="Current job title" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-org">Organization</label>
+              <input id="cf-org" type="text" value={organization} onChange={e => setOrganization(e.target.value)} placeholder="Employer" />
+            </div>
+          </div>
+
+          {/* Section: Contact info */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>Contact info</p>
+          <div className="form-grid">
+            <div className="form-field">
+              <label htmlFor="cf-email">Primary email</label>
+              <input id="cf-email" type="text" value={primaryEmail} onChange={e => setPrimaryEmail(e.target.value)} placeholder="Lowercased on save" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-phone">Primary phone</label>
+              <input id="cf-phone" type="text" value={primaryPhone} onChange={e => setPrimaryPhone(e.target.value)} placeholder="+1 555 000 0000" />
+            </div>
+          </div>
+
+          {/* Section: Location & locale */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>Location &amp; locale</p>
+          <div className="form-grid">
+            <div className="form-field">
+              <label htmlFor="cf-tz">Timezone</label>
+              <input id="cf-tz" type="text" value={timezone} onChange={e => setTimezone(e.target.value)} placeholder="America/New_York" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-locale">Locale</label>
+              <input id="cf-locale" type="text" value={locale} onChange={e => setLocale(e.target.value)} placeholder="en-US" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-location">Location</label>
+              <input id="cf-location" type="text" value={location} onChange={e => setLocation(e.target.value)} placeholder="City, region" />
+            </div>
+          </div>
+
+          {/* Section: Links & bio */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>Links &amp; bio</p>
+          <div className="form-field">
+            <label htmlFor="cf-linkedin">LinkedIn URL</label>
+            <input id="cf-linkedin" type="text" value={linkedinUrl} onChange={e => setLinkedinUrl(e.target.value)} placeholder="https://linkedin.com/in/…" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="cf-bio">Bio</label>
+            <textarea id="cf-bio" rows={3} value={bio} onChange={e => setBio(e.target.value)} placeholder="Short narrative (max 500 chars)" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="cf-birthday">Birthday</label>
+            <input id="cf-birthday" type="text" value={birthday} onChange={e => setBirthday(e.target.value)} placeholder="YYYY-MM-DD or --MM-DD" />
+          </div>
+
+          {/* Section: System */}
+          <p style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--app-fg-muted)', margin: '16px 0 6px' }}>System</p>
+          <div className="form-grid">
+            <div className="form-field">
+              <label htmlFor="cf-status">Status</label>
+              <select id="cf-status" value={status} onChange={e => setStatus(e.target.value as ContactStatus)}>
+                <option value="confirmed">Confirmed</option>
+                <option value="provisional">Provisional</option>
+                <option value="blocked">Blocked</option>
+              </select>
+            </div>
+            <div className="form-field">
+              <label htmlFor="cf-trust">Trust level</label>
+              <select id="cf-trust" value={trustLevel ?? ''} onChange={e => setTrustLevel((e.target.value || null) as TrustLevel)}>
+                <option value="">None</option>
+                <option value="ceo">CEO</option>
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+            </div>
+          </div>
+          <div className="form-field">
+            <label htmlFor="cf-kg">KG node ID</label>
+            <input id="cf-kg" type="text" value={kgNodeId} onChange={e => setKgNodeId(e.target.value)} placeholder="UUID — optional" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="cf-notes">Notes</label>
+            <textarea id="cf-notes" rows={4} value={notes} onChange={e => setNotes(e.target.value)} />
+          </div>
+        </div>
+      </div>
+```
+
+- [ ] **Step 7: Run Console TypeScript typecheck**
+
+```bash
+pnpm --prefix /path/to/worktree/apps/console run typecheck
+```
+Expected: No errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C /path/to/worktree add apps/console/src/pages/ContactsPage.tsx
+git -C /path/to/worktree commit -m "feat: Console UI — Title+Org table columns, 6-section canonical drawer"
+```
+
+---
+
+## Task 8: Backfill Script Tests (write first — they will fail)
+
+**Files:**
+- Create: `scripts/backfill-contact-attributes.test.ts`
+
+The backfill script will export a testable `runBackfill(pool)` function. These tests mock the pool's `query` method.
+
+- [ ] **Step 1: Create the test file**
+
+Create `scripts/backfill-contact-attributes.test.ts`:
+
+```typescript
+// scripts/backfill-contact-attributes.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Pool } from 'pg';
+import { runBackfill } from './backfill-contact-attributes.js';
+
+// A minimal pool mock: query() returns different results based on which call it is.
+function makeMockPool(queryResponses: Array<{ rows: Record<string, unknown>[] }>): Pool {
+  let callIndex = 0;
+  return {
+    query: vi.fn(() => {
+      const response = queryResponses[callIndex++] ?? { rows: [] };
+      return Promise.resolve(response);
+    }),
+  } as unknown as Pool;
+}
+
+describe('runBackfill', () => {
+  it('skips contacts with no kg_node_id', async () => {
+    const pool = makeMockPool([
+      // contacts query: returns one contact with null kg_node_id
+      { rows: [{ id: 'c1', kg_node_id: null, system_role: null }] },
+    ]);
+
+    const result = await runBackfill(pool);
+    expect(result.processed).toBe(0);
+    expect(result.written).toBe(0);
+  });
+
+  it('populates columns from matching KG fact nodes', async () => {
+    const updateMock = vi.fn().mockResolvedValue({ rows: [] });
+    const pool = {
+      query: vi.fn()
+        // Call 1: contacts with kg_node_id
+        .mockResolvedValueOnce({
+          rows: [{ id: 'c1', kg_node_id: 'kg1', system_role: null,
+                   preferred_name: null, title: null, organization: null,
+                   primary_email: null, primary_phone: null, timezone: null,
+                   locale: null, location: null, pronouns: null,
+                   linkedin_url: null, bio: null, birthday: null }],
+        })
+        // Call 2: fact nodes for this contact
+        .mockResolvedValueOnce({
+          rows: [
+            { id: 'f1', properties: { attribute: 'job_title', value: 'CTO' }, confidence: 0.9, last_confirmed_at: '2026-01-01' },
+            { id: 'f2', properties: { attribute: 'organization', value: 'Acme' }, confidence: 0.8, last_confirmed_at: '2026-01-01' },
+          ],
+        })
+        // Call 3: UPDATE contacts
+        .mockImplementation(updateMock),
+    } as unknown as Pool;
+
+    const result = await runBackfill(pool);
+    expect(result.processed).toBe(1);
+    expect(result.written).toBeGreaterThan(0);
+
+    // Verify the UPDATE was called with expected values
+    const updateCall = (pool.query as ReturnType<typeof vi.fn>).mock.calls[2]!;
+    const sql = updateCall[0] as string;
+    const params = updateCall[1] as unknown[];
+    expect(sql).toContain('UPDATE contacts SET');
+    // title = 'CTO' should be in the params
+    expect(params).toContain('CTO');
+    // organization = 'Acme' should be in the params
+    expect(params).toContain('Acme');
+  });
+
+  it('prefers higher confidence when two facts target same column', async () => {
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [{ id: 'c1', kg_node_id: 'kg1', system_role: null,
+                   preferred_name: null, title: null, organization: null,
+                   primary_email: null, primary_phone: null, timezone: null,
+                   locale: null, location: null, pronouns: null,
+                   linkedin_url: null, bio: null, birthday: null }],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            // Two facts for title — higher confidence wins
+            { id: 'f1', properties: { attribute: 'title', value: 'VP' }, confidence: 0.7, last_confirmed_at: '2025-12-01' },
+            { id: 'f2', properties: { attribute: 'title', value: 'CTO' }, confidence: 0.95, last_confirmed_at: '2025-11-01' },
+          ],
+        })
+        .mockResolvedValue({ rows: [] }),
+    } as unknown as Pool;
+
+    await runBackfill(pool);
+
+    const updateCall = (pool.query as ReturnType<typeof vi.fn>).mock.calls[2]!;
+    const params = updateCall[1] as unknown[];
+    expect(params).toContain('CTO');
+    expect(params).not.toContain('VP');
+  });
+
+  it('uses last_confirmed_at as tiebreaker when confidence is equal', async () => {
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [{ id: 'c1', kg_node_id: 'kg1', system_role: null,
+                   preferred_name: null, title: null, organization: null,
+                   primary_email: null, primary_phone: null, timezone: null,
+                   locale: null, location: null, pronouns: null,
+                   linkedin_url: null, bio: null, birthday: null }],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            { id: 'f1', properties: { attribute: 'title', value: 'VP' }, confidence: 0.8, last_confirmed_at: '2025-06-01' },
+            { id: 'f2', properties: { attribute: 'title', value: 'CTO' }, confidence: 0.8, last_confirmed_at: '2026-01-01' }, // more recent
+          ],
+        })
+        .mockResolvedValue({ rows: [] }),
+    } as unknown as Pool;
+
+    await runBackfill(pool);
+
+    const updateCall = (pool.query as ReturnType<typeof vi.fn>).mock.calls[2]!;
+    const params = updateCall[1] as unknown[];
+    expect(params).toContain('CTO'); // more recent wins
+    expect(params).not.toContain('VP');
+  });
+
+  it('skips already-populated columns (idempotency)', async () => {
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 'c1', kg_node_id: 'kg1', system_role: null,
+            preferred_name: null,
+            title: 'Existing Title',  // already populated
+            organization: null, primary_email: null, primary_phone: null,
+            timezone: null, locale: null, location: null, pronouns: null,
+            linkedin_url: null, bio: null, birthday: null,
+          }],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            { id: 'f1', properties: { attribute: 'job_title', value: 'New Title' }, confidence: 0.99, last_confirmed_at: '2026-01-01' },
+          ],
+        })
+        .mockResolvedValue({ rows: [] }),
+    } as unknown as Pool;
+
+    await runBackfill(pool);
+
+    const calls = (pool.query as ReturnType<typeof vi.fn>).mock.calls;
+    // The UPDATE call should NOT include title since it was already populated.
+    // If no columns change, no UPDATE is issued at all.
+    const updateCall = calls.find(c => (c[0] as string).includes('UPDATE contacts SET'));
+    if (updateCall) {
+      const params = updateCall[1] as unknown[];
+      expect(params).not.toContain('New Title');
+    }
+  });
+
+  it('does not apply role KG fact to title when contact has a system_role', async () => {
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 'c1', kg_node_id: 'kg1',
+            system_role: 'principal',  // has system_role — role fact should not apply to title
+            preferred_name: null, title: null, organization: null,
+            primary_email: null, primary_phone: null, timezone: null,
+            locale: null, location: null, pronouns: null,
+            linkedin_url: null, bio: null, birthday: null,
+          }],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            { id: 'f1', properties: { attribute: 'role', value: 'Principal' }, confidence: 0.99, last_confirmed_at: '2026-01-01' },
+          ],
+        })
+        .mockResolvedValue({ rows: [] }),
+    } as unknown as Pool;
+
+    await runBackfill(pool);
+
+    const calls = (pool.query as ReturnType<typeof vi.fn>).mock.calls;
+    const updateCall = calls.find(c => (c[0] as string).includes('UPDATE contacts SET'));
+    // No update should be issued because the only fact was 'role' which is skipped
+    // when system_role is set, and no other columns changed.
+    expect(updateCall).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+pnpm --prefix /path/to/worktree run test -- scripts/backfill-contact-attributes.test.ts
+```
+Expected: FAIL — `Cannot find module './backfill-contact-attributes.js'`.
+
+---
+
+## Task 9: Backfill Script Implementation
+
+**Files:**
+- Create: `scripts/backfill-contact-attributes.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Create the backfill script**
+
+Create `scripts/backfill-contact-attributes.ts`:
+
+```typescript
+// scripts/backfill-contact-attributes.ts
+//
+// Backfills contact canonical columns from KG fact nodes.
+// Each contact's kg_node_id is used to find related fact nodes via
+// 'relates_to' edges. For each NULL column, the fact with the highest
+// confidence (tiebreak: most recent last_confirmed_at) is written.
+//
+// Run: pnpm run backfill:contact-attributes
+// Safety: idempotent — only writes to NULL columns.
+
+import pg from 'pg';
+
+const { Pool } = pg;
+
+// Mapping from KG fact attribute keys to contact columns.
+// Keys are compared case-insensitively.
+const ATTRIBUTE_MAP: Record<string, string> = {
+  preferred_name: 'preferred_name',
+  nickname: 'preferred_name',
+  job_title: 'title',
+  title: 'title',
+  // 'role' maps to title only when contact.system_role IS NULL (handled in code)
+  organization: 'organization',
+  employer: 'organization',
+  company: 'organization',
+  current_employer: 'organization',
+  email: 'primary_email',
+  primary_email: 'primary_email',
+  phone: 'primary_phone',
+  phone_number: 'primary_phone',
+  mobile: 'primary_phone',
+  timezone: 'timezone',
+  tz: 'timezone',
+  locale: 'locale',
+  language: 'locale',
+  home_city: 'location',
+  current_location: 'location',
+  location: 'location',
+  city: 'location',
+  pronouns: 'pronouns',
+  linkedin: 'linkedin_url',
+  linkedin_url: 'linkedin_url',
+  bio: 'bio',
+  biography: 'bio',
+  birthday: 'birthday',
+  birthdate: 'birthday',
+  dob: 'birthday',
+};
+
+// All 12 canonical column names (snake_case, matching DB columns).
+const CANONICAL_COLUMNS = [
+  'preferred_name', 'title', 'organization', 'primary_email', 'primary_phone',
+  'timezone', 'locale', 'location', 'pronouns', 'linkedin_url', 'bio', 'birthday',
+];
+
+type ContactRowForBackfill = {
+  id: string;
+  kg_node_id: string;
+  system_role: string | null;
+  preferred_name: string | null;
+  title: string | null;
+  organization: string | null;
+  primary_email: string | null;
+  primary_phone: string | null;
+  timezone: string | null;
+  locale: string | null;
+  location: string | null;
+  pronouns: string | null;
+  linkedin_url: string | null;
+  bio: string | null;
+  birthday: string | null;
+};
+
+type FactRow = {
+  id: string;
+  properties: { attribute?: string; value?: string };
+  confidence: number;
+  last_confirmed_at: string | null;
+};
+
+export async function runBackfill(pool: pg.Pool): Promise<{
+  processed: number;
+  written: number;
+  skipped: number;
+  errors: number;
+}> {
+  // Fetch all contacts that have a KG node linked.
+  const contactsResult = await pool.query<ContactRowForBackfill>(
+    `SELECT id, kg_node_id, system_role,
+            preferred_name, title, organization, primary_email, primary_phone,
+            timezone, locale, location, pronouns, linkedin_url, bio, birthday
+     FROM contacts WHERE kg_node_id IS NOT NULL`,
+  );
+
+  const contacts = contactsResult.rows;
+  let processed = 0;
+  let written = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const contact of contacts) {
+    try {
+      // Fetch all fact nodes reachable via a single 'relates_to' edge
+      // from this contact's KG person node (either direction).
+      const factsResult = await pool.query<FactRow>(
+        `SELECT n.id, n.properties, n.confidence, n.last_confirmed_at
+         FROM kg_nodes n
+         JOIN kg_edges e ON (
+           (e.source_id = $1 AND e.target_id = n.id)
+           OR (e.target_id = $1 AND e.source_id = n.id)
+         )
+         WHERE e.relationship = 'relates_to'
+           AND n.type = 'fact'`,
+        [contact.kg_node_id],
+      );
+
+      const facts = factsResult.rows;
+
+      // Group facts by target column. For each column collect all candidates,
+      // then pick the one with highest confidence (tiebreak: most recent last_confirmed_at).
+      const candidates: Record<string, Array<{ value: string; confidence: number; confirmedAt: number }>> = {};
+
+      for (const fact of facts) {
+        const attrRaw = fact.properties?.attribute;
+        const value = fact.properties?.value;
+        if (!attrRaw || !value) continue;
+
+        const attr = attrRaw.toLowerCase();
+
+        // 'role' only maps to 'title' when system_role IS NULL
+        if (attr === 'role' && contact.system_role != null) continue;
+
+        const col = attr === 'role' ? 'title' : ATTRIBUTE_MAP[attr];
+        if (!col) continue;
+
+        const confirmedAt = fact.last_confirmed_at
+          ? new Date(fact.last_confirmed_at).getTime()
+          : 0;
+
+        if (!candidates[col]) candidates[col] = [];
+        candidates[col].push({ value, confidence: Number(fact.confidence), confirmedAt });
+      }
+
+      // Determine which NULL columns have a candidate value.
+      const updates: Record<string, string> = {};
+      for (const col of CANONICAL_COLUMNS) {
+        // Only write to NULL columns (idempotent safety)
+        if (contact[col as keyof ContactRowForBackfill] != null) {
+          skipped++;
+          continue;
+        }
+
+        const colCandidates = candidates[col];
+        if (!colCandidates || colCandidates.length === 0) continue;
+
+        // Sort: highest confidence first; tiebreak on most recent last_confirmed_at
+        colCandidates.sort((a, b) =>
+          b.confidence !== a.confidence
+            ? b.confidence - a.confidence
+            : b.confirmedAt - a.confirmedAt,
+        );
+
+        updates[col] = colCandidates[0]!.value;
+      }
+
+      if (Object.keys(updates).length === 0) {
+        processed++;
+        continue;
+      }
+
+      // Build a parameterized UPDATE for only the changed columns.
+      const setClauses: string[] = [];
+      const params: unknown[] = [contact.id];
+      for (const [col, val] of Object.entries(updates)) {
+        params.push(val);
+        setClauses.push(`${col} = $${params.length}`);
+      }
+
+      await pool.query(
+        `UPDATE contacts SET ${setClauses.join(', ')} WHERE id = $1`,
+        params,
+      );
+
+      written += Object.keys(updates).length;
+      processed++;
+      console.log(
+        `[backfill] contact ${contact.id}: wrote ${Object.keys(updates).join(', ')}`,
+      );
+    } catch (err) {
+      console.error(`[backfill] contact ${contact.id} failed:`, err);
+      errors++;
+    }
+  }
+
+  console.log(
+    `[backfill] done — processed: ${processed}, written: ${written}, skipped: ${skipped}, errors: ${errors}`,
+  );
+  return { processed, written, skipped, errors };
+}
+
+// CLI entry point — only runs when executed directly
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^.*\//, ''))) {
+  const databaseUrl = process.env['DATABASE_URL'];
+  if (!databaseUrl) {
+    console.error('[backfill] DATABASE_URL is not set');
+    process.exit(1);
+  }
+  const pool = new Pool({ connectionString: databaseUrl });
+  runBackfill(pool)
+    .then(({ errors }) => {
+      void pool.end();
+      process.exit(errors > 0 ? 1 : 0);
+    })
+    .catch(err => {
+      console.error('[backfill] fatal error:', err);
+      void pool.end();
+      process.exit(1);
+    });
+}
+```
+
+- [ ] **Step 2: Run backfill unit tests**
+
+```bash
+pnpm --prefix /path/to/worktree run test -- scripts/backfill-contact-attributes.test.ts
+```
+Expected: All tests PASS.
+
+- [ ] **Step 3: Add the npm script to `package.json`**
+
+In `package.json`, find the `"scripts"` block. Add the backfill entry:
+
+```json
+"backfill:contact-attributes": "tsx scripts/backfill-contact-attributes.ts",
+```
+
+(Add it alongside the other script entries.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /path/to/worktree add scripts/backfill-contact-attributes.ts scripts/backfill-contact-attributes.test.ts package.json
+git -C /path/to/worktree commit -m "feat: backfill script for contact canonical attributes"
+```
+
+---
+
+## Task 10: Final Typecheck + Full Test Run
+
+- [ ] **Step 1: Run full typecheck**
+
+```bash
+pnpm --prefix /path/to/worktree run typecheck
+```
+Expected: No errors.
+
+- [ ] **Step 2: Run all unit tests**
+
+```bash
+pnpm --prefix /path/to/worktree run test -- tests/unit/
+```
+Expected: All tests PASS.
+
+- [ ] **Step 3: Run integration tests (requires DATABASE_URL)**
+
+```bash
+pnpm --prefix /path/to/worktree run test -- tests/integration/contacts.test.ts
+```
+Expected: All tests PASS (or gracefully skipped if DATABASE_URL unset).
+
+- [ ] **Step 4: Update CHANGELOG.md**
+
+Add to the `## [Unreleased]` section in `CHANGELOG.md`:
+
+```markdown
+### Added
+- **Contact canonical attributes** — 12 structured profile fields (`title`, `organization`, `primary_email`, etc.) persisted directly on the `contacts` row; backfill script populates from KG facts. (#829)
+```
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git -C /path/to/worktree add CHANGELOG.md
+git -C /path/to/worktree commit -m "chore: CHANGELOG for contact canonical attributes (#829)"
+```
+
+---
+
+## Acceptance Criteria Checklist
+
+- [ ] Migration 048 adds 12 columns with CHECK constraints; rolls back cleanly
+- [ ] Backfill script populates columns from KG facts; re-run is idempotent
+- [ ] `ContactService.createContact` stores all 12 fields; `updateContactFields()` validates primaryEmail
+- [ ] HTTP API: GET list returns all 12 fields; POST/PATCH accept and validate them (400 on invalid input)
+- [ ] Console table: Role column replaced with Title + Organization
+- [ ] Console drawer: 6 grouped sections covering all 12 new fields
+- [ ] All existing tests pass; new unit + integration + backfill tests all green
+- [ ] Typecheck and lint clean

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "inspect-prompts": "tsx --env-file=.env scripts/inspect-prompts.ts",
     "render-coordinator-prompt": "tsx --env-file=.env scripts/render-coordinator-prompt.ts",
     "redteam": "promptfoo redteam run --config tests/redteam/promptfooconfig.yaml --env-file .env",
-    "redteam:report": "promptfoo view"
+    "redteam:report": "promptfoo view",
+    "backfill:contact-attributes": "tsx scripts/backfill-contact-attributes.ts"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "render-coordinator-prompt": "tsx --env-file=.env scripts/render-coordinator-prompt.ts",
     "redteam": "promptfoo redteam run --config tests/redteam/promptfooconfig.yaml --env-file .env",
     "redteam:report": "promptfoo view",
-    "backfill:contact-attributes": "tsx scripts/backfill-contact-attributes.ts"
+    "backfill:contact-attributes": "tsx --env-file=.env scripts/backfill-contact-attributes.ts"
   },
   "license": "MIT",
   "dependencies": {

--- a/scripts/backfill-contact-attributes.test.ts
+++ b/scripts/backfill-contact-attributes.test.ts
@@ -22,7 +22,7 @@ describe('runBackfill', () => {
 
     const result = await runBackfill(pool);
     expect(result.processed).toBe(0);
-    expect(result.written).toBe(0);
+    expect(result.columnsWritten).toBe(0);
   });
 
   it('populates columns from matching KG fact nodes', async () => {
@@ -50,7 +50,7 @@ describe('runBackfill', () => {
 
     const result = await runBackfill(pool);
     expect(result.processed).toBe(1);
-    expect(result.written).toBeGreaterThan(0);
+    expect(result.columnsWritten).toBeGreaterThan(0);
 
     // Verify the UPDATE was called with expected values
     const updateCall = (pool.query as ReturnType<typeof vi.fn>).mock.calls[2]!;

--- a/scripts/backfill-contact-attributes.test.ts
+++ b/scripts/backfill-contact-attributes.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Pool } from 'pg';
+import { runBackfill } from './backfill-contact-attributes.js';
+
+// A minimal pool mock: query() returns different results based on which call it is.
+function makeMockPool(queryResponses: Array<{ rows: Record<string, unknown>[] }>): Pool {
+  let callIndex = 0;
+  return {
+    query: vi.fn(() => {
+      const response = queryResponses[callIndex++] ?? { rows: [] };
+      return Promise.resolve(response);
+    }),
+  } as unknown as Pool;
+}
+
+describe('runBackfill', () => {
+  it('skips contacts with no kg_node_id', async () => {
+    const pool = makeMockPool([
+      // contacts query: returns one contact with null kg_node_id
+      { rows: [{ id: 'c1', kg_node_id: null, system_role: null }] },
+    ]);
+
+    const result = await runBackfill(pool);
+    expect(result.processed).toBe(0);
+    expect(result.written).toBe(0);
+  });
+
+  it('populates columns from matching KG fact nodes', async () => {
+    const updateMock = vi.fn().mockResolvedValue({ rows: [] });
+    const pool = {
+      query: vi.fn()
+        // Call 1: contacts with kg_node_id
+        .mockResolvedValueOnce({
+          rows: [{ id: 'c1', kg_node_id: 'kg1', system_role: null,
+                   preferred_name: null, title: null, organization: null,
+                   primary_email: null, primary_phone: null, timezone: null,
+                   locale: null, location: null, pronouns: null,
+                   linkedin_url: null, bio: null, birthday: null }],
+        })
+        // Call 2: fact nodes for this contact
+        .mockResolvedValueOnce({
+          rows: [
+            { id: 'f1', properties: { attribute: 'job_title', value: 'CTO' }, confidence: 0.9, last_confirmed_at: '2026-01-01' },
+            { id: 'f2', properties: { attribute: 'organization', value: 'Acme' }, confidence: 0.8, last_confirmed_at: '2026-01-01' },
+          ],
+        })
+        // Call 3: UPDATE contacts
+        .mockImplementation(updateMock),
+    } as unknown as Pool;
+
+    const result = await runBackfill(pool);
+    expect(result.processed).toBe(1);
+    expect(result.written).toBeGreaterThan(0);
+
+    // Verify the UPDATE was called with expected values
+    const updateCall = (pool.query as ReturnType<typeof vi.fn>).mock.calls[2]!;
+    const sql = updateCall[0] as string;
+    const params = updateCall[1] as unknown[];
+    expect(sql).toContain('UPDATE contacts SET');
+    // title = 'CTO' should be in the params
+    expect(params).toContain('CTO');
+    // organization = 'Acme' should be in the params
+    expect(params).toContain('Acme');
+  });
+
+  it('prefers higher confidence when two facts target same column', async () => {
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [{ id: 'c1', kg_node_id: 'kg1', system_role: null,
+                   preferred_name: null, title: null, organization: null,
+                   primary_email: null, primary_phone: null, timezone: null,
+                   locale: null, location: null, pronouns: null,
+                   linkedin_url: null, bio: null, birthday: null }],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            // Two facts for title — higher confidence wins
+            { id: 'f1', properties: { attribute: 'title', value: 'VP' }, confidence: 0.7, last_confirmed_at: '2025-12-01' },
+            { id: 'f2', properties: { attribute: 'title', value: 'CTO' }, confidence: 0.95, last_confirmed_at: '2025-11-01' },
+          ],
+        })
+        .mockResolvedValue({ rows: [] }),
+    } as unknown as Pool;
+
+    await runBackfill(pool);
+
+    const updateCall = (pool.query as ReturnType<typeof vi.fn>).mock.calls[2]!;
+    const params = updateCall[1] as unknown[];
+    expect(params).toContain('CTO');
+    expect(params).not.toContain('VP');
+  });
+
+  it('uses last_confirmed_at as tiebreaker when confidence is equal', async () => {
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [{ id: 'c1', kg_node_id: 'kg1', system_role: null,
+                   preferred_name: null, title: null, organization: null,
+                   primary_email: null, primary_phone: null, timezone: null,
+                   locale: null, location: null, pronouns: null,
+                   linkedin_url: null, bio: null, birthday: null }],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            { id: 'f1', properties: { attribute: 'title', value: 'VP' }, confidence: 0.8, last_confirmed_at: '2025-06-01' },
+            { id: 'f2', properties: { attribute: 'title', value: 'CTO' }, confidence: 0.8, last_confirmed_at: '2026-01-01' }, // more recent
+          ],
+        })
+        .mockResolvedValue({ rows: [] }),
+    } as unknown as Pool;
+
+    await runBackfill(pool);
+
+    const updateCall = (pool.query as ReturnType<typeof vi.fn>).mock.calls[2]!;
+    const params = updateCall[1] as unknown[];
+    expect(params).toContain('CTO'); // more recent wins
+    expect(params).not.toContain('VP');
+  });
+
+  it('skips already-populated columns (idempotency)', async () => {
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 'c1', kg_node_id: 'kg1', system_role: null,
+            preferred_name: null,
+            title: 'Existing Title',  // already populated
+            organization: null, primary_email: null, primary_phone: null,
+            timezone: null, locale: null, location: null, pronouns: null,
+            linkedin_url: null, bio: null, birthday: null,
+          }],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            { id: 'f1', properties: { attribute: 'job_title', value: 'New Title' }, confidence: 0.99, last_confirmed_at: '2026-01-01' },
+          ],
+        })
+        .mockResolvedValue({ rows: [] }),
+    } as unknown as Pool;
+
+    await runBackfill(pool);
+
+    const calls = (pool.query as ReturnType<typeof vi.fn>).mock.calls;
+    // The UPDATE call should NOT include title since it was already populated.
+    // If no columns change, no UPDATE is issued at all.
+    const updateCall = calls.find(c => (c[0] as string).includes('UPDATE contacts SET'));
+    if (updateCall) {
+      const params = updateCall[1] as unknown[];
+      expect(params).not.toContain('New Title');
+    }
+  });
+
+  it('does not apply role KG fact to title when contact has a system_role', async () => {
+    const pool = {
+      query: vi.fn()
+        .mockResolvedValueOnce({
+          rows: [{
+            id: 'c1', kg_node_id: 'kg1',
+            system_role: 'principal',  // has system_role — role fact should not apply to title
+            preferred_name: null, title: null, organization: null,
+            primary_email: null, primary_phone: null, timezone: null,
+            locale: null, location: null, pronouns: null,
+            linkedin_url: null, bio: null, birthday: null,
+          }],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            { id: 'f1', properties: { attribute: 'role', value: 'Principal' }, confidence: 0.99, last_confirmed_at: '2026-01-01' },
+          ],
+        })
+        .mockResolvedValue({ rows: [] }),
+    } as unknown as Pool;
+
+    await runBackfill(pool);
+
+    const calls = (pool.query as ReturnType<typeof vi.fn>).mock.calls;
+    const updateCall = calls.find(c => (c[0] as string).includes('UPDATE contacts SET'));
+    // No update should be issued because the only fact was 'role' which is skipped
+    // when system_role is set, and no other columns changed.
+    expect(updateCall).toBeUndefined();
+  });
+});

--- a/scripts/backfill-contact-attributes.ts
+++ b/scripts/backfill-contact-attributes.ts
@@ -84,9 +84,10 @@ type FactRow = {
 
 export async function runBackfill(pool: pg.Pool): Promise<{
   processed: number;
-  written: number;
+  columnsWritten: number;
   skipped: number;
   errors: number;
+  failedContactIds: string[];
 }> {
   // Fetch all contacts that have a KG node linked.
   const contactsResult = await pool.query<ContactRowForBackfill>(
@@ -98,9 +99,11 @@ export async function runBackfill(pool: pg.Pool): Promise<{
 
   const contacts = contactsResult.rows;
   let processed = 0;
-  let written = 0;
+  let columnsWritten = 0;
+  // skipped counts columns that already had a non-null value and were left untouched
   let skipped = 0;
   let errors = 0;
+  const failedContactIds: string[] = [];
 
   for (const contact of contacts) {
     // Guard against null kg_node_id entries (defensive — the query filters these,
@@ -114,11 +117,13 @@ export async function runBackfill(pool: pg.Pool): Promise<{
         `SELECT n.id, n.properties, n.confidence, n.last_confirmed_at
          FROM kg_nodes n
          JOIN kg_edges e ON (
-           (e.source_id = $1 AND e.target_id = n.id)
-           OR (e.target_id = $1 AND e.source_id = n.id)
+           (e.source_node_id = $1 AND e.target_node_id = n.id)
+           OR (e.target_node_id = $1 AND e.source_node_id = n.id)
          )
-         WHERE e.relationship = 'relates_to'
-           AND n.type = 'fact'`,
+         WHERE e.type = 'relates_to'
+           AND e.archived_at IS NULL
+           AND n.type = 'fact'
+           AND n.archived_at IS NULL`,
         [contact.kg_node_id],
       );
 
@@ -193,17 +198,18 @@ export async function runBackfill(pool: pg.Pool): Promise<{
         params,
       );
 
-      written += Object.keys(updates).length;
+      columnsWritten += Object.keys(updates).length;
       processed++;
       logger.info({ contactId: contact.id, columns: Object.keys(updates) }, 'backfill: wrote columns');
     } catch (err) {
       logger.error({ contactId: contact.id, err }, 'backfill: contact failed');
       errors++;
+      failedContactIds.push(contact.id);
     }
   }
 
-  logger.info({ processed, written, skipped, errors }, 'backfill: done');
-  return { processed, written, skipped, errors };
+  logger.info({ processed, columnsWritten, skipped, errors, failedContactIds }, 'backfill: done');
+  return { processed, columnsWritten, skipped, errors, failedContactIds };
 }
 
 // CLI entry point — only runs when executed directly
@@ -215,13 +221,13 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
   }
   const pool = new Pool({ connectionString: databaseUrl });
   runBackfill(pool)
-    .then(({ errors }) => {
-      void pool.end();
+    .then(async ({ errors }) => {
+      await pool.end();
       process.exit(errors > 0 ? 1 : 0);
     })
-    .catch(err => {
+    .catch(async (err) => {
       logger.error({ err }, 'backfill: fatal error');
-      void pool.end();
+      await pool.end();
       process.exit(1);
     });
 }

--- a/scripts/backfill-contact-attributes.ts
+++ b/scripts/backfill-contact-attributes.ts
@@ -9,6 +9,9 @@
 // Safety: idempotent — only writes to NULL columns.
 
 import pg from 'pg';
+import pino from 'pino';
+
+const logger = pino({ name: 'backfill-contact-attributes' });
 
 const { Pool } = pg;
 
@@ -74,7 +77,8 @@ type ContactRowForBackfill = {
 type FactRow = {
   id: string;
   properties: { attribute?: string; value?: string };
-  confidence: number;
+  // node-pg returns NUMERIC as string at runtime; Number() coercion is applied at use site
+  confidence: string;
   last_confirmed_at: string | null;
 };
 
@@ -176,6 +180,10 @@ export async function runBackfill(pool: pg.Pool): Promise<{
       const setClauses: string[] = [];
       const params: unknown[] = [contact.id];
       for (const [col, val] of Object.entries(updates)) {
+        // col is always a CANONICAL_COLUMNS member by construction; guard against future drift
+        if (!CANONICAL_COLUMNS.includes(col)) {
+          throw new Error(`[backfill] refusing to interpolate unknown column: ${col}`);
+        }
         params.push(val);
         setClauses.push(`${col} = $${params.length}`);
       }
@@ -187,18 +195,14 @@ export async function runBackfill(pool: pg.Pool): Promise<{
 
       written += Object.keys(updates).length;
       processed++;
-      console.log(
-        `[backfill] contact ${contact.id}: wrote ${Object.keys(updates).join(', ')}`,
-      );
+      logger.info({ contactId: contact.id, columns: Object.keys(updates) }, 'backfill: wrote columns');
     } catch (err) {
-      console.error(`[backfill] contact ${contact.id} failed:`, err);
+      logger.error({ contactId: contact.id, err }, 'backfill: contact failed');
       errors++;
     }
   }
 
-  console.log(
-    `[backfill] done — processed: ${processed}, written: ${written}, skipped: ${skipped}, errors: ${errors}`,
-  );
+  logger.info({ processed, written, skipped, errors }, 'backfill: done');
   return { processed, written, skipped, errors };
 }
 
@@ -206,7 +210,7 @@ export async function runBackfill(pool: pg.Pool): Promise<{
 if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
   const databaseUrl = process.env['DATABASE_URL'];
   if (!databaseUrl) {
-    console.error('[backfill] DATABASE_URL is not set');
+    logger.error('backfill: DATABASE_URL is not set');
     process.exit(1);
   }
   const pool = new Pool({ connectionString: databaseUrl });
@@ -216,7 +220,7 @@ if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).
       process.exit(errors > 0 ? 1 : 0);
     })
     .catch(err => {
-      console.error('[backfill] fatal error:', err);
+      logger.error({ err }, 'backfill: fatal error');
       void pool.end();
       process.exit(1);
     });

--- a/scripts/backfill-contact-attributes.ts
+++ b/scripts/backfill-contact-attributes.ts
@@ -203,7 +203,7 @@ export async function runBackfill(pool: pg.Pool): Promise<{
 }
 
 // CLI entry point — only runs when executed directly
-if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^.*\//, ''))) {
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
   const databaseUrl = process.env['DATABASE_URL'];
   if (!databaseUrl) {
     console.error('[backfill] DATABASE_URL is not set');

--- a/scripts/backfill-contact-attributes.ts
+++ b/scripts/backfill-contact-attributes.ts
@@ -1,0 +1,223 @@
+// scripts/backfill-contact-attributes.ts
+//
+// Backfills contact canonical columns from KG fact nodes.
+// Each contact's kg_node_id is used to find related fact nodes via
+// 'relates_to' edges. For each NULL column, the fact with the highest
+// confidence (tiebreak: most recent last_confirmed_at) is written.
+//
+// Run: pnpm run backfill:contact-attributes
+// Safety: idempotent — only writes to NULL columns.
+
+import pg from 'pg';
+
+const { Pool } = pg;
+
+// Mapping from KG fact attribute keys to contact columns.
+// Keys are compared case-insensitively.
+const ATTRIBUTE_MAP: Record<string, string> = {
+  preferred_name: 'preferred_name',
+  nickname: 'preferred_name',
+  job_title: 'title',
+  title: 'title',
+  // 'role' maps to title only when contact.system_role IS NULL (handled in code)
+  organization: 'organization',
+  employer: 'organization',
+  company: 'organization',
+  current_employer: 'organization',
+  email: 'primary_email',
+  primary_email: 'primary_email',
+  phone: 'primary_phone',
+  phone_number: 'primary_phone',
+  mobile: 'primary_phone',
+  timezone: 'timezone',
+  tz: 'timezone',
+  locale: 'locale',
+  language: 'locale',
+  home_city: 'location',
+  current_location: 'location',
+  location: 'location',
+  city: 'location',
+  pronouns: 'pronouns',
+  linkedin: 'linkedin_url',
+  linkedin_url: 'linkedin_url',
+  bio: 'bio',
+  biography: 'bio',
+  birthday: 'birthday',
+  birthdate: 'birthday',
+  dob: 'birthday',
+};
+
+// All 12 canonical column names (snake_case, matching DB columns).
+const CANONICAL_COLUMNS = [
+  'preferred_name', 'title', 'organization', 'primary_email', 'primary_phone',
+  'timezone', 'locale', 'location', 'pronouns', 'linkedin_url', 'bio', 'birthday',
+];
+
+type ContactRowForBackfill = {
+  id: string;
+  kg_node_id: string | null;
+  system_role: string | null;
+  preferred_name: string | null;
+  title: string | null;
+  organization: string | null;
+  primary_email: string | null;
+  primary_phone: string | null;
+  timezone: string | null;
+  locale: string | null;
+  location: string | null;
+  pronouns: string | null;
+  linkedin_url: string | null;
+  bio: string | null;
+  birthday: string | null;
+};
+
+type FactRow = {
+  id: string;
+  properties: { attribute?: string; value?: string };
+  confidence: number;
+  last_confirmed_at: string | null;
+};
+
+export async function runBackfill(pool: pg.Pool): Promise<{
+  processed: number;
+  written: number;
+  skipped: number;
+  errors: number;
+}> {
+  // Fetch all contacts that have a KG node linked.
+  const contactsResult = await pool.query<ContactRowForBackfill>(
+    `SELECT id, kg_node_id, system_role,
+            preferred_name, title, organization, primary_email, primary_phone,
+            timezone, locale, location, pronouns, linkedin_url, bio, birthday
+     FROM contacts WHERE kg_node_id IS NOT NULL`,
+  );
+
+  const contacts = contactsResult.rows;
+  let processed = 0;
+  let written = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const contact of contacts) {
+    // Guard against null kg_node_id entries (defensive — the query filters these,
+    // but mocks or callers might not).
+    if (!contact.kg_node_id) continue;
+
+    try {
+      // Fetch all fact nodes reachable via a single 'relates_to' edge
+      // from this contact's KG person node (either direction).
+      const factsResult = await pool.query<FactRow>(
+        `SELECT n.id, n.properties, n.confidence, n.last_confirmed_at
+         FROM kg_nodes n
+         JOIN kg_edges e ON (
+           (e.source_id = $1 AND e.target_id = n.id)
+           OR (e.target_id = $1 AND e.source_id = n.id)
+         )
+         WHERE e.relationship = 'relates_to'
+           AND n.type = 'fact'`,
+        [contact.kg_node_id],
+      );
+
+      const facts = factsResult.rows;
+
+      // Group facts by target column. For each column collect all candidates,
+      // then pick the one with highest confidence (tiebreak: most recent last_confirmed_at).
+      const candidates: Record<string, Array<{ value: string; confidence: number; confirmedAt: number }>> = {};
+
+      for (const fact of facts) {
+        const attrRaw = fact.properties?.attribute;
+        const value = fact.properties?.value;
+        if (!attrRaw || !value) continue;
+
+        const attr = attrRaw.toLowerCase();
+
+        // 'role' only maps to 'title' when system_role IS NULL
+        if (attr === 'role' && contact.system_role != null) continue;
+
+        const col = attr === 'role' ? 'title' : ATTRIBUTE_MAP[attr];
+        if (!col) continue;
+
+        const confirmedAt = fact.last_confirmed_at
+          ? new Date(fact.last_confirmed_at).getTime()
+          : 0;
+
+        if (!candidates[col]) candidates[col] = [];
+        candidates[col].push({ value, confidence: Number(fact.confidence), confirmedAt });
+      }
+
+      // Determine which NULL columns have a candidate value.
+      const updates: Record<string, string> = {};
+      for (const col of CANONICAL_COLUMNS) {
+        // Only write to NULL columns (idempotent safety)
+        if (contact[col as keyof ContactRowForBackfill] != null) {
+          skipped++;
+          continue;
+        }
+
+        const colCandidates = candidates[col];
+        if (!colCandidates || colCandidates.length === 0) continue;
+
+        // Sort: highest confidence first; tiebreak on most recent last_confirmed_at
+        colCandidates.sort((a, b) =>
+          b.confidence !== a.confidence
+            ? b.confidence - a.confidence
+            : b.confirmedAt - a.confirmedAt,
+        );
+
+        updates[col] = colCandidates[0]!.value;
+      }
+
+      if (Object.keys(updates).length === 0) {
+        processed++;
+        continue;
+      }
+
+      // Build a parameterized UPDATE for only the changed columns.
+      const setClauses: string[] = [];
+      const params: unknown[] = [contact.id];
+      for (const [col, val] of Object.entries(updates)) {
+        params.push(val);
+        setClauses.push(`${col} = $${params.length}`);
+      }
+
+      await pool.query(
+        `UPDATE contacts SET ${setClauses.join(', ')} WHERE id = $1`,
+        params,
+      );
+
+      written += Object.keys(updates).length;
+      processed++;
+      console.log(
+        `[backfill] contact ${contact.id}: wrote ${Object.keys(updates).join(', ')}`,
+      );
+    } catch (err) {
+      console.error(`[backfill] contact ${contact.id} failed:`, err);
+      errors++;
+    }
+  }
+
+  console.log(
+    `[backfill] done — processed: ${processed}, written: ${written}, skipped: ${skipped}, errors: ${errors}`,
+  );
+  return { processed, written, skipped, errors };
+}
+
+// CLI entry point — only runs when executed directly
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^.*\//, ''))) {
+  const databaseUrl = process.env['DATABASE_URL'];
+  if (!databaseUrl) {
+    console.error('[backfill] DATABASE_URL is not set');
+    process.exit(1);
+  }
+  const pool = new Pool({ connectionString: databaseUrl });
+  runBackfill(pool)
+    .then(({ errors }) => {
+      void pool.end();
+      process.exit(errors > 0 ? 1 : 0);
+    })
+    .catch(err => {
+      console.error('[backfill] fatal error:', err);
+      void pool.end();
+      process.exit(1);
+    });
+}

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -736,67 +736,72 @@ export async function knowledgeGraphRoutes(
       return reply.status(400).send({ error: canonicalError });
     }
 
-    if (typeof body.displayName === 'string') {
-      await contactService.updateDisplayName(id, body.displayName);
-    }
-    if (typeof body.role === 'string') {
-      await contactService.setRole(id, body.role);
-    } else if (body.role === null) {
-      // Explicit null means "clear the role field" — setRole doesn't accept null so go direct.
-      await pool.query(`UPDATE contacts SET role = NULL, updated_at = $2 WHERE id = $1`, [
-        id,
-        new Date().toISOString(),
-      ]);
-    }
-    if (typeof body.status === 'string') {
-      await contactService.setStatus(id, body.status as ContactStatus);
-    }
-    if ('trustLevel' in body) {
-      await contactService.setTrustLevel(id, (body.trustLevel as TrustLevel | null));
-    }
-
-    // Notes and kgNodeId are updated directly by preserving the rest of the contact.
-    // This route exists only for the web UI and does not expose generic backend mutation.
-    if (typeof body.notes === 'string' || typeof body.kgNodeId === 'string' || body.notes === null || body.kgNodeId === null) {
-      const refreshed = await contactService.getContact(id);
-      if (!refreshed) {
-        return reply.status(404).send({ error: 'Contact not found.' });
+    try {
+      if (typeof body.displayName === 'string' && body.displayName.trim().length > 0) {
+        await contactService.updateDisplayName(id, body.displayName);
       }
-      await pool.query(
-        `UPDATE contacts
-         SET notes = $2, kg_node_id = $3, updated_at = $4
-         WHERE id = $1`,
-        [
+      if (typeof body.role === 'string') {
+        await contactService.setRole(id, body.role);
+      } else if (body.role === null) {
+        // Explicit null means "clear the role field" — setRole doesn't accept null so go direct.
+        await pool.query(`UPDATE contacts SET role = NULL, updated_at = $2 WHERE id = $1`, [
           id,
-          typeof body.notes === 'string' ? body.notes : body.notes === null ? null : refreshed.notes,
-          normalizedKgNodeId !== undefined ? normalizedKgNodeId : refreshed.kgNodeId,
           new Date().toISOString(),
-        ],
-      );
-    }
-
-    // Apply canonical fields if any were included in the request body.
-    const CANONICAL_KEYS: Array<keyof typeof canonicalFields> = [
-      'preferredName', 'title', 'organization', 'primaryEmail', 'primaryPhone',
-      'timezone', 'locale', 'location', 'pronouns', 'linkedinUrl', 'bio', 'birthday',
-    ];
-    const hasCanonicalFields = CANONICAL_KEYS.some(k => k in (body as Record<string, unknown>));
-    if (hasCanonicalFields) {
-      try {
-        await contactService.updateContactFields(id, canonicalFields);
-      } catch (err) {
-        // updateContactFields throws for primaryEmail CCI mismatch
-        return reply.status(400).send({ error: (err as Error).message });
+        ]);
       }
-    }
+      if (typeof body.status === 'string') {
+        await contactService.setStatus(id, body.status as ContactStatus);
+      }
+      if ('trustLevel' in body) {
+        await contactService.setTrustLevel(id, (body.trustLevel as TrustLevel | null));
+      }
 
-    const updated = await contactService.getContact(id);
-    if (!updated) {
-      return reply.status(404).send({ error: 'Contact not found after update.' });
+      // Notes and kgNodeId are updated directly by preserving the rest of the contact.
+      // This route exists only for the web UI and does not expose generic backend mutation.
+      if (typeof body.notes === 'string' || typeof body.kgNodeId === 'string' || body.notes === null || body.kgNodeId === null) {
+        const refreshed = await contactService.getContact(id);
+        if (!refreshed) {
+          return reply.status(404).send({ error: 'Contact not found.' });
+        }
+        await pool.query(
+          `UPDATE contacts
+           SET notes = $2, kg_node_id = $3, updated_at = $4
+           WHERE id = $1`,
+          [
+            id,
+            typeof body.notes === 'string' ? body.notes : body.notes === null ? null : refreshed.notes,
+            normalizedKgNodeId !== undefined ? normalizedKgNodeId : refreshed.kgNodeId,
+            new Date().toISOString(),
+          ],
+        );
+      }
+
+      // Apply canonical fields if any were included in the request body.
+      const CANONICAL_KEYS: Array<keyof typeof canonicalFields> = [
+        'preferredName', 'title', 'organization', 'primaryEmail', 'primaryPhone',
+        'timezone', 'locale', 'location', 'pronouns', 'linkedinUrl', 'bio', 'birthday',
+      ];
+      const hasCanonicalFields = CANONICAL_KEYS.some(k => k in (body as Record<string, unknown>));
+      if (hasCanonicalFields) {
+        try {
+          await contactService.updateContactFields(id, canonicalFields);
+        } catch (err) {
+          // updateContactFields throws for primaryEmail CCI mismatch — return 400, not 500.
+          return reply.status(400).send({ error: (err as Error).message });
+        }
+      }
+
+      const updated = await contactService.getContact(id);
+      if (!updated) {
+        return reply.status(404).send({ error: 'Contact not found after update.' });
+      }
+      return reply.send({
+        contact: serializeContact(updated),
+      });
+    } catch (err) {
+      request.log.error({ err }, 'contacts: PATCH mutation failed');
+      return reply.status(500).send({ error: 'An error occurred while updating the contact.' });
     }
-    return reply.send({
-      contact: serializeContact(updated),
-    });
   });
 
   app.delete('/api/kg/contacts/:id', KG_RATE, async (request, reply) => {

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -5,6 +5,7 @@ import type { EventBus } from '../../../bus/bus.js';
 import { createInboundMessage } from '../../../bus/events.js';
 import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
+import { ContactValidationError } from '../../../contacts/contact-service.js';
 import type { Contact, ContactCanonicalFields, ContactStatus, TrustLevel } from '../../../contacts/types.js';
 import { MessageRejectedError, type EventRouter } from '../event-router.js';
 import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
@@ -786,8 +787,12 @@ export async function knowledgeGraphRoutes(
         try {
           await contactService.updateContactFields(id, canonicalFields);
         } catch (err) {
-          // updateContactFields throws for primaryEmail CCI mismatch — return 400, not 500.
-          return reply.status(400).send({ error: (err as Error).message });
+          if (err instanceof ContactValidationError) {
+            // Client sent invalid data (e.g., primaryEmail not linked to this contact)
+            return reply.status(400).send({ error: err.message });
+          }
+          // All other errors (DB failures, etc.) propagate to the outer catch → 500
+          throw err;
         }
       }
 

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -588,6 +588,19 @@ export async function knowledgeGraphRoutes(
 
     const fields: ContactCanonicalFields = {};
 
+    // Reject non-string, non-nullish values — the str() helper would silently coerce
+    // them to null, which would erase existing data on PATCH.
+    const CANONICAL_STRING_KEYS = [
+      'preferredName', 'title', 'organization', 'primaryPhone', 'timezone', 'locale',
+      'location', 'pronouns', 'birthday', 'linkedinUrl', 'bio', 'primaryEmail',
+    ] as const;
+    const badKey = CANONICAL_STRING_KEYS.find(
+      k => k in body && body[k] !== null && body[k] !== undefined && typeof body[k] !== 'string',
+    );
+    if (badKey) {
+      return { error: `${badKey} must be a string or null.`, fields };
+    }
+
     if ('preferredName' in body) fields.preferredName = str(body.preferredName);
     if ('title' in body) fields.title = str(body.title);
     if ('organization' in body) fields.organization = str(body.organization);
@@ -735,6 +748,19 @@ export async function knowledgeGraphRoutes(
     const { error: canonicalError, fields: canonicalFields } = extractAndValidateCanonicalFields(body as Record<string, unknown>);
     if (canonicalError) {
       return reply.status(400).send({ error: canonicalError });
+    }
+
+    // Validate primaryEmail against CCI before any mutations so a bad value can never
+    // produce partial writes (other fields committed, response still 400).
+    if (canonicalFields.primaryEmail != null) {
+      try {
+        await contactService.validatePrimaryEmail(id, canonicalFields.primaryEmail);
+      } catch (err) {
+        if (err instanceof ContactValidationError) {
+          return reply.status(400).send({ error: err.message });
+        }
+        throw err;
+      }
     }
 
     try {

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -618,8 +618,14 @@ export async function knowledgeGraphRoutes(
     if (fields.primaryEmail != null && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(fields.primaryEmail)) {
       return { error: 'Invalid primaryEmail format.', fields };
     }
-    if (fields.linkedinUrl != null && !/^https?:\/\//.test(fields.linkedinUrl)) {
-      return { error: 'linkedinUrl must start with http:// or https://.', fields };
+    if (fields.linkedinUrl != null && !/^https?:\/\/(www\.)?linkedin\.com\//.test(fields.linkedinUrl)) {
+      return { error: 'linkedinUrl must be a linkedin.com URL (e.g. https://linkedin.com/in/…).', fields };
+    }
+    if (fields.primaryPhone != null && !/^\+[1-9]\d{6,14}$/.test(fields.primaryPhone)) {
+      return { error: 'primaryPhone must be in E.164 format (e.g. +15551234567).', fields };
+    }
+    if (fields.locale != null && !/^[a-z]{2,3}(-[A-Z]{2,4})?$/.test(fields.locale)) {
+      return { error: 'locale must be a BCP 47 code (e.g. en-US, fr, zh-Hans).', fields };
     }
     if (fields.bio != null && fields.bio.length > 500) {
       return { error: 'bio must be 500 characters or fewer.', fields };

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -5,7 +5,7 @@ import type { EventBus } from '../../../bus/bus.js';
 import { createInboundMessage } from '../../../bus/events.js';
 import type { Logger } from '../../../logger.js';
 import type { ContactService } from '../../../contacts/contact-service.js';
-import type { ContactStatus, TrustLevel } from '../../../contacts/types.js';
+import type { Contact, ContactCanonicalFields, ContactStatus, TrustLevel } from '../../../contacts/types.js';
 import { MessageRejectedError, type EventRouter } from '../event-router.js';
 import { assertSecret, compareSecrets, hashToken, type SessionStore } from '../session-auth.js';
 import { markdownToHtml } from '../../../utils/markdown-to-html.js';
@@ -544,23 +544,87 @@ export async function knowledgeGraphRoutes(
     return reply.status(204).send();
   });
 
+  // Serialize a Contact object to the HTTP response shape.
+  // Returns all canonical fields so the Console UI can display them
+  // without a separate detail fetch.
+  function serializeContact(c: Contact) {
+    return {
+      id: c.id,
+      kgNodeId: c.kgNodeId,
+      displayName: c.displayName,
+      role: c.role,
+      status: c.status,
+      trustLevel: c.trustLevel,
+      systemRole: c.systemRole,
+      notes: c.notes,
+      createdAt: c.createdAt.toISOString(),
+      updatedAt: c.updatedAt.toISOString(),
+      // Canonical fields (migration 048)
+      preferredName: c.preferredName,
+      title: c.title,
+      organization: c.organization,
+      primaryEmail: c.primaryEmail,
+      primaryPhone: c.primaryPhone,
+      timezone: c.timezone,
+      locale: c.locale,
+      location: c.location,
+      pronouns: c.pronouns,
+      linkedinUrl: c.linkedinUrl,
+      bio: c.bio,
+      birthday: c.birthday,
+    };
+  }
+
+  // Validate canonical fields from a POST/PATCH body.
+  // Returns an error string if invalid, or null if all checks pass.
+  // `fields` entries are trimmed and empty-string-coerced to null.
+  function extractAndValidateCanonicalFields(body: Record<string, unknown>): {
+    error: string | null;
+    fields: ContactCanonicalFields;
+  } {
+    const str = (v: unknown): string | null =>
+      typeof v === 'string' && v.trim().length > 0 ? v.trim() : null;
+
+    const fields: ContactCanonicalFields = {};
+
+    if ('preferredName' in body) fields.preferredName = str(body.preferredName);
+    if ('title' in body) fields.title = str(body.title);
+    if ('organization' in body) fields.organization = str(body.organization);
+    if ('primaryPhone' in body) fields.primaryPhone = str(body.primaryPhone);
+    if ('timezone' in body) fields.timezone = str(body.timezone);
+    if ('locale' in body) fields.locale = str(body.locale);
+    if ('location' in body) fields.location = str(body.location);
+    if ('pronouns' in body) fields.pronouns = str(body.pronouns);
+    if ('birthday' in body) fields.birthday = str(body.birthday);
+    if ('linkedinUrl' in body) fields.linkedinUrl = str(body.linkedinUrl);
+    if ('bio' in body) fields.bio = str(body.bio);
+    if ('primaryEmail' in body) fields.primaryEmail = str(body.primaryEmail);
+
+    // Format validation
+    if (fields.primaryEmail != null && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(fields.primaryEmail)) {
+      return { error: 'Invalid primaryEmail format.', fields };
+    }
+    if (fields.linkedinUrl != null && !/^https?:\/\//.test(fields.linkedinUrl)) {
+      return { error: 'linkedinUrl must start with http:// or https://.', fields };
+    }
+    if (fields.bio != null && fields.bio.length > 500) {
+      return { error: 'bio must be 500 characters or fewer.', fields };
+    }
+    if (fields.birthday != null &&
+        !/^\d{4}-\d{2}-\d{2}$/.test(fields.birthday) &&
+        !/^--\d{2}-\d{2}$/.test(fields.birthday)) {
+      return { error: 'birthday must be YYYY-MM-DD or --MM-DD.', fields };
+    }
+
+    return { error: null, fields };
+  }
+
   app.get('/api/kg/contacts', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     try {
       const contacts = await contactService.listContacts();
       return reply.send({
-        contacts: contacts.map((contact) => ({
-          id: contact.id,
-          kgNodeId: contact.kgNodeId,
-          displayName: contact.displayName,
-          role: contact.role,
-          status: contact.status,
-          trustLevel: contact.trustLevel,
-          systemRole: contact.systemRole,
-          notes: contact.notes,
-          createdAt: contact.createdAt.toISOString(),
-          updatedAt: contact.updatedAt.toISOString(),
-        })),
+        contacts: contacts.map(serializeContact),
       });
     } catch (err) {
       logger.error({ err }, 'GET /api/kg/contacts failed');
@@ -600,6 +664,11 @@ export async function knowledgeGraphRoutes(
       return reply.status(400).send({ error: 'Invalid kgNodeId: must be a valid UUID.' });
     }
 
+    const { error: canonicalError, fields: canonicalFields } = extractAndValidateCanonicalFields(body as Record<string, unknown>);
+    if (canonicalError) {
+      return reply.status(400).send({ error: canonicalError });
+    }
+
     const created = await contactService.createContact({
       displayName: body.displayName,
       role: typeof body.role === 'string' && body.role.trim().length > 0 ? body.role : undefined,
@@ -607,6 +676,7 @@ export async function knowledgeGraphRoutes(
       notes: typeof body.notes === 'string' && body.notes.trim().length > 0 ? body.notes : undefined,
       kgNodeId,
       source: 'kg_web_ui',
+      ...canonicalFields,
     });
 
     // Apply trustLevel if provided — createContact always initialises it to null.
@@ -621,17 +691,7 @@ export async function knowledgeGraphRoutes(
       return reply.status(500).send({ error: 'Contact created but could not be retrieved.' });
     }
     return reply.status(201).send({
-      contact: {
-        id: freshCreated.id,
-        kgNodeId: freshCreated.kgNodeId,
-        displayName: freshCreated.displayName,
-        role: freshCreated.role,
-        status: freshCreated.status,
-        trustLevel: freshCreated.trustLevel,
-        notes: freshCreated.notes,
-        createdAt: freshCreated.createdAt.toISOString(),
-        updatedAt: freshCreated.updatedAt.toISOString(),
-      },
+      contact: serializeContact(freshCreated),
     });
   });
 
@@ -669,6 +729,11 @@ export async function knowledgeGraphRoutes(
         : undefined;
     if (typeof normalizedKgNodeId === 'string' && !UUID_RE.test(normalizedKgNodeId)) {
       return reply.status(400).send({ error: 'Invalid kgNodeId: must be a valid UUID.' });
+    }
+
+    const { error: canonicalError, fields: canonicalFields } = extractAndValidateCanonicalFields(body as Record<string, unknown>);
+    if (canonicalError) {
+      return reply.status(400).send({ error: canonicalError });
     }
 
     if (typeof body.displayName === 'string') {
@@ -710,22 +775,27 @@ export async function knowledgeGraphRoutes(
       );
     }
 
+    // Apply canonical fields if any were included in the request body.
+    const CANONICAL_KEYS: Array<keyof typeof canonicalFields> = [
+      'preferredName', 'title', 'organization', 'primaryEmail', 'primaryPhone',
+      'timezone', 'locale', 'location', 'pronouns', 'linkedinUrl', 'bio', 'birthday',
+    ];
+    const hasCanonicalFields = CANONICAL_KEYS.some(k => k in (body as Record<string, unknown>));
+    if (hasCanonicalFields) {
+      try {
+        await contactService.updateContactFields(id, canonicalFields);
+      } catch (err) {
+        // updateContactFields throws for primaryEmail CCI mismatch
+        return reply.status(400).send({ error: (err as Error).message });
+      }
+    }
+
     const updated = await contactService.getContact(id);
     if (!updated) {
       return reply.status(404).send({ error: 'Contact not found after update.' });
     }
     return reply.send({
-      contact: {
-        id: updated.id,
-        kgNodeId: updated.kgNodeId,
-        displayName: updated.displayName,
-        role: updated.role,
-        status: updated.status,
-        trustLevel: updated.trustLevel,
-        notes: updated.notes,
-        createdAt: updated.createdAt.toISOString(),
-        updatedAt: updated.updatedAt.toISOString(),
-      },
+      contact: serializeContact(updated),
     });
   });
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -38,6 +38,14 @@ import type {
 import type { DedupService } from './dedup-service.js';
 import type { ContactCalendar, CreateCalendarLinkOptions, ResolvedCalendar } from './calendar-types.js';
 
+/** Thrown when a caller provides invalid data for a contact field (e.g., primaryEmail not in CCI). */
+export class ContactValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContactValidationError';
+  }
+}
+
 // -- Backend interface --
 
 interface ContactServiceBackend {
@@ -598,7 +606,7 @@ export class ContactService {
         (i) => i.channel === 'email' && i.channelIdentifier.toLowerCase() === emailLower,
       );
       if (!match) {
-        throw new Error(
+        throw new ContactValidationError(
           `primaryEmail '${fields.primaryEmail}' not found in contact_channel_identities for contact ${contactId}`,
         );
       }

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -18,6 +18,7 @@ import { TRUST_RANK, IdentityNotFoundError } from './types.js';
 import type {
   AuthOverride,
   Contact,
+  ContactCanonicalFields,
   ContactStatus,
   ChannelIdentity,
   ContactServiceOptions,
@@ -235,6 +236,19 @@ export class ContactService {
       notes: options.notes ?? null,
       createdAt: now,
       updatedAt: now,
+      // Canonical fields (migration 048)
+      preferredName: options.preferredName ?? null,
+      title: options.title ?? null,
+      organization: options.organization ?? null,
+      primaryEmail: options.primaryEmail ?? null,
+      primaryPhone: options.primaryPhone ?? null,
+      timezone: options.timezone ?? null,
+      locale: options.locale ?? null,
+      location: options.location ?? null,
+      pronouns: options.pronouns ?? null,
+      linkedinUrl: options.linkedinUrl ?? null,
+      bio: options.bio ?? null,
+      birthday: options.birthday ?? null,
     };
 
     try {
@@ -560,6 +574,46 @@ export class ContactService {
   }
 
   /**
+   * Update canonical profile attributes on a contact.
+   *
+   * Only fields present in `fields` are changed — absent keys leave the current
+   * value untouched. If `fields.primaryEmail` is non-null, validates that the
+   * email exists in `contact_channel_identities` for this contact (channel = 'email'),
+   * case-insensitively. Throws with a descriptive message if not found.
+   */
+  async updateContactFields(
+    contactId: string,
+    fields: ContactCanonicalFields,
+  ): Promise<Contact> {
+    const contact = await this.backend.getContact(contactId);
+    if (!contact) {
+      throw new Error(`Contact not found: ${contactId}`);
+    }
+
+    // Validate primaryEmail against channel identities before writing.
+    if (fields.primaryEmail != null) {
+      const identities = await this.backend.getIdentitiesForContact(contactId);
+      const emailLower = fields.primaryEmail.toLowerCase();
+      const match = identities.find(
+        (i) => i.channel === 'email' && i.channelIdentifier.toLowerCase() === emailLower,
+      );
+      if (!match) {
+        throw new Error(
+          `primaryEmail '${fields.primaryEmail}' not found in contact_channel_identities for contact ${contactId}`,
+        );
+      }
+    }
+
+    const updated: Contact = {
+      ...contact,
+      ...fields,
+      updatedAt: new Date(),
+    };
+
+    return this.updateStoredContact(updated);
+  }
+
+  /**
    * Atomically promote a contact from provisional → confirmed.
    * Returns true if the promotion happened, false if the contact was not provisional
    * at write time (concurrent block or already confirmed). This is the preferred
@@ -847,6 +901,48 @@ export class ContactService {
   }
 }
 
+// -- Postgres-specific row shape (all 26 columns) --
+// Shared across all queries that return a full Contact record.
+// The 12 canonical fields (added in migration 048) are always
+// null-safe — they default to null when the column was added after
+// the row was first written.
+type ContactRow = {
+  id: string;
+  kg_node_id: string | null;
+  display_name: string;
+  role: string | null;
+  system_role: string | null;
+  status: string;
+  contact_confidence: string;
+  trust_level: string | null;
+  last_seen_at: Date | null;
+  inbound_message_count: string;
+  outbound_message_count: string;
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+  // Canonical fields (migration 048)
+  preferred_name: string | null;
+  title: string | null;
+  organization: string | null;
+  primary_email: string | null;
+  primary_phone: string | null;
+  timezone: string | null;
+  locale: string | null;
+  location: string | null;
+  pronouns: string | null;
+  linkedin_url: string | null;
+  bio: string | null;
+  birthday: string | null;
+};
+
+// Column list for all SELECT queries that return a full Contact row.
+const CONTACT_COLS =
+  'id, kg_node_id, display_name, role, system_role, status, contact_confidence, trust_level, ' +
+  'last_seen_at, inbound_message_count, outbound_message_count, notes, created_at, updated_at, ' +
+  'preferred_name, title, organization, primary_email, primary_phone, timezone, locale, location, ' +
+  'pronouns, linkedin_url, bio, birthday';
+
 // -- Postgres backend --
 
 /**
@@ -862,37 +958,29 @@ class PostgresContactBackend implements ContactServiceBackend {
   async createContact(contact: Contact): Promise<void> {
     this.logger.debug({ contactId: contact.id }, 'contacts: creating contact');
     await this.pool.query(
-      `INSERT INTO contacts (id, kg_node_id, display_name, role, system_role, status, notes, created_at, updated_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-      [contact.id, contact.kgNodeId, contact.displayName, contact.role, contact.systemRole, contact.status, contact.notes, contact.createdAt, contact.updatedAt],
+      `INSERT INTO contacts (
+         id, kg_node_id, display_name, role, system_role, status, notes, created_at, updated_at,
+         preferred_name, title, organization, primary_email, primary_phone, timezone, locale,
+         location, pronouns, linkedin_url, bio, birthday
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,
+                 $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)`,
+      [
+        contact.id, contact.kgNodeId, contact.displayName, contact.role, contact.systemRole,
+        contact.status, contact.notes, contact.createdAt, contact.updatedAt,
+        contact.preferredName, contact.title, contact.organization, contact.primaryEmail,
+        contact.primaryPhone, contact.timezone, contact.locale, contact.location,
+        contact.pronouns, contact.linkedinUrl, contact.bio, contact.birthday,
+      ],
     );
   }
 
   async getContact(id: string): Promise<Contact | undefined> {
-    const result = await this.pool.query<{
-      id: string;
-      kg_node_id: string | null;
-      display_name: string;
-      role: string | null;
-      system_role: string | null;
-      status: string;
-      contact_confidence: string;
-      trust_level: string | null;
-      last_seen_at: Date | null;
-      inbound_message_count: string;  // INT returned as string by node-pg
-      outbound_message_count: string;
-      notes: string | null;
-      created_at: Date;
-      updated_at: Date;
-    }>(
-      `SELECT id, kg_node_id, display_name, role, system_role, status, contact_confidence, trust_level, last_seen_at, inbound_message_count, outbound_message_count, notes, created_at, updated_at
-       FROM contacts WHERE id = $1`,
+    const result = await this.pool.query<ContactRow>(
+      `SELECT ${CONTACT_COLS} FROM contacts WHERE id = $1`,
       [id],
     );
-
     const row = result.rows[0];
     if (!row) return undefined;
-
     return this.rowToContact(row);
   }
 
@@ -901,24 +989,8 @@ class PostgresContactBackend implements ContactServiceBackend {
     // Uses ILIKE with wildcards — the idx_contacts_display_name btree index won't help here,
     // but the contacts table is small (hundreds, not millions) so a seq scan is fine.
     // For exact match, the caller can filter the results further.
-    const result = await this.pool.query<{
-      id: string;
-      kg_node_id: string | null;
-      display_name: string;
-      role: string | null;
-      system_role: string | null;
-      status: string;
-      contact_confidence: string;
-      trust_level: string | null;
-      last_seen_at: Date | null;
-      inbound_message_count: string;  // INT returned as string by node-pg
-      outbound_message_count: string;
-      notes: string | null;
-      created_at: Date;
-      updated_at: Date;
-    }>(
-      `SELECT id, kg_node_id, display_name, role, system_role, status, contact_confidence, trust_level, last_seen_at, inbound_message_count, outbound_message_count, notes, created_at, updated_at
-       FROM contacts WHERE display_name ILIKE $1`,
+    const result = await this.pool.query<ContactRow>(
+      `SELECT ${CONTACT_COLS} FROM contacts WHERE display_name ILIKE $1`,
       [`%${name}%`],
     );
 
@@ -926,24 +998,8 @@ class PostgresContactBackend implements ContactServiceBackend {
   }
 
   async findContactByRole(role: string): Promise<Contact[]> {
-    const result = await this.pool.query<{
-      id: string;
-      kg_node_id: string | null;
-      display_name: string;
-      role: string | null;
-      system_role: string | null;
-      status: string;
-      contact_confidence: string;
-      trust_level: string | null;
-      last_seen_at: Date | null;
-      inbound_message_count: string;  // INT returned as string by node-pg
-      outbound_message_count: string;
-      notes: string | null;
-      created_at: Date;
-      updated_at: Date;
-    }>(
-      `SELECT id, kg_node_id, display_name, role, system_role, status, contact_confidence, trust_level, last_seen_at, inbound_message_count, outbound_message_count, notes, created_at, updated_at
-       FROM contacts WHERE role = $1 ORDER BY created_at ASC`,
+    const result = await this.pool.query<ContactRow>(
+      `SELECT ${CONTACT_COLS} FROM contacts WHERE role = $1 ORDER BY created_at ASC`,
       [role],
     );
 
@@ -951,24 +1007,8 @@ class PostgresContactBackend implements ContactServiceBackend {
   }
 
   async findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null> {
-    const result = await this.pool.query<{
-      id: string;
-      kg_node_id: string | null;
-      display_name: string;
-      role: string | null;
-      system_role: string | null;
-      status: string;
-      contact_confidence: string;
-      trust_level: string | null;
-      last_seen_at: Date | null;
-      inbound_message_count: string;
-      outbound_message_count: string;
-      notes: string | null;
-      created_at: Date;
-      updated_at: Date;
-    }>(
-      `SELECT id, kg_node_id, display_name, role, system_role, status, contact_confidence, trust_level, last_seen_at, inbound_message_count, outbound_message_count, notes, created_at, updated_at
-       FROM contacts WHERE system_role = $1 LIMIT 1`,
+    const result = await this.pool.query<ContactRow>(
+      `SELECT ${CONTACT_COLS} FROM contacts WHERE system_role = $1 LIMIT 1`,
       [systemRole],
     );
 
@@ -978,7 +1018,6 @@ class PostgresContactBackend implements ContactServiceBackend {
   }
 
   async listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]> {
-    const cols = 'id, kg_node_id, display_name, role, system_role, status, contact_confidence, trust_level, last_seen_at, inbound_message_count, outbound_message_count, notes, created_at, updated_at';
     const conditions: string[] = [];
     const params: unknown[] = [];
 
@@ -988,29 +1027,14 @@ class PostgresContactBackend implements ContactServiceBackend {
     }
 
     const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
-    let sql = `SELECT ${cols} FROM contacts${where} ORDER BY created_at ASC`;
+    let sql = `SELECT ${CONTACT_COLS} FROM contacts${where} ORDER BY created_at ASC`;
 
     if (filters?.limit != null) {
       params.push(filters.limit);
       sql += ` LIMIT $${params.length}`;
     }
 
-    const result = await this.pool.query<{
-      id: string;
-      kg_node_id: string | null;
-      display_name: string;
-      role: string | null;
-      system_role: string | null;
-      status: string;
-      contact_confidence: string;
-      trust_level: string | null;
-      last_seen_at: Date | null;
-      inbound_message_count: string;
-      outbound_message_count: string;
-      notes: string | null;
-      created_at: Date;
-      updated_at: Date;
-    }>(sql, params);
+    const result = await this.pool.query<ContactRow>(sql, params);
 
     return result.rows.map((row) => this.rowToContact(row));
   }
@@ -1021,9 +1045,20 @@ class PostgresContactBackend implements ContactServiceBackend {
     // system_role is included so bootstrap and any future setter can persist it through the standard update path.
     // contact_confidence and last_seen_at remain scoring-owned and are not updated here.
     await this.pool.query(
-      `UPDATE contacts SET kg_node_id = $2, display_name = $3, role = $4, system_role = $5, status = $6, notes = $7, trust_level = $8, updated_at = $9
+      `UPDATE contacts SET
+         kg_node_id = $2, display_name = $3, role = $4, system_role = $5, status = $6,
+         notes = $7, trust_level = $8, updated_at = $9,
+         preferred_name = $10, title = $11, organization = $12, primary_email = $13,
+         primary_phone = $14, timezone = $15, locale = $16, location = $17,
+         pronouns = $18, linkedin_url = $19, bio = $20, birthday = $21
        WHERE id = $1`,
-      [contact.id, contact.kgNodeId, contact.displayName, contact.role, contact.systemRole, contact.status, contact.notes, contact.trustLevel, contact.updatedAt],
+      [
+        contact.id, contact.kgNodeId, contact.displayName, contact.role, contact.systemRole,
+        contact.status, contact.notes, contact.trustLevel, contact.updatedAt,
+        contact.preferredName, contact.title, contact.organization, contact.primaryEmail,
+        contact.primaryPhone, contact.timezone, contact.locale, contact.location,
+        contact.pronouns, contact.linkedinUrl, contact.bio, contact.birthday,
+      ],
     );
   }
 
@@ -1376,28 +1411,15 @@ class PostgresContactBackend implements ContactServiceBackend {
 
   // -- Row mapping helpers --
 
-  private rowToContact(row: {
-    id: string;
-    kg_node_id: string | null;
-    display_name: string;
-    role: string | null;
-    system_role: string | null;
-    status: string;
-    contact_confidence: string;  // NUMERIC returned as string by node-pg
-    trust_level: string | null;
-    last_seen_at: Date | null;
-    inbound_message_count: string;
-    outbound_message_count: string;
-    notes: string | null;
-    created_at: Date;
-    updated_at: Date;
-  }): Contact {
+  private rowToContact(row: ContactRow): Contact {
     return {
       id: row.id,
       kgNodeId: row.kg_node_id,
       displayName: row.display_name,
       role: row.role,
-      systemRole: (row.system_role === 'principal' || row.system_role === 'agent') ? row.system_role : null,
+      systemRole: (row.system_role === 'principal' || row.system_role === 'agent' || row.system_role === 'system')
+        ? row.system_role
+        : null,
       status: row.status as ContactStatus,
       // PostgreSQL returns NUMERIC as a string via node-pg.
       // Guard against NaN — if migration 020 hasn't run, the column is absent and
@@ -1415,6 +1437,19 @@ class PostgresContactBackend implements ContactServiceBackend {
       notes: row.notes,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      // Canonical fields (migration 048)
+      preferredName: row.preferred_name,
+      title: row.title,
+      organization: row.organization,
+      primaryEmail: row.primary_email,
+      primaryPhone: row.primary_phone,
+      timezone: row.timezone,
+      locale: row.locale,
+      location: row.location,
+      pronouns: row.pronouns,
+      linkedinUrl: row.linkedin_url,
+      bio: row.bio,
+      birthday: row.birthday,
     };
   }
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -582,6 +582,25 @@ export class ContactService {
   }
 
   /**
+   * Validate that `primaryEmail` is present in `contact_channel_identities` for this
+   * contact (channel = 'email', case-insensitive). Throws `ContactValidationError` if not.
+   * Call this before any writes when the PATCH handler needs to reject invalid emails
+   * without producing partial mutations.
+   */
+  async validatePrimaryEmail(contactId: string, primaryEmail: string): Promise<void> {
+    const identities = await this.backend.getIdentitiesForContact(contactId);
+    const emailLower = primaryEmail.toLowerCase();
+    const match = identities.find(
+      (i) => i.channel === 'email' && i.channelIdentifier.toLowerCase() === emailLower,
+    );
+    if (!match) {
+      throw new ContactValidationError(
+        `primaryEmail '${primaryEmail}' not found in contact_channel_identities for contact ${contactId}`,
+      );
+    }
+  }
+
+  /**
    * Update canonical profile attributes on a contact.
    *
    * Only fields present in `fields` are changed — absent keys leave the current

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -248,7 +248,7 @@ export class ContactService {
       preferredName: options.preferredName ?? null,
       title: options.title ?? null,
       organization: options.organization ?? null,
-      primaryEmail: options.primaryEmail ?? null,
+      primaryEmail: options.primaryEmail?.toLowerCase() ?? null,
       primaryPhone: options.primaryPhone ?? null,
       timezone: options.timezone ?? null,
       locale: options.locale ?? null,
@@ -631,9 +631,20 @@ export class ContactService {
       }
     }
 
+    // Filter undefined entries — spreading undefined values would clear existing columns on
+    // a partial PATCH (Object spread copies undefined keys, which overwrite non-undefined values).
+    const definedFields = Object.fromEntries(
+      Object.entries(fields).filter(([, value]) => value !== undefined),
+    ) as ContactCanonicalFields;
+
+    // Normalize primaryEmail to lowercase for consistent storage and CCI comparison.
+    if (definedFields.primaryEmail != null) {
+      definedFields.primaryEmail = definedFields.primaryEmail.toLowerCase();
+    }
+
     const updated: Contact = {
       ...contact,
-      ...fields,
+      ...definedFields,
       updatedAt: new Date(),
     };
 

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -15,8 +15,38 @@ export interface Contact {
   inboundMessageCount: number;
   outboundMessageCount: number;
   notes: string | null;
+  // Canonical profile attributes (migration 048). All nullable — populated by
+  // backfill script or via updateContactFields(). Source of truth for specialists.
+  preferredName: string | null;
+  title: string | null;
+  organization: string | null;
+  primaryEmail: string | null;
+  primaryPhone: string | null;
+  timezone: string | null;
+  locale: string | null;
+  location: string | null;
+  pronouns: string | null;
+  linkedinUrl: string | null;
+  bio: string | null;
+  birthday: string | null;
   createdAt: Date;
   updatedAt: Date;
+}
+
+/** Subset of Contact fields that can be written via updateContactFields(). */
+export interface ContactCanonicalFields {
+  preferredName?: string | null;
+  title?: string | null;
+  organization?: string | null;
+  primaryEmail?: string | null;
+  primaryPhone?: string | null;
+  timezone?: string | null;
+  locale?: string | null;
+  location?: string | null;
+  pronouns?: string | null;
+  linkedinUrl?: string | null;
+  bio?: string | null;
+  birthday?: string | null;
 }
 
 export interface ChannelIdentity {
@@ -83,6 +113,19 @@ export interface CreateContactOptions {
   /** If provided, links to this existing KG node. Otherwise auto-creates one. */
   kgNodeId?: string;
   source: string;
+  // Canonical profile attributes — optional on create, used by CRM import paths.
+  preferredName?: string | null;
+  title?: string | null;
+  organization?: string | null;
+  primaryEmail?: string | null;
+  primaryPhone?: string | null;
+  timezone?: string | null;
+  locale?: string | null;
+  location?: string | null;
+  pronouns?: string | null;
+  linkedinUrl?: string | null;
+  bio?: string | null;
+  birthday?: string | null;
 }
 
 /** Options for adding a channel identity to a contact */

--- a/src/db/migrations/048_add_contact_canonical_attributes.sql
+++ b/src/db/migrations/048_add_contact_canonical_attributes.sql
@@ -1,0 +1,29 @@
+-- Up Migration
+
+ALTER TABLE contacts ADD COLUMN preferred_name  TEXT;
+ALTER TABLE contacts ADD COLUMN title           TEXT;
+ALTER TABLE contacts ADD COLUMN organization    TEXT;
+ALTER TABLE contacts ADD COLUMN primary_email   TEXT;
+ALTER TABLE contacts ADD COLUMN primary_phone   TEXT;
+ALTER TABLE contacts ADD COLUMN timezone        TEXT;
+ALTER TABLE contacts ADD COLUMN locale          TEXT;
+ALTER TABLE contacts ADD COLUMN location        TEXT;
+ALTER TABLE contacts ADD COLUMN pronouns        TEXT;
+ALTER TABLE contacts ADD COLUMN linkedin_url    TEXT;
+ALTER TABLE contacts ADD COLUMN bio             TEXT;
+ALTER TABLE contacts ADD COLUMN birthday        TEXT;
+
+ALTER TABLE contacts ADD CONSTRAINT contacts_primary_email_format_check
+  CHECK (primary_email ~ '^[^@\s]+@[^@\s]+\.[^@\s]+$');
+ALTER TABLE contacts ADD CONSTRAINT contacts_linkedin_url_format_check
+  CHECK (linkedin_url ~ '^https?://');
+ALTER TABLE contacts ADD CONSTRAINT contacts_bio_length_check
+  CHECK (length(bio) <= 500);
+ALTER TABLE contacts ADD CONSTRAINT contacts_birthday_format_check
+  CHECK (birthday ~ '^\d{4}-\d{2}-\d{2}$' OR birthday ~ '^--\d{2}-\d{2}$');
+
+-- Rollback: ALTER TABLE contacts
+--   DROP COLUMN preferred_name, DROP COLUMN title, DROP COLUMN organization,
+--   DROP COLUMN primary_email, DROP COLUMN primary_phone, DROP COLUMN timezone,
+--   DROP COLUMN locale, DROP COLUMN location, DROP COLUMN pronouns,
+--   DROP COLUMN linkedin_url, DROP COLUMN bio, DROP COLUMN birthday;

--- a/src/db/migrations/048_add_contact_canonical_attributes.sql
+++ b/src/db/migrations/048_add_contact_canonical_attributes.sql
@@ -18,7 +18,7 @@ ALTER TABLE contacts ADD CONSTRAINT contacts_primary_email_format_check
 ALTER TABLE contacts ADD CONSTRAINT contacts_linkedin_url_format_check
   CHECK (linkedin_url ~ '^https?://');
 ALTER TABLE contacts ADD CONSTRAINT contacts_bio_length_check
-  CHECK (length(bio) <= 500);
+  CHECK (char_length(bio) <= 500);
 ALTER TABLE contacts ADD CONSTRAINT contacts_birthday_format_check
   CHECK (birthday ~ '^\d{4}-\d{2}-\d{2}$' OR birthday ~ '^--\d{2}-\d{2}$');
 

--- a/src/db/migrations/048_add_contact_canonical_attributes.sql
+++ b/src/db/migrations/048_add_contact_canonical_attributes.sql
@@ -21,6 +21,10 @@ ALTER TABLE contacts ADD CONSTRAINT contacts_bio_length_check
   CHECK (char_length(bio) <= 500);
 ALTER TABLE contacts ADD CONSTRAINT contacts_birthday_format_check
   CHECK (birthday ~ '^\d{4}-\d{2}-\d{2}$' OR birthday ~ '^--\d{2}-\d{2}$');
+ALTER TABLE contacts ADD CONSTRAINT contacts_primary_phone_format_check
+  CHECK (primary_phone ~ '^\+[1-9][0-9]{6,14}$');
+ALTER TABLE contacts ADD CONSTRAINT contacts_locale_format_check
+  CHECK (locale ~ '^[a-z]{2,3}(-[A-Z]{2,4})?$');
 
 -- Rollback: ALTER TABLE contacts
 --   DROP COLUMN preferred_name, DROP COLUMN title, DROP COLUMN organization,

--- a/tests/integration/contacts.test.ts
+++ b/tests/integration/contacts.test.ts
@@ -357,7 +357,8 @@ describeIf('Contacts Integration', () => {
       const updated = await contactService.updateContactFields(contact.id, {
         primaryEmail: 'CCI-TEST@EXAMPLE.COM',
       });
-      expect(updated.primaryEmail).toBe('CCI-TEST@EXAMPLE.COM');
+      // Normalized to lowercase on write
+      expect(updated.primaryEmail).toBe('cci-test@example.com');
     });
   });
 });

--- a/tests/integration/contacts.test.ts
+++ b/tests/integration/contacts.test.ts
@@ -280,4 +280,84 @@ describeIf('Contacts Integration', () => {
       expect(found?.confidence).toBe('certain'); // "c white" variant matches exactly → 1.0
     });
   });
+
+  describe('canonical fields — service layer', () => {
+    it('createContact stores and retrieves canonical fields', async () => {
+      const contact = await contactService.createContact({
+        displayName: 'Integration Canonical',
+        source: 'integration-test',
+        title: 'Principal Engineer',
+        organization: 'Acme Corp',
+        timezone: 'America/Chicago',
+        bio: 'Integration bio.',
+      });
+
+      const fetched = await contactService.getContact(contact.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.title).toBe('Principal Engineer');
+      expect(fetched!.organization).toBe('Acme Corp');
+      expect(fetched!.timezone).toBe('America/Chicago');
+      expect(fetched!.bio).toBe('Integration bio.');
+    });
+
+    it('updateContactFields round-trips through Postgres', async () => {
+      const contact = await contactService.createContact({
+        displayName: 'Update Integration',
+        source: 'integration-test',
+      });
+
+      const updated = await contactService.updateContactFields(contact.id, {
+        title: 'Senior Engineer',
+        linkedinUrl: 'https://linkedin.com/in/testperson',
+        birthday: '1990-04-15',
+      });
+
+      const fetched = await contactService.getContact(updated.id);
+      expect(fetched!.title).toBe('Senior Engineer');
+      expect(fetched!.linkedinUrl).toBe('https://linkedin.com/in/testperson');
+      expect(fetched!.birthday).toBe('1990-04-15');
+    });
+
+    it('listContacts returns canonical fields for all contacts', async () => {
+      const contact = await contactService.createContact({
+        displayName: 'List Canonical',
+        source: 'integration-test',
+        organization: 'TestOrg',
+      });
+
+      const all = await contactService.listContacts();
+      const found = all.find(c => c.id === contact.id);
+      expect(found).toBeDefined();
+      expect(found!.organization).toBe('TestOrg');
+      // Unprovided fields are null
+      expect(found!.preferredName).toBeNull();
+    });
+
+    it('updateContactFields primaryEmail validation rejects unknown email', async () => {
+      const contact = await contactService.createContact({
+        displayName: 'Email Reject',
+        source: 'integration-test',
+      });
+      await expect(
+        contactService.updateContactFields(contact.id, { primaryEmail: 'nobody@example.com' }),
+      ).rejects.toThrow(/not found.*contact_channel_identities|contact_channel_identities.*not found/i);
+    });
+
+    it('updateContactFields primaryEmail accepts email that exists in CCI', async () => {
+      const contact = await contactService.createContact({
+        displayName: 'Email Accept',
+        source: 'integration-test',
+      });
+      await contactService.linkIdentity({
+        contactId: contact.id,
+        channel: 'email',
+        channelIdentifier: 'cci-test@example.com',
+        source: 'ceo_stated',
+      });
+      const updated = await contactService.updateContactFields(contact.id, {
+        primaryEmail: 'CCI-TEST@EXAMPLE.COM',
+      });
+      expect(updated.primaryEmail).toBe('CCI-TEST@EXAMPLE.COM');
+    });
+  });
 });

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -774,8 +774,8 @@ describe('ContactService', () => {
       const updated = await service.updateContactFields(contact.id, {
         primaryEmail: 'MATCH@EXAMPLE.COM',
       });
-      // Stored as-is (lowercasing is app responsibility, not enforced here)
-      expect(updated.primaryEmail).toBe('MATCH@EXAMPLE.COM');
+      // Normalized to lowercase on write
+      expect(updated.primaryEmail).toBe('match@example.com');
     });
   });
 });

--- a/tests/unit/contacts/contact-service.test.ts
+++ b/tests/unit/contacts/contact-service.test.ts
@@ -666,6 +666,118 @@ describe('ContactService', () => {
       )).toBe(true);
     });
   });
+
+  describe('canonical fields', () => {
+    it('createContact stores canonical fields when provided', async () => {
+      const contact = await service.createContact({
+        displayName: 'Canonical Test',
+        source: 'test',
+        title: 'VP Engineering',
+        organization: 'Acme Corp',
+        timezone: 'America/New_York',
+        bio: 'A short bio.',
+      });
+      expect(contact.title).toBe('VP Engineering');
+      expect(contact.organization).toBe('Acme Corp');
+      expect(contact.timezone).toBe('America/New_York');
+      expect(contact.bio).toBe('A short bio.');
+      // Unprovided fields default to null
+      expect(contact.preferredName).toBeNull();
+      expect(contact.primaryEmail).toBeNull();
+    });
+
+    it('createContact defaults unprovided canonical fields to null', async () => {
+      const contact = await service.createContact({
+        displayName: 'No Canonical',
+        source: 'test',
+      });
+      expect(contact.preferredName).toBeNull();
+      expect(contact.title).toBeNull();
+      expect(contact.organization).toBeNull();
+      expect(contact.primaryEmail).toBeNull();
+      expect(contact.primaryPhone).toBeNull();
+      expect(contact.timezone).toBeNull();
+      expect(contact.locale).toBeNull();
+      expect(contact.location).toBeNull();
+      expect(contact.pronouns).toBeNull();
+      expect(contact.linkedinUrl).toBeNull();
+      expect(contact.bio).toBeNull();
+      expect(contact.birthday).toBeNull();
+    });
+
+    it('updateContactFields round-trip: field persists and updatedAt bumps', async () => {
+      const contact = await service.createContact({
+        displayName: 'Update Test',
+        source: 'test',
+      });
+      const before = contact.updatedAt;
+
+      // Advance time so updatedAt will differ
+      await new Promise(r => setTimeout(r, 5));
+
+      const updated = await service.updateContactFields(contact.id, {
+        title: 'Director',
+        organization: 'Globex',
+      });
+      expect(updated.title).toBe('Director');
+      expect(updated.organization).toBe('Globex');
+      expect(updated.updatedAt.getTime()).toBeGreaterThan(before.getTime());
+    });
+
+    it('updateContactFields only touches provided fields', async () => {
+      const contact = await service.createContact({
+        displayName: 'Partial Test',
+        source: 'test',
+        title: 'CEO',
+        organization: 'StartupCo',
+        timezone: 'Europe/London',
+      });
+      const updated = await service.updateContactFields(contact.id, {
+        title: 'CTO',
+        // organization and timezone NOT provided
+      });
+      expect(updated.title).toBe('CTO');
+      expect(updated.organization).toBe('StartupCo'); // unchanged
+      expect(updated.timezone).toBe('Europe/London'); // unchanged
+    });
+
+    it('updateContactFields throws when contact not found', async () => {
+      await expect(
+        service.updateContactFields('non-existent-id', { title: 'X' }),
+      ).rejects.toThrow('not found');
+    });
+
+    it('updateContactFields with primaryEmail validates against CCI', async () => {
+      const contact = await service.createContact({
+        displayName: 'Email Test',
+        source: 'test',
+      });
+      // No CCI row exists — should throw
+      await expect(
+        service.updateContactFields(contact.id, { primaryEmail: 'test@example.com' }),
+      ).rejects.toThrow(/not found.*contact_channel_identities|contact_channel_identities.*not found/i);
+    });
+
+    it('updateContactFields with primaryEmail succeeds when CCI row exists', async () => {
+      const contact = await service.createContact({
+        displayName: 'Email Match Test',
+        source: 'test',
+      });
+      // Add the matching CCI row
+      await service.linkIdentity({
+        contactId: contact.id,
+        channel: 'email',
+        channelIdentifier: 'match@example.com',
+        source: 'ceo_stated',
+      });
+      // Case-insensitive comparison — provide uppercase
+      const updated = await service.updateContactFields(contact.id, {
+        primaryEmail: 'MATCH@EXAMPLE.COM',
+      });
+      // Stored as-is (lowercasing is app responsibility, not enforced here)
+      expect(updated.primaryEmail).toBe('MATCH@EXAMPLE.COM');
+    });
+  });
 });
 
 describe('EntityMemory.mergeEntities', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       'src/**/*.test.ts',
       'skills/**/*.test.ts',
       'apps/**/*.test.ts',
+      'scripts/**/*.test.ts',
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## **User description**
## Summary

- Closes #829
- Adds 12 canonical profile fields directly on the `contacts` row (`title`, `organization`, `primary_email`, `primary_phone`, `preferred_name`, `timezone`, `locale`, `location`, `pronouns`, `linkedin_url`, `bio`, `birthday`)
- Ships migration 048 with 4 CHECK constraints (email format, LinkedIn URL prefix, bio ≤ 500 chars, birthday format)
- Backfill script (`scripts/backfill-contact-attributes.ts`) reads KG fact nodes and populates NULL columns — idempotent, re-run safe
- `ContactService` gains `updateContactFields()` with `primaryEmail` CCI validation (case-insensitive) and typed `ContactValidationError` for proper 400 vs 500 routing
- HTTP API (GET/POST/PATCH `/api/kg/contacts`) serializes all 12 fields; validates format on write
- Console UI replaces Role column with Title + Organization; drawer gains 6 grouped sections

## Test plan

- [ ] Run `pnpm run typecheck` — expect clean
- [ ] Run `pnpm run test -- tests/unit/contacts/contact-service.test.ts` — expect all pass including new `describe('canonical fields')` block
- [ ] Run `pnpm run test -- scripts/backfill-contact-attributes.test.ts` — expect 6/6 pass
- [ ] Apply migration 048 to a dev DB and run `pnpm run test -- tests/integration/contacts.test.ts` — expect new canonical field tests to pass
- [ ] Smoke-test Console UI: open Contacts page, confirm Title + Org columns visible, open a contact drawer, confirm 6 sections with all new fields
- [ ] Test PATCH with an invalid `primaryEmail` (one not in contact_channel_identities) — expect 400
- [ ] Test PATCH with a valid `primaryEmail` — expect 200 with field persisted
- [ ] Run `pnpm run backfill:contact-attributes` against dev DB after migration — expect structured log of columns written

## Notes

- Issue #830 (wire enrichment/agents/stop new KG fact writes) is a follow-up; this PR is the foundation only
- `MergeGoldenRecord` does not yet include the 12 canonical fields — flagged for #830 scope


___

## **CodeAnt-AI Description**
**Store and show canonical contact details across the app**

### What Changed
- Contacts now keep 12 profile fields directly on the contact record, and new contacts can save them on create
- Editing a contact now includes these fields in the drawer, and the contacts table shows Title and Organization instead of Role
- Contact search now matches name, title, and organization
- The API returns the new fields on contact list, create, and update calls, and rejects invalid email, LinkedIn, bio length, and birthday values
- A backfill command fills missing fields from linked KG facts and skips already filled values

### Impact
`✅ Faster contact lookup by title or company`
`✅ Fewer missing profile details in contact records`
`✅ Clearer contact editing in Console`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 12 new contact profile fields: preferred name, pronouns, title, organization, primary email/phone, timezone, locale, location, LinkedIn URL, bio, and birthday.
  * Expanded contact search to include title and organization.
  * Updated contacts table to display Title and Organization columns.
  * Restructured contact edit form with grouped sections for all new fields.

* **Documentation**
  * Added design and implementation documentation for contact canonical attributes.

* **Tests**
  * Added unit and integration test coverage for canonical fields.
  * Added backfill script test suite.

* **Chores**
  * Added backfill command to package scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->