### PR TITLE
feat: Tasks v1 (1/7) — promote agent_tasks → tasks; flip scheduler FK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ bus event types) are noted explicitly even in the `0.x` range.
 
 ## [Unreleased]
 
+### Changed
+- **`agent_tasks` → `tasks` migration** — promotes the scheduler's persistent-task table to a first-class tasks table with CEO-visible columns (`title`, `owner`, `priority`, `due_at`, `tags`, etc.); flips the `scheduled_job_id` back-FK to a forward `scheduled_jobs.task_id`; adds a status CHECK accepting both legacy and new task-lifecycle values. No behavior change for existing scheduler and persistent-task callers. (Tasks v1, issue 1 of 7, closes #834)
+
 ### Added
 - **`contact-update` skill** — direct write path for canonical contact attributes (title, organization, phone, timezone, etc.) with E.164 phone normalization. Pinned to coordinator, ceo-inbox, research-analyst, and contacts. (#863)
 - **Contact canonical attributes** — 12 structured profile fields (`title`, `organization`, `primary_email`, etc.) persisted directly on the `contacts` row; backfill script populates from KG facts. (#829)

--- a/docs/wip/2026-06-01-tasks-and-backlog-design.md
+++ b/docs/wip/2026-06-01-tasks-and-backlog-design.md
@@ -309,6 +309,7 @@ These were considered and intentionally cut from v1 scope. Captured here so futu
 - **Weighted progress rollup.** No `goals` → no rollup.
 - **Explicit `ceo-add-task` skill.** Coordinator prompt handles CEO entry via `task-create` for v1.
 - **Interactive digest controls (snooze / done / reassign).** Read-only digest in v1; interactivity can come later if usage warrants.
+- **Revisit `intent_anchor`-based drift detection.** The scheduler's `intent_anchor` / linked-tasks mechanism (spec 07, pre-existing) creates a `tasks` row for drift-detection bookkeeping on persistent recurring jobs. No agent YAML schedule entries currently use it. Before any do, evaluate whether the complexity is justified: drift detection could potentially be handled using only `scheduled_jobs` fields (e.g. a `stuck_at` timestamp or `paused_reason` text column) without coupling the scheduler to the tasks table at all. If the tasks table is for CEO-visible work, internal scheduler state may not belong there.
 
 ---
 

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -39,7 +39,7 @@ export interface AgentYamlConfig {
     agent_id?: string;             // target agent for this job (defaults to config.name if omitted)
     /** Expected wall-clock duration in seconds. Drives stuck-job recovery timeout. */
     expectedDurationSeconds?: number;
-    /** When set, creates a linked agent_tasks row that enables drift detection for this job.
+    /** When set, creates a linked tasks row that enables drift detection for this job.
      *  Should express the stable original goal of the recurring task in plain language. */
     intent_anchor?: string;
   }>;

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -278,7 +278,12 @@ export async function knowledgeGraphRoutes(
   });
 
   const validContactStatuses: ContactStatus[] = ['confirmed', 'provisional', 'blocked'];
-  const validTaskStatuses = ['active', 'pending', 'paused', 'completed', 'failed', 'cancelled'];
+  const validTaskStatuses = [
+    // Legacy values used by the scheduler before task skills shipped
+    'active', 'pending', 'paused', 'completed', 'failed',
+    // Task-lifecycle values introduced by migration 049
+    'open', 'in_progress', 'blocked', 'waiting', 'done', 'cancelled',
+  ];
   // Reused across contacts endpoints — Postgres UUID columns throw cast errors on bad input
   // so we reject at the API boundary with a 400 instead.
   const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -291,7 +296,6 @@ export async function knowledgeGraphRoutes(
     progress: Record<string, unknown> | null;
     error_budget: Record<string, unknown> | null;
     conversation_id: string | null;
-    scheduled_job_id: string | null;
     created_at: string;
     updated_at: string;
   }) {
@@ -303,7 +307,6 @@ export async function knowledgeGraphRoutes(
       progress: row.progress ?? {},
       errorBudget: row.error_budget ?? {},
       conversationId: row.conversation_id,
-      scheduledJobId: row.scheduled_job_id,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
@@ -312,8 +315,8 @@ export async function knowledgeGraphRoutes(
   app.get('/api/kg/tasks', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const result = await pool.query(
-      `SELECT id, agent_id, intent_anchor, status, progress, error_budget, conversation_id, scheduled_job_id, created_at, updated_at
-       FROM agent_tasks
+      `SELECT id, agent_id, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at
+       FROM tasks
        ORDER BY updated_at DESC
        LIMIT 500`,
     );
@@ -327,7 +330,6 @@ export async function knowledgeGraphRoutes(
           progress: Record<string, unknown> | null;
           error_budget: Record<string, unknown> | null;
           conversation_id: string | null;
-          scheduled_job_id: string | null;
           created_at: string;
           updated_at: string;
         }),
@@ -344,7 +346,6 @@ export async function knowledgeGraphRoutes(
       progress?: unknown;
       errorBudget?: unknown;
       conversationId?: unknown;
-      scheduledJobId?: unknown;
     };
     if (typeof body.agentId !== 'string' || body.agentId.trim().length === 0) {
       return reply.status(400).send({ error: 'agentId is required.' });
@@ -367,33 +368,27 @@ export async function knowledgeGraphRoutes(
       typeof body.conversationId === 'string' && body.conversationId.trim().length > 0
         ? body.conversationId.trim()
         : null;
-    const scheduledJobId =
-      typeof body.scheduledJobId === 'string' && body.scheduledJobId.trim().length > 0
-        ? body.scheduledJobId.trim()
-        : null;
     if (conversationId && !UUID_RE.test(conversationId)) {
       return reply.status(400).send({ error: 'Invalid conversationId: must be a valid UUID.' });
     }
-    if (scheduledJobId && !UUID_RE.test(scheduledJobId)) {
-      return reply.status(400).send({ error: 'Invalid scheduledJobId: must be a valid UUID.' });
-    }
 
+    const intentAnchor = body.intentAnchor.trim();
     const inserted = await pool.query(
-      `INSERT INTO agent_tasks (agent_id, intent_anchor, status, progress, error_budget, conversation_id, scheduled_job_id, updated_at)
-       VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6, $7, now())
-       RETURNING id, agent_id, intent_anchor, status, progress, error_budget, conversation_id, scheduled_job_id, created_at, updated_at`,
+      `INSERT INTO tasks (agent_id, title, intent_anchor, status, progress, error_budget, conversation_id, updated_at)
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7, now())
+       RETURNING id, agent_id, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at`,
       [
         body.agentId.trim(),
-        body.intentAnchor.trim(),
+        intentAnchor,   // use intentAnchor as the task title
+        intentAnchor,
         status,
         JSON.stringify((body.progress as Record<string, unknown> | undefined) ?? {}),
         JSON.stringify((body.errorBudget as Record<string, unknown> | undefined) ?? {}),
         conversationId,
-        scheduledJobId,
       ],
     );
     if (!inserted.rowCount) {
-      logger.error('kg: INSERT agent_tasks returned no rows');
+      logger.error('kg: INSERT tasks returned no rows');
       return reply.status(500).send({ error: 'Failed to create task.' });
     }
     return reply.status(201).send({
@@ -406,7 +401,6 @@ export async function knowledgeGraphRoutes(
           progress: Record<string, unknown> | null;
           error_budget: Record<string, unknown> | null;
           conversation_id: string | null;
-          scheduled_job_id: string | null;
           created_at: string;
           updated_at: string;
         },
@@ -427,12 +421,11 @@ export async function knowledgeGraphRoutes(
       progress?: unknown;
       errorBudget?: unknown;
       conversationId?: unknown;
-      scheduledJobId?: unknown;
     };
 
     const existing = await pool.query(
-      `SELECT id, agent_id, intent_anchor, status, progress, error_budget, conversation_id, scheduled_job_id, created_at, updated_at
-       FROM agent_tasks
+      `SELECT id, agent_id, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at
+       FROM tasks
        WHERE id = $1`,
       [id],
     );
@@ -447,7 +440,6 @@ export async function knowledgeGraphRoutes(
       progress: Record<string, unknown> | null;
       error_budget: Record<string, unknown> | null;
       conversation_id: string | null;
-      scheduled_job_id: string | null;
       created_at: string;
       updated_at: string;
     };
@@ -473,31 +465,21 @@ export async function knowledgeGraphRoutes(
         : body.conversationId === null
         ? null
         : row.conversation_id;
-    const scheduledJobId =
-      typeof body.scheduledJobId === 'string'
-        ? body.scheduledJobId.trim() || null
-        : body.scheduledJobId === null
-        ? null
-        : row.scheduled_job_id;
     if (conversationId && !UUID_RE.test(conversationId)) {
       return reply.status(400).send({ error: 'Invalid conversationId: must be a valid UUID.' });
     }
-    if (scheduledJobId && !UUID_RE.test(scheduledJobId)) {
-      return reply.status(400).send({ error: 'Invalid scheduledJobId: must be a valid UUID.' });
-    }
 
     const updated = await pool.query(
-      `UPDATE agent_tasks
+      `UPDATE tasks
        SET agent_id = $2,
            intent_anchor = $3,
            status = $4,
            progress = $5::jsonb,
            error_budget = $6::jsonb,
            conversation_id = $7,
-           scheduled_job_id = $8,
            updated_at = now()
        WHERE id = $1
-       RETURNING id, agent_id, intent_anchor, status, progress, error_budget, conversation_id, scheduled_job_id, created_at, updated_at`,
+       RETURNING id, agent_id, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at`,
       [
         id,
         agentId,
@@ -506,12 +488,11 @@ export async function knowledgeGraphRoutes(
         JSON.stringify((body.progress as Record<string, unknown> | undefined) ?? row.progress ?? {}),
         JSON.stringify((body.errorBudget as Record<string, unknown> | undefined) ?? row.error_budget ?? {}),
         conversationId,
-        scheduledJobId,
       ],
     );
     // Guard against concurrent deletes between the existence check and the UPDATE.
     if (!updated.rowCount) {
-      logger.warn({ taskId: id }, 'kg: PATCH agent_tasks matched 0 rows — likely concurrent delete');
+      logger.warn({ taskId: id }, 'kg: PATCH tasks matched 0 rows — likely concurrent delete');
       return reply.status(404).send({ error: 'Agent task not found.' });
     }
     return reply.send({
@@ -524,7 +505,6 @@ export async function knowledgeGraphRoutes(
           progress: Record<string, unknown> | null;
           error_budget: Record<string, unknown> | null;
           conversation_id: string | null;
-          scheduled_job_id: string | null;
           created_at: string;
           updated_at: string;
         },
@@ -538,7 +518,7 @@ export async function knowledgeGraphRoutes(
     if (!UUID_RE.test(id)) {
       return reply.status(400).send({ error: 'Invalid task id.' });
     }
-    const deleted = await pool.query('DELETE FROM agent_tasks WHERE id = $1', [id]);
+    const deleted = await pool.query('DELETE FROM tasks WHERE id = $1', [id]);
     if (deleted.rowCount === 0) {
       return reply.status(404).send({ error: 'Agent task not found.' });
     }

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -477,6 +477,7 @@ export async function knowledgeGraphRoutes(
     const updated = await pool.query(
       `UPDATE tasks
        SET agent_id = $2,
+           title = $3,
            intent_anchor = $3,
            status = $4,
            progress = $5::jsonb,

--- a/src/channels/http/routes/kg.ts
+++ b/src/channels/http/routes/kg.ts
@@ -291,6 +291,7 @@ export async function knowledgeGraphRoutes(
   function serializeTask(row: {
     id: string;
     agent_id: string;
+    title: string;
     intent_anchor: string;
     status: string;
     progress: Record<string, unknown> | null;
@@ -302,6 +303,7 @@ export async function knowledgeGraphRoutes(
     return {
       id: row.id,
       agentId: row.agent_id,
+      title: row.title,
       intentAnchor: row.intent_anchor,
       status: row.status,
       progress: row.progress ?? {},
@@ -315,7 +317,7 @@ export async function knowledgeGraphRoutes(
   app.get('/api/kg/tasks', KG_RATE, async (request, reply) => {
     if (!assertSecret(request, reply, webAppBootstrapSecret, sessions)) return;
     const result = await pool.query(
-      `SELECT id, agent_id, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at
+      `SELECT id, agent_id, title, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at
        FROM tasks
        ORDER BY updated_at DESC
        LIMIT 500`,
@@ -325,6 +327,7 @@ export async function knowledgeGraphRoutes(
         serializeTask(row as {
           id: string;
           agent_id: string;
+          title: string;
           intent_anchor: string;
           status: string;
           progress: Record<string, unknown> | null;
@@ -376,7 +379,7 @@ export async function knowledgeGraphRoutes(
     const inserted = await pool.query(
       `INSERT INTO tasks (agent_id, title, intent_anchor, status, progress, error_budget, conversation_id, updated_at)
        VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7, now())
-       RETURNING id, agent_id, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at`,
+       RETURNING id, agent_id, title, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at`,
       [
         body.agentId.trim(),
         intentAnchor,   // use intentAnchor as the task title
@@ -396,6 +399,7 @@ export async function knowledgeGraphRoutes(
         inserted.rows[0]! as {
           id: string;
           agent_id: string;
+          title: string;
           intent_anchor: string;
           status: string;
           progress: Record<string, unknown> | null;
@@ -424,7 +428,7 @@ export async function knowledgeGraphRoutes(
     };
 
     const existing = await pool.query(
-      `SELECT id, agent_id, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at
+      `SELECT id, agent_id, title, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at
        FROM tasks
        WHERE id = $1`,
       [id],
@@ -435,6 +439,7 @@ export async function knowledgeGraphRoutes(
     const row = existing.rows[0] as {
       id: string;
       agent_id: string;
+      title: string;
       intent_anchor: string;
       status: string;
       progress: Record<string, unknown> | null;
@@ -479,7 +484,7 @@ export async function knowledgeGraphRoutes(
            conversation_id = $7,
            updated_at = now()
        WHERE id = $1
-       RETURNING id, agent_id, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at`,
+       RETURNING id, agent_id, title, intent_anchor, status, progress, error_budget, conversation_id, created_at, updated_at`,
       [
         id,
         agentId,
@@ -500,6 +505,7 @@ export async function knowledgeGraphRoutes(
         updated.rows[0]! as {
           id: string;
           agent_id: string;
+          title: string;
           intent_anchor: string;
           status: string;
           progress: Record<string, unknown> | null;

--- a/src/db/migrations/049_promote_agent_tasks_to_tasks.sql
+++ b/src/db/migrations/049_promote_agent_tasks_to_tasks.sql
@@ -9,6 +9,30 @@ ALTER TABLE agent_tasks RENAME TO tasks;
 ALTER TABLE scheduled_jobs
   ADD COLUMN task_id UUID REFERENCES tasks(id) ON DELETE SET NULL;
 
+-- Preflight: the old schema used a non-unique index on scheduled_job_id, so
+-- application logic (not the DB) enforced one-task-per-job. If duplicates exist
+-- the UPDATE...FROM below would pick one arbitrarily and silently drop the
+-- other links. Fail loudly instead so the operator can investigate before data
+-- is permanently lost.
+DO $$
+DECLARE dup_count INT;
+BEGIN
+  SELECT COUNT(*) INTO dup_count
+  FROM (
+    SELECT scheduled_job_id
+    FROM tasks
+    WHERE scheduled_job_id IS NOT NULL
+    GROUP BY scheduled_job_id
+    HAVING COUNT(*) > 1
+  ) dups;
+  IF dup_count > 0 THEN
+    RAISE EXCEPTION
+      'Migration 049 preflight: % scheduled_job_id value(s) are referenced by more than one '
+      'tasks row. Resolve duplicates before re-running this migration.',
+      dup_count;
+  END IF;
+END $$;
+
 -- Backfill scheduled_jobs.task_id from the existing tasks.scheduled_job_id.
 -- Every tasks row that linked to a scheduled_job gets the forward FK populated.
 UPDATE scheduled_jobs sj

--- a/src/db/migrations/049_promote_agent_tasks_to_tasks.sql
+++ b/src/db/migrations/049_promote_agent_tasks_to_tasks.sql
@@ -1,0 +1,124 @@
+-- Up Migration
+
+-- Rename agent_tasks → tasks. The existing index on scheduled_job_id is dropped
+-- automatically when we drop that column in a later step.
+ALTER TABLE agent_tasks RENAME TO tasks;
+
+-- Add the forward FK on scheduled_jobs BEFORE dropping the back-FK on tasks,
+-- so we can backfill task_id from the existing scheduled_job_id values.
+ALTER TABLE scheduled_jobs
+  ADD COLUMN task_id UUID REFERENCES tasks(id) ON DELETE SET NULL;
+
+-- Backfill scheduled_jobs.task_id from the existing tasks.scheduled_job_id.
+-- Every tasks row that linked to a scheduled_job gets the forward FK populated.
+UPDATE scheduled_jobs sj
+  SET task_id = t.id
+  FROM tasks t
+  WHERE t.scheduled_job_id = sj.id;
+
+-- Drop the old back-FK column (Postgres automatically drops the idx_agent_tasks_job index).
+ALTER TABLE tasks DROP COLUMN scheduled_job_id;
+
+-- Expand the status column: add CHECK with both legacy scheduler values and the
+-- new task-lifecycle values. Legacy values remain valid until task skills ship in
+-- issue 2, so existing scheduler code continues to work unchanged.
+ALTER TABLE tasks
+  ADD CONSTRAINT tasks_status_ck
+    CHECK (status IN (
+      -- Legacy values used by the scheduler before task skills shipped
+      'active', 'pending', 'paused', 'completed', 'failed',
+      -- Task-lifecycle values introduced by this migration
+      'open', 'in_progress', 'blocked', 'waiting', 'done', 'cancelled'
+    ));
+
+-- Add CEO-visible and task-management columns.
+--
+-- title: NOT NULL with empty-string DEFAULT so existing scheduler INSERT paths
+--   continue to work without modification; backfilled from intent_anchor below.
+-- owner, source, priority, created_by, tags: safe defaults that correctly
+--   describe existing scheduler-created tasks.
+-- Nullable columns (description, waiting_on_contact_id, waiting_on_text,
+-- parent_task_id, blocked_by_task_id, due_at, source_agent_id): no backfill needed.
+ALTER TABLE tasks
+  ADD COLUMN title                 TEXT         NOT NULL DEFAULT '',
+  ADD COLUMN description           TEXT,
+  ADD COLUMN owner                 TEXT         NOT NULL DEFAULT 'curia'
+    CHECK (owner IN ('curia', 'ceo', 'external')),
+  ADD COLUMN waiting_on_contact_id UUID         REFERENCES contacts(id) ON DELETE SET NULL,
+  ADD COLUMN waiting_on_text       TEXT,
+  ADD COLUMN parent_task_id        UUID         REFERENCES tasks(id),
+  ADD COLUMN blocked_by_task_id    UUID         REFERENCES tasks(id),
+  ADD COLUMN priority              INTEGER      NOT NULL DEFAULT 50,
+  ADD COLUMN due_at                TIMESTAMPTZ,
+  ADD COLUMN source                TEXT         NOT NULL DEFAULT 'agent'
+    CHECK (source IN ('ceo', 'agent', 'scheduler', 'coordinator')),
+  ADD COLUMN source_agent_id       TEXT,
+  ADD COLUMN created_by            TEXT         NOT NULL DEFAULT 'system',
+  ADD COLUMN tags                  TEXT[]       NOT NULL DEFAULT '{}';
+
+-- Backfill existing rows:
+--   title:          truncated intent_anchor (the durable goal statement is the
+--                   best available title until the task-create skill ships)
+--   source_agent_id: from agent_id (the agent that originally created the task)
+--   owner and source are already correct from the defaults above
+UPDATE tasks
+  SET title          = LEFT(intent_anchor, 255),
+      source_agent_id = agent_id
+  WHERE title = '';
+
+-- Indexes for common task-management query patterns:
+--   tasks_open_priority_idx: backlog sweep and digest queries (open/in_progress by priority)
+--   tasks_parent_idx:        subtask queries via parent_task_id
+--   scheduled_jobs_task_idx: wake-up routing (issue 4) — find the schedule linked to a task
+CREATE INDEX tasks_open_priority_idx ON tasks (priority DESC, due_at NULLS LAST)
+  WHERE status IN ('open', 'in_progress');
+
+CREATE INDEX tasks_parent_idx ON tasks (parent_task_id)
+  WHERE parent_task_id IS NOT NULL;
+
+CREATE INDEX scheduled_jobs_task_idx ON scheduled_jobs (task_id)
+  WHERE task_id IS NOT NULL;
+
+-- Down Migration
+
+DROP INDEX IF EXISTS scheduled_jobs_task_idx;
+DROP INDEX IF EXISTS tasks_parent_idx;
+DROP INDEX IF EXISTS tasks_open_priority_idx;
+
+-- Remove columns added in this migration.
+ALTER TABLE tasks
+  DROP COLUMN IF EXISTS tags,
+  DROP COLUMN IF EXISTS created_by,
+  DROP COLUMN IF EXISTS source_agent_id,
+  DROP COLUMN IF EXISTS source,
+  DROP COLUMN IF EXISTS due_at,
+  DROP COLUMN IF EXISTS priority,
+  DROP COLUMN IF EXISTS blocked_by_task_id,
+  DROP COLUMN IF EXISTS parent_task_id,
+  DROP COLUMN IF EXISTS waiting_on_text,
+  DROP COLUMN IF EXISTS waiting_on_contact_id,
+  DROP COLUMN IF EXISTS owner,
+  DROP COLUMN IF EXISTS description,
+  DROP COLUMN IF EXISTS title;
+
+-- Remove the status CHECK added in this migration.
+ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_status_ck;
+
+-- Re-add the back-FK column on tasks (restoring the original FK direction).
+ALTER TABLE tasks
+  ADD COLUMN scheduled_job_id UUID REFERENCES scheduled_jobs(id) ON DELETE SET NULL;
+
+-- Backfill tasks.scheduled_job_id from scheduled_jobs.task_id (reverse of up-migration step).
+UPDATE tasks t
+  SET scheduled_job_id = sj.id
+  FROM scheduled_jobs sj
+  WHERE sj.task_id = t.id;
+
+-- Drop the forward FK column on scheduled_jobs.
+ALTER TABLE scheduled_jobs DROP COLUMN IF EXISTS task_id;
+
+-- Restore the original index on the back-FK column.
+CREATE INDEX IF NOT EXISTS idx_agent_tasks_job ON tasks (scheduled_job_id);
+
+-- Rename tasks back to agent_tasks.
+ALTER TABLE tasks RENAME TO agent_tasks;

--- a/src/db/queries/tasks.ts
+++ b/src/db/queries/tasks.ts
@@ -1,0 +1,97 @@
+import type { Pool } from 'pg';
+
+// -- DB row shape (snake_case, mirrors Postgres column names) --
+
+export interface DbTaskRow {
+  id: string;
+  agent_id: string;
+  intent_anchor: string;
+  status: string;
+  progress: Record<string, unknown> | null;
+  error_budget: Record<string, unknown> | null;
+  conversation_id: string | null;
+  created_at: string;
+  updated_at: string;
+  // Columns added by migration 049
+  title: string;
+  description: string | null;
+  owner: string;
+  waiting_on_contact_id: string | null;
+  waiting_on_text: string | null;
+  parent_task_id: string | null;
+  blocked_by_task_id: string | null;
+  priority: number;
+  due_at: string | null;
+  source: string;
+  source_agent_id: string | null;
+  created_by: string;
+  tags: string[];
+}
+
+// -- Public camelCase shape --
+
+export interface TaskRow {
+  id: string;
+  agentId: string;
+  intentAnchor: string;
+  status: string;
+  progress: Record<string, unknown>;
+  errorBudget: Record<string, unknown>;
+  conversationId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  title: string;
+  description: string | null;
+  owner: string;
+  waitingOnContactId: string | null;
+  waitingOnText: string | null;
+  parentTaskId: string | null;
+  blockedByTaskId: string | null;
+  priority: number;
+  dueAt: string | null;
+  source: string;
+  sourceAgentId: string | null;
+  createdBy: string;
+  tags: string[];
+}
+
+export function mapTaskRow(row: DbTaskRow): TaskRow {
+  return {
+    id: row.id,
+    agentId: row.agent_id,
+    intentAnchor: row.intent_anchor,
+    status: row.status,
+    progress: row.progress ?? {},
+    errorBudget: row.error_budget ?? {},
+    conversationId: row.conversation_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    title: row.title,
+    description: row.description,
+    owner: row.owner,
+    waitingOnContactId: row.waiting_on_contact_id,
+    waitingOnText: row.waiting_on_text,
+    parentTaskId: row.parent_task_id,
+    blockedByTaskId: row.blocked_by_task_id,
+    priority: row.priority,
+    dueAt: row.due_at,
+    source: row.source,
+    sourceAgentId: row.source_agent_id,
+    createdBy: row.created_by,
+    tags: row.tags,
+  };
+}
+
+// Fetch a single task row by ID. Returns null if not found.
+export async function getTaskById(pool: Pool, taskId: string): Promise<TaskRow | null> {
+  const { rows } = await pool.query(
+    `SELECT id, agent_id, intent_anchor, status, progress, error_budget, conversation_id,
+            created_at, updated_at, title, description, owner, waiting_on_contact_id,
+            waiting_on_text, parent_task_id, blocked_by_task_id, priority, due_at,
+            source, source_agent_id, created_by, tags
+       FROM tasks WHERE id = $1`,
+    [taskId],
+  );
+  const row = rows[0] as DbTaskRow | undefined;
+  return row ? mapTaskRow(row) : null;
+}

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -36,7 +36,7 @@ export interface CreateJobResult {
   agentTaskId?: string;
 }
 
-/** Full job row with optional linked agent_task fields (from a LEFT JOIN). */
+/** Full job row with optional linked task fields (from a LEFT JOIN on tasks). */
 export interface JobRow {
   id: string;
   agentId: string;
@@ -52,7 +52,7 @@ export interface JobRow {
   createdAt: string;
   /** IANA timezone used for cron wall-clock interpretation. */
   timezone: string;
-  // Linked agent_task fields (null when no task is linked)
+  // Linked task fields (null when no task is linked via scheduled_jobs.task_id)
   agentTaskId: string | null;
   intentAnchor: string | null;
   progress: Record<string, unknown> | null;
@@ -221,19 +221,30 @@ export class SchedulerService {
     const { rows } = await this.pool.query(insertSql, insertParams);
     const jobId = (rows[0] as { id: string }).id;
 
-    // If an intentAnchor is provided, create a linked agent_task for persistent state tracking.
+    // If an intentAnchor is provided, create a linked task row and bind it to the job.
+    // The FK direction is scheduled_jobs.task_id → tasks.id, so we INSERT the task
+    // first and then UPDATE the job row with the new task's id.
     let agentTaskId: string | undefined;
     if (intentAnchor) {
+      // Single round-trip: INSERT task and UPDATE scheduled_jobs.task_id atomically.
       const taskSql = `
-        INSERT INTO agent_tasks (agent_id, intent_anchor, status, error_budget, scheduled_job_id)
-        VALUES ($1, $2, $3, $4, $5)
-        RETURNING id
+        WITH new_task AS (
+          INSERT INTO tasks (agent_id, title, intent_anchor, status, error_budget, source_agent_id)
+          VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+          RETURNING id
+        ),
+        link_job AS (
+          UPDATE scheduled_jobs SET task_id = (SELECT id FROM new_task) WHERE id = $7
+        )
+        SELECT id FROM new_task
       `;
       const taskParams = [
         agentId,
+        intentAnchor,   // use intentAnchor as the task title
         intentAnchor,
         'active',
         JSON.stringify(errorBudget ?? {}),
+        agentId,        // source_agent_id
         jobId,
       ];
       const taskResult = await this.pool.query(taskSql, taskParams);
@@ -259,11 +270,11 @@ export class SchedulerService {
   async getJob(jobId: string): Promise<JobRow | null> {
     const sql = `
       SELECT sj.*,
-             at.id AS agent_task_id,
-             at.intent_anchor,
-             at.progress
+             t.id AS agent_task_id,
+             t.intent_anchor,
+             t.progress
         FROM scheduled_jobs sj
-        LEFT JOIN agent_tasks at ON at.scheduled_job_id = sj.id
+        LEFT JOIN tasks t ON sj.task_id = t.id
        WHERE sj.id = $1
     `;
     const { rows } = await this.pool.query(sql, [jobId]);
@@ -296,11 +307,11 @@ export class SchedulerService {
 
     const sql = `
       SELECT sj.*,
-             at.id AS agent_task_id,
-             at.intent_anchor,
-             at.progress
+             t.id AS agent_task_id,
+             t.intent_anchor,
+             t.progress
         FROM scheduled_jobs sj
-        LEFT JOIN agent_tasks at ON at.scheduled_job_id = sj.id
+        LEFT JOIN tasks t ON sj.task_id = t.id
        ${whereClause}
        ORDER BY sj.created_at DESC
     `;
@@ -313,32 +324,37 @@ export class SchedulerService {
       `UPDATE scheduled_jobs SET status = $1 WHERE id = $2`,
       ['cancelled', jobId],
     );
-    // Also cancel linked agent_task if any
+    // Also cancel the linked task if any (FK is now on scheduled_jobs.task_id → tasks.id).
     await this.pool.query(
-      `UPDATE agent_tasks SET status = 'cancelled', updated_at = now() WHERE scheduled_job_id = $1`,
+      `UPDATE tasks t
+          SET status = 'cancelled', updated_at = now()
+         FROM scheduled_jobs sj
+        WHERE sj.id = $1 AND t.id = sj.task_id`,
       [jobId],
     );
     this.logger.info({ jobId }, 'Scheduled job cancelled');
   }
 
   /**
-   * Pause a job and its linked agent_task due to intent drift detection.
+   * Pause a job and its linked task due to intent drift detection.
    * Sets status = 'paused' on both tables in a single query.
    * The CEO must review and resume or cancel the job manually.
    */
   async pauseJobForDrift(jobId: string): Promise<void> {
-    // Update both tables atomically: pause the job and its linked agent_task.
+    // Update both tables atomically: pause the job and its linked task.
     // Uses a CTE so both updates happen in one round-trip and stay consistent.
+    // The FK is now scheduled_jobs.task_id → tasks.id, so we join through scheduled_jobs.
     await this.pool.query(
       `WITH paused_job AS (
          UPDATE scheduled_jobs
             SET status = 'paused'
           WHERE id = $1
        )
-       UPDATE agent_tasks
+       UPDATE tasks t
           SET status     = 'paused',
               updated_at = now()
-        WHERE scheduled_job_id = $1`,
+         FROM scheduled_jobs sj
+        WHERE sj.id = $1 AND t.id = sj.task_id`,
       [jobId],
     );
 
@@ -376,13 +392,14 @@ export class SchedulerService {
       [jobId, nextRunAt],
     );
 
-    // Also resume any agent_tasks that were paused by the drift-detection path.
-    // Suspended jobs (failure-threshold path) don't set agent_tasks.status, so this
+    // Also resume any tasks that were paused by the drift-detection path.
+    // Suspended jobs (failure-threshold path) don't set tasks.status, so this
     // UPDATE is a no-op for them — it only affects drift-paused jobs.
     await this.pool.query(
-      `UPDATE agent_tasks
+      `UPDATE tasks t
           SET status = 'active', updated_at = now()
-        WHERE scheduled_job_id = $1 AND status = 'paused'`,
+         FROM scheduled_jobs sj
+        WHERE sj.id = $1 AND t.id = sj.task_id AND t.status = 'paused'`,
       [jobId],
     );
 
@@ -448,9 +465,11 @@ export class SchedulerService {
    * Note: ON CONFLICT ON CONSTRAINT only works with named CONSTRAINTS, not named indexes —
    * so we use the column-based syntax here to match the CREATE UNIQUE INDEX definition.
    *
-   * When schedule.intent_anchor is present, also creates a linked agent_tasks row so the
+   * When schedule.intent_anchor is present, also creates a linked tasks row so the
    * drift detector can fire for this job. The INSERT is guarded by WHERE NOT EXISTS to
-   * preserve the existing agent_task row (and its accumulated progress) across restarts.
+   * preserve the existing task row (and its accumulated progress) across restarts.
+   * The FK direction is scheduled_jobs.task_id → tasks.id, so after inserting the task
+   * we UPDATE scheduled_jobs.task_id. Both operations are in one CTE for atomicity.
    */
   async upsertDeclarativeJob(
     sourceAgentId: string,
@@ -520,32 +539,45 @@ export class SchedulerService {
     const { rows } = await this.pool.query(sql, params);
     const jobId = (rows[0] as { id: string }).id;
 
-    // If intent_anchor is set, create a linked agent_tasks row so the drift detector can
+    // If intent_anchor is set, create a linked tasks row so the drift detector can
     // fire for this job — same pattern as createJob(). The WHERE NOT EXISTS guard ensures
     // this is a no-op on restart (preserving accumulated progress in the existing row).
+    //
+    // Both the INSERT into tasks and the UPDATE of scheduled_jobs.task_id happen in one
+    // CTE so the operation is atomic. rowCount of the UPDATE tells us whether a new task
+    // was created (1) or the guard fired and the existing row was preserved (0).
     if (schedule.intent_anchor) {
       const taskSql = `
-        INSERT INTO agent_tasks (agent_id, intent_anchor, status, error_budget, scheduled_job_id)
-        SELECT $1, $2, $3, $4, $5
-        WHERE NOT EXISTS (SELECT 1 FROM agent_tasks WHERE scheduled_job_id = $5)
+        WITH new_task AS (
+          INSERT INTO tasks (agent_id, title, intent_anchor, status, error_budget, source_agent_id)
+          SELECT $1, $2, $3, $4, $5::jsonb, $6
+          WHERE NOT EXISTS (SELECT 1 FROM scheduled_jobs WHERE id = $7 AND task_id IS NOT NULL)
+          RETURNING id
+        )
+        UPDATE scheduled_jobs
+           SET task_id = new_task.id
+          FROM new_task
+         WHERE scheduled_jobs.id = $7
       `;
       let taskResult: { rowCount: number | null };
       try {
         taskResult = await this.pool.query(taskSql, [
           agentId,
-          schedule.intent_anchor,
+          schedule.intent_anchor,   // title
+          schedule.intent_anchor,   // intent_anchor
           'active',
           JSON.stringify({}),
+          agentId,                  // source_agent_id
           jobId,
         ]);
       } catch (err) {
         // Re-throw so loadDeclarativeJobs treats the whole upsert as failed.
-        // The scheduled_jobs row was already written, but without the agent_tasks
+        // The scheduled_jobs row was already written, but without the tasks
         // link the drift detector cannot fire — running silently in a degraded state
         // is worse than a loud failure that prompts operator attention.
         this.logger.error(
           { err, agentId, jobId, intentAnchor: schedule.intent_anchor },
-          'upsertDeclarativeJob: failed to create agent_tasks row — job will run without drift detection until this is resolved',
+          'upsertDeclarativeJob: failed to create tasks row — job will run without drift detection until this is resolved',
         );
         throw err;
       }
@@ -554,8 +586,8 @@ export class SchedulerService {
       this.logger.info(
         { agentId, jobId, intentAnchor: schedule.intent_anchor, anchorCreated },
         anchorCreated
-          ? 'upsertDeclarativeJob: agent_tasks row created for intent_anchor (drift detection enabled)'
-          : 'upsertDeclarativeJob: agent_tasks row already exists — skipped (restart idempotency)',
+          ? 'upsertDeclarativeJob: tasks row created for intent_anchor (drift detection enabled)'
+          : 'upsertDeclarativeJob: tasks row already exists — skipped (restart idempotency)',
       );
     }
 
@@ -624,11 +656,11 @@ export class SchedulerService {
       );
     }
 
-    // TODO: if declarative schedules ever use intent_anchor, cancelling the scheduled_jobs row
-    // here leaves the linked agent_tasks row orphaned (scheduled_job_id becomes NULL). At that
-    // point this method should also cancel any agent_tasks rows whose scheduled_job_id was
-    // just cleared — mirror the cleanup in cancelJob(). No declarative schedules use
-    // intent_anchor today, so this is safe to defer.
+    // TODO: if declarative schedules ever use intent_anchor, cancelling the scheduled_jobs rows
+    // here leaves the linked tasks rows in 'active' status with no job pointing at them.
+    // At that point this method should also set status = 'cancelled' on any tasks whose
+    // linked scheduled_jobs row was just cancelled — mirror the cleanup in cancelJob().
+    // No declarative schedules use intent_anchor today, so this is safe to defer.
     return rows.length;
   }
 

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -567,8 +567,10 @@ export class SchedulerService {
     // The CTE surfaces both outcomes via a SELECT at the end:
     //   - rows = [] (empty): WHERE NOT EXISTS fired — existing task preserved (idempotent)
     //   - rows = [{ task_id, job_id }]: new task created and job linked
-    //   - rows = [{ task_id, job_id: null }]: orphan — INSERT succeeded but UPDATE failed
-    //     (scheduled_jobs row disappeared in a race); treated as a hard error.
+    //   - rows = [{ task_id, job_id: null }]: INSERT succeeded but link_job UPDATE returned
+    //     no rows — either the job was deleted concurrently, or a parallel startup already
+    //     set task_id (AND task_id IS NULL guard prevents overwriting). The cleanup_orphan
+    //     CTE deletes the just-inserted task so no orphan accumulates; treated as a hard error.
     if (schedule.intent_anchor) {
       const taskSql = `
         WITH new_task AS (
@@ -582,7 +584,13 @@ export class SchedulerService {
              SET task_id = new_task.id
             FROM new_task
            WHERE scheduled_jobs.id = $7
+             AND task_id IS NULL
           RETURNING scheduled_jobs.id AS job_id
+        ),
+        cleanup_orphan AS (
+          DELETE FROM tasks
+           WHERE id = (SELECT id FROM new_task)
+             AND NOT EXISTS (SELECT 1 FROM link_job)
         )
         SELECT new_task.id AS task_id, link_job.job_id
           FROM new_task
@@ -694,11 +702,13 @@ export class SchedulerService {
       );
     }
 
-    // TODO: if declarative schedules ever use intent_anchor, cancelling the scheduled_jobs rows
-    // here leaves the linked tasks rows in 'active' status with no job pointing at them.
-    // At that point this method should also set status = 'cancelled' on any tasks whose
-    // linked scheduled_jobs row was just cancelled — mirror the cleanup in cancelJob().
-    // No declarative schedules use intent_anchor today, so this is safe to defer.
+    // TODO: this method only cancels scheduled_jobs rows. When a stale declarative schedule has
+    // an intent_anchor, upsertDeclarativeJob creates a linked tasks row (via scheduled_jobs.task_id).
+    // Cancelling the scheduled_jobs row here leaves that tasks row in 'active' status with no job
+    // pointing at it. When agent YAML schedules start using intent_anchor, add a mirror cleanup here
+    // (UPDATE tasks SET status='cancelled' WHERE id IN (SELECT task_id FROM ... cancelled rows))
+    // to match the cancelJob() pattern. No agent YAML schedule entries use intent_anchor today,
+    // so this is safe to defer until they do.
     return rows.length;
   }
 

--- a/src/scheduler/scheduler-service.ts
+++ b/src/scheduler/scheduler-service.ts
@@ -224,9 +224,12 @@ export class SchedulerService {
     // If an intentAnchor is provided, create a linked task row and bind it to the job.
     // The FK direction is scheduled_jobs.task_id → tasks.id, so we INSERT the task
     // first and then UPDATE the job row with the new task's id.
+    //
+    // The CTE surfaces both the task id and the job id from the UPDATE so that a
+    // silent UPDATE failure (scheduled_jobs row disappeared in a race) is detectable —
+    // link_job with 0 matched rows returns job_id=null via the LEFT JOIN.
     let agentTaskId: string | undefined;
     if (intentAnchor) {
-      // Single round-trip: INSERT task and UPDATE scheduled_jobs.task_id atomically.
       const taskSql = `
         WITH new_task AS (
           INSERT INTO tasks (agent_id, title, intent_anchor, status, error_budget, source_agent_id)
@@ -234,9 +237,14 @@ export class SchedulerService {
           RETURNING id
         ),
         link_job AS (
-          UPDATE scheduled_jobs SET task_id = (SELECT id FROM new_task) WHERE id = $7
+          UPDATE scheduled_jobs SET task_id = new_task.id
+            FROM new_task
+           WHERE scheduled_jobs.id = $7
+          RETURNING scheduled_jobs.id AS job_id
         )
-        SELECT id FROM new_task
+        SELECT new_task.id AS task_id, link_job.job_id
+          FROM new_task
+          LEFT JOIN link_job ON true
       `;
       const taskParams = [
         agentId,
@@ -248,7 +256,20 @@ export class SchedulerService {
         jobId,
       ];
       const taskResult = await this.pool.query(taskSql, taskParams);
-      agentTaskId = (taskResult.rows[0] as { id: string }).id;
+      const taskRow = taskResult.rows[0] as { task_id: string; job_id: string | null } | undefined;
+      if (!taskRow?.task_id) {
+        throw new Error(`createJob: INSERT into tasks returned no row for job ${jobId}`);
+      }
+      if (!taskRow.job_id) {
+        // The INSERT succeeded but the UPDATE found no scheduled_jobs row.
+        // This means a concurrent cancel removed the job between the INSERT above and this CTE.
+        this.logger.error(
+          { agentId, jobId, taskId: taskRow.task_id },
+          'createJob: task row created but scheduled_jobs.task_id link failed — orphaned task',
+        );
+        throw new Error(`createJob: scheduled_jobs row ${jobId} not found when linking task`);
+      }
+      agentTaskId = taskRow.task_id;
     }
 
     // Publish schedule.created event for audit trail.
@@ -543,9 +564,11 @@ export class SchedulerService {
     // fire for this job — same pattern as createJob(). The WHERE NOT EXISTS guard ensures
     // this is a no-op on restart (preserving accumulated progress in the existing row).
     //
-    // Both the INSERT into tasks and the UPDATE of scheduled_jobs.task_id happen in one
-    // CTE so the operation is atomic. rowCount of the UPDATE tells us whether a new task
-    // was created (1) or the guard fired and the existing row was preserved (0).
+    // The CTE surfaces both outcomes via a SELECT at the end:
+    //   - rows = [] (empty): WHERE NOT EXISTS fired — existing task preserved (idempotent)
+    //   - rows = [{ task_id, job_id }]: new task created and job linked
+    //   - rows = [{ task_id, job_id: null }]: orphan — INSERT succeeded but UPDATE failed
+    //     (scheduled_jobs row disappeared in a race); treated as a hard error.
     if (schedule.intent_anchor) {
       const taskSql = `
         WITH new_task AS (
@@ -553,13 +576,19 @@ export class SchedulerService {
           SELECT $1, $2, $3, $4, $5::jsonb, $6
           WHERE NOT EXISTS (SELECT 1 FROM scheduled_jobs WHERE id = $7 AND task_id IS NOT NULL)
           RETURNING id
+        ),
+        link_job AS (
+          UPDATE scheduled_jobs
+             SET task_id = new_task.id
+            FROM new_task
+           WHERE scheduled_jobs.id = $7
+          RETURNING scheduled_jobs.id AS job_id
         )
-        UPDATE scheduled_jobs
-           SET task_id = new_task.id
+        SELECT new_task.id AS task_id, link_job.job_id
           FROM new_task
-         WHERE scheduled_jobs.id = $7
+          LEFT JOIN link_job ON true
       `;
-      let taskResult: { rowCount: number | null };
+      let taskResult: { rows: unknown[] };
       try {
         taskResult = await this.pool.query(taskSql, [
           agentId,
@@ -581,8 +610,17 @@ export class SchedulerService {
         );
         throw err;
       }
-      // rowCount === 0 means the WHERE NOT EXISTS guard fired — an existing row was preserved.
-      const anchorCreated = (taskResult.rowCount ?? 0) > 0;
+      const resultRow = taskResult.rows[0] as { task_id: string; job_id: string | null } | undefined;
+      if (resultRow && !resultRow.job_id) {
+        // INSERT succeeded but the UPDATE found no scheduled_jobs row.
+        // This is a race: the job was cancelled between the upsert above and this CTE.
+        this.logger.error(
+          { agentId, jobId, intentAnchor: schedule.intent_anchor, taskId: resultRow.task_id },
+          'upsertDeclarativeJob: tasks row created but scheduled_jobs.task_id link failed — orphaned task',
+        );
+        throw new Error(`upsertDeclarativeJob: scheduled_jobs row ${jobId} not found when linking task`);
+      }
+      const anchorCreated = resultRow != null;
       this.logger.info(
         { agentId, jobId, intentAnchor: schedule.intent_anchor, anchorCreated },
         anchorCreated

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -246,11 +246,11 @@ export class Scheduler {
     try {
       const sql = `
         SELECT sj.*,
-               at.id AS agent_task_id,
-               at.intent_anchor,
-               at.progress
+               t.id AS agent_task_id,
+               t.intent_anchor,
+               t.progress
           FROM scheduled_jobs sj
-          LEFT JOIN agent_tasks at ON at.scheduled_job_id = sj.id
+          LEFT JOIN tasks t ON sj.task_id = t.id
          WHERE sj.status IN ('pending', 'failed')
            AND sj.next_run_at <= now()
          ORDER BY sj.next_run_at ASC

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -104,7 +104,7 @@ describe('SchedulerService', () => {
       const taskId = 'task-aaa';
       // First call: INSERT into scheduled_jobs
       pool.query.mockResolvedValueOnce({ rows: [{ id: jobId }] });
-      // Second call: INSERT into agent_tasks
+      // Second call: CTE that INSERTs into tasks and UPDATEs scheduled_jobs.task_id
       pool.query.mockResolvedValueOnce({ rows: [{ id: taskId }] });
 
       const params: CreateJobParams = {
@@ -120,10 +120,10 @@ describe('SchedulerService', () => {
       expect(result.jobId).toBe(jobId);
       expect(result.agentTaskId).toBe(taskId);
 
-      // Two queries: job insert + task insert
+      // Two queries: job insert + task CTE (INSERT tasks + UPDATE scheduled_jobs.task_id)
       expect(pool.query).toHaveBeenCalledTimes(2);
       const taskSql = pool.query.mock.calls[1]?.[0] as string;
-      expect(taskSql).toContain('INSERT INTO agent_tasks');
+      expect(taskSql).toContain('INSERT INTO tasks');
     });
 
     it('rejects when neither cronExpr nor runAt is provided', async () => {
@@ -202,15 +202,15 @@ describe('SchedulerService', () => {
       expect(params).toContain('job-cancel');
     });
 
-    it('also cancels the linked agent_task', async () => {
+    it('also cancels the linked task', async () => {
       pool.query.mockResolvedValue({ rows: [] });
 
       await svc.cancelJob('job-cancel');
 
-      // Second query should update agent_tasks
+      // Second query should update tasks via JOIN through scheduled_jobs
       expect(pool.query).toHaveBeenCalledTimes(2);
       const [sql2] = pool.query.mock.calls[1] as [string, unknown[]];
-      expect(sql2).toContain('agent_tasks');
+      expect(sql2).toContain('tasks');
       expect(sql2).toContain('cancelled');
     });
   });
@@ -218,7 +218,7 @@ describe('SchedulerService', () => {
   // -- pauseJobForDrift --
 
   describe('pauseJobForDrift', () => {
-    it('sets scheduled_jobs.status to paused and agent_tasks.status to paused', async () => {
+    it('sets scheduled_jobs.status to paused and tasks.status to paused', async () => {
       pool.query.mockResolvedValue({ rows: [] });
 
       await svc.pauseJobForDrift('job-drift-1');
@@ -227,7 +227,7 @@ describe('SchedulerService', () => {
       const [sql, params] = pool.query.mock.calls[0] as [string, unknown[]];
       expect(sql).toContain("status = 'paused'");
       expect(sql).toContain('scheduled_jobs');
-      expect(sql).toContain('agent_tasks');
+      expect(sql).toContain('tasks');
       expect(params).toContain('job-drift-1');
     });
   });
@@ -242,7 +242,7 @@ describe('SchedulerService', () => {
       });
       // Second query: UPDATE scheduled_jobs
       pool.query.mockResolvedValueOnce({ rows: [] });
-      // Third query: UPDATE agent_tasks (resume drift-paused tasks; no-op for suspended jobs)
+      // Third query: UPDATE tasks (resume drift-paused tasks; no-op for suspended jobs)
       pool.query.mockResolvedValueOnce({ rows: [] });
 
       await svc.unsuspendJob('job-unsuspend');
@@ -259,9 +259,9 @@ describe('SchedulerService', () => {
       expect(params2[0]).toBe('job-unsuspend');
       // params2[1] should be a Date (the recalculated next_run_at)
       expect(params2[1]).toBeInstanceOf(Date);
-      // Third call resumes any drift-paused agent_tasks
+      // Third call resumes any drift-paused tasks (via JOIN through scheduled_jobs)
       const [sql3, params3] = pool.query.mock.calls[2] as [string, unknown[]];
-      expect(sql3).toContain('agent_tasks');
+      expect(sql3).toContain('tasks');
       expect(sql3).toContain('active');
       expect(params3[0]).toBe('job-unsuspend');
     });
@@ -789,8 +789,9 @@ describe('SchedulerService', () => {
       }
     });
 
-    it('creates an agent_tasks row when intent_anchor is provided', async () => {
-      // First query: the scheduled_jobs upsert; second query: the agent_tasks INSERT (row created).
+    it('creates a tasks row when intent_anchor is provided', async () => {
+      // First query: the scheduled_jobs upsert; second query: CTE that INSERTs tasks row
+      // and UPDATEs scheduled_jobs.task_id atomically (rowCount=1 means row was created).
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-anchor' }] });
       pool.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
@@ -802,10 +803,11 @@ describe('SchedulerService', () => {
 
       expect(pool.query).toHaveBeenCalledTimes(2);
 
-      // Second call must be the agent_tasks INSERT with WHERE NOT EXISTS guard.
+      // Second call must be the CTE: INSERT INTO tasks WHERE NOT EXISTS + UPDATE scheduled_jobs.
       const [taskSql, taskParams] = pool.query.mock.calls[1] as [string, unknown[]];
-      expect(taskSql).toContain('INSERT INTO agent_tasks');
+      expect(taskSql).toContain('INSERT INTO tasks');
       expect(taskSql).toContain('WHERE NOT EXISTS');
+      expect(taskSql).toContain('UPDATE scheduled_jobs');
       expect(taskParams).toContain('coordinator');
       expect(taskParams).toContain('Produce a weekly summary of key business metrics');
       expect(taskParams).toContain('active');
@@ -818,8 +820,8 @@ describe('SchedulerService', () => {
       );
     });
 
-    it('is idempotent on restart — skips agent_tasks INSERT when row already exists', async () => {
-      // rowCount: 0 means WHERE NOT EXISTS fired — the existing row was preserved.
+    it('is idempotent on restart — skips tasks INSERT when row already exists', async () => {
+      // rowCount: 0 means the WHERE NOT EXISTS guard fired — the existing row was preserved.
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-anchor-2' }] });
       pool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
 
@@ -838,7 +840,7 @@ describe('SchedulerService', () => {
       );
     });
 
-    it('does not create an agent_tasks row when intent_anchor is absent', async () => {
+    it('does not create a tasks row when intent_anchor is absent', async () => {
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-no-anchor' }] });
 
       await svc.upsertDeclarativeJob('coordinator', 'coordinator', {

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -804,11 +804,13 @@ describe('SchedulerService', () => {
       expect(pool.query).toHaveBeenCalledTimes(2);
 
       // Second call must be the CTE: INSERT INTO tasks WHERE NOT EXISTS + UPDATE scheduled_jobs
-      // + SELECT new_task.id AS task_id, link_job.job_id.
+      // (guarded by AND task_id IS NULL) + cleanup_orphan DELETE + SELECT.
       const [taskSql, taskParams] = pool.query.mock.calls[1] as [string, unknown[]];
       expect(taskSql).toContain('INSERT INTO tasks');
       expect(taskSql).toContain('WHERE NOT EXISTS');
       expect(taskSql).toContain('UPDATE scheduled_jobs');
+      expect(taskSql).toContain('AND task_id IS NULL');
+      expect(taskSql).toContain('cleanup_orphan');
       expect(taskSql).toContain('task_id');
       expect(taskSql).toContain('job_id');
       expect(taskParams).toContain('coordinator');
@@ -856,8 +858,10 @@ describe('SchedulerService', () => {
     });
 
     it('throws when tasks INSERT succeeds but scheduled_jobs UPDATE fails (orphan race)', async () => {
-      // Simulate the race where the scheduled_jobs row disappears between the upsert
-      // and the task-link CTE: INSERT returns a task_id but job_id is null.
+      // Simulate the race where the scheduled_jobs row disappears (or was already linked
+      // by a concurrent startup) between the upsert and the task-link CTE.
+      // The cleanup_orphan CTE deletes the orphan task (DB-side); INSERT returns task_id
+      // but job_id is null, indicating the link failed.
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-race' }] });
       pool.query.mockResolvedValueOnce({ rows: [{ task_id: 'task-orphan', job_id: null }] });
 

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -104,8 +104,8 @@ describe('SchedulerService', () => {
       const taskId = 'task-aaa';
       // First call: INSERT into scheduled_jobs
       pool.query.mockResolvedValueOnce({ rows: [{ id: jobId }] });
-      // Second call: CTE that INSERTs into tasks and UPDATEs scheduled_jobs.task_id
-      pool.query.mockResolvedValueOnce({ rows: [{ id: taskId }] });
+      // Second call: CTE returns { task_id, job_id } confirming both INSERT and UPDATE succeeded
+      pool.query.mockResolvedValueOnce({ rows: [{ task_id: taskId, job_id: jobId }] });
 
       const params: CreateJobParams = {
         agentId: 'agent-3',
@@ -790,10 +790,10 @@ describe('SchedulerService', () => {
     });
 
     it('creates a tasks row when intent_anchor is provided', async () => {
-      // First query: the scheduled_jobs upsert; second query: CTE that INSERTs tasks row
-      // and UPDATEs scheduled_jobs.task_id atomically (rowCount=1 means row was created).
+      // First query: the scheduled_jobs upsert; second query: CTE returns { task_id, job_id }
+      // confirming both the tasks INSERT and scheduled_jobs UPDATE succeeded.
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-anchor' }] });
-      pool.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+      pool.query.mockResolvedValueOnce({ rows: [{ task_id: 'task-new', job_id: 'job-anchor' }] });
 
       await svc.upsertDeclarativeJob('coordinator', 'coordinator', {
         cron: '0 9 * * 1',
@@ -803,11 +803,14 @@ describe('SchedulerService', () => {
 
       expect(pool.query).toHaveBeenCalledTimes(2);
 
-      // Second call must be the CTE: INSERT INTO tasks WHERE NOT EXISTS + UPDATE scheduled_jobs.
+      // Second call must be the CTE: INSERT INTO tasks WHERE NOT EXISTS + UPDATE scheduled_jobs
+      // + SELECT new_task.id AS task_id, link_job.job_id.
       const [taskSql, taskParams] = pool.query.mock.calls[1] as [string, unknown[]];
       expect(taskSql).toContain('INSERT INTO tasks');
       expect(taskSql).toContain('WHERE NOT EXISTS');
       expect(taskSql).toContain('UPDATE scheduled_jobs');
+      expect(taskSql).toContain('task_id');
+      expect(taskSql).toContain('job_id');
       expect(taskParams).toContain('coordinator');
       expect(taskParams).toContain('Produce a weekly summary of key business metrics');
       expect(taskParams).toContain('active');

--- a/tests/unit/scheduler/scheduler-service.test.ts
+++ b/tests/unit/scheduler/scheduler-service.test.ts
@@ -855,6 +855,26 @@ describe('SchedulerService', () => {
       expect(pool.query).toHaveBeenCalledTimes(1);
     });
 
+    it('throws when tasks INSERT succeeds but scheduled_jobs UPDATE fails (orphan race)', async () => {
+      // Simulate the race where the scheduled_jobs row disappears between the upsert
+      // and the task-link CTE: INSERT returns a task_id but job_id is null.
+      pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-race' }] });
+      pool.query.mockResolvedValueOnce({ rows: [{ task_id: 'task-orphan', job_id: null }] });
+
+      await expect(
+        svc.upsertDeclarativeJob('coordinator', 'coordinator', {
+          cron: '0 9 * * 1',
+          task: 'weekly digest',
+          intent_anchor: 'Produce a weekly summary',
+        }),
+      ).rejects.toThrow(/scheduled_jobs row.*not found when linking task/);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ jobId: 'job-race', taskId: 'task-orphan' }),
+        expect.stringContaining('orphaned task'),
+      );
+    });
+
     it('stamps a system originator with systemRole system and channel declarative', async () => {
       pool.query.mockResolvedValueOnce({ rows: [{ id: 'job-orig' }] });
 


### PR DESCRIPTION
## **User description**
## Summary

- **Migration 049** renames `agent_tasks` → `tasks`, drops `agent_tasks.scheduled_job_id`, adds a forward FK `scheduled_jobs.task_id → tasks.id`, and adds CEO-visible columns (`title`, `description`, `owner`, `priority`, `due_at`, `tags`, etc.) with backfill from existing rows.
- **`src/db/queries/tasks.ts`** — new module with `DbTaskRow`, `TaskRow`, `mapTaskRow`, and `getTaskById` for the full column set.
- **`scheduler-service.ts`** — all `LEFT JOIN agent_tasks ON at.scheduled_job_id = sj.id` flipped to `LEFT JOIN tasks t ON sj.task_id = t.id`; `createJob`/`upsertDeclarativeJob` now INSERT into `tasks` then UPDATE `scheduled_jobs.task_id` via a RETURNING CTE that detects silent UPDATE failures (orphan-race guard).
- **`scheduler.ts`** — `pollDueJobs` JOIN flipped.
- **`kg.ts`** — renamed table references, `scheduledJobId` removed from POST/PATCH body, `validTaskStatuses` expanded, `title` added to all task API responses.
- **Tests** — 3014 passing (+1 new test for the upsertDeclarativeJob orphan-race path).

No user-facing behavior changes. Existing scheduler and persistent-task paths are unchanged.

## Known pre-existing issues (not in scope for this PR)

- `cancelJob` and `pauseJobForDrift` do not check `rowCount` on the `scheduled_jobs` UPDATE — they log success even when the job row does not exist. Pre-existing pattern; will address in a follow-up.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 3014 passed (2 pre-existing DB-integration failures unrelated to this change)
- [x] `rg "scheduled_job_id" src/ --include="*.ts"` — zero results
- [x] `rg "agent_tasks" src/ --include="*.ts"` — zero results
- [ ] Migration up/down on fresh Postgres (run locally before merge)
- [ ] Migration up on a snapshot of prod data (verify existing persistent agent tasks resume)

Closes #834


___

## **CodeAnt-AI Description**
Promote scheduler-linked tasks to first-class tasks and keep job links consistent

### What Changed
- The scheduler now stores and reads linked work from `tasks` instead of the older `agent_tasks` table, while keeping existing scheduled jobs working.
- Task responses now include a visible title, and the task API no longer accepts or returns the old scheduled-job link field.
- Creating or pausing/cancelling a job now updates the linked task through the new forward job-to-task link.
- If a task is created but the matching scheduled job disappears during the link step, the request now fails instead of leaving an orphaned task.
- Existing task statuses and task-listing behavior now accept both the old scheduler states and the newer task-lifecycle states.

### Impact
`✅ Clearer task records in the API`
`✅ Fewer orphaned tasks after job races`
`✅ Safer scheduler-to-task linking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks gain expanded lifecycle states and richer metadata: title, owner, source, priority, due date and tags.

* **Documentation**
  * Docs updated to reflect the task model and scheduler interaction considerations.

* **Chores**
  * Database migration consolidates task storage and indexing; existing scheduler behaviour is preserved during migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->