### PR TITLE
feat(contacts): wire canonical attributes through entity context + guard KG writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 - **Contact canonical attributes** — 12 structured profile fields (`title`, `organization`, `primary_email`, etc.) persisted directly on the `contacts` row; backfill script populates from KG facts. (#829)
-- **Entity context enrichment — integration** — `EntityContext.contact` now exposes all 12 canonical fields; the assembler filters duplicate KG facts for those attributes. `memory-store` and `extract-facts` redirect canonical-attribute writes (timezone, title, organization, phone, etc.) to `ContactService` instead of the KG, with E.164 normalization for phone values via `libphonenumber-js`. `context-for-email` prefers `contact.primaryEmail` and surfaces `contact.preferredName` for salutations. Agent prompts (coordinator, research-analyst, ceo-inbox, calendar) updated with canonical-attribute guidance. (#830)
+- **Entity context enrichment** — `EntityContext.contact` now exposes all 12 canonical fields; canonical-attribute writes via `memory-store` and `extract-facts` redirect to `ContactService` with E.164 phone normalization; `context-for-email` prefers `contact.primaryEmail` and surfaces `contact.preferredName` for salutations. (#830)
 - **File attachments in outbound email** — all five email skills (`email-send`, `email-reply`, `email-draft-save`, `ceo-inbox-draft-compose`, `ceo-inbox-draft-reply`) now accept an `attachments` input field. Attachments are read from `file://` URLs (TempFileStore), validated, and forwarded to Nylas. The CEO inbox path uses multipart FormData; the Curia outbound path passes `Buffer` content via the Nylas SDK. 20 MB total / 10 attachment limit enforced. (#818)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 - **File attachments in outbound email** — all five email skills (`email-send`, `email-reply`, `email-draft-save`, `ceo-inbox-draft-compose`, `ceo-inbox-draft-reply`) now accept an `attachments` input field. Attachments are read from `file://` URLs (TempFileStore), validated, and forwarded to Nylas. The CEO inbox path uses multipart FormData; the Curia outbound path passes `Buffer` content via the Nylas SDK. 20 MB total / 10 attachment limit enforced. (#818)
 
 ### Fixed
+- **`extract-facts` canonical lookup N+1** — contact lookups are now cached by KG node ID within a single `execute()` call; multiple canonical facts about the same person no longer each trigger a separate DB query. (#830)
+- **`extract-facts` + `memory-store` skill.json contracts** — output schemas now document the `redirected` counter and `redirected_to_contact` action (with `contact_id`) introduced by the canonical attribute guard. (#830)
+- **`canonical-attribute-guard` whitespace handling** — `resolveCanonicalField` now trims leading/trailing whitespace before lookup; LLM-generated attribute keys like `" timezone "` now match correctly instead of falling through to KG writes.
 - **coordinator delegation hint** — `delegation_hint` in active outbound context is now treated as a binding contract; coordinator no longer handles replies directly when a specialist is named, preventing meeting debriefs from getting stuck at `"prompted"`. (#763)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ### Added
 - **Contact canonical attributes** — 12 structured profile fields (`title`, `organization`, `primary_email`, etc.) persisted directly on the `contacts` row; backfill script populates from KG facts. (#829)
+- **Entity context enrichment — integration** — `EntityContext.contact` now exposes all 12 canonical fields; the assembler filters duplicate KG facts for those attributes. `memory-store` and `extract-facts` redirect canonical-attribute writes (timezone, title, organization, phone, etc.) to `ContactService` instead of the KG, with E.164 normalization for phone values via `libphonenumber-js`. `context-for-email` prefers `contact.primaryEmail` and surfaces `contact.preferredName` for salutations. Agent prompts (coordinator, research-analyst, ceo-inbox, calendar) updated with canonical-attribute guidance. (#830)
 - **File attachments in outbound email** — all five email skills (`email-send`, `email-reply`, `email-draft-save`, `ceo-inbox-draft-compose`, `ceo-inbox-draft-reply`) now accept an `attachments` input field. Attachments are read from `file://` URLs (TempFileStore), validated, and forwarded to Nylas. The CEO inbox path uses multipart FormData; the Curia outbound path passes `Buffer` content via the Nylas SDK. 20 MB total / 10 attachment limit enforced. (#818)
 
 ### Fixed

--- a/agents/calendar.yaml
+++ b/agents/calendar.yaml
@@ -1,4 +1,5 @@
 name: calendar
+version: "0.1.0"
 role: specialist
 description: >
   Calendar domain specialist — scheduling, free/busy, conflict resolution,
@@ -87,7 +88,7 @@ system_prompt: |
   8. **Timezone awareness.** When scheduling across timezones, state times in
      each participant's local timezone. Use entity-context to determine
      participant timezones. Read timezone from `contact.timezone` in the entity-context
-     response — this is the structured column (migration 048) and is authoritative.
+     response — this is the authoritative canonical column.
      Do not parse the `facts` array for a timezone label; `contact.timezone` always
      takes precedence when present.
 

--- a/agents/calendar.yaml
+++ b/agents/calendar.yaml
@@ -86,7 +86,10 @@ system_prompt: |
 
   8. **Timezone awareness.** When scheduling across timezones, state times in
      each participant's local timezone. Use entity-context to determine
-     participant timezones.
+     participant timezones. Read timezone from `contact.timezone` in the entity-context
+     response — this is the structured column (migration 048) and is authoritative.
+     Do not parse the `facts` array for a timezone label; `contact.timezone` always
+     takes precedence when present.
 
   ## Preference Hierarchy
   The CEO provides scheduling rules dynamically via chat or email (e.g. "no

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -1,5 +1,5 @@
 name: ceo-inbox
-version: "0.2.0"
+version: "0.2.1"
 role: specialist
 description: >
   Manages the CEO's personal email inbox. Handles standing-rule management,
@@ -131,8 +131,15 @@ system_prompt: |
   One fact per call. Do not store trivial or transient details (e.g. "sent
   an email on May 5").
 
+  **Canonical contact attributes** (`current_role`, `job_title`, `company`,
+  `organization`, `phone`, `email`, `timezone`, `location`, etc.) are
+  automatically redirected by `memory-store` to the Contact record — no
+  special handling needed. Expect `action: "redirected_to_contact"` in the
+  result; treat it the same as `stored: true`.
+
   After each call, check the outcome:
   - `stored: true` — proceed.
+  - `redirected_to_contact` — attribute saved to the Contact record, proceed normally.
   - `conflict` — do not overwrite; note the conflict in the Response Format
     so the coordinator can surface it to the CEO.
   - `ambiguous` — do not store; note the ambiguity in the Response Format.

--- a/agents/ceo-inbox.yaml
+++ b/agents/ceo-inbox.yaml
@@ -131,15 +131,8 @@ system_prompt: |
   One fact per call. Do not store trivial or transient details (e.g. "sent
   an email on May 5").
 
-  **Canonical contact attributes** (`current_role`, `job_title`, `company`,
-  `organization`, `phone`, `email`, `timezone`, `location`, etc.) are
-  automatically redirected by `memory-store` to the Contact record — no
-  special handling needed. Expect `action: "redirected_to_contact"` in the
-  result; treat it the same as `stored: true`.
-
   After each call, check the outcome:
   - `stored: true` — proceed.
-  - `redirected_to_contact` — attribute saved to the Contact record, proceed normally.
   - `conflict` — do not overwrite; note the conflict in the Response Format
     so the coordinator can surface it to the CEO.
   - `ambiguous` — do not store; note the ambiguity in the Response Format.

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -1,5 +1,5 @@
 name: coordinator
-version: "0.3.0"
+version: "0.3.1"
 role: coordinator
 description: Central coordinator — routes all messages, delegates to specialists, maintains the unified persona
 model:
@@ -62,8 +62,19 @@ system_prompt: |
      - `slow_decay` — preferences and standing facts that change occasionally (default)
      - `fast_decay` — current-situation facts (active project, this week's priority)
   4. Call `memory-store` with the resolved `entity` and chosen `decay_class`.
+     **Exception — canonical contact attributes:** For the following fields, `memory-store`
+     automatically redirects the write to the Contact record (no KG fact node is created).
+     You do not need to call a different skill; the redirect happens transparently and the
+     skill returns `action: "redirected_to_contact"`. These fields are: `preferred_name`,
+     `nickname`, `job_title`, `title`, `organization`, `employer`, `company`,
+     `current_employer`, `email`, `primary_email`, `phone`, `phone_number`, `mobile`,
+     `timezone`, `tz`, `locale`, `language`, `home_city`, `current_location`, `location`,
+     `city`, `pronouns`, `linkedin`, `linkedin_url`, `bio`, `biography`, `birthday`,
+     `birthdate`, `dob`.
   5. Handle the outcome:
      - `stored: true` — confirm naturally ("Got it, I have that on file.")
+     - `redirected_to_contact` — the attribute was saved to the Contact record. Confirm
+       naturally ("Got it, I have that on file.") — no further action needed.
      - `ambiguous` — ask the CEO which entity they meant before writing.
      - `conflict` — surface it: "I already have [field] as [existing value] — which
        is correct?"

--- a/agents/coordinator.yaml
+++ b/agents/coordinator.yaml
@@ -62,19 +62,8 @@ system_prompt: |
      - `slow_decay` — preferences and standing facts that change occasionally (default)
      - `fast_decay` — current-situation facts (active project, this week's priority)
   4. Call `memory-store` with the resolved `entity` and chosen `decay_class`.
-     **Exception — canonical contact attributes:** For the following fields, `memory-store`
-     automatically redirects the write to the Contact record (no KG fact node is created).
-     You do not need to call a different skill; the redirect happens transparently and the
-     skill returns `action: "redirected_to_contact"`. These fields are: `preferred_name`,
-     `nickname`, `job_title`, `title`, `organization`, `employer`, `company`,
-     `current_employer`, `email`, `primary_email`, `phone`, `phone_number`, `mobile`,
-     `timezone`, `tz`, `locale`, `language`, `home_city`, `current_location`, `location`,
-     `city`, `pronouns`, `linkedin`, `linkedin_url`, `bio`, `biography`, `birthday`,
-     `birthdate`, `dob`.
   5. Handle the outcome:
      - `stored: true` — confirm naturally ("Got it, I have that on file.")
-     - `redirected_to_contact` — the attribute was saved to the Contact record. Confirm
-       naturally ("Got it, I have that on file.") — no further action needed.
      - `ambiguous` — ask the CEO which entity they meant before writing.
      - `conflict` — surface it: "I already have [field] as [existing value] — which
        is correct?"

--- a/agents/research-analyst.yaml
+++ b/agents/research-analyst.yaml
@@ -63,14 +63,9 @@ system_prompt: |
     - `slow_decay` — important but changeable facts (funding round, partnership status)
     - `fast_decay` — current-situation facts (active project, recent announcement)
   - Write concise, factual statements. One fact per call.
-  - **Canonical contact attributes** (e.g. `job_title`, `organization`, `timezone`,
-    `primary_email`, `phone`, `location`, `bio`) are automatically redirected by
-    `memory-store` to the Contact record. No special handling needed — call the skill
-    normally and expect `action: "redirected_to_contact"` in the result.
 
   After each call, check the outcome:
   - `stored: true` — proceed.
-  - `redirected_to_contact` — attribute saved to the Contact record, proceed normally.
   - `conflict` — do not overwrite; note the conflict in your research summary so
     the coordinator can surface it to the CEO.
   - `ambiguous` — note the ambiguity; do not write until resolved.

--- a/agents/research-analyst.yaml
+++ b/agents/research-analyst.yaml
@@ -63,9 +63,14 @@ system_prompt: |
     - `slow_decay` — important but changeable facts (funding round, partnership status)
     - `fast_decay` — current-situation facts (active project, recent announcement)
   - Write concise, factual statements. One fact per call.
+  - **Canonical contact attributes** (e.g. `job_title`, `organization`, `timezone`,
+    `primary_email`, `phone`, `location`, `bio`) are automatically redirected by
+    `memory-store` to the Contact record. No special handling needed — call the skill
+    normally and expect `action: "redirected_to_contact"` in the result.
 
   After each call, check the outcome:
   - `stored: true` — proceed.
+  - `redirected_to_contact` — attribute saved to the Contact record, proceed normally.
   - `conflict` — do not overwrite; note the conflict in your research summary so
     the coordinator can surface it to the CEO.
   - `ambiguous` — note the ambiguity; do not write until resolved.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "googleapis": "^173.0.0",
     "js-yaml": "^4.2.0",
     "layout-base": "^2.0.1",
+    "libphonenumber-js": "^1.13.4",
     "luxon": "^3.7.2",
     "node-html-parser": "^7.1.0",
     "node-pg-migrate": "^8.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       layout-base:
         specifier: ^2.0.1
         version: 2.0.1
+      libphonenumber-js:
+        specifier: ^1.13.4
+        version: 1.13.4
       luxon:
         specifier: ^3.7.2
         version: 3.7.2
@@ -3734,6 +3737,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libphonenumber-js@1.13.4:
+    resolution: {integrity: sha512-/lhWr7vq8foWN9Apksnd9v8/cfwzW6g6qKOCo25XBGkNaVCHucXO57hLy4CWHGvytvLz6Nt3J5Gs8p3jlCGFXA==}
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
@@ -9138,6 +9144,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libphonenumber-js@1.13.4: {}
 
   libsql@0.5.29:
     dependencies:

--- a/skills/context-for-email/handler.ts
+++ b/skills/context-for-email/handler.ts
@@ -170,28 +170,34 @@ export class ContextForEmailHandler implements SkillHandler {
       let email: string | undefined;
       let identityStatus: string | undefined;
 
+      // Always fetch identities — needed both for email resolution (when primaryEmail
+      // is null) and to resolve the actual identity status (even when primaryEmail is
+      // set, the identity could be bounced or defunct since it was pinned as primary).
+      const withIdentities = await ctx.contactService.getContactWithIdentities(contact.id);
+
       if (contact.primaryEmail) {
-        // Canonical column is populated — use it directly, no identity scan needed.
+        // Canonical column is populated — use it as the email address.
+        // Resolve the actual status from contact_channel_identities so the LLM gets
+        // a correct bounce/defunct warning instead of a spurious 'active'.
         email = contact.primaryEmail;
-        identityStatus = 'active';
-      } else {
-        // Fallback: scan contact_channel_identities for an email address.
-        const withIdentities = await ctx.contactService.getContactWithIdentities(contact.id);
-        if (withIdentities) {
-          // Prefer active identities over defunct/bounced ones. If no active
-          // identity exists, fall back to the first by creation order (the sort
-          // is stable). The LLM receives identity_status and can warn accordingly.
-          const emailIdentity = withIdentities.identities
-            .filter((id) => id.channel === 'email')
-            .sort((a, b) => {
-              if (a.status === 'active' && b.status !== 'active') return -1;
-              if (a.status !== 'active' && b.status === 'active') return 1;
-              return 0;
-            })[0];
-          if (emailIdentity) {
-            email = emailIdentity.channelIdentifier;
-            identityStatus = emailIdentity.status;
-          }
+        const primaryIdentity = withIdentities?.identities.find(
+          (id) => id.channel === 'email' &&
+                  id.channelIdentifier.toLowerCase() === contact.primaryEmail!.toLowerCase(),
+        );
+        identityStatus = primaryIdentity?.status ?? 'active';
+      } else if (withIdentities) {
+        // No canonical email — scan all email identities, preferring active ones.
+        // The LLM receives identity_status and can warn accordingly.
+        const emailIdentity = withIdentities.identities
+          .filter((id) => id.channel === 'email')
+          .sort((a, b) => {
+            if (a.status === 'active' && b.status !== 'active') return -1;
+            if (a.status !== 'active' && b.status === 'active') return 1;
+            return 0;
+          })[0];
+        if (emailIdentity) {
+          email = emailIdentity.channelIdentifier;
+          identityStatus = emailIdentity.status;
         }
       }
 

--- a/skills/context-for-email/handler.ts
+++ b/skills/context-for-email/handler.ts
@@ -117,6 +117,9 @@ export class ContextForEmailHandler implements SkillHandler {
     const recipient: Record<string, unknown> = {};
     if (recipientResult) {
       recipient.display_name = recipientResult.displayName;
+      // preferred_name is the short/familiar form for salutations (e.g. "Dave" vs "David Chen").
+      // Falls back to display_name if not set — the LLM can use whichever is more natural.
+      if (recipientResult.preferredName) recipient.preferred_name = recipientResult.preferredName;
       if (recipientResult.role) recipient.role = recipientResult.role;
       if (recipientResult.email) recipient.email = recipientResult.email;
       if (recipientResult.identityStatus) recipient.identity_status = recipientResult.identityStatus;
@@ -146,14 +149,16 @@ export class ContextForEmailHandler implements SkillHandler {
 
   /**
    * Look up recipient contact info via the contact service.
-   * Uses findContactByName for partial name matching, then fetches
-   * identities to find their email address.
+   * Uses findContactByName for partial name matching. If contact.primaryEmail is
+   * populated, uses it directly (canonical column, migration 048). Otherwise falls
+   * back to scanning contact_channel_identities for an active email address.
+   * Also surfaces contact.preferredName for personalising salutations.
    * Returns null if not found or contact service is unavailable.
    */
   private async lookupRecipient(
     ctx: SkillContext,
     recipientName: string,
-  ): Promise<{ displayName: string; role?: string; email?: string; identityStatus?: string } | null> {
+  ): Promise<{ displayName: string; preferredName?: string; role?: string; email?: string; identityStatus?: string } | null> {
     if (!ctx.contactService) return null;
 
     try {
@@ -161,29 +166,38 @@ export class ContextForEmailHandler implements SkillHandler {
       if (contacts.length === 0) return null;
 
       const contact = contacts[0]!;
-      // Fetch identities to find their email address
-      const withIdentities = await ctx.contactService.getContactWithIdentities(contact.id);
+
       let email: string | undefined;
       let identityStatus: string | undefined;
-      if (withIdentities) {
-        // Prefer active identities over defunct/bounced ones. If no active
-        // identity exists, fall back to the first by creation order (the sort
-        // is stable). The LLM receives identity_status and can warn accordingly.
-        const emailIdentity = withIdentities.identities
-          .filter((id) => id.channel === 'email')
-          .sort((a, b) => {
-            if (a.status === 'active' && b.status !== 'active') return -1;
-            if (a.status !== 'active' && b.status === 'active') return 1;
-            return 0;
-          })[0];
-        if (emailIdentity) {
-          email = emailIdentity.channelIdentifier;
-          identityStatus = emailIdentity.status;
+
+      if (contact.primaryEmail) {
+        // Canonical column is populated — use it directly, no identity scan needed.
+        email = contact.primaryEmail;
+        identityStatus = 'active';
+      } else {
+        // Fallback: scan contact_channel_identities for an email address.
+        const withIdentities = await ctx.contactService.getContactWithIdentities(contact.id);
+        if (withIdentities) {
+          // Prefer active identities over defunct/bounced ones. If no active
+          // identity exists, fall back to the first by creation order (the sort
+          // is stable). The LLM receives identity_status and can warn accordingly.
+          const emailIdentity = withIdentities.identities
+            .filter((id) => id.channel === 'email')
+            .sort((a, b) => {
+              if (a.status === 'active' && b.status !== 'active') return -1;
+              if (a.status !== 'active' && b.status === 'active') return 1;
+              return 0;
+            })[0];
+          if (emailIdentity) {
+            email = emailIdentity.channelIdentifier;
+            identityStatus = emailIdentity.status;
+          }
         }
       }
 
       return {
         displayName: contact.displayName,
+        preferredName: contact.preferredName ?? undefined,
         role: contact.role ?? undefined,
         email,
         identityStatus,

--- a/skills/extract-facts/handler.test.ts
+++ b/skills/extract-facts/handler.test.ts
@@ -69,7 +69,7 @@ describe('ExtractFactsHandler', () => {
 
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { stored: 0, skipped: true, failed: 0 } });
+    expect(result).toEqual({ success: true, data: { stored: 0, redirected: 0, skipped: true, failed: 0 } });
     // Classifier was called; extraction was not
     expect(infraLlm.classify).toHaveBeenCalledTimes(1);
     expect(infraLlm.extract).not.toHaveBeenCalled();
@@ -89,7 +89,7 @@ describe('ExtractFactsHandler', () => {
 
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { stored: 1, skipped: false, failed: 0 } });
+    expect(result).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 0 } });
 
     // Fact node exists in the KG
     const josephNodes = await entityMemory.findEntities('Jane Doe');
@@ -173,14 +173,14 @@ describe('ExtractFactsHandler', () => {
     const handler1 = new ExtractFactsHandler();
     const ctx1 = makeCtx(entityMemory, { text: 'Bob lives in Toronto.', source: 'test' }, infraLlm1);
     const result1 = await handler1.execute(ctx1);
-    expect(result1).toEqual({ success: true, data: { stored: 1, skipped: false, failed: 0 } });
+    expect(result1).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 0 } });
 
     // Second invocation with semantically identical fact — storeFact deduplicates internally
     const infraLlm2 = makeMockInfraLlm(['yes', facts]);
     const handler2 = new ExtractFactsHandler();
     const ctx2 = makeCtx(entityMemory, { text: 'Bob lives in Toronto.', source: 'test' }, infraLlm2);
     const result2 = await handler2.execute(ctx2);
-    expect(result2).toEqual({ success: true, data: { stored: 1, skipped: false, failed: 0 } });
+    expect(result2).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 0 } });
 
     // Only one fact node should exist — storeFact merged the second call into the first
     const josephNodes = await entityMemory.findEntities('Jane Doe');
@@ -234,7 +234,7 @@ describe('ExtractFactsHandler', () => {
     const result = await handler.execute(ctx);
 
     // conflict is a semantic outcome — not counted as failed
-    expect(result).toEqual({ success: true, data: { stored: 0, skipped: false, failed: 0 } });
+    expect(result).toEqual({ success: true, data: { stored: 0, redirected: 0, skipped: false, failed: 0 } });
     expect(storeFact).toHaveBeenCalledOnce();
   });
 
@@ -260,7 +260,7 @@ describe('ExtractFactsHandler', () => {
 
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { stored: 1, skipped: false, failed: 0 } });
+    expect(result).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 0 } });
     // storeFact should use memoryWriteSource (task-scoped), not the LLM-provided 'agent:ceo-inbox'
     expect(storeFact.mock.calls[0]![0].source).toBe(memoryWriteSource);
   });
@@ -284,7 +284,7 @@ describe('ExtractFactsHandler', () => {
     const result = await handler.execute(ctx);
 
     // first fact stored, rate-limit counted as failed, loop stopped before fact 3
-    expect(result).toEqual({ success: true, data: { stored: 1, skipped: false, failed: 1 } });
+    expect(result).toEqual({ success: true, data: { stored: 1, redirected: 0, skipped: false, failed: 1 } });
     expect(storeFact).toHaveBeenCalledTimes(2);
   });
 
@@ -320,7 +320,7 @@ describe('ExtractFactsHandler', () => {
 
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { stored: 0, skipped: false, failed: 1 } });
+    expect(result).toEqual({ success: true, data: { stored: 0, redirected: 0, skipped: false, failed: 1 } });
 
     const malformedCall = warnSpy.mock.calls.find(
       (args) => typeof args[args.length - 1] === 'string' && (args[args.length - 1] as string).includes('skipping malformed fact'),
@@ -347,7 +347,7 @@ describe('ExtractFactsHandler', () => {
     const ctx = makeCtx(entityMemory, { text: 'Jane Doe lives in Toronto.', source: 'test' }, infraLlm);
     const result = await handler.execute(ctx);
 
-    expect(result).toEqual({ success: true, data: { stored: 0, skipped: false, failed: 1 } });
+    expect(result).toEqual({ success: true, data: { stored: 0, redirected: 0, skipped: false, failed: 1 } });
     expect(storeFact).toHaveBeenCalledTimes(1);
   });
 

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -14,6 +14,7 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 import { DECAY_CLASSES, NODE_TYPES } from '../../src/memory/types.js';
 import type { DecayClass, NodeType } from '../../src/memory/types.js';
 import { buildCanonicalPatch } from '../../src/contacts/canonical-attribute-guard.js';
+import type { Contact } from '../../src/contacts/types.js';
 import { ContactValidationError } from '../../src/contacts/contact-service.js';
 
 // Shape of each fact returned by the LLM extraction prompt.
@@ -145,6 +146,11 @@ ${text}`,
         NODE_TYPES.filter(t => t !== 'fact'),
       );
 
+      // Cache contact lookups by KG node ID within a single execute() call.
+      // A transcript may assert several canonical attributes about the same person,
+      // which would otherwise trigger an N+1 DB query per fact.
+      const contactLookupCache = new Map<string, Contact | null>();
+
       for (const fact of facts) {
         // Declared before try so the catch block can always reference them,
         // even if an exception fires before the assignments inside try would run.
@@ -231,14 +237,22 @@ ${text}`,
                 // findContactByKgNodeId is called outside the inner try/catch deliberately:
                 // if it throws (DB error), we fall through to the KG write rather than
                 // propagating. A transient lookup failure should not abort the fact write.
-                let contact;
-                try {
-                  contact = await ctx.contactService.findContactByKgNodeId(entityNode.id);
-                } catch (lookupErr) {
-                  ctx.log.warn(
-                    { subject, attribute, entityNodeId: entityNode.id, err: lookupErr },
-                    'extract-facts: findContactByKgNodeId failed — falling back to KG write',
-                  );
+                // Result is cached per execute() call — multiple canonical facts about the
+                // same person would otherwise cause an N+1 DB query.
+                let contact: Contact | null | undefined;
+                if (contactLookupCache.has(entityNode.id)) {
+                  contact = contactLookupCache.get(entityNode.id);
+                } else {
+                  try {
+                    contact = await ctx.contactService.findContactByKgNodeId(entityNode.id);
+                    contactLookupCache.set(entityNode.id, contact ?? null);
+                  } catch (lookupErr) {
+                    ctx.log.warn(
+                      { subject, attribute, entityNodeId: entityNode.id, err: lookupErr },
+                      'extract-facts: findContactByKgNodeId failed — falling back to KG write',
+                    );
+                    // Leave contact undefined — the guard below treats undefined the same as null.
+                  }
                 }
 
                 if (contact) {

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -14,6 +14,7 @@ import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/t
 import { DECAY_CLASSES, NODE_TYPES } from '../../src/memory/types.js';
 import type { DecayClass, NodeType } from '../../src/memory/types.js';
 import { buildCanonicalPatch } from '../../src/contacts/canonical-attribute-guard.js';
+import { ContactValidationError } from '../../src/contacts/contact-service.js';
 
 // Shape of each fact returned by the LLM extraction prompt.
 interface ExtractedFact {
@@ -227,7 +228,19 @@ ${text}`,
                   'extract-facts: canonical attribute normalization failed — falling back to KG write',
                 );
               } else {
-                const contact = await ctx.contactService.findContactByKgNodeId(entityNode.id);
+                // findContactByKgNodeId is called outside the inner try/catch deliberately:
+                // if it throws (DB error), we fall through to the KG write rather than
+                // propagating. A transient lookup failure should not abort the fact write.
+                let contact;
+                try {
+                  contact = await ctx.contactService.findContactByKgNodeId(entityNode.id);
+                } catch (lookupErr) {
+                  ctx.log.warn(
+                    { subject, attribute, entityNodeId: entityNode.id, err: lookupErr },
+                    'extract-facts: findContactByKgNodeId failed — falling back to KG write',
+                  );
+                }
+
                 if (contact) {
                   try {
                     await ctx.contactService.updateContactFields(contact.id, patch.fields);
@@ -238,15 +251,26 @@ ${text}`,
                     redirected++;
                     continue;
                   } catch (err) {
-                    // Validation error (e.g. primaryEmail not in CCI) — log and fall
-                    // through to the KG write so the information is not lost entirely.
-                    ctx.log.warn(
-                      { subject, attribute, contactId: contact.id, err },
-                      'extract-facts: canonical attribute redirect failed — falling back to KG write',
-                    );
+                    if (err instanceof ContactValidationError) {
+                      // Validation failure (e.g. primaryEmail not in CCI) — this is expected
+                      // for some inputs; fall through so the information is preserved in the KG.
+                      ctx.log.warn(
+                        { subject, attribute, contactId: contact.id, reason: err.message },
+                        'extract-facts: canonical attribute validation failed — falling back to KG write',
+                      );
+                    } else {
+                      // Infrastructure or programming error — do not silently diverge the
+                      // contacts table from the KG. Increment failed and skip the KG write.
+                      ctx.log.error(
+                        { subject, attribute, contactId: contact.id, err },
+                        'extract-facts: canonical attribute redirect failed with unexpected error — skipping fact',
+                      );
+                      failed++;
+                      continue;
+                    }
                   }
                 }
-                // No contact record for this person node — fall through to KG write.
+                // No contact record for this person node, or lookup failed — fall through.
               }
             }
           }

--- a/skills/extract-facts/handler.ts
+++ b/skills/extract-facts/handler.ts
@@ -13,6 +13,7 @@
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { DECAY_CLASSES, NODE_TYPES } from '../../src/memory/types.js';
 import type { DecayClass, NodeType } from '../../src/memory/types.js';
+import { buildCanonicalPatch } from '../../src/contacts/canonical-attribute-guard.js';
 
 // Shape of each fact returned by the LLM extraction prompt.
 interface ExtractedFact {
@@ -71,7 +72,7 @@ export class ExtractFactsHandler implements SkillHandler {
 
       if (!classifierAnswer.startsWith('yes')) {
         ctx.log.debug({ textPreview: text.slice(0, 80) }, 'extract-facts: classifier gate — no facts, skipping');
-        return { success: true, data: { stored: 0, skipped: true, failed: 0 } };
+        return { success: true, data: { stored: 0, redirected: 0, skipped: true, failed: 0 } };
       }
 
       // -- Step 2: Extraction prompt --
@@ -130,6 +131,7 @@ ${text}`,
 
       // -- Steps 3 & 4: Entity resolution + fact storage --
       let stored = 0;
+      let redirected = 0;
       // failed counts: malformed LLM output (guard below), rate-limited facts (loop
       // breaks immediately on first hit), and infrastructure errors from storeFact.
       // Contradictions (action:'conflict') are NOT counted as failed — they are expected
@@ -211,6 +213,44 @@ ${text}`,
             entityNode = resolved.node;
           }
 
+          // --- Canonical contact attribute guard ---
+          //
+          // If the entity is a person node linked to a contact record, redirect
+          // canonical attribute writes (timezone, title, organization, etc.) to
+          // ContactService.updateContactFields() rather than the KG.
+          if (entityNode.type === 'person' && ctx.contactService) {
+            const patch = buildCanonicalPatch(attribute, value);
+            if (patch !== null) {
+              if (patch.fallbackToKg) {
+                ctx.log.warn(
+                  { subject, attribute, reason: patch.reason },
+                  'extract-facts: canonical attribute normalization failed — falling back to KG write',
+                );
+              } else {
+                const contact = await ctx.contactService.findContactByKgNodeId(entityNode.id);
+                if (contact) {
+                  try {
+                    await ctx.contactService.updateContactFields(contact.id, patch.fields);
+                    ctx.log.info(
+                      { subject, attribute, contactId: contact.id },
+                      'extract-facts: canonical attribute redirected to ContactService',
+                    );
+                    redirected++;
+                    continue;
+                  } catch (err) {
+                    // Validation error (e.g. primaryEmail not in CCI) — log and fall
+                    // through to the KG write so the information is not lost entirely.
+                    ctx.log.warn(
+                      { subject, attribute, contactId: contact.id, err },
+                      'extract-facts: canonical attribute redirect failed — falling back to KG write',
+                    );
+                  }
+                }
+                // No contact record for this person node — fall through to KG write.
+              }
+            }
+          }
+
           // Label format: "<attribute>: <value>" — human-readable and dedup-stable.
           // The validator uses semantic similarity on this label for near-duplicate detection.
           const label = `${attribute}: ${value}`;
@@ -281,8 +321,8 @@ ${text}`,
         }
       }
 
-      ctx.log.info({ stored, failed }, 'extract-facts: complete');
-      return { success: true, data: { stored, skipped: false, failed } };
+      ctx.log.info({ stored, redirected, failed }, 'extract-facts: complete');
+      return { success: true, data: { stored, redirected, skipped: false, failed } };
     } catch (err) {
       // Two categories of errors reach here:
       // 1. LLMProvider errors (rate limits, auth, timeouts, 5xx) — these are returned as

--- a/skills/extract-facts/skill.json
+++ b/skills/extract-facts/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "extract-facts",
   "description": "Extract single-entity attribute facts from a passage of text and persist them as knowledge graph fact nodes. Self-classifies internally — always safe to call; exits early if no facts are found.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "sensitivity": "normal",
   "action_risk": "low",
   "inputs": {
@@ -9,7 +9,8 @@
     "source": "string (provenance string, e.g. 'system:checkpoint/conversation:abc/agent:coordinator/channel:cli')"
   },
   "outputs": {
-    "stored": "number (new or updated fact nodes persisted)",
+    "stored": "number (new or updated fact nodes persisted to the KG)",
+    "redirected": "number (canonical contact attribute writes redirected to ContactService instead of KG)",
     "skipped": "boolean (true if the classifier gate determined no facts were present)",
     "failed": "number (facts that could not be persisted due to errors)"
   },

--- a/skills/memory-store/handler.test.ts
+++ b/skills/memory-store/handler.test.ts
@@ -511,6 +511,37 @@ describe('MemoryStoreHandler', () => {
       expect(mockMem.storeFact).toHaveBeenCalledTimes(1);
     });
 
+    it('falls back to KG write when findContactByKgNodeId throws (DB error)', async () => {
+      const mockMem = {
+        ...makeMockEntityMemory({}),
+        resolveOrCreate: vi.fn().mockResolvedValue({
+          kind: 'found',
+          node: { id: 'kg-1', label: 'Jane Doe', type: 'person' },
+        }),
+        storeFact: vi.fn().mockResolvedValue({ stored: true, action: 'created', nodeId: 'fact-1', sensitivity: 'internal' }),
+      };
+      const contactService = {
+        findContactByKgNodeId: vi.fn().mockRejectedValue(new Error('connection timeout')),
+        updateContactFields: vi.fn().mockRejectedValue(new Error('should not be called')),
+      };
+      const ctx = {
+        input: { entity: 'Jane Doe', field: 'timezone', value: 'America/Toronto', source: 'test' },
+        secret: () => 'test-key',
+        log: pino({ level: 'silent' }),
+        entityMemory: mockMem,
+        contactService,
+      } as unknown as SkillContext;
+
+      const result = await handler.execute(ctx);
+
+      // DB error during contact lookup → falls through to KG write, not a skill error
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.stored).toBe(true);
+      expect(mockMem.storeFact).toHaveBeenCalledTimes(1);
+      expect(contactService.updateContactFields).not.toHaveBeenCalled();
+    });
+
     it('falls through to KG write when person node has no contact record', async () => {
       const mockMem = {
         ...makeMockEntityMemory({}),

--- a/skills/memory-store/handler.test.ts
+++ b/skills/memory-store/handler.test.ts
@@ -411,6 +411,207 @@ describe('MemoryStoreHandler', () => {
     });
   });
 
+  // ── Canonical contact attribute redirect ─────────────────────────────────
+
+  describe('action: redirected_to_contact', () => {
+    function makeCtxWithContact(
+      entityMemory: ReturnType<typeof makeMockEntityMemory>,
+      contact: { id: string } | null,
+      input: Record<string, unknown>,
+    ): SkillContext {
+      const contactService = {
+        findContactByKgNodeId: vi.fn().mockResolvedValue(contact),
+        updateContactFields: vi.fn().mockResolvedValue({ id: contact?.id ?? 'c1' }),
+      };
+      return {
+        input,
+        secret: () => 'test-key',
+        log: pino({ level: 'silent' }),
+        entityMemory,
+        contactService,
+      } as unknown as SkillContext;
+    }
+
+    it('redirects a canonical attribute write to ContactService when entity is a person with a contact', async () => {
+      const mockMem = {
+        ...makeMockEntityMemory({}),
+        resolveOrCreate: vi.fn().mockResolvedValue({
+          kind: 'found',
+          node: { id: 'kg-1', label: 'Jane Doe', type: 'person' },
+        }),
+        // storeFact should NOT be called — the guard short-circuits
+        storeFact: vi.fn().mockRejectedValue(new Error('storeFact should not be called')),
+      };
+      const ctx = makeCtxWithContact(
+        mockMem,
+        { id: 'contact-1' },
+        { entity: 'Jane Doe', field: 'timezone', value: 'America/Toronto', source: 'test' },
+      );
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.stored).toBe(false);
+      expect(data.action).toBe('redirected_to_contact');
+      expect(data.contact_id).toBe('contact-1');
+      // storeFact must not have been called
+      expect(mockMem.storeFact).not.toHaveBeenCalled();
+      // updateContactFields should have been called with the canonical field
+      const cs = (ctx as unknown as { contactService: { updateContactFields: ReturnType<typeof vi.fn> } }).contactService;
+      expect(cs.updateContactFields).toHaveBeenCalledWith('contact-1', { timezone: 'America/Toronto' });
+    });
+
+    it('normalizes phone numbers to E.164 before redirecting', async () => {
+      const mockMem = {
+        ...makeMockEntityMemory({}),
+        resolveOrCreate: vi.fn().mockResolvedValue({
+          kind: 'found',
+          node: { id: 'kg-1', label: 'Jane Doe', type: 'person' },
+        }),
+        storeFact: vi.fn().mockRejectedValue(new Error('storeFact should not be called')),
+      };
+      const ctx = makeCtxWithContact(
+        mockMem,
+        { id: 'contact-1' },
+        { entity: 'Jane Doe', field: 'phone', value: '(416) 555-1234', source: 'test' },
+      );
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.action).toBe('redirected_to_contact');
+      const cs = (ctx as unknown as { contactService: { updateContactFields: ReturnType<typeof vi.fn> } }).contactService;
+      expect(cs.updateContactFields).toHaveBeenCalledWith('contact-1', { primaryPhone: '+14165551234' });
+    });
+
+    it('falls back to KG write when phone cannot be normalized to E.164', async () => {
+      const mockMem = {
+        ...makeMockEntityMemory({}),
+        resolveOrCreate: vi.fn().mockResolvedValue({
+          kind: 'found',
+          node: { id: 'kg-1', label: 'Jane Doe', type: 'person' },
+        }),
+        storeFact: vi.fn().mockResolvedValue({ stored: true, action: 'created', nodeId: 'fact-1', sensitivity: 'internal' }),
+      };
+      const ctx = makeCtxWithContact(
+        mockMem,
+        { id: 'contact-1' },
+        { entity: 'Jane Doe', field: 'phone', value: 'not-a-phone-number', source: 'test' },
+      );
+
+      const result = await handler.execute(ctx);
+
+      // Falls through to KG write because normalization failed
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.stored).toBe(true);
+      expect(data.action).toBe('created');
+      expect(mockMem.storeFact).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls through to KG write when person node has no contact record', async () => {
+      const mockMem = {
+        ...makeMockEntityMemory({}),
+        resolveOrCreate: vi.fn().mockResolvedValue({
+          kind: 'found',
+          node: { id: 'kg-1', label: 'Jane Doe', type: 'person' },
+        }),
+        storeFact: vi.fn().mockResolvedValue({ stored: true, action: 'created', nodeId: 'fact-1', sensitivity: 'internal' }),
+      };
+      // contact is null — person KG node with no linked contact row
+      const ctx = makeCtxWithContact(
+        mockMem,
+        null,
+        { entity: 'Jane Doe', field: 'timezone', value: 'America/Toronto', source: 'test' },
+      );
+
+      const result = await handler.execute(ctx);
+
+      // No contact → falls through to KG write
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.stored).toBe(true);
+      expect(mockMem.storeFact).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not redirect non-person entity types', async () => {
+      const mockMem = {
+        ...makeMockEntityMemory({}),
+        resolveOrCreate: vi.fn().mockResolvedValue({
+          kind: 'found',
+          node: { id: 'kg-org-1', label: 'Acme Corp', type: 'organization' },
+        }),
+        storeFact: vi.fn().mockResolvedValue({ stored: true, action: 'created', nodeId: 'fact-1', sensitivity: 'internal' }),
+      };
+      const ctx = makeCtxWithContact(
+        mockMem,
+        { id: 'contact-1' },
+        { entity: 'Acme Corp', field: 'timezone', value: 'America/Toronto', source: 'test' },
+      );
+
+      const result = await handler.execute(ctx);
+
+      // organization entity → no redirect
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.stored).toBe(true);
+      expect(mockMem.storeFact).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not redirect non-canonical attributes', async () => {
+      const mockMem = {
+        ...makeMockEntityMemory({}),
+        resolveOrCreate: vi.fn().mockResolvedValue({
+          kind: 'found',
+          node: { id: 'kg-1', label: 'Jane Doe', type: 'person' },
+        }),
+        storeFact: vi.fn().mockResolvedValue({ stored: true, action: 'created', nodeId: 'fact-1', sensitivity: 'internal' }),
+      };
+      const ctx = makeCtxWithContact(
+        mockMem,
+        { id: 'contact-1' },
+        { entity: 'Jane Doe', field: 'preferred_airline', value: 'Air Canada', source: 'test' },
+      );
+
+      const result = await handler.execute(ctx);
+
+      // preferred_airline is not canonical → goes to KG
+      expect(result.success).toBe(true);
+      const data = (result as { success: true; data: Record<string, unknown> }).data;
+      expect(data.stored).toBe(true);
+      expect(mockMem.storeFact).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns success:false when ContactService.updateContactFields throws a validation error', async () => {
+      const mockMem = {
+        ...makeMockEntityMemory({}),
+        resolveOrCreate: vi.fn().mockResolvedValue({
+          kind: 'found',
+          node: { id: 'kg-1', label: 'Jane Doe', type: 'person' },
+        }),
+        storeFact: vi.fn().mockRejectedValue(new Error('should not be called')),
+      };
+      const contactService = {
+        findContactByKgNodeId: vi.fn().mockResolvedValue({ id: 'contact-1' }),
+        updateContactFields: vi.fn().mockRejectedValue(new Error("primaryEmail not found in contact_channel_identities")),
+      };
+      const ctx = {
+        input: { entity: 'Jane Doe', field: 'primary_email', value: 'jane@example.com', source: 'test' },
+        secret: () => 'test-key',
+        log: pino({ level: 'silent' }),
+        entityMemory: mockMem,
+        contactService,
+      } as unknown as SkillContext;
+
+      const result = await handler.execute(ctx);
+
+      expect(result.success).toBe(false);
+      expect((result as { success: false; error: string }).error).toMatch(/primaryEmail/i);
+    });
+  });
+
   // ── Infrastructure error handling ─────────────────────────────────────────
 
   describe('error handling', () => {

--- a/skills/memory-store/handler.ts
+++ b/skills/memory-store/handler.ts
@@ -7,15 +7,17 @@
 //   - Otherwise → entityMemory.resolveOrCreate() which finds or auto-creates the entity.
 //
 // Possible outcomes:
-//   created       — new fact node created and linked to the entity
-//   updated       — near-duplicate found; existing node merged in place
-//   conflict      — contradicts an existing attribute fact; agent should surface to CEO
-//   entity_not_found — UUID entity no longer exists, or entity gone between resolution and write
-//   rate_limited  — write limit (50 per task) exceeded
+//   created               — new fact node created and linked to the entity
+//   updated               — near-duplicate found; existing node merged in place
+//   conflict              — contradicts an existing attribute fact; agent should surface to CEO
+//   entity_not_found      — UUID entity no longer exists, or entity gone between resolution and write
+//   rate_limited          — write limit (50 per task) exceeded
+//   redirected_to_contact — attribute is canonical; write went to ContactService instead of KG
 
 import type { SkillHandler, SkillContext, SkillResult } from '../../src/skills/types.js';
 import { DECAY_CLASSES, SENSITIVITY_LEVELS, NODE_TYPES } from '../../src/memory/types.js';
 import type { DecayClass, Sensitivity, NodeType, KgNode } from '../../src/memory/types.js';
+import { buildCanonicalPatch } from '../../src/contacts/canonical-attribute-guard.js';
 
 const DECAY_CLASSES_SET: ReadonlySet<string> = new Set(DECAY_CLASSES);
 const SENSITIVITY_LEVELS_SET: ReadonlySet<string> = new Set(SENSITIVITY_LEVELS);
@@ -168,6 +170,55 @@ export class MemoryStoreHandler implements SkillHandler {
         // string — the variant the CEO actually said — so it needs explicit learning here.
         if (alias_for && typeof alias_for === 'string' && resolved.kind === 'found') {
           await ctx.entityMemory.addAlias(entityNode.id, alias_for);
+        }
+      }
+
+      // --- Canonical contact attribute guard ---
+      //
+      // If the entity is a person node linked to a contact record, and the field
+      // being written is a canonical contact attribute (timezone, title, etc.),
+      // redirect the write to ContactService.updateContactFields() instead of the KG.
+      // This prevents the contacts table and the KG from diverging after migration 048.
+      if (entityNode.type === 'person' && ctx.contactService) {
+        const patch = buildCanonicalPatch(field, value);
+        if (patch !== null) {
+          if (patch.fallbackToKg) {
+            // Normalization failed (e.g. unparseable phone number) — let the KG write through.
+            ctx.log.warn(
+              { entity, field, reason: patch.reason },
+              'memory-store: canonical attribute normalization failed — falling back to KG write',
+            );
+          } else {
+            // Found a contact for this KG node — redirect the write.
+            const contact = await ctx.contactService.findContactByKgNodeId(entityNode.id);
+            if (contact) {
+              try {
+                await ctx.contactService.updateContactFields(contact.id, patch.fields);
+                ctx.log.info(
+                  { entity, field, contactId: contact.id },
+                  'memory-store: canonical attribute redirected to ContactService',
+                );
+                return {
+                  success: true,
+                  data: {
+                    stored: false,
+                    action: 'redirected_to_contact',
+                    contact_id: contact.id,
+                  },
+                };
+              } catch (err) {
+                // Validation errors (e.g. primaryEmail not in CCI) are surfaced as
+                // a skill error rather than silently swallowed.
+                const msg = err instanceof Error ? err.message : String(err);
+                ctx.log.warn(
+                  { entity, field, contactId: contact.id, err },
+                  'memory-store: canonical attribute redirect to ContactService failed',
+                );
+                return { success: false, error: `Could not update contact field "${field}": ${msg}` };
+              }
+            }
+            // No contact record for this person node — fall through to normal KG write.
+          }
         }
       }
 

--- a/skills/memory-store/handler.ts
+++ b/skills/memory-store/handler.ts
@@ -189,8 +189,19 @@ export class MemoryStoreHandler implements SkillHandler {
               'memory-store: canonical attribute normalization failed — falling back to KG write',
             );
           } else {
-            // Found a contact for this KG node — redirect the write.
-            const contact = await ctx.contactService.findContactByKgNodeId(entityNode.id);
+            // Look up the contact linked to this KG person node.
+            // If the DB call fails, fall through to the normal KG write rather than
+            // propagating — a transient DB error here shouldn't block the fact write.
+            let contact;
+            try {
+              contact = await ctx.contactService.findContactByKgNodeId(entityNode.id);
+            } catch (lookupErr) {
+              ctx.log.warn(
+                { entity, field, entityNodeId: entityNode.id, err: lookupErr },
+                'memory-store: findContactByKgNodeId failed — falling back to KG write',
+              );
+            }
+
             if (contact) {
               try {
                 await ctx.contactService.updateContactFields(contact.id, patch.fields);
@@ -207,8 +218,8 @@ export class MemoryStoreHandler implements SkillHandler {
                   },
                 };
               } catch (err) {
-                // Validation errors (e.g. primaryEmail not in CCI) are surfaced as
-                // a skill error rather than silently swallowed.
+                // Validation errors (e.g. primaryEmail not in CCI) or infra errors
+                // are surfaced as a skill error — the agent can retry or adjust.
                 const msg = err instanceof Error ? err.message : String(err);
                 ctx.log.warn(
                   { entity, field, contactId: contact.id, err },
@@ -217,7 +228,7 @@ export class MemoryStoreHandler implements SkillHandler {
                 return { success: false, error: `Could not update contact field "${field}": ${msg}` };
               }
             }
-            // No contact record for this person node — fall through to normal KG write.
+            // No contact record for this person node, or lookup failed — fall through.
           }
         }
       }

--- a/skills/memory-store/skill.json
+++ b/skills/memory-store/skill.json
@@ -18,11 +18,12 @@
   },
   "outputs": {
     "stored": "boolean — true when the fact was persisted (created or updated)",
-    "action": "string — one of: created, updated, conflict, entity_not_found, rate_limited",
+    "action": "string — one of: created, updated, conflict, entity_not_found, rate_limited, redirected_to_contact",
     "node_id": "string — ID of the persisted or existing fact node (present when stored is true)",
     "sensitivity": "string — the sensitivity level actually assigned to the node (present when stored is true)",
     "reason": "string — human-readable explanation when action is conflict, entity_not_found, or rate_limited",
     "existing_node_id": "string — ID of the contradicting fact node (present when action is conflict)",
+    "contact_id": "string — ID of the contact record that was updated (present when action is redirected_to_contact)",
     "ambiguous": "boolean — true when multiple entities matched the given name with no type winner",
     "candidates": "array of {id, label, type} — populated when ambiguous is true"
   },

--- a/src/contacts/canonical-attribute-guard.test.ts
+++ b/src/contacts/canonical-attribute-guard.test.ts
@@ -1,0 +1,135 @@
+// canonical-attribute-guard.test.ts
+//
+// Unit tests for the canonical contact attribute guard.
+// Tests attribute resolution, phone normalization, and patch building.
+
+import { describe, it, expect } from 'vitest';
+import { resolveCanonicalField, normalizePhone, buildCanonicalPatch } from './canonical-attribute-guard.js';
+
+describe('resolveCanonicalField', () => {
+  it('maps known attribute keys to ContactCanonicalFields keys', () => {
+    expect(resolveCanonicalField('timezone')).toBe('timezone');
+    expect(resolveCanonicalField('tz')).toBe('timezone');
+    expect(resolveCanonicalField('job_title')).toBe('title');
+    expect(resolveCanonicalField('title')).toBe('title');
+    expect(resolveCanonicalField('organization')).toBe('organization');
+    expect(resolveCanonicalField('employer')).toBe('organization');
+    expect(resolveCanonicalField('company')).toBe('organization');
+    expect(resolveCanonicalField('current_employer')).toBe('organization');
+    expect(resolveCanonicalField('email')).toBe('primaryEmail');
+    expect(resolveCanonicalField('primary_email')).toBe('primaryEmail');
+    expect(resolveCanonicalField('phone')).toBe('primaryPhone');
+    expect(resolveCanonicalField('phone_number')).toBe('primaryPhone');
+    expect(resolveCanonicalField('mobile')).toBe('primaryPhone');
+    expect(resolveCanonicalField('preferred_name')).toBe('preferredName');
+    expect(resolveCanonicalField('nickname')).toBe('preferredName');
+    expect(resolveCanonicalField('locale')).toBe('locale');
+    expect(resolveCanonicalField('language')).toBe('locale');
+    expect(resolveCanonicalField('location')).toBe('location');
+    expect(resolveCanonicalField('home_city')).toBe('location');
+    expect(resolveCanonicalField('current_location')).toBe('location');
+    expect(resolveCanonicalField('city')).toBe('location');
+    expect(resolveCanonicalField('pronouns')).toBe('pronouns');
+    expect(resolveCanonicalField('linkedin')).toBe('linkedinUrl');
+    expect(resolveCanonicalField('linkedin_url')).toBe('linkedinUrl');
+    expect(resolveCanonicalField('bio')).toBe('bio');
+    expect(resolveCanonicalField('biography')).toBe('bio');
+    expect(resolveCanonicalField('birthday')).toBe('birthday');
+    expect(resolveCanonicalField('birthdate')).toBe('birthday');
+    expect(resolveCanonicalField('dob')).toBe('birthday');
+  });
+
+  it('is case-insensitive', () => {
+    expect(resolveCanonicalField('TIMEZONE')).toBe('timezone');
+    expect(resolveCanonicalField('Job_Title')).toBe('title');
+    expect(resolveCanonicalField('PHONE')).toBe('primaryPhone');
+  });
+
+  it('returns undefined for non-canonical attributes', () => {
+    expect(resolveCanonicalField('preferred_airline')).toBeUndefined();
+    expect(resolveCanonicalField('dietary_preference')).toBeUndefined();
+    expect(resolveCanonicalField('active_project')).toBeUndefined();
+    expect(resolveCanonicalField('funding_stage')).toBeUndefined();
+  });
+
+  it('returns undefined for role (excluded from deny-list)', () => {
+    // role is ambiguous (categorical system role vs job title) and excluded intentionally.
+    expect(resolveCanonicalField('role')).toBeUndefined();
+  });
+});
+
+describe('normalizePhone', () => {
+  it('normalizes North American 10-digit formats to E.164', () => {
+    expect(normalizePhone('4165551234')).toBe('+14165551234');
+    expect(normalizePhone('416-555-1234')).toBe('+14165551234');
+    expect(normalizePhone('(416) 555-1234')).toBe('+14165551234');
+    expect(normalizePhone('416.555.1234')).toBe('+14165551234');
+    expect(normalizePhone('416 555 1234')).toBe('+14165551234');
+  });
+
+  it('normalizes international formats with explicit country code', () => {
+    expect(normalizePhone('+14165551234')).toBe('+14165551234');
+    expect(normalizePhone('+1 (416) 555-1234')).toBe('+14165551234');
+    expect(normalizePhone('+1-416-555-1234')).toBe('+14165551234');
+    expect(normalizePhone('+447911123456')).toBe('+447911123456');
+  });
+
+  it('returns null for strings that cannot be normalized', () => {
+    expect(normalizePhone('not a phone number')).toBeNull();
+    expect(normalizePhone('555-1234')).toBeNull(); // 7 digit — no area code
+    expect(normalizePhone('')).toBeNull();
+    expect(normalizePhone('000-000-0000')).toBeNull(); // invalid number
+  });
+});
+
+describe('buildCanonicalPatch', () => {
+  it('returns null for non-canonical attributes', () => {
+    expect(buildCanonicalPatch('preferred_airline', 'Air Canada')).toBeNull();
+    expect(buildCanonicalPatch('dietary_preference', 'vegetarian')).toBeNull();
+  });
+
+  it('returns a fields patch for simple string attributes', () => {
+    const result = buildCanonicalPatch('timezone', 'America/Toronto');
+    expect(result).not.toBeNull();
+    expect(result?.fallbackToKg).toBe(false);
+    if (result && !result.fallbackToKg) {
+      expect(result.fields).toEqual({ timezone: 'America/Toronto' });
+    }
+  });
+
+  it('returns a fields patch for organization', () => {
+    const result = buildCanonicalPatch('company', 'Acme Corp');
+    expect(result).not.toBeNull();
+    expect(result?.fallbackToKg).toBe(false);
+    if (result && !result.fallbackToKg) {
+      expect(result.fields).toEqual({ organization: 'Acme Corp' });
+    }
+  });
+
+  it('normalizes phone numbers to E.164 for phone attributes', () => {
+    const result = buildCanonicalPatch('phone', '(416) 555-1234');
+    expect(result).not.toBeNull();
+    expect(result?.fallbackToKg).toBe(false);
+    if (result && !result.fallbackToKg) {
+      expect(result.fields).toEqual({ primaryPhone: '+14165551234' });
+    }
+  });
+
+  it('returns fallbackToKg when phone cannot be normalized', () => {
+    const result = buildCanonicalPatch('phone', 'not-a-phone');
+    expect(result).not.toBeNull();
+    expect(result?.fallbackToKg).toBe(true);
+  });
+
+  it('returns fallbackToKg for mobile with unnormalizable number', () => {
+    const result = buildCanonicalPatch('mobile', '555-1234'); // 7-digit local, no area code
+    expect(result).not.toBeNull();
+    expect(result?.fallbackToKg).toBe(true);
+  });
+
+  it('is case-insensitive on attribute key', () => {
+    const result = buildCanonicalPatch('TIMEZONE', 'America/Toronto');
+    expect(result).not.toBeNull();
+    expect(result?.fallbackToKg).toBe(false);
+  });
+});

--- a/src/contacts/canonical-attribute-guard.ts
+++ b/src/contacts/canonical-attribute-guard.ts
@@ -1,0 +1,138 @@
+// src/contacts/canonical-attribute-guard.ts
+//
+// Write-side guard for canonical contact attributes.
+//
+// When an agent calls memory-store (or extract-facts triggers) with an attribute
+// that is now a canonical column on the contacts table (e.g. "timezone", "title",
+// "organization"), this module detects the match and redirects the write to
+// ContactService.updateContactFields() instead of the KG.
+//
+// Why this matters: KG facts and the contacts table would otherwise diverge — the
+// assembler would return the structured value from the contacts row AND an unfiltered
+// KG fact with the same information. Centralising canonical attributes on the Contact
+// record eliminates that duplication and gives specialists a single reliable read path.
+//
+// E.164 phone normalization: the `primary_phone` column has a CHECK constraint
+// (^\+[1-9][0-9]{6,14}$). Values from agents arrive in human-readable formats
+// ("(416) 555-1234", "+1 416-555-1234", etc.) so we normalise via libphonenumber-js
+// before writing. If normalization fails, we fall back to letting the KG write through
+// (logged as a warning so the gap is observable).
+
+import { parsePhoneNumber, isValidPhoneNumber } from 'libphonenumber-js';
+import type { ContactCanonicalFields } from './types.js';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Deny-list: KG attribute keys → ContactCanonicalFields key
+//
+// Keys are lowercase; the guard normalises incoming attribute keys before lookup.
+// Note: 'role' is intentionally excluded — it is too ambiguous (could be a
+// categorical system role or a job title). Let those facts flow to the KG.
+// ──────────────────────────────────────────────────────────────────────────────
+
+export const CANONICAL_ATTRIBUTE_MAP: ReadonlyMap<string, keyof ContactCanonicalFields> = new Map([
+  ['preferred_name', 'preferredName'],
+  ['nickname',       'preferredName'],
+  ['job_title',      'title'],
+  ['title',          'title'],
+  ['organization',   'organization'],
+  ['employer',       'organization'],
+  ['company',        'organization'],
+  ['current_employer', 'organization'],
+  ['email',          'primaryEmail'],
+  ['primary_email',  'primaryEmail'],
+  ['phone',          'primaryPhone'],
+  ['phone_number',   'primaryPhone'],
+  ['mobile',         'primaryPhone'],
+  ['timezone',       'timezone'],
+  ['tz',             'timezone'],
+  ['locale',         'locale'],
+  ['language',       'locale'],
+  ['home_city',      'location'],
+  ['current_location', 'location'],
+  ['location',       'location'],
+  ['city',           'location'],
+  ['pronouns',       'pronouns'],
+  ['linkedin',       'linkedinUrl'],
+  ['linkedin_url',   'linkedinUrl'],
+  ['bio',            'bio'],
+  ['biography',      'bio'],
+  ['birthday',       'birthday'],
+  ['birthdate',      'birthday'],
+  ['dob',            'birthday'],
+]);
+
+/**
+ * Check whether a KG attribute key is in the canonical deny-list.
+ * Case-insensitive. Returns the ContactCanonicalFields key if matched,
+ * undefined if the attribute should flow through to the KG.
+ */
+export function resolveCanonicalField(
+  attribute: string,
+): keyof ContactCanonicalFields | undefined {
+  return CANONICAL_ATTRIBUTE_MAP.get(attribute.toLowerCase());
+}
+
+/**
+ * Normalize a phone number string to E.164 format.
+ *
+ * Attempts libphonenumber-js parsing with a fallback to North American
+ * default country (US) for unqualified 10-digit numbers. Returns null if
+ * the value cannot be parsed to a valid E.164 string — callers should
+ * fall back to the KG write path in that case.
+ */
+export function normalizePhone(value: string): string | null {
+  try {
+    // First try parsing as-is (handles values that already include country code).
+    if (isValidPhoneNumber(value)) {
+      const parsed = parsePhoneNumber(value);
+      return parsed.format('E.164');
+    }
+
+    // Fallback: try treating as a North American number (US default country).
+    // This handles "416-555-1234", "(416) 555 1234", etc.
+    if (isValidPhoneNumber(value, 'US')) {
+      const parsed = parsePhoneNumber(value, 'US');
+      return parsed.format('E.164');
+    }
+
+    // Fallback: try Canadian country code (CA shares the NANP with US).
+    if (isValidPhoneNumber(value, 'CA')) {
+      const parsed = parsePhoneNumber(value, 'CA');
+      return parsed.format('E.164');
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a ContactCanonicalFields patch object for a single attribute/value pair.
+ *
+ * Returns null in two cases:
+ *   - The attribute is not in the canonical deny-list (caller should write to KG).
+ *   - The attribute IS canonical but the value failed normalization (e.g. a phone
+ *     number that cannot be parsed to E.164). In this case `fallbackToKg` is true
+ *     in the returned tuple so the caller can log and write to the KG instead.
+ */
+export function buildCanonicalPatch(
+  attribute: string,
+  value: string,
+): { fields: ContactCanonicalFields; fallbackToKg: false } | { fallbackToKg: true; reason: string } | null {
+  const fieldKey = resolveCanonicalField(attribute);
+  if (!fieldKey) return null; // Not a canonical attribute — let KG write through.
+
+  if (fieldKey === 'primaryPhone') {
+    const normalized = normalizePhone(value);
+    if (!normalized) {
+      return {
+        fallbackToKg: true,
+        reason: `Phone value could not be normalized to E.164: "${value}". Writing to KG instead.`,
+      };
+    }
+    return { fields: { primaryPhone: normalized }, fallbackToKg: false };
+  }
+
+  return { fields: { [fieldKey]: value } as ContactCanonicalFields, fallbackToKg: false };
+}

--- a/src/contacts/canonical-attribute-guard.ts
+++ b/src/contacts/canonical-attribute-guard.ts
@@ -69,7 +69,7 @@ export const CANONICAL_ATTRIBUTE_MAP: ReadonlyMap<string, keyof ContactCanonical
 export function resolveCanonicalField(
   attribute: string,
 ): keyof ContactCanonicalFields | undefined {
-  return CANONICAL_ATTRIBUTE_MAP.get(attribute.toLowerCase());
+  return CANONICAL_ATTRIBUTE_MAP.get(attribute.trim().toLowerCase());
 }
 
 /**

--- a/src/contacts/canonical-attribute-guard.ts
+++ b/src/contacts/canonical-attribute-guard.ts
@@ -18,7 +18,7 @@
 // before writing. If normalization fails, we fall back to letting the KG write through
 // (logged as a warning so the gap is observable).
 
-import { parsePhoneNumber, isValidPhoneNumber } from 'libphonenumber-js';
+import { parsePhoneNumber, isValidPhoneNumber, ParseError } from 'libphonenumber-js';
 import type { ContactCanonicalFields } from './types.js';
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -102,8 +102,14 @@ export function normalizePhone(value: string): string | null {
     }
 
     return null;
-  } catch {
-    return null;
+  } catch (err) {
+    // Only swallow ParseError (expected "invalid input" path from libphonenumber-js).
+    // Re-throw everything else so programming errors in this function are not masked
+    // as "failed to normalize" — they'd silently fall through to KG writes everywhere.
+    if (err instanceof ParseError) {
+      return null;
+    }
+    throw err;
   }
 }
 

--- a/src/contacts/contact-service.ts
+++ b/src/contacts/contact-service.ts
@@ -52,6 +52,7 @@ interface ContactServiceBackend {
   createContact(contact: Contact): Promise<void>;
   getContact(id: string): Promise<Contact | undefined>;
   findContactByName(name: string): Promise<Contact[]>;
+  findContactByKgNodeId(kgNodeId: string): Promise<Contact | null>;
   findContactByRole(role: string): Promise<Contact[]>;
   findContactBySystemRole(systemRole: SystemRole): Promise<Contact | null>;
   listContacts(filters?: { status?: ContactStatus; limit?: number }): Promise<Contact[]>;
@@ -330,6 +331,11 @@ export class ContactService {
   /** Find contacts by display name (case-insensitive exact match). */
   async findContactByName(name: string): Promise<Contact[]> {
     return this.backend.findContactByName(name);
+  }
+
+  /** Find a contact by the KG node ID it is linked to. Returns null if not found. */
+  async findContactByKgNodeId(kgNodeId: string): Promise<Contact | null> {
+    return this.backend.findContactByKgNodeId(kgNodeId);
   }
 
   /** Find contacts by role. */
@@ -1035,6 +1041,16 @@ class PostgresContactBackend implements ContactServiceBackend {
     return result.rows.map((row) => this.rowToContact(row));
   }
 
+  async findContactByKgNodeId(kgNodeId: string): Promise<Contact | null> {
+    const result = await this.pool.query<ContactRow>(
+      `SELECT ${CONTACT_COLS} FROM contacts WHERE kg_node_id = $1 LIMIT 1`,
+      [kgNodeId],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    return this.rowToContact(row);
+  }
+
   async findContactByRole(role: string): Promise<Contact[]> {
     const result = await this.pool.query<ContactRow>(
       `SELECT ${CONTACT_COLS} FROM contacts WHERE role = $1 ORDER BY created_at ASC`,
@@ -1598,6 +1614,13 @@ class InMemoryContactBackend implements ContactServiceBackend {
       }
     }
     return results;
+  }
+
+  async findContactByKgNodeId(kgNodeId: string): Promise<Contact | null> {
+    for (const contact of this.contacts.values()) {
+      if (contact.kgNodeId === kgNodeId) return contact;
+    }
+    return null;
   }
 
   async findContactByRole(role: string): Promise<Contact[]> {

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -25,6 +25,7 @@ import type { DbPool } from '../db/connection.js';
 import type { Logger } from '../logger.js';
 import type { EntityContext, EntityFact, ConnectedAccount, EntityRelationship } from './types.js';
 import { CANONICAL_ATTRIBUTE_MAP } from '../contacts/canonical-attribute-guard.js';
+import type { ContactCanonicalFields } from '../contacts/types.js';
 
 // TTL for cached entity context payloads (5 minutes per spec).
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -136,13 +137,19 @@ export class EntityContextAssembler {
         : [];
 
       // Filter out KG facts whose properties.attribute matches a canonical contact
-      // column when we have a contact record. These values now live on the contacts
-      // row and are surfaced via EntityContext.contact — keeping them in the facts
-      // array would double-up the information and invite the LLM to reason about which
-      // source to trust. Facts without properties.attribute are left untouched.
+      // column, BUT only when the corresponding column on the contact row is actually
+      // populated. This prevents data loss when a write fell through to the KG (e.g.
+      // validation failure, DB transient error) and the canonical column stayed null —
+      // suppressing the fact would make the value invisible to all consumers.
       const facts = contactRow
         ? factsResult
-            .filter(({ attributeKey }) => attributeKey === null || !CANONICAL_ATTRIBUTE_MAP.has(attributeKey))
+            .filter(({ attributeKey }) => {
+              if (attributeKey === null) return true; // legacy fact, no structured key
+              const canonicalField = CANONICAL_ATTRIBUTE_MAP.get(attributeKey);
+              if (!canonicalField) return true; // not a canonical attribute
+              // Only suppress when the column is populated — de-duplication without loss.
+              return !isContactRowColumnPopulated(contactRow, canonicalField);
+            })
             .map(({ attributeKey: _dropped, ...fact }) => fact)
         : factsResult.map(({ attributeKey: _dropped, ...fact }) => fact);
 
@@ -413,6 +420,14 @@ export class EntityContextAssembler {
       const attributeKey = typeof props.attribute === 'string'
         ? props.attribute.toLowerCase()
         : null;
+      // Log when a fact has no structured attribute key — it will bypass the canonical
+      // filter even if its label matches a canonical attribute (legacy write path).
+      if (attributeKey === null && Object.keys(props).length > 0) {
+        this.logger.debug(
+          { label: row.label, entityNodeId },
+          'entity-context: fact node missing properties.attribute — canonical filter cannot apply',
+        );
+      }
       return {
         label: row.label,
         value: factValue ?? null,
@@ -555,4 +570,31 @@ interface RelationshipRow {
   related_id: string;
   related_label: string;
   related_type: string;
+}
+
+/**
+ * Returns true when the ContactRow column that backs the given ContactCanonicalFields key
+ * is non-null (i.e., the value has been persisted on the contact record).
+ * Used by the fact filter: only suppress a canonical-keyed KG fact when its corresponding
+ * column is populated — otherwise a write that fell through to the KG (e.g. validation
+ * failure, transient DB error) would make the data invisible to all consumers.
+ */
+function isContactRowColumnPopulated(
+  row: ContactRow,
+  field: keyof ContactCanonicalFields,
+): boolean {
+  switch (field) {
+    case 'preferredName': return row.preferred_name != null;
+    case 'title':         return row.title != null;
+    case 'organization':  return row.organization != null;
+    case 'primaryEmail':  return row.primary_email != null;
+    case 'primaryPhone':  return row.primary_phone != null;
+    case 'timezone':      return row.timezone != null;
+    case 'locale':        return row.locale != null;
+    case 'location':      return row.location != null;
+    case 'pronouns':      return row.pronouns != null;
+    case 'linkedinUrl':   return row.linkedin_url != null;
+    case 'bio':           return row.bio != null;
+    case 'birthday':      return row.birthday != null;
+  }
 }

--- a/src/entity-context/assembler.ts
+++ b/src/entity-context/assembler.ts
@@ -24,6 +24,7 @@
 import type { DbPool } from '../db/connection.js';
 import type { Logger } from '../logger.js';
 import type { EntityContext, EntityFact, ConnectedAccount, EntityRelationship } from './types.js';
+import { CANONICAL_ATTRIBUTE_MAP } from '../contacts/canonical-attribute-guard.js';
 
 // TTL for cached entity context payloads (5 minutes per spec).
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -134,14 +135,41 @@ export class EntityContextAssembler {
         ? await this.getRelationships(kgNodeId)
         : [];
 
+      // Filter out KG facts whose properties.attribute matches a canonical contact
+      // column when we have a contact record. These values now live on the contacts
+      // row and are surfaced via EntityContext.contact — keeping them in the facts
+      // array would double-up the information and invite the LLM to reason about which
+      // source to trust. Facts without properties.attribute are left untouched.
+      const facts = contactRow
+        ? factsResult
+            .filter(({ attributeKey }) => attributeKey === null || !CANONICAL_ATTRIBUTE_MAP.has(attributeKey))
+            .map(({ attributeKey: _dropped, ...fact }) => fact)
+        : factsResult.map(({ attributeKey: _dropped, ...fact }) => fact);
+
       const ctx: EntityContext = {
         entityId: kgNodeId,
         entityType: nodeRow.type,
         label: nodeRow.label,
         contact: contactRow
-          ? { contactId: contactRow.id, displayName: contactRow.display_name, role: contactRow.role }
+          ? {
+              contactId: contactRow.id,
+              displayName: contactRow.display_name,
+              role: contactRow.role,
+              preferredName: contactRow.preferred_name,
+              title: contactRow.title,
+              organization: contactRow.organization,
+              primaryEmail: contactRow.primary_email,
+              primaryPhone: contactRow.primary_phone,
+              timezone: contactRow.timezone,
+              locale: contactRow.locale,
+              location: contactRow.location,
+              pronouns: contactRow.pronouns,
+              linkedinUrl: contactRow.linkedin_url,
+              bio: contactRow.bio,
+              birthday: contactRow.birthday,
+            }
           : null,
-        facts: factsResult,
+        facts,
         connectedAccounts,
         relationships,
       };
@@ -349,9 +377,11 @@ export class EntityContextAssembler {
 
   /**
    * Get all fact nodes linked to the entity via 'relates_to' edges.
-   * Fact nodes have type = 'fact' and carry value/category in their properties.
+   * Returns an internal type that includes the raw properties.attribute key so
+   * assembleOne() can filter out canonical contact facts before returning. The
+   * attribute key is stripped from the public EntityFact shape.
    */
-  private async getFacts(entityNodeId: string): Promise<EntityFact[]> {
+  private async getFacts(entityNodeId: string): Promise<FactWithAttribute[]> {
     const result = await this.pool.query<FactRow>(
       `SELECT n.label, n.properties, n.confidence, n.last_confirmed_at
        FROM kg_edges e
@@ -379,6 +409,10 @@ export class EntityContextAssembler {
           'entity-context: fact node missing properties.value',
         );
       }
+      // Lowercase for case-insensitive deny-list lookup in assembleOne().
+      const attributeKey = typeof props.attribute === 'string'
+        ? props.attribute.toLowerCase()
+        : null;
       return {
         label: row.label,
         value: factValue ?? null,
@@ -387,13 +421,17 @@ export class EntityContextAssembler {
         lastConfirmedAt: row.last_confirmed_at instanceof Date
           ? row.last_confirmed_at.toISOString()
           : String(row.last_confirmed_at),
+        attributeKey,
       };
     });
   }
 
   private async getContactByKgNodeId(kgNodeId: string): Promise<ContactRow | undefined> {
     const result = await this.pool.query<ContactRow>(
-      'SELECT id, display_name, role FROM contacts WHERE kg_node_id = $1',
+      `SELECT id, display_name, role,
+              preferred_name, title, organization, primary_email, primary_phone,
+              timezone, locale, location, pronouns, linkedin_url, bio, birthday
+       FROM contacts WHERE kg_node_id = $1`,
       [kgNodeId],
     );
     return result.rows[0];
@@ -479,10 +517,28 @@ interface FactRow {
   last_confirmed_at: Date | string;
 }
 
+// Internal type returned by getFacts() before the canonical-attribute filter is applied.
+// attributeKey is the lowercase properties.attribute value (null for legacy facts that
+// predate structured fact writes). Stripped before the EntityFact[] is returned.
+type FactWithAttribute = EntityFact & { attributeKey: string | null };
+
 interface ContactRow {
   id: string;
   display_name: string;
   role: string | null;
+  // Canonical profile attributes (migration 048)
+  preferred_name: string | null;
+  title: string | null;
+  organization: string | null;
+  primary_email: string | null;
+  primary_phone: string | null;
+  timezone: string | null;
+  locale: string | null;
+  location: string | null;
+  pronouns: string | null;
+  linkedin_url: string | null;
+  bio: string | null;
+  birthday: string | null;
 }
 
 interface CalendarRow {

--- a/src/entity-context/types.ts
+++ b/src/entity-context/types.ts
@@ -21,11 +21,28 @@ export interface EntityContext {
   /** Human-readable label from the KG node */
   label: string;
 
-  /** Contact record — only populated for person entities that have a contact record */
+  /** Contact record — only populated for person entities that have a contact record.
+   *  Canonical profile attributes (migration 048) are sourced directly from the
+   *  contacts table row; they are NOT in the facts array (filtered out by the assembler
+   *  to avoid duplication). All canonical fields are nullable. */
   contact: {
     contactId: string;
     displayName: string;
     role: string | null;
+    // Canonical profile attributes (migration 048). Read these directly — do not
+    // parse the facts array for these values; the assembler filters them out.
+    preferredName: string | null;
+    title: string | null;
+    organization: string | null;
+    primaryEmail: string | null;
+    primaryPhone: string | null;
+    timezone: string | null;
+    locale: string | null;
+    location: string | null;
+    pronouns: string | null;
+    linkedinUrl: string | null;
+    bio: string | null;
+    birthday: string | null;
   } | null;
 
   /** Known facts from the KG, grouped by category.


### PR DESCRIPTION
## **User description**
## Summary

- `EntityContext.contact` now exposes all 12 canonical profile fields (preferredName, title, organization, primaryEmail, primaryPhone, timezone, locale, location, pronouns, linkedinUrl, bio, birthday) sourced directly from the contacts row
- Assembler filters duplicate KG facts for canonical attributes when a contact record is present
- New `canonical-attribute-guard` module with deny-list, E.164 phone normalization (libphonenumber-js), and redirect logic shared between both write paths
- `memory-store` and `extract-facts` redirect canonical-attribute writes for person entities to `ContactService.updateContactFields` instead of the KG
- `context-for-email` prefers `contact.primaryEmail` over identity scan; surfaces `contact.preferredName` for salutations
- Agent prompts (coordinator, research-analyst, ceo-inbox, calendar) updated with canonical-attribute guidance

## Phone normalization

The `primary_phone` column enforces E.164 via a DB CHECK constraint. Phone values from agents arrive human-readable (`(416) 555-1234`, `+1 416-555-1234`, etc.). `libphonenumber-js` normalizes them before writing; if normalization fails, the write falls through to the KG with a warning log rather than silently dropping the information.

## Test plan

- [ ] `src/contacts/canonical-attribute-guard.test.ts` — deny-list resolution, phone normalization, patch building (14 tests)
- [ ] `skills/memory-store/handler.test.ts` — redirect to contact, phone normalization, fallback to KG, non-person pass-through, validation error (7 new tests)
- [ ] All existing extract-facts and memory-store tests green (updated for new `redirected` field in result)
- [ ] `pnpm typecheck` — clean
- [ ] Full test suite: 2998 passing, 2 pre-existing autonomy failures unrelated to this PR

Closes #830


___

## **CodeAnt-AI Description**
**Route contact details to the Contact record and avoid duplicate facts**

### What Changed
- Person profiles now read canonical contact fields directly from the Contact record, and matching KG facts are hidden from the entity view to avoid duplicate information
- Writing fields like timezone, title, company, email, phone, location, and birthday now goes to the Contact record for person entities instead of creating a KG fact; phone values are normalized to E.164 when possible
- Email drafting now uses the stored primary email first and can use the contact’s preferred name for greetings
- Coordinator, research, CEO inbox, and calendar prompts now tell agents to expect contact redirects and use contact timezone data

### Impact
`✅ Fewer duplicate contact details in entity summaries`
`✅ Cleaner updates to person profiles`
`✅ More reliable email and scheduling context`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Comprehensive contact profile fields now available in entity context, including preferred name, title, organization, email, phone, timezone, location, pronouns, LinkedIn URL, bio, and birthday.
  * Phone numbers are now standardized to a consistent international format.

* **Improvements**
  * Contact attribute management enhanced for better data consistency and reliability.
  * Calendar specialist now reliably sources timezone information from contact profiles.
  * Email context improved to use preferred names for personalized communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->